### PR TITLE
Move waiter badge to primary work-order header

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1448,6 +1448,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                 <StatusBadge variant={formatDecisionStatus({ workStatus: wo.status }).variant} size="sm">
                   {formatDecisionStatus({ workStatus: wo.status }).label}
                 </StatusBadge>
+                {isWaiter ? (
+                  <StatusBadge variant="danger" size="sm">
+                    Waiter
+                  </StatusBadge>
+                ) : null}
                 {hasAnyApprovalItems ? (
                   <StatusBadge variant="warning" size="sm">
                     {approvalPending.length + approvalPendingQuotes.length} awaiting approval
@@ -1507,11 +1512,6 @@ export default function WorkOrderIdClient(): JSX.Element {
                       >
                         {formatDecisionStatus({ workStatus: wo.status }).label}
                       </StatusBadge>
-                      {isWaiter && (
-                        <StatusBadge variant="danger" size="sm">
-                          Waiter
-                        </StatusBadge>
-                      )}
                     </div>
                   </div>
                   <div className={cn(cardInner, "p-2")}>

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -1114,15 +1114,13 @@ export default function MobileWorkOrderClient({
                   <span className={chip(canonicalHeaderStatus)}>
                     {canonicalHeaderStatus.replaceAll("_", " ")}
                   </span>
-                </div>
-                <p className="text-[11px] text-slate-400">
-                  Created {createdAtText}
                   {isWaiter ? (
-                    <span className="ml-2 rounded-full border border-red-400/65 bg-red-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-red-200">
+                    <span className="rounded-full border border-red-400/65 bg-red-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-red-200">
                       Waiter
                     </span>
                   ) : null}
-                </p>
+                </div>
+                <p className="text-[11px] text-slate-400">Created {createdAtText}</p>
               </div>
             </div>
             <div className="mt-2 flex gap-1.5 overflow-x-auto pb-1">


### PR DESCRIPTION
### Motivation
- Make the operationally-important `Waiter` flag visible at a glance by placing it next to the primary lifecycle status in the work-order header rather than inside the contextual Order State panel. 
- Source of truth for the flag is the existing work-order waiter fields (`is_waiter` with legacy fallbacks `waiter` and `customer_waiting`) and that source was preserved.  
- The Order State panel previously contained a duplicate pill which visually disconnected the waiter context when the user scrolled into the job workspace.  
- The work-order header component (`WorkOrderIdClient` in `app/work-orders/[id]/Client.tsx`) is shared across the main `[/work-orders/[id]]` view, split quote-review, and focused-job routes, so a single header change covers Owner/Admin/Advisor/Technician views; mobile uses `MobileWorkOrderClient` and was aligned separately. 

### Description
- Moved the `Waiter` pill from the `Order state` card into the primary work-order header so header layout is `EL000001   IN PROGRESS   WAITER`, using the existing `StatusBadge variant="danger" size="sm"` styling and preserving visual tone.  
- Removed the duplicate `Waiter` pill from the `Order state` panel while leaving the lifecycle status and other contextual pills intact.  
- Aligned mobile header in `MobileWorkOrderClient` so the `Waiter` pill sits beside the lifecycle status and `Created` metadata remains on its own line to preserve wrapping on narrower screens.  
- Preserved waiter logic and source (no new state derived, no changes to job cards, active indicators, punch dots, job-card borders, or timer logic).  
- Files changed: `app/work-orders/[id]/Client.tsx` and `features/work-orders/mobile/MobileWorkOrderClient.tsx`. 

### Testing
- Ran `npm run typecheck` which completed successfully.  
- Ran `npm run lint` which reported pre-existing repository lint errors unrelated to these changes; no new lint errors were introduced for the modified files.  
- Verified visually in code that the `isWaiter` computation remains the existing pattern (`is_waiter || waiter || customer_waiting`) and the header uses `flex-wrap`/`gap` to support tablet and mobile wrapping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51c0e03688832881877f2988c881fc)