### PR TITLE
Fix async vehicle CSV import queue staging

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -13,13 +13,15 @@ type ImportJobInsert = Record<string, unknown>;
 type JobInsertBuilder = {
   insert(values: ImportJobInsert): {
     select(columns: string): {
-      single(): Promise<{ data: { id: string; total_rows: number | null; status: string | null } | null; error: Error | null }>;
+      single(): Promise<{ data: { id: string; total_rows: number | null; status: string | null } | null; error: SupabaseError | null }>;
     };
   };
 };
 
+type SupabaseError = Error & { code?: string; details?: string; hint?: string };
+
 type RowInsertBuilder = {
-  insert(values: Array<Record<string, unknown>>): Promise<{ error: Error | null }>;
+  insert(values: Array<Record<string, unknown>>): Promise<{ error: SupabaseError | null }>;
 };
 
 type LooseSupabase<T> = { from(table: string): T };
@@ -80,18 +82,32 @@ export async function POST(req: Request) {
     if (jobError) {
       console.error("[vehicle-import:job-create-failed]", {
         message: jobError.message,
+        code: jobError.code,
+        details: jobError.details,
+        hint: jobError.hint,
         jobPayload,
       });
       throw jobError;
     }
     if (!job?.id) throw new Error("Vehicle import job could not be created.");
 
-    const stagedRows = stageVehicleImportRows(job.id, rows);
+    const stagedRows = stageVehicleImportRows(job.id, shopId, rows);
     for (const batch of chunkArray(stagedRows, VEHICLE_IMPORT_STAGING_BATCH_SIZE)) {
       const { error } = await (supabase as unknown as LooseSupabase<RowInsertBuilder>)
         .from("import_job_rows")
         .insert(batch);
-      if (error) throw error;
+      if (error) {
+        console.error("[vehicle-import:rows-stage-failed]", {
+          message: error.message,
+          code: error.code,
+          details: error.details,
+          hint: error.hint,
+          jobId: job.id,
+          batchSize: batch.length,
+          sampleRow: batch[0],
+        });
+        throw error;
+      }
     }
 
     return NextResponse.json({
@@ -102,7 +118,12 @@ export async function POST(req: Request) {
     });
   } catch (error) {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to queue vehicle import." },
+      {
+        error: error instanceof Error ? error.message : "Unable to queue vehicle import.",
+        details: typeof error === "object" && error && "details" in error ? (error as { details?: unknown }).details : undefined,
+        code: typeof error === "object" && error && "code" in error ? (error as { code?: unknown }).code : undefined,
+        hint: typeof error === "object" && error && "hint" in error ? (error as { hint?: unknown }).hint : undefined,
+      },
       { status: 500 },
     );
   }

--- a/db/sql/2026-07-08_vehicle_import_jobs.sql
+++ b/db/sql/2026-07-08_vehicle_import_jobs.sql
@@ -1,0 +1,7 @@
+-- Vehicle CSV async import support: allow vehicle import jobs.
+-- Existing rows are already limited to vehicle_history/invoices by the prior check;
+-- this migration only widens the accepted import_type values.
+alter table public.import_jobs drop constraint if exists import_jobs_import_type_check;
+alter table public.import_jobs
+  add constraint import_jobs_import_type_check
+  check (import_type in ('vehicle_history', 'invoices', 'vehicles'));

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -5965,6 +5965,122 @@ export type Database = {
           },
         ]
       }
