### PR TITLE
Polish guided onboarding executive summary

### DIFF
--- a/app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx
+++ b/app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx
@@ -4,54 +4,19 @@ import RunAnalysisButton from "./RunAnalysisButton";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { filterGuidedAnalysisRecommendations } from "@/features/onboarding-v2/analysis/filterGuidedAnalysisRecommendations";
+import { buildExecutiveSummary } from "@/features/onboarding-v2/analysis/buildExecutiveSummary";
+import { collectGuidedOnboardingEvidence, type GuidedOnboardingEvidence } from "@/features/onboarding-v2/analysis/server";
 import type { AiRecommendationRecord } from "@/features/ai/server/types";
-import type { Json } from "@shared/types/types/supabase";
 
-type Props = {
-  params: Promise<{ sessionId: string }>;
-};
+type Props = { params: Promise<{ sessionId: string }> };
+type GuidedSessionRow = { id: string; shop_id: string };
+type SupabaseQueryResult<T> = { data: T | null; error: { message: string } | null };
+type SupabaseSelectQuery<T> = { select(columns: string): SupabaseSelectQuery<T>; eq(column: string, value: string): SupabaseSelectQuery<T>; in(column: string, values: string[]): SupabaseSelectQuery<T>; order(column: string, options: { ascending: boolean }): SupabaseSelectQuery<T>; limit(count: number): Promise<SupabaseQueryResult<T[]>>; maybeSingle(): Promise<SupabaseQueryResult<T>> };
+type GuidedAnalysisSupabaseReader = { from<T>(table: string): SupabaseSelectQuery<T> };
 
-type GuidedSessionRow = {
-  id: string;
-  shop_id: string;
-};
+type SummaryData = { recommendations: AiRecommendationRecord[]; evidence: GuidedOnboardingEvidence | null };
 
