### PR TITLE
Enforce canonical tech_shifts write path

### DIFF
--- a/app/api/scheduling/shifts/[id]/route.ts
+++ b/app/api/scheduling/shifts/[id]/route.ts
@@ -1,133 +1,23 @@
 import { NextResponse, type NextRequest } from "next/server";
-import type { Database } from "@shared/types/types/supabase";
-import {
-  createServerSupabaseRoute,
-  createAdminSupabase,
-} from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
-
-type DB = Database;
-
-type Caller = {
-  id: string;
-  role: string | null;
-  shop_id: string | null;
-};
-
-async function authz() {
-  const supabase = createServerSupabaseRoute();
-
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabase.auth.getUser();
-
-  if (userErr || !user) {
-    return {
-      ok: false as const,
-      res: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
-    };
-  }
-
-  const { data: me, error: meErr } = await supabase
-    .from("profiles")
-    .select("id, role, shop_id")
-    .eq("id", user.id)
-    .maybeSingle<Caller>();
-
-  if (meErr || !me || !me.shop_id) {
-    return {
-      ok: false as const,
-      res: NextResponse.json({ error: "Missing shop" }, { status: 403 }),
-    };
-  }
-
-  const actor = getActorCapabilities({ role: me.role });
-  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
-  return { ok: true as const, me, isAdmin };
-}
-
-type ShiftUpdate = Pick<
-  DB["public"]["Tables"]["tech_shifts"]["Update"],
-  "start_time" | "end_time" | "type" | "status"
->;
 
 type RouteContext = { params: Promise<{ id: string }> };
 
 /* --------------------------------------------------------- */
 /* PATCH /api/scheduling/shifts/:id                          */
 /* --------------------------------------------------------- */
