### PR TITLE
Persist guided onboarding context across navigation

### DIFF
--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { format } from "date-fns";
@@ -14,7 +13,7 @@ import {
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { VehicleHistoryCsvImportCard } from "@/features/work-orders/components/VehicleHistoryCsvImportCard";
 import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
-import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 
 type DB = Database;
 type HistoryRow = DB["public"]["Tables"]["history"]["Row"];
@@ -69,13 +68,7 @@ function fmtDate(iso: string | null | undefined, pattern = "PPpp"): string {
 }
 
 export default function WorkOrdersHistoryClient(): JSX.Element {
-  const searchParams = useSearchParams();
-  const guidedQuery = useMemo(
-    () => parseGuidedOnboardingQuery(searchParams),
-    [searchParams],
-  );
-  const vehicleHistoryGuidedQuery =
-    guidedQuery?.onboardingStep === "vehicle_history" ? guidedQuery : null;
+  const vehicleHistoryGuidedQuery = usePersistentGuidedOnboardingQuery("vehicle_history");
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState<string | null>(null);
   const [rows, setRows] = useState<Row[]>([]);

--- a/features/billing/components/InvoiceCsvImportCard.tsx
+++ b/features/billing/components/InvoiceCsvImportCard.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
 import { GuidedImportFooterActions } from "@/features/shared/components/import/GuidedImportFooterActions";
 import { GuidedImportSummary } from "@/features/shared/components/import/GuidedImportSummary";
 import { CsvImportProgress, type CsvImportProgressState } from "@/features/shared/components/import/CsvImportProgress";
 import { useImportJobProgress, type ImportJobProgressJob } from "@/features/shared/components/import/useImportJobProgress";
-import { parseGuidedOnboardingQuery, type GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
+import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type InvoiceImportRow = { invoice_id?: string | null; invoice_number?: string | null; work_order_number?: string | null; customer_id?: string | null; customer_email?: string | null; customer_phone?: string | null; customer_name?: string | null; customer?: string | null; email?: string | null; phone?: string | null; name?: string | null; vehicle_id?: string | null; vin?: string | null; invoice_date?: string | null; due_date?: string | null; paid_date?: string | null; status?: string | null; payment_status?: string | null; service_category?: string | null; description?: string | null; labor_hours?: string | null; labor_total?: string | null; parts_total?: string | null; shop_supplies?: string | null; subtotal?: string | null; tax?: string | null; total?: string | null; amount_paid?: string | null; balance_due?: string | null; advisor?: string | null; technician?: string | null; notes?: string | null; source_system?: string | null };
 type ImportCounts = { imported: number; updated: number; skipped: number; failed: number; duplicates: number };
@@ -25,7 +26,7 @@ function localValidation(row: InvoiceImportRow): string | null { if (!hasValidDa
 function downloadSample() { const blob = new Blob([SAMPLE], { type: "text/csv;charset=utf-8" }); const a = document.createElement("a"); a.href = URL.createObjectURL(blob); a.download = "invoice-import-template.csv"; a.click(); URL.revokeObjectURL(a.href); }
 
 export function InvoiceCsvImportCard({ onImported, onImportActiveChange }: { onImported?: () => void; onImportActiveChange?: (active: boolean) => void }) {
-  const router = useRouter(); const searchParams = useSearchParams(); const guidedQuery = useMemo<GuidedOnboardingQuery | null>(() => parseGuidedOnboardingQuery(new URLSearchParams(searchParams.toString())), [searchParams]);
+  const router = useRouter(); const guidedQuery = usePersistentGuidedOnboardingQuery("invoices") as GuidedOnboardingQuery | null;
   const fileInputRef = useRef<HTMLInputElement | null>(null); const [file, setFile] = useState<File | null>(null); const [fileName, setFileName] = useState<string | null>(null); const [headers, setHeaders] = useState<string[]>([]); const [rows, setRows] = useState<InvoiceImportRow[]>([]); const [parseError, setParseError] = useState<string | null>(null); const [importError, setImportError] = useState<string | null>(null); const [response, setResponse] = useState<ImportResponse | null>(null); const [importing, setImporting] = useState(false); const [activeJobId, setActiveJobId] = useState<string | null>(null); const [completingOnboarding, setCompletingOnboarding] = useState(false); const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
   const isOnboarding = Boolean(guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "invoices"); const rowValidation = useMemo(() => rows.map(localValidation), [rows]); const importableRows = useMemo(() => rows.filter((_, index) => !rowValidation[index]), [rows, rowValidation]); const previewRows = importableRows.slice(0, 5);
   function reset() { setRows([]); setHeaders([]); setParseError(null); setImportError(null); setResponse(null); setProgress(null); }

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -16,7 +16,7 @@ import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicate
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
 import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
-import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 
 type DB = Database;
 
@@ -569,9 +569,7 @@ export default function CustomerProfilePage(): JSX.Element {
   const router = useRouter();
   const sp = useSearchParams();
 
-  const guidedQuery = useMemo(() => parseGuidedOnboardingQuery(sp), [sp]);
-  const customerGuidedQuery =
-    guidedQuery?.onboardingStep === "customers" ? guidedQuery : null;
+  const customerGuidedQuery = usePersistentGuidedOnboardingQuery("customers");
 
   const supabase = useMemo(() => createBrowserSupabase(), []);
 

--- a/features/onboarding-v2/components/GuidedPageStepPanel.tsx
+++ b/features/onboarding-v2/components/GuidedPageStepPanel.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import React, { useState } from "react";
+import { useRouter } from "next/navigation";
 import type { GuidedOnboardingStepKey } from "@/features/onboarding-v2/guided/types";
 import {
   getGuidedStepPageInstructions,
-  parseGuidedPageContext,
   type GuidedPageContext,
 } from "@/features/onboarding-v2/guided/pageContext";
+import { usePersistentGuidedPageContext } from "@/features/onboarding-v2/guided/persistence";
 
 type GuidedPanelAction = {
   label: string;
@@ -28,8 +28,7 @@ const baseButtonClass =
 
 export default function GuidedPageStepPanel({ context: contextOverride, className = "", actions }: GuidedPageStepPanelProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const parsedContext = useMemo(() => parseGuidedPageContext(searchParams), [searchParams]);
+  const parsedContext = usePersistentGuidedPageContext();
   const context = contextOverride === undefined ? parsedContext : contextOverride;
   const [busyAction, setBusyAction] = useState<FinishAction | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/features/onboarding-v2/guided/persistence.tsx
+++ b/features/onboarding-v2/guided/persistence.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { getGuidedOnboardingStep, isGuidedOnboardingStepKey } from "./steps";
+import { parseGuidedPageContext, type GuidedPageContext } from "./pageContext";
+import type { GuidedOnboardingStepKey } from "./types";
+import {
+  isSafeGuidedReturnTo,
+  parseGuidedOnboardingQuery,
+  type GuidedOnboardingQuery,
+} from "./query";
+
+const STORAGE_KEY = "profixiq:guided-onboarding:v2:active-context";
+const STORAGE_TTL_MS = 1000 * 60 * 60 * 24;
+const GUIDED_PARAM_KEYS = ["setup", "guidedSessionId", "guidedStep", "focus", "returnTo", "highlight"] as const;
+
+type SavedGuidedContext = {
+  setup: "guided";
+  guidedSessionId: string;
+  guidedStep: GuidedOnboardingStepKey;
+  returnTo: string;
+  highlight: string;
+  focus?: string;
+  savedAt: number;
+};
+
+const STEP_PATH_PREFIXES: Record<GuidedOnboardingStepKey, string[]> = {
+  customers: ["/customers"],
+  vehicles: ["/vehicles"],
+  vehicle_history: ["/work-orders/history"],
+  invoices: ["/billing"],
+  parts: ["/parts/inventory"],
+  staff: ["/dashboard/owner/create-user"],
+  pricing_shop_defaults: ["/dashboard/owner/settings"],
+  analysis: ["/dashboard/onboarding-v2"],
+};
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined";
+}
+
+function readSavedGuidedContext(): SavedGuidedContext | null {
+  if (!canUseStorage()) return null;
+  const raw = window.sessionStorage.getItem(STORAGE_KEY) ?? window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<SavedGuidedContext>;
+    if (parsed.setup !== "guided") return null;
+    if (!parsed.guidedSessionId || !parsed.guidedStep || !parsed.highlight) return null;
+    if (!isGuidedOnboardingStepKey(parsed.guidedStep)) return null;
+    if (!isSafeGuidedReturnTo(parsed.returnTo)) return null;
+    if (Date.now() - Number(parsed.savedAt ?? 0) > STORAGE_TTL_MS) return null;
+    return parsed as SavedGuidedContext;
+  } catch {
+    return null;
+  }
+}
+
+function writeSavedGuidedContext(context: SavedGuidedContext): void {
+  if (!canUseStorage()) return;
+  const raw = JSON.stringify(context);
+  window.sessionStorage.setItem(STORAGE_KEY, raw);
+  window.localStorage.setItem(STORAGE_KEY, raw);
+}
+
+function pathMatchesGuidedStep(pathname: string, stepKey: GuidedOnboardingStepKey): boolean {
+  return STEP_PATH_PREFIXES[stepKey].some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+function toSavedContext(query: GuidedOnboardingQuery, params: URLSearchParams): SavedGuidedContext | null {
+  if (!isGuidedOnboardingStepKey(query.onboardingStep)) return null;
+  const step = getGuidedOnboardingStep(query.onboardingStep);
+  if (!step) return null;
+  return {
+    setup: "guided",
+    guidedSessionId: query.onboardingSession,
+    guidedStep: query.onboardingStep,
+    returnTo: query.returnTo,
+    highlight: query.highlight,
+    focus: params.get("focus") ?? step.highlightQuery?.focus,
+    savedAt: Date.now(),
+  };
+}
+
+function buildRestoredSearch(params: URLSearchParams, saved: SavedGuidedContext): string {
+  const next = new URLSearchParams(params.toString());
+  next.set("setup", "guided");
+  next.set("guidedSessionId", saved.guidedSessionId);
+  next.set("guidedStep", saved.guidedStep);
+  next.set("returnTo", saved.returnTo);
+  next.set("highlight", saved.highlight);
+  if (saved.focus) next.set("focus", saved.focus);
+  return next.toString();
+}
+
+export function clearSavedGuidedOnboardingContext(): void {
+  if (!canUseStorage()) return;
+  window.sessionStorage.removeItem(STORAGE_KEY);
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export function usePersistentGuidedOnboardingQuery(expectedStep?: GuidedOnboardingStepKey): GuidedOnboardingQuery | null {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+
+  const parsed = useMemo(() => parseGuidedOnboardingQuery(new URLSearchParams(search)), [search]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(search);
+    if (parsed) {
+      const saved = toSavedContext(parsed, params);
+      if (saved) writeSavedGuidedContext(saved);
+      return;
+    }
+
+    if (params.has("setup") && params.get("setup") !== "guided") return;
+    if (GUIDED_PARAM_KEYS.some((key) => params.has(key))) return;
+
+    const saved = readSavedGuidedContext();
+    if (!saved) return;
+    if (expectedStep && saved.guidedStep !== expectedStep) return;
+    if (!pathMatchesGuidedStep(pathname, saved.guidedStep)) return;
+
+    const restored = buildRestoredSearch(params, saved);
+    router.replace(`${pathname}?${restored}`, { scroll: false });
+  }, [expectedStep, parsed, pathname, router, search]);
+
+  if (parsed && (!expectedStep || parsed.onboardingStep === expectedStep)) return parsed;
+  return null;
+}
+
+export function usePersistentGuidedPageContext(): GuidedPageContext | null {
+  const searchParams = useSearchParams();
+  const search = searchParams.toString();
+  usePersistentGuidedOnboardingQuery();
+  return useMemo(() => parseGuidedPageContext(new URLSearchParams(search)), [search]);
+}

--- a/features/vehicles/app/vehicles/page.tsx
+++ b/features/vehicles/app/vehicles/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { VehicleCsvImportCard } from "@/features/vehicles/components/VehicleCsvImportCard";
-import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -108,9 +108,7 @@ function sortVehicleRows(rows: VehicleSearchRow[]): VehicleSearchRow[] {
 
 export default function VehicleFilesPage() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const guidedQuery = useMemo(() => parseGuidedOnboardingQuery(searchParams), [searchParams]);
-  const vehicleGuidedQuery = guidedQuery?.onboardingStep === "vehicles" ? guidedQuery : null;
+  const vehicleGuidedQuery = usePersistentGuidedOnboardingQuery("vehicles");
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(true);

--- a/tests/guided-onboarding-page-panels.test.tsx
+++ b/tests/guided-onboarding-page-panels.test.tsx
@@ -18,11 +18,14 @@ import {
 } from "@/features/onboarding-v2/guided/steps";
 
 const routerPush = vi.fn();
+const routerReplace = vi.fn();
 let currentSearchParams = new URLSearchParams();
+let currentPathname = "/customers/search";
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: routerPush }),
+  useRouter: () => ({ push: routerPush, replace: routerReplace }),
   useSearchParams: () => currentSearchParams,
+  usePathname: () => currentPathname,
 }));
 
 function read(path: string) {
@@ -43,7 +46,11 @@ const productionPageFiles = [
 
 beforeEach(() => {
   routerPush.mockReset();
+  routerReplace.mockReset();
   currentSearchParams = new URLSearchParams();
+  currentPathname = "/customers/search";
+  window.sessionStorage.clear();
+  window.localStorage.clear();
   vi.restoreAllMocks();
 });
 
@@ -79,6 +86,53 @@ describe("guided onboarding page panels", () => {
     expect(
       screen.getByRole("button", { name: "Back to guided setup" }),
     ).toBeInTheDocument();
+  });
+
+
+  it("restores guided context from storage when safe params are missing", async () => {
+    currentPathname = "/billing";
+    window.sessionStorage.setItem(
+      "profixiq:guided-onboarding:v2:active-context",
+      JSON.stringify({
+        setup: "guided",
+        guidedSessionId: "session-restore",
+        guidedStep: "invoices",
+        returnTo: "/dashboard/onboarding-v2/session-restore",
+        highlight: "invoices",
+        focus: "invoices",
+        savedAt: Date.now(),
+      }),
+    );
+
+    render(<GuidedPageStepPanel />);
+
+    await waitFor(() => {
+      expect(routerReplace).toHaveBeenCalledWith(
+        "/billing?setup=guided&guidedSessionId=session-restore&guidedStep=invoices&returnTo=%2Fdashboard%2Fonboarding-v2%2Fsession-restore&highlight=invoices&focus=invoices",
+        { scroll: false },
+      );
+    });
+  });
+
+  it("does not restore guided context onto unrelated regular pages", async () => {
+    currentPathname = "/billing";
+    window.sessionStorage.setItem(
+      "profixiq:guided-onboarding:v2:active-context",
+      JSON.stringify({
+        setup: "guided",
+        guidedSessionId: "session-restore",
+        guidedStep: "customers",
+        returnTo: "/dashboard/onboarding-v2/session-restore",
+        highlight: "customer-import",
+        savedAt: Date.now(),
+      }),
+    );
+
+    const { container } = render(<GuidedPageStepPanel />);
+
+    expect(container).toBeEmptyDOMElement();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(routerReplace).not.toHaveBeenCalled();
   });
 
   it("rejects unknown guided steps before rendering", () => {


### PR DESCRIPTION
### Motivation
- Guided onboarding banners and actions relied solely on live URL query params (`setup=guided`, `guidedSessionId`, `guidedStep`, `highlight`, `returnTo`, `focus`) and therefore disappeared when users navigated away and returned (refresh, tab switch, back/forward) because the params were missing.  
- The goal is to restore the guided UI when it is safe to do so while not forcing guided UI for regular users or unrelated pages.

### Description
- Add a client-side persistence layer `usePersistentGuidedOnboardingQuery` and `usePersistentGuidedPageContext` in `features/onboarding-v2/guided/persistence.tsx` that treats URL params as canonical, saves valid guided context to `sessionStorage` and `localStorage`, and restores missing query params only when the saved step is safe for the current path.  
- Wire the new persistence hooks into page-level components and import cards so guided controls survive refresh/back/forward/tab-switch: updated `GuidedPageStepPanel` to use `usePersistentGuidedPageContext` and updated guided import/page usages to call `usePersistentGuidedOnboardingQuery`.  
- Restore behavior is conservative: contexts expire after a TTL, `returnTo` is validated, saved contexts are scoped by step and matched against a step->path whitelist, and restoration uses `router.replace(..., { scroll: false })` to avoid navigation side-effects.  
- Files changed: `features/onboarding-v2/guided/persistence.tsx`, `features/onboarding-v2/components/GuidedPageStepPanel.tsx`, `features/billing/components/InvoiceCsvImportCard.tsx`, `features/vehicles/app/vehicles/page.tsx`, `features/customers/app/customers/[id]/page.tsx`, `app/work-orders/history/WorkOrdersHistoryClient.tsx`, and `tests/guided-onboarding-page-panels.test.tsx` (added regression coverage for restore and non-restore cases).

### Testing
- Ran `npm run typecheck` and it succeeded.  
- Ran `npx eslint` on the changed files and the changed files passed linting; running eslint across the whole `app/billing`/`app/dashboard/onboarding-v2`/`features` set revealed pre-existing unrelated lint errors outside the scope of this change.  
- Ran focused unit tests: `npx vitest run tests/guided-onboarding-page-panels.test.tsx` and the test file (including the new restore / non-restore tests) passed.  
- Ran full test suite `npx vitest run tests` where the suite exposed one unrelated existing test failure (`tests/vehicle-csv-import-route.test.ts` expecting a literal source substring in `CsvImportProgress`), so overall repo tests are not green due to that pre-existing assertion; the guided onboarding changes did not introduce new failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c444c90248328947e87c127a687f9)