### PR TITLE
Make vehicle CSV imports synchronous

### DIFF
--- a/app/api/vehicles/import/route.ts
+++ b/app/api/vehicles/import/route.ts
@@ -2,29 +2,13 @@ import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import {
   VEHICLE_IMPORT_MAX_ROWS,
-  VEHICLE_IMPORT_SAMPLE_LIMIT,
-  VEHICLE_IMPORT_STAGING_BATCH_SIZE,
-  chunkArray,
-  stageVehicleImportRows,
+  processVehicleImportRows,
   type VehicleImportRow,
 } from "@/features/vehicles/server/vehicle-import-job";
-type ImportJobInsert = Record<string, unknown>;
 
-type JobInsertBuilder = {
-  insert(values: ImportJobInsert): {
-    select(columns: string): {
-      single(): Promise<{ data: { id: string; total_rows: number | null; status: string | null } | null; error: SupabaseError | null }>;
-    };
-  };
+type VehicleImportBody = {
+  rows?: unknown;
 };
-
-type SupabaseError = Error & { code?: string; details?: string; hint?: string };
-
-type RowInsertBuilder = {
-  insert(values: Array<Record<string, unknown>>): Promise<{ error: SupabaseError | null }>;
-};
-
-type LooseSupabase<T> = { from(table: string): T };
 
 export async function POST(req: Request) {
   try {
@@ -33,96 +17,40 @@ export async function POST(req: Request) {
     });
     if (!access.ok) return access.response;
 
-    const body = await req.json().catch(() => null);
-    const rows = Array.isArray(body?.rows) ? (body.rows as VehicleImportRow[]) : [];
-    if (!rows.length) {
-      return NextResponse.json({ error: "No vehicle rows provided." }, { status: 400 });
-    }
-    if (rows.length > VEHICLE_IMPORT_MAX_ROWS) {
+    const { supabase, profile } = access;
+    const shopId = profile.shop_id;
+    if (!shopId) {
       return NextResponse.json(
-        { error: `Vehicle CSV contains ${rows.length} rows. Please split files into ${VEHICLE_IMPORT_MAX_ROWS} rows or fewer.` },
+        { error: "No active shop is selected." },
         { status: 400 },
       );
     }
 
-    const { supabase, profile } = access;
-    const shopId = profile.shop_id;
-    if (!shopId) {
-      return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
+    const body = (await req.json().catch(() => ({}))) as VehicleImportBody;
+    const rows = Array.isArray(body.rows) ? (body.rows as VehicleImportRow[]) : [];
+    if (!rows.length) {
+      return NextResponse.json(
+        { error: "No vehicle rows provided." },
+        { status: 400 },
+      );
+    }
+    if (rows.length > VEHICLE_IMPORT_MAX_ROWS) {
+      return NextResponse.json(
+        {
+          error: `Vehicle CSV contains ${rows.length} rows. Please split files into ${VEHICLE_IMPORT_MAX_ROWS} rows or fewer.`,
+        },
+        { status: 400 },
+      );
     }
 
-    const sourceRef = `staging://import_job_rows/vehicles/${shopId}/${Date.now()}`;
-    const jobPayload: ImportJobInsert = {
-      shop_id: shopId,
-      created_by: profile.id,
-      import_type: "vehicles",
-      status: "queued",
-      total_rows: rows.length,
-      processed_rows: 0,
-      imported_count: 0,
-      skipped_count: 0,
-      failed_count: 0,
-      source_storage_path: sourceRef,
-      summary: {
-        ok: true,
-        counts: { created: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 },
-        totalRows: rows.length,
-        skippedRows: [],
-        failedRows: [],
-        sampleLimit: VEHICLE_IMPORT_SAMPLE_LIMIT,
-        storageCleanup: "CSV rows are staged in import_job_rows; no Supabase Storage object is created.",
-      },
-    };
+    const summary = await processVehicleImportRows(supabase, shopId, rows);
 
-    const { data: job, error: jobError } = await (supabase as unknown as LooseSupabase<JobInsertBuilder>)
-      .from("import_jobs")
-      .insert(jobPayload)
-      .select("id, total_rows, status")
-      .single();
-    if (jobError) {
-      console.error("[vehicle-import:job-create-failed]", {
-        message: jobError.message,
-        code: jobError.code,
-        details: jobError.details,
-        hint: jobError.hint,
-        jobPayload,
-      });
-      throw jobError;
-    }
-    if (!job?.id) throw new Error("Vehicle import job could not be created.");
-
-    const stagedRows = stageVehicleImportRows(job.id, shopId, rows);
-    for (const batch of chunkArray(stagedRows, VEHICLE_IMPORT_STAGING_BATCH_SIZE)) {
-      const { error } = await (supabase as unknown as LooseSupabase<RowInsertBuilder>)
-        .from("import_job_rows")
-        .insert(batch);
-      if (error) {
-        console.error("[vehicle-import:rows-stage-failed]", {
-          message: error.message,
-          code: error.code,
-          details: error.details,
-          hint: error.hint,
-          jobId: job.id,
-          batchSize: batch.length,
-          sampleRow: batch[0],
-        });
-        throw error;
-      }
-    }
-
-    return NextResponse.json({
-      ok: true,
-      jobId: job.id,
-      job: { id: job.id, status: job.status, totalRows: job.total_rows ?? rows.length },
-      explanation: `Vehicle import job queued with ${rows.length} row(s).`,
-    });
+    return NextResponse.json(summary);
   } catch (error) {
     return NextResponse.json(
       {
-        error: error instanceof Error ? error.message : "Unable to queue vehicle import.",
-        details: typeof error === "object" && error && "details" in error ? (error as { details?: unknown }).details : undefined,
-        code: typeof error === "object" && error && "code" in error ? (error as { code?: unknown }).code : undefined,
-        hint: typeof error === "object" && error && "hint" in error ? (error as { hint?: unknown }).hint : undefined,
+        error:
+          error instanceof Error ? error.message : "Unable to import vehicles.",
       },
       { status: 500 },
     );

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
 import {
@@ -54,33 +54,15 @@ type ImportCounts = {
   updated: number;
   skipped: number;
   failed: number;
+  duplicates?: number;
 };
 
 type ImportResponse = {
   ok?: boolean;
   error?: string;
-  jobId?: string;
-  job?: { id: string; status?: string | null; totalRows?: number | null };
-  explanation?: string;
-};
-
-type ImportJobResponse = {
-  ok?: boolean;
-  error?: string;
-  job?: {
-    id: string;
-    status: string | null;
-    totalRows: number;
-    processedRows: number;
-    importedCount: number;
-    skippedCount: number;
-    failedCount: number;
-    summary?: {
-      counts?: Partial<ImportCounts & { duplicates: number }>;
-      skippedRows?: Array<{ row: number; reason: string }>;
-      failedRows?: Array<{ row: number; error: string }>;
-    } | null;
-  };
+  counts?: ImportCounts;
+  skippedRows?: Array<{ row: number; reason: string }>;
+  failedRows?: Array<{ row: number; error: string }>;
 };
 
 const SUPPORTED_COLUMNS = [
@@ -262,6 +244,13 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     counts.failed === 0,
   );
 
+  function hasNonFatalImportResult(nextCounts: ImportCounts): boolean {
+    return (
+      nextCounts.created + nextCounts.updated + nextCounts.skipped > 0 &&
+      nextCounts.failed === 0
+    );
+  }
+
   async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0] ?? null;
     setRows([]);
@@ -310,7 +299,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     }
   }
 
-  const completeOnboardingAfterImport = useCallback(async (nextCounts: ImportCounts) => {
+  async function completeOnboardingAfterImport(nextCounts: ImportCounts) {
     if (!guidedQuery) return;
 
     setCompletingOnboarding(true);
@@ -338,102 +327,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     } finally {
       setCompletingOnboarding(false);
     }
-  }, [guidedQuery]);
-
-  const applyJobProgress = useCallback(
-    async (job: NonNullable<ImportJobResponse["job"]>) => {
-      const created = Number(job.summary?.counts?.created ?? 0);
-      const updated = Number(job.summary?.counts?.updated ?? 0);
-      const duplicates = Number(job.summary?.counts?.duplicates ?? 0);
-      const nextCounts: ImportCounts = {
-        created,
-        updated,
-        skipped: Number(job.skippedCount ?? job.summary?.counts?.skipped ?? 0),
-        failed: Number(job.failedCount ?? job.summary?.counts?.failed ?? 0),
-      };
-      const total = job.totalRows || importableRows.length;
-      const processed = Math.min(total, job.processedRows || 0);
-      const percent = total > 0 ? Math.min(99, Math.round((processed / total) * 100)) : 0;
-
-      if (job.status === "completed" || job.status === "failed") {
-        setCounts(nextCounts);
-        setSkippedRows(job.summary?.skippedRows ?? []);
-        setFailedRows(job.summary?.failedRows ?? []);
-        const completedProgress: CsvImportProgressState = {
-          phase:
-            job.status === "failed" || nextCounts.failed > 0
-              ? "Import completed with failures"
-              : "Completed",
-          phaseKey: job.status === "failed" || nextCounts.failed > 0 ? "failed" : "completed",
-          processed: total,
-          total,
-          percent: 100,
-          imported: nextCounts.created + nextCounts.updated,
-          skipped: nextCounts.skipped,
-          failed: nextCounts.failed,
-        };
-        setImportProgress(completedProgress);
-
-        if (
-          isOnboarding &&
-          nextCounts.created + nextCounts.updated + nextCounts.skipped > 0 &&
-          nextCounts.failed === 0
-        ) {
-          setImportProgress({ ...completedProgress, phase: "Completing guided step", phaseKey: "finalizing", percent: 98 });
-          await completeOnboardingAfterImport(nextCounts);
-          setImportProgress(completedProgress);
-        }
-
-        router.refresh();
-        setImporting(false);
-        return true;
-      }
-
-      setImportProgress({
-        phase: `Processing vehicle rows${duplicates ? ` · ${duplicates} duplicate(s)` : ""}`,
-        phaseKey: "processing",
-        processed,
-        total,
-        percent,
-        imported: nextCounts.created + nextCounts.updated,
-        skipped: nextCounts.skipped,
-        failed: nextCounts.failed,
-      });
-      return false;
-    },
-    [completeOnboardingAfterImport, importableRows.length, isOnboarding, router],
-  );
-
-  const pollImportJob = useCallback(async (jobId: string) => {
-    const response = await fetch(`/api/import-jobs/${encodeURIComponent(jobId)}`, {
-      method: "GET",
-      cache: "no-store",
-    });
-    const payload = (await response.json().catch(() => ({}))) as ImportJobResponse;
-    if (!response.ok || payload.ok === false || !payload.job) {
-      throw new Error(payload.error ?? "Unable to load vehicle import progress.");
-    }
-    return applyJobProgress(payload.job);
-  }, [applyJobProgress]);
-
-  useEffect(() => {
-    if (!importing || !importProgress || importProgress.phaseKey !== "processing") return;
-    const jobId = (importProgress as CsvImportProgressState & { jobId?: string }).jobId;
-    if (!jobId) return;
-    let cancelled = false;
-    const timer = window.setInterval(() => {
-      void pollImportJob(jobId).catch((error) => {
-        if (cancelled) return;
-        setImportError(error instanceof Error ? error.message : "Unable to load vehicle import progress.");
-        setImportProgress({ phase: "failed", phaseKey: "failed", processed: 0, total: importableRows.length, percent: 100 });
-        setImporting(false);
-      });
-    }, 1200);
-    return () => {
-      cancelled = true;
-      window.clearInterval(timer);
-    };
-  }, [importProgress, importableRows.length, importing, pollImportJob]);
+  }
 
   async function confirmImport() {
     if (!importableRows.length) {
@@ -446,17 +340,37 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
     setImporting(true);
     setImportError(null);
     setImportProgress({
-      phase: "Queueing vehicle import",
+      phase: "Preparing rows",
       phaseKey: "processing",
       processed: 0,
       total: importableRows.length,
-      percent: 0,
+      percent: 30,
     });
     setCounts(null);
     setSkippedRows([]);
     setFailedRows([]);
+    let progressTimer: number | null = null;
 
     try {
+      progressTimer = window.setInterval(() => {
+        setImportProgress((current) => {
+          if (!current || current.phaseKey !== "processing") return current;
+          const nextPercent = Math.min(90, current.percent + 3);
+          return {
+            ...current,
+            phase: "Importing rows",
+            processed: Math.min(
+              importableRows.length,
+              Math.max(
+                current.processed,
+                Math.floor((nextPercent / 100) * importableRows.length),
+              ),
+            ),
+            percent: nextPercent,
+          };
+        });
+      }, 650);
+
       const response = await fetch("/api/vehicles/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -464,21 +378,53 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
       });
 
       const payload = (await response.json().catch(() => ({}))) as ImportResponse;
-      const jobId = payload.jobId ?? payload.job?.id;
-      if (!response.ok || payload.ok === false || !jobId) {
-        throw new Error(payload.error ?? "Unable to queue vehicle import.");
+      if (!response.ok || payload.ok === false || !payload.counts) {
+        throw new Error(payload.error ?? "Unable to import vehicles.");
+      }
+
+      if (progressTimer) window.clearInterval(progressTimer);
+      progressTimer = null;
+      setImportProgress({
+        phase: "Finalizing",
+        phaseKey: "finalizing",
+        processed: importableRows.length,
+        total: importableRows.length,
+        percent: 95,
+      });
+      setCounts(payload.counts);
+      setSkippedRows(payload.skippedRows ?? []);
+      setFailedRows(payload.failedRows ?? []);
+
+      if (
+        isOnboarding &&
+        hasNonFatalImportResult(payload.counts)
+      ) {
+        setImportProgress({
+          phase: "Completing guided step",
+          phaseKey: "finalizing",
+          processed: importableRows.length,
+          total: importableRows.length,
+          percent: 98,
+        });
+        await completeOnboardingAfterImport(payload.counts);
       }
 
       setImportProgress({
-        phase: "Vehicle import queued",
-        phaseKey: "processing",
-        processed: 0,
-        total: payload.job?.totalRows ?? importableRows.length,
-        percent: 0,
-        jobId,
-      } as CsvImportProgressState & { jobId: string });
-      await pollImportJob(jobId);
+        phase:
+          payload.counts.failed > 0
+            ? "Import completed with failures"
+            : "Completed",
+        phaseKey: payload.counts.failed > 0 ? "failed" : "completed",
+        processed: importableRows.length,
+        total: importableRows.length,
+        percent: 100,
+        imported: payload.counts.created + payload.counts.updated,
+        skipped: payload.counts.skipped,
+        failed: payload.counts.failed,
+      });
+      router.refresh();
     } catch (error) {
+      if (progressTimer) window.clearInterval(progressTimer);
       setImportProgress({
         phase: "failed",
         phaseKey: "failed",
@@ -489,9 +435,12 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
       setImportError(
         error instanceof Error ? error.message : "Unable to import vehicles.",
       );
+    } finally {
+      if (progressTimer) window.clearInterval(progressTimer);
       setImporting(false);
     }
   }
+
 
   return (
     <GuidedSetupCardShell
@@ -545,7 +494,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         parsedRows={rows.length}
         readyRows={importableRows.length}
         needsReviewRows={skippedPreviewCount}
-        duplicateRows={0}
+        duplicateRows={counts?.duplicates ?? 0}
         invalidRows={skippedPreviewCount}
         parseError={parseError}
       />
@@ -563,7 +512,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
           imported={counts.created + counts.updated}
           skipped={counts.skipped}
           failed={counts.failed}
-          duplicates={0}
+          duplicates={counts.duplicates ?? 0}
           skippedRows={skippedRows}
           failedRows={failedRows}
         />

--- a/features/vehicles/server/vehicle-import-job.ts
+++ b/features/vehicles/server/vehicle-import-job.ts
@@ -76,6 +76,83 @@ function summaryCount(summary: Record<string, unknown> | null, key: string): num
 function samples(summary: Record<string, unknown> | null) { return { skippedRows: Array.isArray(summary?.skippedRows) ? summary.skippedRows as Array<{ row: number; reason: string }> : [], failedRows: Array.isArray(summary?.failedRows) ? summary.failedRows as Array<{ row: number; error: string }> : [] }; }
 function updatePayload(normalized: VehicleInsert): VehicleUpdate { return omitNullishVehicleUpdate({ unit_number: normalized.unit_number, vin: normalized.vin, license_plate: normalized.license_plate, state_province: normalized.state_province, year: normalized.year, make: normalized.make, model: normalized.model, customer_id: normalized.customer_id, external_id: normalized.external_id, submodel: normalized.submodel, color: normalized.color, mileage: normalized.mileage, odometer_unit: normalized.odometer_unit, engine: normalized.engine, fuel_type: normalized.fuel_type, drivetrain: normalized.drivetrain, body_type: normalized.body_type, asset_type: normalized.asset_type, status: normalized.status, purchase_date: normalized.purchase_date, in_service_date: normalized.in_service_date, last_service_date: normalized.last_service_date, tags: normalized.tags, notes: normalized.notes, import_notes: normalized.import_notes }); }
 
+export async function processVehicleImportRows(supabase: SupabaseClient<DB>, shopId: string, rows: VehicleImportRow[]) {
+  const customers = await loadCustomerResolverIndex(supabase, shopId);
+  const counts: VehicleCounts = { created: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 };
+  const skippedRows: Array<{ row: number; reason: string }> = [];
+  const failedRows: Array<{ row: number; error: string }> = [];
+  const normalizedRows: Array<{ rowNumber: number; vehicle: VehicleInsert }> = [];
+  const seenIdentities = new Set<string>();
+
+  for (const [index, row] of rows.entries()) {
+    const rowNumber = index + 1;
+    const normalizedResult = normalizeRow(row, shopId, customers);
+    if (!normalizedResult.ok) {
+      counts.skipped += 1;
+      skippedRows.push({ row: rowNumber, reason: normalizedResult.reason });
+      continue;
+    }
+
+    const vehicle = normalizedResult.vehicle;
+    const identityKeys = [
+      vehicle.external_id ? `external_id:${vehicle.external_id}` : null,
+      vehicle.vin ? `vin:${vehicle.vin}` : null,
+      vehicle.unit_number ? `unit_number:${vehicle.unit_number}` : null,
+      vehicle.license_plate ? `license_plate:${vehicle.license_plate}` : null,
+    ].filter(Boolean) as string[];
+    const duplicateKey = identityKeys.find((key) => seenIdentities.has(key));
+    if (duplicateKey) {
+      counts.duplicates += 1;
+      counts.skipped += 1;
+      skippedRows.push({ row: rowNumber, reason: `Duplicate vehicle identity within this CSV (${duplicateKey}).` });
+      continue;
+    }
+    identityKeys.forEach((key) => seenIdentities.add(key));
+    normalizedRows.push({ rowNumber, vehicle });
+  }
+
+  const existingVehicles = await loadExistingVehicleIndex(supabase, shopId, normalizedRows.map((entry) => entry.vehicle));
+  const inserts: VehicleInsert[] = [];
+  const insertRows: number[] = [];
+
+  for (const entry of normalizedRows) {
+    try {
+      const existing = findExistingVehicleInIndex(existingVehicles, entry.vehicle);
+      if (existing) {
+        const { error } = await supabase.from("vehicles").update(updatePayload(entry.vehicle)).eq("id", existing.id).eq("shop_id", shopId);
+        if (error) throw error;
+        counts.updated += 1;
+        continue;
+      }
+      inserts.push(entry.vehicle);
+      insertRows.push(entry.rowNumber);
+    } catch (error) {
+      counts.failed += 1;
+      failedRows.push({ row: entry.rowNumber, error: error instanceof Error ? error.message : "Vehicle row failed to import." });
+    }
+  }
+
+  for (let index = 0; index < inserts.length; index += VEHICLE_IMPORT_STAGING_BATCH_SIZE) {
+    const vehicleBatch = inserts.slice(index, index + VEHICLE_IMPORT_STAGING_BATCH_SIZE);
+    const rowBatch = insertRows.slice(index, index + VEHICLE_IMPORT_STAGING_BATCH_SIZE);
+    const { error } = await supabase.from("vehicles").insert(vehicleBatch);
+    if (error) {
+      counts.failed += rowBatch.length;
+      failedRows.push(...rowBatch.map((row) => ({ row, error: error.message })));
+    } else {
+      counts.created += vehicleBatch.length;
+    }
+  }
+
+  return compactImportSummary({
+    counts,
+    totalRows: rows.length,
+    skippedRows,
+    failedRows,
+    sampleLimit: VEHICLE_IMPORT_SAMPLE_LIMIT,
+  });
+}
+
 export async function processVehicleImportJobBatch(supabase: SupabaseClient<DB>, jobId?: string, batchSize = VEHICLE_IMPORT_BATCH_SIZE) {
   const client = supabase as unknown as SupabaseClient; let jobQuery = client.from("import_jobs").select("id, shop_id, total_rows, processed_rows, imported_count, skipped_count, failed_count, summary").eq("import_type", "vehicles").in("status", ["queued", "processing"]).order("created_at", { ascending: true }).limit(1); if (jobId) jobQuery = jobQuery.eq("id", jobId);
   const { data: job, error: jobError } = await jobQuery.maybeSingle<JobRow>(); if (jobError) throw jobError; if (!job) return { ok: true, processed: 0, completed: false, job: null };

--- a/tests/vehicle-csv-import-route.test.ts
+++ b/tests/vehicle-csv-import-route.test.ts
@@ -131,7 +131,7 @@ describe("guided CSV import progress UI", () => {
     expect(customerSource).toContain("Customer CSV import progress");
     expect(vehicleSource).toContain("Vehicle CSV import progress");
     expect(customerSource).toContain('phase: "Preparing rows"');
-    expect(vehicleSource).toContain('phase: "Queueing vehicle import"');
+    expect(vehicleSource).toContain('phase: "Preparing rows"');
     expect(customerSource).toContain('phase: "Completing guided step"');
     expect(vehicleSource).toContain('phase: "Completing guided step"');
   });


### PR DESCRIPTION
### Motivation
- Vehicle CSV imports were queuing import jobs and polling `/api/import-jobs/:jobId`, which caused the UI to hang at the final "Processing Vehicle Rows" step while rows had already been inserted; the goal is to match the reliable synchronous Customer importer pattern.
- The change makes vehicle imports single-request/synchronous so the final UI state is derived from the API response and Vehicle Files refresh automatically after completion.

### Description
- Replace the import-job staging path in `app/api/vehicles/import/route.ts` with a synchronous flow that calls `processVehicleImportRows(...)` and returns a compact import summary (`counts`, `skippedRows`, `failedRows`).
- Add `processVehicleImportRows` to `features/vehicles/server/vehicle-import-job.ts` to normalize rows, resolve customers, dedupe within-CSV identities, update existing vehicles deterministically, insert new vehicles in batches, and return compact diagnostics.
- Update `features/vehicles/components/VehicleCsvImportCard.tsx` to match `CustomerCsvImportCard.tsx` client pattern by removing job creation/polling, using local progress phases (`Preparing rows`, `Importing rows`, `Finalizing`, `Completed`), handling the API response directly, showing counts/skipped/failed rows, completing onboarding when appropriate, and calling `router.refresh()` after success.
- Adjust tests to reflect the synchronous client pattern and updated progress phases.
- Files changed: `app/api/vehicles/import/route.ts`, `features/vehicles/components/VehicleCsvImportCard.tsx`, `features/vehicles/server/vehicle-import-job.ts`, `tests/vehicle-csv-import-route.test.ts`.

### Testing
- Ran `npm run typecheck` and it completed with no type errors.
- Ran `npx eslint features/vehicles/components app/api/vehicles features/shared/components/import --ext .ts,.tsx` with no lint errors reported.
- Ran `npx vitest run tests/vehicle-csv-import-route.test.ts` and all tests passed (10/10).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ec5295964832891e6ecfcd6dd0a1b)