### PR TITLE
Move guided analysis filter out of Next page to fix App Router export error

### DIFF
--- a/app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx
@@ -3,6 +3,7 @@ import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageS
 import RunAnalysisButton from "./RunAnalysisButton";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { filterGuidedAnalysisRecommendations } from "@/features/onboarding-v2/analysis/filterGuidedAnalysisRecommendations";
 import type { AiRecommendationRecord } from "@/features/ai/server/types";
 import type { Json } from "@shared/types/types/supabase";
 
@@ -48,29 +49,6 @@ function jsonHasContent(value: Json | null | undefined): boolean {
   if (Array.isArray(value)) return value.length > 0;
   if (typeof value === "object") return Object.keys(value).length > 0;
   return Boolean(value);
-}
-
-function metadataMatchesSession(metadata: Json | null | undefined, sessionId: string): boolean {
-  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;
-  return metadata.guidedSessionId === sessionId || metadata.sessionId === sessionId;
-}
-
-function isOnboardingScopedRecommendation(recommendation: AiRecommendationRecord, sessionId: string): boolean {
-  return recommendation.domain === "onboarding" ||
-    (recommendation.subject_type === "guided_onboarding_session" && recommendation.subject_id === sessionId) ||
-    metadataMatchesSession(recommendation.metadata, sessionId);
-}
-
-export function filterGuidedAnalysisRecommendations(
-  recommendations: AiRecommendationRecord[],
-  sessionId: string,
-): AiRecommendationRecord[] {
-  const onboardingScoped = recommendations.filter((recommendation) =>
-    isOnboardingScopedRecommendation(recommendation, sessionId),
-  );
-
-  if (onboardingScoped.length > 0) return onboardingScoped;
-  return recommendations.filter((recommendation) => recommendation.domain === "shop_boost");
 }
 
 async function loadGuidedAnalysisRecommendations(sessionId: string): Promise<AiRecommendationRecord[]> {

--- a/features/onboarding-v2/analysis/filterGuidedAnalysisRecommendations.ts
+++ b/features/onboarding-v2/analysis/filterGuidedAnalysisRecommendations.ts
@@ -1,0 +1,25 @@
+import type { AiRecommendationRecord } from "@/features/ai/server/types";
+import type { Json } from "@shared/types/types/supabase";
+
+function metadataMatchesSession(metadata: Json | null | undefined, sessionId: string): boolean {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;
+  return metadata.guidedSessionId === sessionId || metadata.sessionId === sessionId;
+}
+
+function isOnboardingScopedRecommendation(recommendation: AiRecommendationRecord, sessionId: string): boolean {
+  return recommendation.domain === "onboarding" ||
+    (recommendation.subject_type === "guided_onboarding_session" && recommendation.subject_id === sessionId) ||
+    metadataMatchesSession(recommendation.metadata, sessionId);
+}
+
+export function filterGuidedAnalysisRecommendations(
+  recommendations: AiRecommendationRecord[],
+  sessionId: string,
+): AiRecommendationRecord[] {
+  const onboardingScoped = recommendations.filter((recommendation) =>
+    isOnboardingScopedRecommendation(recommendation, sessionId),
+  );
+
+  if (onboardingScoped.length > 0) return onboardingScoped;
+  return recommendations.filter((recommendation) => recommendation.domain === "shop_boost");
+}

--- a/tests/guided-onboarding-ai-analysis.test.ts
+++ b/tests/guided-onboarding-ai-analysis.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { GUIDED_ONBOARDING_STEP_KEYS } from "@/features/onboarding-v2/guided/steps";
-import { filterGuidedAnalysisRecommendations } from "../app/dashboard/onboarding-v2/[sessionId]/summary/page";
+import { filterGuidedAnalysisRecommendations } from "@/features/onboarding-v2/analysis/filterGuidedAnalysisRecommendations";
 import type { AiRecommendationRecord } from "@/features/ai/server/types";
 
 function read(path: string) {


### PR DESCRIPTION
### Motivation
- Fix a Vercel/Next App Router build error where a helper (`filterGuidedAnalysisRecommendations`) was exported from a `page.tsx` route file, which is not allowed by Next.js page export rules.

### Description
- Moved the `filterGuidedAnalysisRecommendations` function and its small private helpers into `features/onboarding-v2/analysis/filterGuidedAnalysisRecommendations.ts` so the logic lives in a non-route module.
- Updated `app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx` to import the filter helper and ensured the file only exports the default page component.
- Updated `tests/guided-onboarding-ai-analysis.test.ts` to import the helper from the new feature module without changing filter behavior.
- No functional changes to the AI Analysis behavior or filtering logic were made.

### Testing
- Ran `npm run typecheck`, which completed successfully with no TypeScript errors.
- Ran `npx vitest run tests/guided-onboarding-ai-analysis.test.ts`, with all tests passing (`11 tests, 11 passed`).
- Ran `pnpm build`, which failed due to network font fetch errors from Google Fonts for `Black Ops One` and `Inter`, and not because of the route export; the original Page export error is no longer present.

Files changed: `features/onboarding-v2/analysis/filterGuidedAnalysisRecommendations.ts`, `app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx`, `tests/guided-onboarding-ai-analysis.test.ts`.

Commit: `404695b4630dc797d92a0919903a71af348160cf`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a501f7e430083288282a4e6d4696685)