### PR TITLE
Fix live invoice import progress

### DIFF
--- a/app/api/import-jobs/[jobId]/route.ts
+++ b/app/api/import-jobs/[jobId]/route.ts
@@ -5,6 +5,10 @@ import {
   processVehicleHistoryImportJobBatch,
   VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
 } from "@/features/work-orders/server/vehicle-history-import-job";
+import {
+  INVOICE_IMPORT_BATCH_SIZE,
+  processInvoiceImportJobBatch,
+} from "@/features/billing/server/invoice-import-job";
 
 type ImportJobApiRow = {
   id: string;
@@ -45,9 +49,11 @@ export async function GET(
     );
 
   const loadJob = () =>
-    (access.supabase as unknown as {
-      from: (table: "import_jobs") => ImportJobApiQuery;
-    })
+    (
+      access.supabase as unknown as {
+        from: (table: "import_jobs") => ImportJobApiQuery;
+      }
+    )
       .from("import_jobs")
       .select(
         "id, import_type, status, total_rows, processed_rows, imported_count, skipped_count, failed_count, error_message, summary, created_at, updated_at, completed_at",
@@ -71,6 +77,14 @@ export async function GET(
         createAdminSupabase(),
         jobId,
         VEHICLE_HISTORY_IMPORT_BATCH_SIZE,
+      );
+      const refreshed = await loadJob();
+      data = refreshed.data ?? data;
+    } else if (data.import_type === "invoices") {
+      await processInvoiceImportJobBatch(
+        createAdminSupabase(),
+        jobId,
+        INVOICE_IMPORT_BATCH_SIZE,
       );
       const refreshed = await loadJob();
       data = refreshed.data ?? data;

--- a/app/api/invoices/import/route.ts
+++ b/app/api/invoices/import/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { parseCsvFileFromFormData } from "@/features/shared/lib/import/csv";
 import {
-  importInvoiceRowsSynchronously,
+  createInvoiceImportJob,
   INVOICE_IMPORT_MAX_ROWS,
 } from "@/features/billing/server/invoice-import-job";
 import {
@@ -57,12 +57,14 @@ export async function POST(req: Request) {
         { status: 400 },
       );
 
-    const result = await importInvoiceRowsSynchronously({
+    const userId = profile.id ?? null;
+    const result = await createInvoiceImportJob({
       supabase,
       shopId,
       rows: parsed.rows.map(normalizeInvoiceImportRow),
+      createdBy: userId,
     });
-    return NextResponse.json({ ok: true, ...result });
+    return NextResponse.json(result);
   } catch (error) {
     return NextResponse.json(
       {

--- a/features/billing/components/InvoiceCsvImportCard.tsx
+++ b/features/billing/components/InvoiceCsvImportCard.tsx
@@ -18,6 +18,10 @@ import {
   CsvImportProgress,
   type CsvImportProgressState,
 } from "@/features/shared/components/import/CsvImportProgress";
+import {
+  useImportJobProgress,
+  type ImportJobProgressJob,
+} from "@/features/shared/components/import/useImportJobProgress";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
 import type { GuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
 import {
@@ -38,6 +42,7 @@ type ImportCounts = {
 type ImportResponse = {
   ok?: boolean;
   error?: string;
+  jobId?: string;
   counts?: ImportCounts;
   totalRows?: number;
   skippedRows?: Array<{
@@ -113,7 +118,9 @@ export function InvoiceCsvImportCard({
   const [response, setResponse] = useState<ImportResponse | null>(null);
   const [importing, setImporting] = useState(false);
   const [completingOnboarding, setCompletingOnboarding] = useState(false);
-  const [progress, setProgress] = useState<CsvImportProgressState | null>(null);
+  const [localProgress, setLocalProgress] =
+    useState<CsvImportProgressState | null>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
   const isOnboarding = Boolean(
     guidedQuery?.onboardingSession && guidedQuery.onboardingStep === "invoices",
   );
@@ -129,7 +136,8 @@ export function InvoiceCsvImportCard({
     setParseError(null);
     setImportError(null);
     setResponse(null);
-    setProgress(null);
+    setLocalProgress(null);
+    setJobId(null);
   }
   function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const nextFile = event.target.files?.[0] ?? null;
@@ -146,7 +154,7 @@ export function InvoiceCsvImportCard({
       setParseError("Please choose a .csv file.");
       return;
     }
-    setProgress({
+    setLocalProgress({
       phase: "Reading file",
       phaseKey: "reading_file",
       processed: 0,
@@ -166,7 +174,7 @@ export function InvoiceCsvImportCard({
             .filter(Boolean),
         );
         setRows(parsed);
-        setProgress({
+        setLocalProgress({
           phase: "Validating rows",
           phaseKey: "validating",
           processed: parsed.length,
@@ -177,7 +185,7 @@ export function InvoiceCsvImportCard({
           setParseError("No invoice rows were found in that CSV.");
       },
       error: (error) => {
-        setProgress(null);
+        setLocalProgress(null);
         setParseError(error.message || "Unable to parse that CSV file.");
       },
     });
@@ -212,11 +220,56 @@ export function InvoiceCsvImportCard({
     },
     [guidedQuery, isOnboarding],
   );
+  const handleJobComplete = useCallback(
+    async (job: ImportJobProgressJob) => {
+      const summary = (job.summary ?? {}) as Partial<ImportResponse> & {
+        counts?: Partial<ImportCounts>;
+      };
+      const counts: ImportCounts = {
+        imported: job.importedCount,
+        updated: summary.counts?.updated ?? 0,
+        skipped: job.skippedCount,
+        failed: job.failedCount,
+        duplicates: summary.counts?.duplicates ?? 0,
+      };
+      const nextResponse: ImportResponse = {
+        ok: true,
+        jobId: job.id,
+        counts,
+        totalRows: job.totalRows,
+        skippedRows: summary.skippedRows as ImportResponse["skippedRows"],
+        failedRows: summary.failedRows as ImportResponse["failedRows"],
+      };
+      setResponse(nextResponse);
+      setImporting(false);
+      if (job.status === "failed") return;
+      if (isOnboarding && counts.imported > 0 && counts.failed === 0) {
+        await completeOnboardingAfterImport(counts);
+      }
+      // Keep the completion refresh behavior equivalent to the previous synchronous payload path.
+      // if (payload.counts.imported > 0) onImported?.();
+      if (counts.imported > 0) onImported?.();
+    },
+    [completeOnboardingAfterImport, isOnboarding, onImported],
+  );
+
+  const handleJobError = useCallback((message: string) => {
+    setImportError(message);
+    setImporting(false);
+  }, []);
+
+  const { progress: jobProgress } = useImportJobProgress(jobId, {
+    initialTotal: importableRows.length,
+    onComplete: handleJobComplete,
+    onError: handleJobError,
+  });
+  const progress = jobProgress ?? localProgress;
+
   useEffect(() => {
     onImportActiveChange?.(importing);
   }, [importing, onImportActiveChange]);
   async function confirmImport() {
-    if (importing || completingOnboarding) return;
+    if (importing || completingOnboarding || response?.counts) return;
     if (!file || !importableRows.length) {
       setImportError(
         "Upload a CSV with at least one valid invoice row before importing.",
@@ -226,12 +279,17 @@ export function InvoiceCsvImportCard({
     setImporting(true);
     setImportError(null);
     setResponse(null);
-    setProgress({
-      phase: "Uploading CSV",
-      phaseKey: "importing",
+    setJobId(null);
+    setLocalProgress({
+      phase: "Preparing Rows",
+      phaseKey: "processing",
       processed: 0,
       total: importableRows.length,
-      percent: 10,
+      percent: 30,
+      imported: 0,
+      skipped: 0,
+      failed: 0,
+      duplicates: 0,
     });
     try {
       const formData = new FormData();
@@ -241,38 +299,32 @@ export function InvoiceCsvImportCard({
         body: formData,
       });
       const payload = (await res.json().catch(() => ({}))) as ImportResponse;
-      if (!res.ok || payload.ok === false || !payload.counts)
+      if (!res.ok || payload.ok === false || !payload.jobId) {
         throw new Error(payload.error ?? "Unable to import invoice CSV.");
-      setProgress({
-        phase: "Finalizing import",
-        phaseKey: "finalizing",
-        processed: payload.totalRows ?? importableRows.length,
+      }
+      setJobId(payload.jobId);
+      setLocalProgress({
+        phase: "Importing Rows",
+        phaseKey: "processing",
+        processed: 0,
         total: payload.totalRows ?? importableRows.length,
-        percent: 90,
+        percent: 0,
+        imported: 0,
+        skipped: 0,
+        failed: 0,
+        duplicates: 0,
       });
-      setResponse(payload);
-      setProgress({
-        phase: "Import complete",
-        phaseKey: "completed",
-        processed: payload.totalRows ?? importableRows.length,
-        total: payload.totalRows ?? importableRows.length,
-        percent: 100,
-      });
-      setImporting(false);
-      if (
-        isOnboarding &&
-        payload.counts.imported > 0 &&
-        payload.counts.failed === 0
-      )
-        await completeOnboardingAfterImport(payload.counts);
-      if (payload.counts.imported > 0) onImported?.();
     } catch (error) {
-      setProgress({
+      setLocalProgress({
         phase: "Import failed",
         phaseKey: "failed",
         processed: 0,
         total: importableRows.length,
         percent: 100,
+        imported: 0,
+        skipped: 0,
+        failed: importableRows.length,
+        duplicates: 0,
       });
       setImportError(
         error instanceof Error
@@ -415,7 +467,7 @@ export function InvoiceCsvImportCard({
         importing={importing}
         completing={completingOnboarding}
         canConfirm={Boolean(
-          file && importableRows.length > 0 && !response?.counts,
+          file && importableRows.length > 0 && !response?.counts && !importing,
         )}
         onConfirm={() => void confirmImport()}
         isOnboarding={isOnboarding}

--- a/features/billing/server/invoice-import-job.ts
+++ b/features/billing/server/invoice-import-job.ts
@@ -1,6 +1,9 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { chunkArray } from "@/features/shared/lib/import/csv";
+import {
+  chunkArray,
+  compactImportSummary,
+} from "@/features/shared/lib/import/csv";
 import {
   getCustomerAuthoritativeId,
   getInvoiceNumber,
@@ -408,6 +411,68 @@ function samples(summary: Record<string, unknown> | null) {
   };
 }
 
+export async function createInvoiceImportJob({
+  supabase,
+  shopId,
+  rows,
+  createdBy = null,
+}: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  rows: InvoiceImportRow[];
+  createdBy?: string | null;
+}) {
+  const client = supabase as unknown as SupabaseClient;
+  const normalizedRows = rows.map(normalizeInvoiceImportRow);
+  const { data: job, error: jobError } = await client
+    .from("import_jobs")
+    .insert({
+      shop_id: shopId,
+      import_type: "invoices",
+      status: "queued",
+      total_rows: normalizedRows.length,
+      processed_rows: 0,
+      imported_count: 0,
+      skipped_count: 0,
+      failed_count: 0,
+      created_by: createdBy,
+      summary: {
+        ok: true,
+        counts: {
+          imported: 0,
+          updated: 0,
+          skipped: 0,
+          failed: 0,
+          duplicates: 0,
+        },
+        totalRows: normalizedRows.length,
+        skippedRows: [],
+        failedRows: [],
+        duplicates: 0,
+      },
+    })
+    .select("id")
+    .single<{ id: string }>();
+  if (jobError) throw jobError;
+  if (!job?.id) throw new Error("Unable to create invoice import job.");
+
+  for (const batch of chunkArray(normalizedRows, INVOICE_IMPORT_BATCH_SIZE)) {
+    const offset = normalizedRows.indexOf(batch[0]);
+    const { error: rowsError } = await client.from("import_job_rows").insert(
+      batch.map((row, index) => ({
+        job_id: job.id,
+        shop_id: shopId,
+        row_number: offset + index + 1,
+        raw_row: row,
+        status: "queued",
+      })),
+    );
+    if (rowsError) throw rowsError;
+  }
+
+  return { ok: true, jobId: job.id, totalRows: normalizedRows.length };
+}
+
 export async function processInvoiceImportJobBatch(
   supabase: SupabaseClient<DB>,
   jobId?: string,
@@ -445,12 +510,26 @@ export async function processInvoiceImportJobBatch(
 
   const rows = (data ?? []) as StagedRow[];
   if (!rows.length) {
+    const finalSummary = compactImportSummary({
+      counts: {
+        imported: job.imported_count ?? 0,
+        updated: 0,
+        skipped: job.skipped_count ?? 0,
+        failed: job.failed_count ?? 0,
+        duplicates: Number(job.summary?.duplicates ?? 0),
+      },
+      totalRows: job.processed_rows ?? 0,
+      skippedRows: samples(job.summary).skippedRows,
+      failedRows: samples(job.summary).failedRows,
+      sampleLimit: INVOICE_IMPORT_SAMPLE_LIMIT,
+    });
     await client
       .from("import_jobs")
       .update({
         status: "completed",
         completed_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
+        summary: finalSummary,
       })
       .eq("id", job.id);
     return { ok: true, processed: 0, completed: true, job: { id: job.id } };
@@ -809,11 +888,8 @@ export async function processInvoiceImportJobBatch(
   }
 
   const processedRows = (job.processed_rows ?? 0) + rows.length;
-  const summary = {
-    skippedRows: sample.skippedRows.slice(0, INVOICE_IMPORT_SAMPLE_LIMIT),
-    failedRows: sample.failedRows.slice(0, INVOICE_IMPORT_SAMPLE_LIMIT),
-    duplicates: Number(job.summary?.duplicates ?? 0) + counts.duplicates,
-  };
+  const duplicateCount =
+    Number(job.summary?.duplicates ?? 0) + counts.duplicates;
   const [
     { count: queuedCount },
     { count: importedCount },
@@ -862,7 +938,20 @@ export async function processInvoiceImportJobBatch(
       skipped_count: reconciledSkipped,
       failed_count: reconciledFailed,
       summary: {
-        ...summary,
+        ...compactImportSummary({
+          counts: {
+            imported: reconciledImported,
+            updated: 0,
+            skipped: reconciledSkipped,
+            failed: reconciledFailed,
+            duplicates: duplicateCount,
+          },
+          totalRows: job.total_rows ?? reconciledProcessed,
+          skippedRows: sample.skippedRows,
+          failedRows: sample.failedRows,
+          sampleLimit: INVOICE_IMPORT_SAMPLE_LIMIT,
+        }),
+        duplicates: duplicateCount,
         accounting: {
           imported: reconciledImported,
           skipped: reconciledSkipped,

--- a/features/shared/components/import/useImportJobProgress.ts
+++ b/features/shared/components/import/useImportJobProgress.ts
@@ -60,10 +60,18 @@ function toProgress(
         : job.status === "queued"
           ? "queued"
           : "processing";
+  const phaseLabel =
+    job.status === "queued"
+      ? "Queued"
+      : job.status === "processing"
+        ? "Importing Rows"
+        : job.status === "completed"
+          ? "Import complete"
+          : "Import failed";
   const phase =
     stalled && (job.status === "queued" || job.status === "processing")
-      ? `Still processing… ${job.status}`
-      : job.status;
+      ? `Still processing… ${phaseLabel}`
+      : phaseLabel;
 
   const summary = job.summary as { duplicates?: number } | null | undefined;
 


### PR DESCRIPTION
### Motivation
- Invoice CSV imports showed phase/percent but did not update live Imported/Skipped/Failed/Duplicates counts because the card consumed a synchronous import response and local state instead of polling durable `import_jobs` counts.
- Make `InvoiceCsvImportCard` match Customers/Vehicles/History importers so progress is live, durable, and consistent with server-side job rows.

### Description
- `InvoiceCsvImportCard` now submits a durable import job and `import_job_rows` via the `createInvoiceImportJob` flow and uses the shared `useImportJobProgress` hook for live polling and counts, and prevents double submission and repeating confirm after completion.
- The invoice import API at `/api/invoices/import` now creates a queued import job (`createInvoiceImportJob`) instead of performing the entire import synchronously, and returns `{ jobId, totalRows }` for client polling.
- `features/billing/server/invoice-import-job.ts` gained `createInvoiceImportJob`, improved job summary handling to include `duplicates` and sample `skippedRows`/`failedRows` using `compactImportSummary`, and publishes those summary fields while processing and at completion.
- The import job status endpoint (`app/api/import-jobs/[jobId]/route.ts`) is extended to process invoice jobs during polling so the job advances server-side while the UI polls, and `useImportJobProgress` phase labels were adjusted to match other importers.
- Files changed: `features/billing/components/InvoiceCsvImportCard.tsx`, `features/billing/server/invoice-import-job.ts`, `app/api/invoices/import/route.ts`, `app/api/import-jobs/[jobId]/route.ts`, and `features/shared/components/import/useImportJobProgress.ts`.

### Testing
- Ran `npm run typecheck` which succeeded with no type errors.
- Ran ESLint with `npx eslint features/billing/components/InvoiceCsvImportCard.tsx features/shared/components/import/CsvImportProgress.tsx features/shared/components/import/useImportJobProgress.ts --ext .ts,.tsx` which succeeded with no new warnings.
- Ran targeted tests with `npx vitest run tests/invoice-import-billing-page-stability.test.ts tests/invoice-import-work-order-optional.test.ts` and both test files passed (26 tests total passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd9bfe85c8328bac2f2cd9807a720)