### PR TITLE
Fix historical invoice import constraints

### DIFF
--- a/db/sql/2026-07-06_invoice_import_work_order_optional.sql
+++ b/db/sql/2026-07-06_invoice_import_work_order_optional.sql
@@ -61,3 +61,33 @@ execute function public.enforce_invoice_work_order_for_active_invoices();
 
 comment on function public.enforce_invoice_work_order_for_active_invoices() is
   'Requires work_order_id for normal active invoices while allowing read-only historical invoice_csv imports to keep work_order_id null.';
+
+-- Align deployed invoice check constraints with the historical invoice import path.
+-- Exact prior definitions observed in deployed environments:
+--   invoices_work_order_id_required_chk: check (work_order_id is not null)
+--   invoices_paid_requires_paid_at_chk: check (status <> 'paid' or paid_at is not null)
+-- The replacement keeps normal invoices protected while allowing only read-only
+-- invoice_csv imports to omit work_order_id. The paid rule remains unchanged.
+
+alter table public.invoices
+  drop constraint if exists invoices_work_order_id_required_chk;
+
+alter table public.invoices
+  add constraint invoices_work_order_id_required_chk
+  check (
+    work_order_id is not null
+    or public.invoice_is_historical_import(coalesce(metadata::jsonb, '{}'::jsonb))
+  ) not valid;
+
+alter table public.invoices
+  drop constraint if exists invoices_paid_requires_paid_at_chk;
+
+alter table public.invoices
+  add constraint invoices_paid_requires_paid_at_chk
+  check (status <> 'paid' or paid_at is not null) not valid;
+
+comment on constraint invoices_work_order_id_required_chk on public.invoices is
+  'Normal invoices require work_order_id; read-only historical invoice_csv imports may store legacy invoice records without creating active work orders.';
+
+comment on constraint invoices_paid_requires_paid_at_chk on public.invoices is
+  'Paid invoices, including historical imports, must include paid_at; the importer derives paid_at from paid_date or invoice_date for paid CSV rows.';

--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -6,38 +6,222 @@ type DB = Database;
 export const INVOICE_IMPORT_BATCH_SIZE = 1000;
 export const INVOICE_IMPORT_SAMPLE_LIMIT = 25;
 export const INVOICE_IMPORT_MAX_ROWS = 20_000;
+
 type InvoiceImportRow = Record<string, unknown>;
 type JobRow = { id: string; shop_id: string; processed_rows: number | null; imported_count: number | null; skipped_count: number | null; failed_count: number | null; summary: Record<string, unknown> | null };
 type StagedRow = { id: string; row_number: number; raw_row: InvoiceImportRow; status: string | null };
 type Counts = { imported: number; skipped: number; failed: number; duplicates: number };
