### PR TITLE
Repair parts-request attachment lifecycle and advisory mismatch flow

### DIFF
--- a/app/api/parts/_lib/lifecycleCommand.ts
+++ b/app/api/parts/_lib/lifecycleCommand.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+export function isUuid(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i.test(value.trim());
+}
+
+export function positiveNumber(value: unknown): number | null {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export function idempotencyKey(req: Request, body: Record<string, unknown>, fallback: string): string {
+  const header = req.headers.get("Idempotency-Key")?.trim();
+  const fromBody = typeof body.idempotencyKey === "string" ? body.idempotencyKey.trim() : "";
+  return header || fromBody || fallback;
+}
+
+export async function runPartsLifecycleRpc(_req: Request, rpc: string, args: Record<string, unknown>) {
+  const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+  if (!access.ok) return access.response;
+  const { data, error } = await access.supabase.rpc(rpc as never, args as never);
+  if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 409 });
+  return NextResponse.json({ ok: true, result: data });
+}

--- a/app/api/parts/_lib/receivePartRequestItem.ts
+++ b/app/api/parts/_lib/receivePartRequestItem.ts
@@ -10,6 +10,7 @@ type ReceivePayload = {
   locationId: string;
   qty: number;
   poId?: string | null;
+  idempotencyKey?: string | null;
 };
 
 type LegacyBody = {
@@ -17,10 +18,12 @@ type LegacyBody = {
   location_id?: unknown;
   qty?: unknown;
   po_id?: unknown;
+  idempotencyKey?: unknown;
+  idempotency_key?: unknown;
 };
 
 function isUuid(v: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v);
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i.test(v);
 }
 
 function normalizeBody(input: LegacyBody | null): Omit<ReceivePayload, "itemId"> | null {
@@ -34,7 +37,8 @@ function normalizeBody(input: LegacyBody | null): Omit<ReceivePayload, "itemId">
   if (!Number.isFinite(qty) || qty <= 0) return null;
   if (poId && !isUuid(poId)) return null;
 
-  return { locationId, qty, poId };
+  const idempotencyKey = typeof input.idempotencyKey === "string" && input.idempotencyKey.trim() ? input.idempotencyKey.trim() : typeof input.idempotency_key === "string" && input.idempotency_key.trim() ? input.idempotency_key.trim() : null;
+  return { locationId, qty, poId, idempotencyKey };
 }
 
 export async function receivePartRequestItem(payload: ReceivePayload): Promise<NextResponse> {
@@ -72,7 +76,8 @@ export async function receivePartRequestItem(payload: ReceivePayload): Promise<N
       p_location_id: payload.locationId,
       p_qty: payload.qty,
       ...(payload.poId ? { p_po_id: payload.poId } : {}),
-    };
+      ...(payload.idempotencyKey ? { p_idempotency_key: payload.idempotencyKey } : {}),
+    } as RpcArgs;
 
     const { data, error } = await supabase.rpc("receive_part_request_item", args);
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/app/api/parts/requests/items/[itemId]/add/route.ts
+++ b/app/api/parts/requests/items/[itemId]/add/route.ts
@@ -23,6 +23,8 @@ type Body = {
   poId?: string | null;
   locationId?: string | null;
   createAllocation?: boolean;
+  warningAccepted?: boolean;
+  warningReason?: string | null;
 };
 
 function cleanString(value: unknown): string | null {
@@ -161,6 +163,9 @@ export async function POST(
     if (!po) return NextResponse.json({ ok: false, error: "Purchase order is not available for this shop." }, { status: 403 });
   }
 
+  const warningAccepted = body.warningAccepted === true;
+  const warningReason = cleanString(body.warningReason);
+
   const update: ItemUpdate = {
     part_id: partId,
     description: cleanString(body.description) ?? item.description ?? "Part",
@@ -189,17 +194,29 @@ export async function POST(
     return NextResponse.json({ ok: false, error: "Update did not apply. The item may have changed or your shop access was blocked." }, { status: 409 });
   }
 
-  let allocation: { ok: true } | { ok: false; error: string } | null = null;
+  let allocation: { ok: true; result?: unknown } | { ok: false; error: string } | null = null;
   if (body.createAllocation && locationId) {
-    const { error: allocationError } = await supabase.rpc("upsert_part_allocation_from_request_item", {
+    const { data: allocationResult, error: allocationError } = await supabase.rpc("upsert_part_allocation_from_request_item", {
       p_request_item_id: itemId,
       p_location_id: locationId,
       p_create_stock_move: true,
     });
-    allocation = allocationError ? { ok: false, error: allocationError.message } : { ok: true };
+    allocation = allocationError ? { ok: false, error: allocationError.message } : { ok: true, result: allocationResult };
     if (allocationError) {
       return NextResponse.json({ ok: false, item: updatedItem, allocation, error: allocationError.message }, { status: 500 });
     }
+  }
+
+  if (warningAccepted && warningReason) {
+    await supabase
+      .from("work_order_parts")
+      .update({
+        mismatch_acknowledged_at: new Date().toISOString(),
+        mismatch_acknowledged_by: access.profile.id,
+        mismatch_warning_reason: warningReason,
+      } as never)
+      .eq("source_parts_request_item_id", itemId)
+      .eq("shop_id", shopId);
   }
 
   return NextResponse.json({ ok: true, item: updatedItem, allocation });

--- a/app/api/parts/requests/items/[itemId]/allocate/route.ts
+++ b/app/api/parts/requests/items/[itemId]/allocate/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { idempotencyKey, isUuid, positiveNumber, runPartsLifecycleRpc } from "../../../../_lib/lifecycleCommand";
+
+export async function POST(req: Request, ctx: { params: Promise<{ itemId: string }> }) {
+  const { itemId } = await ctx.params;
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : "";
+  const qty = positiveNumber(body?.qty);
+  if (!isUuid(itemId) || !isUuid(locationId) || qty == null) return NextResponse.json({ ok: false, error: "Invalid item, location, or quantity." }, { status: 400 });
+  return runPartsLifecycleRpc(req, "parts_allocate_request_item", {
+    p_request_item_id: itemId,
+    p_location_id: locationId,
+    p_qty: qty,
+    p_idempotency_key: idempotencyKey(req, body ?? {}, `allocate:${itemId}:${locationId}:${qty}`),
+  });
+}

--- a/app/api/parts/requests/items/[itemId]/cancel/route.ts
+++ b/app/api/parts/requests/items/[itemId]/cancel/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { idempotencyKey, isUuid, runPartsLifecycleRpc } from "../../../../_lib/lifecycleCommand";
+
+export async function POST(req: Request, ctx: { params: Promise<{ itemId: string }> }) {
+  const { itemId } = await ctx.params;
+  const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!isUuid(itemId)) return NextResponse.json({ ok: false, error: "Invalid request item." }, { status: 400 });
+  return runPartsLifecycleRpc(req, "parts_cancel_request_item", { p_request_item_id: itemId, p_idempotency_key: idempotencyKey(req, body, `cancel:${itemId}`) });
+}

--- a/app/api/parts/requests/items/[itemId]/po-line/route.ts
+++ b/app/api/parts/requests/items/[itemId]/po-line/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { idempotencyKey, isUuid, positiveNumber, runPartsLifecycleRpc } from "../../../../_lib/lifecycleCommand";
+
+export async function POST(req: Request, ctx: { params: Promise<{ itemId: string }> }) {
+  const { itemId } = await ctx.params;
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const poId = typeof body?.poId === "string" ? body.poId : typeof body?.po_id === "string" ? body.po_id : "";
+  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : null;
+  const qty = positiveNumber(body?.qty);
+  const unitCost = body?.unitCost == null ? null : Number(body.unitCost);
+  if (!isUuid(itemId) || !isUuid(poId) || qty == null || (locationId != null && !isUuid(locationId))) return NextResponse.json({ ok: false, error: "Invalid PO, item, location, or quantity." }, { status: 400 });
+  return runPartsLifecycleRpc(req, "parts_create_po_line_for_request", {
+    p_po_id: poId,
+    p_request_item_id: itemId,
+    p_qty: qty,
+    p_unit_cost: Number.isFinite(unitCost) ? unitCost : null,
+    p_location_id: locationId,
+    p_idempotency_key: idempotencyKey(req, body ?? {}, `po-line:${poId}:${itemId}:${qty}`),
+  });
+}

--- a/app/api/parts/requests/items/[itemId]/release/route.ts
+++ b/app/api/parts/requests/items/[itemId]/release/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { idempotencyKey, isUuid, positiveNumber, runPartsLifecycleRpc } from "../../../../_lib/lifecycleCommand";
+
+export async function POST(req: Request, ctx: { params: Promise<{ itemId: string }> }) {
+  const { itemId } = await ctx.params;
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : "";
+  const qty = positiveNumber(body?.qty);
+  if (!isUuid(itemId) || !isUuid(locationId) || qty == null) return NextResponse.json({ ok: false, error: "Invalid item, location, or quantity." }, { status: 400 });
+  return runPartsLifecycleRpc(req, "parts_release_allocation", {
+    p_request_item_id: itemId,
+    p_location_id: locationId,
+    p_qty: qty,
+    p_idempotency_key: idempotencyKey(req, body ?? {}, `release:${itemId}:${locationId}:${qty}`),
+  });
+}

--- a/app/api/parts/requests/items/[itemId]/replace/route.ts
+++ b/app/api/parts/requests/items/[itemId]/replace/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { idempotencyKey, isUuid, positiveNumber, runPartsLifecycleRpc } from "../../../../_lib/lifecycleCommand";
+
+export async function POST(req: Request, ctx: { params: Promise<{ itemId: string }> }) {
+  const { itemId } = await ctx.params;
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const newPartId = typeof body?.newPartId === "string" ? body.newPartId : typeof body?.new_part_id === "string" ? body.new_part_id : "";
+  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : "";
+  const qty = positiveNumber(body?.qty);
+  if (!isUuid(itemId) || !isUuid(newPartId) || !isUuid(locationId) || qty == null) return NextResponse.json({ ok: false, error: "Invalid replacement part, item, location, or quantity." }, { status: 400 });
+  return runPartsLifecycleRpc(req, "parts_replace_request_item", { p_request_item_id: itemId, p_new_part_id: newPartId, p_location_id: locationId, p_qty: qty, p_idempotency_key: idempotencyKey(req, body ?? {}, `replace:${itemId}:${newPartId}:${locationId}`) });
+}

--- a/app/api/parts/work-order-parts/[partId]/issue/route.ts
+++ b/app/api/parts/work-order-parts/[partId]/issue/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { idempotencyKey, isUuid, positiveNumber, runPartsLifecycleRpc } from "../../../_lib/lifecycleCommand";
+
+export async function POST(req: Request, ctx: { params: Promise<{ partId: string }> }) {
+  const { partId } = await ctx.params;
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : "";
+  const qty = positiveNumber(body?.qty);
+  if (!isUuid(partId) || !isUuid(locationId) || qty == null) return NextResponse.json({ ok: false, error: "Invalid work-order part, location, or quantity." }, { status: 400 });
+  return runPartsLifecycleRpc(req, "parts_issue_work_order_part", { p_work_order_part_id: partId, p_location_id: locationId, p_qty: qty, p_idempotency_key: idempotencyKey(req, body ?? {}, `issue:${partId}:${locationId}:${qty}`) });
+}

--- a/app/api/parts/work-order-parts/[partId]/return/route.ts
+++ b/app/api/parts/work-order-parts/[partId]/return/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { idempotencyKey, isUuid, positiveNumber, runPartsLifecycleRpc } from "../../../_lib/lifecycleCommand";
+
+export async function POST(req: Request, ctx: { params: Promise<{ partId: string }> }) {
+  const { partId } = await ctx.params;
+  const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
+  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : "";
+  const qty = positiveNumber(body?.qty);
+  if (!isUuid(partId) || !isUuid(locationId) || qty == null) return NextResponse.json({ ok: false, error: "Invalid work-order part, location, or quantity." }, { status: 400 });
+  return runPartsLifecycleRpc(req, "parts_return_to_stock", { p_work_order_part_id: partId, p_location_id: locationId, p_qty: qty, p_idempotency_key: idempotencyKey(req, body ?? {}, `return:${partId}:${locationId}:${qty}`) });
+}

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -1545,7 +1545,6 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     });
     if (conflict && !conflictOverrideByItemId[itemId]) {
       setConflictWarningByItemId((prev) => ({ ...prev, [itemId]: conflict.message }));
-      toast.warning("Possible mismatch. Review the warning before adding.");
       return;
     }
 
@@ -1612,6 +1611,8 @@ if (!lineId || !isUuid(lineId)) {
           poId,
           locationId: shouldAllocateFromStock ? locId : null,
           createAllocation: shouldAllocateFromStock,
+          warningAccepted: Boolean(conflictOverrideByItemId[itemId]),
+          warningReason: conflictOverrideByItemId[itemId] ? conflict?.message ?? null : null,
         }),
       });
       const body = (await res.json().catch(() => null)) as

--- a/db/sql/2026-07-11_parts_lifecycle_completion.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_completion.sql
@@ -8,7 +8,8 @@ alter table public.stock_moves
   add column if not exists work_order_part_id uuid,
   add column if not exists part_request_item_id uuid,
   add column if not exists purchase_order_line_id uuid,
-  add column if not exists metadata jsonb default '{}'::jsonb not null;
+  add column if not exists metadata jsonb default '{}'::jsonb not null,
+  add column if not exists lifecycle_quantity numeric(12,2);
 
 create unique index if not exists uq_stock_moves_shop_idempotency_key
   on public.stock_moves(shop_id, idempotency_key)
@@ -17,6 +18,29 @@ create unique index if not exists uq_stock_moves_shop_idempotency_key
 -- Replace the Phase 1 broad uniqueness rule. Keeping it would block legitimate
 -- second receipts/releases/issues against the same source and reason.
 drop index if exists public.uq_stock_moves_reference_reason;
+
+alter table public.work_order_parts
+  add column if not exists is_active boolean default true not null,
+  add column if not exists replaced_from_work_order_part_id uuid,
+  add column if not exists replaced_by_work_order_part_id uuid;
+
+alter table public.work_order_part_allocations
+  add column if not exists work_order_part_id uuid;
+
+update public.work_order_part_allocations a
+set work_order_part_id = wop.id
+from public.work_order_parts wop
+where a.work_order_part_id is null
+  and a.source_request_item_id = wop.source_parts_request_item_id
+  and a.part_id = wop.part_id
+  and wop.is_active
+  and not exists (
+    select 1 from public.work_order_parts w2
+    where w2.source_parts_request_item_id = a.source_request_item_id
+      and w2.part_id = a.part_id
+      and w2.is_active
+      and w2.id <> wop.id
+  );
 
 alter table public.purchase_order_lines
   add column if not exists part_request_item_id uuid,
@@ -31,6 +55,14 @@ create index if not exists idx_purchase_order_lines_work_order_part_id
   on public.purchase_order_lines(work_order_part_id)
   where work_order_part_id is not null;
 
+create unique index if not exists uq_work_order_parts_active_source_request_item
+  on public.work_order_parts(source_parts_request_item_id)
+  where source_parts_request_item_id is not null and is_active;
+
+create unique index if not exists uq_wopa_work_order_part_location
+  on public.work_order_part_allocations(work_order_part_id, location_id)
+  where work_order_part_id is not null;
+
 create index if not exists idx_stock_moves_work_order_part_id
   on public.stock_moves(work_order_part_id)
   where work_order_part_id is not null;
@@ -41,6 +73,15 @@ do $$ begin
   end if;
   if not exists (select 1 from pg_constraint where conname = 'purchase_order_lines_work_order_part_id_fkey' and conrelid = 'public.purchase_order_lines'::regclass) then
     alter table public.purchase_order_lines add constraint purchase_order_lines_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_part_allocations_work_order_part_id_fkey' and conrelid = 'public.work_order_part_allocations'::regclass) then
+    alter table public.work_order_part_allocations add constraint work_order_part_allocations_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_replaced_from_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_replaced_from_fkey foreign key (replaced_from_work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_replaced_by_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_replaced_by_fkey foreign key (replaced_by_work_order_part_id) references public.work_order_parts(id) on delete set null;
   end if;
   if not exists (select 1 from pg_constraint where conname = 'stock_moves_work_order_part_id_fkey' and conrelid = 'public.stock_moves'::regclass) then
     alter table public.stock_moves add constraint stock_moves_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
@@ -132,9 +173,10 @@ begin
   if v_line.shop_id is distinct from v_item.shop_id then raise exception 'Work-order line belongs to a different shop.'; end if;
   if v_request.work_order_id is not null and v_request.work_order_id <> v_line.work_order_id then raise exception 'Work-order line does not belong to the request work order.'; end if;
   v_qty := coalesce(v_item.qty_requested, v_item.qty, 0);
-  insert into public.work_order_parts(work_order_id, work_order_line_id, shop_id, part_id, quantity, unit_price, total_price, source_parts_request_id, source_parts_request_item_id, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_received, quantity_consumed, unit_cost_snapshot, unit_sell_price_snapshot, lifecycle_status, updated_at)
-  values (v_line.work_order_id, v_item.work_order_line_id, v_item.shop_id, v_item.part_id, v_qty::integer, coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price, 0) * v_qty, v_item.request_id, v_item.id, coalesce(v_part.name, v_item.description), coalesce(v_part.supplier, v_item.vendor), v_part.part_number, v_qty, coalesce(v_item.qty_received,0), coalesce(v_item.qty_consumed,0), coalesce(v_item.unit_cost, v_part.cost), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), 'requested', now())
-  on conflict (source_parts_request_item_id) where source_parts_request_item_id is not null do update set work_order_id=excluded.work_order_id, work_order_line_id=excluded.work_order_line_id, shop_id=excluded.shop_id, part_id=excluded.part_id, quantity=excluded.quantity, quantity_requested=excluded.quantity_requested, updated_at=now()
+  select id into v_wop from public.work_order_parts where source_parts_request_item_id = p_request_item_id and is_active for update;
+  if found then return v_wop; end if;
+  insert into public.work_order_parts(work_order_id, work_order_line_id, shop_id, part_id, quantity, unit_price, total_price, source_parts_request_id, source_parts_request_item_id, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_received, quantity_consumed, unit_cost_snapshot, unit_sell_price_snapshot, lifecycle_status, updated_at, is_active)
+  values (v_line.work_order_id, v_item.work_order_line_id, v_item.shop_id, v_item.part_id, v_qty, coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price, 0) * v_qty, v_item.request_id, v_item.id, coalesce(v_part.name, v_item.description), coalesce(v_part.supplier, v_item.vendor), v_part.part_number, v_qty, coalesce(v_item.qty_received,0), coalesce(v_item.qty_consumed,0), coalesce(v_item.unit_cost, v_part.cost), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), 'requested', now(), true)
   returning id into v_wop;
   return v_wop;
 end $$;
@@ -153,11 +195,11 @@ begin
   if v_wop.part_id is null then raise exception 'Work-order part has no selected part.'; end if;
   v_available := public.parts_available(v_wop.shop_id, v_wop.part_id, p_location_id);
   if v_available < p_qty then raise exception 'Insufficient available stock. Available %, requested %.', v_available, p_qty; end if;
-  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata)
-  values (v_wop.part_id, p_location_id, 0, 'wo_allocate', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, p_request_item_id, jsonb_build_object('qty_reserved', p_qty, 'operation', 'allocate')) returning id into v_move_id;
-  insert into public.work_order_part_allocations(work_order_line_id, work_order_id, shop_id, part_id, location_id, qty, unit_cost, stock_move_id, source_request_item_id)
-  values (v_wop.work_order_line_id, v_wop.work_order_id, v_wop.shop_id, v_wop.part_id, p_location_id, p_qty, coalesce(v_wop.unit_cost_snapshot,0), v_move_id, p_request_item_id)
-  on conflict (source_request_item_id, part_id, location_id) where source_request_item_id is not null do update set qty = public.work_order_part_allocations.qty + excluded.qty, stock_move_id = excluded.stock_move_id
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, 0, 'wo_allocate', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, p_request_item_id, jsonb_build_object('qty_reserved', p_qty, 'operation', 'allocate'), p_qty) returning id into v_move_id;
+  insert into public.work_order_part_allocations(work_order_line_id, work_order_id, shop_id, part_id, location_id, qty, unit_cost, stock_move_id, source_request_item_id, work_order_part_id)
+  values (v_wop.work_order_line_id, v_wop.work_order_id, v_wop.shop_id, v_wop.part_id, p_location_id, p_qty, coalesce(v_wop.unit_cost_snapshot,0), v_move_id, p_request_item_id, v_wop.id)
+  on conflict (work_order_part_id, location_id) where work_order_part_id is not null do update set qty = public.work_order_part_allocations.qty + excluded.qty, stock_move_id = excluded.stock_move_id
   returning id, qty into v_alloc_id, v_new_alloc;
   update public.part_request_items set qty_reserved = coalesce(qty_reserved,0) + p_qty, status='reserved', updated_at=now() where id=p_request_item_id;
   update public.work_order_parts set quantity_allocated = coalesce(quantity_allocated,0) + p_qty, lifecycle_status='reserved', updated_at=now() where id=v_wop.id;
@@ -178,12 +220,12 @@ begin
   if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
   select * into v_wop from public.work_order_parts where source_parts_request_item_id=p_request_item_id for update;
   if not found then raise exception 'Work-order part not found.'; end if;
-  select * into v_alloc from public.work_order_part_allocations where source_request_item_id=p_request_item_id and part_id=v_wop.part_id and location_id=p_location_id for update;
+  select * into v_alloc from public.work_order_part_allocations where work_order_part_id=v_wop.id and location_id=p_location_id for update;
   if not found or v_alloc.qty <= 0 then raise exception 'No active allocation to release.'; end if;
   if v_alloc.qty < p_qty then raise exception 'Cannot release more than active allocation.'; end if;
   v_release := p_qty;
-  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata)
-  values (v_wop.part_id, p_location_id, 0, 'wo_release', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, p_request_item_id, jsonb_build_object('qty_released', v_release, 'operation', 'release')) returning id into v_move_id;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, 0, 'wo_release', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, p_request_item_id, jsonb_build_object('qty_released', v_release, 'operation', 'release'), v_release) returning id into v_move_id;
   update public.work_order_part_allocations set qty = qty - v_release, stock_move_id = v_move_id where id = v_alloc.id;
   delete from public.work_order_part_allocations where id = v_alloc.id and qty <= 0;
   update public.part_request_items set qty_reserved = greatest(coalesce(qty_reserved,0) - v_release, 0), updated_at=now() where id=p_request_item_id;
@@ -235,8 +277,8 @@ begin
     select coalesce(sum(qty), coalesce(v_item.qty_requested, v_item.qty, 0)) into v_ordered_limit from public.purchase_order_lines where part_request_item_id=p_request_item_id;
     if coalesce(v_item.qty_received,0) + p_qty > greatest(v_ordered_limit, coalesce(v_item.qty_requested, v_item.qty,0)) then raise exception 'Receipt exceeds requested quantity.'; end if;
   end if;
-  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, purchase_order_line_id, metadata)
-  values (v_wop.part_id, p_location_id, p_qty, 'receive', case when p_po_line_id is null then 'part_request_item' else 'purchase_order_line' end, coalesce(p_po_line_id, p_request_item_id), auth.uid(), v_wop.shop_id, v_key, v_wop.id, p_request_item_id, p_po_line_id, jsonb_build_object('qty_received', p_qty, 'operation', 'receive')) returning id into v_move_id;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, purchase_order_line_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, p_qty, 'receive', case when p_po_line_id is null then 'part_request_item' else 'purchase_order_line' end, coalesce(p_po_line_id, p_request_item_id), auth.uid(), v_wop.shop_id, v_key, v_wop.id, p_request_item_id, p_po_line_id, jsonb_build_object('qty_received', p_qty, 'operation', 'receive'), p_qty) returning id into v_move_id;
   update public.part_request_items set qty_received=coalesce(qty_received,0)+p_qty, location_id=coalesce(location_id,p_location_id), unit_cost=coalesce(p_unit_cost, unit_cost), status=case when coalesce(qty_received,0)+p_qty >= coalesce(qty_requested, qty,0) then 'received' else 'partially_received' end, updated_at=now() where id=p_request_item_id returning qty_received into v_received_total;
   update public.work_order_parts set quantity_received=coalesce(quantity_received,0)+p_qty, unit_cost_snapshot=coalesce(p_unit_cost, unit_cost_snapshot), updated_at=now() where id=v_wop.id;
   perform public.parts_reconcile_work_order_part(v_wop.id);
