### PR TITLE
Treat invoice-number unique constraint violations as skipped duplicates and prevent same-batch duplicates

### DIFF
--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -21,6 +21,13 @@ const num = (value: unknown) => { const text = clean(value); if (!text) return n
 const date = (value: unknown) => { const text = clean(value); if (!text) return null; const parsed = new Date(text); return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString(); };
 const vin = (value: unknown) => clean(value)?.toUpperCase().replace(/[^A-Z0-9]/g, "") ?? null;
 
+function isInvoiceNumberUniqueConflict(error: unknown) {
+  const candidate = error as { code?: string; message?: string; details?: string; hint?: string } | null | undefined;
+  if (!candidate) return false;
+  const text = [candidate.message, candidate.details, candidate.hint].filter(Boolean).join(" ");
+  return candidate.code === "23505" && text.includes("invoices_shop_invoice_number_idx");
+}
+
 async function duplicateInvoice(client: SupabaseClient, shopId: string, invoiceNumber: string | null, sourceId: string | null) {
   if (invoiceNumber) {
     const { data, error } = await client.from("invoices").select("id").eq("shop_id", shopId).eq("invoice_number", invoiceNumber).limit(1);
@@ -119,6 +126,7 @@ export async function processInvoiceImportJobBatch(supabase: SupabaseClient<DB>,
 
   const counts: Counts = { imported: 0, skipped: 0, failed: 0, duplicates: 0 };
   const sample = samples(job.summary);
+  const pendingInvoiceNumbers = new Set<string>();
   const inserts: Array<{ stagedId: string; rowNumber: number; invoiceNumber: string | null; workOrderNumber: string | null; payload: DB["public"]["Tables"]["invoices"]["Insert"] }> = [];
 
   for (const staged of rows) {
@@ -137,10 +145,10 @@ export async function processInvoiceImportJobBatch(supabase: SupabaseClient<DB>,
         continue;
       }
 
-      if (await duplicateInvoice(client, job.shop_id, invoiceNumber, sourceId)) {
+      if (pendingInvoiceNumbers.has(invoiceNumber) || await duplicateInvoice(client, job.shop_id, invoiceNumber, sourceId)) {
         counts.skipped++;
         counts.duplicates++;
-        const reason = "Duplicate invoice already exists.";
+        const reason = pendingInvoiceNumbers.has(invoiceNumber) ? "Duplicate invoice already exists in this import batch." : "Duplicate invoice already exists.";
         sample.skippedRows.push({ row: staged.row_number, reason, invoiceNumber, workOrderNumber });
         await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id);
         continue;
@@ -162,6 +170,7 @@ export async function processInvoiceImportJobBatch(supabase: SupabaseClient<DB>,
         continue;
       }
 
+      pendingInvoiceNumbers.add(invoiceNumber);
       inserts.push({
         stagedId: staged.id,
         rowNumber: staged.row_number,
@@ -216,9 +225,17 @@ export async function processInvoiceImportJobBatch(supabase: SupabaseClient<DB>,
       for (const entry of batch) {
         const { error: rowError } = await supabase.from("invoices").insert(entry.payload);
         if (rowError) {
-          counts.failed++;
-          sample.failedRows.push({ row: entry.rowNumber, error: rowError.message, invoiceNumber: entry.invoiceNumber, workOrderNumber: entry.workOrderNumber });
-          await client.from("import_job_rows").update({ status: "failed", error_message: rowError.message }).eq("id", entry.stagedId);
+          if (isInvoiceNumberUniqueConflict(rowError)) {
+            counts.skipped++;
+            counts.duplicates++;
+            const reason = "Duplicate invoice already exists.";
+            sample.skippedRows.push({ row: entry.rowNumber, reason, invoiceNumber: entry.invoiceNumber, workOrderNumber: entry.workOrderNumber });
+            await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", entry.stagedId);
+          } else {
+            counts.failed++;
+            sample.failedRows.push({ row: entry.rowNumber, error: rowError.message, invoiceNumber: entry.invoiceNumber, workOrderNumber: entry.workOrderNumber });
+            await client.from("import_job_rows").update({ status: "failed", error_message: rowError.message }).eq("id", entry.stagedId);
+          }
         } else {
           counts.imported++;
           await client.from("import_job_rows").update({ status: "imported" }).eq("id", entry.stagedId);


### PR DESCRIPTION
### Motivation
- The importer was counting PostgreSQL unique-index rejections on `(shop_id, invoice_number)` as failures because duplicates that existed only inside the current CSV/batch reached the INSERT step and were rejected by the `invoices_shop_invoice_number_idx` index.
- The goal is to make duplicate handling deterministic so index conflicts are treated identically to other detected duplicates (skipped + duplicate_count++) and to make repeated imports idempotent.

### Description
- Add an in-memory `Set` (`pendingInvoiceNumbers`) to track invoice numbers queued for insertion in the current processing batch and skip later rows in the same batch with the same invoice number. (file changed: `features/billing/server/invoice-import-job.ts`).
- Add `isInvoiceNumberUniqueConflict` to detect Postgres `23505` unique-violation errors that reference `invoices_shop_invoice_number_idx`, and treat those row-level insert errors as skipped duplicates instead of failed rows. (file changed: `features/billing/server/invoice-import-job.ts`).
- Preserve the existing bulk-insert then per-row fallback architecture and only reclassify index-constraint errors as skips, leaving genuine insert errors counted as failures. (file changed: `features/billing/server/invoice-import-job.ts`).
- Update duplicate accounting so `skipped_count` and `summary.duplicates` include both pre-insert and index-conflict duplicates while `failed_count` is reserved for non-duplicate failures. (file changed: `features/billing/server/invoice-import-job.ts`).

### Testing
- Ran `npm run typecheck` which completed successfully with no TS errors.
- Ran `npx eslint features/billing app/api/internal/import-jobs` which completed without reported lint errors.
- Ran `npx vitest run tests` which mostly passed but surfaced a single pre-existing unrelated test failure in `tests/vehicle-csv-import-route.test.ts` (UI assertion expecting a literal `processed}/{total} rows` string), so the failure is outside the invoice-import changes and did not indicate a regression in invoice import handling.

Files changed:
- `features/billing/server/invoice-import-job.ts`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4be18761b08328a21d244714494d65)