### PR TITLE
Make history and invoice CSV imports synchronous

### DIFF
--- a/app/api/invoices/import/route.ts
+++ b/app/api/invoices/import/route.ts
@@ -1,32 +1,36 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import { chunkArray, parseCsvFileFromFormData } from "@/features/shared/lib/import/csv";
-import { INVOICE_IMPORT_MAX_ROWS, INVOICE_IMPORT_SAMPLE_LIMIT } from "@/features/billing/server/invoice-import-job";
-import type { Database } from "@shared/types/types/supabase";
+import { parseCsvFileFromFormData } from "@/features/shared/lib/import/csv";
+import {
+  importInvoiceRowsSynchronously,
+  INVOICE_IMPORT_MAX_ROWS,
+} from "@/features/billing/server/invoice-import-job";
 
 type InvoiceImportRow = Record<string, unknown>;
-type JsonRecord = Record<string, unknown>;
-type JobInsertBuilder = { insert: (payload: unknown) => { select: (columns: string) => { single: () => Promise<{ data: { id: string; total_rows: number; status: string } | null; error: Error | null }> } } };
-type RowInsertBuilder = { insert: (payload: unknown) => Promise<{ error: Error | null }> };
-type LooseSupabase<TBuilder> = { from: (table: string) => TBuilder };
-type ImportJobInsert = { shop_id: string; created_by: string; import_type: "invoices"; status: "queued"; total_rows: number; processed_rows: number; imported_count: number; skipped_count: number; failed_count: number; source_storage_path: string; summary: JsonRecord };
-const STAGING_INSERT_BATCH_SIZE = 500;
 
 export async function POST(req: Request) {
   try {
     const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin", "manager", "advisor"] });
     if (!access.ok) return access.response;
-    if (!(req.headers.get("content-type")?.toLowerCase() ?? "").includes("multipart/form-data")) return NextResponse.json({ error: "Invoice import requires multipart/form-data with a CSV file field." }, { status: 415 });
+    if (!(req.headers.get("content-type")?.toLowerCase() ?? "").includes("multipart/form-data")) {
+      return NextResponse.json({ error: "Invoice import requires multipart/form-data with a CSV file field." }, { status: 415 });
+    }
+
     const formData = await req.formData();
     let parsed;
-    try { parsed = await parseCsvFileFromFormData<InvoiceImportRow>({ formData, maxRows: INVOICE_IMPORT_MAX_ROWS }); } catch (error) { return NextResponse.json({ error: error instanceof Error ? error.message : "Unable to parse invoice CSV." }, { status: 400 }); }
-    const { supabase, profile } = access; const shopId = profile.shop_id; if (!shopId) return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
-    const sourceRef = `staging://import_job_rows/invoices/${shopId}/${Date.now()}`;
-    const jobPayload: ImportJobInsert = { shop_id: shopId, created_by: profile.id, import_type: "invoices", status: "queued", total_rows: parsed.rows.length, processed_rows: 0, imported_count: 0, skipped_count: 0, failed_count: 0, source_storage_path: sourceRef, summary: { storageCleanup: "CSV rows are staged in import_job_rows with retention metadata; no Supabase Storage object is created.", sampleLimit: INVOICE_IMPORT_SAMPLE_LIMIT, skippedRows: [], failedRows: [] } };
-    const { data: job, error: jobError } = await (supabase as unknown as LooseSupabase<JobInsertBuilder>).from("import_jobs").insert(jobPayload).select("id, total_rows, status").single();
-    if (jobError || !job) throw jobError ?? new Error("Unable to create invoice import job.");
-    const stagedRows = parsed.rows.map((row, index) => ({ job_id: job.id, shop_id: shopId, row_number: index + 1, raw_row: row as Database["public"]["Tables"]["invoices"]["Insert"]["metadata"], status: "queued" }));
-    for (const batch of chunkArray(stagedRows, STAGING_INSERT_BATCH_SIZE)) { const { error } = await (supabase as unknown as LooseSupabase<RowInsertBuilder>).from("import_job_rows").insert(batch); if (error) throw error; }
-    return NextResponse.json({ ok: true, jobId: job.id, status: job.status, totalRows: job.total_rows }, { status: 202 });
-  } catch (error) { return NextResponse.json({ error: error instanceof Error ? error.message : "Unable to queue invoice import." }, { status: 500 }); }
+    try {
+      parsed = await parseCsvFileFromFormData<InvoiceImportRow>({ formData, maxRows: INVOICE_IMPORT_MAX_ROWS });
+    } catch (error) {
+      return NextResponse.json({ error: error instanceof Error ? error.message : "Unable to parse invoice CSV." }, { status: 400 });
+    }
+
+    const { supabase, profile } = access;
+    const shopId = profile.shop_id;
+    if (!shopId) return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
+
+    const result = await importInvoiceRowsSynchronously({ supabase, shopId, rows: parsed.rows });
+    return NextResponse.json({ ok: true, ...result });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Unable to import invoice CSV." }, { status: 500 });
+  }
 }

--- a/app/api/work-orders/history/import/route.ts
+++ b/app/api/work-orders/history/import/route.ts
@@ -1,44 +1,12 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import { chunkArray, parseCsvFileFromFormData } from "@/features/shared/lib/import/csv";
+import { parseCsvFileFromFormData } from "@/features/shared/lib/import/csv";
 import {
+  importVehicleHistoryRowsSynchronously,
   VEHICLE_HISTORY_IMPORT_MAX_ROWS,
-  VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,
 } from "@/features/work-orders/server/vehicle-history-import-job";
