### PR TITLE
Fix invoice import customer external ID matching

### DIFF
--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -89,6 +89,88 @@ function matchedCustomerName(customer: MatchedCustomer): string | null {
   );
 }
 
+type CustomerLookupMaps = {
+  byExternalId: Map<string, MatchedCustomer>;
+  byExternalIdKey: Map<string, MatchedCustomer>;
+  byEmail: Map<string, MatchedCustomer>;
+  byPhone: Map<string, MatchedCustomer>;
+  byName: Map<string, MatchedCustomer>;
+};
+
+export function buildCustomerLookupMaps(
+  customers: MatchedCustomer[],
+): CustomerLookupMaps {
+  const byExternalId = new Map<string, MatchedCustomer>();
+  const byExternalIdKey = new Map<string, MatchedCustomer>();
+  const byEmail = new Map<string, MatchedCustomer>();
+  const byPhone = new Map<string, MatchedCustomer>();
+  const byName = new Map<string, MatchedCustomer>();
+
+  for (const customer of customers) {
+    const externalId = clean(customer.external_id);
+    if (externalId && !byExternalId.has(externalId)) {
+      byExternalId.set(externalId, customer);
+    }
+
+    const externalIdKey = key(customer.external_id);
+    if (externalIdKey && !byExternalIdKey.has(externalIdKey)) {
+      byExternalIdKey.set(externalIdKey, customer);
+    }
+
+    const email = key(customer.email);
+    if (email && !byEmail.has(email)) byEmail.set(email, customer);
+
+    for (const phoneValue of [customer.phone, customer.phone_number]) {
+      const normalizedPhone = phone(phoneValue);
+      if (normalizedPhone && !byPhone.has(normalizedPhone)) {
+        byPhone.set(normalizedPhone, customer);
+      }
+    }
+
+    const name = key(matchedCustomerName(customer));
+    if (name && !byName.has(name)) byName.set(name, customer);
+  }
+
+  return { byExternalId, byExternalIdKey, byEmail, byPhone, byName };
+}
+
+export function resolveInvoiceImportCustomer(
+  row: InvoiceImportRow,
+  customerLookupMaps: CustomerLookupMaps,
+) {
+  const legacyCustomerId = clean(row.customer_id);
+  const customerByLegacyId = legacyCustomerId
+    ? (customerLookupMaps.byExternalId.get(legacyCustomerId) ??
+      customerLookupMaps.byExternalIdKey.get(key(legacyCustomerId)!) ??
+      null)
+    : null;
+  const customerEmailKey = key(row.customer_email ?? row.email);
+  const customerByEmail = customerEmailKey
+    ? (customerLookupMaps.byEmail.get(customerEmailKey) ?? null)
+    : null;
+  const customerPhoneKey = phone(row.customer_phone ?? row.phone);
+  const customerByPhone = customerPhoneKey
+    ? (customerLookupMaps.byPhone.get(customerPhoneKey) ?? null)
+    : null;
+  const customerNameKey = key(row.customer_name ?? row.customer ?? row.name);
+  const customerByName = customerNameKey
+    ? (customerLookupMaps.byName.get(customerNameKey) ?? null)
+    : null;
+  const customer =
+    customerByLegacyId ?? customerByEmail ?? customerByPhone ?? customerByName;
+  const customerMatchSource = customerByLegacyId
+    ? "customer_external_id"
+    : customerByEmail
+      ? "email"
+      : customerByPhone
+        ? "phone"
+        : customerByName
+          ? "name"
+          : null;
+
+  return { customer, customerMatchSource, legacyCustomerId };
+}
+
 function isInvoiceNumberUniqueConflict(error: unknown) {
   const candidate = error as
     | { code?: string; message?: string; details?: string; hint?: string }
@@ -288,27 +370,9 @@ export async function processInvoiceImportJobBatch(
         .eq("shop_id", job.shop_id),
     ]);
 