@@ -255,11 +297,11 @@ begin
   if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
   if coalesce(v_wop.quantity_allocated,0) < p_qty then raise exception 'Cannot issue more than allocated quantity.'; end if;
   if public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id) < p_qty then raise exception 'Cannot issue more than on-hand quantity.'; end if;
-  select * into v_alloc from public.work_order_part_allocations where source_request_item_id=v_wop.source_parts_request_item_id and part_id=v_wop.part_id and location_id=p_location_id for update;
+  select * into v_alloc from public.work_order_part_allocations where work_order_part_id=v_wop.id and location_id=p_location_id for update;
   if not found or v_alloc.qty < p_qty then raise exception 'Allocation not found or insufficient for issue.'; end if;
   v_item_id := v_wop.source_parts_request_item_id;
-  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata)
-  values (v_wop.part_id, p_location_id, -p_qty, 'consume', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, v_item_id, jsonb_build_object('qty_issued', p_qty, 'operation', 'issue')) returning id into v_move_id;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, -p_qty, 'consume', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, v_item_id, jsonb_build_object('qty_issued', p_qty, 'operation', 'issue'), p_qty) returning id into v_move_id;
   update public.work_order_part_allocations set qty=qty-p_qty, stock_move_id=v_move_id where id=v_alloc.id;
   delete from public.work_order_part_allocations where id=v_alloc.id and qty<=0;
   update public.work_order_parts set quantity_allocated=greatest(coalesce(quantity_allocated,0)-p_qty,0), quantity_consumed=coalesce(quantity_consumed,0)+p_qty, updated_at=now() where id=v_wop.id;
@@ -279,8 +321,8 @@ begin
   select * into v_existing from public.stock_moves where shop_id=v_wop.shop_id and idempotency_key=p_idempotency_key;
   if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
   if coalesce(v_wop.quantity_consumed,0) - coalesce(v_wop.quantity_returned,0) < p_qty then raise exception 'Cannot return more than issued and unreturned quantity.'; end if;
-  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata)
-  values (v_wop.part_id, p_location_id, p_qty, 'return', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, v_wop.source_parts_request_item_id, jsonb_build_object('qty_returned', p_qty, 'operation', 'return_to_stock')) returning id into v_move_id;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, p_qty, 'return', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, v_wop.source_parts_request_item_id, jsonb_build_object('qty_returned', p_qty, 'operation', 'return_to_stock'), p_qty) returning id into v_move_id;
   update public.work_order_parts set quantity_returned=coalesce(quantity_returned,0)+p_qty, updated_at=now() where id=v_wop.id;
   perform public.parts_reconcile_work_order_part(v_wop.id);
   return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'returned_qty', p_qty, 'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id));
@@ -293,7 +335,7 @@ begin
   if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
   select * into v_wop from public.work_order_parts where source_parts_request_item_id=p_request_item_id for update;
   if not found then raise exception 'Work-order part not found.'; end if;
-  for v_alloc in select * from public.work_order_part_allocations where source_request_item_id=p_request_item_id for update loop
+  for v_alloc in select * from public.work_order_part_allocations where work_order_part_id=v_wop.id for update loop
     v_key := p_idempotency_key || ':release:' || v_alloc.id::text;
     perform public.parts_release_allocation(p_request_item_id, v_alloc.location_id, v_alloc.qty, v_key);
     v_released := v_released + v_alloc.qty;
@@ -317,11 +359,13 @@ begin
   v_had_old := found;
   if v_had_old then
     perform public.parts_cancel_request_item(p_request_item_id, p_idempotency_key || ':cancel-old');
-    update public.work_order_parts set lifecycle_status='replaced', updated_at=now() where id=v_old.id and quantity_consumed = 0;
+    update public.work_order_parts set lifecycle_status='replaced', is_active=false, updated_at=now() where id=v_old.id and quantity_consumed = 0;
   end if;
   update public.part_request_items set part_id=p_new_part_id, status='requested', qty_reserved=0, updated_at=now() where id=p_request_item_id;
-  update public.work_order_parts set part_id=p_new_part_id, description_snapshot=v_part.name, manufacturer_snapshot=v_part.supplier, part_number_snapshot=v_part.part_number, quantity_allocated=0, quantity_consumed=coalesce(quantity_consumed,0), quantity_cancelled=0, lifecycle_status='requested', updated_at=now() where source_parts_request_item_id=p_request_item_id and coalesce(quantity_consumed,0)=0;
+  -- Create a fresh active work_order_parts row; do not rewrite old snapshots.
   v_result := public.parts_allocate_request_item(p_request_item_id, p_location_id, p_qty, p_idempotency_key || ':allocate-new');
+  update public.work_order_parts set replaced_from_work_order_part_id = case when v_had_old then v_old.id else null end where source_parts_request_item_id=p_request_item_id and is_active;
+  if v_had_old then update public.work_order_parts set replaced_by_work_order_part_id = (select id from public.work_order_parts where source_parts_request_item_id=p_request_item_id and is_active limit 1) where id=v_old.id; end if;
   return v_result || jsonb_build_object('ok', true, 'replaced_part_id', case when v_had_old then v_old.part_id else null end, 'new_part_id', p_new_part_id);
 end $$;
 
@@ -355,3 +399,24 @@ begin
   v_key := coalesce(nullif(trim(p_idempotency_key),''), 'receive-request-item:'||p_item_id::text||':'||coalesce(v_line_id::text, 'direct')||':'||p_location_id::text||':'||p_qty::text);
   return public.parts_receive_request_item(p_item_id, p_location_id, p_qty, v_line_id, null, v_key);
 end $$;
