### PR TITLE
Fix workforce sold labor deduplication

### DIFF
--- a/features/workforce/lib/activityTypes.ts
+++ b/features/workforce/lib/activityTypes.ts
@@ -1,10 +1,99 @@
-export type WorkforceOperationalState = "working_on_job" | "clocked_in_idle" | "on_break" | "on_lunch" | "off_shift" | "shift_ended";
+export type WorkforceOperationalState =
+  | "working_on_job"
+  | "clocked_in_idle"
+  | "on_break"
+  | "on_lunch"
+  | "off_shift"
+  | "shift_ended";
 export type WorkforceExceptionSeverity = "blocking" | "warning" | "info";
-export type WorkforceExceptionCode = "clocked_in_no_active_job" | "active_job_off_shift" | "multiple_active_jobs" | "shift_ended_with_active_job" | "active_job_unassigned" | "long_break" | "long_lunch" | "job_over_estimate" | "overlapping_job_segments";
-export type WorkforceActivityException = { code: WorkforceExceptionCode; severity: WorkforceExceptionSeverity; message: string; recommendedAction: string; relatedEmployeeId?: string | null; relatedWorkOrderId?: string | null; relatedLineId?: string | null };
-export type WorkforceCurrentJob = { laborSegmentId: string; workOrderId: string; workOrderNumber: string | null; workOrderStatus: string | null; lineId: string; lineDescription: string | null; jobType: string | null; customerId: string | null; customerName: string | null; vehicleId: string | null; vehicleLabel: string | null; jobStartedAt: string; elapsedMinutes: number; assignedTechId: string | null };
-export type WorkforceTodayMetrics = { shiftMinutes: number; breakMinutes: number; lunchMinutes: number; jobMinutes: number; productiveMinutes: number; idleMinutes: number; soldLaborHours: number; completedJobCount: number };
-export type WorkforceTechnicianActivity = { userId: string; employeeName: string; employeeEmail: string | null; workforceRole: string | null; shiftId: string | null; shiftStatus: string | null; shiftActivity: string | null; shiftStartTime: string | null; shiftEndTime: string | null; latestShiftEventType: string | null; latestShiftEventAt: string | null; currentJob: WorkforceCurrentJob | null; today: WorkforceTodayMetrics; operationalState: WorkforceOperationalState; exceptions: WorkforceActivityException[] };
-export type WorkforceActivityFeedItem = { id: string; timestamp: string; employeeName: string; action: string; workOrderNumber?: string | null; lineDescription?: string | null; workOrderId?: string | null; lineId?: string | null };
-export type WorkforceActivitySummary = { activeTechnicians: number; workingOnJobs: number; idleTechnicians: number; onBreak: number; onLunch: number; endedToday: number; jobMinutesToday: number; utilizationPct: number; activeExceptionCount: number };
-export type WorkforceActivityResponse = { activities: WorkforceTechnicianActivity[]; feed: WorkforceActivityFeedItem[]; summary: WorkforceActivitySummary; generatedAt: string; sourceMap: Record<string, string> };
+export type WorkforceExceptionCode =
+  | "clocked_in_no_active_job"
+  | "active_job_off_shift"
+  | "multiple_active_jobs"
+  | "shift_ended_with_active_job"
+  | "active_job_unassigned"
+  | "long_break"
+  | "long_lunch"
+  | "job_over_estimate"
+  | "overlapping_job_segments";
+export type WorkforceActivityException = {
+  code: WorkforceExceptionCode;
+  severity: WorkforceExceptionSeverity;
+  message: string;
+  recommendedAction: string;
+  relatedEmployeeId?: string | null;
+  relatedWorkOrderId?: string | null;
+  relatedLineId?: string | null;
+};
+export type WorkforceCurrentJob = {
+  laborSegmentId: string;
+  workOrderId: string;
+  workOrderNumber: string | null;
+  workOrderStatus: string | null;
+  lineId: string;
+  lineDescription: string | null;
+  jobType: string | null;
+  customerId: string | null;
+  customerName: string | null;
+  vehicleId: string | null;
+  vehicleLabel: string | null;
+  jobStartedAt: string;
+  elapsedMinutes: number;
+  assignedTechId: string | null;
+};
+export type WorkforceTodayMetrics = {
+  shiftMinutes: number;
+  breakMinutes: number;
+  lunchMinutes: number;
+  jobMinutes: number;
+  productiveMinutes: number;
+  idleMinutes: number;
+  soldLaborHours: number;
+  completedJobCount: number;
+};
+export type WorkforceTechnicianActivity = {
+  userId: string;
+  employeeName: string;
+  employeeEmail: string | null;
+  workforceRole: string | null;
+  shiftId: string | null;
+  shiftStatus: string | null;
+  shiftActivity: string | null;
+  shiftStartTime: string | null;
+  shiftEndTime: string | null;
+  latestShiftEventType: string | null;
+  latestShiftEventAt: string | null;
+  currentJob: WorkforceCurrentJob | null;
+  today: WorkforceTodayMetrics;
+  operationalState: WorkforceOperationalState;
+  exceptions: WorkforceActivityException[];
+};
+export type WorkforceActivityFeedItem = {
+  id: string;
+  timestamp: string;
+  employeeName: string;
+  action: string;
+  workOrderNumber?: string | null;
+  lineDescription?: string | null;
+  workOrderId?: string | null;
+  lineId?: string | null;
+};
+export type WorkforceActivitySummary = {
+  activeTechnicians: number;
+  workingOnJobs: number;
+  idleTechnicians: number;
+  onBreak: number;
+  onLunch: number;
+  endedToday: number;
+  jobMinutesToday: number;
+  soldLaborHoursToday: number;
+  utilizationPct: number;
+  activeExceptionCount: number;
+};
+export type WorkforceActivityResponse = {
+  activities: WorkforceTechnicianActivity[];
+  feed: WorkforceActivityFeedItem[];
+  summary: WorkforceActivitySummary;
+  generatedAt: string;
+  sourceMap: Record<string, string>;
+};

--- a/features/workforce/server/buildWorkforceActivity.ts
+++ b/features/workforce/server/buildWorkforceActivity.ts
@@ -1,85 +1,697 @@
 import type { Database } from "@/features/shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { getShopTodayTomorrowRanges } from "@/features/shared/lib/utils/shopDayWindow";
-import { clampNonNegative, hasOverlaps, overlapMinutes, sumPairedDurations } from "../lib/activityMetrics";
-import { WORKFORCE_ACTIVITY_THRESHOLDS, exception } from "../lib/activityExceptions";
-import type { WorkforceActivityFeedItem, WorkforceActivityResponse, WorkforceOperationalState, WorkforceTechnicianActivity } from "../lib/activityTypes";
+import {
+  clampNonNegative,
+  hasOverlaps,
+  overlapMinutes,
+  sumPairedDurations,
+} from "../lib/activityMetrics";
+import {
+  WORKFORCE_ACTIVITY_THRESHOLDS,
+  exception,
+} from "../lib/activityExceptions";
+import type {
+  WorkforceActivityFeedItem,
+  WorkforceActivityResponse,
+  WorkforceOperationalState,
+  WorkforceTechnicianActivity,
+} from "../lib/activityTypes";
 
 type DB = Database;
 type Shift = DB["public"]["Tables"]["tech_shifts"]["Row"];
 type Punch = DB["public"]["Tables"]["punch_events"]["Row"];
 type Segment = DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"];
