### PR TITLE
Revert vehicle CSV import to synchronous flow

### DIFF
--- a/app/api/import-jobs/[jobId]/route.ts
+++ b/app/api/import-jobs/[jobId]/route.ts
@@ -5,10 +5,6 @@ import {
   processVehicleHistoryImportJobBatch,
   VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
 } from "@/features/work-orders/server/vehicle-history-import-job";
-import {
-  processVehicleImportJobBatch,
-  VEHICLE_IMPORT_BATCH_SIZE,
-} from "@/features/vehicles/server/vehicle-import-job";
 
 type ImportJobApiRow = {
   id: string;
@@ -75,14 +71,6 @@ export async function GET(
         createAdminSupabase(),
         jobId,
         VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
-      );
-      const refreshed = await loadJob();
-      data = refreshed.data ?? data;
-    } else if (data.import_type === "vehicles") {
-      await processVehicleImportJobBatch(
-        createAdminSupabase(),
-        jobId,
-        VEHICLE_IMPORT_BATCH_SIZE,
       );
       const refreshed = await loadJob();
       data = refreshed.data ?? data;

--- a/app/api/internal/import-jobs/tick/route.ts
+++ b/app/api/internal/import-jobs/tick/route.ts
@@ -9,15 +9,11 @@ import {
   INVOICE_IMPORT_BATCH_SIZE,
   processInvoiceImportJobBatch,
 } from "@/features/billing/server/invoice-import-job";
-import {
-  processVehicleImportJobBatch,
-  VEHICLE_IMPORT_BATCH_SIZE,
-} from "@/features/vehicles/server/vehicle-import-job";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-const SUPPORTED_IMPORT_TYPES = ["vehicle_history", "invoices", "vehicles"] as const;
+const SUPPORTED_IMPORT_TYPES = ["vehicle_history", "invoices"] as const;
 const STALE_PROCESSING_JOB_MINUTES = 15;
 type SupportedImportType = (typeof SUPPORTED_IMPORT_TYPES)[number];
 type ImportJobDispatchRow = {
@@ -152,10 +148,6 @@ async function processImportType(
 ) {
   if (importType === "invoices") {
     return processInvoiceImportJobBatch(admin, jobId, INVOICE_IMPORT_BATCH_SIZE);
-  }
-
-  if (importType === "vehicles") {
-    return processVehicleImportJobBatch(admin, jobId, VEHICLE_IMPORT_BATCH_SIZE);
   }
 
   return processVehicleHistoryImportJobBatch(

--- a/db/sql/2026-07-08_vehicle_import_jobs.sql
+++ b/db/sql/2026-07-08_vehicle_import_jobs.sql
@@ -1,7 +1,0 @@
--- Vehicle CSV async import support: allow vehicle import jobs.
--- Existing rows are already limited to vehicle_history/invoices by the prior check;
--- this migration only widens the accepted import_type values.
-alter table public.import_jobs drop constraint if exists import_jobs_import_type_check;
-alter table public.import_jobs
-  add constraint import_jobs_import_type_check
-  check (import_type in ('vehicle_history', 'invoices', 'vehicles'));

--- a/features/vehicles/server/vehicle-import-job.ts
+++ b/features/vehicles/server/vehicle-import-job.ts
@@ -1,13 +1,12 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { chunkArray, compactImportSummary } from "@/features/shared/lib/import/csv";
+import { compactImportSummary } from "@/features/shared/lib/import/csv";
 
 type DB = Database;
 type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
 
-export const VEHICLE_IMPORT_BATCH_SIZE = 1000;
-export const VEHICLE_IMPORT_STAGING_BATCH_SIZE = 1000;
+const VEHICLE_IMPORT_INSERT_BATCH_SIZE = 1000;
 export const VEHICLE_IMPORT_SAMPLE_LIMIT = 25;
 export const VEHICLE_IMPORT_MAX_ROWS = 20_000;
 
@@ -16,8 +15,6 @@ type CustomerResolverRow = Pick<DB["public"]["Tables"]["customers"]["Row"], "id"
 type CustomerResolverIndex = { byExternalId: Map<string, string>; byEmail: Map<string, string>; byPhone: Map<string, string>; byName: Map<string, string> };
 type NormalizedVehicleResult = { ok: true; vehicle: VehicleInsert } | { ok: false; reason: string };
 export type VehicleImportRow = { vehicle_id?: unknown; customer_id?: unknown; customer_email?: unknown; email?: unknown; customer_phone?: unknown; phone?: unknown; customer_name?: unknown; name?: unknown; plate?: unknown; state_province?: unknown; trim?: unknown; color?: unknown; odometer?: unknown; odometer_unit?: unknown; engine?: unknown; fuel_type?: unknown; drive_type?: unknown; body_type?: unknown; asset_type?: unknown; status?: unknown; purchase_date?: unknown; in_service_date?: unknown; last_service_date?: unknown; tags?: unknown; notes?: unknown; unit_number?: unknown; vin?: unknown; license_plate?: unknown; year?: unknown; make?: unknown; model?: unknown };
-type JobRow = { id: string; shop_id: string; total_rows: number | null; processed_rows: number | null; imported_count: number | null; skipped_count: number | null; failed_count: number | null; summary: Record<string, unknown> | null };
-type StagedRow = { id: string; row_number: number; raw_row: VehicleImportRow; status: string | null };
 type VehicleCounts = { created: number; updated: number; skipped: number; failed: number; duplicates: number };
 
 function cleanString(value: unknown): string | null { const text = String(value ?? "").trim(); return text.length ? text : null; }
@@ -69,11 +66,6 @@ async function loadExistingVehicleIndex(supabase: SupabaseClient<DB>, shopId: st
 function findExistingVehicleInIndex(index: Map<string, VehicleMatch>, normalized: VehicleInsert): VehicleMatch | null {
   return (normalized.external_id ? index.get(`external_id:${normalized.external_id}`) : null) ?? (normalized.vin ? index.get(`vin:${normalized.vin}`) : null) ?? (normalized.unit_number ? index.get(`unit_number:${normalized.unit_number}`) : null) ?? (normalized.license_plate ? index.get(`license_plate:${normalized.license_plate}`) : null) ?? null;
 }
-function summaryCount(summary: Record<string, unknown> | null, key: string): number {
-  const counts = summary?.counts as Record<string, unknown> | undefined;
-  return Number(counts?.[key] ?? summary?.[key] ?? 0);
-}
-function samples(summary: Record<string, unknown> | null) { return { skippedRows: Array.isArray(summary?.skippedRows) ? summary.skippedRows as Array<{ row: number; reason: string }> : [], failedRows: Array.isArray(summary?.failedRows) ? summary.failedRows as Array<{ row: number; error: string }> : [] }; }
 function updatePayload(normalized: VehicleInsert): VehicleUpdate { return omitNullishVehicleUpdate({ unit_number: normalized.unit_number, vin: normalized.vin, license_plate: normalized.license_plate, state_province: normalized.state_province, year: normalized.year, make: normalized.make, model: normalized.model, customer_id: normalized.customer_id, external_id: normalized.external_id, submodel: normalized.submodel, color: normalized.color, mileage: normalized.mileage, odometer_unit: normalized.odometer_unit, engine: normalized.engine, fuel_type: normalized.fuel_type, drivetrain: normalized.drivetrain, body_type: normalized.body_type, asset_type: normalized.asset_type, status: normalized.status, purchase_date: normalized.purchase_date, in_service_date: normalized.in_service_date, last_service_date: normalized.last_service_date, tags: normalized.tags, notes: normalized.notes, import_notes: normalized.import_notes }); }
 
 export async function processVehicleImportRows(supabase: SupabaseClient<DB>, shopId: string, rows: VehicleImportRow[]) {
@@ -132,9 +124,9 @@ export async function processVehicleImportRows(supabase: SupabaseClient<DB>, sho
     }
   }
 
-  for (let index = 0; index < inserts.length; index += VEHICLE_IMPORT_STAGING_BATCH_SIZE) {
-    const vehicleBatch = inserts.slice(index, index + VEHICLE_IMPORT_STAGING_BATCH_SIZE);
-    const rowBatch = insertRows.slice(index, index + VEHICLE_IMPORT_STAGING_BATCH_SIZE);
+  for (let index = 0; index < inserts.length; index += VEHICLE_IMPORT_INSERT_BATCH_SIZE) {
+    const vehicleBatch = inserts.slice(index, index + VEHICLE_IMPORT_INSERT_BATCH_SIZE);
+    const rowBatch = insertRows.slice(index, index + VEHICLE_IMPORT_INSERT_BATCH_SIZE);
     const { error } = await supabase.from("vehicles").insert(vehicleBatch);
     if (error) {
       counts.failed += rowBatch.length;
@@ -153,94 +145,3 @@ export async function processVehicleImportRows(supabase: SupabaseClient<DB>, sho
   });
 }
 
-export async function processVehicleImportJobBatch(supabase: SupabaseClient<DB>, jobId?: string, batchSize = VEHICLE_IMPORT_BATCH_SIZE) {
-  const client = supabase as unknown as SupabaseClient; let jobQuery = client.from("import_jobs").select("id, shop_id, total_rows, processed_rows, imported_count, skipped_count, failed_count, summary").eq("import_type", "vehicles").in("status", ["queued", "processing"]).order("created_at", { ascending: true }).limit(1); if (jobId) jobQuery = jobQuery.eq("id", jobId);
-  const { data: job, error: jobError } = await jobQuery.maybeSingle<JobRow>(); if (jobError) throw jobError; if (!job) return { ok: true, processed: 0, completed: false, job: null };
-  await client.from("import_jobs").update({ status: "processing", updated_at: new Date().toISOString() }).eq("id", job.id);
-  const { data: stagedRows, error: rowsError } = await client.from("import_job_rows").select("id, row_number, raw_row, status").eq("job_id", job.id).eq("status", "queued").order("row_number", { ascending: true }).limit(batchSize); if (rowsError) throw rowsError;
-  const rows = (stagedRows ?? []) as StagedRow[];
-  if (!rows.length) { const finalSummary = compactImportSummary({ counts: { created: summaryCount(job.summary, "created"), updated: summaryCount(job.summary, "updated"), skipped: job.skipped_count ?? 0, failed: job.failed_count ?? 0, duplicates: summaryCount(job.summary, "duplicates") }, totalRows: job.processed_rows ?? 0, skippedRows: samples(job.summary).skippedRows, failedRows: samples(job.summary).failedRows, sampleLimit: VEHICLE_IMPORT_SAMPLE_LIMIT }); await client.from("import_jobs").update({ status: "completed", completed_at: new Date().toISOString(), updated_at: new Date().toISOString(), summary: finalSummary }).eq("id", job.id); return { ok: true, processed: 0, completed: true, job: { id: job.id } }; }
-  const customers = await loadCustomerResolverIndex(supabase, job.shop_id); const counts: VehicleCounts = { created: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 }; const rowSamples = samples(job.summary);
-  const normalizedRows: Array<{ staged: StagedRow; vehicle: VehicleInsert }> = [];
-  const importedRowIds: string[] = [];
-  const skippedByReason = new Map<string, string[]>();
-  const failedByMessage = new Map<string, string[]>();
-
-  for (const staged of rows) {
-    const normalizedResult = normalizeRow(staged.raw_row, job.shop_id, customers);
-    if (!normalizedResult.ok) {
-      counts.skipped++;
-      rowSamples.skippedRows.push({ row: staged.row_number, reason: normalizedResult.reason });
-      const ids = skippedByReason.get(normalizedResult.reason) ?? [];
-      ids.push(staged.id);
-      skippedByReason.set(normalizedResult.reason, ids);
-      continue;
-    }
-    normalizedRows.push({ staged, vehicle: normalizedResult.vehicle });
-  }
-
-  const existingVehicles = await loadExistingVehicleIndex(supabase, job.shop_id, normalizedRows.map((entry) => entry.vehicle));
-  const inserts: VehicleInsert[] = [];
-  const insertRowIds: string[] = [];
-  const insertRowNumbers: number[] = [];
-
-  for (const entry of normalizedRows) {
-    try {
-      const existing = findExistingVehicleInIndex(existingVehicles, entry.vehicle);
-      if (existing) {
-        const { error } = await supabase.from("vehicles").update(updatePayload(entry.vehicle)).eq("id", existing.id).eq("shop_id", job.shop_id);
-        if (error) throw error;
-        counts.updated++;
-        importedRowIds.push(entry.staged.id);
-        continue;
-      }
-      inserts.push(entry.vehicle);
-      insertRowIds.push(entry.staged.id);
-      insertRowNumbers.push(entry.staged.row_number);
-    } catch (error) {
-      counts.failed++;
-      const message = error instanceof Error ? error.message : "Vehicle row failed to import.";
-      rowSamples.failedRows.push({ row: entry.staged.row_number, error: message });
-      const ids = failedByMessage.get(message) ?? [];
-      ids.push(entry.staged.id);
-      failedByMessage.set(message, ids);
-    }
-  }
-
-  for (let index = 0; index < inserts.length; index += VEHICLE_IMPORT_STAGING_BATCH_SIZE) {
-    const vehicleBatch = inserts.slice(index, index + VEHICLE_IMPORT_STAGING_BATCH_SIZE);
-    const rowIdBatch = insertRowIds.slice(index, index + VEHICLE_IMPORT_STAGING_BATCH_SIZE);
-    const { error } = await supabase.from("vehicles").insert(vehicleBatch);
-    if (error) {
-      counts.failed += rowIdBatch.length;
-      rowSamples.failedRows.push(...rowIdBatch.map((_, offset) => ({ row: insertRowNumbers[index + offset] ?? 0, error: error.message })));
-      const ids = failedByMessage.get(error.message) ?? [];
-      ids.push(...rowIdBatch);
-      failedByMessage.set(error.message, ids);
-    } else {
-      counts.created += vehicleBatch.length;
-      importedRowIds.push(...rowIdBatch);
-    }
-  }
-
-  for (const ids of chunkArray(importedRowIds, VEHICLE_IMPORT_STAGING_BATCH_SIZE)) { if (ids.length) await client.from("import_job_rows").update({ status: "imported" }).in("id", ids); }
-  for (const [reason, ids] of skippedByReason) { for (const batch of chunkArray(ids, VEHICLE_IMPORT_STAGING_BATCH_SIZE)) await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).in("id", batch); }
-  for (const [message, ids] of failedByMessage) { for (const batch of chunkArray(ids, VEHICLE_IMPORT_STAGING_BATCH_SIZE)) await client.from("import_job_rows").update({ status: "failed", error_message: message }).in("id", batch); }
-  rowSamples.skippedRows = rowSamples.skippedRows.slice(0, VEHICLE_IMPORT_SAMPLE_LIMIT); rowSamples.failedRows = rowSamples.failedRows.slice(0, VEHICLE_IMPORT_SAMPLE_LIMIT);
-  const totalRows = Math.max(0, job.total_rows ?? 0); const previousCreated = summaryCount(job.summary, "created") || (job.imported_count ?? 0); const previousUpdated = summaryCount(job.summary, "updated"); const nextCreated = previousCreated + counts.created; const nextUpdated = previousUpdated + counts.updated; const nextImported = nextCreated + nextUpdated; const nextSkipped = (job.skipped_count ?? 0) + counts.skipped; const nextFailed = (job.failed_count ?? 0) + counts.failed; const processedRows = totalRows > 0 ? Math.min(totalRows, nextImported + nextSkipped + nextFailed) : nextImported + nextSkipped + nextFailed;
-  const { count: remainingCount, error: remainingError } = await client.from("import_job_rows").select("id", { count: "exact", head: true }).eq("job_id", job.id).eq("status", "queued"); if (remainingError) throw remainingError; const completed = (remainingCount ?? 0) === 0;
-  const summary = compactImportSummary({ counts: { created: nextCreated, updated: nextUpdated, skipped: nextSkipped, failed: nextFailed, duplicates: summaryCount(job.summary, "duplicates") + counts.duplicates }, totalRows: completed && totalRows > 0 ? totalRows : processedRows, skippedRows: rowSamples.skippedRows, failedRows: rowSamples.failedRows, sampleLimit: VEHICLE_IMPORT_SAMPLE_LIMIT });
-  await client.from("import_jobs").update({ status: completed ? "completed" : "processing", processed_rows: completed && totalRows > 0 ? totalRows : processedRows, imported_count: nextImported, skipped_count: nextSkipped, failed_count: nextFailed, summary, completed_at: completed ? new Date().toISOString() : null, updated_at: new Date().toISOString() }).eq("id", job.id);
-  return { ok: true, processed: rows.length, completed, job: { id: job.id } };
-}
-
-export function stageVehicleImportRows(jobId: string, shopId: string, rows: VehicleImportRow[]) {
-  return rows.map((row, index) => ({
-    job_id: jobId,
-    shop_id: shopId,
-    row_number: index + 1,
-    raw_row: row as Record<string, unknown>,
-    status: "queued",
-  }));
-}
-export { chunkArray };

--- a/supabase/migrations/202607080001_vehicle_import_jobs.sql
+++ b/supabase/migrations/202607080001_vehicle_import_jobs.sql
@@ -1,7 +1,0 @@
--- Vehicle CSV async import support: allow vehicle import jobs.
--- Existing rows are already limited to vehicle_history/invoices by the prior check;
--- this migration only widens the accepted import_type values.
-alter table public.import_jobs drop constraint if exists import_jobs_import_type_check;
-alter table public.import_jobs
-  add constraint import_jobs_import_type_check
-  check (import_type in ('vehicle_history', 'invoices', 'vehicles'));

--- a/tests/vehicle-csv-import-route.test.ts
+++ b/tests/vehicle-csv-import-route.test.ts
@@ -25,8 +25,8 @@ describe("vehicle CSV import route", () => {
     const source = routeSource();
 
     expect(source).toContain('"Customer not found for external customer_id."');
-    expect(source).toContain("counts.skipped++");
-    expect(source).toContain("skippedByReason");
+    expect(source).toContain("counts.skipped += 1");
+    expect(source).toContain("skippedRows.push");
   });
 
   it("matches re-imported vehicles without relying on duplicate insert conflicts", () => {
@@ -37,7 +37,24 @@ describe("vehicle CSV import route", () => {
     );
     expect(source).toContain("loadExistingVehicleIndex");
     expect(source).toContain(".in(field, values[field])");
-    expect(source).toContain("counts.updated++");
+    expect(source).toContain("counts.updated += 1");
+  });
+
+
+
+  it("stays synchronous and does not use import job staging", () => {
+    const source = routeSource();
+    const vehicleSource = `${source}\n${cardSource()}`;
+
+    expect(vehicleSource).toContain('fetch("/api/vehicles/import"');
+    expect(vehicleSource).toContain("processVehicleImportRows");
+    expect(vehicleSource).not.toContain("import_jobs");
+    expect(vehicleSource).not.toContain("import_job_rows");
+    expect(vehicleSource).not.toContain("processVehicleImportJobBatch");
+    expect(vehicleSource).not.toContain("stageVehicleImportRows");
+    expect(vehicleSource).not.toContain("useImportJobProgress");
+    expect(vehicleSource).not.toContain("/api/import-jobs/");
+    expect(vehicleSource).not.toContain("/api/internal/import-jobs/tick");
   });
 
   it("persists supported CSV vehicle detail fields and returns compact diagnostics", () => {


### PR DESCRIPTION
### Motivation
- Root cause: vehicle CSV import still contained leftover async-job staging and worker code that read/wrote `import_jobs`/`import_job_rows`, causing the UI to attempt PATCHes against staged rows and fail; the intent is to match the customer import synchronous architecture. 
- The change ensures vehicle CSV import parses client-side, posts a single `POST /api/vehicles/import`, and receives a final summary without polling or staged rows.

### Description
- Removed the vehicle async/staging execution path from `features/vehicles/server/vehicle-import-job.ts` so only `processVehicleImportRows` (synchronous row processor) remains and no `import_jobs`/`import_job_rows` calls exist in the vehicle importer. 
- Stopped dispatching vehicle CSV jobs in import endpoints by removing the `vehicles` branch from `app/api/import-jobs/[jobId]/route.ts` and dropping `vehicles` from the supported types and branch in `app/api/internal/import-jobs/tick/route.ts`. 
- Deleted the vehicle import migration files that widened `import_jobs.import_type` for vehicles: `db/sql/2026-07-08_vehicle_import_jobs.sql` and `supabase/migrations/202607080001_vehicle_import_jobs.sql`. 
- Made the UI mirror the customer import flow: `features/vehicles/components/VehicleCsvImportCard.tsx` parses/preview client-side, `POST`s `rows` to `/api/vehicles/import`, uses the API response for final counts and calls `router.refresh()` to refresh vehicle files; tests were updated to assert synchronous architecture.

### Testing
- Ran type checking with `npm run typecheck` which completed successfully. 
- Ran linting with `npx eslint features/vehicles/components app/api/vehicles features/shared/components/import --ext .ts,.tsx` which completed without errors. 
- Ran the focused test suite `npx vitest run tests/vehicle-csv-import-route.test.ts` and all tests passed (11/11).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ecc7d10148328ae3651342ace7018)