### PR TITLE
Wire guided onboarding AI business analysis recommendations

### DIFF
--- a/app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx
@@ -1,11 +1,116 @@
+import Link from "next/link";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
+import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import type { AiRecommendationRecord } from "@/features/ai/server/types";
+import type { Json } from "@shared/types/types/supabase";
 
 type Props = {
   params: Promise<{ sessionId: string }>;
 };
 
+type GuidedSessionRow = {
+  id: string;
+  shop_id: string;
+};
+
+type SupabaseQueryResult<T> = {
+  data: T | null;
+  error: { message: string } | null;
+};
+
+type SupabaseSelectQuery<T> = {
+  select(columns: string): SupabaseSelectQuery<T>;
+  eq(column: string, value: string): SupabaseSelectQuery<T>;
+  in(column: string, values: string[]): SupabaseSelectQuery<T>;
+  order(column: string, options: { ascending: boolean }): SupabaseSelectQuery<T>;
+  limit(count: number): Promise<SupabaseQueryResult<T[]>>;
+  maybeSingle(): Promise<SupabaseQueryResult<T>>;
+};
+
+type GuidedAnalysisSupabaseReader = {
+  from<T>(table: string): SupabaseSelectQuery<T>;
+};
+
+const GUIDED_ANALYSIS_CATEGORIES = [
+  ["1", "Inspection templates first", "Recommend inspection templates that match the shop's vehicle mix, common jobs, and inspection goals before building canned services."],
+  ["2", "Menu items and canned services second", "Recommend menu items after inspection guidance, because canned services can attach inspections."],
+  ["3", "Inventory improvements", "Flag fast-moving parts, missing stock coverage, reorder opportunities, and cleanup candidates."],
+  ["4", "Vendor suggestions", "Identify vendor gaps or consolidation opportunities from configured parts and invoice patterns."],
+  ["5", "Customer and fleet segments", "Suggest segments for retention, fleet handling, declined work follow-up, and targeted communication."],
+  ["6", "Maintenance packages", "Recommend packages that align with shop history, vehicle types, and recurring mileage or time intervals."],
+  ["7", "Automation rules", "Suggest reminders, review prompts, approval follow-ups, and internal workflow automations for owner review."],
+] as const;
+
+function jsonHasContent(value: Json | null | undefined): boolean {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return Boolean(value);
+}
+
+function metadataMatchesSession(metadata: Json | null | undefined, sessionId: string): boolean {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;
+  return metadata.guidedSessionId === sessionId || metadata.sessionId === sessionId;
+}
+
+function isOnboardingScopedRecommendation(recommendation: AiRecommendationRecord, sessionId: string): boolean {
+  return recommendation.domain === "onboarding" ||
+    (recommendation.subject_type === "guided_onboarding_session" && recommendation.subject_id === sessionId) ||
+    metadataMatchesSession(recommendation.metadata, sessionId);
+}
+
+export function filterGuidedAnalysisRecommendations(
+  recommendations: AiRecommendationRecord[],
+  sessionId: string,
+): AiRecommendationRecord[] {
+  const onboardingScoped = recommendations.filter((recommendation) =>
+    isOnboardingScopedRecommendation(recommendation, sessionId),
+  );
+
+  if (onboardingScoped.length > 0) return onboardingScoped;
+  return recommendations.filter((recommendation) => recommendation.domain === "shop_boost");
+}
+
+async function loadGuidedAnalysisRecommendations(sessionId: string): Promise<AiRecommendationRecord[]> {
+  const { profile } = await requireAdminPageAccess({ allow: ["owner", "admin", "manager", "advisor"] });
+  const supabase = createServerSupabaseRSC();
+  const reader = supabase as unknown as GuidedAnalysisSupabaseReader;
+  const shopId = profile.shop_id!;
+
+  await supabase.rpc("set_current_shop_id", { p_shop_id: shopId });
+
+  const { data: session, error: sessionError } = await reader
+    .from<GuidedSessionRow>("guided_onboarding_sessions")
+    .select("id, shop_id")
+    .eq("id", sessionId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (sessionError) throw new Error(sessionError.message);
+  if (!session) return [];
+  const guidedSession = session as GuidedSessionRow;
+
+  const { data, error } = await reader
+    .from<AiRecommendationRecord>("ai_recommendations")
+    .select("*")
+    .eq("shop_id", shopId)
+    .in("status", ["open", "acknowledged"])
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (error) throw new Error(error.message);
+  return filterGuidedAnalysisRecommendations((data ?? []) as AiRecommendationRecord[], guidedSession.id);
+}
+
+function formatConfidence(confidence: number | null) {
+  if (confidence == null) return "Not scored";
+  return `${Math.round(confidence * 100)}%`;
+}
+
 export default async function GuidedOnboardingAnalysisSummaryPage({ params }: Props) {
   const { sessionId } = await params;
+  const recommendations = await loadGuidedAnalysisRecommendations(sessionId);
 
   return (
     <main className="mx-auto w-full max-w-5xl space-y-6 px-4 pb-10 pt-6 text-neutral-100 sm:px-6 lg:px-8">
@@ -16,25 +121,72 @@ export default async function GuidedOnboardingAnalysisSummaryPage({ params }: Pr
         <p className="mt-3 max-w-3xl text-sm leading-6 text-neutral-300">
           ProFixIQ AI Business Analysis reviews the customers, vehicles, history, invoices, parts, and shop defaults that were imported or configured during guided setup. It recommends next actions for the shop; it does not auto-create operational records.
         </p>
-        <p className="mt-2 text-xs text-neutral-500">Session: {sessionId}</p>
+        <div className="mt-5 flex flex-wrap items-center gap-3">
+          <Link href="/dashboard/ai-recommendations" className="rounded-full border border-orange-300/35 bg-orange-300/10 px-4 py-2 text-sm font-semibold text-orange-100 transition hover:bg-orange-300/20">
+            Open AI Recommendations
+          </Link>
+          <p className="text-xs text-neutral-500">Session: {sessionId}</p>
+        </div>
       </section>
 
       <section className="grid gap-4 md:grid-cols-2">
-        {[
-          ["1", "Inspection templates first", "Recommend inspection templates that match the shop's vehicle mix, common jobs, and inspection goals before building canned services."],
-          ["2", "Menu items and canned services second", "Recommend menu items after inspection guidance, because canned services can attach inspections."],
-          ["3", "Inventory improvements", "Flag fast-moving parts, missing stock coverage, reorder opportunities, and cleanup candidates."],
-          ["4", "Vendor suggestions", "Identify vendor gaps or consolidation opportunities from configured parts and invoice patterns."],
-          ["5", "Customer and fleet segments", "Suggest segments for retention, fleet handling, declined work follow-up, and targeted communication."],
-          ["6", "Maintenance packages", "Recommend packages that align with shop history, vehicle types, and recurring mileage or time intervals."],
-          ["7", "Automation rules", "Suggest reminders, review prompts, approval follow-ups, and internal workflow automations for owner review."],
-        ].map(([index, title, description]) => (
+        {GUIDED_ANALYSIS_CATEGORIES.map(([index, title, description]) => (
           <article key={title} className="rounded-2xl border border-white/10 bg-black/35 p-5 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl">
             <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-orange-300/30 bg-orange-300/10 text-sm font-semibold text-orange-100">{index}</span>
             <h2 className="mt-4 text-lg font-semibold text-white">{title}</h2>
             <p className="mt-2 text-sm leading-6 text-neutral-300">{description}</p>
           </article>
         ))}
+      </section>
+
+      <section className="rounded-[2rem] border border-white/10 bg-black/35 p-6 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">Current recommendations</p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">Reviewable AI Business Analysis signals</h2>
+          </div>
+          <Link href="/dashboard/ai-recommendations" className="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/15">
+            Review in AI Recommendations
+          </Link>
+        </div>
+
+        {recommendations.length > 0 ? (
+          <div className="mt-5 space-y-4">
+            {recommendations.map((recommendation) => (
+              <article key={recommendation.id} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <h3 className="text-lg font-semibold text-white">{recommendation.title}</h3>
+                    {recommendation.summary ? <p className="mt-2 text-sm leading-6 text-neutral-300">{recommendation.summary}</p> : null}
+                  </div>
+                  <Link href="/dashboard/ai-recommendations" className="shrink-0 rounded-full border border-orange-300/30 bg-orange-300/10 px-3 py-1.5 text-xs font-semibold text-orange-100 transition hover:bg-orange-300/20">
+                    Review in AI Recommendations
+                  </Link>
+                </div>
+                <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
+                  {[
+                    ["Domain", recommendation.domain],
+                    ["Type", recommendation.recommendation_type],
+                    ["Priority", recommendation.priority],
+                    ["Confidence", formatConfidence(recommendation.confidence)],
+                    ["Risk", recommendation.risk_tier],
+                    ["Status", recommendation.status],
+                    ["Missing data", jsonHasContent(recommendation.missing_data) ? "Yes" : "No"],
+                  ].map(([label, value]) => (
+                    <div key={label} className="rounded-xl border border-white/10 bg-black/25 px-3 py-2">
+                      <dt className="uppercase tracking-[0.16em] text-neutral-500">{label}</dt>
+                      <dd className="mt-1 font-semibold text-neutral-100">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="mt-5 rounded-2xl border border-dashed border-white/15 bg-white/[0.03] p-5 text-sm leading-6 text-neutral-300">
+            No AI Business Analysis has been generated yet. Your imported onboarding data is ready. The next step will run analysis and create reviewable recommendations.
+          </div>
+        )}
       </section>
     </main>
   );

--- a/tests/guided-onboarding-ai-analysis.test.ts
+++ b/tests/guided-onboarding-ai-analysis.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { GUIDED_ONBOARDING_STEP_KEYS } from "@/features/onboarding-v2/guided/steps";
+import { filterGuidedAnalysisRecommendations } from "../app/dashboard/onboarding-v2/[sessionId]/summary/page";
+import type { AiRecommendationRecord } from "@/features/ai/server/types";
+
+function read(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+function recommendation(overrides: Partial<AiRecommendationRecord>): AiRecommendationRecord {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    shop_id: "shop-1",
+    domain: "shop_boost",
+    recommendation_type: "launch_improvement",
+    subject_type: "shop",
+    subject_id: null,
+    title: "Improve launch readiness",
+    summary: "Review imported data before launch.",
+    status: "open",
+    priority: "normal",
+    confidence: 0.75,
+    risk_tier: "low",
+    evidence_snapshot_id: null,
+    evidence_snapshot_ids: [],
+    missing_data: [],
+    recommended_action: {},
+    side_effects: [],
+    requires_approval: false,
+    requires_owner_pin: false,
+    source: "manual",
+    source_run_id: null,
+    created_by: "user-1",
+    assigned_to: null,
+    dismissed_by: null,
+    dismissed_at: null,
+    resolved_by: null,
+    resolved_at: null,
+    expires_at: null,
+    created_at: "2026-07-09T00:00:00.000Z",
+    updated_at: "2026-07-09T00:00:00.000Z",
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("guided onboarding AI Business Analysis page", () => {
+  it("renders the static seven guidance categories in order", () => {
+    const source = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
+
+    expect(source).toContain("Inspection templates first");
+    expect(source).toContain("Menu items and canned services second");
+    expect(source).toContain("Inventory improvements");
+    expect(source).toContain("Vendor suggestions");
+    expect(source).toContain("Customer and fleet segments");
+    expect(source).toContain("Maintenance packages");
+    expect(source).toContain("Automation rules");
+    expect(source.indexOf("Inspection templates first")).toBeLessThan(source.indexOf("Menu items and canned services second"));
+  });
+
+  it("renders the empty state when no recommendations exist", () => {
+    const source = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
+
+    expect(source).toContain("No AI Business Analysis has been generated yet");
+    expect(source).toContain("Your imported onboarding data is ready");
+  });
+
+  it("filters existing shop-scoped recommendations for onboarding before falling back to shop_boost", () => {
+    const matches = filterGuidedAnalysisRecommendations([
+      recommendation({ id: "shop-boost", domain: "shop_boost" }),
+      recommendation({ id: "onboarding-domain", domain: "onboarding" }),
+      recommendation({ id: "session-subject", subject_type: "guided_onboarding_session", subject_id: "session-123" }),
+      recommendation({ id: "session-metadata", metadata: { guidedSessionId: "session-123" } }),
+      recommendation({ id: "other", domain: "work_orders" }),
+    ], "session-123");
+
+    expect(matches.map((item) => item.id)).toEqual(["onboarding-domain", "session-subject", "session-metadata"]);
+
+    const fallback = filterGuidedAnalysisRecommendations([
+      recommendation({ id: "shop-boost", domain: "shop_boost" }),
+      recommendation({ id: "other", domain: "work_orders" }),
+    ], "session-123");
+
+    expect(fallback.map((item) => item.id)).toEqual(["shop-boost"]);
+  });
+
+  it("renders existing recommendation fields and links to the shared review center", () => {
+    const source = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
+
+    expect(source).toContain("Current recommendations");
+    expect(source).toContain("recommendation.title");
+    expect(source).toContain("recommendation.summary");
+    expect(source).toContain("recommendation.domain");
+    expect(source).toContain("recommendation.recommendation_type");
+    expect(source).toContain("recommendation.priority");
+    expect(source).toContain("formatConfidence(recommendation.confidence)");
+    expect(source).toContain("recommendation.risk_tier");
+    expect(source).toContain("recommendation.status");
+    expect(source).toContain("jsonHasContent(recommendation.missing_data)");
+    expect(source).toContain('href="/dashboard/ai-recommendations"');
+  });
+
+  it("does not add generation or POST behavior", () => {
+    const source = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
+
+    expect(source).not.toContain("method: \"POST\"");
+    expect(source).not.toContain("method: 'POST'");
+    expect(source).not.toContain("Run Analysis");
+    expect(source).not.toContain("createAiRecommendation");
+    expect(source).not.toContain("insert(");
+  });
+
+  it("keeps Staff removed and Shop Settings before AI Analysis", () => {
+    expect(GUIDED_ONBOARDING_STEP_KEYS).toEqual([
+      "customers",
+      "vehicles",
+      "vehicle_history",
+      "invoices",
+      "parts",
+      "shop_settings",
+      "analysis",
+    ]);
+    expect(GUIDED_ONBOARDING_STEP_KEYS).not.toContain("staff");
+  });
+});


### PR DESCRIPTION
### Motivation
- Surface existing, shop-scoped AI recommendations on the Guided Onboarding AI Business Analysis page instead of a purely static UI so shops can review evidence-backed signals. 
- Reuse the canonical `ai_recommendations` substrate and the existing review center rather than generating new recommendations or calling AI during Phase 1. 
- Preserve the guided onboarding flow and the seven static guidance categories as empty-state guidance while adding a read-only recommendations area.

### Description
- Update `app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx` to authenticate with `requireAdminPageAccess`, set tenant context via `set_current_shop_id`, confirm the `guided_onboarding_sessions` row belongs to the current `shop_id`, and load `ai_recommendations` for the shop (status in `["open","acknowledged"]`, ordered newest first, limited to 100). 
- Add an in-memory filter `filterGuidedAnalysisRecommendations` that prefers recommendations matching `domain === "onboarding"` or `subject_type === "guided_onboarding_session" && subject_id === sessionId` or metadata fields `guidedSessionId` / `sessionId`, and falls back to `domain === "shop_boost"` only when no onboarding-scoped records exist. 
- Preserve the seven static onboarding categories (Inspection templates first; Menu items and canned services second; Inventory improvements; Vendor suggestions; Customer and fleet segments; Maintenance packages; Automation rules) and add a “Current recommendations” section that displays `title`, `summary`, `domain`, `recommendation_type`, `priority`, `confidence`, `risk_tier`, `status`, a missing-data indicator, and CTAs linking to `/dashboard/ai-recommendations`. 
- Add tests `tests/guided-onboarding-ai-analysis.test.ts` that assert the static categories remain, the empty-state copy is present when no recommendations exist, the filtering behavior is correct, no generation/POST logic is introduced, and guided step ordering remains unchanged.

### Testing
- Ran `npm run typecheck` and the TypeScript check completed successfully. 
- Ran `npx eslint app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx features/onboarding-v2 features/ai --ext .ts,.tsx` which reported pre-existing lint failures in unrelated `features/ai` files but did not introduce lint errors in the modified onboarding summary page. 
- Ran `npx vitest run tests/guided-onboarding* tests/onboarding*` and all guided-onboarding tests passed (4 test files, 52 tests passed). 
- Changes included in commit `437a3e866d83756a1bd01deb5b2bf8cfe845879f` and PR titled `Wire guided onboarding AI business analysis recommendations`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ffbadd0748328b6233613bfaaab21)