### PR TITLE
Attendance: Enrich shifts with employee identity & show active shifts as In progress

### DIFF
--- a/app/api/scheduling/shifts/route.ts
+++ b/app/api/scheduling/shifts/route.ts
@@ -14,6 +14,34 @@ type Caller = {
   shop_id: string | null;
 };
 
+type ProfileIdentity = {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  role: string | null;
+};
+
+type AttendanceShift = DB["public"]["Tables"]["tech_shifts"]["Row"] & {
+  userId: string | null;
+  employeeName: string;
+  employeeEmail: string | null;
+  employee: {
+    id: string | null;
+    name: string;
+    email: string | null;
+  };
+};
+
+function employeeNameFromProfile(profile: Pick<ProfileIdentity, "full_name" | "email"> | undefined): string {
+  const fullName = profile?.full_name?.trim();
+  if (fullName) return fullName;
+
+  const email = profile?.email?.trim();
+  if (email) return email;
+
+  return "Unknown employee";
+}
+
 async function authz() {
   const supabase = createServerSupabaseRoute();
 
@@ -103,7 +131,49 @@ export async function GET(req: NextRequest) {
   const { data: shifts, error: sErr } = await shiftQ;
   if (sErr) return NextResponse.json({ error: sErr.message }, { status: 500 });
 
-  const shiftIds = (shifts ?? []).map((s) => s.id).filter(Boolean) as string[];
+  const shiftRows = (shifts ?? []) as DB["public"]["Tables"]["tech_shifts"]["Row"][];
+  const shiftIds = shiftRows.map((s) => s.id).filter(Boolean) as string[];
+  const shiftUserIds = Array.from(
+    new Set(
+      shiftRows
+        .map((s) => (typeof s.user_id === "string" ? s.user_id : null))
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+
+  const profilesById = new Map<string, ProfileIdentity>();
+  if (shiftUserIds.length > 0) {
+    const { data: profileRows, error: profileErr } = await admin
+      .from("profiles")
+      .select("id, full_name, email, role")
+      .eq("shop_id", a.me.shop_id)
+      .in("id", shiftUserIds);
+
+    if (profileErr) return NextResponse.json({ error: profileErr.message }, { status: 500 });
+
+    for (const profile of (profileRows ?? []) as ProfileIdentity[]) {
+      profilesById.set(profile.id, profile);
+    }
+  }
+
+  const attendanceShifts: AttendanceShift[] = shiftRows.map((shift) => {
+    const userId = typeof shift.user_id === "string" ? shift.user_id : null;
+    const profile = userId ? profilesById.get(userId) : undefined;
+    const employeeName = employeeNameFromProfile(profile);
+    const employeeEmail = profile?.email?.trim() || null;
+
+    return {
+      ...shift,
+      userId,
+      employeeName,
+      employeeEmail,
+      employee: {
+        id: profile?.id ?? null,
+        name: employeeName,
+        email: employeeEmail,
+      },
+    };
+  });
 
   // Punches
   let punches: DB["public"]["Tables"]["punch_events"]["Row"][] = [];
@@ -144,7 +214,7 @@ export async function GET(req: NextRequest) {
   }
 
   return NextResponse.json({
-    shifts: shifts ?? [],
+    shifts: attendanceShifts,
     punches,
     billableMinutes,
   });

--- a/features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx
@@ -4,9 +4,13 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { WorkforceQuickLinks } from "./WorkforceQuickLinks";
 
-type ShiftRow = {
+export type ShiftRow = {
   id?: string | null;
   user_id?: string | null;
+  userId?: string | null;
+  employeeName?: string | null;
+  employeeEmail?: string | null;
+  employee?: { id?: string | null; name?: string | null; email?: string | null } | null;
   start_time?: string | null;
   end_time?: string | null;
   type?: string | null;
@@ -14,7 +18,7 @@ type ShiftRow = {
   [key: string]: unknown;
 };
 
-type PunchRow = {
+export type PunchRow = {
   id?: string | null;
   shift_id?: string | null;
   user_id?: string | null;
@@ -39,10 +43,30 @@ function safeDate(value: string | null | undefined): Date | null {
   return Number.isNaN(d.getTime()) ? null : d;
 }
 
-function formatDateTime(value: string | null | undefined) {
+export function formatDateTime(value: string | null | undefined, timezone?: string | null) {
   const d = safeDate(value);
   if (!d) return "Unknown time";
-  return d.toLocaleString();
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: timezone || undefined,
+  }).format(d);
+}
+
+export function getEmployeeDisplayName(shift: Pick<ShiftRow, "employeeName" | "employeeEmail" | "employee">): string {
+  const employeeName = shift.employeeName?.trim() || shift.employee?.name?.trim();
+  if (employeeName) return employeeName;
+
+  const employeeEmail = shift.employeeEmail?.trim() || shift.employee?.email?.trim();
+  if (employeeEmail) return employeeEmail;
+
+  return "Unknown employee";
+}
+
+export function formatShiftRange(shift: Pick<ShiftRow, "start_time" | "end_time">, timezone?: string | null): string {
+  const start = formatDateTime(shift.start_time, timezone);
+  const end = shift.end_time ? formatDateTime(shift.end_time, timezone) : "In progress";
+  return `${start} → ${end}`;
 }
 
 function normalizeEventType(p: PunchRow): string {
@@ -142,6 +166,7 @@ export function AttendanceOverviewClient({ from, to, timezone }: AttendanceOverv
       }
     }
 
+
     const buckets: Record<NowBucket, Array<{ label: string; shiftLabel: string; lastEvent: string }>> = {
       clocked_in: [],
       break: [],
@@ -152,7 +177,7 @@ export function AttendanceOverviewClient({ from, to, timezone }: AttendanceOverv
 
     for (const s of shifts) {
       const shiftId = typeof s.id === "string" ? s.id : "";
-      const userId = typeof s.user_id === "string" ? s.user_id : "unknown";
+      const userId = typeof s.user_id === "string" ? s.user_id : typeof s.userId === "string" ? s.userId : "unknown";
       const shiftPunches = punchesByShift.get(shiftId) ?? unlinkedPunchesByUser.get(userId) ?? [];
       const state = shiftStateFromPunches(shiftPunches);
       const sorted = [...shiftPunches].sort((a, b) => {
@@ -163,9 +188,9 @@ export function AttendanceOverviewClient({ from, to, timezone }: AttendanceOverv
       const latest = sorted[0];
 
       buckets[state].push({
-        label: userId,
-        shiftLabel: `${formatDateTime(s.start_time)} → ${formatDateTime(s.end_time)}`,
-        lastEvent: latest ? `${displayEventType(normalizeEventType(latest))} • ${formatDateTime(latest.timestamp)}` : "No punches",
+        label: getEmployeeDisplayName(s),
+        shiftLabel: formatShiftRange(s, timezone),
+        lastEvent: latest ? `${displayEventType(normalizeEventType(latest))} · ${formatDateTime(latest.timestamp, timezone)}` : "No punches",
       });
     }
 
@@ -184,7 +209,24 @@ export function AttendanceOverviewClient({ from, to, timezone }: AttendanceOverv
       endedToday,
       billableMinutes: typeof data?.billableMinutes === "number" ? Math.max(0, data.billableMinutes) : 0,
     };
-  }, [data?.billableMinutes, punches, shifts]);
+  }, [data?.billableMinutes, punches, shifts, timezone]);
+
+  const employeeNameByShiftId = useMemo(() => {
+    const names = new Map<string, string>();
+    for (const s of shifts) {
+      if (typeof s.id === "string") names.set(s.id, getEmployeeDisplayName(s));
+    }
+    return names;
+  }, [shifts]);
+
+  const employeeNameByUserId = useMemo(() => {
+    const names = new Map<string, string>();
+    for (const s of shifts) {
+      const userId = typeof s.user_id === "string" ? s.user_id : typeof s.userId === "string" ? s.userId : null;
+      if (userId) names.set(userId, getEmployeeDisplayName(s));
+    }
+    return names;
+  }, [shifts]);
 
   const recentPunches = useMemo(() => {
     return [...punches]
@@ -284,8 +326,12 @@ export function AttendanceOverviewClient({ from, to, timezone }: AttendanceOverv
                 ) : (
                   recentPunches.map((p, i) => (
                     <div key={p.id ?? i} className="grid grid-cols-4 gap-2 rounded-lg border border-white/10 bg-black/20 p-3 text-sm">
-                      <div className="text-white">{formatDateTime(p.timestamp)}</div>
-                      <div className="text-neutral-300">{String(p.user_id ?? "Unknown person")}</div>
+                      <div className="text-white">{formatDateTime(p.timestamp, timezone)}</div>
+                      <div className="text-neutral-300">{
+                        (typeof p.shift_id === "string" ? employeeNameByShiftId.get(p.shift_id) : null)
+                          ?? (typeof p.user_id === "string" ? employeeNameByUserId.get(p.user_id) : null)
+                          ?? "Unknown employee"
+                      }</div>
                       <div className="text-neutral-300">{displayEventType(normalizeEventType(p))}</div>
                       <div className="text-neutral-400">{p.note ? String(p.note) : "—"}</div>
                     </div>

--- a/tests/attendance-display-enrichment.test.ts
+++ b/tests/attendance-display-enrichment.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  formatShiftRange,
+  getEmployeeDisplayName,
+} from "@/features/dashboard/app/dashboard/workforce/AttendanceOverviewClient";
+
+const UUID = "cc4edd23-11e3-4a3c-8cd1-8851f1e13b2c";
+
+describe("Attendance display enrichment", () => {
+  it("uses profile full name instead of raw UUIDs", () => {
+    expect(getEmployeeDisplayName({ employeeName: "Edward Lakin", employeeEmail: null, employee: null })).toBe("Edward Lakin");
+  });
+
+  it("falls back to email when full name is blank", () => {
+    expect(getEmployeeDisplayName({ employeeName: "   ", employeeEmail: "edward@example.com", employee: null })).toBe("edward@example.com");
+  });
+
+  it("uses Unknown employee when no profile identity is resolvable", () => {
+    expect(getEmployeeDisplayName({ employeeName: null, employeeEmail: null, employee: null })).toBe("Unknown employee");
+  });
+
+  it("does not fall back to a user UUID as the operator-facing employee name", () => {
+    const label = getEmployeeDisplayName({ employeeName: null, employeeEmail: null, employee: { id: UUID, name: "", email: null } });
+    expect(label).toBe("Unknown employee");
+    expect(label).not.toContain(UUID);
+  });
+
+  it("displays active shifts with a null end time as in progress", () => {
+    const label = formatShiftRange({ start_time: "2026-07-10T17:03:00.000Z", end_time: null }, "America/Edmonton");
+    expect(label).toContain("In progress");
+    expect(label).not.toContain("Unknown time");
+  });
+
+  it("displays completed shifts with the formatted end time", () => {
+    const label = formatShiftRange(
+      { start_time: "2026-07-10T17:03:00.000Z", end_time: "2026-07-10T17:05:00.000Z" },
+      "America/Edmonton",
+    );
+    expect(label).not.toContain("In progress");
+    expect(label).not.toContain("Unknown time");
+    expect(label).toContain("11:05");
+  });
+});
+
+describe("Attendance API profile enrichment contract", () => {
+  const route = readFileSync("app/api/scheduling/shifts/route.ts", "utf8");
+
+  it("batch loads profiles for returned shift user IDs", () => {
+    expect(route).toContain("shiftUserIds");
+    expect(route).toContain('.from("profiles")');
+    expect(route).toContain('.in("id", shiftUserIds)');
+  });
+
+  it("keeps profile enrichment scoped to the caller shop", () => {
+    expect(route).toContain('.eq("shop_id", a.me.shop_id)');
+  });
+
+  it("returns employee identity fields in the attendance shift DTO", () => {
+    expect(route).toContain("employeeName");
+    expect(route).toContain("employeeEmail");
+    expect(route).toContain("employee: {");
+  });
+});


### PR DESCRIPTION
### Motivation
- The Attendance UI was rendering raw `tech_shifts.user_id` UUIDs and treating `end_time = null` as an unknown time, exposing UUIDs to operators and showing "Unknown time" for active shifts. 
- The change aims to provide a clear operator-facing identity (name/email) and a readable active-shift status while preserving tenant scoping and avoiding N+1 lookups.

### Description
- The scheduling GET route now collects unique `tech_shifts.user_id` values, batch-queries `profiles` scoped with `.eq("shop_id", a.me.shop_id)`, and maps profiles by `id` to avoid N+1 queries, enriching each shift with `userId`, `employeeName`, `employeeEmail`, and a nested `employee` object (see `app/api/scheduling/shifts/route.ts`).
- The Attendance client was updated with display helpers: `formatDateTime` (uses `Intl.DateTimeFormat` with a shop timezone), `getEmployeeDisplayName` (fallback order: `full_name`, `email`, then `"Unknown employee"`), and `formatShiftRange` (renders `end_time = null` as `In progress`) in `features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx`.
- Now board cards and the recent punch rows use the enriched employee fields (and in-client maps by shift/user id) to display readable names instead of UUIDs, and timestamps are formatted with the provided shop timezone.
- Files changed: `app/api/scheduling/shifts/route.ts`, `features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx`, and a new test `tests/attendance-display-enrichment.test.ts`.

### Testing
- Ran typecheck: `npx tsc --noEmit`, which completed successfully.
- Ran targeted and related tests: `npx vitest run tests/attendance-display-enrichment.test.ts` and `npx vitest run tests/mobile-shift-lifecycle-route.test.ts tests/workforce-shift-corrections-contract.test.ts`, and the combined test run reports all tests passing.
- The new attendance display tests verify name/email fallbacks, UUID leakage prevention, active-shift `In progress` wording, completed-shift formatting, batched profile lookup presence in the route, and shop-scoped profile query; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5127a2bf088328acdcf03fc7d0ecf0)