### PR TITLE
Unify customer Service History and make imported history records inspectable

### DIFF
--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -9,12 +9,11 @@ import type { Database } from "@shared/types/types/supabase";
 import {
   fmtCustomerName,
   fmtVehicle,
-  formatMoneyLike,
-  historyTitle,
   parseHistoryNotes,
 } from "./historyDisplay";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { VehicleHistoryCsvImportCard } from "@/features/work-orders/components/VehicleHistoryCsvImportCard";
+import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
 import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type DB = Database;
@@ -294,153 +293,40 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
             <div className="grid gap-2">
               {rows.map((r) => {
                 const p = parseHistoryNotes(r.notes);
-                const title = historyTitle({
-                  id: r.id,
-                  workOrderLabel: p.workOrderLabel,
-                  invoiceLabel: p.invoiceLabel,
-                });
                 return (
-                  <article
+                  <ImportedHistoryRecordCard
                     key={r.id}
-                    className="rounded-2xl border border-slate-700/60 bg-slate-950/70 p-3 shadow-[0_14px_38px_rgba(2,6,23,0.82)]"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <h3 className="font-mono text-sm text-sky-200">
-                          {title}
-                        </h3>
-                        <div className="text-sm text-neutral-200">
-                          {fmtCustomerName(r.customers)}
-                        </div>
-                        <div className="text-xs text-neutral-400">
-                          {fmtVehicle(r.vehicles)}
-                        </div>
-                        {r.vehicles?.vin ? (
-                          <div className="text-[11px] text-neutral-500">
-                            VIN: {r.vehicles.vin}
-                          </div>
+                    row={r}
+                    serviceDateLabel={fmtDate(r.service_date ?? r.created_at)}
+                    vehicleLabel={fmtVehicle(r.vehicles)}
+                    vehicleIdentifiers={
+                      r.vehicles?.vin ? `VIN ${r.vehicles.vin}` : null
+                    }
+                    summary={
+                      r.description?.trim() ||
+                      p.extraLines.join(" • ") ||
+                      "Imported historical service record"
+                    }
+                    action={
+                      <div className="flex flex-wrap items-center gap-3">
+                        <Link
+                          href={`/work-orders/history/${r.id}`}
+                          className="text-xs uppercase tracking-[0.16em] text-sky-200 hover:text-sky-100"
+                        >
+                          View history details
+                        </Link>
+                        {r.work_order_id ? (
+                          <Link
+                            href={`/work-orders/view/${r.work_order_id}`}
+                            className="text-xs text-cyan-300/85 hover:text-cyan-200"
+                          >
+                            Open linked work order
+                          </Link>
                         ) : null}
                       </div>
-                      <div className="text-right">
-                        <div className="font-mono text-xs text-sky-200">
-                          {fmtDate(r.service_date ?? r.created_at)}
-                        </div>
-                        <span className="mt-1 inline-flex rounded-full border border-sky-400/35 bg-sky-500/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-sky-100">
-                          Read only
-                        </span>
-                      </div>
-                    </div>
-                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.12em]">
-                      {r.historical_status ? (
-                        <span className="rounded-full border border-slate-600 px-2 py-0.5">
-                          {r.historical_status}
-                        </span>
-                      ) : null}
-                      {r.payment_state ? (
-                        <span className="rounded-full border border-cyan-700/60 px-2 py-0.5">
-                          {r.payment_state}
-                        </span>
-                      ) : null}
-                      {r.approval_state ? (
-                        <span className="rounded-full border border-sky-700/60 px-2 py-0.5">
-                          {r.approval_state}
-                        </span>
-                      ) : null}
-                    </div>
-                    <div className="mt-3 grid gap-2 text-xs text-neutral-300 sm:grid-cols-2 lg:grid-cols-4">
-                      <div>
-                        Work order:{" "}
-                        <span className="text-neutral-100">
-                          {r.work_order_number ?? p.workOrderLabel ?? "—"}
-                        </span>
-                      </div>
-                      <div>
-                        Invoice:{" "}
-                        <span className="text-neutral-100">
-                          {r.invoice_number ?? p.invoiceLabel ?? "—"}
-                        </span>
-                      </div>
-                      <div>
-                        Total:{" "}
-                        <span className="text-neutral-100">
-                          {formatMoneyLike(String(r.total ?? "")) ??
-                            formatMoneyLike(p.totalLabel) ??
-                            "—"}
-                        </span>
-                      </div>
-                      <div>
-                        Labor:{" "}
-                        <span className="text-neutral-100">
-                          {formatMoneyLike(String(r.labor_sale ?? "")) ??
-                            formatMoneyLike(p.laborLabel) ??
-                            "—"}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="mt-2 text-xs text-neutral-300">
-                      Advisor:{" "}
-                      <span className="text-neutral-100">
-                        {r.advisor_name ?? "—"}
-                      </span>{" "}
-                      · Tech:{" "}
-                      <span className="text-neutral-100">
-                        {r.assigned_tech_name ?? "—"}
-                      </span>{" "}
-                      · Odometer:{" "}
-                      <span className="text-neutral-100">
-                        {r.odometer ?? "—"}
-                      </span>
-                    </div>
-                    <div className="mt-2 rounded-xl border border-slate-700/55 bg-slate-900/60 px-3 py-2 text-sm text-neutral-200">
-                      <div className="mb-1 text-[10px] uppercase tracking-[0.14em] text-neutral-400">
-                        Service summary
-                      </div>
-                      {r.description?.trim() ||
-                        p.invoiceLabel ||
-                        p.workOrderLabel ||
-                        "Imported historical service record"}
-                    </div>
-                    {p.extraLines.length > 0 ? (
-                      <div className="mt-2 rounded-xl border border-slate-700/55 bg-slate-900/50 px-3 py-2 text-[11px] text-neutral-400">
-                        <div className="mb-1 uppercase tracking-[0.14em] text-neutral-500">
-                          Details
-                        </div>
-                        {p.extraLines.map((line, idx) => (
-                          <div key={`${r.id}-line-${idx}`}>{line}</div>
-                        ))}
-                      </div>
-                    ) : null}
-                    <div className="mt-2 rounded-xl border border-cyan-900/40 bg-slate-900/40 px-3 py-2 text-[11px] text-slate-400">
-                      <div className="mb-1 uppercase tracking-[0.14em] text-cyan-300/80">
-                        Import trace
-                      </div>
-                      <div>Source external ID: {p.sourceExternalId ?? "—"}</div>
-                      <div>Source row ID: {p.sourceRowId ?? "—"}</div>
-                      <div>
-                        Onboarding session: {p.onboardingSessionId ?? "—"}
-                      </div>
-                      <div>
-                        Live work order ID:{" "}
-                        {p.liveWorkOrderId ?? r.work_order_id ?? "—"}
-                      </div>
-                    </div>
-                    <div className="mt-3 flex flex-wrap items-center gap-3">
-                      <Link
-                        href={`/work-orders/history/${r.id}`}
-                        className="text-xs uppercase tracking-[0.16em] text-sky-200 hover:text-sky-100"
-                      >
-                        View history details
-                      </Link>
-                      {r.work_order_id ? (
-                        <Link
-                          href={`/work-orders/view/${r.work_order_id}`}
-                          className="text-xs text-cyan-300/85 hover:text-cyan-200"
-                        >
-                          Open linked work order
-                        </Link>
-                      ) : null}
-                    </div>
-                  </article>
+                    }
+                    className="shadow-[0_14px_38px_rgba(2,6,23,0.82)]"
+                  />
                 );
               })}
             </div>

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -15,6 +15,7 @@ import { format } from "date-fns";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
+import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
 import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type DB = Database;
@@ -358,14 +359,6 @@ function formatHistoryDate(iso: string | null | undefined): string {
   return format(d, "PP");
 }
 
-function formatMoney(value: number | null | undefined): string | null {
-  if (value == null || !Number.isFinite(value)) return null;
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(value);
-}
-
 function formatImportedVehicle(
   vehicle: ImportedHistory["vehicles"] | null | undefined,
 ): string | null {
@@ -616,9 +609,11 @@ export default function CustomerProfilePage(): JSX.Element {
 
   const [workOrders, setWorkOrders] = useState<WorkOrder[]>([]);
   const [importedHistory, setImportedHistory] = useState<ImportedHistory[]>([]);
-  const [showAllHistory, setShowAllHistory] = useState<boolean>(false);
-  const [showAllImportedHistory, setShowAllImportedHistory] =
+  const [showAllServiceHistory, setShowAllServiceHistory] =
     useState<boolean>(false);
+  const [expandedImportedHistoryId, setExpandedImportedHistoryId] = useState<
+    string | null
+  >(null);
 
   const [rawVehicleMedia, setRawVehicleMedia] = useState<VehicleMedia[]>([]);
   const [media, setMedia] = useState<DisplayMedia[]>([]);
@@ -665,15 +660,35 @@ export default function CustomerProfilePage(): JSX.Element {
     [selectedVehicle],
   );
 
-  const historySlice = useMemo(() => {
-    if (showAllHistory) return workOrders;
-    return workOrders.slice(0, 3);
-  }, [showAllHistory, workOrders]);
+  const serviceHistory = useMemo(() => {
+    const vehicleById = new Map(
+      vehicles.map((vehicle) => [vehicle.id, vehicle]),
+    );
+    const workOrderEntries = workOrders.map((wo) => ({
+      kind: "work_order" as const,
+      id: wo.id,
+      date: String(wo.created_at ?? ""),
+      workOrder: wo,
+      vehicle: wo.vehicle_id ? (vehicleById.get(wo.vehicle_id) ?? null) : null,
+    }));
+    const importedEntries = importedHistory.map((row) => ({
+      kind: "imported" as const,
+      id: row.id,
+      date: row.service_date ?? row.created_at ?? "",
+      imported: row,
+    }));
 
-  const importedHistorySlice = useMemo(() => {
-    if (showAllImportedHistory) return importedHistory;
-    return importedHistory.slice(0, 5);
-  }, [importedHistory, showAllImportedHistory]);
+    return [...workOrderEntries, ...importedEntries].sort((a, b) => {
+      const bd = new Date(b.date).getTime();
+      const ad = new Date(a.date).getTime();
+      return (Number.isFinite(bd) ? bd : 0) - (Number.isFinite(ad) ? ad : 0);
+    });
+  }, [importedHistory, vehicles, workOrders]);
+
+  const serviceHistorySlice = useMemo(() => {
+    if (showAllServiceHistory) return serviceHistory;
+    return serviceHistory.slice(0, 8);
+  }, [serviceHistory, showAllServiceHistory]);
 
   const selectedVehicleImportedHistory = useMemo(() => {
     if (!selectedVehicleId) return [];
@@ -2147,7 +2162,6 @@ export default function CustomerProfilePage(): JSX.Element {
                 </div>
               </div>
             </div>
-
             {/* Vehicles */}
             <div className={`${CARD_BASE} p-4`}>
               <div className="flex flex-wrap items-start justify-between gap-3">
@@ -2290,31 +2304,67 @@ export default function CustomerProfilePage(): JSX.Element {
                         <div className="mt-2 space-y-2">
                           {selectedVehicleImportedHistory
                             .slice(0, 3)
-                            .map((row) => (
-                              <div
-                                key={row.id}
-                                className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2"
-                              >
-                                <div className="text-xs font-semibold text-white">
-                                  {formatHistoryDate(row.service_date)}
+                            .map((row) => {
+                              const expanded =
+                                expandedImportedHistoryId === row.id;
+                              return (
+                                <div key={row.id} className="space-y-2">
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      setExpandedImportedHistoryId((current) =>
+                                        current === row.id ? null : row.id,
+                                      )
+                                    }
+                                    className="w-full rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-left transition hover:border-[var(--accent-copper-soft)]/65 focus:outline-none focus:ring-2 focus:ring-[var(--accent-copper-soft)]/45"
+                                    aria-expanded={expanded}
+                                  >
+                                    <div className="flex items-start justify-between gap-2">
+                                      <div className="min-w-0">
+                                        <div className="text-xs font-semibold text-white">
+                                          {formatHistoryDate(row.service_date)}
+                                        </div>
+                                        <div className="mt-1 text-[11px] text-neutral-400">
+                                          {[
+                                            row.work_order_number
+                                              ? `WO ${row.work_order_number}`
+                                              : null,
+                                            row.invoice_number
+                                              ? `Invoice ${row.invoice_number}`
+                                              : null,
+                                            row.odometer != null
+                                              ? `${formatNumberLike(row.odometer)} mi`
+                                              : null,
+                                          ]
+                                            .filter(Boolean)
+                                            .join(" • ") ||
+                                            "Imported service record"}
+                                        </div>
+                                      </div>
+                                      <span className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[var(--accent-copper,#C57A4A)]">
+                                        {expanded ? "Hide" : "Details"}
+                                      </span>
+                                    </div>
+                                  </button>
+                                  {expanded ? (
+                                    <ImportedHistoryRecordCard
+                                      row={row}
+                                      serviceDateLabel={formatHistoryDate(
+                                        row.service_date,
+                                      )}
+                                      vehicleLabel={formatImportedVehicle(
+                                        row.vehicles,
+                                      )}
+                                      vehicleIdentifiers={formatImportedIdentifiers(
+                                        row.vehicles,
+                                      )}
+                                      summary={importedHistorySummary(row)}
+                                      compact
+                                    />
+                                  ) : null}
                                 </div>
-                                <div className="mt-1 text-[11px] text-neutral-400">
-                                  {[
-                                    row.work_order_number
-                                      ? `WO ${row.work_order_number}`
-                                      : null,
-                                    row.invoice_number
-                                      ? `Invoice ${row.invoice_number}`
-                                      : null,
-                                    row.odometer != null
-                                      ? `${formatNumberLike(row.odometer)} mi`
-                                      : null,
-                                  ]
-                                    .filter(Boolean)
-                                    .join(" • ") || "Imported service record"}
-                                </div>
-                              </div>
-                            ))}
+                              );
+                            })}
                         </div>
                       </div>
                     ) : null}
@@ -2322,176 +2372,116 @@ export default function CustomerProfilePage(): JSX.Element {
                 </div>
               ) : null}
             </div>
-
-            {/* History */}
+            {/* Service History */}
             <div className={`${CARD_BASE} p-4`}>
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <h2 className="text-sm font-semibold text-white sm:text-base">
-                    Work Order History
+                    Service History
                   </h2>
                   <p className="mt-1 text-[11px] text-neutral-400">
-                    Showing {showAllHistory ? "all" : "latest 3"} work orders
-                    for this customer.
+                    Unified timeline of live ProFixIQ work orders and read-only
+                    imported vehicle history.
                   </p>
                 </div>
 
-                {workOrders.length > 3 ? (
+                {serviceHistory.length > 8 ? (
                   <button
                     type="button"
-                    onClick={() => setShowAllHistory((v) => !v)}
+                    onClick={() => setShowAllServiceHistory((v) => !v)}
                     className="text-[11px] font-semibold text-[rgba(184,115,51,0.95)] hover:underline"
                   >
-                    {showAllHistory ? "Show less" : "Show all"}
+                    {showAllServiceHistory ? "Show less" : "Show all"}
                   </button>
                 ) : null}
               </div>
 
-              {workOrders.length === 0 ? (
+              {serviceHistory.length === 0 ? (
                 <div
                   className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}
                 >
-                  No work orders yet.
-                </div>
-              ) : (
-                <div className="mt-3 space-y-2">
-                  {historySlice.map((wo) => (
-                    <button
-                      key={wo.id}
-                      type="button"
-                      onClick={() => router.push(`/work-orders/${wo.id}`)}
-                      className={`${CARD_INNER} w-full p-3 text-left hover:border-[var(--accent-copper-soft)]/65`}
-                      title="Open work order"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <div className="truncate text-sm font-semibold text-white">
-                            {(wo as unknown as Record<string, unknown>)[
-                              "custom_id"
-                            ]
-                              ? `WO ${(wo as unknown as Record<string, unknown>)["custom_id"] as string}`
-                              : `WO #${wo.id.slice(0, 8)}`}
-                          </div>
-                          <div className="mt-0.5 text-[11px] text-neutral-400">
-                            {safeDate(wo.created_at)}
-                          </div>
-                        </div>
-
-                        <span
-                          className={chipClass(
-                            (wo as unknown as Record<string, unknown>)[
-                              "status"
-                            ] as string | null,
-                          )}
-                        >
-                          {String(
-                            ((wo as unknown as Record<string, unknown>)[
-                              "status"
-                            ] as string | null) ?? "awaiting",
-                          ).replaceAll("_", " ")}
-                        </span>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Imported History */}
-            <div className={`${CARD_BASE} p-4`}>
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <h2 className="text-sm font-semibold text-white sm:text-base">
-                    Imported Vehicle History
-                  </h2>
-                  <p className="mt-1 text-[11px] text-neutral-400">
-                    Historical-only service records imported into vehicle
-                    history. These do not create active work orders.
-                  </p>
-                </div>
-
-                {importedHistory.length > 5 ? (
-                  <button
-                    type="button"
-                    onClick={() => setShowAllImportedHistory((v) => !v)}
-                    className="text-[11px] font-semibold text-[rgba(184,115,51,0.95)] hover:underline"
-                  >
-                    {showAllImportedHistory ? "Show less" : "Show all"}
-                  </button>
-                ) : null}
-              </div>
-
-              {importedHistory.length === 0 ? (
-                <div
-                  className={`${CARD_INNER} mt-3 p-3 text-sm text-neutral-300`}
-                >
-                  No imported vehicle history yet.
+                  No service history yet.
                 </div>
               ) : (
                 <div className="mt-3 space-y-3">
-                  {importedHistorySlice.map((row) => {
-                    const vehicleLabel = formatImportedVehicle(row.vehicles);
-                    const vehicleIds = formatImportedIdentifiers(row.vehicles);
-                    const summary = importedHistorySummary(row);
-                    const moneyParts = [
-                      row.total != null
-                        ? `Total ${formatMoney(row.total)}`
-                        : null,
-                      row.labor_sale != null
-                        ? `Labor ${formatMoney(row.labor_sale)}`
-                        : null,
-                      row.labor_hours != null
-                        ? `${row.labor_hours} labor hrs`
-                        : null,
-                    ].filter(Boolean);
+                  {serviceHistorySlice.map((entry) => {
+                    if (entry.kind === "work_order") {
+                      const wo = entry.workOrder;
+                      const status = String(
+                        ((wo as unknown as Record<string, unknown>)[
+                          "status"
+                        ] as string | null) ?? "awaiting",
+                      );
+                      const normalizedStatus = status.toLowerCase();
+                      const lifecycleLabel =
+                        normalizedStatus.includes("complete") ||
+                        normalizedStatus.includes("invoice")
+                          ? "Completed"
+                          : normalizedStatus.includes("progress")
+                            ? "In progress"
+                            : "Active";
+                      const customId = (
+                        wo as unknown as Record<string, unknown>
+                      )["custom_id"] as string | undefined;
+                      const vehicle = entry.vehicle;
+                      const vehicleLabel = vehicle
+                        ? fmtVehicleLabel(vehicle)
+                        : null;
 
+                      return (
+                        <button
+                          key={`wo-${wo.id}`}
+                          type="button"
+                          onClick={() => router.push(`/work-orders/${wo.id}`)}
+                          className={`${CARD_INNER} w-full p-3 text-left hover:border-[var(--accent-copper-soft)]/65`}
+                          title="Open work order"
+                        >
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-semibold text-white">
+                                {customId
+                                  ? `WO ${customId}`
+                                  : `WO #${wo.id.slice(0, 8)}`}
+                              </div>
+                              <div className="mt-0.5 text-[11px] text-neutral-400">
+                                {safeDate(wo.created_at)}
+                                {vehicleLabel ? ` • ${vehicleLabel}` : ""}
+                              </div>
+                            </div>
+
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className={chipClass(status)}>
+                                {lifecycleLabel}
+                              </span>
+                              <span className="rounded-full border border-slate-600/70 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-neutral-300">
+                                {status.replaceAll("_", " ")}
+                              </span>
+                            </div>
+                          </div>
+                        </button>
+                      );
+                    }
+
+                    const row = entry.imported;
                     return (
-                      <div key={row.id} className={`${CARD_INNER} p-3`}>
-                        <div className="flex flex-wrap items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <div className="text-sm font-semibold text-white">
-                              {formatHistoryDate(row.service_date)}
-                            </div>
-                            <div className="mt-1 text-[11px] text-neutral-400">
-                              {[vehicleLabel, vehicleIds]
-                                .filter(Boolean)
-                                .join(" • ") || "Vehicle not linked"}
-                            </div>
-                          </div>
-                          <span className="rounded-full border border-[var(--accent-copper-soft)]/45 bg-[var(--accent-copper-soft)]/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--accent-copper,#C57A4A)]">
-                            Read-only imported
-                          </span>
-                        </div>
-
-                        <div className="mt-3 grid gap-2 text-xs text-neutral-300 sm:grid-cols-2 lg:grid-cols-4">
-                          <DetailRow
-                            label="Work order"
-                            value={row.work_order_number ?? "—"}
-                          />
-                          <DetailRow
-                            label="Invoice"
-                            value={row.invoice_number ?? "—"}
-                          />
-                          <DetailRow
-                            label="Odometer"
-                            value={
-                              row.odometer != null
-                                ? formatNumberLike(row.odometer)
-                                : "—"
-                            }
-                          />
-                          <DetailRow
-                            label="Amount"
-                            value={moneyParts.join(" • ") || "—"}
-                          />
-                        </div>
-
-                        {summary ? (
-                          <div className="mt-3 rounded-lg border border-[color:var(--desktop-border)] bg-black/20 px-3 py-2 text-sm leading-6 text-neutral-200">
-                            {summary}
-                          </div>
-                        ) : null}
-                      </div>
+                      <ImportedHistoryRecordCard
+                        key={`imported-${row.id}`}
+                        row={row}
+                        serviceDateLabel={formatHistoryDate(
+                          row.service_date ?? row.created_at,
+                        )}
+                        vehicleLabel={formatImportedVehicle(row.vehicles)}
+                        vehicleIdentifiers={formatImportedIdentifiers(
+                          row.vehicles,
+                        )}
+                        summary={importedHistorySummary(row)}
+                        collapsed={expandedImportedHistoryId !== row.id}
+                        onToggle={() =>
+                          setExpandedImportedHistoryId((current) =>
+                            current === row.id ? null : row.id,
+                          )
+                        }
+                      />
                     );
                   })}
                 </div>

--- a/features/work-orders/components/ImportedHistoryRecordCard.tsx
+++ b/features/work-orders/components/ImportedHistoryRecordCard.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+type VehicleLike = {
+  year?: string | number | null;
+  make?: string | null;
+  model?: string | null;
+  vin?: string | null;
+  license_plate?: string | null;
+  unit_number?: string | null;
+} | null;
+
+export type ImportedHistoryRecordLike = {
+  id: string;
+  service_date?: string | null;
+  created_at?: string | null;
+  description?: string | null;
+  notes?: string | null;
+  work_order_number?: string | null;
+  invoice_number?: string | null;
+  odometer?: string | number | null;
+  symptom?: string | null;
+  cause?: string | null;
+  correction?: string | null;
+  labor_hours?: string | number | null;
+  labor_sale?: number | null;
+  parts_sale?: number | null;
+  tax?: number | null;
+  total?: number | null;
+  advisor_name?: string | null;
+  assigned_tech_name?: string | null;
+  source_external_id?: string | null;
+  source_row_id?: string | null;
+  imported_from_session_id?: string | null;
+  vehicles?: VehicleLike;
+};
+
+type Props = {
+  row: ImportedHistoryRecordLike;
+  serviceDateLabel: string;
+  vehicleLabel?: string | null;
+  vehicleIdentifiers?: string | null;
+  summary?: string | null;
+  compact?: boolean;
+  collapsed?: boolean;
+  onToggle?: () => void;
+  action?: ReactNode;
+  className?: string;
+};
+
+function formatMoney(value: number | null | undefined): string | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(value);
+}
+
+function formatNumberLike(value: string | number | null | undefined): string {
+  if (value == null || value === "") return "—";
+  if (typeof value === "number")
+    return Number.isFinite(value) ? value.toLocaleString() : "—";
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && /^\d+(\.\d+)?$/.test(value.trim())
+    ? numeric.toLocaleString()
+    : value;
+}
+
+function textOrDash(value: string | number | null | undefined): string {
+  if (value == null) return "—";
+  const text = String(value).trim();
+  return text.length > 0 ? text : "—";
+}
+
+function Detail({
+  label,
+  value,
+}: {
+  label: string;
+  value: ReactNode;
+}): JSX.Element {
+  return (
+    <div className="rounded-lg border border-[color:var(--desktop-border)] bg-black/15 px-3 py-2">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-neutral-500">
+        {label}
+      </div>
+      <div className="mt-1 break-words text-xs text-neutral-100">{value}</div>
+    </div>
+  );
+}
+
+export function ImportedHistoryRecordCard({
+  row,
+  serviceDateLabel,
+  vehicleLabel,
+  vehicleIdentifiers,
+  summary,
+  compact = false,
+  collapsed = false,
+  onToggle,
+  action,
+  className = "",
+}: Props): JSX.Element {
+  const detailsId = `imported-history-details-${row.id}`;
+  const serviceSummary =
+    (summary ??
+      [
+        row.symptom ? `Complaint: ${row.symptom}` : null,
+        row.cause ? `Cause: ${row.cause}` : null,
+        row.correction ? `Correction: ${row.correction}` : null,
+      ]
+        .filter(Boolean)
+        .join(" • ")) ||
+    row.description?.trim() ||
+    row.notes?.trim() ||
+    "Imported historical service record";
+  const moneyParts = [
+    row.total != null ? `Total ${formatMoney(row.total)}` : null,
+    row.labor_sale != null ? `Labor ${formatMoney(row.labor_sale)}` : null,
+    row.labor_hours != null
+      ? `${formatNumberLike(row.labor_hours)} labor hrs`
+      : null,
+  ].filter(Boolean);
+
+  return (
+    <article
+      className={`rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 ${className}`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-white">
+            {serviceDateLabel}
+          </div>
+          <div className="mt-1 text-[11px] text-neutral-400">
+            {[vehicleLabel, vehicleIdentifiers].filter(Boolean).join(" • ") ||
+              "Vehicle not linked"}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full border border-[var(--accent-copper-soft)]/45 bg-[var(--accent-copper-soft)]/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--accent-copper,#C57A4A)]">
+            Read-only imported
+          </span>
+          {onToggle ? (
+            <button
+              type="button"
+              onClick={onToggle}
+              aria-expanded={!collapsed}
+              aria-controls={detailsId}
+              className="rounded-full border border-sky-400/35 bg-sky-500/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-sky-100 hover:border-sky-300/60"
+            >
+              {collapsed ? "View details" : "Hide details"}
+            </button>
+          ) : null}
+          {action}
+        </div>
+      </div>
+
+      {!collapsed ? (
+        <div
+          id={detailsId}
+          className={compact ? "mt-3 space-y-3" : "mt-3 space-y-3"}
+        >
+          <div className="grid gap-2 text-xs text-neutral-300 sm:grid-cols-2 lg:grid-cols-4">
+            <Detail
+              label="Work order"
+              value={textOrDash(row.work_order_number)}
+            />
+            <Detail label="Invoice" value={textOrDash(row.invoice_number)} />
+            <Detail
+              label="Odometer"
+              value={
+                row.odometer != null ? formatNumberLike(row.odometer) : "—"
+              }
+            />
+            <Detail label="Amount" value={moneyParts.join(" • ") || "—"} />
+          </div>
+          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-black/20 px-3 py-2 text-sm leading-6 text-neutral-200">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-neutral-500">
+              Service summary
+            </div>
+            {serviceSummary}
+          </div>
+        </div>
+      ) : null}
+    </article>
+  );
+}


### PR DESCRIPTION
### Motivation
- Imported vehicle history rows shown on the customer detail and selected-vehicle card were not clickable, preventing inspection of details.
- Customer page duplicated history UI into separate “Work Order History” and “Imported Vehicle History” sections instead of a single chronological service timeline.
- Reuse of an existing history detail UI was preferred to avoid markup duplication while keeping imported records read-only and preserving shop/RLS boundaries.

### Description
- Added a shared read-only detail component `ImportedHistoryRecordCard` to `features/work-orders/components/ImportedHistoryRecordCard.tsx` and used it where imported record details are shown. 
- Made the selected-vehicle mini-list rows clickable/expandable by adding `expandedImportedHistoryId` state and rendering `ImportedHistoryRecordCard` (compact) inline; the mini-list remains limited to the latest 3 records. (`features/customers/app/customers/[id]/page.tsx`).
- Replaced the separate customer sections with a unified `Service History` timeline that merges live `work_orders` and imported `history` rows, sorts newest-first, shows a default slice (latest 8) with a “Show all” control, and retains normal routing for active work orders while keeping imported records read-only. (`features/customers/app/customers/[id]/page.tsx`).
- Reused the new `ImportedHistoryRecordCard` on the main Vehicle History page so imported record detail rendering is consistent (`app/work-orders/history/WorkOrdersHistoryClient.tsx`).
- No import job logic, import routes, or creation of active `work_orders` from imported data were changed; shop scoping / RLS behavior was preserved.

### Testing
- Ran `npm run typecheck` and it completed successfully with no TypeScript errors.
- Ran `npx eslint features/customers app/customers app/work-orders/history features/work-orders` which completed; lint reported existing warnings in unrelated `features/work-orders` files but no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b249e03b083288fa7a52127aad39d)