### PR TITLE
Fix historical invoice CSV import lookups

### DIFF
--- a/app/api/invoices/import/route.ts
+++ b/app/api/invoices/import/route.ts
@@ -5,32 +5,73 @@ import {
   importInvoiceRowsSynchronously,
   INVOICE_IMPORT_MAX_ROWS,
 } from "@/features/billing/server/invoice-import-job";
-
-type InvoiceImportRow = Record<string, unknown>;
+import {
+  normalizeInvoiceImportRow,
+  type InvoiceImportRow,
+} from "@/features/billing/lib/invoice-import-normalizer";
 
 export async function POST(req: Request) {
   try {
-    const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin", "manager", "advisor"] });
+    const access = await requireShopScopedApiAccess({
+      allowRoles: ["owner", "admin", "manager", "advisor"],
+    });
     if (!access.ok) return access.response;
-    if (!(req.headers.get("content-type")?.toLowerCase() ?? "").includes("multipart/form-data")) {
-      return NextResponse.json({ error: "Invoice import requires multipart/form-data with a CSV file field." }, { status: 415 });
+    if (
+      !(req.headers.get("content-type")?.toLowerCase() ?? "").includes(
+        "multipart/form-data",
+      )
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Invoice import requires multipart/form-data with a CSV file field.",
+        },
+        { status: 415 },
+      );
     }
 
     const formData = await req.formData();
     let parsed;
     try {
-      parsed = await parseCsvFileFromFormData<InvoiceImportRow>({ formData, maxRows: INVOICE_IMPORT_MAX_ROWS });
+      parsed = await parseCsvFileFromFormData<InvoiceImportRow>({
+        formData,
+        maxRows: INVOICE_IMPORT_MAX_ROWS,
+      });
     } catch (error) {
-      return NextResponse.json({ error: error instanceof Error ? error.message : "Unable to parse invoice CSV." }, { status: 400 });
+      return NextResponse.json(
+        {
+          error:
+            error instanceof Error
+              ? error.message
+              : "Unable to parse invoice CSV.",
+        },
+        { status: 400 },
+      );
     }
 
     const { supabase, profile } = access;
     const shopId = profile.shop_id;
-    if (!shopId) return NextResponse.json({ error: "No active shop is selected." }, { status: 400 });
+    if (!shopId)
+      return NextResponse.json(
+        { error: "No active shop is selected." },
+        { status: 400 },
+      );
 
-    const result = await importInvoiceRowsSynchronously({ supabase, shopId, rows: parsed.rows });
+    const result = await importInvoiceRowsSynchronously({
+      supabase,
+      shopId,
+      rows: parsed.rows.map(normalizeInvoiceImportRow),
+    });
     return NextResponse.json({ ok: true, ...result });
   } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Unable to import invoice CSV." }, { status: 500 });
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to import invoice CSV.",
+      },
+      { status: 500 },
+    );
   }
 }

--- a/features/billing/components/InvoiceCsvImportCard.tsx
+++ b/features/billing/components/InvoiceCsvImportCard.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
@@ -14,42 +20,14 @@ import {
 } from "@/features/shared/components/import/CsvImportProgress";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import {
+  cleanInvoiceImportHeader,
+  getInvoiceNumber,
+  INVOICE_IMPORT_SUPPORTED_COLUMNS,
+  normalizeInvoiceImportRow,
+  type InvoiceImportRow,
+} from "@/features/billing/lib/invoice-import-normalizer";
 
-type InvoiceImportRow = {
-  invoice_id?: string | null;
-  invoice_number?: string | null;
-  work_order_number?: string | null;
-  customer_id?: string | null;
-  customer_email?: string | null;
-  customer_phone?: string | null;
-  customer_name?: string | null;
-  customer?: string | null;
-  email?: string | null;
-  phone?: string | null;
-  name?: string | null;
-  vehicle_id?: string | null;
-  vin?: string | null;
-  invoice_date?: string | null;
-  due_date?: string | null;
-  paid_date?: string | null;
-  status?: string | null;
-  payment_status?: string | null;
-  service_category?: string | null;
-  description?: string | null;
-  labor_hours?: string | null;
-  labor_total?: string | null;
-  parts_total?: string | null;
-  shop_supplies?: string | null;
-  subtotal?: string | null;
-  tax?: string | null;
-  total?: string | null;
-  amount_paid?: string | null;
-  balance_due?: string | null;
-  advisor?: string | null;
-  technician?: string | null;
-  notes?: string | null;
-  source_system?: string | null;
-};
 type ImportCounts = {
   imported: number;
   updated: number;
@@ -75,63 +53,8 @@ type ImportResponse = {
     workOrderNumber: string | null;
   }>;
 };
-const SUPPORTED_COLUMNS = [
-  "invoice_id",
-  "invoice_number",
-  "work_order_number",
-  "customer_id",
-  "customer_email",
-  "customer_phone",
-  "customer_name",
-  "customer",
-  "email",
-  "phone",
-  "name",
-  "vehicle_id",
-  "vin",
-  "invoice_date",
-  "due_date",
-  "paid_date",
-  "status",
-  "payment_status",
-  "service_category",
-  "description",
-  "labor_hours",
-  "labor_total",
-  "parts_total",
-  "shop_supplies",
-  "subtotal",
-  "tax",
-  "total",
-  "amount_paid",
-  "balance_due",
-  "advisor",
-  "technician",
-  "notes",
-  "source_system",
-] as const;
-const RECOMMENDED_COLUMNS = SUPPORTED_COLUMNS.join(", ");
+const RECOMMENDED_COLUMNS = INVOICE_IMPORT_SUPPORTED_COLUMNS.join(", ");
 const SAMPLE = `${RECOMMENDED_COLUMNS}\nLEG-INV-1001,INV-1001,RO-1001,CUST-1001,avery@example.com,555-0101,Avery Customer,Avery Customer,avery@example.com,555-0101,Avery Customer,VEH-2001,1HGCM82633A004352,2024-03-18,2024-04-17,2024-03-20,closed,paid,Brakes,Front brake service,2.4,360.00,240.00,18.00,618.00,30.90,648.90,648.90,0.00,Avery Advisor,Sam Tech,Imported paid invoice,Legacy DMS`;
