### PR TITLE
Fix import jobs tick cron dispatch

### DIFF
--- a/app/api/internal/import-jobs/tick/route.ts
+++ b/app/api/internal/import-jobs/tick/route.ts
@@ -13,7 +13,34 @@ import {
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+const SUPPORTED_IMPORT_TYPES = ["vehicle_history", "invoices"] as const;
+type SupportedImportType = (typeof SUPPORTED_IMPORT_TYPES)[number];
+type ImportJobDispatchRow = { id: string; import_type: string | null };
+type ImportJobDispatchClient = {
+  from(table: "import_jobs"): {
+    select(columns: string): ImportJobDispatchQuery;
+  };
+};
+type ImportJobDispatchQuery = {
+  in(column: string, values: readonly string[]): ImportJobDispatchQuery;
+  order(column: string, options: { ascending: boolean }): ImportJobDispatchQuery;
+  limit(count: number): ImportJobDispatchQuery;
+  eq(column: string, value: string): ImportJobDispatchQuery;
+  maybeSingle(): Promise<{ data: ImportJobDispatchRow | null; error: Error | null }>;
+};
+
+function isSupportedImportType(value: string | null | undefined): value is SupportedImportType {
+  return SUPPORTED_IMPORT_TYPES.includes(value as SupportedImportType);
+}
+
 function authorize(req: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  const authorization = req.headers.get("authorization");
+
+  if (cronSecret && authorization === `Bearer ${cronSecret}`) {
+    return { ok: true } as const;
+  }
+
   return requireInternalApiSecret({
     request: req,
     envSecretName: "INTERNAL_IMPORT_JOBS_SECRET",
@@ -22,21 +49,90 @@ function authorize(req: Request) {
   });
 }
 
+async function findDispatchJob(admin: ReturnType<typeof createAdminSupabase>, jobId?: string) {
+  let query = (admin as unknown as ImportJobDispatchClient)
+    .from("import_jobs")
+    .select("id, import_type")
+    .in("status", ["queued", "processing"])
+    .in("import_type", [...SUPPORTED_IMPORT_TYPES])
+    .order("created_at", { ascending: true })
+    .limit(1);
+
+  if (jobId) query = query.eq("id", jobId);
+
+  const { data, error } = await query.maybeSingle();
+  if (error) throw error;
+  return data ?? null;
+}
+
+async function processImportType(
+  admin: ReturnType<typeof createAdminSupabase>,
+  importType: SupportedImportType,
+  jobId?: string,
+) {
+  if (importType === "invoices") {
+    return processInvoiceImportJobBatch(admin, jobId, INVOICE_IMPORT_BATCH_SIZE);
+  }
+
+  return processVehicleHistoryImportJobBatch(
+    admin,
+    jobId,
+    VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+  );
+}
+
 async function run(req: Request) {
   const gate = authorize(req);
   if (!gate.ok) return gate.response;
+
   const url = new URL(req.url);
   const jobId = url.searchParams.get("jobId") || undefined;
-  const importType = url.searchParams.get("importType") ?? url.searchParams.get("type");
+  const requestedImportType = url.searchParams.get("importType") ?? url.searchParams.get("type");
   const admin = createAdminSupabase();
-  const result = importType === "invoices"
-    ? await processInvoiceImportJobBatch(admin, jobId, INVOICE_IMPORT_BATCH_SIZE)
-    : await processVehicleHistoryImportJobBatch(
-        admin,
-        jobId,
-        VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+
+  if (requestedImportType) {
+    if (!isSupportedImportType(requestedImportType)) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: `Unsupported import_type: ${requestedImportType}`,
+          supportedImportTypes: SUPPORTED_IMPORT_TYPES,
+        },
+        { status: 400 },
       );
-  return NextResponse.json(result);
+    }
+
+    const result = await processImportType(admin, requestedImportType, jobId);
+    return NextResponse.json({ ...result, importType: requestedImportType });
+  }
+
+  const dispatchJob = await findDispatchJob(admin, jobId);
+  if (!dispatchJob) {
+    return NextResponse.json({
+      ok: true,
+      processed: 0,
+      completed: false,
+      job: null,
+      supportedImportTypes: SUPPORTED_IMPORT_TYPES,
+    });
+  }
+
+  if (!isSupportedImportType(dispatchJob.import_type)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        processed: 0,
+        completed: false,
+        job: { id: dispatchJob.id },
+        error: `Unsupported import_type: ${dispatchJob.import_type ?? "unknown"}`,
+        supportedImportTypes: SUPPORTED_IMPORT_TYPES,
+      },
+      { status: 400 },
+    );
+  }
+
+  const result = await processImportType(admin, dispatchJob.import_type, dispatchJob.id);
+  return NextResponse.json({ ...result, importType: dispatchJob.import_type });
 }
 
 export async function GET(req: Request) {

--- a/tests/import-jobs-tick-route.test.ts
+++ b/tests/import-jobs-tick-route.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const processVehicleHistoryImportJobBatchMock = vi.fn();
+const processInvoiceImportJobBatchMock = vi.fn();
+let dispatchJob: { id: string; import_type: string | null } | null = null;
+const adminClient = { marker: "admin" };
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: vi.fn(() => ({
+    ...adminClient,
+    from: vi.fn((table: string) => {
+      expect(table).toBe("import_jobs");
+      const query: any = {
+        select: vi.fn(() => query),
+        in: vi.fn(() => query),
+        order: vi.fn(() => query),
+        limit: vi.fn(() => query),
+        eq: vi.fn(() => query),
+        maybeSingle: vi.fn(async () => ({ data: dispatchJob, error: null })),
+      };
+      return query;
+    }),
+  })),
+}));
+
+vi.mock("@/features/work-orders/server/vehicle-history-import-job", () => ({
+  VEHICLE_HISTORY_IMPORT_BATCH_SIZE: 1000,
+  processVehicleHistoryImportJobBatch: processVehicleHistoryImportJobBatchMock,
+}));
+
+vi.mock("@/features/billing/server/invoice-import-job", () => ({
+  INVOICE_IMPORT_BATCH_SIZE: 1000,
+  processInvoiceImportJobBatch: processInvoiceImportJobBatchMock,
+}));
+
+function request(path = "/api/internal/import-jobs/tick", headers: HeadersInit = {}) {
+  return new Request(`http://localhost${path}`, { method: "GET", headers });
+}
+
+describe("/api/internal/import-jobs/tick route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.INTERNAL_IMPORT_JOBS_SECRET = "manual-secret";
+    process.env.CRON_SECRET = "cron-secret";
+    dispatchJob = null;
+    processVehicleHistoryImportJobBatchMock.mockResolvedValue({ ok: true, processed: 1, completed: true, job: { id: "vehicle-job" } });
+    processInvoiceImportJobBatchMock.mockResolvedValue({ ok: true, processed: 1, completed: true, job: { id: "invoice-job" } });
+  });
+
+  it("accepts Vercel cron bearer authorization", async () => {
+    dispatchJob = { id: "invoice-job", import_type: "invoices" };
+
+    const { GET } = await import("../app/api/internal/import-jobs/tick/route");
+    const response = await GET(request("/api/internal/import-jobs/tick", { authorization: "Bearer cron-secret" }));
+
+    expect(response.status).toBe(200);
+    expect(processInvoiceImportJobBatchMock).toHaveBeenCalledWith(expect.anything(), "invoice-job", 1000);
+  });
+
+  it("accepts manual internal import jobs secret authorization", async () => {
+    dispatchJob = { id: "vehicle-job", import_type: "vehicle_history" };
+
+    const { GET } = await import("../app/api/internal/import-jobs/tick/route");
+    const response = await GET(request("/api/internal/import-jobs/tick", { "x-internal-import-jobs-secret": "manual-secret" }));
+
+    expect(response.status).toBe(200);
+    expect(processVehicleHistoryImportJobBatchMock).toHaveBeenCalledWith(expect.anything(), "vehicle-job", 1000);
+  });
+
+  it("plain tick dispatches invoices when invoices are oldest and available", async () => {
+    dispatchJob = { id: "oldest-invoice-job", import_type: "invoices" };
+
+    const { GET } = await import("../app/api/internal/import-jobs/tick/route");
+    const response = await GET(request("/api/internal/import-jobs/tick", { authorization: "Bearer cron-secret" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.importType).toBe("invoices");
+    expect(processInvoiceImportJobBatchMock).toHaveBeenCalledWith(expect.anything(), "oldest-invoice-job", 1000);
+    expect(processVehicleHistoryImportJobBatchMock).not.toHaveBeenCalled();
+  });
+
+  it("targeted importType=invoices still works", async () => {
+    const { GET } = await import("../app/api/internal/import-jobs/tick/route");
+    const response = await GET(request("/api/internal/import-jobs/tick?importType=invoices", { authorization: "Bearer cron-secret" }));
+
+    expect(response.status).toBe(200);
+    expect(processInvoiceImportJobBatchMock).toHaveBeenCalledWith(expect.anything(), undefined, 1000);
+    expect(processVehicleHistoryImportJobBatchMock).not.toHaveBeenCalled();
+  });
+
+  it("vehicle_history still works", async () => {
+    dispatchJob = { id: "vehicle-job", import_type: "vehicle_history" };
+
+    const { GET } = await import("../app/api/internal/import-jobs/tick/route");
+    const response = await GET(request("/api/internal/import-jobs/tick", { authorization: "Bearer cron-secret" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.importType).toBe("vehicle_history");
+    expect(processVehicleHistoryImportJobBatchMock).toHaveBeenCalledWith(expect.anything(), "vehicle-job", 1000);
+  });
+
+  it("rejects unsupported targeted import types safely", async () => {
+    const { GET } = await import("../app/api/internal/import-jobs/tick/route");
+    const response = await GET(request("/api/internal/import-jobs/tick?importType=parts", { authorization: "Bearer cron-secret" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Unsupported import_type");
+    expect(processInvoiceImportJobBatchMock).not.toHaveBeenCalled();
+    expect(processVehicleHistoryImportJobBatchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/vehicle-history-csv-import-architecture.test.ts
+++ b/tests/vehicle-history-csv-import-architecture.test.ts
@@ -81,11 +81,11 @@ describe("vehicle history CSV import job architecture", () => {
     expect(source).toContain("const formData = new FormData()");
     expect(source).toContain('formData.append("file", file)');
     expect(source).toContain("setActiveJobId(payload.jobId)");
-    expect(source).toContain("/api/import-jobs/${encodeURIComponent(pollingJobId)}");
-    expect(source).toContain("setTimeout(() => void pollJobStatus(), 1500)");
-    expect(source).toContain('job.status === "completed" || job.status === "failed"');
+    expect(source).toContain("useImportJobProgress(activeJobId");
+    expect(source).toContain("onComplete: handleJobComplete");
+    expect(source).toContain('job.status === "failed"');
     expect(source).toContain("setActiveJobId(null)");
-    expect(source).toContain("clearTimeout(timeoutId)");
+    expect(readFileSync("features/shared/components/import/useImportJobProgress.ts", "utf8")).toContain("clearTimeout(timeoutId)");
     expect(source).not.toContain("JSON.stringify({ rows: importableRows })");
   });
 


### PR DESCRIPTION
### Motivation
- Vercel Cron requests need to authenticate without the existing `x-internal-import-jobs-secret` header, and the tick route should process the oldest queued job across supported import types instead of defaulting to `vehicle_history`.
- The system must continue to support manual curl usage with the internal secret and allow targeted testing via `?jobId=` and `?importType=`.

### Description
- Add support for `Authorization: Bearer ${CRON_SECRET}` in addition to the existing `x-internal-import-jobs-secret`/`INTERNAL_IMPORT_JOBS_SECRET` by extending the route authorization check in `app/api/internal/import-jobs/tick/route.ts`.
- Introduce a `SUPPORTED_IMPORT_TYPES` list (`vehicle_history`, `invoices`) and dispatch logic that, for a plain `/api/internal/import-jobs/tick` request, selects the oldest queued/processing import job across supported types and routes it to the correct processor.
- Preserve `?jobId=` and `?importType=` behavior for targeted/manual testing and return a clear `400` response for unsupported `importType` values.
- Keep existing vehicle history processing and ensure invoice processing is invoked when invoice jobs are selected; add `importType` in JSON responses for clarity.
- Add `tests/import-jobs-tick-route.test.ts` to cover cron bearer auth, manual secret auth, plain dispatch to invoices, targeted `?importType=invoices`, vehicle history processing, and unsupported `importType` handling, and update `tests/vehicle-history-csv-import-architecture.test.ts` expectations to match the shared polling hook usage.

### Testing
- Ran typecheck: `npm run typecheck` — succeeded.
- Ran ESLint: `npx eslint app/api/internal/import-jobs features/billing/server features/work-orders/server` — completed with existing warnings (not introduced by this change) in `features/billing/server/invoice-import-job.ts`.
- Ran unit tests: `npx vitest run tests/import-jobs-tick-route.test.ts tests/vehicle-history-csv-import-architecture.test.ts` — all added/related tests passed (both test files green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3149bc8083289ff9f63a0cd91aef)