### PR TITLE
Fix guided onboarding analysis source_run_id UUID misuse

### DIFF
--- a/features/onboarding-v2/analysis/server.ts
+++ b/features/onboarding-v2/analysis/server.ts
@@ -170,8 +170,7 @@ export async function runGuidedOnboardingAnalysis({ supabase, actor, sessionId }
       requiresApproval: false,
       requiresOwnerPin: false,
       source: GUIDED_ANALYSIS_SOURCE,
-      sourceRunId,
-      metadata: { guidedSessionId: sessionId, sessionId, evidence, category: draft.category, deterministic: true, noAutoCreate: true },
+      metadata: { guidedSessionId: sessionId, sessionId, sourceRunId, evidence, category: draft.category, deterministic: true, noAutoCreate: true },
     }));
   }
   return { createdCount: created.length, skippedCount: skipped.length, recommendations: [...created, ...skipped], evidence, categories: drafts.map((d) => d.category) };


### PR DESCRIPTION
### Motivation
- The guided analysis constructed a prefixed run identifier (`guided_onboarding_analysis:<sessionId>`) and passed it as `sourceRunId` into `createAiRecommendation`, which attempted to write that string into the `ai_recommendations.source_run_id` UUID column and produced invalid UUID errors.

### Description
- Stop passing the prefixed `sourceRunId` into `createAiRecommendation` and instead include the identifier inside the recommendation `metadata` as `metadata.sourceRunId`, preserving `subjectId: sessionId` and leaving `ai_recommendations.source_run_id` null; change made in `features/onboarding-v2/analysis/server.ts`.

### Testing
- Ran `npm run typecheck` which passed, and `npm run build` which failed due to Next.js being unable to fetch Google Fonts in this environment (unrelated to the change); commit `43d32c5c65064530267eab57f2abc4ce66971c6d`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a504d003ca88328b1d500bc9312e9b2)