-function cleanHeader(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, "_")
-    .replace(/[^a-z0-9_]/g, "");
-}
-function cleanCell(value: unknown): string | null {
-  const text = String(value ?? "").trim();
-  return text.length ? text : null;
-}
-function normalizeParsedRow(row: Record<string, unknown>): InvoiceImportRow {
-  const normalized: InvoiceImportRow = {};
-  for (const [header, value] of Object.entries(row)) {
-    const key = cleanHeader(header);
-    if (!(SUPPORTED_COLUMNS as readonly string[]).includes(key)) continue;
-    normalized[key as keyof InvoiceImportRow] = cleanCell(value);
-  }
-  return normalized;
-}
 function hasValidDate(row: InvoiceImportRow): boolean {
   return Boolean(
     row.invoice_date && !Number.isNaN(new Date(row.invoice_date).getTime()),
@@ -144,8 +67,7 @@ function validOptionalNumber(value: string | null | undefined): boolean {
 function localValidation(row: InvoiceImportRow): string | null {
   if (!hasValidDate(row))
     return "invoice_date is required and must be a valid date";
-  if (!row.invoice_number && !row.invoice_id)
-    return "invoice_number or invoice_id is required";
+  if (!getInvoiceNumber(row)) return "invoice_number or invoice_id is required";
   for (const field of [
     "labor_hours",
     "labor_total",
@@ -236,10 +158,12 @@ export function InvoiceCsvImportCard({
       skipEmptyLines: true,
       complete: (results) => {
         const parsed = (results.data ?? [])
-          .map(normalizeParsedRow)
+          .map(normalizeInvoiceImportRow)
           .filter((row) => Object.keys(row).length > 0);
         setHeaders(
-          (results.meta.fields ?? []).map(cleanHeader).filter(Boolean),
+          (results.meta.fields ?? [])
+            .map(cleanInvoiceImportHeader)
+            .filter(Boolean),
         );
         setRows(parsed);
         setProgress({
@@ -335,7 +259,11 @@ export function InvoiceCsvImportCard({
         percent: 100,
       });
       setImporting(false);
-      if (isOnboarding && payload.counts.imported > 0 && payload.counts.failed === 0)
+      if (
+        isOnboarding &&
+        payload.counts.imported > 0 &&
+        payload.counts.failed === 0
+      )
         await completeOnboardingAfterImport(payload.counts);
       if (payload.counts.imported > 0) onImported?.();
     } catch (error) {
@@ -486,7 +414,9 @@ export function InvoiceCsvImportCard({
       <GuidedImportFooterActions
         importing={importing}
         completing={completingOnboarding}
-        canConfirm={Boolean(file && importableRows.length > 0)}
+        canConfirm={Boolean(
+          file && importableRows.length > 0 && !response?.counts,
+        )}
         onConfirm={() => void confirmImport()}
         isOnboarding={isOnboarding}
         returnTo={guidedQuery?.returnTo}

--- a/features/billing/lib/invoice-import-normalizer.ts
+++ b/features/billing/lib/invoice-import-normalizer.ts
@@ -1,0 +1,180 @@
+export type InvoiceImportRow = {
+  invoice_id?: string | null;
+  imported_invoice_id?: string | null;
+  invoice_number?: string | null;
+  work_order_number?: string | null;
+  customer_id?: string | null;
+  external_id?: string | null;
+  customer_number?: string | null;
+  customerid?: string | null;
+  customernumber?: string | null;
+  customer_email?: string | null;
+  customer_phone?: string | null;
+  customer_name?: string | null;
+  customer?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  name?: string | null;
+  vehicle_id?: string | null;
+  vehicle_external_id?: string | null;
+  vehicle_number?: string | null;
+  vehicleid?: string | null;
+  vehiclenumber?: string | null;
+  vin?: string | null;
+  invoice_date?: string | null;
+  due_date?: string | null;
+  paid_date?: string | null;
+  status?: string | null;
+  payment_status?: string | null;
+  service_category?: string | null;
+  description?: string | null;
+  labor_hours?: string | null;
+  labor_total?: string | null;
+  parts_total?: string | null;
+  shop_supplies?: string | null;
+  subtotal?: string | null;
+  tax?: string | null;
+  total?: string | null;
+  amount_paid?: string | null;
+  balance_due?: string | null;
+  advisor?: string | null;
+  technician?: string | null;
+  notes?: string | null;
+  source_system?: string | null;
+};
+
+export const INVOICE_IMPORT_SUPPORTED_COLUMNS = [
+  "invoice_id",
+  "imported_invoice_id",
+  "invoice_number",
+  "work_order_number",
+  "customer_id",
+  "external_id",
+  "customer_number",
+  "customerid",
+  "customernumber",
+  "customer_email",
+  "customer_phone",
+  "customer_name",
+  "customer",
+  "email",
+  "phone",
+  "name",
+  "vehicle_id",
+  "vehicle_external_id",
+  "vehicle_number",
+  "vehicleid",
+  "vehiclenumber",
+  "vin",
+  "invoice_date",
+  "due_date",
+  "paid_date",
+  "status",
+  "payment_status",
+  "service_category",
+  "description",
+  "labor_hours",
+  "labor_total",
+  "parts_total",
+  "shop_supplies",
+  "subtotal",
+  "tax",
+  "total",
+  "amount_paid",
+  "balance_due",
+  "advisor",
+  "technician",
+  "notes",
+  "source_system",
+] as const;
+
+const HEADER_ALIASES: Record<string, keyof InvoiceImportRow> = {
+  importedinvoiceid: "imported_invoice_id",
+  imported_invoice_id: "imported_invoice_id",
+  source_invoice_id: "imported_invoice_id",
+  sourceinvoiceid: "imported_invoice_id",
+  invoiceid: "invoice_id",
+  invoice_id: "invoice_id",
+  invoicenumber: "invoice_number",
+  invoice_number: "invoice_number",
+  workordernumber: "work_order_number",
+  work_order_number: "work_order_number",
+  ro_number: "work_order_number",
+  ronumber: "work_order_number",
+  customerid: "customerid",
+  customer_id: "customer_id",
+  externalid: "external_id",
+  external_id: "external_id",
+  customernumber: "customernumber",
+  customer_number: "customer_number",
+  vehicleid: "vehicleid",
+  vehicle_id: "vehicle_id",
+  vehicleexternalid: "vehicle_external_id",
+  vehicle_external_id: "vehicle_external_id",
+  vehiclenumber: "vehiclenumber",
+  vehicle_number: "vehicle_number",
+};
+
+export function cleanInvoiceImportHeader(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-z0-9_]/g, "");
+}
+export function cleanInvoiceImportCell(value: unknown): string | null {
+  const text = String(value ?? "").trim();
+  return text.length ? text : null;
+}
+export function normalizeInvoiceImportRow(
+  row: Record<string, unknown>,
+): InvoiceImportRow {
+  const normalized: InvoiceImportRow = {};
+  for (const [header, value] of Object.entries(row)) {
+    const cleaned = cleanInvoiceImportHeader(header);
+    const aliasKey = cleaned.replace(/_/g, "");
+    const canonical =
+      HEADER_ALIASES[cleaned] ?? HEADER_ALIASES[aliasKey] ?? cleaned;
+    if (
+      !(INVOICE_IMPORT_SUPPORTED_COLUMNS as readonly string[]).includes(
+        canonical,
+      )
+    )
+      continue;
+    normalized[canonical as keyof InvoiceImportRow] =
+      cleanInvoiceImportCell(value);
+  }
+  return normalized;
+}
+export function getInvoiceSourceId(
+  row: InvoiceImportRow | Record<string, unknown>,
+): string | null {
+  return cleanInvoiceImportCell(row.imported_invoice_id ?? row.invoice_id);
+}
+export function getInvoiceNumber(
+  row: InvoiceImportRow | Record<string, unknown>,
+): string | null {
+  return cleanInvoiceImportCell(row.invoice_number) ?? getInvoiceSourceId(row);
+}
+export function getCustomerAuthoritativeId(
+  row: InvoiceImportRow | Record<string, unknown>,
+): string | null {
+  return cleanInvoiceImportCell(
+    row.customer_id ??
+      row.external_id ??
+      row.customer_number ??
+      row.customerid ??
+      row.customernumber,
+  );
+}
+export function getVehicleAuthoritativeId(
+  row: InvoiceImportRow | Record<string, unknown>,
+): string | null {
+  return cleanInvoiceImportCell(
+    row.vehicle_id ??
+      row.vehicle_external_id ??
+      row.vehicle_number ??
+      row.vehicleid ??
+      row.vehiclenumber,
+  );
+}

--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -1,13 +1,20 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { chunkArray } from "@/features/shared/lib/import/csv";
+import {
+  getCustomerAuthoritativeId,
+  getInvoiceNumber,
+  getInvoiceSourceId,
+  getVehicleAuthoritativeId,
+  normalizeInvoiceImportRow,
+  type InvoiceImportRow,
+} from "@/features/billing/lib/invoice-import-normalizer";
 
 type DB = Database;
 export const INVOICE_IMPORT_BATCH_SIZE = 1000;
 export const INVOICE_IMPORT_SAMPLE_LIMIT = 25;
 export const INVOICE_IMPORT_MAX_ROWS = 20_000;
 
-type InvoiceImportRow = Record<string, unknown>;
 type JobRow = {
   id: string;
   shop_id: string;
@@ -58,6 +65,15 @@ type ExistingInvoiceMatch = {
   invoice_number?: string | null;
   metadata?: Record<string, unknown> | null;
 };
+
+const INVOICE_IMPORT_DEBUG =
+  process.env.INVOICE_IMPORT_DEBUG === "1" ||
+  process.env.INVOICE_IMPORT_DEBUG === "true";
+
+function debugInvoiceImport(event: string, details: Record<string, unknown>) {
+  if (!INVOICE_IMPORT_DEBUG) return;
+  console.info(`[invoice-import] ${event}`, details);
+}
 
 const clean = (value: unknown) => {
   const text = String(value ?? "").trim();
@@ -143,7 +159,7 @@ export function resolveInvoiceImportCustomer(
   row: InvoiceImportRow,
   customerLookupMaps: CustomerLookupMaps,
 ) {
-  const legacyCustomerId = clean(row.customer_id);
+  const legacyCustomerId = getCustomerAuthoritativeId(row);
   const customerByLegacyId = legacyCustomerId
     ? (customerLookupMaps.byExternalId.get(legacyCustomerId) ??
       customerLookupMaps.byExternalIdKey.get(key(legacyCustomerId)!) ??
@@ -161,15 +177,16 @@ export function resolveInvoiceImportCustomer(
   const customerByName = customerNameKey
     ? (customerLookupMaps.byName.get(customerNameKey) ?? null)
     : null;
-  const customer =
-    customerByLegacyId ?? customerByEmail ?? customerByPhone ?? customerByName;
+  const customer = legacyCustomerId
+    ? customerByLegacyId
+    : (customerByEmail ?? customerByPhone ?? customerByName);
   const customerMatchSource = customerByLegacyId
     ? "customer_external_id"
-    : customerByEmail
+    : !legacyCustomerId && customerByEmail
       ? "email"
-      : customerByPhone
+      : !legacyCustomerId && customerByPhone
         ? "phone"
-        : customerByName
+        : !legacyCustomerId && customerByName
           ? "name"
           : null;
 
@@ -183,18 +200,61 @@ export function resolveInvoiceImportCustomer(
   };
 }
 
-function postgrestInList(values: Iterable<string>) {
-  return Array.from(values)
-    .map(
-      (value) => `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`,
-    )
-    .join(",");
-}
-
 function importedInvoiceId(
   metadata: Record<string, unknown> | null | undefined,
 ) {
   return clean(metadata?.imported_invoice_id);
+}
+
+async function fetchHistoricalInvoiceCsvMatches(
+  client: SupabaseClient,
+  shopId: string,
+  invoiceNumbers: Set<string>,
+  sourceIds: Set<string>,
+) {
+  const historicalBySourceId = new Map<string, ExistingInvoiceMatch>();
+  const historicalByInvoiceNumber = new Map<string, ExistingInvoiceMatch>();
+  const wantedSourceIds = new Set(
+    Array.from(sourceIds).map((value) => value.toLowerCase()),
+  );
+  const wantedInvoiceNumbers = new Set(
+    Array.from(invoiceNumbers).map((value) => value.toLowerCase()),
+  );
+  const pageSize = 1000;
+
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await client
+      .from("invoices")
+      .select("id, invoice_number, metadata")
+      .eq("shop_id", shopId)
+      .contains("metadata", { import_type: "invoice_csv" })
+      .range(from, from + pageSize - 1);
+    if (error) throw error;
+
+    const rows = (data ?? []) as ExistingInvoiceMatch[];
+    for (const invoice of rows) {
+      const sourceId = importedInvoiceId(invoice.metadata);
+      if (
+        sourceId &&
+        wantedSourceIds.has(sourceId.toLowerCase()) &&
+        !historicalBySourceId.has(sourceId)
+      ) {
+        historicalBySourceId.set(sourceId, invoice);
+      }
+      const invoiceNumber = clean(invoice.invoice_number);
+      if (
+        invoiceNumber &&
+        wantedInvoiceNumbers.has(invoiceNumber.toLowerCase()) &&
+        !historicalByInvoiceNumber.has(invoiceNumber)
+      ) {
+        historicalByInvoiceNumber.set(invoiceNumber, invoice);
+      }
+    }
+
+    if (rows.length < pageSize) break;
+  }
+
+  return { historicalBySourceId, historicalByInvoiceNumber };
 }
 
 async function fetchBatchInvoiceMatches(
@@ -203,60 +263,31 @@ async function fetchBatchInvoiceMatches(
   invoiceNumbers: Set<string>,
   sourceIds: Set<string>,
 ) {
-  const historicalBySourceId = new Map<string, ExistingInvoiceMatch>();
-  const historicalByInvoiceNumber = new Map<string, ExistingInvoiceMatch>();
   const liveCollisionsByInvoiceNumber = new Map<string, ExistingInvoiceMatch>();
+  const { historicalBySourceId, historicalByInvoiceNumber } =
+    await fetchHistoricalInvoiceCsvMatches(
+      client,
+      shopId,
+      invoiceNumbers,
+      sourceIds,
+    );
 
-  const historicalFilters = [
-    sourceIds.size
-      ? `metadata->>imported_invoice_id.in.(${postgrestInList(sourceIds)})`
-      : null,
-    invoiceNumbers.size
-      ? `invoice_number.in.(${postgrestInList(invoiceNumbers)})`
-      : null,
-  ].filter(Boolean);
+  for (const chunk of chunkArray(Array.from(invoiceNumbers), 100)) {
+    const { data: liveRows, error: liveError } = chunk.length
+      ? await client
+          .from("invoices")
+          .select("id, invoice_number, metadata")
+          .eq("shop_id", shopId)
+          .in("invoice_number", chunk)
+      : { data: [], error: null };
+    if (liveError) throw liveError;
 
-  const historicalQuery = historicalFilters.length
-    ? client
-        .from("invoices")
-        .select("id, invoice_number, metadata")
-        .eq("shop_id", shopId)
-        .contains("metadata", { import_type: "invoice_csv" })
-        .or(historicalFilters.join(","))
-    : Promise.resolve({ data: [], error: null });
-
-  const liveQuery = invoiceNumbers.size
-    ? client
-        .from("invoices")
-        .select("id, invoice_number, metadata")
-        .eq("shop_id", shopId)
-        .in("invoice_number", Array.from(invoiceNumbers))
-    : Promise.resolve({ data: [], error: null });
-
-  const [
-    { data: historicalRows, error: historicalError },
-    { data: liveRows, error: liveError },
-  ] = await Promise.all([historicalQuery, liveQuery]);
-
-  if (historicalError) throw historicalError;
-  if (liveError) throw liveError;
-
-  for (const invoice of (historicalRows ?? []) as ExistingInvoiceMatch[]) {
-    const sourceId = importedInvoiceId(invoice.metadata);
-    if (sourceId && !historicalBySourceId.has(sourceId)) {
-      historicalBySourceId.set(sourceId, invoice);
-    }
-    const invoiceNumber = clean(invoice.invoice_number);
-    if (invoiceNumber && !historicalByInvoiceNumber.has(invoiceNumber)) {
-      historicalByInvoiceNumber.set(invoiceNumber, invoice);
-    }
-  }
-
-  for (const invoice of (liveRows ?? []) as ExistingInvoiceMatch[]) {
-    if (isHistoricalInvoiceCsvMetadata(invoice.metadata)) continue;
-    const invoiceNumber = clean(invoice.invoice_number);
-    if (invoiceNumber && !liveCollisionsByInvoiceNumber.has(invoiceNumber)) {
-      liveCollisionsByInvoiceNumber.set(invoiceNumber, invoice);
+    for (const invoice of (liveRows ?? []) as ExistingInvoiceMatch[]) {
+      if (isHistoricalInvoiceCsvMetadata(invoice.metadata)) continue;
+      const invoiceNumber = clean(invoice.invoice_number);
+      if (invoiceNumber && !liveCollisionsByInvoiceNumber.has(invoiceNumber)) {
+        liveCollisionsByInvoiceNumber.set(invoiceNumber, invoice);
+      }
     }
   }
 
@@ -428,9 +459,10 @@ export async function processInvoiceImportJobBatch(
   const batchInvoiceNumbers = new Set<string>();
   const batchSourceIds = new Set<string>();
   for (const staged of rows) {
-    const row = staged.raw_row;
-    const invoiceNumber = clean(row.invoice_number ?? row.invoice_id);
-    const sourceId = clean(row.invoice_id);
+    const rawRow = staged.raw_row;
+    const row = normalizeInvoiceImportRow(rawRow);
+    const invoiceNumber = getInvoiceNumber(row);
+    const sourceId = getInvoiceSourceId(row);
     if (invoiceNumber) batchInvoiceNumbers.add(invoiceNumber);
     if (sourceId) batchSourceIds.add(sourceId);
   }
@@ -497,9 +529,10 @@ export async function processInvoiceImportJobBatch(
   }> = [];
 
   for (const staged of rows) {
-    const row = staged.raw_row;
-    const invoiceNumber = clean(row.invoice_number ?? row.invoice_id);
-    const sourceId = clean(row.invoice_id);
+    const rawRow = staged.raw_row;
+    const row = normalizeInvoiceImportRow(rawRow);
+    const invoiceNumber = getInvoiceNumber(row);
+    const sourceId = getInvoiceSourceId(row);
     const workOrderNumber = clean(row.work_order_number);
 
     try {
@@ -524,10 +557,16 @@ export async function processInvoiceImportJobBatch(
 
       const existingHistoricalInvoice =
         (sourceId ? historicalBySourceId.get(sourceId) : null) ??
-        historicalByInvoiceNumber.get(invoiceNumber) ??
+        (!sourceId ? historicalByInvoiceNumber.get(invoiceNumber) : null) ??
         null;
+      const existingInvoiceMatchSource =
+        sourceId && existingHistoricalInvoice
+          ? "imported_invoice_id"
+          : existingHistoricalInvoice
+            ? "invoice_number"
+            : null;
       if (
-        pendingInvoiceNumbers.has(invoiceNumber) &&
+        pendingInvoiceNumbers.has(sourceId ?? invoiceNumber) &&
         !existingHistoricalInvoice
       ) {
         counts.skipped++;
@@ -549,10 +588,11 @@ export async function processInvoiceImportJobBatch(
       const workOrder = workOrderNumber
         ? workOrdersByNumber.get(workOrderNumber.toLowerCase())
         : null;
+      const authoritativeVehicleId = getVehicleAuthoritativeId(row);
       const vehicle =
-        (clean(row.vehicle_id)
-          ? (vehiclesById.get(clean(row.vehicle_id)!) ??
-            vehiclesById.get(clean(row.vehicle_id)!.toLowerCase()))
+        (authoritativeVehicleId
+          ? (vehiclesById.get(authoritativeVehicleId) ??
+            vehiclesById.get(authoritativeVehicleId.toLowerCase()))
           : null) ?? (vin(row.vin) ? vehiclesById.get(vin(row.vin)!) : null);
       const {
         customer,
@@ -574,8 +614,8 @@ export async function processInvoiceImportJobBatch(
             ? "work_order_customer_id"
             : null);
       const vehicleMatchSource = vehicle
-        ? clean(row.vehicle_id)
-          ? "vehicle_id"
+        ? authoritativeVehicleId
+          ? "vehicle_external_id"
           : vin(row.vin)
             ? "vin"
             : null
@@ -630,7 +670,22 @@ export async function processInvoiceImportJobBatch(
         continue;
       }
 
-      pendingInvoiceNumbers.add(invoiceNumber);
+      if (INVOICE_IMPORT_DEBUG && staged.row_number <= 10) {
+        debugInvoiceImport("row", {
+          rawRow,
+          normalizedRow: row,
+          invoiceIdentity: sourceId ?? invoiceNumber,
+          customerIdentity: legacyCustomerId,
+          vehicleIdentity: authoritativeVehicleId ?? vin(row.vin),
+          matchedCustomerId: customerId,
+          customerMatchSource: customerMatchSourceResolved,
+          matchedVehicleId: vehicleId,
+          vehicleMatchSource,
+          existingInvoiceMatchSource,
+        });
+      }
+
+      pendingInvoiceNumbers.add(sourceId ?? invoiceNumber);
       writes.push({
         stagedId: staged.id,
         rowNumber: staged.row_number,
@@ -661,7 +716,7 @@ export async function processInvoiceImportJobBatch(
             import_type: "invoice_csv",
             imported_invoice_id: sourceId,
             legacy_customer_id: legacyCustomerId,
-            legacy_vehicle_id: clean(row.vehicle_id),
+            legacy_vehicle_id: authoritativeVehicleId,
             matched_customer_id: customerId,
             matched_vehicle_id: vehicleId,
             customer_match_source: customerMatchSourceResolved,
@@ -679,7 +734,7 @@ export async function processInvoiceImportJobBatch(
               num(row.balance_due) ?? Math.max(0, total - amountPaid),
             advisor: clean(row.advisor),
             technician: clean(row.technician),
-            raw_row: row,
+            raw_row: rawRow,
           } as DB["public"]["Tables"]["invoices"]["Insert"]["metadata"],
         },
       });
@@ -836,16 +891,36 @@ export async function importInvoiceRowsSynchronously({
   rows: InvoiceImportRow[];
 }) {
   const client = supabase as unknown as SupabaseClient;
-  const counts = { imported: 0, updated: 0, skipped: 0, failed: 0, duplicates: 0 };
+  const counts = {
+    imported: 0,
+    updated: 0,
+    skipped: 0,
+    failed: 0,
+    duplicates: 0,
+  };
   const sample = { skippedRows: [] as unknown[], failedRows: [] as unknown[] };
 
-  const [{ data: customers }, { data: vehicles }, { data: workOrders }] = await Promise.all([
-    client.from("customers").select("id, external_id, email, phone, phone_number, name, business_name, first_name, last_name").eq("shop_id", shopId),
-    client.from("vehicles").select("id, external_id, vin, customer_id").eq("shop_id", shopId),
-    client.from("work_orders").select("id, custom_id, customer_id, vehicle_id").eq("shop_id", shopId),
-  ]);
+  const [{ data: customers }, { data: vehicles }, { data: workOrders }] =
+    await Promise.all([
+      client
+        .from("customers")
+        .select(
+          "id, external_id, email, phone, phone_number, name, business_name, first_name, last_name",
+        )
+        .eq("shop_id", shopId),
+      client
+        .from("vehicles")
+        .select("id, external_id, vin, customer_id")
+        .eq("shop_id", shopId),
+      client
+        .from("work_orders")
+        .select("id, custom_id, customer_id, vehicle_id")
+        .eq("shop_id", shopId),
+    ]);
 
-  const customerLookupMaps = buildCustomerLookupMaps((customers ?? []) as MatchedCustomer[]);
+  const customerLookupMaps = buildCustomerLookupMaps(
+    (customers ?? []) as MatchedCustomer[],
+  );
   const vehiclesById = new Map<string, MatchedVehicle>();
   for (const vehicle of (vehicles ?? []) as MatchedVehicle[]) {
     if (vehicle.id) vehiclesById.set(vehicle.id, vehicle);
@@ -861,56 +936,140 @@ export async function importInvoiceRowsSynchronously({
     if (workOrder.id) workOrdersByNumber.set(workOrder.id, workOrder);
   }
 
-  for (const batchRows of chunkArray(rows.map((raw, index) => ({ raw, rowNumber: index + 1 })), INVOICE_IMPORT_BATCH_SIZE)) {
+  for (const batchRows of chunkArray(
+    rows.map((raw, index) => ({ raw, rowNumber: index + 1 })),
+    INVOICE_IMPORT_BATCH_SIZE,
+  )) {
     const batchInvoiceNumbers = new Set<string>();
     const batchSourceIds = new Set<string>();
     for (const staged of batchRows) {
-      const invoiceNumber = clean(staged.raw.invoice_number ?? staged.raw.invoice_id);
-      const sourceId = clean(staged.raw.invoice_id);
+      const row = normalizeInvoiceImportRow(staged.raw);
+      const invoiceNumber = getInvoiceNumber(row);
+      const sourceId = getInvoiceSourceId(row);
       if (invoiceNumber) batchInvoiceNumbers.add(invoiceNumber);
       if (sourceId) batchSourceIds.add(sourceId);
     }
-    const { historicalBySourceId, historicalByInvoiceNumber, liveCollisionsByInvoiceNumber } = await fetchBatchInvoiceMatches(client, shopId, batchInvoiceNumbers, batchSourceIds);
+    const {
+      historicalBySourceId,
+      historicalByInvoiceNumber,
+      liveCollisionsByInvoiceNumber,
+    } = await fetchBatchInvoiceMatches(
+      client,
+      shopId,
+      batchInvoiceNumbers,
+      batchSourceIds,
+    );
     const pendingInvoiceNumbers = new Set<string>();
 
     for (const staged of batchRows) {
-      const row = staged.raw;
-      const invoiceNumber = clean(row.invoice_number ?? row.invoice_id);
-      const sourceId = clean(row.invoice_id);
+      const rawRow = staged.raw;
+      const row = normalizeInvoiceImportRow(rawRow);
+      const invoiceNumber = getInvoiceNumber(row);
+      const sourceId = getInvoiceSourceId(row);
       const workOrderNumber = clean(row.work_order_number);
       try {
         const issued = date(row.invoice_date);
         if (!issued || !invoiceNumber) {
-          const reason = !issued ? "Invalid or missing invoice_date." : "Missing invoice_number or invoice_id.";
+          const reason = !issued
+            ? "Invalid or missing invoice_date."
+            : "Missing invoice_number or invoice_id.";
           counts.skipped++;
-          sample.skippedRows.push({ row: staged.rowNumber, reason, invoiceNumber, workOrderNumber });
+          sample.skippedRows.push({
+            row: staged.rowNumber,
+            reason,
+            invoiceNumber,
+            workOrderNumber,
+          });
           continue;
         }
-        const existingHistoricalInvoice = (sourceId ? historicalBySourceId.get(sourceId) : null) ?? historicalByInvoiceNumber.get(invoiceNumber) ?? null;
-        if (pendingInvoiceNumbers.has(invoiceNumber) && !existingHistoricalInvoice) {
+        const existingHistoricalInvoice =
+          (sourceId ? historicalBySourceId.get(sourceId) : null) ??
+          (!sourceId ? historicalByInvoiceNumber.get(invoiceNumber) : null) ??
+          null;
+        const existingInvoiceMatchSource =
+          sourceId && existingHistoricalInvoice
+            ? "imported_invoice_id"
+            : existingHistoricalInvoice
+              ? "invoice_number"
+              : null;
+        if (
+          pendingInvoiceNumbers.has(sourceId ?? invoiceNumber) &&
+          !existingHistoricalInvoice
+        ) {
           counts.skipped++;
           counts.duplicates++;
-          sample.skippedRows.push({ row: staged.rowNumber, reason: "Duplicate invoice already exists in this import batch.", invoiceNumber, workOrderNumber });
+          sample.skippedRows.push({
+            row: staged.rowNumber,
+            reason: "Duplicate invoice already exists in this import batch.",
+            invoiceNumber,
+            workOrderNumber,
+          });
           continue;
         }
-        const liveCollision = !existingHistoricalInvoice ? (liveCollisionsByInvoiceNumber.get(invoiceNumber) ?? null) : null;
+        const liveCollision = !existingHistoricalInvoice
+          ? (liveCollisionsByInvoiceNumber.get(invoiceNumber) ?? null)
+          : null;
         if (liveCollision) {
           counts.skipped++;
-          sample.skippedRows.push({ row: staged.rowNumber, reason: "live_invoice_number_collision", invoiceNumber, workOrderNumber, liveInvoiceId: liveCollision.id });
+          sample.skippedRows.push({
+            row: staged.rowNumber,
+            reason: "live_invoice_number_collision",
+            invoiceNumber,
+            workOrderNumber,
+            liveInvoiceId: liveCollision.id,
+          });
           continue;
         }
         const status = normalizeInvoiceImportStatus(row);
         if (!status) {
           counts.skipped++;
-          sample.skippedRows.push({ row: staged.rowNumber, reason: "Invoice status represents a credit/refund reversal and is not imported as an invoice.", invoiceNumber, workOrderNumber, sourceStatus: clean(row.payment_status ?? row.status) });
+          sample.skippedRows.push({
+            row: staged.rowNumber,
+            reason:
+              "Invoice status represents a credit/refund reversal and is not imported as an invoice.",
+            invoiceNumber,
+            workOrderNumber,
+            sourceStatus: clean(row.payment_status ?? row.status),
+          });
           continue;
         }
-        const workOrder = workOrderNumber ? workOrdersByNumber.get(workOrderNumber.toLowerCase()) : null;
-        const vehicle = (clean(row.vehicle_id) ? (vehiclesById.get(clean(row.vehicle_id)!) ?? vehiclesById.get(clean(row.vehicle_id)!.toLowerCase())) : null) ?? (vin(row.vin) ? vehiclesById.get(vin(row.vin)!) : null);
-        const { customer, customerMatchSource, legacyCustomerId, customerEmailKey, customerPhoneKey, customerNameKey } = resolveInvoiceImportCustomer(row, customerLookupMaps);
-        const fallbackCustomerId = vehicle?.customer_id ?? workOrder?.customer_id ?? null;
+        const workOrder = workOrderNumber
+          ? workOrdersByNumber.get(workOrderNumber.toLowerCase())
+          : null;
+        const authoritativeVehicleId = getVehicleAuthoritativeId(row);
+        const vehicle =
+          (authoritativeVehicleId
+            ? (vehiclesById.get(authoritativeVehicleId) ??
+              vehiclesById.get(authoritativeVehicleId.toLowerCase()))
+            : null) ?? (vin(row.vin) ? vehiclesById.get(vin(row.vin)!) : null);
+        const {
+          customer,
+          customerMatchSource,
+          legacyCustomerId,
+          customerEmailKey,
+          customerPhoneKey,
+          customerNameKey,
+        } = resolveInvoiceImportCustomer(row, customerLookupMaps);
+        const fallbackCustomerId =
+          vehicle?.customer_id ?? workOrder?.customer_id ?? null;
         const customerId = customer?.id ?? fallbackCustomerId;
         const vehicleId = vehicle?.id ?? workOrder?.vehicle_id ?? null;
+        const customerMatchSourceResolved =
+          customerMatchSource ??
+          (vehicle?.customer_id
+            ? "vehicle_customer_id"
+            : workOrder?.customer_id
+              ? "work_order_customer_id"
+              : null);
+        const vehicleMatchSource = vehicle
+          ? authoritativeVehicleId
+            ? "vehicle_external_id"
+            : vin(row.vin)
+              ? "vin"
+              : null
+          : workOrder?.vehicle_id
+            ? "work_order_vehicle_id"
+            : null;
         const total = num(row.total) ?? num(row.subtotal) ?? 0;
         const amountPaid = num(row.amount_paid) ?? 0;
         const payload: DB["public"]["Tables"]["invoices"]["Insert"] = {
@@ -927,20 +1086,87 @@ export async function importInvoiceRowsSynchronously({
           subtotal: num(row.subtotal) ?? total,
           tax_total: num(row.tax) ?? 0,
           total,
-          notes: [clean(row.description), clean(row.notes)].filter(Boolean).join("\n") || null,
-          metadata: { imported: true, read_only: true, import_type: "invoice_csv", imported_invoice_id: sourceId, legacy_customer_id: legacyCustomerId, legacy_vehicle_id: clean(row.vehicle_id), matched_customer_id: customerId, matched_vehicle_id: vehicleId, customer_match_source: customerMatchSource ?? (vehicle?.customer_id ? "vehicle_customer_id" : workOrder?.customer_id ? "work_order_customer_id" : null), customer_match_failed_reason: customerId ? null : legacyCustomerId ? "legacy_customer_id_not_found" : customerEmailKey || customerPhoneKey || customerNameKey ? "customer_lookup_fields_not_found" : "no_customer_lookup_fields", vehicle_match_source: vehicle ? clean(row.vehicle_id) ? "vehicle_id" : vin(row.vin) ? "vin" : null : workOrder?.vehicle_id ? "work_order_vehicle_id" : null, source_system: clean(row.source_system), work_order_number: workOrderNumber, vehicle_id: vehicleId, vin: clean(row.vin), service_category: clean(row.service_category), labor_hours: num(row.labor_hours), shop_supplies: num(row.shop_supplies), amount_paid: amountPaid, balance_due: num(row.balance_due) ?? Math.max(0, total - amountPaid), advisor: clean(row.advisor), technician: clean(row.technician), raw_row: row } as DB["public"]["Tables"]["invoices"]["Insert"]["metadata"],
+          notes:
+            [clean(row.description), clean(row.notes)]
+              .filter(Boolean)
+              .join("\n") || null,
+          metadata: {
+            imported: true,
+            read_only: true,
+            import_type: "invoice_csv",
+            imported_invoice_id: sourceId,
+            legacy_customer_id: legacyCustomerId,
+            legacy_vehicle_id: authoritativeVehicleId,
+            matched_customer_id: customerId,
+            matched_vehicle_id: vehicleId,
+            customer_match_source: customerMatchSourceResolved,
+            customer_match_failed_reason: customerId
+              ? null
+              : legacyCustomerId
+                ? "legacy_customer_id_not_found"
+                : customerEmailKey || customerPhoneKey || customerNameKey
+                  ? "customer_lookup_fields_not_found"
+                  : "no_customer_lookup_fields",
+            vehicle_match_source: vehicleMatchSource,
+            source_system: clean(row.source_system),
+            work_order_number: workOrderNumber,
+            vehicle_id: vehicleId,
+            vin: clean(row.vin),
+            service_category: clean(row.service_category),
+            labor_hours: num(row.labor_hours),
+            shop_supplies: num(row.shop_supplies),
+            amount_paid: amountPaid,
+            balance_due:
+              num(row.balance_due) ?? Math.max(0, total - amountPaid),
+            advisor: clean(row.advisor),
+            technician: clean(row.technician),
+            raw_row: rawRow,
+          } as DB["public"]["Tables"]["invoices"]["Insert"]["metadata"],
         };
-        pendingInvoiceNumbers.add(invoiceNumber);
-        const write = existingHistoricalInvoice ? supabase.from("invoices").update(payload).eq("id", existingHistoricalInvoice.id) : supabase.from("invoices").insert(payload);
+        if (INVOICE_IMPORT_DEBUG && staged.rowNumber <= 10) {
+          debugInvoiceImport("row", {
+            rawRow,
+            normalizedRow: row,
+            invoiceIdentity: sourceId ?? invoiceNumber,
+            customerIdentity: legacyCustomerId,
+            vehicleIdentity: authoritativeVehicleId ?? vin(row.vin),
+            matchedCustomerId: customerId,
+            customerMatchSource: customerMatchSourceResolved,
+            matchedVehicleId: vehicleId,
+            vehicleMatchSource,
+            existingInvoiceMatchSource,
+          });
+        }
+
+        pendingInvoiceNumbers.add(sourceId ?? invoiceNumber);
+        const write = existingHistoricalInvoice
+          ? supabase
+              .from("invoices")
+              .update(payload)
+              .eq("id", existingHistoricalInvoice.id)
+          : supabase.from("invoices").insert(payload);
         const { error } = await write;
         if (error) {
-          if (!existingHistoricalInvoice && isInvoiceNumberUniqueConflict(error)) {
+          if (
+            !existingHistoricalInvoice &&
+            isInvoiceNumberUniqueConflict(error)
+          ) {
             counts.skipped++;
             counts.duplicates++;
-            sample.skippedRows.push({ row: staged.rowNumber, reason: "live_invoice_number_collision", invoiceNumber, workOrderNumber });
+            sample.skippedRows.push({
+              row: staged.rowNumber,
+              reason: "live_invoice_number_collision",
+              invoiceNumber,
+              workOrderNumber,
+            });
           } else {
             counts.failed++;
-            sample.failedRows.push({ row: staged.rowNumber, error: error.message, invoiceNumber, workOrderNumber });
+            sample.failedRows.push({
+              row: staged.rowNumber,
+              error: error.message,
+              invoiceNumber,
+              workOrderNumber,
+            });
           }
         } else {
           counts.imported++;
@@ -948,7 +1174,15 @@ export async function importInvoiceRowsSynchronously({
         }
       } catch (error) {
         counts.failed++;
-        sample.failedRows.push({ row: staged.rowNumber, error: error instanceof Error ? error.message : "Invoice row failed to import.", invoiceNumber, workOrderNumber });
+        sample.failedRows.push({
+          row: staged.rowNumber,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Invoice row failed to import.",
+          invoiceNumber,
+          workOrderNumber,
+        });
       }
     }
   }

--- a/tests/invoice-import-billing-page-stability.test.ts
+++ b/tests/invoice-import-billing-page-stability.test.ts
@@ -51,3 +51,9 @@ it("shows legacy customer diagnostics when the customer join is missing", () => 
   expect(billingPage).toContain("customer_match_failed_reason");
   expect(billingPage).toContain("Customer match diagnostics");
 });
+
+it("uses the shared invoice normalizer in the import card preview", () => {
+  expect(importCard).toContain("normalizeInvoiceImportRow");
+  expect(importCard).toContain("INVOICE_IMPORT_SUPPORTED_COLUMNS");
+  expect(importCard).toContain("!response?.counts");
+});

--- a/tests/invoice-import-work-order-optional.test.ts
+++ b/tests/invoice-import-work-order-optional.test.ts
@@ -248,3 +248,23 @@ describe("historical invoice imports", () => {
     );
   });
 });
+
+it("does not generate unsupported PostgREST JSON arrow OR filters for invoice lookups", () => {
+  expect(importer).not.toContain("metadata->>imported_invoice_id.in");
+  expect(importer).not.toContain(".or(historicalFilters.join" );
+  expect(importer).toContain("fetchHistoricalInvoiceCsvMatches");
+  expect(importer).toContain(".contains(\"metadata\", { import_type: \"invoice_csv\" })");
+  expect(importer).toContain(".range(from, from + pageSize - 1)");
+});
+
+it("chunks live invoice-number collision checks so 2600 IDs avoid giant URLs", () => {
+  expect(importer).toContain("for (const chunk of chunkArray(Array.from(invoiceNumbers), 100))");
+  expect(importer).not.toContain("postgrestInList");
+});
+
+it("uses source invoice identity before invoice-number fallback and never work_order_number", () => {
+  expect(importer).toContain("getInvoiceSourceId(row)");
+  expect(importer).toContain("getInvoiceNumber(row)");
+  expect(importer).toContain("pendingInvoiceNumbers.has(sourceId ?? invoiceNumber)");
+  expect(importer).not.toContain("pendingInvoiceNumbers.has(workOrderNumber");
+});


### PR DESCRIPTION
### Motivation
- Historical invoice CSV imports were failing with Supabase 400s due to an invalid PostgREST JSON-arrow `or(...)` filter and URL-length risks for large onboarding batches.  
- The importer needed to follow the same authoritative identity, matching, and idempotency patterns already used by Customers, Vehicles, and History importers.  
- The UI preview and server processing diverged on normalization and duplicate reporting, causing inconsistent behavior and possible double-submits.  
- Added diagnostics to help debug mapping/matching issues during large imports without changing live invoice semantics.

### Description
- Added a shared normalizer `features/billing/lib/invoice-import-normalizer.ts` with canonical header aliases and helper functions `getInvoiceSourceId`, `getInvoiceNumber`, `getCustomerAuthoritativeId`, and `getVehicleAuthoritativeId`.  
- Replaced the invalid historical lookup approach with a paged historical fetch `fetchHistoricalInvoiceCsvMatches(...)` that uses `.contains("metadata", { import_type: "invoice_csv" })` and in-memory matching, and split live invoice-number checks into chunked `.in(...)` queries to avoid giant URLs; updated `fetchBatchInvoiceMatches(...)` accordingly in `features/billing/server/invoice-import-job.ts`.  
- Implemented the invoice identity hierarchy (source id / `imported_invoice_id`/`invoice_id` first, then `invoice_number`, with `work_order_number` as relationship context only) and updated duplicate detection and idempotent refresh behavior so historical rows update when matched by source id.  
- Made customer/vehicle matching authoritative: customer authoritative aliases resolve to `customers.external_id` first and, if an authoritative customer ID exists, do not fallback to email/phone/name; vehicle authoritative aliases resolve by external id first then VIN.  
- Wire UI and API to the normalizer: `app/api/invoices/import/route.ts` now maps parsed rows through `normalizeInvoiceImportRow`, and `features/billing/components/InvoiceCsvImportCard.tsx` uses the shared normalizer for preview and disables Confirm once a completed result exists to prevent double submission.  
- Added `INVOICE_IMPORT_DEBUG` and `debugInvoiceImport(...)` to log diagnostic details (raw row, normalized row, invoice/customer/vehicle identity and match sources, existing match source) for the first 10 rows when enabled.  
- Added regression tests to assert removal of unsupported PostgREST JSON-arrow filters, chunked live checks, source-id-first identity, and shared normalizer usage in the UI preview (`tests/invoice-import-work-order-optional.test.ts` and `tests/invoice-import-billing-page-stability.test.ts`).

### Testing
- Ran `npm run typecheck` and TypeScript checks completed successfully.  
- Ran `npx eslint features/billing/server/invoice-import-job.ts features/billing/components/InvoiceCsvImportCard.tsx app/api/invoices/import/route.ts app/api/internal/import-jobs/tick/route.ts --ext .ts,.tsx` with no lint failures.  
- Ran unit/regression tests `npx vitest run tests/invoice-import-work-order-optional.test.ts tests/invoice-import-billing-page-stability.test.ts` and all test files and tests passed.  
- Commit containing these changes: `eefcd962722ee8618792d398b3974ff367099348`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fc8f4e0948328920e98bae1e2c15d)