### PR TITLE
Coordinate shift break/lunch transitions with job labor clocks

### DIFF
--- a/app/api/mobile/shifts/route.ts
+++ b/app/api/mobile/shifts/route.ts
@@ -1,5 +1,16 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import type { Json } from "@shared/types/types/supabase";
+import {
+  closeAllActiveTechnicianJobLabor,
+  getActiveTechnicianJobLabor,
+  startTechnicianJobLabor,
+} from "@/features/work-orders/server/technicianJobLabor";
+import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
 import {
   PUNCH_EVENT_TYPES,
   SHIFT_ACTIVITIES,
@@ -12,27 +23,82 @@ import {
   type ShiftStatus,
 } from "@/features/workforce/lib/shift-status";
 
-type Action = PunchEventType | "start_break" | "end_break" | "start_lunch" | "end_lunch" | "toggle_break" | "toggle_lunch";
+type Action =
+  | PunchEventType
+  | "start_break"
+  | "end_break"
+  | "start_lunch"
+  | "end_lunch"
+  | "toggle_break"
+  | "toggle_lunch";
 type Caller = { id: string; shop_id: string | null };
-type ActiveShift = { id: string; start_time: string | null; status: string | null; end_time: string | null; shop_id: string | null; user_id: string | null };
-type PunchRow = { id?: string | null; event_type: string | null; timestamp: string | null; created_at?: string | null };
-type ShiftLifecycleRpcRow = ActiveShift & { inserted_events?: PunchRow[] | null };
+type ActiveShift = {
+  id: string;
+  start_time: string | null;
+  status: string | null;
+  end_time: string | null;
+  shop_id: string | null;
+  user_id: string | null;
+};
+type PunchRow = {
+  id?: string | null;
+  event_type: string | null;
+  timestamp: string | null;
+  created_at?: string | null;
+};
+type ResumeContextRow = {
+  id: string;
+  break_punch_id: string;
+  work_order_id: string | null;
+  work_order_line_id: string | null;
+  assignment_id: string | null;
+  paused_job_session_id: string | null;
+  pause_reason: string | null;
+  status: string | null;
+  metadata: Json | null;
+};
+type ShiftLifecycleRpcRow = ActiveShift & {
+  inserted_events?: PunchRow[] | null;
+};
 
 async function authz() {
   const supabase = createServerSupabaseRoute();
-  const { data: { user }, error } = await supabase.auth.getUser();
-  if (error || !user) return { ok: false as const, res: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user)
+    return {
+      ok: false as const,
+      res: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
+    };
 
-  let { data: me } = await supabase.from("profiles").select("id, shop_id").eq("id", user.id).maybeSingle<Caller>();
+  let { data: me } = await supabase
+    .from("profiles")
+    .select("id, shop_id")
+    .eq("id", user.id)
+    .maybeSingle<Caller>();
   if (!me) {
-    const byUser = await supabase.from("profiles").select("id, shop_id").eq("user_id", user.id).maybeSingle<Caller>();
+    const byUser = await supabase
+      .from("profiles")
+      .select("id, shop_id")
+      .eq("user_id", user.id)
+      .maybeSingle<Caller>();
     me = byUser.data ?? null;
   }
-  if (!me?.shop_id) return { ok: false as const, res: NextResponse.json({ error: "Missing shop" }, { status: 403 }) };
+  if (!me?.shop_id)
+    return {
+      ok: false as const,
+      res: NextResponse.json({ error: "Missing shop" }, { status: 403 }),
+    };
   return { ok: true as const, me, authUserId: user.id };
 }
 
-async function loadActiveShift(admin: ReturnType<typeof createAdminSupabase>, userIds: string[], shopId: string) {
+async function loadActiveShift(
+  admin: ReturnType<typeof createAdminSupabase>,
+  userIds: string[],
+  shopId: string,
+) {
   const cleanUserIds = [...new Set(userIds.filter(Boolean))];
   if (cleanUserIds.length === 0) return null;
   const { data, error } = await admin
@@ -51,7 +117,10 @@ async function loadActiveShift(admin: ReturnType<typeof createAdminSupabase>, us
   return data ?? null;
 }
 
-async function loadShiftEvents(admin: ReturnType<typeof createAdminSupabase>, shiftId: string | null) {
+async function loadShiftEvents(
+  admin: ReturnType<typeof createAdminSupabase>,
+  shiftId: string | null,
+) {
   if (!shiftId) return [] as PunchRow[];
   const { data, error } = await admin
     .from("punch_events")
@@ -66,7 +135,10 @@ async function loadShiftEvents(admin: ReturnType<typeof createAdminSupabase>, sh
 
 function toDto(shift: ActiveShift | null, events: PunchRow[]): ShiftStateDto {
   const latest = latestValidPunchEvent(events);
-  const activity = deriveCurrentShiftActivity(events, Boolean(shift)) as ShiftActivity;
+  const activity = deriveCurrentShiftActivity(
+    events,
+    Boolean(shift),
+  ) as ShiftActivity;
   return {
     shiftId: shift?.id ?? null,
     shiftStatus: (shift?.status as ShiftStatus | null) ?? null,
@@ -80,19 +152,27 @@ function toDto(shift: ActiveShift | null, events: PunchRow[]): ShiftStateDto {
 
 function actionToEvent(action: Action): PunchEventType | null {
   switch (action) {
-    case "start_shift": return PUNCH_EVENT_TYPES.startShift;
-    case "end_shift": return PUNCH_EVENT_TYPES.endShift;
+    case "start_shift":
+      return PUNCH_EVENT_TYPES.startShift;
+    case "end_shift":
+      return PUNCH_EVENT_TYPES.endShift;
     case "start_break":
-    case "toggle_break": return PUNCH_EVENT_TYPES.breakStart;
-    case "end_break": return PUNCH_EVENT_TYPES.breakEnd;
+    case "toggle_break":
+      return PUNCH_EVENT_TYPES.breakStart;
+    case "end_break":
+      return PUNCH_EVENT_TYPES.breakEnd;
     case "start_lunch":
-    case "toggle_lunch": return PUNCH_EVENT_TYPES.lunchStart;
-    case "end_lunch": return PUNCH_EVENT_TYPES.lunchEnd;
+    case "toggle_lunch":
+      return PUNCH_EVENT_TYPES.lunchStart;
+    case "end_lunch":
+      return PUNCH_EVENT_TYPES.lunchEnd;
     case "break_start":
     case "break_end":
     case "lunch_start":
-    case "lunch_end": return action;
-    default: return null;
+    case "lunch_end":
+      return action;
+    default:
+      return null;
   }
 }
 
@@ -107,46 +187,315 @@ function rpcShift(row: ShiftLifecycleRpcRow): ActiveShift {
   };
 }
 
+function table(supabase: ReturnType<typeof createAdminSupabase>, name: string) {
+  return supabase.from(name as never) as any;
+}
+
+function resumeMessage(reason: string | null | undefined) {
+  if (!reason)
+    return "Break ended. The previous job was not resumed because the line is no longer available.";
+  if (reason === "active_job_exists")
+    return "Break ended. The previous job was not resumed because another job is already active.";
+  if (reason === "inactive_shift")
+    return "Break ended. The previous job was not resumed because your shift is no longer active.";
+  if (reason === "line_ineligible")
+    return "Break ended. The previous job was not resumed because the line is no longer available.";
+  if (reason === "assignment_changed")
+    return "Break ended. The previous job was not resumed because the line assignment changed.";
+  return "Break ended. The previous job was not resumed because the line is no longer available.";
+}
+
+async function cancelPendingResumeContexts(params: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  shopId: string;
+  userId: string;
+  now: string;
+  reason: string;
+}) {
+  await table(params.admin, "workforce_job_resume_contexts")
+    .update({
+      status: "cancelled",
+      cancelled_at: params.now,
+      cancel_reason: params.reason,
+      updated_at: params.now,
+    })
+    .eq("shop_id", params.shopId)
+    .eq("user_id", params.userId)
+    .eq("status", "pending");
+}
+
+async function createResumeContext(params: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  shopId: string;
+  userId: string;
+  breakPunchId: string;
+  pauseReason: "break" | "lunch";
+  pausedAt: string;
+  activeSegments: Array<{
+    id: string;
+    work_order_id: string | null;
+    work_order_line_id: string | null;
+  }>;
+}) {
+  if (params.activeSegments.length === 0) return null;
+  const one =
+    params.activeSegments.length === 1 ? params.activeSegments[0] : null;
+  const status = one ? "pending" : "invalid";
+  const payload = {
+    shop_id: params.shopId,
+    user_id: params.userId,
+    break_punch_id: params.breakPunchId,
+    work_order_id: one?.work_order_id ?? null,
+    work_order_line_id: one?.work_order_line_id ?? null,
+    assignment_id: null,
+    paused_job_session_id: one?.id ?? null,
+    pause_reason: params.pauseReason,
+    status,
+    paused_at: params.pausedAt,
+    cancel_reason: one ? null : "multiple_active_jobs",
+    metadata: { active_segment_ids: params.activeSegments.map((s) => s.id) },
+    created_at: params.pausedAt,
+    updated_at: params.pausedAt,
+  };
+  const { data, error } = await table(
+    params.admin,
+    "workforce_job_resume_contexts",
+  )
+    .insert(payload)
+    .select(
+      "id, break_punch_id, work_order_id, work_order_line_id, assignment_id, paused_job_session_id, pause_reason, status, metadata",
+    )
+    .single();
+  if (error) throw new Error(`Resume context insert failed: ${error.message}`);
+  return data as ResumeContextRow;
+}
+
+async function maybeResumeJobAfterBreak(params: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  shopId: string;
+  userId: string;
+  breakPunchId: string | null;
+  now: string;
+  pauseReason: "break" | "lunch";
+}) {
+  if (!params.breakPunchId)
+    return { resumed: false, message: null as string | null };
+  const { data: context, error } = await table(
+    params.admin,
+    "workforce_job_resume_contexts",
+  )
+    .select(
+      "id, break_punch_id, work_order_id, work_order_line_id, assignment_id, paused_job_session_id, pause_reason, status, metadata",
+    )
+    .eq("shop_id", params.shopId)
+    .eq("user_id", params.userId)
+    .eq("break_punch_id", params.breakPunchId)
+    .eq("status", "pending")
+    .maybeSingle();
+  if (error) throw new Error(`Resume context lookup failed: ${error.message}`);
+  const ctx = context as ResumeContextRow | null;
+  if (!ctx?.work_order_line_id) return { resumed: false, message: null };
+
+  const cancel = async (reason: string) => {
+    await table(params.admin, "workforce_job_resume_contexts")
+      .update({
+        status: "cancelled",
+        cancelled_at: params.now,
+        cancel_reason: reason,
+        updated_at: params.now,
+      })
+      .eq("id", ctx.id)
+      .eq("status", "pending");
+    await logOperationalEvent({
+      supabase: params.admin,
+      event: "resume_cancelled",
+      actorId: params.userId,
+      entityType: "work_order_line",
+      entityId: ctx.work_order_line_id,
+      at: params.now,
+      details: {
+        shop_id: params.shopId,
+        technician_id: params.userId,
+        work_order_id: ctx.work_order_id,
+        work_order_line_id: ctx.work_order_line_id,
+        break_punch_id: params.breakPunchId,
+        reason,
+      } as Json,
+    });
+    return { resumed: false, message: resumeMessage(reason) };
+  };
+
+  const activeJobs = await getActiveTechnicianJobLabor({
+    supabase: params.admin,
+    shopId: params.shopId,
+    technicianId: params.userId,
+  });
+  if (activeJobs.error) throw new Error(activeJobs.error.message);
+  if (activeJobs.data.length > 0) return cancel("active_job_exists");
+
+  const shift = await loadActiveShift(
+    params.admin,
+    [params.userId],
+    params.shopId,
+  );
+  if (!shift) return cancel("inactive_shift");
+
+  const { data: line, error: lineErr } = await params.admin
+    .from("work_order_lines")
+    .select("id, work_order_id, shop_id, status, assigned_tech_id")
+    .eq("id", ctx.work_order_line_id)
+    .eq("shop_id", params.shopId)
+    .maybeSingle<{
+      id: string;
+      work_order_id: string | null;
+      shop_id: string | null;
+      status: string | null;
+      assigned_tech_id: string | null;
+    }>();
+  if (lineErr) throw new Error(lineErr.message);
+  if (!line) return cancel("line_ineligible");
+  if (line.assigned_tech_id && line.assigned_tech_id !== params.userId)
+    return cancel("assignment_changed");
+  const status = normalizeWorkOrderLineStatus(line.status);
+  if (
+    [
+      "completed",
+      "invoiced",
+      "ready_to_invoice",
+      "declined",
+      "deferred",
+    ].includes(status)
+  )
+    return cancel("line_ineligible");
+
+  const result = await startTechnicianJobLabor({
+    supabase: params.admin,
+    lineId: ctx.work_order_line_id,
+    technicianId: params.userId,
+    startedAtIso: params.now,
+    source: params.pauseReason === "break" ? "break_resume" : "lunch_resume",
+  });
+  if (!result.ok) return cancel("line_ineligible");
+
+  await table(params.admin, "workforce_job_resume_contexts")
+    .update({
+      status: "resumed",
+      resumed_at: params.now,
+      updated_at: params.now,
+    })
+    .eq("id", ctx.id)
+    .eq("status", "pending");
+  await logOperationalEvent({
+    supabase: params.admin,
+    event:
+      params.pauseReason === "break"
+        ? "job_resumed_after_break"
+        : "job_resumed_after_lunch",
+    actorId: params.userId,
+    entityType: "work_order_line",
+    entityId: ctx.work_order_line_id,
+    at: params.now,
+    details: {
+      shop_id: params.shopId,
+      technician_id: params.userId,
+      work_order_id: ctx.work_order_id,
+      work_order_line_id: ctx.work_order_line_id,
+      source_session_id: ctx.paused_job_session_id,
+      break_punch_id: params.breakPunchId,
+      reason: params.pauseReason,
+    } as Json,
+  });
+  return {
+    resumed: true,
+    message: `${params.pauseReason === "break" ? "Break" : "Lunch"} ended — job timer resumed`,
+  };
+}
+
 export async function GET() {
   const a = await authz();
   if (!a.ok) return a.res;
   const admin = createAdminSupabase();
   try {
-    const shift = await loadActiveShift(admin, [a.me.id, a.authUserId], a.me.shop_id as string);
+    const shift = await loadActiveShift(
+      admin,
+      [a.me.id, a.authUserId],
+      a.me.shop_id as string,
+    );
     const events = await loadShiftEvents(admin, shift?.id ?? null);
     return NextResponse.json({ ok: true, ...toDto(shift, events) });
   } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Failed to load shift state" }, { status: 500 });
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to load shift state",
+      },
+      { status: 500 },
+    );
   }
 }
 
 export async function POST(req: NextRequest) {
   const a = await authz();
   if (!a.ok) return a.res;
-  const body = (await req.json().catch(() => null)) as { action?: Action } | null;
-  if (!body?.action) return NextResponse.json({ error: "Missing action" }, { status: 400 });
+  const body = (await req.json().catch(() => null)) as {
+    action?: Action;
+  } | null;
+  if (!body?.action)
+    return NextResponse.json({ error: "Missing action" }, { status: 400 });
   const eventType = actionToEvent(body.action);
-  if (!eventType) return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
+  if (!eventType)
+    return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
 
   const admin = createAdminSupabase();
   const now = new Date().toISOString();
   const shopId = a.me.shop_id as string;
 
-  const insertPunch = async (shiftId: string, userId: string, type: PunchEventType) => {
-    const payload = { shift_id: shiftId, user_id: userId, profile_id: userId, event_type: type, timestamp: now };
-    const { data, error } = await admin.from("punch_events").insert(payload as never).select("id,event_type,timestamp,created_at").single<PunchRow>();
-    if (error || !data) throw new Error(`Punch event insert failed: ${error?.message ?? "missing inserted row"}`);
+  const insertPunch = async (
+    shiftId: string,
+    userId: string,
+    type: PunchEventType,
+  ) => {
+    const payload = {
+      shift_id: shiftId,
+      user_id: userId,
+      profile_id: userId,
+      event_type: type,
+      timestamp: now,
+    };
+    const { data, error } = await admin
+      .from("punch_events")
+      .insert(payload as never)
+      .select("id,event_type,timestamp,created_at")
+      .single<PunchRow>();
+    if (error || !data)
+      throw new Error(
+        `Punch event insert failed: ${error?.message ?? "missing inserted row"}`,
+      );
     return data;
   };
 
   try {
-    const current = await loadActiveShift(admin, [a.me.id, a.authUserId], shopId);
+    const current = await loadActiveShift(
+      admin,
+      [a.me.id, a.authUserId],
+      shopId,
+    );
     const activeShiftUserId = current?.user_id ?? a.me.id;
     const events = await loadShiftEvents(admin, current?.id ?? null);
     const activity = deriveCurrentShiftActivity(events, Boolean(current));
 
     if (eventType === PUNCH_EVENT_TYPES.startShift) {
-      const { data, error } = await (admin as unknown as { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: ShiftLifecycleRpcRow[] | null; error: { message: string } | null }> }).rpc("start_canonical_shift", {
+      const { data, error } = await (
+        admin as unknown as {
+          rpc: (
+            fn: string,
+            args: Record<string, unknown>,
+          ) => Promise<{
+            data: ShiftLifecycleRpcRow[] | null;
+            error: { message: string } | null;
+          }>;
+        }
+      ).rpc("start_canonical_shift", {
         p_shop_id: shopId,
         p_user_id: a.me.id,
         p_profile_id: a.me.id,
@@ -155,21 +504,92 @@ export async function POST(req: NextRequest) {
       const row = data?.[0] ?? null;
       if (error || !row) {
         const message = error?.message ?? "Start shift RPC returned no row";
-        const status = message.toLowerCase().includes("active shift already exists") ? 409 : 500;
-        return NextResponse.json({ error: `start_canonical_shift failed: ${message}` }, { status });
+        const status = message
+          .toLowerCase()
+          .includes("active shift already exists")
+          ? 409
+          : 500;
+        return NextResponse.json(
+          { error: `start_canonical_shift failed: ${message}` },
+          { status },
+        );
       }
-      return NextResponse.json({ ok: true, ...toDto(rpcShift(row), row.inserted_events ?? []) });
+      return NextResponse.json({
+        ok: true,
+        ...toDto(rpcShift(row), row.inserted_events ?? []),
+      });
     }
 
-    if (!current) return NextResponse.json({ error: "No active shift" }, { status: 409 });
+    if (!current)
+      return NextResponse.json({ error: "No active shift" }, { status: 409 });
 
-    if (eventType === PUNCH_EVENT_TYPES.breakStart && activity !== SHIFT_ACTIVITIES.working) return NextResponse.json({ error: "Cannot start break unless currently working" }, { status: 409 });
-    if (eventType === PUNCH_EVENT_TYPES.breakEnd && activity !== SHIFT_ACTIVITIES.onBreak) return NextResponse.json({ error: "Cannot end break when not on break" }, { status: 409 });
-    if (eventType === PUNCH_EVENT_TYPES.lunchStart && activity !== SHIFT_ACTIVITIES.working) return NextResponse.json({ error: "Cannot start lunch unless currently working" }, { status: 409 });
-    if (eventType === PUNCH_EVENT_TYPES.lunchEnd && activity !== SHIFT_ACTIVITIES.onLunch) return NextResponse.json({ error: "Cannot end lunch when not on lunch" }, { status: 409 });
+    if (
+      eventType === PUNCH_EVENT_TYPES.breakStart &&
+      activity !== SHIFT_ACTIVITIES.working
+    )
+      return NextResponse.json(
+        { error: "Cannot start break unless currently working" },
+        { status: 409 },
+      );
+    if (
+      eventType === PUNCH_EVENT_TYPES.breakEnd &&
+      activity !== SHIFT_ACTIVITIES.onBreak
+    )
+      return NextResponse.json(
+        { error: "Cannot end break when not on break" },
+        { status: 409 },
+      );
+    if (
+      eventType === PUNCH_EVENT_TYPES.lunchStart &&
+      activity !== SHIFT_ACTIVITIES.working
+    )
+      return NextResponse.json(
+        { error: "Cannot start lunch unless currently working" },
+        { status: 409 },
+      );
+    if (
+      eventType === PUNCH_EVENT_TYPES.lunchEnd &&
+      activity !== SHIFT_ACTIVITIES.onLunch
+    )
+      return NextResponse.json(
+        { error: "Cannot end lunch when not on lunch" },
+        { status: 409 },
+      );
 
     if (eventType === PUNCH_EVENT_TYPES.endShift) {
-      const { data, error } = await (admin as unknown as { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: ShiftLifecycleRpcRow[] | null; error: { message: string } | null }> }).rpc("complete_canonical_shift", {
+      const closed = await closeAllActiveTechnicianJobLabor({
+        supabase: admin,
+        shopId,
+        technicianId: activeShiftUserId,
+        endedAtIso: now,
+        reason: "shift_end",
+        event: "job_stopped_at_end_day",
+      });
+      if (!closed.ok)
+        return NextResponse.json(
+          {
+            error: `Unable to stop active job timers before ending shift: ${closed.error}`,
+          },
+          { status: closed.status },
+        );
+      await cancelPendingResumeContexts({
+        admin,
+        shopId,
+        userId: activeShiftUserId,
+        now,
+        reason: "shift_ended",
+      });
+      const { data, error } = await (
+        admin as unknown as {
+          rpc: (
+            fn: string,
+            args: Record<string, unknown>,
+          ) => Promise<{
+            data: ShiftLifecycleRpcRow[] | null;
+            error: { message: string } | null;
+          }>;
+        }
+      ).rpc("complete_canonical_shift", {
         p_shift_id: current.id,
         p_shop_id: shopId,
         p_user_id: activeShiftUserId,
@@ -179,15 +599,130 @@ export async function POST(req: NextRequest) {
       const row = data?.[0] ?? null;
       if (error || !row) {
         const message = error?.message ?? "Complete shift RPC returned no row";
-        const status = message.toLowerCase().includes("no matching active shift") ? 409 : 500;
-        return NextResponse.json({ error: `complete_canonical_shift failed: ${message}` }, { status });
+        const status = message
+          .toLowerCase()
+          .includes("no matching active shift")
+          ? 409
+          : 500;
+        return NextResponse.json(
+          { error: `complete_canonical_shift failed: ${message}` },
+          { status },
+        );
       }
-      return NextResponse.json({ ok: true, ...toDto(rpcShift(row), [...events, ...(row.inserted_events ?? [])]) });
+      return NextResponse.json({
+        ok: true,
+        ...toDto(rpcShift(row), [...events, ...(row.inserted_events ?? [])]),
+        jobTimersStopped: closed.closed.length,
+        breakOrLunchEnded:
+          activity === SHIFT_ACTIVITIES.onBreak ||
+          activity === SHIFT_ACTIVITIES.onLunch,
+        message: `Shift ended${closed.closed.length ? ` — ${closed.closed.length} job timer${closed.closed.length === 1 ? "" : "s"} stopped` : ""}${activity === SHIFT_ACTIVITIES.onBreak || activity === SHIFT_ACTIVITIES.onLunch ? " — break/lunch ended" : ""}`,
+      });
     }
 
-    const inserted = await insertPunch(current.id, activeShiftUserId, eventType);
-    return NextResponse.json({ ok: true, ...toDto(current, [...events, inserted]) });
+    if (
+      eventType === PUNCH_EVENT_TYPES.breakStart ||
+      eventType === PUNCH_EVENT_TYPES.lunchStart
+    ) {
+      const pauseReason =
+        eventType === PUNCH_EVENT_TYPES.breakStart ? "break" : "lunch";
+      const activeJobs = await getActiveTechnicianJobLabor({
+        supabase: admin,
+        shopId,
+        technicianId: activeShiftUserId,
+      });
+      if (activeJobs.error) throw new Error(activeJobs.error.message);
+      const closed = await closeAllActiveTechnicianJobLabor({
+        supabase: admin,
+        shopId,
+        technicianId: activeShiftUserId,
+        endedAtIso: now,
+        reason: pauseReason,
+        event:
+          pauseReason === "break"
+            ? "job_paused_for_break"
+            : "job_paused_for_lunch",
+      });
+      if (!closed.ok)
+        return NextResponse.json(
+          {
+            error: `Unable to pause active job timer before starting ${pauseReason}: ${closed.error}`,
+          },
+          { status: closed.status },
+        );
+      const inserted = await insertPunch(
+        current.id,
+        activeShiftUserId,
+        eventType,
+      );
+      if (activeJobs.data.length > 0 && inserted.id) {
+        await createResumeContext({
+          admin,
+          shopId,
+          userId: activeShiftUserId,
+          breakPunchId: inserted.id,
+          pauseReason,
+          pausedAt: now,
+          activeSegments: activeJobs.data,
+        });
+      }
+      return NextResponse.json({
+        ok: true,
+        ...toDto(current, [...events, inserted]),
+        jobTimerPaused: activeJobs.data.length === 1,
+        autoResumeEligible: activeJobs.data.length === 1,
+        message:
+          activeJobs.data.length === 1
+            ? `${pauseReason === "break" ? "Break" : "Lunch"} started — job timer paused`
+            : undefined,
+      });
+    }
+
+    // Checked append-only fallback: return NextResponse.json({ ok: true, ...toDto(current
+    const inserted = await insertPunch(
+      current.id,
+      activeShiftUserId,
+      eventType,
+    );
+
+    if (
+      eventType === PUNCH_EVENT_TYPES.breakEnd ||
+      eventType === PUNCH_EVENT_TYPES.lunchEnd
+    ) {
+      const pauseReason =
+        eventType === PUNCH_EVENT_TYPES.breakEnd ? "break" : "lunch";
+      const startEventType =
+        eventType === PUNCH_EVENT_TYPES.breakEnd
+          ? PUNCH_EVENT_TYPES.breakStart
+          : PUNCH_EVENT_TYPES.lunchStart;
+      const breakStart = [...events]
+        .reverse()
+        .find((event) => event.event_type === startEventType && event.id);
+      const resume = await maybeResumeJobAfterBreak({
+        admin,
+        shopId,
+        userId: activeShiftUserId,
+        breakPunchId: breakStart?.id ?? null,
+        now,
+        pauseReason,
+      });
+      return NextResponse.json({
+        ok: true,
+        ...toDto(current, [...events, inserted]),
+        jobTimerResumed: resume.resumed,
+        resumeMessage: resume.message,
+        message: resume.message ?? undefined,
+      });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      ...toDto(current, [...events, inserted]),
+    });
   } catch (error) {
-    return NextResponse.json({ error: error instanceof Error ? error.message : "Shift punch failed" }, { status: 500 });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Shift punch failed" },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/scheduling/punches/route.ts
+++ b/app/api/scheduling/punches/route.ts
@@ -4,7 +4,11 @@ import {
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
-import { isPunchEventType, type PunchEventType } from "@/features/workforce/lib/shift-status";
+import {
+  isPunchEventType,
+  type PunchEventType,
+} from "@/features/workforce/lib/shift-status";
+import { closeAllActiveTechnicianJobLabor } from "@/features/work-orders/server/technicianJobLabor";
 
 type Caller = {
   id: string;
@@ -69,22 +73,17 @@ export async function POST(req: NextRequest) {
   if (!a.ok) return a.res;
 
   const body = (await req.json().catch(() => null)) as PunchCreateBody | null;
-  if (!body) return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  if (!body)
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
 
   if (!body.shift_id) {
     return NextResponse.json({ error: "Missing shift_id" }, { status: 400 });
   }
   if (!isPunchEventTypeDb(body.event_type)) {
-    return NextResponse.json(
-      { error: "Invalid event_type" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Invalid event_type" }, { status: 400 });
   }
   if (!isIsoDate(body.timestamp)) {
-    return NextResponse.json(
-      { error: "Invalid timestamp" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "Invalid timestamp" }, { status: 400 });
   }
 
   const admin = createAdminSupabase();
@@ -94,10 +93,15 @@ export async function POST(req: NextRequest) {
     .from("tech_shifts")
     .select("id, shop_id, user_id")
     .eq("id", body.shift_id)
-    .maybeSingle<{ id: string; shop_id: string | null; user_id: string | null }>();
+    .maybeSingle<{
+      id: string;
+      shop_id: string | null;
+      user_id: string | null;
+    }>();
 
   if (sErr) return NextResponse.json({ error: sErr.message }, { status: 500 });
-  if (!shift) return NextResponse.json({ error: "Shift not found" }, { status: 404 });
+  if (!shift)
+    return NextResponse.json({ error: "Shift not found" }, { status: 404 });
   if (shift.shop_id !== a.me.shop_id) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
@@ -108,25 +112,21 @@ export async function POST(req: NextRequest) {
   }
 
   if (body.event_type === "end_shift" && shift.user_id) {
-    const { data: activeJobPunches, error: activeJobsErr } = await admin
-      .from("work_order_line_labor_segments")
-      .select("id")
-      .eq("shop_id", a.me.shop_id)
-      .eq("technician_id", shift.user_id)
-      .is("ended_at", null);
+    const closed = await closeAllActiveTechnicianJobLabor({
+      supabase: admin,
+      shopId: a.me.shop_id as string,
+      technicianId: shift.user_id,
+      endedAtIso: body.timestamp,
+      reason: "shift_end",
+      event: "job_stopped_at_end_day",
+    });
 
-    if (activeJobsErr) {
-      return NextResponse.json({ error: activeJobsErr.message }, { status: 500 });
-    }
-
-    if ((activeJobPunches?.length ?? 0) > 0) {
+    if (!closed.ok) {
       return NextResponse.json(
         {
-          error:
-            "Cannot clock out while a job is still active. Pause or finish active jobs first.",
-          activeJobCount: activeJobPunches?.length ?? 0,
+          error: `Unable to stop active job timers before ending shift: ${closed.error}`,
         },
-        { status: 409 },
+        { status: closed.status },
       );
     }
   }
@@ -149,8 +149,11 @@ export async function POST(req: NextRequest) {
   if (error && error.message.includes("shop_id")) {
     const withoutShopId = { ...payload };
     delete (withoutShopId as { shop_id?: string | null }).shop_id;
-    const retry = await admin.from("punch_events").insert(withoutShopId as never);
-    if (retry.error) return NextResponse.json({ error: retry.error.message }, { status: 500 });
+    const retry = await admin
+      .from("punch_events")
+      .insert(withoutShopId as never);
+    if (retry.error)
+      return NextResponse.json({ error: retry.error.message }, { status: 500 });
     return NextResponse.json({ ok: true });
   }
 

--- a/app/api/time/shift/end/route.ts
+++ b/app/api/time/shift/end/route.ts
@@ -1,10 +1,23 @@
 import { NextResponse } from "next/server";
-import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import { SHIFT_STATUSES } from "@/features/workforce/lib/shift-status";
+import { closeAllActiveTechnicianJobLabor } from "@/features/work-orders/server/technicianJobLabor";
 
 type Caller = { id: string; shop_id: string | null };
-type ShiftRow = { id: string; shop_id: string | null; user_id: string | null; start_time: string | null };
-type ShiftLifecycleRpcRow = ShiftRow & { status: string | null; end_time: string | null; inserted_events?: unknown[] | null };
+type ShiftRow = {
+  id: string;
+  shop_id: string | null;
+  user_id: string | null;
+  start_time: string | null;
+};
+type ShiftLifecycleRpcRow = ShiftRow & {
+  status: string | null;
+  end_time: string | null;
+  inserted_events?: unknown[] | null;
+};
 
 export async function POST() {
   const supabase = createServerSupabaseRoute();
@@ -13,8 +26,10 @@ export async function POST() {
     error: userErr,
   } = await supabase.auth.getUser();
 
-  if (userErr) return NextResponse.json({ error: userErr.message }, { status: 500 });
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (userErr)
+    return NextResponse.json({ error: userErr.message }, { status: 500 });
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   let { data: me } = await supabase
     .from("profiles")
@@ -30,24 +45,10 @@ export async function POST() {
     me = byUser.data ?? null;
   }
 
-  if (!me?.shop_id) return NextResponse.json({ error: "Missing shop" }, { status: 403 });
+  if (!me?.shop_id)
+    return NextResponse.json({ error: "Missing shop" }, { status: 403 });
 
   const admin = createAdminSupabase();
-
-  const { data: activeJobs, error: activeJobsErr } = await admin
-    .from("work_order_line_labor_segments")
-    .select("id")
-    .eq("technician_id", me.id)
-    .is("ended_at", null)
-    .limit(2);
-
-  if (activeJobsErr) return NextResponse.json({ error: activeJobsErr.message }, { status: 500 });
-  if ((activeJobs?.length ?? 0) > 0) {
-    return NextResponse.json(
-      { error: `Cannot end shift while ${(activeJobs ?? []).length} job punch(es) are active.` },
-      { status: 409 },
-    );
-  }
 
   const { data: shifts, error: shiftErr } = await admin
     .from("tech_shifts")
@@ -58,7 +59,8 @@ export async function POST() {
     .order("start_time", { ascending: false })
     .limit(5);
 
-  if (shiftErr) return NextResponse.json({ error: shiftErr.message }, { status: 500 });
+  if (shiftErr)
+    return NextResponse.json({ error: shiftErr.message }, { status: 500 });
   const shift =
     ((shifts ?? []) as ShiftRow[]).find((s) => s.shop_id === me.shop_id) ??
     ((shifts ?? []) as ShiftRow[]).find((s) => s.shop_id == null) ??
@@ -74,7 +76,34 @@ export async function POST() {
   }
 
   const now = new Date().toISOString();
-  const { data, error } = await (admin as unknown as { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: ShiftLifecycleRpcRow[] | null; error: { message: string } | null }> }).rpc("complete_canonical_shift", {
+  const closed = await closeAllActiveTechnicianJobLabor({
+    supabase: admin,
+    shopId: me.shop_id,
+    technicianId: me.id,
+    endedAtIso: now,
+    reason: "shift_end",
+    event: "job_stopped_at_end_day",
+  });
+  if (!closed.ok) {
+    return NextResponse.json(
+      {
+        error: `Unable to stop active job timers before ending shift: ${closed.error}`,
+      },
+      { status: closed.status },
+    );
+  }
+
+  const { data, error } = await (
+    admin as unknown as {
+      rpc: (
+        fn: string,
+        args: Record<string, unknown>,
+      ) => Promise<{
+        data: ShiftLifecycleRpcRow[] | null;
+        error: { message: string } | null;
+      }>;
+    }
+  ).rpc("complete_canonical_shift", {
     p_shift_id: shift.id,
     p_shop_id: me.shop_id,
     p_user_id: shift.user_id ?? me.id,
@@ -85,9 +114,19 @@ export async function POST() {
   const row = data?.[0] ?? null;
   if (error || !row) {
     const message = error?.message ?? "Complete shift RPC returned no row";
-    const status = message.toLowerCase().includes("no matching active shift") ? 409 : 500;
-    return NextResponse.json({ error: `complete_canonical_shift failed: ${message}` }, { status });
+    const status = message.toLowerCase().includes("no matching active shift")
+      ? 409
+      : 500;
+    return NextResponse.json(
+      { error: `complete_canonical_shift failed: ${message}` },
+      { status },
+    );
   }
 
-  return NextResponse.json({ ok: true, shiftId: row.id, endedAt: row.end_time ?? now });
+  return NextResponse.json({
+    ok: true,
+    shiftId: row.id,
+    endedAt: row.end_time ?? now,
+    jobTimersStopped: closed.closed.length,
+  });
 }

--- a/app/api/work-orders/lines/[id]/pause/route.ts
+++ b/app/api/work-orders/lines/[id]/pause/route.ts
@@ -2,10 +2,12 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
+import { stopTechnicianJobLabor } from "@/features/work-orders/server/technicianJobLabor";
 
 function getId(req: NextRequest) {
-  const m = req.nextUrl.pathname.match(/\/api\/work-orders\/lines\/([^/]+)\/pause$/);
+  const m = req.nextUrl.pathname.match(
+    /\/api\/work-orders\/lines\/([^/]+)\/pause$/,
+  );
   return m?.[1] ?? null;
 }
 
@@ -15,28 +17,28 @@ export async function POST(req: NextRequest) {
 
   const supabase = createServerSupabaseRoute();
   const { data: auth, error: authErr } = await supabase.auth.getUser();
-  if (authErr) return NextResponse.json({ error: authErr.message }, { status: 500 });
-  if (!auth?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (authErr)
+    return NextResponse.json({ error: authErr.message }, { status: 500 });
+  if (!auth?.user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = (await req.json().catch(() => null)) as
-    | { holdReason?: string; notes?: string | null }
-    | null;
+  const body = (await req.json().catch(() => null)) as {
+    holdReason?: string;
+    notes?: string | null;
+  } | null;
 
-  const result = await applyJobPunchTransition({
+  const result = await stopTechnicianJobLabor({
     supabase,
     lineId: id,
-    action: "pause",
     technicianId: auth.user.id,
-    options: {
-      pause: {
-        holdReason: body?.holdReason,
-        notes: body?.notes ?? null,
-      },
-    },
+    reason: body?.holdReason,
   });
 
   if (!result.ok) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status },
+    );
   }
 
   return NextResponse.json(result.payload ?? { ok: true });

--- a/app/api/work-orders/lines/[id]/start/route.ts
+++ b/app/api/work-orders/lines/[id]/start/route.ts
@@ -2,10 +2,12 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
+import { startTechnicianJobLabor } from "@/features/work-orders/server/technicianJobLabor";
 
 function getId(req: NextRequest) {
-  const m = req.nextUrl.pathname.match(/\/api\/work-orders\/lines\/([^/]+)\/start$/);
+  const m = req.nextUrl.pathname.match(
+    /\/api\/work-orders\/lines\/([^/]+)\/start$/,
+  );
   return m?.[1] ?? null;
 }
 
@@ -15,25 +17,27 @@ export async function POST(req: NextRequest) {
 
   const supabase = createServerSupabaseRoute();
   const { data: auth, error: authErr } = await supabase.auth.getUser();
-  if (authErr) return NextResponse.json({ error: authErr.message }, { status: 500 });
-  if (!auth?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (authErr)
+    return NextResponse.json({ error: authErr.message }, { status: 500 });
+  if (!auth?.user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const body = (await req.json().catch(() => null)) as
-    | { allowConcurrentJobPunches?: boolean }
-    | null;
+  const body = (await req.json().catch(() => null)) as {
+    allowConcurrentJobPunches?: boolean;
+  } | null;
 
-  const result = await applyJobPunchTransition({
+  const result = await startTechnicianJobLabor({
     supabase,
     lineId: id,
-    action: "start",
     technicianId: auth.user.id,
-    options: {
-      allowConcurrentJobPunches: body?.allowConcurrentJobPunches === true,
-    },
+    allowConcurrentJobPunches: body?.allowConcurrentJobPunches === true,
   });
 
   if (!result.ok) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status },
+    );
   }
 
   return NextResponse.json(result.payload ?? { ok: true });

--- a/features/shared/components/ShiftTracker.tsx
+++ b/features/shared/components/ShiftTracker.tsx
@@ -9,9 +9,18 @@ import {
 
 type ShiftType = "shift" | "break" | "lunch";
 type Mode = "none" | "shift" | "break" | "lunch" | "ended";
-type ShiftAction = "start_shift" | "end_shift" | "start_break" | "end_break" | "start_lunch" | "end_lunch";
+type ShiftAction =
+  | "start_shift"
+  | "end_shift"
+  | "start_break"
+  | "end_break"
+  | "start_lunch"
+  | "end_lunch";
 
-function modeFromActivity(activity: MobileShiftState["activity"] | undefined, shiftStatus?: MobileShiftState["shiftStatus"]): Mode {
+function modeFromActivity(
+  activity: MobileShiftState["activity"] | undefined,
+  shiftStatus?: MobileShiftState["shiftStatus"],
+): Mode {
   if (shiftStatus === "completed") return "ended";
   if (activity === "working") return "shift";
   if (activity === "on_break") return "break";
@@ -34,6 +43,7 @@ export default function ShiftTracker({
   const [shiftState, setShiftState] = useState<MobileShiftState | null>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
 
   const shiftId = shiftState?.shiftId ?? null;
   const startTime = shiftState?.startTime ?? null;
@@ -64,6 +74,7 @@ export default function ShiftTracker({
       if (busy || !userId) return;
       setBusy(true);
       setErr(null);
+      setNotice(null);
 
       try {
         const res = await fetch("/api/mobile/shifts", {
@@ -72,7 +83,12 @@ export default function ShiftTracker({
           body: JSON.stringify({ action }),
         });
         const body = (await res.json().catch(() => null)) as
-          | ({ ok?: boolean; error?: string } & Partial<MobileShiftState>)
+          | ({
+              ok?: boolean;
+              error?: string;
+              message?: string;
+              resumeMessage?: string;
+            } & Partial<MobileShiftState>)
           | null;
         if (!res.ok || !body?.ok) throw new Error(body?.error ?? fallback);
 
@@ -88,7 +104,19 @@ export default function ShiftTracker({
           mode: body.mode ?? modeFromActivity(activity, body.shiftStatus),
         });
 
-        if (action === "end_shift") {
+        if (body.message || body.resumeMessage) {
+          setNotice(body.message ?? body.resumeMessage ?? null);
+        }
+
+        if (
+          [
+            "end_shift",
+            "start_break",
+            "end_break",
+            "start_lunch",
+            "end_lunch",
+          ].includes(action)
+        ) {
           window.dispatchEvent(new CustomEvent("wol:refresh"));
         }
       } catch (error) {
@@ -112,12 +140,20 @@ export default function ShiftTracker({
   );
 
   const toggleBreak = useCallback(
-    () => postShiftAction(mode === "break" ? "end_break" : "start_break", "Failed to toggle break"),
+    () =>
+      postShiftAction(
+        mode === "break" ? "end_break" : "start_break",
+        "Failed to toggle break",
+      ),
     [mode, postShiftAction],
   );
 
   const toggleLunch = useCallback(
-    () => postShiftAction(mode === "lunch" ? "end_lunch" : "start_lunch", "Failed to toggle lunch"),
+    () =>
+      postShiftAction(
+        mode === "lunch" ? "end_lunch" : "start_lunch",
+        "Failed to toggle lunch",
+      ),
     [mode, postShiftAction],
   );
 
@@ -132,13 +168,20 @@ export default function ShiftTracker({
     [],
   );
 
-  const niceStatus = mode === "none" ? "Off shift" : mode === "ended" ? "Shift ended" : mode;
+  const niceStatus =
+    mode === "none" ? "Off shift" : mode === "ended" ? "Shift ended" : mode;
 
   return (
     <div className="text-sm mt-4 space-y-2">
       {err && (
         <div className="rounded border border-red-500/40 bg-red-500/10 p-2 text-red-300">
           {err}
+        </div>
+      )}
+
+      {notice && (
+        <div className="rounded border border-emerald-500/40 bg-emerald-500/10 p-2 text-emerald-200">
+          {notice}
         </div>
       )}
 

--- a/features/work-orders/server/applyJobPunchTransition.ts
+++ b/features/work-orders/server/applyJobPunchTransition.ts
@@ -25,6 +25,9 @@ type FinishOptions = {
 type PauseOptions = {
   holdReason?: string | null;
   notes?: string | null;
+  preserveLineStatus?: boolean;
+  event?: string;
+  details?: DB["public"]["Tables"]["activity_logs"]["Insert"]["context"];
 };
 
 type ResumeOptions = {
@@ -33,6 +36,8 @@ type ResumeOptions = {
 
 type TransitionOptions = {
   allowConcurrentJobPunches?: boolean;
+  nowIso?: string;
+  startSource?: string;
   pause?: PauseOptions;
   resume?: ResumeOptions;
   finish?: FinishOptions;
@@ -303,7 +308,7 @@ export async function applyJobPunchTransition({
       }
     }
 
-    const now = new Date().toISOString();
+    const now = options?.nowIso ?? new Date().toISOString();
     const shouldResetPunchClock =
       action === "start" ||
       status === "on_hold" ||
@@ -341,7 +346,9 @@ export async function applyJobPunchTransition({
       technicianId: lineTechId,
       actorId: technicianId,
       startedAtIso: now,
-      source: action === "start" ? "job_start" : "job_resume",
+      source:
+        options?.startSource ??
+        (action === "start" ? "job_start" : "job_resume"),
     });
 
     if (segmentErr) {
@@ -386,17 +393,23 @@ export async function applyJobPunchTransition({
       return err(409, getWorkOrderLineTransitionError(status, "on_hold"));
     }
 
-    const now = new Date().toISOString();
+    const now = options?.nowIso ?? new Date().toISOString();
     const shouldCloseActivePunch =
       Boolean(line.punched_in_at) && !line.punched_out_at;
 
+    const preserveLineStatus = options?.pause?.preserveLineStatus === true;
     const { error: updateErr } = await supabase
       .from("work_order_lines")
       .update({
-        status: "on_hold",
-        hold_reason:
-          cleanString(options?.pause?.holdReason) ?? "Paused by technician",
-        notes: options?.pause?.notes ?? undefined,
+        ...(preserveLineStatus
+          ? {}
+          : {
+              status: "on_hold",
+              hold_reason:
+                cleanString(options?.pause?.holdReason) ??
+                "Paused by technician",
+              notes: options?.pause?.notes ?? undefined,
+            }),
         ...(shouldCloseActivePunch ? { punched_out_at: now } : {}),
       } as DB["public"]["Tables"]["work_order_lines"]["Update"])
       .eq("id", lineId)
@@ -410,9 +423,11 @@ export async function applyJobPunchTransition({
       workOrderLineId: lineId,
       technicianId: pauseTechId,
       endedAtIso: now,
-      pauseReason: cleanString(options?.pause?.holdReason)
-        ? `hold:${cleanString(options?.pause?.holdReason)}`
-        : "hold",
+      pauseReason: preserveLineStatus
+        ? (cleanString(options?.pause?.holdReason) ?? "labor_pause")
+        : cleanString(options?.pause?.holdReason)
+          ? `hold:${cleanString(options?.pause?.holdReason)}`
+          : "hold",
     });
 
     if (closeErr) return err(400, closeErr.message);
@@ -425,10 +440,11 @@ export async function applyJobPunchTransition({
 
     await logOperationalEvent({
       supabase,
-      event: "pause",
+      event: options?.pause?.event ?? "pause",
       actorId: technicianId,
       entityType: "work_order_line",
       entityId: lineId,
+      details: options?.pause?.details,
       at: now,
     });
 

--- a/features/work-orders/server/technicianJobLabor.ts
+++ b/features/work-orders/server/technicianJobLabor.ts
@@ -1,0 +1,189 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@shared/types/types/supabase";
+import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
+import {
+  closeActiveLaborSegments,
+  syncLinePunchMirrorFromSegments,
+} from "@/features/work-orders/server/laborSegments";
+import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+
+type DB = Database;
+
+type ActiveLaborSegment = {
+  id: string;
+  shop_id: string | null;
+  work_order_id: string | null;
+  work_order_line_id: string | null;
+  technician_id: string | null;
+  started_at: string | null;
+};
+
+type JobLaborResult =
+  | { ok: true; payload?: unknown }
+  | { ok: false; status: number; error: string };
+
+export async function startTechnicianJobLabor(params: {
+  supabase: SupabaseClient<DB>;
+  lineId: string;
+  technicianId: string;
+  startedAtIso?: string;
+  source?: "manual" | "break_resume" | "lunch_resume";
+  allowConcurrentJobPunches?: boolean;
+}): Promise<JobLaborResult> {
+  return applyJobPunchTransition({
+    supabase: params.supabase,
+    lineId: params.lineId,
+    action: "start",
+    technicianId: params.technicianId,
+    options: {
+      allowConcurrentJobPunches: params.allowConcurrentJobPunches === true,
+      nowIso: params.startedAtIso,
+      startSource:
+        params.source === "break_resume"
+          ? "job_resumed_after_break"
+          : params.source === "lunch_resume"
+            ? "job_resumed_after_lunch"
+            : undefined,
+    },
+  });
+}
+
+export async function stopTechnicianJobLabor(params: {
+  supabase: SupabaseClient<DB>;
+  lineId: string;
+  technicianId: string;
+  endedAtIso?: string;
+  reason?: string;
+  preserveLineStatus?: boolean;
+  event?: string;
+  details?: Json;
+}): Promise<JobLaborResult> {
+  return applyJobPunchTransition({
+    supabase: params.supabase,
+    lineId: params.lineId,
+    action: "pause",
+    technicianId: params.technicianId,
+    options: {
+      nowIso: params.endedAtIso,
+      pause: {
+        holdReason: params.reason,
+        preserveLineStatus: params.preserveLineStatus === true,
+        event: params.event,
+        details: params.details,
+      },
+    },
+  });
+}
+
+export async function getActiveTechnicianJobLabor(params: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  technicianId: string;
+}) {
+  const { data, error } = await params.supabase
+    .from("work_order_line_labor_segments")
+    .select(
+      "id, shop_id, work_order_id, work_order_line_id, technician_id, started_at",
+    )
+    .eq("shop_id", params.shopId)
+    .eq("technician_id", params.technicianId)
+    .is("ended_at", null)
+    .order("started_at", { ascending: true });
+
+  return { data: (data ?? []) as ActiveLaborSegment[], error };
+}
+
+export async function closeAllActiveTechnicianJobLabor(params: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  technicianId: string;
+  endedAtIso: string;
+  reason: string;
+  event?: string;
+  breakPunchId?: string | null;
+}) {
+  const { data: active, error } = await getActiveTechnicianJobLabor(params);
+  if (error)
+    return {
+      ok: false as const,
+      status: 500,
+      error: error.message,
+      closed: [] as ActiveLaborSegment[],
+    };
+
+  if (active.length > 1) {
+    await logOperationalEvent({
+      supabase: params.supabase,
+      event: "integrity_warning_multiple_active_jobs",
+      actorId: params.technicianId,
+      entityType: "technician",
+      entityId: params.technicianId,
+      at: params.endedAtIso,
+      details: {
+        shop_id: params.shopId,
+        technician_id: params.technicianId,
+        active_segment_ids: active.map((segment) => segment.id),
+        reason: params.reason,
+        break_punch_id: params.breakPunchId ?? null,
+      } as Json,
+    });
+  }
+
+  const lineIds = [
+    ...new Set(
+      active
+        .map((segment) => segment.work_order_line_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+  for (const lineId of lineIds) {
+    const { error: closeErr } = await closeActiveLaborSegments({
+      supabase: params.supabase,
+      workOrderLineId: lineId,
+      technicianId: params.technicianId,
+      endedAtIso: params.endedAtIso,
+      pauseReason: params.reason,
+    });
+    if (closeErr)
+      return {
+        ok: false as const,
+        status: 500,
+        error: closeErr.message,
+        closed: active,
+      };
+
+    const { error: syncErr } = await syncLinePunchMirrorFromSegments({
+      supabase: params.supabase,
+      workOrderLineId: lineId,
+    });
+    if (syncErr)
+      return {
+        ok: false as const,
+        status: 500,
+        error: syncErr.message,
+        closed: active,
+      };
+  }
+
+  for (const segment of active) {
+    await logOperationalEvent({
+      supabase: params.supabase,
+      event: params.event ?? "job_stopped_at_end_day",
+      actorId: params.technicianId,
+      entityType: "work_order_line",
+      entityId: segment.work_order_line_id,
+      at: params.endedAtIso,
+      details: {
+        shop_id: params.shopId,
+        technician_id: params.technicianId,
+        work_order_id: segment.work_order_id,
+        work_order_line_id: segment.work_order_line_id,
+        source_session_id: segment.id,
+        reason: params.reason,
+        break_punch_id: params.breakPunchId ?? null,
+      } as Json,
+    });
+  }
+
+  return { ok: true as const, closed: active };
+}

--- a/supabase/migrations/202607110001_workforce_job_resume_contexts.sql
+++ b/supabase/migrations/202607110001_workforce_job_resume_contexts.sql
@@ -1,0 +1,95 @@
+-- Durable auto-resume context for job labor paused by break/lunch punches.
+-- Additive and safe for existing data: no backfill is required because only new
+-- break/lunch transitions write rows here.
+
+begin;
+
+create table if not exists public.workforce_job_resume_contexts (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  break_punch_id uuid not null references public.punch_events(id) on delete cascade,
+  work_order_id uuid references public.work_orders(id) on delete set null,
+  work_order_line_id uuid references public.work_order_lines(id) on delete set null,
+  assignment_id uuid,
+  paused_job_session_id uuid references public.work_order_line_labor_segments(id) on delete set null,
+  pause_reason text not null check (pause_reason in ('break', 'lunch')),
+  status text not null default 'pending' check (status in ('pending', 'resumed', 'cancelled', 'invalid')),
+  paused_at timestamptz not null,
+  resumed_at timestamptz,
+  cancelled_at timestamptz,
+  cancel_reason text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_wjrc_shop_user_status
+  on public.workforce_job_resume_contexts (shop_id, user_id, status, paused_at desc);
+
+create index if not exists idx_wjrc_line_status
+  on public.workforce_job_resume_contexts (shop_id, work_order_line_id, status)
+  where work_order_line_id is not null;
+
+create unique index if not exists uq_wjrc_one_pending_per_break_punch
+  on public.workforce_job_resume_contexts (break_punch_id)
+  where status = 'pending';
+
+alter table public.workforce_job_resume_contexts enable row level security;
+
+do $$
+begin
+  if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'workforce_job_resume_contexts' and policyname = 'wjrc_select_same_shop') then
+    create policy "wjrc_select_same_shop"
+      on public.workforce_job_resume_contexts
+      for select
+      to authenticated
+      using (
+        exists (
+          select 1 from public.profiles p
+          where p.id = auth.uid()
+            and p.shop_id = workforce_job_resume_contexts.shop_id
+        )
+      );
+  end if;
+
+  if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'workforce_job_resume_contexts' and policyname = 'wjrc_insert_self_same_shop') then
+    create policy "wjrc_insert_self_same_shop"
+      on public.workforce_job_resume_contexts
+      for insert
+      to authenticated
+      with check (
+        user_id = auth.uid()
+        and exists (
+          select 1 from public.profiles p
+          where p.id = auth.uid()
+            and p.shop_id = workforce_job_resume_contexts.shop_id
+        )
+      );
+  end if;
+
+  if not exists (select 1 from pg_policies where schemaname = 'public' and tablename = 'workforce_job_resume_contexts' and policyname = 'wjrc_update_self_same_shop') then
+    create policy "wjrc_update_self_same_shop"
+      on public.workforce_job_resume_contexts
+      for update
+      to authenticated
+      using (
+        user_id = auth.uid()
+        and exists (
+          select 1 from public.profiles p
+          where p.id = auth.uid()
+            and p.shop_id = workforce_job_resume_contexts.shop_id
+        )
+      )
+      with check (
+        user_id = auth.uid()
+        and exists (
+          select 1 from public.profiles p
+          where p.id = auth.uid()
+            and p.shop_id = workforce_job_resume_contexts.shop_id
+        )
+      );
+  end if;
+end $$;
+
+commit;

--- a/tests/coordinated-shift-job-clock.test.ts
+++ b/tests/coordinated-shift-job-clock.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const mobileRoute = readFileSync("app/api/mobile/shifts/route.ts", "utf8");
+const jobService = readFileSync(
+  "features/work-orders/server/technicianJobLabor.ts",
+  "utf8",
+);
+const transition = readFileSync(
+  "features/work-orders/server/applyJobPunchTransition.ts",
+  "utf8",
+);
+const migration = readFileSync(
+  "supabase/migrations/202607110001_workforce_job_resume_contexts.sql",
+  "utf8",
+);
+
+describe("coordinated shift and job clock source contract", () => {
+  it("ends day by closing active job labor before completing the canonical shift", () => {
+    expect(mobileRoute).toContain("closeAllActiveTechnicianJobLabor");
+    expect(mobileRoute).toContain('reason: "shift_end"');
+    expect(mobileRoute).toContain('event: "job_stopped_at_end_day"');
+    expect(
+      mobileRoute.indexOf("closeAllActiveTechnicianJobLabor"),
+    ).toBeLessThan(mobileRoute.indexOf('rpc("complete_canonical_shift"'));
+  });
+
+  it("starts break/lunch by pausing job labor without changing line status and records resume context", () => {
+    expect(mobileRoute).toContain(
+      "eventType === PUNCH_EVENT_TYPES.breakStart ||",
+    );
+    expect(mobileRoute).toContain("createResumeContext");
+    expect(mobileRoute).toContain("job_paused_for_break");
+    expect(mobileRoute).toContain("job_paused_for_lunch");
+    expect(jobService).toContain(
+      "preserveLineStatus: params.preserveLineStatus === true",
+    );
+    expect(transition).toContain("preserveLineStatus");
+    expect(transition).toContain("? {}");
+  });
+
+  it("ends break/lunch by resuming only the context tied to the specific break/lunch punch", () => {
+    expect(mobileRoute).toContain("maybeResumeJobAfterBreak");
+    expect(mobileRoute).toContain('.eq("break_punch_id", params.breakPunchId)');
+    expect(mobileRoute).toContain('.eq("status", "pending")');
+    expect(mobileRoute).toContain("job_resumed_after_break");
+    expect(mobileRoute).toContain("job_resumed_after_lunch");
+  });
+
+  it("persists durable tenant-scoped resume contexts with pending uniqueness", () => {
+    expect(migration).toContain(
+      "create table if not exists public.workforce_job_resume_contexts",
+    );
+    expect(migration).toContain("shop_id uuid not null");
+    expect(migration).toContain("break_punch_id uuid not null");
+    expect(migration).toContain("uq_wjrc_one_pending_per_break_punch");
+    expect(migration).toContain(
+      "alter table public.workforce_job_resume_contexts enable row level security",
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure End Day also stops any active job timers and make break/lunch actions pause and (when eligible) resume the exact job session without changing line status, assignment, or reporting semantics, while reusing existing canonical job punch logic and preserving RLS/tenant boundaries.

### Description
- Add durable resume context storage via a new migration `workforce_job_resume_contexts` with tenant scoping, pending/resumed/cancelled states, indexes, a one-pending-context-per-break-punch unique index, and RLS to persist break-scoped auto-resume metadata.
- Extract canonical job-clock helpers in `features/work-orders/server/technicianJobLabor.ts` (`startTechnicianJobLabor`, `stopTechnicianJobLabor`, `getActiveTechnicianJobLabor`, `closeAllActiveTechnicianJobLabor`) and extend `applyJobPunchTransition` to accept `nowIso`, `startSource`, and a `preserveLineStatus` pause mode to support atomic pause/resume without undesired status transitions.
- Wire coordinated behavior into routes: mobile shift lifecycle (`app/api/mobile/shifts/route.ts`) now closes active job timers before `complete_canonical_shift`, pauses active jobs on `break_start`/`lunch_start` and creates resume contexts, and attempts an eligible resume on `break_end`/`lunch_end`; admin/legacy scheduling and End Day endpoints (`app/api/scheduling/punches/route.ts`, `app/api/time/shift/end/route.ts`) also close active job timers before ending shifts; job start/pause routes now call the new helpers. 
- Minor UI update in `features/shared/components/ShiftTracker.tsx` surfaces friendly messages for pause/resume/end-day outcomes and disables duplicate submissions, and a focused test `tests/coordinated-shift-job-clock.test.ts` documents the source contract.

### Testing
- Typecheck: ran `npm run typecheck` and it succeeded with no new TypeScript errors.
- Lint: ran `npx eslint` against the targeted scheduling/workforce/work-orders paths and it passed for the targeted dirs (repo-wide pre-existing warnings remain unrelated to the change).
- Unit/contract tests: ran targeted `npx vitest` suites including the new `tests/coordinated-shift-job-clock.test.ts` and scheduling/workforce/labor/work-order tests and the targeted test runs passed (all targeted tests green during validation).
- Build: `pnpm build` failed in this environment due to network font fetches from `next/font` (unrelated to the code changes), so production build was not validated here.

Commit: `b42ffb448d4fcf29f37e5fc21363514329dee762`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51afdf585c83289984ca0e3adb4e3a)