### PR TITLE
Show imported vehicle history on customer detail page

### DIFF
--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -1,7 +1,13 @@
 // features/customers/app/customers/[id]/page.tsx (FULL FILE REPLACEMENT)
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
@@ -16,6 +22,33 @@ type DB = Database;
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
 type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
+type ImportedHistory = Pick<
+  DB["public"]["Tables"]["history"]["Row"],
+  | "id"
+  | "customer_id"
+  | "vehicle_id"
+  | "work_order_id"
+  | "service_date"
+  | "description"
+  | "notes"
+  | "created_at"
+  | "work_order_number"
+  | "invoice_number"
+  | "odometer"
+  | "symptom"
+  | "cause"
+  | "correction"
+  | "labor_hours"
+  | "labor_sale"
+  | "total"
+  | "imported_from_session_id"
+  | "source_system"
+> & {
+  vehicles: Pick<
+    Vehicle,
+    "year" | "make" | "model" | "vin" | "license_plate" | "unit_number"
+  > | null;
+};
 type VehicleMedia = DB["public"]["Tables"]["vehicle_media"]["Row"];
 
 type CustomerSearchRow = Pick<
@@ -65,7 +98,7 @@ type ParamsShape = Record<string, string | string[]>;
 
 function paramToString(v: string | string[] | undefined): string | null {
   if (!v) return null;
-  return Array.isArray(v) ? v[0] ?? null : v;
+  return Array.isArray(v) ? (v[0] ?? null) : v;
 }
 
 const looksLikeUuid = (s: string | null): boolean =>
@@ -73,7 +106,8 @@ const looksLikeUuid = (s: string | null): boolean =>
 
 const CARD_BASE =
   "rounded-2xl border border-[color:var(--metal-border-soft,#1f2937)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[0_18px_45px_rgba(0,0,0,0.85)] backdrop-blur-xl";
-const CARD_INNER = "rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-[color:var(--desktop-item-bg)]";
+const CARD_INNER =
+  "rounded-xl border border-[color:var(--metal-border-soft,#374151)] bg-[color:var(--desktop-item-bg)]";
 
 const STATUS_CHIP_BASE =
   "inline-flex items-center whitespace-nowrap rounded-full border px-3 py-1 text-[11px] font-semibold tracking-wide";
@@ -98,13 +132,27 @@ function fmtName(c: Pick<Customer, "first_name" | "last_name"> | null): string {
     [c.first_name ?? "", c.last_name ?? ""].filter(Boolean).join(" ") || "—"
   );
 }
