### PR TITLE
Harden regular invoice readiness flow

### DIFF
--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -38,6 +38,26 @@ function numericValue(value: unknown): number | null {
   return null;
 }
 
+
+function hasMeaningfulJson(value: unknown): boolean {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value as Record<string, unknown>).length > 0;
+  if (typeof value === "string") return value.trim().length > 0;
+  return Boolean(value);
+}
+
+function lineRequiresParts(line: Record<string, unknown>): boolean {
+  if (line.no_parts_required === true) return false;
+  if (line.parts_required === true) return true;
+  if (hasMeaningfulJson(line.parts_required)) return true;
+  if (hasMeaningfulJson(line.parts_needed)) return true;
+  if (typeof line.parts === "string" && line.parts.trim().length > 0) return true;
+  if (line.parts_verification_required === true) return true;
+  const status = String(line.status ?? "").trim().toLowerCase();
+  return status === "pending_parts" || status === "awaiting_parts";
+}
+
 function partRequestItemHasBillablePrice(row: Record<string, unknown>): boolean {
   const quotedPrice = numericValue(row.quoted_price);
   const unitPrice = numericValue(row.unit_price);
@@ -87,6 +107,24 @@ export async function reviewWorkOrder({
     }
   }
 
+
+  const { data: stagedPartRows } = await supabase
+    .from("work_order_parts")
+    .select("work_order_line_id, quantity, unit_price, total_price")
+    .eq("work_order_id", workOrderId)
+    .eq("shop_id", shopId);
+
+  for (const row of stagedPartRows ?? []) {
+    const record = row as Record<string, unknown>;
+    const lineId = typeof row.work_order_line_id === "string" ? row.work_order_line_id : "";
+    const qty = numericValue(record.quantity) ?? 0;
+    const unitPrice = numericValue(record.unit_price);
+    const totalPrice = numericValue(record.total_price);
+    if (lineId && qty > 0 && ((unitPrice != null && unitPrice > 0) || (totalPrice != null && totalPrice > 0))) {
+      hasBillablePartsByLine.set(lineId, true);
+    }
+  }
+
   const { data: linkedPartRequestRows } = await supabase
     .from("part_request_items")
     .select("work_order_line_id, quote_line_id, status, approved, qty, qty_requested, qty_approved, quoted_price, unit_price, unit_cost")
@@ -127,6 +165,13 @@ export async function reviewWorkOrder({
       issues: [{ kind: "missing_wo", message: "WO not found" }],
     };
   }
+
+  const { data: shop } = await supabase
+    .from("shops")
+    .select("labor_rate")
+    .eq("id", shopId)
+    .maybeSingle<{ labor_rate: number | null }>();
+  const shopLaborRate = numericValue(shop?.labor_rate);
 
   const { data: lines, error: lnErr } = await supabase
     .from("work_order_lines")
@@ -182,8 +227,36 @@ export async function reviewWorkOrder({
     const noCharge = (ln as Record<string, unknown>)["no_charge"] === true;
     const laborNA = (ln as Record<string, unknown>)["labor_marked_na"] === true;
     const hasBillableParts = hasBillablePartsByLine.get(String(ln.id)) === true;
+    if (lineRequiresParts(ln as Record<string, unknown>) && !hasBillableParts) {
+      issues.push({
+        kind: "missing_required_parts",
+        lineId: ln.id,
+        message: `Required parts are missing from line: ${ln.description ?? ln.complaint ?? "job"}`,
+      });
+    }
+
+    const laborHours = numericValue(ln.labor_time) ?? 0;
+    const lineLaborRate = numericValue((ln as Record<string, unknown>)["labor_rate"]);
+    const effectiveLaborRate = lineLaborRate && lineLaborRate > 0 ? lineLaborRate : shopLaborRate ?? 0;
+    const explicitLaborTotal = numericValue((ln as Record<string, unknown>)["labor_total"]);
+    const laborTotal = explicitLaborTotal != null && explicitLaborTotal > 0 ? explicitLaborTotal : laborHours * effectiveLaborRate;
+
+    if (!noCharge && !laborNA && laborHours > 0 && !(laborTotal > 0) && !hasBillableParts) {
+      issues.push({
+        kind: "invalid_labor_total",
+        lineId: ln.id,
+        message: `Labor pricing is missing or invalid for line: ${ln.description ?? ln.complaint ?? "job"}`,
+      });
+    } else if (!noCharge && !laborNA && laborHours >= 1 && laborTotal > 0 && laborTotal <= laborHours + 0.01 && effectiveLaborRate <= 1) {
+      issues.push({
+        kind: "suspicious_labor_total",
+        lineId: ln.id,
+        message: `Labor total looks like hours were used as dollars for line: ${ln.description ?? ln.complaint ?? "job"}`,
+      });
+    }
+
     const laborRequired = !noCharge && !laborNA && !hasBillableParts;
-    if (laborRequired && !(typeof ln.labor_time === "number" && ln.labor_time > 0)) {
+    if (laborRequired && !(laborHours > 0)) {
       issues.push({
         kind: "no_labor_time",
         lineId: ln.id,

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -403,56 +403,12 @@ export default function BillingPage(): JSX.Element {
     [load],
   );
 
-  const handleInvoice = useCallback(
-    async (row: Row) => {
-      if (!confirm("Create and email a Stripe invoice to the customer?"))
-        return;
-
-      try {
-        const customerEmail = row.customers?.email?.trim() ?? "";
-        if (!customerEmail) {
-          toast.error("Customer email is required before sending an invoice.");
-          return;
-        }
-
-        const customerName = [
-          row.customers?.first_name ?? "",
-          row.customers?.last_name ?? "",
-        ]
-          .join(" ")
-          .trim();
-
-        const res = await fetch("/api/invoices/send", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            workOrderId: row.id,
-            customerEmail,
-            customerName: customerName.length ? customerName : undefined,
-          }),
-        });
-
-        const j = (await res.json().catch(() => null)) as {
-          ok?: boolean;
-          stripeInvoiceId?: string;
-          error?: string;
-        } | null;
-
-        if (!res.ok || !j?.ok) {
-          toast.error(j?.error ?? "Failed to create invoice.");
-          return;
-        }
-
-        toast.success("Invoice created and emailed.");
-        await load();
-      } catch (e) {
-        const msg =
-          e instanceof Error ? e.message : "Failed to create invoice.";
-        toast.error(msg);
-      }
-    },
-    [load],
-  );
+  const handleInvoice = useCallback((row: Row) => {
+    const previewUrl = `/work-orders/invoice/${row.id}`;
+    if (typeof window !== "undefined") {
+      window.location.assign(previewUrl);
+    }
+  }, []);
 
   const total = rows.length + historicalInvoices.length;
   const historicalCount = historicalInvoices.length;
@@ -796,7 +752,7 @@ export default function BillingPage(): JSX.Element {
                       onClick={() => void handleInvoice(r)}
                       disabled={r.status === "invoiced"}
                       className="rounded-full border border-emerald-400/70 bg-emerald-500/10 px-3 py-1.5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
-                      title="Create and email Stripe invoice"
+                      title="Open invoice preview"
                     >
                       Invoice
                     </button>

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -39,7 +39,7 @@ export type InvoiceSnapshotPart = {
 export type InvoiceSnapshotLine = Pick<
   WorkOrderLineRow,
   "id" | "line_no" | "description" | "complaint" | "cause" | "correction" | "labor_time"
->;
+> & { labor_total?: number | null };
 
 export type InvoiceSnapshot = {
   workOrder: Pick<
@@ -391,7 +391,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
 
   const { data: linesRaw } = await supabase
     .from("work_order_lines")
-    .select("id, line_no, description, complaint, cause, correction, labor_time")
+    .select("id, line_no, description, complaint, cause, correction, labor_time, labor_total")
     .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .order("line_no", { ascending: true })

--- a/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
+++ b/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
@@ -25,7 +25,7 @@ export function normalizeLaborHoursInput(
 }
 
 export function resolveWorkOrderLinePricing(args: {
-  line: Pick<WorkOrderLine, "labor_time"> & { id?: string; price_estimate?: number | null };
+  line: Pick<WorkOrderLine, "labor_time"> & { id?: string; price_estimate?: number | null; labor_total?: number | null; labor_rate?: number | null };
   quote?: Partial<WorkOrderQuoteLine> | null;
   shopLaborRate: number | null;
   stagedParts?: Array<Pick<WorkOrderPart, "quantity" | "unit_price" | "total_price">>;
@@ -63,7 +63,9 @@ export function resolveWorkOrderLinePricing(args: {
   const quotedHours = toNum(quote?.est_labor_hours) ?? toNum(quote?.labor_hours);
   const laborHours = quotedHours ?? lineHours;
 
-  const laborRate = toNum(shopLaborRate) ?? 0;
+  const explicitLineLaborTotal = toNum(line.labor_total);
+  const explicitLineLaborRate = toNum(line.labor_rate);
+  const laborRate = explicitLineLaborRate != null && explicitLineLaborRate > 0 ? explicitLineLaborRate : toNum(shopLaborRate) ?? 0;
   const quotedLaborTotal = toNum(quote?.labor_total);
 
   const stagedPartsTotal = stagedParts.reduce((sum, part) => {
@@ -84,13 +86,16 @@ export function resolveWorkOrderLinePricing(args: {
   const lineTotal = toNum(quote?.grand_total) ?? toNum(quote?.subtotal) ?? toNum(line.price_estimate) ?? (laborHours * laborRate) + partsTotal;
   const computedLaborTotal = laborHours * laborRate;
   const inferredLaborFromLineTotal = Math.max(0, lineTotal - partsTotal);
+  const explicitLineLaborTotalIsUsable = explicitLineLaborTotal != null && explicitLineLaborTotal > 0;
   const quotedLaborTotalIsUsable = quotedLaborTotal != null && quotedLaborTotal > 0;
   const computedLaborTotalIsUsable = computedLaborTotal > 0;
-  const laborTotal = quotedLaborTotalIsUsable
-    ? quotedLaborTotal
-    : computedLaborTotalIsUsable
-      ? computedLaborTotal
-      : inferredLaborFromLineTotal;
+  const laborTotal = explicitLineLaborTotalIsUsable
+    ? explicitLineLaborTotal
+    : quotedLaborTotalIsUsable
+      ? quotedLaborTotal
+      : computedLaborTotalIsUsable
+        ? computedLaborTotal
+        : inferredLaborFromLineTotal;
 
   return { laborHours, laborRate, laborTotal, partsCount, partsTotal, lineTotal };
 }

--- a/tests/live-invoice-flow-safety.test.ts
+++ b/tests/live-invoice-flow-safety.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolveWorkOrderLinePricing } from "../features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+
+const reviewSource = readFileSync("app/api/work-orders/[id]/_lib/reviewWorkOrder.ts", "utf8");
+const billingPage = readFileSync("app/billing/page.tsx", "utf8");
+const previewClient = readFileSync("features/work-orders/components/InvoicePreviewPageClient.tsx", "utf8");
+const sendRoute = readFileSync("app/api/invoices/send/route.ts", "utf8");
+const snapshotSource = readFileSync("features/invoices/server/getInvoiceSnapshot.ts", "utf8");
+
+describe("regular live invoice flow safety", () => {
+  it("prices 1.0 labor hour from explicit total or labor rate, never as $1.00", () => {
+    expect(resolveWorkOrderLinePricing({
+      line: { labor_time: 1, labor_total: 150, labor_rate: null },
+      shopLaborRate: 125,
+    }).laborTotal).toBe(150);
+
+    expect(resolveWorkOrderLinePricing({
+      line: { labor_time: 1, labor_total: null, labor_rate: null },
+      shopLaborRate: 125,
+    }).laborTotal).toBe(125);
+  });
+
+  it("blocks AI/invoice review when parts are required but no billable parts are attached", () => {
+    expect(reviewSource).toContain("function lineRequiresParts");
+    expect(reviewSource).toContain("missing_required_parts");
+    expect(reviewSource).toContain("work_order_parts");
+    expect(reviewSource).toContain("work_order_part_allocations");
+    expect(reviewSource).toContain("part_request_items");
+  });
+
+  it("flags invalid or suspicious labor totals before invoice readiness passes", () => {
+    expect(reviewSource).toContain("invalid_labor_total");
+    expect(reviewSource).toContain("suspicious_labor_total");
+    expect(reviewSource).toContain("Labor total looks like hours were used as dollars");
+  });
+
+  it("includes persisted parts and labor in the canonical invoice preview totals", () => {
+    expect(snapshotSource).toContain("labor_total");
+    expect(snapshotSource).toContain("labor_rate");
+    expect(snapshotSource).toContain("work_order_part_allocations");
+    expect(snapshotSource).toContain("work_order_parts");
+    expect(snapshotSource).toContain("quote_line_part_request");
+    expect(previewClient).toContain("/api/work-orders/${workOrderId}/invoice");
+    expect(previewClient).toContain("snapshotJson?.snapshot?.parts");
+    expect(previewClient).toContain("canonicalInvoiceTotal");
+  });
+
+  it("billing Invoice button navigates to preview instead of sending", () => {
+    expect(billingPage).toContain("/work-orders/invoice/${row.id}");
+    expect(billingPage).toContain("window.location.assign(previewUrl)");
+    expect(billingPage).not.toContain('fetch("/api/invoices/send"');
+  });
+
+  it("invoice send remains only behind preview confirmation", () => {
+    expect(previewClient).toContain("Send invoice");
+    expect(previewClient).toContain('fetch("/api/invoices/send"');
+    expect(sendRoute).toContain("Invoice review failed. Resolve blocking issues before sending.");
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent invoices from being created with incorrect pricing when line-level labor/parts are missing or misinterpreted (e.g., 1.0 hours being treated as $1.00). 
- Ensure AI/invoice review fails clearly when a line requires parts but no billable parts are attached, or when labor pricing looks invalid or suspicious. 
- Make the billing action open the canonical invoice preview before any send/email side-effects occur so users can confirm totals and attachments. 
- Preserve historical/imported invoices as read-only and avoid changing their behavior.

### Description
- Prefer explicit persisted line pricing when resolving labor: `resolveWorkOrderLinePricing` now accepts and prefers `line.labor_total` and `line.labor_rate`, then quoted totals, then `labor_hours * labor_rate` as fallback; implementation in `features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts`.
- Include persisted line `labor_total` in the canonical invoice snapshot so preview/send read the work-order’s persisted pricing and parts; change in `features/invoices/server/getInvoiceSnapshot.ts` (select `labor_total` and surface it in the snapshot).
- Harden `reviewWorkOrder` to detect required-part signals (new `lineRequiresParts`) and to check `work_order_parts`, `work_order_part_allocations`, and `part_request_items`; add blocking issues `missing_required_parts`, `invalid_labor_total`, and `suspicious_labor_total` with clear messages when detected; changes in `app/api/work-orders/[id]/_lib/reviewWorkOrder.ts`.
- Change billing card behavior so the `Invoice` action navigates to the existing preview route instead of calling `/api/invoices/send` directly; change in `app/billing/page.tsx` (replace immediate send with `window.location.assign('/work-orders/invoice/${id}')`).
- Add regression test coverage asserting labor pricing resolution, required-parts blocking, parts/labor inclusion in preview snapshot, and that sends only happen from the preview page; new test file `tests/live-invoice-flow-safety.test.ts`.
- Files changed: `features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts`, `features/invoices/server/getInvoiceSnapshot.ts`, `app/api/work-orders/[id]/_lib/reviewWorkOrder.ts`, `app/billing/page.tsx`, and `tests/live-invoice-flow-safety.test.ts`.

### Testing
- Ran `npm run typecheck` and it succeeded with no new TypeScript errors related to these changes.
- Ran targeted ESLint: `npx eslint app/api/work-orders/[id]/_lib/reviewWorkOrder.ts app/billing/page.tsx features/invoices/server/getInvoiceSnapshot.ts features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts tests/live-invoice-flow-safety.test.ts` and it completed cleanly for the changed files.
- Ran the new unit/regression tests: `npx vitest run tests/live-invoice-flow-safety.test.ts` and the test suite passed (all assertions in the new test file succeeded).
- Running the full lint (`npx eslint features app/api app/billing app/work-orders`) and full test suite (`npx vitest run tests`) surfaced unrelated, pre-existing issues (one unrelated test expectation and several lint warnings/errors elsewhere in the repo); those are external to this change and were not introduced by these edits.

If you want, I can (a) run the full test suite and help triage the unrelated failing test, or (b) prepare a small follow-up to backfill `labor_total` for historical rows if you prefer persisting that data via a migration/backfill first.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c54a9323c832890dd28a01181caeb)