### PR TITLE
Wire V2 inventory selection into canonical parts-request row state

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -803,6 +803,31 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     return { partId: null, error: "Pick a stock part first." };
   }
 
+  function applyInventoryPartToItem(reqId: string, item: UiItem, partId: string | null): void {
+    const selectedPart = partId
+      ? parts.find((part) => String(part.id) === String(partId)) ?? null
+      : null;
+    const partNumber = selectedPart
+      ? String(selectedPart.part_number ?? selectedPart.sku ?? "").trim()
+      : "";
+    const manufacturer = selectedPart
+      ? String(selectedPart.supplier ?? "").trim()
+      : "";
+    const currentDesc = String(item.description ?? "").trim();
+
+    updateItem(reqId, String(item.id), {
+      ui_part_id: partId,
+      requested_part_number: partNumber || item.requested_part_number,
+      requested_manufacturer: manufacturer || item.requested_manufacturer,
+      description: currentDesc
+        ? item.description
+        : (selectedPart?.name ?? item.description ?? "").trim(),
+      ui_price:
+        item.ui_price ??
+        (selectedPart?.price == null ? undefined : toNum(selectedPart.price, 0)),
+    });
+  }
+
   function getPartForConflict(partId: string | null): PartRow | null {
     return partId ? parts.find((p) => String(p.id) === String(partId)) ?? null : null;
   }
@@ -1979,27 +2004,11 @@ if (!lineId || !isUuid(lineId)) {
                                           className={`${selectBase} w-full py-1.5`}
                                           value={it.ui_part_id ?? ""}
                                           onChange={(e) => {
-                                            const nextPartId =
-                                              e.target.value || null;
-                                            const p = parts.find(
-                                              (x) =>
-                                                String(x.id) === String(nextPartId),
+                                            applyInventoryPartToItem(
+                                              r.req.id,
+                                              it,
+                                              e.target.value || null,
                                             );
-
-                                            // ✅ do NOT clobber user's typed request; only fill if empty
-                                            const currentDesc = String(
-                                              it.description ?? "",
-                                            ).trim();
-
-                                            updateItem(r.req.id, String(it.id), {
-                                              ui_part_id: nextPartId,
-                                              description: currentDesc
-                                                ? it.description
-                                                : (p?.name ??
-                                                    it.description ??
-                                                    "").trim(),
-                                              ui_price: it.ui_price ?? (p?.price == null ? undefined : toNum(p.price, 0)),
-                                            });
                                           }}
                                           disabled={rowBusy}
                                         >
@@ -2032,10 +2041,10 @@ if (!lineId || !isUuid(lineId)) {
                                                 <button
                                                   type="button"
                                                   className="mt-2 underline decoration-dotted underline-offset-2 hover:text-white"
-                                                  onClick={() => updateItem(r.req.id, String(it.id), { ui_part_id: topSuggestion.part_id })}
+                                                  onClick={() => applyInventoryPartToItem(r.req.id, it, topSuggestion.part_id)}
                                                   disabled={rowBusy || topSuggestion.part_id === it.ui_part_id}
                                                 >
-                                                  Use this match
+                                                  Use Inventory
                                                 </button>
                                               </div>
                                             </details>
@@ -2386,7 +2395,7 @@ if (!lineId || !isUuid(lineId)) {
                                             ? "Saving…"
                                             : isQuoteOnlyPreApprovalItem
                                               ? "Save Quote"
-                                              : "Add"}
+                                              : "Add to Job"}
                                         </button>
 
                                         {isQuoteOnlyPreApprovalItem ? (


### PR DESCRIPTION
### Motivation
- V2 presentation controls were filling UI fields but not updating the canonical row state V1 business flows rely on, causing `Add to Job` to fail and preventing menu/YMM learning from running.
- The goal is to make the V2 workbench a pure presentation layer that reuses the proven V1 functions rather than duplicating business logic or introducing new persistence paths.

### Description
- Added `applyInventoryPartToItem(reqId, item, partId)` which maps an inventory selection into the canonical `UiItem` fields (via the existing `updateItem`): `ui_part_id`, `requested_part_number`, `requested_manufacturer`, `ui_price`, and conditionally fills `description` only when empty. This intentionally does not persist `part_id` through `/edit`.
- Rewired V2 presentation callbacks to reuse V1 flows without duplicating internals: inventory dropdown and stock-suggestion actions now call `applyInventoryPartToItem(...)` which updates the same `UiItem` state that V1 reads.
- Kept all V1 business functions unchanged and wired V2 to call them: `addAndAttach` is still used for allocation, `persistItemFields` is still used for saving draft fields, `savePreApprovalQuote` is still used for quote-origin/pre-approval rows, and `createOrReusePoAndAssign` is still used for ordering/PO assignment.
- Small UX label change: the normal allocation button now reads `Add to Job` (presentation only); the underlying call remains `addAndAttach(reqId, itemId)` so `/api/parts/requests/items/[itemId]/add` and `/api/menu-items/upsert-from-line` are still invoked.

V2 callback rewiring (exact mapping):
- Use Inventory (inventory dropdown / AI suggestion) → `applyInventoryPartToItem(...)` → `updateItem(...)` (updates canonical `UiItem` state: `ui_part_id`, `requested_part_number`, `requested_manufacturer`, `ui_price`).
- Save drafts → `persistItemFields(itemId, ...)` (unchanged; only draft fields persisted: `description`, `requested_part_number`, `requested_manufacturer`, `qty`, `quoted_price`).
- Add to Job → `addAndAttach(reqId, itemId)` (unchanged; calls `/api/parts/requests/items/[itemId]/add`).
- Quote-origin / pre-approval Save → `savePreApprovalQuote(reqId, itemId)` (unchanged).
- Order (create/reuse PO & assign) → `createOrReusePoAndAssign(item, supplierId, ...)` (unchanged).
- Receive → unchanged (continues to use existing `ReceiveDrawer`).

### Testing
- Ran TypeScript check: `npx tsc --noEmit` — success.
- Ran targeted lint: `npx eslint app/parts/requests/[id]/page.tsx` — success.
- Verified by inspection that `addAndAttach` still calls `/api/parts/requests/items/[itemId]/add` and the subsequent menu upsert call to `/api/menu-items/upsert-from-line` remains intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d8fdcc8588328b96ba394634f5a71)