-type SupabaseQueryResult<T> = {
-  data: T | null;
-  error: { message: string } | null;
-};
-
-type SupabaseSelectQuery<T> = {
-  select(columns: string): SupabaseSelectQuery<T>;
-  eq(column: string, value: string): SupabaseSelectQuery<T>;
-  in(column: string, values: string[]): SupabaseSelectQuery<T>;
-  order(column: string, options: { ascending: boolean }): SupabaseSelectQuery<T>;
-  limit(count: number): Promise<SupabaseQueryResult<T[]>>;
-  maybeSingle(): Promise<SupabaseQueryResult<T>>;
-};
-
-type GuidedAnalysisSupabaseReader = {
-  from<T>(table: string): SupabaseSelectQuery<T>;
-};
-
-const GUIDED_ANALYSIS_CATEGORIES = [
-  ["1", "Inspection templates first", "Recommend inspection templates that match the shop's vehicle mix, common jobs, and inspection goals before building canned services."],
-  ["2", "Menu items and canned services second", "Recommend menu items after inspection guidance, because canned services can attach inspections."],
-  ["3", "Inventory improvements", "Flag fast-moving parts, missing stock coverage, reorder opportunities, and cleanup candidates."],
-  ["4", "Vendor suggestions", "Identify vendor gaps or consolidation opportunities from configured parts and invoice patterns."],
-  ["5", "Customer and fleet segments", "Suggest segments for retention, fleet handling, declined work follow-up, and targeted communication."],
-  ["6", "Maintenance packages", "Recommend packages that align with shop history, vehicle types, and recurring mileage or time intervals."],
-  ["7", "Automation rules", "Suggest reminders, review prompts, approval follow-ups, and internal workflow automations for owner review."],
-] as const;
-
-function jsonHasContent(value: Json | null | undefined): boolean {
-  if (value == null) return false;
-  if (Array.isArray(value)) return value.length > 0;
-  if (typeof value === "object") return Object.keys(value).length > 0;
-  return Boolean(value);
-}
-
-async function loadGuidedAnalysisRecommendations(sessionId: string): Promise<AiRecommendationRecord[]> {
+async function loadGuidedAnalysisSummaryData(sessionId: string): Promise<SummaryData> {
   const { profile } = await requireAdminPageAccess({ allow: ["owner", "admin", "manager", "advisor"] });
   const supabase = createServerSupabaseRSC();
   const reader = supabase as unknown as GuidedAnalysisSupabaseReader;
@@ -67,107 +32,86 @@ async function loadGuidedAnalysisRecommendations(sessionId: string): Promise<AiR
     .maybeSingle();
 
   if (sessionError) throw new Error(sessionError.message);
-  if (!session) return [];
-  const guidedSession = session as GuidedSessionRow;
+  if (!session) return { recommendations: [], evidence: null };
 
-  const { data, error } = await reader
-    .from<AiRecommendationRecord>("ai_recommendations")
-    .select("*")
-    .eq("shop_id", shopId)
-    .in("status", ["open", "acknowledged"])
-    .order("created_at", { ascending: false })
-    .limit(100);
+  const [{ data, error }, evidence] = await Promise.all([
+    reader
+      .from<AiRecommendationRecord>("ai_recommendations")
+      .select("*")
+      .eq("shop_id", shopId)
+      .in("status", ["open", "acknowledged"])
+      .order("created_at", { ascending: false })
+      .limit(100),
+    collectGuidedOnboardingEvidence(supabase, shopId),
+  ]);
 
   if (error) throw new Error(error.message);
-  return filterGuidedAnalysisRecommendations((data ?? []) as AiRecommendationRecord[], guidedSession.id);
+  return { recommendations: filterGuidedAnalysisRecommendations((data ?? []) as AiRecommendationRecord[], session.id), evidence };
 }
 
-function formatConfidence(confidence: number | null) {
-  if (confidence == null) return "Not scored";
-  return `${Math.round(confidence * 100)}%`;
+function formatCount(value: number) { return new Intl.NumberFormat("en-US").format(value); }
+function impactClass(impact: "high" | "medium" | "low") {
+  if (impact === "high") return "border-orange-300/40 bg-orange-300/15 text-orange-100";
+  if (impact === "medium") return "border-sky-300/35 bg-sky-300/10 text-sky-100";
+  return "border-white/15 bg-white/10 text-neutral-200";
 }
 
 export default async function GuidedOnboardingAnalysisSummaryPage({ params }: Props) {
   const { sessionId } = await params;
-  const recommendations = await loadGuidedAnalysisRecommendations(sessionId);
+  const { recommendations, evidence } = await loadGuidedAnalysisSummaryData(sessionId);
+  const hasAnalysis = recommendations.length > 0 && evidence != null;
+  const summary = hasAnalysis ? buildExecutiveSummary(evidence, recommendations) : null;
 
   return (
-    <main className="mx-auto w-full max-w-5xl space-y-6 px-4 pb-10 pt-6 text-neutral-100 sm:px-6 lg:px-8">
+    <main className="mx-auto w-full max-w-6xl space-y-6 px-4 pb-10 pt-6 text-neutral-100 sm:px-6 lg:px-8">
       <GuidedPageStepPanel />
-      <section className="rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(251,146,60,0.18),transparent_35%),linear-gradient(180deg,rgba(255,255,255,0.07),rgba(255,255,255,0.02))] p-6 shadow-[0_24px_80px_rgba(0,0,0,0.45)] backdrop-blur-xl">
-        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">Guided Setup · AI Business Analysis</p>
-        <h1 className="mt-3 text-3xl font-semibold text-white sm:text-4xl">Review recommended launch improvements</h1>
-        <p className="mt-3 max-w-3xl text-sm leading-6 text-neutral-300">
-          ProFixIQ AI Business Analysis reviews the customers, vehicles, history, invoices, parts, and shop defaults that were imported or configured during guided setup. It recommends next actions for the shop; it does not auto-create operational records.
-        </p>
-        <div className="mt-5 flex flex-wrap items-center gap-3">
-          <RunAnalysisButton sessionId={sessionId} hasRecommendations={recommendations.length > 0} />
-          <Link href="/dashboard/ai-recommendations" className="rounded-full border border-orange-300/35 bg-orange-300/10 px-4 py-2 text-sm font-semibold text-orange-100 transition hover:bg-orange-300/20">
-            Open AI Recommendations
-          </Link>
-          <p className="text-xs text-neutral-500">Session: {sessionId}</p>
-        </div>
-      </section>
-
-      <section className="grid gap-4 md:grid-cols-2">
-        {GUIDED_ANALYSIS_CATEGORIES.map(([index, title, description]) => (
-          <article key={title} className="rounded-2xl border border-white/10 bg-black/35 p-5 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl">
-            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-orange-300/30 bg-orange-300/10 text-sm font-semibold text-orange-100">{index}</span>
-            <h2 className="mt-4 text-lg font-semibold text-white">{title}</h2>
-            <p className="mt-2 text-sm leading-6 text-neutral-300">{description}</p>
-          </article>
-        ))}
-      </section>
-
-      <section className="rounded-[2rem] border border-white/10 bg-black/35 p-6 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <section className="overflow-hidden rounded-[2rem] border border-white/10 bg-[radial-gradient(circle_at_top_left,rgba(251,146,60,0.22),transparent_34%),radial-gradient(circle_at_bottom_right,rgba(56,189,248,0.16),transparent_30%),linear-gradient(180deg,rgba(255,255,255,0.08),rgba(255,255,255,0.025))] p-6 shadow-[0_30px_90px_rgba(0,0,0,0.5)] backdrop-blur-xl sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-orange-200/85">Guided Setup · AI Executive Summary</p>
+        <div className="mt-4 grid gap-6 lg:grid-cols-[1.35fr_0.65fr] lg:items-end">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">Current recommendations</p>
-            <h2 className="mt-2 text-2xl font-semibold text-white">Reviewable AI Business Analysis signals</h2>
+            <h1 className="text-3xl font-semibold text-white sm:text-5xl">{hasAnalysis ? "Your business analysis is ready." : "Run your AI Business Analysis."}</h1>
+            <p className="mt-4 max-w-3xl text-sm leading-6 text-neutral-300 sm:text-base">
+              {hasAnalysis ? "ProFixIQ reviewed the information imported during guided setup. Here is what your data says about your shop and where the platform can help first." : "ProFixIQ will review customers, vehicles, service history, invoices, parts, vendors, inspection templates, menu items, and shop defaults. It creates owner-reviewable recommendations only; it does not auto-create operational records."}
+            </p>
           </div>
-          <Link href="/dashboard/ai-recommendations" className="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/15">
-            Review in AI Recommendations
-          </Link>
+          <div className="flex flex-col gap-3 rounded-3xl border border-white/10 bg-black/30 p-4">
+            {summary ? <><p className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">Launch Readiness</p><div className="flex items-end gap-3"><span className="text-5xl font-semibold text-white">{summary.readiness.score}</span><span className="pb-2 text-lg text-neutral-400">/100</span></div><p className="font-semibold text-orange-100">{summary.readiness.label}</p><p className="text-xs leading-5 text-neutral-400">{summary.readiness.summary}</p></> : <><p className="text-xs font-semibold uppercase tracking-[0.18em] text-neutral-400">Launch Readiness</p><p className="text-sm leading-6 text-neutral-300">No readiness score is shown until analysis has been run against the current onboarding data.</p></>}
+            <RunAnalysisButton sessionId={sessionId} hasRecommendations={recommendations.length > 0} />
+          </div>
         </div>
-
-        {recommendations.length > 0 ? (
-          <div className="mt-5 space-y-4">
-            {recommendations.map((recommendation) => (
-              <article key={recommendation.id} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div>
-                    <h3 className="text-lg font-semibold text-white">{recommendation.title}</h3>
-                    {recommendation.summary ? <p className="mt-2 text-sm leading-6 text-neutral-300">{recommendation.summary}</p> : null}
-                  </div>
-                  <Link href="/dashboard/ai-recommendations" className="shrink-0 rounded-full border border-orange-300/30 bg-orange-300/10 px-3 py-1.5 text-xs font-semibold text-orange-100 transition hover:bg-orange-300/20">
-                    Review in AI Recommendations
-                  </Link>
-                </div>
-                <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4">
-                  {[
-                    ["Domain", recommendation.domain],
-                    ["Type", recommendation.recommendation_type],
-                    ["Priority", recommendation.priority],
-                    ["Confidence", formatConfidence(recommendation.confidence)],
-                    ["Risk", recommendation.risk_tier],
-                    ["Status", recommendation.status],
-                    ["Missing data", jsonHasContent(recommendation.missing_data) ? "Yes" : "No"],
-                  ].map(([label, value]) => (
-                    <div key={label} className="rounded-xl border border-white/10 bg-black/25 px-3 py-2">
-                      <dt className="uppercase tracking-[0.16em] text-neutral-500">{label}</dt>
-                      <dd className="mt-1 font-semibold text-neutral-100">{value}</dd>
-                    </div>
-                  ))}
-                </dl>
-              </article>
-            ))}
-          </div>
-        ) : (
-          <div className="mt-5 rounded-2xl border border-dashed border-white/15 bg-white/[0.03] p-5 text-sm leading-6 text-neutral-300">
-            No AI Business Analysis has been generated yet. Your imported onboarding data is ready. The next step will run analysis and create reviewable recommendations.
-          </div>
-        )}
       </section>
+
+      {summary ? (
+        <>
+          <section className="rounded-[2rem] border border-white/10 bg-black/35 p-6 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">Business snapshot</p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">ProFixIQ analyzed your business, not just your setup form.</h2>
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {[["Customers", summary.analyzed.customers], ["Vehicles", summary.analyzed.vehicles], ["Service-history records", summary.analyzed.historyRecords], ["Historical invoices", summary.analyzed.invoices], ["Parts", summary.analyzed.parts], ...(summary.analyzed.vendors != null ? [["Vendors", summary.analyzed.vendors] as const] : []), ...(summary.analyzed.yearsOfHistory != null ? [["Years of history", summary.analyzed.yearsOfHistory] as const] : [])].map(([label, value]) => <div key={label} className="rounded-2xl border border-white/10 bg-white/[0.045] p-4"><p className="text-xs uppercase tracking-[0.16em] text-neutral-500">{label}</p><p className="mt-2 text-3xl font-semibold text-white">{formatCount(Number(value))}</p></div>)}
+            </div>
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-[0.95fr_1.05fr]">
+            <article className="rounded-[2rem] border border-white/10 bg-black/35 p-6 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl"><p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">AI Executive Summary</p><h2 className="mt-2 text-2xl font-semibold text-white">{summary.shopProfile.headline}</h2><p className="mt-3 text-sm leading-6 text-neutral-300">{summary.shopProfile.description}</p><p className="mt-4 text-sm leading-6 text-neutral-300">{summary.closingSummary}</p></article>
+            <article className="rounded-[2rem] border border-white/10 bg-black/35 p-6 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl"><p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">What ProFixIQ learned</p><div className="mt-4 space-y-3">{summary.strengths.length > 0 ? summary.strengths.map((item) => <div key={item.title} className="rounded-2xl border border-emerald-300/15 bg-emerald-300/[0.06] p-4"><h3 className="font-semibold text-white">{item.title}</h3><p className="mt-1 text-sm leading-6 text-neutral-300">{item.description}</p></div>) : <p className="rounded-2xl border border-dashed border-white/15 bg-white/[0.03] p-4 text-sm leading-6 text-neutral-300">There is not enough imported evidence yet to identify a clear strength. Add more setup data and re-run analysis.</p>}</div></article>
+          </section>
+
+          <section className="rounded-[2rem] border border-white/10 bg-black/35 p-6 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl"><p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">What we noticed</p><div className="mt-4 grid gap-3 md:grid-cols-2">{summary.observations.map((item) => <article key={item.title} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4"><h3 className="font-semibold text-white">{item.title}</h3><p className="mt-2 text-sm leading-6 text-neutral-300">{item.description}</p>{item.supportingMetric ? <p className="mt-3 text-xs font-semibold uppercase tracking-[0.16em] text-orange-200/70">{item.supportingMetric}</p> : null}</article>)}</div></section>
+
+          <section className="rounded-[2rem] border border-white/10 bg-black/35 p-6 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"><div><p className="text-xs font-semibold uppercase tracking-[0.2em] text-orange-200/80">Highest-impact opportunities</p><h2 className="mt-2 text-2xl font-semibold text-white">Start with the next few owner-reviewed decisions.</h2></div><Link href="/dashboard/ai-recommendations" className="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/15">Review All AI Recommendations</Link></div>
+            <div className="mt-5 grid gap-4 lg:grid-cols-3">{summary.priorities.map((priority) => <article key={priority.recommendationId ?? priority.title} className="flex flex-col rounded-2xl border border-white/10 bg-white/[0.045] p-5"><div className="flex items-center justify-between gap-3"><span className="flex h-9 w-9 items-center justify-center rounded-full border border-orange-300/30 bg-orange-300/10 font-semibold text-orange-100">{priority.rank}</span><span className={`rounded-full border px-3 py-1 text-xs font-semibold capitalize ${impactClass(priority.impact)}`}>{priority.impact} impact</span></div><p className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-neutral-500">{priority.category}</p><h3 className="mt-2 text-lg font-semibold text-white">{priority.title}</h3><p className="mt-2 flex-1 text-sm leading-6 text-neutral-300">{priority.description}</p><Link href="/dashboard/ai-recommendations" className="mt-4 rounded-full border border-orange-300/30 bg-orange-300/10 px-4 py-2 text-center text-sm font-semibold text-orange-100 transition hover:bg-orange-300/20">Review recommendation</Link></article>)}</div>
+          </section>
+
+          <section className="flex flex-col gap-3 rounded-[2rem] border border-white/10 bg-white/[0.04] p-6 sm:flex-row sm:items-center sm:justify-between"><div><h2 className="text-xl font-semibold text-white">Ready for the next step?</h2><p className="mt-1 text-sm text-neutral-300">Continue activation when the launch priorities have been reviewed.</p></div><div className="flex flex-wrap gap-3"><Link href={`/dashboard/onboarding-v2/${sessionId}`} className="rounded-full bg-orange-300 px-4 py-2 text-sm font-semibold text-black transition hover:bg-orange-200">Continue to Shop Activation</Link><Link href="/dashboard/ai-recommendations" className="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/15">Review All AI Recommendations</Link></div></section>
+        </>
+      ) : (
+        <section className="rounded-[2rem] border border-dashed border-white/15 bg-black/35 p-6 text-sm leading-6 text-neutral-300 shadow-[0_18px_55px_rgba(0,0,0,0.30)] backdrop-blur-xl">
+          <h2 className="text-2xl font-semibold text-white">What the analysis will review</h2>
+          <p className="mt-3 max-w-3xl">Run AI Business Analysis to create a deterministic executive summary from the evidence already collected during guided setup. No launch score, observations, or priorities are shown until recommendations exist.</p>
+          <div className="mt-5 grid gap-3 md:grid-cols-3"><div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">Customers, vehicles, history, and invoices</div><div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">Parts, vendor coverage, and stock cleanup signals</div><div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">Shop settings, inspection templates, and menu items</div></div>
+        </section>
+      )}
     </main>
   );
 }

--- a/features/onboarding-v2/analysis/buildExecutiveSummary.ts
+++ b/features/onboarding-v2/analysis/buildExecutiveSummary.ts
@@ -1,0 +1,149 @@
+import "server-only";
+
+import type { AiRecommendationRecord } from "@/features/ai/server/types";
+import type { GuidedOnboardingEvidence } from "./server";
+
+export type ReadinessLabel = "Ready to launch" | "Strong foundation" | "Good start" | "More setup recommended";
+export type PriorityImpact = "high" | "medium" | "low";
+
+export type ExecutiveSummary = {
+  readiness: {
+    score: number;
+    label: ReadinessLabel;
+    summary: string;
+  };
+  shopProfile: {
+    headline: string;
+    description: string;
+  };
+  analyzed: {
+    customers: number;
+    vehicles: number;
+    historyRecords: number;
+    invoices: number;
+    parts: number;
+    yearsOfHistory?: number;
+    vendors?: number;
+  };
+  strengths: Array<{ title: string; description: string }>;
+  observations: Array<{ title: string; description: string; supportingMetric?: string }>;
+  priorities: Array<{
+    rank: number;
+    category: string;
+    title: string;
+    description: string;
+    impact: PriorityImpact;
+    recommendationId?: string;
+  }>;
+  closingSummary: string;
+};
+
+export const READINESS_SCORE_WEIGHTS = {
+  customersImported: 10,
+  vehiclesImported: 10,
+  serviceHistoryPresent: 12,
+  invoicesPresent: 8,
+  partsPresent: 8,
+  shopHoursConfigured: 8,
+  laborRateConfigured: 10,
+  taxRateConfigured: 8,
+  shopSuppliesConfigured: 6,
+  workflowDefaultsConfigured: 8,
+  inspectionTemplatesReady: 6,
+  menuItemsReady: 6,
+} as const;
+
+function readinessLabel(score: number): ReadinessLabel {
+  if (score >= 90) return "Ready to launch";
+  if (score >= 75) return "Strong foundation";
+  if (score >= 50) return "Good start";
+  return "More setup recommended";
+}
+
+export function calculateLaunchReadinessScore(evidence: GuidedOnboardingEvidence): number {
+  const weights = READINESS_SCORE_WEIGHTS;
+  const score =
+    (evidence.customerCount > 0 ? weights.customersImported : 0) +
+    (evidence.vehicleCount > 0 ? weights.vehiclesImported : 0) +
+    (evidence.historyCount > 0 ? weights.serviceHistoryPresent : 0) +
+    (evidence.invoiceCount > 0 ? weights.invoicesPresent : 0) +
+    (evidence.partsCount > 0 ? weights.partsPresent : 0) +
+    (evidence.shopSettings.hoursConfigured ? weights.shopHoursConfigured : 0) +
+    (evidence.shopSettings.laborRateConfigured ? weights.laborRateConfigured : 0) +
+    (evidence.shopSettings.taxRateConfigured ? weights.taxRateConfigured : 0) +
+    (evidence.shopSettings.shopSuppliesConfigured ? weights.shopSuppliesConfigured : 0) +
+    (evidence.shopSettings.workflowDefaultsConfigured ? weights.workflowDefaultsConfigured : 0) +
+    (evidence.inspectionTemplateCount > 0 ? weights.inspectionTemplatesReady : 0) +
+    (evidence.menuItemCount > 0 ? weights.menuItemsReady : 0);
+
+  return Math.max(0, Math.min(100, score));
+}
+
+function recommendationCategory(recommendation: AiRecommendationRecord): string {
+  const metadata = recommendation.metadata;
+  if (metadata && typeof metadata === "object" && !Array.isArray(metadata) && typeof metadata.category === "string") return metadata.category;
+  return "Launch opportunity";
+}
+
+function impactFor(recommendation: AiRecommendationRecord): PriorityImpact {
+  if (recommendation.priority === "urgent" || recommendation.priority === "high") return "high";
+  if (recommendation.priority === "normal") return "medium";
+  return "low";
+}
+
+const priorityWeight = { urgent: 4, high: 3, normal: 2, low: 1 } as const;
+
+export function buildExecutiveSummary(evidence: GuidedOnboardingEvidence, recommendations: AiRecommendationRecord[]): ExecutiveSummary {
+  const score = calculateLaunchReadinessScore(evidence);
+  const label = readinessLabel(score);
+  const hasHistory = evidence.historyCount > 0 || evidence.invoiceCount > 0;
+  const hasServicePatterns = evidence.commonServiceCategories.length > 0 || evidence.commonJobs.length >= 3;
+
+  const strengths: ExecutiveSummary["strengths"] = [];
+  if (evidence.customerCount > 0 && evidence.vehicleCount > 0) strengths.push({ title: "Customer and vehicle foundation", description: `ProFixIQ reviewed ${evidence.customerCount} customers and ${evidence.vehicleCount} vehicles, giving the shop a usable base for launch workflows.` });
+  if (evidence.historyCount >= 25 || evidence.invoiceCount >= 10) strengths.push({ title: "Historical service coverage", description: `Your imported data includes ${evidence.historyCount} service-history records and ${evidence.invoiceCount} historical invoices for launch planning.` });
+  if (evidence.partsCount > 0 && evidence.partsWithVendorCount > 0) strengths.push({ title: "Inventory identity is started", description: `${evidence.partsWithVendorCount} parts include vendor information, which helps purchasing review begin from real inventory records.` });
+  if (evidence.shopSettings.hoursConfigured && evidence.shopSettings.laborRateConfigured && evidence.shopSettings.taxRateConfigured) strengths.push({ title: "Core shop settings are configured", description: "Shop hours, labor rate, and tax settings are present, so launch readiness is not based on imported records alone." });
+  if (hasServicePatterns) strengths.push({ title: "Recurring service patterns are visible", description: "Repeated service names or categories appear in the imported history, creating a practical starting point for reviewed templates, menu items, and packages." });
+
+  const observations: ExecutiveSummary["observations"] = [];
+  if (hasServicePatterns) observations.push({ title: "Service history contains repeatable patterns", description: `ProFixIQ found ${evidence.commonServiceCategories.length} recurring service categories and ${evidence.commonJobs.length} common job descriptions in the imported records.`, supportingMetric: `${evidence.commonServiceCategories.length + evidence.commonJobs.length} pattern signals` });
+  else observations.push({ title: "Service mix is not yet clear", description: "There is not yet enough categorized service history to identify a dominant service mix.", supportingMetric: "Insufficient categorized history" });
+  if (evidence.partsCount > 0) observations.push({ title: "Parts data is ready for cleanup review", description: `Your inventory includes ${evidence.partsCount} parts, with ${evidence.zeroStockPartsCount} zero-stock parts, ${evidence.lowStockPartsCount} low-stock parts, and ${evidence.partsMissingCategoryCount} missing category values.`, supportingMetric: `${evidence.partsCount} parts analyzed` });
+  if (evidence.inspectionTemplateCount < 2 && hasHistory) observations.push({ title: "Inspection coverage is still light", description: `Your history is populated, but only ${evidence.inspectionTemplateCount} inspection templates were found. Standardizing inspections should come before broad canned-service rollout.`, supportingMetric: `${evidence.inspectionTemplateCount} templates` });
+  if (evidence.menuItemCount < 5 && hasServicePatterns) observations.push({ title: "Menu item coverage can follow inspection review", description: `ProFixIQ found repeatable service signals and ${evidence.menuItemCount} menu items, so reviewed canned services are a logical next setup step.`, supportingMetric: `${evidence.menuItemCount} menu items` });
+
+  const priorities = recommendations
+    .slice()
+    .sort((a, b) => (priorityWeight[b.priority] - priorityWeight[a.priority]) || ((b.confidence ?? 0) - (a.confidence ?? 0)))
+    .slice(0, 3)
+    .map((recommendation, index) => ({
+      rank: index + 1,
+      category: recommendationCategory(recommendation),
+      title: recommendation.title,
+      description: recommendation.summary || "Review this owner-approved setup opportunity in the AI Recommendations center.",
+      impact: impactFor(recommendation),
+      recommendationId: recommendation.id,
+    }));
+
+  return {
+    readiness: { score, label, summary: `${label}: this score measures setup and data readiness only. It is based on imported records, configured shop defaults, and reviewed launch building blocks—not financial performance.` },
+    shopProfile: {
+      headline: hasHistory ? "ProFixIQ reviewed your imported operating history." : "ProFixIQ reviewed the setup data available so far.",
+      description: hasHistory ? "Your business analysis is based on real customers, vehicles, service history, invoices, parts, and shop defaults imported during guided setup." : "Your business analysis is intentionally conservative because service history is limited or not yet imported.",
+    },
+    analyzed: {
+      customers: evidence.customerCount,
+      vehicles: evidence.vehicleCount,
+      historyRecords: evidence.historyCount,
+      invoices: evidence.invoiceCount,
+      parts: evidence.partsCount,
+      yearsOfHistory: evidence.yearsOfHistory,
+      vendors: evidence.vendorCount,
+    },
+    strengths: strengths.slice(0, 4),
+    observations: observations.slice(0, 4),
+    priorities,
+    closingSummary: priorities.length > 0 ? "Start with the highest-impact review items, then continue to shop activation once the owner is comfortable with the launch setup." : "Run or re-run AI Business Analysis after more setup data is available to generate owner-reviewable launch priorities.",
+  };
+}

--- a/features/onboarding-v2/analysis/server.ts
+++ b/features/onboarding-v2/analysis/server.ts
@@ -26,6 +26,8 @@ export type GuidedOnboardingEvidence = {
   partsMissingVendorCount: number;
   partsWithVendorCount: number;
   partsMissingCategoryCount: number;
+  vendorCount?: number;
+  yearsOfHistory?: number;
   commonServiceCategories: string[];
   commonJobs: string[];
   inspectionTemplateCount: number;
@@ -70,6 +72,23 @@ async function sampleColumn(supabase: SupabaseLike, table: string, shopId: strin
   return (data ?? []) as unknown as Record<string, unknown>[];
 }
 
+function validDate(value: unknown): Date | null {
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function calculateYearsOfHistory(rows: Record<string, unknown>[]): number | undefined {
+  const dates = rows
+    .flatMap((row) => [row.service_date, row.completed_at, row.created_at, row.invoice_date, row.date])
+    .map(validDate)
+    .filter((date): date is Date => date != null)
+    .sort((a, b) => a.getTime() - b.getTime());
+  if (dates.length < 2) return undefined;
+  const years = (dates[dates.length - 1].getTime() - dates[0].getTime()) / (1000 * 60 * 60 * 24 * 365.25);
+  return Math.max(1, Math.round(years * 10) / 10);
+}
+
 function topStrings(rows: Record<string, unknown>[], keys: string[], limit = 5): string[] {
   const counts = new Map<string, number>();
   for (const row of rows) {
@@ -85,7 +104,7 @@ export async function collectGuidedOnboardingEvidence(supabase: SupabaseLike, sh
   const [
     customerCount, vehicleCount, historyCount, invoiceCount, partsCount,
     lowStockPartsCount, zeroStockPartsCount, partsMissingVendorCount, partsWithVendorCount, partsMissingCategoryCount,
-    inspectionTemplateCount, menuItemCount, hoursCount,
+    inspectionTemplateCount, menuItemCount, hoursCount, vendorCount,
   ] = await Promise.all([
     countRows(supabase, "customers", shopId),
     countRows(supabase, "vehicles", shopId),
@@ -100,11 +119,12 @@ export async function collectGuidedOnboardingEvidence(supabase: SupabaseLike, sh
     countRows(supabase, "inspection_templates", shopId),
     countRows(supabase, "menu_items", shopId),
     countRows(supabase, "shop_hours", shopId),
+    countRows(supabase, "vendors", shopId),
   ]);
 
   const [lineSamples, invoiceSamples, shopRows] = await Promise.all([
-    sampleColumn(supabase, "work_order_lines", shopId, "description,name,category,service_category", 200),
-    sampleColumn(supabase, "invoices", shopId, "service_category,category,description", 100),
+    sampleColumn(supabase, "work_order_lines", shopId, "description,name,category,service_category,service_date,completed_at,created_at,date", 200),
+    sampleColumn(supabase, "invoices", shopId, "service_category,category,description,invoice_date,created_at,date", 100),
     sampleColumn(supabase, "shops", shopId, "labor_rate,tax_rate,shop_supplies_enabled,shop_supplies_percent,supplies_percent,workflow_defaults,default_workflow_status", 1),
   ]);
   const shop = shopRows[0] ?? {};
@@ -112,6 +132,8 @@ export async function collectGuidedOnboardingEvidence(supabase: SupabaseLike, sh
   return {
     customerCount, vehicleCount, historyCount, invoiceCount, partsCount,
     lowStockPartsCount, zeroStockPartsCount, partsMissingVendorCount, partsWithVendorCount, partsMissingCategoryCount,
+    vendorCount,
+    yearsOfHistory: calculateYearsOfHistory([...lineSamples, ...invoiceSamples]),
     commonServiceCategories: topStrings([...lineSamples, ...invoiceSamples], ["service_category", "category"], 6),
     commonJobs: topStrings(lineSamples, ["description", "name"], 6),
     inspectionTemplateCount,

--- a/tests/guided-onboarding-ai-analysis.test.ts
+++ b/tests/guided-onboarding-ai-analysis.test.ts
@@ -3,7 +3,9 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { GUIDED_ONBOARDING_STEP_KEYS } from "@/features/onboarding-v2/guided/steps";
 import { filterGuidedAnalysisRecommendations } from "@/features/onboarding-v2/analysis/filterGuidedAnalysisRecommendations";
+import { buildExecutiveSummary, calculateLaunchReadinessScore, READINESS_SCORE_WEIGHTS } from "@/features/onboarding-v2/analysis/buildExecutiveSummary";
 import type { AiRecommendationRecord } from "@/features/ai/server/types";
+import type { GuidedOnboardingEvidence } from "@/features/onboarding-v2/analysis/server";
 
 function read(path: string) {
   return readFileSync(join(process.cwd(), path), "utf8");
@@ -47,24 +49,23 @@ function recommendation(overrides: Partial<AiRecommendationRecord>): AiRecommend
 }
 
 describe("guided onboarding AI Business Analysis page", () => {
-  it("renders the static seven guidance categories in order", () => {
+  it("renders a polished executive summary instead of the static category database view", () => {
     const source = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
 
-    expect(source).toContain("Inspection templates first");
-    expect(source).toContain("Menu items and canned services second");
-    expect(source).toContain("Inventory improvements");
-    expect(source).toContain("Vendor suggestions");
-    expect(source).toContain("Customer and fleet segments");
-    expect(source).toContain("Maintenance packages");
-    expect(source).toContain("Automation rules");
-    expect(source.indexOf("Inspection templates first")).toBeLessThan(source.indexOf("Menu items and canned services second"));
+    expect(source).toContain("AI Executive Summary");
+    expect(source).toContain("Business snapshot");
+    expect(source).toContain("What ProFixIQ learned");
+    expect(source).toContain("Highest-impact opportunities");
+    expect(source).toContain("Continue to Shop Activation");
+    expect(source).not.toContain("Reviewable AI Business Analysis signals");
   });
 
-  it("renders the empty state when no recommendations exist", () => {
+  it("renders the empty state when no recommendations exist without showing a fake score", () => {
     const source = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
 
-    expect(source).toContain("No AI Business Analysis has been generated yet");
-    expect(source).toContain("Your imported onboarding data is ready");
+    expect(source).toContain("What the analysis will review");
+    expect(source).toContain("No launch score, observations, or priorities are shown until recommendations exist");
+    expect(source).toContain("No readiness score is shown until analysis has been run");
   });
 
   it("filters existing shop-scoped recommendations for onboarding before falling back to shop_boost", () => {
@@ -86,20 +87,19 @@ describe("guided onboarding AI Business Analysis page", () => {
     expect(fallback.map((item) => item.id)).toEqual(["shop-boost"]);
   });
 
-  it("renders existing recommendation fields and links to the shared review center", () => {
+  it("does not render raw recommendation metadata on onboarding and links priorities to the shared review center", () => {
     const source = read("app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx");
 
-    expect(source).toContain("Current recommendations");
-    expect(source).toContain("recommendation.title");
-    expect(source).toContain("recommendation.summary");
-    expect(source).toContain("recommendation.domain");
-    expect(source).toContain("recommendation.recommendation_type");
-    expect(source).toContain("recommendation.priority");
-    expect(source).toContain("formatConfidence(recommendation.confidence)");
-    expect(source).toContain("recommendation.risk_tier");
-    expect(source).toContain("recommendation.status");
-    expect(source).toContain("jsonHasContent(recommendation.missing_data)");
+    expect(source).toContain("summary.priorities.map");
+    expect(source).toContain("Review recommendation");
     expect(source).toContain('href="/dashboard/ai-recommendations"');
+    expect(source).not.toContain("recommendation.domain");
+    expect(source).not.toContain("recommendation.recommendation_type");
+    expect(source).not.toContain("recommendation.subject_type");
+    expect(source).not.toContain("recommendation.risk_tier");
+    expect(source).not.toContain("recommendation.status");
+    expect(source).not.toContain("recommended_action");
+    expect(source).not.toContain("guided_onboarding_analysis");
   });
 
   it("keeps recommendation creation out of the server-rendered page", () => {
@@ -185,5 +185,62 @@ describe("guided onboarding deterministic analysis phase 2", () => {
     expect(source).toContain("Customer and fleet segments");
     expect(source).toContain("Maintenance packages");
     expect(source).toContain("Automation rules");
+  });
+});
+
+
+const baseEvidence: GuidedOnboardingEvidence = {
+  customerCount: 42,
+  vehicleCount: 57,
+  historyCount: 88,
+  invoiceCount: 21,
+  partsCount: 130,
+  lowStockPartsCount: 12,
+  zeroStockPartsCount: 4,
+  partsMissingVendorCount: 8,
+  partsWithVendorCount: 80,
+  partsMissingCategoryCount: 9,
+  vendorCount: 6,
+  yearsOfHistory: 3.5,
+  commonServiceCategories: ["Brakes", "Oil service"],
+  commonJobs: ["Brake inspection", "Oil change", "Tire rotation"],
+  inspectionTemplateCount: 1,
+  menuItemCount: 2,
+  shopSettings: { laborRateConfigured: true, hoursConfigured: true, shopSuppliesConfigured: true, taxRateConfigured: true, workflowDefaultsConfigured: false },
+};
+
+describe("guided onboarding executive summary builder", () => {
+  it("uses actual evidence counts in the analyzed snapshot", () => {
+    const summary = buildExecutiveSummary(baseEvidence, [recommendation({ id: "r1", priority: "high", metadata: { category: "Inventory improvements" } })]);
+
+    expect(summary.analyzed).toMatchObject({ customers: 42, vehicles: 57, historyRecords: 88, invoices: 21, parts: 130, vendors: 6, yearsOfHistory: 3.5 });
+  });
+
+  it("uses the documented deterministic readiness weights and clamps the score to 0-100", () => {
+    const score = calculateLaunchReadinessScore(baseEvidence);
+
+    expect(READINESS_SCORE_WEIGHTS.customersImported).toBe(10);
+    expect(score).toBe(92);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  it("shows honest fallback language when categorized service evidence is missing", () => {
+    const summary = buildExecutiveSummary({ ...baseEvidence, historyCount: 0, invoiceCount: 0, commonJobs: [], commonServiceCategories: [] }, []);
+
+    expect(summary.observations.some((item) => item.description.includes("There is not yet enough categorized service history"))).toBe(true);
+    expect(summary.priorities).toHaveLength(0);
+  });
+
+  it("limits ranked priorities to three", () => {
+    const summary = buildExecutiveSummary(baseEvidence, [
+      recommendation({ id: "r1", priority: "low" }),
+      recommendation({ id: "r2", priority: "high" }),
+      recommendation({ id: "r3", priority: "normal" }),
+      recommendation({ id: "r4", priority: "urgent" }),
+    ]);
+
+    expect(summary.priorities).toHaveLength(3);
+    expect(summary.priorities.map((item) => item.rank)).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
### Motivation

- The existing guided-onboarding summary exposed raw recommendation records and internal metadata and felt like a database viewer rather than a consultant-style executive summary. 
- The goal was to keep the deterministic Phase 2 recommendation architecture while presenting a polished, evidence-backed executive summary to help owners prioritize launch work.

### Description

- Added a reusable server-side executive-summary builder `features/onboarding-v2/analysis/buildExecutiveSummary.ts` that emits a typed `ExecutiveSummary` object containing `readiness`, `shopProfile`, `analyzed`, `strengths`, `observations`, `priorities`, and `closingSummary`.
- Implemented a deterministic Launch Readiness score with documented weights (customers 10, vehicles 10, service history 12, invoices 8, parts 8, shop hours 8, labor rate 10, tax rate 8, shop supplies 6, workflow defaults 8, inspection templates 6, menu items 6) and clamped to 0–100; labels map to the requested ranges and summary copy clarifies this measures setup/data readiness only.
- Replaced the onboarding summary UI with a polished executive view at `app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx` that shows a personal opening, Launch Readiness card (only shown after analysis), a business snapshot of analyzed counts, consultant-style strengths and observations (all evidence-backed), and up to three ranked highest-impact priorities sourced from existing persisted `ai_recommendations` that link to `/dashboard/ai-recommendations` for full review.
- Extended evidence collection in `features/onboarding-v2/analysis/server.ts` to include `vendor` counts and a years-of-history calculation derived from sampled service/invoice date fields, while preserving bounded, deterministic reads and avoiding any AI provider calls.
- Priority-ranking logic selects up to three recommendations sorted by priority weight (`urgent` > `high` > `normal` > `low`) then confidence, and maps persisted records into owner-facing cards without exposing raw internal fields (domain, subject_type, source, recommendation_type, internal action keys, status, raw metadata fields are not rendered on the onboarding page).
- Files changed: `app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx`, `features/onboarding-v2/analysis/buildExecutiveSummary.ts` (new), `features/onboarding-v2/analysis/server.ts`, and updated `tests/guided-onboarding-ai-analysis.test.ts` to assert summary behavior and the absence of raw metadata on the onboarding page.

### Testing

- Ran type-check: `npm run typecheck` — passed.
- Linted the changed paths: `npx eslint app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx app/dashboard/onboarding-v2/[sessionId]/summary/RunAnalysisButton.tsx features/onboarding-v2/analysis --ext .ts,.tsx` — passed.
- Ran unit tests: `npx vitest run tests/guided-onboarding-ai-analysis.test.ts tests/guided-onboarding*` — all relevant tests passed (total tests in suite passed; updated onboarding analysis tests pass).
- Attempted production build: `pnpm build` — build ran but failed in this environment due to inability to fetch Google Fonts from `fonts.googleapis.com` (font fetch network errors); this is an environment limitation only and did not indicate code/type errors.

If you want, I can: provide a short walkthrough of the new `ExecutiveSummary` type and builder, or adjust the readiness weights or the exact priority tiebreaker logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a505343b8408328888e7990db4058b1)