### PR TITLE
Chunk vehicle import duplicate lookups

### DIFF
--- a/features/vehicles/server/vehicle-import-job.ts
+++ b/features/vehicles/server/vehicle-import-job.ts
@@ -7,6 +7,7 @@ type VehicleInsert = DB["public"]["Tables"]["vehicles"]["Insert"];
 type VehicleUpdate = DB["public"]["Tables"]["vehicles"]["Update"];
 
 const VEHICLE_IMPORT_INSERT_BATCH_SIZE = 1000;
+const VEHICLE_IMPORT_LOOKUP_CHUNK_SIZE = 100;
 export const VEHICLE_IMPORT_SAMPLE_LIMIT = 25;
 export const VEHICLE_IMPORT_MAX_ROWS = 20_000;
 
@@ -57,9 +58,14 @@ async function loadExistingVehicleIndex(supabase: SupabaseClient<DB>, shopId: st
   const index = new Map<string, VehicleMatch>();
   for (const field of ["external_id", "vin", "unit_number", "license_plate"] as const) {
     if (!values[field].length) continue;
-    const { data, error } = await supabase.from("vehicles").select("id, external_id, vin, unit_number, license_plate").eq("shop_id", shopId).in(field, values[field]);
-    if (error) throw error;
-    for (const vehicle of (data ?? []) as VehicleMatch[]) addMatch(index, field, vehicle);
+    for (let start = 0; start < values[field].length; start += VEHICLE_IMPORT_LOOKUP_CHUNK_SIZE) {
+      const chunk = values[field].slice(start, start + VEHICLE_IMPORT_LOOKUP_CHUNK_SIZE);
+      const { data, error } = await supabase.from("vehicles").select("id, external_id, vin, unit_number, license_plate").eq("shop_id", shopId).in(field, chunk);
+      if (error) {
+        throw new Error(`Vehicle duplicate lookup failed for ${field} chunk ${Math.floor(start / VEHICLE_IMPORT_LOOKUP_CHUNK_SIZE) + 1} (${chunk.length} values): ${error.message}`);
+      }
+      for (const vehicle of (data ?? []) as VehicleMatch[]) addMatch(index, field, vehicle);
+    }
   }
   return index;
 }

--- a/tests/vehicle-csv-import-route.test.ts
+++ b/tests/vehicle-csv-import-route.test.ts
@@ -36,7 +36,9 @@ describe("vehicle CSV import route", () => {
       '"external_id" | "vin" | "unit_number" | "license_plate"',
     );
     expect(source).toContain("loadExistingVehicleIndex");
-    expect(source).toContain(".in(field, values[field])");
+    expect(source).toContain("VEHICLE_IMPORT_LOOKUP_CHUNK_SIZE = 100");
+    expect(source).toContain("start += VEHICLE_IMPORT_LOOKUP_CHUNK_SIZE");
+    expect(source).toContain(".in(field, chunk)");
     expect(source).toContain("counts.updated += 1");
   });
 


### PR DESCRIPTION
### Motivation
- The duplicate precheck gathered all incoming `external_id`/VIN/unit/plate values into a single Supabase `.in()` call which produced oversized PostgREST URLs and caused `GET /rest/v1/vehicles` to return `400` for large CSVs.
- The import must remain synchronous and production-safe, so duplicate lookups should be bounded and retried/merged per chunk instead of sent as one giant query.

### Description
- Add `VEHICLE_IMPORT_LOOKUP_CHUNK_SIZE = 100` and update `loadExistingVehicleIndex` to slice identity value arrays and call `.in(field, chunk)` per chunk, merging returned matches into the index map.
- Surface detailed errors when any chunk query fails, including the field, chunk number, chunk size, and the Supabase error message to aid debugging.
- Preserve the existing synchronous import flow and existing update/insert logic without introducing `import_jobs` or staging rows.
- Files changed: `features/vehicles/server/vehicle-import-job.ts` and test update `tests/vehicle-csv-import-route.test.ts` to assert chunked lookups.

### Testing
- Ran `npm run typecheck` and TypeScript checks completed successfully.
- Ran `npx eslint app/api/vehicles features/vehicles/components --ext .ts,.tsx` with no lint failures reported.
- Ran `npx vitest run tests/vehicle-csv-import-route.test.ts` and the test suite passed (11 tests, 11 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ecfbb136c8328a9cdec7d0bb56597)