-function bestCustomerDisplayName(c: Pick<Customer, "business_name" | "name" | "first_name" | "last_name" | "email" | "phone" | "phone_number"> | null): string {
+function bestCustomerDisplayName(
+  c: Pick<
+    Customer,
+    | "business_name"
+    | "name"
+    | "first_name"
+    | "last_name"
+    | "email"
+    | "phone"
+    | "phone_number"
+  > | null,
+): string {
   if (!c) return "—";
   const biz = c.business_name?.trim();
   if (biz) return biz;
   const name = c.name?.trim();
   if (name) return name;
-  const person = [c.first_name ?? "", c.last_name ?? ""].filter(Boolean).join(" ").trim();
+  const person = [c.first_name ?? "", c.last_name ?? ""]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
   if (person) return person;
   return c.email ?? c.phone ?? c.phone_number ?? "—";
 }
@@ -119,24 +167,38 @@ function customerSearchHaystack(c: CustomerSearchRow): string {
     c.phone,
     c.phone_number,
   ]
-    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .filter(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
+    )
     .join(" ")
     .toLowerCase();
 }
 
 function sortCustomerRows(rows: CustomerSearchRow[]): CustomerSearchRow[] {
   return [...rows].sort((a, b) =>
-    bestCustomerDisplayName(a).localeCompare(bestCustomerDisplayName(b), undefined, {
-      numeric: true,
-      sensitivity: "base",
-    }),
+    bestCustomerDisplayName(a).localeCompare(
+      bestCustomerDisplayName(b),
+      undefined,
+      {
+        numeric: true,
+        sensitivity: "base",
+      },
+    ),
   );
 }
 
 function fmtVehicleLabel(v: Vehicle): string {
-  return [v.year != null ? String(v.year) : "", v.make ?? "", v.model ?? "", v.submodel ?? ""]
-    .filter((part) => typeof part === "string" && part.trim().length > 0)
-    .join(" ") || "Vehicle";
+  return (
+    [
+      v.year != null ? String(v.year) : "",
+      v.make ?? "",
+      v.model ?? "",
+      v.submodel ?? "",
+    ]
+      .filter((part) => typeof part === "string" && part.trim().length > 0)
+      .join(" ") || "Vehicle"
+  );
 }
 
 function safeDate(iso: string | null): string {
@@ -154,37 +216,57 @@ function compactDate(iso: string | null | undefined): string | null {
   return format(d, "MMM yyyy");
 }
 
-function formatNumberLike(value: string | number | null | undefined): string | null {
+function formatNumberLike(
+  value: string | number | null | undefined,
+): string | null {
   if (value == null) return null;
   const raw = String(value).trim();
   if (!raw) return null;
   const numeric = Number(raw.replace(/,/g, ""));
   if (!Number.isFinite(numeric)) return raw;
-  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(numeric);
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(
+    numeric,
+  );
 }
 
 function formatEngineFuel(vehicle: Vehicle): string | null {
-  return [strOrNull(vehicle.engine), strOrNull(vehicle.fuel_type)].filter(Boolean).join(" ") || null;
+  return (
+    [strOrNull(vehicle.engine), strOrNull(vehicle.fuel_type)]
+      .filter(Boolean)
+      .join(" ") || null
+  );
 }
 
 function formatDriveBody(vehicle: Vehicle): string | null {
-  return [strOrNull(vehicle.drivetrain), strOrNull(vehicle.body_type)].filter(Boolean).join(" ") || null;
+  return (
+    [strOrNull(vehicle.drivetrain), strOrNull(vehicle.body_type)]
+      .filter(Boolean)
+      .join(" ") || null
+  );
 }
 
 function formatVehicleStatus(value: string | null | undefined): string | null {
   const clean = strOrNull(value);
   if (!clean) return null;
-  return clean.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+  return clean
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
-function formatOdometer(value: string | number | null | undefined, unit: string | null | undefined): string | null {
+function formatOdometer(
+  value: string | number | null | undefined,
+  unit: string | null | undefined,
+): string | null {
   const formatted = formatNumberLike(value);
   if (!formatted) return null;
   const cleanUnit = strOrNull(unit);
   return cleanUnit ? `${formatted} ${cleanUnit}` : formatted;
 }
 
-function formatPlateWithRegion(plate: string | null | undefined, region: string | null | undefined): string | null {
+function formatPlateWithRegion(
+  plate: string | null | undefined,
+  region: string | null | undefined,
+): string | null {
   const cleanPlateValue = strOrNull(plate);
   if (!cleanPlateValue) return null;
   const cleanRegion = strOrNull(region);
@@ -232,7 +314,6 @@ function optNumber(obj: Record<string, unknown>, key: string): number | null {
   return null;
 }
 
-
 function compactSecondaryDetails(input: {
   firstName?: string | null;
   lastName?: string | null;
@@ -243,10 +324,18 @@ function compactSecondaryDetails(input: {
   city?: string | null;
   province?: string | null;
 }): string | null {
-  const contactName = [input.firstName ?? "", input.lastName ?? ""].filter(Boolean).join(" ").trim();
+  const contactName = [input.firstName ?? "", input.lastName ?? ""]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
   const phone = input.phone ?? input.phoneNumber ?? null;
-  const location = [input.city ?? "", input.province ?? ""].filter(Boolean).join(", ").trim();
-  const parts = [contactName, phone ?? "", input.email ?? "", location].filter((part) => part && part !== input.businessName);
+  const location = [input.city ?? "", input.province ?? ""]
+    .filter(Boolean)
+    .join(", ")
+    .trim();
+  const parts = [contactName, phone ?? "", input.email ?? "", location].filter(
+    (part) => part && part !== input.businessName,
+  );
   return parts.length ? parts.join(" • ") : null;
 }
 
@@ -262,6 +351,62 @@ function strOrNull(v: string | null | undefined): string | null {
   return t ? t : null;
 }
 
+function formatHistoryDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return format(d, "PP");
+}
+
+function formatMoney(value: number | null | undefined): string | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+}
+
+function formatImportedVehicle(
+  vehicle: ImportedHistory["vehicles"] | null | undefined,
+): string | null {
+  if (!vehicle) return null;
+  const label = [
+    vehicle.year != null ? String(vehicle.year) : "",
+    vehicle.make ?? "",
+    vehicle.model ?? "",
+  ]
+    .filter((part) => part.trim().length > 0)
+    .join(" ")
+    .trim();
+  return label || (vehicle.unit_number ? `Unit ${vehicle.unit_number}` : null);
+}
+
+function formatImportedIdentifiers(
+  vehicle: ImportedHistory["vehicles"] | null | undefined,
+): string | null {
+  if (!vehicle) return null;
+  return (
+    [
+      vehicle.vin ? `VIN ${vehicle.vin}` : null,
+      vehicle.license_plate ? `Plate ${vehicle.license_plate}` : null,
+    ]
+      .filter(Boolean)
+      .join(" • ") || null
+  );
+}
+
+function importedHistorySummary(row: ImportedHistory): string | null {
+  const complaintCauseCorrection = [
+    row.symptom ? `Complaint: ${row.symptom}` : null,
+    row.cause ? `Cause: ${row.cause}` : null,
+    row.correction ? `Correction: ${row.correction}` : null,
+  ].filter(Boolean);
+
+  if (complaintCauseCorrection.length > 0)
+    return complaintCauseCorrection.join(" • ");
+  return strOrNull(row.description) ?? strOrNull(row.notes);
+}
+
 function normalizeEmail(v: string | null | undefined): string | null {
   const email = strOrNull(v);
   return email ? email.toLowerCase() : null;
@@ -274,12 +419,18 @@ function normalizePhone(v: string | null | undefined): string | null {
   return digits || raw;
 }
 
-function splitCustomerName(name: string): { firstName: string | null; lastName: string | null } {
+function splitCustomerName(name: string): {
+  firstName: string | null;
+  lastName: string | null;
+} {
   const clean = strOrNull(name);
   if (!clean) return { firstName: null, lastName: null };
   const parts = clean.split(/\s+/).filter(Boolean);
   if (parts.length === 1) return { firstName: parts[0], lastName: null };
-  return { firstName: parts.slice(0, -1).join(" "), lastName: parts.at(-1) ?? null };
+  return {
+    firstName: parts.slice(0, -1).join(" "),
+    lastName: parts.at(-1) ?? null,
+  };
 }
 
 /** Storage buckets (from your screenshot set). We don't store bucket in DB, so we "probe" candidates. */
@@ -464,7 +615,10 @@ export default function CustomerProfilePage(): JSX.Element {
   );
 
   const [workOrders, setWorkOrders] = useState<WorkOrder[]>([]);
+  const [importedHistory, setImportedHistory] = useState<ImportedHistory[]>([]);
   const [showAllHistory, setShowAllHistory] = useState<boolean>(false);
+  const [showAllImportedHistory, setShowAllImportedHistory] =
+    useState<boolean>(false);
 
   const [rawVehicleMedia, setRawVehicleMedia] = useState<VehicleMedia[]>([]);
   const [media, setMedia] = useState<DisplayMedia[]>([]);
@@ -491,9 +645,15 @@ export default function CustomerProfilePage(): JSX.Element {
   // Create customer from directory mode
   const [createCustomerOpen, setCreateCustomerOpen] = useState(false);
   const [creatingCustomer, setCreatingCustomer] = useState(false);
-  const [createCustomerError, setCreateCustomerError] = useState<string | null>(null);
-  const [customerImportPlaceholderVisible, setCustomerImportPlaceholderVisible] = useState(false);
-  const [newCustomer, setNewCustomer] = useState<NewCustomerDraft>(EMPTY_NEW_CUSTOMER);
+  const [createCustomerError, setCreateCustomerError] = useState<string | null>(
+    null,
+  );
+  const [
+    customerImportPlaceholderVisible,
+    setCustomerImportPlaceholderVisible,
+  ] = useState(false);
+  const [newCustomer, setNewCustomer] =
+    useState<NewCustomerDraft>(EMPTY_NEW_CUSTOMER);
 
   const selectedVehicle = useMemo(() => {
     if (!selectedVehicleId) return null;
@@ -509,6 +669,18 @@ export default function CustomerProfilePage(): JSX.Element {
     if (showAllHistory) return workOrders;
     return workOrders.slice(0, 3);
   }, [showAllHistory, workOrders]);
+
+  const importedHistorySlice = useMemo(() => {
+    if (showAllImportedHistory) return importedHistory;
+    return importedHistory.slice(0, 5);
+  }, [importedHistory, showAllImportedHistory]);
+
+  const selectedVehicleImportedHistory = useMemo(() => {
+    if (!selectedVehicleId) return [];
+    return importedHistory.filter(
+      (row) => row.vehicle_id === selectedVehicleId,
+    );
+  }, [importedHistory, selectedVehicleId]);
 
   // ------------------ Fetch customer file ------------------
   const fetchCustomerFile = useCallback(
@@ -532,6 +704,7 @@ export default function CustomerProfilePage(): JSX.Element {
           setVehicles([]);
           setSelectedVehicleId(null);
           setWorkOrders([]);
+          setImportedHistory([]);
           setRawVehicleMedia([]);
           setMedia([]);
           setViewError("Customer not found / not visible.");
@@ -550,7 +723,19 @@ export default function CustomerProfilePage(): JSX.Element {
         if (vsErr) throw vsErr;
 
         const directVehicles = (vs ?? []) as Vehicle[];
-        const directVehicleIds = directVehicles.map((v) => v.id).filter(Boolean);
+        const directVehicleIds = directVehicles
+          .map((v) => v.id)
+          .filter(Boolean);
+
+        const { data: historyRows, error: historyErr } = await supabase
+          .from("history")
+          .select(
+            "id,customer_id,vehicle_id,work_order_id,service_date,description,notes,created_at,work_order_number,invoice_number,odometer,symptom,cause,correction,labor_hours,labor_sale,total,imported_from_session_id,source_system,vehicles:vehicles(year,make,model,vin,license_plate,unit_number)",
+          )
+          .eq("customer_id", customerId)
+          .order("service_date", { ascending: false });
+
+        if (historyErr) throw historyErr;
 
         const { data: directWos, error: directWoErr } = await supabase
           .from("work_orders")
@@ -573,17 +758,27 @@ export default function CustomerProfilePage(): JSX.Element {
         const fallbackWosByNameCandidates = [
           cust.business_name,
           cust.name,
-          [cust.first_name ?? "", cust.last_name ?? ""].filter(Boolean).join(" ").trim(),
-        ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+          [cust.first_name ?? "", cust.last_name ?? ""]
+            .filter(Boolean)
+            .join(" ")
+            .trim(),
+        ].filter(
+          (value): value is string =>
+            typeof value === "string" && value.trim().length > 0,
+        );
 
         let fallbackWosByName: WorkOrder[] = [];
-        if ((directWos?.length ?? 0) === 0 && (fallbackWosByVehicle.data?.length ?? 0) === 0) {
+        if (
+          (directWos?.length ?? 0) === 0 &&
+          (fallbackWosByVehicle.data?.length ?? 0) === 0
+        ) {
           for (const candidate of fallbackWosByNameCandidates) {
             let byNameQuery = supabase
               .from("work_orders")
               .select("*")
               .ilike("customer_name", candidate);
-            if (cust.shop_id) byNameQuery = byNameQuery.eq("shop_id", cust.shop_id);
+            if (cust.shop_id)
+              byNameQuery = byNameQuery.eq("shop_id", cust.shop_id);
             const byNameRes = await byNameQuery
               .order("created_at", { ascending: false })
               .limit(25);
@@ -606,24 +801,34 @@ export default function CustomerProfilePage(): JSX.Element {
           workOrdersById.set(wo.id, wo);
         }
         const mergedWorkOrders = Array.from(workOrdersById.values()).sort(
-          (a, b) => new Date(String(b.created_at ?? "")).getTime() - new Date(String(a.created_at ?? "")).getTime(),
+          (a, b) =>
+            new Date(String(b.created_at ?? "")).getTime() -
+            new Date(String(a.created_at ?? "")).getTime(),
         );
 
         const fallbackVehicleIds = Array.from(
           new Set(
             mergedWorkOrders
               .map((wo) => wo.vehicle_id)
-              .filter((id): id is string => typeof id === "string" && id.length > 0),
+              .filter(
+                (id): id is string => typeof id === "string" && id.length > 0,
+              ),
           ),
         ).filter((id) => !directVehicleIds.includes(id));
 
         const fallbackVehiclesRes = fallbackVehicleIds.length
-          ? await supabase.from("vehicles").select("*").in("id", fallbackVehicleIds)
+          ? await supabase
+              .from("vehicles")
+              .select("*")
+              .in("id", fallbackVehicleIds)
           : { data: [], error: null };
 
         if (fallbackVehiclesRes.error) throw fallbackVehiclesRes.error;
 
-        const vrows = [...directVehicles, ...((fallbackVehiclesRes.data ?? []) as Vehicle[])];
+        const vrows = [
+          ...directVehicles,
+          ...((fallbackVehiclesRes.data ?? []) as Vehicle[]),
+        ];
         setVehicles(vrows);
 
         setSelectedVehicleId((prev) => {
@@ -632,6 +837,21 @@ export default function CustomerProfilePage(): JSX.Element {
         });
 
         setWorkOrders(mergedWorkOrders);
+        setImportedHistory(
+          ((historyRows ?? []) as unknown[]).map((row) => {
+            const record = row as ImportedHistory & {
+              vehicles?:
+                | ImportedHistory["vehicles"]
+                | ImportedHistory["vehicles"][];
+            };
+            return {
+              ...record,
+              vehicles: Array.isArray(record.vehicles)
+                ? (record.vehicles[0] ?? null)
+                : (record.vehicles ?? null),
+            };
+          }),
+        );
       } catch (e: unknown) {
         const msg =
           e instanceof Error ? e.message : "Failed to load customer file.";
@@ -640,6 +860,7 @@ export default function CustomerProfilePage(): JSX.Element {
         setVehicles([]);
         setSelectedVehicleId(null);
         setWorkOrders([]);
+        setImportedHistory([]);
         setRawVehicleMedia([]);
         setMedia([]);
       } finally {
@@ -747,46 +968,53 @@ export default function CustomerProfilePage(): JSX.Element {
     };
   }, [rawVehicleMedia, buildDisplayUrl]);
 
-  const getOrLinkShopId = useCallback(async (userId: string): Promise<string | null> => {
-    const byUserId = await supabase
-      .from("profiles")
-      .select("shop_id")
-      .eq("user_id", userId)
-      .maybeSingle();
+  const getOrLinkShopId = useCallback(
+    async (userId: string): Promise<string | null> => {
+      const byUserId = await supabase
+        .from("profiles")
+        .select("shop_id")
+        .eq("user_id", userId)
+        .maybeSingle();
 
-    if (byUserId.error) throw byUserId.error;
-    if (byUserId.data?.shop_id) return byUserId.data.shop_id;
+      if (byUserId.error) throw byUserId.error;
+      if (byUserId.data?.shop_id) return byUserId.data.shop_id;
 
-    const byId = await supabase
-      .from("profiles")
-      .select("shop_id")
-      .eq("id", userId)
-      .maybeSingle();
+      const byId = await supabase
+        .from("profiles")
+        .select("shop_id")
+        .eq("id", userId)
+        .maybeSingle();
 
-    if (byId.error) throw byId.error;
-    if (byId.data?.shop_id) return byId.data.shop_id;
+      if (byId.error) throw byId.error;
+      if (byId.data?.shop_id) return byId.data.shop_id;
 
-    const ownedShop = await supabase
-      .from("shops")
-      .select("id")
-      .eq("owner_id", userId)
-      .maybeSingle();
+      const ownedShop = await supabase
+        .from("shops")
+        .select("id")
+        .eq("owner_id", userId)
+        .maybeSingle();
 
-    if (ownedShop.error) throw ownedShop.error;
-    return ownedShop.data?.id ?? null;
-  }, [supabase]);
+      if (ownedShop.error) throw ownedShop.error;
+      return ownedShop.data?.id ?? null;
+    },
+    [supabase],
+  );
 
   const createCustomer = useCallback(async () => {
     setCreateCustomerError(null);
 
     const customerName = strOrNull(newCustomer.customerName);
     const businessName = strOrNull(newCustomer.businessName);
-    const isBusinessLike = newCustomer.customerType === "business" || newCustomer.customerType === "fleet";
+    const isBusinessLike =
+      newCustomer.customerType === "business" ||
+      newCustomer.customerType === "fleet";
     const displayName = isBusinessLike ? businessName : customerName;
 
     if (!displayName) {
       setCreateCustomerError(
-        isBusinessLike ? "Business name is required." : "Customer name is required.",
+        isBusinessLike
+          ? "Business name is required."
+          : "Customer name is required.",
       );
       return;
     }
@@ -797,7 +1025,8 @@ export default function CustomerProfilePage(): JSX.Element {
         data: { user },
       } = await supabase.auth.getUser();
 
-      if (!user?.id) throw new Error("You must be signed in to create a customer.");
+      if (!user?.id)
+        throw new Error("You must be signed in to create a customer.");
 
       const shopId = await getOrLinkShopId(user.id);
       if (!shopId) throw new Error("Your profile isn’t linked to a shop yet.");
@@ -837,7 +1066,9 @@ export default function CustomerProfilePage(): JSX.Element {
       setNewCustomer(EMPTY_NEW_CUSTOMER);
       router.push(`/customers/${data.id}`);
     } catch (e: unknown) {
-      setCreateCustomerError(e instanceof Error ? e.message : "Failed to create customer.");
+      setCreateCustomerError(
+        e instanceof Error ? e.message : "Failed to create customer.",
+      );
     } finally {
       setCreatingCustomer(false);
     }
@@ -980,7 +1211,9 @@ export default function CustomerProfilePage(): JSX.Element {
           storage_path: storagePath,
         } satisfies DB["public"]["Tables"]["vehicle_media"]["Insert"];
 
-        const { error: insErr } = await supabase.from("vehicle_media").insert(insertRow);
+        const { error: insErr } = await supabase
+          .from("vehicle_media")
+          .insert(insertRow);
         if (insErr) {
           setViewError(insErr.message);
           return;
@@ -1006,15 +1239,20 @@ export default function CustomerProfilePage(): JSX.Element {
       last_name: customer.last_name ?? null,
       name: typeof r["name"] === "string" ? (r["name"] as string) : "",
       business_name:
-        typeof r["business_name"] === "string" ? (r["business_name"] as string) : "",
+        typeof r["business_name"] === "string"
+          ? (r["business_name"] as string)
+          : "",
       email: customer.email ?? null,
       phone: customer.phone ?? null,
       phone_number: customer.phone_number ?? null,
       address: typeof r["address"] === "string" ? (r["address"] as string) : "",
       city: typeof r["city"] === "string" ? (r["city"] as string) : "",
-      province: typeof r["province"] === "string" ? (r["province"] as string) : "",
+      province:
+        typeof r["province"] === "string" ? (r["province"] as string) : "",
       postal_code:
-        typeof r["postal_code"] === "string" ? (r["postal_code"] as string) : "",
+        typeof r["postal_code"] === "string"
+          ? (r["postal_code"] as string)
+          : "",
     });
   }, [customer]);
 
@@ -1023,11 +1261,17 @@ export default function CustomerProfilePage(): JSX.Element {
 
     const updateRecord: Record<string, unknown> = {
       first_name:
-        typeof custDraft["first_name"] === "string" ? custDraft["first_name"] : null,
+        typeof custDraft["first_name"] === "string"
+          ? custDraft["first_name"]
+          : null,
       last_name:
-        typeof custDraft["last_name"] === "string" ? custDraft["last_name"] : null,
+        typeof custDraft["last_name"] === "string"
+          ? custDraft["last_name"]
+          : null,
       name:
-        typeof custDraft["name"] === "string" ? (custDraft["name"] as string) || null : null,
+        typeof custDraft["name"] === "string"
+          ? (custDraft["name"] as string) || null
+          : null,
       business_name:
         typeof custDraft["business_name"] === "string"
           ? (custDraft["business_name"] as string) || null
@@ -1035,7 +1279,9 @@ export default function CustomerProfilePage(): JSX.Element {
       email: typeof custDraft["email"] === "string" ? custDraft["email"] : null,
       phone: typeof custDraft["phone"] === "string" ? custDraft["phone"] : null,
       phone_number:
-        typeof custDraft["phone_number"] === "string" ? custDraft["phone_number"] : null,
+        typeof custDraft["phone_number"] === "string"
+          ? custDraft["phone_number"]
+          : null,
     };
 
     // Optional fields (if your schema has them, they'll save; if not, Supabase will error and we show it)
@@ -1075,25 +1321,37 @@ export default function CustomerProfilePage(): JSX.Element {
 
     const updateRecord: Record<string, unknown> = {
       year:
-        typeof vehDraft["year"] === "number" ? vehDraft["year"] : selectedVehicle.year ?? null,
+        typeof vehDraft["year"] === "number"
+          ? vehDraft["year"]
+          : (selectedVehicle.year ?? null),
       make:
-        typeof vehDraft["make"] === "string" ? vehDraft["make"] : selectedVehicle.make ?? null,
+        typeof vehDraft["make"] === "string"
+          ? vehDraft["make"]
+          : (selectedVehicle.make ?? null),
       model:
-        typeof vehDraft["model"] === "string" ? vehDraft["model"] : selectedVehicle.model ?? null,
+        typeof vehDraft["model"] === "string"
+          ? vehDraft["model"]
+          : (selectedVehicle.model ?? null),
       vin:
-        typeof vehDraft["vin"] === "string" ? vehDraft["vin"] : selectedVehicle.vin ?? null,
+        typeof vehDraft["vin"] === "string"
+          ? vehDraft["vin"]
+          : (selectedVehicle.vin ?? null),
       license_plate:
         typeof vehDraft["license_plate"] === "string"
           ? vehDraft["license_plate"]
-          : (selectedVehicle as unknown as Record<string, unknown>)["license_plate"] ??
+          : ((selectedVehicle as unknown as Record<string, unknown>)[
+              "license_plate"
+            ] ??
             selectedVehicle.license_plate ??
-            null,
+            null),
       mileage:
         typeof vehDraft["mileage"] === "string"
           ? vehDraft["mileage"]
-          : (selectedVehicle as unknown as Record<string, unknown>)["mileage"] ??
+          : ((selectedVehicle as unknown as Record<string, unknown>)[
+              "mileage"
+            ] ??
             selectedVehicle.mileage ??
-            null,
+            null),
     };
 
     // Optional-ish vehicle fields (confirmed by your vehicles table)
@@ -1101,7 +1359,10 @@ export default function CustomerProfilePage(): JSX.Element {
       updateRecord["unit_number"] = vehDraft["unit_number"] || null;
     if (typeof vehDraft["color"] === "string")
       updateRecord["color"] = vehDraft["color"] || null;
-    if (vehDraft["engine_hours"] === null || typeof vehDraft["engine_hours"] === "number") {
+    if (
+      vehDraft["engine_hours"] === null ||
+      typeof vehDraft["engine_hours"] === "number"
+    ) {
       updateRecord["engine_hours"] = vehDraft["engine_hours"];
     }
 
@@ -1137,14 +1398,20 @@ export default function CustomerProfilePage(): JSX.Element {
       "tags",
       "notes",
     ] as const) {
-      if (typeof vehDraft[key] === "string") updateRecord[key] = vehDraft[key] || null;
+      if (typeof vehDraft[key] === "string")
+        updateRecord[key] = vehDraft[key] || null;
     }
 
     const duplicateCheck = await checkVehicleDuplicates({
       vin: typeof updateRecord["vin"] === "string" ? updateRecord["vin"] : null,
       licensePlate:
-        typeof updateRecord["license_plate"] === "string" ? updateRecord["license_plate"] : null,
-      unitNumber: typeof updateRecord["unit_number"] === "string" ? updateRecord["unit_number"] : null,
+        typeof updateRecord["license_plate"] === "string"
+          ? updateRecord["license_plate"]
+          : null,
+      unitNumber:
+        typeof updateRecord["unit_number"] === "string"
+          ? updateRecord["unit_number"]
+          : null,
       customerId: customer?.id ?? null,
       vehicleId: selectedVehicle.id,
     });
@@ -1153,13 +1420,19 @@ export default function CustomerProfilePage(): JSX.Element {
       (match) => match.match_type === "vin" && match.same_customer === false,
     );
     if (blockingMatch) {
-      setViewError("This VIN is already assigned to another customer. Contact shop/admin to move vehicle.");
+      setViewError(
+        "This VIN is already assigned to another customer. Contact shop/admin to move vehicle.",
+      );
       return;
     }
 
-    const sameCustomerMatch = duplicateCheck.matches.find((match) => match.same_customer === true);
+    const sameCustomerMatch = duplicateCheck.matches.find(
+      (match) => match.same_customer === true,
+    );
     if (sameCustomerMatch) {
-      setViewError("Vehicle already exists for this customer. Open/edit the existing vehicle instead.");
+      setViewError(
+        "Vehicle already exists for this customer. Open/edit the existing vehicle instead.",
+      );
       return;
     }
 
@@ -1216,31 +1489,55 @@ export default function CustomerProfilePage(): JSX.Element {
       customer_id: customer.id,
       shop_id: customer.shop_id,
       year: typeof newVeh["year"] === "number" ? newVeh["year"] : null,
-      make: typeof newVeh["make"] === "string" ? (newVeh["make"] as string) || null : null,
-      model: typeof newVeh["model"] === "string" ? (newVeh["model"] as string) || null : null,
-      vin: typeof newVeh["vin"] === "string" ? (newVeh["vin"] as string) || null : null,
+      make:
+        typeof newVeh["make"] === "string"
+          ? (newVeh["make"] as string) || null
+          : null,
+      model:
+        typeof newVeh["model"] === "string"
+          ? (newVeh["model"] as string) || null
+          : null,
+      vin:
+        typeof newVeh["vin"] === "string"
+          ? (newVeh["vin"] as string) || null
+          : null,
       license_plate:
-        typeof newVeh["license_plate"] === "string" ? (newVeh["license_plate"] as string) || null : null,
-      mileage: typeof newVeh["mileage"] === "string" ? (newVeh["mileage"] as string) || null : null,
+        typeof newVeh["license_plate"] === "string"
+          ? (newVeh["license_plate"] as string) || null
+          : null,
+      mileage:
+        typeof newVeh["mileage"] === "string"
+          ? (newVeh["mileage"] as string) || null
+          : null,
     };
 
-    if (typeof newVeh["unit_number"] === "string") insertRecord["unit_number"] = newVeh["unit_number"] || null;
-    if (typeof newVeh["color"] === "string") insertRecord["color"] = newVeh["color"] || null;
-    if (typeof newVeh["engine_hours"] === "number") insertRecord["engine_hours"] = newVeh["engine_hours"];
+    if (typeof newVeh["unit_number"] === "string")
+      insertRecord["unit_number"] = newVeh["unit_number"] || null;
+    if (typeof newVeh["color"] === "string")
+      insertRecord["color"] = newVeh["color"] || null;
+    if (typeof newVeh["engine_hours"] === "number")
+      insertRecord["engine_hours"] = newVeh["engine_hours"];
 
     // ✅ extra vehicle profile fields (confirmed by your vehicles table)
-    if (typeof newVeh["submodel"] === "string") insertRecord["submodel"] = newVeh["submodel"] || null;
+    if (typeof newVeh["submodel"] === "string")
+      insertRecord["submodel"] = newVeh["submodel"] || null;
 
-    if (typeof newVeh["engine"] === "string") insertRecord["engine"] = newVeh["engine"] || null;
-    if (typeof newVeh["engine_type"] === "string") insertRecord["engine_type"] = newVeh["engine_type"] || null;
-    if (typeof newVeh["engine_family"] === "string") insertRecord["engine_family"] = newVeh["engine_family"] || null;
+    if (typeof newVeh["engine"] === "string")
+      insertRecord["engine"] = newVeh["engine"] || null;
+    if (typeof newVeh["engine_type"] === "string")
+      insertRecord["engine_type"] = newVeh["engine_type"] || null;
+    if (typeof newVeh["engine_family"] === "string")
+      insertRecord["engine_family"] = newVeh["engine_family"] || null;
 
-    if (typeof newVeh["transmission"] === "string") insertRecord["transmission"] = newVeh["transmission"] || null;
+    if (typeof newVeh["transmission"] === "string")
+      insertRecord["transmission"] = newVeh["transmission"] || null;
     if (typeof newVeh["transmission_type"] === "string")
       insertRecord["transmission_type"] = newVeh["transmission_type"] || null;
 
-    if (typeof newVeh["fuel_type"] === "string") insertRecord["fuel_type"] = newVeh["fuel_type"] || null;
-    if (typeof newVeh["drivetrain"] === "string") insertRecord["drivetrain"] = newVeh["drivetrain"] || null;
+    if (typeof newVeh["fuel_type"] === "string")
+      insertRecord["fuel_type"] = newVeh["fuel_type"] || null;
+    if (typeof newVeh["drivetrain"] === "string")
+      insertRecord["drivetrain"] = newVeh["drivetrain"] || null;
     for (const key of [
       "state_province",
       "odometer_unit",
@@ -1253,14 +1550,20 @@ export default function CustomerProfilePage(): JSX.Element {
       "tags",
       "notes",
     ] as const) {
-      if (typeof newVeh[key] === "string") insertRecord[key] = newVeh[key] || null;
+      if (typeof newVeh[key] === "string")
+        insertRecord[key] = newVeh[key] || null;
     }
 
     const duplicateCheck = await checkVehicleDuplicates({
       vin: typeof insertRecord["vin"] === "string" ? insertRecord["vin"] : null,
       licensePlate:
-        typeof insertRecord["license_plate"] === "string" ? insertRecord["license_plate"] : null,
-      unitNumber: typeof insertRecord["unit_number"] === "string" ? insertRecord["unit_number"] : null,
+        typeof insertRecord["license_plate"] === "string"
+          ? insertRecord["license_plate"]
+          : null,
+      unitNumber:
+        typeof insertRecord["unit_number"] === "string"
+          ? insertRecord["unit_number"]
+          : null,
       customerId: customer.id,
     });
 
@@ -1268,13 +1571,19 @@ export default function CustomerProfilePage(): JSX.Element {
       (match) => match.match_type === "vin" && match.same_customer === false,
     );
     if (blockingMatch) {
-      setViewError("This VIN is already assigned to another customer. Contact shop/admin to move vehicle.");
+      setViewError(
+        "This VIN is already assigned to another customer. Contact shop/admin to move vehicle.",
+      );
       return;
     }
 
-    const sameCustomerMatch = duplicateCheck.matches.find((match) => match.same_customer === true);
+    const sameCustomerMatch = duplicateCheck.matches.find(
+      (match) => match.same_customer === true,
+    );
     if (sameCustomerMatch) {
-      setViewError("Vehicle already exists for this customer. Open/edit the existing vehicle instead.");
+      setViewError(
+        "Vehicle already exists for this customer. Open/edit the existing vehicle instead.",
+      );
       setSelectedVehicleId(sameCustomerMatch.id);
       setAddVehicleOpen(false);
       return;
@@ -1317,17 +1626,28 @@ export default function CustomerProfilePage(): JSX.Element {
           actions={{
             customers: {
               label: "Prepare customer CSV import",
-              description: "Customer CSV import will be connected here. You can safely create customers manually now without leaving this page.",
+              description:
+                "Customer CSV import will be connected here. You can safely create customers manually now without leaving this page.",
               onClick: () => setCustomerImportPlaceholderVisible(true),
             },
           }}
         />
 
-
         {customerImportPlaceholderVisible ? (
-          <div className={`${CARD_BASE} border-[var(--accent-copper-soft)]/55 p-4 text-sm text-neutral-200`} data-guided-customer-import-placeholder>
-            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper,#C57A4A)]">Customer import</div>
-            <p className="mt-2">Customer CSV import will be connected here. For now, use <span className="font-semibold text-white">+ Create Customer</span> to add records safely.</p>
+          <div
+            className={`${CARD_BASE} border-[var(--accent-copper-soft)]/55 p-4 text-sm text-neutral-200`}
+            data-guided-customer-import-placeholder
+          >
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper,#C57A4A)]">
+              Customer import
+            </div>
+            <p className="mt-2">
+              Customer CSV import will be connected here. For now, use{" "}
+              <span className="font-semibold text-white">
+                + Create Customer
+              </span>{" "}
+              to add records safely.
+            </p>
             <button
               type="button"
               onClick={() => {
@@ -1356,7 +1676,8 @@ export default function CustomerProfilePage(): JSX.Element {
                 Customer Files
               </h1>
               <p className="mt-1 text-xs text-neutral-400">
-                Search by name, email, or phone. Open a customer to view the full file.
+                Search by name, email, or phone. Open a customer to view the
+                full file.
               </p>
             </div>
 
@@ -1420,7 +1741,8 @@ export default function CustomerProfilePage(): JSX.Element {
                             {bestCustomerDisplayName(r)}
                           </div>
                           <div className="mt-0.5 truncate text-[11px] text-neutral-400">
-                            {r.business_name?.trim() && (r.first_name || r.last_name)
+                            {r.business_name?.trim() &&
+                            (r.first_name || r.last_name)
                               ? fmtName(r)
                               : r.business_name?.trim()
                                 ? "—"
@@ -1429,10 +1751,19 @@ export default function CustomerProfilePage(): JSX.Element {
                                   : "—"}
                           </div>
                           <div className="mt-0.5 text-[11px] text-neutral-400">
-                            {compactSecondaryDetails({ firstName: r.first_name, lastName: r.last_name, businessName: r.business_name, email: r.email, phone: r.phone, phoneNumber: r.phone_number }) ?? "No contact details imported"}
+                            {compactSecondaryDetails({
+                              firstName: r.first_name,
+                              lastName: r.last_name,
+                              businessName: r.business_name,
+                              email: r.email,
+                              phone: r.phone,
+                              phoneNumber: r.phone_number,
+                            }) ?? "No contact details imported"}
                           </div>
                         </div>
-                        <div className="text-[10px] text-neutral-500">{safeDate(r.created_at)}</div>
+                        <div className="text-[10px] text-neutral-500">
+                          {safeDate(r.created_at)}
+                        </div>
                       </div>
                     </button>
                   );
@@ -1472,7 +1803,8 @@ export default function CustomerProfilePage(): JSX.Element {
         >
           <div className="space-y-4">
             <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 text-xs leading-5 text-neutral-300">
-              Use this as a secondary management path. The primary launch flow remains Work Order → Customer → Vehicle.
+              Use this as a secondary management path. The primary launch flow
+              remains Work Order → Customer → Vehicle.
             </div>
 
             {createCustomerError ? (
@@ -1501,9 +1833,15 @@ export default function CustomerProfilePage(): JSX.Element {
               </label>
 
               <label className="block text-xs font-semibold uppercase tracking-[0.14em] text-neutral-400">
-                {newCustomer.customerType === "individual" ? "Customer name" : "Business name"}
+                {newCustomer.customerType === "individual"
+                  ? "Customer name"
+                  : "Business name"}
                 <input
-                  value={newCustomer.customerType === "individual" ? newCustomer.customerName : newCustomer.businessName}
+                  value={
+                    newCustomer.customerType === "individual"
+                      ? newCustomer.customerName
+                      : newCustomer.businessName
+                  }
                   onChange={(e) => {
                     const value = e.target.value;
                     setNewCustomer((draft) =>
@@ -1512,7 +1850,11 @@ export default function CustomerProfilePage(): JSX.Element {
                         : { ...draft, businessName: value },
                     );
                   }}
-                  placeholder={newCustomer.customerType === "individual" ? "Jane Doe" : "Acme Fleet Services"}
+                  placeholder={
+                    newCustomer.customerType === "individual"
+                      ? "Jane Doe"
+                      : "Acme Fleet Services"
+                  }
                   className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
                 />
               </label>
@@ -1523,7 +1865,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 Contact name
                 <input
                   value={newCustomer.customerName}
-                  onChange={(e) => setNewCustomer((draft) => ({ ...draft, customerName: e.target.value }))}
+                  onChange={(e) =>
+                    setNewCustomer((draft) => ({
+                      ...draft,
+                      customerName: e.target.value,
+                    }))
+                  }
                   placeholder="Primary contact"
                   className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
                 />
@@ -1535,7 +1882,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 Phone
                 <input
                   value={newCustomer.phone}
-                  onChange={(e) => setNewCustomer((draft) => ({ ...draft, phone: e.target.value }))}
+                  onChange={(e) =>
+                    setNewCustomer((draft) => ({
+                      ...draft,
+                      phone: e.target.value,
+                    }))
+                  }
                   placeholder="(555) 555-1234"
                   className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
                 />
@@ -1544,7 +1896,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 Email
                 <input
                   value={newCustomer.email}
-                  onChange={(e) => setNewCustomer((draft) => ({ ...draft, email: e.target.value }))}
+                  onChange={(e) =>
+                    setNewCustomer((draft) => ({
+                      ...draft,
+                      email: e.target.value,
+                    }))
+                  }
                   placeholder="customer@example.com"
                   className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
                 />
@@ -1555,7 +1912,12 @@ export default function CustomerProfilePage(): JSX.Element {
               Address
               <input
                 value={newCustomer.address}
-                onChange={(e) => setNewCustomer((draft) => ({ ...draft, address: e.target.value }))}
+                onChange={(e) =>
+                  setNewCustomer((draft) => ({
+                    ...draft,
+                    address: e.target.value,
+                  }))
+                }
                 placeholder="Street address"
                 className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
               />
@@ -1566,7 +1928,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 City
                 <input
                   value={newCustomer.city}
-                  onChange={(e) => setNewCustomer((draft) => ({ ...draft, city: e.target.value }))}
+                  onChange={(e) =>
+                    setNewCustomer((draft) => ({
+                      ...draft,
+                      city: e.target.value,
+                    }))
+                  }
                   className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
                 />
               </label>
@@ -1574,7 +1941,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 State / Province
                 <input
                   value={newCustomer.province}
-                  onChange={(e) => setNewCustomer((draft) => ({ ...draft, province: e.target.value }))}
+                  onChange={(e) =>
+                    setNewCustomer((draft) => ({
+                      ...draft,
+                      province: e.target.value,
+                    }))
+                  }
                   className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
                 />
               </label>
@@ -1582,7 +1954,12 @@ export default function CustomerProfilePage(): JSX.Element {
                 Postal code
                 <input
                   value={newCustomer.postalCode}
-                  onChange={(e) => setNewCustomer((draft) => ({ ...draft, postalCode: e.target.value }))}
+                  onChange={(e) =>
+                    setNewCustomer((draft) => ({
+                      ...draft,
+                      postalCode: e.target.value,
+                    }))
+                  }
                   className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
                 />
               </label>
@@ -1592,7 +1969,12 @@ export default function CustomerProfilePage(): JSX.Element {
               Notes
               <textarea
                 value={newCustomer.notes}
-                onChange={(e) => setNewCustomer((draft) => ({ ...draft, notes: e.target.value }))}
+                onChange={(e) =>
+                  setNewCustomer((draft) => ({
+                    ...draft,
+                    notes: e.target.value,
+                  }))
+                }
                 rows={3}
                 placeholder="Launch-essential customer notes"
                 className="mt-1 w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm normal-case tracking-normal text-white placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
@@ -1609,9 +1991,15 @@ export default function CustomerProfilePage(): JSX.Element {
     return (
       <PageShell>
         <div className={`${CARD_BASE} p-4`}>
-          <div className="text-sm text-neutral-200">This route expects a customer id.</div>
+          <div className="text-sm text-neutral-200">
+            This route expects a customer id.
+          </div>
           <div className="mt-2 text-xs text-neutral-400">
-            Use <span className="font-mono text-neutral-200">/customers/search</span> to open the customer directory.
+            Use{" "}
+            <span className="font-mono text-neutral-200">
+              /customers/search
+            </span>{" "}
+            to open the customer directory.
           </div>
           <div className="mt-4">
             <button
@@ -1647,7 +2035,9 @@ export default function CustomerProfilePage(): JSX.Element {
           <div className={`${CARD_BASE} h-56 animate-pulse`} />
         </div>
       ) : !customer ? (
-        <div className={`${CARD_BASE} p-4 text-sm text-red-300`}>Customer not found.</div>
+        <div className={`${CARD_BASE} p-4 text-sm text-red-300`}>
+          Customer not found.
+        </div>
       ) : (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_380px]">
           {/* LEFT */}
@@ -1659,19 +2049,26 @@ export default function CustomerProfilePage(): JSX.Element {
                   {(() => {
                     const biz = customer.business_name?.trim() ?? "";
                     const title = bestCustomerDisplayName(customer);
-                    const customerRecord = customer as unknown as Record<string, unknown>;
+                    const customerRecord = customer as unknown as Record<
+                      string,
+                      unknown
+                    >;
 
                     return (
                       <>
                         <h1
                           className="truncate text-2xl font-semibold text-white sm:text-3xl"
-                          style={{ fontFamily: "var(--font-blackops), system-ui" }}
+                          style={{
+                            fontFamily: "var(--font-blackops), system-ui",
+                          }}
                         >
                           {title}
                         </h1>
 
                         {biz && (customer.first_name || customer.last_name) ? (
-                          <div className="mt-1 text-xs text-neutral-400">{fmtName(customer)}</div>
+                          <div className="mt-1 text-xs text-neutral-400">
+                            {fmtName(customer)}
+                          </div>
                         ) : null}
 
                         <div className="mt-2 text-sm text-neutral-300">
@@ -1682,8 +2079,14 @@ export default function CustomerProfilePage(): JSX.Element {
                             email: customer.email,
                             phone: customer.phone,
                             phoneNumber: customer.phone_number,
-                            city: typeof customerRecord["city"] === "string" ? customerRecord["city"] : null,
-                            province: typeof customerRecord["province"] === "string" ? customerRecord["province"] : null,
+                            city:
+                              typeof customerRecord["city"] === "string"
+                                ? customerRecord["city"]
+                                : null,
+                            province:
+                              typeof customerRecord["province"] === "string"
+                                ? customerRecord["province"]
+                                : null,
                           }) ?? "No contact details imported"}
                         </div>
                       </>
@@ -1691,12 +2094,24 @@ export default function CustomerProfilePage(): JSX.Element {
                   })()}
 
                   <div className="mt-2 text-sm leading-6 text-neutral-400">
-                    <div>{asText((customer as unknown as Record<string, unknown>)["address"])}</div>
+                    <div>
+                      {asText(
+                        (customer as unknown as Record<string, unknown>)[
+                          "address"
+                        ],
+                      )}
+                    </div>
                     <div>
                       {[
-                        (customer as unknown as Record<string, unknown>)["city"],
-                        (customer as unknown as Record<string, unknown>)["province"],
-                        (customer as unknown as Record<string, unknown>)["postal_code"],
+                        (customer as unknown as Record<string, unknown>)[
+                          "city"
+                        ],
+                        (customer as unknown as Record<string, unknown>)[
+                          "province"
+                        ],
+                        (customer as unknown as Record<string, unknown>)[
+                          "postal_code"
+                        ],
                       ]
                         .map((x) => (typeof x === "string" ? x : ""))
                         .filter((x) => x.length)
@@ -1719,7 +2134,9 @@ export default function CustomerProfilePage(): JSX.Element {
                     onClick={() =>
                       router.push(
                         `/work-orders/create?customerId=${customer.id}${
-                          selectedVehicleId ? `&vehicleId=${selectedVehicleId}` : ""
+                          selectedVehicleId
+                            ? `&vehicleId=${selectedVehicleId}`
+                            : ""
                         }`,
                       )
                     }
@@ -1735,8 +2152,12 @@ export default function CustomerProfilePage(): JSX.Element {
             <div className={`${CARD_BASE} p-4`}>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
-                  <h2 className="text-sm font-semibold text-white sm:text-base">Vehicles</h2>
-                  <p className="mt-1 text-[11px] text-neutral-400">Select a vehicle to view details and files.</p>
+                  <h2 className="text-sm font-semibold text-white sm:text-base">
+                    Vehicles
+                  </h2>
+                  <p className="mt-1 text-[11px] text-neutral-400">
+                    Select a vehicle to view details and files.
+                  </p>
                 </div>
 
                 <div className="flex flex-wrap items-center gap-2">
@@ -1751,7 +2172,9 @@ export default function CustomerProfilePage(): JSX.Element {
                   {vehicles.length > 0 ? (
                     <select
                       value={selectedVehicleId ?? ""}
-                      onChange={(e) => setSelectedVehicleId(e.target.value || null)}
+                      onChange={(e) =>
+                        setSelectedVehicleId(e.target.value || null)
+                      }
                       className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white focus:outline-none"
                     >
                       {vehicles.map((v) => (
@@ -1775,25 +2198,65 @@ export default function CustomerProfilePage(): JSX.Element {
               </div>
 
               {vehicles.length === 0 ? (
-                <div className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}>No vehicles linked to this customer yet.</div>
+                <div
+                  className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}
+                >
+                  No vehicles linked to this customer yet.
+                </div>
               ) : selectedVehicle ? (
                 <div className="mt-3 space-y-3">
                   <div className={`${CARD_INNER} p-4`}>
                     <div className="min-w-0 space-y-2">
                       <div className="break-words text-lg font-semibold leading-tight text-white sm:text-xl">
-                        <span aria-hidden className="mr-2">🚗</span>{fmtVehicleLabel(selectedVehicle)}
+                        <span aria-hidden className="mr-2">
+                          🚗
+                        </span>
+                        {fmtVehicleLabel(selectedVehicle)}
                       </div>
                     </div>
 
                     <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                      <DetailRow label="VIN" value={selectedVehicle.vin ?? "Not recorded"} />
-                      <DetailRow label="Plate" value={formatPlateWithRegion(selectedVehicle.license_plate, selectedVehicle.state_province)} />
-                      <DetailRow label="Mileage" value={formatOdometer(selectedVehicle.mileage, selectedVehicle.odometer_unit)} />
-                      <DetailRow label="Engine" value={formatEngineFuel(selectedVehicle)} />
-                      <DetailRow label="Drive" value={formatDriveBody(selectedVehicle)} />
-                      <DetailRow label="Status" value={formatVehicleStatus(selectedVehicle.status) ?? "Customer Vehicle"} />
-                      <DetailRow label="Customer since" value={compactDate(customer?.customer_since)} />
-                      <DetailRow label="Unit #" value={selectedVehicle.unit_number} />
+                      <DetailRow
+                        label="VIN"
+                        value={selectedVehicle.vin ?? "Not recorded"}
+                      />
+                      <DetailRow
+                        label="Plate"
+                        value={formatPlateWithRegion(
+                          selectedVehicle.license_plate,
+                          selectedVehicle.state_province,
+                        )}
+                      />
+                      <DetailRow
+                        label="Mileage"
+                        value={formatOdometer(
+                          selectedVehicle.mileage,
+                          selectedVehicle.odometer_unit,
+                        )}
+                      />
+                      <DetailRow
+                        label="Engine"
+                        value={formatEngineFuel(selectedVehicle)}
+                      />
+                      <DetailRow
+                        label="Drive"
+                        value={formatDriveBody(selectedVehicle)}
+                      />
+                      <DetailRow
+                        label="Status"
+                        value={
+                          formatVehicleStatus(selectedVehicle.status) ??
+                          "Customer Vehicle"
+                        }
+                      />
+                      <DetailRow
+                        label="Customer since"
+                        value={compactDate(customer?.customer_since)}
+                      />
+                      <DetailRow
+                        label="Unit #"
+                        value={selectedVehicle.unit_number}
+                      />
                       <DetailRow label="Color" value={selectedVehicle.color} />
                     </div>
 
@@ -1804,8 +2267,54 @@ export default function CustomerProfilePage(): JSX.Element {
                         </div>
                         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                           {vehicleExtraDetails.map((it) => (
-                            <DetailRow key={it.label} label={it.label} value={it.value} />
+                            <DetailRow
+                              key={it.label}
+                              label={it.label}
+                              value={it.value}
+                            />
                           ))}
+                        </div>
+                      </div>
+                    ) : null}
+
+                    {selectedVehicleImportedHistory.length > 0 ? (
+                      <div className="mt-4 rounded-xl border border-[var(--accent-copper-soft)]/35 bg-black/20 p-3">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-300">
+                            Imported history for selected vehicle
+                          </div>
+                          <span className="rounded-full border border-[var(--accent-copper-soft)]/45 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--accent-copper,#C57A4A)]">
+                            Read-only
+                          </span>
+                        </div>
+                        <div className="mt-2 space-y-2">
+                          {selectedVehicleImportedHistory
+                            .slice(0, 3)
+                            .map((row) => (
+                              <div
+                                key={row.id}
+                                className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2"
+                              >
+                                <div className="text-xs font-semibold text-white">
+                                  {formatHistoryDate(row.service_date)}
+                                </div>
+                                <div className="mt-1 text-[11px] text-neutral-400">
+                                  {[
+                                    row.work_order_number
+                                      ? `WO ${row.work_order_number}`
+                                      : null,
+                                    row.invoice_number
+                                      ? `Invoice ${row.invoice_number}`
+                                      : null,
+                                    row.odometer != null
+                                      ? `${formatNumberLike(row.odometer)} mi`
+                                      : null,
+                                  ]
+                                    .filter(Boolean)
+                                    .join(" • ") || "Imported service record"}
+                                </div>
+                              </div>
+                            ))}
                         </div>
                       </div>
                     ) : null}
@@ -1818,9 +2327,12 @@ export default function CustomerProfilePage(): JSX.Element {
             <div className={`${CARD_BASE} p-4`}>
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <h2 className="text-sm font-semibold text-white sm:text-base">Work Order History</h2>
+                  <h2 className="text-sm font-semibold text-white sm:text-base">
+                    Work Order History
+                  </h2>
                   <p className="mt-1 text-[11px] text-neutral-400">
-                    Showing {showAllHistory ? "all" : "latest 3"} work orders for this customer.
+                    Showing {showAllHistory ? "all" : "latest 3"} work orders
+                    for this customer.
                   </p>
                 </div>
 
@@ -1836,7 +2348,11 @@ export default function CustomerProfilePage(): JSX.Element {
               </div>
 
               {workOrders.length === 0 ? (
-                <div className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}>No work orders yet.</div>
+                <div
+                  className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}
+                >
+                  No work orders yet.
+                </div>
               ) : (
                 <div className="mt-3 space-y-2">
                   {historySlice.map((wo) => (
@@ -1850,19 +2366,134 @@ export default function CustomerProfilePage(): JSX.Element {
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0">
                           <div className="truncate text-sm font-semibold text-white">
-                            {(wo as unknown as Record<string, unknown>)["custom_id"]
+                            {(wo as unknown as Record<string, unknown>)[
+                              "custom_id"
+                            ]
                               ? `WO ${(wo as unknown as Record<string, unknown>)["custom_id"] as string}`
                               : `WO #${wo.id.slice(0, 8)}`}
                           </div>
-                          <div className="mt-0.5 text-[11px] text-neutral-400">{safeDate(wo.created_at)}</div>
+                          <div className="mt-0.5 text-[11px] text-neutral-400">
+                            {safeDate(wo.created_at)}
+                          </div>
                         </div>
 
-                        <span className={chipClass((wo as unknown as Record<string, unknown>)["status"] as string | null)}>
-                          {String(((wo as unknown as Record<string, unknown>)["status"] as string | null) ?? "awaiting").replaceAll("_", " ")}
+                        <span
+                          className={chipClass(
+                            (wo as unknown as Record<string, unknown>)[
+                              "status"
+                            ] as string | null,
+                          )}
+                        >
+                          {String(
+                            ((wo as unknown as Record<string, unknown>)[
+                              "status"
+                            ] as string | null) ?? "awaiting",
+                          ).replaceAll("_", " ")}
                         </span>
                       </div>
                     </button>
                   ))}
+                </div>
+              )}
+            </div>
+
+            {/* Imported History */}
+            <div className={`${CARD_BASE} p-4`}>
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold text-white sm:text-base">
+                    Imported Vehicle History
+                  </h2>
+                  <p className="mt-1 text-[11px] text-neutral-400">
+                    Historical-only service records imported into vehicle
+                    history. These do not create active work orders.
+                  </p>
+                </div>
+
+                {importedHistory.length > 5 ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllImportedHistory((v) => !v)}
+                    className="text-[11px] font-semibold text-[rgba(184,115,51,0.95)] hover:underline"
+                  >
+                    {showAllImportedHistory ? "Show less" : "Show all"}
+                  </button>
+                ) : null}
+              </div>
+
+              {importedHistory.length === 0 ? (
+                <div
+                  className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}
+                >
+                  No imported vehicle history yet.
+                </div>
+              ) : (
+                <div className="mt-3 space-y-3">
+                  {importedHistorySlice.map((row) => {
+                    const vehicleLabel = formatImportedVehicle(row.vehicles);
+                    const vehicleIds = formatImportedIdentifiers(row.vehicles);
+                    const summary = importedHistorySummary(row);
+                    const moneyParts = [
+                      row.total != null
+                        ? `Total ${formatMoney(row.total)}`
+                        : null,
+                      row.labor_sale != null
+                        ? `Labor ${formatMoney(row.labor_sale)}`
+                        : null,
+                      row.labor_hours != null
+                        ? `${row.labor_hours} labor hrs`
+                        : null,
+                    ].filter(Boolean);
+
+                    return (
+                      <div key={row.id} className={`${CARD_INNER} p-3`}>
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="text-sm font-semibold text-white">
+                              {formatHistoryDate(row.service_date)}
+                            </div>
+                            <div className="mt-1 text-[11px] text-neutral-400">
+                              {[vehicleLabel, vehicleIds]
+                                .filter(Boolean)
+                                .join(" • ") || "Vehicle not linked"}
+                            </div>
+                          </div>
+                          <span className="rounded-full border border-[var(--accent-copper-soft)]/45 bg-[var(--accent-copper-soft)]/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--accent-copper,#C57A4A)]">
+                            Read-only imported
+                          </span>
+                        </div>
+
+                        <div className="mt-3 grid gap-2 text-xs text-neutral-300 sm:grid-cols-2 lg:grid-cols-4">
+                          <DetailRow
+                            label="Work order"
+                            value={row.work_order_number ?? "—"}
+                          />
+                          <DetailRow
+                            label="Invoice"
+                            value={row.invoice_number ?? "—"}
+                          />
+                          <DetailRow
+                            label="Odometer"
+                            value={
+                              row.odometer != null
+                                ? formatNumberLike(row.odometer)
+                                : "—"
+                            }
+                          />
+                          <DetailRow
+                            label="Amount"
+                            value={moneyParts.join(" • ") || "—"}
+                          />
+                        </div>
+
+                        {summary ? (
+                          <div className="mt-3 rounded-lg border border-[color:var(--desktop-border)] bg-black/20 px-3 py-2 text-sm leading-6 text-neutral-200">
+                            {summary}
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })}
                 </div>
               )}
             </div>
@@ -1871,8 +2502,12 @@ export default function CustomerProfilePage(): JSX.Element {
           {/* RIGHT */}
           <aside className="space-y-6">
             <div className={`${CARD_BASE} p-4`}>
-              <h3 className="text-sm font-semibold text-white">Upload Vehicle Photos</h3>
-              <p className="mt-1 text-[11px] text-neutral-400">Condition photos, damage evidence, before/after.</p>
+              <h3 className="text-sm font-semibold text-white">
+                Upload Vehicle Photos
+              </h3>
+              <p className="mt-1 text-[11px] text-neutral-400">
+                Condition photos, damage evidence, before/after.
+              </p>
               <div className="mt-3">
                 <input
                   type="file"
@@ -1885,13 +2520,21 @@ export default function CustomerProfilePage(): JSX.Element {
                   }}
                   className="w-full text-sm text-neutral-200"
                 />
-                {uploadingPhoto ? <div className="mt-2 text-[11px] text-neutral-400">Uploading photo…</div> : null}
+                {uploadingPhoto ? (
+                  <div className="mt-2 text-[11px] text-neutral-400">
+                    Uploading photo…
+                  </div>
+                ) : null}
               </div>
             </div>
 
             <div className={`${CARD_BASE} p-4`}>
-              <h3 className="text-sm font-semibold text-white">Upload Documents</h3>
-              <p className="mt-1 text-[11px] text-neutral-400">Registration, CVIP, inspection PDFs, misc docs.</p>
+              <h3 className="text-sm font-semibold text-white">
+                Upload Documents
+              </h3>
+              <p className="mt-1 text-[11px] text-neutral-400">
+                Registration, CVIP, inspection PDFs, misc docs.
+              </p>
               <div className="mt-3">
                 <input
                   type="file"
@@ -1905,7 +2548,9 @@ export default function CustomerProfilePage(): JSX.Element {
                   className="w-full text-sm text-neutral-200"
                 />
                 {uploadingDoc ? (
-                  <div className="mt-2 text-[11px] text-neutral-400">Uploading document…</div>
+                  <div className="mt-2 text-[11px] text-neutral-400">
+                    Uploading document…
+                  </div>
                 ) : null}
               </div>
             </div>
@@ -1913,8 +2558,12 @@ export default function CustomerProfilePage(): JSX.Element {
             <div className={`${CARD_BASE} p-4`}>
               <div className="flex items-center justify-between gap-2">
                 <div>
-                  <h3 className="text-sm font-semibold text-white">Vehicle Gallery & Files</h3>
-                  <p className="mt-1 text-[11px] text-neutral-400">Files shown for the selected vehicle.</p>
+                  <h3 className="text-sm font-semibold text-white">
+                    Vehicle Gallery & Files
+                  </h3>
+                  <p className="mt-1 text-[11px] text-neutral-400">
+                    Files shown for the selected vehicle.
+                  </p>
                 </div>
                 {selectedVehicleId ? (
                   <button
@@ -1928,15 +2577,23 @@ export default function CustomerProfilePage(): JSX.Element {
               </div>
 
               {!selectedVehicleId ? (
-                <div className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}>Select a vehicle to view files.</div>
+                <div
+                  className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}
+                >
+                  Select a vehicle to view files.
+                </div>
               ) : media.length === 0 ? (
-                <div className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}>No files uploaded yet.</div>
+                <div
+                  className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}
+                >
+                  No files uploaded yet.
+                </div>
               ) : (
                 <div className="mt-3 grid grid-cols-2 gap-2">
                   {media.map((m) => {
                     const url = m.displayUrl ?? m.url ?? null;
                     const img = m.kind === "photo" || isImageUrl(url);
-                    const title = m.filename ?? (m.type ?? "file");
+                    const title = m.filename ?? m.type ?? "file";
 
                     return (
                       <button
@@ -1951,7 +2608,11 @@ export default function CustomerProfilePage(): JSX.Element {
                       >
                         {img && url ? (
                           // eslint-disable-next-line @next/next/no-img-element
-                          <img src={url} alt={title} className="h-28 w-full object-cover" />
+                          <img
+                            src={url}
+                            alt={title}
+                            className="h-28 w-full object-cover"
+                          />
                         ) : (
                           <div className="flex h-28 w-full items-center justify-center px-2 text-center text-[11px] text-neutral-300">
                             Open file
@@ -1989,16 +2650,25 @@ export default function CustomerProfilePage(): JSX.Element {
         }
       >
         {!viewerItem ? (
-          <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>No file selected.</div>
+          <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>
+            No file selected.
+          </div>
         ) : !viewerItem.displayUrl ? (
           <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>
-            This file doesn’t have a viewable URL yet (likely a private bucket without a signed URL).
+            This file doesn’t have a viewable URL yet (likely a private bucket
+            without a signed URL).
           </div>
         ) : viewerItem.kind === "photo" || isImageUrl(viewerItem.displayUrl) ? (
           // eslint-disable-next-line @next/next/no-img-element
-          <img src={viewerItem.displayUrl} alt={viewerItem.filename ?? "photo"} className="w-full rounded-xl" />
+          <img
+            src={viewerItem.displayUrl}
+            alt={viewerItem.filename ?? "photo"}
+            className="w-full rounded-xl"
+          />
         ) : (
-          <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>Document ready. Use “Open in new tab”.</div>
+          <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>
+            Document ready. Use “Open in new tab”.
+          </div>
         )}
       </Modal>
 
@@ -2043,10 +2713,14 @@ export default function CustomerProfilePage(): JSX.Element {
             ] as const
           ).map(([label, key]) => (
             <div key={key} className="space-y-1">
-              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">{label}</div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">
+                {label}
+              </div>
               <input
                 value={String(custDraft[key] ?? "")}
-                onChange={(e) => setCustDraft((p) => ({ ...p, [key]: e.target.value }))}
+                onChange={(e) =>
+                  setCustDraft((p) => ({ ...p, [key]: e.target.value }))
+                }
                 className="w-full rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]"
               />
             </div>
@@ -2079,7 +2753,9 @@ export default function CustomerProfilePage(): JSX.Element {
         }
       >
         {!selectedVehicle ? (
-          <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>No vehicle selected.</div>
+          <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>
+            No vehicle selected.
+          </div>
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {(
@@ -2114,7 +2790,9 @@ export default function CustomerProfilePage(): JSX.Element {
               ] as const
             ).map(([label, key]) => (
               <div key={key} className="space-y-1">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">{label}</div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">
+                  {label}
+                </div>
                 <input
                   value={String(vehDraft[key] ?? "")}
                   onChange={(e) => {
@@ -2122,7 +2800,10 @@ export default function CustomerProfilePage(): JSX.Element {
                     setVehDraft((p) => {
                       if (key === "year" || key === "engine_hours") {
                         const n = raw.trim().length ? Number(raw) : null;
-                        return { ...p, [key]: Number.isFinite(n as number) ? n : null };
+                        return {
+                          ...p,
+                          [key]: Number.isFinite(n as number) ? n : null,
+                        };
                       }
                       return { ...p, [key]: raw };
                     });
@@ -2161,7 +2842,9 @@ export default function CustomerProfilePage(): JSX.Element {
         }
       >
         {!customer ? (
-          <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>No customer loaded.</div>
+          <div className={`${CARD_INNER} p-3 text-sm text-neutral-300`}>
+            No customer loaded.
+          </div>
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             {(
@@ -2196,7 +2879,9 @@ export default function CustomerProfilePage(): JSX.Element {
               ] as const
             ).map(([label, key]) => (
               <div key={key} className="space-y-1">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">{label}</div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-neutral-400">
+                  {label}
+                </div>
                 <input
                   value={String(newVeh[key] ?? "")}
                   onChange={(e) => {
@@ -2204,7 +2889,10 @@ export default function CustomerProfilePage(): JSX.Element {
                     setNewVeh((p) => {
                       if (key === "year" || key === "engine_hours") {
                         const n = raw.trim().length ? Number(raw) : null;
-                        return { ...p, [key]: Number.isFinite(n as number) ? n : null };
+                        return {
+                          ...p,
+                          [key]: Number.isFinite(n as number) ? n : null,
+                        };
                       }
                       return { ...p, [key]: raw };
                     });


### PR DESCRIPTION
### Motivation
- Imported vehicle history records are stored in the existing `history` table (historical-only) and were not shown on the Customer detail page because the page only loaded `work_orders`. 
- Customers that received CSV-imported history therefore saw “No work orders yet” despite historical service records existing. 
- The page should surface those read-only historical records without changing import logic or creating active `work_orders`, and must preserve shop scoping/RLS patterns.

### Description
- Load historical-only rows by `customer_id` from the `history` table in the existing customer file loader and normalize the returned shape for UI consumption. (Added a new `ImportedHistory` type and `importedHistory` state.)
- Add a new UI section `Imported Vehicle History` (separate from `Work Order History`) that displays service date, vehicle year/make/model, VIN/plate, work order number, invoice number, odometer, complaint/cause/correction summary, total/labor when available, and a read-only/imported badge. 
- Surface selected-vehicle imported history inside the vehicle details card when records exist for the selected vehicle so vehicle-level pages show relevant imported history. 
- Preserve live work orders as-is (no conversion of history rows into active `work_orders`), do not modify import job logic, and keep existing shop scoping / RLS assumptions intact.

Files changed
- `features/customers/app/customers/[id]/page.tsx` (loads `history` rows, new `ImportedHistory` type, new state/logic, and UI sections)

### Testing
- Ran `npm run typecheck` and it completed without type errors (success).
- Ran `npx eslint features/customers app/customers app/api/customers` and it completed without reported lint errors (success).
- Verified (code paths only) that imported history is fetched alongside existing work order queries and rendered in the new `Imported Vehicle History` section and in the vehicle details card when applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b14d2b4cc83289d7bdea0f3481656)