### PR TITLE
Standardize CSV import UX for customers, vehicles, history, and invoices

### DIFF
--- a/features/billing/components/InvoiceCsvImportCard.tsx
+++ b/features/billing/components/InvoiceCsvImportCard.tsx
@@ -1,46 +1,565 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
 import { GuidedImportFooterActions } from "@/features/shared/components/import/GuidedImportFooterActions";
 import { GuidedImportSummary } from "@/features/shared/components/import/GuidedImportSummary";
-import { CsvImportProgress, type CsvImportProgressState } from "@/features/shared/components/import/CsvImportProgress";
-import { useImportJobProgress, type ImportJobProgressJob } from "@/features/shared/components/import/useImportJobProgress";
+import { CsvImportPreviewCard } from "@/features/shared/components/import/CsvImportPreviewCard";
+import { CsvImportCompletionSummary } from "@/features/shared/components/import/CsvImportCompletionSummary";
+import {
+  CsvImportProgress,
+  type CsvImportProgressState,
+} from "@/features/shared/components/import/CsvImportProgress";
+import {
+  useImportJobProgress,
+  type ImportJobProgressJob,
+} from "@/features/shared/components/import/useImportJobProgress";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
-type InvoiceImportRow = { invoice_id?: string | null; invoice_number?: string | null; work_order_number?: string | null; customer_id?: string | null; customer_email?: string | null; customer_phone?: string | null; customer_name?: string | null; customer?: string | null; email?: string | null; phone?: string | null; name?: string | null; vehicle_id?: string | null; vin?: string | null; invoice_date?: string | null; due_date?: string | null; paid_date?: string | null; status?: string | null; payment_status?: string | null; service_category?: string | null; description?: string | null; labor_hours?: string | null; labor_total?: string | null; parts_total?: string | null; shop_supplies?: string | null; subtotal?: string | null; tax?: string | null; total?: string | null; amount_paid?: string | null; balance_due?: string | null; advisor?: string | null; technician?: string | null; notes?: string | null; source_system?: string | null };
-type ImportCounts = { imported: number; updated: number; skipped: number; failed: number; duplicates: number };
-type ImportResponse = { ok?: boolean; error?: string; jobId?: string; counts?: ImportCounts; totalRows?: number; skippedRows?: Array<{ row: number; reason: string; invoiceNumber: string | null; workOrderNumber: string | null }>; failedRows?: Array<{ row: number; error: string; invoiceNumber: string | null; workOrderNumber: string | null }> };
-const SUPPORTED_COLUMNS = ["invoice_id", "invoice_number", "work_order_number", "customer_id", "customer_email", "customer_phone", "customer_name", "customer", "email", "phone", "name", "vehicle_id", "vin", "invoice_date", "due_date", "paid_date", "status", "payment_status", "service_category", "description", "labor_hours", "labor_total", "parts_total", "shop_supplies", "subtotal", "tax", "total", "amount_paid", "balance_due", "advisor", "technician", "notes", "source_system"] as const;
+type InvoiceImportRow = {
+  invoice_id?: string | null;
+  invoice_number?: string | null;
+  work_order_number?: string | null;
+  customer_id?: string | null;
+  customer_email?: string | null;
+  customer_phone?: string | null;
+  customer_name?: string | null;
+  customer?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  name?: string | null;
+  vehicle_id?: string | null;
+  vin?: string | null;
+  invoice_date?: string | null;
+  due_date?: string | null;
+  paid_date?: string | null;
+  status?: string | null;
+  payment_status?: string | null;
+  service_category?: string | null;
+  description?: string | null;
+  labor_hours?: string | null;
+  labor_total?: string | null;
+  parts_total?: string | null;
+  shop_supplies?: string | null;
+  subtotal?: string | null;
+  tax?: string | null;
+  total?: string | null;
+  amount_paid?: string | null;
+  balance_due?: string | null;
+  advisor?: string | null;
+  technician?: string | null;
+  notes?: string | null;
+  source_system?: string | null;
+};
+type ImportCounts = {
+  imported: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  duplicates: number;
+};
+type ImportResponse = {
+  ok?: boolean;
+  error?: string;
+  jobId?: string;
+  counts?: ImportCounts;
+  totalRows?: number;
+  skippedRows?: Array<{
+    row: number;
+    reason: string;
+    invoiceNumber: string | null;
+    workOrderNumber: string | null;
+  }>;
+  failedRows?: Array<{
+    row: number;
+    error: string;
+    invoiceNumber: string | null;
+    workOrderNumber: string | null;
+  }>;
+};
+const SUPPORTED_COLUMNS = [
+  "invoice_id",
+  "invoice_number",
+  "work_order_number",
+  "customer_id",
+  "customer_email",
+  "customer_phone",
+  "customer_name",
+  "customer",
+  "email",
+  "phone",
+  "name",
+  "vehicle_id",
+  "vin",
+  "invoice_date",
+  "due_date",
+  "paid_date",
+  "status",
+  "payment_status",
+  "service_category",
+  "description",
+  "labor_hours",
+  "labor_total",
+  "parts_total",
+  "shop_supplies",
+  "subtotal",
+  "tax",
+  "total",
+  "amount_paid",
+  "balance_due",
+  "advisor",
+  "technician",
+  "notes",
+  "source_system",
+] as const;
 const RECOMMENDED_COLUMNS = SUPPORTED_COLUMNS.join(", ");
 const SAMPLE = `${RECOMMENDED_COLUMNS}\nLEG-INV-1001,INV-1001,RO-1001,CUST-1001,avery@example.com,555-0101,Avery Customer,Avery Customer,avery@example.com,555-0101,Avery Customer,VEH-2001,1HGCM82633A004352,2024-03-18,2024-04-17,2024-03-20,closed,paid,Brakes,Front brake service,2.4,360.00,240.00,18.00,618.00,30.90,648.90,648.90,0.00,Avery Advisor,Sam Tech,Imported paid invoice,Legacy DMS`;