-type Profile = { id: string; full_name: string | null; email: string | null; role: string | null };
-type Line = { id: string; work_order_id: string; description: string | null; job_type: string | null; assigned_tech_id: string | null; labor_time: number | null; status: string | null; line_status: string | null; shop_id: string; updated_at: string | null; punched_out_at: string | null };
-type WO = { id: string; shop_id: string; custom_id: string | null; external_id: string | null; status: string | null; customer_id: string | null; customer_name: string | null; vehicle_id: string | null; vehicle_year: number | null; vehicle_make: string | null; vehicle_model: string | null; vehicle_unit_number: string | null; vehicle_license_plate: string | null };
-type Customer = { id: string; name: string | null; business_name: string | null; first_name: string | null; last_name: string | null; shop_id: string | null };
-type Vehicle = { id: string; year: number | null; make: string | null; model: string | null; unit_number: string | null; license_plate: string | null; shop_id: string | null };
-const INACTIVE_LINE = new Set(["completed", "cancelled", "closed", "invoiced", "declined", "voided"]);
-function name(p?: Profile) { return p?.full_name?.trim() || p?.email?.trim() || "Unknown employee"; }
-function woNum(wo?: WO) { return wo?.custom_id || wo?.external_id || null; }
-function cust(c?: Customer, wo?: WO) { return c?.business_name || c?.name || [c?.first_name, c?.last_name].filter(Boolean).join(" ") || wo?.customer_name || null; }
-function vehicle(v?: Vehicle, wo?: WO) { const parts = [v?.year ?? wo?.vehicle_year, v?.make ?? wo?.vehicle_make, v?.model ?? wo?.vehicle_model].filter(Boolean); const unit = v?.unit_number ?? wo?.vehicle_unit_number; const plate = v?.license_plate ?? wo?.vehicle_license_plate; return [...parts, unit ? `Unit ${unit}` : null, plate ? `Plate ${plate}` : null].filter(Boolean).join(" ") || null; }
-function latestPunch(events: Punch[]) { return [...events].sort((a,b)=>new Date(b.timestamp).getTime()-new Date(a.timestamp).getTime())[0] ?? null; }
-function activityFromEvents(shift: Shift | null, events: Punch[]) { const latest = latestPunch(events); const t = latest?.event_type?.toLowerCase(); if (shift?.end_time || t === "end_shift") return "shift_ended"; const lunchStart = [...events].reverse().find(e=>e.event_type === "lunch_start" || e.event_type === "lunch_end")?.event_type === "lunch_start"; if (lunchStart) return "on_lunch"; const breakStart = [...events].reverse().find(e=>e.event_type === "break_start" || e.event_type === "break_end")?.event_type === "break_start"; if (breakStart) return "on_break"; return shift ? "clocked_in_idle" : "off_shift"; }
-
-export async function buildWorkforceActivity(params: { shopId: string; timezone?: string | null; now?: Date }) {
-  const admin = createAdminSupabase();
-  const now = params.now ?? new Date(); const nowIso = now.toISOString();
-  const ranges = getShopTodayTomorrowRanges(params.timezone, now); const from = ranges.today.start; const to = ranges.today.end;
-  const [shiftsRes, profilesRes, punchesRes, segmentsRes] = await Promise.all([
-    admin.from("tech_shifts").select("*").eq("shop_id", params.shopId).gte("start_time", from).lte("start_time", to).order("start_time", { ascending: false }),
-    admin.from("profiles").select("id, full_name, email, role").eq("shop_id", params.shopId),
-    admin.from("punch_events").select("*").gte("timestamp", from).lte("timestamp", to).order("timestamp", { ascending: true }),
-    admin.from("work_order_line_labor_segments").select("*").eq("shop_id", params.shopId).lt("started_at", to).or(`ended_at.is.null,ended_at.gte.${from}`).order("started_at", { ascending: false }),
-  ]);
-  const err = [shiftsRes, profilesRes, punchesRes, segmentsRes].find(r=>r.error)?.error; if (err) throw err;
-  const shifts = (shiftsRes.data ?? []) as Shift[]; const profiles = (profilesRes.data ?? []) as Profile[]; const punches = (punchesRes.data ?? []) as Punch[]; const segments = (segmentsRes.data ?? []) as Segment[];
-  const lineIds = [...new Set(segments.map(s=>s.work_order_line_id))]; const woIds = [...new Set(segments.map(s=>s.work_order_id))];
-  const [linesRes, woRes] = await Promise.all([
-    lineIds.length ? admin.from("work_order_lines").select("id,work_order_id,description,job_type,assigned_tech_id,labor_time,status,line_status,shop_id,updated_at,punched_out_at").eq("shop_id", params.shopId).in("id", lineIds) : Promise.resolve({ data: [], error: null }),
-    woIds.length ? admin.from("work_orders").select("id,shop_id,custom_id,external_id,status,customer_id,customer_name,vehicle_id,vehicle_year,vehicle_make,vehicle_model,vehicle_unit_number,vehicle_license_plate").eq("shop_id", params.shopId).in("id", woIds) : Promise.resolve({ data: [], error: null }),
-  ]);
-  if (linesRes.error || woRes.error) throw (linesRes.error || woRes.error);
-  const lines = (linesRes.data ?? []) as Line[]; const wos = (woRes.data ?? []) as WO[];
-  const customerIds = [...new Set(wos.map(w=>w.customer_id).filter(Boolean))] as string[]; const vehicleIds = [...new Set(wos.map(w=>w.vehicle_id).filter(Boolean))] as string[];
-  const [customersRes, vehiclesRes] = await Promise.all([
-    customerIds.length ? admin.from("customers").select("id,name,business_name,first_name,last_name,shop_id").eq("shop_id", params.shopId).in("id", customerIds) : Promise.resolve({ data: [], error: null }),
-    vehicleIds.length ? admin.from("vehicles").select("id,year,make,model,unit_number,license_plate,shop_id").eq("shop_id", params.shopId).in("id", vehicleIds) : Promise.resolve({ data: [], error: null }),
-  ]);
-  if (customersRes.error || vehiclesRes.error) throw (customersRes.error || vehiclesRes.error);
-  return composeWorkforceActivity({ shopId: params.shopId, nowIso, from, to, shifts, profiles, punches, segments, lines, workOrders: wos, customers: (customersRes.data ?? []) as Customer[], vehicles: (vehiclesRes.data ?? []) as Vehicle[] });
+type Profile = {
+  id: string;
+  full_name: string | null;
+  email: string | null;
+  role: string | null;
+};
+type Line = {
+  id: string;
+  work_order_id: string;
+  description: string | null;
+  job_type: string | null;
+  assigned_tech_id: string | null;
+  labor_time: number | null;
+  status: string | null;
+  line_status: string | null;
+  line_type?: string | null;
+  shop_id: string;
+  updated_at: string | null;
+  punched_out_at: string | null;
+};
+type WO = {
+  id: string;
+  shop_id: string;
+  custom_id: string | null;
+  external_id: string | null;
+  status: string | null;
+  customer_id: string | null;
+  customer_name: string | null;
+  vehicle_id: string | null;
+  vehicle_year: number | null;
+  vehicle_make: string | null;
+  vehicle_model: string | null;
+  vehicle_unit_number: string | null;
+  vehicle_license_plate: string | null;
+};
+type Customer = {
+  id: string;
+  name: string | null;
+  business_name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  shop_id: string | null;
+};
+type Vehicle = {
+  id: string;
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  unit_number: string | null;
+  license_plate: string | null;
+  shop_id: string | null;
+};
+const INACTIVE_LINE = new Set([
+  "completed",
+  "cancelled",
+  "closed",
+  "invoiced",
+  "declined",
+  "voided",
+]);
+const INFORMATIONAL_LINE_TYPES = new Set([
+  "informational",
+  "info",
+  "note",
+  "notes",
+  "inspection_note",
+]);
+function name(p?: Profile) {
+  return p?.full_name?.trim() || p?.email?.trim() || "Unknown employee";
+}
+function woNum(wo?: WO) {
+  return wo?.custom_id || wo?.external_id || null;
+}
+function cust(c?: Customer, wo?: WO) {
+  return (
+    c?.business_name ||
+    c?.name ||
+    [c?.first_name, c?.last_name].filter(Boolean).join(" ") ||
+    wo?.customer_name ||
+    null
+  );
+}
+function vehicle(v?: Vehicle, wo?: WO) {
+  const parts = [
+    v?.year ?? wo?.vehicle_year,
+    v?.make ?? wo?.vehicle_make,
+    v?.model ?? wo?.vehicle_model,
+  ].filter(Boolean);
+  const unit = v?.unit_number ?? wo?.vehicle_unit_number;
+  const plate = v?.license_plate ?? wo?.vehicle_license_plate;
+  return (
+    [...parts, unit ? `Unit ${unit}` : null, plate ? `Plate ${plate}` : null]
+      .filter(Boolean)
+      .join(" ") || null
+  );
+}
+function latestPunch(events: Punch[]) {
+  return (
+    [...events].sort(
+      (a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    )[0] ?? null
+  );
+}
+function canonicalSoldLaborHours(line?: Line): number {
+  const hours = Number(line?.labor_time ?? 0);
+  return Number.isFinite(hours) && hours > 0 ? hours : 0;
+}
+function isSoldLaborLine(line: Line | undefined, shopId: string): line is Line {
+  return Boolean(
+    line &&
+    line.shop_id === shopId &&
+    !INFORMATIONAL_LINE_TYPES.has(String(line.line_type ?? "").toLowerCase()) &&
+    canonicalSoldLaborHours(line) > 0,
+  );
+}
+function soldLaborHoursForSegments(
+  segments: Segment[],
+  lines: Map<string, Line>,
+  workOrders: Map<string, WO>,
+  shopId: string,
+): number {
+  const lineIds = new Set<string>();
+  for (const segment of segments) {
+    const line = lines.get(segment.work_order_line_id);
+    if (
+      segment.shop_id === shopId &&
+      isSoldLaborLine(line, shopId) &&
+      workOrders.has(segment.work_order_id)
+    )
+      lineIds.add(line.id);
+  }
+  return [...lineIds].reduce(
+    (sum, lineId) => sum + canonicalSoldLaborHours(lines.get(lineId)),
+    0,
+  );
+}
+function activityFromEvents(shift: Shift | null, events: Punch[]) {
+  const latest = latestPunch(events);
+  const t = latest?.event_type?.toLowerCase();
+  if (shift?.end_time || t === "end_shift") return "shift_ended";
+  const lunchStart =
+    [...events]
+      .reverse()
+      .find(
+        (e) => e.event_type === "lunch_start" || e.event_type === "lunch_end",
+      )?.event_type === "lunch_start";
+  if (lunchStart) return "on_lunch";
+  const breakStart =
+    [...events]
+      .reverse()
+      .find(
+        (e) => e.event_type === "break_start" || e.event_type === "break_end",
+      )?.event_type === "break_start";
+  if (breakStart) return "on_break";
+  return shift ? "clocked_in_idle" : "off_shift";
 }
 
-export function composeWorkforceActivity(input: { shopId: string; nowIso: string; from: string; to: string; shifts: Shift[]; profiles: Profile[]; punches: Punch[]; segments: Segment[]; lines: Line[]; workOrders: WO[]; customers: Customer[]; vehicles: Vehicle[] }): WorkforceActivityResponse {
-  const profiles = new Map(input.profiles.map(p=>[p.id,p])); const lines = new Map(input.lines.filter(l=>l.shop_id===input.shopId).map(l=>[l.id,l])); const wos = new Map(input.workOrders.filter(w=>w.shop_id===input.shopId).map(w=>[w.id,w])); const customers = new Map(input.customers.map(c=>[c.id,c])); const vehicles = new Map(input.vehicles.map(v=>[v.id,v]));
-  const users = new Set<string>([...input.shifts.map(s=>s.user_id).filter(Boolean) as string[], ...input.segments.map(s=>s.technician_id)]);
-  const punchesByShift = new Map<string, Punch[]>(); input.punches.forEach(p=>{ if(p.shift_id) punchesByShift.set(p.shift_id,[...(punchesByShift.get(p.shift_id)??[]),p]); });
-  const shiftsByUser = new Map<string, Shift>(); input.shifts.forEach(s=>{ if(s.user_id && (!shiftsByUser.get(s.user_id) || new Date(s.start_time)>new Date(shiftsByUser.get(s.user_id)!.start_time))) shiftsByUser.set(s.user_id,s); });
-  const segsByUser = new Map<string, Segment[]>(); input.segments.forEach(s=>segsByUser.set(s.technician_id,[...(segsByUser.get(s.technician_id)??[]),s]));
+export async function buildWorkforceActivity(params: {
+  shopId: string;
+  timezone?: string | null;
+  now?: Date;
+}) {
+  const admin = createAdminSupabase();
+  const now = params.now ?? new Date();
+  const nowIso = now.toISOString();
+  const ranges = getShopTodayTomorrowRanges(params.timezone, now);
+  const from = ranges.today.start;
+  const to = ranges.today.end;
+  const [shiftsRes, profilesRes, punchesRes, segmentsRes] = await Promise.all([
+    admin
+      .from("tech_shifts")
+      .select("*")
+      .eq("shop_id", params.shopId)
+      .gte("start_time", from)
+      .lte("start_time", to)
+      .order("start_time", { ascending: false }),
+    admin
+      .from("profiles")
+      .select("id, full_name, email, role")
+      .eq("shop_id", params.shopId),
+    admin
+      .from("punch_events")
+      .select("*")
+      .gte("timestamp", from)
+      .lte("timestamp", to)
+      .order("timestamp", { ascending: true }),
+    admin
+      .from("work_order_line_labor_segments")
+      .select("*")
+      .eq("shop_id", params.shopId)
+      .lt("started_at", to)
+      .or(`ended_at.is.null,ended_at.gte.${from}`)
+      .order("started_at", { ascending: false }),
+  ]);
+  const err = [shiftsRes, profilesRes, punchesRes, segmentsRes].find(
+    (r) => r.error,
+  )?.error;
+  if (err) throw err;
+  const shifts = (shiftsRes.data ?? []) as Shift[];
+  const profiles = (profilesRes.data ?? []) as Profile[];
+  const punches = (punchesRes.data ?? []) as Punch[];
+  const segments = (segmentsRes.data ?? []) as Segment[];
+  const lineIds = [...new Set(segments.map((s) => s.work_order_line_id))];
+  const woIds = [...new Set(segments.map((s) => s.work_order_id))];
+  const [linesRes, woRes] = await Promise.all([
+    lineIds.length
+      ? admin
+          .from("work_order_lines")
+          .select(
+            "id,work_order_id,description,job_type,assigned_tech_id,labor_time,status,line_status,line_type,shop_id,updated_at,punched_out_at",
+          )
+          .eq("shop_id", params.shopId)
+          .in("id", lineIds)
+      : Promise.resolve({ data: [], error: null }),
+    woIds.length
+      ? admin
+          .from("work_orders")
+          .select(
+            "id,shop_id,custom_id,external_id,status,customer_id,customer_name,vehicle_id,vehicle_year,vehicle_make,vehicle_model,vehicle_unit_number,vehicle_license_plate",
+          )
+          .eq("shop_id", params.shopId)
+          .in("id", woIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  if (linesRes.error || woRes.error) throw linesRes.error || woRes.error;
+  const lines = (linesRes.data ?? []) as Line[];
+  const wos = (woRes.data ?? []) as WO[];
+  const customerIds = [
+    ...new Set(wos.map((w) => w.customer_id).filter(Boolean)),
+  ] as string[];
+  const vehicleIds = [
+    ...new Set(wos.map((w) => w.vehicle_id).filter(Boolean)),
+  ] as string[];
+  const [customersRes, vehiclesRes] = await Promise.all([
+    customerIds.length
+      ? admin
+          .from("customers")
+          .select("id,name,business_name,first_name,last_name,shop_id")
+          .eq("shop_id", params.shopId)
+          .in("id", customerIds)
+      : Promise.resolve({ data: [], error: null }),
+    vehicleIds.length
+      ? admin
+          .from("vehicles")
+          .select("id,year,make,model,unit_number,license_plate,shop_id")
+          .eq("shop_id", params.shopId)
+          .in("id", vehicleIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  if (customersRes.error || vehiclesRes.error)
+    throw customersRes.error || vehiclesRes.error;
+  return composeWorkforceActivity({
+    shopId: params.shopId,
+    nowIso,
+    from,
+    to,
+    shifts,
+    profiles,
+    punches,
+    segments,
+    lines,
+    workOrders: wos,
+    customers: (customersRes.data ?? []) as Customer[],
+    vehicles: (vehiclesRes.data ?? []) as Vehicle[],
+  });
+}
+
+export function composeWorkforceActivity(input: {
+  shopId: string;
+  nowIso: string;
+  from: string;
+  to: string;
+  shifts: Shift[];
+  profiles: Profile[];
+  punches: Punch[];
+  segments: Segment[];
+  lines: Line[];
+  workOrders: WO[];
+  customers: Customer[];
+  vehicles: Vehicle[];
+}): WorkforceActivityResponse {
+  const profiles = new Map(input.profiles.map((p) => [p.id, p]));
+  const lines = new Map(
+    input.lines.filter((l) => l.shop_id === input.shopId).map((l) => [l.id, l]),
+  );
+  const wos = new Map(
+    input.workOrders
+      .filter((w) => w.shop_id === input.shopId)
+      .map((w) => [w.id, w]),
+  );
+  const customers = new Map(input.customers.map((c) => [c.id, c]));
+  const vehicles = new Map(input.vehicles.map((v) => [v.id, v]));
+  const users = new Set<string>([
+    ...(input.shifts.map((s) => s.user_id).filter(Boolean) as string[]),
+    ...input.segments.map((s) => s.technician_id),
+  ]);
+  const punchesByShift = new Map<string, Punch[]>();
+  input.punches.forEach((p) => {
+    if (p.shift_id)
+      punchesByShift.set(p.shift_id, [
+        ...(punchesByShift.get(p.shift_id) ?? []),
+        p,
+      ]);
+  });
+  const shiftsByUser = new Map<string, Shift>();
+  input.shifts.forEach((s) => {
+    if (
+      s.user_id &&
+      (!shiftsByUser.get(s.user_id) ||
+        new Date(s.start_time) >
+          new Date(shiftsByUser.get(s.user_id)!.start_time))
+    )
+      shiftsByUser.set(s.user_id, s);
+  });
+  const segsByUser = new Map<string, Segment[]>();
+  input.segments.forEach((s) =>
+    segsByUser.set(s.technician_id, [
+      ...(segsByUser.get(s.technician_id) ?? []),
+      s,
+    ]),
+  );
   const activities: WorkforceTechnicianActivity[] = [];
-  for (const userId of [...users].sort((a,b)=>name(profiles.get(a)).localeCompare(name(profiles.get(b))))) {
-    const shift = shiftsByUser.get(userId) ?? null; const shiftEvents = shift?.id ? (punchesByShift.get(shift.id) ?? []) : []; const latest = latestPunch(shiftEvents); const userSegs = segsByUser.get(userId) ?? [];
-    const activeSegs = userSegs.filter(s=>!s.ended_at && lines.has(s.work_order_line_id) && wos.has(s.work_order_id) && !INACTIVE_LINE.has(String(lines.get(s.work_order_line_id)?.line_status || lines.get(s.work_order_line_id)?.status || "").toLowerCase())).sort((a,b)=>new Date(a.started_at).getTime()-new Date(b.started_at).getTime() || a.id.localeCompare(b.id));
-    const active = activeSegs[0] ?? null; const line = active ? lines.get(active.work_order_line_id) : undefined; const wo = active ? wos.get(active.work_order_id) : undefined;
-    const currentJob = active && line && wo ? { laborSegmentId: active.id, workOrderId: wo.id, workOrderNumber: woNum(wo), workOrderStatus: wo.status, lineId: line.id, lineDescription: line.description, jobType: line.job_type, customerId: wo.customer_id, customerName: cust(wo.customer_id ? customers.get(wo.customer_id) : undefined, wo), vehicleId: wo.vehicle_id, vehicleLabel: vehicle(wo.vehicle_id ? vehicles.get(wo.vehicle_id) : undefined, wo), jobStartedAt: active.started_at, elapsedMinutes: overlapMinutes(active.started_at, null, active.started_at, input.nowIso), assignedTechId: line.assigned_tech_id } : null;
-    const breakMinutes = sumPairedDurations(shiftEvents, "break_start", "break_end", input.nowIso); const lunchMinutes = sumPairedDurations(shiftEvents, "lunch_start", "lunch_end", input.nowIso); const shiftMinutes = shift ? overlapMinutes(shift.start_time, shift.end_time, input.from, input.nowIso) : 0;
-    const jobMinutes = clampNonNegative(userSegs.reduce((sum,s)=>sum+overlapMinutes(s.started_at, s.ended_at, input.from, input.nowIso),0)); const soldLaborHours = userSegs.reduce((sum,s)=>sum+Math.max(0, Number(lines.get(s.work_order_line_id)?.labor_time ?? 0)),0); const completedJobCount = userSegs.filter(s=>s.ended_at && new Date(s.ended_at)>=new Date(input.from) && new Date(s.ended_at)<new Date(input.to)).length;
-    const exceptions = [] as WorkforceTechnicianActivity["exceptions"]; const base = activityFromEvents(shift, shiftEvents); let operationalState: WorkforceOperationalState = currentJob ? "working_on_job" : base; if (base === "on_break" || base === "on_lunch" || base === "shift_ended") operationalState = base;
-    const idleMinutes = clampNonNegative(shiftMinutes - breakMinutes - lunchMinutes - jobMinutes); if (shift && !shift.end_time && !currentJob && operationalState === "clocked_in_idle" && idleMinutes > WORKFORCE_ACTIVITY_THRESHOLDS.idleMinutes) exceptions.push(exception({ code:"clocked_in_no_active_job", severity:"warning", message:`Clocked in with no active job for ${idleMinutes} min.`, recommendedAction:"Assign work or confirm waiting state.", relatedEmployeeId:userId }));
-    if (active && !shift) exceptions.push(exception({ code:"active_job_off_shift", severity:"blocking", message:"Active job segment exists while technician is off shift.", recommendedAction:"Start/correct shift or close the job segment.", relatedEmployeeId:userId, relatedWorkOrderId: active.work_order_id, relatedLineId: active.work_order_line_id }));
-    if (activeSegs.length>1) exceptions.push(exception({ code:"multiple_active_jobs", severity:"blocking", message:"Multiple active job segments are open for this technician.", recommendedAction:"Close the incorrect active segment before payroll review.", relatedEmployeeId:userId, relatedWorkOrderId: active.work_order_id, relatedLineId: active.work_order_line_id }));
-    if (active && shift?.end_time) exceptions.push(exception({ code:"shift_ended_with_active_job", severity:"blocking", message:"Shift ended while a job segment remains active.", recommendedAction:"Close or correct the job segment.", relatedEmployeeId:userId, relatedWorkOrderId: active.work_order_id, relatedLineId: active.work_order_line_id }));
-    if (active && (!line?.assigned_tech_id || line.assigned_tech_id !== userId)) exceptions.push(exception({ code:"active_job_unassigned", severity:"warning", message:"Active job is not assigned to the technician punching it.", recommendedAction:"Assign the line or verify the punch.", relatedEmployeeId:userId, relatedWorkOrderId: active.work_order_id, relatedLineId: active.work_order_line_id }));
-    if (breakMinutes > WORKFORCE_ACTIVITY_THRESHOLDS.longBreakMinutes && operationalState === "on_break") exceptions.push(exception({ code:"long_break", severity:"warning", message:`Break has exceeded ${WORKFORCE_ACTIVITY_THRESHOLDS.longBreakMinutes} min.`, recommendedAction:"Check technician status.", relatedEmployeeId:userId }));
-    if (lunchMinutes > WORKFORCE_ACTIVITY_THRESHOLDS.longLunchMinutes && operationalState === "on_lunch") exceptions.push(exception({ code:"long_lunch", severity:"warning", message:`Lunch has exceeded ${WORKFORCE_ACTIVITY_THRESHOLDS.longLunchMinutes} min.`, recommendedAction:"Check technician status.", relatedEmployeeId:userId }));
-    if (currentJob && Number(line?.labor_time ?? 0)>0 && currentJob.elapsedMinutes / 60 > Number(line?.labor_time) * WORKFORCE_ACTIVITY_THRESHOLDS.jobOverEstimateRatio) exceptions.push(exception({ code:"job_over_estimate", severity:"warning", message:"Elapsed job time is materially over sold labor time.", recommendedAction:"Review estimate vs. actual progress.", relatedEmployeeId:userId, relatedWorkOrderId: currentJob.workOrderId, relatedLineId: currentJob.lineId }));
-    if (hasOverlaps(userSegs, input.nowIso)) exceptions.push(exception({ code:"overlapping_job_segments", severity:"blocking", message:"Overlapping job segments make productive time inconsistent.", recommendedAction:"Correct overlapping job punches.", relatedEmployeeId:userId }));
-    activities.push({ userId, employeeName: name(profiles.get(userId)), employeeEmail: profiles.get(userId)?.email ?? null, workforceRole: profiles.get(userId)?.role ?? null, shiftId: shift?.id ?? null, shiftStatus: shift?.status ?? null, shiftActivity: operationalState, shiftStartTime: shift?.start_time ?? null, shiftEndTime: shift?.end_time ?? null, latestShiftEventType: latest?.event_type ?? null, latestShiftEventAt: latest?.timestamp ?? null, currentJob, today: { shiftMinutes, breakMinutes, lunchMinutes, jobMinutes, productiveMinutes: jobMinutes, idleMinutes, soldLaborHours, completedJobCount }, operationalState, exceptions });
+  for (const userId of [...users].sort((a, b) =>
+    name(profiles.get(a)).localeCompare(name(profiles.get(b))),
+  )) {
+    const shift = shiftsByUser.get(userId) ?? null;
+    const shiftEvents = shift?.id ? (punchesByShift.get(shift.id) ?? []) : [];
+    const latest = latestPunch(shiftEvents);
+    const userSegs = segsByUser.get(userId) ?? [];
+    const activeSegs = userSegs
+      .filter(
+        (s) =>
+          !s.ended_at &&
+          lines.has(s.work_order_line_id) &&
+          wos.has(s.work_order_id) &&
+          !INACTIVE_LINE.has(
+            String(
+              lines.get(s.work_order_line_id)?.line_status ||
+                lines.get(s.work_order_line_id)?.status ||
+                "",
+            ).toLowerCase(),
+          ),
+      )
+      .sort(
+        (a, b) =>
+          new Date(a.started_at).getTime() - new Date(b.started_at).getTime() ||
+          a.id.localeCompare(b.id),
+      );
+    const active = activeSegs[0] ?? null;
+    const line = active ? lines.get(active.work_order_line_id) : undefined;
+    const wo = active ? wos.get(active.work_order_id) : undefined;
+    const currentJob =
+      active && line && wo
+        ? {
+            laborSegmentId: active.id,
+            workOrderId: wo.id,
+            workOrderNumber: woNum(wo),
+            workOrderStatus: wo.status,
+            lineId: line.id,
+            lineDescription: line.description,
+            jobType: line.job_type,
+            customerId: wo.customer_id,
+            customerName: cust(
+              wo.customer_id ? customers.get(wo.customer_id) : undefined,
+              wo,
+            ),
+            vehicleId: wo.vehicle_id,
+            vehicleLabel: vehicle(
+              wo.vehicle_id ? vehicles.get(wo.vehicle_id) : undefined,
+              wo,
+            ),
+            jobStartedAt: active.started_at,
+            elapsedMinutes: overlapMinutes(
+              active.started_at,
+              null,
+              active.started_at,
+              input.nowIso,
+            ),
+            assignedTechId: line.assigned_tech_id,
+          }
+        : null;
+    const breakMinutes = sumPairedDurations(
+      shiftEvents,
+      "break_start",
+      "break_end",
+      input.nowIso,
+    );
+    const lunchMinutes = sumPairedDurations(
+      shiftEvents,
+      "lunch_start",
+      "lunch_end",
+      input.nowIso,
+    );
+    const shiftMinutes = shift
+      ? overlapMinutes(
+          shift.start_time,
+          shift.end_time,
+          input.from,
+          input.nowIso,
+        )
+      : 0;
+    const jobMinutes = clampNonNegative(
+      userSegs.reduce(
+        (sum, s) =>
+          sum +
+          overlapMinutes(s.started_at, s.ended_at, input.from, input.nowIso),
+        0,
+      ),
+    );
+    const soldLaborHours = soldLaborHoursForSegments(
+      userSegs,
+      lines,
+      wos,
+      input.shopId,
+    );
+    const completedJobCount = userSegs.filter(
+      (s) =>
+        s.ended_at &&
+        new Date(s.ended_at) >= new Date(input.from) &&
+        new Date(s.ended_at) < new Date(input.to),
+    ).length;
+    const exceptions = [] as WorkforceTechnicianActivity["exceptions"];
+    const base = activityFromEvents(shift, shiftEvents);
+    let operationalState: WorkforceOperationalState = currentJob
+      ? "working_on_job"
+      : base;
+    if (base === "on_break" || base === "on_lunch" || base === "shift_ended")
+      operationalState = base;
+    const idleMinutes = clampNonNegative(
+      shiftMinutes - breakMinutes - lunchMinutes - jobMinutes,
+    );
+    if (
+      shift &&
+      !shift.end_time &&
+      !currentJob &&
+      operationalState === "clocked_in_idle" &&
+      idleMinutes > WORKFORCE_ACTIVITY_THRESHOLDS.idleMinutes
+    )
+      exceptions.push(
+        exception({
+          code: "clocked_in_no_active_job",
+          severity: "warning",
+          message: `Clocked in with no active job for ${idleMinutes} min.`,
+          recommendedAction: "Assign work or confirm waiting state.",
+          relatedEmployeeId: userId,
+        }),
+      );
+    if (active && !shift)
+      exceptions.push(
+        exception({
+          code: "active_job_off_shift",
+          severity: "blocking",
+          message: "Active job segment exists while technician is off shift.",
+          recommendedAction: "Start/correct shift or close the job segment.",
+          relatedEmployeeId: userId,
+          relatedWorkOrderId: active.work_order_id,
+          relatedLineId: active.work_order_line_id,
+        }),
+      );
+    if (activeSegs.length > 1)
+      exceptions.push(
+        exception({
+          code: "multiple_active_jobs",
+          severity: "blocking",
+          message: "Multiple active job segments are open for this technician.",
+          recommendedAction:
+            "Close the incorrect active segment before payroll review.",
+          relatedEmployeeId: userId,
+          relatedWorkOrderId: active.work_order_id,
+          relatedLineId: active.work_order_line_id,
+        }),
+      );
+    if (active && shift?.end_time)
+      exceptions.push(
+        exception({
+          code: "shift_ended_with_active_job",
+          severity: "blocking",
+          message: "Shift ended while a job segment remains active.",
+          recommendedAction: "Close or correct the job segment.",
+          relatedEmployeeId: userId,
+          relatedWorkOrderId: active.work_order_id,
+          relatedLineId: active.work_order_line_id,
+        }),
+      );
+    if (active && (!line?.assigned_tech_id || line.assigned_tech_id !== userId))
+      exceptions.push(
+        exception({
+          code: "active_job_unassigned",
+          severity: "warning",
+          message: "Active job is not assigned to the technician punching it.",
+          recommendedAction: "Assign the line or verify the punch.",
+          relatedEmployeeId: userId,
+          relatedWorkOrderId: active.work_order_id,
+          relatedLineId: active.work_order_line_id,
+        }),
+      );
+    if (
+      breakMinutes > WORKFORCE_ACTIVITY_THRESHOLDS.longBreakMinutes &&
+      operationalState === "on_break"
+    )
+      exceptions.push(
+        exception({
+          code: "long_break",
+          severity: "warning",
+          message: `Break has exceeded ${WORKFORCE_ACTIVITY_THRESHOLDS.longBreakMinutes} min.`,
+          recommendedAction: "Check technician status.",
+          relatedEmployeeId: userId,
+        }),
+      );
+    if (
+      lunchMinutes > WORKFORCE_ACTIVITY_THRESHOLDS.longLunchMinutes &&
+      operationalState === "on_lunch"
+    )
+      exceptions.push(
+        exception({
+          code: "long_lunch",
+          severity: "warning",
+          message: `Lunch has exceeded ${WORKFORCE_ACTIVITY_THRESHOLDS.longLunchMinutes} min.`,
+          recommendedAction: "Check technician status.",
+          relatedEmployeeId: userId,
+        }),
+      );
+    if (
+      currentJob &&
+      Number(line?.labor_time ?? 0) > 0 &&
+      currentJob.elapsedMinutes / 60 >
+        Number(line?.labor_time) *
+          WORKFORCE_ACTIVITY_THRESHOLDS.jobOverEstimateRatio
+    )
+      exceptions.push(
+        exception({
+          code: "job_over_estimate",
+          severity: "warning",
+          message: "Elapsed job time is materially over sold labor time.",
+          recommendedAction: "Review estimate vs. actual progress.",
+          relatedEmployeeId: userId,
+          relatedWorkOrderId: currentJob.workOrderId,
+          relatedLineId: currentJob.lineId,
+        }),
+      );
+    if (hasOverlaps(userSegs, input.nowIso))
+      exceptions.push(
+        exception({
+          code: "overlapping_job_segments",
+          severity: "blocking",
+          message:
+            "Overlapping job segments make productive time inconsistent.",
+          recommendedAction: "Correct overlapping job punches.",
+          relatedEmployeeId: userId,
+        }),
+      );
+    activities.push({
+      userId,
+      employeeName: name(profiles.get(userId)),
+      employeeEmail: profiles.get(userId)?.email ?? null,
+      workforceRole: profiles.get(userId)?.role ?? null,
+      shiftId: shift?.id ?? null,
+      shiftStatus: shift?.status ?? null,
+      shiftActivity: operationalState,
+      shiftStartTime: shift?.start_time ?? null,
+      shiftEndTime: shift?.end_time ?? null,
+      latestShiftEventType: latest?.event_type ?? null,
+      latestShiftEventAt: latest?.timestamp ?? null,
+      currentJob,
+      today: {
+        shiftMinutes,
+        breakMinutes,
+        lunchMinutes,
+        jobMinutes,
+        productiveMinutes: jobMinutes,
+        idleMinutes,
+        soldLaborHours,
+        completedJobCount,
+      },
+      operationalState,
+      exceptions,
+    });
   }
   const feed: WorkforceActivityFeedItem[] = [
-    ...input.punches.map(p=>({ id:p.id, timestamp:p.timestamp, employeeName:name(profiles.get(p.user_id ?? "")), action:String(p.event_type).replaceAll("_"," "), })),
-    ...input.segments.flatMap(s=>{ const l=lines.get(s.work_order_line_id); const w=wos.get(s.work_order_id); return [{ id:`${s.id}:start`, timestamp:s.started_at, employeeName:name(profiles.get(s.technician_id)), action:"started job", workOrderNumber:woNum(w), lineDescription:l?.description ?? null, workOrderId:s.work_order_id, lineId:s.work_order_line_id }, ...(s.ended_at ? [{ id:`${s.id}:end`, timestamp:s.ended_at, employeeName:name(profiles.get(s.technician_id)), action:"finished job", workOrderNumber:woNum(w), lineDescription:l?.description ?? null, workOrderId:s.work_order_id, lineId:s.work_order_line_id }] : [])]; })
-  ].sort((a,b)=>new Date(b.timestamp).getTime()-new Date(a.timestamp).getTime()).slice(0,50);
-  const worked = activities.reduce((s,a)=>s+a.today.shiftMinutes-a.today.breakMinutes-a.today.lunchMinutes,0); const job = activities.reduce((s,a)=>s+a.today.jobMinutes,0);
-  return { activities, feed, summary: { activeTechnicians: activities.filter(a=>a.operationalState!=="off_shift"&&a.operationalState!=="shift_ended").length, workingOnJobs: activities.filter(a=>a.operationalState==="working_on_job").length, idleTechnicians: activities.filter(a=>a.operationalState==="clocked_in_idle").length, onBreak: activities.filter(a=>a.operationalState==="on_break").length, onLunch: activities.filter(a=>a.operationalState==="on_lunch").length, endedToday: activities.filter(a=>a.operationalState==="shift_ended").length, jobMinutesToday: job, utilizationPct: worked>0 ? Math.round((job/worked)*100) : 0, activeExceptionCount: activities.reduce((s,a)=>s+a.exceptions.length,0) }, generatedAt: input.nowIso, sourceMap: { shiftState:"tech_shifts + punch_events", jobActivity:"work_order_line_labor_segments + work_order_lines + work_orders", identity:"profiles scoped by shop_id", customerVehicle:"customers + vehicles scoped by shop_id" } };
+    ...input.punches.map((p) => ({
+      id: p.id,
+      timestamp: p.timestamp,
+      employeeName: name(profiles.get(p.user_id ?? "")),
+      action: String(p.event_type).replaceAll("_", " "),
+    })),
+    ...input.segments.flatMap((s) => {
+      const l = lines.get(s.work_order_line_id);
+      const w = wos.get(s.work_order_id);
+      return [
+        {
+          id: `${s.id}:start`,
+          timestamp: s.started_at,
+          employeeName: name(profiles.get(s.technician_id)),
+          action: "started job",
+          workOrderNumber: woNum(w),
+          lineDescription: l?.description ?? null,
+          workOrderId: s.work_order_id,
+          lineId: s.work_order_line_id,
+        },
+        ...(s.ended_at
+          ? [
+              {
+                id: `${s.id}:end`,
+                timestamp: s.ended_at,
+                employeeName: name(profiles.get(s.technician_id)),
+                action: "finished job",
+                workOrderNumber: woNum(w),
+                lineDescription: l?.description ?? null,
+                workOrderId: s.work_order_id,
+                lineId: s.work_order_line_id,
+              },
+            ]
+          : []),
+      ];
+    }),
+  ]
+    .sort(
+      (a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    )
+    .slice(0, 50);
+  const worked = activities.reduce(
+    (s, a) =>
+      s + a.today.shiftMinutes - a.today.breakMinutes - a.today.lunchMinutes,
+    0,
+  );
+  const job = activities.reduce((s, a) => s + a.today.jobMinutes, 0);
+  const soldLaborHoursToday = soldLaborHoursForSegments(
+    input.segments,
+    lines,
+    wos,
+    input.shopId,
+  );
+  return {
+    activities,
+    feed,
+    summary: {
+      activeTechnicians: activities.filter(
+        (a) =>
+          a.operationalState !== "off_shift" &&
+          a.operationalState !== "shift_ended",
+      ).length,
+      workingOnJobs: activities.filter(
+        (a) => a.operationalState === "working_on_job",
+      ).length,
+      idleTechnicians: activities.filter(
+        (a) => a.operationalState === "clocked_in_idle",
+      ).length,
+      onBreak: activities.filter((a) => a.operationalState === "on_break")
+        .length,
+      onLunch: activities.filter((a) => a.operationalState === "on_lunch")
+        .length,
+      endedToday: activities.filter((a) => a.operationalState === "shift_ended")
+        .length,
+      jobMinutesToday: job,
+      soldLaborHoursToday,
+      utilizationPct: worked > 0 ? Math.round((job / worked) * 100) : 0,
+      activeExceptionCount: activities.reduce(
+        (s, a) => s + a.exceptions.length,
+        0,
+      ),
+    },
+    generatedAt: input.nowIso,
+    sourceMap: {
+      shiftState: "tech_shifts + punch_events",
+      jobActivity:
+        "work_order_line_labor_segments + work_order_lines + work_orders",
+      identity: "profiles scoped by shop_id",
+      customerVehicle: "customers + vehicles scoped by shop_id",
+    },
+  };
 }

--- a/tests/workforce-activity.test.ts
+++ b/tests/workforce-activity.test.ts
@@ -1,24 +1,437 @@
 import { describe, expect, it } from "vitest";
 import { composeWorkforceActivity } from "@/features/workforce/server/buildWorkforceActivity";
 
-const shopId = "shop-1"; const nowIso = "2026-07-10T18:00:00.000Z"; const from = "2026-07-10T06:00:00.000Z"; const to = "2026-07-11T06:00:00.000Z";
-function base(overrides: Partial<Parameters<typeof composeWorkforceActivity>[0]> = {}) { return composeWorkforceActivity({ shopId, nowIso, from, to, profiles:[{ id:"tech-1", full_name:"Edward Lakin", email:"ed@example.com", role:"technician"}], shifts:[], punches:[], segments:[], lines:[], workOrders:[], customers:[], vehicles:[], ...overrides } as any); }
-const shift = { id:"shift-1", shop_id:shopId, user_id:"tech-1", start_time:"2026-07-10T17:00:00.000Z", end_time:null, status:"active", type:"shift", created_at:null };
-const line = { id:"line-1", shop_id:shopId, work_order_id:"wo-1", description:"Oil and filter change", job_type:"maintenance", assigned_tech_id:"tech-1", labor_time:1, status:"active", line_status:"active", updated_at:null, punched_out_at:null };
-const wo = { id:"wo-1", shop_id:shopId, custom_id:"EL000001", external_id:null, status:"open", customer_id:"cust-1", customer_name:null, vehicle_id:"veh-1", vehicle_year:null, vehicle_make:null, vehicle_model:null, vehicle_unit_number:null, vehicle_license_plate:null };
-const segment = { id:"seg-1", shop_id:shopId, technician_id:"tech-1", work_order_id:"wo-1", work_order_line_id:"line-1", started_at:"2026-07-10T17:30:00.000Z", ended_at:null, pause_reason:null, source:"job_punch", created_at:"2026-07-10T17:30:00.000Z", updated_at:"2026-07-10T17:30:00.000Z", created_by:null };
+const shopId = "shop-1";
+const nowIso = "2026-07-10T18:00:00.000Z";
+const from = "2026-07-10T06:00:00.000Z";
+const to = "2026-07-11T06:00:00.000Z";
+function base(
+  overrides: Partial<Parameters<typeof composeWorkforceActivity>[0]> = {},
+) {
+  return composeWorkforceActivity({
+    shopId,
+    nowIso,
+    from,
+    to,
+    profiles: [
+      {
+        id: "tech-1",
+        full_name: "Edward Lakin",
+        email: "ed@example.com",
+        role: "technician",
+      },
+    ],
+    shifts: [],
+    punches: [],
+    segments: [],
+    lines: [],
+    workOrders: [],
+    customers: [],
+    vehicles: [],
+    ...overrides,
+  } as any);
+}
+const shift = {
+  id: "shift-1",
+  shop_id: shopId,
+  user_id: "tech-1",
+  start_time: "2026-07-10T17:00:00.000Z",
+  end_time: null,
+  status: "active",
+  type: "shift",
+  created_at: null,
+};
+const line = {
+  id: "line-1",
+  shop_id: shopId,
+  work_order_id: "wo-1",
+  description: "Oil and filter change",
+  job_type: "maintenance",
+  assigned_tech_id: "tech-1",
+  labor_time: 1,
+  status: "active",
+  line_status: "active",
+  updated_at: null,
+  punched_out_at: null,
+};
+const wo = {
+  id: "wo-1",
+  shop_id: shopId,
+  custom_id: "EL000001",
+  external_id: null,
+  status: "open",
+  customer_id: "cust-1",
+  customer_name: null,
+  vehicle_id: "veh-1",
+  vehicle_year: null,
+  vehicle_make: null,
+  vehicle_model: null,
+  vehicle_unit_number: null,
+  vehicle_license_plate: null,
+};
+const segment = {
+  id: "seg-1",
+  shop_id: shopId,
+  technician_id: "tech-1",
+  work_order_id: "wo-1",
+  work_order_line_id: "line-1",
+  started_at: "2026-07-10T17:30:00.000Z",
+  ended_at: null,
+  pause_reason: null,
+  source: "job_punch",
+  created_at: "2026-07-10T17:30:00.000Z",
+  updated_at: "2026-07-10T17:30:00.000Z",
+  created_by: null,
+};
 
 describe("workforce activity DTO", () => {
-  it("maps active shift plus active segment to working_on_job with enrichment", () => { const r = base({ shifts:[shift], segments:[segment], lines:[line], workOrders:[wo], customers:[{id:"cust-1", shop_id:shopId, name:"Gabriel Anderson", business_name:null, first_name:null, last_name:null}], vehicles:[{id:"veh-1", shop_id:shopId, year:2022, make:"GMC", model:"Savana", unit_number:null, license_plate:null}] }); const a = r.activities[0]; expect(a.operationalState).toBe("working_on_job"); expect(a.currentJob?.workOrderNumber).toBe("EL000001"); expect(a.currentJob?.elapsedMinutes).toBe(30); expect(a.currentJob?.customerName).toBe("Gabriel Anderson"); expect(a.currentJob?.vehicleLabel).toContain("2022 GMC Savana"); });
-  it("maps active shift with no segment to idle and clamps idle non-negative", () => { const a = base({ shifts:[shift] }).activities[0]; expect(a.operationalState).toBe("clocked_in_idle"); expect(a.today.idleMinutes).toBeGreaterThanOrEqual(0); });
-  it("break/lunch state overrides working display", () => { const a = base({ shifts:[shift], punches:[{id:"p1", shift_id:"shift-1", user_id:"tech-1", profile_id:null, event_type:"break_start", timestamp:"2026-07-10T17:50:00.000Z", note:null, created_at:null}], segments:[segment], lines:[line], workOrders:[wo] }).activities[0]; expect(a.operationalState).toBe("on_break"); });
-  it("flags active segment with no shift", () => { const a = base({ segments:[segment], lines:[line], workOrders:[wo] }).activities[0]; expect(a.exceptions.map(e=>e.code)).toContain("active_job_off_shift"); });
-  it("selects multiple active segments deterministically and emits exception", () => { const seg2 = { ...segment, id:"seg-2", started_at:"2026-07-10T17:40:00.000Z" }; const a = base({ shifts:[shift], segments:[seg2, segment], lines:[line], workOrders:[wo] }).activities[0]; expect(a.currentJob?.laborSegmentId).toBe("seg-1"); expect(a.exceptions.map(e=>e.code)).toContain("multiple_active_jobs"); });
-  it("flags ended shift with open segment", () => { const a = base({ shifts:[{...shift, end_time:"2026-07-10T17:55:00.000Z"}], segments:[segment], lines:[line], workOrders:[wo] }).activities[0]; expect(a.exceptions.map(e=>e.code)).toContain("shift_ended_with_active_job"); });
-  it("calculates break duration", () => { const a = base({ shifts:[shift], punches:[{id:"p1", shift_id:"shift-1", user_id:"tech-1", profile_id:null, event_type:"lunch_start", timestamp:"2026-07-10T17:00:00.000Z", note:null, created_at:null},{id:"p2", shift_id:"shift-1", user_id:"tech-1", profile_id:null, event_type:"lunch_end", timestamp:"2026-07-10T17:30:00.000Z", note:null, created_at:null}] }).activities[0]; expect(a.today.lunchMinutes).toBe(30); });
-  it("keeps sold labor separate from actual job time", () => { const a = base({ shifts:[shift], segments:[{...segment, ended_at:"2026-07-10T17:45:00.000Z"}], lines:[{...line, labor_time:2}], workOrders:[wo] }).activities[0]; expect(a.today.jobMinutes).toBe(15); expect(a.today.soldLaborHours).toBe(2); });
-  it("enforces same-shop lines and work orders", () => { const r = base({ segments:[segment], lines:[{...line, shop_id:"other"}], workOrders:[wo] }); expect(r.activities[0].currentJob).toBeNull(); });
+  it("maps active shift plus active segment to working_on_job with enrichment", () => {
+    const r = base({
+      shifts: [shift],
+      segments: [segment],
+      lines: [line],
+      workOrders: [wo],
+      customers: [
+        {
+          id: "cust-1",
+          shop_id: shopId,
+          name: "Gabriel Anderson",
+          business_name: null,
+          first_name: null,
+          last_name: null,
+        },
+      ],
+      vehicles: [
+        {
+          id: "veh-1",
+          shop_id: shopId,
+          year: 2022,
+          make: "GMC",
+          model: "Savana",
+          unit_number: null,
+          license_plate: null,
+        },
+      ],
+    });
+    const a = r.activities[0];
+    expect(a.operationalState).toBe("working_on_job");
+    expect(a.currentJob?.workOrderNumber).toBe("EL000001");
+    expect(a.currentJob?.elapsedMinutes).toBe(30);
+    expect(a.currentJob?.customerName).toBe("Gabriel Anderson");
+    expect(a.currentJob?.vehicleLabel).toContain("2022 GMC Savana");
+  });
+  it("maps active shift with no segment to idle and clamps idle non-negative", () => {
+    const a = base({ shifts: [shift] }).activities[0];
+    expect(a.operationalState).toBe("clocked_in_idle");
+    expect(a.today.idleMinutes).toBeGreaterThanOrEqual(0);
+  });
+  it("break/lunch state overrides working display", () => {
+    const a = base({
+      shifts: [shift],
+      punches: [
+        {
+          id: "p1",
+          shift_id: "shift-1",
+          user_id: "tech-1",
+          profile_id: null,
+          event_type: "break_start",
+          timestamp: "2026-07-10T17:50:00.000Z",
+          note: null,
+          created_at: null,
+        },
+      ],
+      segments: [segment],
+      lines: [line],
+      workOrders: [wo],
+    }).activities[0];
+    expect(a.operationalState).toBe("on_break");
+  });
+  it("flags active segment with no shift", () => {
+    const a = base({ segments: [segment], lines: [line], workOrders: [wo] })
+      .activities[0];
+    expect(a.exceptions.map((e) => e.code)).toContain("active_job_off_shift");
+  });
+  it("selects multiple active segments deterministically and emits exception", () => {
+    const seg2 = {
+      ...segment,
+      id: "seg-2",
+      started_at: "2026-07-10T17:40:00.000Z",
+    };
+    const a = base({
+      shifts: [shift],
+      segments: [seg2, segment],
+      lines: [line],
+      workOrders: [wo],
+    }).activities[0];
+    expect(a.currentJob?.laborSegmentId).toBe("seg-1");
+    expect(a.exceptions.map((e) => e.code)).toContain("multiple_active_jobs");
+  });
+  it("flags ended shift with open segment", () => {
+    const a = base({
+      shifts: [{ ...shift, end_time: "2026-07-10T17:55:00.000Z" }],
+      segments: [segment],
+      lines: [line],
+      workOrders: [wo],
+    }).activities[0];
+    expect(a.exceptions.map((e) => e.code)).toContain(
+      "shift_ended_with_active_job",
+    );
+  });
+  it("calculates break duration", () => {
+    const a = base({
+      shifts: [shift],
+      punches: [
+        {
+          id: "p1",
+          shift_id: "shift-1",
+          user_id: "tech-1",
+          profile_id: null,
+          event_type: "lunch_start",
+          timestamp: "2026-07-10T17:00:00.000Z",
+          note: null,
+          created_at: null,
+        },
+        {
+          id: "p2",
+          shift_id: "shift-1",
+          user_id: "tech-1",
+          profile_id: null,
+          event_type: "lunch_end",
+          timestamp: "2026-07-10T17:30:00.000Z",
+          note: null,
+          created_at: null,
+        },
+      ],
+    }).activities[0];
+    expect(a.today.lunchMinutes).toBe(30);
+  });
+  it("keeps sold labor separate from actual job time", () => {
+    const a = base({
+      shifts: [shift],
+      segments: [{ ...segment, ended_at: "2026-07-10T17:45:00.000Z" }],
+      lines: [{ ...line, labor_time: 2 }],
+      workOrders: [wo],
+    }).activities[0];
+    expect(a.today.jobMinutes).toBe(15);
+    expect(a.today.soldLaborHours).toBe(2);
+  });
 
-  it("reports no current job after hold release closes the active labor segment", () => { const releasedLine = {...line, status:"awaiting", line_status:"awaiting", punched_out_at:"2026-07-10T17:45:00.000Z"}; const closedSegment = {...segment, ended_at:"2026-07-10T17:45:00.000Z"}; const a = base({ shifts:[shift], segments:[closedSegment], lines:[releasedLine], workOrders:[wo] }).activities[0]; expect(a.operationalState).toBe("clocked_in_idle"); expect(a.currentJob).toBeNull(); });
-  it("orders combined feed newest first", () => { const r = base({ shifts:[shift], punches:[{id:"p1", shift_id:"shift-1", user_id:"tech-1", profile_id:null, event_type:"start_shift", timestamp:"2026-07-10T17:00:00.000Z", note:null, created_at:null}], segments:[segment], lines:[line], workOrders:[wo] }); expect(r.feed[0].action).toBe("started job"); });
+  it("counts one line with one segment as one sold labor estimate", () => {
+    const a = base({
+      shifts: [shift],
+      segments: [{ ...segment, ended_at: "2026-07-10T17:45:00.000Z" }],
+      lines: [line],
+      workOrders: [wo],
+    }).activities[0];
+    expect(a.today.soldLaborHours).toBe(1);
+  });
+
+  it("deduplicates sold labor for the same line with two segments while summing actual minutes", () => {
+    const resumed = {
+      ...segment,
+      id: "seg-2",
+      started_at: "2026-07-10T17:50:00.000Z",
+      ended_at: null,
+    };
+    const a = base({
+      shifts: [shift],
+      segments: [{ ...segment, ended_at: "2026-07-10T17:45:00.000Z" }, resumed],
+      lines: [line],
+      workOrders: [wo],
+    }).activities[0];
+
+    expect(a.today.jobMinutes).toBe(25);
+    expect(a.today.soldLaborHours).toBe(1);
+    expect(a.currentJob?.lineId).toBe("line-1");
+    expect(a.currentJob?.workOrderNumber).toBe("EL000001");
+  });
+
+  it("keeps sold labor stable through repeated pause and resume segments", () => {
+    const a = base({
+      shifts: [shift],
+      segments: [
+        {
+          ...segment,
+          id: "seg-1",
+          started_at: "2026-07-10T17:00:00.000Z",
+          ended_at: "2026-07-10T17:10:00.000Z",
+        },
+        {
+          ...segment,
+          id: "seg-2",
+          started_at: "2026-07-10T17:20:00.000Z",
+          ended_at: "2026-07-10T17:30:00.000Z",
+        },
+        {
+          ...segment,
+          id: "seg-3",
+          started_at: "2026-07-10T17:40:00.000Z",
+          ended_at: null,
+        },
+      ],
+      lines: [line],
+      workOrders: [wo],
+    }).activities[0];
+
+    expect(a.today.jobMinutes).toBe(40);
+    expect(a.today.soldLaborHours).toBe(1);
+  });
+
+  it("sums sold labor for two unique active lines", () => {
+    const line2 = {
+      ...line,
+      id: "line-2",
+      labor_time: 2,
+      description: "Brake service",
+    };
+    const wo2 = { ...wo, id: "wo-2", custom_id: "EL000002" };
+    const a = base({
+      shifts: [shift],
+      segments: [
+        { ...segment, ended_at: "2026-07-10T17:45:00.000Z" },
+        {
+          ...segment,
+          id: "seg-2",
+          work_order_id: "wo-2",
+          work_order_line_id: "line-2",
+          started_at: "2026-07-10T17:45:00.000Z",
+          ended_at: null,
+        },
+      ],
+      lines: [line, line2],
+      workOrders: [wo, wo2],
+    }).activities[0];
+
+    expect(a.today.soldLaborHours).toBe(3);
+  });
+
+  it("deduplicates sold labor when duplicate segment rows point to the same line", () => {
+    const a = base({
+      shifts: [shift],
+      segments: [segment, { ...segment, id: "seg-duplicate" }],
+      lines: [line],
+      workOrders: [wo],
+    }).activities[0];
+    expect(a.today.soldLaborHours).toBe(1);
+  });
+
+  it("excludes cross-shop lines and segments from sold labor", () => {
+    const a = base({
+      shifts: [shift],
+      segments: [{ ...segment, shop_id: "other-shop" }],
+      lines: [line],
+      workOrders: [wo],
+    }).activities[0];
+
+    expect(a.today.soldLaborHours).toBe(0);
+  });
+
+  it("treats null, negative, and informational labor lines as zero sold labor", () => {
+    const nullLine = { ...line, id: "line-null", labor_time: null };
+    const negativeLine = { ...line, id: "line-negative", labor_time: -2 };
+    const infoLine = {
+      ...line,
+      id: "line-info",
+      labor_time: 5,
+      line_type: "informational",
+    };
+    const a = base({
+      shifts: [shift],
+      segments: [
+        { ...segment, id: "seg-null", work_order_line_id: "line-null" },
+        { ...segment, id: "seg-negative", work_order_line_id: "line-negative" },
+        { ...segment, id: "seg-info", work_order_line_id: "line-info" },
+      ],
+      lines: [nullLine, negativeLine, infoLine],
+      workOrders: [wo],
+    }).activities[0];
+
+    expect(a.today.soldLaborHours).toBe(0);
+  });
+
+  it("deduplicates shop summary sold hours by unique line across segments and technicians", () => {
+    const r = base({
+      profiles: [
+        {
+          id: "tech-1",
+          full_name: "Edward Lakin",
+          email: "ed@example.com",
+          role: "technician",
+        },
+        {
+          id: "tech-2",
+          full_name: "Mina Perez",
+          email: "mina@example.com",
+          role: "technician",
+        },
+      ],
+      shifts: [shift, { ...shift, id: "shift-2", user_id: "tech-2" }],
+      segments: [
+        {
+          ...segment,
+          id: "seg-1",
+          technician_id: "tech-1",
+          ended_at: "2026-07-10T17:40:00.000Z",
+        },
+        {
+          ...segment,
+          id: "seg-2",
+          technician_id: "tech-2",
+          started_at: "2026-07-10T17:45:00.000Z",
+        },
+      ],
+      lines: [line],
+      workOrders: [wo],
+    });
+
+    expect(r.summary.soldLaborHoursToday).toBe(1);
+  });
+
+  it("enforces same-shop lines and work orders", () => {
+    const r = base({
+      segments: [segment],
+      lines: [{ ...line, shop_id: "other" }],
+      workOrders: [wo],
+    });
+    expect(r.activities[0].currentJob).toBeNull();
+  });
+
+  it("reports no current job after hold release closes the active labor segment", () => {
+    const releasedLine = {
+      ...line,
+      status: "awaiting",
+      line_status: "awaiting",
+      punched_out_at: "2026-07-10T17:45:00.000Z",
+    };
+    const closedSegment = { ...segment, ended_at: "2026-07-10T17:45:00.000Z" };
+    const a = base({
+      shifts: [shift],
+      segments: [closedSegment],
+      lines: [releasedLine],
+      workOrders: [wo],
+    }).activities[0];
+    expect(a.operationalState).toBe("clocked_in_idle");
+    expect(a.currentJob).toBeNull();
+  });
+  it("orders combined feed newest first", () => {
+    const r = base({
+      shifts: [shift],
+      punches: [
+        {
+          id: "p1",
+          shift_id: "shift-1",
+          user_id: "tech-1",
+          profile_id: null,
+          event_type: "start_shift",
+          timestamp: "2026-07-10T17:00:00.000Z",
+          note: null,
+          created_at: null,
+        },
+      ],
+      segments: [segment],
+      lines: [line],
+      workOrders: [wo],
+    });
+    expect(r.feed[0].action).toBe("started job");
+  });
 });


### PR DESCRIPTION
### Motivation
- Root cause: `soldLaborHours` was being computed by iterating segments and adding `work_order_lines.labor_time` per segment, so pause/resume (multiple `work_order_line_labor_segments` for the same line) doubled sold labor even though the canonical sold value lives on the work-order line.
- Business intent: maintain segment-based actual minutes while making sold labor a line-based, deduplicated sum and preserve tenant/shop isolation and informational-line exclusions.

### Description
- Reworked `composeWorkforceActivity` in `features/workforce/server/buildWorkforceActivity.ts` to separate time domains by adding `canonicalSoldLaborHours`, `isSoldLaborLine`, and `soldLaborHoursForSegments` helpers that deduplicate sold labor by unique `work_order_line_id` and apply filters for shop, informational `line_type`, null/negative labor, and missing work orders.
- Kept `jobMinutes` as the sum of overlap minutes across every labor segment, while replacing per-segment sold aggregation with a per-unique-line aggregation for technician rows and a shop-level `soldLaborHoursToday` summary computed over all segments deduplicated by line.
- Extended DB enrichment to select `line_type` for lines and updated `features/workforce/lib/activityTypes.ts` to add `soldLaborHoursToday` to the returned `WorkforceActivitySummary` contract.
- Added regression tests in `tests/workforce-activity.test.ts` covering: single-segment sold labor, same-line multi-segments (pause/resume) preserved sold=one, repeated pause/resume, two unique lines summing, duplicate segment rows, cross-shop exclusion, null/negative/informational labor treated as zero, and shop-level deduplication across multiple technicians; also preserved existing behavior for current-job context and exceptions.

### Testing
- Ran unit tests: `npx vitest run tests/workforce-activity.test.ts tests/attendance-display-enrichment.test.ts tests/work-order-job-punch-transition.test.ts tests/mobile-shift-lifecycle-route.test.ts tests/shift-status.test.ts` — all tests passed (48 passed, 0 failed).
- Type-check: `npx tsc --noEmit` — success.
- Notes: No DB schema migrations were required; changes are read-model logic only. Technician-level attribution remains: a technician who had any segment for a line during the shop day will see that line's canonical sold hours once, while shop summary deduplicates across technicians to avoid double-counting; multi-technician allocation policy remains a product decision for future work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a513fab17d48328a5ef690da088e8ad)