-  const customersById = new Map<string, MatchedCustomer>();
-  const customersByEmail = new Map<string, MatchedCustomer>();
-  const customersByPhone = new Map<string, MatchedCustomer>();
-  const customersByName = new Map<string, MatchedCustomer>();
-  for (const customer of (customers ?? []) as MatchedCustomer[]) {
-    if (customer.id) customersById.set(customer.id, customer);
-    const external = key(customer.external_id);
-    if (external && !customersById.has(external))
-      customersById.set(external, customer);
-    const email = key(customer.email);
-    if (email && !customersByEmail.has(email))
-      customersByEmail.set(email, customer);
-    for (const phoneValue of [customer.phone, customer.phone_number]) {
-      const normalizedPhone = phone(phoneValue);
-      if (normalizedPhone && !customersByPhone.has(normalizedPhone)) {
-        customersByPhone.set(normalizedPhone, customer);
-      }
-    }
-    const name = key(matchedCustomerName(customer));
-    if (name && !customersByName.has(name)) customersByName.set(name, customer);
-  }
+  const customerLookupMaps = buildCustomerLookupMaps(
+    (customers ?? []) as MatchedCustomer[],
+  );
 
   const vehiclesById = new Map<string, MatchedVehicle>();
   for (const vehicle of (vehicles ?? []) as MatchedVehicle[]) {
@@ -393,41 +457,10 @@ export async function processInvoiceImportJobBatch(
           ? (vehiclesById.get(clean(row.vehicle_id)!) ??
             vehiclesById.get(clean(row.vehicle_id)!.toLowerCase()))
           : null) ?? (vin(row.vin) ? vehiclesById.get(vin(row.vin)!) : null);
-      const legacyCustomerId = clean(row.customer_id);
-      const customerByLegacyId = legacyCustomerId
-        ? (customersById.get(legacyCustomerId) ??
-          customersById.get(legacyCustomerId.toLowerCase()) ??
-          null)
-        : null;
-      const customerEmailKey = key(row.customer_email ?? row.email);
-      const customerByEmail = customerEmailKey
-        ? (customersByEmail.get(customerEmailKey) ?? null)
-        : null;
-      const customerPhoneKey = phone(row.customer_phone ?? row.phone);
-      const customerByPhone = customerPhoneKey
-        ? (customersByPhone.get(customerPhoneKey) ?? null)
-        : null;
-      const customerNameKey = key(
-        row.customer_name ?? row.customer ?? row.name,
-      );
-      const customerByName = customerNameKey
-        ? (customersByName.get(customerNameKey) ?? null)
-        : null;
-      const customer =
-        customerByLegacyId ??
-        customerByEmail ??
-        customerByPhone ??
-        customerByName;
-      const customerMatchSource = customerByLegacyId
-        ? "customer_id"
-        : customerByEmail
-          ? "email"
-          : customerByPhone
-            ? "phone"
-            : customerByName
-              ? "name"
-              : null;
-      const fallbackCustomerId = vehicle?.customer_id ?? workOrder?.customer_id ?? null;
+      const { customer, customerMatchSource, legacyCustomerId } =
+        resolveInvoiceImportCustomer(row, customerLookupMaps);
+      const fallbackCustomerId =
+        vehicle?.customer_id ?? workOrder?.customer_id ?? null;
       const customerId = customer?.id ?? fallbackCustomerId;
       const vehicleId = vehicle?.id ?? workOrder?.vehicle_id ?? null;
       const customerMatchSourceResolved =

--- a/tests/invoice-import-work-order-optional.test.ts
+++ b/tests/invoice-import-work-order-optional.test.ts
@@ -1,9 +1,20 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { normalizeInvoiceImportStatus, resolveImportedInvoicePaidAt } from "../features/billing/server/invoice-import-job";
+import {
+  buildCustomerLookupMaps,
+  normalizeInvoiceImportStatus,
+  resolveImportedInvoicePaidAt,
+  resolveInvoiceImportCustomer,
+} from "../features/billing/server/invoice-import-job";
 
-const importer = readFileSync("features/billing/server/invoice-import-job.ts", "utf8");
-const migration = readFileSync("db/sql/2026-07-06_invoice_import_work_order_optional.sql", "utf8");
+const importer = readFileSync(
+  "features/billing/server/invoice-import-job.ts",
+  "utf8",
+);
+const migration = readFileSync(
+  "db/sql/2026-07-06_invoice_import_work_order_optional.sql",
+  "utf8",
+);
 
 describe("historical invoice imports", () => {
   it("keeps the existing matched-work-order-or-null importer behavior", () => {
@@ -22,9 +33,15 @@ describe("historical invoice imports", () => {
     expect(migration).toContain("must belong to a work_order");
     expect(migration).toContain("invoice_is_historical_import");
     expect(migration).toContain("p_metadata->>'import_type' = 'invoice_csv'");
-    expect(migration).toContain("enforce_invoice_work_order_for_active_invoices");
-    expect(migration).toContain("drop constraint if exists invoices_work_order_id_required_chk");
-    expect(migration).toContain("add constraint invoices_work_order_id_required_chk");
+    expect(migration).toContain(
+      "enforce_invoice_work_order_for_active_invoices",
+    );
+    expect(migration).toContain(
+      "drop constraint if exists invoices_work_order_id_required_chk",
+    );
+    expect(migration).toContain(
+      "add constraint invoices_work_order_id_required_chk",
+    );
     expect(migration).toContain("work_order_id is not null");
   });
 
@@ -34,39 +51,91 @@ describe("historical invoice imports", () => {
   });
 
   it("keeps the paid invoice constraint and lets the importer satisfy it", () => {
-    expect(migration).toContain("drop constraint if exists invoices_paid_requires_paid_at_chk");
-    expect(migration).toContain("add constraint invoices_paid_requires_paid_at_chk");
-    expect(migration).toContain("check (status <> 'paid' or paid_at is not null)");
+    expect(migration).toContain(
+      "drop constraint if exists invoices_paid_requires_paid_at_chk",
+    );
+    expect(migration).toContain(
+      "add constraint invoices_paid_requires_paid_at_chk",
+    );
+    expect(migration).toContain(
+      "check (status <> 'paid' or paid_at is not null)",
+    );
   });
 
   it("sets paid_at from paid_date for paid imported invoices", () => {
-    const paidAt = resolveImportedInvoicePaidAt({ payment_status: "paid", paid_date: "2024-03-20", invoice_date: "2024-03-18" }, "2024-03-18T00:00:00.000Z");
+    const paidAt = resolveImportedInvoicePaidAt(
+      {
+        payment_status: "paid",
+        paid_date: "2024-03-20",
+        invoice_date: "2024-03-18",
+      },
+      "2024-03-18T00:00:00.000Z",
+    );
     expect(paidAt).toBe("2024-03-20T00:00:00.000Z");
   });
 
   it("falls back to invoice_date for paid imported invoices without paid_date", () => {
     const issuedAt = "2024-03-18T00:00:00.000Z";
-    expect(resolveImportedInvoicePaidAt({ payment_status: "paid" }, issuedAt)).toBe(issuedAt);
+    expect(
+      resolveImportedInvoicePaidAt({ payment_status: "paid" }, issuedAt),
+    ).toBe(issuedAt);
   });
 
   it("does not require paid_at for unpaid, void, or draft imported invoices", () => {
-    expect(normalizeInvoiceImportStatus({ payment_status: "unpaid" })).toBe("issued");
-    expect(resolveImportedInvoicePaidAt({ payment_status: "unpaid", paid_date: "2024-03-20" }, "2024-03-18T00:00:00.000Z")).toBeNull();
-    expect(resolveImportedInvoicePaidAt({ status: "void" }, "2024-03-18T00:00:00.000Z")).toBeNull();
-    expect(resolveImportedInvoicePaidAt({ status: "draft" }, "2024-03-18T00:00:00.000Z")).toBeNull();
+    expect(normalizeInvoiceImportStatus({ payment_status: "unpaid" })).toBe(
+      "issued",
+    );
+    expect(
+      resolveImportedInvoicePaidAt(
+        { payment_status: "unpaid", paid_date: "2024-03-20" },
+        "2024-03-18T00:00:00.000Z",
+      ),
+    ).toBeNull();
+    expect(
+      resolveImportedInvoicePaidAt(
+        { status: "void" },
+        "2024-03-18T00:00:00.000Z",
+      ),
+    ).toBeNull();
+    expect(
+      resolveImportedInvoicePaidAt(
+        { status: "draft" },
+        "2024-03-18T00:00:00.000Z",
+      ),
+    ).toBeNull();
   });
 
   it("normalizes common CSV invoice statuses to canonical database statuses", () => {
-    expect(normalizeInvoiceImportStatus({ payment_status: "open" })).toBe("issued");
-    expect(normalizeInvoiceImportStatus({ payment_status: "partial" })).toBe("issued");
-    expect(normalizeInvoiceImportStatus({ payment_status: "partially_paid" })).toBe("issued");
-    expect(normalizeInvoiceImportStatus({ payment_status: "paid_in_full" })).toBe("paid");
-    expect(normalizeInvoiceImportStatus({ payment_status: "closed_paid" })).toBe("paid");
-    expect(normalizeInvoiceImportStatus({ payment_status: "void" })).toBe("void");
-    expect(normalizeInvoiceImportStatus({ payment_status: "cancelled" })).toBe("void");
-    expect(normalizeInvoiceImportStatus({ payment_status: "written_off" })).toBe("void");
-    expect(normalizeInvoiceImportStatus({ payment_status: "credit" })).toBeNull();
-    expect(normalizeInvoiceImportStatus({ payment_status: "refunded" })).toBeNull();
+    expect(normalizeInvoiceImportStatus({ payment_status: "open" })).toBe(
+      "issued",
+    );
+    expect(normalizeInvoiceImportStatus({ payment_status: "partial" })).toBe(
+      "issued",
+    );
+    expect(
+      normalizeInvoiceImportStatus({ payment_status: "partially_paid" }),
+    ).toBe("issued");
+    expect(
+      normalizeInvoiceImportStatus({ payment_status: "paid_in_full" }),
+    ).toBe("paid");
+    expect(
+      normalizeInvoiceImportStatus({ payment_status: "closed_paid" }),
+    ).toBe("paid");
+    expect(normalizeInvoiceImportStatus({ payment_status: "void" })).toBe(
+      "void",
+    );
+    expect(normalizeInvoiceImportStatus({ payment_status: "cancelled" })).toBe(
+      "void",
+    );
+    expect(
+      normalizeInvoiceImportStatus({ payment_status: "written_off" }),
+    ).toBe("void");
+    expect(
+      normalizeInvoiceImportStatus({ payment_status: "credit" }),
+    ).toBeNull();
+    expect(
+      normalizeInvoiceImportStatus({ payment_status: "refunded" }),
+    ).toBeNull();
   });
 
   it("preserves legacy invoice and work-order numbers as text metadata", () => {
@@ -78,11 +147,39 @@ describe("historical invoice imports", () => {
     expect(importer).toContain("customer_email");
     expect(importer).toContain("customer_phone");
     expect(importer).toContain("customer_name");
-    expect(importer).toContain("const fallbackCustomerId = vehicle?.customer_id ?? workOrder?.customer_id ?? null");
-    expect(importer).toContain("customer_match_source: customerMatchSourceResolved");
+    expect(importer).toContain("const fallbackCustomerId =");
+    expect(importer).toContain(
+      "vehicle?.customer_id ?? workOrder?.customer_id ?? null",
+    );
+    expect(importer).toContain(
+      "customer_match_source: customerMatchSourceResolved",
+    );
     expect(importer).toContain("vehicle_match_source: vehicleMatchSource");
     expect(importer).toContain("matched_customer_id: customerId");
     expect(importer).toContain("matched_vehicle_id: vehicleId");
+  });
+
+  it("matches raw customer_id to customers.external_id and assigns the matched customer UUID", () => {
+    const matchedCustomer = {
+      id: "a59bf3dd-4ae9-4f31-874c-e29a5ca2634e",
+      external_id: "CUST-101566",
+      name: "Emily Clark",
+    };
+
+    const result = resolveInvoiceImportCustomer(
+      { customer_id: "CUST-101566" },
+      buildCustomerLookupMaps([matchedCustomer]),
+    );
+
+    expect(result.legacyCustomerId).toBe("CUST-101566");
+    expect(result.customer?.id).toBe("a59bf3dd-4ae9-4f31-874c-e29a5ca2634e");
+    expect(result.customerMatchSource).toBe("customer_external_id");
+    expect(importer).toContain("customer_id: customerId");
+    expect(importer).toContain("legacy_customer_id: legacyCustomerId");
+    expect(importer).toContain("matched_customer_id: customerId");
+    expect(importer).toContain(
+      "customer_match_source: customerMatchSourceResolved",
+    );
   });
 
   it("counts duplicate imported invoices as skipped rather than failed", () => {
@@ -91,5 +188,4 @@ describe("historical invoice imports", () => {
     expect(importer).toContain("Duplicate invoice already exists.");
     expect(importer).toContain("Duplicates are counted as skipped rows.");
   });
-
 });


### PR DESCRIPTION
### Motivation
- The importer treated `raw_row.customer_id` ambiguously and failed to match CSV legacy IDs to `customers.external_id`, causing `invoices.customer_id` to be left null for known customers.
- The goal is to ensure exact `raw_row.customer_id` → `customers.external_id` matching, preserve the resolved customer UUID in the final insert, and record the match source for auditing.

### Description
- Added `buildCustomerLookupMaps()` and `resolveInvoiceImportCustomer()` to build explicit lookup maps and to resolve `row.customer_id` against `customers.external_id` (exact) then a normalized key, falling back to email/phone/name.
- Switched the importer to use the resolved `{ customer, customerMatchSource, legacyCustomerId }` before composing the invoice payload so `customer_id` in the insert payload is `customerId` (matched or vehicle/work-order fallback).
- Ensured metadata includes `legacy_customer_id`, `matched_customer_id`, and `customer_match_source: "customer_external_id"` when matched from the CSV external id, and that no later spreads overwrite the `customer_id` payload.
- Added a regression test that calls `resolveInvoiceImportCustomer()` with `raw_row.customer_id = "CUST-101566"` against a customer with `external_id = "CUST-101566"` and asserts the matched UUID and metadata usage.

### Testing
- Ran `npm run typecheck` and it succeeded with no type errors.
- Ran `npx eslint features/billing app/api/internal/import-jobs app/api/import-jobs app/api/invoices` with no reported linter errors.
- Ran `npx vitest run tests/invoice-import-work-order-optional.test.ts` and all tests passed (13 tests), including the new regression test verifying `CUST-101566` → `a59bf3dd-4ae9-4f31-874c-e29a5ca2634e` mapping.

Files changed:
- `features/billing/server/invoice-import-job.ts`
- `tests/invoice-import-work-order-optional.test.ts`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c072a8ee4832895d486b161a8b62e)