-import type { Database } from "@shared/types/types/supabase";
 
 type HistoryImportRow = Record<string, unknown>;
-type JsonRecord = Record<string, unknown>;
-type JobInsertBuilder = {
-  insert: (payload: unknown) => {
-    select: (columns: string) => {
-      single: () => Promise<{
-        data: { id: string; total_rows: number; status: string } | null;
-        error: Error | null;
-      }>;
-    };
-  };
-};
-type RowInsertBuilder = {
-  insert: (payload: unknown) => Promise<{ error: Error | null }>;
-};
-type LooseSupabase<TBuilder> = { from: (table: string) => TBuilder };
-
-type ImportJobInsert = {
-  shop_id: string;
-  created_by: string;
-  import_type: "vehicle_history";
-  status: "queued";
-  total_rows: number;
-  processed_rows: number;
-  imported_count: number;
-  skipped_count: number;
-  failed_count: number;
-  source_storage_path: string;
-  summary: JsonRecord;
-};
-
-const STAGING_INSERT_BATCH_SIZE = 500;
 
 export async function POST(req: Request) {
   try {
@@ -50,22 +18,12 @@ export async function POST(req: Request) {
     const contentType = req.headers.get("content-type")?.toLowerCase() ?? "";
     if (!contentType.includes("multipart/form-data")) {
       return NextResponse.json(
-        {
-          error:
-            "Vehicle history import requires multipart/form-data with a CSV file field.",
-        },
+        { error: "Vehicle history import requires multipart/form-data with a CSV file field." },
         { status: 415 },
       );
     }
 
-    const formData = await req.formData().catch((error) => {
-      throw new Error(
-        error instanceof Error
-          ? `Unable to read CSV upload: ${error.message}`
-          : "Unable to read CSV upload.",
-      );
-    });
-
+    const formData = await req.formData();
     let parsed;
     try {
       parsed = await parseCsvFileFromFormData<HistoryImportRow>({
@@ -74,12 +32,7 @@ export async function POST(req: Request) {
       });
     } catch (error) {
       return NextResponse.json(
-        {
-          error:
-            error instanceof Error
-              ? error.message
-              : "Unable to parse vehicle history CSV.",
-        },
+        { error: error instanceof Error ? error.message : "Unable to parse vehicle history CSV." },
         { status: 400 },
       );
     }
@@ -87,75 +40,19 @@ export async function POST(req: Request) {
     const { supabase, profile } = access;
     const shopId = profile.shop_id;
     if (!shopId) {
-      return NextResponse.json(
-        { error: "No active shop is selected." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
     }
 
-    const createdBy = profile.id;
-    const sourceRef = `staging://import_job_rows/vehicle_history/${shopId}/${Date.now()}`;
-    const jobPayload: ImportJobInsert = {
-      shop_id: shopId,
-      created_by: createdBy,
-      import_type: "vehicle_history",
-      status: "queued",
-      total_rows: parsed.rows.length,
-      processed_rows: 0,
-      imported_count: 0,
-      skipped_count: 0,
-      failed_count: 0,
-      source_storage_path: sourceRef,
-      summary: {
-        storageCleanup: "CSV rows are staged in import_job_rows with retention metadata; no Supabase Storage object is created.",
-        sampleLimit: VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,
-        skippedRows: [],
-        failedRows: [],
-      },
-    };
+    const result = await importVehicleHistoryRowsSynchronously({
+      supabase,
+      shopId,
+      rows: parsed.rows,
+    });
 
-    const { data: job, error: jobError } = await (supabase as unknown as LooseSupabase<JobInsertBuilder>)
-      .from("import_jobs")
-      .insert(jobPayload)
-      .select("id, total_rows, status")
-      .single();
-
-    if (jobError || !job) {
-      throw jobError ?? new Error("Unable to create vehicle history import job.");
-    }
-
-    const stagedRows = parsed.rows.map((row, index) => ({
-      job_id: job.id,
-      shop_id: shopId,
-      row_number: index + 1,
-      raw_row: row as Database["public"]["Tables"]["history"]["Insert"]["source_payload"],
-      status: "queued",
-    }));
-
-    for (const batch of chunkArray(stagedRows, STAGING_INSERT_BATCH_SIZE)) {
-      const { error } = await (supabase as unknown as LooseSupabase<RowInsertBuilder>)
-        .from("import_job_rows")
-        .insert(batch);
-      if (error) throw error;
-    }
-
-    return NextResponse.json(
-      {
-        ok: true,
-        jobId: job.id,
-        status: job.status,
-        totalRows: job.total_rows,
-      },
-      { status: 202 },
-    );
+    return NextResponse.json(result);
   } catch (error) {
     return NextResponse.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Unable to queue vehicle history import.",
-      },
+      { error: error instanceof Error ? error.message : "Unable to import vehicle history CSV." },
       { status: 500 },
     );
   }

--- a/features/billing/components/InvoiceCsvImportCard.tsx
+++ b/features/billing/components/InvoiceCsvImportCard.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
@@ -18,10 +12,6 @@ import {
   CsvImportProgress,
   type CsvImportProgressState,
 } from "@/features/shared/components/import/CsvImportProgress";
-import {
-  useImportJobProgress,
-  type ImportJobProgressJob,
-} from "@/features/shared/components/import/useImportJobProgress";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
@@ -70,7 +60,6 @@ type ImportCounts = {
 type ImportResponse = {
   ok?: boolean;
   error?: string;
-  jobId?: string;
   counts?: ImportCounts;
   totalRows?: number;
   skippedRows?: Array<{
@@ -201,7 +190,6 @@ export function InvoiceCsvImportCard({
   const [importError, setImportError] = useState<string | null>(null);
   const [response, setResponse] = useState<ImportResponse | null>(null);
   const [importing, setImporting] = useState(false);
-  const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
   const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
   const isOnboarding = Boolean(
@@ -300,64 +288,9 @@ export function InvoiceCsvImportCard({
     },
     [guidedQuery, isOnboarding],
   );
-  const handleJobComplete = useCallback(
-    async (job: ImportJobProgressJob) => {
-      const counts: ImportCounts = {
-        imported: job.importedCount,
-        updated: 0,
-        skipped: job.skippedCount,
-        failed: job.failedCount,
-        duplicates: Number(
-          (job.summary as { duplicates?: number } | null | undefined)
-            ?.duplicates ?? 0,
-        ),
-      };
-      const summary = job.summary as
-        | {
-            skippedRows?: ImportResponse["skippedRows"];
-            failedRows?: ImportResponse["failedRows"];
-          }
-        | null
-        | undefined;
-      const nextResponse: ImportResponse = {
-        ok: job.status === "completed",
-        jobId: job.id,
-        counts,
-        totalRows: job.totalRows,
-        skippedRows: summary?.skippedRows ?? [],
-        failedRows: summary?.failedRows ?? [],
-        error: job.errorMessage ?? undefined,
-      };
-      setResponse(nextResponse);
-      setImporting(false);
-      setActiveJobId(null);
-      if (job.status === "failed") {
-        setImportError(job.errorMessage ?? "Invoice import job failed.");
-        return;
-      }
-      if (isOnboarding && counts.imported > 0 && counts.failed === 0)
-        await completeOnboardingAfterImport(counts);
-      if (counts.imported > 0) onImported?.();
-    },
-    [completeOnboardingAfterImport, isOnboarding, onImported],
-  );
-  const handleJobPollError = useCallback(
-    (message: string, job?: ImportJobProgressJob) => {
-      if (job?.status === "failed") setImportError(message);
-    },
-    [],
-  );
-  const { progress: jobProgress } = useImportJobProgress(activeJobId, {
-    initialTotal: importableRows.length,
-    onComplete: handleJobComplete,
-    onError: handleJobPollError,
-  });
   useEffect(() => {
-    if (jobProgress) setProgress(jobProgress);
-  }, [jobProgress]);
-  useEffect(() => {
-    onImportActiveChange?.(Boolean(activeJobId));
-  }, [activeJobId, onImportActiveChange]);
+    onImportActiveChange?.(importing);
+  }, [importing, onImportActiveChange]);
   async function confirmImport() {
     if (importing || completingOnboarding) return;
     if (!file || !importableRows.length) {
@@ -369,7 +302,6 @@ export function InvoiceCsvImportCard({
     setImporting(true);
     setImportError(null);
     setResponse(null);
-    setActiveJobId(null);
     setProgress({
       phase: "Uploading CSV",
       phaseKey: "importing",
@@ -385,21 +317,27 @@ export function InvoiceCsvImportCard({
         body: formData,
       });
       const payload = (await res.json().catch(() => ({}))) as ImportResponse;
-      if (!res.ok || payload.ok === false || !payload.jobId)
-        throw new Error(payload.error ?? "Unable to queue invoice import.");
-      setResponse({
-        ok: true,
-        jobId: payload.jobId,
-        totalRows: payload.totalRows,
-      });
+      if (!res.ok || payload.ok === false || !payload.counts)
+        throw new Error(payload.error ?? "Unable to import invoice CSV.");
       setProgress({
-        phase: "Importing records",
-        phaseKey: "importing",
-        processed: 0,
+        phase: "Finalizing import",
+        phaseKey: "finalizing",
+        processed: payload.totalRows ?? importableRows.length,
         total: payload.totalRows ?? importableRows.length,
-        percent: 25,
+        percent: 90,
       });
-      setActiveJobId(payload.jobId);
+      setResponse(payload);
+      setProgress({
+        phase: "Import complete",
+        phaseKey: "completed",
+        processed: payload.totalRows ?? importableRows.length,
+        total: payload.totalRows ?? importableRows.length,
+        percent: 100,
+      });
+      setImporting(false);
+      if (isOnboarding && payload.counts.imported > 0 && payload.counts.failed === 0)
+        await completeOnboardingAfterImport(payload.counts);
+      if (payload.counts.imported > 0) onImported?.();
     } catch (error) {
       setProgress({
         phase: "Import failed",
@@ -411,7 +349,7 @@ export function InvoiceCsvImportCard({
       setImportError(
         error instanceof Error
           ? error.message
-          : "Unable to queue invoice import.",
+          : "Unable to import invoice CSV.",
       );
       setImporting(false);
     }

--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -825,3 +825,138 @@ export async function processInvoiceImportJobBatch(
 
   return { ok: true, processed: rows.length, completed, job: { id: job.id } };
 }
+
+export async function importInvoiceRowsSynchronously({
+  supabase,
+  shopId,
+  rows,
+}: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  rows: InvoiceImportRow[];
+}) {
+  const client = supabase as unknown as SupabaseClient;
+  const counts = { imported: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 };
+  const sample = { skippedRows: [] as unknown[], failedRows: [] as unknown[] };
+
+  const [{ data: customers }, { data: vehicles }, { data: workOrders }] = await Promise.all([
+    client.from("customers").select("id, external_id, email, phone, phone_number, name, business_name, first_name, last_name").eq("shop_id", shopId),
+    client.from("vehicles").select("id, external_id, vin, customer_id").eq("shop_id", shopId),
+    client.from("work_orders").select("id, custom_id, customer_id, vehicle_id").eq("shop_id", shopId),
+  ]);
+
+  const customerLookupMaps = buildCustomerLookupMaps((customers ?? []) as MatchedCustomer[]);
+  const vehiclesById = new Map<string, MatchedVehicle>();
+  for (const vehicle of (vehicles ?? []) as MatchedVehicle[]) {
+    if (vehicle.id) vehiclesById.set(vehicle.id, vehicle);
+    const external = String(vehicle.external_id ?? "").toLowerCase();
+    if (external) vehiclesById.set(external, vehicle);
+    const normalizedVin = vin(vehicle.vin);
+    if (normalizedVin) vehiclesById.set(normalizedVin, vehicle);
+  }
+  const workOrdersByNumber = new Map<string, MatchedWorkOrder>();
+  for (const workOrder of (workOrders ?? []) as MatchedWorkOrder[]) {
+    const customId = String(workOrder.custom_id ?? "").toLowerCase();
+    if (customId) workOrdersByNumber.set(customId, workOrder);
+    if (workOrder.id) workOrdersByNumber.set(workOrder.id, workOrder);
+  }
+
+  for (const batchRows of chunkArray(rows.map((raw, index) => ({ raw, rowNumber: index + 1 })), INVOICE_IMPORT_BATCH_SIZE)) {
+    const batchInvoiceNumbers = new Set<string>();
+    const batchSourceIds = new Set<string>();
+    for (const staged of batchRows) {
+      const invoiceNumber = clean(staged.raw.invoice_number ?? staged.raw.invoice_id);
+      const sourceId = clean(staged.raw.invoice_id);
+      if (invoiceNumber) batchInvoiceNumbers.add(invoiceNumber);
+      if (sourceId) batchSourceIds.add(sourceId);
+    }
+    const { historicalBySourceId, historicalByInvoiceNumber, liveCollisionsByInvoiceNumber } = await fetchBatchInvoiceMatches(client, shopId, batchInvoiceNumbers, batchSourceIds);
+    const pendingInvoiceNumbers = new Set<string>();
+
+    for (const staged of batchRows) {
+      const row = staged.raw;
+      const invoiceNumber = clean(row.invoice_number ?? row.invoice_id);
+      const sourceId = clean(row.invoice_id);
+      const workOrderNumber = clean(row.work_order_number);
+      try {
+        const issued = date(row.invoice_date);
+        if (!issued || !invoiceNumber) {
+          const reason = !issued ? "Invalid or missing invoice_date." : "Missing invoice_number or invoice_id.";
+          counts.skipped++;
+          sample.skippedRows.push({ row: staged.rowNumber, reason, invoiceNumber, workOrderNumber });
+          continue;
+        }
+        const existingHistoricalInvoice = (sourceId ? historicalBySourceId.get(sourceId) : null) ?? historicalByInvoiceNumber.get(invoiceNumber) ?? null;
+        if (pendingInvoiceNumbers.has(invoiceNumber) && !existingHistoricalInvoice) {
+          counts.skipped++;
+          counts.duplicates++;
+          sample.skippedRows.push({ row: staged.rowNumber, reason: "Duplicate invoice already exists in this import batch.", invoiceNumber, workOrderNumber });
+          continue;
+        }
+        const liveCollision = !existingHistoricalInvoice ? (liveCollisionsByInvoiceNumber.get(invoiceNumber) ?? null) : null;
+        if (liveCollision) {
+          counts.skipped++;
+          sample.skippedRows.push({ row: staged.rowNumber, reason: "live_invoice_number_collision", invoiceNumber, workOrderNumber, liveInvoiceId: liveCollision.id });
+          continue;
+        }
+        const status = normalizeInvoiceImportStatus(row);
+        if (!status) {
+          counts.skipped++;
+          sample.skippedRows.push({ row: staged.rowNumber, reason: "Invoice status represents a credit/refund reversal and is not imported as an invoice.", invoiceNumber, workOrderNumber, sourceStatus: clean(row.payment_status ?? row.status) });
+          continue;
+        }
+        const workOrder = workOrderNumber ? workOrdersByNumber.get(workOrderNumber.toLowerCase()) : null;
+        const vehicle = (clean(row.vehicle_id) ? (vehiclesById.get(clean(row.vehicle_id)!) ?? vehiclesById.get(clean(row.vehicle_id)!.toLowerCase())) : null) ?? (vin(row.vin) ? vehiclesById.get(vin(row.vin)!) : null);
+        const { customer, customerMatchSource, legacyCustomerId, customerEmailKey, customerPhoneKey, customerNameKey } = resolveInvoiceImportCustomer(row, customerLookupMaps);
+        const fallbackCustomerId = vehicle?.customer_id ?? workOrder?.customer_id ?? null;
+        const customerId = customer?.id ?? fallbackCustomerId;
+        const vehicleId = vehicle?.id ?? workOrder?.vehicle_id ?? null;
+        const total = num(row.total) ?? num(row.subtotal) ?? 0;
+        const amountPaid = num(row.amount_paid) ?? 0;
+        const payload: DB["public"]["Tables"]["invoices"]["Insert"] = {
+          shop_id: shopId,
+          customer_id: customerId,
+          work_order_id: workOrder?.id ?? null,
+          invoice_number: invoiceNumber,
+          issued_at: issued,
+          due_date: date(row.due_date),
+          paid_at: resolveImportedInvoicePaidAt(row, issued, status),
+          status,
+          labor_cost: num(row.labor_total) ?? 0,
+          parts_cost: num(row.parts_total) ?? 0,
+          subtotal: num(row.subtotal) ?? total,
+          tax_total: num(row.tax) ?? 0,
+          total,
+          notes: [clean(row.description), clean(row.notes)].filter(Boolean).join("\n") || null,
+          metadata: { imported: true, read_only: true, import_type: "invoice_csv", imported_invoice_id: sourceId, legacy_customer_id: legacyCustomerId, legacy_vehicle_id: clean(row.vehicle_id), matched_customer_id: customerId, matched_vehicle_id: vehicleId, customer_match_source: customerMatchSource ?? (vehicle?.customer_id ? "vehicle_customer_id" : workOrder?.customer_id ? "work_order_customer_id" : null), customer_match_failed_reason: customerId ? null : legacyCustomerId ? "legacy_customer_id_not_found" : customerEmailKey || customerPhoneKey || customerNameKey ? "customer_lookup_fields_not_found" : "no_customer_lookup_fields", vehicle_match_source: vehicle ? clean(row.vehicle_id) ? "vehicle_id" : vin(row.vin) ? "vin" : null : workOrder?.vehicle_id ? "work_order_vehicle_id" : null, source_system: clean(row.source_system), work_order_number: workOrderNumber, vehicle_id: vehicleId, vin: clean(row.vin), service_category: clean(row.service_category), labor_hours: num(row.labor_hours), shop_supplies: num(row.shop_supplies), amount_paid: amountPaid, balance_due: num(row.balance_due) ?? Math.max(0, total - amountPaid), advisor: clean(row.advisor), technician: clean(row.technician), raw_row: row } as DB["public"]["Tables"]["invoices"]["Insert"]["metadata"],
+        };
+        pendingInvoiceNumbers.add(invoiceNumber);
+        const write = existingHistoricalInvoice ? supabase.from("invoices").update(payload).eq("id", existingHistoricalInvoice.id) : supabase.from("invoices").insert(payload);
+        const { error } = await write;
+        if (error) {
+          if (!existingHistoricalInvoice && isInvoiceNumberUniqueConflict(error)) {
+            counts.skipped++;
+            counts.duplicates++;
+            sample.skippedRows.push({ row: staged.rowNumber, reason: "live_invoice_number_collision", invoiceNumber, workOrderNumber });
+          } else {
+            counts.failed++;
+            sample.failedRows.push({ row: staged.rowNumber, error: error.message, invoiceNumber, workOrderNumber });
+          }
+        } else {
+          counts.imported++;
+          if (existingHistoricalInvoice) counts.updated++;
+        }
+      } catch (error) {
+        counts.failed++;
+        sample.failedRows.push({ row: staged.rowNumber, error: error instanceof Error ? error.message : "Invoice row failed to import.", invoiceNumber, workOrderNumber });
+      }
+    }
+  }
+
+  return {
+    counts,
+    totalRows: rows.length,
+    skippedRows: sample.skippedRows.slice(0, INVOICE_IMPORT_SAMPLE_LIMIT),
+    failedRows: sample.failedRows.slice(0, INVOICE_IMPORT_SAMPLE_LIMIT),
+  };
+}

--- a/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
+++ b/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
@@ -18,10 +12,6 @@ import {
   CsvImportProgress,
   type CsvImportProgressState,
 } from "@/features/shared/components/import/CsvImportProgress";
-import {
-  useImportJobProgress,
-  type ImportJobProgressJob,
-} from "@/features/shared/components/import/useImportJobProgress";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 
 type HistoryImportRow = {
@@ -58,7 +48,6 @@ type ImportCounts = {
 type ImportResponse = {
   ok?: boolean;
   error?: string;
-  jobId?: string;
   counts?: ImportCounts;
   totalRows?: number;
   skippedRows?: Array<{
@@ -175,7 +164,6 @@ export function VehicleHistoryCsvImportCard({
   const [importError, setImportError] = useState<string | null>(null);
   const [response, setResponse] = useState<ImportResponse | null>(null);
   const [importing, setImporting] = useState(false);
-  const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
   const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
 
@@ -279,62 +267,6 @@ export function VehicleHistoryCsvImportCard({
     [guidedQuery, isOnboarding],
   );
 
-  const handleJobComplete = useCallback(
-    async (job: ImportJobProgressJob) => {
-      const summary = job.summary as
-        | {
-            skippedRows?: ImportResponse["skippedRows"];
-            failedRows?: ImportResponse["failedRows"];
-            duplicates?: number;
-          }
-        | null
-        | undefined;
-      const counts: ImportCounts = {
-        imported: job.importedCount,
-        updated: 0,
-        skipped: job.skippedCount,
-        failed: job.failedCount,
-        duplicates: Number(summary?.duplicates ?? 0),
-      };
-      const nextResponse: ImportResponse = {
-        ok: job.status === "completed",
-        jobId: job.id,
-        counts,
-        totalRows: job.totalRows,
-        skippedRows: summary?.skippedRows ?? [],
-        failedRows: summary?.failedRows ?? [],
-        error: job.errorMessage ?? undefined,
-      };
-      setResponse(nextResponse);
-      setImporting(false);
-      setActiveJobId(null);
-      if (job.status === "failed") {
-        setImportError(
-          job.errorMessage ?? "Vehicle history import job failed.",
-        );
-        return;
-      }
-      if (isOnboarding && counts.imported > 0 && counts.failed === 0)
-        await completeOnboardingAfterImport(counts);
-      if (counts.imported > 0) onImported?.();
-    },
-    [completeOnboardingAfterImport, isOnboarding, onImported],
-  );
-  const handleJobPollError = useCallback(
-    (message: string, job?: ImportJobProgressJob) => {
-      if (job?.status === "failed") setImportError(message);
-    },
-    [],
-  );
-  const { progress: jobProgress } = useImportJobProgress(activeJobId, {
-    initialTotal: importableRows.length,
-    onComplete: handleJobComplete,
-    onError: handleJobPollError,
-  });
-  useEffect(() => {
-    if (jobProgress) setProgress(jobProgress);
-  }, [jobProgress]);
-
   async function confirmImport() {
     if (importing || completingOnboarding) return;
     if (!file || !importableRows.length) {
@@ -346,7 +278,6 @@ export function VehicleHistoryCsvImportCard({
     setImporting(true);
     setImportError(null);
     setResponse(null);
-    setActiveJobId(null);
     setProgress({
       phase: "Uploading CSV",
       phaseKey: "importing",
@@ -378,24 +309,31 @@ export function VehicleHistoryCsvImportCard({
         body: formData,
       });
       const payload = (await res.json().catch(() => ({}))) as ImportResponse;
-      if (!res.ok || payload.ok === false || !payload.jobId) {
+      if (!res.ok || payload.ok === false || !payload.counts) {
         throw new Error(
-          payload.error ?? "Unable to queue vehicle history import.",
+          payload.error ?? "Unable to import vehicle history CSV.",
         );
       }
-      setResponse({
-        ok: true,
-        jobId: payload.jobId,
-        totalRows: payload.totalRows,
-      });
       setProgress({
-        phase: "Importing records",
-        phaseKey: "importing",
-        processed: 0,
+        phase: "Finalizing import",
+        phaseKey: "finalizing",
+        processed: payload.totalRows ?? importableRows.length,
         total: payload.totalRows ?? importableRows.length,
-        percent: 25,
+        percent: 90,
       });
-      setActiveJobId(payload.jobId);
+      setResponse(payload);
+      setProgress({
+        phase: "Import complete",
+        phaseKey: "completed",
+        processed: payload.totalRows ?? importableRows.length,
+        total: payload.totalRows ?? importableRows.length,
+        percent: 100,
+      });
+      setImporting(false);
+      if (isOnboarding && payload.counts.imported > 0 && payload.counts.failed === 0) {
+        await completeOnboardingAfterImport(payload.counts);
+      }
+      if (payload.counts.imported > 0) onImported?.();
     } catch (error) {
       setProgress({
         phase: "Import failed",
@@ -407,7 +345,7 @@ export function VehicleHistoryCsvImportCard({
       setImportError(
         error instanceof Error
           ? error.message
-          : "Unable to queue vehicle history import.",
+          : "Unable to import vehicle history CSV.",
       );
       setImporting(false);
     }

--- a/features/work-orders/server/vehicle-history-import-job.ts
+++ b/features/work-orders/server/vehicle-history-import-job.ts
@@ -147,3 +147,79 @@ export async function processVehicleHistoryImportJobBatch(supabase: SupabaseClie
   await client.from("import_jobs").update({ status: completed ? "completed" : "processing", processed_rows: reconciledProcessed, imported_count: nextImported, skipped_count: reconciledSkipped, failed_count: nextFailed, summary, completed_at: completed ? new Date().toISOString() : null, updated_at: new Date().toISOString() }).eq("id", job.id);
   return { ok: true, processed: rows.length, completed, job: { id: job.id } };
 }
+
+export async function importVehicleHistoryRowsSynchronously({
+  supabase,
+  shopId,
+  rows,
+}: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  rows: HistoryImportRow[];
+}) {
+  const resolver = await loadResolver(supabase, shopId);
+  const counts: ImportCounts = { imported: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 };
+  const samples = { skippedRows: [] as unknown[], failedRows: [] as unknown[] };
+  const payloads: Array<{ rowNumber: number; repairOrderNumber: string | null; invoiceNumber: string | null; payload: DB["public"]["Tables"]["history"]["Insert"] & Record<string, unknown> }> = [];
+
+  for (const [index, row] of rows.entries()) {
+    const rowNumber = index + 1;
+    const repairOrderNumber = clean(row.repair_order_number ?? row.work_order_number);
+    const invoiceNumber = clean(row.invoice_number);
+    try {
+      const serviceDate = validDate(row.service_date);
+      const invalidNumber = ([ ["odometer", row.odometer], ["labor_hours", row.labor_hours], ["total", row.total] ] as const).find(([, value]) => clean(value) && num(value) === null);
+      if (!serviceDate || invalidNumber) {
+        const reason = !serviceDate ? "Invalid or missing service_date." : `${invalidNumber?.[0] ?? "value"} must be numeric when provided.`;
+        counts.skipped++;
+        samples.skippedRows.push({ row: rowNumber, reason, repairOrderNumber, invoiceNumber });
+        continue;
+      }
+      const vehicle = resolveVehicle(row, resolver);
+      const customer = resolveCustomer(row, resolver) ?? (vehicle?.customer_id ? resolver.customersById.get(vehicle.customer_id) ?? null : null);
+      if (!customer || ((clean(row.vehicle_id) || clean(row.vin)) && !vehicle)) {
+        const reason = !customer ? "Existing customer could not be matched." : "Existing vehicle could not be matched.";
+        counts.skipped++;
+        samples.skippedRows.push({ row: rowNumber, reason, repairOrderNumber, invoiceNumber });
+        continue;
+      }
+      let duplicateFound = false;
+      if (repairOrderNumber) duplicateFound = Boolean(await findDuplicateHistoryId(supabase, shopId, customer.id, "work_order_number", repairOrderNumber));
+      if (!duplicateFound && invoiceNumber) duplicateFound = Boolean(await findDuplicateHistoryId(supabase, shopId, customer.id, "invoice_number", invoiceNumber));
+      if (duplicateFound) {
+        counts.skipped++;
+        counts.duplicates++;
+        samples.skippedRows.push({ row: rowNumber, reason: "Duplicate repair order/invoice already exists.", repairOrderNumber, invoiceNumber });
+        continue;
+      }
+      const parts = clean(row.parts);
+      const notes = [clean(row.notes), parts ? `Parts: ${parts}` : null, clean(row.service_category) ? `Service category: ${clean(row.service_category)}` : null].filter(Boolean).join("\n") || null;
+      const description = [clean(row.service_category), clean(row.complaint), clean(row.correction)].filter(Boolean).join(" · ") || "Imported historical service record";
+      payloads.push({ rowNumber, repairOrderNumber, invoiceNumber, payload: { shop_id: shopId, customer_id: customer.id, vehicle_id: vehicle?.id ?? null, service_date: serviceDate, description, notes, work_order_number: repairOrderNumber, invoice_number: invoiceNumber, odometer: num(row.odometer), symptom: clean(row.complaint), cause: clean(row.cause), correction: clean(row.correction), labor_hours: num(row.labor_hours), total: num(row.total), advisor_name: clean(row.advisor), assigned_tech_name: clean(row.technician), historical_status: "imported", source_system: "vehicle_history_csv", source_row_id: String(rowNumber), source_payload: JSON.parse(JSON.stringify({ imported_at: new Date().toISOString(), raw_row: row, service_category: clean(row.service_category), parts: clean(row.parts) })) as DB["public"]["Tables"]["history"]["Insert"]["source_payload"] } });
+    } catch (error) {
+      counts.failed++;
+      samples.failedRows.push({ row: rowNumber, error: error instanceof Error ? error.message : "History row failed to import.", repairOrderNumber, invoiceNumber });
+    }
+  }
+
+  for (const batch of chunkArray(payloads, VEHICLE_HISTORY_IMPORT_BATCH_SIZE)) {
+    const { error } = await supabase.from("history").insert(batch.map((entry) => entry.payload));
+    if (error) {
+      for (const entry of batch) {
+        const { error: rowError } = await supabase.from("history").insert(entry.payload);
+        if (rowError) {
+          counts.failed++;
+          samples.failedRows.push({ row: entry.rowNumber, error: rowError.message, repairOrderNumber: entry.repairOrderNumber, invoiceNumber: entry.invoiceNumber });
+        } else counts.imported++;
+      }
+    } else counts.imported += batch.length;
+  }
+
+  return compactImportSummary({
+    counts,
+    totalRows: rows.length,
+    skippedRows: samples.skippedRows,
+    failedRows: samples.failedRows,
+    sampleLimit: VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,
+  });
+}

--- a/tests/invoice-import-billing-page-stability.test.ts
+++ b/tests/invoice-import-billing-page-stability.test.ts
@@ -34,7 +34,7 @@ describe("invoice import billing page stability", () => {
       "setTimeout(() => void load({ background: true }), 60);",
     );
     expect(importCard).toContain(
-      "onImportActiveChange?.(Boolean(activeJobId))",
+      "onImportActiveChange?.(importing)",
     );
   });
 
@@ -42,7 +42,7 @@ describe("invoice import billing page stability", () => {
     expect(billingPage).toContain(
       "onImported={() => void load({ background: true })}",
     );
-    expect(importCard).toContain("if (counts.imported > 0) onImported?.();");
+    expect(importCard).toContain("if (payload.counts.imported > 0) onImported?.();");
   });
 });
 

--- a/tests/vehicle-history-csv-import-architecture.test.ts
+++ b/tests/vehicle-history-csv-import-architecture.test.ts
@@ -7,8 +7,6 @@ const workerSource = () =>
   readFileSync("features/work-orders/server/vehicle-history-import-job.ts", "utf8");
 const tickSource = () =>
   readFileSync("app/api/internal/import-jobs/tick/route.ts", "utf8");
-const statusSource = () =>
-  readFileSync("app/api/import-jobs/[jobId]/route.ts", "utf8");
 const cardSource = () =>
   readFileSync(
     "features/work-orders/components/VehicleHistoryCsvImportCard.tsx",
@@ -17,20 +15,19 @@ const cardSource = () =>
 const migrationSource = () =>
   readFileSync("db/sql/2026-07-05_vehicle_history_import_jobs.sql", "utf8");
 
-describe("vehicle history CSV import job architecture", () => {
-  it("upload route accepts multipart CSV, creates a job, stages rows, and returns jobId", () => {
+describe("vehicle history CSV import synchronous architecture", () => {
+  it("upload route accepts multipart CSV, processes rows synchronously, and returns final counts", () => {
     const source = routeSource();
 
     expect(source).toContain('contentType.includes("multipart/form-data")');
     expect(source).toContain("await req.formData()");
     expect(source).toContain("parseCsvFileFromFormData<HistoryImportRow>");
-    expect(source).toContain('.from("import_jobs")');
-    expect(source).toContain('.from("import_job_rows")');
-    expect(source).toContain("jobId: job.id");
-    expect(source).toContain("{ status: 202 }");
-    expect(source).not.toContain('.from("history").insert');
-    expect(source).not.toContain("loadResolver");
-    expect(source).not.toContain("findDuplicateHistoryId");
+    expect(source).toContain("importVehicleHistoryRowsSynchronously");
+    expect(source).toContain("return NextResponse.json(result)");
+    expect(source).not.toContain('.from("import_jobs")');
+    expect(source).not.toContain('.from("import_job_rows")');
+    expect(source).not.toContain("jobId");
+    expect(source).not.toContain("{ status: 202 }");
     expect(source).not.toContain("await req.json()");
   });
 
@@ -49,19 +46,14 @@ describe("vehicle history CSV import job architecture", () => {
     expect(worker).not.toContain('.from("dispatch');
   });
 
-  it("job progress and compact summary are persisted", () => {
+  it("synchronous importer returns compact final counts and samples", () => {
     const worker = workerSource();
-    const status = statusSource();
 
-    expect(worker).toContain("processed_rows: processedRows");
-    expect(worker).toContain("imported_count");
-    expect(worker).toContain("skipped_count");
-    expect(worker).toContain("failed_count");
+    expect(worker).toContain("importVehicleHistoryRowsSynchronously");
+    expect(worker).toContain("compactImportSummary");
     expect(worker).toContain("VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT");
-    expect(worker).toContain("slice(0, VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT)");
-    expect(status).toContain('.from("import_jobs")');
-    expect(status).toContain('.eq("shop_id", shopId)');
-    expect(status).toContain("processedRows");
+    expect(worker).toContain("sampleLimit: VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT");
+    expect(worker).toContain("totalRows: rows.length");
   });
 
   it("uses shop-scoped history duplicate detection without giant customer_id.in filters", () => {
@@ -71,21 +63,20 @@ describe("vehicle history CSV import job architecture", () => {
     expect(migration).toContain("alter table public.history add column if not exists shop_id");
     expect(migration).toContain("update public.history h");
     expect(worker).toContain("findDuplicateHistoryId");
-    expect(worker).toContain('.eq("shop_id" as "id", shopId)');
+    expect(worker).toContain('.eq("shop_id", shopId)');
     expect(worker).not.toContain('.in("customer_id"');
   });
 
-  it("UI creates a job, polls status, and stops polling on terminal states", () => {
+  it("UI posts one import request and uses local progress without polling", () => {
     const source = cardSource();
 
     expect(source).toContain("const formData = new FormData()");
     expect(source).toContain('formData.append("file", file)');
-    expect(source).toContain("setActiveJobId(payload.jobId)");
-    expect(source).toContain("useImportJobProgress(activeJobId");
-    expect(source).toContain("onComplete: handleJobComplete");
-    expect(source).toContain('job.status === "failed"');
-    expect(source).toContain("setActiveJobId(null)");
-    expect(readFileSync("features/shared/components/import/useImportJobProgress.ts", "utf8")).toContain("clearTimeout(timeoutId)");
+    expect(source).toContain("payload.counts");
+    expect(source).toContain('phase: "Import complete"');
+    expect(source).not.toContain("setActiveJobId");
+    expect(source).not.toContain("useImportJobProgress");
+    expect(source).not.toContain("handleJobComplete");
     expect(source).not.toContain("JSON.stringify({ rows: importableRows })");
   });
 
@@ -94,6 +85,6 @@ describe("vehicle history CSV import job architecture", () => {
 
     expect(source).toContain("/steps/vehicle_history/complete");
     expect(source).toContain('summary: { importType: "vehicle_history_csv", ...nextCounts }');
-    expect(source).toContain("counts.imported > 0 && counts.failed === 0");
+    expect(source).toContain("payload.counts.imported > 0 && payload.counts.failed === 0");
   });
 });


### PR DESCRIPTION
### Motivation
- The Vehicle History and Historical Invoice import UIs used the older queued `import_jobs` + polling pattern which introduced stuck/polling failure risk for onboarding flows. 
- Customers and Vehicles already use a simple, reliable one-request synchronous import pattern, so history/invoices should be aligned to reduce complexity and avoid background polling in the UI.

### Description
- Replace the queued/staging flow for history and invoice onboarding imports with a single POST that parses the multipart CSV and calls server-side synchronous import handlers that process rows in safe chunks and return final counts + sample rows. 
- Add `importVehicleHistoryRowsSynchronously` and `importInvoiceRowsSynchronously` server functions that preserve customer/vehicle/work-order matching, duplicate detection, live-collision protection (invoices), validation, chunked inserts, and compact summary/sample limits. 
- Update the UI import cards to perform client-side parse/preview then one `fetch` POST, show local progress phases (no polling or `import_jobs`), and refresh lists via `onImported` after successful completion. 
- Files changed: `app/api/work-orders/history/import/route.ts`, `features/work-orders/server/vehicle-history-import-job.ts`, `features/work-orders/components/VehicleHistoryCsvImportCard.tsx`, `app/api/invoices/import/route.ts`, `features/billing/server/invoice-import-job.ts`, `features/billing/components/InvoiceCsvImportCard.tsx`, and two updated tests under `tests/` to assert the synchronous contract.

### Testing
- Ran `npm run typecheck` which completed successfully with no new TypeScript errors. 
- Ran ESLint (`npx eslint ... --ext .ts,.tsx`) which completed successfully and surfaced only existing unrelated warnings. 
- Ran the focused test suite with `npx vitest run tests/vehicle-history-csv-import-architecture.test.ts tests/import-jobs-tick-route.test.ts tests/invoice-import-work-order-optional.test.ts tests/invoice-import-billing-page-stability.test.ts` and all tests passed (4 test files, 34 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ef33c13908328be8a795002f9b96c)