### PR TITLE
Fix Workforce activity feed job event semantics

### DIFF
--- a/features/work-orders/server/applyJobPunchTransition.ts
+++ b/features/work-orders/server/applyJobPunchTransition.ts
@@ -100,12 +100,14 @@ export async function applyJobPunchTransition({
   }
 
   if (!line) return err(404, "Line not found");
-  if ((line.line_type ?? "job") === "info") return err(409, "Info lines are non-actionable.");
+  if ((line.line_type ?? "job") === "info")
+    return err(409, "Info lines are non-actionable.");
 
   const status = normalizeWorkOrderLineStatus(line.status);
 
   if (action === "start" || action === "resume") {
-    const resumeToAwaiting = action === "resume" && options?.resume?.toAwaiting === true;
+    const resumeToAwaiting =
+      action === "resume" && options?.resume?.toAwaiting === true;
 
     if (resumeToAwaiting) {
       if (status === "completed" || status === "invoiced") {
@@ -144,14 +146,23 @@ export async function applyJobPunchTransition({
     const punchable = Boolean(line.punchable);
 
     if (status === "completed" || status === "invoiced") {
-      return err(409, action === "start" ? "Cannot start a closed line." : "Cannot resume a closed line.");
+      return err(
+        409,
+        action === "start"
+          ? "Cannot start a closed line."
+          : "Cannot resume a closed line.",
+      );
     }
 
     if (!canTransitionWorkOrderLineStatus(status, "in_progress")) {
       return err(409, getWorkOrderLineTransitionError(status, "in_progress"));
     }
 
-    if (status === "awaiting_approval" && approvalState !== "approved" && !punchable) {
+    if (
+      status === "awaiting_approval" &&
+      approvalState !== "approved" &&
+      !punchable
+    ) {
       return err(
         409,
         action === "start"
@@ -182,7 +193,8 @@ export async function applyJobPunchTransition({
       end_time: string | null;
     } | null = null;
 
-    const { data: firstOpenShift, error: firstOpenShiftErr } = await openShiftQuery.maybeSingle();
+    const { data: firstOpenShift, error: firstOpenShiftErr } =
+      await openShiftQuery.maybeSingle();
 
     if (firstOpenShiftErr) return err(400, firstOpenShiftErr.message);
     openShift = firstOpenShift;
@@ -200,36 +212,40 @@ export async function applyJobPunchTransition({
         fallbackQuery = fallbackQuery.eq("shop_id", line.shop_id);
       }
 
-      const { data: fallbackOpenShift, error: fallbackOpenShiftErr } = await fallbackQuery.maybeSingle();
+      const { data: fallbackOpenShift, error: fallbackOpenShiftErr } =
+        await fallbackQuery.maybeSingle();
       if (fallbackOpenShiftErr) return err(400, fallbackOpenShiftErr.message);
       openShift = fallbackOpenShift;
     }
 
     if (!openShift) {
-      const { data: anyShopOpenShift, error: anyShopOpenShiftErr } = await supabase
-        .from("tech_shifts")
-        .select("id, shop_id, status, start_time, end_time")
-        .eq("user_id", lineTechId)
-        .eq("status", SHIFT_STATUSES.active)
-        .order("start_time", { ascending: false })
-        .limit(1)
-        .maybeSingle();
+      const { data: anyShopOpenShift, error: anyShopOpenShiftErr } =
+        await supabase
+          .from("tech_shifts")
+          .select("id, shop_id, status, start_time, end_time")
+          .eq("user_id", lineTechId)
+          .eq("status", SHIFT_STATUSES.active)
+          .order("start_time", { ascending: false })
+          .limit(1)
+          .maybeSingle();
 
       if (anyShopOpenShiftErr) return err(400, anyShopOpenShiftErr.message);
       openShift = anyShopOpenShift;
     }
 
     if (!openShift) {
-      const { data: anyShopLegacyOpenShift, error: anyShopLegacyOpenShiftErr } = await supabase
-        .from("tech_shifts")
-        .select("id, shop_id, status, start_time, end_time")
-        .eq("user_id", lineTechId)
-        .is("end_time", null)
-        .order("start_time", { ascending: false })
-        .limit(1)
-        .maybeSingle();
+      const { data: anyShopLegacyOpenShift, error: anyShopLegacyOpenShiftErr } =
+        await supabase
+          .from("tech_shifts")
+          .select("id, shop_id, status, start_time, end_time")
+          .eq("user_id", lineTechId)
+          .is("end_time", null)
+          .order("start_time", { ascending: false })
+          .limit(1)
+          .maybeSingle();
 
-      if (anyShopLegacyOpenShiftErr) return err(400, anyShopLegacyOpenShiftErr.message);
+      if (anyShopLegacyOpenShiftErr)
+        return err(400, anyShopLegacyOpenShiftErr.message);
       openShift = anyShopLegacyOpenShift;
     }
 
@@ -274,7 +290,8 @@ export async function applyJobPunchTransition({
         activeSegmentQuery = activeSegmentQuery.eq("shop_id", line.shop_id);
       }
 
-      const { data: activeSegments, error: activeSegmentErr } = await activeSegmentQuery;
+      const { data: activeSegments, error: activeSegmentErr } =
+        await activeSegmentQuery;
 
       if (activeSegmentErr) return err(400, activeSegmentErr.message);
 
@@ -288,10 +305,15 @@ export async function applyJobPunchTransition({
 
     const now = new Date().toISOString();
     const shouldResetPunchClock =
-      action === "start" || status === "on_hold" || Boolean(line.punched_out_at);
+      action === "start" ||
+      status === "on_hold" ||
+      Boolean(line.punched_out_at);
 
     if (!line.shop_id || !line.work_order_id) {
-      return err(409, "Cannot start labor segment until line has shop_id and work_order_id.");
+      return err(
+        409,
+        "Cannot start labor segment until line has shop_id and work_order_id.",
+      );
     }
 
     const { error: updateErr } = await supabase
@@ -324,8 +346,14 @@ export async function applyJobPunchTransition({
 
     if (segmentErr) {
       const message = segmentErr.message.toLowerCase();
-      if (message.includes("uq_wolls_active_by_tech") || message.includes("ex_wolls_no_overlap")) {
-        return err(409, "Technician already has overlapping active labor. Pause/finish current job first.");
+      if (
+        message.includes("uq_wolls_active_by_tech") ||
+        message.includes("ex_wolls_no_overlap")
+      ) {
+        return err(
+          409,
+          "Technician already has overlapping active labor. Pause/finish current job first.",
+        );
       }
       return err(400, segmentErr.message);
     }
@@ -359,13 +387,15 @@ export async function applyJobPunchTransition({
     }
 
     const now = new Date().toISOString();
-    const shouldCloseActivePunch = Boolean(line.punched_in_at) && !line.punched_out_at;
+    const shouldCloseActivePunch =
+      Boolean(line.punched_in_at) && !line.punched_out_at;
 
     const { error: updateErr } = await supabase
       .from("work_order_lines")
       .update({
         status: "on_hold",
-        hold_reason: cleanString(options?.pause?.holdReason) ?? "Paused by technician",
+        hold_reason:
+          cleanString(options?.pause?.holdReason) ?? "Paused by technician",
         notes: options?.pause?.notes ?? undefined,
         ...(shouldCloseActivePunch ? { punched_out_at: now } : {}),
       } as DB["public"]["Tables"]["work_order_lines"]["Update"])
@@ -380,11 +410,17 @@ export async function applyJobPunchTransition({
       workOrderLineId: lineId,
       technicianId: pauseTechId,
       endedAtIso: now,
+      pauseReason: cleanString(options?.pause?.holdReason)
+        ? `hold:${cleanString(options?.pause?.holdReason)}`
+        : "hold",
     });
 
     if (closeErr) return err(400, closeErr.message);
 
-    const { error: syncErr } = await syncLinePunchMirrorFromSegments({ supabase, workOrderLineId: lineId });
+    const { error: syncErr } = await syncLinePunchMirrorFromSegments({
+      supabase,
+      workOrderLineId: lineId,
+    });
     if (syncErr) return err(400, syncErr.message);
 
     await logOperationalEvent({
@@ -419,7 +455,10 @@ export async function applyJobPunchTransition({
   }
 
   if (laborTime <= 0) {
-    return err(400, "Labor time must be greater than 0 before finishing this job.");
+    return err(
+      400,
+      "Labor time must be greater than 0 before finishing this job.",
+    );
   }
 
   const nowIso = new Date().toISOString();
@@ -430,11 +469,15 @@ export async function applyJobPunchTransition({
     workOrderLineId: lineId,
     technicianId: finishTechId,
     endedAtIso: nowIso,
+    pauseReason: "completed",
   });
 
   if (closeErr) return err(400, closeErr.message);
 
-  const { error: syncErr } = await syncLinePunchMirrorFromSegments({ supabase, workOrderLineId: lineId });
+  const { error: syncErr } = await syncLinePunchMirrorFromSegments({
+    supabase,
+    workOrderLineId: lineId,
+  });
   if (syncErr) return err(400, syncErr.message);
 
   const updatePayload: DB["public"]["Tables"]["work_order_lines"]["Update"] = {
@@ -472,7 +515,10 @@ export async function applyJobPunchTransition({
     .eq("work_order_line_id", lineId);
 
   if (inspectionErr) {
-    console.warn("[finish] inspections finalize failed:", inspectionErr.message);
+    console.warn(
+      "[finish] inspections finalize failed:",
+      inspectionErr.message,
+    );
   }
 
   try {

--- a/features/work-orders/server/laborSegments.ts
+++ b/features/work-orders/server/laborSegments.ts
@@ -3,9 +3,11 @@ import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 
-type LaborSegmentRow = DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"];
+type LaborSegmentRow =
+  DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"];
 
-type LaborSegmentInsert = DB["public"]["Tables"]["work_order_line_labor_segments"]["Insert"];
+type LaborSegmentInsert =
+  DB["public"]["Tables"]["work_order_line_labor_segments"]["Insert"];
 
 export async function startLaborSegment(params: {
   supabase: SupabaseClient<DB>;
@@ -27,7 +29,9 @@ export async function startLaborSegment(params: {
     source: params.source ?? "job_punch",
   };
 
-  const { error } = await params.supabase.from("work_order_line_labor_segments").insert(payload);
+  const { error } = await params.supabase
+    .from("work_order_line_labor_segments")
+    .insert(payload);
   return { error };
 }
 
@@ -36,10 +40,16 @@ export async function closeActiveLaborSegments(params: {
   workOrderLineId?: string;
   technicianId?: string;
   endedAtIso: string;
+  pauseReason?: string | null;
 }) {
   let query = params.supabase
     .from("work_order_line_labor_segments")
-    .update({ ended_at: params.endedAtIso })
+    .update({
+      ended_at: params.endedAtIso,
+      ...(params.pauseReason !== undefined
+        ? { pause_reason: params.pauseReason }
+        : {}),
+    })
     .is("ended_at", null);
 
   if (params.workOrderLineId) {
@@ -81,7 +91,10 @@ export async function syncLinePunchMirrorFromSegments(params: {
 
   if (segErr) return { error: segErr };
 
-  const rows = (segments ?? []) as Pick<LaborSegmentRow, "started_at" | "ended_at">[];
+  const rows = (segments ?? []) as Pick<
+    LaborSegmentRow,
+    "started_at" | "ended_at"
+  >[];
   if (rows.length === 0) {
     const { error } = await params.supabase
       .from("work_order_lines")
@@ -96,7 +109,10 @@ export async function syncLinePunchMirrorFromSegments(params: {
   let latestEndedAt: string | null = null;
   for (const segment of rows) {
     if (!segment.ended_at) continue;
-    if (!latestEndedAt || new Date(segment.ended_at).getTime() > new Date(latestEndedAt).getTime()) {
+    if (
+      !latestEndedAt ||
+      new Date(segment.ended_at).getTime() > new Date(latestEndedAt).getTime()
+    ) {
       latestEndedAt = segment.ended_at;
     }
   }

--- a/features/workforce/server/buildWorkforceActivity.ts
+++ b/features/workforce/server/buildWorkforceActivity.ts
@@ -22,6 +22,7 @@ type DB = Database;
 type Shift = DB["public"]["Tables"]["tech_shifts"]["Row"];
 type Punch = DB["public"]["Tables"]["punch_events"]["Row"];
 type Segment = DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"];
+type OperationalLog = DB["public"]["Tables"]["activity_logs"]["Row"];
 type Profile = {
   id: string;
   full_name: string | null;
@@ -41,6 +42,7 @@ type Line = {
   shop_id: string;
   updated_at: string | null;
   punched_out_at: string | null;
+  hold_reason?: string | null;
 };
 type WO = {
   id: string;
@@ -122,7 +124,8 @@ function latestPunch(events: Punch[]) {
   return (
     [...events].sort(
       (a, b) =>
-        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime() ||
+        a.id.localeCompare(b.id),
     )[0] ?? null
   );
 }
@@ -159,6 +162,84 @@ function soldLaborHoursForSegments(
     0,
   );
 }
+type LaborSegmentFeedAction =
+  | "started_job"
+  | "resumed_job"
+  | "placed_on_hold"
+  | "paused_job"
+  | "completed_job"
+  | "stopped_at_shift_end"
+  | "stopped_job_time";
+
+function normalizeToken(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replaceAll(" ", "_");
+}
+
+function eventNear(log: OperationalLog, at: string): boolean {
+  if (!log.timestamp) return false;
+  return (
+    Math.abs(new Date(log.timestamp).getTime() - new Date(at).getTime()) <= 5000
+  );
+}
+
+function logsForLineAt(
+  logsByLine: Map<string, OperationalLog[]>,
+  lineId: string,
+  at: string,
+): OperationalLog[] {
+  return (logsByLine.get(lineId) ?? []).filter((log) => eventNear(log, at));
+}
+
+export function resolveLaborSegmentFeedAction(params: {
+  segment: Segment;
+  sameLineEarlierSegments: Segment[];
+  logsAtTimestamp?: OperationalLog[];
+}): LaborSegmentFeedAction {
+  const { segment, sameLineEarlierSegments, logsAtTimestamp = [] } = params;
+  if (!segment.ended_at) {
+    return sameLineEarlierSegments.some(
+      (s) =>
+        s.id !== segment.id &&
+        new Date(s.started_at).getTime() <
+          new Date(segment.started_at).getTime(),
+    )
+      ? "resumed_job"
+      : "started_job";
+  }
+  const closeReason = [segment.pause_reason, segment.source]
+    .map(normalizeToken)
+    .filter(Boolean)
+    .join(" ");
+  const logEvents = logsAtTimestamp.map((log) => normalizeToken(log.action));
+  if (logEvents.includes("pause") || closeReason.includes("hold"))
+    return "placed_on_hold";
+  if (closeReason.includes("pause")) return "paused_job";
+  if (
+    logEvents.includes("finish") ||
+    logEvents.includes("complete") ||
+    closeReason.includes("finish") ||
+    closeReason.includes("complete")
+  )
+    return "completed_job";
+  if (closeReason.includes("shift_end") || closeReason.includes("end_shift"))
+    return "stopped_at_shift_end";
+  return "stopped_job_time";
+}
+
+function actionCopy(action: LaborSegmentFeedAction, line?: Line): string {
+  if (action === "started_job") return "started job";
+  if (action === "resumed_job") return "resumed job";
+  if (action === "completed_job") return "completed job";
+  if (action === "stopped_at_shift_end") return "job time stopped at shift end";
+  if (action === "stopped_job_time") return "stopped job time";
+  if (action === "paused_job") return "paused job";
+  const reason = line?.hold_reason?.trim();
+  return reason ? `placed job on hold — ${reason}` : "placed job on hold";
+}
+
 function activityFromEvents(shift: Shift | null, events: Punch[]) {
   const latest = latestPunch(events);
   const t = latest?.event_type?.toLowerCase();
@@ -232,7 +313,7 @@ export async function buildWorkforceActivity(params: {
       ? admin
           .from("work_order_lines")
           .select(
-            "id,work_order_id,description,job_type,assigned_tech_id,labor_time,status,line_status,line_type,shop_id,updated_at,punched_out_at",
+            "id,work_order_id,description,job_type,assigned_tech_id,labor_time,status,line_status,line_type,shop_id,updated_at,punched_out_at,hold_reason",
           )
           .eq("shop_id", params.shopId)
           .in("id", lineIds)
@@ -250,6 +331,16 @@ export async function buildWorkforceActivity(params: {
   if (linesRes.error || woRes.error) throw linesRes.error || woRes.error;
   const lines = (linesRes.data ?? []) as Line[];
   const wos = (woRes.data ?? []) as WO[];
+  const operationalLogsRes = lineIds.length
+    ? await admin
+        .from("activity_logs")
+        .select("*")
+        .eq("target_table", "work_order_line")
+        .in("target_id", lineIds)
+        .gte("timestamp", from)
+        .lte("timestamp", to)
+    : { data: [], error: null };
+  if (operationalLogsRes.error) throw operationalLogsRes.error;
   const customerIds = [
     ...new Set(wos.map((w) => w.customer_id).filter(Boolean)),
   ] as string[];
@@ -287,6 +378,7 @@ export async function buildWorkforceActivity(params: {
     workOrders: wos,
     customers: (customersRes.data ?? []) as Customer[],
     vehicles: (vehiclesRes.data ?? []) as Vehicle[],
+    operationalLogs: (operationalLogsRes.data ?? []) as OperationalLog[],
   });
 }
 
@@ -303,6 +395,7 @@ export function composeWorkforceActivity(input: {
   workOrders: WO[];
   customers: Customer[];
   vehicles: Vehicle[];
+  operationalLogs?: OperationalLog[];
 }): WorkforceActivityResponse {
   const profiles = new Map(input.profiles.map((p) => [p.id, p]));
   const lines = new Map(
@@ -601,6 +694,22 @@ export function composeWorkforceActivity(input: {
       exceptions,
     });
   }
+  const logsByLine = new Map<string, OperationalLog[]>();
+  for (const log of input.operationalLogs ?? []) {
+    if (log.target_table === "work_order_line" && log.target_id) {
+      logsByLine.set(log.target_id, [
+        ...(logsByLine.get(log.target_id) ?? []),
+        log,
+      ]);
+    }
+  }
+  const segmentsByLine = new Map<string, Segment[]>();
+  for (const segment of input.segments) {
+    segmentsByLine.set(segment.work_order_line_id, [
+      ...(segmentsByLine.get(segment.work_order_line_id) ?? []),
+      segment,
+    ]);
+  }
   const feed: WorkforceActivityFeedItem[] = [
     ...input.punches.map((p) => ({
       id: p.id,
@@ -611,12 +720,18 @@ export function composeWorkforceActivity(input: {
     ...input.segments.flatMap((s) => {
       const l = lines.get(s.work_order_line_id);
       const w = wos.get(s.work_order_id);
+      const sameLineEarlierSegments =
+        segmentsByLine.get(s.work_order_line_id) ?? [];
+      const startAction = resolveLaborSegmentFeedAction({
+        segment: { ...s, ended_at: null },
+        sameLineEarlierSegments,
+      });
       return [
         {
           id: `${s.id}:start`,
           timestamp: s.started_at,
           employeeName: name(profiles.get(s.technician_id)),
-          action: "started job",
+          action: actionCopy(startAction, l),
           workOrderNumber: woNum(w),
           lineDescription: l?.description ?? null,
           workOrderId: s.work_order_id,
@@ -628,7 +743,18 @@ export function composeWorkforceActivity(input: {
                 id: `${s.id}:end`,
                 timestamp: s.ended_at,
                 employeeName: name(profiles.get(s.technician_id)),
-                action: "finished job",
+                action: actionCopy(
+                  resolveLaborSegmentFeedAction({
+                    segment: s,
+                    sameLineEarlierSegments,
+                    logsAtTimestamp: logsForLineAt(
+                      logsByLine,
+                      s.work_order_line_id,
+                      s.ended_at,
+                    ),
+                  }),
+                  l,
+                ),
                 workOrderNumber: woNum(w),
                 lineDescription: l?.description ?? null,
                 workOrderId: s.work_order_id,
@@ -638,10 +764,42 @@ export function composeWorkforceActivity(input: {
           : []),
       ];
     }),
+    ...(input.operationalLogs ?? [])
+      .filter((log) => {
+        if (
+          log.action !== "resume" ||
+          log.target_table !== "work_order_line" ||
+          !log.timestamp ||
+          !log.target_id
+        )
+          return false;
+        return !(segmentsByLine.get(log.target_id) ?? []).some(
+          (segment) =>
+            Math.abs(
+              new Date(segment.started_at).getTime() -
+                new Date(log.timestamp!).getTime(),
+            ) <= 5000,
+        );
+      })
+      .map((log) => {
+        const l = log.target_id ? lines.get(log.target_id) : undefined;
+        const w = l ? wos.get(l.work_order_id) : undefined;
+        return {
+          id: `${log.id}:release`,
+          timestamp: log.timestamp!,
+          employeeName: name(profiles.get(log.user_id ?? "")),
+          action: "released hold on job",
+          workOrderNumber: woNum(w),
+          lineDescription: l?.description ?? null,
+          workOrderId: l?.work_order_id ?? null,
+          lineId: l?.id ?? null,
+        };
+      }),
   ]
     .sort(
       (a, b) =>
-        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime() ||
+        a.id.localeCompare(b.id),
     )
     .slice(0, 50);
   const worked = activities.reduce(
@@ -689,7 +847,7 @@ export function composeWorkforceActivity(input: {
     sourceMap: {
       shiftState: "tech_shifts + punch_events",
       jobActivity:
-        "work_order_line_labor_segments + work_order_lines + work_orders",
+        "work_order_line_labor_segments + activity_logs + work_order_lines + work_orders",
       identity: "profiles scoped by shop_id",
       customerVehicle: "customers + vehicles scoped by shop_id",
     },

--- a/tests/workforce-activity.test.ts
+++ b/tests/workforce-activity.test.ts
@@ -413,6 +413,190 @@ describe("workforce activity DTO", () => {
     expect(a.operationalState).toBe("clocked_in_idle");
     expect(a.currentJob).toBeNull();
   });
+  it("reports hold closure as placed on hold instead of finished", () => {
+    const r = base({
+      shifts: [shift],
+      segments: [
+        {
+          ...segment,
+          ended_at: "2026-07-10T17:45:00.000Z",
+          pause_reason: "hold:Awaiting parts",
+        },
+      ],
+      lines: [
+        {
+          ...line,
+          status: "on_hold",
+          line_status: "on_hold",
+          hold_reason: "Awaiting parts",
+        },
+      ],
+      workOrders: [wo],
+      operationalLogs: [
+        {
+          id: "log-pause",
+          action: "pause",
+          user_id: "tech-1",
+          timestamp: "2026-07-10T17:45:00.000Z",
+          target_table: "work_order_line",
+          target_id: "line-1",
+          context: null,
+        },
+      ],
+    } as any);
+    expect(r.feed.map((i) => i.action)).toContain(
+      "placed job on hold — Awaiting parts",
+    );
+    expect(r.feed.map((i) => i.action)).not.toContain("finished job");
+    expect(r.feed.map((i) => i.action)).not.toContain("completed job");
+  });
+
+  it("reports hold release without fabricating resumed work", () => {
+    const r = base({
+      shifts: [shift],
+      segments: [
+        {
+          ...segment,
+          ended_at: "2026-07-10T17:45:00.000Z",
+          pause_reason: "hold",
+        },
+      ],
+      lines: [{ ...line, status: "awaiting", line_status: "awaiting" }],
+      workOrders: [wo],
+      operationalLogs: [
+        {
+          id: "log-release",
+          action: "resume",
+          user_id: "tech-1",
+          timestamp: "2026-07-10T17:50:00.000Z",
+          target_table: "work_order_line",
+          target_id: "line-1",
+          context: null,
+        },
+      ],
+    } as any);
+    expect(r.feed[0].action).toBe("released hold on job");
+    expect(r.feed.map((i) => i.action)).not.toContain("resumed job");
+  });
+
+  it("reports hold release then restart as release followed by resumed job and deduplicates sold labor", () => {
+    const r = base({
+      shifts: [shift],
+      segments: [
+        {
+          ...segment,
+          id: "seg-1",
+          started_at: "2026-07-10T17:00:00.000Z",
+          ended_at: "2026-07-10T17:27:00.000Z",
+          pause_reason: "hold",
+        },
+        {
+          ...segment,
+          id: "seg-2",
+          started_at: "2026-07-10T17:49:00.000Z",
+          ended_at: null,
+          source: "job_resume",
+        },
+      ],
+      lines: [line],
+      workOrders: [wo],
+      operationalLogs: [
+        {
+          id: "log-release",
+          action: "resume",
+          user_id: "tech-1",
+          timestamp: "2026-07-10T17:40:00.000Z",
+          target_table: "work_order_line",
+          target_id: "line-1",
+          context: null,
+        },
+      ],
+    } as any);
+    expect(r.feed.slice(0, 4).map((i) => i.action)).toEqual([
+      "resumed job",
+      "released hold on job",
+      "placed job on hold",
+      "started job",
+    ]);
+    expect(r.activities[0].today.soldLaborHours).toBe(1);
+  });
+
+  it("reports actual completion only when completion semantics are present", () => {
+    const r = base({
+      shifts: [shift],
+      segments: [
+        {
+          ...segment,
+          ended_at: "2026-07-10T17:45:00.000Z",
+          pause_reason: "completed",
+        },
+      ],
+      lines: [{ ...line, status: "completed", line_status: "completed" }],
+      workOrders: [wo],
+      operationalLogs: [
+        {
+          id: "log-finish",
+          action: "finish",
+          user_id: "tech-1",
+          timestamp: "2026-07-10T17:45:00.000Z",
+          target_table: "work_order_line",
+          target_id: "line-1",
+          context: null,
+        },
+      ],
+    } as any);
+    expect(r.feed[0].action).toBe("completed job");
+  });
+
+  it("reports shift-end closure without completion wording", () => {
+    const r = base({
+      shifts: [{ ...shift, end_time: "2026-07-10T17:45:00.000Z" }],
+      segments: [
+        {
+          ...segment,
+          ended_at: "2026-07-10T17:45:00.000Z",
+          pause_reason: "shift_end",
+        },
+      ],
+      lines: [line],
+      workOrders: [wo],
+    });
+    expect(r.feed[0].action).toBe("job time stopped at shift end");
+  });
+
+  it("uses neutral wording for unknown segment closure reasons", () => {
+    const r = base({
+      shifts: [shift],
+      segments: [{ ...segment, ended_at: "2026-07-10T17:45:00.000Z" }],
+      lines: [line],
+      workOrders: [wo],
+    });
+    expect(r.feed[0].action).toBe("stopped job time");
+  });
+
+  it("keeps historical hold wording stable after later line status changes", () => {
+    const r = base({
+      shifts: [shift],
+      segments: [
+        {
+          ...segment,
+          ended_at: "2026-07-10T17:45:00.000Z",
+          pause_reason: "hold:Awaiting parts",
+        },
+      ],
+      lines: [
+        {
+          ...line,
+          status: "completed",
+          line_status: "completed",
+          hold_reason: null,
+        },
+      ],
+      workOrders: [wo],
+    });
+    expect(r.feed[0].action).toBe("placed job on hold");
+  });
+
   it("orders combined feed newest first", () => {
     const r = base({
       shifts: [shift],


### PR DESCRIPTION
### Motivation

- The activity feed incorrectly treated every closed labor segment as a "finished job", causing hold/pause/shift-end closures to be misreported as job completion; the feed must report the real business event that caused the segment to close.
- The change aims to preserve historical accuracy and avoid inferring completion from `ended_at` alone by using existing closure metadata and operational logs where available.

### Description

- Add a segment classifier `resolveLaborSegmentFeedAction(...)` and `actionCopy(...)` in `features/workforce/server/buildWorkforceActivity.ts` to map segments to canonical events (`started_job`, `resumed_job`, `placed_on_hold`, `paused_job`, `completed_job`, `stopped_at_shift_end`, `stopped_job_time`) and to keep human-facing copy separate from classification.
- Extend the workforce activity query to load `activity_logs` for `work_order_line` rows and aggregate logs per line, and use near-timestamp logs plus `pause_reason`/`source` on segments to decide why a segment ended; update feed composition to use the new classifier and include `released hold on job` items from `activity_logs` without fabricating resumes.
- Persist explicit closure reasons by adding an optional `pauseReason` parameter to `closeActiveLaborSegments` and stamping `pause_reason` when pauses/holds or finishes occur in `features/work-orders/server/applyJobPunchTransition.ts`, while continuing to sync the line punch mirror via `syncLinePunchMirrorFromSegments`.
- Add deterministic tie-break ordering for feed items and include `hold_reason` when present in line metadata for clearer hold wording; update `features/workforce/server/buildWorkforceActivity.ts`, `features/work-orders/server/laborSegments.ts`, and `features/work-orders/server/applyJobPunchTransition.ts` accordingly and add regression tests in `tests/workforce-activity.test.ts` covering hold, release, resume, completion, shift-end, neutral closures, historical stability, and ordering.

### Testing

- Ran unit tests with `npx vitest run tests/workforce-activity.test.ts tests/work-order-job-punch-transition.test.ts tests/work-order-line-transitions.test.ts tests/mobile-shift-lifecycle-route.test.ts tests/shift-status.test.ts tests/attendance-display-enrichment.test.ts` and observed all test files passing (total tests passed: 59/59).
- Ran type check with `npx tsc --noEmit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51454308a88328b039439ad0423c19)