### PR TITLE
Add deterministic "Run AI Business Analysis" action and route for guided onboarding

### DIFF
--- a/app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts
+++ b/app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { runGuidedOnboardingAnalysis } from "@/features/onboarding-v2/analysis/server";
+
+type Props = { params: Promise<{ sessionId: string }> };
+
+function jsonError(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function POST(_request: Request, { params }: Props) {
+  const { sessionId } = await params;
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id;
+  if (!shopId) return jsonError("Shop not found", 403);
+
+  try {
+    await access.supabase.rpc("set_current_shop_id", { p_shop_id: shopId });
+
+    const { data: session, error: sessionError } = await access.supabase
+      .from("guided_onboarding_sessions")
+      .select("id, shop_id")
+      .eq("id", sessionId)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (sessionError) return jsonError(sessionError.message, 500);
+    if (!session) return jsonError("Guided onboarding session not found", 404);
+
+    const { data: step, error: stepError } = await access.supabase
+      .from("guided_onboarding_steps")
+      .select("id, step_key")
+      .eq("session_id", sessionId)
+      .eq("shop_id", shopId)
+      .eq("step_key", "analysis")
+      .maybeSingle();
+    if (stepError) return jsonError(stepError.message, 500);
+    if (!step) return jsonError("AI Analysis guided step not found", 404);
+
+    const result = await runGuidedOnboardingAnalysis({
+      supabase: access.supabase as never,
+      actor: { shopId, actorId: access.profile.id, role: access.profile.role, source: "manual" },
+      sessionId,
+    });
+
+    const timestamp = new Date().toISOString();
+    await access.supabase
+      .from("guided_onboarding_steps")
+      .update({ status: "completed", completed_at: timestamp, skipped_at: null, updated_at: timestamp })
+      .eq("session_id", sessionId)
+      .eq("shop_id", shopId)
+      .eq("step_key", "analysis");
+
+    await access.supabase.from("guided_onboarding_events").insert({
+      session_id: sessionId,
+      shop_id: shopId,
+      step_key: "analysis",
+      event_type: "analysis_run_completed",
+      payload: { createdCount: result.createdCount, skippedCount: result.skippedCount, categories: result.categories, deterministic: true, noAutoCreate: true },
+      created_by: access.profile.id,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    return jsonError(error instanceof Error ? error.message : "Failed to run guided onboarding analysis", 500);
+  }
+}

--- a/app/dashboard/onboarding-v2/[sessionId]/summary/RunAnalysisButton.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/summary/RunAnalysisButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+type Props = {
+  sessionId: string;
+  hasRecommendations: boolean;
+};
+
+export default function RunAnalysisButton({ sessionId, hasRecommendations }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [isRunning, setIsRunning] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function runAnalysis() {
+    setError(null);
+    setMessage(null);
+    setIsRunning(true);
+    const response = await fetch(`/api/onboarding-v2/guided/sessions/${sessionId}/analysis`, { method: "POST" });
+    const payload = await response.json().catch(() => null) as { createdCount?: number; skippedCount?: number; error?: string } | null;
+    if (!response.ok) {
+      setError(payload?.error ?? "Unable to run AI Business Analysis.");
+      setIsRunning(false);
+      return;
+    }
+    setMessage(`Analysis complete: ${payload?.createdCount ?? 0} created, ${payload?.skippedCount ?? 0} skipped.`);
+    startTransition(() => router.refresh());
+    setIsRunning(false);
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={runAnalysis}
+        disabled={isRunning || isPending}
+        className="rounded-full border border-orange-300/35 bg-orange-300/10 px-4 py-2 text-sm font-semibold text-orange-100 transition hover:bg-orange-300/20 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isRunning || isPending ? "Running analysis…" : hasRecommendations ? "Re-run analysis" : "Run AI Business Analysis"}
+      </button>
+      {message ? <p className="text-xs text-emerald-200">{message}</p> : null}
+      {error ? <p className="text-xs text-red-200">{error}</p> : null}
+    </div>
+  );
+}

--- a/app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
+import RunAnalysisButton from "./RunAnalysisButton";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import type { AiRecommendationRecord } from "@/features/ai/server/types";
@@ -122,6 +123,7 @@ export default async function GuidedOnboardingAnalysisSummaryPage({ params }: Pr
           ProFixIQ AI Business Analysis reviews the customers, vehicles, history, invoices, parts, and shop defaults that were imported or configured during guided setup. It recommends next actions for the shop; it does not auto-create operational records.
         </p>
         <div className="mt-5 flex flex-wrap items-center gap-3">
+          <RunAnalysisButton sessionId={sessionId} hasRecommendations={recommendations.length > 0} />
           <Link href="/dashboard/ai-recommendations" className="rounded-full border border-orange-300/35 bg-orange-300/10 px-4 py-2 text-sm font-semibold text-orange-100 transition hover:bg-orange-300/20">
             Open AI Recommendations
           </Link>

--- a/features/onboarding-v2/analysis/server.ts
+++ b/features/onboarding-v2/analysis/server.ts
@@ -1,0 +1,178 @@
+import "server-only";
+
+import { createAiRecommendation } from "@/features/ai/server/recommendations";
+import type { AiActorContext, AiRecommendationRecord, AiServerClient } from "@/features/ai/server/types";
+import type { Json } from "@shared/types/types/supabase";
+
+export const GUIDED_ANALYSIS_DOMAIN = "onboarding";
+export const GUIDED_ANALYSIS_SUBJECT_TYPE = "guided_onboarding_session";
+export const GUIDED_ANALYSIS_SOURCE = "guided_onboarding_analysis";
+const DUPLICATE_STATUSES = ["open", "acknowledged", "resolved"];
+
+// Supabase query builders are intentionally loose here because this service probes optional
+// onboarding tables/columns that may vary across import paths.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type GuidedQuery = any;
+type SupabaseLike = AiServerClient & { from(table: string): GuidedQuery };
+
+export type GuidedOnboardingEvidence = {
+  customerCount: number;
+  vehicleCount: number;
+  historyCount: number;
+  invoiceCount: number;
+  partsCount: number;
+  lowStockPartsCount: number;
+  zeroStockPartsCount: number;
+  partsMissingVendorCount: number;
+  partsWithVendorCount: number;
+  partsMissingCategoryCount: number;
+  commonServiceCategories: string[];
+  commonJobs: string[];
+  inspectionTemplateCount: number;
+  menuItemCount: number;
+  shopSettings: {
+    laborRateConfigured: boolean;
+    hoursConfigured: boolean;
+    shopSuppliesConfigured: boolean;
+    taxRateConfigured: boolean;
+    workflowDefaultsConfigured: boolean;
+  };
+};
+
+type RecommendationDraft = {
+  recommendationType: string;
+  category: string;
+  title: string;
+  summary: string;
+  priority: "low" | "normal" | "high" | "urgent";
+  confidence: number;
+  missingData?: Json;
+  recommendedAction: Json;
+};
+
+type RunInput = {
+  supabase: SupabaseLike;
+  actor: AiActorContext;
+  sessionId: string;
+};
+
+async function countRows(supabase: SupabaseLike, table: string, shopId: string, build?: (query: GuidedQuery) => GuidedQuery): Promise<number> {
+  let query = supabase.from(table).select("id", { count: "exact", head: true }).eq("shop_id", shopId);
+  if (build) query = build(query);
+  const { count, error } = await query;
+  if (error) return 0;
+  return count ?? 0;
+}
+
+async function sampleColumn(supabase: SupabaseLike, table: string, shopId: string, columns: string, limit = 100): Promise<Record<string, unknown>[]> {
+  const { data, error } = await supabase.from(table).select(columns).eq("shop_id", shopId).limit(limit);
+  if (error) return [];
+  return (data ?? []) as unknown as Record<string, unknown>[];
+}
+
+function topStrings(rows: Record<string, unknown>[], keys: string[], limit = 5): string[] {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const value = keys.map((key) => row[key]).find((item) => typeof item === "string" && item.trim().length > 0);
+    if (typeof value !== "string") continue;
+    const cleaned = value.trim().slice(0, 80);
+    counts.set(cleaned, (counts.get(cleaned) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, limit).map(([value]) => value);
+}
+
+export async function collectGuidedOnboardingEvidence(supabase: SupabaseLike, shopId: string): Promise<GuidedOnboardingEvidence> {
+  const [
+    customerCount, vehicleCount, historyCount, invoiceCount, partsCount,
+    lowStockPartsCount, zeroStockPartsCount, partsMissingVendorCount, partsWithVendorCount, partsMissingCategoryCount,
+    inspectionTemplateCount, menuItemCount, hoursCount,
+  ] = await Promise.all([
+    countRows(supabase, "customers", shopId),
+    countRows(supabase, "vehicles", shopId),
+    countRows(supabase, "work_order_lines", shopId),
+    countRows(supabase, "invoices", shopId),
+    countRows(supabase, "parts", shopId),
+    countRows(supabase, "parts", shopId, (q) => q.lt("quantity_on_hand", 3)),
+    countRows(supabase, "parts", shopId, (q) => q.lte("quantity_on_hand", 0)),
+    countRows(supabase, "parts", shopId, (q) => q.or("vendor.is.null,vendor.eq.")),
+    countRows(supabase, "parts", shopId, (q) => q.not("vendor", "is", null)),
+    countRows(supabase, "parts", shopId, (q) => q.or("category.is.null,category.eq.")),
+    countRows(supabase, "inspection_templates", shopId),
+    countRows(supabase, "menu_items", shopId),
+    countRows(supabase, "shop_hours", shopId),
+  ]);
+
+  const [lineSamples, invoiceSamples, shopRows] = await Promise.all([
+    sampleColumn(supabase, "work_order_lines", shopId, "description,name,category,service_category", 200),
+    sampleColumn(supabase, "invoices", shopId, "service_category,category,description", 100),
+    sampleColumn(supabase, "shops", shopId, "labor_rate,tax_rate,shop_supplies_enabled,shop_supplies_percent,supplies_percent,workflow_defaults,default_workflow_status", 1),
+  ]);
+  const shop = shopRows[0] ?? {};
+
+  return {
+    customerCount, vehicleCount, historyCount, invoiceCount, partsCount,
+    lowStockPartsCount, zeroStockPartsCount, partsMissingVendorCount, partsWithVendorCount, partsMissingCategoryCount,
+    commonServiceCategories: topStrings([...lineSamples, ...invoiceSamples], ["service_category", "category"], 6),
+    commonJobs: topStrings(lineSamples, ["description", "name"], 6),
+    inspectionTemplateCount,
+    menuItemCount,
+    shopSettings: {
+      laborRateConfigured: typeof shop.labor_rate === "number" && shop.labor_rate > 0,
+      hoursConfigured: hoursCount > 0,
+      shopSuppliesConfigured: Boolean(shop.shop_supplies_enabled) || Number(shop.shop_supplies_percent ?? shop.supplies_percent ?? 0) > 0,
+      taxRateConfigured: typeof shop.tax_rate === "number" && shop.tax_rate >= 0,
+      workflowDefaultsConfigured: Boolean(shop.workflow_defaults) || Boolean(shop.default_workflow_status),
+    },
+  };
+}
+
+function buildDrafts(e: GuidedOnboardingEvidence): RecommendationDraft[] {
+  const drafts: RecommendationDraft[] = [];
+  const hasHistory = e.historyCount > 0 || e.invoiceCount > 0 || e.commonJobs.length > 0 || e.commonServiceCategories.length > 0;
+  if (hasHistory && e.inspectionTemplateCount < 2) drafts.push({ recommendationType: "inspection_templates_first", category: "Inspection templates first", title: "Build inspection templates from completed onboarding history", summary: "Completed service history exists, but inspection template coverage is light. Review templates before canned services so future jobs can attach the right inspection workflow.", priority: "high", confidence: 0.82, recommendedAction: { type: "review_inspection_template_opportunities", autoCreate: false } });
+  if ((e.commonJobs.length > 0 || e.commonServiceCategories.length > 0) && e.menuItemCount < 5) drafts.push({ recommendationType: "menu_items_canned_services", category: "Menu items and canned services second", title: "Review repeated jobs for menu items and canned services", summary: "Repeated onboarding job data can be converted into reviewed menu items after inspection templates are selected.", priority: "normal", confidence: 0.78, recommendedAction: { type: "review_menu_item_candidates", autoCreate: false } });
+  if (e.partsCount > 0 && (e.zeroStockPartsCount > 0 || e.lowStockPartsCount > 0 || e.partsMissingCategoryCount > 0)) drafts.push({ recommendationType: "inventory_improvements", category: "Inventory improvements", title: "Clean up low-stock and uncategorized imported parts", summary: "Parts data includes low or zero stock items, or missing categories. Review reorder and categorization settings before go-live.", priority: e.zeroStockPartsCount > 0 ? "high" : "normal", confidence: 0.84, recommendedAction: { type: "review_inventory_cleanup", autoCreate: false } });
+  if (e.partsCount > 0 && (e.partsWithVendorCount > 0 || e.partsMissingVendorCount > 0)) drafts.push({ recommendationType: "vendor_suggestions", category: "Vendor suggestions", title: "Review vendor coverage for imported parts", summary: "Parts inventory has vendor signals or vendor gaps. Review vendor coverage so purchasing workflows are ready.", priority: "low", confidence: 0.7, recommendedAction: { type: "review_vendor_coverage", autoCreate: false } });
+  if (e.customerCount > 0 && (e.vehicleCount > 0 || hasHistory)) drafts.push({ recommendationType: "customer_fleet_segments", category: "Customer and fleet segments", title: "Define customer and fleet launch segments", summary: "Customer, vehicle, and history data can support owner-reviewed segments for retention, fleet handling, and follow-up.", priority: "normal", confidence: 0.76, recommendedAction: { type: "review_segment_opportunities", autoCreate: false } });
+  if (e.commonServiceCategories.length > 0 || e.commonJobs.length >= 3) drafts.push({ recommendationType: "maintenance_packages", category: "Maintenance packages", title: "Review recurring services for maintenance packages", summary: "Recurring services in onboarding data can inform maintenance packages once reviewed by the shop.", priority: "normal", confidence: 0.74, recommendedAction: { type: "review_maintenance_package_candidates", autoCreate: false } });
+  if (e.customerCount > 0 || e.invoiceCount > 0 || !e.shopSettings.workflowDefaultsConfigured) drafts.push({ recommendationType: "automation_rules", category: "Automation rules", title: "Review launch automation opportunities", summary: "Onboarding data suggests reminder, follow-up, or workflow default opportunities. Review rules before enabling any automation.", priority: "low", confidence: 0.68, missingData: !e.shopSettings.workflowDefaultsConfigured ? ["workflow_defaults"] : [], recommendedAction: { type: "review_automation_rule_candidates", autoCreate: false } });
+  return drafts;
+}
+
+async function findDuplicate(supabase: SupabaseLike, shopId: string, sessionId: string, recommendationType: string) {
+  const { data, error } = await supabase.from("ai_recommendations").select("*").eq("shop_id", shopId).eq("domain", GUIDED_ANALYSIS_DOMAIN).eq("subject_type", GUIDED_ANALYSIS_SUBJECT_TYPE).eq("subject_id", sessionId).eq("recommendation_type", recommendationType).eq("source", GUIDED_ANALYSIS_SOURCE).in("status", DUPLICATE_STATUSES).limit(1).maybeSingle();
+  if (error) throw new Error(error.message);
+  return data as AiRecommendationRecord | null;
+}
+
+export async function runGuidedOnboardingAnalysis({ supabase, actor, sessionId }: RunInput) {
+  const evidence = await collectGuidedOnboardingEvidence(supabase, actor.shopId);
+  const drafts = buildDrafts(evidence);
+  const created: AiRecommendationRecord[] = [];
+  const skipped: AiRecommendationRecord[] = [];
+  const sourceRunId = `${GUIDED_ANALYSIS_SOURCE}:${sessionId}`;
+  for (const draft of drafts) {
+    const existing = await findDuplicate(supabase, actor.shopId, sessionId, draft.recommendationType);
+    if (existing) { skipped.push(existing); continue; }
+    created.push(await createAiRecommendation(supabase as AiServerClient, actor, {
+      domain: GUIDED_ANALYSIS_DOMAIN,
+      recommendationType: draft.recommendationType,
+      subjectType: GUIDED_ANALYSIS_SUBJECT_TYPE,
+      subjectId: sessionId,
+      title: draft.title,
+      summary: draft.summary,
+      priority: draft.priority,
+      confidence: draft.confidence,
+      riskTier: "low",
+      missingData: draft.missingData ?? [],
+      recommendedAction: draft.recommendedAction,
+      sideEffects: [],
+      requiresApproval: false,
+      requiresOwnerPin: false,
+      source: GUIDED_ANALYSIS_SOURCE,
+      sourceRunId,
+      metadata: { guidedSessionId: sessionId, sessionId, evidence, category: draft.category, deterministic: true, noAutoCreate: true },
+    }));
+  }
+  return { createdCount: created.length, skippedCount: skipped.length, recommendations: [...created, ...skipped], evidence, categories: drafts.map((d) => d.category) };
+}

--- a/tests/guided-onboarding-ai-analysis.test.ts
+++ b/tests/guided-onboarding-ai-analysis.test.ts
@@ -102,14 +102,12 @@ describe("guided onboarding AI Business Analysis page", () => {
     expect(source).toContain('href="/dashboard/ai-recommendations"');
   });
 
-  it("does not add generation or POST behavior", () => {
+  it("keeps recommendation creation out of the server-rendered page", () => {
     const source = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
 
-    expect(source).not.toContain("method: \"POST\"");
-    expect(source).not.toContain("method: 'POST'");
-    expect(source).not.toContain("Run Analysis");
     expect(source).not.toContain("createAiRecommendation");
     expect(source).not.toContain("insert(");
+    expect(source).not.toContain("runGuidedOnboardingAnalysis(");
   });
 
   it("keeps Staff removed and Shop Settings before AI Analysis", () => {
@@ -123,5 +121,69 @@ describe("guided onboarding AI Business Analysis page", () => {
       "analysis",
     ]);
     expect(GUIDED_ONBOARDING_STEP_KEYS).not.toContain("staff");
+  });
+});
+
+describe("guided onboarding deterministic analysis phase 2", () => {
+  it("adds an explicit run button without running analysis automatically on page load", () => {
+    const pageSource = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
+    const buttonSource = read("app/dashboard/onboarding-v2/[sessionId]/summary/RunAnalysisButton.tsx");
+
+    expect(pageSource).toContain("<RunAnalysisButton");
+    expect(buttonSource).toContain("Run AI Business Analysis");
+    expect(buttonSource).toContain("Re-run analysis");
+    expect(buttonSource).toContain("method: \"POST\"");
+    expect(pageSource).not.toContain("runGuidedOnboardingAnalysis(");
+  });
+
+  it("adds a shop-scoped POST route that verifies session and analysis step access", () => {
+    const source = read("app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts");
+
+    expect(source).toContain("export async function POST");
+    expect(source).toContain("requireShopScopedApiAccess({ allowRoles: [\"owner\", \"admin\"] })");
+    expect(source).toContain('.from("guided_onboarding_sessions")');
+    expect(source).toContain('.eq("shop_id", shopId)');
+    expect(source).toContain('.from("guided_onboarding_steps")');
+    expect(source).toContain('.eq("step_key", "analysis")');
+    expect(source).toContain("analysis_run_completed");
+  });
+
+  it("collects bounded deterministic shop evidence and never calls an AI provider", () => {
+    const source = read("features/onboarding-v2/analysis/server.ts");
+
+    for (const table of ["customers", "vehicles", "work_order_lines", "invoices", "parts", "inspection_templates", "menu_items", "shop_hours", "shops"]) {
+      expect(source).toContain(`\"${table}\"`);
+    }
+    expect(source).toContain('select("id", { count: "exact", head: true })');
+    expect(source).toContain(", 200)");
+    expect(source).toContain("deterministic: true");
+    expect(source).toContain("noAutoCreate: true");
+    expect(source).not.toMatch(/openai|anthropic|chat\.completions|responses\.create|generateText/i);
+  });
+
+  it("creates onboarding session recommendations with idempotent duplicate checks", () => {
+    const source = read("features/onboarding-v2/analysis/server.ts");
+
+    expect(source).toContain('GUIDED_ANALYSIS_DOMAIN = "onboarding"');
+    expect(source).toContain('GUIDED_ANALYSIS_SUBJECT_TYPE = "guided_onboarding_session"');
+    expect(source).toContain('GUIDED_ANALYSIS_SOURCE = "guided_onboarding_analysis"');
+    expect(source).toContain("createAiRecommendation");
+    expect(source).toContain('.eq("recommendation_type", recommendationType)');
+    expect(source).toContain('.in("status", DUPLICATE_STATUSES)');
+    expect(source).toContain("skippedCount");
+    expect(source).toContain("sideEffects: []");
+    expect(source).toContain("autoCreate: false");
+  });
+
+  it("generates only the seven reviewable category families", () => {
+    const source = read("features/onboarding-v2/analysis/server.ts");
+
+    expect(source).toContain("Inspection templates first");
+    expect(source).toContain("Menu items and canned services second");
+    expect(source).toContain("Inventory improvements");
+    expect(source).toContain("Vendor suggestions");
+    expect(source).toContain("Customer and fleet segments");
+    expect(source).toContain("Maintenance packages");
+    expect(source).toContain("Automation rules");
   });
 });


### PR DESCRIPTION
### Motivation
- Provide an explicit, deterministic, reviewable “Run AI Business Analysis” action for guided onboarding that creates durable `ai_recommendations` from completed onboarding data without calling any model or making operational side effects.
- Keep behavior idempotent and shop-scoped so repeated runs do not produce duplicate recommendations and are safe for multi-tenant shops.

### Description
- Added a client Run button and UX: `app/dashboard/onboarding-v2/[sessionId]/summary/RunAnalysisButton.tsx` and wired it into the summary page so owners/admins can `POST` to run analysis manually without auto-running on page load. (Page import updates in `app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx`).
- Added shop-scoped POST route `POST /api/onboarding-v2/guided/sessions/[sessionId]/analysis` at `app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts` that verifies auth, shop ownership of the guided session, and the existence of the `analysis` guided step before running the service; it marks the analysis step completed and logs a guided onboarding event after the run.
- Implemented a deterministic, rule-based analysis service at `features/onboarding-v2/analysis/server.ts` that collects bounded evidence (counts + small samples) for customers, vehicles, work-order lines, invoices, parts (including low/zero stock and vendor/category signals), inspection templates, menu items, shop hours, and shop settings presence, then drafts recommendations in the seven pre-defined category families and creates reviewable `ai_recommendations` via `createAiRecommendation`.
- Idempotency: before creating each recommendation the service searches for existing recommendations matching `shop_id`, `domain = "onboarding"`, `subject_type = "guided_onboarding_session"`, `subject_id = sessionId`, `recommendation_type`, and `source = "guided_onboarding_analysis"` in statuses `open|acknowledged|resolved` and skips creation if found; created recommendations include `metadata.guidedSessionId`, `deterministic: true`, and `noAutoCreate: true` and use `risk_tier: low` and empty `side_effects`.
- Tests: extended `tests/guided-onboarding-ai-analysis.test.ts` to assert presence of the run button, route checks, evidence collection, idempotency, category coverage, and absence of any AI/model provider calls.

### Testing
- `npm run typecheck` executed successfully with no new type errors. (Type-level looseness in the analysis service is deliberate and annotated.)
- `npx eslint app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts features/onboarding-v2/analysis features/ai/server/recommendations.ts --ext .ts,.tsx` passed (warnings where intentionally documented were addressed).
- `npx vitest run tests/guided-onboarding* tests/onboarding*` ran and all targeted tests passed: 57 tests total (tests for the new run button, POST route behavior, evidence collection, idempotency, and no AI calls passed).

Files changed/added
- Added `app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts` (POST route).
- Added `features/onboarding-v2/analysis/server.ts` (deterministic analysis service and evidence collection).
- Added `app/dashboard/onboarding-v2/[sessionId]/summary/RunAnalysisButton.tsx` and updated `app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx` to include the button.
- Updated `tests/guided-onboarding-ai-analysis.test.ts` to cover Phase 2 behavior.

Notes / confirmations
- No AI/model provider or external LLM calls are made anywhere in the new code; analysis is deterministic and rule-based only.
- No operational side effects are performed except writing/de-duping `ai_recommendations` and logging guided onboarding events; nothing auto-creates inspection templates, menu items, maintenance packages, automation rules, vendors, or segments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ffec40d408328b51483faddb45b32)