### PR TITLE
Clarify customer CSV skipped rows and disable repeated confirm after completion

### DIFF
--- a/app/api/customers/import/route.ts
+++ b/app/api/customers/import/route.ts
@@ -25,7 +25,7 @@ type CustomerRow = Pick<
   | "customer_since"
   | "updated_at"
 >;
-type CustomerMatch = Pick<CustomerRow, "id"> & {
+type CustomerMatch = Pick<CustomerRow, "id" | "external_id"> & {
   matchedBy?: string;
   matchedValue?: string | null;
 };
@@ -39,8 +39,12 @@ const CUSTOMER_IDENTITY_PAGE_SIZE = 1000;
 
 type ImportRowSummary = {
   customerName: string | null;
+  businessName: string | null;
   email: string | null;
   phone: string | null;
+  detectedExternalId: string | null;
+  detectedCustomerId: string | null;
+  detectedCustomerNumber: string | null;
 };
 
 type SkippedCustomerImportRow = ImportRowSummary & {
@@ -55,6 +59,8 @@ type SkippedCustomerImportRow = ImportRowSummary & {
     | "missing_identity"
     | "existing_customer";
   matchedValue?: string | null;
+  matchedExistingExternalId?: string | null;
+  matchedExistingCustomerId?: string | null;
 };
 
 type FailedCustomerImportRow = ImportRowSummary & {
@@ -175,6 +181,7 @@ async function loadExistingCustomerIdentities(
         if (!byExternalId.has(externalKey)) {
           byExternalId.set(externalKey, {
             id: customer.id,
+            external_id: customer.external_id,
             ...describeIdentityKey(externalKey),
           });
         }
@@ -185,6 +192,7 @@ async function loadExistingCustomerIdentities(
         if (!byFallbackIdentity.has(key))
           byFallbackIdentity.set(key, {
             id: customer.id,
+            external_id: customer.external_id,
             ...describeIdentityKey(key),
           });
       }
@@ -215,9 +223,13 @@ function importRowSummary(
   row: ImportRow,
   normalized?: CustomerInsert | null,
 ): ImportRowSummary {
-  const rawName =
+  const businessName =
     cleanString(row.company_name) ??
     cleanString(row.business_name) ??
+    normalized?.business_name ??
+    null;
+  const rawName =
+    businessName ??
     cleanString(row.display_name) ??
     cleanString(row.name) ??
     [cleanString(row.first_name), cleanString(row.last_name)]
@@ -227,6 +239,7 @@ function importRowSummary(
   const name = rawName || normalized?.name || normalized?.business_name || null;
   return {
     customerName: name || null,
+    businessName,
     email: cleanString(row.email) ?? normalized?.email ?? null,
     phone:
       cleanPhone(row.phone) ??
@@ -236,6 +249,29 @@ function importRowSummary(
       normalized?.phone ??
       normalized?.phone_number ??
       null,
+    detectedExternalId: cleanString(row.external_id),
+    detectedCustomerId: cleanString(row.customer_id),
+    detectedCustomerNumber: cleanString(row.customer_number),
+  };
+}
+
+function matchedExistingDetails(match: CustomerMatch): {
+  matchedExistingExternalId: string | null;
+  matchedExistingCustomerId: string | null;
+} {
+  return {
+    matchedExistingExternalId: match.external_id ?? null,
+    matchedExistingCustomerId: match.id ?? null,
+  };
+}
+
+function noMatchedExistingDetails(): {
+  matchedExistingExternalId: null;
+  matchedExistingCustomerId: null;
+} {
+  return {
+    matchedExistingExternalId: null,
+    matchedExistingCustomerId: null,
   };
 }
 
@@ -295,7 +331,13 @@ function rememberPendingCustomerIdentity(
   key: string,
   rowIndex: number,
 ) {
-  const match = { id: `pending-${rowIndex}`, ...describeIdentityKey(key) };
+  const match = {
+    id: `pending-${rowIndex}`,
+    external_id: key.startsWith("external:")
+      ? (describeIdentityKey(key).matchedValue ?? null)
+      : null,
+    ...describeIdentityKey(key),
+  };
   if (key.startsWith("external:"))
     existingIdentities.byExternalId.set(key, match);
   else existingIdentities.byFallbackIdentity.set(key, match);
@@ -306,7 +348,13 @@ function rememberCreatedCustomerIdentity(
   key: string,
   row: number,
 ) {
-  const match = { id: `created-${row}`, ...describeIdentityKey(key) };
+  const match = {
+    id: `created-${row}`,
+    external_id: key.startsWith("external:")
+      ? (describeIdentityKey(key).matchedValue ?? null)
+      : null,
+    ...describeIdentityKey(key),
+  };
   if (key.startsWith("external:"))
     existingIdentities.byExternalId.set(key, match);
   else existingIdentities.byFallbackIdentity.set(key, match);
@@ -444,6 +492,7 @@ export async function POST(req: Request) {
             reason: "Missing customer name, company, email, and phone.",
             ...importRowSummary(raw as ImportRow),
             matchedBy: "missing_identity",
+            ...noMatchedExistingDetails(),
           });
           continue;
         }
@@ -463,6 +512,7 @@ export async function POST(req: Request) {
             ...importRowSummary(raw as ImportRow, normalized),
             matchedBy: "duplicate_in_csv",
             matchedValue: duplicateMatch.matchedValue,
+            ...noMatchedExistingDetails(),
           });
           continue;
         }
@@ -509,6 +559,7 @@ export async function POST(req: Request) {
             ...importRowSummary(raw as ImportRow, normalized),
             matchedBy,
             matchedValue: existing.matchedValue ?? existing.id,
+            ...matchedExistingDetails(existing),
           });
           continue;
         }
@@ -555,6 +606,7 @@ export async function POST(req: Request) {
               safeError.constraint === "customers_shop_email_uq"
                 ? normalizeEmail(pending.customer.email)
                 : safeError.constraint,
+            ...noMatchedExistingDetails(),
           });
           continue;
         }

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -60,10 +60,16 @@ type SkippedImportRow = {
   row: number;
   reason: string;
   customerName: string | null;
+  businessName?: string | null;
   email: string | null;
   phone: string | null;
   matchedBy: string;
   matchedValue?: string | null;
+  detectedExternalId?: string | null;
+  detectedCustomerId?: string | null;
+  detectedCustomerNumber?: string | null;
+  matchedExistingExternalId?: string | null;
+  matchedExistingCustomerId?: string | null;
 };
 
 type FailedImportRow = {
@@ -132,10 +138,7 @@ const CUSTOMER_IMPORT_DEBUG =
   process.env.NODE_ENV === "development";
 
 const CUSTOMER_ID_HEADER_ALIASES = new Set([
-  "customer_id",
-  "external_id",
   "customerid",
-  "customer_number",
   "customernumber",
   "customer",
 ]);
@@ -265,6 +268,9 @@ export function CustomerCsvImportCard({
     counts.created + counts.updated + counts.skipped > 0 &&
     counts.failed === 0,
   );
+  const importCompleted = Boolean(counts);
+  const canConfirmImport =
+    importableRows.length > 0 && !importing && !importCompleted;
 
   function resetImportState() {
     setRows([]);
@@ -362,6 +368,7 @@ export function CustomerCsvImportCard({
   }
 
   async function confirmImport() {
+    if (importCompleted || importing) return;
     if (!importableRows.length) {
       setImportError(
         "Upload a CSV with at least one customer name, company, email, or phone before importing.",
@@ -637,7 +644,7 @@ export function CustomerCsvImportCard({
       <GuidedImportFooterActions
         importing={importing}
         completing={completingOnboarding}
-        canConfirm={importableRows.length > 0}
+        canConfirm={canConfirmImport}
         onConfirm={() => void confirmImport()}
         isOnboarding={isOnboarding}
         returnTo={guidedQuery?.returnTo}

--- a/features/shared/components/import/CsvImportCompletionSummary.tsx
+++ b/features/shared/components/import/CsvImportCompletionSummary.tsx
@@ -1,6 +1,21 @@
 import { GuidedImportSummary } from "./GuidedImportSummary";
 
-type SampleRow = { row: number; reason?: string; error?: string };
+type SampleRow = {
+  row: number;
+  reason?: string;
+  error?: string;
+  customerName?: string | null;
+  businessName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  matchedBy?: string | null;
+  matchedValue?: string | null;
+  detectedExternalId?: string | null;
+  detectedCustomerId?: string | null;
+  detectedCustomerNumber?: string | null;
+  matchedExistingExternalId?: string | null;
+  matchedExistingCustomerId?: string | null;
+};
 
 type Props = {
   imported: number;
@@ -21,6 +36,33 @@ export function CsvImportCompletionSummary({
   skippedRows = [],
   failedRows = [],
 }: Props) {
+  const describeRow = (item: SampleRow) =>
+    [
+      item.customerName ? `customer: ${item.customerName}` : null,
+      item.businessName ? `business: ${item.businessName}` : null,
+      item.email ? `email: ${item.email}` : null,
+      item.phone ? `phone: ${item.phone}` : null,
+      item.detectedExternalId
+        ? `external_id: ${item.detectedExternalId}`
+        : null,
+      item.detectedCustomerId
+        ? `customer_id: ${item.detectedCustomerId}`
+        : null,
+      item.detectedCustomerNumber
+        ? `customer_number: ${item.detectedCustomerNumber}`
+        : null,
+      item.matchedBy ? `matched_by: ${item.matchedBy}` : null,
+      item.matchedExistingExternalId
+        ? `matched_existing_external_id: ${item.matchedExistingExternalId}`
+        : null,
+      item.matchedExistingCustomerId
+        ? `matched_existing_customer_id: ${item.matchedExistingCustomerId}`
+        : null,
+      item.matchedValue ? `matched_value: ${item.matchedValue}` : null,
+    ]
+      .filter(Boolean)
+      .join("; ");
+
   return (
     <GuidedImportSummary tone={failed > 0 ? "warning" : "success"}>
       <div className="font-semibold">
@@ -33,6 +75,7 @@ export function CsvImportCompletionSummary({
           {skippedRows.slice(0, 5).map((item) => (
             <li key={`skipped-${item.row}-${item.reason}`}>
               Row {item.row}: {item.reason ?? "Skipped"}
+              {describeRow(item) ? ` (${describeRow(item)})` : null}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
### Motivation
- Improve clarity for why rows are skipped during customer CSV import by surfacing detected authoritative IDs and matched existing customer identifiers so operators can prove the decision.  
- Prevent confusion and accidental repeated imports by disabling the “Confirm import” action once an import result exists or while an import is in progress.  
- Root cause: skipped-row payloads lacked diagnostic fields (detected `external_id`/`customer_id`/`customer_number`, business/name/email/phone, and matched-existing IDs) and the UI parser collapsed `external_id`/`customer_number` headers into `customer_id`, which obscured whether rows truly lacked authoritative IDs and allowed the confirm button to remain enabled after completion.

### Description
- Backend: extended skipped-row metadata in `/api/customers/import` to include `customerName`, `businessName`, `email`, `phone`, `detectedExternalId`, `detectedCustomerId`, `detectedCustomerNumber`, `matchedBy`, `matchedValue`, `matchedExistingExternalId`, and `matchedExistingCustomerId`; preserved `external_id` on loaded identity maps so responses can include matched existing external IDs. (file: `app/api/customers/import/route.ts`)
- Backend: added helper functions `matchedExistingDetails` and `noMatchedExistingDetails`, and ensured all skipped/duplicate/duplicate-constraint cases attach the richer diagnostic fields. (file: `app/api/customers/import/route.ts`)
- Frontend parser: stopped collapsing `external_id` and `customer_number` into `customer_id` so detected authoritative headers are preserved in parsed rows. (file: `features/customers/components/CustomerCsvImportCard.tsx`)
- Frontend UX: added `importCompleted`/`canConfirmImport` guard and a short-circuit in `confirmImport` so the confirm button is disabled/ignored when an import result is present or while importing. (file: `features/customers/components/CustomerCsvImportCard.tsx`)
- UI: upgraded `CsvImportCompletionSummary` to render richer skipped-row diagnostics (customer/business/email/phone, detected authoritative IDs, match source, matched existing IDs and matched value) for easier triage. (file: `features/shared/components/import/CsvImportCompletionSummary.tsx`)
- Files changed: `app/api/customers/import/route.ts`, `features/customers/components/CustomerCsvImportCard.tsx`, `features/shared/components/import/CsvImportCompletionSummary.tsx`.

### Testing
- Ran type check with `npm run typecheck`; result: success (no TypeScript errors).  
- Ran lint on the affected files with `npx eslint app/api/customers/import/route.ts features/customers/components/CustomerCsvImportCard.tsx --ext .ts,.tsx`; result: success (no lint errors).  
- Ran unit tests `npx vitest run tests/customer-csv-import-identity-matching.test.ts`; result: all tests passed (7 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fab6c07f0832882b4923797e779ab)