### PR TITLE
Limit and improve historical invoice display; strengthen CSV import customer/vehicle matching

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
@@ -32,6 +32,8 @@ type InvoiceMetadata = {
   vehicle_id?: string | null;
   source_system?: string | null;
   raw_row?: Record<string, unknown> | null;
+  legacy_customer_id?: string | null;
+  legacy_vehicle_id?: string | null;
 };
 
 type Status =
@@ -125,6 +127,9 @@ export default function BillingPage(): JSX.Element {
   const [q, setQ] = useState("");
   const [status, setStatus] = useState<Status | "">("");
   const [err, setErr] = useState<string | null>(null);
+  const [historicalVisibleLimit, setHistoricalVisibleLimit] = useState(25);
+  const [expandedHistoricalInvoiceId, setExpandedHistoricalInvoiceId] =
+    useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -267,6 +272,8 @@ export default function BillingPage(): JSX.Element {
 
     setRows(filtered);
     setHistoricalInvoices(statusFilteredHistoricalInvoices);
+    setHistoricalVisibleLimit(25);
+    setExpandedHistoricalInvoiceId(null);
     setLoading(false);
   }, [q, status, supabase]);
 
@@ -409,6 +416,10 @@ export default function BillingPage(): JSX.Element {
 
   const total = rows.length + historicalInvoices.length;
   const historicalCount = historicalInvoices.length;
+  const visibleHistoricalInvoices = historicalInvoices.slice(
+    0,
+    historicalVisibleLimit,
+  );
   const completedCount = useMemo(
     () =>
       rows.filter(
@@ -564,7 +575,7 @@ export default function BillingPage(): JSX.Element {
             />
           ))}
         </div>
-      ) : rows.length === 0 ? (
+      ) : rows.length === 0 && historicalInvoices.length === 0 ? (
         <div className="rounded-[24px] border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-6 text-sm text-neutral-400">
           No live billing work orders or imported historical invoices match your
           current filters.
@@ -771,7 +782,8 @@ export default function BillingPage(): JSX.Element {
                 </p>
               </div>
               <div className="text-sm font-semibold text-amber-100">
-                {historicalInvoices.length} shown
+                Showing {visibleHistoricalInvoices.length} of{" "}
+                {historicalInvoices.length}
               </div>
             </div>
           </div>
@@ -788,7 +800,7 @@ export default function BillingPage(): JSX.Element {
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/10">
-                {historicalInvoices.map((invoice) => {
+                {visibleHistoricalInvoices.map((invoice) => {
                   const metadata = invoice.metadata as InvoiceMetadata | null;
                   const rawRow = metadata?.raw_row ?? {};
                   const customerName =
@@ -810,49 +822,130 @@ export default function BillingPage(): JSX.Element {
                     metadata?.vin ?? String(rawRow.vin ?? "No VIN");
 
                   return (
-                    <tr key={invoice.id} className="text-neutral-200">
-                      <td className="px-5 py-4">
-                        <div className="font-semibold text-white">
-                          {invoice.invoice_number ??
-                            `#${invoice.id.slice(0, 8)}`}
-                        </div>
-                        <div className="mt-1 inline-flex rounded-full border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-100">
-                          Read-only historical
-                        </div>
-                      </td>
-                      <td className="px-5 py-4">
-                        <div>{customerName}</div>
-                        {invoice.customers?.email ? (
-                          <div className="text-xs text-neutral-500">
-                            {invoice.customers.email}
+                    <Fragment key={invoice.id}>
+                      <tr
+                        className="cursor-pointer text-neutral-200 transition hover:bg-white/[0.04]"
+                        onClick={() =>
+                          setExpandedHistoricalInvoiceId((current) =>
+                            current === invoice.id ? null : invoice.id,
+                          )
+                        }
+                      >
+                        <td className="px-5 py-4">
+                          <div className="font-semibold text-white">
+                            {invoice.invoice_number ??
+                              `#${invoice.id.slice(0, 8)}`}
                           </div>
-                        ) : null}
-                      </td>
-                      <td className="px-5 py-4">
-                        <div>{workOrderText}</div>
-                        <div className="text-xs text-neutral-500">
-                          VIN {vinText}
-                        </div>
-                      </td>
-                      <td className="px-5 py-4">
-                        <span className="inline-flex rounded-full border border-amber-400/30 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.12em] text-amber-100">
-                          {invoice.status}
-                        </span>
-                      </td>
-                      <td className="px-5 py-4 text-right font-semibold text-[var(--accent-copper-light)]">
-                        {formatMoney(invoice.total)}
-                      </td>
-                      <td className="px-5 py-4 text-neutral-300">
-                        {invoice.issued_at
-                          ? format(new Date(invoice.issued_at), "PP")
-                          : "—"}
-                      </td>
-                    </tr>
+                          <div className="mt-1 inline-flex rounded-full border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-100">
+                            Read-only historical
+                          </div>
+                        </td>
+                        <td className="px-5 py-4">
+                          <div>{customerName}</div>
+                          {invoice.customers?.email ? (
+                            <div className="text-xs text-neutral-500">
+                              {invoice.customers.email}
+                            </div>
+                          ) : null}
+                        </td>
+                        <td className="px-5 py-4">
+                          <div>{workOrderText}</div>
+                          <div className="text-xs text-neutral-500">
+                            VIN {vinText}
+                          </div>
+                        </td>
+                        <td className="px-5 py-4">
+                          <span className="inline-flex rounded-full border border-amber-400/30 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.12em] text-amber-100">
+                            {invoice.status}
+                          </span>
+                        </td>
+                        <td className="px-5 py-4 text-right font-semibold text-[var(--accent-copper-light)]">
+                          {formatMoney(invoice.total)}
+                        </td>
+                        <td className="px-5 py-4 text-neutral-300">
+                          {invoice.issued_at
+                            ? format(new Date(invoice.issued_at), "PP")
+                            : "—"}
+                          <div className="mt-1 text-xs text-amber-100/80">
+                            {expandedHistoricalInvoiceId === invoice.id
+                              ? "Hide details"
+                              : "View details"}
+                          </div>
+                        </td>
+                      </tr>
+                      {expandedHistoricalInvoiceId === invoice.id ? (
+                        <tr className="bg-black/20 text-neutral-300">
+                          <td colSpan={6} className="px-5 py-4">
+                            <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4 md:grid-cols-3">
+                              <div>
+                                <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+                                  Legacy customer id
+                                </div>
+                                <div className="mt-1 text-sm text-white">
+                                  {String(
+                                    rawRow.customer_id ??
+                                      metadata?.legacy_customer_id ??
+                                      "—",
+                                  )}
+                                </div>
+                              </div>
+                              <div>
+                                <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+                                  Legacy vehicle id
+                                </div>
+                                <div className="mt-1 text-sm text-white">
+                                  {String(
+                                    rawRow.vehicle_id ??
+                                      metadata?.legacy_vehicle_id ??
+                                      "—",
+                                  )}
+                                </div>
+                              </div>
+                              <div>
+                                <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+                                  Source
+                                </div>
+                                <div className="mt-1 text-sm text-white">
+                                  {metadata?.source_system ??
+                                    String(
+                                      rawRow.source_system ?? "CSV import",
+                                    )}
+                                </div>
+                              </div>
+                              <div className="md:col-span-3">
+                                <div className="text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+                                  Notes
+                                </div>
+                                <div className="mt-1 whitespace-pre-wrap text-sm text-neutral-200">
+                                  {invoice.notes ||
+                                    String(
+                                      rawRow.description ??
+                                        rawRow.notes ??
+                                        "No notes",
+                                    )}
+                                </div>
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      ) : null}
+                    </Fragment>
                   );
                 })}
               </tbody>
             </table>
           </div>
+          {visibleHistoricalInvoices.length < historicalInvoices.length ? (
+            <div className="border-t border-amber-500/15 px-5 py-4 text-center sm:px-6">
+              <button
+                type="button"
+                onClick={() => setHistoricalVisibleLimit((limit) => limit + 25)}
+                className="rounded-full border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm font-semibold text-amber-100 transition hover:bg-amber-500/20"
+              >
+                Show 25 more historical invoices
+              </button>
+            </div>
+          ) : null}
         </section>
       ) : null}
     </div>

--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -30,7 +30,17 @@ type Counts = {
   failed: number;
   duplicates: number;
 };
-type MatchedCustomer = { id: string; external_id?: string | null };
+type MatchedCustomer = {
+  id: string;
+  external_id?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  phone_number?: string | null;
+  name?: string | null;
+  business_name?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+};
 type MatchedVehicle = {
   id: string;
   external_id?: string | null;
@@ -49,6 +59,11 @@ const clean = (value: unknown) => {
   return text || null;
 };
 const key = (value: unknown) => clean(value)?.toLowerCase() ?? null;
+const phone = (value: unknown) => {
+  const text = clean(value);
+  if (!text) return null;
+  return text.replace(/\D/g, "") || text;
+};
 const num = (value: unknown) => {
   const text = clean(value);
   if (!text) return null;
@@ -65,6 +80,14 @@ const vin = (value: unknown) =>
   clean(value)
     ?.toUpperCase()
     .replace(/[^A-Z0-9]/g, "") ?? null;
+
+function matchedCustomerName(customer: MatchedCustomer): string | null {
+  return (
+    clean(customer.name) ??
+    clean(customer.business_name) ??
+    clean([customer.first_name, customer.last_name].filter(Boolean).join(" "))
+  );
+}
 
 function isInvoiceNumberUniqueConflict(error: unknown) {
   const candidate = error as
@@ -251,7 +274,9 @@ export async function processInvoiceImportJobBatch(
     await Promise.all([
       client
         .from("customers")
-        .select("id, external_id")
+        .select(
+          "id, external_id, email, phone, phone_number, name, business_name, first_name, last_name",
+        )
         .eq("shop_id", job.shop_id),
       client
         .from("vehicles")
@@ -264,10 +289,25 @@ export async function processInvoiceImportJobBatch(
     ]);
 
   const customersById = new Map<string, MatchedCustomer>();
+  const customersByEmail = new Map<string, MatchedCustomer>();
+  const customersByPhone = new Map<string, MatchedCustomer>();
+  const customersByName = new Map<string, MatchedCustomer>();
   for (const customer of (customers ?? []) as MatchedCustomer[]) {
     if (customer.id) customersById.set(customer.id, customer);
-    const external = String(customer.external_id ?? "").toLowerCase();
-    if (external) customersById.set(external, customer);
+    const external = key(customer.external_id);
+    if (external && !customersById.has(external))
+      customersById.set(external, customer);
+    const email = key(customer.email);
+    if (email && !customersByEmail.has(email))
+      customersByEmail.set(email, customer);
+    for (const phoneValue of [customer.phone, customer.phone_number]) {
+      const normalizedPhone = phone(phoneValue);
+      if (normalizedPhone && !customersByPhone.has(normalizedPhone)) {
+        customersByPhone.set(normalizedPhone, customer);
+      }
+    }
+    const name = key(matchedCustomerName(customer));
+    if (name && !customersByName.has(name)) customersByName.set(name, customer);
   }
 
   const vehiclesById = new Map<string, MatchedVehicle>();
@@ -353,10 +393,40 @@ export async function processInvoiceImportJobBatch(
           ? (vehiclesById.get(clean(row.vehicle_id)!) ??
             vehiclesById.get(clean(row.vehicle_id)!.toLowerCase()))
           : null) ?? (vin(row.vin) ? vehiclesById.get(vin(row.vin)!) : null);
-      const customer = clean(row.customer_id)
-        ? (customersById.get(clean(row.customer_id)!) ??
-          customersById.get(clean(row.customer_id)!.toLowerCase()))
+      const legacyCustomerId = clean(row.customer_id);
+      const customerByLegacyId = legacyCustomerId
+        ? (customersById.get(legacyCustomerId) ??
+          customersById.get(legacyCustomerId.toLowerCase()) ??
+          null)
         : null;
+      const customerEmailKey = key(row.customer_email ?? row.email);
+      const customerByEmail = customerEmailKey
+        ? (customersByEmail.get(customerEmailKey) ?? null)
+        : null;
+      const customerPhoneKey = phone(row.customer_phone ?? row.phone);
+      const customerByPhone = customerPhoneKey
+        ? (customersByPhone.get(customerPhoneKey) ?? null)
+        : null;
+      const customerNameKey = key(
+        row.customer_name ?? row.customer ?? row.name,
+      );
+      const customerByName = customerNameKey
+        ? (customersByName.get(customerNameKey) ?? null)
+        : null;
+      const customer =
+        customerByLegacyId ??
+        customerByEmail ??
+        customerByPhone ??
+        customerByName;
+      const customerMatchSource = customerByLegacyId
+        ? "customer_id"
+        : customerByEmail
+          ? "email"
+          : customerByPhone
+            ? "phone"
+            : customerByName
+              ? "name"
+              : null;
       const customerId =
         customer?.id ?? workOrder?.customer_id ?? vehicle?.customer_id ?? null;
       const vehicleId = vehicle?.id ?? workOrder?.vehicle_id ?? null;
@@ -410,6 +480,17 @@ export async function processInvoiceImportJobBatch(
             read_only: true,
             import_type: "invoice_csv",
             imported_invoice_id: sourceId,
+            legacy_customer_id: legacyCustomerId,
+            legacy_vehicle_id: clean(row.vehicle_id),
+            matched_customer_id: customer?.id ?? null,
+            matched_vehicle_id: vehicle?.id ?? null,
+            customer_match_source:
+              customerMatchSource ??
+              (workOrder?.customer_id
+                ? "work_order_customer_id"
+                : vehicle?.customer_id
+                  ? "vehicle_customer_id"
+                  : null),
             source_system: clean(row.source_system),
             work_order_number: workOrderNumber,
             vehicle_id: vehicleId,


### PR DESCRIPTION
### Motivation
- Root cause: the CSV invoice importer previously only indexed customers by `id` and `external_id`, so rows that referenced customers by email, phone, or name could not resolve a `customer_id` and appeared as “Unknown customer”.
- The Customer Billing UI was rendering hundreds of imported historical invoices at once causing poor UX and potential rendering/performance issues and needed a capped, incremental display with quick detail access.
- Changes must be non-destructive: imported invoices remain read-only and the importer must not create customers, vehicles, work orders, or active invoices.

### Description
- Importer: expand customer load to include `email`, `phone`, `phone_number`, `name`, `business_name`, `first_name`, and `last_name`, build lookup maps (legacy id, email, phone, name), and match in order: legacy `customer_id` → email → phone → name → fallback to `work_order.customer_id` → `vehicle.customer_id`; vehicle matching still resolves by `id`, `external_id`, and normalized VIN and `vehicle.customer_id` is used as a fallback customer when `customer_id` is missing. 
- Metadata: preserve legacy identifiers and match info by storing `legacy_customer_id`, `legacy_vehicle_id`, `matched_customer_id`, `matched_vehicle_id`, and `customer_match_source` on imported invoice `metadata` for auditing and troubleshooting. 
- UI: limit historical invoice rendering to the newest 25 by default, reset the visible limit on search/filter reload, add a “Show 25 more historical invoices” control that increments the visible window, and make each historical row clickable/expandable to reveal legacy customer id, legacy vehicle id, source, and notes without changing live billing actions. 
- Files changed: `app/billing/page.tsx` and `features/billing/server/invoice-import-job.ts`.

### Testing
- Ran `npm run typecheck` (TypeScript `tsc --noEmit`) and it completed successfully. 
- Ran `npx eslint features/billing app/customer-billing app/api/import-jobs app/api/internal/import-jobs` which failed due to the provided pattern `app/customer-billing` not existing in the repo, then ran `npx eslint features/billing app/api/import-jobs app/api/internal/import-jobs app/billing` which completed without errors.
- Verified behavior changes in the Billing page: historical list now defaults to 25, “Show 25 more” increments by 25, search/filter still restricts results, and expanded rows display preserved legacy metadata (functional verification during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4becae8b248328bf1058e259f20344)