### PR TITLE
Treat CSV external_id as authoritative and disable fallback matching for rows with external_id

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -239,8 +239,12 @@ function findExistingCustomer(
   normalized: CustomerInsert,
 ): CustomerMatch | null {
   const externalKey = customerExternalIdentityKey(normalized);
-  if (externalKey)
+  if (externalKey) {
+    // CSV customer_id/external_id values are authoritative. Rows with an
+    // external identity may only update when that exact external_id already
+    // exists; company/email/phone/name fallbacks are intentionally disabled.
     return existingIdentities.byExternalId.get(externalKey) ?? null;
+  }
 
   for (const key of customerFallbackIdentityKeys(normalized)) {
     const existing = existingIdentities.byFallbackIdentity.get(key);

--- a/features/customers/import/normalizeImportedCustomerRow.ts
+++ b/features/customers/import/normalizeImportedCustomerRow.ts
@@ -8,6 +8,7 @@ export type ImportRow = {
   last_name?: unknown;
   name?: unknown;
   customer_id?: unknown;
+  external_id?: unknown;
   company_name?: unknown;
   business_name?: unknown;
   display_name?: unknown;
@@ -97,7 +98,7 @@ export function normalizeImportedCustomerRow(
   return {
     shop_id: shopId,
     user_id: null,
-    external_id: cleanString(row.customer_id),
+    external_id: cleanString(row.customer_id) ?? cleanString(row.external_id),
     first_name: firstName,
     last_name: lastName,
     name: explicitName ?? displayName,

--- a/tests/customer-csv-import-identity-matching.test.ts
+++ b/tests/customer-csv-import-identity-matching.test.ts
@@ -167,6 +167,112 @@ describe("customer CSV import identity matching", () => {
     ]);
   });
 
+  it("creates a new customer when an external_id row shares Rocky Mountain Towing fallback identity with another external_id", async () => {
+    mockSupabase = createSupabaseMock([
+      {
+        id: "existing-rocky-mountain",
+        external_id: "CUST-100181",
+        email: "dispatch@rockymountaintowing.example",
+        phone: "4035550181",
+        name: "Rocky Mountain Towing",
+        business_name: "Rocky Mountain Towing",
+        address: "100 Tow Yard Rd",
+        city: "Calgary",
+        province: "AB",
+        postal_code: "T2P 1A1",
+      },
+    ]);
+
+    const body = await postRows([
+      {
+        customer_id: "CUST-100386",
+        company_name: "Rocky Mountain Towing",
+        email: "dispatch@rockymountaintowing.example",
+        phone: "(403) 555-0181",
+        address: "100 Tow Yard Rd",
+        city: "Calgary",
+        province: "AB",
+        postal_code: "T2P 1A1",
+        customer_since: "2024-03-01",
+      },
+    ]);
+
+    expect(body.counts).toMatchObject({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+      duplicates: 0,
+    });
+    expect(body.skippedRows).toEqual([]);
+    expect(mockSupabase.updates).toEqual([]);
+    expect(mockSupabase.inserted).toHaveLength(1);
+    expect(mockSupabase.inserted[0]).toMatchObject({
+      external_id: "CUST-100386",
+      business_name: "Rocky Mountain Towing",
+    });
+  });
+
+  it("treats external_id column values like customer_id values for Northline and Red Deer style rows", async () => {
+    mockSupabase = createSupabaseMock([
+      {
+        id: "existing-northline",
+        external_id: "CUST-100777",
+        email: "ap@northline.example",
+        phone: "7805551177",
+        business_name: "Northline Contracting",
+        city: "Edmonton",
+        province: "AB",
+      },
+      {
+        id: "existing-red-deer",
+        external_id: "CUST-100888",
+        email: "rentals@reddeer.example",
+        phone: "4035551310",
+        business_name: "Red Deer Rentals",
+        city: "Red Deer",
+        province: "AB",
+      },
+    ]);
+
+    const body = await postRows([
+      {
+        external_id: "CUST-101177",
+        company_name: "Northline Contracting",
+        email: "ap@northline.example",
+        phone: "780-555-1177",
+        city: "Edmonton",
+        province: "AB",
+      },
+      {
+        external_id: "CUST-101310",
+        company_name: "Red Deer Rentals",
+        email: "rentals@reddeer.example",
+        phone: "403-555-1310",
+        city: "Red Deer",
+        province: "AB",
+      },
+    ]);
+
+    expect(body.counts).toMatchObject({
+      created: 2,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+      duplicates: 0,
+    });
+    expect(
+      body.counts.created +
+        body.counts.updated +
+        body.counts.skipped +
+        body.counts.failed,
+    ).toBe(2);
+    expect(mockSupabase.updates).toEqual([]);
+    expect(
+      mockSupabase.inserted.map((customer) => customer.external_id),
+    ).toEqual(["CUST-101177", "CUST-101310"]);
+  });
+
   it("still uses fallback duplicate protection when customer_id is missing", async () => {
     const body = await postRows([
       {


### PR DESCRIPTION
### Motivation

- Root cause: imported rows with `external_id` were not normalized as authoritative because the normalizer only read `customer_id`, so those rows fell through to fallback matching (email/phone/name/location) and could hit the branch that updates an existing customer’s historical dates.  
- Goal: ensure CSV rows that provide `customer_id` or `external_id` only match exact `external_id` records and otherwise create new customers, avoiding fallback matching and pending-identity tracking for those rows.

### Description

- Treat `external_id` as an alias for `customer_id` in the row normalizer by accepting `external_id` and setting `external_id: cleanString(row.customer_id) ?? cleanString(row.external_id)` in `normalizeImportedCustomerRow` (file `features/customers/import/normalizeImportedCustomerRow.ts`).
- Gate the existing-customer lookup so rows with an authoritative external identity only consult `existingIdentities.byExternalId` and never run fallback matching (`findExistingCustomer` in `app/api/customers/import/route.ts`).
- Add regression tests to cover the Rocky Mountain Towing, Northline Contracting, and Red Deer Rentals scenarios and assert created+updated+skipped+failed equals parsed rows, in `tests/customer-csv-import-identity-matching.test.ts`.
- Files changed: `app/api/customers/import/route.ts`, `features/customers/import/normalizeImportedCustomerRow.ts`, and `tests/customer-csv-import-identity-matching.test.ts`.

### Testing

- Ran `npm run typecheck` and the build typecheck succeeded with no errors.  
- Ran `npx eslint app/api/customers/import/route.ts features/customers/components/CustomerCsvImportCard.tsx --ext .ts,.tsx` and lint passed.  
- Ran `npx vitest run tests/customer-csv-import-identity-matching.test.ts` and all tests passed: 1 test file, 6 tests total (✓ 6 passed).  

Additional notes: the exact branch fixed is the branch in `POST` that previously exercised the "Matched existing customer; historical date fields were updated." path after `findExistingCustomer` returned a fallback match; `findExistingCustomer` is now explicitly gated to only return fallback matches when there is no `external_id`. This prevents rows with `normalized.external_id` from being matched/updated by email/phone/name fallbacks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f0ff178a08328bf151877de405a94)