### PR TITLE
Use canonical history/invoices/parts sources for Guided Onboarding evidence

### DIFF
--- a/features/onboarding-v2/analysis/server.ts
+++ b/features/onboarding-v2/analysis/server.ts
@@ -27,6 +27,7 @@ export type GuidedOnboardingEvidence = {
   partsWithVendorCount: number;
   partsMissingCategoryCount: number;
   vendorCount?: number;
+  evidenceWarnings?: string[];
   yearsOfHistory?: number;
   commonServiceCategories: string[];
   commonJobs: string[];
@@ -58,18 +59,36 @@ type RunInput = {
   sessionId: string;
 };
 
-async function countRows(supabase: SupabaseLike, table: string, shopId: string, build?: (query: GuidedQuery) => GuidedQuery): Promise<number> {
+type EvidenceQueryResult<T> = { value: T; reliable: boolean; warning?: string };
+
+function warnEvidenceQuery(warning: string, error?: unknown) {
+  if (process.env.NODE_ENV !== "production") console.warn(`[guided-onboarding-evidence] ${warning}`, error);
+}
+
+function queryWarning(table: string, purpose: string): string {
+  return `${purpose} could not be verified from ${table}`;
+}
+
+async function countRows(supabase: SupabaseLike, table: string, shopId: string, build?: (query: GuidedQuery) => GuidedQuery, purpose = `${table} count`): Promise<EvidenceQueryResult<number>> {
   let query = supabase.from(table).select("id", { count: "exact", head: true }).eq("shop_id", shopId);
   if (build) query = build(query);
   const { count, error } = await query;
-  if (error) return 0;
-  return count ?? 0;
+  if (error) {
+    const warning = queryWarning(table, purpose);
+    warnEvidenceQuery(warning, error);
+    return { value: 0, reliable: false, warning };
+  }
+  return { value: count ?? 0, reliable: true };
 }
 
-async function sampleColumn(supabase: SupabaseLike, table: string, shopId: string, columns: string, limit = 100): Promise<Record<string, unknown>[]> {
+async function sampleColumn(supabase: SupabaseLike, table: string, shopId: string, columns: string, limit = 100, purpose = `${table} sample`): Promise<EvidenceQueryResult<Record<string, unknown>[]>> {
   const { data, error } = await supabase.from(table).select(columns).eq("shop_id", shopId).limit(limit);
-  if (error) return [];
-  return (data ?? []) as unknown as Record<string, unknown>[];
+  if (error) {
+    const warning = queryWarning(table, purpose);
+    warnEvidenceQuery(warning, error);
+    return { value: [], reliable: false, warning };
+  }
+  return { value: (data ?? []) as unknown as Record<string, unknown>[], reliable: true };
 }
 
 function validDate(value: unknown): Date | null {
@@ -102,45 +121,58 @@ function topStrings(rows: Record<string, unknown>[], keys: string[], limit = 5):
 
 export async function collectGuidedOnboardingEvidence(supabase: SupabaseLike, shopId: string): Promise<GuidedOnboardingEvidence> {
   const [
-    customerCount, vehicleCount, historyCount, invoiceCount, partsCount,
-    lowStockPartsCount, zeroStockPartsCount, partsMissingVendorCount, partsWithVendorCount, partsMissingCategoryCount,
-    inspectionTemplateCount, menuItemCount, hoursCount, vendorCount,
+    customerRows, vehicleRows, historyRows, invoiceRows, partsRows,
+    inspectionTemplateRows, menuItemRows, hoursRows, vendorRows,
   ] = await Promise.all([
-    countRows(supabase, "customers", shopId),
-    countRows(supabase, "vehicles", shopId),
-    countRows(supabase, "work_order_lines", shopId),
-    countRows(supabase, "invoices", shopId),
-    countRows(supabase, "parts", shopId),
-    countRows(supabase, "parts", shopId, (q) => q.lt("quantity_on_hand", 3)),
-    countRows(supabase, "parts", shopId, (q) => q.lte("quantity_on_hand", 0)),
-    countRows(supabase, "parts", shopId, (q) => q.or("vendor.is.null,vendor.eq.")),
-    countRows(supabase, "parts", shopId, (q) => q.not("vendor", "is", null)),
-    countRows(supabase, "parts", shopId, (q) => q.or("category.is.null,category.eq.")),
+    countRows(supabase, "customers", shopId, undefined, "shop-scoped customer count"),
+    countRows(supabase, "vehicles", shopId, undefined, "shop-scoped vehicle count"),
+    countRows(supabase, "history", shopId, undefined, "canonical service-history count"),
+    countRows(supabase, "invoices", shopId, (q) => q.contains("metadata", { import_type: "invoice_csv" }), "historical invoice_csv count"),
+    countRows(supabase, "parts", shopId, undefined, "canonical inventory part count"),
     countRows(supabase, "inspection_templates", shopId),
     countRows(supabase, "menu_items", shopId),
     countRows(supabase, "shop_hours", shopId),
-    countRows(supabase, "vendors", shopId),
+    countRows(supabase, "vendors", shopId, undefined, "canonical vendor-record count"),
   ]);
 
-  const [lineSamples, invoiceSamples, shopRows] = await Promise.all([
-    sampleColumn(supabase, "work_order_lines", shopId, "description,name,category,service_category,service_date,completed_at,created_at,date", 200),
-    sampleColumn(supabase, "invoices", shopId, "service_category,category,description,invoice_date,created_at,date", 100),
+  const [historySamplesRes, invoiceSamplesRes, partsRes, stockMovesRes, shopRowsRes] = await Promise.all([
+    sampleColumn(supabase, "history", shopId, "description,service_date,created_at,historical_status,source_payload", 500, "canonical service-history samples"),
+    sampleColumn(supabase, "invoices", shopId, "metadata,issued_at,created_at", 100, "historical invoice_csv samples"),
+    sampleColumn(supabase, "parts", shopId, "id,name,category,supplier,low_stock_threshold", 10000, "canonical inventory parts"),
+    sampleColumn(supabase, "stock_moves", shopId, "part_id,qty_change", 10000, "inventory stock movement totals"),
     sampleColumn(supabase, "shops", shopId, "labor_rate,tax_rate,shop_supplies_enabled,shop_supplies_percent,supplies_percent,workflow_defaults,default_workflow_status", 1),
   ]);
-  const shop = shopRows[0] ?? {};
+  const warnings = [customerRows, vehicleRows, historyRows, invoiceRows, partsRows, inspectionTemplateRows, menuItemRows, hoursRows, vendorRows, historySamplesRes, invoiceSamplesRes, partsRes, stockMovesRes, shopRowsRes].flatMap((r) => r.warning ? [r.warning] : []);
+  const historySamples = historySamplesRes.value;
+  const parts = partsRes.value;
+  const stockByPart = new Map<string, number>();
+  for (const move of stockMovesRes.value) {
+    const partId = typeof move.part_id === "string" ? move.part_id : "";
+    if (!partId) continue;
+    stockByPart.set(partId, (stockByPart.get(partId) ?? 0) + Number(move.qty_change ?? 0));
+  }
+  const normalizedVendors = new Set(parts.map((p) => typeof p.supplier === "string" ? p.supplier.trim().toLowerCase() : "").filter(Boolean));
+  const partsMissingVendorCount = partsRes.reliable ? parts.filter((p) => !(typeof p.supplier === "string" && p.supplier.trim())).length : 0;
+  const partsWithVendorCount = partsRes.reliable ? parts.length - partsMissingVendorCount : 0;
+  const partsMissingCategoryCount = partsRes.reliable ? parts.filter((p) => !(typeof p.category === "string" && p.category.trim())).length : 0;
+  const lowStockPartsCount = partsRes.reliable && stockMovesRes.reliable ? parts.filter((p) => (stockByPart.get(String(p.id)) ?? 0) > 0 && (stockByPart.get(String(p.id)) ?? 0) < Number(p.low_stock_threshold ?? 3)).length : 0;
+  const zeroStockPartsCount = partsRes.reliable && stockMovesRes.reliable ? parts.filter((p) => (stockByPart.get(String(p.id)) ?? 0) <= 0).length : 0;
+  const vendorCount = vendorRows.value > 0 ? vendorRows.value : normalizedVendors.size > 0 ? normalizedVendors.size : vendorRows.reliable ? 0 : undefined;
+  const shop = shopRowsRes.value[0] ?? {};
 
   return {
-    customerCount, vehicleCount, historyCount, invoiceCount, partsCount,
+    customerCount: customerRows.value, vehicleCount: vehicleRows.value, historyCount: historyRows.value, invoiceCount: invoiceRows.value, partsCount: partsRows.value,
     lowStockPartsCount, zeroStockPartsCount, partsMissingVendorCount, partsWithVendorCount, partsMissingCategoryCount,
     vendorCount,
-    yearsOfHistory: calculateYearsOfHistory([...lineSamples, ...invoiceSamples]),
-    commonServiceCategories: topStrings([...lineSamples, ...invoiceSamples], ["service_category", "category"], 6),
-    commonJobs: topStrings(lineSamples, ["description", "name"], 6),
-    inspectionTemplateCount,
-    menuItemCount,
+    evidenceWarnings: warnings,
+    yearsOfHistory: calculateYearsOfHistory(historySamples),
+    commonServiceCategories: topStrings(historySamples.map((row) => ({ ...row, service_category: typeof row.source_payload === "object" && row.source_payload ? (row.source_payload as Record<string, unknown>).service_category : undefined })), ["service_category"], 6),
+    commonJobs: topStrings(historySamples, ["description"], 6),
+    inspectionTemplateCount: inspectionTemplateRows.value,
+    menuItemCount: menuItemRows.value,
     shopSettings: {
       laborRateConfigured: typeof shop.labor_rate === "number" && shop.labor_rate > 0,
-      hoursConfigured: hoursCount > 0,
+      hoursConfigured: hoursRows.value > 0,
       shopSuppliesConfigured: Boolean(shop.shop_supplies_enabled) || Number(shop.shop_supplies_percent ?? shop.supplies_percent ?? 0) > 0,
       taxRateConfigured: typeof shop.tax_rate === "number" && shop.tax_rate >= 0,
       workflowDefaultsConfigured: Boolean(shop.workflow_defaults) || Boolean(shop.default_workflow_status),

--- a/tests/guided-onboarding-ai-analysis.test.ts
+++ b/tests/guided-onboarding-ai-analysis.test.ts
@@ -151,11 +151,11 @@ describe("guided onboarding deterministic analysis phase 2", () => {
   it("collects bounded deterministic shop evidence and never calls an AI provider", () => {
     const source = read("features/onboarding-v2/analysis/server.ts");
 
-    for (const table of ["customers", "vehicles", "work_order_lines", "invoices", "parts", "inspection_templates", "menu_items", "shop_hours", "shops"]) {
+    for (const table of ["customers", "vehicles", "history", "invoices", "parts", "stock_moves", "inspection_templates", "menu_items", "shop_hours", "shops"]) {
       expect(source).toContain(`\"${table}\"`);
     }
     expect(source).toContain('select("id", { count: "exact", head: true })');
-    expect(source).toContain(", 200)");
+    expect(source).toContain(", 500,");
     expect(source).toContain("deterministic: true");
     expect(source).toContain("noAutoCreate: true");
     expect(source).not.toMatch(/openai|anthropic|chat\.completions|responses\.create|generateText/i);
@@ -242,5 +242,57 @@ describe("guided onboarding executive summary builder", () => {
 
     expect(summary.priorities).toHaveLength(3);
     expect(summary.priorities.map((item) => item.rank)).toEqual([1, 2, 3]);
+  });
+});
+
+describe("guided onboarding evidence canonical sources", () => {
+  it("uses history as the canonical service-history source instead of active work_order_lines", () => {
+    const source = read("features/onboarding-v2/analysis/server.ts");
+
+    expect(source).toContain('countRows(supabase, "history", shopId');
+    expect(source).toContain('sampleColumn(supabase, "history", shopId');
+    expect(source).not.toContain('countRows(supabase, "work_order_lines"');
+    expect(source).not.toContain('sampleColumn(supabase, "work_order_lines"');
+  });
+
+  it("counts only historical invoice CSV imports for the onboarding invoice snapshot", () => {
+    const source = read("features/onboarding-v2/analysis/server.ts");
+
+    expect(source).toContain('countRows(supabase, "invoices", shopId, (q) => q.contains("metadata", { import_type: "invoice_csv" })');
+    expect(source).toContain('"historical invoice_csv count"');
+  });
+
+  it("uses canonical parts rows and stock movement totals without counting stock-location joins as parts", () => {
+    const source = read("features/onboarding-v2/analysis/server.ts");
+
+    expect(source).toContain('countRows(supabase, "parts", shopId, undefined, "canonical inventory part count")');
+    expect(source).toContain('sampleColumn(supabase, "stock_moves", shopId, "part_id,qty_change"');
+    expect(source).toContain('stockByPart.set(partId, (stockByPart.get(partId) ?? 0) + Number(move.qty_change ?? 0))');
+    expect(source).not.toContain('countRows(supabase, "v_part_stock"');
+    expect(source).not.toContain('countRows(supabase, "stock_locations"');
+  });
+
+  it("derives vendor coverage from imported part supplier strings before showing zero vendors", () => {
+    const source = read("features/onboarding-v2/analysis/server.ts");
+
+    expect(source).toContain('normalizedVendors.size > 0 ? normalizedVendors.size');
+    expect(source).toContain('typeof p.supplier === "string"');
+    expect(source).not.toContain('q.or("vendor.is.null,vendor.eq.")');
+  });
+
+  it("keeps failed optional evidence queries from becoming silent confident zeroes", () => {
+    const source = read("features/onboarding-v2/analysis/server.ts");
+
+    expect(source).toContain('EvidenceQueryResult');
+    expect(source).toContain('evidenceWarnings');
+    expect(source).toContain('warnEvidenceQuery');
+    expect(source).toContain('reliable: false');
+  });
+
+  it("readiness naturally increases when canonical history and parts are present", () => {
+    const suppressed = calculateLaunchReadinessScore({ ...baseEvidence, historyCount: 0, partsCount: 0 });
+    const corrected = calculateLaunchReadinessScore({ ...baseEvidence, historyCount: 7343, partsCount: 228 });
+
+    expect(corrected - suppressed).toBe(READINESS_SCORE_WEIGHTS.serviceHistoryPresent + READINESS_SCORE_WEIGHTS.partsPresent);
   });
 });


### PR DESCRIPTION
### Motivation
- The Guided Onboarding executive summary was using non-canonical sources (e.g. `work_order_lines`, ad-hoc inventory fields) which undercounted imported history and parts and produced misleading vendor/evidence zeros. 
- The goal is to make the analysis use the exact canonical sources that the History, Invoices, and Parts pages/importers use so the readiness score and observations reflect real imported data. 

### Description
- Replace the non-canonical evidence queries in `collectGuidedOnboardingEvidence()` to use the same canonical sources: `history` for service-history, `invoices` filtered by `metadata.import_type = 'invoice_csv'` for historical invoices, and `parts` (distinct part rows) plus summed `stock_moves` by `part_id` for inventory/stock signals. (files changed: `features/onboarding-v2/analysis/server.ts`)
- Change vendor semantics so canonical `vendors` rows are preferred and, if absent, distinct normalized `parts.supplier` strings are used as a fallback; if vendor evidence is unreliable the metric can be omitted instead of showing "0".
- Replace the old `countRows()`/`sampleColumn()` behavior that returned a silent `0` on error with an `EvidenceQueryResult<T>` shape that includes `value`, `reliable`, and optional `warning`; development warnings are logged via `warnEvidenceQuery()` and unreliable metrics are surfaced in `evidenceWarnings` instead of being treated as confident zeros. (file: `features/onboarding-v2/analysis/server.ts`)
- Drive samples and summary signals (years of history, common service categories, common jobs) from the canonical `history` samples and map `source_payload` fields where needed so the summary uses the same data the History page shows.
- Update unit tests to assert the canonical sources and the new evidence behavior and readiness effect; added/modified tests in `tests/guided-onboarding-ai-analysis.test.ts` to cover history source, invoice filter, parts/stock approach, vendor fallback, query reliability, and readiness score impact.

### Testing
- Ran `npm run typecheck` and it succeeded.
- Ran `npx eslint features/onboarding-v2/analysis/server.ts features/onboarding-v2/analysis/buildExecutiveSummary.ts app/dashboard/onboarding-v2/[sessionId]/summary/page.tsx --ext .ts,.tsx` and lint for the touched files passed.
- Ran unit tests with `npx vitest run tests/guided-onboarding-ai-analysis.test.ts tests/guided-onboarding*` and all tests passed (all onboarding-related tests green after updates).
- Ran `pnpm build`; build failed only due to the environment being unable to fetch Google Fonts (`Inter`, `Black Ops One`) from fonts.googleapis.com and not because of code or type errors, so production compilation is otherwise unchanged.

Files changed:
- features/onboarding-v2/analysis/server.ts
- tests/guided-onboarding-ai-analysis.test.ts

Canonical sources now used:
- History: `public.history` (shop-scoped `.eq("shop_id", shopId)`) for history counts and samples.
- Invoices: `public.invoices` filtered with `.contains("metadata", { import_type: "invoice_csv" })` for historical invoice evidence.
- Parts: `public.parts` for canonical part rows and `public.stock_moves` summed by `part_id` for on-hand/low/zero stock signals.

Evidence-query/UX changes:
- Optional query errors no longer silently return confident zeros; they return a reliability flag and a `evidenceWarnings` array is available for the analysis flow.
- Vendor metric shows canonical vendor-record count if present, otherwise distinct normalized `parts.supplier` names, and will be omitted (`undefined`) if vendor evidence is unreliable.

Behavioral effect:
- Service-history and parts counts reported by the executive summary now match the same canonical sources used by the History and Parts UI and importers, which restores the true readiness score when imported data is present.

If you want, I can also open a follow-up PR to add a small UI note showing the `evidenceWarnings` (developer-only) in the analysis debug panel to make query reliability visible to support engineers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a505de1cf8483289c0ff9e111b496f2)