### PR TITLE
Add audited admin shift correction workflow (Workforce W1A)

### DIFF
--- a/app/api/workforce/attendance/corrections/route.ts
+++ b/app/api/workforce/attendance/corrections/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+
+type CorrectionType = "create_missing_shift" | "adjust_start" | "adjust_end" | "adjust_start_and_end" | "void_shift";
+
+type Body = {
+  correction_type?: CorrectionType;
+  target_user_id?: string;
+  shift_id?: string;
+  corrected_start_time?: string;
+  corrected_end_time?: string;
+  reason?: string;
+};
+
+type Caller = { id: string; role: string | null; shop_id: string | null };
+
+function isIso(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(new Date(value).getTime());
+}
+
+async function authz() {
+  const supabase = createServerSupabaseRoute();
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !user) return { ok: false as const, response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
+
+  const { data: me, error: meErr } = await supabase
+    .from("profiles")
+    .select("id, role, shop_id")
+    .eq("id", user.id)
+    .maybeSingle<Caller>();
+
+  if (meErr || !me?.shop_id) return { ok: false as const, response: NextResponse.json({ error: "Missing shop context" }, { status: 403 }) };
+  const caps = getActorCapabilities({ role: me.role });
+  if (!caps.isKnownRole || !caps.canManageScheduling) return { ok: false as const, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  return { ok: true as const, me };
+}
+
+export async function POST(req: Request) {
+  const auth = await authz();
+  if (!auth.ok) return auth.response;
+
+  const body = (await req.json().catch(() => null)) as Body | null;
+  const reason = body?.reason?.trim();
+  if (!body?.correction_type) return NextResponse.json({ error: "correction_type is required" }, { status: 400 });
+  if (!body.target_user_id) return NextResponse.json({ error: "target_user_id is required" }, { status: 400 });
+  if (!reason) return NextResponse.json({ error: "Correction reason is required" }, { status: 400 });
+  if (body.target_user_id === auth.me.id) return NextResponse.json({ error: "Use the employee shift lifecycle for your own shift; admin corrections cannot target yourself." }, { status: 403 });
+
+  const needsShift = body.correction_type !== "create_missing_shift";
+  if (needsShift && !body.shift_id) return NextResponse.json({ error: "shift_id is required" }, { status: 400 });
+  if (body.correction_type === "create_missing_shift" && (!isIso(body.corrected_start_time) || !isIso(body.corrected_end_time))) {
+    return NextResponse.json({ error: "corrected_start_time and corrected_end_time are required" }, { status: 400 });
+  }
+  if ((body.correction_type === "adjust_start" || body.correction_type === "adjust_start_and_end") && !isIso(body.corrected_start_time)) {
+    return NextResponse.json({ error: "corrected_start_time is required" }, { status: 400 });
+  }
+  if ((body.correction_type === "adjust_end" || body.correction_type === "adjust_start_and_end") && !isIso(body.corrected_end_time)) {
+    return NextResponse.json({ error: "corrected_end_time is required" }, { status: 400 });
+  }
+
+  const admin = createAdminSupabase() as any;
+  const { data, error } = await admin.rpc("apply_shift_correction", {
+    p_shop_id: auth.me.shop_id,
+    p_actor_profile_id: auth.me.id,
+    p_target_user_id: body.target_user_id,
+    p_shift_id: body.shift_id ?? null,
+    p_correction_type: body.correction_type,
+    p_corrected_start_time: body.corrected_start_time ?? null,
+    p_corrected_end_time: body.corrected_end_time ?? null,
+    p_reason: reason,
+  });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true, correction: data });
+}

--- a/features/dashboard/app/dashboard/admin/SchedulingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/SchedulingClient.tsx
@@ -9,7 +9,6 @@ import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
-import { SHIFT_STATUSES } from "@/features/workforce/lib/shift-status";
 
 type DB = Database;
 
@@ -200,6 +199,8 @@ function hoursMinutesLabel(mins: number): string {
   const m = mins % 60;
   return `${h}h ${m}m`;
 }
