### PR TITLE
Harden canonical shift lifecycle transactions

### DIFF
--- a/app/api/mobile/shifts/route.ts
+++ b/app/api/mobile/shifts/route.ts
@@ -15,7 +15,8 @@ import {
 type Action = PunchEventType | "start_break" | "end_break" | "start_lunch" | "end_lunch" | "toggle_break" | "toggle_lunch";
 type Caller = { id: string; shop_id: string | null };
 type ActiveShift = { id: string; start_time: string | null; status: string | null; end_time: string | null; shop_id: string | null; user_id: string | null };
-type PunchRow = { event_type: string | null; timestamp: string | null };
+type PunchRow = { id?: string | null; event_type: string | null; timestamp: string | null; created_at?: string | null };
+type ShiftLifecycleRpcRow = ActiveShift & { inserted_events?: PunchRow[] | null };
 
 async function authz() {
   const supabase = createServerSupabaseRoute();
@@ -42,6 +43,8 @@ async function loadActiveShift(admin: ReturnType<typeof createAdminSupabase>, us
     .eq("status", SHIFT_STATUSES.active)
     .is("end_time", null)
     .order("start_time", { ascending: false })
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: false })
     .limit(1)
     .maybeSingle<ActiveShift>();
   if (error) throw new Error(error.message);
@@ -52,9 +55,11 @@ async function loadShiftEvents(admin: ReturnType<typeof createAdminSupabase>, sh
   if (!shiftId) return [] as PunchRow[];
   const { data, error } = await admin
     .from("punch_events")
-    .select("event_type,timestamp")
+    .select("id,event_type,timestamp,created_at")
     .eq("shift_id", shiftId)
-    .order("timestamp", { ascending: true });
+    .order("timestamp", { ascending: true })
+    .order("created_at", { ascending: true })
+    .order("id", { ascending: true });
   if (error) throw new Error(error.message);
   return (data ?? []) as PunchRow[];
 }
@@ -91,6 +96,17 @@ function actionToEvent(action: Action): PunchEventType | null {
   }
 }
 