-export async function PATCH(req: NextRequest, context: RouteContext) {
-  const { id } = await context.params;
-
-  const a = await authz();
-  if (!a.ok) return a.res;
-  if (!a.isAdmin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const body = (await req.json().catch(() => null)) as Partial<ShiftUpdate> | null;
-  if (!body) return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-
-  const update: Partial<ShiftUpdate> = {
-    ...(body.start_time !== undefined ? { start_time: body.start_time } : {}),
-    ...(body.end_time !== undefined ? { end_time: body.end_time } : {}),
-    ...(body.type !== undefined ? { type: body.type } : {}),
-    ...(body.status !== undefined ? { status: body.status } : {}),
-  };
-
-  if (Object.keys(update).length === 0) {
-    return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
-  }
-
-  const admin = createAdminSupabase();
-
-  const { data: shift, error: sErr } = await admin
-    .from("tech_shifts")
-    .select("id, shop_id")
-    .eq("id", id)
-    .maybeSingle<{ id: string; shop_id: string | null }>();
-
-  if (sErr) return NextResponse.json({ error: sErr.message }, { status: 500 });
-  if (!shift) return NextResponse.json({ error: "Shift not found" }, { status: 404 });
-  if (shift.shop_id !== a.me.shop_id) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const { error } = await admin.from("tech_shifts").update(update).eq("id", id);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-  return NextResponse.json({ ok: true });
+export async function PATCH(_req: NextRequest, _context: RouteContext) {
+  return NextResponse.json(
+    { error: "Shift lifecycle writes must use the canonical shift API." },
+    { status: 410 },
+  );
 }
 
 /* --------------------------------------------------------- */
 /* DELETE /api/scheduling/shifts/:id                         */
 /* --------------------------------------------------------- */
-export async function DELETE(_req: NextRequest, context: RouteContext) {
-  const { id } = await context.params;
-
-  const a = await authz();
-  if (!a.ok) return a.res;
-  if (!a.isAdmin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const admin = createAdminSupabase();
-
-  const { data: shift, error: sErr } = await admin
-    .from("tech_shifts")
-    .select("id, shop_id")
-    .eq("id", id)
-    .maybeSingle<{ id: string; shop_id: string | null }>();
-
-  if (sErr) return NextResponse.json({ error: sErr.message }, { status: 500 });
-  if (!shift) return NextResponse.json({ error: "Shift not found" }, { status: 404 });
-  if (shift.shop_id !== a.me.shop_id) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const { error } = await admin.from("tech_shifts").delete().eq("id", id);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-  return NextResponse.json({ ok: true });
+export async function DELETE(_req: NextRequest, _context: RouteContext) {
+  return NextResponse.json(
+    { error: "Shift lifecycle writes must use the canonical shift API." },
+    { status: 410 },
+  );
 }

--- a/app/api/scheduling/shifts/route.ts
+++ b/app/api/scheduling/shifts/route.ts
@@ -5,7 +5,6 @@ import {
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
-import { SHIFT_STATUSES } from "@/features/workforce/lib/shift-status";
 
 type DB = Database;
 
@@ -154,49 +153,9 @@ export async function GET(req: NextRequest) {
 /* --------------------------------------------------------- */
 /* POST /api/scheduling/shifts                               */
 /* --------------------------------------------------------- */
-export async function POST(req: NextRequest) {
-  const a = await authz();
-  if (!a.ok) return a.res;
-  if (!a.isAdmin) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const body = (await req.json().catch(() => null)) as
-    | Partial<DB["public"]["Tables"]["tech_shifts"]["Insert"]>
-    | null;
-
-  if (!body) return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-
-  if (!body.user_id || !body.start_time) {
-    return NextResponse.json(
-      { error: "Missing user_id or start_time" },
-      { status: 400 },
-    );
-  }
-
-  const admin = createAdminSupabase();
-  const requestedStatus = String(body.status ?? SHIFT_STATUSES.active);
-  const status = requestedStatus === "closed"
-    ? SHIFT_STATUSES.completed
-    : requestedStatus === "open"
-      ? SHIFT_STATUSES.active
-      : requestedStatus;
-  if (status !== SHIFT_STATUSES.active && status !== SHIFT_STATUSES.completed) {
-    return NextResponse.json({ error: "Invalid shift status" }, { status: 400 });
-  }
-
-  // Force shop scope + ensure required columns are satisfied
-  const insert: DB["public"]["Tables"]["tech_shifts"]["Insert"] = {
-    user_id: body.user_id,
-    shop_id: a.me.shop_id,
-    start_time: body.start_time,
-    end_time: body.end_time ?? null,
-    type: (body.type ?? "shift") as DB["public"]["Tables"]["tech_shifts"]["Insert"]["type"],
-    status: status as DB["public"]["Tables"]["tech_shifts"]["Insert"]["status"],
-  };
-
-  const { error } = await admin.from("tech_shifts").insert(insert);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-  return NextResponse.json({ ok: true });
+export async function POST() {
+  return NextResponse.json(
+    { error: "Shift lifecycle writes must use the canonical shift API." },
+    { status: 410 },
+  );
 }

--- a/tests/mobile-shift-lifecycle-route.test.ts
+++ b/tests/mobile-shift-lifecycle-route.test.ts
@@ -90,3 +90,37 @@ describe("mobile shift lifecycle hardening", () => {
     expect(sql).toContain("when 'end_shift' then 3");
   });
 });
+
+describe("canonical tech_shifts write routing", () => {
+  const read = (path: string) => readFileSync(path, "utf8");
+
+  it("keeps technician shift controls routed through /api/mobile/shifts", () => {
+    for (const path of [
+      "features/shared/components/ShiftTracker.tsx",
+      "features/mobile/components/MobileShiftTracker.tsx",
+      "features/shared/components/ui/PunchController.tsx",
+    ]) {
+      const source = read(path);
+      expect(source).toContain('/api/mobile/shifts');
+      expect(source).not.toContain('.from("tech_shifts")');
+      expect(source).not.toContain(".from('tech_shifts')");
+    }
+  });
+
+  it("prevents admin scheduling shift endpoints from writing tech_shifts directly", () => {
+    for (const path of [
+      "app/api/scheduling/shifts/route.ts",
+      "app/api/scheduling/shifts/[id]/route.ts",
+    ]) {
+      const source = read(path);
+      expect(source).toContain("Shift lifecycle writes must use the canonical shift API.");
+      expect(source).not.toMatch(/from\(["']tech_shifts["']\)\.(insert|update|upsert|delete)\b/);
+    }
+  });
+
+  it("keeps legacy time shift end completion on the canonical RPC", () => {
+    const source = read("app/api/time/shift/end/route.ts");
+    expect(source).toContain('.rpc("complete_canonical_shift"');
+    expect(source).not.toMatch(/from\(["']tech_shifts["']\)\.(insert|update|upsert|delete)\b/);
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent ad-hoc writes to `tech_shifts` from admin scheduling endpoints and ensure every lifecycle mutation goes through the canonical, transactional shift API used by mobile/technician flows.
- Centralize shift lifecycle semantics so `tech_shifts` and `punch_events` remain consistent and transactional via the existing RPCs (`start_canonical_shift`, `complete_canonical_shift`).

### Description

- Disabled direct writes from admin scheduling endpoints by changing `POST /api/scheduling/shifts` to return a `410` with a clear error message instead of inserting into `tech_shifts` (file: `app/api/scheduling/shifts/route.ts`).
- Disabled direct writes from the per-shift admin endpoint by changing `PATCH` and `DELETE` on `/api/scheduling/shifts/:id` to return `410` with the same canonical-route error instead of updating/deleting `tech_shifts` (file: `app/api/scheduling/shifts/[id]/route.ts`).
- Added regression assertions ensuring technician-facing components route through `/api/mobile/shifts` and do not call `.from("tech_shifts")`, and verifying admin scheduling endpoints no longer perform direct `tech_shifts` writes (file: `tests/mobile-shift-lifecycle-route.test.ts`).
- Performed a code audit to confirm there are no remaining direct `insert`/`update`/`upsert`/`delete` invocations against `tech_shifts` under `app/` or `features/`.

### Testing

- Ran `npx vitest run tests/mobile-shift-lifecycle-route.test.ts` and all tests passed (11 tests).
- Ran type-check `npx tsc --noEmit` and it completed with no type errors.
- Performed an automated scan for direct `.from('tech_shifts').(insert|update|upsert|delete)` usages and found none remaining under `app/` or `features/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51196feb0c8328911848d18c699bc5)