### PR TITLE
Allow historical invoice imports without work orders

### DIFF
--- a/db/sql/2026-07-06_invoice_import_work_order_optional.sql
+++ b/db/sql/2026-07-06_invoice_import_work_order_optional.sql
@@ -1,0 +1,63 @@
+-- Historical invoice imports are read-only billing records. They should attach to a
+-- matched work order when one exists, but they must not require one or create one.
+--
+-- Root cause guardrail: some deployed databases have an invoice validation trigger
+-- whose function raises: 'invoice <id> must belong to a work_order'. That trigger is
+-- valid for normal in-app invoice creation, but it blocks historical imports whose
+-- metadata marks them as imported/read_only/import_type=invoice_csv.
+
+create or replace function public.invoice_is_historical_import(p_metadata jsonb)
+returns boolean
+language sql
+immutable
+as $$
+  select coalesce((p_metadata->>'imported')::boolean, false)
+     and coalesce((p_metadata->>'read_only')::boolean, false)
+     and p_metadata->>'import_type' = 'invoice_csv'
+$$;
+
+create or replace function public.enforce_invoice_work_order_for_active_invoices()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.work_order_id is null
+     and not public.invoice_is_historical_import(coalesce(new.metadata::jsonb, '{}'::jsonb)) then
+    raise exception 'invoice % must belong to a work_order', new.id
+      using errcode = '23514';
+  end if;
+
+  return new;
+end;
+$$;
+
+do $$
+declare
+  trigger_record record;
+begin
+  -- Remove only invoice triggers backed by functions containing the exact failure
+  -- message. This preserves unrelated invoice triggers/policies/defaults.
+  for trigger_record in
+    select t.tgname
+    from pg_trigger t
+    join pg_class c on c.oid = t.tgrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    join pg_proc p on p.oid = t.tgfoid
+    where n.nspname = 'public'
+      and c.relname = 'invoices'
+      and not t.tgisinternal
+      and pg_get_functiondef(p.oid) like '%must belong to a work_order%'
+  loop
+    execute format('drop trigger if exists %I on public.invoices', trigger_record.tgname);
+  end loop;
+end $$;
+
+drop trigger if exists enforce_invoice_work_order_for_active_invoices on public.invoices;
+create trigger enforce_invoice_work_order_for_active_invoices
+before insert or update of work_order_id, metadata
+on public.invoices
+for each row
+execute function public.enforce_invoice_work_order_for_active_invoices();
+
+comment on function public.enforce_invoice_work_order_for_active_invoices() is
+  'Requires work_order_id for normal active invoices while allowing read-only historical invoice_csv imports to keep work_order_id null.';

--- a/tests/invoice-import-work-order-optional.test.ts
+++ b/tests/invoice-import-work-order-optional.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const importer = readFileSync("features/billing/server/invoice-import-job.ts", "utf8");
+const migration = readFileSync("db/sql/2026-07-06_invoice_import_work_order_optional.sql", "utf8");
+
+describe("historical invoice imports", () => {
+  it("keeps the existing matched-work-order-or-null importer behavior", () => {
+    expect(importer).toContain("work_order_id: wo?.id ?? null");
+    expect(importer).not.toContain("from(\"work_orders\").insert");
+    expect(importer).not.toContain("from(\"work_orders\").upsert");
+  });
+
+  it("marks invoice CSV rows as read-only historical imports", () => {
+    expect(importer).toContain("imported: true");
+    expect(importer).toContain("read_only: true");
+    expect(importer).toContain('import_type: "invoice_csv"');
+  });
+
+  it("allows only read-only invoice CSV imports to bypass the active invoice work-order trigger", () => {
+    expect(migration).toContain("must belong to a work_order");
+    expect(migration).toContain("invoice_is_historical_import");
+    expect(migration).toContain("p_metadata->>'import_type' = 'invoice_csv'");
+    expect(migration).toContain("enforce_invoice_work_order_for_active_invoices");
+  });
+});


### PR DESCRIPTION
### Motivation
- The invoice CSV importer was producing `invoice <id> must belong to a work_order` for every row because a database trigger required `work_order_id` for all invoice inserts, blocking historical/read-only imports. 
- Historical imports are intended to be read-only billing records that attach an existing `work_order_id` when present but must succeed with `work_order_id = NULL` when no matching work order exists. 

### Description
- Added a SQL migration `db/sql/2026-07-06_invoice_import_work_order_optional.sql` that installs `public.invoice_is_historical_import(jsonb)` and `public.enforce_invoice_work_order_for_active_invoices()` and replaces only the invoice triggers whose backing function contains the exact failure text `must belong to a work_order`. 
- The new trigger enforces `work_order_id` for normal (non-imported) invoices but exempts read-only CSV imports when `metadata.imported = true`, `metadata.read_only = true`, and `metadata.import_type = 'invoice_csv'`. 
- Verified importer code already sets `work_order_id: wo?.id ?? null` and stamps `metadata` with `imported: true`, `read_only: true`, and `import_type: "invoice_csv"`, so no application changes to importer logic were required. 
- Added regression coverage file `tests/invoice-import-work-order-optional.test.ts` to assert the importer payload and migration guardrails. 

### Testing
- Ran `npm run typecheck` and it completed successfully. 
- Ran `npx eslint features/billing app/api/internal/import-jobs` which completed with existing `@typescript-eslint/no-explicit-any` warnings in `features/billing/server/invoice-import-job.ts` and no new errors. 
- Ran unit tests with `npx vitest run tests/invoice-import-work-order-optional.test.ts tests/import-jobs-tick-route.test.ts` and all tests passed. 

Files changed:
- `db/sql/2026-07-06_invoice_import_work_order_optional.sql` (new migration)
- `tests/invoice-import-work-order-optional.test.ts` (new test)

Notes:
- Normal in-app invoice creation remains unchanged and will still raise the validation error when `work_order_id` is missing for active invoices. 
- Historical CSV imports now import successfully both with and without matching work orders, and the importer will never create work orders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bbfae093083288f985c810795bf08)