+function rpcShift(row: ShiftLifecycleRpcRow): ActiveShift {
+  return {
+    id: row.id,
+    start_time: row.start_time,
+    status: row.status,
+    end_time: row.end_time,
+    shop_id: row.shop_id,
+    user_id: row.user_id,
+  };
+}
+
 export async function GET() {
   const a = await authz();
   if (!a.ok) return a.res;
@@ -117,10 +133,10 @@ export async function POST(req: NextRequest) {
   const shopId = a.me.shop_id as string;
 
   const insertPunch = async (shiftId: string, userId: string, type: PunchEventType) => {
-    const payload = { shop_id: shopId, shift_id: shiftId, user_id: userId, profile_id: userId, event_type: type, timestamp: now };
-    const { data, error } = await admin.from("punch_events").insert(payload as never).select("id").single<{ id: string }>();
+    const payload = { shift_id: shiftId, user_id: userId, profile_id: userId, event_type: type, timestamp: now };
+    const { data, error } = await admin.from("punch_events").insert(payload as never).select("id,event_type,timestamp,created_at").single<PunchRow>();
     if (error || !data) throw new Error(`Punch event insert failed: ${error?.message ?? "missing inserted row"}`);
-    return data.id;
+    return data;
   };
 
   try {
@@ -130,16 +146,19 @@ export async function POST(req: NextRequest) {
     const activity = deriveCurrentShiftActivity(events, Boolean(current));
 
     if (eventType === PUNCH_EVENT_TYPES.startShift) {
-      if (current) return NextResponse.json({ error: "Active shift already exists" }, { status: 409 });
-      const { data, error } = await admin.from("tech_shifts").insert({ shop_id: shopId, user_id: a.me.id, start_time: now, end_time: null, type: "shift", status: SHIFT_STATUSES.active }).select("id,start_time,status,end_time,shop_id,user_id").single<ActiveShift>();
-      if (error || !data) return NextResponse.json({ error: error?.message ?? "Failed to start shift" }, { status: 500 });
-      try {
-        await insertPunch(data.id, a.me.id, PUNCH_EVENT_TYPES.startShift);
-      } catch (punchError) {
-        await admin.from("tech_shifts").delete().eq("id", data.id).eq("shop_id", shopId).eq("user_id", a.me.id);
-        return NextResponse.json({ error: punchError instanceof Error ? punchError.message : "Punch event insert failed" }, { status: 500 });
+      const { data, error } = await (admin as unknown as { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: ShiftLifecycleRpcRow[] | null; error: { message: string } | null }> }).rpc("start_canonical_shift", {
+        p_shop_id: shopId,
+        p_user_id: a.me.id,
+        p_profile_id: a.me.id,
+        p_timestamp: now,
+      });
+      const row = data?.[0] ?? null;
+      if (error || !row) {
+        const message = error?.message ?? "Start shift RPC returned no row";
+        const status = message.toLowerCase().includes("active shift already exists") ? 409 : 500;
+        return NextResponse.json({ error: `start_canonical_shift failed: ${message}` }, { status });
       }
-      return NextResponse.json({ ok: true, ...toDto(data, [{ event_type: PUNCH_EVENT_TYPES.startShift, timestamp: now }]) });
+      return NextResponse.json({ ok: true, ...toDto(rpcShift(row), row.inserted_events ?? []) });
     }
 
     if (!current) return NextResponse.json({ error: "No active shift" }, { status: 409 });
@@ -150,25 +169,24 @@ export async function POST(req: NextRequest) {
     if (eventType === PUNCH_EVENT_TYPES.lunchEnd && activity !== SHIFT_ACTIVITIES.onLunch) return NextResponse.json({ error: "Cannot end lunch when not on lunch" }, { status: 409 });
 
     if (eventType === PUNCH_EVENT_TYPES.endShift) {
-      const insertedPunchIds: string[] = [];
-      if (activity === SHIFT_ACTIVITIES.onBreak) insertedPunchIds.push(await insertPunch(current.id, activeShiftUserId, PUNCH_EVENT_TYPES.breakEnd));
-      if (activity === SHIFT_ACTIVITIES.onLunch) insertedPunchIds.push(await insertPunch(current.id, activeShiftUserId, PUNCH_EVENT_TYPES.lunchEnd));
-      insertedPunchIds.push(await insertPunch(current.id, activeShiftUserId, PUNCH_EVENT_TYPES.endShift));
-      const { data, error } = await admin.from("tech_shifts").update({ end_time: now, status: SHIFT_STATUSES.completed, type: "shift" }).eq("id", current.id).eq("shop_id", shopId).eq("user_id", activeShiftUserId).eq("status", SHIFT_STATUSES.active).select("id,start_time,status,end_time,shop_id,user_id").maybeSingle<ActiveShift>();
-      if (error || !data) {
-        await admin.from("punch_events").delete().in("id", insertedPunchIds).eq("shift_id", current.id);
-        return NextResponse.json({ error: error?.message ?? "Shift close failed: no matching active shift in this shop" }, { status: error ? 500 : 409 });
+      const { data, error } = await (admin as unknown as { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: ShiftLifecycleRpcRow[] | null; error: { message: string } | null }> }).rpc("complete_canonical_shift", {
+        p_shift_id: current.id,
+        p_shop_id: shopId,
+        p_user_id: activeShiftUserId,
+        p_profile_id: activeShiftUserId,
+        p_timestamp: now,
+      });
+      const row = data?.[0] ?? null;
+      if (error || !row) {
+        const message = error?.message ?? "Complete shift RPC returned no row";
+        const status = message.toLowerCase().includes("no matching active shift") ? 409 : 500;
+        return NextResponse.json({ error: `complete_canonical_shift failed: ${message}` }, { status });
       }
-      const closingEvents = insertedPunchIds.length === 2 && activity === SHIFT_ACTIVITIES.onBreak
-        ? [{ event_type: PUNCH_EVENT_TYPES.breakEnd, timestamp: now }, { event_type: eventType, timestamp: now }]
-        : insertedPunchIds.length === 2 && activity === SHIFT_ACTIVITIES.onLunch
-          ? [{ event_type: PUNCH_EVENT_TYPES.lunchEnd, timestamp: now }, { event_type: eventType, timestamp: now }]
-          : [{ event_type: eventType, timestamp: now }];
-      return NextResponse.json({ ok: true, ...toDto(data, [...events, ...closingEvents]) });
+      return NextResponse.json({ ok: true, ...toDto(rpcShift(row), [...events, ...(row.inserted_events ?? [])]) });
     }
 
-    await insertPunch(current.id, activeShiftUserId, eventType);
-    return NextResponse.json({ ok: true, ...toDto(current, [...events, { event_type: eventType, timestamp: now }]) });
+    const inserted = await insertPunch(current.id, activeShiftUserId, eventType);
+    return NextResponse.json({ ok: true, ...toDto(current, [...events, inserted]) });
   } catch (error) {
     return NextResponse.json({ error: error instanceof Error ? error.message : "Shift punch failed" }, { status: 500 });
   }

--- a/features/workforce/lib/shift-status.ts
+++ b/features/workforce/lib/shift-status.ts
@@ -29,6 +29,7 @@ export const SHIFT_ACTIVITIES = {
 export type ShiftActivity = (typeof SHIFT_ACTIVITIES)[keyof typeof SHIFT_ACTIVITIES];
 
 export type ShiftEventLike = {
+  id?: string | null;
   event_type?: string | null;
   timestamp?: string | null;
   created_at?: string | null;
@@ -45,6 +46,14 @@ export type ShiftStateDto = {
 };
 
 const EVENT_TYPE_VALUES = new Set<string>(Object.values(PUNCH_EVENT_TYPES));
+const EVENT_TYPE_PRIORITY: Record<PunchEventType, number> = {
+  [PUNCH_EVENT_TYPES.startShift]: 0,
+  [PUNCH_EVENT_TYPES.breakStart]: 1,
+  [PUNCH_EVENT_TYPES.lunchStart]: 1,
+  [PUNCH_EVENT_TYPES.breakEnd]: 2,
+  [PUNCH_EVENT_TYPES.lunchEnd]: 2,
+  [PUNCH_EVENT_TYPES.endShift]: 3,
+};
 
 export function isActiveShiftStatus(status: string | null | undefined): status is "active" {
   return status === SHIFT_STATUSES.active;
@@ -73,13 +82,30 @@ function eventTime(event: ShiftEventLike): string {
   return event.timestamp ?? event.created_at ?? "";
 }
 
+function eventCreatedAt(event: ShiftEventLike): string {
+  return event.created_at ?? "";
+}
+
+function eventPriority(event: ShiftEventLike): number {
+  return isPunchEventType(event.event_type) ? EVENT_TYPE_PRIORITY[event.event_type] : -1;
+}
+
+function compareShiftEvents(a: ShiftEventLike, b: ShiftEventLike): number {
+  return (
+    eventTime(a).localeCompare(eventTime(b)) ||
+    eventCreatedAt(a).localeCompare(eventCreatedAt(b)) ||
+    eventPriority(a) - eventPriority(b) ||
+    (a.id ?? "").localeCompare(b.id ?? "")
+  );
+}
+
 export function latestValidPunchEvent(events: readonly ShiftEventLike[] | null | undefined): {
   eventType: PunchEventType | null;
   eventAt: string | null;
 } {
   const latest = [...(events ?? [])]
     .filter((event) => isPunchEventType(event.event_type))
-    .sort((a, b) => eventTime(a).localeCompare(eventTime(b)))
+    .sort(compareShiftEvents)
     .at(-1);
 
   return {

--- a/supabase/manual/20260710_workforce_w0_normalize_tech_shift_status.sql
+++ b/supabase/manual/20260710_workforce_w0_normalize_tech_shift_status.sql
@@ -3,6 +3,9 @@
 
 begin;
 
+alter table public.tech_shifts
+  drop constraint if exists tech_shifts_status_check;
+
 update public.tech_shifts
 set status = case
   when status = 'open' then 'active'
@@ -12,10 +15,10 @@ end
 where status in ('open', 'closed', 'ended');
 
 alter table public.tech_shifts
-  drop constraint if exists tech_shifts_status_check;
+  add constraint tech_shifts_status_check
+  check (status = any (array['active'::text, 'completed'::text])) not valid;
 
 alter table public.tech_shifts
-  add constraint tech_shifts_status_check
-  check (status = any (array['active'::text, 'completed'::text]));
+  validate constraint tech_shifts_status_check;
 
 commit;

--- a/supabase/manual/20260710_workforce_w0_transactional_shift_lifecycle.sql
+++ b/supabase/manual/20260710_workforce_w0_transactional_shift_lifecycle.sql
@@ -1,0 +1,188 @@
+-- Workforce W0.1: transactional canonical shift lifecycle hardening.
+-- Schema compatibility note: current generated types show punch_events has id, user_id,
+-- profile_id, shift_id, event_type, timestamp, and created_at, but no shop_id. These
+-- RPCs therefore scope punch events through the locked tech_shifts row instead of
+-- writing punch_events.shop_id.
+
+begin;
+
+create or replace function public.start_canonical_shift(
+  p_shop_id uuid,
+  p_user_id uuid,
+  p_profile_id uuid,
+  p_timestamp timestamptz default now()
+)
+returns table (
+  id uuid,
+  start_time timestamptz,
+  status text,
+  end_time timestamptz,
+  shop_id uuid,
+  user_id uuid,
+  inserted_events jsonb
+)
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_shift public.tech_shifts%rowtype;
+  v_event public.punch_events%rowtype;
+begin
+  if exists (
+    select 1
+    from public.tech_shifts ts
+    where ts.shop_id = p_shop_id
+      and ts.user_id = p_user_id
+      and ts.status = 'active'
+      and ts.end_time is null
+  ) then
+    raise exception 'Active shift already exists for this shop/user'
+      using errcode = '23505';
+  end if;
+
+  insert into public.tech_shifts (shop_id, user_id, status, type, start_time, end_time)
+  values (p_shop_id, p_user_id, 'active', 'shift', p_timestamp, null)
+  returning * into v_shift;
+
+  insert into public.punch_events (shift_id, user_id, profile_id, event_type, timestamp)
+  values (v_shift.id, p_user_id, p_profile_id, 'start_shift', p_timestamp)
+  returning * into v_event;
+
+  return query
+  select
+    v_shift.id,
+    v_shift.start_time,
+    v_shift.status,
+    v_shift.end_time,
+    v_shift.shop_id,
+    v_shift.user_id,
+    jsonb_build_array(jsonb_build_object(
+      'id', v_event.id,
+      'event_type', v_event.event_type,
+      'timestamp', v_event.timestamp,
+      'created_at', v_event.created_at
+    ));
+end;
+$$;
+
+create or replace function public.complete_canonical_shift(
+  p_shift_id uuid,
+  p_shop_id uuid,
+  p_user_id uuid,
+  p_profile_id uuid,
+  p_timestamp timestamptz default now()
+)
+returns table (
+  id uuid,
+  start_time timestamptz,
+  status text,
+  end_time timestamptz,
+  shop_id uuid,
+  user_id uuid,
+  inserted_events jsonb
+)
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_shift public.tech_shifts%rowtype;
+  v_latest_event_type text;
+  v_auto_close_event public.punch_events%rowtype;
+  v_end_event public.punch_events%rowtype;
+  v_inserted_events jsonb := '[]'::jsonb;
+begin
+  select *
+  into v_shift
+  from public.tech_shifts ts
+  where ts.id = p_shift_id
+    and ts.shop_id = p_shop_id
+    and ts.user_id = p_user_id
+    and ts.status = 'active'
+    and ts.end_time is null
+  for update;
+
+  if not found then
+    raise exception 'No matching active shift in this shop/user'
+      using errcode = 'P0002';
+  end if;
+
+  select pe.event_type
+  into v_latest_event_type
+  from public.punch_events pe
+  where pe.shift_id = v_shift.id
+    and pe.event_type in ('start_shift', 'break_start', 'break_end', 'lunch_start', 'lunch_end', 'end_shift')
+  order by
+    pe.timestamp desc,
+    pe.created_at desc nulls last,
+    case pe.event_type
+      when 'end_shift' then 3
+      when 'break_end' then 2
+      when 'lunch_end' then 2
+      when 'break_start' then 1
+      when 'lunch_start' then 1
+      when 'start_shift' then 0
+      else -1
+    end desc,
+    pe.id desc
+  limit 1;
+
+  if v_latest_event_type = 'break_start' then
+    insert into public.punch_events (shift_id, user_id, profile_id, event_type, timestamp)
+    values (v_shift.id, p_user_id, p_profile_id, 'break_end', p_timestamp)
+    returning * into v_auto_close_event;
+
+    v_inserted_events := v_inserted_events || jsonb_build_array(jsonb_build_object(
+      'id', v_auto_close_event.id,
+      'event_type', v_auto_close_event.event_type,
+      'timestamp', v_auto_close_event.timestamp,
+      'created_at', v_auto_close_event.created_at
+    ));
+  elsif v_latest_event_type = 'lunch_start' then
+    insert into public.punch_events (shift_id, user_id, profile_id, event_type, timestamp)
+    values (v_shift.id, p_user_id, p_profile_id, 'lunch_end', p_timestamp)
+    returning * into v_auto_close_event;
+
+    v_inserted_events := v_inserted_events || jsonb_build_array(jsonb_build_object(
+      'id', v_auto_close_event.id,
+      'event_type', v_auto_close_event.event_type,
+      'timestamp', v_auto_close_event.timestamp,
+      'created_at', v_auto_close_event.created_at
+    ));
+  end if;
+
+  insert into public.punch_events (shift_id, user_id, profile_id, event_type, timestamp)
+  values (v_shift.id, p_user_id, p_profile_id, 'end_shift', p_timestamp + interval '1 microsecond')
+  returning * into v_end_event;
+
+  v_inserted_events := v_inserted_events || jsonb_build_array(jsonb_build_object(
+    'id', v_end_event.id,
+    'event_type', v_end_event.event_type,
+    'timestamp', v_end_event.timestamp,
+    'created_at', v_end_event.created_at
+  ));
+
+  update public.tech_shifts ts
+  set status = 'completed', end_time = p_timestamp, type = 'shift'
+  where ts.id = v_shift.id
+  returning * into v_shift;
+
+  return query
+  select
+    v_shift.id,
+    v_shift.start_time,
+    v_shift.status,
+    v_shift.end_time,
+    v_shift.shop_id,
+    v_shift.user_id,
+    v_inserted_events;
+end;
+$$;
+
+revoke all on function public.start_canonical_shift(uuid, uuid, uuid, timestamptz) from public;
+revoke all on function public.complete_canonical_shift(uuid, uuid, uuid, uuid, timestamptz) from public;
+grant execute on function public.start_canonical_shift(uuid, uuid, uuid, timestamptz) to authenticated, service_role;
+grant execute on function public.complete_canonical_shift(uuid, uuid, uuid, uuid, timestamptz) to authenticated, service_role;
+
+commit;

--- a/tests/mobile-shift-lifecycle-route.test.ts
+++ b/tests/mobile-shift-lifecycle-route.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const routeSource = () => readFileSync("app/api/mobile/shifts/route.ts", "utf8");
+const rpcMigration = () => readFileSync("supabase/manual/20260710_workforce_w0_transactional_shift_lifecycle.sql", "utf8");
+
+describe("mobile shift lifecycle hardening", () => {
+  it("starts shifts through the transactional RPC instead of manual insert/delete compensation", () => {
+    const source = routeSource();
+
+    expect(source).toContain('.rpc("start_canonical_shift"');
+    expect(source).toContain("p_shop_id: shopId");
+    expect(source).toContain("p_user_id: a.me.id");
+    expect(source).toContain("start_canonical_shift failed");
+    expect(source).not.toContain('.from("tech_shifts").insert');
+    expect(source).not.toContain('.from("tech_shifts").delete()');
+  });
+
+  it("completes shifts through the transactional RPC instead of partial auto-close/update compensation", () => {
+    const source = routeSource();
+
+    expect(source).toContain('.rpc("complete_canonical_shift"');
+    expect(source).toContain("p_shift_id: current.id");
+    expect(source).toContain("complete_canonical_shift failed");
+    expect(source).not.toContain('.from("tech_shifts").update');
+    expect(source).not.toContain('.from("punch_events").delete()');
+  });
+
+  it("keeps break and lunch as checked append-only writes guarded by route ordering", () => {
+    const source = routeSource();
+
+    expect(source).toContain("Punch event insert failed");
+    expect(source).toContain("Cannot start break unless currently working");
+    expect(source).toContain("Cannot end break when not on break");
+    expect(source).toContain("Cannot start lunch unless currently working");
+    expect(source).toContain("Cannot end lunch when not on lunch");
+    expect(source).toContain("return NextResponse.json({ ok: true, ...toDto(current");
+  });
+
+  it("defines atomic start and complete RPCs with narrow grants and explicit search_path", () => {
+    const sql = rpcMigration();
+
+    expect(sql).toContain("create or replace function public.start_canonical_shift");
+    expect(sql).toContain("create or replace function public.complete_canonical_shift");
+    expect(sql).toContain("security invoker");
+    expect(sql).toContain("set search_path = public, pg_temp");
+    expect(sql).toContain("for update");
+    expect(sql).toContain("grant execute on function public.start_canonical_shift");
+    expect(sql).toContain("grant execute on function public.complete_canonical_shift");
+  });
+
+  it("documents rollback and tenant-isolation contracts in the RPC migration", () => {
+    const sql = rpcMigration();
+
+    expect(sql).toContain("ts.shop_id = p_shop_id");
+    expect(sql).toContain("ts.user_id = p_user_id");
+    expect(sql).toContain("Active shift already exists");
+    expect(sql).toContain("No matching active shift in this shop/user");
+    expect(sql).toContain("no shop_id");
+  });
+
+  it("auto-closes break/lunch before end_shift with deterministic end_shift ordering", () => {
+    const sql = rpcMigration();
+
+    expect(sql).toContain("v_latest_event_type = 'break_start'");
+    expect(sql).toContain("'break_end'");
+    expect(sql).toContain("v_latest_event_type = 'lunch_start'");
+    expect(sql).toContain("'lunch_end'");
+    expect(sql).toContain("p_timestamp + interval '1 microsecond'");
+    expect(sql).toContain("when 'end_shift' then 3");
+  });
+});

--- a/tests/shift-status.test.ts
+++ b/tests/shift-status.test.ts
@@ -63,4 +63,20 @@ describe("canonical shift lifecycle helpers", () => {
     expect(latest.eventType).toBe(PUNCH_EVENT_TYPES.startShift);
     expect(deriveCurrentShiftActivity([{ event_type: "end_shift", timestamp: "2026-07-10T18:00:00.000Z" }])).toBe(SHIFT_ACTIVITIES.offShift);
   });
+
+  it("orders same-time events deterministically with end_shift winning ties", () => {
+    const sameTime = "2026-07-10T18:00:00.000Z";
+    const latest = latestValidPunchEvent([
+      { id: "z", event_type: "break_start", timestamp: sameTime, created_at: sameTime },
+      { id: "a", event_type: "end_shift", timestamp: sameTime, created_at: sameTime },
+      { id: "y", event_type: "lunch_end", timestamp: sameTime, created_at: sameTime },
+    ]);
+
+    expect(latest.eventType).toBe(PUNCH_EVENT_TYPES.endShift);
+    expect(deriveCurrentShiftActivity([
+      { id: "z", event_type: "break_start", timestamp: sameTime, created_at: sameTime },
+      { id: "a", event_type: "end_shift", timestamp: sameTime, created_at: sameTime },
+    ])).toBe(SHIFT_ACTIVITIES.offShift);
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Fix partial-failure and non-deterministic behaviors in shift start/end flows by making start and end transitions atomic and deterministic.\
- Prevent silent compensation/delete failures and remove windows where break/lunch end succeeds but shift close fails.\
- Preserve tenant isolation and existing time model while avoiding schema redesign.\

### Description
- Add transactional Postgres RPCs `public.start_canonical_shift(p_shop_id uuid, p_user_id uuid, p_profile_id uuid, p_timestamp timestamptz)` and `public.complete_canonical_shift(p_shift_id uuid, p_shop_id uuid, p_user_id uuid, p_profile_id uuid, p_timestamp timestamptz)` implemented in `supabase/manual/20260710_workforce_w0_transactional_shift_lifecycle.sql`, both `SECURITY INVOKER`, explicit `search_path = public, pg_temp`, and grants limited to `authenticated` and `service_role`.\
- Update `app/api/mobile/shifts/route.ts` to call the new RPCs for start/end actions and remove manual multi-write insert/update/delete compensation sequences while preserving route-level auth/shop checks and keeping break/lunch as guarded single inserts.\
- Make latest event selection deterministic by adding event id/created_at handling and explicit event priority (start_shift:0, break_start/lunch_start:1, break_end/lunch_end:2, end_shift:3) in `features/workforce/lib/shift-status.ts`, and update DB reads in the route to order by `timestamp`, `created_at`, then `id`.\
- Correct the W0 normalization migration ordering in `supabase/manual/20260710_workforce_w0_normalize_tech_shift_status.sql` to drop old constraint, normalize rows, add the check as `NOT VALID`, then validate.\
- Add source-level tests: `tests/mobile-shift-lifecycle-route.test.ts` (route → RPC usage and contracts) and deterministic tie test in `tests/shift-status.test.ts`. Files changed: `app/api/mobile/shifts/route.ts`, `features/workforce/lib/shift-status.ts`, `supabase/manual/20260710_workforce_w0_transactional_shift_lifecycle.sql`, `supabase/manual/20260710_workforce_w0_normalize_tech_shift_status.sql`, `tests/mobile-shift-lifecycle-route.test.ts`, `tests/shift-status.test.ts`.\

### Testing
- Type-check: ran `npx tsc --noEmit` and it completed successfully.\
- Unit/source tests: ran `npx vitest run tests/shift-status.test.ts tests/workforce-document-readiness.test.ts` and then `npx vitest run tests/shift-status.test.ts tests/workforce-document-readiness.test.ts tests/mobile-shift-lifecycle-route.test.ts`, all tests passed (3 test files, 37 tests).\
- The new migration SQL is provided under `supabase/manual/20260710_workforce_w0_transactional_shift_lifecycle.sql` and must be applied to the target Supabase/Postgres environment before deploying the updated route in production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50ffcb0e0c8328bfe0fb4fdb135d68)