### PR TITLE
Fix vehicle CSV identity hierarchy

### DIFF
--- a/features/vehicles/server/vehicle-import-job.ts
+++ b/features/vehicles/server/vehicle-import-job.ts
@@ -52,6 +52,13 @@ function normalizeRow(row: VehicleImportRow, shopId: string, customers: Customer
 }
 function pushUnique(values: string[], value: string | null | undefined) { if (value && !values.includes(value)) values.push(value); }
 function addMatch(index: Map<string, VehicleMatch>, field: "external_id" | "vin" | "unit_number" | "license_plate", vehicle: VehicleMatch) { const value = vehicle[field]; if (value && !index.has(`${field}:${value}`)) index.set(`${field}:${value}`, vehicle); }
+export function getVehicleAuthoritativeIdentity(vehicle: Pick<VehicleInsert, "external_id" | "vin" | "license_plate" | "unit_number">): string | null {
+  if (vehicle.external_id) return `external_id:${vehicle.external_id}`;
+  if (vehicle.vin) return `vin:${vehicle.vin}`;
+  if (vehicle.license_plate) return `license_plate:${vehicle.license_plate}`;
+  if (vehicle.unit_number) return `unit_number:${vehicle.unit_number}`;
+  return null;
+}
 async function loadExistingVehicleIndex(supabase: SupabaseClient<DB>, shopId: string, normalizedRows: VehicleInsert[]): Promise<Map<string, VehicleMatch>> {
   const values = { external_id: [] as string[], vin: [] as string[], unit_number: [] as string[], license_plate: [] as string[] };
   for (const row of normalizedRows) { pushUnique(values.external_id, row.external_id); pushUnique(values.vin, row.vin); pushUnique(values.unit_number, row.unit_number); pushUnique(values.license_plate, row.license_plate); }
@@ -70,7 +77,8 @@ async function loadExistingVehicleIndex(supabase: SupabaseClient<DB>, shopId: st
   return index;
 }
 function findExistingVehicleInIndex(index: Map<string, VehicleMatch>, normalized: VehicleInsert): VehicleMatch | null {
-  return (normalized.external_id ? index.get(`external_id:${normalized.external_id}`) : null) ?? (normalized.vin ? index.get(`vin:${normalized.vin}`) : null) ?? (normalized.unit_number ? index.get(`unit_number:${normalized.unit_number}`) : null) ?? (normalized.license_plate ? index.get(`license_plate:${normalized.license_plate}`) : null) ?? null;
+  const identity = getVehicleAuthoritativeIdentity(normalized);
+  return identity ? index.get(identity) ?? null : null;
 }
 function updatePayload(normalized: VehicleInsert): VehicleUpdate { return omitNullishVehicleUpdate({ unit_number: normalized.unit_number, vin: normalized.vin, license_plate: normalized.license_plate, state_province: normalized.state_province, year: normalized.year, make: normalized.make, model: normalized.model, customer_id: normalized.customer_id, external_id: normalized.external_id, submodel: normalized.submodel, color: normalized.color, mileage: normalized.mileage, odometer_unit: normalized.odometer_unit, engine: normalized.engine, fuel_type: normalized.fuel_type, drivetrain: normalized.drivetrain, body_type: normalized.body_type, asset_type: normalized.asset_type, status: normalized.status, purchase_date: normalized.purchase_date, in_service_date: normalized.in_service_date, last_service_date: normalized.last_service_date, tags: normalized.tags, notes: normalized.notes, import_notes: normalized.import_notes }); }
 
@@ -92,20 +100,14 @@ export async function processVehicleImportRows(supabase: SupabaseClient<DB>, sho
     }
 
     const vehicle = normalizedResult.vehicle;
-    const identityKeys = [
-      vehicle.external_id ? `external_id:${vehicle.external_id}` : null,
-      vehicle.vin ? `vin:${vehicle.vin}` : null,
-      vehicle.unit_number ? `unit_number:${vehicle.unit_number}` : null,
-      vehicle.license_plate ? `license_plate:${vehicle.license_plate}` : null,
-    ].filter(Boolean) as string[];
-    const duplicateKey = identityKeys.find((key) => seenIdentities.has(key));
-    if (duplicateKey) {
+    const identityKey = getVehicleAuthoritativeIdentity(vehicle);
+    if (identityKey && seenIdentities.has(identityKey)) {
       counts.duplicates += 1;
       counts.skipped += 1;
-      skippedRows.push({ row: rowNumber, reason: `Duplicate vehicle identity within this CSV (${duplicateKey}).` });
+      skippedRows.push({ row: rowNumber, reason: `Duplicate vehicle identity within this CSV (${identityKey}).` });
       continue;
     }
-    identityKeys.forEach((key) => seenIdentities.add(key));
+    if (identityKey) seenIdentities.add(identityKey);
     normalizedRows.push({ rowNumber, vehicle });
   }
 

--- a/tests/vehicle-csv-import-route.test.ts
+++ b/tests/vehicle-csv-import-route.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { processVehicleImportRows } from "@/features/vehicles/server/vehicle-import-job";
 import { describe, expect, it } from "vitest";
 
 const routeSource = () =>
@@ -200,5 +201,134 @@ describe("guided CSV import progress UI", () => {
       'summary: { importType: "vehicle_csv", ...nextCounts }',
     );
     expect(vehicleSource).toContain("payload.error ??");
+  });
+});
+
+type VehicleRecord = {
+  id: string;
+  shop_id: string;
+  external_id?: string | null;
+  vin?: string | null;
+  unit_number?: string | null;
+  license_plate?: string | null;
+  make?: string | null;
+  model?: string | null;
+};
+
+function createVehicleImportSupabase(existingVehicles: VehicleRecord[] = []) {
+  const vehicles = [...existingVehicles];
+  const updates: Array<{ id: string; payload: Record<string, unknown> }> = [];
+
+  const from = (table: string) => {
+    if (table === "customers") {
+      return {
+        select: () => ({
+          eq: () => ({
+            range: async () => ({ data: [], error: null }),
+          }),
+        }),
+      };
+    }
+
+    if (table !== "vehicles") throw new Error(`Unexpected table ${table}`);
+
+    return {
+      select: () => {
+        const filters: Record<string, unknown> = {};
+        return {
+          eq(field: string, value: unknown) {
+            filters[field] = value;
+            return this;
+          },
+          async in(field: keyof VehicleRecord, values: unknown[]) {
+            return {
+              data: vehicles.filter((vehicle) => vehicle.shop_id === filters.shop_id && values.includes(vehicle[field])),
+              error: null,
+            };
+          },
+        };
+      },
+      update(payload: Record<string, unknown>) {
+        const filters: Record<string, unknown> = {};
+        return {
+          eq(field: string, value: unknown) {
+            filters[field] = value;
+            if (filters.id && filters.shop_id) {
+              const vehicle = vehicles.find((entry) => entry.id === filters.id && entry.shop_id === filters.shop_id);
+              if (vehicle) Object.assign(vehicle, payload);
+              updates.push({ id: String(filters.id), payload });
+              return Promise.resolve({ error: null });
+            }
+            return this;
+          },
+        };
+      },
+      async insert(payload: VehicleRecord[]) {
+        vehicles.push(...payload.map((vehicle, index) => ({ ...vehicle, id: vehicle.id ?? `inserted-${vehicles.length + index + 1}` })));
+        return { error: null };
+      },
+    };
+  };
+
+  return { supabase: { from }, vehicles, updates };
+}
+
+describe("vehicle CSV import duplicate identity hierarchy", () => {
+  it("imports two rows with different vehicle_id values and the same unit_number", async () => {
+    const { supabase } = createVehicleImportSupabase();
+
+    const summary = await processVehicleImportRows(supabase as never, "shop-1", [
+      { vehicle_id: "veh-1", unit_number: "UNIT-617", make: "Ford", model: "F-150" },
+      { vehicle_id: "veh-2", unit_number: "UNIT-617", make: "Ford", model: "F-250" },
+    ]);
+
+    expect(summary.counts.created).toBe(2);
+    expect(summary.counts.duplicates).toBe(0);
+    expect(summary.counts.skipped).toBe(0);
+  });
+
+  it("dedupes two rows with no vehicle_id and the same unit_number", async () => {
+    const { supabase } = createVehicleImportSupabase();
+
+    const summary = await processVehicleImportRows(supabase as never, "shop-1", [
+      { unit_number: "UNIT-617", make: "Ford", model: "F-150" },
+      { unit_number: "UNIT-617", make: "Ford", model: "F-250" },
+    ]);
+
+    expect(summary.counts.created).toBe(1);
+    expect(summary.counts.duplicates).toBe(1);
+    expect(summary.counts.skipped).toBe(1);
+    expect(summary.skippedRows[0]).toMatchObject({ reason: "Duplicate vehicle identity within this CSV (unit_number:UNIT-617)." });
+  });
+
+  it("dedupes two rows with the same vehicle_id", async () => {
+    const { supabase } = createVehicleImportSupabase();
+
+    const summary = await processVehicleImportRows(supabase as never, "shop-1", [
+      { vehicle_id: "veh-1", unit_number: "UNIT-617", make: "Ford", model: "F-150" },
+      { vehicle_id: "veh-1", unit_number: "UNIT-999", make: "Ford", model: "F-250" },
+    ]);
+
+    expect(summary.counts.created).toBe(1);
+    expect(summary.counts.duplicates).toBe(1);
+    expect(summary.skippedRows[0]).toMatchObject({ reason: "Duplicate vehicle identity within this CSV (external_id:veh-1)." });
+  });
+
+  it("updates by external_id even if unit_number collides with another vehicle", async () => {
+    const { supabase, vehicles, updates } = createVehicleImportSupabase([
+      { id: "target", shop_id: "shop-1", external_id: "veh-1", unit_number: "UNIT-OLD", make: "Ford", model: "F-150" },
+      { id: "unit-collision", shop_id: "shop-1", external_id: "veh-2", unit_number: "UNIT-617", make: "Ford", model: "F-250" },
+    ]);
+
+    const summary = await processVehicleImportRows(supabase as never, "shop-1", [
+      { vehicle_id: "veh-1", unit_number: "UNIT-617", make: "Ford", model: "Updated" },
+    ]);
+
+    expect(summary.counts.updated).toBe(1);
+    expect(summary.counts.created).toBe(0);
+    expect(updates).toHaveLength(1);
+    expect(updates[0].id).toBe("target");
+    expect(vehicles.find((vehicle) => vehicle.id === "target")?.model).toBe("Updated");
+    expect(vehicles.find((vehicle) => vehicle.id === "unit-collision")?.model).toBe("F-250");
   });
 });


