### PR TITLE
Fix customer CSV identity alias mapping

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -72,7 +72,12 @@ type PendingCustomerInsert = {
 
 type CustomerImportBody = {
   rows?: unknown;
+  headers?: unknown;
 };
+
+const CUSTOMER_IMPORT_DEBUG =
+  process.env.CUSTOMER_IMPORT_DEBUG === "1" ||
+  process.env.NODE_ENV === "development";
 
 function cleanString(value: unknown): string | null {
   const text = String(value ?? "").trim();
@@ -234,22 +239,54 @@ function importRowSummary(
   };
 }
 
+function logCustomerImportTrace(label: string, payload: unknown) {
+  if (!CUSTOMER_IMPORT_DEBUG) return;
+  console.info(`[customer-csv-import] ${label}`, payload);
+}
+
 function findExistingCustomer(
   existingIdentities: ExistingCustomerIdentityMaps,
   normalized: CustomerInsert,
+  rowNumber?: number,
 ): CustomerMatch | null {
   const externalKey = customerExternalIdentityKey(normalized);
   if (externalKey) {
     // CSV customer_id/external_id values are authoritative. Rows with an
     // external identity may only update when that exact external_id already
     // exists; company/email/phone/name fallbacks are intentionally disabled.
-    return existingIdentities.byExternalId.get(externalKey) ?? null;
+    const existing = existingIdentities.byExternalId.get(externalKey) ?? null;
+    logCustomerImportTrace("Matching branch", {
+      row: rowNumber,
+      externalId: normalized.external_id ?? null,
+      branch: "EXTERNAL_ID",
+      matchedBy: existing?.matchedBy ?? null,
+      existingCustomer: existing?.matchedValue ?? existing?.id ?? null,
+    });
+    return existing;
   }
 
-  for (const key of customerFallbackIdentityKeys(normalized)) {
+  const fallbackKeys = customerFallbackIdentityKeys(normalized);
+  for (const key of fallbackKeys) {
     const existing = existingIdentities.byFallbackIdentity.get(key);
-    if (existing) return existing;
+    if (existing) {
+      logCustomerImportTrace("Matching branch", {
+        row: rowNumber,
+        externalId: normalized.external_id ?? null,
+        branch: `${(existing.matchedBy ?? "identity").toUpperCase()}_FALLBACK`,
+        reason: "externalId missing",
+        matchedBy: existing.matchedBy ?? null,
+        existingCustomer: existing.matchedValue ?? existing.id,
+      });
+      return existing;
+    }
   }
+  logCustomerImportTrace("Matching branch", {
+    row: rowNumber,
+    externalId: normalized.external_id ?? null,
+    branch: "NO_MATCH",
+    reason: externalKey ? "external_id_not_found" : "externalId missing",
+    fallbackKeys,
+  });
   return null;
 }
 
@@ -356,6 +393,8 @@ export async function POST(req: Request) {
 
     const body = (await req.json().catch(() => ({}))) as CustomerImportBody;
     const rawRows = Array.isArray(body.rows) ? body.rows : [];
+    const detectedHeaders = Array.isArray(body.headers) ? body.headers : [];
+    logCustomerImportTrace("Detected headers", detectedHeaders);
 
     const counts = {
       created: 0,
@@ -377,10 +416,26 @@ export async function POST(req: Request) {
 
     for (const [index, raw] of rawRows.entries()) {
       try {
+        if (index < 10) {
+          logCustomerImportTrace("Raw parsed row", { row: index + 1, raw });
+        }
+
         const normalized = normalizeImportedCustomerRow(
           raw as ImportRow,
           shopId,
         );
+
+        if (index < 10) {
+          logCustomerImportTrace("Normalized row", {
+            row: index + 1,
+            externalId: normalized?.external_id ?? null,
+            customerId: (raw as ImportRow).customer_id ?? null,
+            email: normalized?.email ?? null,
+            phone: normalized?.phone ?? normalized?.phone_number ?? null,
+            businessName: normalized?.business_name ?? null,
+            name: normalized?.name ?? null,
+          });
+        }
 
         if (!normalized) {
           counts.skipped += 1;
@@ -412,7 +467,11 @@ export async function POST(req: Request) {
           continue;
         }
 
-        const existing = findExistingCustomer(existingIdentities, normalized);
+        const existing = findExistingCustomer(
+          existingIdentities,
+          normalized,
+          index + 1,
+        );
 
         if (existing?.id) {
           const datePatch: Pick<

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -15,6 +15,7 @@ import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/quer
 
 type CustomerImportRow = {
   customer_id?: string | null;
+  external_id?: string | null;
   customer_type?: string | null;
   company_name?: string | null;
   business_name?: string | null;
@@ -89,6 +90,8 @@ type Props = {
 
 const SUPPORTED_COLUMNS = [
   "customer_id",
+  "external_id",
+  "customer_number",
   "customer_type",
   "company_name",
   "business_name",
@@ -124,6 +127,19 @@ const SUPPORTED_COLUMNS = [
 const RECOMMENDED_COLUMNS =
   "customer_id, display_name, company_name, first_name, last_name, email, phone_primary, phone_secondary, address1, city, province, postal_code, customer_since, created_at, updated_at";
 
+const CUSTOMER_IMPORT_DEBUG =
+  process.env.NEXT_PUBLIC_CUSTOMER_IMPORT_DEBUG === "1" ||
+  process.env.NODE_ENV === "development";
+
+const CUSTOMER_ID_HEADER_ALIASES = new Set([
+  "customer_id",
+  "external_id",
+  "customerid",
+  "customer_number",
+  "customernumber",
+  "customer",
+]);
+
 function cleanHeader(value: string): string {
   return value
     .trim()
@@ -141,7 +157,10 @@ function normalizeParsedRow(row: Record<string, unknown>): CustomerImportRow {
   const normalized: CustomerImportRow = {};
 
   for (const [header, value] of Object.entries(row)) {
-    const key = cleanHeader(header);
+    const cleanedHeader = cleanHeader(header);
+    const key = CUSTOMER_ID_HEADER_ALIASES.has(cleanedHeader)
+      ? "customer_id"
+      : cleanedHeader;
     if (!(SUPPORTED_COLUMNS as readonly string[]).includes(key)) continue;
 
     const cell = cleanCell(value);
@@ -156,8 +175,30 @@ function normalizeParsedRow(row: Record<string, unknown>): CustomerImportRow {
   return normalized;
 }
 
+function logCustomerImportParserTrace(
+  headers: string[],
+  rawRows: Record<string, unknown>[],
+  parsedRows: CustomerImportRow[],
+) {
+  if (!CUSTOMER_IMPORT_DEBUG) return;
+
+  console.info("[customer-csv-import] Detected headers", headers);
+  rawRows.slice(0, 10).forEach((rawRow, index) => {
+    console.info("[customer-csv-import] Raw parsed row", {
+      row: index + 1,
+      rawRow,
+    });
+    console.info("[customer-csv-import] Parsed/normalized UI row", {
+      row: index + 1,
+      parsedRow: parsedRows[index],
+    });
+  });
+}
+
 function hasImportableIdentity(row: CustomerImportRow): boolean {
   return Boolean(
+    row.customer_id ||
+    row.external_id ||
     row.email ||
     row.phone ||
     row.phone_primary ||
@@ -173,6 +214,8 @@ function hasImportableIdentity(row: CustomerImportRow): boolean {
 
 function displayName(row: CustomerImportRow): string {
   return (
+    row.customer_id ||
+    row.external_id ||
     row.company_name ||
     row.business_name ||
     row.display_name ||
@@ -259,12 +302,17 @@ export function CustomerCsvImportCard({
       header: true,
       skipEmptyLines: true,
       complete: (results) => {
-        const parsedRows = (results.data ?? [])
+        const rawParsedRows = results.data ?? [];
+        const detectedHeaders = results.meta.fields ?? [];
+        const parsedRows = rawParsedRows
           .map(normalizeParsedRow)
           .filter((row) => Object.keys(row).length > 0);
-        setHeaders(
-          (results.meta.fields ?? []).map(cleanHeader).filter(Boolean),
+        logCustomerImportParserTrace(
+          detectedHeaders,
+          rawParsedRows,
+          parsedRows,
         );
+        setHeaders(detectedHeaders.map(cleanHeader).filter(Boolean));
         setRows(parsedRows);
         setImportProgress({
           phase: "Reading file",
@@ -355,7 +403,7 @@ export function CustomerCsvImportCard({
       const response = await fetch("/api/customers/import", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ rows: importableRows }),
+        body: JSON.stringify({ rows: importableRows, headers }),
       });
       const payload = (await response
         .json()

--- a/features/customers/import/normalizeImportedCustomerRow.ts
+++ b/features/customers/import/normalizeImportedCustomerRow.ts
@@ -9,6 +9,7 @@ export type ImportRow = {
   name?: unknown;
   customer_id?: unknown;
   external_id?: unknown;
+  customer_number?: unknown;
   company_name?: unknown;
   business_name?: unknown;
   display_name?: unknown;
@@ -98,7 +99,10 @@ export function normalizeImportedCustomerRow(
   return {
     shop_id: shopId,
     user_id: null,
-    external_id: cleanString(row.customer_id) ?? cleanString(row.external_id),
+    external_id:
+      cleanString(row.customer_id) ??
+      cleanString(row.external_id) ??
+      cleanString(row.customer_number),
     first_name: firstName,
     last_name: lastName,
     name: explicitName ?? displayName,

--- a/tests/customer-csv-import-identity-matching.test.ts
+++ b/tests/customer-csv-import-identity-matching.test.ts
@@ -273,6 +273,40 @@ describe("customer CSV import identity matching", () => {
     ).toEqual(["CUST-101177", "CUST-101310"]);
   });
 
+  it("treats customer_number rows as authoritative external identities", async () => {
+    mockSupabase = createSupabaseMock([
+      {
+        id: "existing-email",
+        external_id: "CUST-100181",
+        email: "dispatch@example.com",
+        phone: "4035550181",
+      },
+    ]);
+
+    const body = await postRows([
+      {
+        customer_number: "CUST-100386",
+        company_name: "Rocky Mountain Towing",
+        email: "dispatch@example.com",
+        phone: "(403) 555-0181",
+      },
+    ]);
+
+    expect(body.counts).toMatchObject({
+      created: 1,
+      updated: 0,
+      skipped: 0,
+      failed: 0,
+      duplicates: 0,
+    });
+    expect(body.skippedRows).toEqual([]);
+    expect(mockSupabase.updates).toEqual([]);
+    expect(mockSupabase.inserted[0]).toMatchObject({
+      external_id: "CUST-100386",
+      email: "dispatch@example.com",
+    });
+  });
+
   it("still uses fallback duplicate protection when customer_id is missing", async () => {
     const body = await postRows([
       {


### PR DESCRIPTION
### Motivation

- Instrument the importer to trace why rows with an explicit external/customer ID were falling back to email matching so the root cause can be proven instead of guessed.
- Ensure every CSV header variant that should be authoritative for customer identity actually survives UI parsing and server normalization so external IDs are respected during matching.

### Description

- Add client-side parser header aliasing and tracing: `CUSTOMER_ID_HEADER_ALIASES` maps common variants (e.g. `external_id`, `customerid`, `customer_number`, `customernumber`, `customer`) to the canonical `customer_id`, and `logCustomerImportParserTrace` emits detected headers, raw parsed rows, and UI-normalized rows when `NEXT_PUBLIC_CUSTOMER_IMPORT_DEBUG=1` or in development. (changes in `features/customers/components/CustomerCsvImportCard.tsx`).
- Pass the detected headers from the UI to the API and add server-side tracing with `CUSTOMER_IMPORT_DEBUG` so the route logs detected headers, raw API rows, normalized rows, matching branch, and matched identity details for the first 10 rows and any fallback matches. (changes in `app/api/customers/import/route.ts`).
- Extend server normalization to accept `customer_number` and fold `customer_id`, `external_id`, or `customer_number` into `external_id`, preserving authoritative identity through `normalizeImportedCustomerRow`. (changes in `features/customers/import/normalizeImportedCustomerRow.ts`).
- Update importability/display logic to consider `customer_id`/`external_id` as valid identities, and add a regression test asserting `customer_number` is treated as an authoritative external id that prevents email fallback. (changes in `features/customers/components/CustomerCsvImportCard.tsx` and `tests/customer-csv-import-identity-matching.test.ts`).

### Testing

- Ran `npx tsc --noEmit` and the TypeScript check passed. 
- Ran the targeted test suite with `vitest` for customer CSV identity and related import tests via `npx vitest run tests/customer-csv-import-identity-matching.test.ts tests/guided-onboarding-v2-foundation.test.ts tests/vehicle-csv-import-route.test.ts` and all tests passed. 
- Ran `npm run lint` which surfaced pre-existing unrelated lint errors elsewhere in the repo; lint failures are not caused by these changes and are outside this PR's scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f12c0d67883289a629db85e470d5f)