### PR TITLE
Fix legacy shift status writers

### DIFF
--- a/app/api/time/shift/end/route.ts
+++ b/app/api/time/shift/end/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
 import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { SHIFT_STATUSES } from "@/features/workforce/lib/shift-status";
+
+type Caller = { id: string; shop_id: string | null };
+type ShiftRow = { id: string; shop_id: string | null; user_id: string | null; start_time: string | null };
+type ShiftLifecycleRpcRow = ShiftRow & { status: string | null; end_time: string | null; inserted_events?: unknown[] | null };
 
 export async function POST() {
   const supabase = createServerSupabaseRoute();
@@ -11,11 +16,19 @@ export async function POST() {
   if (userErr) return NextResponse.json({ error: userErr.message }, { status: 500 });
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { data: me } = await supabase
+  let { data: me } = await supabase
     .from("profiles")
     .select("id, shop_id")
     .eq("id", user.id)
-    .maybeSingle();
+    .maybeSingle<Caller>();
+  if (!me) {
+    const byUser = await supabase
+      .from("profiles")
+      .select("id, shop_id")
+      .eq("user_id", user.id)
+      .maybeSingle<Caller>();
+    me = byUser.data ?? null;
+  }
 
   if (!me?.shop_id) return NextResponse.json({ error: "Missing shop" }, { status: 403 });
 
@@ -24,7 +37,7 @@ export async function POST() {
   const { data: activeJobs, error: activeJobsErr } = await admin
     .from("work_order_line_labor_segments")
     .select("id")
-    .eq("technician_id", user.id)
+    .eq("technician_id", me.id)
     .is("ended_at", null)
     .limit(2);
 
@@ -38,16 +51,17 @@ export async function POST() {
 
   const { data: shifts, error: shiftErr } = await admin
     .from("tech_shifts")
-    .select("id, shop_id, start_time")
-    .eq("user_id", user.id)
-    .eq("status", "open")
+    .select("id, shop_id, user_id, start_time")
+    .eq("user_id", me.id)
+    .eq("status", SHIFT_STATUSES.active)
+    .is("end_time", null)
     .order("start_time", { ascending: false })
     .limit(5);
 
   if (shiftErr) return NextResponse.json({ error: shiftErr.message }, { status: 500 });
   const shift =
-    (shifts ?? []).find((s) => s.shop_id === me.shop_id) ??
-    (shifts ?? []).find((s) => s.shop_id == null) ??
+    ((shifts ?? []) as ShiftRow[]).find((s) => s.shop_id === me.shop_id) ??
+    ((shifts ?? []) as ShiftRow[]).find((s) => s.shop_id == null) ??
     null;
   if (!shift) {
     return NextResponse.json(
@@ -60,20 +74,20 @@ export async function POST() {
   }
 
   const now = new Date().toISOString();
-  const { error: updErr } = await admin
-    .from("tech_shifts")
-    .update({ end_time: now, status: "closed", type: "shift" })
-    .eq("id", shift.id);
-
-  if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
-
-  await admin.from("punch_events").insert({
-    shift_id: shift.id,
-    user_id: user.id,
-    profile_id: user.id,
-    event_type: "end_shift",
-    timestamp: now,
+  const { data, error } = await (admin as unknown as { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: ShiftLifecycleRpcRow[] | null; error: { message: string } | null }> }).rpc("complete_canonical_shift", {
+    p_shift_id: shift.id,
+    p_shop_id: me.shop_id,
+    p_user_id: shift.user_id ?? me.id,
+    p_profile_id: shift.user_id ?? me.id,
+    p_timestamp: now,
   });
 
-  return NextResponse.json({ ok: true, shiftId: shift.id, endedAt: now });
+  const row = data?.[0] ?? null;
+  if (error || !row) {
+    const message = error?.message ?? "Complete shift RPC returned no row";
+    const status = message.toLowerCase().includes("no matching active shift") ? 409 : 500;
+    return NextResponse.json({ error: `complete_canonical_shift failed: ${message}` }, { status });
+  }
+
+  return NextResponse.json({ ok: true, shiftId: row.id, endedAt: row.end_time ?? now });
 }

--- a/features/shared/components/ShiftTracker.tsx
+++ b/features/shared/components/ShiftTracker.tsx
@@ -1,36 +1,25 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { formatDistanceToNow } from "date-fns";
-
+import {
+  fetchMobileShiftState,
+  type MobileShiftState,
+} from "@/features/mobile/shifts/client";
 
 type ShiftType = "shift" | "break" | "lunch";
 type Mode = "none" | "shift" | "break" | "lunch" | "ended";
+type ShiftAction = "start_shift" | "end_shift" | "start_break" | "end_break" | "start_lunch" | "end_lunch";
 
-type PunchEventType =
-  | "start_shift"
-  | "end_shift"
-  | "break_start"
-  | "break_end"
-  | "lunch_start"
-  | "lunch_end";
-
-type PgErrorLike = { code?: string | null; message?: string | null };
-
-function toShiftType(input: unknown, fallback: ShiftType): ShiftType {
-  const v = String(input ?? "").toLowerCase().trim();
-  if (v === "shift" || v === "break" || v === "lunch") return v;
-  return fallback;
+function modeFromActivity(activity: MobileShiftState["activity"] | undefined, shiftStatus?: MobileShiftState["shiftStatus"]): Mode {
+  if (shiftStatus === "completed") return "ended";
+  if (activity === "working") return "shift";
+  if (activity === "on_break") return "break";
+  if (activity === "on_lunch") return "lunch";
+  return "none";
 }
 
-function formatPgErr(e: unknown, fallback: string): string {
-  if (e && typeof e === "object") {
-    const pe = e as PgErrorLike;
-    const code = pe.code ? `${pe.code}: ` : "";
-    const msg = pe.message ?? null;
-    if (msg) return `${code}${msg}`;
-  }
+function formatErr(e: unknown, fallback: string): string {
   if (e instanceof Error) return e.message;
   if (typeof e === "string") return e;
   return fallback;
@@ -38,257 +27,110 @@ function formatPgErr(e: unknown, fallback: string): string {
 
 export default function ShiftTracker({
   userId,
-  defaultShiftType = "shift",
 }: {
   userId: string;
   defaultShiftType?: ShiftType;
 }): JSX.Element {
-  const supabase = useMemo(() => createBrowserSupabase(), []);
-
-  const [shiftId, setShiftId] = useState<string | null>(null);
-  const [startTime, setStartTime] = useState<string | null>(null);
-  const [mode, setMode] = useState<Mode>("none");
+  const [shiftState, setShiftState] = useState<MobileShiftState | null>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
-  const safeDefaultType = useMemo(
-    () => toShiftType(defaultShiftType, "shift"),
-    [defaultShiftType],
-  );
+  const shiftId = shiftState?.shiftId ?? null;
+  const startTime = shiftState?.startTime ?? null;
+  const mode = shiftState?.mode ?? "none";
 
-  const insertPunch = useCallback(
-    async (sid: string, event: PunchEventType) => {
-      const { error } = await supabase.from("punch_events").insert({
-        shift_id: sid,
-        user_id: userId,
-        profile_id: userId,
-        event_type: event,
-        timestamp: new Date().toISOString(),
-      });
-
-      if (error) {
-        console.error("[ShiftTracker] insertPunch failed:", error);
-        setErr(`${error.code ?? "punch_error"}: ${error.message}`);
-      }
-    },
-    [supabase, userId],
-  );
-
+  const applyShiftState = useCallback((state: MobileShiftState) => {
+    setShiftState(state);
+  }, []);
 
   const loadOpenShift = useCallback(async () => {
     if (!userId) return;
     setErr(null);
 
-    const { data: shift, error: sErr } = await supabase
-      .from("tech_shifts")
-      .select("id, start_time, type, status, end_time")
-      .eq("user_id", userId)
-      .eq("status", "open")
-      .order("start_time", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (sErr) {
-      setErr(`${sErr.code ?? "load_error"}: ${sErr.message}`);
-      setShiftId(null);
-      setStartTime(null);
-      setMode("none");
-      return;
+    try {
+      applyShiftState(await fetchMobileShiftState());
+    } catch (error) {
+      setErr(formatErr(error, "Failed to load shift state"));
+      setShiftState(null);
     }
-
-    let open = shift ?? null;
-
-    if (!open) {
-      const { data: fb, error: fbErr } = await supabase
-        .from("tech_shifts")
-        .select("id, start_time, type, status, end_time")
-        .eq("user_id", userId)
-        .is("end_time", null)
-        .order("start_time", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (fbErr) {
-        setErr(`${fbErr.code ?? "load_error"}: ${fbErr.message}`);
-        setShiftId(null);
-        setStartTime(null);
-        setMode("none");
-        return;
-      }
-      open = fb ?? null;
-    }
-
-    if (!open) {
-      setShiftId(null);
-      setStartTime(null);
-      setMode("none");
-      return;
-    }
-
-    setShiftId(open.id);
-    setStartTime(open.start_time ?? null);
-
-    const { data: lastPunch, error: pErr } = await supabase
-      .from("punch_events")
-      .select("event_type")
-      .eq("shift_id", open.id)
-      .order("timestamp", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (pErr) {
-      setMode(toShiftType(open.type, "shift"));
-      return;
-    }
-
-    const ev = lastPunch?.event_type ?? null;
-
-    const computed: Mode =
-      ev === "break_start"
-        ? "break"
-        : ev === "lunch_start"
-          ? "lunch"
-          : "shift";
-
-    setMode(computed);
-  }, [supabase, userId]);
+  }, [applyShiftState, userId]);
 
   useEffect(() => {
     void loadOpenShift();
   }, [loadOpenShift]);
 
-  const startShift = useCallback(async () => {
-    if (busy || !userId) return;
-    setBusy(true);
-    setErr(null);
+  const postShiftAction = useCallback(
+    async (action: ShiftAction, fallback: string) => {
+      if (busy || !userId) return;
+      setBusy(true);
+      setErr(null);
 
-    try {
-      const { data: existing, error: exErr } = await supabase
-        .from("tech_shifts")
-        .select("id, start_time, type")
-        .eq("user_id", userId)
-        .eq("status", "open")
-        .order("start_time", { ascending: false })
-        .limit(1)
-        .maybeSingle();
+      try {
+        const res = await fetch("/api/mobile/shifts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action }),
+        });
+        const body = (await res.json().catch(() => null)) as
+          | ({ ok?: boolean; error?: string } & Partial<MobileShiftState>)
+          | null;
+        if (!res.ok || !body?.ok) throw new Error(body?.error ?? fallback);
 
-      if (exErr) throw exErr;
+        const activity = body.activity ?? "off_shift";
+        applyShiftState({
+          shiftId: body.shiftId ?? null,
+          shiftStatus: body.shiftStatus ?? null,
+          activity,
+          startTime: body.startTime ?? null,
+          endTime: body.endTime ?? null,
+          latestEventType: body.latestEventType ?? null,
+          latestEventAt: body.latestEventAt ?? null,
+          mode: body.mode ?? modeFromActivity(activity, body.shiftStatus),
+        });
 
-      if (existing) {
-        setShiftId(existing.id);
-        setStartTime(existing.start_time ?? null);
-        setMode(toShiftType(existing.type, "shift"));
-        return;
+        if (action === "end_shift") {
+          window.dispatchEvent(new CustomEvent("wol:refresh"));
+        }
+      } catch (error) {
+        setErr(formatErr(error, fallback));
+        await loadOpenShift().catch(() => undefined);
+      } finally {
+        setBusy(false);
       }
+    },
+    [applyShiftState, busy, loadOpenShift, userId],
+  );
 
-      const now = new Date().toISOString();
+  const startShift = useCallback(
+    () => postShiftAction("start_shift", "Failed to start shift"),
+    [postShiftAction],
+  );
 
-      const { data, error } = await supabase
-        .from("tech_shifts")
-        .insert({
-          user_id: userId,
-          start_time: now,
-          type: safeDefaultType,
-          status: "open",
-          end_time: null,
-        })
-        .select("id, start_time")
-        .single();
+  const endShift = useCallback(
+    () => postShiftAction("end_shift", "Failed to end shift"),
+    [postShiftAction],
+  );
 
-      if (error) throw error;
+  const toggleBreak = useCallback(
+    () => postShiftAction(mode === "break" ? "end_break" : "start_break", "Failed to toggle break"),
+    [mode, postShiftAction],
+  );
 
-      setShiftId(data.id);
-      setStartTime(data.start_time ?? now);
-      setMode("shift");
-
-      await insertPunch(data.id, "start_shift");
-    } catch (e: unknown) {
-      setErr(formatPgErr(e, "Failed to start shift"));
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, supabase, userId, safeDefaultType, insertPunch]);
-
-  const endShift = useCallback(async () => {
-    if (busy || !shiftId) return;
-    setBusy(true);
-    setErr(null);
-
-    try {
-      const res = await fetch("/api/time/shift/end", { method: "POST" });
-      const json = (await res.json().catch(() => null)) as { error?: string } | null;
-      if (!res.ok) {
-        throw new Error(json?.error ?? "Failed to end shift");
-      }
-
-      window.dispatchEvent(new CustomEvent("wol:refresh"));
-      setShiftId(null);
-      setStartTime(null);
-      setMode("ended");
-    } catch (e: unknown) {
-      setErr(formatPgErr(e, "Failed to end shift"));
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, shiftId]);
-
-  const toggleBreak = useCallback(async () => {
-    if (busy || !shiftId) return;
-    setBusy(true);
-    setErr(null);
-
-    try {
-      const isEnding = mode === "break";
-      const nextType: ShiftType = isEnding ? "shift" : "break";
-
-      const { error } = await supabase
-        .from("tech_shifts")
-        .update({ type: nextType, status: "open" })
-        .eq("id", shiftId);
-
-      if (error) throw error;
-
-      await insertPunch(shiftId, isEnding ? "break_end" : "break_start");
-      setMode(nextType);
-    } catch (e: unknown) {
-      setErr(formatPgErr(e, "Failed to toggle break"));
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, supabase, shiftId, mode, insertPunch]);
-
-  const toggleLunch = useCallback(async () => {
-    if (busy || !shiftId) return;
-    setBusy(true);
-    setErr(null);
-
-    try {
-      const isEnding = mode === "lunch";
-      const nextType: ShiftType = isEnding ? "shift" : "lunch";
-
-      const { error } = await supabase
-        .from("tech_shifts")
-        .update({ type: nextType, status: "open" })
-        .eq("id", shiftId);
-
-      if (error) throw error;
-
-      await insertPunch(shiftId, isEnding ? "lunch_end" : "lunch_start");
-      setMode(nextType);
-    } catch (e: unknown) {
-      setErr(formatPgErr(e, "Failed to toggle lunch"));
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, supabase, shiftId, mode, insertPunch]);
+  const toggleLunch = useCallback(
+    () => postShiftAction(mode === "lunch" ? "end_lunch" : "start_lunch", "Failed to toggle lunch"),
+    [mode, postShiftAction],
+  );
 
   const btnBase =
     "rounded border px-4 py-2 text-white transition-colors bg-transparent hover:bg-white/5 focus:outline-none disabled:opacity-60 disabled:cursor-not-allowed";
-  const btnOutline = {
-    yellow: `${btnBase} border-yellow-500`,
-    orange: `${btnBase} border-orange-500`,
-    red: `${btnBase} border-red-500`,
-  };
+  const btnOutline = useMemo(
+    () => ({
+      yellow: `${btnBase} border-yellow-500`,
+      orange: `${btnBase} border-orange-500`,
+      red: `${btnBase} border-red-500`,
+    }),
+    [],
+  );
 
   const niceStatus = mode === "none" ? "Off shift" : mode === "ended" ? "Shift ended" : mode;
 
@@ -328,7 +170,7 @@ export default function ShiftTracker({
             <button
               className={`${btnOutline.yellow} flex-1 py-3 text-base`}
               onClick={() => void toggleBreak()}
-              disabled={busy}
+              disabled={busy || mode === "lunch"}
             >
               {mode === "break" ? "End Break" : "Break"}
             </button>
@@ -336,7 +178,7 @@ export default function ShiftTracker({
             <button
               className={`${btnOutline.orange} flex-1 py-3 text-base`}
               onClick={() => void toggleLunch()}
-              disabled={busy}
+              disabled={busy || mode === "break"}
             >
               {mode === "lunch" ? "End Lunch" : "Lunch"}
             </button>
@@ -345,7 +187,7 @@ export default function ShiftTracker({
           <button
             className={`${btnOutline.red} w-full py-3 text-base`}
             onClick={() => void endShift()}
-            disabled={busy}
+            disabled={busy || !shiftId}
           >
             End Shift
           </button>

--- a/features/work-orders/server/applyJobPunchTransition.ts
+++ b/features/work-orders/server/applyJobPunchTransition.ts
@@ -11,6 +11,7 @@ import {
   syncLinePunchMirrorFromSegments,
 } from "@/features/work-orders/server/laborSegments";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+import { SHIFT_STATUSES } from "@/features/workforce/lib/shift-status";
 
 type DB = Database;
 
@@ -165,7 +166,7 @@ export async function applyJobPunchTransition({
       .from("tech_shifts")
       .select("id, shop_id, status, start_time, end_time")
       .eq("user_id", lineTechId)
-      .eq("status", "open")
+      .eq("status", SHIFT_STATUSES.active)
       .order("start_time", { ascending: false })
       .limit(1);
 
@@ -209,7 +210,7 @@ export async function applyJobPunchTransition({
         .from("tech_shifts")
         .select("id, shop_id, status, start_time, end_time")
         .eq("user_id", lineTechId)
-        .eq("status", "open")
+        .eq("status", SHIFT_STATUSES.active)
         .order("start_time", { ascending: false })
         .limit(1)
         .maybeSingle();

--- a/supabase/manual/20260710_workforce_w0_normalize_tech_shift_status.sql
+++ b/supabase/manual/20260710_workforce_w0_normalize_tech_shift_status.sql
@@ -15,6 +15,9 @@ end
 where status in ('open', 'closed', 'ended');
 
 alter table public.tech_shifts
+  alter column status set default 'active';
+
+alter table public.tech_shifts
   add constraint tech_shifts_status_check
   check (status = any (array['active'::text, 'completed'::text])) not valid;
 

--- a/tests/mobile-shift-lifecycle-route.test.ts
+++ b/tests/mobile-shift-lifecycle-route.test.ts
@@ -5,6 +5,26 @@ const routeSource = () => readFileSync("app/api/mobile/shifts/route.ts", "utf8")
 const rpcMigration = () => readFileSync("supabase/manual/20260710_workforce_w0_transactional_shift_lifecycle.sql", "utf8");
 
 describe("mobile shift lifecycle hardening", () => {
+
+  it("routes the visible desktop Start Shift button through /api/mobile/shifts without legacy tech_shifts status inserts", () => {
+    const source = readFileSync("features/shared/components/ShiftTracker.tsx", "utf8");
+
+    expect(source).toContain('fetch("/api/mobile/shifts"');
+    expect(source).toContain('body: JSON.stringify({ action })');
+    expect(source).not.toContain('.from("tech_shifts")');
+    expect(source).not.toContain('status: "open"');
+    expect(source).not.toContain('.eq("status", "open")');
+    expect(source).not.toContain('/api/time/shift/end');
+  });
+
+  it("normalizes the tech_shifts status default to active", () => {
+    const sql = readFileSync("supabase/manual/20260710_workforce_w0_normalize_tech_shift_status.sql", "utf8");
+
+    expect(sql).toContain("alter column status set default 'active'");
+    expect(sql).toContain("when status = 'open' then 'active'");
+    expect(sql).toContain("when status in ('closed', 'ended') then 'completed'");
+  });
+
   it("starts shifts through the transactional RPC instead of manual insert/delete compensation", () => {
     const source = routeSource();
 


### PR DESCRIPTION
### Motivation
- Production DB constrains `tech_shifts.status` to `active`/`completed` but some UI paths were still writing legacy `open`/`closed`, causing PostgreSQL 23514 errors. 
- Ensure the visible Start Shift action uses the transactional RPC that writes `status = 'active'` and that all active UI flows no longer write legacy `open` values. 

### Description
- Replaced the legacy desktop writer so the visible Start Shift button in `features/shared/components/ShiftTracker.tsx` calls the mobile helper and posts to `/api/mobile/shifts` instead of inserting into `tech_shifts` with `status: "open"`. 
- Confirmed and relied on the transactional RPC in `supabase/manual/20260710_workforce_w0_transactional_shift_lifecycle.sql` (`start_canonical_shift`) which inserts `status = 'active'` and creates the `start_shift` punch event atomically. 
- Updated end/complete paths to use the canonical RPC: `app/api/time/shift/end/route.ts` now calls `complete_canonical_shift` (instead of updating `status: 'closed'`), and job-punch lookup logic in `features/work-orders/server/applyJobPunchTransition.ts` was normalized to use `SHIFT_STATUSES.active`. 
- Normalization migration updated: `supabase/manual/20260710_workforce_w0_normalize_tech_shift_status.sql` backfills `open`/`closed` → `active`/`completed` and sets the `tech_shifts.status` column default to `'active'`. 
- Added/updated a focused test `tests/mobile-shift-lifecycle-route.test.ts` that asserts the visible Start Shift path posts to `/api/mobile/shifts`, does not perform `.from("tech_shifts").insert`, and verifies the migration includes `alter column status set default 'active'`.

### Testing
- Ran the targeted unit test: `npx vitest run tests/mobile-shift-lifecycle-route.test.ts`, result: 1 file, 8 tests — all passed. 
- Ran the TypeScript check: `npx tsc --noEmit`, result: success (no type errors). 
- Performed repository audit checks for remaining visible-path direct `tech_shifts` inserts/legacy `status: "open"` and validated the Start Shift UI path and server routes now use the RPCs as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5115eddb048328886a444fe406c060)