-const clean = (v: unknown) => { const t = String(v ?? "").trim(); return t || null; };
-const key = (v: unknown) => clean(v)?.toLowerCase() ?? null;
-const num = (v: unknown) => { const t = clean(v); if (!t) return null; const n = Number(t.replace(/[$,]/g, "")); return Number.isFinite(n) ? n : null; };
-const date = (v: unknown) => { const t = clean(v); if (!t) return null; const d = new Date(t); return Number.isNaN(d.getTime()) ? null : d.toISOString(); };
-const vin = (v: unknown) => clean(v)?.toUpperCase().replace(/[^A-Z0-9]/g, "") ?? null;
-async function duplicateInvoice(client: SupabaseClient, shopId: string, invoiceNumber: string | null, sourceId: string | null) { if (invoiceNumber) { const { data, error } = await client.from("invoices").select("id").eq("shop_id", shopId).eq("invoice_number", invoiceNumber).limit(1); if (error) throw error; if (data?.length) return true; } if (sourceId) { const { data, error } = await client.from("invoices").select("id").eq("shop_id", shopId).contains("metadata", { imported_invoice_id: sourceId }).limit(1); if (error) throw error; if (data?.length) return true; } return false; }
-function normalizeStatus(row: InvoiceImportRow) { const raw = key(row.payment_status ?? row.status); if (raw?.includes("paid")) return "paid"; if (raw?.includes("void") || raw?.includes("cancel")) return "void"; return "imported"; }
-function samples(summary: Record<string, unknown> | null) { return { skippedRows: Array.isArray(summary?.skippedRows) ? summary.skippedRows as unknown[] : [], failedRows: Array.isArray(summary?.failedRows) ? summary.failedRows as unknown[] : [] }; }
+type MatchedCustomer = { id: string; external_id?: string | null };
+type MatchedVehicle = { id: string; external_id?: string | null; vin?: string | null; customer_id?: string | null };
+type MatchedWorkOrder = { id: string; custom_id?: string | null; customer_id?: string | null; vehicle_id?: string | null };
+
+const clean = (value: unknown) => { const text = String(value ?? "").trim(); return text || null; };
+const key = (value: unknown) => clean(value)?.toLowerCase() ?? null;
+const num = (value: unknown) => { const text = clean(value); if (!text) return null; const parsed = Number(text.replace(/[$,]/g, "")); return Number.isFinite(parsed) ? parsed : null; };
+const date = (value: unknown) => { const text = clean(value); if (!text) return null; const parsed = new Date(text); return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString(); };
+const vin = (value: unknown) => clean(value)?.toUpperCase().replace(/[^A-Z0-9]/g, "") ?? null;
+
+async function duplicateInvoice(client: SupabaseClient, shopId: string, invoiceNumber: string | null, sourceId: string | null) {
+  if (invoiceNumber) {
+    const { data, error } = await client.from("invoices").select("id").eq("shop_id", shopId).eq("invoice_number", invoiceNumber).limit(1);
+    if (error) throw error;
+    if (data?.length) return true;
+  }
+
+  if (sourceId) {
+    const { data, error } = await client.from("invoices").select("id").eq("shop_id", shopId).contains("metadata", { imported_invoice_id: sourceId }).limit(1);
+    if (error) throw error;
+    if (data?.length) return true;
+  }
+
+  return false;
+}
+
+export function normalizeInvoiceImportStatus(row: InvoiceImportRow) {
+  const raw = key(row.payment_status ?? row.status);
+  if (raw?.includes("void") || raw?.includes("cancel")) return "void";
+  if (raw?.includes("draft")) return "draft";
+  if (raw === "paid" || raw === "closed_paid" || raw === "paid_in_full" || raw?.endsWith("_paid")) return "paid";
+  return "imported";
+}
+
+export function resolveImportedInvoicePaidAt(row: InvoiceImportRow, issuedAt: string, status = normalizeInvoiceImportStatus(row)) {
+  if (status !== "paid") return null;
+  return date(row.paid_date) ?? issuedAt;
+}
+
+function samples(summary: Record<string, unknown> | null) {
+  return {
+    skippedRows: Array.isArray(summary?.skippedRows) ? summary.skippedRows as unknown[] : [],
+    failedRows: Array.isArray(summary?.failedRows) ? summary.failedRows as unknown[] : [],
+  };
+}
+
 export async function processInvoiceImportJobBatch(supabase: SupabaseClient<DB>, jobId?: string, batchSize = INVOICE_IMPORT_BATCH_SIZE) {
   const client = supabase as unknown as SupabaseClient;
   let jobQuery = client.from("import_jobs").select("id, shop_id, processed_rows, imported_count, skipped_count, failed_count, summary").eq("import_type", "invoices").in("status", ["queued", "processing"]).order("created_at", { ascending: true }).limit(1);
   if (jobId) jobQuery = jobQuery.eq("id", jobId);
-  const { data: job, error: jobError } = await jobQuery.maybeSingle<JobRow>(); if (jobError) throw jobError; if (!job) return { ok: true, processed: 0, completed: false, job: null };
+
+  const { data: job, error: jobError } = await jobQuery.maybeSingle<JobRow>();
+  if (jobError) throw jobError;
+  if (!job) return { ok: true, processed: 0, completed: false, job: null };
+
   await client.from("import_jobs").update({ status: "processing", updated_at: new Date().toISOString() }).eq("id", job.id);
-  const { data, error } = await client.from("import_job_rows").select("id, row_number, raw_row, status").eq("job_id", job.id).eq("status", "queued").order("row_number", { ascending: true }).limit(batchSize); if (error) throw error;
-  const rows = (data ?? []) as StagedRow[]; if (!rows.length) { await client.from("import_jobs").update({ status: "completed", completed_at: new Date().toISOString(), updated_at: new Date().toISOString() }).eq("id", job.id); return { ok: true, processed: 0, completed: true, job: { id: job.id } }; }
-  const [{ data: customers }, { data: vehicles }, { data: workOrders }] = await Promise.all([client.from("customers").select("id, external_id").eq("shop_id", job.shop_id), client.from("vehicles").select("id, external_id, vin, customer_id").eq("shop_id", job.shop_id), client.from("work_orders").select("id, custom_id, customer_id, vehicle_id").eq("shop_id", job.shop_id)]);
-  const customersById = new Map<string, any>();
-  for (const c of (customers ?? []) as any[]) { if (c.id) customersById.set(c.id, c); const external = String(c.external_id ?? "").toLowerCase(); if (external) customersById.set(external, c); }
-  const vehiclesById = new Map<string, any>();
-  for (const v of (vehicles ?? []) as any[]) { if (v.id) vehiclesById.set(v.id, v); const external = String(v.external_id ?? "").toLowerCase(); if (external) vehiclesById.set(external, v); const normalizedVin = vin(v.vin); if (normalizedVin) vehiclesById.set(normalizedVin, v); }
-  const workOrdersByNumber = new Map<string, any>();
-  for (const w of (workOrders ?? []) as any[]) { const customId = String(w.custom_id ?? "").toLowerCase(); if (customId) workOrdersByNumber.set(customId, w); if (w.id) workOrdersByNumber.set(w.id, w); }
-  const counts: Counts = { imported: 0, skipped: 0, failed: 0, duplicates: 0 }; const sample = samples(job.summary); const inserts: Array<{ stagedId: string; rowNumber: number; invoiceNumber: string | null; workOrderNumber: string | null; payload: DB["public"]["Tables"]["invoices"]["Insert"] }> = [];
-  for (const staged of rows) { const row = staged.raw_row; const invoiceNumber = clean(row.invoice_number ?? row.invoice_id); const sourceId = clean(row.invoice_id); const workOrderNumber = clean(row.work_order_number); try { const issued = date(row.invoice_date); if (!issued || !invoiceNumber) { const reason = !issued ? "Invalid or missing invoice_date." : "Missing invoice_number or invoice_id."; counts.skipped++; sample.skippedRows.push({ row: staged.row_number, reason, invoiceNumber, workOrderNumber }); await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id); continue; } if (await duplicateInvoice(client, job.shop_id, invoiceNumber, sourceId)) { counts.skipped++; counts.duplicates++; const reason = "Duplicate invoice already exists."; sample.skippedRows.push({ row: staged.row_number, reason, invoiceNumber, workOrderNumber }); await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id); continue; } const wo: any = workOrderNumber ? workOrdersByNumber.get(workOrderNumber.toLowerCase()) : null; const veh: any = (clean(row.vehicle_id) ? vehiclesById.get(clean(row.vehicle_id)!) ?? vehiclesById.get(clean(row.vehicle_id)!.toLowerCase()) : null) ?? (vin(row.vin) ? vehiclesById.get(vin(row.vin)!) : null); const cust: any = (clean(row.customer_id) ? customersById.get(clean(row.customer_id)!) ?? customersById.get(clean(row.customer_id)!.toLowerCase()) : null); const customerId = cust?.id ?? wo?.customer_id ?? veh?.customer_id ?? null; const vehicleId = veh?.id ?? wo?.vehicle_id ?? null; const total = num(row.total) ?? num(row.subtotal) ?? 0; const amountPaid = num(row.amount_paid) ?? 0; inserts.push({ stagedId: staged.id, rowNumber: staged.row_number, invoiceNumber, workOrderNumber, payload: { shop_id: job.shop_id, customer_id: customerId, work_order_id: wo?.id ?? null, invoice_number: invoiceNumber, issued_at: issued, due_date: date(row.due_date), paid_at: date(row.paid_date), status: normalizeStatus(row), labor_cost: num(row.labor_total) ?? 0, parts_cost: num(row.parts_total) ?? 0, subtotal: num(row.subtotal) ?? total, tax_total: num(row.tax) ?? 0, total, notes: [clean(row.description), clean(row.notes)].filter(Boolean).join("\n") || null, metadata: { imported: true, read_only: true, import_type: "invoice_csv", imported_invoice_id: sourceId, source_system: clean(row.source_system), work_order_number: workOrderNumber, vehicle_id: vehicleId, vin: clean(row.vin), service_category: clean(row.service_category), labor_hours: num(row.labor_hours), shop_supplies: num(row.shop_supplies), amount_paid: amountPaid, balance_due: num(row.balance_due) ?? Math.max(0, total - amountPaid), advisor: clean(row.advisor), technician: clean(row.technician), raw_row: row } as DB["public"]["Tables"]["invoices"]["Insert"]["metadata"] } }); } catch (e) { const message = e instanceof Error ? e.message : "Invoice row failed to import."; counts.failed++; sample.failedRows.push({ row: staged.row_number, error: message, invoiceNumber, workOrderNumber }); await client.from("import_job_rows").update({ status: "failed", error_message: message }).eq("id", staged.id); } }
-  for (const batch of chunkArray(inserts, batchSize)) { const { error: insertError } = await supabase.from("invoices").insert(batch.map((e) => e.payload)); if (insertError) { for (const entry of batch) { const { error: rowError } = await supabase.from("invoices").insert(entry.payload); if (rowError) { counts.failed++; sample.failedRows.push({ row: entry.rowNumber, error: rowError.message, invoiceNumber: entry.invoiceNumber, workOrderNumber: entry.workOrderNumber }); await client.from("import_job_rows").update({ status: "failed", error_message: rowError.message }).eq("id", entry.stagedId); } else { counts.imported++; await client.from("import_job_rows").update({ status: "imported" }).eq("id", entry.stagedId); } } } else { counts.imported += batch.length; await client.from("import_job_rows").update({ status: "imported" }).in("id", batch.map((e) => e.stagedId)); } }
-  const processedRows = (job.processed_rows ?? 0) + rows.length; const summary = { skippedRows: sample.skippedRows.slice(0, INVOICE_IMPORT_SAMPLE_LIMIT), failedRows: sample.failedRows.slice(0, INVOICE_IMPORT_SAMPLE_LIMIT), duplicates: Number(job.summary?.duplicates ?? 0) + counts.duplicates };
-  const { count } = await client.from("import_job_rows").select("id", { count: "exact", head: true }).eq("job_id", job.id).eq("status", "queued"); const completed = (count ?? 0) === 0;
+
+  const { data, error } = await client.from("import_job_rows").select("id, row_number, raw_row, status").eq("job_id", job.id).eq("status", "queued").order("row_number", { ascending: true }).limit(batchSize);
+  if (error) throw error;
+
+  const rows = (data ?? []) as StagedRow[];
+  if (!rows.length) {
+    await client.from("import_jobs").update({ status: "completed", completed_at: new Date().toISOString(), updated_at: new Date().toISOString() }).eq("id", job.id);
+    return { ok: true, processed: 0, completed: true, job: { id: job.id } };
+  }
+
+  const [{ data: customers }, { data: vehicles }, { data: workOrders }] = await Promise.all([
+    client.from("customers").select("id, external_id").eq("shop_id", job.shop_id),
+    client.from("vehicles").select("id, external_id, vin, customer_id").eq("shop_id", job.shop_id),
+    client.from("work_orders").select("id, custom_id, customer_id, vehicle_id").eq("shop_id", job.shop_id),
+  ]);
+
+  const customersById = new Map<string, MatchedCustomer>();
+  for (const customer of (customers ?? []) as MatchedCustomer[]) {
+    if (customer.id) customersById.set(customer.id, customer);
+    const external = String(customer.external_id ?? "").toLowerCase();
+    if (external) customersById.set(external, customer);
+  }
+
+  const vehiclesById = new Map<string, MatchedVehicle>();
+  for (const vehicle of (vehicles ?? []) as MatchedVehicle[]) {
+    if (vehicle.id) vehiclesById.set(vehicle.id, vehicle);
+    const external = String(vehicle.external_id ?? "").toLowerCase();
+    if (external) vehiclesById.set(external, vehicle);
+    const normalizedVin = vin(vehicle.vin);
+    if (normalizedVin) vehiclesById.set(normalizedVin, vehicle);
+  }
+
+  const workOrdersByNumber = new Map<string, MatchedWorkOrder>();
+  for (const workOrder of (workOrders ?? []) as MatchedWorkOrder[]) {
+    const customId = String(workOrder.custom_id ?? "").toLowerCase();
+    if (customId) workOrdersByNumber.set(customId, workOrder);
+    if (workOrder.id) workOrdersByNumber.set(workOrder.id, workOrder);
+  }
+
+  const counts: Counts = { imported: 0, skipped: 0, failed: 0, duplicates: 0 };
+  const sample = samples(job.summary);
+  const inserts: Array<{ stagedId: string; rowNumber: number; invoiceNumber: string | null; workOrderNumber: string | null; payload: DB["public"]["Tables"]["invoices"]["Insert"] }> = [];
+
+  for (const staged of rows) {
+    const row = staged.raw_row;
+    const invoiceNumber = clean(row.invoice_number ?? row.invoice_id);
+    const sourceId = clean(row.invoice_id);
+    const workOrderNumber = clean(row.work_order_number);
+
+    try {
+      const issued = date(row.invoice_date);
+      if (!issued || !invoiceNumber) {
+        const reason = !issued ? "Invalid or missing invoice_date." : "Missing invoice_number or invoice_id.";
+        counts.skipped++;
+        sample.skippedRows.push({ row: staged.row_number, reason, invoiceNumber, workOrderNumber });
+        await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id);
+        continue;
+      }
+
+      if (await duplicateInvoice(client, job.shop_id, invoiceNumber, sourceId)) {
+        counts.skipped++;
+        counts.duplicates++;
+        const reason = "Duplicate invoice already exists.";
+        sample.skippedRows.push({ row: staged.row_number, reason, invoiceNumber, workOrderNumber });
+        await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id);
+        continue;
+      }
+
+      const workOrder = workOrderNumber ? workOrdersByNumber.get(workOrderNumber.toLowerCase()) : null;
+      const vehicle = (clean(row.vehicle_id) ? vehiclesById.get(clean(row.vehicle_id)!) ?? vehiclesById.get(clean(row.vehicle_id)!.toLowerCase()) : null) ?? (vin(row.vin) ? vehiclesById.get(vin(row.vin)!) : null);
+      const customer = (clean(row.customer_id) ? customersById.get(clean(row.customer_id)!) ?? customersById.get(clean(row.customer_id)!.toLowerCase()) : null);
+      const customerId = customer?.id ?? workOrder?.customer_id ?? vehicle?.customer_id ?? null;
+      const vehicleId = vehicle?.id ?? workOrder?.vehicle_id ?? null;
+      const total = num(row.total) ?? num(row.subtotal) ?? 0;
+      const amountPaid = num(row.amount_paid) ?? 0;
+      const status = normalizeInvoiceImportStatus(row);
+
+      inserts.push({
+        stagedId: staged.id,
+        rowNumber: staged.row_number,
+        invoiceNumber,
+        workOrderNumber,
+        payload: {
+          shop_id: job.shop_id,
+          customer_id: customerId,
+          work_order_id: workOrder?.id ?? null,
+          invoice_number: invoiceNumber,
+          issued_at: issued,
+          due_date: date(row.due_date),
+          paid_at: resolveImportedInvoicePaidAt(row, issued, status),
+          status,
+          labor_cost: num(row.labor_total) ?? 0,
+          parts_cost: num(row.parts_total) ?? 0,
+          subtotal: num(row.subtotal) ?? total,
+          tax_total: num(row.tax) ?? 0,
+          total,
+          notes: [clean(row.description), clean(row.notes)].filter(Boolean).join("\n") || null,
+          metadata: {
+            imported: true,
+            read_only: true,
+            import_type: "invoice_csv",
+            imported_invoice_id: sourceId,
+            source_system: clean(row.source_system),
+            work_order_number: workOrderNumber,
+            vehicle_id: vehicleId,
+            vin: clean(row.vin),
+            service_category: clean(row.service_category),
+            labor_hours: num(row.labor_hours),
+            shop_supplies: num(row.shop_supplies),
+            amount_paid: amountPaid,
+            balance_due: num(row.balance_due) ?? Math.max(0, total - amountPaid),
+            advisor: clean(row.advisor),
+            technician: clean(row.technician),
+            raw_row: row,
+          } as DB["public"]["Tables"]["invoices"]["Insert"]["metadata"],
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Invoice row failed to import.";
+      counts.failed++;
+      sample.failedRows.push({ row: staged.row_number, error: message, invoiceNumber, workOrderNumber });
+      await client.from("import_job_rows").update({ status: "failed", error_message: message }).eq("id", staged.id);
+    }
+  }
+
+  for (const batch of chunkArray(inserts, batchSize)) {
+    const { error: insertError } = await supabase.from("invoices").insert(batch.map((entry) => entry.payload));
+    if (insertError) {
+      for (const entry of batch) {
+        const { error: rowError } = await supabase.from("invoices").insert(entry.payload);
+        if (rowError) {
+          counts.failed++;
+          sample.failedRows.push({ row: entry.rowNumber, error: rowError.message, invoiceNumber: entry.invoiceNumber, workOrderNumber: entry.workOrderNumber });
+          await client.from("import_job_rows").update({ status: "failed", error_message: rowError.message }).eq("id", entry.stagedId);
+        } else {
+          counts.imported++;
+          await client.from("import_job_rows").update({ status: "imported" }).eq("id", entry.stagedId);
+        }
+      }
+    } else {
+      counts.imported += batch.length;
+      await client.from("import_job_rows").update({ status: "imported" }).in("id", batch.map((entry) => entry.stagedId));
+    }
+  }
+
+  const processedRows = (job.processed_rows ?? 0) + rows.length;
+  const summary = {
+    skippedRows: sample.skippedRows.slice(0, INVOICE_IMPORT_SAMPLE_LIMIT),
+    failedRows: sample.failedRows.slice(0, INVOICE_IMPORT_SAMPLE_LIMIT),
+    duplicates: Number(job.summary?.duplicates ?? 0) + counts.duplicates,
+  };
+  const { count } = await client.from("import_job_rows").select("id", { count: "exact", head: true }).eq("job_id", job.id).eq("status", "queued");
+  const completed = (count ?? 0) === 0;
+
   await client.from("import_jobs").update({ status: completed ? "completed" : "processing", processed_rows: processedRows, imported_count: (job.imported_count ?? 0) + counts.imported, skipped_count: (job.skipped_count ?? 0) + counts.skipped, failed_count: (job.failed_count ?? 0) + counts.failed, summary, completed_at: completed ? new Date().toISOString() : null, updated_at: new Date().toISOString() }).eq("id", job.id);
+
   return { ok: true, processed: rows.length, completed, job: { id: job.id } };
 }