+
+type ShiftCorrectionResponse = { ok: true; correction: { id: string; shift_id: string; corrected_by: string; corrected_at: string; reason: string; payroll_rebuild_status: string } };
 
 type SchedulingContext = {
   me: UserLite;
@@ -813,25 +814,28 @@ export default function SchedulingClient(): JSX.Element {
       return;
     }
 
-    setCreatingShift(true);
     setErr(null);
 
-    const payload: Partial<ShiftRow> = {
-      user_id: uid,
-      shop_id: currentShopId,
-      start_time: startIso,
-      end_time: endIso,
-      // IMPORTANT: satisfy tech_shifts constraints
-      type: "shift",
-      status: SHIFT_STATUSES.open,
-    };
+    const reason = window.prompt("Reason for adding this missing worked shift (required):")?.trim();
+    if (!reason) {
+      setErr("A correction reason is required.");
+      return;
+    }
 
+    setCreatingShift(true);
     try {
-      await fetchJson<{ ok: true }>("/api/scheduling/shifts", {
+      const result = await fetchJson<ShiftCorrectionResponse>("/api/workforce/attendance/corrections", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({
+          correction_type: "create_missing_shift",
+          target_user_id: uid,
+          corrected_start_time: startIso,
+          corrected_end_time: endIso,
+          reason,
+        }),
       });
+      setErr(`Correction applied. Payroll status: ${result.correction.payroll_rebuild_status}.`);
       await loadShifts();
     } catch (e) {
       setErr(safeMsg(e, "Failed to create shift."));
@@ -840,8 +844,8 @@ export default function SchedulingClient(): JSX.Element {
     }
   }
 
-  async function updateShiftTime(
-    shiftId: string,
+  async function correctShiftTime(
+    shift: ShiftRow,
     field: "start_time" | "end_time",
     value: string,
   ): Promise<void> {
@@ -850,65 +854,62 @@ export default function SchedulingClient(): JSX.Element {
       setErr("Invalid shift time.");
       return;
     }
-
-    setErr(null);
-    try {
-      await fetchJson<{ ok: true }>(`/api/scheduling/shifts/${shiftId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ [field]: iso }),
-      });
-      await loadShifts();
-    } catch (e) {
-      setErr(safeMsg(e, "Failed to update shift."));
+    if (!shift.user_id) {
+      setErr("Shift is missing an employee.");
+      return;
     }
-  }
-
-  async function deleteShift(shiftId: string): Promise<void> {
-    setErr(null);
-    try {
-      await fetchJson<{ ok: true }>(`/api/scheduling/shifts/${shiftId}`, {
-        method: "DELETE",
-      });
-      await loadShifts();
-    } catch (e) {
-      setErr(safeMsg(e, "Failed to delete shift."));
-    }
-  }
-
-  async function duplicateShift(shift: ShiftRow): Promise<void> {
-    if (!currentShopId) return;
-    if (!shift.user_id || !shift.start_time) return;
-
-    // hard-lock: shifts are admin-created only
-    if (!canEditAll) {
-      setErr("Forbidden");
+    const reason = window.prompt(`Reason for correcting ${field === "start_time" ? "start" : "end"} time (required):`)?.trim();
+    if (!reason) {
+      setErr("A correction reason is required.");
       return;
     }
 
     setErr(null);
-    setCreatingShift(true);
     try {
-      const payload: Partial<ShiftRow> = {
-        user_id: shift.user_id,
-        shop_id: currentShopId,
-        start_time: shift.start_time,
-        end_time: shift.end_time ?? null,
-        type: (shift.type ?? "shift") as ShiftRow["type"],
-        status: (shift.status ?? "open") as ShiftRow["status"],
-      };
-
-      await fetchJson<{ ok: true }>("/api/scheduling/shifts", {
+      const result = await fetchJson<ShiftCorrectionResponse>("/api/workforce/attendance/corrections", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({
+          correction_type: field === "start_time" ? "adjust_start" : "adjust_end",
+          target_user_id: shift.user_id,
+          shift_id: shift.id,
+          [field === "start_time" ? "corrected_start_time" : "corrected_end_time"]: iso,
+          reason,
+        }),
       });
-
+      setErr(`Correction applied. Payroll status: ${result.correction.payroll_rebuild_status}.`);
       await loadShifts();
     } catch (e) {
-      setErr(safeMsg(e, "Failed to duplicate shift."));
-    } finally {
-      setCreatingShift(false);
+      setErr(safeMsg(e, "Failed to correct shift."));
+    }
+  }
+
+  async function voidShift(shift: ShiftRow): Promise<void> {
+    if (!shift.user_id) {
+      setErr("Shift is missing an employee.");
+      return;
+    }
+    const reason = window.prompt("Reason for voiding this worked shift (required):")?.trim();
+    if (!reason) {
+      setErr("A correction reason is required.");
+      return;
+    }
+    setErr(null);
+    try {
+      const result = await fetchJson<ShiftCorrectionResponse>("/api/workforce/attendance/corrections", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          correction_type: "void_shift",
+          target_user_id: shift.user_id,
+          shift_id: shift.id,
+          reason,
+        }),
+      });
+      setErr(`Shift voided without deleting evidence. Payroll status: ${result.correction.payroll_rebuild_status}.`);
+      await loadShifts();
+    } catch (e) {
+      setErr(safeMsg(e, "Failed to void shift."));
     }
   }
 
@@ -1149,7 +1150,7 @@ export default function SchedulingClient(): JSX.Element {
   return (
     <PageShell
       title="Scheduling & Time"
-      description="Shifts, punches, and job-time sessions for your shop (all roles)."
+      description="Actual worked shifts, punches, and job-time sessions for your shop. Planned schedules live in Workforce Scheduling."
     >
       <div className="space-y-5">
         {/* Top controls */}
@@ -1309,10 +1310,10 @@ export default function SchedulingClient(): JSX.Element {
                 Scheduling
               </div>
               <div className="mt-1 text-sm font-semibold text-neutral-100">
-                Create a shift
+                Add missing worked shift
               </div>
               <div className="mt-1 text-xs text-neutral-400">
-                Shifts are shop-scoped. Punches belong to the shift owner (Rule A).
+                Actual worked-time corrections are audited and shop-scoped. Planned schedules belong in Workforce Scheduling templates/overrides.
               </div>
             </div>
 
@@ -1370,13 +1371,13 @@ export default function SchedulingClient(): JSX.Element {
                 disabled={!canEditAll || creatingShift}
                 onClick={() => void createShift()}
               >
-                {creatingShift ? "Creating…" : "Create shift"}
+                {creatingShift ? "Applying…" : "Add missing worked shift"}
               </Button>
             </div>
 
             {!canEditAll && (
               <div className="mt-3 text-xs text-neutral-500">
-                You can view your own shifts here. Managers/Admins can create schedules for all staff.
+                You can view your own shifts here. Managers/Admins can add audited missing worked shifts. Planned schedules live in Workforce Scheduling.
               </div>
             )}
           </div>
@@ -1514,9 +1515,8 @@ export default function SchedulingClient(): JSX.Element {
             punchesByShift={punchesByShift}
             canEditAll={canEditAll}
             userName={userName}
-            onUpdateShiftTime={updateShiftTime}
-            onDeleteShift={deleteShift}
-            onDuplicateShift={duplicateShift}
+            onCorrectShiftTime={correctShiftTime}
+            onVoidShift={voidShift}
             onAddPunch={addPunch}
             onUpdatePunch={updatePunch}
             onDeletePunch={deletePunch}
@@ -1551,13 +1551,12 @@ function ShiftsView(props: {
   canEditAll: boolean;
   userName: (id: string | null) => string;
 
-  onUpdateShiftTime: (
-    shiftId: string,
+  onCorrectShiftTime: (
+    shift: ShiftRow,
     field: "start_time" | "end_time",
     value: string,
   ) => Promise<void>;
-  onDeleteShift: (shiftId: string) => Promise<void>;
-  onDuplicateShift: (shift: ShiftRow) => Promise<void>;
+  onVoidShift: (shift: ShiftRow) => Promise<void>;
 
   onAddPunch: (shiftId: string, type: PunchType, when: string) => Promise<void>;
   onUpdatePunch: (punchId: string, when: string, type?: PunchType) => Promise<void>;
@@ -1572,9 +1571,8 @@ function ShiftsView(props: {
     punchesByShift,
     canEditAll,
     userName,
-    onUpdateShiftTime,
-    onDeleteShift,
-    onDuplicateShift,
+    onCorrectShiftTime,
+    onVoidShift,
     onAddPunch,
     onUpdatePunch,
     onDeletePunch,
@@ -1625,7 +1623,7 @@ function ShiftsView(props: {
                 <input
                   type="datetime-local"
                   value={isoToLocalInput(s.start_time)}
-                  onChange={(e) => void onUpdateShiftTime(s.id, "start_time", e.target.value)}
+                  onChange={(e) => void onCorrectShiftTime(s, "start_time", e.target.value)}
                   className={[T.input, T.border].join(" ")}
                   disabled={!canEditAll}
                 />
@@ -1636,7 +1634,7 @@ function ShiftsView(props: {
                 <input
                   type="datetime-local"
                   value={isoToLocalInput(s.end_time ?? null)}
-                  onChange={(e) => void onUpdateShiftTime(s.id, "end_time", e.target.value)}
+                  onChange={(e) => void onCorrectShiftTime(s, "end_time", e.target.value)}
                   className={[T.input, T.border].join(" ")}
                   disabled={!canEditAll}
                 />
@@ -1654,10 +1652,11 @@ function ShiftsView(props: {
                     size="xs"
                     variant="outline"
                     className="text-[0.7rem]"
-                    disabled={!canEditAll}
-                    onClick={() => void onDuplicateShift(s)}
+                    disabled={true}
+                    onClick={() => undefined}
+                    title="Duplicate actual shifts is disabled; duplicate planned schedules in Workforce Scheduling templates/overrides."
                   >
-                    Duplicate
+                    Duplicate disabled
                   </Button>
                   <Button
                     type="button"
@@ -1665,9 +1664,9 @@ function ShiftsView(props: {
                     variant="ghost"
                     className="text-[0.7rem] text-red-300 hover:bg-red-900/20"
                     disabled={!canEditAll}
-                    onClick={() => void onDeleteShift(s.id)}
+                    onClick={() => void onVoidShift(s)}
                   >
-                    Delete
+                    Void shift
                   </Button>
                 </div>
               </div>

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -153,8 +153,9 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
   const [{ data: shifts, error: shiftsErr }, { data: jobSegments, error: jobsErr }] = await Promise.all([
     admin
       .from("tech_shifts")
-      .select("id, user_id, type, status, start_time, end_time")
+      .select("id, user_id, type, status, start_time, end_time, excluded_from_payroll")
       .eq("shop_id", shopId)
+      .neq("excluded_from_payroll", true)
       .gte("start_time", rangeStart)
       .lte("start_time", rangeEnd),
     admin

--- a/supabase/manual/20260710_workforce_w1a_shift_corrections.sql
+++ b/supabase/manual/20260710_workforce_w1a_shift_corrections.sql
@@ -1,0 +1,139 @@
+-- Workforce W1A: audited admin shift correction workflow.
+-- Additive model: corrections preserve original shift/punch evidence and expose an
+-- excluded_from_payroll flag for voided actual-work shifts.
+
+alter table public.tech_shifts
+  add column if not exists excluded_from_payroll boolean not null default false;
+
+create table if not exists public.shift_corrections (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  shift_id uuid references public.tech_shifts(id) on delete set null,
+  target_user_id uuid not null references public.profiles(id) on delete restrict,
+  actor_profile_id uuid not null references public.profiles(id) on delete restrict,
+  correction_type text not null check (correction_type in ('create_missing_shift','adjust_start','adjust_end','adjust_start_and_end','void_shift')),
+  reason text not null check (length(trim(reason)) > 0),
+  original_data jsonb not null default '{}'::jsonb,
+  corrected_data jsonb not null default '{}'::jsonb,
+  status text not null default 'applied' check (status in ('applied')),
+  payroll_rebuild_status text not null default 'not_required' check (payroll_rebuild_status in ('not_required','rebuild_required')),
+  created_at timestamptz not null default now(),
+  applied_at timestamptz not null default now()
+);
+
+create index if not exists idx_shift_corrections_shop_created on public.shift_corrections(shop_id, created_at desc);
+create index if not exists idx_shift_corrections_shift on public.shift_corrections(shift_id);
+create index if not exists idx_shift_corrections_target on public.shift_corrections(shop_id, target_user_id, created_at desc);
+
+alter table public.shift_corrections enable row level security;
+
+do $$
+begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='shift_corrections' and policyname='shift_corrections_shop_select') then
+    create policy shift_corrections_shop_select on public.shift_corrections
+      for select using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.shop_id = shift_corrections.shop_id));
+  end if;
+end $$;
+
+create or replace function public.apply_shift_correction(
+  p_shop_id uuid,
+  p_actor_profile_id uuid,
+  p_target_user_id uuid,
+  p_shift_id uuid,
+  p_correction_type text,
+  p_corrected_start_time timestamptz,
+  p_corrected_end_time timestamptz,
+  p_reason text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor public.profiles%rowtype;
+  v_target public.profiles%rowtype;
+  v_shift public.tech_shifts%rowtype;
+  v_new_shift public.tech_shifts%rowtype;
+  v_original jsonb := '{}'::jsonb;
+  v_corrected jsonb := '{}'::jsonb;
+  v_start timestamptz;
+  v_end timestamptz;
+  v_correction_id uuid;
+  v_period public.payroll_pay_periods%rowtype;
+  v_payroll_status text := 'not_required';
+begin
+  if p_reason is null or length(trim(p_reason)) = 0 then
+    raise exception 'Correction reason is required';
+  end if;
+  if p_actor_profile_id = p_target_user_id then
+    raise exception 'Admin corrections cannot target the actor''s own shift';
+  end if;
+  if p_correction_type not in ('create_missing_shift','adjust_start','adjust_end','adjust_start_and_end','void_shift') then
+    raise exception 'Unsupported correction type';
+  end if;
+
+  select * into v_actor from public.profiles where id = p_actor_profile_id and shop_id = p_shop_id;
+  if not found then raise exception 'Actor is not in shop'; end if;
+  if coalesce(v_actor.role, '') not in ('owner','admin','manager') then raise exception 'Forbidden'; end if;
+
+  select * into v_target from public.profiles where id = p_target_user_id and shop_id = p_shop_id;
+  if not found then raise exception 'Target user is not in shop'; end if;
+
+  if p_correction_type = 'create_missing_shift' then
+    v_start := p_corrected_start_time; v_end := p_corrected_end_time;
+    if v_start is null or v_end is null or v_end <= v_start then raise exception 'Corrected shift interval is invalid'; end if;
+    if exists (select 1 from public.tech_shifts s where s.shop_id=p_shop_id and s.user_id=p_target_user_id and coalesce(s.excluded_from_payroll,false)=false and tstzrange(s.start_time, coalesce(s.end_time, 'infinity'::timestamptz), '[)') && tstzrange(v_start, v_end, '[)')) then
+      raise exception 'Corrected shift overlaps another non-voided shift';
+    end if;
+    insert into public.tech_shifts (shop_id, user_id, status, type, start_time, end_time, excluded_from_payroll)
+      values (p_shop_id, p_target_user_id, 'completed', 'shift', v_start, v_end, false)
+      returning * into v_new_shift;
+    insert into public.punch_events (shift_id, user_id, profile_id, event_type, timestamp, note) values
+      (v_new_shift.id, p_target_user_id, p_target_user_id, 'start_shift', v_start, 'Admin correction: missing shift start'),
+      (v_new_shift.id, p_target_user_id, p_target_user_id, 'end_shift', v_end, 'Admin correction: missing shift end');
+    p_shift_id := v_new_shift.id;
+    v_corrected := jsonb_build_object('shift_id', p_shift_id, 'start_time', v_start, 'end_time', v_end, 'status', 'completed', 'excluded_from_payroll', false);
+  else
+    select * into v_shift from public.tech_shifts where id = p_shift_id and shop_id = p_shop_id and user_id = p_target_user_id for update;
+    if not found then raise exception 'Shift not found for target user in shop'; end if;
+    v_original := to_jsonb(v_shift);
+    v_start := coalesce(p_corrected_start_time, v_shift.start_time);
+    v_end := coalesce(p_corrected_end_time, v_shift.end_time);
+
+    if p_correction_type = 'void_shift' then
+      update public.tech_shifts set excluded_from_payroll = true where id = v_shift.id;
+      v_corrected := jsonb_build_object('shift_id', v_shift.id, 'excluded_from_payroll', true, 'start_time', v_shift.start_time, 'end_time', v_shift.end_time);
+    else
+      if v_start is null or v_end is null or v_end <= v_start then raise exception 'Corrected shift interval is invalid'; end if;
+      if exists (select 1 from public.tech_shifts s where s.shop_id=p_shop_id and s.user_id=p_target_user_id and s.id <> v_shift.id and coalesce(s.excluded_from_payroll,false)=false and tstzrange(s.start_time, coalesce(s.end_time, 'infinity'::timestamptz), '[)') && tstzrange(v_start, v_end, '[)')) then
+        raise exception 'Corrected shift overlaps another non-voided shift';
+      end if;
+      update public.tech_shifts set start_time = v_start, end_time = v_end, status = 'completed', excluded_from_payroll = false where id = v_shift.id;
+      insert into public.punch_events (shift_id, user_id, profile_id, event_type, timestamp, note) values
+        (v_shift.id, p_target_user_id, p_target_user_id, 'start_shift', v_start, 'Admin correction: effective boundary start'),
+        (v_shift.id, p_target_user_id, p_target_user_id, 'end_shift', v_end, 'Admin correction: effective boundary end');
+      v_corrected := jsonb_build_object('shift_id', v_shift.id, 'start_time', v_start, 'end_time', v_end, 'status', 'completed', 'excluded_from_payroll', false);
+    end if;
+  end if;
+
+  select * into v_period from public.payroll_pay_periods
+    where shop_id = p_shop_id and v_start::date between period_start and period_end
+    order by period_start desc limit 1;
+  if found then
+    if v_period.status in ('approved','exported') then raise exception 'Approved/exported payroll periods are locked; reopen before correcting attendance'; end if;
+    update public.payroll_pay_periods set notes = concat_ws(E'\n', notes, 'Attendance correction applied; rebuild required.'), updated_at = now() where id = v_period.id;
+    v_payroll_status := 'rebuild_required';
+  end if;
+
+  insert into public.shift_corrections (shop_id, shift_id, target_user_id, actor_profile_id, correction_type, reason, original_data, corrected_data, payroll_rebuild_status)
+  values (p_shop_id, p_shift_id, p_target_user_id, p_actor_profile_id, p_correction_type, trim(p_reason), v_original, v_corrected, v_payroll_status)
+  returning id into v_correction_id;
+
+  insert into public.audit_logs (actor_id, action, target, metadata)
+  values (p_actor_profile_id, 'shift_correction.applied', p_shift_id::text, jsonb_build_object('correction_id', v_correction_id, 'shop_id', p_shop_id, 'target_user_id', p_target_user_id, 'correction_type', p_correction_type, 'reason', trim(p_reason), 'payroll_rebuild_status', v_payroll_status));
+
+  return jsonb_build_object('id', v_correction_id, 'shift_id', p_shift_id, 'correction_type', p_correction_type, 'corrected_by', p_actor_profile_id, 'corrected_at', now(), 'reason', trim(p_reason), 'payroll_rebuild_status', v_payroll_status);
+end;
+$$;
+
+grant execute on function public.apply_shift_correction(uuid, uuid, uuid, uuid, text, timestamptz, timestamptz, text) to service_role;

--- a/tests/workforce-shift-corrections-contract.test.ts
+++ b/tests/workforce-shift-corrections-contract.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const ui = readFileSync("features/dashboard/app/dashboard/admin/SchedulingClient.tsx", "utf8");
+const route = readFileSync("app/api/workforce/attendance/corrections/route.ts", "utf8");
+const migration = readFileSync("supabase/manual/20260710_workforce_w1a_shift_corrections.sql", "utf8");
+const payroll = readFileSync("features/payroll-time/server/payrollTime.ts", "utf8");
+
+describe("Workforce W1A shift correction contract", () => {
+  it("removes legacy actual-shift create/update/delete calls from the admin UI", () => {
+    expect(ui).not.toContain('`/api/scheduling/shifts/${shiftId}`');
+    expect(ui).not.toContain('fetchJson<{ ok: true }>("/api/scheduling/shifts"');
+    expect(ui).not.toContain('onUpdateShiftTime');
+    expect(ui).not.toContain('onDeleteShift');
+    expect(ui).not.toContain("onDuplicateShift");
+    expect(ui).toContain("/api/workforce/attendance/corrections");
+    expect(ui).toContain("Duplicate actual shifts is disabled");
+    expect(ui).toContain("Void shift");
+    expect(ui).toContain("Add missing worked shift");
+  });
+
+  it("requires audited correction reasons and server-side actor authorization", () => {
+    expect(route).toContain("Correction reason is required");
+    expect(route).toContain("canManageScheduling");
+    expect(route).toContain("body.target_user_id === auth.me.id");
+    expect(route).toContain("apply_shift_correction");
+    expect(route).not.toContain("actor_profile_id?:");
+  });
+
+  it("models correction records, void exclusion, payroll locking, and rollback-capable RPC behavior", () => {
+    expect(migration).toContain("create table if not exists public.shift_corrections");
+    expect(migration).toContain("excluded_from_payroll boolean not null default false");
+    expect(migration).toContain("for update");
+    expect(migration).toContain("Approved/exported payroll periods are locked");
+    expect(migration).toContain("insert into public.audit_logs");
+    expect(migration).toContain("insert into public.punch_events");
+    expect(migration).toContain("Corrected shift overlaps another non-voided shift");
+  });
+
+  it("keeps voided shifts out of payroll materialization", () => {
+    expect(payroll).toContain('.neq("excluded_from_payroll", true)');
+  });
+});


### PR DESCRIPTION
### Motivation
- Restore safe manager/admin attendance corrections without reintroducing generic `tech_shifts` CRUD and while preserving punch/shift evidence and tenant scoping. 
- Provide an auditable, transactional replacement for legacy admin scheduling actions (create/duplicate/update/delete) that previously returned 410. 

### Description
- Add a dedicated server API `POST /api/workforce/attendance/corrections` which validates actor scope/role, requires a reason, prevents self-correction, and calls the transactional DB RPC `apply_shift_correction`. (file: `app/api/workforce/attendance/corrections/route.ts`).
- Add a non-breaking SQL migration (manual file) that: adds `tech_shifts.excluded_from_payroll`, creates `public.shift_corrections`, installs `apply_shift_correction(...)` RPC that locks shifts, validates intervals/overlaps, writes correction records, appends audit log entries and deterministic punch events, and marks payroll periods as rebuild-required when applicable. (file: `supabase/manual/20260710_workforce_w1a_shift_corrections.sql`).
- Update admin Scheduling UI to use the new correction API: replace `Create` with “Add missing worked shift”, replace direct edit with “Correct worked time” (audited), replace `Delete` with `Void shift` (marks excluded, preserves evidence), and disable duplicating actual shifts with explanatory copy pointing to Workforce Scheduling templates. UI now prompts for a correction reason and surfaces returned payroll rebuild status. (file: `features/dashboard/app/dashboard/admin/SchedulingClient.tsx`).
- Exclude voided shifts from payroll materialization by filtering `excluded_from_payroll = true` in payroll rebuild logic. (file: `features/payroll-time/server/payrollTime.ts`).
- Add a small contract test covering UI endpoint removal and correction workflow expectations. (file: `tests/workforce-shift-corrections-contract.test.ts`).

### Testing
- Ran TypeScript check: `npx tsc --noEmit` which succeeded. 
- Ran targeted unit/contract tests: `npx vitest run tests/mobile-shift-lifecycle-route.test.ts tests/workforce-shift-corrections-contract.test.ts tests/shift-status.test.ts` and all tests passed. 
- Manual contract assertions in `tests/workforce-shift-corrections-contract.test.ts` confirm the UI no longer calls legacy scheduling write endpoints, the correction API requires a reason and admin capability, migration contains correction/audit logic, and payroll excludes voided shifts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511cacd3cc83289bc62628ef82c734)