-function cleanHeader(value: string): string { return value.trim().toLowerCase().replace(/\s+/g, "_").replace(/[^a-z0-9_]/g, ""); }
-function cleanCell(value: unknown): string | null { const text = String(value ?? "").trim(); return text.length ? text : null; }
-function normalizeParsedRow(row: Record<string, unknown>): InvoiceImportRow { const normalized: InvoiceImportRow = {}; for (const [header, value] of Object.entries(row)) { const key = cleanHeader(header); if (!(SUPPORTED_COLUMNS as readonly string[]).includes(key)) continue; normalized[key as keyof InvoiceImportRow] = cleanCell(value); } return normalized; }
-function hasValidDate(row: InvoiceImportRow): boolean { return Boolean(row.invoice_date && !Number.isNaN(new Date(row.invoice_date).getTime())); }
-function validOptionalNumber(value: string | null | undefined): boolean { if (!value) return true; return Number.isFinite(Number(value.replace(/[$,]/g, ""))); }
-function localValidation(row: InvoiceImportRow): string | null { if (!hasValidDate(row)) return "invoice_date is required and must be a valid date"; if (!row.invoice_number && !row.invoice_id) return "invoice_number or invoice_id is required"; for (const field of ["labor_hours", "labor_total", "parts_total", "shop_supplies", "subtotal", "tax", "total", "amount_paid", "balance_due"] as const) { if (!validOptionalNumber(row[field])) return `${field} must be numeric`; } return null; }
-function downloadSample() { const blob = new Blob([SAMPLE], { type: "text/csv;charset=utf-8" }); const a = document.createElement("a"); a.href = URL.createObjectURL(blob); a.download = "invoice-import-template.csv"; a.click(); URL.revokeObjectURL(a.href); }
+function cleanHeader(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
+}
+function cleanCell(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text.length ? text : null;
+}
+function normalizeParsedRow(row: Record<string, unknown>): InvoiceImportRow {
+  const normalized: InvoiceImportRow = {};
+  for (const [header, value] of Object.entries(row)) {
+    const key = cleanHeader(header);
+    if (!(SUPPORTED_COLUMNS as readonly string[]).includes(key)) continue;
+    normalized[key as keyof InvoiceImportRow] = cleanCell(value);
+  }
+  return normalized;
+}
+function hasValidDate(row: InvoiceImportRow): boolean {
+  return Boolean(
+    row.invoice_date && !Number.isNaN(new Date(row.invoice_date).getTime()),
+  );
+}
+function validOptionalNumber(value: string | null | undefined): boolean {
+  if (!value) return true;
+  return Number.isFinite(Number(value.replace(/[$,]/g, "")));
+}
+function localValidation(row: InvoiceImportRow): string | null {
+  if (!hasValidDate(row))
+    return "invoice_date is required and must be a valid date";
+  if (!row.invoice_number && !row.invoice_id)
+    return "invoice_number or invoice_id is required";
+  for (const field of [
+    "labor_hours",
+    "labor_total",
+    "parts_total",
+    "shop_supplies",
+    "subtotal",
+    "tax",
+    "total",
+    "amount_paid",
+    "balance_due",
+  ] as const) {
+    if (!validOptionalNumber(row[field])) return `${field} must be numeric`;
+  }
+  return null;
+}
+function downloadSample() {
+  const blob = new Blob([SAMPLE], { type: "text/csv;charset=utf-8" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "invoice-import-template.csv";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
 
-export function InvoiceCsvImportCard({ onImported, onImportActiveChange }: { onImported?: () => void; onImportActiveChange?: (active: boolean) => void }) {
-  const router = useRouter(); const guidedQuery = usePersistentGuidedOnboardingQuery("invoices") as GuidedOnboardingQuery | null;
-  const fileInputRef = useRef<HTMLInputElement | null>(null); const [file, setFile] = useState<File | null>(null); const [fileName, setFileName] = useState<string | null>(null); const [headers, setHeaders] = useState<string[]>([]); const [rows, setRows] = useState<InvoiceImportRow[]>([]); const [parseError, setParseError] = useState<string | null>(null); const [importError, setImportError] = useState<string | null>(null); const [response, setResponse] = useState<ImportResponse | null>(null); const [importing, setImporting] = useState(false); const [activeJobId, setActiveJobId] = useState<string | null>(null); const [completingOnboarding, setCompletingOnboarding] = useState(false); const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
-  const isOnboarding = Boolean(guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "invoices"); const rowValidation = useMemo(() => rows.map(localValidation), [rows]); const importableRows = useMemo(() => rows.filter((_, index) => !rowValidation[index]), [rows, rowValidation]); const previewRows = importableRows.slice(0, 5);
-  function reset() { setRows([]); setHeaders([]); setParseError(null); setImportError(null); setResponse(null); setProgress(null); }
-  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) { const nextFile = event.target.files?.[0] ?? null; reset(); if (!nextFile) { setFile(null); setFileName(null); return; } setFile(nextFile); setFileName(nextFile.name); if (!nextFile.name.toLowerCase().endsWith(".csv")) { setFile(null); setParseError("Please choose a .csv file."); return; } setProgress({ phase: "Reading file", phaseKey: "reading_file", processed: 0, total: 0, percent: 5 }); Papa.parse<Record<string, unknown>>(nextFile, { header: true, skipEmptyLines: true, complete: (results) => { const parsed = (results.data ?? []).map(normalizeParsedRow).filter((row) => Object.keys(row).length > 0); setHeaders((results.meta.fields ?? []).map(cleanHeader).filter(Boolean)); setRows(parsed); setProgress({ phase: "Validating rows", phaseKey: "validating", processed: parsed.length, total: parsed.length, percent: parsed.length ? 25 : 0 }); if (!parsed.length) setParseError("No invoice rows were found in that CSV."); }, error: (error) => { setProgress(null); setParseError(error.message || "Unable to parse that CSV file."); } }); }
-  const completeOnboardingAfterImport = useCallback(async (nextCounts: ImportCounts) => { if (!guidedQuery || !isOnboarding) return; setCompletingOnboarding(true); try { const res = await fetch(`/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/invoices/complete`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ summary: { importType: "invoice_csv", ...nextCounts } }) }); const payload = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string }; if (!res.ok || payload.ok === false) throw new Error(payload.error ?? "Invoice import succeeded, but onboarding completion failed."); } finally { setCompletingOnboarding(false); } }, [guidedQuery, isOnboarding]);
-  const handleJobComplete = useCallback(async (job: ImportJobProgressJob) => { const counts: ImportCounts = { imported: job.importedCount, updated: 0, skipped: job.skippedCount, failed: job.failedCount, duplicates: Number((job.summary as { duplicates?: number } | null | undefined)?.duplicates ?? 0) }; const summary = job.summary as { skippedRows?: ImportResponse["skippedRows"]; failedRows?: ImportResponse["failedRows"] } | null | undefined; const nextResponse: ImportResponse = { ok: job.status === "completed", jobId: job.id, counts, totalRows: job.totalRows, skippedRows: summary?.skippedRows ?? [], failedRows: summary?.failedRows ?? [], error: job.errorMessage ?? undefined }; setResponse(nextResponse); setImporting(false); setActiveJobId(null); if (job.status === "failed") { setImportError(job.errorMessage ?? "Invoice import job failed."); return; } if (isOnboarding && counts.imported > 0 && counts.failed === 0) await completeOnboardingAfterImport(counts); if (counts.imported > 0) onImported?.(); }, [completeOnboardingAfterImport, isOnboarding, onImported]);
-  const handleJobPollError = useCallback((message: string, job?: ImportJobProgressJob) => { if (job?.status === "failed") setImportError(message); }, []);
-  const { progress: jobProgress } = useImportJobProgress(activeJobId, { initialTotal: importableRows.length, onComplete: handleJobComplete, onError: handleJobPollError });
-  useEffect(() => { if (jobProgress) setProgress(jobProgress); }, [jobProgress]);
-  useEffect(() => { onImportActiveChange?.(Boolean(activeJobId)); }, [activeJobId, onImportActiveChange]);
-  async function confirmImport() { if (importing || completingOnboarding) return; if (!file || !importableRows.length) { setImportError("Upload a CSV with at least one valid invoice row before importing."); return; } setImporting(true); setImportError(null); setResponse(null); setActiveJobId(null); setProgress({ phase: "Uploading CSV", phaseKey: "importing", processed: 0, total: importableRows.length, percent: 10 }); try { const formData = new FormData(); formData.append("file", file); const res = await fetch("/api/invoices/import", { method: "POST", body: formData }); const payload = (await res.json().catch(() => ({}))) as ImportResponse; if (!res.ok || payload.ok === false || !payload.jobId) throw new Error(payload.error ?? "Unable to queue invoice import."); setResponse({ ok: true, jobId: payload.jobId, totalRows: payload.totalRows }); setProgress({ phase: "Importing records", phaseKey: "importing", processed: 0, total: payload.totalRows ?? importableRows.length, percent: 25 }); setActiveJobId(payload.jobId); } catch (error) { setProgress({ phase: "Import failed", phaseKey: "failed", processed: 0, total: importableRows.length, percent: 100 }); setImportError(error instanceof Error ? error.message : "Unable to queue invoice import."); setImporting(false); } }
-  return <GuidedImportCardLayout testId="invoice-csv-import-card" eyebrow="Operations · Customer Billing" title={isOnboarding ? "Upload invoice CSV" : "Import historical invoices"} description={<><p>Upload a CSV, review the parsed invoice preview, then explicitly confirm the import.</p><p>Supported columns include <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>. Imported invoices are historical/read-only billing records. They can match existing customers, vehicles, VINs, invoice numbers, and work order numbers where available, but they never create active work orders.</p></>} actions={<><input ref={fileInputRef} data-testid="invoice-csv-file-input" type="file" accept=".csv,text/csv" onChange={handleFileChange} className="sr-only" /><button type="button" onClick={() => fileInputRef.current?.click()} className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-white hover:border-[var(--accent-copper-soft)]/65">Choose CSV file</button><button type="button" onClick={downloadSample} className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08]">Download template</button></>}>
-    <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-neutral-300"><div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between"><div><span className="font-semibold text-neutral-100">Selected file:</span> {fileName ?? "No CSV selected"}</div>{headers.length ? <div className="text-xs text-neutral-400">Detected {headers.length} columns</div> : null}</div>{parseError ? <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">{parseError}</div> : null}{rows.length ? <div className="mt-3 grid gap-2 sm:grid-cols-3"><div className="rounded-lg border border-white/10 bg-white/[0.03] p-2"><div className="text-lg font-semibold text-white">{rows.length}</div><div className="text-xs text-neutral-400">Rows parsed</div></div><div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2"><div className="text-lg font-semibold text-emerald-100">{importableRows.length}</div><div className="text-xs text-neutral-400">Ready to import</div></div><div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2"><div className="text-lg font-semibold text-amber-100">{rows.length - importableRows.length}</div><div className="text-xs text-neutral-400">Need review</div></div></div> : null}</div>
-    {previewRows.length ? <div className="mt-4 overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]"><div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">Preview</div><div className="overflow-x-auto"><table className="w-full min-w-[900px] text-left text-sm"><thead className="text-xs uppercase tracking-[0.12em] text-neutral-500"><tr><th className="px-3 py-2">Invoice date</th><th className="px-3 py-2">Invoice / RO</th><th className="px-3 py-2">Customer / Vehicle</th><th className="px-3 py-2">Status</th><th className="px-3 py-2">Total</th></tr></thead><tbody className="divide-y divide-white/10 text-neutral-200">{previewRows.map((row, index) => <tr key={`${row.invoice_number ?? row.invoice_id}-${index}`}><td className="px-3 py-2 font-medium text-white">{row.invoice_date ?? "—"}</td><td className="px-3 py-2">{row.invoice_number ?? row.invoice_id ?? "—"}<div className="text-xs text-neutral-500">{row.work_order_number ?? "No work order match"}</div></td><td className="px-3 py-2">{row.customer_id ?? "Customer match optional"}<div className="text-xs text-neutral-500">{row.vehicle_id ?? row.vin ?? "Vehicle match optional"}</div></td><td className="px-3 py-2">{row.payment_status ?? row.status ?? "—"}</td><td className="px-3 py-2">{row.total ?? row.balance_due ?? "—"}</td></tr>)}</tbody></table></div></div> : null}
-    {rows.length - importableRows.length > 0 ? <GuidedImportSummary tone="warning">Validation results: {rows.length - importableRows.length} row(s) need review before import. Fix invoice dates, invoice identifiers, or numeric amount fields.</GuidedImportSummary> : null}<CsvImportProgress progress={progress} label="Invoice CSV import progress" />{response?.counts ? <GuidedImportSummary tone={response.counts.failed ? "error" : "success"}>Import results: Imported {response.counts.imported}, Skipped {response.counts.skipped}, Duplicates {response.counts.duplicates}, Failed {response.counts.failed}.</GuidedImportSummary> : null}{response?.skippedRows?.length ? <div className="mt-4 rounded-xl border border-amber-500/25 bg-amber-950/20 p-3 text-sm text-amber-50">Skipped rows: {response.skippedRows.slice(0, 8).map((r) => `Row ${r.row}: ${r.reason}`).join(" · ")}</div> : null}{response?.failedRows?.length ? <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/20 p-3 text-sm text-red-50">Failed rows: {response.failedRows.slice(0, 8).map((r) => `Row ${r.row}: ${r.error}`).join(" · ")}</div> : null}{importError ? <GuidedImportSummary tone="error">{importError}</GuidedImportSummary> : null}<GuidedImportFooterActions importing={importing} completing={completingOnboarding} canConfirm={Boolean(file && importableRows.length > 0)} onConfirm={() => void confirmImport()} isOnboarding={isOnboarding} returnTo={guidedQuery?.returnTo} hasResult={Boolean(response?.counts)} importSucceeded={Boolean(response?.counts && response.counts.imported > 0 && response.counts.failed === 0)} onContinue={() => router.push(guidedQuery!.returnTo)} />
-  </GuidedImportCardLayout>;
+export function InvoiceCsvImportCard({
+  onImported,
+  onImportActiveChange,
+}: {
+  onImported?: () => void;
+  onImportActiveChange?: (active: boolean) => void;
+}) {
+  const router = useRouter();
+  const guidedQuery = usePersistentGuidedOnboardingQuery(
+    "invoices",
+  ) as GuidedOnboardingQuery | null;
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [rows, setRows] = useState<InvoiceImportRow[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [response, setResponse] = useState<ImportResponse | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [activeJobId, setActiveJobId] = useState<string | null>(null);
+  const [completingOnboarding, setCompletingOnboarding] = useState(false);
+  const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
+  const isOnboarding = Boolean(
+    guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "invoices",
+  );
+  const rowValidation = useMemo(() => rows.map(localValidation), [rows]);
+  const importableRows = useMemo(
+    () => rows.filter((_, index) => !rowValidation[index]),
+    [rows, rowValidation],
+  );
+  const previewRows = importableRows.slice(0, 5);
+  function reset() {
+    setRows([]);
+    setHeaders([]);
+    setParseError(null);
+    setImportError(null);
+    setResponse(null);
+    setProgress(null);
+  }
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const nextFile = event.target.files?.[0] ?? null;
+    reset();
+    if (!nextFile) {
+      setFile(null);
+      setFileName(null);
+      return;
+    }
+    setFile(nextFile);
+    setFileName(nextFile.name);
+    if (!nextFile.name.toLowerCase().endsWith(".csv")) {
+      setFile(null);
+      setParseError("Please choose a .csv file.");
+      return;
+    }
+    setProgress({
+      phase: "Reading file",
+      phaseKey: "reading_file",
+      processed: 0,
+      total: 0,
+      percent: 5,
+    });
+    Papa.parse<Record<string, unknown>>(nextFile, {
+      header: true,
+      skipEmptyLines: true,
+      complete: (results) => {
+        const parsed = (results.data ?? [])
+          .map(normalizeParsedRow)
+          .filter((row) => Object.keys(row).length > 0);
+        setHeaders(
+          (results.meta.fields ?? []).map(cleanHeader).filter(Boolean),
+        );
+        setRows(parsed);
+        setProgress({
+          phase: "Validating rows",
+          phaseKey: "validating",
+          processed: parsed.length,
+          total: parsed.length,
+          percent: parsed.length ? 25 : 0,
+        });
+        if (!parsed.length)
+          setParseError("No invoice rows were found in that CSV.");
+      },
+      error: (error) => {
+        setProgress(null);
+        setParseError(error.message || "Unable to parse that CSV file.");
+      },
+    });
+  }
+  const completeOnboardingAfterImport = useCallback(
+    async (nextCounts: ImportCounts) => {
+      if (!guidedQuery || !isOnboarding) return;
+      setCompletingOnboarding(true);
+      try {
+        const res = await fetch(
+          `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/invoices/complete`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              summary: { importType: "invoice_csv", ...nextCounts },
+            }),
+          },
+        );
+        const payload = (await res.json().catch(() => ({}))) as {
+          ok?: boolean;
+          error?: string;
+        };
+        if (!res.ok || payload.ok === false)
+          throw new Error(
+            payload.error ??
+              "Invoice import succeeded, but onboarding completion failed.",
+          );
+      } finally {
+        setCompletingOnboarding(false);
+      }
+    },
+    [guidedQuery, isOnboarding],
+  );
+  const handleJobComplete = useCallback(
+    async (job: ImportJobProgressJob) => {
+      const counts: ImportCounts = {
+        imported: job.importedCount,
+        updated: 0,
+        skipped: job.skippedCount,
+        failed: job.failedCount,
+        duplicates: Number(
+          (job.summary as { duplicates?: number } | null | undefined)
+            ?.duplicates ?? 0,
+        ),
+      };
+      const summary = job.summary as
+        | {
+            skippedRows?: ImportResponse["skippedRows"];
+            failedRows?: ImportResponse["failedRows"];
+          }
+        | null
+        | undefined;
+      const nextResponse: ImportResponse = {
+        ok: job.status === "completed",
+        jobId: job.id,
+        counts,
+        totalRows: job.totalRows,
+        skippedRows: summary?.skippedRows ?? [],
+        failedRows: summary?.failedRows ?? [],
+        error: job.errorMessage ?? undefined,
+      };
+      setResponse(nextResponse);
+      setImporting(false);
+      setActiveJobId(null);
+      if (job.status === "failed") {
+        setImportError(job.errorMessage ?? "Invoice import job failed.");
+        return;
+      }
+      if (isOnboarding && counts.imported > 0 && counts.failed === 0)
+        await completeOnboardingAfterImport(counts);
+      if (counts.imported > 0) onImported?.();
+    },
+    [completeOnboardingAfterImport, isOnboarding, onImported],
+  );
+  const handleJobPollError = useCallback(
+    (message: string, job?: ImportJobProgressJob) => {
+      if (job?.status === "failed") setImportError(message);
+    },
+    [],
+  );
+  const { progress: jobProgress } = useImportJobProgress(activeJobId, {
+    initialTotal: importableRows.length,
+    onComplete: handleJobComplete,
+    onError: handleJobPollError,
+  });
+  useEffect(() => {
+    if (jobProgress) setProgress(jobProgress);
+  }, [jobProgress]);
+  useEffect(() => {
+    onImportActiveChange?.(Boolean(activeJobId));
+  }, [activeJobId, onImportActiveChange]);
+  async function confirmImport() {
+    if (importing || completingOnboarding) return;
+    if (!file || !importableRows.length) {
+      setImportError(
+        "Upload a CSV with at least one valid invoice row before importing.",
+      );
+      return;
+    }
+    setImporting(true);
+    setImportError(null);
+    setResponse(null);
+    setActiveJobId(null);
+    setProgress({
+      phase: "Uploading CSV",
+      phaseKey: "importing",
+      processed: 0,
+      total: importableRows.length,
+      percent: 10,
+    });
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetch("/api/invoices/import", {
+        method: "POST",
+        body: formData,
+      });
+      const payload = (await res.json().catch(() => ({}))) as ImportResponse;
+      if (!res.ok || payload.ok === false || !payload.jobId)
+        throw new Error(payload.error ?? "Unable to queue invoice import.");
+      setResponse({
+        ok: true,
+        jobId: payload.jobId,
+        totalRows: payload.totalRows,
+      });
+      setProgress({
+        phase: "Importing records",
+        phaseKey: "importing",
+        processed: 0,
+        total: payload.totalRows ?? importableRows.length,
+        percent: 25,
+      });
+      setActiveJobId(payload.jobId);
+    } catch (error) {
+      setProgress({
+        phase: "Import failed",
+        phaseKey: "failed",
+        processed: 0,
+        total: importableRows.length,
+        percent: 100,
+      });
+      setImportError(
+        error instanceof Error
+          ? error.message
+          : "Unable to queue invoice import.",
+      );
+      setImporting(false);
+    }
+  }
+  return (
+    <GuidedImportCardLayout
+      testId="invoice-csv-import-card"
+      eyebrow="Operations · Customer Billing"
+      title={isOnboarding ? "Upload invoice CSV" : "Import historical invoices"}
+      description={
+        <>
+          <p>
+            Upload a CSV, review the parsed invoice preview, then explicitly
+            confirm the import.
+          </p>
+          <p>
+            Supported columns include{" "}
+            <span className="text-neutral-100">{RECOMMENDED_COLUMNS}</span>.
+            Imported invoices are historical/read-only billing records. They can
+            match existing customers, vehicles, VINs, invoice numbers, and work
+            order numbers where available, but they never create active work
+            orders.
+          </p>
+        </>
+      }
+      actions={
+        <>
+          <input
+            ref={fileInputRef}
+            data-testid="invoice-csv-file-input"
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            className="sr-only"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-2 text-sm font-semibold text-white hover:border-[var(--accent-copper-soft)]/65"
+          >
+            Choose CSV file
+          </button>
+          <button
+            type="button"
+            onClick={downloadSample}
+            className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08]"
+          >
+            Download template
+          </button>
+        </>
+      }
+    >
+      <CsvImportPreviewCard
+        fileName={fileName}
+        headersCount={headers.length}
+        parsedRows={rows.length}
+        readyRows={importableRows.length}
+        needsReviewRows={rows.length - importableRows.length}
+        duplicateRows={response?.counts?.duplicates ?? 0}
+        invalidRows={rows.length - importableRows.length}
+        parseError={parseError}
+      />
+      {previewRows.length ? (
+        <div className="mt-4 overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
+          <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">
+            Preview
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[900px] text-left text-sm">
+              <thead className="text-xs uppercase tracking-[0.12em] text-neutral-500">
+                <tr>
+                  <th className="px-3 py-2">Invoice date</th>
+                  <th className="px-3 py-2">Invoice / RO</th>
+                  <th className="px-3 py-2">Customer / Vehicle</th>
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2">Total</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10 text-neutral-200">
+                {previewRows.map((row, index) => (
+                  <tr key={`${row.invoice_number ?? row.invoice_id}-${index}`}>
+                    <td className="px-3 py-2 font-medium text-white">
+                      {row.invoice_date ?? "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.invoice_number ?? row.invoice_id ?? "—"}
+                      <div className="text-xs text-neutral-500">
+                        {row.work_order_number ?? "No work order match"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.customer_id ?? "Customer match optional"}
+                      <div className="text-xs text-neutral-500">
+                        {row.vehicle_id ?? row.vin ?? "Vehicle match optional"}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.payment_status ?? row.status ?? "—"}
+                    </td>
+                    <td className="px-3 py-2">
+                      {row.total ?? row.balance_due ?? "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+      {rows.length - importableRows.length > 0 ? (
+        <GuidedImportSummary tone="warning">
+          Validation results: {rows.length - importableRows.length} row(s) need
+          review before import. Fix invoice dates, invoice identifiers, or
+          numeric amount fields.
+        </GuidedImportSummary>
+      ) : null}
+      <CsvImportProgress
+        progress={progress}
+        label="Invoice CSV import progress"
+      />
+      {response?.counts ? (
+        <CsvImportCompletionSummary
+          imported={response.counts.imported}
+          skipped={response.counts.skipped}
+          failed={response.counts.failed}
+          duplicates={response.counts.duplicates}
+          skippedRows={response.skippedRows}
+          failedRows={response.failedRows}
+        />
+      ) : null}
+      {importError ? (
+        <GuidedImportSummary tone="error">{importError}</GuidedImportSummary>
+      ) : null}
+      <GuidedImportFooterActions
+        importing={importing}
+        completing={completingOnboarding}
+        canConfirm={Boolean(file && importableRows.length > 0)}
+        onConfirm={() => void confirmImport()}
+        isOnboarding={isOnboarding}
+        returnTo={guidedQuery?.returnTo}
+        hasResult={Boolean(response?.counts)}
+        importSucceeded={Boolean(
+          response?.counts &&
+          response.counts.imported > 0 &&
+          response.counts.failed === 0,
+        )}
+        onContinue={() => router.push(guidedQuery!.returnTo)}
+      />
+    </GuidedImportCardLayout>
+  );
 }

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useMemo, useRef, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
@@ -9,6 +8,9 @@ import {
   CsvImportProgress,
   type CsvImportProgressState,
 } from "@/features/shared/components/import/CsvImportProgress";
+import { CsvImportPreviewCard } from "@/features/shared/components/import/CsvImportPreviewCard";
+import { CsvImportCompletionSummary } from "@/features/shared/components/import/CsvImportCompletionSummary";
+import { GuidedImportFooterActions } from "@/features/shared/components/import/GuidedImportFooterActions";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type CustomerImportRow = {
@@ -515,49 +517,16 @@ export function CustomerCsvImportCard({
         </>
       }
     >
-      <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
-        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <span className="font-semibold text-neutral-100">
-              Selected file:
-            </span>{" "}
-            {fileName ?? "No CSV selected"}
-          </div>
-          {headers.length ? (
-            <div className="text-xs text-neutral-400">
-              Detected {headers.length} columns
-            </div>
-          ) : null}
-        </div>
-        {parseError ? (
-          <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">
-            {parseError}
-          </div>
-        ) : null}
-        {rows.length ? (
-          <div className="mt-3 grid gap-2 sm:grid-cols-3">
-            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
-              <div className="text-lg font-semibold text-white">
-                {rows.length}
-              </div>
-              <div className="text-xs text-neutral-400">Rows parsed</div>
-            </div>
-            <div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2">
-              <div className="text-lg font-semibold text-emerald-100">
-                {importableRows.length}
-              </div>
-              <div className="text-xs text-neutral-400">Ready to import</div>
-            </div>
-            <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2">
-              <div className="text-lg font-semibold text-amber-100">
-                {skippedPreviewCount}
-              </div>
-              <div className="text-xs text-neutral-400">Missing identity</div>
-            </div>
-          </div>
-        ) : null}
-      </div>
-
+      <CsvImportPreviewCard
+        fileName={fileName}
+        headersCount={headers.length}
+        parsedRows={rows.length}
+        readyRows={importableRows.length}
+        needsReviewRows={skippedPreviewCount}
+        duplicateRows={counts?.duplicates ?? counts?.skipped ?? 0}
+        invalidRows={skippedPreviewCount}
+        parseError={parseError}
+      />
       {previewRows.length ? (
         <div className="mt-4 overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
           <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">
@@ -595,149 +564,39 @@ export function CustomerCsvImportCard({
           </div>
         </div>
       ) : null}
-
       <CsvImportProgress
         progress={importProgress}
         label="Customer CSV import progress"
       />
-
       {counts ? (
-        <div className="mt-4 rounded-xl border border-emerald-500/25 bg-emerald-950/25 p-3 text-sm text-emerald-50">
-          Import results: Imported {counts.created}, Updated {counts.updated},
-          Skipped {counts.skipped}, Failed {counts.failed}.
-        </div>
-      ) : null}
-      {failedRows.length ? (
-        <div className="mt-4 overflow-hidden rounded-xl border border-red-500/25 bg-red-950/20 text-sm text-red-50">
-          <div className="border-b border-red-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-red-100">
-            Failed rows
-          </div>
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[820px] text-left">
-              <thead className="text-xs uppercase tracking-[0.12em] text-red-100/70">
-                <tr>
-                  <th className="px-3 py-2">Row</th>
-                  <th className="px-3 py-2">Customer</th>
-                  <th className="px-3 py-2">Email</th>
-                  <th className="px-3 py-2">Phone</th>
-                  <th className="px-3 py-2">Error</th>
-                  <th className="px-3 py-2">Constraint</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-red-500/15 text-red-50/90">
-                {failedRows.slice(0, 25).map((row) => (
-                  <tr key={`${row.row}-${row.constraint ?? row.error}`}>
-                    <td className="px-3 py-2">{row.row}</td>
-                    <td className="px-3 py-2">{row.customerName ?? "—"}</td>
-                    <td className="px-3 py-2">{row.email ?? "—"}</td>
-                    <td className="px-3 py-2">{row.phone ?? "—"}</td>
-                    <td className="px-3 py-2">{row.error}</td>
-                    <td className="px-3 py-2">{row.constraint ?? "—"}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          {failedRows.length > 25 ? (
-            <div className="px-3 py-2 text-xs text-red-100/70">
-              Showing first 25 of {failedRows.length} failed rows.
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      {skippedRows.length ? (
-        <div className="mt-4 overflow-hidden rounded-xl border border-amber-500/25 bg-amber-950/20 text-sm text-amber-50">
-          <div className="border-b border-amber-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-amber-100">
-            Skipped rows
-          </div>
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[760px] text-left">
-              <thead className="text-xs uppercase tracking-[0.12em] text-amber-100/70">
-                <tr>
-                  <th className="px-3 py-2">Row</th>
-                  <th className="px-3 py-2">Customer</th>
-                  <th className="px-3 py-2">Email</th>
-                  <th className="px-3 py-2">Phone</th>
-                  <th className="px-3 py-2">Reason</th>
-                  <th className="px-3 py-2">Matched by</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-amber-500/15 text-amber-50/90">
-                {skippedRows.slice(0, 25).map((row) => (
-                  <tr
-                    key={`${row.row}-${row.matchedBy}-${row.matchedValue ?? row.customerName ?? row.email ?? row.phone ?? "row"}`}
-                  >
-                    <td className="px-3 py-2">{row.row}</td>
-                    <td className="px-3 py-2">{row.customerName ?? "—"}</td>
-                    <td className="px-3 py-2">{row.email ?? "—"}</td>
-                    <td className="px-3 py-2">{row.phone ?? "—"}</td>
-                    <td className="px-3 py-2">{row.reason}</td>
-                    <td className="px-3 py-2">
-                      {row.matchedBy}
-                      {row.matchedValue ? ` · ${row.matchedValue}` : ""}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-          {skippedRows.length > 25 ? (
-            <div className="px-3 py-2 text-xs text-amber-100/70">
-              Showing first 25 of {skippedRows.length} skipped rows.
-            </div>
-          ) : null}
-        </div>
+        <CsvImportCompletionSummary
+          imported={counts.created + counts.updated}
+          skipped={counts.skipped}
+          failed={counts.failed}
+          duplicates={counts.duplicates ?? counts.skipped}
+          skippedRows={skippedRows}
+          failedRows={failedRows}
+        />
       ) : null}
       {importError ? (
         <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/30 p-3 text-sm text-red-100">
           {importError}
         </div>
       ) : null}
-
-      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-        <button
-          type="button"
-          onClick={() => void confirmImport()}
-          disabled={importing || completingOnboarding || !importableRows.length}
-          className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black shadow-[0_0_22px_rgba(212,118,49,0.45)] hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-55"
-        >
-          {importing
-            ? "Importing…"
-            : completingOnboarding
-              ? "Completing onboarding…"
-              : "Confirm import"}
-        </button>
-        {isOnboarding && importSucceeded ? (
-          <button
-            type="button"
-            onClick={() => router.push(guidedQuery!.returnTo)}
-            className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
-          >
-            Continue onboarding
-          </button>
-        ) : null}
-        {isOnboarding ? (
-          <>
-            <button
-              type="button"
-              onClick={() => void skipOnboardingStep()}
-              disabled={
-                busyAction !== null || importing || completingOnboarding
-              }
-              className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08] disabled:opacity-55"
-            >
-              {busyAction === "skip" ? "Skipping…" : "Skip for now"}
-            </button>
-            <Link
-              href={guidedQuery!.returnTo}
-              className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
-            >
-              Return to Data Onboarding
-            </Link>
-          </>
-        ) : null}
-      </div>
+      <GuidedImportFooterActions
+        importing={importing}
+        completing={completingOnboarding}
+        canConfirm={importableRows.length > 0}
+        onConfirm={() => void confirmImport()}
+        isOnboarding={isOnboarding}
+        returnTo={guidedQuery?.returnTo}
+        hasResult={Boolean(counts)}
+        importSucceeded={importSucceeded}
+        onContinue={() => router.push(guidedQuery!.returnTo)}
+        onSkip={isOnboarding ? () => void skipOnboardingStep() : undefined}
+        skipDisabled={busyAction !== null}
+        skipLabel={busyAction === "skip" ? "Skipping…" : "Skip for now"}
+      />{" "}
     </GuidedSetupCardShell>
   );
 }

--- a/features/shared/components/import/CsvImportCompletionSummary.tsx
+++ b/features/shared/components/import/CsvImportCompletionSummary.tsx
@@ -1,0 +1,51 @@
+import { GuidedImportSummary } from "./GuidedImportSummary";
+
+type SampleRow = { row: number; reason?: string; error?: string };
+
+type Props = {
+  imported: number;
+  skipped: number;
+  failed: number;
+  duplicates?: number;
+  processingTime?: string | null;
+  skippedRows?: SampleRow[];
+  failedRows?: SampleRow[];
+};
+
+export function CsvImportCompletionSummary({
+  imported,
+  skipped,
+  failed,
+  duplicates = 0,
+  processingTime,
+  skippedRows = [],
+  failedRows = [],
+}: Props) {
+  return (
+    <GuidedImportSummary tone={failed > 0 ? "warning" : "success"}>
+      <div className="font-semibold">
+        Imported {imported}, skipped {skipped}, failed {failed}, duplicates{" "}
+        {duplicates}.
+        {processingTime ? <> Processing time: {processingTime}.</> : null}
+      </div>
+      {skippedRows.length > 0 ? (
+        <ul className="mt-2 list-disc pl-5 text-xs">
+          {skippedRows.slice(0, 5).map((item) => (
+            <li key={`skipped-${item.row}-${item.reason}`}>
+              Row {item.row}: {item.reason ?? "Skipped"}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {failedRows.length > 0 ? (
+        <ul className="mt-2 list-disc pl-5 text-xs">
+          {failedRows.slice(0, 5).map((item) => (
+            <li key={`failed-${item.row}-${item.error}`}>
+              Row {item.row}: {item.error ?? "Failed"}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </GuidedImportSummary>
+  );
+}

--- a/features/shared/components/import/CsvImportPreviewCard.tsx
+++ b/features/shared/components/import/CsvImportPreviewCard.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from "react";
+
+export type CsvImportPreviewMetric = {
+  label: string;
+  value: number;
+  tone?: "default" | "success" | "warning" | "error";
+};
+
+type Props = {
+  fileName?: string | null;
+  headersCount?: number;
+  parsedRows: number;
+  readyRows: number;
+  needsReviewRows?: number;
+  duplicateRows?: number;
+  invalidRows?: number;
+  parseError?: string | null;
+  children?: ReactNode;
+};
+
+const toneClassName: Record<
+  NonNullable<CsvImportPreviewMetric["tone"]>,
+  string
+> = {
+  default: "border-white/10 bg-white/[0.03] text-white",
+  success: "border-emerald-500/20 bg-emerald-950/20 text-emerald-100",
+  warning: "border-amber-500/20 bg-amber-950/20 text-amber-100",
+  error: "border-red-500/20 bg-red-950/20 text-red-100",
+};
+
+export function CsvImportPreviewCard({
+  fileName,
+  headersCount = 0,
+  parsedRows,
+  readyRows,
+  needsReviewRows = 0,
+  duplicateRows = 0,
+  invalidRows = 0,
+  parseError,
+  children,
+}: Props) {
+  const metrics: CsvImportPreviewMetric[] = [
+    { label: "Parsed Rows", value: parsedRows },
+    { label: "Ready to Import", value: readyRows, tone: "success" },
+    {
+      label: "Needs Review",
+      value: needsReviewRows,
+      tone: needsReviewRows ? "warning" : "default",
+    },
+    {
+      label: "Duplicate Rows",
+      value: duplicateRows,
+      tone: duplicateRows ? "warning" : "default",
+    },
+    {
+      label: "Invalid Rows",
+      value: invalidRows,
+      tone: invalidRows ? "error" : "default",
+    },
+  ];
+
+  return (
+    <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <span className="font-semibold text-neutral-100">Selected file:</span>{" "}
+          {fileName ?? "No CSV selected"}
+        </div>
+        {headersCount > 0 ? (
+          <div className="text-xs text-neutral-400">
+            Detected {headersCount} columns
+          </div>
+        ) : null}
+      </div>
+      {parseError ? (
+        <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">
+          {parseError}
+        </div>
+      ) : null}
+      {parsedRows > 0 ? (
+        <div className="mt-3 grid gap-2 sm:grid-cols-5">
+          {metrics.map((metric) => (
+            <div
+              key={metric.label}
+              className={`rounded-lg border p-2 ${toneClassName[metric.tone ?? "default"]}`}
+            >
+              <div className="text-lg font-semibold">{metric.value}</div>
+              <div className="text-xs text-neutral-400">{metric.label}</div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}

--- a/features/shared/components/import/CsvImportProgress.tsx
+++ b/features/shared/components/import/CsvImportProgress.tsx
@@ -19,6 +19,7 @@ export type CsvImportProgressState = {
   imported?: number;
   skipped?: number;
   failed?: number;
+  duplicates?: number;
   status?: string;
   stalled?: boolean;
 };
@@ -66,20 +67,43 @@ export function CsvImportProgress({
             {label}
           </div>
           <div className="font-semibold capitalize">{progress.phase}</div>
-          {progress.stalled ? <div className="text-xs opacity-75">Still processing on the server. Progress will update as more rows finish.</div> : null}
+          {progress.stalled ? (
+            <div className="text-xs opacity-75">
+              Still processing on the server. Progress will update as more rows
+              finish.
+            </div>
+          ) : null}
         </div>
         <div className="text-xs opacity-80">
           {total > 0 ? (
-            <>{processed}/{total} rows · </>
+            <>
+              {processed}/{total} rows ·{" "}
+            </>
           ) : null}
           {percent}%
         </div>
       </div>
-      {(progress.imported !== undefined || progress.skipped !== undefined || progress.failed !== undefined) ? (
-        <div className="mt-3 grid gap-2 text-xs sm:grid-cols-3">
-          <div className="rounded-lg bg-black/20 px-2 py-1">Imported: <span className="font-semibold">{progress.imported ?? 0}</span></div>
-          <div className="rounded-lg bg-black/20 px-2 py-1">Skipped: <span className="font-semibold">{progress.skipped ?? 0}</span></div>
-          <div className="rounded-lg bg-black/20 px-2 py-1">Failed: <span className="font-semibold">{progress.failed ?? 0}</span></div>
+      {progress.imported !== undefined ||
+      progress.skipped !== undefined ||
+      progress.failed !== undefined ||
+      progress.duplicates !== undefined ? (
+        <div className="mt-3 grid gap-2 text-xs sm:grid-cols-4">
+          <div className="rounded-lg bg-black/20 px-2 py-1">
+            Imported:{" "}
+            <span className="font-semibold">{progress.imported ?? 0}</span>
+          </div>
+          <div className="rounded-lg bg-black/20 px-2 py-1">
+            Skipped:{" "}
+            <span className="font-semibold">{progress.skipped ?? 0}</span>
+          </div>
+          <div className="rounded-lg bg-black/20 px-2 py-1">
+            Failed:{" "}
+            <span className="font-semibold">{progress.failed ?? 0}</span>
+          </div>
+          <div className="rounded-lg bg-black/20 px-2 py-1">
+            Duplicates:{" "}
+            <span className="font-semibold">{progress.duplicates ?? 0}</span>
+          </div>
         </div>
       ) : null}
       <div className="mt-3 h-2 overflow-hidden rounded-full bg-black/35">

--- a/features/shared/components/import/useImportJobProgress.ts
+++ b/features/shared/components/import/useImportJobProgress.ts
@@ -3,7 +3,11 @@
 import { useEffect, useState } from "react";
 import type { CsvImportProgressState } from "./CsvImportProgress";
 
-export type ImportJobProgressStatus = "queued" | "processing" | "completed" | "failed";
+export type ImportJobProgressStatus =
+  | "queued"
+  | "processing"
+  | "completed"
+  | "failed";
 
 export type ImportJobProgressJob = {
   id: string;
@@ -18,7 +22,11 @@ export type ImportJobProgressJob = {
   updatedAt?: string | null;
 };
 
-type ImportJobProgressResponse = { ok?: boolean; error?: string; job?: ImportJobProgressJob };
+type ImportJobProgressResponse = {
+  ok?: boolean;
+  error?: string;
+  job?: ImportJobProgressJob;
+};
 
 type Options = {
   initialTotal?: number;
@@ -33,14 +41,31 @@ function percent(processed: number, total: number) {
   return Math.max(0, Math.min(100, Math.round((processed / total) * 100)));
 }
 
-function toProgress(job: ImportJobProgressJob, initialTotal = 0, stalled = false): CsvImportProgressState {
+function toProgress(
+  job: ImportJobProgressJob,
+  initialTotal = 0,
+  stalled = false,
+): CsvImportProgressState {
   const total = job.totalRows || initialTotal || 0;
-  const processed = job.status === "completed" && total ? Math.max(job.processedRows, total) : job.processedRows;
+  const processed =
+    job.status === "completed" && total
+      ? Math.max(job.processedRows, total)
+      : job.processedRows;
   const calculated = percent(processed, total);
-  const phaseKey = job.status === "failed" ? "failed" : job.status === "completed" ? "completed" : job.status === "queued" ? "queued" : "processing";
-  const phase = stalled && (job.status === "queued" || job.status === "processing")
-    ? `Still processing… ${job.status}`
-    : job.status;
+  const phaseKey =
+    job.status === "failed"
+      ? "failed"
+      : job.status === "completed"
+        ? "completed"
+        : job.status === "queued"
+          ? "queued"
+          : "processing";
+  const phase =
+    stalled && (job.status === "queued" || job.status === "processing")
+      ? `Still processing… ${job.status}`
+      : job.status;
+
+  const summary = job.summary as { duplicates?: number } | null | undefined;
 
   return {
     phase,
@@ -51,13 +76,23 @@ function toProgress(job: ImportJobProgressJob, initialTotal = 0, stalled = false
     imported: job.importedCount,
     skipped: job.skippedCount,
     failed: job.failedCount,
+    duplicates: Number(summary?.duplicates ?? 0),
     status: job.status,
     stalled,
   };
 }
 
-export function useImportJobProgress(jobId: string | null, options: Options = {}) {
-  const { initialTotal = 0, pollMs = 1500, stalledAfterMs = 15000, onComplete, onError } = options;
+export function useImportJobProgress(
+  jobId: string | null,
+  options: Options = {},
+) {
+  const {
+    initialTotal = 0,
+    pollMs = 1500,
+    stalledAfterMs = 15000,
+    onComplete,
+    onError,
+  } = options;
   const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
   const [lastJob, setLastJob] = useState<ImportJobProgressJob | null>(null);
 
@@ -71,27 +106,39 @@ export function useImportJobProgress(jobId: string | null, options: Options = {}
 
     async function poll() {
       try {
-        const res = await fetch(`/api/import-jobs/${encodeURIComponent(pollingJobId)}`);
-        const payload = (await res.json().catch(() => ({}))) as ImportJobProgressResponse;
-        if (!res.ok || payload.ok === false || !payload.job) throw new Error(payload.error ?? "Unable to load import job status.");
+        const res = await fetch(
+          `/api/import-jobs/${encodeURIComponent(pollingJobId)}`,
+        );
+        const payload = (await res
+          .json()
+          .catch(() => ({}))) as ImportJobProgressResponse;
+        if (!res.ok || payload.ok === false || !payload.job)
+          throw new Error(payload.error ?? "Unable to load import job status.");
         if (stopped) return;
         const job = payload.job;
         if (job.processedRows !== lastProcessed) {
           lastProcessed = job.processedRows;
           lastMovementAt = Date.now();
         }
-        const stalled = Date.now() - lastMovementAt >= stalledAfterMs && (job.status === "queued" || job.status === "processing");
+        const stalled =
+          Date.now() - lastMovementAt >= stalledAfterMs &&
+          (job.status === "queued" || job.status === "processing");
         setLastJob(job);
         setProgress(toProgress(job, initialTotal, stalled));
         if (job.status === "completed" || job.status === "failed") {
-          if (job.status === "failed") onError?.(job.errorMessage ?? "Import job failed.", job);
+          if (job.status === "failed")
+            onError?.(job.errorMessage ?? "Import job failed.", job);
           await onComplete?.(job);
           return;
         }
         timeoutId = setTimeout(() => void poll(), pollMs);
       } catch (error) {
         if (stopped) return;
-        onError?.(error instanceof Error ? error.message : "Unable to poll import status.");
+        onError?.(
+          error instanceof Error
+            ? error.message
+            : "Unable to poll import status.",
+        );
         timeoutId = setTimeout(() => void poll(), pollMs);
       }
     }

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import React, { useMemo, useRef, useState } from "react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
 import {
   CsvImportProgress,
   type CsvImportProgressState,
 } from "@/features/shared/components/import/CsvImportProgress";
+import { CsvImportPreviewCard } from "@/features/shared/components/import/CsvImportPreviewCard";
+import { CsvImportCompletionSummary } from "@/features/shared/components/import/CsvImportCompletionSummary";
+import { GuidedImportFooterActions } from "@/features/shared/components/import/GuidedImportFooterActions";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type Props = {
@@ -483,79 +485,36 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         </>
       }
     >
-      <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2 text-sm text-neutral-300">
-        <span className="font-semibold text-neutral-100">Selected file:</span>{" "}
-        {fileName ?? "No CSV selected"}
-      </div>
-
-      {parseError ? (
-        <div className="mt-3 rounded-xl border border-red-500/35 bg-red-950/40 p-3 text-sm text-red-200">
-          {parseError}
-        </div>
-      ) : null}
-
+      <CsvImportPreviewCard
+        fileName={fileName}
+        parsedRows={rows.length}
+        readyRows={importableRows.length}
+        needsReviewRows={skippedPreviewCount}
+        duplicateRows={0}
+        invalidRows={skippedPreviewCount}
+        parseError={parseError}
+      />
       {importError ? (
         <div className="mt-3 rounded-xl border border-red-500/35 bg-red-950/40 p-3 text-sm text-red-200">
           {importError}
         </div>
       ) : null}
-
       <CsvImportProgress
         progress={importProgress}
         label="Vehicle CSV import progress"
       />
-
       {counts ? (
-        <div className="mt-3 rounded-xl border border-emerald-500/35 bg-emerald-950/30 p-3 text-sm text-emerald-200">
-          Import complete. Imported: {counts.created}. Updated: {counts.updated}
-          . Skipped: {counts.skipped}. Failed: {counts.failed}.
-          {failedRows.length || skippedRows.length ? (
-            <details className="mt-2 text-xs text-emerald-50/80">
-              <summary className="cursor-pointer font-semibold">
-                Developer diagnostics
-              </summary>
-              <div className="mt-2 max-h-48 overflow-auto rounded-lg border border-white/10 bg-black/25 p-2 text-left">
-                {[
-                  ...failedRows.map(
-                    (row) => `Failed row ${row.row}: ${row.error}`,
-                  ),
-                  ...skippedRows.map(
-                    (row) => `Skipped row ${row.row}: ${row.reason}`,
-                  ),
-                ]
-                  .slice(0, 25)
-                  .map((line) => (
-                    <div key={line}>{line}</div>
-                  ))}
-              </div>
-            </details>
-          ) : null}
-        </div>
+        <CsvImportCompletionSummary
+          imported={counts.created + counts.updated}
+          skipped={counts.skipped}
+          failed={counts.failed}
+          duplicates={0}
+          skippedRows={skippedRows}
+          failedRows={failedRows}
+        />
       ) : null}
-
       {rows.length ? (
         <div className="mt-4 space-y-3">
-          <div className="grid gap-3 sm:grid-cols-3">
-            <div className="rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3">
-              <div className="text-lg font-semibold text-white">
-                {rows.length}
-              </div>
-              <div className="text-xs text-neutral-400">Rows found</div>
-            </div>
-            <div className="rounded-xl border border-emerald-500/25 bg-black/20 p-3">
-              <div className="text-lg font-semibold text-emerald-100">
-                {importableRows.length}
-              </div>
-              <div className="text-xs text-neutral-400">Ready to import</div>
-            </div>
-            <div className="rounded-xl border border-amber-500/25 bg-black/20 p-3">
-              <div className="text-lg font-semibold text-amber-100">
-                {skippedPreviewCount}
-              </div>
-              <div className="text-xs text-neutral-400">Missing identity</div>
-            </div>
-          </div>
-
           {previewRows.length ? (
             <div className="overflow-hidden rounded-xl border border-[color:var(--desktop-border)]">
               <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">
@@ -579,38 +538,17 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
           ) : null}
         </div>
       ) : null}
-
-      <div className="mt-4 flex flex-wrap gap-2">
-        <button
-          type="button"
-          disabled={importing || completingOnboarding || !importableRows.length}
-          onClick={() => void confirmImport()}
-          className="rounded-xl bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-sm font-semibold text-black disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {importing
-            ? "Importing…"
-            : completingOnboarding
-              ? "Completing onboarding…"
-              : "Confirm import"}
-        </button>
-        {isOnboarding && importSucceeded ? (
-          <button
-            type="button"
-            onClick={() => router.push(guidedQuery!.returnTo)}
-            className="rounded-xl border border-emerald-500/35 bg-emerald-950/25 px-4 py-2 text-sm font-semibold text-emerald-100 hover:bg-emerald-900/30"
-          >
-            Continue onboarding
-          </button>
-        ) : null}
-        {isOnboarding ? (
-          <Link
-            href={guidedQuery!.returnTo}
-            className="rounded-xl border border-sky-500/30 bg-sky-950/25 px-4 py-2 text-center text-sm font-semibold text-sky-100 hover:bg-sky-900/30"
-          >
-            Return to Data Onboarding
-          </Link>
-        ) : null}
-      </div>
+      <GuidedImportFooterActions
+        importing={importing}
+        completing={completingOnboarding}
+        canConfirm={importableRows.length > 0}
+        onConfirm={() => void confirmImport()}
+        isOnboarding={isOnboarding}
+        returnTo={guidedQuery?.returnTo}
+        hasResult={Boolean(counts)}
+        importSucceeded={importSucceeded}
+        onContinue={() => router.push(guidedQuery!.returnTo)}
+      />{" "}
     </GuidedSetupCardShell>
   );
 }

--- a/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
+++ b/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
@@ -1,16 +1,27 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
 import { GuidedImportFooterActions } from "@/features/shared/components/import/GuidedImportFooterActions";
 import { GuidedImportSummary } from "@/features/shared/components/import/GuidedImportSummary";
+import { CsvImportPreviewCard } from "@/features/shared/components/import/CsvImportPreviewCard";
+import { CsvImportCompletionSummary } from "@/features/shared/components/import/CsvImportCompletionSummary";
 import {
   CsvImportProgress,
   type CsvImportProgressState,
 } from "@/features/shared/components/import/CsvImportProgress";
-import { useImportJobProgress, type ImportJobProgressJob } from "@/features/shared/components/import/useImportJobProgress";
+import {
+  useImportJobProgress,
+  type ImportJobProgressJob,
+} from "@/features/shared/components/import/useImportJobProgress";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type HistoryImportRow = {
@@ -236,51 +247,93 @@ export function VehicleHistoryCsvImportCard({
       },
     });
   }
-  const completeOnboardingAfterImport = useCallback(async (
-    nextCounts: ImportCounts,
-  ) => {
-    if (!guidedQuery || !isOnboarding) return;
-    setCompletingOnboarding(true);
-    try {
-      const res = await fetch(
-        `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicle_history/complete`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            summary: { importType: "vehicle_history_csv", ...nextCounts },
-          }),
-        },
-      );
-      const payload = (await res.json().catch(() => ({}))) as {
-        ok?: boolean;
-        error?: string;
-      };
-      if (!res.ok || payload.ok === false) {
-        throw new Error(
-          payload.error ??
-            "Vehicle history import succeeded, but onboarding completion failed.",
+  const completeOnboardingAfterImport = useCallback(
+    async (nextCounts: ImportCounts) => {
+      if (!guidedQuery || !isOnboarding) return;
+      setCompletingOnboarding(true);
+      try {
+        const res = await fetch(
+          `/api/onboarding-v2/guided/sessions/${encodeURIComponent(guidedQuery.onboardingSession)}/steps/vehicle_history/complete`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              summary: { importType: "vehicle_history_csv", ...nextCounts },
+            }),
+          },
         );
+        const payload = (await res.json().catch(() => ({}))) as {
+          ok?: boolean;
+          error?: string;
+        };
+        if (!res.ok || payload.ok === false) {
+          throw new Error(
+            payload.error ??
+              "Vehicle history import succeeded, but onboarding completion failed.",
+          );
+        }
+      } finally {
+        setCompletingOnboarding(false);
       }
-    } finally {
-      setCompletingOnboarding(false);
-    }
-  }, [guidedQuery, isOnboarding]);
+    },
+    [guidedQuery, isOnboarding],
+  );
 
-  const handleJobComplete = useCallback(async (job: ImportJobProgressJob) => {
-    const summary = job.summary as { skippedRows?: ImportResponse["skippedRows"]; failedRows?: ImportResponse["failedRows"]; duplicates?: number } | null | undefined;
-    const counts: ImportCounts = { imported: job.importedCount, updated: 0, skipped: job.skippedCount, failed: job.failedCount, duplicates: Number(summary?.duplicates ?? 0) };
-    const nextResponse: ImportResponse = { ok: job.status === "completed", jobId: job.id, counts, totalRows: job.totalRows, skippedRows: summary?.skippedRows ?? [], failedRows: summary?.failedRows ?? [], error: job.errorMessage ?? undefined };
-    setResponse(nextResponse);
-    setImporting(false);
-    setActiveJobId(null);
-    if (job.status === "failed") { setImportError(job.errorMessage ?? "Vehicle history import job failed."); return; }
-    if (isOnboarding && counts.imported > 0 && counts.failed === 0) await completeOnboardingAfterImport(counts);
-    if (counts.imported > 0) onImported?.();
-  }, [completeOnboardingAfterImport, isOnboarding, onImported]);
-  const handleJobPollError = useCallback((message: string, job?: ImportJobProgressJob) => { if (job?.status === "failed") setImportError(message); }, []);
-  const { progress: jobProgress } = useImportJobProgress(activeJobId, { initialTotal: importableRows.length, onComplete: handleJobComplete, onError: handleJobPollError });
-  useEffect(() => { if (jobProgress) setProgress(jobProgress); }, [jobProgress]);
+  const handleJobComplete = useCallback(
+    async (job: ImportJobProgressJob) => {
+      const summary = job.summary as
+        | {
+            skippedRows?: ImportResponse["skippedRows"];
+            failedRows?: ImportResponse["failedRows"];
+            duplicates?: number;
+          }
+        | null
+        | undefined;
+      const counts: ImportCounts = {
+        imported: job.importedCount,
+        updated: 0,
+        skipped: job.skippedCount,
+        failed: job.failedCount,
+        duplicates: Number(summary?.duplicates ?? 0),
+      };
+      const nextResponse: ImportResponse = {
+        ok: job.status === "completed",
+        jobId: job.id,
+        counts,
+        totalRows: job.totalRows,
+        skippedRows: summary?.skippedRows ?? [],
+        failedRows: summary?.failedRows ?? [],
+        error: job.errorMessage ?? undefined,
+      };
+      setResponse(nextResponse);
+      setImporting(false);
+      setActiveJobId(null);
+      if (job.status === "failed") {
+        setImportError(
+          job.errorMessage ?? "Vehicle history import job failed.",
+        );
+        return;
+      }
+      if (isOnboarding && counts.imported > 0 && counts.failed === 0)
+        await completeOnboardingAfterImport(counts);
+      if (counts.imported > 0) onImported?.();
+    },
+    [completeOnboardingAfterImport, isOnboarding, onImported],
+  );
+  const handleJobPollError = useCallback(
+    (message: string, job?: ImportJobProgressJob) => {
+      if (job?.status === "failed") setImportError(message);
+    },
+    [],
+  );
+  const { progress: jobProgress } = useImportJobProgress(activeJobId, {
+    initialTotal: importableRows.length,
+    onComplete: handleJobComplete,
+    onError: handleJobPollError,
+  });
+  useEffect(() => {
+    if (jobProgress) setProgress(jobProgress);
+  }, [jobProgress]);
 
   async function confirmImport() {
     if (importing || completingOnboarding) return;
@@ -326,9 +379,15 @@ export function VehicleHistoryCsvImportCard({
       });
       const payload = (await res.json().catch(() => ({}))) as ImportResponse;
       if (!res.ok || payload.ok === false || !payload.jobId) {
-        throw new Error(payload.error ?? "Unable to queue vehicle history import.");
+        throw new Error(
+          payload.error ?? "Unable to queue vehicle history import.",
+        );
       }
-      setResponse({ ok: true, jobId: payload.jobId, totalRows: payload.totalRows });
+      setResponse({
+        ok: true,
+        jobId: payload.jobId,
+        totalRows: payload.totalRows,
+      });
       setProgress({
         phase: "Importing records",
         phaseKey: "importing",
@@ -404,48 +463,16 @@ export function VehicleHistoryCsvImportCard({
         </>
       }
     >
-      <div className="mt-4 rounded-xl border border-white/10 bg-black/20 p-3 text-sm text-neutral-300">
-        <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <span className="font-semibold text-neutral-100">
-              Selected file:
-            </span>{" "}
-            {fileName ?? "No CSV selected"}
-          </div>
-          {headers.length ? (
-            <div className="text-xs text-neutral-400">
-              Detected {headers.length} columns
-            </div>
-          ) : null}
-        </div>
-        {parseError ? (
-          <div className="mt-3 rounded-lg border border-red-500/25 bg-red-950/30 p-2 text-red-100">
-            {parseError}
-          </div>
-        ) : null}
-        {rows.length ? (
-          <div className="mt-3 grid gap-2 sm:grid-cols-3">
-            <div className="rounded-lg border border-white/10 bg-white/[0.03] p-2">
-              <div className="text-lg font-semibold text-white">
-                {rows.length}
-              </div>
-              <div className="text-xs text-neutral-400">Rows parsed</div>
-            </div>
-            <div className="rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2">
-              <div className="text-lg font-semibold text-emerald-100">
-                {importableRows.length}
-              </div>
-              <div className="text-xs text-neutral-400">Ready to import</div>
-            </div>
-            <div className="rounded-lg border border-amber-500/20 bg-amber-950/20 p-2">
-              <div className="text-lg font-semibold text-amber-100">
-                {rows.length - importableRows.length}
-              </div>
-              <div className="text-xs text-neutral-400">Need review</div>
-            </div>
-          </div>
-        ) : null}
-      </div>
+      <CsvImportPreviewCard
+        fileName={fileName}
+        headersCount={headers.length}
+        parsedRows={rows.length}
+        readyRows={importableRows.length}
+        needsReviewRows={rows.length - importableRows.length}
+        duplicateRows={response?.counts?.duplicates ?? 0}
+        invalidRows={rows.length - importableRows.length}
+        parseError={parseError}
+      />
       {previewRows.length ? (
         <div className="mt-4 overflow-hidden rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]">
           <div className="border-b border-[color:var(--desktop-border)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-400">
@@ -508,31 +535,14 @@ export function VehicleHistoryCsvImportCard({
         label="Vehicle history CSV import progress"
       />
       {response?.counts ? (
-        <GuidedImportSummary
-          tone={response.counts.failed ? "error" : "success"}
-        >
-          Import results: Imported {response.counts.imported}, Skipped{" "}
-          {response.counts.skipped}, Duplicates {response.counts.duplicates},
-          Failed {response.counts.failed}.
-        </GuidedImportSummary>
-      ) : null}
-      {response?.skippedRows?.length ? (
-        <div className="mt-4 rounded-xl border border-amber-500/25 bg-amber-950/20 p-3 text-sm text-amber-50">
-          Skipped rows:{" "}
-          {response.skippedRows
-            .slice(0, 8)
-            .map((r) => `Row ${r.row}: ${r.reason}`)
-            .join(" · ")}
-        </div>
-      ) : null}
-      {response?.failedRows?.length ? (
-        <div className="mt-4 rounded-xl border border-red-500/25 bg-red-950/20 p-3 text-sm text-red-50">
-          Failed rows:{" "}
-          {response.failedRows
-            .slice(0, 8)
-            .map((r) => `Row ${r.row}: ${r.error}`)
-            .join(" · ")}
-        </div>
+        <CsvImportCompletionSummary
+          imported={response.counts.imported}
+          skipped={response.counts.skipped}
+          failed={response.counts.failed}
+          duplicates={response.counts.duplicates}
+          skippedRows={response.skippedRows}
+          failedRows={response.failedRows}
+        />
       ) : null}
       {importError ? (
         <GuidedImportSummary tone="error">{importError}</GuidedImportSummary>


### PR DESCRIPTION
### Motivation
- Bring Customer, Vehicle, Vehicle History, and Historical Invoice CSV import flows into parity with the Parts Inventory canonical importer so users see the same multi-stage experience across onboarding and imports.
- Reduce duplicated UI code by consolidating preview, completion, and progress behaviors into shared components and reuse the existing import-job polling where available.

### Description
- Added shared preview and completion components: `CsvImportPreviewCard` and `CsvImportCompletionSummary` under `features/shared/components/import` to present Parsed/Ready/Needs Review/Duplicates/Invalid metrics and sample skipped/failed rows. 
- Extended `CsvImportProgress` to surface `duplicates` and updated `useImportJobProgress` to read `duplicates` from job summaries so async jobs show duplicate totals during polling. 
- Updated the four import cards to use the shared preview, progress, completion summary, and footer action components while preserving each importer’s existing backend integration (synchronous `/api/customers/import` and `/api/vehicles/import` flows remain unchanged; job-based importers still use `/api/*/import` + polling). 
- Files changed: `features/shared/components/import/CsvImportPreviewCard.tsx`, `CsvImportCompletionSummary.tsx`, `CsvImportProgress.tsx`, `useImportJobProgress.ts`, and the four importer cards in `features/customers`, `features/vehicles`, `features/work-orders`, and `features/billing`.

### Testing
- Ran `npx tsc --noEmit` and `npm run typecheck` which completed successfully with no new type errors. 
- Ran `npx eslint features/customers/components features/vehicles/components features/shared/components/import app/api --ext .ts,.tsx` which completed with no new errors and the repository’s pre-existing warnings (28 warnings in `app/api/shop-boost/*`). 
- Verified locally that each importer preserves its previous backend behavior and that progress/completion UI now shows parsed/ready/needs-review/duplicates/invalid counts and the Parts-style completion summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dae7d9a4c8328b51295f1a6efdb39)