### PR DESCRIPTION
### Motivation
- The CSV vehicle importer treated all populated identity fields as equally authoritative, causing rows with a unique `vehicle_id`/`external_id` to be skipped when a weaker field like `unit_number` repeated. 
- The intended import hierarchy is that `vehicle_id`/`external_id` is authoritative, falling back to `vin`, then `license_plate`, then `unit_number` only when higher-priority values are absent.

### Description
- Added `getVehicleAuthoritativeIdentity()` which returns a single prioritized identity key (`external_id:<value>`, then `vin:<value>`, then `license_plate:<value>`, then `unit_number:<value>`) and exported it for clarity. 
- Replaced same-CSV duplicate detection to use only the single authoritative identity key per row when tracking `seenIdentities`. 
- Updated `findExistingVehicleInIndex()` to resolve existing matches using the same authoritative identity and to avoid falling back from `external_id` to other fields when `external_id` is present. 
- Kept `loadExistingVehicleIndex()` broad (preloads `external_id`, `vin`, `unit_number`, `license_plate`) while making the in-memory matching hierarchy-aware, and added regression tests covering the new behavior.

### Testing
- Ran `npm run typecheck` and it passed without errors. 
- Linted the modified file with `npx eslint features/vehicles/server/vehicle-import-job.ts --ext .ts,.tsx` and it reported no issues. 
- Executed `npx vitest run tests/vehicle-csv-import-route.test.ts` and all tests passed (15 tests). 
- Files changed: `features/vehicles/server/vehicle-import-job.ts`, `tests/vehicle-csv-import-route.test.ts`; Commit: `d2d220c3dc6f0139d6ac71458f68da05a61a12bd`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc25136308328af9a13e1ddfa436a)