### PR TITLE
Fix onboarding CSV external ID matching and history import counters

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -195,8 +195,10 @@ function resolveCustomerId(
   customers: CustomerResolverIndex,
 ): string | null {
   const externalCustomerId = normalizeLookupKey(row.customer_id);
-  if (externalCustomerId)
-    return customers.byExternalId.get(externalCustomerId) ?? null;
+  if (externalCustomerId) {
+    const match = customers.byExternalId.get(externalCustomerId);
+    if (match) return match;
+  }
 
   const email = normalizeLookupKey(row.customer_email ?? row.email);
   if (email) {

--- a/features/integrations/imports/runFullImport.ts
+++ b/features/integrations/imports/runFullImport.ts
@@ -989,15 +989,31 @@ function classifyDeterministicCustomerMiss(args: {
 }
 
 function sourceExternalId(domain: "customer" | "vehicle" | "work_order" | "invoice", sourceId: string): string {
-  const normalized = sourceId.trim().toLowerCase();
+  const raw = sourceId.trim();
+  if ((domain === "customer" || domain === "vehicle") && raw) return raw;
+  const normalized = raw.toLowerCase();
   return `import:source:${domain}:${sha1(normalized || sourceId).slice(0, 20)}`;
 }
 
-function sourceIdentityHashes(sourceId: string | null | undefined): string[] {
+function sourceIdentityKeys(sourceId: string | null | undefined): string[] {
   const raw = String(sourceId ?? "").trim();
   if (!raw) return [];
   const normalized = raw.toLowerCase();
-  return Array.from(new Set([sha1(raw).slice(0, 20), sha1(normalized).slice(0, 20)]));
+  return Array.from(new Set([raw, normalized, sha1(raw).slice(0, 20), sha1(normalized).slice(0, 20)]));
+}
+
+function sourceIdentityHashes(sourceId: string | null | undefined): string[] {
+  return sourceIdentityKeys(sourceId);
+}
+
+function rememberExistingExternalId(map: Map<string, string>, externalId: string | null | undefined, linkedId: string): void {
+  if (!linkedId) return;
+  const raw = String(externalId ?? "").trim();
+  if (!raw) return;
+  map.set(raw, linkedId);
+  map.set(raw.toLowerCase(), linkedId);
+  const legacyMatch = raw.match(/^import:source:(?:customer|vehicle):([a-f0-9]{20})$/);
+  if (legacyMatch?.[1]) map.set(legacyMatch[1], linkedId);
 }
 
 function resolveSourceLinkedId(map: Map<string, string>, sourceId: string | null | undefined): string | null {
@@ -1624,8 +1640,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
       addUniqueMatch(uniqueCustomersByEmail, conflictingCustomerEmails, email, id);
       addUniqueMatch(uniqueCustomersByPhone, conflictingCustomerPhones, phone, id);
       addUniqueMatch(uniqueCustomersByName, conflictingCustomerNames, normalizedName, id);
-      const sourceMatch = externalId.match(/^import:source:customer:([a-f0-9]{20})$/);
-      if (sourceMatch?.[1] && id) customersBySourceId.set(sourceMatch[1], id);
+      rememberExistingExternalId(customersBySourceId, externalId, id);
     }
   }
 
@@ -1660,8 +1675,7 @@ export async function runShopBoostImport(args: RunArgs): Promise<ShopBoostImport
         compositeKey(customerId, plate),
         id,
       );
-      const sourceMatch = externalId.match(/^import:source:vehicle:([a-f0-9]{20})$/);
-      if (sourceMatch?.[1] && id) vehiclesBySourceId.set(sourceMatch[1], id);
+      rememberExistingExternalId(vehiclesBySourceId, externalId, id);
     }
   }
 

--- a/features/work-orders/server/vehicle-history-import-job.ts
+++ b/features/work-orders/server/vehicle-history-import-job.ts
@@ -20,7 +20,7 @@ type VehicleRef = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "extern
 type Resolver = { customersById: Map<string, CustomerRef>; customersByExternal: Map<string, CustomerRef>; customersByEmail: Map<string, CustomerRef>; customersByPhone: Map<string, CustomerRef>; customersByName: Map<string, CustomerRef>; vehiclesById: Map<string, VehicleRef>; vehiclesByExternal: Map<string, VehicleRef>; vehiclesByVin: Map<string, VehicleRef>; };
 type ImportCounts = { imported: number; updated: number; skipped: number; failed: number; duplicates: number };
 