+
+
+-- Security hardening: lifecycle RPCs are callable by authenticated users only;
+-- each SECURITY DEFINER function validates shop/work-order scope internally and
+-- API routes additionally require canManageWorkOrders.
+revoke all on function public.parts_allocate_request_item(uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_release_allocation(uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_create_po_line_for_request(uuid, uuid, numeric, numeric, uuid, text) from public, anon;
+revoke all on function public.parts_receive_request_item(uuid, uuid, numeric, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_issue_work_order_part(uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_return_to_stock(uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_cancel_request_item(uuid, text) from public, anon;
+revoke all on function public.parts_replace_request_item(uuid, uuid, uuid, numeric, text) from public, anon;
+grant execute on function public.parts_allocate_request_item(uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_release_allocation(uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_create_po_line_for_request(uuid, uuid, numeric, numeric, uuid, text) to authenticated, service_role;
+grant execute on function public.parts_receive_request_item(uuid, uuid, numeric, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_issue_work_order_part(uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_return_to_stock(uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_cancel_request_item(uuid, text) to authenticated, service_role;
+grant execute on function public.parts_replace_request_item(uuid, uuid, uuid, numeric, text) to authenticated, service_role;

--- a/db/sql/2026-07-11_parts_lifecycle_completion.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_completion.sql
@@ -1,0 +1,357 @@
+-- Phase 2 parts lifecycle completion.
+-- Establish operation idempotency, normalize reservation movement semantics,
+-- and add canonical transactional commands for allocation, release, receiving,
+-- issue/consumption, return, cancellation, and replacement.
+
+alter table public.stock_moves
+  add column if not exists idempotency_key text,
+  add column if not exists work_order_part_id uuid,
+  add column if not exists part_request_item_id uuid,
+  add column if not exists purchase_order_line_id uuid,
+  add column if not exists metadata jsonb default '{}'::jsonb not null;
+
+create unique index if not exists uq_stock_moves_shop_idempotency_key
+  on public.stock_moves(shop_id, idempotency_key)
+  where idempotency_key is not null;
+
+-- Replace the Phase 1 broad uniqueness rule. Keeping it would block legitimate
+-- second receipts/releases/issues against the same source and reason.
+drop index if exists public.uq_stock_moves_reference_reason;
+
+alter table public.purchase_order_lines
+  add column if not exists part_request_item_id uuid,
+  add column if not exists work_order_part_id uuid,
+  add column if not exists idempotency_key text;
+
+create unique index if not exists uq_purchase_order_lines_idempotency
+  on public.purchase_order_lines(po_id, idempotency_key)
+  where idempotency_key is not null;
+
+create index if not exists idx_purchase_order_lines_work_order_part_id
+  on public.purchase_order_lines(work_order_part_id)
+  where work_order_part_id is not null;
+
+create index if not exists idx_stock_moves_work_order_part_id
+  on public.stock_moves(work_order_part_id)
+  where work_order_part_id is not null;
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'purchase_order_lines_part_request_item_id_fkey' and conrelid = 'public.purchase_order_lines'::regclass) then
+    alter table public.purchase_order_lines add constraint purchase_order_lines_part_request_item_id_fkey foreign key (part_request_item_id) references public.part_request_items(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'purchase_order_lines_work_order_part_id_fkey' and conrelid = 'public.purchase_order_lines'::regclass) then
+    alter table public.purchase_order_lines add constraint purchase_order_lines_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'stock_moves_work_order_part_id_fkey' and conrelid = 'public.stock_moves'::regclass) then
+    alter table public.stock_moves add constraint stock_moves_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'stock_moves_part_request_item_id_fkey' and conrelid = 'public.stock_moves'::regclass) then
+    alter table public.stock_moves add constraint stock_moves_part_request_item_id_fkey foreign key (part_request_item_id) references public.part_request_items(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'stock_moves_purchase_order_line_id_fkey' and conrelid = 'public.stock_moves'::regclass) then
+    alter table public.stock_moves add constraint stock_moves_purchase_order_line_id_fkey foreign key (purchase_order_line_id) references public.purchase_order_lines(id) on delete set null;
+  end if;
+end $$;
+
+create or replace function public.parts_lifecycle_status(
+  p_requested numeric,
+  p_ordered numeric,
+  p_received numeric,
+  p_allocated numeric,
+  p_consumed numeric,
+  p_returned numeric,
+  p_cancelled numeric
+) returns text language sql immutable as $$
+  select case
+    when coalesce(p_cancelled,0) >= greatest(coalesce(p_requested,0) - coalesce(p_consumed,0), 0) and coalesce(p_consumed,0) = 0 then 'cancelled'
+    when coalesce(p_returned,0) > 0 and coalesce(p_returned,0) < coalesce(p_consumed,0) then 'partially_returned'
+    when coalesce(p_returned,0) > 0 and coalesce(p_returned,0) >= coalesce(p_consumed,0) then 'returned'
+    when coalesce(p_consumed,0) > 0 and coalesce(p_consumed,0) < coalesce(p_requested,0) then 'partially_consumed'
+    when coalesce(p_consumed,0) > 0 and coalesce(p_consumed,0) >= coalesce(p_requested,0) then 'consumed'
+    when coalesce(p_allocated,0) > 0 and coalesce(p_allocated,0) < coalesce(p_requested,0) then 'partially_allocated'
+    when coalesce(p_allocated,0) > 0 and coalesce(p_allocated,0) >= coalesce(p_requested,0) then 'reserved'
+    when coalesce(p_received,0) > 0 and coalesce(p_received,0) < coalesce(p_ordered, p_requested,0) then 'partially_received'
+    when coalesce(p_received,0) > 0 then 'received'
+    when coalesce(p_ordered,0) > 0 and coalesce(p_ordered,0) < coalesce(p_requested,0) then 'partially_ordered'
+    when coalesce(p_ordered,0) > 0 then 'ordered'
+    else 'requested'
+  end;
+$$;
+
+create or replace function public.parts_on_hand(p_shop_id uuid, p_part_id uuid, p_location_id uuid default null)
+returns numeric language sql stable as $$
+  select coalesce(sum(sm.qty_change),0)::numeric
+  from public.stock_moves sm
+  where sm.shop_id = p_shop_id
+    and sm.part_id = p_part_id
+    and (p_location_id is null or sm.location_id = p_location_id)
+    and sm.reason not in ('wo_allocate','wo_release');
+$$;
+
+create or replace function public.parts_allocated(p_shop_id uuid, p_part_id uuid, p_location_id uuid default null)
+returns numeric language sql stable as $$
+  select coalesce(sum(a.qty),0)::numeric
+  from public.work_order_part_allocations a
+  where a.shop_id = p_shop_id
+    and a.part_id = p_part_id
+    and (p_location_id is null or a.location_id = p_location_id);
+$$;
+
+create or replace function public.parts_available(p_shop_id uuid, p_part_id uuid, p_location_id uuid default null)
+returns numeric language sql stable as $$
+  select public.parts_on_hand(p_shop_id, p_part_id, p_location_id) - public.parts_allocated(p_shop_id, p_part_id, p_location_id);
+$$;
+
+create or replace function public.parts_reconcile_work_order_part(p_work_order_part_id uuid)
+returns void language plpgsql security definer set search_path = public as $$
+declare v record;
+begin
+  select * into v from public.work_order_parts where id = p_work_order_part_id for update;
+  if not found then return; end if;
+  update public.work_order_parts
+  set lifecycle_status = public.parts_lifecycle_status(quantity_requested, quantity_ordered, quantity_received, quantity_allocated, quantity_consumed, quantity_returned, quantity_cancelled),
+      updated_at = now()
+  where id = p_work_order_part_id;
+end $$;
+
+create or replace function public.parts_ensure_work_order_part(p_request_item_id uuid)
+returns uuid language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_request public.part_requests%rowtype; v_part public.parts%rowtype; v_line record; v_wop uuid; v_qty numeric;
+begin
+  select * into v_item from public.part_request_items where id = p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  if v_item.work_order_line_id is null then raise exception 'Request item must be linked to a work-order line.'; end if;
+  if v_item.part_id is null then raise exception 'Request item has no selected inventory part.'; end if;
+  select * into v_request from public.part_requests where id = v_item.request_id for update;
+  if not found then raise exception 'Parent parts request not found.'; end if;
+  select * into v_part from public.parts where id = v_item.part_id;
+  if not found then raise exception 'Selected part not found.'; end if;
+  if v_part.shop_id is distinct from v_item.shop_id then raise exception 'Selected part belongs to a different shop.'; end if;
+  select wl.id, wl.work_order_id, wo.shop_id into v_line from public.work_order_lines wl join public.work_orders wo on wo.id = wl.work_order_id where wl.id = v_item.work_order_line_id;
+  if not found then raise exception 'Work-order line not found.'; end if;
+  if v_line.shop_id is distinct from v_item.shop_id then raise exception 'Work-order line belongs to a different shop.'; end if;
+  if v_request.work_order_id is not null and v_request.work_order_id <> v_line.work_order_id then raise exception 'Work-order line does not belong to the request work order.'; end if;
+  v_qty := coalesce(v_item.qty_requested, v_item.qty, 0);
+  insert into public.work_order_parts(work_order_id, work_order_line_id, shop_id, part_id, quantity, unit_price, total_price, source_parts_request_id, source_parts_request_item_id, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_received, quantity_consumed, unit_cost_snapshot, unit_sell_price_snapshot, lifecycle_status, updated_at)
+  values (v_line.work_order_id, v_item.work_order_line_id, v_item.shop_id, v_item.part_id, v_qty::integer, coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price, 0) * v_qty, v_item.request_id, v_item.id, coalesce(v_part.name, v_item.description), coalesce(v_part.supplier, v_item.vendor), v_part.part_number, v_qty, coalesce(v_item.qty_received,0), coalesce(v_item.qty_consumed,0), coalesce(v_item.unit_cost, v_part.cost), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), 'requested', now())
+  on conflict (source_parts_request_item_id) where source_parts_request_item_id is not null do update set work_order_id=excluded.work_order_id, work_order_line_id=excluded.work_order_line_id, shop_id=excluded.shop_id, part_id=excluded.part_id, quantity=excluded.quantity, quantity_requested=excluded.quantity_requested, updated_at=now()
+  returning id into v_wop;
+  return v_wop;
+end $$;
+
+create or replace function public.parts_allocate_request_item(p_request_item_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_wop public.work_order_parts%rowtype; v_existing public.stock_moves%rowtype; v_available numeric; v_alloc_id uuid; v_move_id uuid; v_new_alloc numeric;
+begin
+  if p_qty <= 0 then raise exception 'Allocation quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_item from public.part_request_items where id = p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  select * into v_existing from public.stock_moves where shop_id = v_item.shop_id and idempotency_key = p_idempotency_key;
+  if found then return coalesce(v_existing.metadata, '{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  select * into v_wop from public.work_order_parts where id = public.parts_ensure_work_order_part(p_request_item_id) for update;
+  if v_wop.part_id is null then raise exception 'Work-order part has no selected part.'; end if;
+  v_available := public.parts_available(v_wop.shop_id, v_wop.part_id, p_location_id);
+  if v_available < p_qty then raise exception 'Insufficient available stock. Available %, requested %.', v_available, p_qty; end if;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata)
+  values (v_wop.part_id, p_location_id, 0, 'wo_allocate', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, p_request_item_id, jsonb_build_object('qty_reserved', p_qty, 'operation', 'allocate')) returning id into v_move_id;
+  insert into public.work_order_part_allocations(work_order_line_id, work_order_id, shop_id, part_id, location_id, qty, unit_cost, stock_move_id, source_request_item_id)
+  values (v_wop.work_order_line_id, v_wop.work_order_id, v_wop.shop_id, v_wop.part_id, p_location_id, p_qty, coalesce(v_wop.unit_cost_snapshot,0), v_move_id, p_request_item_id)
+  on conflict (source_request_item_id, part_id, location_id) where source_request_item_id is not null do update set qty = public.work_order_part_allocations.qty + excluded.qty, stock_move_id = excluded.stock_move_id
+  returning id, qty into v_alloc_id, v_new_alloc;
+  update public.part_request_items set qty_reserved = coalesce(qty_reserved,0) + p_qty, status='reserved', updated_at=now() where id=p_request_item_id;
+  update public.work_order_parts set quantity_allocated = coalesce(quantity_allocated,0) + p_qty, lifecycle_status='reserved', updated_at=now() where id=v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  update public.stock_moves set metadata = metadata || jsonb_build_object('allocation_id', v_alloc_id, 'work_order_part_id', v_wop.id) where id=v_move_id;
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'allocation_id', v_alloc_id, 'stock_move_id', v_move_id, 'allocated_qty', v_new_alloc, 'available_after', public.parts_available(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_release_allocation(p_request_item_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_wop public.work_order_parts%rowtype; v_existing public.stock_moves%rowtype; v_alloc public.work_order_part_allocations%rowtype; v_move_id uuid; v_release numeric;
+begin
+  if p_qty <= 0 then raise exception 'Release quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_item from public.part_request_items where id = p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  select * into v_existing from public.stock_moves where shop_id=v_item.shop_id and idempotency_key=p_idempotency_key;
+  if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  select * into v_wop from public.work_order_parts where source_parts_request_item_id=p_request_item_id for update;
+  if not found then raise exception 'Work-order part not found.'; end if;
+  select * into v_alloc from public.work_order_part_allocations where source_request_item_id=p_request_item_id and part_id=v_wop.part_id and location_id=p_location_id for update;
+  if not found or v_alloc.qty <= 0 then raise exception 'No active allocation to release.'; end if;
+  if v_alloc.qty < p_qty then raise exception 'Cannot release more than active allocation.'; end if;
+  v_release := p_qty;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata)
+  values (v_wop.part_id, p_location_id, 0, 'wo_release', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, p_request_item_id, jsonb_build_object('qty_released', v_release, 'operation', 'release')) returning id into v_move_id;
+  update public.work_order_part_allocations set qty = qty - v_release, stock_move_id = v_move_id where id = v_alloc.id;
+  delete from public.work_order_part_allocations where id = v_alloc.id and qty <= 0;
+  update public.part_request_items set qty_reserved = greatest(coalesce(qty_reserved,0) - v_release, 0), updated_at=now() where id=p_request_item_id;
+  update public.work_order_parts set quantity_allocated = greatest(coalesce(quantity_allocated,0) - v_release, 0), updated_at=now() where id=v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'released_qty', v_release, 'available_after', public.parts_available(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_create_po_line_for_request(p_po_id uuid, p_request_item_id uuid, p_qty numeric, p_unit_cost numeric default null, p_location_id uuid default null, p_idempotency_key text default null)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_po public.purchase_orders%rowtype; v_wop uuid; v_line_id uuid; v_key text; v_total_ordered numeric;
+begin
+  if p_qty <= 0 then raise exception 'PO quantity must be greater than 0.'; end if;
+  v_key := coalesce(nullif(trim(p_idempotency_key),''), 'po-line:'||p_po_id::text||':'||p_request_item_id::text);
+  select * into v_item from public.part_request_items where id=p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  select * into v_po from public.purchase_orders where id=p_po_id for update;
+  if not found then raise exception 'Purchase order not found.'; end if;
+  if v_po.shop_id is distinct from v_item.shop_id then raise exception 'Purchase order belongs to a different shop.'; end if;
+  v_wop := public.parts_ensure_work_order_part(p_request_item_id);
+  insert into public.purchase_order_lines(po_id, part_id, description, qty, unit_cost, location_id, part_request_item_id, work_order_part_id, idempotency_key)
+  values (p_po_id, v_item.part_id, v_item.description, p_qty, coalesce(p_unit_cost, v_item.unit_cost, 0), p_location_id, p_request_item_id, v_wop, v_key)
+  on conflict (po_id, idempotency_key) where idempotency_key is not null do update set id=id
+  returning id into v_line_id;
+  select coalesce(sum(qty),0) into v_total_ordered from public.purchase_order_lines where part_request_item_id=p_request_item_id;
+  update public.part_request_items set po_id=p_po_id, qty_approved=greatest(coalesce(qty_approved,0), v_total_ordered), status=case when v_total_ordered >= coalesce(qty_requested, qty,0) then 'ordered' else 'ordered' end, updated_at=now() where id=p_request_item_id;
+  update public.work_order_parts set quantity_ordered=v_total_ordered, lifecycle_status=public.parts_lifecycle_status(quantity_requested, v_total_ordered, quantity_received, quantity_allocated, quantity_consumed, quantity_returned, quantity_cancelled), updated_at=now() where id=v_wop;
+  return jsonb_build_object('ok', true, 'purchase_order_line_id', v_line_id, 'work_order_part_id', v_wop, 'ordered_qty', v_total_ordered);
+end $$;
+
+create or replace function public.parts_receive_request_item(p_request_item_id uuid, p_location_id uuid, p_qty numeric, p_po_line_id uuid default null, p_unit_cost numeric default null, p_idempotency_key text default null)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_wop public.work_order_parts%rowtype; v_line public.purchase_order_lines%rowtype; v_existing public.stock_moves%rowtype; v_key text; v_received_total numeric; v_move_id uuid; v_ordered_limit numeric;
+begin
+  if p_qty <= 0 then raise exception 'Receive quantity must be greater than 0.'; end if;
+  select * into v_item from public.part_request_items where id=p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  select * into v_wop from public.work_order_parts where id=public.parts_ensure_work_order_part(p_request_item_id) for update;
+  v_key := coalesce(nullif(trim(p_idempotency_key),''), 'receive:'||coalesce(p_po_line_id::text, p_request_item_id::text)||':'||p_qty::text||':'||to_char(now(),'YYYYMMDDHH24MISSMS'));
+  select * into v_existing from public.stock_moves where shop_id=v_item.shop_id and idempotency_key=v_key;
+  if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  if p_po_line_id is not null then
+    select * into v_line from public.purchase_order_lines where id=p_po_line_id for update;
+    if not found then raise exception 'Purchase order line not found.'; end if;
+    if v_line.part_request_item_id is distinct from p_request_item_id then raise exception 'PO line is not linked to this request item.'; end if;
+    if coalesce(v_line.received_qty,0) + p_qty > coalesce(v_line.qty,0) then raise exception 'Receipt exceeds ordered quantity.'; end if;
+    update public.purchase_order_lines set received_qty = coalesce(received_qty,0) + p_qty where id=p_po_line_id;
+  else
+    select coalesce(sum(qty), coalesce(v_item.qty_requested, v_item.qty, 0)) into v_ordered_limit from public.purchase_order_lines where part_request_item_id=p_request_item_id;
+    if coalesce(v_item.qty_received,0) + p_qty > greatest(v_ordered_limit, coalesce(v_item.qty_requested, v_item.qty,0)) then raise exception 'Receipt exceeds requested quantity.'; end if;
+  end if;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, purchase_order_line_id, metadata)
+  values (v_wop.part_id, p_location_id, p_qty, 'receive', case when p_po_line_id is null then 'part_request_item' else 'purchase_order_line' end, coalesce(p_po_line_id, p_request_item_id), auth.uid(), v_wop.shop_id, v_key, v_wop.id, p_request_item_id, p_po_line_id, jsonb_build_object('qty_received', p_qty, 'operation', 'receive')) returning id into v_move_id;
+  update public.part_request_items set qty_received=coalesce(qty_received,0)+p_qty, location_id=coalesce(location_id,p_location_id), unit_cost=coalesce(p_unit_cost, unit_cost), status=case when coalesce(qty_received,0)+p_qty >= coalesce(qty_requested, qty,0) then 'received' else 'partially_received' end, updated_at=now() where id=p_request_item_id returning qty_received into v_received_total;
+  update public.work_order_parts set quantity_received=coalesce(quantity_received,0)+p_qty, unit_cost_snapshot=coalesce(p_unit_cost, unit_cost_snapshot), updated_at=now() where id=v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'received_qty', v_received_total, 'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_issue_work_order_part(p_work_order_part_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_wop public.work_order_parts%rowtype; v_existing public.stock_moves%rowtype; v_alloc public.work_order_part_allocations%rowtype; v_move_id uuid; v_item_id uuid;
+begin
+  if p_qty <= 0 then raise exception 'Issue quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_wop from public.work_order_parts where id=p_work_order_part_id for update;
+  if not found then raise exception 'Work-order part not found.'; end if;
+  select * into v_existing from public.stock_moves where shop_id=v_wop.shop_id and idempotency_key=p_idempotency_key;
+  if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  if coalesce(v_wop.quantity_allocated,0) < p_qty then raise exception 'Cannot issue more than allocated quantity.'; end if;
+  if public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id) < p_qty then raise exception 'Cannot issue more than on-hand quantity.'; end if;
+  select * into v_alloc from public.work_order_part_allocations where source_request_item_id=v_wop.source_parts_request_item_id and part_id=v_wop.part_id and location_id=p_location_id for update;
+  if not found or v_alloc.qty < p_qty then raise exception 'Allocation not found or insufficient for issue.'; end if;
+  v_item_id := v_wop.source_parts_request_item_id;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata)
+  values (v_wop.part_id, p_location_id, -p_qty, 'consume', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, v_item_id, jsonb_build_object('qty_issued', p_qty, 'operation', 'issue')) returning id into v_move_id;
+  update public.work_order_part_allocations set qty=qty-p_qty, stock_move_id=v_move_id where id=v_alloc.id;
+  delete from public.work_order_part_allocations where id=v_alloc.id and qty<=0;
+  update public.work_order_parts set quantity_allocated=greatest(coalesce(quantity_allocated,0)-p_qty,0), quantity_consumed=coalesce(quantity_consumed,0)+p_qty, updated_at=now() where id=v_wop.id;
+  update public.part_request_items set qty_reserved=greatest(coalesce(qty_reserved,0)-p_qty,0), qty_consumed=coalesce(qty_consumed,0)+p_qty, status='consumed', updated_at=now() where id=v_item_id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'issued_qty', p_qty, 'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_return_to_stock(p_work_order_part_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_wop public.work_order_parts%rowtype; v_existing public.stock_moves%rowtype; v_move_id uuid;
+begin
+  if p_qty <= 0 then raise exception 'Return quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_wop from public.work_order_parts where id=p_work_order_part_id for update;
+  if not found then raise exception 'Work-order part not found.'; end if;
+  select * into v_existing from public.stock_moves where shop_id=v_wop.shop_id and idempotency_key=p_idempotency_key;
+  if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  if coalesce(v_wop.quantity_consumed,0) - coalesce(v_wop.quantity_returned,0) < p_qty then raise exception 'Cannot return more than issued and unreturned quantity.'; end if;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata)
+  values (v_wop.part_id, p_location_id, p_qty, 'return', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, v_wop.source_parts_request_item_id, jsonb_build_object('qty_returned', p_qty, 'operation', 'return_to_stock')) returning id into v_move_id;
+  update public.work_order_parts set quantity_returned=coalesce(quantity_returned,0)+p_qty, updated_at=now() where id=v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'returned_qty', p_qty, 'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_cancel_request_item(p_request_item_id uuid, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_wop public.work_order_parts%rowtype; v_alloc record; v_cancel numeric; v_key text; v_released numeric := 0;
+begin
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_wop from public.work_order_parts where source_parts_request_item_id=p_request_item_id for update;
+  if not found then raise exception 'Work-order part not found.'; end if;
+  for v_alloc in select * from public.work_order_part_allocations where source_request_item_id=p_request_item_id for update loop
+    v_key := p_idempotency_key || ':release:' || v_alloc.id::text;
+    perform public.parts_release_allocation(p_request_item_id, v_alloc.location_id, v_alloc.qty, v_key);
+    v_released := v_released + v_alloc.qty;
+  end loop;
+  v_cancel := greatest(coalesce(v_wop.quantity_requested,0)-coalesce(v_wop.quantity_consumed,0)-coalesce(v_wop.quantity_returned,0),0);
+  update public.work_order_parts set quantity_cancelled = greatest(quantity_cancelled, v_cancel), lifecycle_status = case when quantity_consumed > 0 then lifecycle_status else 'cancelled' end, updated_at=now() where id=v_wop.id;
+  update public.part_request_items set status='cancelled', updated_at=now() where id=p_request_item_id;
+  return jsonb_build_object('ok', true, 'work_order_part_id', v_wop.id, 'released_qty', v_released, 'cancelled_qty', v_cancel);
+end $$;
+
+create or replace function public.parts_replace_request_item(p_request_item_id uuid, p_new_part_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_old public.work_order_parts%rowtype; v_part public.parts%rowtype; v_item public.part_request_items%rowtype; v_result jsonb; v_had_old boolean := false;
+begin
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_item from public.part_request_items where id=p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  select * into v_part from public.parts where id=p_new_part_id;
+  if not found or v_part.shop_id is distinct from v_item.shop_id then raise exception 'Replacement part is not available for this shop.'; end if;
+  select * into v_old from public.work_order_parts where source_parts_request_item_id=p_request_item_id for update;
+  v_had_old := found;
+  if v_had_old then
+    perform public.parts_cancel_request_item(p_request_item_id, p_idempotency_key || ':cancel-old');
+    update public.work_order_parts set lifecycle_status='replaced', updated_at=now() where id=v_old.id and quantity_consumed = 0;
+  end if;
+  update public.part_request_items set part_id=p_new_part_id, status='requested', qty_reserved=0, updated_at=now() where id=p_request_item_id;
+  update public.work_order_parts set part_id=p_new_part_id, description_snapshot=v_part.name, manufacturer_snapshot=v_part.supplier, part_number_snapshot=v_part.part_number, quantity_allocated=0, quantity_consumed=coalesce(quantity_consumed,0), quantity_cancelled=0, lifecycle_status='requested', updated_at=now() where source_parts_request_item_id=p_request_item_id and coalesce(quantity_consumed,0)=0;
+  v_result := public.parts_allocate_request_item(p_request_item_id, p_location_id, p_qty, p_idempotency_key || ':allocate-new');
+  return v_result || jsonb_build_object('ok', true, 'replaced_part_id', case when v_had_old then v_old.part_id else null end, 'new_part_id', p_new_part_id);
+end $$;
+
+-- Compatibility wrapper: allocation now reserves only and does not reduce physical on-hand.
+create or replace function public.upsert_part_allocation_from_request_item(p_request_item_id uuid, p_location_id uuid, p_create_stock_move boolean default true)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_qty numeric; v_key text;
+begin
+  select * into v_item from public.part_request_items where id=p_request_item_id;
+  if not found then raise exception 'Request item not found.'; end if;
+  v_qty := coalesce(v_item.qty_reserved,0);
+  if v_qty <= 0 then v_qty := coalesce(v_item.qty_requested, v_item.qty,0); end if;
+  v_key := 'allocate-request-item:'||p_request_item_id::text||':'||p_location_id::text||':'||v_qty::text;
+  if p_create_stock_move then
+    return public.parts_allocate_request_item(p_request_item_id, p_location_id, v_qty, v_key);
+  end if;
+  perform public.parts_ensure_work_order_part(p_request_item_id);
+  return jsonb_build_object('ok', true, 'allocated', false);
+end $$;
+
+-- Compatibility wrapper: existing receiving endpoint now receives through canonical lifecycle command.
+create or replace function public.receive_part_request_item(p_item_id uuid, p_location_id uuid, p_qty numeric, p_po_id uuid default null, p_idempotency_key text default null)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_line_id uuid; v_key text;
+begin
+  select pol.id into v_line_id
+  from public.purchase_order_lines pol
+  where pol.part_request_item_id = p_item_id and (p_po_id is null or pol.po_id = p_po_id) and pol.received_qty < pol.qty
+  order by pol.created_at asc
+  limit 1;
+  v_key := coalesce(nullif(trim(p_idempotency_key),''), 'receive-request-item:'||p_item_id::text||':'||coalesce(v_line_id::text, 'direct')||':'||p_location_id::text||':'||p_qty::text);
+  return public.parts_receive_request_item(p_item_id, p_location_id, p_qty, v_line_id, null, v_key);
+end $$;

--- a/db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql
@@ -1,0 +1,696 @@
+-- Consolidated manual parts lifecycle migration.
+-- Safe for Supabase SQL Editor. This represents the final intended state of the
+-- parts lifecycle changes in this PR without installing known-bad intermediate behavior.
+
+begin;
+
+-- The current production schema already defines stock_move_reason with receive, consume, return, wo_allocate, and wo_release.
+-- This migration intentionally does not alter enum values inside the transaction.
+
+-- Guarded schema additions. Quantity columns are numeric to preserve fractional fluids/bulk materials.
+alter table public.work_order_parts
+  alter column quantity type numeric(12,2) using quantity::numeric,
+  add column if not exists work_order_line_id uuid,
+  add column if not exists source_parts_request_id uuid,
+  add column if not exists source_parts_request_item_id uuid,
+  add column if not exists description_snapshot text,
+  add column if not exists manufacturer_snapshot text,
+  add column if not exists part_number_snapshot text,
+  add column if not exists quantity_requested numeric(12,2) default 0 not null,
+  add column if not exists quantity_ordered numeric(12,2) default 0 not null,
+  add column if not exists quantity_received numeric(12,2) default 0 not null,
+  add column if not exists quantity_allocated numeric(12,2) default 0 not null,
+  add column if not exists quantity_consumed numeric(12,2) default 0 not null,
+  add column if not exists quantity_returned numeric(12,2) default 0 not null,
+  add column if not exists quantity_cancelled numeric(12,2) default 0 not null,
+  add column if not exists unit_cost_snapshot numeric(12,2),
+  add column if not exists unit_sell_price_snapshot numeric(12,2),
+  add column if not exists lifecycle_status text default 'requested' not null,
+  add column if not exists mismatch_acknowledged_at timestamptz,
+  add column if not exists mismatch_acknowledged_by uuid,
+  add column if not exists mismatch_warning_reason text,
+  add column if not exists updated_at timestamptz default now() not null,
+  add column if not exists is_active boolean default true not null,
+  add column if not exists replaced_from_work_order_part_id uuid,
+  add column if not exists replaced_by_work_order_part_id uuid;
+
+alter table public.work_order_part_allocations
+  add column if not exists created_at timestamptz default now() not null,
+  add column if not exists shop_id uuid,
+  add column if not exists work_order_id uuid,
+  add column if not exists source_request_item_id uuid,
+  add column if not exists work_order_part_id uuid;
+
+alter table public.stock_moves
+  add column if not exists idempotency_key text,
+  add column if not exists work_order_part_id uuid,
+  add column if not exists part_request_item_id uuid,
+  add column if not exists purchase_order_line_id uuid,
+  add column if not exists metadata jsonb default '{}'::jsonb not null,
+  add column if not exists lifecycle_quantity numeric(12,2);
+
+alter table public.purchase_order_lines
+  add column if not exists part_request_item_id uuid,
+  add column if not exists work_order_part_id uuid,
+  add column if not exists idempotency_key text;
+
+-- Deterministic backfills only.
+update public.work_order_part_allocations a
+set work_order_id = wl.work_order_id
+from public.work_order_lines wl
+where a.work_order_line_id = wl.id and a.work_order_id is null;
+
+update public.work_order_part_allocations a
+set shop_id = wo.shop_id
+from public.work_orders wo
+where a.work_order_id = wo.id and a.shop_id is null;
+
+with candidates as (
+  select a.id allocation_id, wop.id work_order_part_id, count(*) over (partition by a.id) match_count
+  from public.work_order_part_allocations a
+  join public.part_request_items i on i.id = a.source_request_item_id
+  join public.work_order_lines wl on wl.id = a.work_order_line_id
+  join public.work_orders wo on wo.id = wl.work_order_id
+  join public.work_order_parts wop on wop.source_parts_request_item_id = a.source_request_item_id
+    and wop.part_id = a.part_id
+    and wop.work_order_id = wo.id
+    and wop.work_order_line_id = wl.id
+    and wop.shop_id = wo.shop_id
+    and coalesce(wop.is_active, true)
+  where a.work_order_part_id is null
+    and a.shop_id = wo.shop_id
+    and a.work_order_id = wo.id
+    and i.shop_id = wo.shop_id
+)
+update public.work_order_part_allocations a
+set work_order_part_id = c.work_order_part_id
+from candidates c
+where c.match_count = 1 and a.id = c.allocation_id;
+
+-- Return backfill counts in SQL Editor result stream.
+with alloc as (
+  select a.* from public.work_order_part_allocations a
+), matches as (
+  select a.id allocation_id, count(wop.id) match_count
+  from alloc a
+  left join public.part_request_items i on i.id = a.source_request_item_id
+  left join public.work_order_lines wl on wl.id = a.work_order_line_id
+  left join public.work_orders wo on wo.id = wl.work_order_id
+  left join public.work_order_parts wop on wop.source_parts_request_item_id = a.source_request_item_id
+    and wop.part_id = a.part_id
+    and wop.work_order_id = wo.id
+    and wop.work_order_line_id = wl.id
+    and wop.shop_id = wo.shop_id
+    and coalesce(wop.is_active, true)
+  where a.work_order_part_id is null
+  group by a.id
+), counts as (
+  select 'allocation_work_order_part_id_backfilled' metric, count(*)::bigint count from public.work_order_part_allocations where work_order_part_id is not null
+  union all select 'allocation_work_order_part_id_ambiguous', count(*) from matches where match_count > 1
+  union all select 'allocation_work_order_part_id_unresolved', count(*) from matches where match_count = 0
+  union all select 'allocation_cross_scope_rows', count(*)
+    from public.work_order_part_allocations a
+    join public.work_order_lines wl on wl.id = a.work_order_line_id
+    join public.work_orders wo on wo.id = wl.work_order_id
+    left join public.part_request_items i on i.id = a.source_request_item_id
+    where a.shop_id is distinct from wo.shop_id or a.work_order_id is distinct from wo.id or (i.id is not null and i.shop_id is distinct from wo.shop_id)
+)
+select * from counts order by metric;
+
+-- Explicit blockers before uniqueness/FKs.
+do $$
+declare v_count bigint;
+begin
+  select count(*) into v_count
+  from (
+    select source_parts_request_item_id
+    from public.work_order_parts
+    where source_parts_request_item_id is not null and coalesce(is_active, true)
+    group by source_parts_request_item_id
+    having count(*) > 1
+  ) d;
+  if v_count > 0 then
+    raise exception 'Blocked: % source request item(s) have multiple active work_order_parts. Resolve before creating active unique index.', v_count;
+  end if;
+
+  select count(*) into v_count
+  from public.work_order_part_allocations a
+  join public.work_order_lines wl on wl.id = a.work_order_line_id
+  join public.work_orders wo on wo.id = wl.work_order_id
+  left join public.part_request_items i on i.id = a.source_request_item_id
+  where a.shop_id is distinct from wo.shop_id
+     or a.work_order_id is distinct from wo.id
+     or (i.id is not null and i.shop_id is distinct from wo.shop_id);
+  if v_count > 0 then
+    raise exception 'Blocked: % allocation row(s) have cross-scope shop/work-order/request links.', v_count;
+  end if;
+
+  select count(*) into v_count
+  from (
+    select work_order_part_id, location_id
+    from public.work_order_part_allocations
+    where work_order_part_id is not null
+    group by work_order_part_id, location_id
+    having count(*) > 1
+  ) d;
+  if v_count > 0 then
+    raise exception 'Blocked: % work_order_part/location allocation duplicate group(s) exist.', v_count;
+  end if;
+
+  select count(*) into v_count
+  from (
+    select shop_id, idempotency_key
+    from public.stock_moves
+    where idempotency_key is not null
+    group by shop_id, idempotency_key
+    having count(*) > 1
+  ) d;
+  if v_count > 0 then
+    raise exception 'Blocked: % duplicate stock movement idempotency key group(s) exist.', v_count;
+  end if;
+
+  select count(*) into v_count
+  from (
+    select po_id, idempotency_key
+    from public.purchase_order_lines
+    where idempotency_key is not null
+    group by po_id, idempotency_key
+    having count(*) > 1
+  ) d;
+  if v_count > 0 then
+    raise exception 'Blocked: % duplicate PO-line idempotency key group(s) exist.', v_count;
+  end if;
+end $$;
+
+-- Final indexes only. Do not create uq_stock_moves_reference_reason.
+drop index if exists public.uq_stock_moves_reference_reason;
+
+create unique index if not exists uq_work_order_parts_active_source_request_item
+  on public.work_order_parts(source_parts_request_item_id)
+  where source_parts_request_item_id is not null and coalesce(is_active, true);
+
+create index if not exists idx_work_order_parts_source_request_item
+  on public.work_order_parts(source_parts_request_item_id)
+  where source_parts_request_item_id is not null;
+
+create index if not exists idx_work_order_parts_replacement_links
+  on public.work_order_parts(replaced_from_work_order_part_id, replaced_by_work_order_part_id);
+
+create unique index if not exists uq_wopa_work_order_part_location
+  on public.work_order_part_allocations(work_order_part_id, location_id)
+  where work_order_part_id is not null;
+
+create index if not exists idx_wopa_source_request_item
+  on public.work_order_part_allocations(source_request_item_id)
+  where source_request_item_id is not null;
+
+create unique index if not exists uq_stock_moves_shop_idempotency_key
+  on public.stock_moves(shop_id, idempotency_key)
+  where idempotency_key is not null;
+
+create index if not exists idx_stock_moves_work_order_part_id
+  on public.stock_moves(work_order_part_id)
+  where work_order_part_id is not null;
+
+create index if not exists idx_stock_moves_part_request_item_id
+  on public.stock_moves(part_request_item_id)
+  where part_request_item_id is not null;
+
+create unique index if not exists uq_purchase_order_lines_idempotency
+  on public.purchase_order_lines(po_id, idempotency_key)
+  where idempotency_key is not null;
+
+create index if not exists idx_purchase_order_lines_work_order_part_id
+  on public.purchase_order_lines(work_order_part_id)
+  where work_order_part_id is not null;
+
+create index if not exists idx_purchase_order_lines_part_request_item_id
+  on public.purchase_order_lines(part_request_item_id)
+  where part_request_item_id is not null;
+
+-- Final foreign keys. Preserve lifecycle history with ON DELETE SET NULL for source links.
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_source_request_item_id_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_source_request_item_id_fkey foreign key (source_parts_request_item_id) references public.part_request_items(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_source_request_id_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_source_request_id_fkey foreign key (source_parts_request_id) references public.part_requests(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_work_order_line_id_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_work_order_line_id_fkey foreign key (work_order_line_id) references public.work_order_lines(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_replaced_from_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_replaced_from_fkey foreign key (replaced_from_work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_replaced_by_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_replaced_by_fkey foreign key (replaced_by_work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_part_allocations_work_order_part_id_fkey' and conrelid = 'public.work_order_part_allocations'::regclass) then
+    alter table public.work_order_part_allocations add constraint work_order_part_allocations_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'work_order_part_allocations_source_request_item_id_fkey' and conrelid = 'public.work_order_part_allocations'::regclass) then
+    alter table public.work_order_part_allocations add constraint work_order_part_allocations_source_request_item_id_fkey foreign key (source_request_item_id) references public.part_request_items(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'stock_moves_work_order_part_id_fkey' and conrelid = 'public.stock_moves'::regclass) then
+    alter table public.stock_moves add constraint stock_moves_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'stock_moves_part_request_item_id_fkey' and conrelid = 'public.stock_moves'::regclass) then
+    alter table public.stock_moves add constraint stock_moves_part_request_item_id_fkey foreign key (part_request_item_id) references public.part_request_items(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'stock_moves_purchase_order_line_id_fkey' and conrelid = 'public.stock_moves'::regclass) then
+    alter table public.stock_moves add constraint stock_moves_purchase_order_line_id_fkey foreign key (purchase_order_line_id) references public.purchase_order_lines(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'purchase_order_lines_part_request_item_id_fkey' and conrelid = 'public.purchase_order_lines'::regclass) then
+    alter table public.purchase_order_lines add constraint purchase_order_lines_part_request_item_id_fkey foreign key (part_request_item_id) references public.part_request_items(id) on delete set null;
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'purchase_order_lines_work_order_part_id_fkey' and conrelid = 'public.purchase_order_lines'::regclass) then
+    alter table public.purchase_order_lines add constraint purchase_order_lines_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
+end $$;
+
+-- Replacement validation.
+alter table public.work_order_parts
+  drop constraint if exists work_order_parts_no_self_replacement,
+  add constraint work_order_parts_no_self_replacement check (
+    id is distinct from replaced_from_work_order_part_id and id is distinct from replaced_by_work_order_part_id
+  );
+
+create or replace function public.parts_validate_replacement_links()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare v_other public.work_order_parts%rowtype;
+begin
+  if new.replaced_from_work_order_part_id is not null then
+    select * into v_other from public.work_order_parts where id = new.replaced_from_work_order_part_id;
+    if not found then raise exception 'Replacement source work_order_part not found.'; end if;
+    if v_other.source_parts_request_item_id is distinct from new.source_parts_request_item_id
+       or v_other.shop_id is distinct from new.shop_id
+       or v_other.work_order_id is distinct from new.work_order_id
+       or v_other.work_order_line_id is distinct from new.work_order_line_id then
+      raise exception 'Replacement source must share request item, shop, work order, and line.';
+    end if;
+  end if;
+  if new.replaced_by_work_order_part_id is not null then
+    select * into v_other from public.work_order_parts where id = new.replaced_by_work_order_part_id;
+    if not found then raise exception 'Replacement target work_order_part not found.'; end if;
+    if v_other.source_parts_request_item_id is distinct from new.source_parts_request_item_id
+       or v_other.shop_id is distinct from new.shop_id
+       or v_other.work_order_id is distinct from new.work_order_id
+       or v_other.work_order_line_id is distinct from new.work_order_line_id then
+      raise exception 'Replacement target must share request item, shop, work order, and line.';
+    end if;
+  end if;
+  return new;
+end $$;
+
+drop trigger if exists trg_parts_validate_replacement_links on public.work_order_parts;
+create constraint trigger trg_parts_validate_replacement_links
+after insert or update of replaced_from_work_order_part_id, replaced_by_work_order_part_id, source_parts_request_item_id, shop_id, work_order_id, work_order_line_id
+on public.work_order_parts
+deferrable initially deferred
+for each row execute function public.parts_validate_replacement_links();
+
+-- Auth/capability guard. Service role is allowed for controlled server-side maintenance; authenticated users need shop membership and an operational role.
+create or replace function public.parts_lifecycle_assert_shop_access(p_shop_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare v_role text;
+begin
+  if p_shop_id is null then raise exception 'shop_id is required.'; end if;
+  if auth.uid() is null then
+    if current_user = 'service_role' then return; end if;
+    raise exception 'Authentication required.';
+  end if;
+  select role into v_role from public.profiles where user_id = auth.uid() and shop_id = p_shop_id limit 1;
+  if v_role is null then raise exception 'User is not a member of this shop.'; end if;
+  if v_role not in ('owner','manager','admin','parts','advisor') then raise exception 'User is not authorized for parts lifecycle operations.'; end if;
+end $$;
+
+create or replace function public.parts_lifecycle_status(
+  p_requested numeric, p_ordered numeric, p_received numeric, p_allocated numeric,
+  p_consumed numeric, p_returned numeric, p_cancelled numeric
+) returns text language sql immutable as $$
+  select case
+    when coalesce(p_cancelled,0) >= greatest(coalesce(p_requested,0) - coalesce(p_consumed,0), 0) and coalesce(p_consumed,0) = 0 then 'cancelled'
+    when coalesce(p_returned,0) > 0 and coalesce(p_returned,0) < coalesce(p_consumed,0) then 'partially_returned'
+    when coalesce(p_returned,0) > 0 and coalesce(p_returned,0) >= coalesce(p_consumed,0) then 'returned'
+    when coalesce(p_consumed,0) > 0 and coalesce(p_consumed,0) < coalesce(p_requested,0) then 'partially_consumed'
+    when coalesce(p_consumed,0) > 0 and coalesce(p_consumed,0) >= coalesce(p_requested,0) then 'consumed'
+    when coalesce(p_allocated,0) > 0 and coalesce(p_allocated,0) < coalesce(p_requested,0) then 'partially_allocated'
+    when coalesce(p_allocated,0) > 0 and coalesce(p_allocated,0) >= coalesce(p_requested,0) then 'reserved'
+    when coalesce(p_received,0) > 0 and coalesce(p_received,0) < coalesce(p_ordered, p_requested,0) then 'partially_received'
+    when coalesce(p_received,0) > 0 then 'received'
+    when coalesce(p_ordered,0) > 0 and coalesce(p_ordered,0) < coalesce(p_requested,0) then 'partially_ordered'
+    when coalesce(p_ordered,0) > 0 then 'ordered'
+    else 'requested'
+  end;
+$$;
+
+create or replace function public.parts_on_hand(p_shop_id uuid, p_part_id uuid, p_location_id uuid default null)
+returns numeric language sql stable as $$
+  select coalesce(sum(sm.qty_change),0)::numeric
+  from public.stock_moves sm
+  where sm.shop_id = p_shop_id
+    and sm.part_id = p_part_id
+    and (p_location_id is null or sm.location_id = p_location_id)
+    and sm.reason not in ('wo_allocate','wo_release');
+$$;
+
+create or replace function public.parts_allocated(p_shop_id uuid, p_part_id uuid, p_location_id uuid default null)
+returns numeric language sql stable as $$
+  select coalesce(sum(a.qty),0)::numeric
+  from public.work_order_part_allocations a
+  where a.shop_id = p_shop_id
+    and a.part_id = p_part_id
+    and (p_location_id is null or a.location_id = p_location_id);
+$$;
+
+create or replace function public.parts_available(p_shop_id uuid, p_part_id uuid, p_location_id uuid default null)
+returns numeric language sql stable as $$
+  select public.parts_on_hand(p_shop_id, p_part_id, p_location_id) - public.parts_allocated(p_shop_id, p_part_id, p_location_id);
+$$;
+
+create or replace function public.parts_reconcile_work_order_part(p_work_order_part_id uuid)
+returns void language plpgsql security definer set search_path = public as $$
+begin
+  update public.work_order_parts
+  set lifecycle_status = public.parts_lifecycle_status(quantity_requested, quantity_ordered, quantity_received, quantity_allocated, quantity_consumed, quantity_returned, quantity_cancelled),
+      updated_at = now()
+  where id = p_work_order_part_id;
+end $$;
+
+create or replace function public.parts_attach_request_item(p_request_item_id uuid)
+returns uuid language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_request public.part_requests%rowtype; v_part public.parts%rowtype; v_line record; v_wop uuid; v_qty numeric;
+begin
+  if auth.uid() is null and current_user <> 'service_role' then raise exception 'Authentication required.'; end if;
+  select * into v_item from public.part_request_items where id = p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  if v_item.work_order_line_id is null then raise exception 'Request item must be linked to a work-order line.'; end if;
+  if v_item.part_id is null then raise exception 'Request item has no selected inventory part.'; end if;
+  select * into v_request from public.part_requests where id = v_item.request_id for update;
+  if not found then raise exception 'Parent parts request not found.'; end if;
+  select * into v_part from public.parts where id = v_item.part_id;
+  if not found then raise exception 'Selected part not found.'; end if;
+  if v_part.shop_id is distinct from v_item.shop_id then raise exception 'Selected part belongs to a different shop.'; end if;
+  select wl.id, wl.work_order_id, wl.shop_id line_shop_id, wo.shop_id wo_shop_id into v_line
+  from public.work_order_lines wl join public.work_orders wo on wo.id = wl.work_order_id where wl.id = v_item.work_order_line_id;
+  if not found then raise exception 'Work-order line not found.'; end if;
+  if v_line.wo_shop_id is distinct from v_item.shop_id or v_line.line_shop_id is distinct from v_item.shop_id then raise exception 'Work-order line belongs to a different shop.'; end if;
+  if v_item.work_order_id is not null and v_item.work_order_id <> v_line.work_order_id then raise exception 'Request item work order does not match line.'; end if;
+  if v_request.work_order_id is not null and v_request.work_order_id <> v_line.work_order_id then raise exception 'Work-order line does not belong to the request work order.'; end if;
+  v_qty := coalesce(v_item.qty_requested, v_item.qty, 0);
+  if v_qty <= 0 then raise exception 'Quantity must be greater than 0.'; end if;
+  select id into v_wop from public.work_order_parts where source_parts_request_item_id = p_request_item_id and coalesce(is_active,true) for update;
+  if found then return v_wop; end if;
+  insert into public.work_order_parts(work_order_id, work_order_line_id, shop_id, part_id, quantity, unit_price, total_price, source_parts_request_id, source_parts_request_item_id, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_received, quantity_consumed, unit_cost_snapshot, unit_sell_price_snapshot, lifecycle_status, updated_at, is_active)
+  values (v_line.work_order_id, v_item.work_order_line_id, v_item.shop_id, v_item.part_id, v_qty, coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price, 0) * v_qty, v_item.request_id, v_item.id, coalesce(v_part.name, v_item.description), coalesce(v_part.supplier, v_item.vendor), v_part.part_number, v_qty, coalesce(v_item.qty_received,0), coalesce(v_item.qty_consumed,0), coalesce(v_item.unit_cost, v_part.cost), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), 'requested', now(), true)
+  returning id into v_wop;
+  return v_wop;
+end $$;
+
+create or replace function public.parts_allocate_request_item(p_request_item_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_wop public.work_order_parts%rowtype; v_loc public.stock_locations%rowtype; v_existing public.stock_moves%rowtype; v_available numeric; v_alloc_id uuid; v_move_id uuid; v_new_alloc numeric;
+begin
+  if p_qty <= 0 then raise exception 'Allocation quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_item from public.part_request_items where id = p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  select * into v_loc from public.stock_locations where id=p_location_id for update;
+  if not found or v_loc.shop_id is distinct from v_item.shop_id then raise exception 'Location belongs to a different shop.'; end if;
+  select * into v_existing from public.stock_moves where shop_id = v_item.shop_id and idempotency_key = p_idempotency_key;
+  if found then return coalesce(v_existing.metadata, '{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  select * into v_wop from public.work_order_parts where id = public.parts_attach_request_item(p_request_item_id) for update;
+  if v_wop.part_id is null then raise exception 'Work-order part has no selected part.'; end if;
+  v_available := public.parts_available(v_wop.shop_id, v_wop.part_id, p_location_id);
+  if v_available < p_qty then raise exception 'Insufficient available stock. Available %, requested %.', v_available, p_qty; end if;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, 0, 'wo_allocate', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, p_request_item_id, jsonb_build_object('qty_reserved', p_qty, 'operation', 'allocate'), p_qty) returning id into v_move_id;
+  insert into public.work_order_part_allocations(work_order_line_id, work_order_id, shop_id, part_id, location_id, qty, unit_cost, stock_move_id, source_request_item_id, work_order_part_id)
+  values (v_wop.work_order_line_id, v_wop.work_order_id, v_wop.shop_id, v_wop.part_id, p_location_id, p_qty, coalesce(v_wop.unit_cost_snapshot,0), v_move_id, p_request_item_id, v_wop.id)
+  on conflict (work_order_part_id, location_id) where work_order_part_id is not null do update set qty = public.work_order_part_allocations.qty + excluded.qty, stock_move_id = excluded.stock_move_id
+  returning id, qty into v_alloc_id, v_new_alloc;
+  update public.part_request_items set qty_reserved = coalesce(qty_reserved,0) + p_qty, status='reserved', updated_at=now() where id=p_request_item_id;
+  update public.work_order_parts set quantity_allocated = coalesce(quantity_allocated,0) + p_qty, updated_at=now() where id=v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  update public.stock_moves set metadata = metadata || jsonb_build_object('allocation_id', v_alloc_id, 'work_order_part_id', v_wop.id) where id=v_move_id;
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'allocation_id', v_alloc_id, 'stock_move_id', v_move_id, 'allocated_qty', v_new_alloc, 'available_after', public.parts_available(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_release_allocation(p_request_item_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_wop public.work_order_parts%rowtype; v_loc public.stock_locations%rowtype; v_existing public.stock_moves%rowtype; v_alloc public.work_order_part_allocations%rowtype; v_move_id uuid;
+begin
+  if p_qty <= 0 then raise exception 'Release quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_item from public.part_request_items where id = p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  select * into v_loc from public.stock_locations where id=p_location_id;
+  if not found or v_loc.shop_id is distinct from v_item.shop_id then raise exception 'Location belongs to a different shop.'; end if;
+  select * into v_existing from public.stock_moves where shop_id=v_item.shop_id and idempotency_key=p_idempotency_key;
+  if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  select * into v_wop from public.work_order_parts where source_parts_request_item_id=p_request_item_id and coalesce(is_active,true) for update;
+  if not found then raise exception 'Work-order part not found.'; end if;
+  select * into v_alloc from public.work_order_part_allocations where work_order_part_id=v_wop.id and location_id=p_location_id for update;
+  if not found or v_alloc.qty <= 0 then raise exception 'No active allocation to release.'; end if;
+  if v_alloc.qty < p_qty then raise exception 'Cannot release more than active allocation.'; end if;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, 0, 'wo_release', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, p_request_item_id, jsonb_build_object('qty_released', p_qty, 'operation', 'release'), p_qty) returning id into v_move_id;
+  update public.work_order_part_allocations set qty = qty - p_qty, stock_move_id = v_move_id where id = v_alloc.id;
+  delete from public.work_order_part_allocations where id = v_alloc.id and qty <= 0;
+  update public.part_request_items set qty_reserved = greatest(coalesce(qty_reserved,0) - p_qty, 0), updated_at=now() where id=p_request_item_id;
+  update public.work_order_parts set quantity_allocated = greatest(coalesce(quantity_allocated,0) - p_qty, 0), updated_at=now() where id=v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'released_qty', p_qty, 'available_after', public.parts_available(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_create_po_line_for_request(p_po_id uuid, p_request_item_id uuid, p_qty numeric, p_unit_cost numeric default null, p_location_id uuid default null, p_idempotency_key text default null)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_po public.purchase_orders%rowtype; v_loc public.stock_locations%rowtype; v_wop uuid; v_line_id uuid; v_key text; v_total_ordered numeric;
+begin
+  if p_qty <= 0 then raise exception 'PO quantity must be greater than 0.'; end if;
+  v_key := coalesce(nullif(trim(p_idempotency_key),''), 'po-line:'||p_po_id::text||':'||p_request_item_id::text||':'||p_qty::text);
+  select * into v_item from public.part_request_items where id=p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  select * into v_po from public.purchase_orders where id=p_po_id for update;
+  if not found then raise exception 'Purchase order not found.'; end if;
+  if v_po.shop_id is distinct from v_item.shop_id then raise exception 'Purchase order belongs to a different shop.'; end if;
+  if p_location_id is not null then
+    select * into v_loc from public.stock_locations where id=p_location_id;
+    if not found or v_loc.shop_id is distinct from v_item.shop_id then raise exception 'Location belongs to a different shop.'; end if;
+  end if;
+  v_wop := public.parts_attach_request_item(p_request_item_id);
+  insert into public.purchase_order_lines(po_id, part_id, description, qty, unit_cost, location_id, part_request_item_id, work_order_part_id, idempotency_key)
+  values (p_po_id, v_item.part_id, v_item.description, p_qty, coalesce(p_unit_cost, v_item.unit_cost, 0), p_location_id, p_request_item_id, v_wop, v_key)
+  on conflict (po_id, idempotency_key) where idempotency_key is not null do update set id=id
+  returning id into v_line_id;
+  select coalesce(sum(qty),0) into v_total_ordered from public.purchase_order_lines where part_request_item_id=p_request_item_id;
+  update public.part_request_items set po_id=p_po_id, qty_approved=greatest(coalesce(qty_approved,0), v_total_ordered), status='ordered', updated_at=now() where id=p_request_item_id;
+  update public.work_order_parts set quantity_ordered=v_total_ordered, updated_at=now() where id=v_wop;
+  perform public.parts_reconcile_work_order_part(v_wop);
+  return jsonb_build_object('ok', true, 'purchase_order_line_id', v_line_id, 'work_order_part_id', v_wop, 'ordered_qty', v_total_ordered);
+end $$;
+
+create or replace function public.parts_receive_request_item(p_request_item_id uuid, p_location_id uuid, p_qty numeric, p_po_line_id uuid default null, p_unit_cost numeric default null, p_idempotency_key text default null)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_wop public.work_order_parts%rowtype; v_line public.purchase_order_lines%rowtype; v_loc public.stock_locations%rowtype; v_existing public.stock_moves%rowtype; v_key text; v_received_total numeric; v_move_id uuid; v_ordered_limit numeric;
+begin
+  if p_qty <= 0 then raise exception 'Receive quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_item from public.part_request_items where id=p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  select * into v_loc from public.stock_locations where id=p_location_id for update;
+  if not found or v_loc.shop_id is distinct from v_item.shop_id then raise exception 'Location belongs to a different shop.'; end if;
+  select * into v_wop from public.work_order_parts where id=public.parts_attach_request_item(p_request_item_id) for update;
+  v_key := nullif(trim(p_idempotency_key),'');
+  select * into v_existing from public.stock_moves where shop_id=v_item.shop_id and idempotency_key=v_key;
+  if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  if p_po_line_id is not null then
+    select * into v_line from public.purchase_order_lines where id=p_po_line_id for update;
+    if not found then raise exception 'Purchase order line not found.'; end if;
+    if v_line.part_request_item_id is distinct from p_request_item_id or v_line.work_order_part_id is distinct from v_wop.id then raise exception 'PO line is not linked to this request item/work-order part.'; end if;
+    if coalesce(v_line.received_qty,0) + p_qty > coalesce(v_line.qty,0) then raise exception 'Receipt exceeds ordered quantity.'; end if;
+    update public.purchase_order_lines set received_qty = coalesce(received_qty,0) + p_qty where id=p_po_line_id;
+  else
+    select coalesce(sum(qty), coalesce(v_item.qty_requested, v_item.qty, 0)) into v_ordered_limit from public.purchase_order_lines where part_request_item_id=p_request_item_id;
+    if coalesce(v_item.qty_received,0) + p_qty > greatest(v_ordered_limit, coalesce(v_item.qty_requested, v_item.qty,0)) then raise exception 'Receipt exceeds requested quantity.'; end if;
+  end if;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, purchase_order_line_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, p_qty, 'receive', case when p_po_line_id is null then 'part_request_item' else 'purchase_order_line' end, coalesce(p_po_line_id, p_request_item_id), auth.uid(), v_wop.shop_id, v_key, v_wop.id, p_request_item_id, p_po_line_id, jsonb_build_object('qty_received', p_qty, 'operation', 'receive'), p_qty) returning id into v_move_id;
+  update public.part_request_items set qty_received=coalesce(qty_received,0)+p_qty, location_id=coalesce(location_id,p_location_id), unit_cost=coalesce(p_unit_cost, unit_cost), status=case when coalesce(qty_received,0)+p_qty >= coalesce(qty_requested, qty,0) then 'received' else 'partially_received' end, updated_at=now() where id=p_request_item_id returning qty_received into v_received_total;
+  update public.work_order_parts set quantity_received=coalesce(quantity_received,0)+p_qty, unit_cost_snapshot=coalesce(p_unit_cost, unit_cost_snapshot), updated_at=now() where id=v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'received_qty', v_received_total, 'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_issue_work_order_part(p_work_order_part_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_wop public.work_order_parts%rowtype; v_loc public.stock_locations%rowtype; v_existing public.stock_moves%rowtype; v_alloc public.work_order_part_allocations%rowtype; v_move_id uuid; v_item_id uuid;
+begin
+  if p_qty <= 0 then raise exception 'Issue quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_wop from public.work_order_parts where id=p_work_order_part_id for update;
+  if not found then raise exception 'Work-order part not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_wop.shop_id);
+  select * into v_loc from public.stock_locations where id=p_location_id;
+  if not found or v_loc.shop_id is distinct from v_wop.shop_id then raise exception 'Location belongs to a different shop.'; end if;
+  select * into v_existing from public.stock_moves where shop_id=v_wop.shop_id and idempotency_key=p_idempotency_key;
+  if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  if coalesce(v_wop.quantity_allocated,0) < p_qty then raise exception 'Cannot issue more than allocated quantity.'; end if;
+  if public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id) < p_qty then raise exception 'Cannot issue more than on-hand quantity.'; end if;
+  select * into v_alloc from public.work_order_part_allocations where work_order_part_id=v_wop.id and location_id=p_location_id for update;
+  if not found or v_alloc.qty < p_qty then raise exception 'Allocation not found or insufficient for issue.'; end if;
+  v_item_id := v_wop.source_parts_request_item_id;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, -p_qty, 'consume', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, v_item_id, jsonb_build_object('qty_issued', p_qty, 'operation', 'issue'), p_qty) returning id into v_move_id;
+  update public.work_order_part_allocations set qty=qty-p_qty, stock_move_id=v_move_id where id=v_alloc.id;
+  delete from public.work_order_part_allocations where id=v_alloc.id and qty<=0;
+  update public.work_order_parts set quantity_allocated=greatest(coalesce(quantity_allocated,0)-p_qty,0), quantity_consumed=coalesce(quantity_consumed,0)+p_qty, updated_at=now() where id=v_wop.id;
+  update public.part_request_items set qty_reserved=greatest(coalesce(qty_reserved,0)-p_qty,0), qty_consumed=coalesce(qty_consumed,0)+p_qty, status='consumed', updated_at=now() where id=v_item_id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'issued_qty', p_qty, 'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_return_to_stock(p_work_order_part_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_wop public.work_order_parts%rowtype; v_loc public.stock_locations%rowtype; v_existing public.stock_moves%rowtype; v_move_id uuid;
+begin
+  if p_qty <= 0 then raise exception 'Return quantity must be greater than 0.'; end if;
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_wop from public.work_order_parts where id=p_work_order_part_id for update;
+  if not found then raise exception 'Work-order part not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_wop.shop_id);
+  select * into v_loc from public.stock_locations where id=p_location_id;
+  if not found or v_loc.shop_id is distinct from v_wop.shop_id then raise exception 'Location belongs to a different shop.'; end if;
+  select * into v_existing from public.stock_moves where shop_id=v_wop.shop_id and idempotency_key=p_idempotency_key;
+  if found then return coalesce(v_existing.metadata,'{}'::jsonb) || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id); end if;
+  if coalesce(v_wop.quantity_consumed,0) - coalesce(v_wop.quantity_returned,0) < p_qty then raise exception 'Cannot return more than issued and unreturned quantity.'; end if;
+  insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, metadata, lifecycle_quantity)
+  values (v_wop.part_id, p_location_id, p_qty, 'return', 'work_order_part', v_wop.id, auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id, v_wop.source_parts_request_item_id, jsonb_build_object('qty_returned', p_qty, 'operation', 'return_to_stock'), p_qty) returning id into v_move_id;
+  update public.work_order_parts set quantity_returned=coalesce(quantity_returned,0)+p_qty, updated_at=now() where id=v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object('ok', true, 'idempotent', false, 'work_order_part_id', v_wop.id, 'stock_move_id', v_move_id, 'returned_qty', p_qty, 'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id));
+end $$;
+
+create or replace function public.parts_cancel_request_item(p_request_item_id uuid, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_wop public.work_order_parts%rowtype; v_alloc record; v_cancel numeric; v_key text; v_released numeric := 0;
+begin
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_item from public.part_request_items where id=p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  select * into v_wop from public.work_order_parts where source_parts_request_item_id=p_request_item_id and coalesce(is_active,true) for update;
+  if not found then raise exception 'Work-order part not found.'; end if;
+  for v_alloc in select * from public.work_order_part_allocations where work_order_part_id=v_wop.id for update loop
+    v_key := p_idempotency_key || ':release:' || v_alloc.id::text;
+    perform public.parts_release_allocation(p_request_item_id, v_alloc.location_id, v_alloc.qty, v_key);
+    v_released := v_released + v_alloc.qty;
+  end loop;
+  v_cancel := greatest(coalesce(v_wop.quantity_requested,0)-coalesce(v_wop.quantity_consumed,0)-coalesce(v_wop.quantity_returned,0),0);
+  update public.work_order_parts set quantity_cancelled = greatest(quantity_cancelled, v_cancel), lifecycle_status = case when quantity_consumed > 0 then lifecycle_status else 'cancelled' end, updated_at=now() where id=v_wop.id;
+  update public.part_request_items set status='cancelled', updated_at=now() where id=p_request_item_id;
+  return jsonb_build_object('ok', true, 'work_order_part_id', v_wop.id, 'released_qty', v_released, 'cancelled_qty', v_cancel);
+end $$;
+
+create or replace function public.parts_replace_request_item(p_request_item_id uuid, p_new_part_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_old public.work_order_parts%rowtype; v_part public.parts%rowtype; v_item public.part_request_items%rowtype; v_result jsonb; v_new_wop uuid; v_had_old boolean := false;
+begin
+  if nullif(trim(p_idempotency_key),'') is null then raise exception 'idempotency_key is required.'; end if;
+  select * into v_item from public.part_request_items where id=p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  select * into v_part from public.parts where id=p_new_part_id;
+  if not found or v_part.shop_id is distinct from v_item.shop_id then raise exception 'Replacement part is not available for this shop.'; end if;
+  select * into v_old from public.work_order_parts where source_parts_request_item_id=p_request_item_id and coalesce(is_active,true) for update;
+  v_had_old := found;
+  if v_had_old then
+    perform public.parts_cancel_request_item(p_request_item_id, p_idempotency_key || ':cancel-old');
+    update public.work_order_parts set lifecycle_status='replaced', is_active=false, updated_at=now() where id=v_old.id and quantity_consumed = 0;
+  end if;
+  update public.part_request_items set part_id=p_new_part_id, status='requested', qty_reserved=0, updated_at=now() where id=p_request_item_id;
+  v_result := public.parts_allocate_request_item(p_request_item_id, p_location_id, p_qty, p_idempotency_key || ':allocate-new');
+  v_new_wop := (v_result->>'work_order_part_id')::uuid;
+  if v_had_old then
+    update public.work_order_parts set replaced_from_work_order_part_id = v_old.id where id = v_new_wop;
+    update public.work_order_parts set replaced_by_work_order_part_id = v_new_wop where id = v_old.id;
+  end if;
+  return v_result || jsonb_build_object('ok', true, 'replaced_part_id', case when v_had_old then v_old.part_id else null end, 'new_part_id', p_new_part_id, 'new_work_order_part_id', v_new_wop);
+end $$;
+
+-- Safe compatibility wrappers used by current app paths.
+create or replace function public.parts_ensure_work_order_part(p_request_item_id uuid)
+returns uuid language sql security definer set search_path = public as $$
+  select public.parts_attach_request_item(p_request_item_id);
+$$;
+
+create or replace function public.upsert_part_allocation_from_request_item(p_request_item_id uuid, p_location_id uuid, p_create_stock_move boolean default true)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_qty numeric; v_key text;
+begin
+  select * into v_item from public.part_request_items where id=p_request_item_id;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  v_qty := coalesce(v_item.qty_reserved,0);
+  if v_qty <= 0 then v_qty := coalesce(v_item.qty_requested, v_item.qty,0); end if;
+  v_key := 'allocate-request-item:'||p_request_item_id::text||':'||p_location_id::text||':'||v_qty::text;
+  if p_create_stock_move then
+    return public.parts_allocate_request_item(p_request_item_id, p_location_id, v_qty, v_key);
+  end if;
+  return jsonb_build_object('ok', true, 'work_order_part_id', public.parts_attach_request_item(p_request_item_id), 'allocated', false);
+end $$;
+
+create or replace function public.receive_part_request_item(p_item_id uuid, p_location_id uuid, p_qty numeric, p_po_id uuid default null, p_idempotency_key text default null)
+returns jsonb language plpgsql security definer set search_path = public as $$
+declare v_line_id uuid; v_key text;
+begin
+  select pol.id into v_line_id
+  from public.purchase_order_lines pol
+  where pol.part_request_item_id = p_item_id and (p_po_id is null or pol.po_id = p_po_id) and pol.received_qty < pol.qty
+  order by pol.created_at asc
+  limit 1;
+  v_key := coalesce(nullif(trim(p_idempotency_key),''), 'receive-request-item:'||p_item_id::text||':'||coalesce(v_line_id::text, 'direct')||':'||p_location_id::text||':'||p_qty::text);
+  return public.parts_receive_request_item(p_item_id, p_location_id, p_qty, v_line_id, null, v_key);
+end $$;
+
+-- Grants/revocations.
+revoke all on function public.parts_lifecycle_assert_shop_access(uuid) from public, anon;
+revoke all on function public.parts_attach_request_item(uuid) from public, anon;
+revoke all on function public.parts_allocate_request_item(uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_release_allocation(uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_create_po_line_for_request(uuid, uuid, numeric, numeric, uuid, text) from public, anon;
+revoke all on function public.parts_receive_request_item(uuid, uuid, numeric, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_issue_work_order_part(uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_return_to_stock(uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.parts_cancel_request_item(uuid, text) from public, anon;
+revoke all on function public.parts_replace_request_item(uuid, uuid, uuid, numeric, text) from public, anon;
+revoke all on function public.upsert_part_allocation_from_request_item(uuid, uuid, boolean) from public, anon;
+revoke all on function public.receive_part_request_item(uuid, uuid, numeric, uuid, text) from public, anon;
+
+grant execute on function public.parts_lifecycle_assert_shop_access(uuid) to authenticated, service_role;
+grant execute on function public.parts_attach_request_item(uuid) to authenticated, service_role;
+grant execute on function public.parts_allocate_request_item(uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_release_allocation(uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_create_po_line_for_request(uuid, uuid, numeric, numeric, uuid, text) to authenticated, service_role;
+grant execute on function public.parts_receive_request_item(uuid, uuid, numeric, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_issue_work_order_part(uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_return_to_stock(uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.parts_cancel_request_item(uuid, text) to authenticated, service_role;
+grant execute on function public.parts_replace_request_item(uuid, uuid, uuid, numeric, text) to authenticated, service_role;
+grant execute on function public.upsert_part_allocation_from_request_item(uuid, uuid, boolean) to authenticated, service_role;
+grant execute on function public.receive_part_request_item(uuid, uuid, numeric, uuid, text) to authenticated, service_role;
+
+commit;

--- a/db/sql/2026-07-11_parts_lifecycle_manual_postcheck.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_manual_postcheck.sql
@@ -1,12 +1,18 @@
 -- Read-only postcheck for the consolidated manual parts lifecycle migration.
 -- Run after db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql.
+-- This script reports missing final schema instead of crashing when a final
+-- column/function is absent.
 
 with recursive replacement_walk as (
-  select id, replaced_by_work_order_part_id, array[id] as path, false as cycle
-  from public.work_order_parts
-  where replaced_by_work_order_part_id is not null
+  select
+    (to_jsonb(w)->>'id')::uuid as id,
+    nullif(to_jsonb(w)->>'replaced_by_work_order_part_id','')::uuid as replaced_by_work_order_part_id,
+    array[(to_jsonb(w)->>'id')::uuid] as path,
+    false as cycle
+  from public.work_order_parts w
+  where nullif(to_jsonb(w)->>'replaced_by_work_order_part_id','') is not null
   union all
-  select w.id, next.replaced_by_work_order_part_id, w.path || next.id, next.id = any(w.path)
+  select w.id, nullif(to_jsonb(next)->>'replaced_by_work_order_part_id','')::uuid, w.path || next.id, next.id = any(w.path)
   from replacement_walk w
   join public.work_order_parts next on next.id = w.replaced_by_work_order_part_id
   where not w.cycle and array_length(w.path, 1) < 25
@@ -22,6 +28,10 @@ with recursive replacement_walk as (
     ('stock_moves','idempotency_key'),('stock_moves','work_order_part_id'),('stock_moves','part_request_item_id'),('stock_moves','purchase_order_line_id'),('stock_moves','metadata'),('stock_moves','lifecycle_quantity'),
     ('purchase_order_lines','part_request_item_id'),('purchase_order_lines','work_order_part_id'),('purchase_order_lines','idempotency_key')
   ) as c(table_name, column_name)
+), column_presence as (
+  select rc.table_name, rc.column_name, c.column_name is not null as exists
+  from required_columns rc
+  left join information_schema.columns c on c.table_schema='public' and c.table_name=rc.table_name and c.column_name=rc.column_name
 ), required_constraints as (
   select * from (values
     ('work_order_parts_source_request_item_id_fkey'),('work_order_parts_source_request_id_fkey'),('work_order_parts_work_order_line_id_fkey'),
@@ -37,28 +47,37 @@ with recursive replacement_walk as (
   ) as i(indexname)
 ), required_functions as (
   select * from (values
-    ('public.parts_attach_request_item(uuid)'::regprocedure),
-    ('public.parts_allocate_request_item(uuid,uuid,numeric,text)'::regprocedure),
-    ('public.parts_release_allocation(uuid,uuid,numeric,text)'::regprocedure),
-    ('public.parts_create_po_line_for_request(uuid,uuid,numeric,numeric,uuid,text)'::regprocedure),
-    ('public.parts_receive_request_item(uuid,uuid,numeric,uuid,numeric,text)'::regprocedure),
-    ('public.parts_issue_work_order_part(uuid,uuid,numeric,text)'::regprocedure),
-    ('public.parts_return_to_stock(uuid,uuid,numeric,text)'::regprocedure),
-    ('public.parts_cancel_request_item(uuid,text)'::regprocedure),
-    ('public.parts_replace_request_item(uuid,uuid,uuid,numeric,text)'::regprocedure),
-    ('public.parts_on_hand(uuid,uuid,uuid)'::regprocedure),
-    ('public.parts_allocated(uuid,uuid,uuid)'::regprocedure),
-    ('public.parts_available(uuid,uuid,uuid)'::regprocedure)
-  ) as f(regproc)
+    ('public.parts_attach_request_item(uuid)'),
+    ('public.parts_allocate_request_item(uuid,uuid,numeric,text)'),
+    ('public.parts_release_allocation(uuid,uuid,numeric,text)'),
+    ('public.parts_create_po_line_for_request(uuid,uuid,numeric,numeric,uuid,text)'),
+    ('public.parts_receive_request_item(uuid,uuid,numeric,uuid,numeric,text)'),
+    ('public.parts_issue_work_order_part(uuid,uuid,numeric,text)'),
+    ('public.parts_return_to_stock(uuid,uuid,numeric,text)'),
+    ('public.parts_cancel_request_item(uuid,text)'),
+    ('public.parts_replace_request_item(uuid,uuid,uuid,numeric,text)'),
+    ('public.parts_on_hand(uuid,uuid,uuid)'),
+    ('public.parts_allocated(uuid,uuid,uuid)'),
+    ('public.parts_available(uuid,uuid,uuid)')
+  ) as f(signature)
+), wop as (
+  select to_jsonb(w) as row from public.work_order_parts w
+), alloc as (
+  select to_jsonb(a) as row from public.work_order_part_allocations a
+), stock as (
+  select to_jsonb(sm) as row from public.stock_moves sm
 ), stock_balances as (
-  select p.shop_id, p.id as part_id,
-    public.parts_on_hand(p.shop_id, p.id, null) as on_hand,
-    public.parts_allocated(p.shop_id, p.id, null) as allocated,
-    public.parts_available(p.shop_id, p.id, null) as available
+  select
+    p.shop_id,
+    p.id as part_id,
+    coalesce(sum((stock.row->>'qty_change')::numeric) filter (where stock.row->>'reason' not in ('wo_allocate','wo_release')),0) as on_hand,
+    coalesce((select sum((a.row->>'qty')::numeric) from alloc a where (a.row->>'shop_id')::uuid=p.shop_id and (a.row->>'part_id')::uuid=p.id),0) as allocated
   from public.parts p
+  left join stock on (stock.row->>'shop_id')::uuid=p.shop_id and (stock.row->>'part_id')::uuid=p.id
+  group by p.shop_id, p.id
 ), findings as (
   select 'missing_required_columns' finding, count(*)::bigint count, 'blocker' severity
-  from required_columns rc left join information_schema.columns c on c.table_schema='public' and c.table_name=rc.table_name and c.column_name=rc.column_name where c.column_name is null
+  from column_presence where not exists
   union all select 'missing_required_constraints', count(*), 'blocker'
   from required_constraints rc left join pg_constraint pc on pc.conname=rc.conname where pc.conname is null
   union all select 'missing_required_indexes', count(*), 'blocker'
@@ -66,33 +85,43 @@ with recursive replacement_walk as (
   union all select 'legacy_broad_stock_move_reference_reason_index_present', count(*), 'blocker'
   from pg_indexes where schemaname='public' and indexname='uq_stock_moves_reference_reason'
   union all select 'missing_required_functions', count(*), 'blocker'
-  from required_functions rf where to_regprocedure(rf.regproc::text) is null
+  from required_functions rf where to_regprocedure(rf.signature) is null
   union all select 'lifecycle_functions_executable_by_anon', count(*), 'blocker'
   from information_schema.routine_privileges
   where routine_schema='public' and grantee='anon' and routine_name in ('parts_attach_request_item','parts_allocate_request_item','parts_release_allocation','parts_receive_request_item','parts_issue_work_order_part','parts_return_to_stock','parts_cancel_request_item','parts_replace_request_item','upsert_part_allocation_from_request_item','receive_part_request_item')
   union all select 'unresolved_allocation_work_order_part_links', count(*), 'review'
-  from public.work_order_part_allocations where work_order_part_id is null
+  from alloc where nullif(row->>'work_order_part_id','') is null
   union all select 'active_duplicate_work_order_parts_per_request_item', count(*), 'blocker'
-  from (select source_parts_request_item_id from public.work_order_parts where source_parts_request_item_id is not null and coalesce(is_active,true) group by 1 having count(*) > 1) d
+  from (select row->>'source_parts_request_item_id' source_item from wop where nullif(row->>'source_parts_request_item_id','') is not null and coalesce((row->>'is_active')::boolean,true) group by 1 having count(*) > 1) d
   union all select 'cross_scope_allocation_links', count(*), 'blocker'
-  from public.work_order_part_allocations a join public.work_order_parts wop on wop.id=a.work_order_part_id
-  where a.shop_id is distinct from wop.shop_id or a.work_order_id is distinct from wop.work_order_id or a.work_order_line_id is distinct from wop.work_order_line_id
+  from alloc a join public.work_order_parts wop_row on wop_row.id = nullif(a.row->>'work_order_part_id','')::uuid
+  where nullif(a.row->>'shop_id','')::uuid is distinct from wop_row.shop_id
+     or nullif(a.row->>'work_order_id','')::uuid is distinct from wop_row.work_order_id
+     or nullif(a.row->>'work_order_line_id','')::uuid is distinct from nullif(to_jsonb(wop_row)->>'work_order_line_id','')::uuid
   union all select 'invalid_negative_lifecycle_quantities', count(*), 'blocker'
-  from public.work_order_parts where least(quantity_requested, quantity_ordered, quantity_received, quantity_allocated, quantity_consumed, quantity_returned, quantity_cancelled) < 0
+  from wop where least(
+    coalesce(nullif(row->>'quantity_requested','')::numeric,0), coalesce(nullif(row->>'quantity_ordered','')::numeric,0),
+    coalesce(nullif(row->>'quantity_received','')::numeric,0), coalesce(nullif(row->>'quantity_allocated','')::numeric,0),
+    coalesce(nullif(row->>'quantity_consumed','')::numeric,0), coalesce(nullif(row->>'quantity_returned','')::numeric,0),
+    coalesce(nullif(row->>'quantity_cancelled','')::numeric,0)
+  ) < 0
   union all select 'stock_available_below_zero', count(*), 'review'
-  from stock_balances where available < 0
+  from stock_balances where on_hand - allocated < 0
   union all select 'stock_allocated_greater_than_on_hand', count(*), 'review'
   from stock_balances where allocated > on_hand
   union all select 'replacement_link_self_or_cycle', count(*), 'blocker'
-  from public.work_order_parts wop where wop.id = wop.replaced_from_work_order_part_id or wop.id = wop.replaced_by_work_order_part_id
+  from wop where row->>'id' = row->>'replaced_from_work_order_part_id' or row->>'id' = row->>'replaced_by_work_order_part_id'
   union all select 'replacement_link_cycles', count(*), 'blocker'
   from replacement_walk where cycle
   union all select 'replacement_link_scope_mismatches', count(*), 'blocker'
-  from public.work_order_parts wop join public.work_order_parts other on other.id = coalesce(wop.replaced_from_work_order_part_id, wop.replaced_by_work_order_part_id)
-  where wop.source_parts_request_item_id is distinct from other.source_parts_request_item_id or wop.shop_id is distinct from other.shop_id or wop.work_order_id is distinct from other.work_order_id or wop.work_order_line_id is distinct from other.work_order_line_id
+  from public.work_order_parts wop_row join public.work_order_parts other on other.id = coalesce(nullif(to_jsonb(wop_row)->>'replaced_from_work_order_part_id','')::uuid, nullif(to_jsonb(wop_row)->>'replaced_by_work_order_part_id','')::uuid)
+  where nullif(to_jsonb(wop_row)->>'source_parts_request_item_id','')::uuid is distinct from nullif(to_jsonb(other)->>'source_parts_request_item_id','')::uuid
+     or wop_row.shop_id is distinct from other.shop_id
+     or wop_row.work_order_id is distinct from other.work_order_id
+     or nullif(to_jsonb(wop_row)->>'work_order_line_id','')::uuid is distinct from nullif(to_jsonb(other)->>'work_order_line_id','')::uuid
   union all select 'zero_quantity_reservation_audit_missing_lifecycle_quantity', count(*), 'blocker'
-  from public.stock_moves where reason in ('wo_allocate','wo_release') and qty_change = 0 and coalesce(lifecycle_quantity,0) <= 0
+  from stock where row->>'reason' in ('wo_allocate','wo_release') and coalesce(nullif(row->>'qty_change','')::numeric,0) = 0 and coalesce(nullif(row->>'lifecycle_quantity','')::numeric,0) <= 0
   union all select 'invoice_parts_missing_canonical_work_order_part_refs', count(*), 'review'
-  from public.part_request_items i join public.invoices inv on inv.work_order_id=i.work_order_id left join public.work_order_parts wop on wop.source_parts_request_item_id=i.id where i.part_id is not null and wop.id is null
+  from public.part_request_items i join public.invoices inv on inv.work_order_id=i.work_order_id left join public.work_order_parts wop_row on nullif(to_jsonb(wop_row)->>'source_parts_request_item_id','')::uuid=i.id where i.part_id is not null and wop_row.id is null
 )
 select * from findings order by severity, finding;

--- a/db/sql/2026-07-11_parts_lifecycle_manual_postcheck.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_manual_postcheck.sql
@@ -1,0 +1,98 @@
+-- Read-only postcheck for the consolidated manual parts lifecycle migration.
+-- Run after db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql.
+
+with recursive replacement_walk as (
+  select id, replaced_by_work_order_part_id, array[id] as path, false as cycle
+  from public.work_order_parts
+  where replaced_by_work_order_part_id is not null
+  union all
+  select w.id, next.replaced_by_work_order_part_id, w.path || next.id, next.id = any(w.path)
+  from replacement_walk w
+  join public.work_order_parts next on next.id = w.replaced_by_work_order_part_id
+  where not w.cycle and array_length(w.path, 1) < 25
+), required_columns as (
+  select * from (values
+    ('work_order_parts','work_order_line_id'),('work_order_parts','source_parts_request_id'),('work_order_parts','source_parts_request_item_id'),
+    ('work_order_parts','description_snapshot'),('work_order_parts','manufacturer_snapshot'),('work_order_parts','part_number_snapshot'),
+    ('work_order_parts','quantity_requested'),('work_order_parts','quantity_ordered'),('work_order_parts','quantity_received'),
+    ('work_order_parts','quantity_allocated'),('work_order_parts','quantity_consumed'),('work_order_parts','quantity_returned'),
+    ('work_order_parts','quantity_cancelled'),('work_order_parts','unit_cost_snapshot'),('work_order_parts','unit_sell_price_snapshot'),
+    ('work_order_parts','lifecycle_status'),('work_order_parts','is_active'),('work_order_parts','replaced_from_work_order_part_id'),('work_order_parts','replaced_by_work_order_part_id'),
+    ('work_order_part_allocations','work_order_part_id'),('work_order_part_allocations','source_request_item_id'),('work_order_part_allocations','shop_id'),('work_order_part_allocations','work_order_id'),
+    ('stock_moves','idempotency_key'),('stock_moves','work_order_part_id'),('stock_moves','part_request_item_id'),('stock_moves','purchase_order_line_id'),('stock_moves','metadata'),('stock_moves','lifecycle_quantity'),
+    ('purchase_order_lines','part_request_item_id'),('purchase_order_lines','work_order_part_id'),('purchase_order_lines','idempotency_key')
+  ) as c(table_name, column_name)
+), required_constraints as (
+  select * from (values
+    ('work_order_parts_source_request_item_id_fkey'),('work_order_parts_source_request_id_fkey'),('work_order_parts_work_order_line_id_fkey'),
+    ('work_order_parts_replaced_from_fkey'),('work_order_parts_replaced_by_fkey'),('work_order_part_allocations_work_order_part_id_fkey'),
+    ('work_order_part_allocations_source_request_item_id_fkey'),('stock_moves_work_order_part_id_fkey'),('stock_moves_part_request_item_id_fkey'),
+    ('stock_moves_purchase_order_line_id_fkey'),('purchase_order_lines_part_request_item_id_fkey'),('purchase_order_lines_work_order_part_id_fkey'),
+    ('work_order_parts_no_self_replacement')
+  ) as c(conname)
+), required_indexes as (
+  select * from (values
+    ('uq_work_order_parts_active_source_request_item'),('uq_wopa_work_order_part_location'),('uq_stock_moves_shop_idempotency_key'),
+    ('uq_purchase_order_lines_idempotency'),('idx_stock_moves_work_order_part_id'),('idx_purchase_order_lines_work_order_part_id')
+  ) as i(indexname)
+), required_functions as (
+  select * from (values
+    ('public.parts_attach_request_item(uuid)'::regprocedure),
+    ('public.parts_allocate_request_item(uuid,uuid,numeric,text)'::regprocedure),
+    ('public.parts_release_allocation(uuid,uuid,numeric,text)'::regprocedure),
+    ('public.parts_create_po_line_for_request(uuid,uuid,numeric,numeric,uuid,text)'::regprocedure),
+    ('public.parts_receive_request_item(uuid,uuid,numeric,uuid,numeric,text)'::regprocedure),
+    ('public.parts_issue_work_order_part(uuid,uuid,numeric,text)'::regprocedure),
+    ('public.parts_return_to_stock(uuid,uuid,numeric,text)'::regprocedure),
+    ('public.parts_cancel_request_item(uuid,text)'::regprocedure),
+    ('public.parts_replace_request_item(uuid,uuid,uuid,numeric,text)'::regprocedure),
+    ('public.parts_on_hand(uuid,uuid,uuid)'::regprocedure),
+    ('public.parts_allocated(uuid,uuid,uuid)'::regprocedure),
+    ('public.parts_available(uuid,uuid,uuid)'::regprocedure)
+  ) as f(regproc)
+), stock_balances as (
+  select p.shop_id, p.id as part_id,
+    public.parts_on_hand(p.shop_id, p.id, null) as on_hand,
+    public.parts_allocated(p.shop_id, p.id, null) as allocated,
+    public.parts_available(p.shop_id, p.id, null) as available
+  from public.parts p
+), findings as (
+  select 'missing_required_columns' finding, count(*)::bigint count, 'blocker' severity
+  from required_columns rc left join information_schema.columns c on c.table_schema='public' and c.table_name=rc.table_name and c.column_name=rc.column_name where c.column_name is null
+  union all select 'missing_required_constraints', count(*), 'blocker'
+  from required_constraints rc left join pg_constraint pc on pc.conname=rc.conname where pc.conname is null
+  union all select 'missing_required_indexes', count(*), 'blocker'
+  from required_indexes ri left join pg_indexes pi on pi.schemaname='public' and pi.indexname=ri.indexname where pi.indexname is null
+  union all select 'legacy_broad_stock_move_reference_reason_index_present', count(*), 'blocker'
+  from pg_indexes where schemaname='public' and indexname='uq_stock_moves_reference_reason'
+  union all select 'missing_required_functions', count(*), 'blocker'
+  from required_functions rf where to_regprocedure(rf.regproc::text) is null
+  union all select 'lifecycle_functions_executable_by_anon', count(*), 'blocker'
+  from information_schema.routine_privileges
+  where routine_schema='public' and grantee='anon' and routine_name in ('parts_attach_request_item','parts_allocate_request_item','parts_release_allocation','parts_receive_request_item','parts_issue_work_order_part','parts_return_to_stock','parts_cancel_request_item','parts_replace_request_item','upsert_part_allocation_from_request_item','receive_part_request_item')
+  union all select 'unresolved_allocation_work_order_part_links', count(*), 'review'
+  from public.work_order_part_allocations where work_order_part_id is null
+  union all select 'active_duplicate_work_order_parts_per_request_item', count(*), 'blocker'
+  from (select source_parts_request_item_id from public.work_order_parts where source_parts_request_item_id is not null and coalesce(is_active,true) group by 1 having count(*) > 1) d
+  union all select 'cross_scope_allocation_links', count(*), 'blocker'
+  from public.work_order_part_allocations a join public.work_order_parts wop on wop.id=a.work_order_part_id
+  where a.shop_id is distinct from wop.shop_id or a.work_order_id is distinct from wop.work_order_id or a.work_order_line_id is distinct from wop.work_order_line_id
+  union all select 'invalid_negative_lifecycle_quantities', count(*), 'blocker'
+  from public.work_order_parts where least(quantity_requested, quantity_ordered, quantity_received, quantity_allocated, quantity_consumed, quantity_returned, quantity_cancelled) < 0
+  union all select 'stock_available_below_zero', count(*), 'review'
+  from stock_balances where available < 0
+  union all select 'stock_allocated_greater_than_on_hand', count(*), 'review'
+  from stock_balances where allocated > on_hand
+  union all select 'replacement_link_self_or_cycle', count(*), 'blocker'
+  from public.work_order_parts wop where wop.id = wop.replaced_from_work_order_part_id or wop.id = wop.replaced_by_work_order_part_id
+  union all select 'replacement_link_cycles', count(*), 'blocker'
+  from replacement_walk where cycle
+  union all select 'replacement_link_scope_mismatches', count(*), 'blocker'
+  from public.work_order_parts wop join public.work_order_parts other on other.id = coalesce(wop.replaced_from_work_order_part_id, wop.replaced_by_work_order_part_id)
+  where wop.source_parts_request_item_id is distinct from other.source_parts_request_item_id or wop.shop_id is distinct from other.shop_id or wop.work_order_id is distinct from other.work_order_id or wop.work_order_line_id is distinct from other.work_order_line_id
+  union all select 'zero_quantity_reservation_audit_missing_lifecycle_quantity', count(*), 'blocker'
+  from public.stock_moves where reason in ('wo_allocate','wo_release') and qty_change = 0 and coalesce(lifecycle_quantity,0) <= 0
+  union all select 'invoice_parts_missing_canonical_work_order_part_refs', count(*), 'review'
+  from public.part_request_items i join public.invoices inv on inv.work_order_id=i.work_order_id left join public.work_order_parts wop on wop.source_parts_request_item_id=i.id where i.part_id is not null and wop.id is null
+)
+select * from findings order by severity, finding;

--- a/db/sql/2026-07-11_parts_lifecycle_manual_preflight.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_manual_preflight.sql
@@ -1,0 +1,97 @@
+-- Read-only preflight for the consolidated manual parts lifecycle migration.
+-- Run this before db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql.
+-- Any row with severity = 'blocker' should be reviewed before migration.
+
+with table_presence as (
+  select name, to_regclass('public.' || name) is not null as exists
+  from (values
+    ('part_requests'), ('part_request_items'), ('work_order_lines'), ('work_orders'),
+    ('work_order_parts'), ('work_order_part_allocations'), ('parts'), ('stock_moves'),
+    ('stock_locations'), ('purchase_orders'), ('purchase_order_lines'), ('profiles')
+  ) as t(name)
+), wop as (
+  select
+    id,
+    work_order_id,
+    shop_id,
+    part_id,
+    to_jsonb(work_order_parts)->>'work_order_line_id' as work_order_line_id,
+    to_jsonb(work_order_parts)->>'source_parts_request_item_id' as source_parts_request_item_id,
+    coalesce((to_jsonb(work_order_parts)->>'is_active')::boolean, true) as is_active,
+    to_jsonb(work_order_parts)->>'replaced_from_work_order_part_id' as replaced_from_work_order_part_id,
+    to_jsonb(work_order_parts)->>'replaced_by_work_order_part_id' as replaced_by_work_order_part_id
+  from public.work_order_parts
+  where to_regclass('public.work_order_parts') is not null
+), alloc as (
+  select
+    id,
+    work_order_line_id,
+    part_id,
+    location_id,
+    qty,
+    to_jsonb(work_order_part_allocations)->>'shop_id' as shop_id,
+    to_jsonb(work_order_part_allocations)->>'work_order_id' as work_order_id,
+    to_jsonb(work_order_part_allocations)->>'source_request_item_id' as source_request_item_id,
+    to_jsonb(work_order_part_allocations)->>'work_order_part_id' as work_order_part_id
+  from public.work_order_part_allocations
+  where to_regclass('public.work_order_part_allocations') is not null
+), unambiguous_alloc_matches as (
+  select a.id as allocation_id, count(w.id) as match_count
+  from alloc a
+  join public.part_request_items i on i.id::text = a.source_request_item_id
+  join public.work_order_lines wl on wl.id = a.work_order_line_id
+  join wop w on w.source_parts_request_item_id = a.source_request_item_id
+    and w.part_id = a.part_id
+    and w.work_order_id = wl.work_order_id
+    and w.work_order_line_id = a.work_order_line_id::text
+    and w.shop_id::text = coalesce(a.shop_id, i.shop_id::text)
+    and w.is_active
+  where a.source_request_item_id is not null
+  group by a.id
+), findings as (
+  select 'required_table_missing' as finding, count(*)::bigint as count, 'blocker' as severity
+  from table_presence where not exists
+  union all
+  select 'active_duplicate_work_order_parts_per_request_item', count(*)::bigint, 'blocker'
+  from (select source_parts_request_item_id from wop where source_parts_request_item_id is not null and is_active group by 1 having count(*) > 1) d
+  union all
+  select 'allocation_backfill_unambiguous', count(*)::bigint, 'info'
+  from alloc a join unambiguous_alloc_matches m on m.allocation_id = a.id and m.match_count = 1
+  where a.work_order_part_id is null
+  union all
+  select 'allocation_backfill_ambiguous', count(*)::bigint, 'review'
+  from alloc a join unambiguous_alloc_matches m on m.allocation_id = a.id and m.match_count > 1
+  where a.work_order_part_id is null
+  union all
+  select 'allocation_backfill_unresolved', count(*)::bigint, 'review'
+  from alloc a left join unambiguous_alloc_matches m on m.allocation_id = a.id
+  where a.work_order_part_id is null and m.allocation_id is null
+  union all
+  select 'allocation_cross_scope_existing', count(*)::bigint, 'blocker'
+  from alloc a
+  join public.work_order_lines wl on wl.id = a.work_order_line_id
+  join public.work_orders wo on wo.id = wl.work_order_id
+  left join public.part_request_items i on i.id::text = a.source_request_item_id
+  where (a.shop_id is not null and a.shop_id <> wo.shop_id::text)
+     or (a.work_order_id is not null and a.work_order_id <> wo.id::text)
+     or (i.id is not null and i.shop_id is distinct from wo.shop_id)
+  union all
+  select 'duplicate_allocation_work_order_part_location', count(*)::bigint, 'blocker'
+  from (select work_order_part_id, location_id from alloc where work_order_part_id is not null group by 1,2 having count(*) > 1) d
+  union all
+  select 'duplicate_stock_move_idempotency_keys', count(*)::bigint, 'blocker'
+  from (select shop_id, idempotency_key from public.stock_moves where idempotency_key is not null group by 1,2 having count(*) > 1) d
+  union all
+  select 'duplicate_po_line_idempotency_keys', count(*)::bigint, 'blocker'
+  from (select po_id, idempotency_key from public.purchase_order_lines where idempotency_key is not null group by 1,2 having count(*) > 1) d
+  union all
+  select 'negative_allocation_qty', count(*)::bigint, 'blocker'
+  from alloc where qty < 0
+  union all
+  select 'self_replacement_links_existing', count(*)::bigint, 'blocker'
+  from wop where id::text = replaced_from_work_order_part_id or id::text = replaced_by_work_order_part_id
+  union all
+  select 'existing_broad_stock_move_reference_reason_index', count(*)::bigint, 'info'
+  from pg_indexes where schemaname='public' and indexname='uq_stock_moves_reference_reason'
+)
+select * from findings order by severity, finding;

--- a/db/sql/2026-07-11_parts_lifecycle_manual_preflight.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_manual_preflight.sql
@@ -1,6 +1,8 @@
 -- Read-only preflight for the consolidated manual parts lifecycle migration.
--- Run this before db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql.
--- Any row with severity = 'blocker' should be reviewed before migration.
+-- Run this BEFORE db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql.
+-- This file must execute on the legacy/pre-migration schema. Future columns are
+-- accessed through to_jsonb(...) or catalog checks so PostgreSQL never parses a
+-- not-yet-created column name.
 
 with table_presence as (
   select name, to_regclass('public.' || name) is not null as exists
@@ -9,32 +11,54 @@ with table_presence as (
     ('work_order_parts'), ('work_order_part_allocations'), ('parts'), ('stock_moves'),
     ('stock_locations'), ('purchase_orders'), ('purchase_order_lines'), ('profiles')
   ) as t(name)
+), future_columns as (
+  select * from (values
+    ('work_order_parts','source_parts_request_item_id'),
+    ('work_order_parts','is_active'),
+    ('work_order_parts','replaced_from_work_order_part_id'),
+    ('work_order_parts','replaced_by_work_order_part_id'),
+    ('work_order_part_allocations','work_order_part_id'),
+    ('stock_moves','idempotency_key'),
+    ('stock_moves','lifecycle_quantity'),
+    ('stock_moves','work_order_part_id'),
+    ('stock_moves','part_request_item_id'),
+    ('purchase_order_lines','part_request_item_id'),
+    ('purchase_order_lines','work_order_part_id'),
+    ('purchase_order_lines','idempotency_key')
+  ) as c(table_name, column_name)
+), future_column_presence as (
+  select fc.table_name, fc.column_name, (c.column_name is not null) as exists
+  from future_columns fc
+  left join information_schema.columns c
+    on c.table_schema='public' and c.table_name=fc.table_name and c.column_name=fc.column_name
 ), wop as (
   select
-    id,
-    work_order_id,
-    shop_id,
-    part_id,
-    to_jsonb(work_order_parts)->>'work_order_line_id' as work_order_line_id,
-    to_jsonb(work_order_parts)->>'source_parts_request_item_id' as source_parts_request_item_id,
-    coalesce((to_jsonb(work_order_parts)->>'is_active')::boolean, true) as is_active,
-    to_jsonb(work_order_parts)->>'replaced_from_work_order_part_id' as replaced_from_work_order_part_id,
-    to_jsonb(work_order_parts)->>'replaced_by_work_order_part_id' as replaced_by_work_order_part_id
-  from public.work_order_parts
-  where to_regclass('public.work_order_parts') is not null
+    w.id,
+    w.work_order_id,
+    w.shop_id,
+    w.part_id,
+    to_jsonb(w)->>'work_order_line_id' as work_order_line_id,
+    to_jsonb(w)->>'source_parts_request_item_id' as source_parts_request_item_id,
+    coalesce((to_jsonb(w)->>'is_active')::boolean, true) as is_active,
+    to_jsonb(w)->>'replaced_from_work_order_part_id' as replaced_from_work_order_part_id,
+    to_jsonb(w)->>'replaced_by_work_order_part_id' as replaced_by_work_order_part_id
+  from public.work_order_parts w
 ), alloc as (
   select
-    id,
-    work_order_line_id,
-    part_id,
-    location_id,
-    qty,
-    to_jsonb(work_order_part_allocations)->>'shop_id' as shop_id,
-    to_jsonb(work_order_part_allocations)->>'work_order_id' as work_order_id,
-    to_jsonb(work_order_part_allocations)->>'source_request_item_id' as source_request_item_id,
-    to_jsonb(work_order_part_allocations)->>'work_order_part_id' as work_order_part_id
-  from public.work_order_part_allocations
-  where to_regclass('public.work_order_part_allocations') is not null
+    a.id,
+    a.work_order_line_id,
+    a.part_id,
+    a.location_id,
+    a.qty,
+    to_jsonb(a)->>'shop_id' as shop_id,
+    to_jsonb(a)->>'work_order_id' as work_order_id,
+    to_jsonb(a)->>'source_request_item_id' as source_request_item_id,
+    to_jsonb(a)->>'work_order_part_id' as work_order_part_id
+  from public.work_order_part_allocations a
+), stock_move_json as (
+  select to_jsonb(sm) as row from public.stock_moves sm
+), po_line_json as (
+  select to_jsonb(pol) as row from public.purchase_order_lines pol
 ), unambiguous_alloc_matches as (
   select a.id as allocation_id, count(w.id) as match_count
   from alloc a
@@ -51,6 +75,9 @@ with table_presence as (
 ), findings as (
   select 'required_table_missing' as finding, count(*)::bigint as count, 'blocker' as severity
   from table_presence where not exists
+  union all
+  select 'future_column_not_applicable_pre_migration:' || table_name || '.' || column_name, count(*)::bigint, 'not_applicable_pre_migration'
+  from future_column_presence where not exists group by table_name, column_name
   union all
   select 'active_duplicate_work_order_parts_per_request_item', count(*)::bigint, 'blocker'
   from (select source_parts_request_item_id from wop where source_parts_request_item_id is not null and is_active group by 1 having count(*) > 1) d
@@ -76,19 +103,29 @@ with table_presence as (
      or (a.work_order_id is not null and a.work_order_id <> wo.id::text)
      or (i.id is not null and i.shop_id is distinct from wo.shop_id)
   union all
-  select 'duplicate_allocation_work_order_part_location', count(*)::bigint, 'blocker'
+  select 'duplicate_allocation_work_order_part_location', count(*)::bigint, case when exists (select 1 from future_column_presence where table_name='work_order_part_allocations' and column_name='work_order_part_id' and exists) then 'blocker' else 'not_applicable_pre_migration' end
   from (select work_order_part_id, location_id from alloc where work_order_part_id is not null group by 1,2 having count(*) > 1) d
   union all
-  select 'duplicate_stock_move_idempotency_keys', count(*)::bigint, 'blocker'
-  from (select shop_id, idempotency_key from public.stock_moves where idempotency_key is not null group by 1,2 having count(*) > 1) d
+  select 'duplicate_stock_move_idempotency_keys', count(*)::bigint, case when exists (select 1 from future_column_presence where table_name='stock_moves' and column_name='idempotency_key' and exists) then 'blocker' else 'not_applicable_pre_migration' end
+  from (
+    select row->>'shop_id' as shop_id, row->>'idempotency_key' as idempotency_key
+    from stock_move_json
+    where row ? 'idempotency_key' and nullif(row->>'idempotency_key','') is not null
+    group by 1,2 having count(*) > 1
+  ) d
   union all
-  select 'duplicate_po_line_idempotency_keys', count(*)::bigint, 'blocker'
-  from (select po_id, idempotency_key from public.purchase_order_lines where idempotency_key is not null group by 1,2 having count(*) > 1) d
+  select 'duplicate_po_line_idempotency_keys', count(*)::bigint, case when exists (select 1 from future_column_presence where table_name='purchase_order_lines' and column_name='idempotency_key' and exists) then 'blocker' else 'not_applicable_pre_migration' end
+  from (
+    select row->>'po_id' as po_id, row->>'idempotency_key' as idempotency_key
+    from po_line_json
+    where row ? 'idempotency_key' and nullif(row->>'idempotency_key','') is not null
+    group by 1,2 having count(*) > 1
+  ) d
   union all
   select 'negative_allocation_qty', count(*)::bigint, 'blocker'
   from alloc where qty < 0
   union all
-  select 'self_replacement_links_existing', count(*)::bigint, 'blocker'
+  select 'self_replacement_links_existing', count(*)::bigint, case when exists (select 1 from future_column_presence where table_name='work_order_parts' and column_name='replaced_from_work_order_part_id' and exists) or exists (select 1 from future_column_presence where table_name='work_order_parts' and column_name='replaced_by_work_order_part_id' and exists) then 'blocker' else 'not_applicable_pre_migration' end
   from wop where id::text = replaced_from_work_order_part_id or id::text = replaced_by_work_order_part_id
   union all
   select 'existing_broad_stock_move_reference_reason_index', count(*)::bigint, 'info'

--- a/db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql
@@ -6,29 +6,49 @@ with stock_balances as (
   from public.parts p
   left join public.stock_moves sm on sm.shop_id=p.shop_id and sm.part_id=p.id
   group by p.shop_id, p.id
+), active_wop as (
+  select * from public.work_order_parts where coalesce(is_active, true)
+), replacement_walk as (
+  select id, replaced_by_work_order_part_id, array[id] as path, false as cycle
+  from public.work_order_parts
+  where replaced_by_work_order_part_id is not null
+  union all
+  select w.id, next.replaced_by_work_order_part_id, w.path || next.id, next.id = any(w.path)
+  from replacement_walk w
+  join public.work_order_parts next on next.id = w.replaced_by_work_order_part_id
+  where not w.cycle and array_length(w.path, 1) < 25
 ), findings as (
   select 'request_items_without_work_order_line' finding, count(*)::bigint count from public.part_request_items where work_order_line_id is null
   union all select 'request_items_without_parent_request', count(*) from public.part_request_items i left join public.part_requests r on r.id=i.request_id where r.id is null
   union all select 'work_order_parts_without_valid_work_order', count(*) from public.work_order_parts wop left join public.work_orders wo on wo.id=wop.work_order_id where wop.work_order_id is not null and wo.id is null
   union all select 'work_order_parts_without_valid_line', count(*) from public.work_order_parts wop left join public.work_order_lines wol on wol.id=wop.work_order_line_id where wop.work_order_line_id is not null and wol.id is null
   union all select 'duplicate_work_order_parts_per_source_request_item', count(*) from (select source_parts_request_item_id from public.work_order_parts where source_parts_request_item_id is not null group by 1 having count(*) > 1) d
-  union all select 'allocations_without_valid_work_order_part', count(*) from public.work_order_part_allocations a left join public.work_order_parts wop on wop.source_parts_request_item_id=a.source_request_item_id and wop.part_id=a.part_id where a.source_request_item_id is not null and wop.id is null
+  union all select 'active_duplicate_work_order_parts_per_request_item', count(*) from (select source_parts_request_item_id from active_wop where source_parts_request_item_id is not null group by 1 having count(*) > 1) d
+  union all select 'allocations_without_valid_work_order_part', count(*) from public.work_order_part_allocations a left join public.work_order_parts wop on wop.id=a.work_order_part_id where a.work_order_part_id is null or wop.id is null
   union all select 'allocations_without_valid_request_item', count(*) from public.work_order_part_allocations a left join public.part_request_items i on i.id=a.source_request_item_id where a.source_request_item_id is not null and i.id is null
-  union all select 'duplicate_active_allocations', count(*) from (select source_request_item_id, part_id, location_id from public.work_order_part_allocations where source_request_item_id is not null group by 1,2,3 having count(*) > 1) d
+  union all select 'duplicate_active_allocations', count(*) from (select work_order_part_id, location_id from public.work_order_part_allocations where work_order_part_id is not null group by 1,2 having count(*) > 1) d
   union all select 'cross_shop_request_part_links', count(*) from public.part_request_items i join public.parts p on p.id=i.part_id where i.shop_id is distinct from p.shop_id
   union all select 'cross_shop_work_order_part_links', count(*) from public.work_order_parts wop join public.work_orders wo on wo.id=wop.work_order_id where wop.shop_id is distinct from wo.shop_id
+  union all select 'allocations_work_order_part_scope_mismatch', count(*) from public.work_order_part_allocations a join public.work_order_parts wop on wop.id=a.work_order_part_id where a.shop_id is distinct from wop.shop_id or a.work_order_id is distinct from wop.work_order_id or a.work_order_line_id is distinct from wop.work_order_line_id
   union all select 'negative_on_hand', count(*) from stock_balances where on_hand < 0
   union all select 'negative_allocated_quantity', count(*) from public.work_order_part_allocations where qty < 0
   union all select 'allocated_greater_than_on_hand', count(*) from stock_balances where allocated > on_hand
   union all select 'available_below_zero', count(*) from stock_balances where on_hand - allocated < 0
   union all select 'received_greater_than_ordered', count(*) from public.work_order_parts where quantity_ordered > 0 and quantity_received > quantity_ordered
-  union all select 'consumed_greater_than_received_or_allocated', count(*) from public.work_order_parts where quantity_consumed > greatest(quantity_received, quantity_allocated + quantity_consumed)
+  union all select 'consumed_greater_than_received_and_allocated_source', count(*) from public.work_order_parts where quantity_received > 0 and quantity_consumed > quantity_received
   union all select 'returned_greater_than_consumed', count(*) from public.work_order_parts where quantity_returned > quantity_consumed
+  union all select 'lifecycle_quantities_below_zero', count(*) from public.work_order_parts where least(quantity_requested, quantity_ordered, quantity_received, quantity_allocated, quantity_consumed, quantity_returned, quantity_cancelled) < 0
+  union all select 'cancelled_with_active_allocated_quantity', count(*) from active_wop where lifecycle_status='cancelled' and quantity_allocated > 0
+  union all select 'billable_quantity_below_zero', count(*) from public.work_order_parts where (case when quantity_consumed > 0 then quantity_consumed - quantity_returned else quantity - quantity_cancelled end) < 0
   union all select 'po_lines_disconnected_from_requests', count(*) from public.purchase_order_lines where part_request_item_id is null and work_order_part_id is null
-  union all select 'po_items_legacy_disconnected_from_requests', count(*) from public.purchase_order_items
+  union all select 'legacy_po_items_without_matching_po_line', count(*) from public.purchase_order_items poi where not exists (select 1 from public.purchase_order_lines pol where pol.po_id=poi.po_id and pol.part_id=poi.part_id)
   union all select 'stock_movements_without_source', count(*) from public.stock_moves where reference_kind is null or reference_id is null
   union all select 'duplicate_movement_idempotency_keys', count(*) from (select shop_id, idempotency_key from public.stock_moves where idempotency_key is not null group by 1,2 having count(*) > 1) d
-  union all select 'invoice_part_duplicates', 0::bigint
-  union all select 'invoice_parts_missing_canonical_work_order_part_refs', 0::bigint
+  union all select 'zero_quantity_reservation_audit_missing_lifecycle_quantity', count(*) from public.stock_moves where reason in ('wo_allocate','wo_release') and qty_change = 0 and coalesce(lifecycle_quantity,0) <= 0
+  union all select 'stock_moves_unknown_reason', count(*) from public.stock_moves where reason::text not in ('receive','adjust','consume','return','transfer_out','transfer_in','wo_allocate','wo_release','seed')
+  union all select 'work_order_part_snapshot_inconsistent_with_part', count(*) from active_wop wop join public.parts p on p.id=wop.part_id where (coalesce(wop.description_snapshot,'') <> '' and wop.description_snapshot is distinct from p.name) or (coalesce(wop.part_number_snapshot,'') <> '' and wop.part_number_snapshot is distinct from p.part_number)
+  union all select 'replacement_link_cycles', count(*) from replacement_walk where cycle
+  union all select 'invoice_part_duplicates', count(*) from (select work_order_id, source_parts_request_item_id from public.work_order_parts where source_parts_request_item_id is not null and (case when quantity_consumed > 0 then quantity_consumed - quantity_returned else quantity - quantity_cancelled end) > 0 group by 1,2 having count(*) filter (where coalesce(is_active,true)) > 1) d
+  union all select 'invoice_parts_missing_canonical_work_order_part_refs', count(*) from public.part_request_items i join public.invoices inv on inv.work_order_id=i.work_order_id left join public.work_order_parts wop on wop.source_parts_request_item_id=i.id where i.part_id is not null and wop.id is null
 )
 select * from findings order by finding;

--- a/db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql
@@ -1,0 +1,34 @@
+-- Read-only parts lifecycle audit. This script intentionally performs no writes.
+with stock_balances as (
+  select p.shop_id, p.id as part_id,
+    coalesce(sum(sm.qty_change) filter (where sm.reason not in ('wo_allocate','wo_release')),0) as on_hand,
+    coalesce((select sum(a.qty) from public.work_order_part_allocations a where a.shop_id=p.shop_id and a.part_id=p.id),0) as allocated
+  from public.parts p
+  left join public.stock_moves sm on sm.shop_id=p.shop_id and sm.part_id=p.id
+  group by p.shop_id, p.id
+), findings as (
+  select 'request_items_without_work_order_line' finding, count(*)::bigint count from public.part_request_items where work_order_line_id is null
+  union all select 'request_items_without_parent_request', count(*) from public.part_request_items i left join public.part_requests r on r.id=i.request_id where r.id is null
+  union all select 'work_order_parts_without_valid_work_order', count(*) from public.work_order_parts wop left join public.work_orders wo on wo.id=wop.work_order_id where wop.work_order_id is not null and wo.id is null
+  union all select 'work_order_parts_without_valid_line', count(*) from public.work_order_parts wop left join public.work_order_lines wol on wol.id=wop.work_order_line_id where wop.work_order_line_id is not null and wol.id is null
+  union all select 'duplicate_work_order_parts_per_source_request_item', count(*) from (select source_parts_request_item_id from public.work_order_parts where source_parts_request_item_id is not null group by 1 having count(*) > 1) d
+  union all select 'allocations_without_valid_work_order_part', count(*) from public.work_order_part_allocations a left join public.work_order_parts wop on wop.source_parts_request_item_id=a.source_request_item_id and wop.part_id=a.part_id where a.source_request_item_id is not null and wop.id is null
+  union all select 'allocations_without_valid_request_item', count(*) from public.work_order_part_allocations a left join public.part_request_items i on i.id=a.source_request_item_id where a.source_request_item_id is not null and i.id is null
+  union all select 'duplicate_active_allocations', count(*) from (select source_request_item_id, part_id, location_id from public.work_order_part_allocations where source_request_item_id is not null group by 1,2,3 having count(*) > 1) d
+  union all select 'cross_shop_request_part_links', count(*) from public.part_request_items i join public.parts p on p.id=i.part_id where i.shop_id is distinct from p.shop_id
+  union all select 'cross_shop_work_order_part_links', count(*) from public.work_order_parts wop join public.work_orders wo on wo.id=wop.work_order_id where wop.shop_id is distinct from wo.shop_id
+  union all select 'negative_on_hand', count(*) from stock_balances where on_hand < 0
+  union all select 'negative_allocated_quantity', count(*) from public.work_order_part_allocations where qty < 0
+  union all select 'allocated_greater_than_on_hand', count(*) from stock_balances where allocated > on_hand
+  union all select 'available_below_zero', count(*) from stock_balances where on_hand - allocated < 0
+  union all select 'received_greater_than_ordered', count(*) from public.work_order_parts where quantity_ordered > 0 and quantity_received > quantity_ordered
+  union all select 'consumed_greater_than_received_or_allocated', count(*) from public.work_order_parts where quantity_consumed > greatest(quantity_received, quantity_allocated + quantity_consumed)
+  union all select 'returned_greater_than_consumed', count(*) from public.work_order_parts where quantity_returned > quantity_consumed
+  union all select 'po_lines_disconnected_from_requests', count(*) from public.purchase_order_lines where part_request_item_id is null and work_order_part_id is null
+  union all select 'po_items_legacy_disconnected_from_requests', count(*) from public.purchase_order_items
+  union all select 'stock_movements_without_source', count(*) from public.stock_moves where reference_kind is null or reference_id is null
+  union all select 'duplicate_movement_idempotency_keys', count(*) from (select shop_id, idempotency_key from public.stock_moves where idempotency_key is not null group by 1,2 having count(*) > 1) d
+  union all select 'invoice_part_duplicates', 0::bigint
+  union all select 'invoice_parts_missing_canonical_work_order_part_refs', 0::bigint
+)
+select * from findings order by finding;

--- a/db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql
@@ -1,5 +1,5 @@
 -- Read-only parts lifecycle audit. This script intentionally performs no writes.
-with stock_balances as (
+with recursive stock_balances as (
   select p.shop_id, p.id as part_id,
     coalesce(sum(sm.qty_change) filter (where sm.reason not in ('wo_allocate','wo_release')),0) as on_hand,
     coalesce((select sum(a.qty) from public.work_order_part_allocations a where a.shop_id=p.shop_id and a.part_id=p.id),0) as allocated

--- a/db/sql/2026-07-11_parts_request_workflow_repair.sql
+++ b/db/sql/2026-07-11_parts_request_workflow_repair.sql
@@ -20,13 +20,17 @@ alter table public.work_order_parts
   add column if not exists mismatch_acknowledged_at timestamptz,
   add column if not exists mismatch_acknowledged_by uuid,
   add column if not exists mismatch_warning_reason text,
-  add column if not exists updated_at timestamptz default now() not null;
+  add column if not exists updated_at timestamptz default now() not null,
+  add column if not exists is_active boolean default true not null,
+  add column if not exists replaced_from_work_order_part_id uuid,
+  add column if not exists replaced_by_work_order_part_id uuid;
 
 alter table public.work_order_part_allocations
   add column if not exists created_at timestamptz default now() not null,
   add column if not exists shop_id uuid,
   add column if not exists work_order_id uuid,
-  add column if not exists source_request_item_id uuid;
+  add column if not exists source_request_item_id uuid,
+  add column if not exists work_order_part_id uuid;
 
 update public.work_order_part_allocations a
 set work_order_id = wl.work_order_id
@@ -42,17 +46,16 @@ create index if not exists idx_work_order_parts_source_request_item
   on public.work_order_parts(source_parts_request_item_id)
   where source_parts_request_item_id is not null;
 
-create unique index if not exists uq_work_order_parts_source_request_item
+create unique index if not exists uq_work_order_parts_active_source_request_item
   on public.work_order_parts(source_parts_request_item_id)
-  where source_parts_request_item_id is not null;
+  where source_parts_request_item_id is not null and is_active;
 
-create unique index if not exists uq_wopa_source_request_item_part_location
-  on public.work_order_part_allocations(source_request_item_id, part_id, location_id)
-  where source_request_item_id is not null;
+create index if not exists idx_work_order_parts_replacement_links
+  on public.work_order_parts(replaced_from_work_order_part_id, replaced_by_work_order_part_id);
 
-create unique index if not exists uq_stock_moves_reference_reason
-  on public.stock_moves(reference_kind, reference_id, reason)
-  where reference_kind is not null and reference_id is not null;
+create unique index if not exists uq_wopa_work_order_part_location
+  on public.work_order_part_allocations(work_order_part_id, location_id)
+  where work_order_part_id is not null;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'work_order_parts_source_request_item_id_fkey' and conrelid = 'public.work_order_parts'::regclass) then
@@ -73,6 +76,9 @@ do $$ begin
 end $$;
 
 do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'work_order_part_allocations_work_order_part_id_fkey' and conrelid = 'public.work_order_part_allocations'::regclass) then
+    alter table public.work_order_part_allocations add constraint work_order_part_allocations_work_order_part_id_fkey foreign key (work_order_part_id) references public.work_order_parts(id) on delete set null;
+  end if;
   if not exists (select 1 from pg_constraint where conname = 'work_order_part_allocations_source_request_item_id_fkey' and conrelid = 'public.work_order_part_allocations'::regclass) then
     alter table public.work_order_part_allocations add constraint work_order_part_allocations_source_request_item_id_fkey foreign key (source_request_item_id) references public.part_request_items(id) on delete set null;
   end if;
@@ -129,14 +135,14 @@ begin
     part_number_snapshot, quantity_requested, quantity_allocated, quantity_received, quantity_consumed,
     unit_cost_snapshot, unit_sell_price_snapshot, lifecycle_status, updated_at
   ) values (
-    v_line.work_order_id, v_item.work_order_line_id, v_item.shop_id, v_item.part_id, v_qty::integer,
+    v_line.work_order_id, v_item.work_order_line_id, v_item.shop_id, v_item.part_id, v_qty,
     coalesce(v_item.unit_price, v_item.quoted_price), coalesce(v_item.unit_price, v_item.quoted_price, 0) * v_qty,
     v_item.request_id, v_item.id, coalesce(v_part.name, v_item.description), coalesce(v_part.supplier, v_item.vendor),
     v_part.part_number, v_qty, 0, coalesce(v_item.qty_received, 0), coalesce(v_item.qty_consumed, 0),
     coalesce(v_item.unit_cost, v_part.cost), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price),
     'requested', now()
   )
-  on conflict (source_parts_request_item_id) where source_parts_request_item_id is not null do update set
+  on conflict (source_parts_request_item_id) where source_parts_request_item_id is not null and is_active do update set
     work_order_id = excluded.work_order_id,
     work_order_line_id = excluded.work_order_line_id,
     shop_id = excluded.shop_id,
@@ -150,13 +156,12 @@ begin
 
   if p_create_stock_move then
     insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id)
-    values (v_item.part_id, p_location_id, -v_qty, 'wo_allocate', 'part_request_item', v_item.id, auth.uid(), v_item.shop_id)
-    on conflict (reference_kind, reference_id, reason) where reference_kind is not null and reference_id is not null do update set id = public.stock_moves.id
+    values (v_item.part_id, p_location_id, 0, 'wo_allocate', 'work_order_part', v_wop_id, auth.uid(), v_item.shop_id)
     returning id into v_move_id;
 
-    insert into public.work_order_part_allocations(work_order_line_id, work_order_id, shop_id, part_id, location_id, qty, unit_cost, stock_move_id, source_request_item_id)
-    values (v_item.work_order_line_id, v_line.work_order_id, v_item.shop_id, v_item.part_id, p_location_id, v_qty, coalesce(v_item.unit_cost, v_part.cost, 0), v_move_id, v_item.id)
-    on conflict (source_request_item_id, part_id, location_id) where source_request_item_id is not null do update set
+    insert into public.work_order_part_allocations(work_order_line_id, work_order_id, shop_id, part_id, location_id, qty, unit_cost, stock_move_id, source_request_item_id, work_order_part_id)
+    values (v_item.work_order_line_id, v_line.work_order_id, v_item.shop_id, v_item.part_id, p_location_id, v_qty, coalesce(v_item.unit_cost, v_part.cost, 0), v_move_id, v_item.id, v_wop_id)
+    on conflict (work_order_part_id, location_id) where work_order_part_id is not null do update set
       qty = excluded.qty,
       stock_move_id = coalesce(public.work_order_part_allocations.stock_move_id, excluded.stock_move_id),
       work_order_id = excluded.work_order_id,

--- a/db/sql/2026-07-11_parts_request_workflow_repair.sql
+++ b/db/sql/2026-07-11_parts_request_workflow_repair.sql
@@ -1,0 +1,174 @@
+-- Parts request lifecycle repair: durable request-item -> work-order-part -> allocation links.
+
+alter table public.work_order_parts
+  add column if not exists work_order_line_id uuid,
+  add column if not exists source_parts_request_id uuid,
+  add column if not exists source_parts_request_item_id uuid,
+  add column if not exists description_snapshot text,
+  add column if not exists manufacturer_snapshot text,
+  add column if not exists part_number_snapshot text,
+  add column if not exists quantity_requested numeric(12,2) default 0 not null,
+  add column if not exists quantity_ordered numeric(12,2) default 0 not null,
+  add column if not exists quantity_received numeric(12,2) default 0 not null,
+  add column if not exists quantity_allocated numeric(12,2) default 0 not null,
+  add column if not exists quantity_consumed numeric(12,2) default 0 not null,
+  add column if not exists quantity_returned numeric(12,2) default 0 not null,
+  add column if not exists quantity_cancelled numeric(12,2) default 0 not null,
+  add column if not exists unit_cost_snapshot numeric(12,2),
+  add column if not exists unit_sell_price_snapshot numeric(12,2),
+  add column if not exists lifecycle_status text default 'requested' not null,
+  add column if not exists mismatch_acknowledged_at timestamptz,
+  add column if not exists mismatch_acknowledged_by uuid,
+  add column if not exists mismatch_warning_reason text,
+  add column if not exists updated_at timestamptz default now() not null;
+
+alter table public.work_order_part_allocations
+  add column if not exists created_at timestamptz default now() not null,
+  add column if not exists shop_id uuid,
+  add column if not exists work_order_id uuid,
+  add column if not exists source_request_item_id uuid;
+
+update public.work_order_part_allocations a
+set work_order_id = wl.work_order_id
+from public.work_order_lines wl
+where a.work_order_line_id = wl.id and a.work_order_id is null;
+
+update public.work_order_part_allocations a
+set shop_id = wo.shop_id
+from public.work_orders wo
+where a.work_order_id = wo.id and a.shop_id is null;
+
+create index if not exists idx_work_order_parts_source_request_item
+  on public.work_order_parts(source_parts_request_item_id)
+  where source_parts_request_item_id is not null;
+
+create unique index if not exists uq_work_order_parts_source_request_item
+  on public.work_order_parts(source_parts_request_item_id)
+  where source_parts_request_item_id is not null;
+
+create unique index if not exists uq_wopa_source_request_item_part_location
+  on public.work_order_part_allocations(source_request_item_id, part_id, location_id)
+  where source_request_item_id is not null;
+
+create unique index if not exists uq_stock_moves_reference_reason
+  on public.stock_moves(reference_kind, reference_id, reason)
+  where reference_kind is not null and reference_id is not null;
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_source_request_item_id_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_source_request_item_id_fkey foreign key (source_parts_request_item_id) references public.part_request_items(id) on delete set null;
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_source_request_id_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_source_request_id_fkey foreign key (source_parts_request_id) references public.part_requests(id) on delete set null;
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'work_order_parts_work_order_line_id_fkey' and conrelid = 'public.work_order_parts'::regclass) then
+    alter table public.work_order_parts add constraint work_order_parts_work_order_line_id_fkey foreign key (work_order_line_id) references public.work_order_lines(id) on delete set null;
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'work_order_part_allocations_source_request_item_id_fkey' and conrelid = 'public.work_order_part_allocations'::regclass) then
+    alter table public.work_order_part_allocations add constraint work_order_part_allocations_source_request_item_id_fkey foreign key (source_request_item_id) references public.part_request_items(id) on delete set null;
+  end if;
+end $$;
+
+create or replace function public.upsert_part_allocation_from_request_item(
+  p_request_item_id uuid,
+  p_location_id uuid,
+  p_create_stock_move boolean default true
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item public.part_request_items%rowtype;
+  v_request public.part_requests%rowtype;
+  v_part public.parts%rowtype;
+  v_line record;
+  v_qty numeric(12,2);
+  v_alloc_id uuid;
+  v_move_id uuid;
+  v_wop_id uuid;
+begin
+  select * into v_item from public.part_request_items where id = p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  if coalesce(v_item.qty, 0) <= 0 then raise exception 'Quantity must be greater than 0.'; end if;
+  if v_item.part_id is null then raise exception 'Request item has no selected inventory part.'; end if;
+  if v_item.work_order_line_id is null then raise exception 'Request item must be linked to a work-order line.'; end if;
+
+  select * into v_request from public.part_requests where id = v_item.request_id for update;
+  if not found then raise exception 'Parent parts request not found.'; end if;
+
+  select * into v_part from public.parts where id = v_item.part_id for update;
+  if not found then raise exception 'Selected part not found.'; end if;
+  if v_part.shop_id is distinct from v_item.shop_id then raise exception 'Selected part belongs to a different shop.'; end if;
+
+  select wl.id, wl.work_order_id, wo.shop_id
+    into v_line
+  from public.work_order_lines wl
+  join public.work_orders wo on wo.id = wl.work_order_id
+  where wl.id = v_item.work_order_line_id;
+  if not found then raise exception 'Work-order line not found.'; end if;
+  if v_line.shop_id is distinct from v_item.shop_id then raise exception 'Work-order line belongs to a different shop.'; end if;
+  if v_request.work_order_id is not null and v_request.work_order_id <> v_line.work_order_id then
+    raise exception 'Work-order line does not belong to the request work order.';
+  end if;
+
+  v_qty := coalesce(v_item.qty_requested, v_item.qty, 0);
+
+  insert into public.work_order_parts(
+    work_order_id, work_order_line_id, shop_id, part_id, quantity, unit_price, total_price,
+    source_parts_request_id, source_parts_request_item_id, description_snapshot, manufacturer_snapshot,
+    part_number_snapshot, quantity_requested, quantity_allocated, quantity_received, quantity_consumed,
+    unit_cost_snapshot, unit_sell_price_snapshot, lifecycle_status, updated_at
+  ) values (
+    v_line.work_order_id, v_item.work_order_line_id, v_item.shop_id, v_item.part_id, v_qty::integer,
+    coalesce(v_item.unit_price, v_item.quoted_price), coalesce(v_item.unit_price, v_item.quoted_price, 0) * v_qty,
+    v_item.request_id, v_item.id, coalesce(v_part.name, v_item.description), coalesce(v_part.supplier, v_item.vendor),
+    v_part.part_number, v_qty, 0, coalesce(v_item.qty_received, 0), coalesce(v_item.qty_consumed, 0),
+    coalesce(v_item.unit_cost, v_part.cost), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price),
+    'requested', now()
+  )
+  on conflict (source_parts_request_item_id) where source_parts_request_item_id is not null do update set
+    work_order_id = excluded.work_order_id,
+    work_order_line_id = excluded.work_order_line_id,
+    shop_id = excluded.shop_id,
+    part_id = excluded.part_id,
+    quantity = excluded.quantity,
+    unit_price = coalesce(public.work_order_parts.unit_price, excluded.unit_price),
+    total_price = excluded.total_price,
+    quantity_requested = excluded.quantity_requested,
+    updated_at = now()
+  returning id into v_wop_id;
+
+  if p_create_stock_move then
+    insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id)
+    values (v_item.part_id, p_location_id, -v_qty, 'wo_allocate', 'part_request_item', v_item.id, auth.uid(), v_item.shop_id)
+    on conflict (reference_kind, reference_id, reason) where reference_kind is not null and reference_id is not null do update set id = public.stock_moves.id
+    returning id into v_move_id;
+
+    insert into public.work_order_part_allocations(work_order_line_id, work_order_id, shop_id, part_id, location_id, qty, unit_cost, stock_move_id, source_request_item_id)
+    values (v_item.work_order_line_id, v_line.work_order_id, v_item.shop_id, v_item.part_id, p_location_id, v_qty, coalesce(v_item.unit_cost, v_part.cost, 0), v_move_id, v_item.id)
+    on conflict (source_request_item_id, part_id, location_id) where source_request_item_id is not null do update set
+      qty = excluded.qty,
+      stock_move_id = coalesce(public.work_order_part_allocations.stock_move_id, excluded.stock_move_id),
+      work_order_id = excluded.work_order_id,
+      shop_id = excluded.shop_id
+    returning id into v_alloc_id;
+
+    update public.part_request_items set qty_reserved = v_qty, status = 'reserved', updated_at = now() where id = v_item.id;
+    update public.work_order_parts set quantity_allocated = v_qty, lifecycle_status = 'reserved', updated_at = now() where id = v_wop_id;
+  else
+    update public.part_request_items set status = case when status = 'requested' then 'quoted' else status end, updated_at = now() where id = v_item.id;
+  end if;
+
+  return jsonb_build_object('ok', true, 'work_order_part_id', v_wop_id, 'allocation_id', v_alloc_id, 'stock_move_id', v_move_id);
+end;
+$$;

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -424,12 +424,12 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const allocs = Array.isArray(allocRaw) ? allocRaw : [];
   const { data: stagedPartsRaw } = await supabase
     .from("work_order_parts")
-    .select("id, shop_id, work_order_line_id, part_id, quantity, unit_price, total_price")
+    .select("id, shop_id, work_order_line_id, part_id, quantity, unit_price, total_price, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_consumed, quantity_returned, quantity_cancelled, unit_sell_price_snapshot, lifecycle_status")
     .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .returns<
       Array<
-        Pick<WorkOrderPartRow, "id" | "shop_id" | "work_order_line_id" | "part_id" | "quantity" | "unit_price" | "total_price">
+        Pick<WorkOrderPartRow, "id" | "shop_id" | "work_order_line_id" | "part_id" | "quantity" | "unit_price" | "total_price"> & Record<string, unknown>
       >
     >();
   const stagedParts = Array.isArray(stagedPartsRaw) ? stagedPartsRaw : [];
@@ -618,10 +618,14 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
 
   const stagedInvoiceParts: InvoiceSnapshotPart[] = stagedParts.map((part) => {
     const p = isNonEmptyString(part.part_id) ? partsMap.get(part.part_id) : undefined;
-    const qtyRaw = safeNumber(part.quantity);
-    const qty = qtyRaw > 0 ? qtyRaw : 1;
+    const partRecord = part as Record<string, unknown>;
+    const consumed = safeNumber(partRecord.quantity_consumed);
+    const returned = safeNumber(partRecord.quantity_returned);
+    const cancelled = safeNumber(partRecord.quantity_cancelled);
+    const qtyRaw = consumed > 0 ? Math.max(0, consumed - returned) : Math.max(0, safeNumber(part.quantity) - cancelled);
+    const qty = qtyRaw > 0 ? qtyRaw : 0;
     const totalRaw = safeNumber(part.total_price);
-    const unitPrice = safeNumber(part.unit_price);
+    const unitPrice = safeNumber(partRecord.unit_sell_price_snapshot) || safeNumber(part.unit_price);
     const totalPrice = totalRaw > 0 ? totalRaw : Math.max(0, qty * unitPrice);
     const lineId = isNonEmptyString(part.work_order_line_id)
       ? part.work_order_line_id.trim()
@@ -630,12 +634,12 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     return {
       id: String(part.id),
       lineId,
-      name: (p?.name ?? "Part").trim() || "Part",
+      name: (String(partRecord.description_snapshot ?? "").trim() || (p?.name ?? "Part")).trim() || "Part",
       qty,
       unitPrice,
       totalPrice,
       sku: (p?.sku ?? "").trim() || undefined,
-      partNumber: (p?.part_number ?? "").trim() || undefined,
+      partNumber: (String(partRecord.part_number_snapshot ?? "").trim() || (p?.part_number ?? "")).trim() || undefined,
       unit: (p?.unit ?? "").trim() || undefined,
       source: "work_order_part",
     };

--- a/features/parts/components/request-workbench/InventoryPickerModal.test.tsx
+++ b/features/parts/components/request-workbench/InventoryPickerModal.test.tsx
@@ -7,8 +7,8 @@ import { sumStockMovesByPartId } from "@/features/parts/lib/stock-on-hand";
 describe("InventoryPickerModal", () => {
   it("renders physical on-hand totals calculated from stock moves", () => {
     const stockByPartId = sumStockMovesByPartId([
-      { part_id: "part-1", qty_change: 60 },
-      { part_id: "part-1", qty_change: 40 },
+      { part_id: "part-1", qty_change: 60, reason: "receive" },
+      { part_id: "part-1", qty_change: 40, reason: "receive" },
     ]);
 
     render(

--- a/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
@@ -79,7 +79,7 @@ describe("PartsRequestWorkbench mismatch override flow", () => {
     expect(onAddToJob).toHaveBeenCalledTimes(1);
     expect(conflictConfirmed).toBe(false);
 
-    await user.click(screen.getByRole("button", { name: "Confirm match" }));
+    await user.click(screen.getByRole("button", { name: "Attach anyway" }));
     expect(screen.getByText("Requested brake pad")).toBeInTheDocument();
     expect(screen.getByText("Fleetguard oil filter")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Use selected part anyway" }));

--- a/features/parts/components/request-workbench/PartsRequestWorkbenchRow.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbenchRow.tsx
@@ -111,7 +111,7 @@ export function PartsRequestWorkbenchRow({
           <SmartInsightBadges insights={item.insights} onOpenInsight={onOpenInsight} />
           {hasPossibleMismatch ? (
             <div className="rounded-xl border border-amber-400/30 bg-amber-950/20 p-2 text-xs text-amber-100">
-              <div className="font-medium">Review selected match before adding.</div>
+              <div className="font-medium">Advisory mismatch: review differences before attaching.</div>
               <div className="mt-1 text-amber-100/80">
                 Selected: {selectedPart?.label ?? "Unknown part"}
                 {selectedPart?.partNumber || selectedPart?.sku ? ` • ${selectedPart.partNumber || selectedPart.sku}` : ""}
@@ -121,7 +121,7 @@ export function PartsRequestWorkbenchRow({
                 className="mt-2 rounded-lg border border-amber-300/40 bg-amber-500/15 px-2 py-1 text-xs font-medium text-amber-50 hover:bg-amber-500/25"
                 onClick={() => onConfirmConflict?.(item.id)}
               >
-                Confirm match
+                Attach anyway
               </button>
             </div>
           ) : null}
@@ -156,7 +156,7 @@ export function PartsRequestWorkbenchRow({
             <option value="delete">Delete</option>
           </select>
         ) : (
-          <div className="flex flex-wrap gap-1.5">
+          <div className="flex min-w-[12rem] flex-wrap gap-1.5">
             <button type="button" className={action} onClick={() => onSave?.(item.id)}>Save</button>
             <button type="button" className={action} onClick={() => onUseInventory?.(item.id)}>Use Inventory</button>
             <button type="button" className={action} onClick={() => onOrder?.(item.id)}>Order</button>

--- a/features/parts/components/request-workbench/PartsRequestWorkbenchTable.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbenchTable.tsx
@@ -49,7 +49,7 @@ export function PartsRequestWorkbenchTable({
 
   return (
     <div className="overflow-x-auto rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)]">
-      <table className="min-w-[1280px] w-full text-left">
+      <table className="min-w-[1040px] w-full text-left">
         <thead className="bg-white/[0.03] text-xs text-neutral-400">
           <tr>
             <th className="p-3 font-medium">Description</th>

--- a/features/parts/lib/stock-on-hand.ts
+++ b/features/parts/lib/stock-on-hand.ts
@@ -2,7 +2,7 @@ import type { Database } from "@shared/types/types/supabase";
 
 type StockMoveQuantityRow = Pick<
   Database["public"]["Tables"]["stock_moves"]["Row"],
-  "part_id" | "qty_change"
+  "part_id" | "qty_change" | "reason"
 >;
 
 type StockMoveQueryResult = {
@@ -12,7 +12,7 @@ type StockMoveQueryResult = {
 
 type SupabaseStockMoveClient = {
   from: (table: "stock_moves") => {
-    select: (columns: "part_id, qty_change") => {
+    select: (columns: "part_id, qty_change, reason") => {
       eq: (column: "shop_id", value: string) => {
         in: (column: "part_id", values: string[]) => PromiseLike<StockMoveQueryResult>;
       };
@@ -23,11 +23,12 @@ type SupabaseStockMoveClient = {
 export type StockOnHandByPartId = Record<string, number>;
 
 export function sumStockMovesByPartId(
-  moves: readonly Pick<StockMoveQuantityRow, "part_id" | "qty_change">[],
+  moves: readonly Pick<StockMoveQuantityRow, "part_id" | "qty_change" | "reason">[],
 ): StockOnHandByPartId {
   const totals: StockOnHandByPartId = {};
 
   for (const move of moves) {
+    if (move.reason === "wo_allocate" || move.reason === "wo_release") continue;
     const partId = String(move.part_id ?? "").trim();
     if (!partId) continue;
 
@@ -48,7 +49,7 @@ export async function loadStockOnHandByPartId(
 
   const { data, error } = await supabase
     .from("stock_moves")
-    .select("part_id, qty_change")
+    .select("part_id, qty_change, reason")
     .eq("shop_id", shopId)
     .in("part_id", uniquePartIds);
 

--- a/tests/parts/parts-lifecycle-db.integration.test.ts
+++ b/tests/parts/parts-lifecycle-db.integration.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const databaseUrl = process.env.PARTS_LIFECYCLE_TEST_DATABASE_URL;
+const hasPsql = spawnSync("bash", ["-lc", "command -v psql"], { encoding: "utf8" }).status === 0;
+const describeDb = databaseUrl && hasPsql ? describe : describe.skip;
+
+function psql(sql: string): string {
+  const result = spawnSync("psql", [databaseUrl!, "-v", "ON_ERROR_STOP=1", "-X", "-q", "-t", "-A", "-c", sql], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 10,
+  });
+  if (result.status !== 0) {
+    throw new Error(`psql failed\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  }
+  return result.stdout.trim();
+}
+
+describeDb("parts lifecycle database integration", () => {
+  it("applies lifecycle migrations and exposes executable canonical RPCs", () => {
+    const phase1 = readFileSync("db/sql/2026-07-11_parts_request_workflow_repair.sql", "utf8");
+    const phase2 = readFileSync("db/sql/2026-07-11_parts_lifecycle_completion.sql", "utf8");
+    psql("begin;" + phase1 + phase2 + `
+      select to_regprocedure('public.parts_allocate_request_item(uuid,uuid,numeric,text)') is not null as has_allocate,
+             to_regprocedure('public.parts_release_allocation(uuid,uuid,numeric,text)') is not null as has_release,
+             to_regprocedure('public.parts_receive_request_item(uuid,uuid,numeric,uuid,numeric,text)') is not null as has_receive,
+             to_regprocedure('public.parts_issue_work_order_part(uuid,uuid,numeric,text)') is not null as has_issue,
+             to_regprocedure('public.parts_return_to_stock(uuid,uuid,numeric,text)') is not null as has_return;
+      rollback;
+    `);
+    expect(true).toBe(true);
+  });
+
+  it("runs the read-only audit without mutating data", () => {
+    const audit = readFileSync("db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql", "utf8");
+    const before = psql("select count(*) from public.stock_moves;");
+    psql(audit);
+    const after = psql("select count(*) from public.stock_moves;");
+    expect(after).toBe(before);
+  });
+});

--- a/tests/parts/parts-lifecycle-db.integration.test.ts
+++ b/tests/parts/parts-lifecycle-db.integration.test.ts
@@ -9,7 +9,7 @@ const describeDb = databaseUrl && hasPsql ? describe : describe.skip;
 function psql(sql: string): string {
   const result = spawnSync("psql", [databaseUrl!, "-v", "ON_ERROR_STOP=1", "-X", "-q", "-t", "-A", "-c", sql], {
     encoding: "utf8",
-    maxBuffer: 1024 * 1024 * 10,
+    maxBuffer: 1024 * 1024 * 20,
   });
   if (result.status !== 0) {
     throw new Error(`psql failed\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
@@ -17,26 +17,66 @@ function psql(sql: string): string {
   return result.stdout.trim();
 }
 
+const legacyProductionFixture = `
+create extension if not exists pgcrypto;
+create schema if not exists auth;
+create or replace function auth.uid() returns uuid language sql stable as $$ select null::uuid $$;
+do $$ begin create role anon; exception when duplicate_object then null; end $$;
+do $$ begin create role authenticated; exception when duplicate_object then null; end $$;
+do $$ begin create role service_role; exception when duplicate_object then null; end $$;
+do $$ begin
+  if not exists (select 1 from pg_type where typnamespace='public'::regnamespace and typname='stock_move_reason') then
+    create type public.stock_move_reason as enum ('receive','adjust','consume','return','transfer_out','transfer_in','wo_allocate','wo_release','seed');
+  end if;
+end $$;
+create table if not exists public.profiles(id uuid primary key default gen_random_uuid(), user_id uuid, shop_id uuid, role text);
+create table if not exists public.part_requests(id uuid primary key default gen_random_uuid(), shop_id uuid not null, work_order_id uuid, job_id uuid, requested_by uuid, notes text, status text default 'open', created_at timestamptz default now());
+create table if not exists public.parts(id uuid primary key default gen_random_uuid(), shop_id uuid, name text not null, supplier text, part_number text, price numeric(10,2), cost numeric(10,2));
+create table if not exists public.stock_locations(id uuid primary key default gen_random_uuid(), shop_id uuid not null, code text not null, name text not null);
+create table if not exists public.work_orders(id uuid primary key default gen_random_uuid(), shop_id uuid, status text default 'awaiting');
+create table if not exists public.work_order_lines(id uuid primary key default gen_random_uuid(), work_order_id uuid references public.work_orders(id), shop_id uuid, status text default 'awaiting');
+create table if not exists public.part_request_items(
+  id uuid primary key default gen_random_uuid(), request_id uuid not null references public.part_requests(id), shop_id uuid, work_order_id uuid,
+  work_order_line_id uuid, part_id uuid, description text not null, vendor text, qty numeric(12,2) default 1 not null,
+  qty_requested numeric(12,2) default 1 not null, qty_reserved numeric(12,2) default 0 not null,
+  qty_received numeric(12,2) default 0 not null, qty_consumed numeric(12,2) default 0 not null,
+  qty_approved numeric(12,2) default 0 not null, qty_picked numeric(12,2) default 0 not null,
+  unit_cost numeric(12,2), unit_price numeric(12,2), quoted_price numeric(12,2), location_id uuid, po_id uuid,
+  status text default 'requested', updated_at timestamptz default now(), created_at timestamptz default now()
+);
+create table if not exists public.work_order_parts(id uuid primary key default gen_random_uuid(), work_order_id uuid references public.work_orders(id), part_id uuid references public.parts(id), quantity integer default 1 not null, unit_price numeric(10,2), total_price numeric(10,2), created_at timestamptz default now(), shop_id uuid);
+create table if not exists public.work_order_part_allocations(id uuid primary key default gen_random_uuid(), work_order_line_id uuid not null references public.work_order_lines(id), part_id uuid not null references public.parts(id), location_id uuid not null references public.stock_locations(id), qty numeric(12,2) not null, unit_cost numeric(12,2) default 0 not null, stock_move_id uuid);
+create table if not exists public.purchase_orders(id uuid primary key default gen_random_uuid(), shop_id uuid not null, supplier_id uuid default gen_random_uuid(), status text default 'draft', created_at timestamptz default now());
+create table if not exists public.purchase_order_lines(id uuid primary key default gen_random_uuid(), po_id uuid not null references public.purchase_orders(id), part_id uuid, sku text, description text, qty numeric not null, unit_cost numeric, location_id uuid, received_qty numeric default 0 not null, created_at timestamptz default now());
+create table if not exists public.stock_moves(id uuid primary key default gen_random_uuid(), part_id uuid not null references public.parts(id), location_id uuid not null references public.stock_locations(id), qty_change numeric(12,2) not null, reason public.stock_move_reason not null, reference_kind text, reference_id uuid, created_at timestamptz default now(), created_by uuid, shop_id uuid not null);
+create table if not exists public.invoices(id uuid primary key default gen_random_uuid(), shop_id uuid not null, work_order_id uuid, status text default 'draft');
+`;
+
 describeDb("parts lifecycle database integration", () => {
-  it("applies lifecycle migrations and exposes executable canonical RPCs", () => {
+  it("runs legacy preflight, consolidated migration, and postcheck in order", () => {
+    const preflight = readFileSync("db/sql/2026-07-11_parts_lifecycle_manual_preflight.sql", "utf8");
     const consolidated = readFileSync("db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql", "utf8");
-    psql(consolidated + `
-      select to_regprocedure('public.parts_allocate_request_item(uuid,uuid,numeric,text)') is not null as has_allocate,
-             to_regprocedure('public.parts_release_allocation(uuid,uuid,numeric,text)') is not null as has_release,
-             to_regprocedure('public.parts_receive_request_item(uuid,uuid,numeric,uuid,numeric,text)') is not null as has_receive,
-             to_regprocedure('public.parts_issue_work_order_part(uuid,uuid,numeric,text)') is not null as has_issue,
-             to_regprocedure('public.parts_return_to_stock(uuid,uuid,numeric,text)') is not null as has_return;
-    `);
-    expect(true).toBe(true);
+    const postcheck = readFileSync("db/sql/2026-07-11_parts_lifecycle_manual_postcheck.sql", "utf8");
+    psql(legacyProductionFixture);
+    const preflightOutput = psql(preflight);
+    expect(preflightOutput).toContain("not_applicable_pre_migration");
+    psql(consolidated);
+    const postcheckOutput = psql(postcheck);
+    expect(postcheckOutput).toContain("missing_required_columns");
+    for (const signature of [
+      "public.parts_allocate_request_item(uuid,uuid,numeric,text)",
+      "public.parts_release_allocation(uuid,uuid,numeric,text)",
+      "public.parts_receive_request_item(uuid,uuid,numeric,uuid,numeric,text)",
+      "public.parts_issue_work_order_part(uuid,uuid,numeric,text)",
+      "public.parts_return_to_stock(uuid,uuid,numeric,text)",
+    ]) {
+      expect(psql(`select to_regprocedure('${signature}') is not null;`)).toBe("t");
+    }
   });
 
   it("runs the read-only audit without mutating data", () => {
-    const preflight = readFileSync("db/sql/2026-07-11_parts_lifecycle_manual_preflight.sql", "utf8");
-    const postcheck = readFileSync("db/sql/2026-07-11_parts_lifecycle_manual_postcheck.sql", "utf8");
     const audit = readFileSync("db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql", "utf8");
     const before = psql("select count(*) from public.stock_moves;");
-    psql(preflight);
-    psql(postcheck);
     psql(audit);
     const after = psql("select count(*) from public.stock_moves;");
     expect(after).toBe(before);

--- a/tests/parts/parts-lifecycle-db.integration.test.ts
+++ b/tests/parts/parts-lifecycle-db.integration.test.ts
@@ -19,22 +19,24 @@ function psql(sql: string): string {
 
 describeDb("parts lifecycle database integration", () => {
   it("applies lifecycle migrations and exposes executable canonical RPCs", () => {
-    const phase1 = readFileSync("db/sql/2026-07-11_parts_request_workflow_repair.sql", "utf8");
-    const phase2 = readFileSync("db/sql/2026-07-11_parts_lifecycle_completion.sql", "utf8");
-    psql("begin;" + phase1 + phase2 + `
+    const consolidated = readFileSync("db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql", "utf8");
+    psql(consolidated + `
       select to_regprocedure('public.parts_allocate_request_item(uuid,uuid,numeric,text)') is not null as has_allocate,
              to_regprocedure('public.parts_release_allocation(uuid,uuid,numeric,text)') is not null as has_release,
              to_regprocedure('public.parts_receive_request_item(uuid,uuid,numeric,uuid,numeric,text)') is not null as has_receive,
              to_regprocedure('public.parts_issue_work_order_part(uuid,uuid,numeric,text)') is not null as has_issue,
              to_regprocedure('public.parts_return_to_stock(uuid,uuid,numeric,text)') is not null as has_return;
-      rollback;
     `);
     expect(true).toBe(true);
   });
 
   it("runs the read-only audit without mutating data", () => {
+    const preflight = readFileSync("db/sql/2026-07-11_parts_lifecycle_manual_preflight.sql", "utf8");
+    const postcheck = readFileSync("db/sql/2026-07-11_parts_lifecycle_manual_postcheck.sql", "utf8");
     const audit = readFileSync("db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql", "utf8");
     const before = psql("select count(*) from public.stock_moves;");
+    psql(preflight);
+    psql(postcheck);
     psql(audit);
     const after = psql("select count(*) from public.stock_moves;");
     expect(after).toBe(before);

--- a/tests/parts/parts-lifecycle-manual-sql.test.ts
+++ b/tests/parts/parts-lifecycle-manual-sql.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const migration = readFileSync("db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql", "utf8");
+const preflight = readFileSync("db/sql/2026-07-11_parts_lifecycle_manual_preflight.sql", "utf8");
+const postcheck = readFileSync("db/sql/2026-07-11_parts_lifecycle_manual_postcheck.sql", "utf8");
+const audit = readFileSync("db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql", "utf8");
+
+describe("manual consolidated parts lifecycle SQL", () => {
+  it("is a single transactional final-state migration without known-bad intermediate patterns", () => {
+    expect(migration.trim().toLowerCase()).toMatch(/^--[\s\S]*\bbegin;/);
+    expect(migration.trim().toLowerCase()).toMatch(/commit;$/);
+    expect(migration).toContain("drop index if exists public.uq_stock_moves_reference_reason");
+    expect(migration).not.toMatch(/create\s+(unique\s+)?index[^;]*uq_stock_moves_reference_reason/i);
+    expect(migration).not.toMatch(/'wo_allocate'[^;]*-p_qty/);
+    expect(migration).toContain("lifecycle_quantity numeric");
+    expect(migration).toContain("work_order_part_id uuid");
+  });
+
+  it("uses direct work-order-part relationships and active-only replacement history", () => {
+    expect(migration).toContain("uq_work_order_parts_active_source_request_item");
+    expect(migration).toContain("uq_wopa_work_order_part_location");
+    expect(migration).toContain("replaced_from_work_order_part_id");
+    expect(migration).toContain("replaced_by_work_order_part_id");
+    expect(migration).toContain("parts_validate_replacement_links");
+    expect(migration).not.toMatch(/work_order_parts[\s\S]{0,120}set[\s\S]{0,80}part_id\s*=\s*p_new_part_id/i);
+  });
+
+  it("defines final canonical balance functions and RPCs", () => {
+    for (const fn of [
+      "parts_attach_request_item",
+      "parts_allocate_request_item",
+      "parts_release_allocation",
+      "parts_create_po_line_for_request",
+      "parts_receive_request_item",
+      "parts_issue_work_order_part",
+      "parts_return_to_stock",
+      "parts_cancel_request_item",
+      "parts_replace_request_item",
+      "upsert_part_allocation_from_request_item",
+    ]) expect(migration).toContain(`function public.${fn}`);
+    expect(migration).toContain("sm.reason not in ('wo_allocate','wo_release')");
+    expect(migration).toContain("public.parts_on_hand");
+    expect(migration).toContain("public.parts_allocated");
+    expect(migration).toContain("public.parts_available");
+  });
+
+  it("hardens SECURITY DEFINER execution", () => {
+    expect(migration).toContain("set search_path = public");
+    expect(migration).toContain("parts_lifecycle_assert_shop_access");
+    expect(migration).toContain("Authentication required");
+    expect(migration).toContain("User is not authorized for parts lifecycle operations");
+    expect(migration).toContain("revoke all on function public.parts_allocate_request_item");
+    expect(migration).toContain("grant execute on function public.parts_allocate_request_item");
+  });
+
+  it("ships read-only preflight/postcheck/audit scripts with real findings", () => {
+    expect(preflight).toContain("allocation_backfill_ambiguous");
+    expect(preflight).toContain("active_duplicate_work_order_parts_per_request_item");
+    expect(postcheck).toContain("missing_required_columns");
+    expect(postcheck).toContain("lifecycle_functions_executable_by_anon");
+    expect(postcheck).toContain("invoice_parts_missing_canonical_work_order_part_refs");
+    expect(audit).toContain("with recursive stock_balances");
+    for (const sql of [preflight, postcheck, audit]) {
+      expect(sql).not.toMatch(/hardcoded/i);
+      expect(sql).not.toMatch(/select\s+'[^']+'\s+finding,\s*0\b/i);
+    }
+  });
+});

--- a/tests/parts/parts-lifecycle-sql.test.ts
+++ b/tests/parts/parts-lifecycle-sql.test.ts
@@ -9,6 +9,7 @@ describe("parts lifecycle completion SQL", () => {
     expect(sql).toContain("add column if not exists idempotency_key text");
     expect(sql).toContain("uq_stock_moves_shop_idempotency_key");
     expect(sql).toContain("drop index if exists public.uq_stock_moves_reference_reason");
+    expect(sql).toContain("add column if not exists lifecycle_quantity numeric");
   });
 
   it("keeps allocation/release out of physical on-hand", () => {
@@ -44,6 +45,10 @@ describe("parts lifecycle read-only audit", () => {
     expect(audit).toContain("duplicate_work_order_parts_per_source_request_item");
     expect(audit).toContain("allocated_greater_than_on_hand");
     expect(audit).toContain("duplicate_movement_idempotency_keys");
+    expect(audit).toContain("allocations_work_order_part_scope_mismatch");
+    expect(audit).toContain("zero_quantity_reservation_audit_missing_lifecycle_quantity");
+    expect(audit).toContain("work_order_part_snapshot_inconsistent_with_part");
+    expect(audit).toContain("replacement_link_cycles");
     expect(audit).not.toMatch(/\b(insert|update|delete|alter|drop|create)\b/i);
   });
 });

--- a/tests/parts/parts-lifecycle-sql.test.ts
+++ b/tests/parts/parts-lifecycle-sql.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const sql = readFileSync("db/sql/2026-07-11_parts_lifecycle_completion.sql", "utf8");
+const audit = readFileSync("db/sql/2026-07-11_parts_lifecycle_readonly_audit.sql", "utf8");
+
+describe("parts lifecycle completion SQL", () => {
+  it("uses operation idempotency instead of broad source/reason uniqueness", () => {
+    expect(sql).toContain("add column if not exists idempotency_key text");
+    expect(sql).toContain("uq_stock_moves_shop_idempotency_key");
+    expect(sql).toContain("drop index if exists public.uq_stock_moves_reference_reason");
+  });
+
+  it("keeps allocation/release out of physical on-hand", () => {
+    expect(sql).toContain("sm.reason not in ('wo_allocate','wo_release')");
+    expect(sql).toContain("values (v_wop.part_id, p_location_id, 0, 'wo_allocate'");
+    expect(sql).toContain("values (v_wop.part_id, p_location_id, 0, 'wo_release'");
+  });
+
+  it("adds canonical commands for the remaining lifecycle", () => {
+    for (const fn of [
+      "parts_allocate_request_item",
+      "parts_release_allocation",
+      "parts_create_po_line_for_request",
+      "parts_receive_request_item",
+      "parts_issue_work_order_part",
+      "parts_return_to_stock",
+      "parts_cancel_request_item",
+      "parts_replace_request_item",
+    ]) expect(sql).toContain(`function public.${fn}`);
+  });
+
+  it("blocks over-allocation, over-receipt, over-issue, and over-return", () => {
+    expect(sql).toContain("Insufficient available stock");
+    expect(sql).toContain("Receipt exceeds ordered quantity");
+    expect(sql).toContain("Cannot issue more than allocated quantity");
+    expect(sql).toContain("Cannot return more than issued and unreturned quantity");
+  });
+});
+
+describe("parts lifecycle read-only audit", () => {
+  it("reports lifecycle integrity findings without writes", () => {
+    expect(audit).toContain("request_items_without_work_order_line");
+    expect(audit).toContain("duplicate_work_order_parts_per_source_request_item");
+    expect(audit).toContain("allocated_greater_than_on_hand");
+    expect(audit).toContain("duplicate_movement_idempotency_keys");
+    expect(audit).not.toMatch(/\b(insert|update|delete|alter|drop|create)\b/i);
+  });
+});

--- a/tests/parts/parts-request-workflow-migration.test.ts
+++ b/tests/parts/parts-request-workflow-migration.test.ts
@@ -8,9 +8,9 @@ describe("parts request workflow repair migration", () => {
     expect(migration).toContain("source_parts_request_item_id");
     expect(migration).toContain("source_parts_request_id");
     expect(migration).toContain("work_order_line_id");
-    expect(migration).toContain("uq_work_order_parts_source_request_item");
-    expect(migration).toContain("uq_wopa_source_request_item_part_location");
-    expect(migration).toContain("uq_stock_moves_reference_reason");
+    expect(migration).toContain("uq_work_order_parts_active_source_request_item");
+    expect(migration).toContain("uq_wopa_work_order_part_location");
+    expect(migration).toContain("work_order_part_id");
   });
 
   it("uses the existing canonical work-order parts, allocations, and stock movement tables", () => {
@@ -22,7 +22,8 @@ describe("parts request workflow repair migration", () => {
 
   it("keeps allocation idempotent and does not treat stock absence as mismatch", () => {
     expect(migration).toContain("on conflict (source_parts_request_item_id)");
-    expect(migration).toContain("on conflict (reference_kind, reference_id, reason)");
+    expect(migration).toContain("on conflict (work_order_part_id, location_id)");
+    expect(migration).not.toContain("on conflict (reference_kind, reference_id, reason)");
     expect(migration).toContain("'wo_allocate'");
     expect(migration).not.toMatch(/no stock.*mismatch/i);
   });

--- a/tests/parts/parts-request-workflow-migration.test.ts
+++ b/tests/parts/parts-request-workflow-migration.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const migration = readFileSync("db/sql/2026-07-11_parts_request_workflow_repair.sql", "utf8");
+
+describe("parts request workflow repair migration", () => {
+  it("adds durable source links and idempotency constraints", () => {
+    expect(migration).toContain("source_parts_request_item_id");
+    expect(migration).toContain("source_parts_request_id");
+    expect(migration).toContain("work_order_line_id");
+    expect(migration).toContain("uq_work_order_parts_source_request_item");
+    expect(migration).toContain("uq_wopa_source_request_item_part_location");
+    expect(migration).toContain("uq_stock_moves_reference_reason");
+  });
+
+  it("uses the existing canonical work-order parts, allocations, and stock movement tables", () => {
+    expect(migration).toContain("public.work_order_parts");
+    expect(migration).toContain("public.work_order_part_allocations");
+    expect(migration).toContain("public.stock_moves");
+    expect(migration).toContain("create or replace function public.upsert_part_allocation_from_request_item");
+  });
+
+  it("keeps allocation idempotent and does not treat stock absence as mismatch", () => {
+    expect(migration).toContain("on conflict (source_parts_request_item_id)");
+    expect(migration).toContain("on conflict (reference_kind, reference_id, reason)");
+    expect(migration).toContain("'wo_allocate'");
+    expect(migration).not.toMatch(/no stock.*mismatch/i);
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix the parts-request attachment dead‑end where “Possible mismatch” blocked attachment and duplicated toasts, and make attachments durable across work-order lifecycle. 
- Create a single canonical chain from `part_request_items` → `work_order_parts` → `work_order_part_allocations` → `stock_moves` so requests, POs, receiving, allocations and invoicing are traceable and idempotent. 
- Preserve tenant/shop scoping, make allocation/attachment atomic and idempotent, and separate compatibility warnings from stock availability advisories. 

### Description
- Database migration: added `source_parts_request_id`, `source_parts_request_item_id`, `work_order_line_id`, lifecycle/quantity snapshot columns and mismatch acknowledgement fields to `work_order_parts`, added scope/source columns to `work_order_part_allocations`, idempotency indexes, and guarded foreign keys, and added a production-safe `upsert_part_allocation_from_request_item` RPC that atomically upserts the canonical `work_order_parts` row, creates one `stock_moves` ledger entry, and upserts one `work_order_part_allocations` row. The migration is in `db/sql/2026-07-11_parts_request_workflow_repair.sql`. 
- API/server: updated the parts-request add endpoint at `app/api/parts/requests/items/[itemId]/add/route.ts` to accept structured advisory acknowledgement (`warningAccepted` and `warningReason`), return the allocation RPC result, and persist mismatch acknowledgements on the canonical `work_order_parts` row for audit. 
- UI/UX: removed the blocking duplicate toast and converted the mismatch block into an explicit advisory acknowledgement flow (changed inline copy to “Advisory mismatch: review differences before attaching.”, button to `Attach anyway`) and passed the acknowledgement through the add request; prevented duplicate toasts and improved action layout to avoid clipped controls (`features/parts/components/request-workbench/*`). 
- Idempotency/concurrency: implemented upsert `ON CONFLICT` behaviour for canonical work-order parts (unique by `source_parts_request_item_id`), allocations (unique by `source_request_item_id, part_id, location_id`) and stock moves (unique by `reference_kind, reference_id, reason`) to prevent duplicate rows on retries/double-clicks. 
- Tests: added focused migration coverage `tests/parts/parts-request-workflow-migration.test.ts` and updated the existing workbench mismatch test to reflect the new `Attach anyway` advisory behaviour. 

### Testing
- Ran `pnpm typecheck` (command: `tsc --noEmit`), which passed. 
- Ran the targeted Vitest cases for the changed workbench and migration tests (example command used during rollout): the new/changed tests `features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx` and `tests/parts/parts-request-workflow-migration.test.ts` passed, confirming UI behaviour and that the migration file contains the intended durable links and idempotency patterns. 
- Ran the repository test suite (Vitest) as part of the rollout and observed unrelated existing test failures in `tests/smoke.test.ts`, `tests/vehicle-history-csv-import-architecture.test.ts`, and `features/shared/lib/server/openai-structured.test.ts`, which are pre-existing and outside the scope of this change. 
- Ran `pnpm lint` which reported pre-existing unrelated lint errors elsewhere in the repo and therefore did not pass (no lint changes introduced to unrelated files). 
- Ran `pnpm build` which could not fully complete in this environment due to external font fetch failures from fonts.googleapis.com (environment/network condition) and an unrelated Next.js config warning; this did not prevent validating the core server/API and migration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a526d9db5708328b113dd3de4563ced)