### PR TITLE
Refresh historical invoice_csv imports and prevent overwriting live invoices

### DIFF
--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -53,6 +53,10 @@ type MatchedWorkOrder = {
   customer_id?: string | null;
   vehicle_id?: string | null;
 };
+type ExistingInvoiceMatch = {
+  id: string;
+  metadata?: Record<string, unknown> | null;
+};
 
 const clean = (value: unknown) => {
   const text = String(value ?? "").trim();
@@ -186,35 +190,67 @@ function isInvoiceNumberUniqueConflict(error: unknown) {
   );
 }
 
-async function duplicateInvoice(
+export function isHistoricalInvoiceCsvMetadata(metadata: unknown) {
+  return (
+    !!metadata &&
+    typeof metadata === "object" &&
+    (metadata as Record<string, unknown>).import_type === "invoice_csv"
+  );
+}
+
+async function findHistoricalInvoice(
   client: SupabaseClient,
   shopId: string,
   invoiceNumber: string | null,
   sourceId: string | null,
-) {
-  if (invoiceNumber) {
-    const { data, error } = await client
-      .from("invoices")
-      .select("id")
-      .eq("shop_id", shopId)
-      .eq("invoice_number", invoiceNumber)
-      .limit(1);
-    if (error) throw error;
-    if (data?.length) return true;
-  }
-
+): Promise<ExistingInvoiceMatch | null> {
   if (sourceId) {
     const { data, error } = await client
       .from("invoices")
-      .select("id")
+      .select("id, metadata")
       .eq("shop_id", shopId)
-      .contains("metadata", { imported_invoice_id: sourceId })
+      .contains("metadata", {
+        import_type: "invoice_csv",
+        imported_invoice_id: sourceId,
+      })
       .limit(1);
     if (error) throw error;
-    if (data?.length) return true;
+    const match = (data?.[0] as ExistingInvoiceMatch | undefined) ?? null;
+    if (match) return match;
   }
 
-  return false;
+  if (invoiceNumber) {
+    const { data, error } = await client
+      .from("invoices")
+      .select("id, metadata")
+      .eq("shop_id", shopId)
+      .eq("invoice_number", invoiceNumber)
+      .contains("metadata", { import_type: "invoice_csv" })
+      .limit(1);
+    if (error) throw error;
+    return (data?.[0] as ExistingInvoiceMatch | undefined) ?? null;
+  }
+
+  return null;
+}
+
+async function hasLiveInvoiceNumberCollision(
+  client: SupabaseClient,
+  shopId: string,
+  invoiceNumber: string | null,
+) {
+  if (!invoiceNumber) return false;
+  const { data, error } = await client
+    .from("invoices")
+    .select("id, metadata")
+    .eq("shop_id", shopId)
+    .eq("invoice_number", invoiceNumber)
+    .limit(10);
+  if (error) throw error;
+
+  return ((data ?? []) as ExistingInvoiceMatch[]).some(
+    (invoice) => !isHistoricalInvoiceCsvMetadata(invoice.metadata),
+  );
 }
 
 export const CANONICAL_INVOICE_IMPORT_STATUSES = [
@@ -393,11 +429,12 @@ export async function processInvoiceImportJobBatch(
   const counts: Counts = { imported: 0, skipped: 0, failed: 0, duplicates: 0 };
   const sample = samples(job.summary);
   const pendingInvoiceNumbers = new Set<string>();
-  const inserts: Array<{
+  const writes: Array<{
     stagedId: string;
     rowNumber: number;
     invoiceNumber: string | null;
     workOrderNumber: string | null;
+    existingInvoiceId: string | null;
     payload: DB["public"]["Tables"]["invoices"]["Insert"];
   }> = [];
 
@@ -427,15 +464,19 @@ export async function processInvoiceImportJobBatch(
         continue;
       }
 
+      const existingHistoricalInvoice = await findHistoricalInvoice(
+        client,
+        job.shop_id,
+        invoiceNumber,
+        sourceId,
+      );
       if (
-        pendingInvoiceNumbers.has(invoiceNumber) ||
-        (await duplicateInvoice(client, job.shop_id, invoiceNumber, sourceId))
+        pendingInvoiceNumbers.has(invoiceNumber) &&
+        !existingHistoricalInvoice
       ) {
         counts.skipped++;
         counts.duplicates++;
-        const reason = pendingInvoiceNumbers.has(invoiceNumber)
-          ? "Duplicate invoice already exists in this import batch."
-          : "Duplicate invoice already exists.";
+        const reason = "Duplicate invoice already exists in this import batch.";
         sample.skippedRows.push({
           row: staged.row_number,
           reason,
@@ -500,12 +541,36 @@ export async function processInvoiceImportJobBatch(
         continue;
       }
 
+      if (
+        !existingHistoricalInvoice &&
+        (await hasLiveInvoiceNumberCollision(
+          client,
+          job.shop_id,
+          invoiceNumber,
+        ))
+      ) {
+        const reason = "live_invoice_number_collision";
+        counts.skipped++;
+        sample.skippedRows.push({
+          row: staged.row_number,
+          reason,
+          invoiceNumber,
+          workOrderNumber,
+        });
+        await client
+          .from("import_job_rows")
+          .update({ status: "skipped", error_message: reason })
+          .eq("id", staged.id);
+        continue;
+      }
+
       pendingInvoiceNumbers.add(invoiceNumber);
-      inserts.push({
+      writes.push({
         stagedId: staged.id,
         rowNumber: staged.row_number,
         invoiceNumber,
         workOrderNumber,
+        existingInvoiceId: existingHistoricalInvoice?.id ?? null,
         payload: {
           shop_id: job.shop_id,
           customer_id: customerId,
@@ -570,60 +635,54 @@ export async function processInvoiceImportJobBatch(
     }
   }
 
-  for (const batch of chunkArray(inserts, batchSize)) {
-    const { error: insertError } = await supabase
-      .from("invoices")
-      .insert(batch.map((entry) => entry.payload));
-    if (insertError) {
-      for (const entry of batch) {
-        const { error: rowError } = await supabase
-          .from("invoices")
-          .insert(entry.payload);
-        if (rowError) {
-          if (isInvoiceNumberUniqueConflict(rowError)) {
-            counts.skipped++;
-            counts.duplicates++;
-            const reason = "Duplicate invoice already exists.";
-            sample.skippedRows.push({
-              row: entry.rowNumber,
-              reason,
-              invoiceNumber: entry.invoiceNumber,
-              workOrderNumber: entry.workOrderNumber,
-            });
-            await client
-              .from("import_job_rows")
-              .update({ status: "skipped", error_message: reason })
-              .eq("id", entry.stagedId);
-          } else {
-            counts.failed++;
-            sample.failedRows.push({
-              row: entry.rowNumber,
-              error: rowError.message,
-              invoiceNumber: entry.invoiceNumber,
-              workOrderNumber: entry.workOrderNumber,
-            });
-            await client
-              .from("import_job_rows")
-              .update({ status: "failed", error_message: rowError.message })
-              .eq("id", entry.stagedId);
-          }
-        } else {
-          counts.imported++;
+  for (const batch of chunkArray(writes, batchSize)) {
+    for (const entry of batch) {
+      const write = entry.existingInvoiceId
+        ? supabase
+            .from("invoices")
+            .update(entry.payload)
+            .eq("id", entry.existingInvoiceId)
+        : supabase.from("invoices").insert(entry.payload);
+      const { error: rowError } = await write;
+
+      if (rowError) {
+        if (
+          !entry.existingInvoiceId &&
+          isInvoiceNumberUniqueConflict(rowError)
+        ) {
+          counts.skipped++;
+          counts.duplicates++;
+          const reason = "live_invoice_number_collision";
+          sample.skippedRows.push({
+            row: entry.rowNumber,
+            reason,
+            invoiceNumber: entry.invoiceNumber,
+            workOrderNumber: entry.workOrderNumber,
+          });
           await client
             .from("import_job_rows")
-            .update({ status: "imported" })
+            .update({ status: "skipped", error_message: reason })
+            .eq("id", entry.stagedId);
+        } else {
+          counts.failed++;
+          sample.failedRows.push({
+            row: entry.rowNumber,
+            error: rowError.message,
+            invoiceNumber: entry.invoiceNumber,
+            workOrderNumber: entry.workOrderNumber,
+          });
+          await client
+            .from("import_job_rows")
+            .update({ status: "failed", error_message: rowError.message })
             .eq("id", entry.stagedId);
         }
+      } else {
+        counts.imported++;
+        await client
+          .from("import_job_rows")
+          .update({ status: "imported" })
+          .eq("id", entry.stagedId);
       }
-    } else {
-      counts.imported += batch.length;
-      await client
-        .from("import_job_rows")
-        .update({ status: "imported" })
-        .in(
-          "id",
-          batch.map((entry) => entry.stagedId),
-        );
     }
   }
 
@@ -689,7 +748,7 @@ export async function processInvoiceImportJobBatch(
           processed: reconciledProcessed,
           totalRows: job.total_rows ?? reconciledProcessed,
           reconcilesToTotal,
-          note: "Duplicates are counted as skipped rows.",
+          note: "Historical invoice_csv reruns refresh existing imported rows; live invoice number collisions are counted as skipped rows.",
         },
       },
       completed_at: completed ? new Date().toISOString() : null,

--- a/tests/invoice-import-work-order-optional.test.ts
+++ b/tests/invoice-import-work-order-optional.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildCustomerLookupMaps,
   normalizeInvoiceImportStatus,
+  isHistoricalInvoiceCsvMetadata,
   resolveImportedInvoicePaidAt,
   resolveInvoiceImportCustomer,
 } from "../features/billing/server/invoice-import-job";
@@ -182,10 +183,56 @@ describe("historical invoice imports", () => {
     );
   });
 
-  it("counts duplicate imported invoices as skipped rather than failed", () => {
-    expect(importer).toContain("counts.skipped++");
-    expect(importer).toContain("counts.duplicates++");
-    expect(importer).toContain("Duplicate invoice already exists.");
-    expect(importer).toContain("Duplicates are counted as skipped rows.");
+  it("refreshes existing invoice_csv rows instead of skipping historical duplicates", () => {
+    expect(importer).toContain("findHistoricalInvoice");
+    expect(importer).toContain(
+      "existingInvoiceId: existingHistoricalInvoice?.id ?? null",
+    );
+    expect(importer).toContain(".update(entry.payload)");
+    expect(importer).toContain("customer_id: customerId");
+    expect(importer).toContain("work_order_id: workOrder?.id ?? null");
+    expect(importer).toContain("matched_customer_id: customerId");
+    expect(importer).toContain(
+      "customer_match_source: customerMatchSourceResolved",
+    );
+  });
+
+  it("does not overwrite live invoices with colliding historical invoice numbers", () => {
+    expect(importer).toContain("hasLiveInvoiceNumberCollision");
+    expect(importer).toContain("live_invoice_number_collision");
+    expect(importer).toContain(
+      "!isHistoricalInvoiceCsvMetadata(invoice.metadata)",
+    );
+  });
+
+  it("prefers source id historical matches before invoice-number fallback", () => {
+    const sourceMatchIndex = importer.indexOf("imported_invoice_id: sourceId");
+    const fallbackIndex = importer.indexOf(
+      '.eq("invoice_number", invoiceNumber)',
+    );
+
+    expect(sourceMatchIndex).toBeGreaterThan(-1);
+    expect(fallbackIndex).toBeGreaterThan(-1);
+    expect(sourceMatchIndex).toBeLessThan(fallbackIndex);
+  });
+
+  it("detects only invoice_csv metadata as historical import metadata", () => {
+    expect(isHistoricalInvoiceCsvMetadata({ import_type: "invoice_csv" })).toBe(
+      true,
+    );
+    expect(isHistoricalInvoiceCsvMetadata({ import_type: "quickbooks" })).toBe(
+      false,
+    );
+    expect(isHistoricalInvoiceCsvMetadata(null)).toBe(false);
+  });
+
+  it("keeps duplicate CSV rows skipped while reruns count refreshed rows as imported", () => {
+    expect(importer).toContain(
+      "Duplicate invoice already exists in this import batch.",
+    );
+    expect(importer).toContain('.update({ status: "imported" })');
+    expect(importer).toContain(
+      "Historical invoice_csv reruns refresh existing imported rows",
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Allow reruns of historical invoice CSV imports to refresh previously imported rows instead of being treated as duplicates to skip. 
- Avoid overwriting or clobbering live invoices when a historical import's invoice number collides with an active invoice. 
- Provide clearer accounting and error handling around duplicate detection and import behavior for `invoice_csv` metadata.

### Description
- Add `isHistoricalInvoiceCsvMetadata`, `findHistoricalInvoice`, and `hasLiveInvoiceNumberCollision` helpers and an `ExistingInvoiceMatch` type to detect prior historical imports and live collisions. 
- Change the import flow to record `existingInvoiceId` for historical matches and perform an `.update(...)` for those invoices while using `.insert(...)` for new invoices, and rename `inserts` to `writes`. 
- Adjust duplicate detection to allow refreshing historical matches while still skipping duplicate rows within the same batch and treating unique-constraint conflicts against live invoices as `live_invoice_number_collision`. 
- Update status updates, counts, and the import job summary note to reflect that historical reruns refresh existing rows and that live collisions are counted as skipped rows.

### Testing
- Ran unit tests with `vitest`, including the updated `tests/invoice-import-work-order-optional.test.ts`, which assert detection of historical metadata, refresh/update behavior, and live-collision handling. 
- All automated tests completed successfully. 
- The updated tests check for `findHistoricalInvoice`, `hasLiveInvoiceNumberCollision`, `isHistoricalInvoiceCsvMetadata`, refreshed `existingInvoiceId` updates, and unchanged work-order matching behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c1fc207ac83289670a835aea92e5d)