--- a/tests/invoice-import-work-order-optional.test.ts
+++ b/tests/invoice-import-work-order-optional.test.ts
@@ -1,14 +1,15 @@
-import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { normalizeInvoiceImportStatus, resolveImportedInvoicePaidAt } from "../features/billing/server/invoice-import-job";
 
 const importer = readFileSync("features/billing/server/invoice-import-job.ts", "utf8");
 const migration = readFileSync("db/sql/2026-07-06_invoice_import_work_order_optional.sql", "utf8");
 
 describe("historical invoice imports", () => {
   it("keeps the existing matched-work-order-or-null importer behavior", () => {
-    expect(importer).toContain("work_order_id: wo?.id ?? null");
-    expect(importer).not.toContain("from(\"work_orders\").insert");
-    expect(importer).not.toContain("from(\"work_orders\").upsert");
+    expect(importer).toContain("work_order_id: workOrder?.id ?? null");
+    expect(importer).not.toContain('from("work_orders").insert');
+    expect(importer).not.toContain('from("work_orders").upsert');
   });
 
   it("marks invoice CSV rows as read-only historical imports", () => {
@@ -17,10 +18,46 @@ describe("historical invoice imports", () => {
     expect(importer).toContain('import_type: "invoice_csv"');
   });
 
-  it("allows only read-only invoice CSV imports to bypass the active invoice work-order trigger", () => {
+  it("allows only read-only invoice CSV imports to bypass the active invoice work-order trigger and check", () => {
     expect(migration).toContain("must belong to a work_order");
     expect(migration).toContain("invoice_is_historical_import");
     expect(migration).toContain("p_metadata->>'import_type' = 'invoice_csv'");
     expect(migration).toContain("enforce_invoice_work_order_for_active_invoices");
+    expect(migration).toContain("drop constraint if exists invoices_work_order_id_required_chk");
+    expect(migration).toContain("add constraint invoices_work_order_id_required_chk");
+    expect(migration).toContain("work_order_id is not null");
+  });
+
+  it("keeps normal invoice work-order rules protected", () => {
+    expect(migration).toContain("or public.invoice_is_historical_import");
+    expect(migration).not.toContain("check (true)");
+  });
+
+  it("keeps the paid invoice constraint and lets the importer satisfy it", () => {
+    expect(migration).toContain("drop constraint if exists invoices_paid_requires_paid_at_chk");
+    expect(migration).toContain("add constraint invoices_paid_requires_paid_at_chk");
+    expect(migration).toContain("check (status <> 'paid' or paid_at is not null)");
+  });
+
+  it("sets paid_at from paid_date for paid imported invoices", () => {
+    const paidAt = resolveImportedInvoicePaidAt({ payment_status: "paid", paid_date: "2024-03-20", invoice_date: "2024-03-18" }, "2024-03-18T00:00:00.000Z");
+    expect(paidAt).toBe("2024-03-20T00:00:00.000Z");
+  });
+
+  it("falls back to invoice_date for paid imported invoices without paid_date", () => {
+    const issuedAt = "2024-03-18T00:00:00.000Z";
+    expect(resolveImportedInvoicePaidAt({ payment_status: "paid" }, issuedAt)).toBe(issuedAt);
+  });
+
+  it("does not require paid_at for unpaid, void, or draft imported invoices", () => {
+    expect(normalizeInvoiceImportStatus({ payment_status: "unpaid" })).toBe("imported");
+    expect(resolveImportedInvoicePaidAt({ payment_status: "unpaid", paid_date: "2024-03-20" }, "2024-03-18T00:00:00.000Z")).toBeNull();
+    expect(resolveImportedInvoicePaidAt({ status: "void" }, "2024-03-18T00:00:00.000Z")).toBeNull();
+    expect(resolveImportedInvoicePaidAt({ status: "draft" }, "2024-03-18T00:00:00.000Z")).toBeNull();
+  });
+
+  it("preserves legacy invoice and work-order numbers as text metadata", () => {
+    expect(importer).toContain("invoice_number: invoiceNumber");
+    expect(importer).toContain("work_order_number: workOrderNumber");
   });
 });


### PR DESCRIPTION
### Motivation
- Historical invoice CSV imports were failing due to deployed invoice constraints requiring `work_order_id` and `paid_at` rules that the importer did not consistently satisfy.
- The goal is to allow read-only/historical imports to be stored without creating active work orders while preserving normal live-invoice protections.

### Description
- Add/adjust a migration that replaces `invoices_work_order_id_required_chk` so the `work_order_id` requirement is enforced for normal invoices but is exempted when `public.invoice_is_historical_import(metadata)` is true, and re-add `invoices_paid_requires_paid_at_chk` unchanged. (`db/sql/2026-07-06_invoice_import_work_order_optional.sql`).
- Update the importer to normalize import statuses and compute `paid_at` for paid imports using `paid_date` with a fallback to `invoice_date`, and to continue matching customers/vehicles/work orders without creating new work orders (preserve `invoice_number` and `work_order_number` in metadata). (`features/billing/server/invoice-import-job.ts`).
- Tighten importer types for matched maps and expose `normalizeInvoiceImportStatus` and `resolveImportedInvoicePaidAt` helpers to make behavior explicit and testable. (`features/billing/server/invoice-import-job.ts`).
- Add regression tests covering: historical invoice import bypassing the work-order requirement, paid/unpaid `paid_at` handling, metadata preservation, and ensuring imports never create work orders. (`tests/invoice-import-work-order-optional.test.ts`).

### Testing
- Ran `npm run typecheck` and the TypeScript check completed successfully. 
- Ran `npx eslint features/billing app/api/internal/import-jobs` which reported only lint warnings and no errors. 
- Ran `npx vitest run tests/invoice-import-work-order-optional.test.ts tests/import-jobs-tick-route.test.ts` and both test files passed (total 15 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bcd28b0708328a362f7cab88b8944)