### PR TITLE
Normalize vehicle-history CSV identity aliases and fix resolver matching

### DIFF
--- a/app/api/work-orders/history/import/route.ts
+++ b/app/api/work-orders/history/import/route.ts
@@ -1,12 +1,17 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { parseCsvFileFromFormData } from "@/features/shared/lib/import/csv";
+import { normalizeVehicleHistoryImportRow } from "@/features/work-orders/import/normalizeVehicleHistoryImportRow";
 import {
   importVehicleHistoryRowsSynchronously,
   VEHICLE_HISTORY_IMPORT_MAX_ROWS,
 } from "@/features/work-orders/server/vehicle-history-import-job";
 
 type HistoryImportRow = Record<string, unknown>;
+
+const VEHICLE_HISTORY_IMPORT_DEBUG =
+  process.env.VEHICLE_HISTORY_IMPORT_DEBUG === "1" ||
+  process.env.CUSTOMER_IMPORT_DEBUG === "1";
 
 export async function POST(req: Request) {
   try {
@@ -18,7 +23,10 @@ export async function POST(req: Request) {
     const contentType = req.headers.get("content-type")?.toLowerCase() ?? "";
     if (!contentType.includes("multipart/form-data")) {
       return NextResponse.json(
-        { error: "Vehicle history import requires multipart/form-data with a CSV file field." },
+        {
+          error:
+            "Vehicle history import requires multipart/form-data with a CSV file field.",
+        },
         { status: 415 },
       );
     }
@@ -32,7 +40,12 @@ export async function POST(req: Request) {
       });
     } catch (error) {
       return NextResponse.json(
-        { error: error instanceof Error ? error.message : "Unable to parse vehicle history CSV." },
+        {
+          error:
+            error instanceof Error
+              ? error.message
+              : "Unable to parse vehicle history CSV.",
+        },
         { status: 400 },
       );
     }
@@ -40,19 +53,43 @@ export async function POST(req: Request) {
     const { supabase, profile } = access;
     const shopId = profile.shop_id;
     if (!shopId) {
-      return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
+      return NextResponse.json(
+        { error: "No active shop is selected." },
+        { status: 400 },
+      );
+    }
+
+    const normalizedRows = parsed.rows.map((row) =>
+      normalizeVehicleHistoryImportRow(row as Record<string, unknown>),
+    );
+    if (VEHICLE_HISTORY_IMPORT_DEBUG) {
+      parsed.rows.slice(0, 10).forEach((rawRow, index) => {
+        console.info("[vehicle-history-import] Raw CSV row", {
+          row: index + 1,
+          rawRow,
+        });
+        console.info("[vehicle-history-import] Normalized row", {
+          row: index + 1,
+          normalizedRow: normalizedRows[index],
+        });
+      });
     }
 
     const result = await importVehicleHistoryRowsSynchronously({
       supabase,
       shopId,
-      rows: parsed.rows,
+      rows: normalizedRows,
     });
 
     return NextResponse.json(result);
   } catch (error) {
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to import vehicle history CSV." },
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to import vehicle history CSV.",
+      },
       { status: 500 },
     );
   }

--- a/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
+++ b/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
@@ -13,29 +13,13 @@ import {
   type CsvImportProgressState,
 } from "@/features/shared/components/import/CsvImportProgress";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
-
-type HistoryImportRow = {
-  customer_id?: string | null;
-  vehicle_id?: string | null;
-  vin?: string | null;
-  customer_name?: string | null;
-  customer_email?: string | null;
-  customer_phone?: string | null;
-  service_date?: string | null;
-  repair_order_number?: string | null;
-  invoice_number?: string | null;
-  odometer?: string | null;
-  service_category?: string | null;
-  complaint?: string | null;
-  cause?: string | null;
-  correction?: string | null;
-  parts?: string | null;
-  labor_hours?: string | null;
-  total?: string | null;
-  technician?: string | null;
-  advisor?: string | null;
-  notes?: string | null;
-};
+import {
+  cleanVehicleHistoryHeader as cleanHeader,
+  normalizeVehicleHistoryImportRow as normalizeParsedRow,
+  rowCustomerExternalId,
+  rowVehicleExternalId,
+  type HistoryImportRow,
+} from "@/features/work-orders/import/normalizeVehicleHistoryImportRow";
 
 type ImportCounts = {
   imported: number;
@@ -64,56 +48,14 @@ type ImportResponse = {
   }>;
 };
 
-const SUPPORTED_COLUMNS = [
-  "customer_id",
-  "vehicle_id",
-  "vin",
-  "customer_name",
-  "customer_email",
-  "customer_phone",
-  "service_date",
-  "repair_order_number",
-  "invoice_number",
-  "odometer",
-  "service_category",
-  "complaint",
-  "cause",
-  "correction",
-  "parts",
-  "labor_hours",
-  "total",
-  "technician",
-  "advisor",
-  "notes",
-] as const;
 const RECOMMENDED_COLUMNS =
   "customer_id, vehicle_id, vin, service_date, repair_order_number, invoice_number, odometer, service_category, complaint, cause, correction, parts, labor_hours, total, technician, advisor, notes";
 const SAMPLE = `${RECOMMENDED_COLUMNS}\nCUST-1001,VEH-204,1HGCM82633A004352,2024-03-18,RO-9182,INV-9182,84520,Brakes,Brake pedal pulsation,Front rotors warped,Replaced front pads and rotors,Front pads; front rotors,2.4,689.42,Sam Tech,Avery Advisor,Imported from legacy system`;
 
