### PR TITLE
Fix work order board Server Component link serialization

### DIFF
--- a/app/work-orders/board/page.tsx
+++ b/app/work-orders/board/page.tsx
@@ -10,7 +10,9 @@ export default async function WorkOrderBoardPage({
 }) {
   const identity = await getDashboardIdentity();
   const params = await searchParams;
-  const rawStage = Array.isArray(params?.stage) ? params?.stage[0] : params?.stage;
+  const rawStage = Array.isArray(params?.stage)
+    ? params?.stage[0]
+    : params?.stage;
   const initialStage = parseWorkOrderBoardStageFilter(rawStage);
   return (
     <main className="min-h-screen px-4 py-6 text-white md:px-6">
@@ -20,7 +22,6 @@ export default async function WorkOrderBoardPage({
           variant="shop"
           title="Shop work order board"
           subtitle="Read-only board for real-time workflow visibility across active work orders."
-          hrefBuilder={(row) => `/work-orders/${row.work_order_id}`}
           initialStage={initialStage}
         />
       </div>

--- a/features/shared/components/workboard/WorkOrderBoard.tsx
+++ b/features/shared/components/workboard/WorkOrderBoard.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../lib/workboard/filters";
 
 type FilterKey = WorkOrderBoardFilterKey;
+type WorkOrderBoardHrefMode = "none" | "shop-work-order";
 
 function labelForFilter(key: FilterKey): string {
   if (key === "all") return "All";
@@ -24,6 +25,23 @@ function isCompletedStage(row: WorkOrderBoardRow): boolean {
   return row.overall_stage === "completed";
 }
 
+function defaultHrefModeForVariant(
+  variant: WorkOrderBoardVariant,
+): WorkOrderBoardHrefMode {
+  return variant === "shop" ? "shop-work-order" : "none";
+}
+
+function resolveWorkOrderBoardHref(
+  row: WorkOrderBoardRow,
+  mode: WorkOrderBoardHrefMode,
+): string | null {
+  if (mode === "shop-work-order") {
+    return `/work-orders/${row.work_order_id}`;
+  }
+
+  return null;
+}
+
 export default function WorkOrderBoard(props: {
   variant: WorkOrderBoardVariant;
   title: string;
@@ -31,6 +49,11 @@ export default function WorkOrderBoard(props: {
   limit?: number;
   fleetId?: string | null;
   compact?: boolean;
+  /**
+   * Serializable href behavior for Server Component callers. Client Component
+   * callers can still use hrefBuilder when they need custom in-client links.
+   */
+  hrefMode?: WorkOrderBoardHrefMode;
   hrefBuilder?: (row: WorkOrderBoardRow) => string | null;
   initialStage?: FilterKey;
 }) {
@@ -108,6 +131,11 @@ export default function WorkOrderBoard(props: {
 
   const showCompletedSection =
     !props.compact && (stageFilter === "all" || stageFilter === "completed");
+  const hrefMode = props.hrefMode ?? defaultHrefModeForVariant(props.variant);
+  const buildRowHref = (row: WorkOrderBoardRow) =>
+    props.hrefBuilder
+      ? props.hrefBuilder(row)
+      : resolveWorkOrderBoardHref(row, hrefMode);
 
   const activeCount = useMemo(
     () => rows.filter((row) => !isCompletedStage(row)).length,
@@ -137,12 +165,33 @@ export default function WorkOrderBoard(props: {
 
   const completedCount = counts.completed;
   const queueGroups = [
-    { label: "At Risk", count: rows.filter((row) => row.risk_level === "danger" || row.risk_level === "warn").length },
-    { label: "Blocked", count: rows.filter((row) => row.overall_stage === "on_hold").length },
-    { label: "Ready to Work", count: rows.filter((row) => row.overall_stage === "awaiting").length },
-    { label: "Working", count: rows.filter((row) => row.overall_stage === "in_progress").length },
-    { label: "Awaiting Approval", count: rows.filter((row) => row.overall_stage === "awaiting_approval").length },
-    { label: "Waiting Parts", count: rows.filter((row) => row.overall_stage === "waiting_parts").length },
+    {
+      label: "At Risk",
+      count: rows.filter(
+        (row) => row.risk_level === "danger" || row.risk_level === "warn",
+      ).length,
+    },
+    {
+      label: "Blocked",
+      count: rows.filter((row) => row.overall_stage === "on_hold").length,
+    },
+    {
+      label: "Ready to Work",
+      count: rows.filter((row) => row.overall_stage === "awaiting").length,
+    },
+    {
+      label: "Working",
+      count: rows.filter((row) => row.overall_stage === "in_progress").length,
+    },
+    {
+      label: "Awaiting Approval",
+      count: rows.filter((row) => row.overall_stage === "awaiting_approval")
+        .length,
+    },
+    {
+      label: "Waiting Parts",
+      count: rows.filter((row) => row.overall_stage === "waiting_parts").length,
+    },
     { label: "Completed Today", count: completedCount },
   ].filter((group) => group.count > 0);
 
@@ -170,7 +219,8 @@ export default function WorkOrderBoard(props: {
                 Active: <span className="text-white">{activeCount}</span>
               </div>
               <div className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-                Needs attention: <span className="text-white">{stalledCount}</span>
+                Needs attention:{" "}
+                <span className="text-white">{stalledCount}</span>
               </div>
               <div className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200">
                 Waiters: <span className="text-white">{waiterCount}</span>
@@ -187,10 +237,17 @@ export default function WorkOrderBoard(props: {
 
         <div className="flex flex-col gap-2 md:min-w-[380px]">
           {queueGroups.length > 0 ? (
-            <div data-testid="queue-awareness-groups" className="flex flex-wrap gap-2">
+            <div
+              data-testid="queue-awareness-groups"
+              className="flex flex-wrap gap-2"
+            >
               {queueGroups.map((group) => (
-                <div key={group.label} className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200">
-                  {group.label}: <span className="text-white">{group.count}</span>
+                <div
+                  key={group.label}
+                  className="rounded-full border border-white/10 bg-black/25 px-3 py-1 text-[11px] font-semibold text-neutral-200"
+                >
+                  {group.label}:{" "}
+                  <span className="text-white">{group.count}</span>
                 </div>
               ))}
             </div>
@@ -216,7 +273,9 @@ export default function WorkOrderBoard(props: {
                 ].join(" ")}
               >
                 {labelForFilter(key)}{" "}
-                <span className="ml-1 text-[10px] opacity-80">{counts[key]}</span>
+                <span className="ml-1 text-[10px] opacity-80">
+                  {counts[key]}
+                </span>
               </button>
             ))}
 
@@ -270,7 +329,9 @@ export default function WorkOrderBoard(props: {
               <div
                 className={[
                   "grid gap-3",
-                  props.compact ? "grid-cols-1" : "md:grid-cols-2 xl:grid-cols-3",
+                  props.compact
+                    ? "grid-cols-1"
+                    : "md:grid-cols-2 xl:grid-cols-3",
                 ].join(" ")}
               >
                 {activeRows.map((row) => (
@@ -279,7 +340,7 @@ export default function WorkOrderBoard(props: {
                     row={row}
                     variant={props.variant}
                     compact={props.compact}
-                    href={props.hrefBuilder ? props.hrefBuilder(row) : null}
+                    href={buildRowHref(row)}
                   />
                 ))}
               </div>
@@ -309,7 +370,7 @@ export default function WorkOrderBoard(props: {
                       row={row}
                       variant={props.variant}
                       compact={false}
-                      href={props.hrefBuilder ? props.hrefBuilder(row) : null}
+                      href={buildRowHref(row)}
                     />
                   ))}
                 </div>

--- a/tests/work-order-board-rsc-boundary.test.tsx
+++ b/tests/work-order-board-rsc-boundary.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import WorkOrderBoard from "@/features/shared/components/workboard/WorkOrderBoard";
+import type { WorkOrderBoardRow } from "@/features/shared/lib/workboard/types";
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+const mockRows: WorkOrderBoardRow[] = [
+  {
+    work_order_id: "wo-shop-link",
+    custom_id: "WO-SHOP-LINK",
+    display_name: "Shop Link Customer",
+    unit_label: null,
+    vehicle_label: null,
+    jobs_total: 2,
+    jobs_completed: 1,
+    progress_pct: 50,
+    assigned_summary: null,
+    overall_stage: "in_progress",
+    risk_level: "none",
+    priority: 3,
+    is_waiter: false,
+    advisor_name: null,
+    first_tech_name: null,
+    tech_names: [],
+  },
+  {
+    work_order_id: "wo-waiting-parts",
+    custom_id: "WO-WAITING-PARTS",
+    display_name: "Waiting Parts Customer",
+    unit_label: null,
+    vehicle_label: null,
+    jobs_total: 1,
+    jobs_completed: 0,
+    progress_pct: 0,
+    assigned_summary: null,
+    overall_stage: "waiting_parts",
+    risk_level: "warn",
+    priority: 2,
+    is_waiter: false,
+    advisor_name: null,
+    first_tech_name: null,
+    tech_names: [],
+  },
+];
+
+vi.mock("@/features/shared/hooks/useWorkOrderBoard", () => ({
+  useWorkOrderBoard: () => ({
+    rows: mockRows,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("WorkOrderBoard Server Component boundary regression", () => {
+  it("keeps the shop board page on serializable props while preserving switcher and initialStage", () => {
+    const source = read("app/work-orders/board/page.tsx");
+
+    expect(source).toContain("<OperationalViewSwitcher");
+    expect(source).toContain("parseWorkOrderBoardStageFilter");
+    expect(source).toContain("initialStage={initialStage}");
+    expect(source).not.toContain("hrefBuilder=");
+  });
+
+  it("resolves shop work-order rows to canonical work order detail hrefs inside the client board", () => {
+    render(<WorkOrderBoard variant="shop" title="Board" />);
+
+    expect(screen.getByText("WO-SHOP-LINK").closest("a")).toHaveAttribute(
+      "href",
+      "/work-orders/wo-shop-link",
+    );
+  });
+
+  it("still initializes from initialStage", () => {
+    render(
+      <WorkOrderBoard
+        variant="shop"
+        title="Board"
+        initialStage="waiting_parts"
+      />,
+    );
+
+    expect(screen.getByText("WO-WAITING-PARTS")).toBeInTheDocument();
+    expect(screen.queryByText("WO-SHOP-LINK")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Motivation
- The production RSC render failure on `/work-orders/board` was caused by a Server Component passing a non-serializable inline function prop (`hrefBuilder`) into the client `WorkOrderBoard`, which breaks Server→Client serialization. 
- The change preserves the page as a Server Component and keeps `OperationalViewSwitcher`, `initialStage` parsing, and all visible board behaviors while removing the non-serializable boundary violation.

### Description
- Removed the inline `hrefBuilder` prop from `app/work-orders/board/page.tsx` and switched the page to pass only serializable props. 
- Added a serializable `hrefMode` contract and internal resolution helpers in `features/shared/components/workboard/WorkOrderBoard.tsx` that default the shop variant to `/work-orders/${row.work_order_id}` while still allowing Client Component parents to supply an optional `hrefBuilder`. 
- Updated `WorkOrderBoard` to compute `buildRowHref(row)` internally and apply it to active and completed `WorkOrderBoardCard` instances, preserving search, refresh, counts, queue groups, card badges, and completed sections. 
- Added a targeted regression test `tests/work-order-board-rsc-boundary.test.tsx` that asserts the page no longer passes `hrefBuilder`, that shop rows link to `/work-orders/[work_order_id]`, that `initialStage` is honored, and that `OperationalViewSwitcher` remains rendered.

### Testing
- Ran `npx tsc --noEmit` and TypeScript validation succeeded. 
- Ran `npx vitest run tests/phase-d1-dashboard-links.test.tsx tests/phase-d2-operational-dashboard.test.tsx tests/phase-d3-dashboard-navigation.test.tsx tests/work-order-board-rsc-boundary.test.tsx` and all test files passed (4 test files, 27 tests total). 
- Ran a code check (`git diff --check`) which reported no issues.

Commit SHA: `66d381772442c8b5e6013cee3f2b75f61fdb1d3c`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5171e35c788328a01cb2b4836d0e86)