### PR TITLE
Normalize imported invoice statuses

### DIFF
--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -37,12 +37,23 @@ async function duplicateInvoice(client: SupabaseClient, shopId: string, invoiceN
   return false;
 }
 
-export function normalizeInvoiceImportStatus(row: InvoiceImportRow) {
-  const raw = key(row.payment_status ?? row.status);
-  if (raw?.includes("void") || raw?.includes("cancel")) return "void";
-  if (raw?.includes("draft")) return "draft";
-  if (raw === "paid" || raw === "closed_paid" || raw === "paid_in_full" || raw?.endsWith("_paid")) return "paid";
-  return "imported";
+export const CANONICAL_INVOICE_IMPORT_STATUSES = ["draft", "issued", "paid", "void"] as const;
+type CanonicalInvoiceImportStatus = (typeof CANONICAL_INVOICE_IMPORT_STATUSES)[number];
+
+const PAID_IMPORT_STATUSES = new Set(["paid", "closed_paid", "paid_in_full", "paid_full", "complete_paid"]);
+const OPEN_IMPORT_STATUSES = new Set(["", "unpaid", "open", "issued", "sent", "partial", "partially_paid", "partial_paid", "payment_due", "past_due", "overdue"]);
+const VOID_IMPORT_STATUSES = new Set(["void", "voided", "cancelled", "canceled", "closed", "written_off", "write_off", "bad_debt", "uncollectible"]);
+const DRAFT_IMPORT_STATUSES = new Set(["draft", "estimate", "pending"]);
+const NEVER_IMPORT_INVOICE_STATUSES = new Set(["credit", "credit_memo", "refund", "refunded", "reversed", "chargeback"]);
+
+export function normalizeInvoiceImportStatus(row: InvoiceImportRow): CanonicalInvoiceImportStatus | null {
+  const raw = key(row.payment_status ?? row.status) ?? "";
+  if (NEVER_IMPORT_INVOICE_STATUSES.has(raw)) return null;
+  if (OPEN_IMPORT_STATUSES.has(raw)) return "issued";
+  if (PAID_IMPORT_STATUSES.has(raw) || raw.endsWith("_paid")) return "paid";
+  if (VOID_IMPORT_STATUSES.has(raw) || raw.includes("void") || raw.includes("cancel")) return "void";
+  if (DRAFT_IMPORT_STATUSES.has(raw)) return "draft";
+  return "issued";
 }
 
 export function resolveImportedInvoicePaidAt(row: InvoiceImportRow, issuedAt: string, status = normalizeInvoiceImportStatus(row)) {
@@ -143,6 +154,13 @@ export async function processInvoiceImportJobBatch(supabase: SupabaseClient<DB>,
       const total = num(row.total) ?? num(row.subtotal) ?? 0;
       const amountPaid = num(row.amount_paid) ?? 0;
       const status = normalizeInvoiceImportStatus(row);
+      if (!status) {
+        const reason = "Invoice status represents a credit/refund reversal and is not imported as an invoice.";
+        counts.skipped++;
+        sample.skippedRows.push({ row: staged.row_number, reason, invoiceNumber, workOrderNumber, sourceStatus: clean(row.payment_status ?? row.status) });
+        await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id);
+        continue;
+      }
 
       inserts.push({
         stagedId: staged.id,

--- a/tests/invoice-import-work-order-optional.test.ts
+++ b/tests/invoice-import-work-order-optional.test.ts
@@ -50,10 +50,23 @@ describe("historical invoice imports", () => {
   });
 
   it("does not require paid_at for unpaid, void, or draft imported invoices", () => {
-    expect(normalizeInvoiceImportStatus({ payment_status: "unpaid" })).toBe("imported");
+    expect(normalizeInvoiceImportStatus({ payment_status: "unpaid" })).toBe("issued");
     expect(resolveImportedInvoicePaidAt({ payment_status: "unpaid", paid_date: "2024-03-20" }, "2024-03-18T00:00:00.000Z")).toBeNull();
     expect(resolveImportedInvoicePaidAt({ status: "void" }, "2024-03-18T00:00:00.000Z")).toBeNull();
     expect(resolveImportedInvoicePaidAt({ status: "draft" }, "2024-03-18T00:00:00.000Z")).toBeNull();
+  });
+
+  it("normalizes common CSV invoice statuses to canonical database statuses", () => {
+    expect(normalizeInvoiceImportStatus({ payment_status: "open" })).toBe("issued");
+    expect(normalizeInvoiceImportStatus({ payment_status: "partial" })).toBe("issued");
+    expect(normalizeInvoiceImportStatus({ payment_status: "partially_paid" })).toBe("issued");
+    expect(normalizeInvoiceImportStatus({ payment_status: "paid_in_full" })).toBe("paid");
+    expect(normalizeInvoiceImportStatus({ payment_status: "closed_paid" })).toBe("paid");
+    expect(normalizeInvoiceImportStatus({ payment_status: "void" })).toBe("void");
+    expect(normalizeInvoiceImportStatus({ payment_status: "cancelled" })).toBe("void");
+    expect(normalizeInvoiceImportStatus({ payment_status: "written_off" })).toBe("void");
+    expect(normalizeInvoiceImportStatus({ payment_status: "credit" })).toBeNull();
+    expect(normalizeInvoiceImportStatus({ payment_status: "refunded" })).toBeNull();
   });
 
   it("preserves legacy invoice and work-order numbers as text metadata", () => {


### PR DESCRIPTION
### Motivation
- The CSV importer normalized unpaid/open-like source statuses to a non-canonical `imported` value, causing the `invoices_status_chk` DB constraint to reject many rows.
- Importer input should be normalized to the app's existing invoice lifecycle (so DB constraints remain unchanged) and credit/refund rows should not create invoices.

### Description
- Replace ad-hoc importer mapping with canonical importer targets and sets: `draft`, `issued`, `paid`, `void`, and a `NEVER_IMPORT_INVOICE_STATUSES` set for credit/refund-like rows.
- Update `normalizeInvoiceImportStatus` to map common CSV/source aliases (e.g. `unpaid`, `open`, `partial`, `partially_paid`, `paid_in_full`, `closed_paid`, `void`, `cancelled`, `written_off`) to canonical statuses and return `null` for non-invoice statuses to skip them.
- Add skip handling in the import pipeline when `normalizeInvoiceImportStatus` returns `null` and preserve existing `paid_at` logic for `paid` imports.
- Files changed: `features/billing/server/invoice-import-job.ts`, `tests/invoice-import-work-order-optional.test.ts`.

### Testing
- Ran typecheck with `npm run typecheck`, result: passed.
- Ran linter with `npx eslint features/billing app/api/internal/import-jobs`, result: passed.
- Ran targeted unit tests with `npx vitest run tests/invoice-import-work-order-optional.test.ts`, result: all tests passed.
- Ran full test suite with `npx vitest run tests`; result: importer-related tests pass, one unrelated pre-existing test failure remains in `tests/vehicle-csv-import-route.test.ts` (expects a specific source substring in `CsvImportProgress`).
- No SQL migration was required and none was applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bd5f40b9c8328b3154d17d2d778b5)