+      import_job_rows: {
+        Row: {
+          created_at: string
+          error_message: string | null
+          id: string
+          job_id: string
+          raw_row: Json
+          row_number: number
+          shop_id: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          error_message?: string | null
+          id?: string
+          job_id: string
+          raw_row: Json
+          row_number: number
+          shop_id: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          error_message?: string | null
+          id?: string
+          job_id?: string
+          raw_row?: Json
+          row_number?: number
+          shop_id?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "import_job_rows_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "import_jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "import_job_rows_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      import_jobs: {
+        Row: {
+          completed_at: string | null
+          created_at: string
+          created_by: string | null
+          error_message: string | null
+          failed_count: number
+          id: string
+          import_type: string
+          imported_count: number
+          processed_rows: number
+          shop_id: string
+          skipped_count: number
+          source_storage_path: string | null
+          status: string
+          summary: Json
+          total_rows: number
+          updated_at: string
+        }
+        Insert: {
+          completed_at?: string | null
+          created_at?: string
+          created_by?: string | null
+          error_message?: string | null
+          failed_count?: number
+          id?: string
+          import_type: string
+          imported_count?: number
+          processed_rows?: number
+          shop_id: string
+          skipped_count?: number
+          source_storage_path?: string | null
+          status?: string
+          summary?: Json
+          total_rows?: number
+          updated_at?: string
+        }
+        Update: {
+          completed_at?: string | null
+          created_at?: string
+          created_by?: string | null
+          error_message?: string | null
+          failed_count?: number
+          id?: string
+          import_type?: string
+          imported_count?: number
+          processed_rows?: number
+          shop_id?: string
+          skipped_count?: number
+          source_storage_path?: string | null
+          status?: string
+          summary?: Json
+          total_rows?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "import_jobs_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       invoices: {
         Row: {
           created_at: string

--- a/features/vehicles/server/vehicle-import-job.ts
+++ b/features/vehicles/server/vehicle-import-job.ts
@@ -87,7 +87,13 @@ export async function processVehicleImportJobBatch(supabase: SupabaseClient<DB>,
   return { ok: true, processed: rows.length, completed, job: { id: job.id } };
 }
 
-export function stageVehicleImportRows(jobId: string, rows: VehicleImportRow[]) {
-  return rows.map((row, index) => ({ job_id: jobId, row_number: index + 1, raw_row: row as Record<string, unknown>, status: "queued" }));
+export function stageVehicleImportRows(jobId: string, shopId: string, rows: VehicleImportRow[]) {
+  return rows.map((row, index) => ({
+    job_id: jobId,
+    shop_id: shopId,
+    row_number: index + 1,
+    raw_row: row as Record<string, unknown>,
+    status: "queued",
+  }));
 }
 export { chunkArray };

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -4789,6 +4789,122 @@ export type Database = {
           },
         ]
       }
+      import_job_rows: {
+        Row: {
+          created_at: string
+          error_message: string | null
+          id: string
+          job_id: string
+          raw_row: Json
+          row_number: number
+          shop_id: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          error_message?: string | null
+          id?: string
+          job_id: string
+          raw_row: Json
+          row_number: number
+          shop_id: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          error_message?: string | null
+          id?: string
+          job_id?: string
+          raw_row?: Json
+          row_number?: number
+          shop_id?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "import_job_rows_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "import_jobs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "import_job_rows_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      import_jobs: {
+        Row: {
+          completed_at: string | null
+          created_at: string
+          created_by: string | null
+          error_message: string | null
+          failed_count: number
+          id: string
+          import_type: string
+          imported_count: number
+          processed_rows: number
+          shop_id: string
+          skipped_count: number
+          source_storage_path: string | null
+          status: string
+          summary: Json
+          total_rows: number
+          updated_at: string
+        }
+        Insert: {
+          completed_at?: string | null
+          created_at?: string
+          created_by?: string | null
+          error_message?: string | null
+          failed_count?: number
+          id?: string
+          import_type: string
+          imported_count?: number
+          processed_rows?: number
+          shop_id: string
+          skipped_count?: number
+          source_storage_path?: string | null
+          status?: string
+          summary?: Json
+          total_rows?: number
+          updated_at?: string
+        }
+        Update: {
+          completed_at?: string | null
+          created_at?: string
+          created_by?: string | null
+          error_message?: string | null
+          failed_count?: number
+          id?: string
+          import_type?: string
+          imported_count?: number
+          processed_rows?: number
+          shop_id?: string
+          skipped_count?: number
+          source_storage_path?: string | null
+          status?: string
+          summary?: Json
+          total_rows?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "import_jobs_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       invoices: {
         Row: {
           created_at: string

--- a/supabase/migrations/202607080001_vehicle_import_jobs.sql
+++ b/supabase/migrations/202607080001_vehicle_import_jobs.sql
@@ -1,0 +1,7 @@
+-- Vehicle CSV async import support: allow vehicle import jobs.
+-- Existing rows are already limited to vehicle_history/invoices by the prior check;
+-- this migration only widens the accepted import_type values.
+alter table public.import_jobs drop constraint if exists import_jobs_import_type_check;
+alter table public.import_jobs
+  add constraint import_jobs_import_type_check
+  check (import_type in ('vehicle_history', 'invoices', 'vehicles'));


### PR DESCRIPTION
### Motivation
- Vehicle CSV import was failing during async queueing because `import_job_rows` inserts did not include the required `shop_id`, causing DB check/constraint errors even after widening `import_jobs` types.
- The route masked the real Supabase error, so the true DB error (constraint violation) was not visible in logs or responses.
- The code must preserve the async job architecture and allow the tick/worker and per-job poller to process `vehicles` jobs.

### Description
- Ensure staged vehicle rows include `shop_id` by changing `stageVehicleImportRows` signature and callers to pass `shopId` so `import_job_rows` inserts satisfy the schema; changed `features/vehicles/server/vehicle-import-job.ts` and `app/api/vehicles/import/route.ts`.
- Surface Supabase error metadata (`code`, `details`, `hint`) in logs and the error response when job creation or row staging fails to reveal the real DB error; updated `app/api/vehicles/import/route.ts` to log and return these fields.
- Add a DB migration to widen the `import_jobs_import_type_check` to include `'vehicles'` so `import_jobs.import_type` accepts vehicle jobs; added `db/sql/2026-07-08_vehicle_import_jobs.sql` and `supabase/migrations/202607080001_vehicle_import_jobs.sql`.
- Add generated Supabase types for `import_jobs` and `import_job_rows` (including `shop_id`) so TypeScript reflects the actual schema; updated `shared/types/types/supabase.ts` and `features/shared/types/types/supabase.ts`.

### Testing
- Ran `npm run typecheck` and the TypeScript check completed successfully.
- Ran `npx eslint app/api/vehicles features/vehicles app/api/import-jobs app/api/internal/import-jobs --ext .ts,.tsx` and linter completed with no errors.
- Verified the import job path: `POST /api/vehicles/import` now creates an `import_jobs` row, stages `import_job_rows` with `shop_id`, and returns `{ ok: true, jobId }`, and the existing `POST /api/import-jobs/[jobId]` and internal tick routes already dispatch `vehicles` to `processVehicleImportJobBatch` (no changes required there).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eb7fe8db88328b701d561686e5bcf)