-type JobRow = { id: string; shop_id: string; processed_rows: number | null; imported_count: number | null; skipped_count: number | null; failed_count: number | null; summary: Record<string, unknown> | null };
+type JobRow = { id: string; shop_id: string; total_rows: number | null; processed_rows: number | null; imported_count: number | null; skipped_count: number | null; failed_count: number | null; summary: Record<string, unknown> | null };
 type StagedRow = { id: string; row_number: number; raw_row: HistoryImportRow; status: string | null };
 
 function clean(value: unknown): string | null { const text = String(value ?? "").trim(); return text ? text : null; }
@@ -47,8 +47,8 @@ async function loadResolver(supabase: SupabaseClient<DB>, shopId: string): Promi
   for (const v of (vehicles ?? []) as VehicleRef[]) { r.vehiclesById.set(v.id, v); const ex = key(v.external_id); if (ex && !r.vehiclesByExternal.has(ex)) r.vehiclesByExternal.set(ex, v); const vk = vin(v.vin); if (vk && !r.vehiclesByVin.has(vk)) r.vehiclesByVin.set(vk, v); }
   return r;
 }
-function resolveCustomer(row: HistoryImportRow, r: Resolver): CustomerRef | null { const cid = clean(row.customer_id); if (cid && r.customersById.has(cid)) return r.customersById.get(cid)!; const ex = key(row.customer_id); if (ex && r.customersByExternal.has(ex)) return r.customersByExternal.get(ex)!; const em = key(row.customer_email ?? row.email); if (em && r.customersByEmail.has(em)) return r.customersByEmail.get(em)!; const ph = phone(row.customer_phone ?? row.phone); if (ph && r.customersByPhone.has(ph)) return r.customersByPhone.get(ph)!; const nm = key(row.customer_name ?? row.name); if (nm && r.customersByName.has(nm)) return r.customersByName.get(nm)!; return null; }
-function resolveVehicle(row: HistoryImportRow, r: Resolver): VehicleRef | null { const vid = clean(row.vehicle_id); if (vid && r.vehiclesById.has(vid)) return r.vehiclesById.get(vid)!; const ex = key(row.vehicle_id); if (ex && r.vehiclesByExternal.has(ex)) return r.vehiclesByExternal.get(ex)!; const vk = vin(row.vin); if (vk && r.vehiclesByVin.has(vk)) return r.vehiclesByVin.get(vk)!; return null; }
+function resolveCustomer(row: HistoryImportRow, r: Resolver): CustomerRef | null { const ex = key(row.customer_id); if (ex && r.customersByExternal.has(ex)) return r.customersByExternal.get(ex)!; const cid = clean(row.customer_id); if (cid && r.customersById.has(cid)) return r.customersById.get(cid)!; const em = key(row.customer_email ?? row.email); if (em && r.customersByEmail.has(em)) return r.customersByEmail.get(em)!; const ph = phone(row.customer_phone ?? row.phone); if (ph && r.customersByPhone.has(ph)) return r.customersByPhone.get(ph)!; const nm = key(row.customer_name ?? row.name); if (nm && r.customersByName.has(nm)) return r.customersByName.get(nm)!; return null; }
+function resolveVehicle(row: HistoryImportRow, r: Resolver): VehicleRef | null { const ex = key(row.vehicle_id); if (ex && r.vehiclesByExternal.has(ex)) return r.vehiclesByExternal.get(ex)!; const vid = clean(row.vehicle_id); if (vid && r.vehiclesById.has(vid)) return r.vehiclesById.get(vid)!; const vk = vin(row.vin); if (vk && r.vehiclesByVin.has(vk)) return r.vehiclesByVin.get(vk)!; return null; }
 
 async function findDuplicateHistoryId(supabase: SupabaseClient<DB>, customerId: string, column: "work_order_number" | "invoice_number", value: string): Promise<string | null> {
   const { data, error } = await supabase.from("history").select("id").eq("customer_id", customerId).eq(column, value).limit(1);
@@ -64,7 +64,7 @@ function compactSamples(summary: Record<string, unknown> | null) {
 
 export async function processVehicleHistoryImportJobBatch(supabase: SupabaseClient<DB>, jobId?: string, batchSize = VEHICLE_HISTORY_IMPORT_BATCH_SIZE) {
   const client = supabase as unknown as SupabaseClient;
-  let jobQuery = client.from("import_jobs").select("id, shop_id, processed_rows, imported_count, skipped_count, failed_count, summary").eq("import_type", "vehicle_history").in("status", ["queued", "processing"]).order("created_at", { ascending: true }).limit(1);
+  let jobQuery = client.from("import_jobs").select("id, shop_id, total_rows, processed_rows, imported_count, skipped_count, failed_count, summary").eq("import_type", "vehicle_history").in("status", ["queued", "processing"]).order("created_at", { ascending: true }).limit(1);
   if (jobId) jobQuery = jobQuery.eq("id", jobId);
   const { data: job, error: jobError } = await jobQuery.maybeSingle<JobRow>();
   if (jobError) throw jobError;
@@ -115,11 +115,17 @@ export async function processVehicleHistoryImportJobBatch(supabase: SupabaseClie
   }
 
   samples.skippedRows = samples.skippedRows.slice(0, VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT); samples.failedRows = samples.failedRows.slice(0, VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT);
-  const processedRows = (job.processed_rows ?? 0) + rows.length;
+  const totalRows = Math.max(0, job.total_rows ?? 0);
+  const nextImported = (job.imported_count ?? 0) + counts.imported;
+  const nextSkipped = (job.skipped_count ?? 0) + counts.skipped;
+  const nextFailed = (job.failed_count ?? 0) + counts.failed;
+  const processedRows = totalRows > 0 ? Math.min(totalRows, nextImported + nextSkipped + nextFailed) : nextImported + nextSkipped + nextFailed;
   const summary = { skippedRows: samples.skippedRows, failedRows: samples.failedRows, duplicates: Number(job.summary?.duplicates ?? 0) + counts.duplicates };
   const { count: remainingCount, error: remainingError } = await client.from("import_job_rows").select("id", { count: "exact", head: true }).eq("job_id", job.id).eq("status", "queued");
   if (remainingError) throw remainingError;
   const completed = (remainingCount ?? 0) === 0;
-  await client.from("import_jobs").update({ status: completed ? "completed" : "processing", processed_rows: processedRows, imported_count: (job.imported_count ?? 0) + counts.imported, skipped_count: (job.skipped_count ?? 0) + counts.skipped, failed_count: (job.failed_count ?? 0) + counts.failed, summary, completed_at: completed ? new Date().toISOString() : null, updated_at: new Date().toISOString() }).eq("id", job.id);
+  const reconciledSkipped = completed && totalRows > 0 ? Math.max(0, totalRows - nextImported - nextFailed) : nextSkipped;
+  const reconciledProcessed = completed && totalRows > 0 ? totalRows : processedRows;
+  await client.from("import_jobs").update({ status: completed ? "completed" : "processing", processed_rows: reconciledProcessed, imported_count: nextImported, skipped_count: reconciledSkipped, failed_count: nextFailed, summary, completed_at: completed ? new Date().toISOString() : null, updated_at: new Date().toISOString() }).eq("id", job.id);
   return { ok: true, processed: rows.length, completed, job: { id: job.id } };
 }


### PR DESCRIPTION
### Motivation
- Onboarding history rows were being skipped because CSV `customer_id`/`vehicle_id` values were not preserved or resolved consistently as `external_id`, causing deterministic matches to fail and large numbers of skipped rows. 
- Import job counters could report `processed_rows` larger than `total_rows` and double-count duplicates, making import summaries unreliable.

### Description
- Prefer and preserve raw CSV external IDs for customers and vehicles by returning raw values for `sourceExternalId` for `customer`/`vehicle` and adding `rememberExistingExternalId` to index both raw and normalized external IDs; this keeps legacy `import:source:*` hashes supported while accepting deterministic CSV IDs. (`features/integrations/imports/runFullImport.ts`)
- Add wider identity keys (`raw`, `normalized`, and short legacy hashes) via `sourceIdentityKeys` so source-linked resolution can match CSV raw IDs, lowercased forms, or legacy hashes. (`features/integrations/imports/runFullImport.ts`)
- Ensure vehicle CSV import resolves `customer_id` against `customers.external_id` first and falls back to email/phone/name matching only if no deterministic external-id match is found. (`app/api/vehicles/import/route.ts`)
- Adjust the vehicle history import resolver to check `customersByExternal` and `vehiclesByExternal` before internal `id` lookups so history rows that reference external CSV IDs are deterministically matched, while retaining email/phone/name/VIN fallbacks. (`features/work-orders/server/vehicle-history-import-job.ts`)
- Reconcile history import job counters by using `total_rows` and computing `processed_rows` as a capped sum of `imported + skipped + failed`, and reconciling `skipped_count` on completion so `processed_rows` never exceeds `total_rows` and duplicate rows increment `skipped` and the `duplicates` summary without double-inflating `processed_rows`. (`features/work-orders/server/vehicle-history-import-job.ts`)

### Testing
- Ran `npm run typecheck` and it completed with no type errors.  
- Ran `npx eslint features/customers features/vehicles features/work-orders app/api/import-jobs app/api/internal/import-jobs --ext .ts,.tsx` and it completed successfully with only pre-existing lint warnings.  
- Verified modified import code paths and resolver behavior by static inspection of `app/api/vehicles/import/route.ts`, `features/integrations/imports/runFullImport.ts`, and `features/work-orders/server/vehicle-history-import-job.ts` to confirm the external-id-first matching and counter reconciliation logic were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e7a00827083289a757dff12f3e9d2)