### PR TITLE
Fix parts request Add RLS workflow

### DIFF
--- a/app/api/parts/requests/items/[itemId]/add/route.ts
+++ b/app/api/parts/requests/items/[itemId]/add/route.ts
@@ -1,0 +1,206 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DB = Database;
+type ItemUpdate = DB["public"]["Tables"]["part_request_items"]["Update"] & {
+  requested_part_number?: string | null;
+  requested_manufacturer?: string | null;
+};
+type ItemRow = DB["public"]["Tables"]["part_request_items"]["Row"] & {
+  requested_part_number?: string | null;
+  requested_manufacturer?: string | null;
+};
+
+type Body = {
+  partId?: string | null;
+  description?: string | null;
+  qty?: number | string | null;
+  quotedPrice?: number | string | null;
+  requestedPartNumber?: string | null;
+  requestedManufacturer?: string | null;
+  workOrderLineId?: string | null;
+  poId?: string | null;
+  locationId?: string | null;
+  createAllocation?: boolean;
+};
+
+function cleanString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function isUuid(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i.test(value.trim());
+}
+
+function nullableUuid(value: unknown, label: string): string | null {
+  const cleaned = cleanString(value);
+  if (!cleaned) return null;
+  if (!isUuid(cleaned)) throw new Error(`${label} must be a valid UUID.`);
+  return cleaned;
+}
+
+function finiteNumber(value: unknown, label: string): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${label} must be a number.`);
+  return parsed;
+}
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ itemId: string }> },
+) {
+  const { itemId: rawItemId } = await ctx.params;
+  const itemId = cleanString(rawItemId);
+  if (!itemId || !isUuid(itemId)) {
+    return NextResponse.json({ ok: false, error: "Invalid itemId." }, { status: 400 });
+  }
+
+  const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+  if (!access.ok) return access.response;
+
+  const supabase = access.supabase;
+  const shopId = access.profile.shop_id;
+
+  const body = (await req.json().catch(() => null)) as Body | null;
+  if (!body) {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  let partId: string | null;
+  let workOrderLineId: string | null;
+  let poId: string | null;
+  let locationId: string | null;
+  let qty: number;
+  let quotedPrice: number;
+  try {
+    partId = nullableUuid(body.partId, "partId");
+    workOrderLineId = nullableUuid(body.workOrderLineId, "workOrderLineId");
+    poId = nullableUuid(body.poId, "poId");
+    locationId = nullableUuid(body.locationId, "locationId");
+    qty = finiteNumber(body.qty, "qty");
+    quotedPrice = finiteNumber(body.quotedPrice, "quotedPrice");
+  } catch (error) {
+    return NextResponse.json(
+      { ok: false, error: error instanceof Error ? error.message : "Invalid request body." },
+      { status: 400 },
+    );
+  }
+
+  if (qty <= 0) {
+    return NextResponse.json({ ok: false, error: "Quantity must be greater than 0." }, { status: 400 });
+  }
+  if (quotedPrice < 0) {
+    return NextResponse.json({ ok: false, error: "Quoted price must be 0 or greater." }, { status: 400 });
+  }
+
+  const { data: item, error: itemError } = await supabase
+    .from("part_request_items")
+    .select("*")
+    .eq("id", itemId)
+    .maybeSingle<ItemRow>();
+
+  if (itemError) return NextResponse.json({ ok: false, error: itemError.message }, { status: 500 });
+  if (!item) return NextResponse.json({ ok: false, error: "Request item not found or blocked by shop access." }, { status: 404 });
+
+  const { data: partRequest, error: requestError } = await supabase
+    .from("part_requests")
+    .select("id, shop_id, work_order_id, status")
+    .eq("id", item.request_id)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (requestError) return NextResponse.json({ ok: false, error: requestError.message }, { status: 500 });
+  if (!partRequest) return NextResponse.json({ ok: false, error: "Parent parts request is not available for this shop." }, { status: 403 });
+
+  if (partRequest.work_order_id) {
+    const { data: workOrder, error: workOrderError } = await supabase
+      .from("work_orders")
+      .select("id, shop_id")
+      .eq("id", partRequest.work_order_id)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (workOrderError) return NextResponse.json({ ok: false, error: workOrderError.message }, { status: 500 });
+    if (!workOrder) return NextResponse.json({ ok: false, error: "Related work order is not available for this shop." }, { status: 403 });
+  }
+
+  if (partId) {
+    const { data: part, error: partError } = await supabase
+      .from("parts")
+      .select("id")
+      .eq("id", partId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (partError) return NextResponse.json({ ok: false, error: partError.message }, { status: 500 });
+    if (!part) return NextResponse.json({ ok: false, error: "Selected part is not available for this shop." }, { status: 403 });
+  }
+
+  if (workOrderLineId) {
+    const { data: line, error: lineError } = await supabase
+      .from("work_order_lines")
+      .select("id, work_order_id, work_orders!inner(id, shop_id)")
+      .eq("id", workOrderLineId)
+      .eq("work_orders.shop_id", shopId)
+      .maybeSingle();
+    if (lineError) return NextResponse.json({ ok: false, error: lineError.message }, { status: 500 });
+    if (!line) return NextResponse.json({ ok: false, error: "Work order line is not available for this shop." }, { status: 403 });
+    if (partRequest.work_order_id && line.work_order_id !== partRequest.work_order_id) {
+      return NextResponse.json({ ok: false, error: "Work order line does not belong to this parts request work order." }, { status: 403 });
+    }
+  }
+
+  if (poId) {
+    const { data: po, error: poError } = await supabase
+      .from("purchase_orders")
+      .select("id")
+      .eq("id", poId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (poError) return NextResponse.json({ ok: false, error: poError.message }, { status: 500 });
+    if (!po) return NextResponse.json({ ok: false, error: "Purchase order is not available for this shop." }, { status: 403 });
+  }
+
+  const update: ItemUpdate = {
+    part_id: partId,
+    description: cleanString(body.description) ?? item.description ?? "Part",
+    qty,
+    qty_requested: qty,
+    quoted_price: quotedPrice,
+    unit_price: quotedPrice,
+    requested_part_number: cleanString(body.requestedPartNumber),
+    requested_manufacturer: cleanString(body.requestedManufacturer),
+    work_order_line_id: workOrderLineId,
+    po_id: poId,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data: updatedItem, error: updateError } = await supabase
+    .from("part_request_items")
+    .update(update as DB["public"]["Tables"]["part_request_items"]["Update"])
+    .eq("id", itemId)
+    .eq("request_id", item.request_id)
+    .eq("shop_id", shopId)
+    .select("*")
+    .maybeSingle<ItemRow>();
+
+  if (updateError) return NextResponse.json({ ok: false, error: updateError.message }, { status: 500 });
+  if (!updatedItem) {
+    return NextResponse.json({ ok: false, error: "Update did not apply. The item may have changed or your shop access was blocked." }, { status: 409 });
+  }
+
+  let allocation: { ok: true } | { ok: false; error: string } | null = null;
+  if (body.createAllocation && locationId) {
+    const { error: allocationError } = await supabase.rpc("upsert_part_allocation_from_request_item", {
+      p_request_item_id: itemId,
+      p_location_id: locationId,
+      p_create_stock_move: true,
+    });
+    allocation = allocationError ? { ok: false, error: allocationError.message } : { ok: true };
+    if (allocationError) {
+      return NextResponse.json({ ok: false, item: updatedItem, allocation, error: allocationError.message }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({ ok: true, item: updatedItem, allocation });
+}

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -1439,69 +1439,55 @@ if (!lineId || !isUuid(lineId)) {
         ? it.work_order_line_id
         : lineId;
 
-      const payload = {
-        part_id: partId,
-        description: desc || it.description || "Part",
-        qty,
-        quoted_price: price,
-        requested_part_number: String(it.requested_part_number ?? "").trim() || null,
-        requested_manufacturer: String(it.requested_manufacturer ?? "").trim() || null,
-        vendor: null,
-        vendor_id: validSupplierId,
-        markup_pct: null,
-        work_order_line_id: safeLineId,
-        ...(poId ? { po_id: poId } : {}),
-      } as unknown as DB["public"]["Tables"]["part_request_items"]["Update"];
+      const res = await fetch(`/api/parts/requests/items/${itemId}/add`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          partId,
+          description: desc || it.description || "Part",
+          qty,
+          quotedPrice: price,
+          requestedPartNumber: String(it.requested_part_number ?? "").trim() || null,
+          requestedManufacturer: String(it.requested_manufacturer ?? "").trim() || null,
+          workOrderLineId: safeLineId,
+          poId,
+          locationId: locId || null,
+          createAllocation: Boolean(locId),
+        }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; item?: ItemRow }
+        | null;
 
-      // ✅ select to detect “no row updated” and avoid silent failures
-      const { data: updated, error: updErr } = await supabase
-        .from("part_request_items")
-        .update(payload)
-        .eq("id", it.id)
-        .select("id")
-        .maybeSingle();
-
-      if (updErr) {
-        toast.error(updErr.message);
-        return;
-      }
-      if (!updated?.id) {
-        toast.error("Update did not apply (no matching row or blocked).");
-        return;
-      }
-
-      if (locId) {
-        const { error } = await supabase.rpc(
-          "upsert_part_allocation_from_request_item",
-          {
-            p_request_item_id: it.id,
-            p_location_id: locId,
-            p_create_stock_move: true,
-          },
+      if (!res.ok || !body?.ok || !body.item) {
+        toast.error(
+          body?.error ||
+            "Could not add this part. The update may have been blocked by shop access.",
         );
+        return;
+      }
 
-        if (error) {
-          toast.error(error.message);
-          return;
-        }
-      } else {
+      if (!locId) {
         toast.warning(
           "No stock location exists for this shop. Item saved, but inventory was not allocated.",
         );
       }
 
+      const updated = body.item;
+
       const nextItems = target.items.map((x) => {
         if (x.id !== itemId) return x;
         return {
           ...x,
-          part_id: partId,
-          ui_part_id: partId,
-          quoted_price: price,
-          qty,
-          work_order_line_id: safeLineId,
+          ...updated,
+          ui_part_id: updated.part_id ?? partId,
+          ui_qty: toNum(updated.qty, qty),
+          ui_price:
+            updated.quoted_price == null
+              ? price
+              : toNum(updated.quoted_price, price),
           ui_added: true,
-          ui_po_id: poId ?? "",
-          po_id: poId ?? null,
+          ui_po_id: updated.po_id ?? poId ?? "",
         } as UiItem;
       });
 
@@ -1522,14 +1508,15 @@ if (!lineId || !isUuid(lineId)) {
                     ? x
                     : ({
                         ...x,
-                        part_id: partId,
-                        ui_part_id: partId,
-                        quoted_price: price,
-                        qty,
-                        work_order_line_id: safeLineId,
+                        ...updated,
+                        ui_part_id: updated.part_id ?? partId,
+                        ui_qty: toNum(updated.qty, qty),
+                        ui_price:
+                          updated.quoted_price == null
+                            ? price
+                            : toNum(updated.quoted_price, price),
                         ui_added: true,
-                        ui_po_id: poId ?? "",
-                        po_id: poId ?? null,
+                        ui_po_id: updated.po_id ?? poId ?? "",
                       } as UiItem),
                 ),
               },


### PR DESCRIPTION
### Motivation
- The Add button used a direct browser `PATCH` against `part_request_items`, which could run with `auth_user: null` under Supabase/RLS and return "no matching row or blocked," causing the client to report a silent blocked update. 
- Move the sensitive update server-side to ensure requests authenticate, enforce shop-scoped access, and run allocation RPCs under the service/server context.

### Description
- Added a new server API route `app/api/parts/requests/items/[itemId]/add/route.ts` that uses the existing `requireShopScopedApiAccess` helper to authenticate, load the item and parent request, validate `shop_id` ownership, and validate inputs (qty > 0, `quotedPrice >= 0`, UUID checks for `partId`, `workOrderLineId`, `poId`, etc.).
- The route updates `part_request_items` with `part_id`, `description`, `qty`, `quoted_price`, `requested_part_number`, `requested_manufacturer`, `work_order_line_id`, and `po_id` and returns the updated row, and it calls `upsert_part_allocation_from_request_item` server-side when allocation is requested.
- Replaced the direct client `supabase.from("part_request_items").update(...).eq("id", ...)` call in `app/parts/requests/[id]/page.tsx` with a `fetch` POST to the new API route and updated the UI state from the returned item (removed reliance on client-side `.single()`/`.maybeSingle()` for this Add flow and added explicit error messages).
- Kept existing client-side validations and added clearer server-side error responses when updates are blocked by RLS/shop mismatch or validation failures.

### Testing
- Ran linting for the modified files with `npx eslint app/api/parts/requests/items/[itemId]/add/route.ts app/parts/requests/[id]/page.tsx` (no blocking errors observed, only warnings). 
- Ran TypeScript typecheck with `npx tsc --noEmit`, which completed successfully with no type errors.
- Verified local UI code now calls the API route and updates local state from the returned item instead of performing the direct client PATCH.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c63bee8ec8328b014c34328a5e6ba)