### PR TITLE
Fix parts request inventory stock totals

### DIFF
--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -20,6 +20,7 @@ import { GuidedImportSummary } from "@/features/shared/components/import/GuidedI
 import { GuidedImportCardLayout } from "@/features/shared/components/import/GuidedImportCardLayout";
 import { GuidedImportFooterActions } from "@/features/shared/components/import/GuidedImportFooterActions";
 import { parseGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/query";
+import { loadStockOnHandByPartId } from "@/features/parts/lib/stock-on-hand";
 
 /* ----------------------------- Types ----------------------------- */
 
@@ -28,7 +29,7 @@ type Part = DB["public"]["Tables"]["parts"]["Row"];
 type PartInsert = DB["public"]["Tables"]["parts"]["Insert"];
 type PartUpdate = DB["public"]["Tables"]["parts"]["Update"];
 type StockLoc = DB["public"]["Tables"]["stock_locations"]["Row"];
-type StockMove = DB["public"]["Tables"]["stock_moves"]["Row"];
+type StockMove = Pick<DB["public"]["Tables"]["stock_moves"]["Row"], "location_id" | "qty_change">;
 type AliasRow = {
   part_id: string;
   alias_type: string | null;
@@ -524,23 +525,11 @@ export default function InventoryPage(): JSX.Element {
         setOnHand({});
         return;
       }
-      const { data, error } = await supabase
-        .from("stock_moves")
-        .select("part_id, qty_change")
-        .in("part_id", partIds)
-        .eq("shop_id", sid);
-
-      if (error || !data) {
+      try {
+        setOnHand(await loadStockOnHandByPartId(supabase, sid, partIds));
+      } catch {
         setOnHand({});
-        return;
       }
-
-      const totals: Record<string, number> = {};
-      (data as StockMove[]).forEach((m) => {
-        const delta = Number(m.qty_change) || 0;
-        totals[m.part_id] = (totals[m.part_id] ?? 0) + delta;
-      });
-      setOnHand(totals);
     },
     [supabase],
   );

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -44,6 +44,10 @@ import {
   type DeterministicSupplierSuggestion,
 } from "@/features/parts/lib/parts/deterministicSupplierMatcher";
 import { getStockSuggestionDisplay } from "@/features/parts/lib/parts/suggestionDisplay";
+import {
+  loadStockOnHandByPartId,
+  toStockSummaryRowsFromOnHand,
+} from "@/features/parts/lib/stock-on-hand";
 
 type DB = Database;
 
@@ -456,7 +460,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
 
     const shopId = woRow.shop_id ?? null;
     if (shopId) {
-      const [{ data: ps }, { data: locs }, { data: poRows }, { data: supRows }, { data: stockRows }, { data: vendorRows }] =
+      const [{ data: ps }, { data: locs }, { data: poRows }, { data: supRows }, { data: vendorRows }] =
         await Promise.all([
           supabase
             .from("parts")
@@ -481,10 +485,6 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
             .eq("shop_id", shopId)
             .order("name", { ascending: true })
             .limit(500),
-          supabase
-            .from("part_stock_summary")
-            .select("part_id, shop_id, on_hand, qty_available")
-            .eq("shop_id", shopId),
           supabase
             .from("vendor_part_numbers")
             .select("id, part_id, shop_id, supplier_id, vendor_sku")
@@ -536,16 +536,19 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
 
       const suggestions: Record<string, DeterministicStockSuggestion[]> = {};
       const supplierSuggestions: Record<string, DeterministicSupplierSuggestion[]> = {};
-      const stockSummaryRows = (((stockRows ?? []) as unknown) as DB["public"]["Views"]["part_stock_summary"]["Row"][]);
-      const stockAvailableMap = new Map<string, number>();
-      const stockAvailableRecord: Record<string, number> = {};
-      for (const stockRow of stockSummaryRows) {
-        if (!stockRow.part_id) continue;
-        const qty = Number((stockRow as { qty_available?: number | null }).qty_available ?? stockRow.on_hand ?? 0);
-        const safeQty = Number.isFinite(qty) ? qty : 0;
-        stockAvailableMap.set(String(stockRow.part_id), safeQty);
-        stockAvailableRecord[String(stockRow.part_id)] = safeQty;
+      let stockAvailableRecord: Record<string, number> = {};
+      try {
+        stockAvailableRecord = await loadStockOnHandByPartId(
+          supabase,
+          shopId,
+          partRows.map((part) => String(part.id)),
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to load inventory stock.";
+        toast.error(`Inventory stock could not be loaded: ${message}`);
       }
+      const stockSummaryRows = toStockSummaryRowsFromOnHand(stockAvailableRecord);
+      const stockAvailableMap = new Map<string, number>(Object.entries(stockAvailableRecord));
       setStockAvailableByPartId(stockAvailableRecord);
       for (const req of uiRequests) {
         for (const item of req.items) {
@@ -557,7 +560,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
             requestedManufacturer: item.requested_manufacturer,
             requestedQty: toNum(item.qty, 1),
             parts: partRows,
-            stockSummaries: ((stockRows ?? []) as unknown) as DB["public"]["Views"]["part_stock_summary"]["Row"][],
+            stockSummaries: stockSummaryRows,
             vendorPartNumbers: ((vendorRows ?? []) as unknown) as DB["public"]["Tables"]["vendor_part_numbers"]["Row"][],
             limit: 2,
           });

--- a/features/parts/components/request-workbench/InventoryPickerModal.test.tsx
+++ b/features/parts/components/request-workbench/InventoryPickerModal.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { InventoryPickerModal } from "./InventoryPickerModal";
+import { sumStockMovesByPartId } from "@/features/parts/lib/stock-on-hand";
+
+describe("InventoryPickerModal", () => {
+  it("renders physical on-hand totals calculated from stock moves", () => {
+    const stockByPartId = sumStockMovesByPartId([
+      { part_id: "part-1", qty_change: 60 },
+      { part_id: "part-1", qty_change: 40 },
+    ]);
+
+    render(
+      <InventoryPickerModal
+        open
+        results={[
+          {
+            value: "part-1",
+            label: "Imported oil filter",
+            onHandQty: stockByPartId["part-1"],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("On hand: 100")).toBeInTheDocument();
+  });
+});

--- a/features/parts/components/request-workbench/InventoryPickerModal.tsx
+++ b/features/parts/components/request-workbench/InventoryPickerModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import type { WorkbenchOption } from "./types";
 import { WorkbenchModalFrame, modalButton, modalInput, modalPrimaryButton } from "./WorkbenchModalFrame";
 
@@ -37,8 +38,10 @@ export function InventoryPickerModal({
   onClose?: () => void;
 }): JSX.Element | null {
   const selected = results.find((result) => result.value === selectedPartId) ?? null;
-  const onHand = Number(selected?.onHandQty ?? 0);
-  const zeroStock = !!selected && onHand <= 0;
+  const selectedOnHand = selected?.onHandQty;
+  const onHand = Number(selectedOnHand ?? 0);
+  const stockUnknown = selectedOnHand == null;
+  const zeroStock = !!selected && !stockUnknown && onHand <= 0;
 
   return (
     <WorkbenchModalFrame
@@ -88,7 +91,9 @@ export function InventoryPickerModal({
                   <div className="mt-1 text-xs text-neutral-400">
                     {[result.sku, result.partNumber, result.manufacturer].filter(Boolean).join(" • ") || "No part metadata"}
                   </div>
-                  <div className="mt-1 text-xs text-neutral-300">On hand: {Number(result.onHandQty ?? 0)}</div>
+                  <div className="mt-1 text-xs text-neutral-300">
+                    On hand: {result.onHandQty == null ? "Unavailable" : Number(result.onHandQty)}
+                  </div>
                 </div>
               </div>
             </label>

--- a/features/parts/components/request-workbench/WorkbenchModalFrame.tsx
+++ b/features/parts/components/request-workbench/WorkbenchModalFrame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import React, { type ReactNode } from "react";
 
 export function WorkbenchModalFrame({
   open,

--- a/features/parts/components/request-workbench/mapToWorkbenchModel.ts
+++ b/features/parts/components/request-workbench/mapToWorkbenchModel.ts
@@ -100,7 +100,9 @@ export function mapRequestToWorkbenchModel(input: {
         sku: nullableText(part.sku),
         partNumber: nullableText(part.part_number),
         manufacturer: nullableText(part.manufacturer ?? part.supplier),
-        onHandQty: input.stockAvailableByPartId?.[partId] ?? 0,
+        onHandQty: Object.prototype.hasOwnProperty.call(input.stockAvailableByPartId ?? {}, partId)
+          ? input.stockAvailableByPartId?.[partId]
+          : null,
       };
     }),
     items: input.items.map((item) => {

--- a/features/parts/lib/stock-on-hand.ts
+++ b/features/parts/lib/stock-on-hand.ts
@@ -1,0 +1,75 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type StockMoveQuantityRow = Pick<
+  Database["public"]["Tables"]["stock_moves"]["Row"],
+  "part_id" | "qty_change"
+>;
+
+type StockMoveQueryResult = {
+  data: StockMoveQuantityRow[] | null;
+  error: { message?: string } | null;
+};
+
+type SupabaseStockMoveClient = {
+  from: (table: "stock_moves") => {
+    select: (columns: "part_id, qty_change") => {
+      eq: (column: "shop_id", value: string) => {
+        in: (column: "part_id", values: string[]) => PromiseLike<StockMoveQueryResult>;
+      };
+    };
+  };
+};
+
+export type StockOnHandByPartId = Record<string, number>;
+
+export function sumStockMovesByPartId(
+  moves: readonly Pick<StockMoveQuantityRow, "part_id" | "qty_change">[],
+): StockOnHandByPartId {
+  const totals: StockOnHandByPartId = {};
+
+  for (const move of moves) {
+    const partId = String(move.part_id ?? "").trim();
+    if (!partId) continue;
+
+    const delta = Number(move.qty_change);
+    totals[partId] = (totals[partId] ?? 0) + (Number.isFinite(delta) ? delta : 0);
+  }
+
+  return totals;
+}
+
+export async function loadStockOnHandByPartId(
+  supabase: SupabaseStockMoveClient,
+  shopId: string,
+  partIds: readonly string[],
+): Promise<StockOnHandByPartId> {
+  const uniquePartIds = Array.from(new Set(partIds.map((id) => String(id).trim()).filter(Boolean)));
+  if (uniquePartIds.length === 0) return {};
+
+  const { data, error } = await supabase
+    .from("stock_moves")
+    .select("part_id, qty_change")
+    .eq("shop_id", shopId)
+    .in("part_id", uniquePartIds);
+
+  if (error) {
+    throw new Error(error.message || "Unable to load stock moves for inventory on-hand totals.");
+  }
+
+  return sumStockMovesByPartId(data ?? []);
+}
+
+export function toStockSummaryRowsFromOnHand(
+  stockOnHandByPartId: StockOnHandByPartId,
+): Database["public"]["Views"]["part_stock_summary"]["Row"][] {
+  return Object.entries(stockOnHandByPartId).map(([part_id, on_hand]) => ({
+    category: null,
+    move_count: null,
+    name: null,
+    on_hand,
+    part_id,
+    price: null,
+    shop_id: null,
+    sku: null,
+  }));
+}


### PR DESCRIPTION
### Motivation
- Prevent inventory picker from showing `On hand: 0` for every part when the stock summary lookup is missing or failed.  The root cause was divergence between the inventory page (which sums `stock_moves.qty_change`) and the request workbench (which relied on `part_stock_summary` and then defaulted missing values to `0`).
- Ensure physical on-hand is the canonical source for the picker UI and avoid silently substituting `qty_available` or stale `parts.quantity` fields for physical on-hand.

### Description
- Introduced a shared helper `loadStockOnHandByPartId` and `sumStockMovesByPartId` in `features/parts/lib/stock-on-hand.ts` that loads `stock_moves.part_id, qty_change`, filters by `shop_id` and part IDs, and returns summed on-hand totals by `part_id`.
- Replaced duplicated on-hand aggregation in `app/parts/inventory/page.tsx` to call `loadStockOnHandByPartId` so the inventory page and request workbench use the same canonical logic.
- Updated `app/parts/requests/[id]/page.tsx` to load stock from `stock_moves` (via the shared helper), use the resulting map for `stockAvailableByPartId` and `inventoryResults.onHandQty`, and surface query failures with a toast instead of defaulting values to zero.
- Changed `mapRequestToWorkbenchModel` (`features/parts/components/request-workbench/mapToWorkbenchModel.ts`) to preserve missing stock as `null` instead of `0` so UI can render unknown stock separately.
- Updated `InventoryPickerModal` (`features/parts/components/request-workbench/InventoryPickerModal.tsx`) to display `On hand: Unavailable` when stock is missing and only show the zero-stock warning for known zero values.
- Added a regression test `features/parts/components/request-workbench/InventoryPickerModal.test.tsx` that uses `sumStockMovesByPartId` to assert that two stock_moves (60 + 40) render `On hand: 100` in the picker.
- Minor test/runtime adjustments: added `React` import to components used in tests and a small typing adapter in the helper to keep compatibility with the Supabase client types.

Files changed: `features/parts/lib/stock-on-hand.ts`, `app/parts/inventory/page.tsx`, `app/parts/requests/[id]/page.tsx`, `features/parts/components/request-workbench/mapToWorkbenchModel.ts`, `features/parts/components/request-workbench/InventoryPickerModal.tsx`, `features/parts/components/request-workbench/WorkbenchModalFrame.tsx`, and added test `features/parts/components/request-workbench/InventoryPickerModal.test.tsx`.

### Testing
- Ran `npm run typecheck` and it completed successfully (no new TypeScript errors introduced). 
- Ran `npx eslint app/parts/requests/[id]/page.tsx app/parts/inventory/page.tsx features/parts --ext .ts,.tsx` which completed with no new errors (6 pre-existing warnings noted in unrelated files). 
- Ran `npx vitest run features/parts/components/request-workbench/InventoryPickerModal.test.tsx` and the new regression test passed, verifying `On hand: 100` renders for summed `stock_moves` totals.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51ab172f1c8328947d70c3ad77c780)