### PR TITLE
Refine parts request workbench incrementally (server edit route + UI simplifications)

### DIFF
--- a/app/api/parts/requests/items/[itemId]/edit/route.ts
+++ b/app/api/parts/requests/items/[itemId]/edit/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DB = Database;
+type ItemUpdate = Pick<
+  DB["public"]["Tables"]["part_request_items"]["Update"],
+  "description" | "requested_part_number" | "requested_manufacturer" | "qty" | "quoted_price" | "updated_at"
+>;
+
+type Body = {
+  description?: string | null;
+  requested_part_number?: string | null;
+  requested_manufacturer?: string | null;
+  qty?: number | string | null;
+  quoted_price?: number | string | null;
+};
+
+function cleanString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function isUuid(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function numberOrNull(value: unknown, label: string): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) throw new Error(`${label} must be a number.`);
+  return parsed;
+}
+
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<{ itemId: string }> },
+) {
+  const { itemId: rawItemId } = await ctx.params;
+  const itemId = cleanString(rawItemId);
+  if (!itemId || !isUuid(itemId)) {
+    return NextResponse.json({ ok: false, error: "Invalid itemId." }, { status: 400 });
+  }
+
+  const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+  if (!access.ok) return access.response;
+
+  const supabase = access.supabase;
+  const shopId = access.profile.shop_id;
+  const body = (await req.json().catch(() => null)) as Body | null;
+  if (!body) {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const { data: item, error: itemError } = await supabase
+    .from("part_request_items")
+    .select("id, request_id, shop_id, work_order_id, quote_line_id")
+    .eq("id", itemId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (itemError) return NextResponse.json({ ok: false, error: itemError.message }, { status: 500 });
+  if (!item) return NextResponse.json({ ok: false, error: "Request item not found or blocked by shop access." }, { status: 404 });
+
+  const { data: parentRequest, error: requestError } = await supabase
+    .from("part_requests")
+    .select("id, shop_id, work_order_id, quote_line_id")
+    .eq("id", item.request_id)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (requestError) return NextResponse.json({ ok: false, error: requestError.message }, { status: 500 });
+  if (!parentRequest) return NextResponse.json({ ok: false, error: "Parent parts request is not available for this shop." }, { status: 403 });
+  if (cleanString(parentRequest.work_order_id) !== cleanString(item.work_order_id)) {
+    return NextResponse.json({ ok: false, error: "Request item work order context mismatch." }, { status: 403 });
+  }
+  if (cleanString(parentRequest.quote_line_id) && cleanString(item.quote_line_id) !== cleanString(parentRequest.quote_line_id)) {
+    return NextResponse.json({ ok: false, error: "Request item quote context mismatch." }, { status: 403 });
+  }
+
+  if (parentRequest.work_order_id) {
+    const { data: workOrder, error: workOrderError } = await supabase
+      .from("work_orders")
+      .select("id, shop_id")
+      .eq("id", parentRequest.work_order_id)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (workOrderError) return NextResponse.json({ ok: false, error: workOrderError.message }, { status: 500 });
+    if (!workOrder) return NextResponse.json({ ok: false, error: "Related work order is not available for this shop." }, { status: 403 });
+  }
+
+  const update: ItemUpdate = { updated_at: new Date().toISOString() };
+  if ("description" in body) update.description = cleanString(body.description) ?? "";
+  if ("requested_part_number" in body) update.requested_part_number = cleanString(body.requested_part_number);
+  if ("requested_manufacturer" in body) update.requested_manufacturer = cleanString(body.requested_manufacturer);
+
+  try {
+    if ("qty" in body) {
+      const qty = numberOrNull(body.qty, "qty");
+      if (qty == null || qty <= 0) return NextResponse.json({ ok: false, error: "qty must be greater than zero." }, { status: 400 });
+      update.qty = Math.max(1, Math.floor(qty));
+    }
+    if ("quoted_price" in body) {
+      const quotedPrice = numberOrNull(body.quoted_price, "quoted_price");
+      if (quotedPrice != null && quotedPrice < 0) return NextResponse.json({ ok: false, error: "quoted_price must be zero or greater." }, { status: 400 });
+      update.quoted_price = quotedPrice;
+    }
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Invalid numeric field." }, { status: 400 });
+  }
+
+  const { data: updatedItem, error: updateError } = await supabase
+    .from("part_request_items")
+    .update(update)
+    .eq("id", itemId)
+    .eq("request_id", item.request_id)
+    .eq("shop_id", shopId)
+    .select("*")
+    .maybeSingle();
+
+  if (updateError) return NextResponse.json({ ok: false, error: updateError.message }, { status: 500 });
+  if (!updatedItem) return NextResponse.json({ ok: false, error: "Update did not apply." }, { status: 409 });
+
+  return NextResponse.json({ ok: true, item: updatedItem });
+}

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -211,6 +211,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   const [locations, setLocations] = useState<LocationRow[]>([]);
   const [defaultLocationId, setDefaultLocationId] = useState<string>("");
   const [stockSuggestionsByItemId, setStockSuggestionsByItemId] = useState<Record<string, DeterministicStockSuggestion[]>>({});
+  const [stockAvailableByPartId, setStockAvailableByPartId] = useState<Record<string, number>>({});
   const [supplierSuggestionsByItemId, setSupplierSuggestionsByItemId] = useState<Record<string, DeterministicSupplierSuggestion[]>>({});
   const [supplierSuggestionAppliedByItemId, setSupplierSuggestionAppliedByItemId] = useState<Record<string, boolean>>({});
   const [conflictWarningByItemId, setConflictWarningByItemId] = useState<Record<string, string>>({});
@@ -367,6 +368,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setSuppliers([]);
       setSelectedPo("");
       setStockSuggestionsByItemId({});
+      setStockAvailableByPartId({});
       setSupplierSuggestionsByItemId({});
       setSupplierSuggestionAppliedByItemId({});
       setLoading(false);
@@ -525,12 +527,16 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       const suggestions: Record<string, DeterministicStockSuggestion[]> = {};
       const supplierSuggestions: Record<string, DeterministicSupplierSuggestion[]> = {};
       const stockSummaryRows = (((stockRows ?? []) as unknown) as DB["public"]["Views"]["part_stock_summary"]["Row"][]);
-      const stockAvailableByPartId = new Map<string, number>();
+      const stockAvailableMap = new Map<string, number>();
+      const stockAvailableRecord: Record<string, number> = {};
       for (const stockRow of stockSummaryRows) {
         if (!stockRow.part_id) continue;
         const qty = Number((stockRow as { qty_available?: number | null }).qty_available ?? stockRow.on_hand ?? 0);
-        stockAvailableByPartId.set(String(stockRow.part_id), Number.isFinite(qty) ? qty : 0);
+        const safeQty = Number.isFinite(qty) ? qty : 0;
+        stockAvailableMap.set(String(stockRow.part_id), safeQty);
+        stockAvailableRecord[String(stockRow.part_id)] = safeQty;
       }
+      setStockAvailableByPartId(stockAvailableRecord);
       for (const req of uiRequests) {
         for (const item of req.items) {
           const desc = String(item.description ?? "").trim();
@@ -549,7 +555,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
           const hasAttachedPart = isUuid(item.part_id);
           const topStockSuggestion = ranked[0] ?? null;
           const selectedPartId = isUuid(item.part_id) ? item.part_id : (isUuid(item.ui_part_id) ? item.ui_part_id : null);
-          const selectedPartStock = selectedPartId ? (stockAvailableByPartId.get(String(selectedPartId)) ?? 0) : 0;
+          const selectedPartStock = selectedPartId ? (stockAvailableMap.get(String(selectedPartId)) ?? 0) : 0;
           const shouldSuggestSupplier =
             !hasAttachedPart ||
             !!topStockSuggestion?.recommended_action && topStockSuggestion.recommended_action === "order_part" ||
@@ -599,6 +605,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setSuppliers([]);
       setSelectedPo("");
       setStockSuggestionsByItemId({});
+      setStockAvailableByPartId({});
       setSupplierSuggestionsByItemId({});
       setSupplierSuggestionAppliedByItemId({});
     }
@@ -645,20 +652,38 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   ): Promise<void> {
     setSavingItemId(itemId);
     try {
-      const { data, error } = await supabase
-        .from("part_request_items")
-        .update({
-          ...patch,
-          updated_at: new Date().toISOString(),
-        })
-        .eq("id", itemId)
-        .select("id")
-        .maybeSingle();
-      if (error) {
-        toast.error(error.message);
+      const res = await fetch(`/api/parts/requests/items/${itemId}/edit`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { ok?: boolean; error?: string; item?: ItemRow }
+        | null;
+      if (!res.ok || !body?.ok) {
+        toast.error(body?.error || "Update did not apply.");
         return;
       }
-      if (!data?.id) toast.error("Update did not apply (no matching row or blocked).");
+      if (body.item) {
+        setRequests((prev) =>
+          prev.map((r) => ({
+            ...r,
+            items: r.items.map((it) =>
+              String(it.id) === String(itemId)
+                ? ({
+                    ...it,
+                    ...body.item,
+                    ui_qty: toNum(body.item?.qty, it.ui_qty),
+                    ui_price:
+                      body.item?.quoted_price == null
+                        ? undefined
+                        : toNum(body.item.quoted_price, it.ui_price ?? 0),
+                  } as UiItem)
+                : it,
+            ),
+          })),
+        );
+      }
     } finally {
       setSavingItemId(null);
     }
@@ -1439,6 +1464,12 @@ if (!lineId || !isUuid(lineId)) {
         ? it.work_order_line_id
         : lineId;
 
+      const selectedStockAvailable = stockAvailableByPartId[String(partId)] ?? 0;
+      const shouldAllocateFromStock = Boolean(locId) && selectedStockAvailable > 0;
+      if (locId && selectedStockAvailable <= 0) {
+        toast.warning("No available stock for the selected part. The item will be saved without blocking allocation/order follow-up.");
+      }
+
       const res = await fetch(`/api/parts/requests/items/${itemId}/add`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1451,8 +1482,8 @@ if (!lineId || !isUuid(lineId)) {
           requestedManufacturer: String(it.requested_manufacturer ?? "").trim() || null,
           workOrderLineId: safeLineId,
           poId,
-          locationId: locId || null,
-          createAllocation: Boolean(locId),
+          locationId: shouldAllocateFromStock ? locId : null,
+          createAllocation: shouldAllocateFromStock,
         }),
       });
       const body = (await res.json().catch(() => null)) as
@@ -1985,108 +2016,70 @@ if (!lineId || !isUuid(lineId)) {
 
 
 
-                                        {showSuggestion && topSuggestion ? (
-                                          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-300">
-                                            <div className="font-medium text-neutral-100">{suggestionDisplay?.headline ?? "Inventory match"}</div>
-                                            <div className="mt-0.5"><span className="text-neutral-100">{topSuggestion.name}</span>
-                                            {topSuggestion.sku_or_part_number ? <span className="text-neutral-500"> · {topSuggestion.sku_or_part_number}</span> : null}
-                                            <span className="text-neutral-500"> · {topSuggestion.qty_available} available</span></div>
-                                            <details className="mt-1 text-neutral-500">
-                                              <summary className="cursor-pointer text-neutral-400">Why?</summary>
-                                              <div>{suggestionDisplay?.technicalReasons.slice(0, 3).join(" · ")}</div>
+                                        <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-neutral-400">
+                                          {showSuggestion && topSuggestion ? (
+                                            <details className="group inline-flex rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1">
+                                              <summary className="cursor-pointer list-none text-neutral-300">
+                                                AI match: <span className="text-neutral-100">{topSuggestion.name}</span>
+                                                <span className={topSuggestion.qty_available > 0 ? "ml-1 text-emerald-300" : "ml-1 text-amber-300"}>
+                                                  {topSuggestion.qty_available > 0 ? `${topSuggestion.qty_available} available` : "no stock — order"}
+                                                </span>
+                                              </summary>
+                                              <div className="mt-2 max-w-md rounded-lg border border-[color:var(--desktop-border)] bg-neutral-950/80 p-2 text-neutral-400 shadow-xl">
+                                                <div className="font-medium text-neutral-100">{suggestionDisplay?.headline ?? "Inventory match"}</div>
+                                                {topSuggestion.sku_or_part_number ? <div>Part/SKU: {topSuggestion.sku_or_part_number}</div> : null}
+                                                <div>{suggestionDisplay?.technicalReasons.slice(0, 3).join(" · ")}</div>
+                                                <button
+                                                  type="button"
+                                                  className="mt-2 underline decoration-dotted underline-offset-2 hover:text-white"
+                                                  onClick={() => updateItem(r.req.id, String(it.id), { ui_part_id: topSuggestion.part_id })}
+                                                  disabled={rowBusy || topSuggestion.part_id === it.ui_part_id}
+                                                >
+                                                  Use this match
+                                                </button>
+                                              </div>
                                             </details>
+                                          ) : null}
+                                          {hasAttachedPart && topSuggestion ? (
+                                            <span className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1 text-neutral-500">
+                                              Alternative match available
+                                            </span>
+                                          ) : null}
+                                          {canCreateInventory ? (
                                             <button
                                               type="button"
-                                              className="mt-1 underline decoration-dotted underline-offset-2 hover:text-white"
-                                              onClick={() => updateItem(r.req.id, String(it.id), { ui_part_id: topSuggestion.part_id })}
-                                              disabled={rowBusy || topSuggestion.part_id === it.ui_part_id}
-                                            >
-                                              {topSuggestion.qty_available <= 0 || topSuggestion.confidence === "low"
-                                                ? (suggestionDisplay?.actionLabel ?? "Create PO")
-                                                : (suggestionDisplay?.actionLabel ?? "Use inventory")}
-                                            </button>
-                                            {topSuggestion.part_id === it.ui_part_id ? (
-                                              <div className="mt-1 text-neutral-500">Inventory match selected. Click <span className="text-neutral-300">{isQuoteOnlyPreApprovalItem ? "Save Quote" : "Add"}</span> to run the normal {isQuoteOnlyPreApprovalItem ? "pre-approval quote" : "attach"} flow.</div>
-                                            ) : null}
-                                          </div>
-                                        ) : hasAttachedPart && topSuggestion ? (
-                                          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-500">
-                                            Stock suggestion available as an alternative, but this row already has an attached part.
-                                          </div>
-                                        ) : null}
-                                        {canCreateInventory ? (
-                                          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-300">
-                                            <div className="font-medium text-neutral-100">No catalog match found</div>
-                                            <div className="text-neutral-500">Create an inventory item and attach it to this request without leaving the page.</div>
-                                            <button
-                                              type="button"
-                                              className="mt-1 underline decoration-dotted underline-offset-2 hover:text-white"
+                                              className="rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1 text-neutral-300 hover:text-white"
                                               onClick={() => openCreateInventoryModal(r.req.id, it)}
                                               disabled={rowBusy}
                                             >
-                                              Create inventory item
+                                              Add to Stock
                                             </button>
-                                          </div>
-                                        ) : null}
-                                        {supplierSuggestion ? (
-                                          <div className="rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1.5 text-[11px] text-neutral-300">
-                                            <div>
-                                              Supplier option:{" "}
-                                              <span className="text-neutral-100">
-                                                {supplierSuggestion.supplier_name ?? "No preferred supplier"}
-                                              </span>
-                                              <span className="text-neutral-500"> · {supplierSuggestion.open_po_id ? "Use inventory" : "Order required"}</span>
-                                            </div>
-                                            {supplierSuggestion.open_po_number ? (
-                                              <div className="text-neutral-500">
-                                                Open PO available: {supplierSuggestion.open_po_number}
-                                              </div>
-                                            ) : null}
-                                            {supplierSuggestion.suggested_unit_cost != null ? (
-                                              <div className="text-neutral-500">
-                                                Last cost: ${supplierSuggestion.suggested_unit_cost.toFixed(2)}
-                                              </div>
-                                            ) : null}
-                                            <details className="mt-1 text-neutral-500">
-                                              <summary className="cursor-pointer text-neutral-400">Why?</summary>
-                                              <div className="mt-1 flex flex-wrap gap-1">
-                                                {supplierSuggestion.reasons.slice(0, 3).map((reason) => (
-                                                  <span key={reason} className="rounded-full border border-[color:var(--desktop-border)] px-2 py-0.5 text-[10px] text-neutral-400">
-                                                    {reason}
-                                                  </span>
-                                                ))}
+                                          ) : null}
+                                          {supplierSuggestion ? (
+                                            <details className="group inline-flex rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2 py-1">
+                                              <summary className="cursor-pointer list-none text-neutral-300">
+                                                Supplier: <span className="text-neutral-100">{supplierSuggestion.supplier_name ?? "review"}</span>
+                                                <span className="ml-1 text-neutral-500">{supplierSuggestion.open_po_id ? "open PO" : "order"}</span>
+                                              </summary>
+                                              <div className="mt-2 max-w-md rounded-lg border border-[color:var(--desktop-border)] bg-neutral-950/80 p-2 text-neutral-400 shadow-xl">
+                                                {supplierSuggestion.open_po_number ? <div>Open PO: {supplierSuggestion.open_po_number}</div> : null}
+                                                {supplierSuggestion.suggested_unit_cost != null ? <div>Last cost: ${supplierSuggestion.suggested_unit_cost.toFixed(2)}</div> : null}
+                                                <div>{supplierSuggestion.reasons.slice(0, 3).join(" · ")}</div>
+                                                {supplierSuggestion.supplier_id ? (
+                                                  <button
+                                                    type="button"
+                                                    className="mt-2 underline decoration-dotted underline-offset-2 hover:text-white"
+                                                    onClick={() => applySupplierSuggestionSelection(r.req.id, String(it.id), supplierSuggestion)}
+                                                    disabled={rowBusy || (it.ui_supplier_id === supplierSuggestion.supplier_id && (!supplierSuggestion.open_po_id || it.ui_po_id === supplierSuggestion.open_po_id))}
+                                                  >
+                                                    Apply supplier/PO suggestion
+                                                  </button>
+                                                ) : null}
+                                                {supplierSuggestionApplied ? <div className="mt-1 text-neutral-500">Suggested supplier selected — confirm with Create/Re-use PO.</div> : null}
                                               </div>
                                             </details>
-                                            {supplierSuggestion.supplier_id ? (
-                                              <button
-                                                type="button"
-                                                className="mt-1 underline decoration-dotted underline-offset-2 hover:text-white"
-                                                onClick={() =>
-                                                  applySupplierSuggestionSelection(
-                                                    r.req.id,
-                                                    String(it.id),
-                                                    supplierSuggestion,
-                                                  )
-                                                }
-                                                disabled={
-                                                  rowBusy ||
-                                                  (it.ui_supplier_id === supplierSuggestion.supplier_id &&
-                                                    (!supplierSuggestion.open_po_id ||
-                                                      it.ui_po_id === supplierSuggestion.open_po_id))
-                                                }
-                                              >
-                                                {supplierSuggestion.recommended_action === "add_to_existing_open_po"
-                                                  ? "Use inventory"
-                                                  : "Create PO"}
-                                              </button>
-                                            ) : null}
-                                            {supplierSuggestionApplied ? (
-                                              <div className="mt-1 text-neutral-500">
-                                                Suggested supplier selected — confirm with Create/Re-use PO.
-                                              </div>
-                                            ) : null}
-                                          </div>
-                                        ) : null}
+                                          ) : null}
+                                        </div>
                                         {approved > 0 || isQuoteOnlyPreApprovalItem ? (
                                           <div className="text-[11px] text-neutral-500">
                                             State{" "}


### PR DESCRIPTION
### Motivation
- Fix brittle client-side edits and noisy AI suggestion UI on the existing Parts Request ID page without replacing or deleting the page. 
- Move the UI toward a workbench feel incrementally while preserving procurement, quote, and receiving behavior. 

### Description
- Added a shop-scoped server edit route `app/api/parts/requests/items/[itemId]/edit/route.ts` that validates authentication, `shop_id`, parent request/work-order/quote context, and applies an RLS-safe update for fields like `description`, `requested_part_number`, `requested_manufacturer`, `qty`, and `quoted_price`. 
- Updated `app/parts/requests/[id]/page.tsx` to persist item field edits via the new `PATCH /api/parts/requests/items/:itemId/edit` route and merge the returned row into UI state, which fixes the Manufacturer/Part # edit-save issue. 
- Kept the existing `add` server route and add flow, but changed the client Add logic to warn (toast) on “no-stock” instead of blocking and to avoid attempting allocation when stock is unavailable; allocation still runs when stock exists. 
- Converted large suggestion cards into compact passive badges/details for stock and supplier suggestions while keeping the deterministic matching logic and the ability to apply suggestions via explicit user actions. 
- Added a small `Add to Stock` action that reuses the existing create-and-attach inventory modal instead of introducing a parallel flow. 
- Files touched: `app/parts/requests/[id]/page.tsx` (targeted UI + behavior edits) and `app/api/parts/requests/items/[itemId]/edit/route.ts` (new server route). 
- Exact old behaviors preserved: quote-origin / pre-approval handling, receive drawer flows, PO create/reuse behavior, allocation RPC (when applicable), quote line sync, status sync, menu-item upsert, and parts events dispatching. 
- Reason for not deleting the page: changes are intentionally incremental and small, replacing direct client writes with a secure server route and compact UI tweaks rather than the 2,500-line deletion or full redesign. 

### Testing
- Ran `npx tsc --noEmit` and it completed successfully. 
- Ran `npx eslint app/parts/requests/[id]/page.tsx app/api/parts/requests/items/[itemId]/edit/route.ts app/api/parts/requests/items/[itemId]/add/route.ts` and it completed successfully. 
- Ran `git diff --check` to verify no trailing whitespace or obvious diff warnings, and results were clean. 
- Result: typecheck and lint passed locally against the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7025dee4832882a387543dfa647f)