-function cleanHeader(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, "_")
-    .replace(/[^a-z0-9_]/g, "");
-}
-function cleanCell(value: unknown): string | null {
-  const text = String(value ?? "").trim();
-  return text.length ? text : null;
-}
-function normalizeParsedRow(row: Record<string, unknown>): HistoryImportRow {
-  const normalized: HistoryImportRow = {};
-  for (const [header, value] of Object.entries(row)) {
-    const key = cleanHeader(header);
-    if (!(SUPPORTED_COLUMNS as readonly string[]).includes(key)) continue;
-    normalized[key as keyof HistoryImportRow] = cleanCell(value);
-  }
-  return normalized;
-}
 function hasLinkIdentity(row: HistoryImportRow): boolean {
   return Boolean(
-    row.customer_id ||
-    row.vehicle_id ||
+    rowCustomerExternalId(row) ||
+    rowVehicleExternalId(row) ||
     row.vin ||
     row.customer_email ||
     row.customer_phone ||

--- a/features/work-orders/import/normalizeVehicleHistoryImportRow.ts
+++ b/features/work-orders/import/normalizeVehicleHistoryImportRow.ts
@@ -1,0 +1,137 @@
+export type HistoryImportRow = {
+  customer_id?: string | null;
+  external_id?: string | null;
+  customer_number?: string | null;
+  customerid?: string | null;
+  customernumber?: string | null;
+  vehicle_id?: string | null;
+  vehicle_external_id?: string | null;
+  vehicle_number?: string | null;
+  vehicleid?: string | null;
+  vehiclenumber?: string | null;
+  vin?: string | null;
+  customer_email?: string | null;
+  email?: string | null;
+  customer_phone?: string | null;
+  phone?: string | null;
+  customer_name?: string | null;
+  name?: string | null;
+  service_date?: string | null;
+  repair_order_number?: string | null;
+  work_order_number?: string | null;
+  invoice_number?: string | null;
+  odometer?: string | null;
+  service_category?: string | null;
+  complaint?: string | null;
+  cause?: string | null;
+  correction?: string | null;
+  parts?: string | null;
+  labor_hours?: string | null;
+  total?: string | null;
+  technician?: string | null;
+  advisor?: string | null;
+  notes?: string | null;
+};
+
+const CUSTOMER_ID_HEADER_ALIASES = new Set([
+  "customer_id",
+  "external_id",
+  "customer_number",
+  "customerid",
+  "customernumber",
+]);
+
+const VEHICLE_ID_HEADER_ALIASES = new Set([
+  "vehicle_id",
+  "vehicle_external_id",
+  "vehicle_number",
+  "vehicleid",
+  "vehiclenumber",
+]);
+
+const SUPPORTED_COLUMNS = new Set([
+  "customer_id",
+  "external_id",
+  "customer_number",
+  "customerid",
+  "customernumber",
+  "vehicle_id",
+  "vehicle_external_id",
+  "vehicle_number",
+  "vehicleid",
+  "vehiclenumber",
+  "vin",
+  "customer_name",
+  "customer_email",
+  "email",
+  "customer_phone",
+  "phone",
+  "name",
+  "service_date",
+  "repair_order_number",
+  "work_order_number",
+  "invoice_number",
+  "odometer",
+  "service_category",
+  "complaint",
+  "cause",
+  "correction",
+  "parts",
+  "labor_hours",
+  "total",
+  "technician",
+  "advisor",
+  "notes",
+]);
+
+export function cleanVehicleHistoryHeader(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
+}
+
+export function cleanVehicleHistoryCell(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text.length ? text : null;
+}
+
+export function rowCustomerExternalId(row: HistoryImportRow): string | null {
+  return (
+    cleanVehicleHistoryCell(row.customer_id) ??
+    cleanVehicleHistoryCell(row.external_id) ??
+    cleanVehicleHistoryCell(row.customer_number) ??
+    cleanVehicleHistoryCell(row.customerid) ??
+    cleanVehicleHistoryCell(row.customernumber)
+  );
+}
+
+export function rowVehicleExternalId(row: HistoryImportRow): string | null {
+  return (
+    cleanVehicleHistoryCell(row.vehicle_id) ??
+    cleanVehicleHistoryCell(row.vehicle_external_id) ??
+    cleanVehicleHistoryCell(row.vehicle_number) ??
+    cleanVehicleHistoryCell(row.vehicleid) ??
+    cleanVehicleHistoryCell(row.vehiclenumber)
+  );
+}
+
+export function normalizeVehicleHistoryImportRow(
+  row: Record<string, unknown>,
+): HistoryImportRow {
+  const normalized: HistoryImportRow = {};
+  for (const [header, value] of Object.entries(row)) {
+    const cleanedHeader = cleanVehicleHistoryHeader(header);
+    const key = CUSTOMER_ID_HEADER_ALIASES.has(cleanedHeader)
+      ? "customer_id"
+      : VEHICLE_ID_HEADER_ALIASES.has(cleanedHeader)
+        ? "vehicle_id"
+        : cleanedHeader;
+    if (!SUPPORTED_COLUMNS.has(cleanedHeader) && !SUPPORTED_COLUMNS.has(key))
+      continue;
+    const cell = cleanVehicleHistoryCell(value);
+    normalized[key as keyof HistoryImportRow] = cell;
+  }
+  return normalized;
+}

--- a/features/work-orders/server/vehicle-history-import-job.ts
+++ b/features/work-orders/server/vehicle-history-import-job.ts
@@ -1,6 +1,16 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { chunkArray, compactImportSummary } from "@/features/shared/lib/import/csv";
+import {
+  chunkArray,
+  compactImportSummary,
+} from "@/features/shared/lib/import/csv";
+import {
+  cleanVehicleHistoryCell,
+  normalizeVehicleHistoryImportRow,
+  rowCustomerExternalId,
+  rowVehicleExternalId,
+  type HistoryImportRow,
+} from "@/features/work-orders/import/normalizeVehicleHistoryImportRow";
 
 type DB = Database;
 export const VEHICLE_HISTORY_IMPORT_BATCH_SIZE = 1000;
@@ -8,18 +18,39 @@ export const VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT = 25;
 export const VEHICLE_HISTORY_IMPORT_MAX_ROWS = 20_000;
 const RESOLVER_PAGE_SIZE = 1000;
 
-type HistoryImportRow = {
-  customer_id?: unknown; vehicle_id?: unknown; vin?: unknown; customer_email?: unknown; email?: unknown;
-  customer_phone?: unknown; phone?: unknown; customer_name?: unknown; name?: unknown; service_date?: unknown;
-  repair_order_number?: unknown; work_order_number?: unknown; invoice_number?: unknown; odometer?: unknown;
-  service_category?: unknown; complaint?: unknown; cause?: unknown; correction?: unknown; parts?: unknown;
-  labor_hours?: unknown; total?: unknown; technician?: unknown; advisor?: unknown; notes?: unknown;
+type CustomerRef = Pick<
+  DB["public"]["Tables"]["customers"]["Row"],
+  | "id"
+  | "external_id"
+  | "email"
+  | "phone"
+  | "phone_number"
+  | "name"
+  | "business_name"
+  | "first_name"
+  | "last_name"
+>;
+type VehicleRef = Pick<
+  DB["public"]["Tables"]["vehicles"]["Row"],
+  "id" | "external_id" | "vin" | "customer_id"
+>;
+type Resolver = {
+  customersById: Map<string, CustomerRef>;
+  customersByExternal: Map<string, CustomerRef>;
+  customersByEmail: Map<string, CustomerRef>;
+  customersByPhone: Map<string, CustomerRef>;
+  customersByName: Map<string, CustomerRef>;
+  vehiclesById: Map<string, VehicleRef>;
+  vehiclesByExternal: Map<string, VehicleRef>;
+  vehiclesByVin: Map<string, VehicleRef>;
 };
-
-type CustomerRef = Pick<DB["public"]["Tables"]["customers"]["Row"], "id" | "external_id" | "email" | "phone" | "phone_number" | "name" | "business_name" | "first_name" | "last_name">;
-type VehicleRef = Pick<DB["public"]["Tables"]["vehicles"]["Row"], "id" | "external_id" | "vin" | "customer_id">;
-type Resolver = { customersById: Map<string, CustomerRef>; customersByExternal: Map<string, CustomerRef>; customersByEmail: Map<string, CustomerRef>; customersByPhone: Map<string, CustomerRef>; customersByName: Map<string, CustomerRef>; vehiclesById: Map<string, VehicleRef>; vehiclesByExternal: Map<string, VehicleRef>; vehiclesByVin: Map<string, VehicleRef>; };
-type ImportCounts = { imported: number; updated: number; skipped: number; failed: number; duplicates: number };
+type ImportCounts = {
+  imported: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  duplicates: number;
+};
 type SkipReasonCode =
   | "customer_not_found"
   | "vehicle_not_found"
@@ -27,27 +58,74 @@ type SkipReasonCode =
   | "duplicate_history"
   | "invalid_service_date"
   | "invalid_numeric_field";
-type DuplicateKey = `${string}:${"work_order_number" | "invoice_number"}:${string}`;
+type DuplicateKey =
+  `${string}:${"work_order_number" | "invoice_number"}:${string}`;
 
 const SKIP_REASON_MESSAGES: Record<SkipReasonCode, string> = {
   customer_not_found: "Existing customer could not be matched.",
   vehicle_not_found: "Existing vehicle could not be matched.",
-  both_customer_and_vehicle_not_found: "Existing customer and vehicle could not be matched.",
+  both_customer_and_vehicle_not_found:
+    "Existing customer and vehicle could not be matched.",
   duplicate_history: "Duplicate repair order/invoice already exists.",
   invalid_service_date: "Invalid or missing service_date.",
   invalid_numeric_field: "Numeric field must be numeric when provided.",
 };
 
-type JobRow = { id: string; shop_id: string; total_rows: number | null; processed_rows: number | null; imported_count: number | null; skipped_count: number | null; failed_count: number | null; summary: Record<string, unknown> | null };
-type StagedRow = { id: string; row_number: number; raw_row: HistoryImportRow; status: string | null };
+type JobRow = {
+  id: string;
+  shop_id: string;
+  total_rows: number | null;
+  processed_rows: number | null;
+  imported_count: number | null;
+  skipped_count: number | null;
+  failed_count: number | null;
+  summary: Record<string, unknown> | null;
+};
+type StagedRow = {
+  id: string;
+  row_number: number;
+  raw_row: HistoryImportRow;
+  status: string | null;
+};
 
-function clean(value: unknown): string | null { const text = String(value ?? "").trim(); return text ? text : null; }
-function key(value: unknown): string | null { return clean(value)?.toLowerCase().replace(/\s+/g, " ") ?? null; }
-function phone(value: unknown): string | null { const text = clean(value); if (!text) return null; return text.replace(/\D/g, "") || text; }
-function vin(value: unknown): string | null { return clean(value)?.toUpperCase().replace(/[^A-Z0-9]/g, "") ?? null; }
-function num(value: unknown): number | null { const text = clean(value); if (!text) return null; const parsed = Number(text.replace(/[$,]/g, "")); return Number.isFinite(parsed) ? parsed : null; }
-function validDate(value: unknown): string | null { const text = clean(value); if (!text) return null; const parsed = new Date(text); return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString(); }
-function customerName(c: CustomerRef): string | null { return c.name || c.business_name || [c.first_name, c.last_name].filter(Boolean).join(" ").trim() || null; }
+function clean(value: unknown): string | null {
+  return cleanVehicleHistoryCell(value);
+}
+function key(value: unknown): string | null {
+  return clean(value)?.toLowerCase().replace(/\s+/g, " ") ?? null;
+}
+function phone(value: unknown): string | null {
+  const text = clean(value);
+  if (!text) return null;
+  return text.replace(/\D/g, "") || text;
+}
+function vin(value: unknown): string | null {
+  return (
+    clean(value)
+      ?.toUpperCase()
+      .replace(/[^A-Z0-9]/g, "") ?? null
+  );
+}
+function num(value: unknown): number | null {
+  const text = clean(value);
+  if (!text) return null;
+  const parsed = Number(text.replace(/[$,]/g, ""));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+function validDate(value: unknown): string | null {
+  const text = clean(value);
+  if (!text) return null;
+  const parsed = new Date(text);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+function customerName(c: CustomerRef): string | null {
+  return (
+    c.name ||
+    c.business_name ||
+    [c.first_name, c.last_name].filter(Boolean).join(" ").trim() ||
+    null
+  );
+}
 
 async function selectAllShopRows<T>(
   supabase: SupabaseClient<DB>,
@@ -73,148 +151,646 @@ async function selectAllShopRows<T>(
 
 function addCustomerRef(r: Resolver, c: CustomerRef) {
   r.customersById.set(c.id, c);
-  const ex = key(c.external_id); if (ex && !r.customersByExternal.has(ex)) r.customersByExternal.set(ex, c);
-  const em = key(c.email); if (em && !r.customersByEmail.has(em)) r.customersByEmail.set(em, c);
-  for (const p of [c.phone, c.phone_number]) { const ph = phone(p); if (ph && !r.customersByPhone.has(ph)) r.customersByPhone.set(ph, c); }
-  for (const n of [c.name, c.business_name, customerName(c)]) { const nk = key(n); if (nk && !r.customersByName.has(nk)) r.customersByName.set(nk, c); }
+  const ex = key(c.external_id);
+  if (ex && !r.customersByExternal.has(ex)) r.customersByExternal.set(ex, c);
+  const em = key(c.email);
+  if (em && !r.customersByEmail.has(em)) r.customersByEmail.set(em, c);
+  for (const p of [c.phone, c.phone_number]) {
+    const ph = phone(p);
+    if (ph && !r.customersByPhone.has(ph)) r.customersByPhone.set(ph, c);
+  }
+  for (const n of [c.name, c.business_name, customerName(c)]) {
+    const nk = key(n);
+    if (nk && !r.customersByName.has(nk)) r.customersByName.set(nk, c);
+  }
 }
 function addVehicleRef(r: Resolver, v: VehicleRef) {
   r.vehiclesById.set(v.id, v);
-  const ex = key(v.external_id); if (ex && !r.vehiclesByExternal.has(ex)) r.vehiclesByExternal.set(ex, v);
-  const vk = vin(v.vin); if (vk && !r.vehiclesByVin.has(vk)) r.vehiclesByVin.set(vk, v);
+  const ex = key(v.external_id);
+  if (ex && !r.vehiclesByExternal.has(ex)) r.vehiclesByExternal.set(ex, v);
+  const vk = vin(v.vin);
+  if (vk && !r.vehiclesByVin.has(vk)) r.vehiclesByVin.set(vk, v);
 }
 
-async function loadResolver(supabase: SupabaseClient<DB>, shopId: string): Promise<Resolver> {
+async function loadResolver(
+  supabase: SupabaseClient<DB>,
+  shopId: string,
+): Promise<Resolver> {
   const [customers, vehicles] = await Promise.all([
-    selectAllShopRows<CustomerRef>(supabase, "customers", "id, external_id, email, phone, phone_number, name, business_name, first_name, last_name", shopId),
-    selectAllShopRows<VehicleRef>(supabase, "vehicles", "id, external_id, vin, customer_id", shopId),
+    selectAllShopRows<CustomerRef>(
+      supabase,
+      "customers",
+      "id, external_id, email, phone, phone_number, name, business_name, first_name, last_name",
+      shopId,
+    ),
+    selectAllShopRows<VehicleRef>(
+      supabase,
+      "vehicles",
+      "id, external_id, vin, customer_id",
+      shopId,
+    ),
   ]);
-  const r: Resolver = { customersById: new Map(), customersByExternal: new Map(), customersByEmail: new Map(), customersByPhone: new Map(), customersByName: new Map(), vehiclesById: new Map(), vehiclesByExternal: new Map(), vehiclesByVin: new Map() };
+  const r: Resolver = {
+    customersById: new Map(),
+    customersByExternal: new Map(),
+    customersByEmail: new Map(),
+    customersByPhone: new Map(),
+    customersByName: new Map(),
+    vehiclesById: new Map(),
+    vehiclesByExternal: new Map(),
+    vehiclesByVin: new Map(),
+  };
   for (const c of customers) addCustomerRef(r, c);
   for (const v of vehicles) addVehicleRef(r, v);
   return r;
 }
-function resolveCustomer(row: HistoryImportRow, r: Resolver): CustomerRef | null { const ex = key(row.customer_id); if (ex && r.customersByExternal.has(ex)) return r.customersByExternal.get(ex)!; const cid = clean(row.customer_id); if (cid && r.customersById.has(cid)) return r.customersById.get(cid)!; const em = key(row.customer_email ?? row.email); if (em && r.customersByEmail.has(em)) return r.customersByEmail.get(em)!; const ph = phone(row.customer_phone ?? row.phone); if (ph && r.customersByPhone.has(ph)) return r.customersByPhone.get(ph)!; const nm = key(row.customer_name ?? row.name); if (nm && r.customersByName.has(nm)) return r.customersByName.get(nm)!; return null; }
-function resolveVehicle(row: HistoryImportRow, r: Resolver): VehicleRef | null { const ex = key(row.vehicle_id); if (ex && r.vehiclesByExternal.has(ex)) return r.vehiclesByExternal.get(ex)!; const vid = clean(row.vehicle_id); if (vid && r.vehiclesById.has(vid)) return r.vehiclesById.get(vid)!; const vk = vin(row.vin); if (vk && r.vehiclesByVin.has(vk)) return r.vehiclesByVin.get(vk)!; return null; }
+export function resolveCustomer(
+  row: HistoryImportRow,
+  r: Resolver,
+): CustomerRef | null {
+  return resolveCustomerWithBranch(row, r).customer;
+}
+export function resolveVehicle(
+  row: HistoryImportRow,
+  r: Resolver,
+): VehicleRef | null {
+  return resolveVehicleWithBranch(row, r).vehicle;
+}
 
-function duplicateKey(customerId: string, column: "work_order_number" | "invoice_number", value: string): DuplicateKey {
+function resolveCustomerWithBranch(
+  row: HistoryImportRow,
+  r: Resolver,
+): { customer: CustomerRef | null; branch: string; identity: string | null } {
+  const externalId = rowCustomerExternalId(row);
+  const ex = key(externalId);
+  if (ex && r.customersByExternal.has(ex))
+    return {
+      customer: r.customersByExternal.get(ex)!,
+      branch: "customer_external_id",
+      identity: externalId,
+    };
+  const cid = clean(externalId);
+  if (cid && r.customersById.has(cid))
+    return {
+      customer: r.customersById.get(cid)!,
+      branch: "customer_uuid",
+      identity: cid,
+    };
+  const em = key(row.customer_email ?? row.email);
+  if (em && r.customersByEmail.has(em))
+    return {
+      customer: r.customersByEmail.get(em)!,
+      branch: "customer_email",
+      identity: em,
+    };
+  const ph = phone(row.customer_phone ?? row.phone);
+  if (ph && r.customersByPhone.has(ph))
+    return {
+      customer: r.customersByPhone.get(ph)!,
+      branch: "customer_phone",
+      identity: ph,
+    };
+  const nm = key(row.customer_name ?? row.name);
+  if (nm && r.customersByName.has(nm))
+    return {
+      customer: r.customersByName.get(nm)!,
+      branch: "customer_name",
+      identity: nm,
+    };
+  return {
+    customer: null,
+    branch: externalId ? "customer_external_id_not_found" : "customer_no_match",
+    identity: externalId,
+  };
+}
+function resolveVehicleWithBranch(
+  row: HistoryImportRow,
+  r: Resolver,
+): { vehicle: VehicleRef | null; branch: string; identity: string | null } {
+  const externalId = rowVehicleExternalId(row);
+  const ex = key(externalId);
+  if (ex && r.vehiclesByExternal.has(ex))
+    return {
+      vehicle: r.vehiclesByExternal.get(ex)!,
+      branch: "vehicle_external_id",
+      identity: externalId,
+    };
+  const vid = clean(externalId);
+  if (vid && r.vehiclesById.has(vid))
+    return {
+      vehicle: r.vehiclesById.get(vid)!,
+      branch: "vehicle_uuid",
+      identity: vid,
+    };
+  const vk = vin(row.vin);
+  if (vk && r.vehiclesByVin.has(vk))
+    return {
+      vehicle: r.vehiclesByVin.get(vk)!,
+      branch: "vehicle_vin",
+      identity: vk,
+    };
+  return {
+    vehicle: null,
+    branch: externalId ? "vehicle_external_id_not_found" : "vehicle_no_match",
+    identity: externalId ?? vk,
+  };
+}
+
+const VEHICLE_HISTORY_IMPORT_DEBUG =
+  process.env.VEHICLE_HISTORY_IMPORT_DEBUG === "1" ||
+  process.env.CUSTOMER_IMPORT_DEBUG === "1";
+function logDebug(message: string, details: Record<string, unknown>) {
+  if (VEHICLE_HISTORY_IMPORT_DEBUG)
+    console.info(`[vehicle-history-import] ${message}`, details);
+}
+
+function duplicateKey(
+  customerId: string,
+  column: "work_order_number" | "invoice_number",
+  value: string,
+): DuplicateKey {
   return `${customerId}:${column}:${value.toLowerCase()}`;
 }
 
-function skipSample(row: number, code: SkipReasonCode, repairOrderNumber: string | null, invoiceNumber: string | null, detail?: string) {
-  return { row, code, reason: detail ?? SKIP_REASON_MESSAGES[code], repairOrderNumber, invoiceNumber };
+function skipSample(
+  row: number,
+  code: SkipReasonCode,
+  repairOrderNumber: string | null,
+  invoiceNumber: string | null,
+  detail?: string,
+) {
+  return {
+    row,
+    code,
+    reason: detail ?? SKIP_REASON_MESSAGES[code],
+    repairOrderNumber,
+    invoiceNumber,
+  };
 }
 
 async function preloadDuplicateHistoryKeys(
   supabase: SupabaseClient<DB>,
   shopId: string,
-  rows: Array<{ customerId: string; repairOrderNumber: string | null; invoiceNumber: string | null }>,
+  rows: Array<{
+    customerId: string;
+    repairOrderNumber: string | null;
+    invoiceNumber: string | null;
+  }>,
 ): Promise<Set<DuplicateKey>> {
   const keys = new Set<DuplicateKey>();
-  const repairOrderNumbers = Array.from(new Set(rows.map((row) => row.repairOrderNumber).filter((value): value is string => Boolean(value))));
-  const invoiceNumbers = Array.from(new Set(rows.map((row) => row.invoiceNumber).filter((value): value is string => Boolean(value))));
+  const repairOrderNumbers = Array.from(
+    new Set(
+      rows
+        .map((row) => row.repairOrderNumber)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+  const invoiceNumbers = Array.from(
+    new Set(
+      rows
+        .map((row) => row.invoiceNumber)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
 
-  for (const batch of chunkArray(repairOrderNumbers, VEHICLE_HISTORY_IMPORT_BATCH_SIZE)) {
-    const { data, error } = await supabase.from("history").select("customer_id, work_order_number").eq("shop_id", shopId).in("work_order_number", batch);
+  for (const batch of chunkArray(
+    repairOrderNumbers,
+    VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+  )) {
+    const { data, error } = await supabase
+      .from("history")
+      .select("customer_id, work_order_number")
+      .eq("shop_id", shopId)
+      .in("work_order_number", batch);
     if (error) throw error;
-    for (const history of data ?? []) if (history.customer_id && history.work_order_number) keys.add(duplicateKey(history.customer_id, "work_order_number", history.work_order_number));
+    for (const history of data ?? [])
+      if (history.customer_id && history.work_order_number)
+        keys.add(
+          duplicateKey(
+            history.customer_id,
+            "work_order_number",
+            history.work_order_number,
+          ),
+        );
   }
-  for (const batch of chunkArray(invoiceNumbers, VEHICLE_HISTORY_IMPORT_BATCH_SIZE)) {
-    const { data, error } = await supabase.from("history").select("customer_id, invoice_number").eq("shop_id", shopId).in("invoice_number", batch);
+  for (const batch of chunkArray(
+    invoiceNumbers,
+    VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+  )) {
+    const { data, error } = await supabase
+      .from("history")
+      .select("customer_id, invoice_number")
+      .eq("shop_id", shopId)
+      .in("invoice_number", batch);
     if (error) throw error;
-    for (const history of data ?? []) if (history.customer_id && history.invoice_number) keys.add(duplicateKey(history.customer_id, "invoice_number", history.invoice_number));
+    for (const history of data ?? [])
+      if (history.customer_id && history.invoice_number)
+        keys.add(
+          duplicateKey(
+            history.customer_id,
+            "invoice_number",
+            history.invoice_number,
+          ),
+        );
   }
   return keys;
 }
 
 function compactSamples(summary: Record<string, unknown> | null) {
   return {
-    skippedRows: Array.isArray(summary?.skippedRows) ? summary.skippedRows as unknown[] : [],
-    failedRows: Array.isArray(summary?.failedRows) ? summary.failedRows as unknown[] : [],
+    skippedRows: Array.isArray(summary?.skippedRows)
+      ? (summary.skippedRows as unknown[])
+      : [],
+    failedRows: Array.isArray(summary?.failedRows)
+      ? (summary.failedRows as unknown[])
+      : [],
   };
 }
 
-export async function processVehicleHistoryImportJobBatch(supabase: SupabaseClient<DB>, jobId?: string, batchSize = VEHICLE_HISTORY_IMPORT_BATCH_SIZE) {
+export async function processVehicleHistoryImportJobBatch(
+  supabase: SupabaseClient<DB>,
+  jobId?: string,
+  batchSize = VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+) {
   const client = supabase as unknown as SupabaseClient;
-  let jobQuery = client.from("import_jobs").select("id, shop_id, total_rows, processed_rows, imported_count, skipped_count, failed_count, summary").eq("import_type", "vehicle_history").in("status", ["queued", "processing"]).order("created_at", { ascending: true }).limit(1);
+  let jobQuery = client
+    .from("import_jobs")
+    .select(
+      "id, shop_id, total_rows, processed_rows, imported_count, skipped_count, failed_count, summary",
+    )
+    .eq("import_type", "vehicle_history")
+    .in("status", ["queued", "processing"])
+    .order("created_at", { ascending: true })
+    .limit(1);
   if (jobId) jobQuery = jobQuery.eq("id", jobId);
   const { data: job, error: jobError } = await jobQuery.maybeSingle<JobRow>();
   if (jobError) throw jobError;
   if (!job) return { ok: true, processed: 0, completed: false, job: null };
 
-  await client.from("import_jobs").update({ status: "processing", updated_at: new Date().toISOString() }).eq("id", job.id);
-  const { data: stagedRows, error: rowsError } = await client.from("import_job_rows").select("id, row_number, raw_row, status").eq("job_id", job.id).eq("status", "queued").order("row_number", { ascending: true }).limit(batchSize);
+  await client
+    .from("import_jobs")
+    .update({ status: "processing", updated_at: new Date().toISOString() })
+    .eq("id", job.id);
+  const { data: stagedRows, error: rowsError } = await client
+    .from("import_job_rows")
+    .select("id, row_number, raw_row, status")
+    .eq("job_id", job.id)
+    .eq("status", "queued")
+    .order("row_number", { ascending: true })
+    .limit(batchSize);
   if (rowsError) throw rowsError;
   const rows = (stagedRows ?? []) as StagedRow[];
   if (!rows.length) {
-    const finalSummary = compactImportSummary({ counts: { imported: job.imported_count ?? 0, updated: 0, skipped: job.skipped_count ?? 0, failed: job.failed_count ?? 0, duplicates: Number(job.summary?.duplicates ?? 0) }, totalRows: job.processed_rows ?? 0, skippedRows: compactSamples(job.summary).skippedRows, failedRows: compactSamples(job.summary).failedRows, sampleLimit: VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT });
-    await client.from("import_jobs").update({ status: "completed", completed_at: new Date().toISOString(), updated_at: new Date().toISOString(), summary: finalSummary }).eq("id", job.id);
+    const finalSummary = compactImportSummary({
+      counts: {
+        imported: job.imported_count ?? 0,
+        updated: 0,
+        skipped: job.skipped_count ?? 0,
+        failed: job.failed_count ?? 0,
+        duplicates: Number(job.summary?.duplicates ?? 0),
+      },
+      totalRows: job.processed_rows ?? 0,
+      skippedRows: compactSamples(job.summary).skippedRows,
+      failedRows: compactSamples(job.summary).failedRows,
+      sampleLimit: VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,
+    });
+    await client
+      .from("import_jobs")
+      .update({
+        status: "completed",
+        completed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        summary: finalSummary,
+      })
+      .eq("id", job.id);
     return { ok: true, processed: 0, completed: true, job: { id: job.id } };
   }
 
   const resolver = await loadResolver(supabase, job.shop_id);
-  const counts: ImportCounts = { imported: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 };
+  const counts: ImportCounts = {
+    imported: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    duplicates: 0,
+  };
   const samples = compactSamples(job.summary);
-  const payloads: Array<{ stagedId: string; rowNumber: number; repairOrderNumber: string | null; invoiceNumber: string | null; payload: DB["public"]["Tables"]["history"]["Insert"] & Record<string, unknown> }> = [];
+  const payloads: Array<{
+    stagedId: string;
+    rowNumber: number;
+    repairOrderNumber: string | null;
+    invoiceNumber: string | null;
+    payload: DB["public"]["Tables"]["history"]["Insert"] &
+      Record<string, unknown>;
+  }> = [];
   const duplicateCandidates = rows.flatMap((staged) => {
-    const row = staged.raw_row;
+    const row = normalizeVehicleHistoryImportRow(
+      staged.raw_row as Record<string, unknown>,
+    );
     const vehicle = resolveVehicle(row, resolver);
-    const customer = resolveCustomer(row, resolver) ?? (vehicle?.customer_id ? resolver.customersById.get(vehicle.customer_id) ?? null : null);
+    const customer =
+      resolveCustomer(row, resolver) ??
+      (vehicle?.customer_id
+        ? (resolver.customersById.get(vehicle.customer_id) ?? null)
+        : null);
     if (!customer) return [];
-    return [{ customerId: customer.id, repairOrderNumber: clean(row.repair_order_number ?? row.work_order_number), invoiceNumber: clean(row.invoice_number) }];
+    return [
+      {
+        customerId: customer.id,
+        repairOrderNumber: clean(
+          row.repair_order_number ?? row.work_order_number,
+        ),
+        invoiceNumber: clean(row.invoice_number),
+      },
+    ];
   });
-  const existingDuplicateKeys = await preloadDuplicateHistoryKeys(supabase, job.shop_id, duplicateCandidates);
+  const existingDuplicateKeys = await preloadDuplicateHistoryKeys(
+    supabase,
+    job.shop_id,
+    duplicateCandidates,
+  );
   const batchDuplicateKeys = new Set<DuplicateKey>();
 
   for (const staged of rows) {
-    const row = staged.raw_row; const rowNumber = staged.row_number; const repairOrderNumber = clean(row.repair_order_number ?? row.work_order_number); const invoiceNumber = clean(row.invoice_number);
+    const row = normalizeVehicleHistoryImportRow(
+      staged.raw_row as Record<string, unknown>,
+    );
+    const rowNumber = staged.row_number;
+    const repairOrderNumber = clean(
+      row.repair_order_number ?? row.work_order_number,
+    );
+    const invoiceNumber = clean(row.invoice_number);
     try {
       const serviceDate = validDate(row.service_date);
-      const invalidNumber = ([ ["odometer", row.odometer], ["labor_hours", row.labor_hours], ["total", row.total] ] as const).find(([, value]) => clean(value) && num(value) === null);
-      if (!serviceDate || invalidNumber) { const code: SkipReasonCode = !serviceDate ? "invalid_service_date" : "invalid_numeric_field"; const reason = !serviceDate ? SKIP_REASON_MESSAGES.invalid_service_date : `${invalidNumber?.[0]} must be numeric when provided.`; counts.skipped++; samples.skippedRows.push(skipSample(rowNumber, code, repairOrderNumber, invoiceNumber, reason)); await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id); continue; }
-      const vehicle = resolveVehicle(row, resolver); const customer = resolveCustomer(row, resolver) ?? (vehicle?.customer_id ? resolver.customersById.get(vehicle.customer_id) ?? null : null);
-      const vehicleWasProvided = Boolean(clean(row.vehicle_id) || clean(row.vin));
-      if (!customer || (vehicleWasProvided && !vehicle)) {
-        const code: SkipReasonCode = !customer && vehicleWasProvided && !vehicle ? "both_customer_and_vehicle_not_found" : !customer ? "customer_not_found" : "vehicle_not_found";
-        const reason = SKIP_REASON_MESSAGES[code];
-        counts.skipped++; samples.skippedRows.push(skipSample(rowNumber, code, repairOrderNumber, invoiceNumber)); await client.from("import_job_rows").update({ status: "skipped", error_message: reason }).eq("id", staged.id); continue;
+      const invalidNumber = (
+        [
+          ["odometer", row.odometer],
+          ["labor_hours", row.labor_hours],
+          ["total", row.total],
+        ] as const
+      ).find(([, value]) => clean(value) && num(value) === null);
+      if (!serviceDate || invalidNumber) {
+        const code: SkipReasonCode = !serviceDate
+          ? "invalid_service_date"
+          : "invalid_numeric_field";
+        const reason = !serviceDate
+          ? SKIP_REASON_MESSAGES.invalid_service_date
+          : `${invalidNumber?.[0]} must be numeric when provided.`;
+        counts.skipped++;
+        samples.skippedRows.push(
+          skipSample(rowNumber, code, repairOrderNumber, invoiceNumber, reason),
+        );
+        await client
+          .from("import_job_rows")
+          .update({ status: "skipped", error_message: reason })
+          .eq("id", staged.id);
+        continue;
       }
-      const repairDuplicateKey = repairOrderNumber ? duplicateKey(customer.id, "work_order_number", repairOrderNumber) : null;
-      const invoiceDuplicateKey = invoiceNumber ? duplicateKey(customer.id, "invoice_number", invoiceNumber) : null;
-      const duplicateFound = Boolean((repairDuplicateKey && (existingDuplicateKeys.has(repairDuplicateKey) || batchDuplicateKeys.has(repairDuplicateKey))) || (invoiceDuplicateKey && (existingDuplicateKeys.has(invoiceDuplicateKey) || batchDuplicateKeys.has(invoiceDuplicateKey))));
-      if (duplicateFound) { counts.skipped++; counts.duplicates++; samples.skippedRows.push(skipSample(rowNumber, "duplicate_history", repairOrderNumber, invoiceNumber)); await client.from("import_job_rows").update({ status: "skipped", error_message: SKIP_REASON_MESSAGES.duplicate_history }).eq("id", staged.id); continue; }
+      const vehicleResolution = resolveVehicleWithBranch(row, resolver);
+      const customerResolution = resolveCustomerWithBranch(row, resolver);
+      const vehicle = vehicleResolution.vehicle;
+      const customer =
+        customerResolution.customer ??
+        (vehicle?.customer_id
+          ? (resolver.customersById.get(vehicle.customer_id) ?? null)
+          : null);
+      logDebug("Resolver result", {
+        rowNumber,
+        normalizedRow: row,
+        customerIdentity: customerResolution.identity,
+        vehicleIdentity: vehicleResolution.identity,
+        customerBranch: customerResolution.branch,
+        vehicleBranch: vehicleResolution.branch,
+        resolvedCustomerId: customer?.id ?? null,
+        resolvedVehicleId: vehicle?.id ?? null,
+      });
+      const vehicleWasProvided = Boolean(
+        rowVehicleExternalId(row) || clean(row.vin),
+      );
+      if (!customer || (vehicleWasProvided && !vehicle)) {
+        const code: SkipReasonCode =
+          !customer && vehicleWasProvided && !vehicle
+            ? "both_customer_and_vehicle_not_found"
+            : !customer
+              ? "customer_not_found"
+              : "vehicle_not_found";
+        const reason = SKIP_REASON_MESSAGES[code];
+        logDebug("Skip reason", {
+          rowNumber,
+          code,
+          reason,
+          customerIdentity: rowCustomerExternalId(row),
+          vehicleIdentity: rowVehicleExternalId(row),
+        });
+        counts.skipped++;
+        samples.skippedRows.push(
+          skipSample(rowNumber, code, repairOrderNumber, invoiceNumber),
+        );
+        await client
+          .from("import_job_rows")
+          .update({ status: "skipped", error_message: reason })
+          .eq("id", staged.id);
+        continue;
+      }
+      const repairDuplicateKey = repairOrderNumber
+        ? duplicateKey(customer.id, "work_order_number", repairOrderNumber)
+        : null;
+      const invoiceDuplicateKey = invoiceNumber
+        ? duplicateKey(customer.id, "invoice_number", invoiceNumber)
+        : null;
+      const duplicateFound = Boolean(
+        (repairDuplicateKey &&
+          (existingDuplicateKeys.has(repairDuplicateKey) ||
+            batchDuplicateKeys.has(repairDuplicateKey))) ||
+        (invoiceDuplicateKey &&
+          (existingDuplicateKeys.has(invoiceDuplicateKey) ||
+            batchDuplicateKeys.has(invoiceDuplicateKey))),
+      );
+      if (duplicateFound) {
+        counts.skipped++;
+        counts.duplicates++;
+        samples.skippedRows.push(
+          skipSample(
+            rowNumber,
+            "duplicate_history",
+            repairOrderNumber,
+            invoiceNumber,
+          ),
+        );
+        await client
+          .from("import_job_rows")
+          .update({
+            status: "skipped",
+            error_message: SKIP_REASON_MESSAGES.duplicate_history,
+          })
+          .eq("id", staged.id);
+        continue;
+      }
       if (repairDuplicateKey) batchDuplicateKeys.add(repairDuplicateKey);
       if (invoiceDuplicateKey) batchDuplicateKeys.add(invoiceDuplicateKey);
-      const parts = clean(row.parts); const notes = [clean(row.notes), parts ? `Parts: ${parts}` : null, clean(row.service_category) ? `Service category: ${clean(row.service_category)}` : null].filter(Boolean).join("\n") || null;
-      const description = [clean(row.service_category), clean(row.complaint), clean(row.correction)].filter(Boolean).join(" · ") || "Imported historical service record";
-      payloads.push({ stagedId: staged.id, rowNumber, repairOrderNumber, invoiceNumber, payload: { shop_id: job.shop_id, customer_id: customer.id, vehicle_id: vehicle?.id ?? null, service_date: serviceDate, description, notes, work_order_number: repairOrderNumber, invoice_number: invoiceNumber, odometer: num(row.odometer), symptom: clean(row.complaint), cause: clean(row.cause), correction: clean(row.correction), labor_hours: num(row.labor_hours), total: num(row.total), advisor_name: clean(row.advisor), assigned_tech_name: clean(row.technician), historical_status: "imported", source_system: "vehicle_history_csv", source_row_id: String(rowNumber), source_payload: JSON.parse(JSON.stringify({ imported_at: new Date().toISOString(), raw_row: row, service_category: clean(row.service_category), parts: clean(row.parts) })) as DB["public"]["Tables"]["history"]["Insert"]["source_payload"] } });
-    } catch (error) { counts.failed++; const message = error instanceof Error ? error.message : "History row failed to import."; samples.failedRows.push({ row: rowNumber, error: message, repairOrderNumber, invoiceNumber }); await client.from("import_job_rows").update({ status: "failed", error_message: message }).eq("id", staged.id); }
+      const parts = clean(row.parts);
+      const notes =
+        [
+          clean(row.notes),
+          parts ? `Parts: ${parts}` : null,
+          clean(row.service_category)
+            ? `Service category: ${clean(row.service_category)}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join("\n") || null;
+      const description =
+        [
+          clean(row.service_category),
+          clean(row.complaint),
+          clean(row.correction),
+        ]
+          .filter(Boolean)
+          .join(" · ") || "Imported historical service record";
+      payloads.push({
+        stagedId: staged.id,
+        rowNumber,
+        repairOrderNumber,
+        invoiceNumber,
+        payload: {
+          shop_id: job.shop_id,
+          customer_id: customer.id,
+          vehicle_id: vehicle?.id ?? null,
+          service_date: serviceDate,
+          description,
+          notes,
+          work_order_number: repairOrderNumber,
+          invoice_number: invoiceNumber,
+          odometer: num(row.odometer),
+          symptom: clean(row.complaint),
+          cause: clean(row.cause),
+          correction: clean(row.correction),
+          labor_hours: num(row.labor_hours),
+          total: num(row.total),
+          advisor_name: clean(row.advisor),
+          assigned_tech_name: clean(row.technician),
+          historical_status: "imported",
+          source_system: "vehicle_history_csv",
+          source_row_id: String(rowNumber),
+          source_payload: JSON.parse(
+            JSON.stringify({
+              imported_at: new Date().toISOString(),
+              raw_row: row,
+              customer_identity: rowCustomerExternalId(row),
+              vehicle_identity: rowVehicleExternalId(row),
+              service_category: clean(row.service_category),
+              parts: clean(row.parts),
+            }),
+          ) as DB["public"]["Tables"]["history"]["Insert"]["source_payload"],
+        },
+      });
+    } catch (error) {
+      counts.failed++;
+      const message =
+        error instanceof Error
+          ? error.message
+          : "History row failed to import.";
+      samples.failedRows.push({
+        row: rowNumber,
+        error: message,
+        repairOrderNumber,
+        invoiceNumber,
+      });
+      await client
+        .from("import_job_rows")
+        .update({ status: "failed", error_message: message })
+        .eq("id", staged.id);
+    }
   }
 
   for (const batch of chunkArray(payloads, VEHICLE_HISTORY_IMPORT_BATCH_SIZE)) {
-    const { error } = await supabase.from("history").insert(batch.map((entry) => entry.payload));
+    const { error } = await supabase
+      .from("history")
+      .insert(batch.map((entry) => entry.payload));
     if (error) {
       for (const entry of batch) {
-        const { error: rowError } = await supabase.from("history").insert(entry.payload);
-        if (rowError) { counts.failed++; samples.failedRows.push({ row: entry.rowNumber, error: rowError.message, repairOrderNumber: entry.repairOrderNumber, invoiceNumber: entry.invoiceNumber }); await client.from("import_job_rows").update({ status: "failed", error_message: rowError.message }).eq("id", entry.stagedId); }
-        else { counts.imported++; await client.from("import_job_rows").update({ status: "imported" }).eq("id", entry.stagedId); }
+        const { error: rowError } = await supabase
+          .from("history")
+          .insert(entry.payload);
+        if (rowError) {
+          counts.failed++;
+          samples.failedRows.push({
+            row: entry.rowNumber,
+            error: rowError.message,
+            repairOrderNumber: entry.repairOrderNumber,
+            invoiceNumber: entry.invoiceNumber,
+          });
+          await client
+            .from("import_job_rows")
+            .update({ status: "failed", error_message: rowError.message })
+            .eq("id", entry.stagedId);
+        } else {
+          counts.imported++;
+          await client
+            .from("import_job_rows")
+            .update({ status: "imported" })
+            .eq("id", entry.stagedId);
+        }
       }
-    } else { counts.imported += batch.length; await client.from("import_job_rows").update({ status: "imported" }).in("id", batch.map((entry) => entry.stagedId)); }
+    } else {
+      counts.imported += batch.length;
+      await client
+        .from("import_job_rows")
+        .update({ status: "imported" })
+        .in(
+          "id",
+          batch.map((entry) => entry.stagedId),
+        );
+    }
   }
 
-  samples.skippedRows = samples.skippedRows.slice(0, VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT); samples.failedRows = samples.failedRows.slice(0, VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT);
+  samples.skippedRows = samples.skippedRows.slice(
+    0,
+    VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,
+  );
+  samples.failedRows = samples.failedRows.slice(
+    0,
+    VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,
+  );
   const totalRows = Math.max(0, job.total_rows ?? 0);
   const nextImported = (job.imported_count ?? 0) + counts.imported;
   const nextSkipped = (job.skipped_count ?? 0) + counts.skipped;
   const nextFailed = (job.failed_count ?? 0) + counts.failed;
-  const processedRows = totalRows > 0 ? Math.min(totalRows, nextImported + nextSkipped + nextFailed) : nextImported + nextSkipped + nextFailed;
-  const summary = { skippedRows: samples.skippedRows, failedRows: samples.failedRows, duplicates: Number(job.summary?.duplicates ?? 0) + counts.duplicates };
-  const { count: remainingCount, error: remainingError } = await client.from("import_job_rows").select("id", { count: "exact", head: true }).eq("job_id", job.id).eq("status", "queued");
+  const processedRows =
+    totalRows > 0
+      ? Math.min(totalRows, nextImported + nextSkipped + nextFailed)
+      : nextImported + nextSkipped + nextFailed;
+  const summary = {
+    skippedRows: samples.skippedRows,
+    failedRows: samples.failedRows,
+    duplicates: Number(job.summary?.duplicates ?? 0) + counts.duplicates,
+  };
+  const { count: remainingCount, error: remainingError } = await client
+    .from("import_job_rows")
+    .select("id", { count: "exact", head: true })
+    .eq("job_id", job.id)
+    .eq("status", "queued");
   if (remainingError) throw remainingError;
   const completed = (remainingCount ?? 0) === 0;
-  const reconciledSkipped = completed && totalRows > 0 ? Math.max(0, totalRows - nextImported - nextFailed) : nextSkipped;
-  const reconciledProcessed = completed && totalRows > 0 ? totalRows : processedRows;
-  await client.from("import_jobs").update({ status: completed ? "completed" : "processing", processed_rows: reconciledProcessed, imported_count: nextImported, skipped_count: reconciledSkipped, failed_count: nextFailed, summary, completed_at: completed ? new Date().toISOString() : null, updated_at: new Date().toISOString() }).eq("id", job.id);
+  const reconciledSkipped =
+    completed && totalRows > 0
+      ? Math.max(0, totalRows - nextImported - nextFailed)
+      : nextSkipped;
+  const reconciledProcessed =
+    completed && totalRows > 0 ? totalRows : processedRows;
+  await client
+    .from("import_jobs")
+    .update({
+      status: completed ? "completed" : "processing",
+      processed_rows: reconciledProcessed,
+      imported_count: nextImported,
+      skipped_count: reconciledSkipped,
+      failed_count: nextFailed,
+      summary,
+      completed_at: completed ? new Date().toISOString() : null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", job.id);
   return { ok: true, processed: rows.length, completed, job: { id: job.id } };
 }
 
@@ -227,70 +803,237 @@ export async function importVehicleHistoryRowsSynchronously({
   shopId: string;
   rows: HistoryImportRow[];
 }) {
+  const normalizedRows = rows.map((row) =>
+    normalizeVehicleHistoryImportRow(row as Record<string, unknown>),
+  );
   const resolver = await loadResolver(supabase, shopId);
-  const counts: ImportCounts = { imported: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 };
+  const counts: ImportCounts = {
+    imported: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    duplicates: 0,
+  };
   const samples = { skippedRows: [] as unknown[], failedRows: [] as unknown[] };
-  const payloads: Array<{ rowNumber: number; repairOrderNumber: string | null; invoiceNumber: string | null; payload: DB["public"]["Tables"]["history"]["Insert"] & Record<string, unknown> }> = [];
-  const duplicateCandidates = rows.flatMap((row) => {
+  const payloads: Array<{
+    rowNumber: number;
+    repairOrderNumber: string | null;
+    invoiceNumber: string | null;
+    payload: DB["public"]["Tables"]["history"]["Insert"] &
+      Record<string, unknown>;
+  }> = [];
+  const duplicateCandidates = normalizedRows.flatMap((row) => {
     const vehicle = resolveVehicle(row, resolver);
-    const customer = resolveCustomer(row, resolver) ?? (vehicle?.customer_id ? resolver.customersById.get(vehicle.customer_id) ?? null : null);
+    const customer =
+      resolveCustomer(row, resolver) ??
+      (vehicle?.customer_id
+        ? (resolver.customersById.get(vehicle.customer_id) ?? null)
+        : null);
     if (!customer) return [];
-    return [{ customerId: customer.id, repairOrderNumber: clean(row.repair_order_number ?? row.work_order_number), invoiceNumber: clean(row.invoice_number) }];
+    return [
+      {
+        customerId: customer.id,
+        repairOrderNumber: clean(
+          row.repair_order_number ?? row.work_order_number,
+        ),
+        invoiceNumber: clean(row.invoice_number),
+      },
+    ];
   });
-  const existingDuplicateKeys = await preloadDuplicateHistoryKeys(supabase, shopId, duplicateCandidates);
+  const existingDuplicateKeys = await preloadDuplicateHistoryKeys(
+    supabase,
+    shopId,
+    duplicateCandidates,
+  );
   const batchDuplicateKeys = new Set<DuplicateKey>();
 
-  for (const [index, row] of rows.entries()) {
+  for (const [index, row] of normalizedRows.entries()) {
     const rowNumber = index + 1;
-    const repairOrderNumber = clean(row.repair_order_number ?? row.work_order_number);
+    const repairOrderNumber = clean(
+      row.repair_order_number ?? row.work_order_number,
+    );
     const invoiceNumber = clean(row.invoice_number);
     try {
       const serviceDate = validDate(row.service_date);
-      const invalidNumber = ([ ["odometer", row.odometer], ["labor_hours", row.labor_hours], ["total", row.total] ] as const).find(([, value]) => clean(value) && num(value) === null);
+      const invalidNumber = (
+        [
+          ["odometer", row.odometer],
+          ["labor_hours", row.labor_hours],
+          ["total", row.total],
+        ] as const
+      ).find(([, value]) => clean(value) && num(value) === null);
       if (!serviceDate || invalidNumber) {
-        const reason = !serviceDate ? "Invalid or missing service_date." : `${invalidNumber?.[0] ?? "value"} must be numeric when provided.`;
+        const reason = !serviceDate
+          ? "Invalid or missing service_date."
+          : `${invalidNumber?.[0] ?? "value"} must be numeric when provided.`;
         counts.skipped++;
-        samples.skippedRows.push(skipSample(rowNumber, !serviceDate ? "invalid_service_date" : "invalid_numeric_field", repairOrderNumber, invoiceNumber, reason));
+        samples.skippedRows.push(
+          skipSample(
+            rowNumber,
+            !serviceDate ? "invalid_service_date" : "invalid_numeric_field",
+            repairOrderNumber,
+            invoiceNumber,
+            reason,
+          ),
+        );
         continue;
       }
-      const vehicle = resolveVehicle(row, resolver);
-      const customer = resolveCustomer(row, resolver) ?? (vehicle?.customer_id ? resolver.customersById.get(vehicle.customer_id) ?? null : null);
-      const vehicleWasProvided = Boolean(clean(row.vehicle_id) || clean(row.vin));
+      const vehicleResolution = resolveVehicleWithBranch(row, resolver);
+      const customerResolution = resolveCustomerWithBranch(row, resolver);
+      const vehicle = vehicleResolution.vehicle;
+      const customer =
+        customerResolution.customer ??
+        (vehicle?.customer_id
+          ? (resolver.customersById.get(vehicle.customer_id) ?? null)
+          : null);
+      logDebug("Resolver result", {
+        rowNumber,
+        normalizedRow: row,
+        customerIdentity: customerResolution.identity,
+        vehicleIdentity: vehicleResolution.identity,
+        customerBranch: customerResolution.branch,
+        vehicleBranch: vehicleResolution.branch,
+        resolvedCustomerId: customer?.id ?? null,
+        resolvedVehicleId: vehicle?.id ?? null,
+      });
+      const vehicleWasProvided = Boolean(
+        rowVehicleExternalId(row) || clean(row.vin),
+      );
       if (!customer || (vehicleWasProvided && !vehicle)) {
-        const code: SkipReasonCode = !customer && vehicleWasProvided && !vehicle ? "both_customer_and_vehicle_not_found" : !customer ? "customer_not_found" : "vehicle_not_found";
+        const code: SkipReasonCode =
+          !customer && vehicleWasProvided && !vehicle
+            ? "both_customer_and_vehicle_not_found"
+            : !customer
+              ? "customer_not_found"
+              : "vehicle_not_found";
+        logDebug("Skip reason", {
+          rowNumber,
+          code,
+          reason: SKIP_REASON_MESSAGES[code],
+          customerIdentity: rowCustomerExternalId(row),
+          vehicleIdentity: rowVehicleExternalId(row),
+        });
         counts.skipped++;
-        samples.skippedRows.push(skipSample(rowNumber, code, repairOrderNumber, invoiceNumber));
+        samples.skippedRows.push(
+          skipSample(rowNumber, code, repairOrderNumber, invoiceNumber),
+        );
         continue;
       }
-      const repairDuplicateKey = repairOrderNumber ? duplicateKey(customer.id, "work_order_number", repairOrderNumber) : null;
-      const invoiceDuplicateKey = invoiceNumber ? duplicateKey(customer.id, "invoice_number", invoiceNumber) : null;
-      const duplicateFound = Boolean((repairDuplicateKey && (existingDuplicateKeys.has(repairDuplicateKey) || batchDuplicateKeys.has(repairDuplicateKey))) || (invoiceDuplicateKey && (existingDuplicateKeys.has(invoiceDuplicateKey) || batchDuplicateKeys.has(invoiceDuplicateKey))));
+      const repairDuplicateKey = repairOrderNumber
+        ? duplicateKey(customer.id, "work_order_number", repairOrderNumber)
+        : null;
+      const invoiceDuplicateKey = invoiceNumber
+        ? duplicateKey(customer.id, "invoice_number", invoiceNumber)
+        : null;
+      const duplicateFound = Boolean(
+        (repairDuplicateKey &&
+          (existingDuplicateKeys.has(repairDuplicateKey) ||
+            batchDuplicateKeys.has(repairDuplicateKey))) ||
+        (invoiceDuplicateKey &&
+          (existingDuplicateKeys.has(invoiceDuplicateKey) ||
+            batchDuplicateKeys.has(invoiceDuplicateKey))),
+      );
       if (duplicateFound) {
         counts.skipped++;
         counts.duplicates++;
-        samples.skippedRows.push(skipSample(rowNumber, "duplicate_history", repairOrderNumber, invoiceNumber));
+        samples.skippedRows.push(
+          skipSample(
+            rowNumber,
+            "duplicate_history",
+            repairOrderNumber,
+            invoiceNumber,
+          ),
+        );
         continue;
       }
       if (repairDuplicateKey) batchDuplicateKeys.add(repairDuplicateKey);
       if (invoiceDuplicateKey) batchDuplicateKeys.add(invoiceDuplicateKey);
       const parts = clean(row.parts);
-      const notes = [clean(row.notes), parts ? `Parts: ${parts}` : null, clean(row.service_category) ? `Service category: ${clean(row.service_category)}` : null].filter(Boolean).join("\n") || null;
-      const description = [clean(row.service_category), clean(row.complaint), clean(row.correction)].filter(Boolean).join(" · ") || "Imported historical service record";
-      payloads.push({ rowNumber, repairOrderNumber, invoiceNumber, payload: { shop_id: shopId, customer_id: customer.id, vehicle_id: vehicle?.id ?? null, service_date: serviceDate, description, notes, work_order_number: repairOrderNumber, invoice_number: invoiceNumber, odometer: num(row.odometer), symptom: clean(row.complaint), cause: clean(row.cause), correction: clean(row.correction), labor_hours: num(row.labor_hours), total: num(row.total), advisor_name: clean(row.advisor), assigned_tech_name: clean(row.technician), historical_status: "imported", source_system: "vehicle_history_csv", source_row_id: String(rowNumber), source_payload: JSON.parse(JSON.stringify({ imported_at: new Date().toISOString(), raw_row: row, service_category: clean(row.service_category), parts: clean(row.parts) })) as DB["public"]["Tables"]["history"]["Insert"]["source_payload"] } });
+      const notes =
+        [
+          clean(row.notes),
+          parts ? `Parts: ${parts}` : null,
+          clean(row.service_category)
+            ? `Service category: ${clean(row.service_category)}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join("\n") || null;
+      const description =
+        [
+          clean(row.service_category),
+          clean(row.complaint),
+          clean(row.correction),
+        ]
+          .filter(Boolean)
+          .join(" · ") || "Imported historical service record";
+      payloads.push({
+        rowNumber,
+        repairOrderNumber,
+        invoiceNumber,
+        payload: {
+          shop_id: shopId,
+          customer_id: customer.id,
+          vehicle_id: vehicle?.id ?? null,
+          service_date: serviceDate,
+          description,
+          notes,
+          work_order_number: repairOrderNumber,
+          invoice_number: invoiceNumber,
+          odometer: num(row.odometer),
+          symptom: clean(row.complaint),
+          cause: clean(row.cause),
+          correction: clean(row.correction),
+          labor_hours: num(row.labor_hours),
+          total: num(row.total),
+          advisor_name: clean(row.advisor),
+          assigned_tech_name: clean(row.technician),
+          historical_status: "imported",
+          source_system: "vehicle_history_csv",
+          source_row_id: String(rowNumber),
+          source_payload: JSON.parse(
+            JSON.stringify({
+              imported_at: new Date().toISOString(),
+              raw_row: row,
+              customer_identity: rowCustomerExternalId(row),
+              vehicle_identity: rowVehicleExternalId(row),
+              service_category: clean(row.service_category),
+              parts: clean(row.parts),
+            }),
+          ) as DB["public"]["Tables"]["history"]["Insert"]["source_payload"],
+        },
+      });
     } catch (error) {
       counts.failed++;
-      samples.failedRows.push({ row: rowNumber, error: error instanceof Error ? error.message : "History row failed to import.", repairOrderNumber, invoiceNumber });
+      samples.failedRows.push({
+        row: rowNumber,
+        error:
+          error instanceof Error
+            ? error.message
+            : "History row failed to import.",
+        repairOrderNumber,
+        invoiceNumber,
+      });
     }
   }
 
   for (const batch of chunkArray(payloads, VEHICLE_HISTORY_IMPORT_BATCH_SIZE)) {
-    const { error } = await supabase.from("history").insert(batch.map((entry) => entry.payload));
+    const { error } = await supabase
+      .from("history")
+      .insert(batch.map((entry) => entry.payload));
     if (error) {
       for (const entry of batch) {
-        const { error: rowError } = await supabase.from("history").insert(entry.payload);
+        const { error: rowError } = await supabase
+          .from("history")
+          .insert(entry.payload);
         if (rowError) {
           counts.failed++;
-          samples.failedRows.push({ row: entry.rowNumber, error: rowError.message, repairOrderNumber: entry.repairOrderNumber, invoiceNumber: entry.invoiceNumber });
+          samples.failedRows.push({
+            row: entry.rowNumber,
+            error: rowError.message,
+            repairOrderNumber: entry.repairOrderNumber,
+            invoiceNumber: entry.invoiceNumber,
+          });
         } else counts.imported++;
       }
     } else counts.imported += batch.length;
@@ -298,7 +1041,7 @@ export async function importVehicleHistoryRowsSynchronously({
 
   return compactImportSummary({
     counts,
-    totalRows: rows.length,
+    totalRows: normalizedRows.length,
     skippedRows: samples.skippedRows,
     failedRows: samples.failedRows,
     sampleLimit: VEHICLE_HISTORY_IMPORT_SAMPLE_LIMIT,

--- a/tests/vehicle-history-identity-aliases.test.ts
+++ b/tests/vehicle-history-identity-aliases.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeVehicleHistoryImportRow,
+  rowCustomerExternalId,
+  rowVehicleExternalId,
+} from "@/features/work-orders/import/normalizeVehicleHistoryImportRow";
+import {
+  resolveCustomer,
+  resolveVehicle,
+} from "@/features/work-orders/server/vehicle-history-import-job";
+
+const customer = {
+  id: "customer-uuid-1",
+  external_id: "CUST-100386",
+  email: null,
+  phone: null,
+  phone_number: null,
+  name: "Customer 100386",
+  business_name: null,
+  first_name: null,
+  last_name: null,
+};
+const vehicle = {
+  id: "vehicle-uuid-1",
+  external_id: "VEH-200055",
+  vin: null,
+  customer_id: customer.id,
+};
+
+function resolver() {
+  return {
+    customersById: new Map([[customer.id, customer]]),
+    customersByExternal: new Map([["cust-100386", customer]]),
+    customersByEmail: new Map(),
+    customersByPhone: new Map(),
+    customersByName: new Map(),
+    vehiclesById: new Map([[vehicle.id, vehicle]]),
+    vehiclesByExternal: new Map([["veh-200055", vehicle]]),
+    vehiclesByVin: new Map(),
+  };
+}
+
+describe("vehicle history import identity aliases", () => {
+  it.each([
+    ["customer_id", "CUST-100386"],
+    ["external_id", "CUST-100386"],
+    ["customer_number", "CUST-100386"],
+    ["customerid", "CUST-100386"],
+    ["customernumber", "CUST-100386"],
+  ])("normalizes and resolves customer alias %s", (header, value) => {
+    const row = normalizeVehicleHistoryImportRow({ [header]: value });
+
+    expect(rowCustomerExternalId(row)).toBe("CUST-100386");
+    expect(resolveCustomer(row, resolver() as never)?.id).toBe(customer.id);
+  });
+
+  it.each([
+    ["vehicle_id", "VEH-200055"],
+    ["vehicle_external_id", "VEH-200055"],
+    ["vehicle_number", "VEH-200055"],
+    ["vehicleid", "VEH-200055"],
+    ["vehiclenumber", "VEH-200055"],
+  ])("normalizes and resolves vehicle alias %s", (header, value) => {
+    const row = normalizeVehicleHistoryImportRow({ [header]: value });
+
+    expect(rowVehicleExternalId(row)).toBe("VEH-200055");
+    expect(resolveVehicle(row, resolver() as never)?.id).toBe(vehicle.id);
+  });
+
+  it.each([
+    ["CUST-100386", "VEH-200055"],
+    ["CUST-101177", "VEH-200168"],
+    ["CUST-101310", "VEH-200187"],
+  ])("preserves skipped-row authoritative ids %s / %s", (cust, veh) => {
+    const row = normalizeVehicleHistoryImportRow({
+      customer_number: cust,
+      vehicle_number: veh,
+    });
+
+    expect(rowCustomerExternalId(row)).toBe(cust);
+    expect(rowVehicleExternalId(row)).toBe(veh);
+  });
+});


### PR DESCRIPTION
### Motivation
- Vehicle history imports were skipping rows because the resolver only considered exact `customer_id`/`vehicle_id` and lost alternative authoritative headers like `external_id`/`customer_number`/`vehicle_number` during parsing. 
- The goal is to preserve and canonicalize all supported identity aliases so history rows resolve to the same customers/vehicles created by the customer importer.

### Description
- Added a dedicated normalizer `features/work-orders/import/normalizeVehicleHistoryImportRow.ts` that maps header aliases to canonical fields and exposes `rowCustomerExternalId()` and `rowVehicleExternalId()` helpers. 
- Updated the API route `app/api/work-orders/history/import/route.ts` and the UI preview `features/work-orders/components/VehicleHistoryCsvImportCard.tsx` to run rows through the new normalizer before validation/submission. 
- Reworked resolver logic in `features/work-orders/server/vehicle-history-import-job.ts` to use the alias-aware helpers and added branch-returning resolver functions (`resolveCustomerWithBranch()` / `resolveVehicleWithBranch()`) and debug logging behind `VEHICLE_HISTORY_IMPORT_DEBUG`/`CUSTOMER_IMPORT_DEBUG`. 
- Normalized rows are now used for duplicate detection, `vehicleWasProvided` checks, source payload recording (now includes `customer_identity` and `vehicle_identity`), and both synchronous and async import paths. 
- Added regression tests `tests/vehicle-history-identity-aliases.test.ts` covering customer and vehicle alias headers and preservation of previously skipped authoritative ids.

### Testing
- Ran targeted unit tests with `pnpm vitest run tests/vehicle-history-identity-aliases.test.ts` and all tests passed (13 tests). 
- Ran type check with `npx tsc --noEmit` and it completed successfully. 
- Files changed: `app/api/work-orders/history/import/route.ts`, `features/work-orders/components/VehicleHistoryCsvImportCard.tsx`, `features/work-orders/import/normalizeVehicleHistoryImportRow.ts`, `features/work-orders/server/vehicle-history-import-job.ts`, and `tests/vehicle-history-identity-aliases.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fa690c1f08328804ab49fe6734d11)