### PR TITLE
Convert vehicle CSV import to async import jobs

### DIFF
--- a/app/api/import-jobs/[jobId]/route.ts
+++ b/app/api/import-jobs/[jobId]/route.ts
@@ -5,6 +5,10 @@ import {
   processVehicleHistoryImportJobBatch,
   VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
 } from "@/features/work-orders/server/vehicle-history-import-job";
+import {
+  processVehicleImportJobBatch,
+  VEHICLE_IMPORT_BATCH_SIZE,
+} from "@/features/vehicles/server/vehicle-import-job";
 
 type ImportJobApiRow = {
   id: string;
@@ -65,17 +69,24 @@ export async function GET(
     );
   }
 
-  if (
-    data.import_type === "vehicle_history" &&
-    (data.status === "queued" || data.status === "processing")
-  ) {
-    await processVehicleHistoryImportJobBatch(
-      createAdminSupabase(),
-      jobId,
-      VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
-    );
-    const refreshed = await loadJob();
-    data = refreshed.data ?? data;
+  if (data.status === "queued" || data.status === "processing") {
+    if (data.import_type === "vehicle_history") {
+      await processVehicleHistoryImportJobBatch(
+        createAdminSupabase(),
+        jobId,
+        VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+      );
+      const refreshed = await loadJob();
+      data = refreshed.data ?? data;
+    } else if (data.import_type === "vehicles") {
+      await processVehicleImportJobBatch(
+        createAdminSupabase(),
+        jobId,
+        VEHICLE_IMPORT_BATCH_SIZE,
+      );
+      const refreshed = await loadJob();
+      data = refreshed.data ?? data;
+    }
   }
 
   return NextResponse.json({

--- a/app/api/internal/import-jobs/tick/route.ts
+++ b/app/api/internal/import-jobs/tick/route.ts
@@ -9,11 +9,15 @@ import {
   INVOICE_IMPORT_BATCH_SIZE,
   processInvoiceImportJobBatch,
 } from "@/features/billing/server/invoice-import-job";
+import {
+  processVehicleImportJobBatch,
+  VEHICLE_IMPORT_BATCH_SIZE,
+} from "@/features/vehicles/server/vehicle-import-job";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const SUPPORTED_IMPORT_TYPES = ["vehicle_history", "invoices"] as const;
+const SUPPORTED_IMPORT_TYPES = ["vehicle_history", "invoices", "vehicles"] as const;
 const STALE_PROCESSING_JOB_MINUTES = 15;
 type SupportedImportType = (typeof SUPPORTED_IMPORT_TYPES)[number];
 type ImportJobDispatchRow = {
@@ -148,6 +152,10 @@ async function processImportType(
 ) {
   if (importType === "invoices") {
     return processInvoiceImportJobBatch(admin, jobId, INVOICE_IMPORT_BATCH_SIZE);
+  }
+
+  if (importType === "vehicles") {
+    return processVehicleImportJobBatch(admin, jobId, VEHICLE_IMPORT_BATCH_SIZE);
   }
 
   return processVehicleHistoryImportJobBatch(

--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -1,517 +1,102 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
+import {
+  VEHICLE_IMPORT_MAX_ROWS,
+  VEHICLE_IMPORT_SAMPLE_LIMIT,
+  VEHICLE_IMPORT_STAGING_BATCH_SIZE,
+  chunkArray,
+  stageVehicleImportRows,
+  type VehicleImportRow,
+} from "@/features/vehicles/server/vehicle-import-job";
+type ImportJobInsert = Record<string, unknown>;
 
-type DB = Database;
-type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
-type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
-
-function omitNullishVehicleUpdate(payload: VehicleUpdate): VehicleUpdate {
-  return Object.fromEntries(
-    Object.entries(payload).filter(([, value]) => value !== null && value !== undefined),
-  ) as VehicleUpdate;
-}
-type VehicleMatch = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id">;
-type CustomerResolverRow = Pick<
-  DB["public"]["Tables"]["customers"]["Row"],
-  | "id"
-  | "external_id"
-  | "email"
-  | "phone"
-  | "phone_number"
-  | "name"
-  | "business_name"
->;
-type CustomerResolverIndex = {
-  byExternalId: Map<string, string>;
-  byEmail: Map<string, string>;
-  byPhone: Map<string, string>;
-  byName: Map<string, string>;
-};
-type NormalizedVehicleResult =
-  | { ok: true; vehicle: VehicleInsert }
-  | { ok: false; reason: string };
-
-type VehicleImportRow = {
-  vehicle_id?: unknown;
-
-  customer_id?: unknown;
-  customer_email?: unknown;
-  email?: unknown;
-  customer_phone?: unknown;
-  phone?: unknown;
-  customer_name?: unknown;
-  name?: unknown;
-
-  plate?: unknown;
-  state_province?: unknown;
-
-  trim?: unknown;
-
-  color?: unknown;
-
-  odometer?: unknown;
-
-  odometer_unit?: unknown;
-
-  engine?: unknown;
-
-  fuel_type?: unknown;
-
-  drive_type?: unknown;
-
-  body_type?: unknown;
-
-  asset_type?: unknown;
-
-  status?: unknown;
-
-  purchase_date?: unknown;
-
-  in_service_date?: unknown;
-
-  last_service_date?: unknown;
-
-  tags?: unknown;
-
-  notes?: unknown;
-  unit_number?: unknown;
-  vin?: unknown;
-  license_plate?: unknown;
-  year?: unknown;
-  make?: unknown;
-  model?: unknown;
-};
-
-function cleanString(value: unknown): string | null {
-  const text = String(value ?? "").trim();
-  return text.length ? text : null;
-}
-
-function cleanVin(value: unknown): string | null {
-  return (
-    cleanString(value)
-      ?.toUpperCase()
-      .replace(/[^A-Z0-9]/g, "") ?? null
-  );
-}
-
-function cleanPlate(value: unknown): string | null {
-  return cleanString(value)?.toUpperCase() ?? null;
-}
-
-function cleanYear(value: unknown): number | null {
-  const text = cleanString(value);
-  if (!text) return null;
-  const parsed = Number(text);
-  if (!Number.isFinite(parsed)) return null;
-  if (parsed < 1900 || parsed > 2100) return null;
-  return Math.trunc(parsed);
-}
-
-function cleanDate(value: unknown): string | null {
-  const text = cleanString(value);
-  if (!text) return null;
-  const parsed = new Date(text);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return text;
-}
-
-function buildVehicleImportNotes(row: VehicleImportRow): string | null {
-  const notes: string[] = [];
-
-  const pairs: Array<[string, unknown]> = [
-    ["csv_customer_id", row.customer_id],
-
-    ["csv_notes", row.notes],
-  ];
-
-  for (const [label, value] of pairs) {
-    const text = cleanString(value);
-
-    if (text) notes.push(`${label}: ${text}`);
-  }
-
-  return notes.length ? notes.join("\n") : null;
-}
-
-function normalizeLookupKey(value: unknown): string | null {
-  const text = cleanString(value)?.toLowerCase().replace(/\s+/g, " ") ?? null;
-  return text || null;
-}
-
-function normalizePhone(value: unknown): string | null {
-  const text = cleanString(value);
-  if (!text) return null;
-  return text.replace(/\D/g, "") || text;
-}
-
-async function loadCustomerResolverIndex(
-  supabase: SupabaseClient<DB>,
-  shopId: string,
-): Promise<CustomerResolverIndex> {
-  const rows: CustomerResolverRow[] = [];
-  const pageSize = 1000;
-
-  for (let from = 0; ; from += pageSize) {
-    const { data, error } = await supabase
-      .from("customers")
-      .select("id, external_id, email, phone, phone_number, name, business_name")
-      .eq("shop_id", shopId)
-      .range(from, from + pageSize - 1);
-
-    if (error) throw error;
-
-    rows.push(...((data ?? []) as CustomerResolverRow[]));
-
-    if (!data || data.length < pageSize) break;
-  }
-
-  console.info("[vehicle-import:customer-resolver-loaded]", {
-    shopId,
-    customersLoaded: rows.length,
-  });
-
-  const index: CustomerResolverIndex = {
-    byExternalId: new Map(),
-    byEmail: new Map(),
-    byPhone: new Map(),
-    byName: new Map(),
-  };
-
-  for (const customer of rows) {
-    const externalId = normalizeLookupKey(customer.external_id);
-    if (externalId && !index.byExternalId.has(externalId)) {
-      index.byExternalId.set(externalId, customer.id);
-    }
-
-    const email = normalizeLookupKey(customer.email);
-    if (email && !index.byEmail.has(email))
-      index.byEmail.set(email, customer.id);
-
-    for (const phoneValue of [customer.phone, customer.phone_number]) {
-      const phone = normalizePhone(phoneValue);
-      if (phone && !index.byPhone.has(phone))
-        index.byPhone.set(phone, customer.id);
-    }
-
-    for (const nameValue of [customer.name, customer.business_name]) {
-      const name = normalizeLookupKey(nameValue);
-      if (name && !index.byName.has(name)) index.byName.set(name, customer.id);
-    }
-  }
-
-  return index;
-}
-
-function resolveCustomerId(
-  row: VehicleImportRow,
-  customers: CustomerResolverIndex,
-): string | null {
-  const externalCustomerId = normalizeLookupKey(row.customer_id);
-  if (externalCustomerId) {
-    const match = customers.byExternalId.get(externalCustomerId);
-    if (match) return match;
-  }
-
-  const email = normalizeLookupKey(row.customer_email ?? row.email);
-  if (email) {
-    const match = customers.byEmail.get(email);
-    if (match) return match;
-  }
-
-  const phone = normalizePhone(row.customer_phone ?? row.phone);
-  if (phone) {
-    const match = customers.byPhone.get(phone);
-    if (match) return match;
-  }
-
-  const name = normalizeLookupKey(row.customer_name ?? row.name);
-  if (name) {
-    const match = customers.byName.get(name);
-    if (match) return match;
-  }
-
-  return null;
-}
-
-function normalizeRow(
-  row: VehicleImportRow,
-
-  shopId: string,
-
-  customers: CustomerResolverIndex,
-): NormalizedVehicleResult {
-  const unitNumber = cleanString(row.unit_number);
-  const vin = cleanVin(row.vin);
-  const plate = cleanPlate(row.license_plate ?? row.plate);
-  const year = cleanYear(row.year);
-  const make = cleanString(row.make);
-  const model = cleanString(row.model);
-
-  const odometer = cleanString(row.odometer);
-
-  const odometerUnit = cleanString(row.odometer_unit);
-
-  const mileage = odometer ?? null;
-
-  const rawCustomerId = cleanString(row.customer_id);
-  const hasCustomerReference = Boolean(
-    rawCustomerId ||
-      cleanString(row.customer_email ?? row.email) ||
-      cleanString(row.customer_phone ?? row.phone) ||
-      cleanString(row.customer_name ?? row.name),
-  );
-  const customerId = resolveCustomerId(row, customers);
-
-  const importNotes = buildVehicleImportNotes(row);
-
-  if (!vin && !unitNumber && !plate && !(year && make && model)) {
-    return { ok: false, reason: "Missing vehicle identity." };
-  }
-
-  if (hasCustomerReference && !customerId) {
-    if (rawCustomerId) {
-      return {
-        ok: false,
-        reason: "Customer not found for external customer_id.",
-      };
-    }
-
-    return {
-      ok: false,
-      reason: "Customer reference could not be resolved.",
+type JobInsertBuilder = {
+  insert(values: ImportJobInsert): {
+    select(columns: string): {
+      single(): Promise<{ data: { id: string; total_rows: number | null; status: string | null } | null; error: Error | null }>;
     };
-  }
-
-  return {
-    ok: true,
-    vehicle: {
-      shop_id: shopId,
-      unit_number: unitNumber,
-      vin,
-      license_plate: plate,
-      state_province: cleanString(row.state_province),
-      year,
-      make,
-      model,
-      customer_id: customerId,
-      external_id: cleanString(row.vehicle_id),
-      submodel: cleanString(row.trim),
-      color: cleanString(row.color),
-      mileage,
-      odometer_unit: odometerUnit,
-      engine: cleanString(row.engine),
-      fuel_type: cleanString(row.fuel_type),
-      drivetrain: cleanString(row.drive_type),
-      body_type: cleanString(row.body_type),
-      asset_type: cleanString(row.asset_type),
-      status: cleanString(row.status),
-      purchase_date: cleanDate(row.purchase_date),
-      in_service_date: cleanDate(row.in_service_date),
-      last_service_date: cleanDate(row.last_service_date),
-      tags: cleanString(row.tags),
-      notes: cleanString(row.notes),
-      import_notes: importNotes,
-    },
   };
-}
+};
 
-async function findVehicleByField(
-  supabase: SupabaseClient<DB>,
-  shopId: string,
-  field: "external_id" | "vin" | "unit_number" | "license_plate",
-  value: string | null | undefined,
-): Promise<VehicleMatch | null> {
-  if (!value) return null;
+type RowInsertBuilder = {
+  insert(values: Array<Record<string, unknown>>): Promise<{ error: Error | null }>;
+};
 
-  const { data, error } = await supabase
-    .from("vehicles")
-    .select("id")
-    .eq("shop_id", shopId)
-    .eq(field, value)
-    .limit(1);
-
-  if (error) throw error;
-  return ((data ?? [])[0] as VehicleMatch | undefined) ?? null;
-}
-
-async function findExistingVehicle(
-  supabase: SupabaseClient<DB>,
-  shopId: string,
-  normalized: VehicleInsert,
-): Promise<VehicleMatch | null> {
-  return (
-    (await findVehicleByField(
-      supabase,
-      shopId,
-      "external_id",
-      normalized.external_id,
-    )) ??
-    (await findVehicleByField(supabase, shopId, "vin", normalized.vin)) ??
-    (await findVehicleByField(
-      supabase,
-      shopId,
-      "unit_number",
-      normalized.unit_number,
-    )) ??
-    (await findVehicleByField(
-      supabase,
-      shopId,
-      "license_plate",
-      normalized.license_plate,
-    ))
-  );
-}
+type LooseSupabase<T> = { from(table: string): T };
 
 export async function POST(req: Request) {
   try {
     const access = await requireShopScopedApiAccess({
       allowRoles: ["owner", "admin", "manager", "advisor"],
     });
-
-    if (!access.ok) {
-      return access.response;
-    }
+    if (!access.ok) return access.response;
 
     const body = await req.json().catch(() => null);
-    const rows = Array.isArray(body?.rows) ? body.rows : [];
-
+    const rows = Array.isArray(body?.rows) ? (body.rows as VehicleImportRow[]) : [];
     if (!rows.length) {
+      return NextResponse.json({ error: "No vehicle rows provided." }, { status: 400 });
+    }
+    if (rows.length > VEHICLE_IMPORT_MAX_ROWS) {
       return NextResponse.json(
-        { error: "No vehicle rows provided." },
+        { error: `Vehicle CSV contains ${rows.length} rows. Please split files into ${VEHICLE_IMPORT_MAX_ROWS} rows or fewer.` },
         { status: 400 },
       );
     }
 
     const { supabase, profile } = access;
     const shopId = profile.shop_id;
-
     if (!shopId) {
-      return NextResponse.json(
-        { error: "No active shop is selected." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
     }
 
-    const counts = {
-      created: 0,
-      updated: 0,
-      skipped: 0,
-      failed: 0,
+    const sourceRef = `staging://import_job_rows/vehicles/${shopId}/${Date.now()}`;
+    const jobPayload: ImportJobInsert = {
+      shop_id: shopId,
+      created_by: profile.id,
+      import_type: "vehicles",
+      status: "queued",
+      total_rows: rows.length,
+      processed_rows: 0,
+      imported_count: 0,
+      skipped_count: 0,
+      failed_count: 0,
+      source_storage_path: sourceRef,
+      summary: {
+        ok: true,
+        counts: { created: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 },
+        totalRows: rows.length,
+        skippedRows: [],
+        failedRows: [],
+        sampleLimit: VEHICLE_IMPORT_SAMPLE_LIMIT,
+        storageCleanup: "CSV rows are staged in import_job_rows; no Supabase Storage object is created.",
+      },
     };
-    const customers = await loadCustomerResolverIndex(supabase, shopId);
-    const skippedRows: Array<{ row: number; reason: string }> = [];
-    const failedRows: Array<{ row: number; error: string }> = [];
 
-    for (const [index, raw] of rows.entries()) {
-      const normalizedResult = normalizeRow(
-        raw as VehicleImportRow,
-        shopId,
-        customers,
-      );
+    const { data: job, error: jobError } = await (supabase as unknown as LooseSupabase<JobInsertBuilder>)
+      .from("import_jobs")
+      .insert(jobPayload)
+      .select("id, total_rows, status")
+      .single();
+    if (jobError) throw jobError;
+    if (!job?.id) throw new Error("Vehicle import job could not be created.");
 
-      if (!normalizedResult.ok) {
-        counts.skipped += 1;
-        skippedRows.push({ row: index + 1, reason: normalizedResult.reason });
-        continue;
-      }
-
-      const normalized = normalizedResult.vehicle;
-
-      try {
-        const existing = await findExistingVehicle(
-          supabase,
-          shopId,
-          normalized,
-        );
-
-        if (existing) {
-          const updatePayload: VehicleUpdate = omitNullishVehicleUpdate({
-            unit_number: normalized.unit_number,
-            vin: normalized.vin,
-            license_plate: normalized.license_plate,
-            state_province: normalized.state_province,
-            year: normalized.year,
-            make: normalized.make,
-            model: normalized.model,
-
-            customer_id: normalized.customer_id,
-
-            external_id: normalized.external_id,
-
-            submodel: normalized.submodel,
-
-            color: normalized.color,
-
-            mileage: normalized.mileage,
-
-            odometer_unit: normalized.odometer_unit,
-
-            engine: normalized.engine,
-
-            fuel_type: normalized.fuel_type,
-
-            drivetrain: normalized.drivetrain,
-
-            body_type: normalized.body_type,
-
-            asset_type: normalized.asset_type,
-
-            status: normalized.status,
-
-            purchase_date: normalized.purchase_date,
-
-            in_service_date: normalized.in_service_date,
-
-            last_service_date: normalized.last_service_date,
-
-            tags: normalized.tags,
-
-            notes: normalized.notes,
-
-            import_notes: normalized.import_notes,
-          });
-
-          const { error } = await supabase
-            .from("vehicles")
-            .update(updatePayload)
-            .eq("id", existing.id)
-            .eq("shop_id", shopId);
-
-          if (error) throw error;
-          counts.updated += 1;
-          continue;
-        }
-
-        const { error } = await supabase.from("vehicles").insert(normalized);
-
-        if (error) throw error;
-        counts.created += 1;
-      } catch (error) {
-        counts.failed += 1;
-        const message = error instanceof Error ? error.message : "Vehicle row failed to import.";
-        failedRows.push({ row: index + 1, error: message });
-        console.warn("Vehicle import row failed", { row: index + 1, error: message });
-      }
+    const stagedRows = stageVehicleImportRows(job.id, rows);
+    for (const batch of chunkArray(stagedRows, VEHICLE_IMPORT_STAGING_BATCH_SIZE)) {
+      const { error } = await (supabase as unknown as LooseSupabase<RowInsertBuilder>)
+        .from("import_job_rows")
+        .insert(batch);
+      if (error) throw error;
     }
-
-    const explanation = `Vehicle import complete: created ${counts.created}, updated ${counts.updated}, skipped ${counts.skipped}, failed ${counts.failed}.`;
 
     return NextResponse.json({
       ok: true,
-      counts,
-      explanation,
-      skippedRows,
-      failedRows,
+      jobId: job.id,
+      job: { id: job.id, status: job.status, totalRows: job.total_rows ?? rows.length },
+      explanation: `Vehicle import job queued with ${rows.length} row(s).`,
     });
   } catch (error) {
     return NextResponse.json(
-      {
-        error:
-          error instanceof Error ? error.message : "Unable to import vehicles.",
-      },
+      { error: error instanceof Error ? error.message : "Unable to queue vehicle import." },
       { status: 500 },
     );
   }

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
 import {
@@ -59,10 +59,28 @@ type ImportCounts = {
 type ImportResponse = {
   ok?: boolean;
   error?: string;
-  counts?: ImportCounts;
+  jobId?: string;
+  job?: { id: string; status?: string | null; totalRows?: number | null };
   explanation?: string;
-  skippedRows?: Array<{ row: number; reason: string }>;
-  failedRows?: Array<{ row: number; error: string }>;
+};
+
+type ImportJobResponse = {
+  ok?: boolean;
+  error?: string;
+  job?: {
+    id: string;
+    status: string | null;
+    totalRows: number;
+    processedRows: number;
+    importedCount: number;
+    skippedCount: number;
+    failedCount: number;
+    summary?: {
+      counts?: Partial<ImportCounts & { duplicates: number }>;
+      skippedRows?: Array<{ row: number; reason: string }>;
+      failedRows?: Array<{ row: number; error: string }>;
+    } | null;
+  };
 };
 
 const SUPPORTED_COLUMNS = [
@@ -292,7 +310,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     }
   }
 
-  async function completeOnboardingAfterImport(nextCounts: ImportCounts) {
+  const completeOnboardingAfterImport = useCallback(async (nextCounts: ImportCounts) => {
     if (!guidedQuery) return;
 
     setCompletingOnboarding(true);
@@ -320,7 +338,102 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     } finally {
       setCompletingOnboarding(false);
     }
-  }
+  }, [guidedQuery]);
+
+  const applyJobProgress = useCallback(
+    async (job: NonNullable<ImportJobResponse["job"]>) => {
+      const created = Number(job.summary?.counts?.created ?? 0);
+      const updated = Number(job.summary?.counts?.updated ?? 0);
+      const duplicates = Number(job.summary?.counts?.duplicates ?? 0);
+      const nextCounts: ImportCounts = {
+        created,
+        updated,
+        skipped: Number(job.skippedCount ?? job.summary?.counts?.skipped ?? 0),
+        failed: Number(job.failedCount ?? job.summary?.counts?.failed ?? 0),
+      };
+      const total = job.totalRows || importableRows.length;
+      const processed = Math.min(total, job.processedRows || 0);
+      const percent = total > 0 ? Math.min(99, Math.round((processed / total) * 100)) : 0;
+
+      if (job.status === "completed" || job.status === "failed") {
+        setCounts(nextCounts);
+        setSkippedRows(job.summary?.skippedRows ?? []);
+        setFailedRows(job.summary?.failedRows ?? []);
+        const completedProgress: CsvImportProgressState = {
+          phase:
+            job.status === "failed" || nextCounts.failed > 0
+              ? "Import completed with failures"
+              : "Completed",
+          phaseKey: job.status === "failed" || nextCounts.failed > 0 ? "failed" : "completed",
+          processed: total,
+          total,
+          percent: 100,
+          imported: nextCounts.created + nextCounts.updated,
+          skipped: nextCounts.skipped,
+          failed: nextCounts.failed,
+        };
+        setImportProgress(completedProgress);
+
+        if (
+          isOnboarding &&
+          nextCounts.created + nextCounts.updated + nextCounts.skipped > 0 &&
+          nextCounts.failed === 0
+        ) {
+          setImportProgress({ ...completedProgress, phase: "Completing guided step", phaseKey: "finalizing", percent: 98 });
+          await completeOnboardingAfterImport(nextCounts);
+          setImportProgress(completedProgress);
+        }
+
+        router.refresh();
+        setImporting(false);
+        return true;
+      }
+
+      setImportProgress({
+        phase: `Processing vehicle rows${duplicates ? ` · ${duplicates} duplicate(s)` : ""}`,
+        phaseKey: "processing",
+        processed,
+        total,
+        percent,
+        imported: nextCounts.created + nextCounts.updated,
+        skipped: nextCounts.skipped,
+        failed: nextCounts.failed,
+      });
+      return false;
+    },
+    [completeOnboardingAfterImport, importableRows.length, isOnboarding, router],
+  );
+
+  const pollImportJob = useCallback(async (jobId: string) => {
+    const response = await fetch(`/api/import-jobs/${encodeURIComponent(jobId)}`, {
+      method: "GET",
+      cache: "no-store",
+    });
+    const payload = (await response.json().catch(() => ({}))) as ImportJobResponse;
+    if (!response.ok || payload.ok === false || !payload.job) {
+      throw new Error(payload.error ?? "Unable to load vehicle import progress.");
+    }
+    return applyJobProgress(payload.job);
+  }, [applyJobProgress]);
+
+  useEffect(() => {
+    if (!importing || !importProgress || importProgress.phaseKey !== "processing") return;
+    const jobId = (importProgress as CsvImportProgressState & { jobId?: string }).jobId;
+    if (!jobId) return;
+    let cancelled = false;
+    const timer = window.setInterval(() => {
+      void pollImportJob(jobId).catch((error) => {
+        if (cancelled) return;
+        setImportError(error instanceof Error ? error.message : "Unable to load vehicle import progress.");
+        setImportProgress({ phase: "failed", phaseKey: "failed", processed: 0, total: importableRows.length, percent: 100 });
+        setImporting(false);
+      });
+    }, 1200);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [importProgress, importableRows.length, importing, pollImportJob]);
 
   async function confirmImport() {
     if (!importableRows.length) {
@@ -333,91 +446,39 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     setImporting(true);
     setImportError(null);
     setImportProgress({
-      phase: "Preparing rows",
+      phase: "Queueing vehicle import",
       phaseKey: "processing",
       processed: 0,
       total: importableRows.length,
-      percent: 30,
+      percent: 0,
     });
     setCounts(null);
     setSkippedRows([]);
     setFailedRows([]);
 
-    let progressTimer: number | null = null;
     try {
-      progressTimer = window.setInterval(() => {
-        setImportProgress((current) => {
-          if (!current || current.phaseKey !== "processing") return current;
-          const nextPercent = Math.min(90, current.percent + 3);
-          return {
-            ...current,
-            processed: Math.min(
-              importableRows.length,
-              Math.max(
-                current.processed,
-                Math.floor((nextPercent / 100) * importableRows.length),
-              ),
-            ),
-            percent: nextPercent,
-          };
-        });
-      }, 650);
-
       const response = await fetch("/api/vehicles/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ rows: importableRows }),
       });
 
-      const payload = (await response
-        .json()
-        .catch(() => ({}))) as ImportResponse;
-
-      if (!response.ok || payload.ok === false || !payload.counts) {
-        throw new Error(payload.error ?? "Unable to import vehicles.");
+      const payload = (await response.json().catch(() => ({}))) as ImportResponse;
+      const jobId = payload.jobId ?? payload.job?.id;
+      if (!response.ok || payload.ok === false || !jobId) {
+        throw new Error(payload.error ?? "Unable to queue vehicle import.");
       }
 
-      if (progressTimer) window.clearInterval(progressTimer);
-      progressTimer = null;
       setImportProgress({
-        phase: "Finalizing",
-        phaseKey: "finalizing",
-        processed: importableRows.length,
-        total: importableRows.length,
-        percent: 95,
-      });
-      setCounts(payload.counts);
-      setSkippedRows(payload.skippedRows ?? []);
-      setFailedRows(payload.failedRows ?? []);
-
-      const completedProgress: CsvImportProgressState = {
-        phase:
-          payload.counts.failed > 0
-            ? "Import completed with failures"
-            : "Completed",
-        phaseKey: payload.counts.failed > 0 ? "failed" : "completed",
-        processed: importableRows.length,
-        total: importableRows.length,
-        percent: 100,
-        imported: payload.counts.created + payload.counts.updated,
-        skipped: payload.counts.skipped,
-        failed: payload.counts.failed,
-      };
-      setImportProgress(completedProgress);
-
-      if (
-        isOnboarding &&
-        payload.counts.created +
-          payload.counts.updated +
-          payload.counts.skipped >
-          0 &&
-        payload.counts.failed === 0
-      ) {
-        await completeOnboardingAfterImport(payload.counts);
-        setImportProgress(completedProgress);
-      }
+        phase: "Vehicle import queued",
+        phaseKey: "processing",
+        processed: 0,
+        total: payload.job?.totalRows ?? importableRows.length,
+        percent: 0,
+        jobId,
+      } as CsvImportProgressState & { jobId: string });
+      await pollImportJob(jobId);
     } catch (error) {
-      if (progressTimer) window.clearInterval(progressTimer);
       setImportProgress({
         phase: "failed",
         phaseKey: "failed",
@@ -428,8 +489,6 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
       setImportError(
         error instanceof Error ? error.message : "Unable to import vehicles.",
       );
-    } finally {
-      if (progressTimer) window.clearInterval(progressTimer);
       setImporting(false);
     }
   }

--- a/features/vehicles/server/vehicle-import-job.ts
+++ b/features/vehicles/server/vehicle-import-job.ts
@@ -1,0 +1,93 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { chunkArray, compactImportSummary } from "@/features/shared/lib/import/csv";
+
+type DB = Database;
+type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
+type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
+
+export const VEHICLE_IMPORT_BATCH_SIZE = 250;
+export const VEHICLE_IMPORT_STAGING_BATCH_SIZE = 1000;
+export const VEHICLE_IMPORT_SAMPLE_LIMIT = 25;
+export const VEHICLE_IMPORT_MAX_ROWS = 20_000;
+
+type VehicleMatch = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id">;
+type CustomerResolverRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "external_id" | "email" | "phone" | "phone_number" | "name" | "business_name">;
+type CustomerResolverIndex = { byExternalId: Map<string, string>; byEmail: Map<string, string>; byPhone: Map<string, string>; byName: Map<string, string> };
+type NormalizedVehicleResult = { ok: true; vehicle: VehicleInsert } | { ok: false; reason: string };
+export type VehicleImportRow = { vehicle_id?: unknown; customer_id?: unknown; customer_email?: unknown; email?: unknown; customer_phone?: unknown; phone?: unknown; customer_name?: unknown; name?: unknown; plate?: unknown; state_province?: unknown; trim?: unknown; color?: unknown; odometer?: unknown; odometer_unit?: unknown; engine?: unknown; fuel_type?: unknown; drive_type?: unknown; body_type?: unknown; asset_type?: unknown; status?: unknown; purchase_date?: unknown; in_service_date?: unknown; last_service_date?: unknown; tags?: unknown; notes?: unknown; unit_number?: unknown; vin?: unknown; license_plate?: unknown; year?: unknown; make?: unknown; model?: unknown };
+type JobRow = { id: string; shop_id: string; total_rows: number | null; processed_rows: number | null; imported_count: number | null; skipped_count: number | null; failed_count: number | null; summary: Record<string, unknown> | null };
+type StagedRow = { id: string; row_number: number; raw_row: VehicleImportRow; status: string | null };
+type VehicleCounts = { created: number; updated: number; skipped: number; failed: number; duplicates: number };
+
+function cleanString(value: unknown): string | null { const text = String(value ?? "").trim(); return text.length ? text : null; }
+function cleanVin(value: unknown): string | null { return cleanString(value)?.toUpperCase().replace(/[^A-Z0-9]/g, "") ?? null; }
+function cleanPlate(value: unknown): string | null { return cleanString(value)?.toUpperCase() ?? null; }
+function cleanYear(value: unknown): number | null { const text = cleanString(value); if (!text) return null; const parsed = Number(text); if (!Number.isFinite(parsed) || parsed < 1900 || parsed > 2100) return null; return Math.trunc(parsed); }
+function cleanDate(value: unknown): string | null { const text = cleanString(value); if (!text) return null; const parsed = new Date(text); return Number.isNaN(parsed.getTime()) ? null : text; }
+function normalizeLookupKey(value: unknown): string | null { return cleanString(value)?.toLowerCase().replace(/\s+/g, " ") ?? null; }
+function normalizePhone(value: unknown): string | null { const text = cleanString(value); if (!text) return null; return text.replace(/\D/g, "") || text; }
+function omitNullishVehicleUpdate(payload: VehicleUpdate): VehicleUpdate { return Object.fromEntries(Object.entries(payload).filter(([, value]) => value !== null && value !== undefined)) as VehicleUpdate; }
+function buildVehicleImportNotes(row: VehicleImportRow): string | null { const notes = [["csv_customer_id", row.customer_id], ["csv_notes", row.notes]].map(([label, value]) => { const text = cleanString(value); return text ? `${label}: ${text}` : null; }).filter(Boolean); return notes.length ? notes.join("\n") : null; }
+
+export async function loadCustomerResolverIndex(supabase: SupabaseClient<DB>, shopId: string): Promise<CustomerResolverIndex> {
+  const rows: CustomerResolverRow[] = []; const pageSize = 1000;
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await supabase.from("customers").select("id, external_id, email, phone, phone_number, name, business_name").eq("shop_id", shopId).range(from, from + pageSize - 1);
+    if (error) throw error; rows.push(...((data ?? []) as CustomerResolverRow[])); if (!data || data.length < pageSize) break;
+  }
+  const index: CustomerResolverIndex = { byExternalId: new Map(), byEmail: new Map(), byPhone: new Map(), byName: new Map() };
+  for (const customer of rows) {
+    const externalId = normalizeLookupKey(customer.external_id); if (externalId && !index.byExternalId.has(externalId)) index.byExternalId.set(externalId, customer.id);
+    const email = normalizeLookupKey(customer.email); if (email && !index.byEmail.has(email)) index.byEmail.set(email, customer.id);
+    for (const phoneValue of [customer.phone, customer.phone_number]) { const phone = normalizePhone(phoneValue); if (phone && !index.byPhone.has(phone)) index.byPhone.set(phone, customer.id); }
+    for (const nameValue of [customer.name, customer.business_name]) { const name = normalizeLookupKey(nameValue); if (name && !index.byName.has(name)) index.byName.set(name, customer.id); }
+  }
+  return index;
+}
+function resolveCustomerId(row: VehicleImportRow, customers: CustomerResolverIndex): string | null { const externalCustomerId = normalizeLookupKey(row.customer_id); if (externalCustomerId) { const match = customers.byExternalId.get(externalCustomerId); if (match) return match; } const email = normalizeLookupKey(row.customer_email ?? row.email); if (email) { const match = customers.byEmail.get(email); if (match) return match; } const phone = normalizePhone(row.customer_phone ?? row.phone); if (phone) { const match = customers.byPhone.get(phone); if (match) return match; } const name = normalizeLookupKey(row.customer_name ?? row.name); if (name) { const match = customers.byName.get(name); if (match) return match; } return null; }
+function normalizeRow(row: VehicleImportRow, shopId: string, customers: CustomerResolverIndex): NormalizedVehicleResult {
+  const unitNumber = cleanString(row.unit_number); const vin = cleanVin(row.vin); const plate = cleanPlate(row.license_plate ?? row.plate); const year = cleanYear(row.year); const make = cleanString(row.make); const model = cleanString(row.model); const rawCustomerId = cleanString(row.customer_id); const hasCustomerReference = Boolean(rawCustomerId || cleanString(row.customer_email ?? row.email) || cleanString(row.customer_phone ?? row.phone) || cleanString(row.customer_name ?? row.name)); const customerId = resolveCustomerId(row, customers);
+  if (!vin && !unitNumber && !plate && !(year && make && model)) return { ok: false, reason: "Missing vehicle identity." };
+  if (hasCustomerReference && !customerId) return { ok: false, reason: rawCustomerId ? "Customer not found for external customer_id." : "Customer reference could not be resolved." };
+  return { ok: true, vehicle: { shop_id: shopId, unit_number: unitNumber, vin, license_plate: plate, state_province: cleanString(row.state_province), year, make, model, customer_id: customerId, external_id: cleanString(row.vehicle_id), submodel: cleanString(row.trim), color: cleanString(row.color), mileage: cleanString(row.odometer), odometer_unit: cleanString(row.odometer_unit), engine: cleanString(row.engine), fuel_type: cleanString(row.fuel_type), drivetrain: cleanString(row.drive_type), body_type: cleanString(row.body_type), asset_type: cleanString(row.asset_type), status: cleanString(row.status), purchase_date: cleanDate(row.purchase_date), in_service_date: cleanDate(row.in_service_date), last_service_date: cleanDate(row.last_service_date), tags: cleanString(row.tags), notes: cleanString(row.notes), import_notes: buildVehicleImportNotes(row) } };
+}
+async function findVehicleByField(supabase: SupabaseClient<DB>, shopId: string, field: "external_id" | "vin" | "unit_number" | "license_plate", value: string | null | undefined): Promise<VehicleMatch | null> { if (!value) return null; const { data, error } = await supabase.from("vehicles").select("id").eq("shop_id", shopId).eq(field, value).limit(1); if (error) throw error; return ((data ?? [])[0] as VehicleMatch | undefined) ?? null; }
+async function findExistingVehicle(supabase: SupabaseClient<DB>, shopId: string, normalized: VehicleInsert): Promise<VehicleMatch | null> { return (await findVehicleByField(supabase, shopId, "external_id", normalized.external_id)) ?? (await findVehicleByField(supabase, shopId, "vin", normalized.vin)) ?? (await findVehicleByField(supabase, shopId, "unit_number", normalized.unit_number)) ?? (await findVehicleByField(supabase, shopId, "license_plate", normalized.license_plate)); }
+function summaryCount(summary: Record<string, unknown> | null, key: string): number {
+  const counts = summary?.counts as Record<string, unknown> | undefined;
+  return Number(counts?.[key] ?? summary?.[key] ?? 0);
+}
+function samples(summary: Record<string, unknown> | null) { return { skippedRows: Array.isArray(summary?.skippedRows) ? summary.skippedRows as Array<{ row: number; reason: string }> : [], failedRows: Array.isArray(summary?.failedRows) ? summary.failedRows as Array<{ row: number; error: string }> : [] }; }
+function updatePayload(normalized: VehicleInsert): VehicleUpdate { return omitNullishVehicleUpdate({ unit_number: normalized.unit_number, vin: normalized.vin, license_plate: normalized.license_plate, state_province: normalized.state_province, year: normalized.year, make: normalized.make, model: normalized.model, customer_id: normalized.customer_id, external_id: normalized.external_id, submodel: normalized.submodel, color: normalized.color, mileage: normalized.mileage, odometer_unit: normalized.odometer_unit, engine: normalized.engine, fuel_type: normalized.fuel_type, drivetrain: normalized.drivetrain, body_type: normalized.body_type, asset_type: normalized.asset_type, status: normalized.status, purchase_date: normalized.purchase_date, in_service_date: normalized.in_service_date, last_service_date: normalized.last_service_date, tags: normalized.tags, notes: normalized.notes, import_notes: normalized.import_notes }); }
+
+export async function processVehicleImportJobBatch(supabase: SupabaseClient<DB>, jobId?: string, batchSize = VEHICLE_IMPORT_BATCH_SIZE) {
+  const client = supabase as unknown as SupabaseClient; let jobQuery = client.from("import_jobs").select("id, shop_id, total_rows, processed_rows, imported_count, skipped_count, failed_count, summary").eq("import_type", "vehicles").in("status", ["queued", "processing"]).order("created_at", { ascending: true }).limit(1); if (jobId) jobQuery = jobQuery.eq("id", jobId);
+  const { data: job, error: jobError } = await jobQuery.maybeSingle<JobRow>(); if (jobError) throw jobError; if (!job) return { ok: true, processed: 0, completed: false, job: null };
+  await client.from("import_jobs").update({ status: "processing", updated_at: new Date().toISOString() }).eq("id", job.id);
+  const { data: stagedRows, error: rowsError } = await client.from("import_job_rows").select("id, row_number, raw_row, status").eq("job_id", job.id).eq("status", "queued").order("row_number", { ascending: true }).limit(batchSize); if (rowsError) throw rowsError;
+  const rows = (stagedRows ?? []) as StagedRow[];
+  if (!rows.length) { const finalSummary = compactImportSummary({ counts: { created: summaryCount(job.summary, "created"), updated: summaryCount(job.summary, "updated"), skipped: job.skipped_count ?? 0, failed: job.failed_count ?? 0, duplicates: summaryCount(job.summary, "duplicates") }, totalRows: job.processed_rows ?? 0, skippedRows: samples(job.summary).skippedRows, failedRows: samples(job.summary).failedRows, sampleLimit: VEHICLE_IMPORT_SAMPLE_LIMIT }); await client.from("import_jobs").update({ status: "completed", completed_at: new Date().toISOString(), updated_at: new Date().toISOString(), summary: finalSummary }).eq("id", job.id); return { ok: true, processed: 0, completed: true, job: { id: job.id } }; }
+  const customers = await loadCustomerResolverIndex(supabase, job.shop_id); const counts: VehicleCounts = { created: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 }; const rowSamples = samples(job.summary);
+  for (const staged of rows) {
+    const rowNumber = staged.row_number;
+    try {
+      const normalizedResult = normalizeRow(staged.raw_row, job.shop_id, customers);
+      if (!normalizedResult.ok) { counts.skipped++; rowSamples.skippedRows.push({ row: rowNumber, reason: normalizedResult.reason }); await client.from("import_job_rows").update({ status: "skipped", error_message: normalizedResult.reason }).eq("id", staged.id); continue; }
+      const normalized = normalizedResult.vehicle; const existing = await findExistingVehicle(supabase, job.shop_id, normalized);
+      if (existing) { const { error } = await supabase.from("vehicles").update(updatePayload(normalized)).eq("id", existing.id).eq("shop_id", job.shop_id); if (error) throw error; counts.updated++; await client.from("import_job_rows").update({ status: "imported" }).eq("id", staged.id); continue; }
+      const { error } = await supabase.from("vehicles").insert(normalized); if (error) throw error; counts.created++; await client.from("import_job_rows").update({ status: "imported" }).eq("id", staged.id);
+    } catch (error) { counts.failed++; const message = error instanceof Error ? error.message : "Vehicle row failed to import."; rowSamples.failedRows.push({ row: rowNumber, error: message }); await client.from("import_job_rows").update({ status: "failed", error_message: message }).eq("id", staged.id); }
+  }
+  rowSamples.skippedRows = rowSamples.skippedRows.slice(0, VEHICLE_IMPORT_SAMPLE_LIMIT); rowSamples.failedRows = rowSamples.failedRows.slice(0, VEHICLE_IMPORT_SAMPLE_LIMIT);
+  const totalRows = Math.max(0, job.total_rows ?? 0); const previousCreated = summaryCount(job.summary, "created") || (job.imported_count ?? 0); const previousUpdated = summaryCount(job.summary, "updated"); const nextCreated = previousCreated + counts.created; const nextUpdated = previousUpdated + counts.updated; const nextImported = nextCreated + nextUpdated; const nextSkipped = (job.skipped_count ?? 0) + counts.skipped; const nextFailed = (job.failed_count ?? 0) + counts.failed; const processedRows = totalRows > 0 ? Math.min(totalRows, nextImported + nextSkipped + nextFailed) : nextImported + nextSkipped + nextFailed;
+  const { count: remainingCount, error: remainingError } = await client.from("import_job_rows").select("id", { count: "exact", head: true }).eq("job_id", job.id).eq("status", "queued"); if (remainingError) throw remainingError; const completed = (remainingCount ?? 0) === 0;
+  const summary = compactImportSummary({ counts: { created: nextCreated, updated: nextUpdated, skipped: nextSkipped, failed: nextFailed, duplicates: summaryCount(job.summary, "duplicates") + counts.duplicates }, totalRows: completed && totalRows > 0 ? totalRows : processedRows, skippedRows: rowSamples.skippedRows, failedRows: rowSamples.failedRows, sampleLimit: VEHICLE_IMPORT_SAMPLE_LIMIT });
+  await client.from("import_jobs").update({ status: completed ? "completed" : "processing", processed_rows: completed && totalRows > 0 ? totalRows : processedRows, imported_count: nextImported, skipped_count: nextSkipped, failed_count: nextFailed, summary, completed_at: completed ? new Date().toISOString() : null, updated_at: new Date().toISOString() }).eq("id", job.id);
+  return { ok: true, processed: rows.length, completed, job: { id: job.id } };
+}
+
+export function stageVehicleImportRows(jobId: string, rows: VehicleImportRow[]) {
+  return rows.map((row, index) => ({ job_id: jobId, row_number: index + 1, raw_row: row as Record<string, unknown>, status: "queued" }));
+}
+export { chunkArray };


### PR DESCRIPTION
### Motivation
- Vehicle CSV imports were processed synchronously and timed out on large files (thousands of rows), so the import should use the same async `import_jobs`/`import_job_rows` pattern used by other imports to avoid long Vercel requests and provide real progress reporting.

### Description
- `/api/vehicles/import` now stages parsed CSV rows by creating an `import_jobs` row (`import_type: "vehicles"`) and inserting `import_job_rows` batches instead of processing rows inline (see `app/api/vehicles/import/route.ts`).
- Added a vehicle batch worker `processVehicleImportJobBatch` and helpers in `features/vehicles/server/vehicle-import-job.ts` that load all customers with pagination for resolver building, validate rows, and perform insert/update operations in batches while updating job counts and samples.
- Polled job progress via the existing import job endpoint by wiring vehicle jobs into `app/api/import-jobs/[jobId]/route.ts` so the frontend can advance queued/processing vehicle jobs and return up-to-date counts and summary.
- Added `vehicles` handling to the internal dispatcher `app/api/internal/import-jobs/tick/route.ts` so cron/internal workers can process vehicle import jobs alongside history/invoices.
- Updated the frontend `VehicleCsvImportCard` to queue the job (`/api/vehicles/import`), poll `/api/import-jobs/[jobId]` for real progress, display imported/skipped/failed/duplicate counts, and preserve guided onboarding completion and vehicle list refresh behavior (see `features/vehicles/components/VehicleCsvImportCard.tsx`).
- Key constants and behavior preserved: customer resolution and matching, validation/skip rules, insert-or-update matching, batch sizes and sample limits (see `features/vehicles/server/vehicle-import-job.ts`).

### Testing
- Ran type checking with `npm run typecheck` and it completed successfully.
- Ran linting with `npx eslint app/api/vehicles features/vehicles app/api/import-jobs app/api/internal/import-jobs --ext .ts,.tsx` and resolved issues so the lint run completed successfully.
- Changes were committed as a single change set including `features/vehicles/server/vehicle-import-job.ts`, `app/api/vehicles/import/route.ts`, `app/api/import-jobs/[jobId]/route.ts`, `app/api/internal/import-jobs/tick/route.ts`, and `features/vehicles/components/VehicleCsvImportCard.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ead2875b48328b56aa4399edef306)