### PR TITLE
Wire payroll timekeeping policy to workforce punches

### DIFF
--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: NextRequest) {
   const activePeriodId = periodId ?? periods?.[0]?.id ?? null;
   if (!activePeriodId) return NextResponse.json({ periods: [], entries: [], exceptions: [] });
 
-  const [{ data: entries, error: entriesErr }, { data: exceptions, error: exErr }] = await Promise.all([
+  const [{ data: entries, error: entriesErr }, { data: exceptions, error: exErr }, { data: roster }] = await Promise.all([
     admin
       .from("payroll_time_entries")
       .select("*, profiles:user_id(full_name, email)")
@@ -40,6 +40,12 @@ export async function GET(req: NextRequest) {
       .eq("shop_id", me.shop_id)
       .eq("period_id", activePeriodId)
       .order("work_date", { ascending: true }),
+    admin
+      .from("people_workforce_profiles")
+      .select("user_id, payroll_ready, employment_status, profiles:user_id(full_name, email)")
+      .eq("shop_id", me.shop_id)
+      .eq("payroll_ready", true)
+      .eq("employment_status", "active"),
   ]);
 
   if (entriesErr) return NextResponse.json({ error: entriesErr.message }, { status: 500 });
@@ -76,7 +82,35 @@ export async function GET(req: NextRequest) {
     awayMap.set(row.user_id, (awayMap.get(row.user_id) ?? 0) + minutes);
   }
 
-  const enrichedEntries = (entries ?? []).map((entry) => ({
+  const entryRows = (entries ?? []) as any[];
+  const entryUsers = new Set(entryRows.map((entry) => entry.user_id));
+  const rosterEntries = ((roster ?? []) as any[])
+    .filter((person) => person.user_id && !entryUsers.has(person.user_id))
+    .map((person) => ({
+      id: `roster-${activePeriodId}-${person.user_id}`,
+      shop_id: me.shop_id,
+      period_id: activePeriodId,
+      user_id: person.user_id,
+      work_date: selectedPeriod?.period_start ?? new Date().toISOString().slice(0, 10),
+      worked_minutes: 0,
+      regular_minutes: 0,
+      overtime_minutes: 0,
+      unpaid_break_minutes: 0,
+      paid_break_minutes: 0,
+      attendance_minutes: 0,
+      job_minutes: 0,
+      adjustment_minutes: 0,
+      has_exceptions: false,
+      blocking_exception_count: 0,
+      warning_exception_count: 0,
+      approval_state: "draft",
+      source_snapshot: { source: "payroll_eligible_roster", note: "No recorded shifts" },
+      profiles: person.profiles ?? null,
+      roster_only: true,
+      payroll_status_label: "No recorded shifts",
+    }));
+
+  const enrichedEntries = [...entryRows, ...rosterEntries].map((entry) => ({
     ...entry,
     scheduled_minutes: scheduleMap.get(`${entry.user_id}|${entry.work_date}`) ?? 0,
     approved_time_away_minutes_in_period: awayMap.get(entry.user_id) ?? 0,

--- a/app/api/payroll-time/settings/route.ts
+++ b/app/api/payroll-time/settings/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import { requirePayrollReviewer } from "../_lib/auth";
+
+const CADENCES = new Set(["weekly", "biweekly", "semimonthly"]);
+
+function intIn(value: unknown, fallback: number, min: number, max: number) {
+  const n = Number(value ?? fallback);
+  if (!Number.isInteger(n) || n < min || n > max) throw new Error(`Value must be an integer between ${min} and ${max}`);
+  return n;
+}
+
+export async function GET() {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+  const admin = createAdminSupabase() as any;
+  const { data, error } = await admin.from("shop_payroll_settings").select("*").eq("shop_id", auth.me.shop_id).maybeSingle();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ settings: data });
+}
+
+export async function PUT(req: NextRequest) {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+  if (!['owner','admin'].includes(String(auth.me.role ?? ''))) return NextResponse.json({ error: "Owner/admin required" }, { status: 403 });
+
+  const pin = await requireOwnerPinVerified(req, createServerSupabaseRoute() as never, {
+    shopId: auth.me.shop_id!,
+    userId: auth.me.id,
+    allowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS, OWNER_PIN_PURPOSES.PRIVILEGED],
+  });
+  if (!pin.ok) return pin.response;
+
+  const body = await req.json().catch(() => ({}));
+  try {
+    const cadence = String(body.cadence ?? "biweekly");
+    if (!CADENCES.has(cadence)) throw new Error("Invalid pay cadence");
+    const payload = {
+      shop_id: auth.me.shop_id,
+      cadence,
+      week_starts_on: intIn(body.week_starts_on, 1, 0, 6),
+      daily_overtime_after_minutes: intIn(body.daily_overtime_after_minutes, 480, 0, 1440),
+      suspicious_shift_minutes: intIn(body.suspicious_shift_minutes, 960, 60, 2880),
+      paid_breaks_per_day: intIn(body.paid_breaks_per_day, 2, 0, 2),
+      paid_break_duration_minutes: intIn(body.paid_break_duration_minutes, 15, 0, 120),
+      breaks_are_paid: body.breaks_are_paid !== false,
+      lunch_is_paid: body.lunch_is_paid === true,
+      default_lunch_duration_minutes: intIn(body.default_lunch_duration_minutes, 30, 0, 240),
+      lunch_required_after_minutes: intIn(body.lunch_required_after_minutes, 300, 0, 1440),
+      updated_at: new Date().toISOString(),
+    };
+    const admin = createAdminSupabase() as any;
+    const { data, error } = await admin.from("shop_payroll_settings").upsert(payload, { onConflict: "shop_id" }).select("*").single();
+    if (error) throw new Error(error.message);
+    void admin.from("audit_logs").insert({ shop_id: auth.me.shop_id, actor_id: auth.me.id, action: "payroll.settings.updated", target_table: "shop_payroll_settings", target_id: data.id, metadata: payload });
+    return NextResponse.json({ ok: true, settings: data });
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : "Invalid payroll settings" }, { status: 400 });
+  }
+}

--- a/app/api/time/shift/end/route.ts
+++ b/app/api/time/shift/end/route.ts
@@ -5,6 +5,7 @@ import {
 } from "@/features/shared/lib/supabase/server";
 import { SHIFT_STATUSES } from "@/features/workforce/lib/shift-status";
 import { closeAllActiveTechnicianJobLabor } from "@/features/work-orders/server/technicianJobLabor";
+import { getOrCreateCurrentPeriod, rebuildPeriod } from "@/features/payroll-time/server/payrollTime";
 
 type Caller = { id: string; shop_id: string | null };
 type ShiftRow = {
@@ -121,6 +122,15 @@ export async function POST() {
       { error: `complete_canonical_shift failed: ${message}` },
       { status },
     );
+  }
+
+  try {
+    const { period } = await getOrCreateCurrentPeriod(me.shop_id, me.id);
+    if (period?.id && (period.status === "open" || period.status === "draft")) {
+      await rebuildPeriod({ shopId: me.shop_id, actorId: me.id, periodId: period.id });
+    }
+  } catch (payrollRefreshError) {
+    console.error("payroll open-period refresh failed after shift end", payrollRefreshError);
   }
 
   return NextResponse.json({

--- a/db/sql/2026-07-12_payroll_timekeeping_policy.sql
+++ b/db/sql/2026-07-12_payroll_timekeeping_policy.sql
@@ -1,0 +1,40 @@
+-- Payroll timekeeping policy defaults.
+-- Additive, non-breaking, shop-scoped via existing shop_payroll_settings RLS policies.
+
+alter table public.shop_payroll_settings
+  add column if not exists paid_breaks_per_day smallint not null default 2,
+  add column if not exists paid_break_duration_minutes integer not null default 15,
+  add column if not exists breaks_are_paid boolean not null default true,
+  add column if not exists lunch_is_paid boolean not null default false,
+  add column if not exists default_lunch_duration_minutes integer not null default 30,
+  add column if not exists lunch_required_after_minutes integer not null default 300;
+
+do $$ begin
+  alter table public.shop_payroll_settings
+    add constraint shop_payroll_settings_paid_breaks_per_day_chk check (paid_breaks_per_day between 0 and 2);
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  alter table public.shop_payroll_settings
+    add constraint shop_payroll_settings_paid_break_duration_minutes_chk check (paid_break_duration_minutes between 0 and 120);
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  alter table public.shop_payroll_settings
+    add constraint shop_payroll_settings_default_lunch_duration_minutes_chk check (default_lunch_duration_minutes between 0 and 240);
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  alter table public.shop_payroll_settings
+    add constraint shop_payroll_settings_lunch_required_after_minutes_chk check (lunch_required_after_minutes between 0 and 1440);
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  alter table public.shop_payroll_settings
+    add constraint shop_payroll_settings_daily_overtime_sensible_chk check (daily_overtime_after_minutes between 0 and 1440);
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  alter table public.shop_payroll_settings
+    add constraint shop_payroll_settings_suspicious_shift_sensible_chk check (suspicious_shift_minutes between 60 and 2880);
+exception when duplicate_object then null; end $$;

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -32,7 +32,11 @@ type Entry = {
   regular_minutes: number;
   overtime_minutes: number;
   unpaid_break_minutes: number;
+  paid_break_minutes: number;
+  attendance_minutes: number;
   job_minutes: number;
+  roster_only?: boolean;
+  payroll_status_label?: string;
   has_exceptions: boolean;
   blocking_exception_count: number;
   warning_exception_count: number;
@@ -357,7 +361,7 @@ export default function PayrollTimeClient() {
         {loading ? (
           <AdminEmptyState title="Loading payroll period" body="Collecting derived payroll-ready rows." />
         ) : filteredEntries.length === 0 ? (
-          <AdminEmptyState title="No derived entries" body="Run rebuild to derive payroll-ready entries from attendance and job source layers." />
+          <AdminEmptyState title="No derived entries" body="Payroll-eligible employees appear here even before recorded shifts; open periods can be rebuilt from attendance and job source layers." />
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
@@ -365,11 +369,14 @@ export default function PayrollTimeClient() {
                 <tr>
                   <th className="px-4 py-2.5 text-left">Employee</th>
                   <th className="px-4 py-2.5 text-left">Date</th>
-                  <th className="px-4 py-2.5 text-right">Worked</th>
+                  <th className="px-4 py-2.5 text-right">Shift duration</th>
+                  <th className="px-4 py-2.5 text-right">Paid breaks</th>
+                  <th className="px-4 py-2.5 text-right">Unpaid lunch</th>
+                  <th className="px-4 py-2.5 text-right">Payroll hours</th>
                   <th className="px-4 py-2.5 text-right">Regular</th>
-                  <th className="px-4 py-2.5 text-right">OT-ready</th>
-                  <th className="px-4 py-2.5 text-right">Unpaid break</th>
-                  <th className="px-4 py-2.5 text-right">Job context</th>
+                  <th className="px-4 py-2.5 text-right">Overtime</th>
+                  <th className="px-4 py-2.5 text-right">Job time</th>
+                  <th className="px-4 py-2.5 text-right">Other paid shop time</th>
                   <th className="px-4 py-2.5 text-right">Scheduled</th>
                   <th className="px-4 py-2.5 text-right">Approved away</th>
                   <th className="px-4 py-2.5 text-left">Exceptions</th>
@@ -383,11 +390,14 @@ export default function PayrollTimeClient() {
                       <p className="text-xs text-neutral-500">{entry.profiles?.email ?? ""}</p>
                     </td>
                     <td className="whitespace-nowrap px-4 py-2.5">{entry.work_date}</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.attendance_minutes)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.paid_break_minutes)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.unpaid_break_minutes)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.worked_minutes)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.regular_minutes)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.overtime_minutes)}h</td>
-                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.unpaid_break_minutes)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.job_minutes)}h</td>
+                    <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(Math.max(0, Number(entry.worked_minutes ?? 0) - Number(entry.job_minutes ?? 0)))}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.scheduled_minutes ?? 0)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.approved_time_away_minutes_in_period ?? 0)}h</td>
                     <td className="px-4 py-2.5">
@@ -396,7 +406,7 @@ export default function PayrollTimeClient() {
                       ) : entry.warning_exception_count > 0 ? (
                         <AdminBadge>{entry.warning_exception_count} warning</AdminBadge>
                       ) : (
-                        <span className="text-xs text-neutral-500">Clean</span>
+                        <span className="text-xs text-neutral-500">{entry.payroll_status_label ?? "Clean"}</span>
                       )}
                     </td>
                   </tr>

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -287,6 +287,20 @@ export default function OwnerSettingsPage() {
   const [newOffEnd, setNewOffEnd] = useState("");
   const [newOffReason, setNewOffReason] = useState("");
 
+  const [payrollSettings, setPayrollSettings] = useState({
+    paid_breaks_per_day: 2,
+    paid_break_duration_minutes: 15,
+    breaks_are_paid: true,
+    lunch_is_paid: false,
+    default_lunch_duration_minutes: 30,
+    lunch_required_after_minutes: 300,
+    daily_overtime_after_minutes: 480,
+    suspicious_shift_minutes: 960,
+    cadence: "biweekly",
+    week_starts_on: 1,
+  });
+  const [payrollSettingsSaving, setPayrollSettingsSaving] = useState(false);
+
   const [emailLogs, setEmailLogs] = useState<EmailLogRow[]>([]);
   const [emailLogsLoading, setEmailLogsLoading] = useState(false);
 
@@ -338,6 +352,24 @@ export default function OwnerSettingsPage() {
     }
     return true;
   };
+
+  async function savePayrollSettings() {
+    if (!guardUnlock()) return;
+    setPayrollSettingsSaving(true);
+    const res = await fetch("/api/payroll-time/settings", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payrollSettings),
+    });
+    const body = await res.json().catch(() => null);
+    setPayrollSettingsSaving(false);
+    if (!res.ok) {
+      toast.error(body?.error || "Failed to save payroll settings");
+      return;
+    }
+    setPayrollSettings((prev) => ({ ...prev, ...(body?.settings ?? {}) }));
+    toast.success("Payroll & timekeeping settings saved.");
+  }
 
   const maybeToastSeatInfo = (used: number, limit: number | null, p: PlanName) => {
     if (limit == null) return;
@@ -589,6 +621,16 @@ try {
       // ignore
     } finally {
       setPricingValidDaysLoading(false);
+    }
+
+    try {
+      const payrollRes = await fetch("/api/payroll-time/settings", { cache: "no-store" });
+      if (payrollRes.ok) {
+        const payrollJson = await payrollRes.json();
+        if (payrollJson?.settings) setPayrollSettings((prev) => ({ ...prev, ...payrollJson.settings }));
+      }
+    } catch {
+      // ignore payroll settings bootstrap failures; section can be reloaded independently
     }
 
     // Organization + Locations
@@ -1290,6 +1332,7 @@ try {
           <a href="#workflow-automation" className={navChipClass}>Workflow</a>
           <a href="#hours-settings" className={navChipClass}>Hours</a>
           <a href="#timeoff-settings" className={navChipClass}>Time off</a>
+          <a href="#payroll-timekeeping" className={navChipClass}>Payroll</a>
           <a href="#billing-stripe" className={navChipClass}>Billing</a>
           <Link href="/dashboard/owner/branding" className={navChipClass}>Brand Studio</Link>
           <a href="#quickbooks-integration" className={navChipClass}>QuickBooks</a>
@@ -1299,6 +1342,32 @@ try {
 
       <div className="grid gap-5 lg:grid-cols-[1.7fr_0.95fr] lg:items-start">
         <div className="space-y-5">
+
+          <OwnerSettingsPanel
+            id="payroll-timekeeping"
+            title="Payroll & Timekeeping"
+            description="Owner-controlled payroll attendance policy. Regular break counts are compliance expectations; payroll calculations use actual punches."
+          >
+            <div className="grid gap-4 p-4 md:grid-cols-2">
+              <label className="space-y-1 text-sm">
+                <span className={labelClass}>Paid breaks per day</span>
+                <select className={selectClass} value={payrollSettings.paid_breaks_per_day} onChange={(e) => setPayrollSettings((p) => ({ ...p, paid_breaks_per_day: Number(e.target.value) }))}>
+                  <option value={0}>0</option><option value={1}>1</option><option value={2}>2</option>
+                </select>
+              </label>
+              <label className="space-y-1 text-sm"><span className={labelClass}>Paid break duration (minutes)</span><Input type="number" min={0} max={120} value={payrollSettings.paid_break_duration_minutes} onChange={(e) => setPayrollSettings((p) => ({ ...p, paid_break_duration_minutes: Number(e.target.value) }))} /></label>
+              <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={payrollSettings.breaks_are_paid} onChange={(e) => setPayrollSettings((p) => ({ ...p, breaks_are_paid: e.target.checked }))} /> Breaks are paid</label>
+              <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={payrollSettings.lunch_is_paid} onChange={(e) => setPayrollSettings((p) => ({ ...p, lunch_is_paid: e.target.checked }))} /> Lunch is paid</label>
+              <label className="space-y-1 text-sm"><span className={labelClass}>Expected lunch duration (minutes)</span><Input type="number" min={0} max={240} value={payrollSettings.default_lunch_duration_minutes} onChange={(e) => setPayrollSettings((p) => ({ ...p, default_lunch_duration_minutes: Number(e.target.value) }))} /></label>
+              <label className="space-y-1 text-sm"><span className={labelClass}>Lunch required after shift length (minutes)</span><Input type="number" min={0} max={1440} value={payrollSettings.lunch_required_after_minutes} onChange={(e) => setPayrollSettings((p) => ({ ...p, lunch_required_after_minutes: Number(e.target.value) }))} /></label>
+              <label className="space-y-1 text-sm"><span className={labelClass}>Daily overtime threshold (minutes)</span><Input type="number" min={0} max={1440} value={payrollSettings.daily_overtime_after_minutes} onChange={(e) => setPayrollSettings((p) => ({ ...p, daily_overtime_after_minutes: Number(e.target.value) }))} /></label>
+              <label className="space-y-1 text-sm"><span className={labelClass}>Suspicious shift threshold (minutes)</span><Input type="number" min={60} max={2880} value={payrollSettings.suspicious_shift_minutes} onChange={(e) => setPayrollSettings((p) => ({ ...p, suspicious_shift_minutes: Number(e.target.value) }))} /></label>
+              <label className="space-y-1 text-sm"><span className={labelClass}>Pay cadence</span><select className={selectClass} value={payrollSettings.cadence} onChange={(e) => setPayrollSettings((p) => ({ ...p, cadence: e.target.value }))}><option value="weekly">Weekly</option><option value="biweekly">Biweekly</option><option value="semimonthly">Semi-monthly</option></select></label>
+              <label className="space-y-1 text-sm"><span className={labelClass}>Week starts on</span><select className={selectClass} value={payrollSettings.week_starts_on} onChange={(e) => setPayrollSettings((p) => ({ ...p, week_starts_on: Number(e.target.value) }))}><option value={0}>Sunday</option><option value={1}>Monday</option><option value={2}>Tuesday</option><option value={3}>Wednesday</option><option value={4}>Thursday</option><option value={5}>Friday</option><option value={6}>Saturday</option></select></label>
+            </div>
+            <div className="border-t border-white/10 p-4"><Button onClick={() => void savePayrollSettings()} disabled={payrollSettingsSaving || !isUnlocked}>{payrollSettingsSaving ? "Saving…" : "Save payroll settings"}</Button></div>
+          </OwnerSettingsPanel>
+
           <OwnerSettingsSectionIntro
             title="Primary configuration"
             description="Core identity and experience controls for your operational cockpit."

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -44,6 +44,91 @@ function dateDiffMinutes(start: string, end: string): number {
   return Math.max(0, Math.round((new Date(end).getTime() - new Date(start).getTime()) / 60000));
 }
 
+
+export type PayrollPolicySnapshot = {
+  paid_breaks_per_day: number;
+  paid_break_duration_minutes: number;
+  breaks_are_paid: boolean;
+  lunch_is_paid: boolean;
+  default_lunch_duration_minutes: number;
+  lunch_required_after_minutes: number;
+  daily_overtime_after_minutes: number;
+  suspicious_shift_minutes: number;
+};
+
+function resolvePayrollPolicy(settings: any): PayrollPolicySnapshot {
+  return {
+    paid_breaks_per_day: Math.min(2, Math.max(0, Number(settings?.paid_breaks_per_day ?? 2))),
+    paid_break_duration_minutes: Math.max(0, Number(settings?.paid_break_duration_minutes ?? 15)),
+    breaks_are_paid: settings?.breaks_are_paid !== false,
+    lunch_is_paid: settings?.lunch_is_paid === true,
+    default_lunch_duration_minutes: Math.max(0, Number(settings?.default_lunch_duration_minutes ?? 30)),
+    lunch_required_after_minutes: Math.max(0, Number(settings?.lunch_required_after_minutes ?? 300)),
+    daily_overtime_after_minutes: Math.max(0, Number(settings?.daily_overtime_after_minutes ?? 480)),
+    suspicious_shift_minutes: Math.max(60, Number(settings?.suspicious_shift_minutes ?? 960)),
+  };
+}
+
+type PunchLike = { id?: string | null; event_type: string | null; timestamp: string | null };
+type RestParseWarning = { code: string; message: string; event_id?: string | null; event_type?: string | null };
+
+export function parsePayrollRestEvents(args: {
+  events: PunchLike[];
+  shiftStart: string;
+  shiftEnd: string;
+  policy: PayrollPolicySnapshot;
+}) {
+  let activeBreakStart: { ts: string; id?: string | null } | null = null;
+  let activeLunchStart: { ts: string; id?: string | null } | null = null;
+  const breakPairs: Array<{ start: string; end: string; minutes: number; start_event_id?: string | null; end_event_id?: string | null }> = [];
+  const lunchPairs: Array<{ start: string; end: string; minutes: number; start_event_id?: string | null; end_event_id?: string | null }> = [];
+  const warnings: RestParseWarning[] = [];
+  const seen = new Set<string>();
+
+  for (const event of [...args.events].sort((a,b)=>String(a.timestamp ?? '').localeCompare(String(b.timestamp ?? '')))) {
+    const eventType = String(event.event_type ?? '').toLowerCase();
+    if (!event.timestamp) continue;
+    const eventTs = clampIso(event.timestamp, args.shiftStart, args.shiftEnd);
+    const dedupeKey = `${eventType}|${eventTs}|${event.id ?? ''}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    if (eventType === 'break_start') {
+      if (activeLunchStart) warnings.push({ code: 'overlapping_rest_events', message: 'Regular break started while lunch was open.', event_id: event.id, event_type: eventType });
+      if (activeBreakStart) warnings.push({ code: 'unclosed_break', message: 'Previous regular break was not closed before another break started.', event_id: event.id, event_type: eventType });
+      activeBreakStart = { ts: eventTs, id: event.id };
+    } else if (eventType === 'break_end') {
+      if (!activeBreakStart) { warnings.push({ code: 'unclosed_break', message: 'Regular break end has no matching break start.', event_id: event.id, event_type: eventType }); continue; }
+      breakPairs.push({ start: activeBreakStart.ts, end: eventTs, minutes: dateDiffMinutes(activeBreakStart.ts, eventTs), start_event_id: activeBreakStart.id, end_event_id: event.id });
+      activeBreakStart = null;
+    } else if (eventType === 'lunch_start') {
+      if (activeBreakStart) warnings.push({ code: 'overlapping_rest_events', message: 'Lunch started while a regular break was open.', event_id: event.id, event_type: eventType });
+      if (activeLunchStart) warnings.push({ code: 'unclosed_lunch', message: 'Previous lunch was not closed before another lunch started.', event_id: event.id, event_type: eventType });
+      activeLunchStart = { ts: eventTs, id: event.id };
+    } else if (eventType === 'lunch_end') {
+      if (!activeLunchStart) { warnings.push({ code: 'unclosed_lunch', message: 'Lunch end has no matching lunch start.', event_id: event.id, event_type: eventType }); continue; }
+      lunchPairs.push({ start: activeLunchStart.ts, end: eventTs, minutes: dateDiffMinutes(activeLunchStart.ts, eventTs), start_event_id: activeLunchStart.id, end_event_id: event.id });
+      activeLunchStart = null;
+    }
+  }
+
+  if (activeBreakStart) {
+    breakPairs.push({ start: activeBreakStart.ts, end: args.shiftEnd, minutes: dateDiffMinutes(activeBreakStart.ts, args.shiftEnd), start_event_id: activeBreakStart.id, end_event_id: 'auto_closed_shift_end' });
+    warnings.push({ code: 'unclosed_break', message: 'Regular break was auto-closed at shift end.', event_id: activeBreakStart.id, event_type: 'break_start' });
+  }
+  if (activeLunchStart) {
+    lunchPairs.push({ start: activeLunchStart.ts, end: args.shiftEnd, minutes: dateDiffMinutes(activeLunchStart.ts, args.shiftEnd), start_event_id: activeLunchStart.id, end_event_id: 'auto_closed_shift_end' });
+    warnings.push({ code: 'unclosed_lunch', message: 'Lunch was auto-closed at shift end.', event_id: activeLunchStart.id, event_type: 'lunch_start' });
+  }
+
+  const regularBreakMinutes = breakPairs.reduce((a,p)=>a+p.minutes,0);
+  const lunchMinutes = lunchPairs.reduce((a,p)=>a+p.minutes,0);
+  const paidBreakMinutes = args.policy.breaks_are_paid ? regularBreakMinutes : (args.policy.lunch_is_paid ? lunchMinutes : 0);
+  const unpaidBreakMinutes = (args.policy.breaks_are_paid ? 0 : regularBreakMinutes) + (args.policy.lunch_is_paid ? 0 : lunchMinutes);
+
+  return { breakPairs, lunchPairs, warnings, regularBreakMinutes, lunchMinutes, paidBreakMinutes, unpaidBreakMinutes };
+}
+
 function clampIso(iso: string, minIso: string, maxIso: string): string {
   const v = new Date(iso).getTime();
   const min = new Date(minIso).getTime();
@@ -144,8 +229,9 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
     .eq("shop_id", shopId)
     .maybeSingle();
 
-  const dailyOvertimeAfter = Number(settings?.daily_overtime_after_minutes ?? 480);
-  const suspiciousShiftMinutes = Number(settings?.suspicious_shift_minutes ?? 960);
+  const policy = resolvePayrollPolicy(settings);
+  const dailyOvertimeAfter = policy.daily_overtime_after_minutes;
+  const suspiciousShiftMinutes = policy.suspicious_shift_minutes;
 
   const rangeStart = `${period.period_start}T00:00:00.000Z`;
   const rangeEnd = `${period.period_end}T23:59:59.999Z`;
@@ -173,7 +259,7 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
   const { data: punchEvents, error: punchEventsErr } = shiftIds.length
     ? await admin
         .from("punch_events")
-        .select("shift_id, event_type, timestamp")
+        .select("id, shift_id, event_type, timestamp")
         .in("shift_id", shiftIds)
         .order("timestamp", { ascending: true })
     : { data: [], error: null };
@@ -182,13 +268,14 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
 
   const punchEventsByShift = new Map<
     string,
-    Array<{ event_type: string | null; timestamp: string | null }>
+    Array<{ id?: string | null; event_type: string | null; timestamp: string | null }>
   >();
   for (const event of punchEvents ?? []) {
     const sid = event.shift_id as string | null;
     if (!sid) continue;
     const current = punchEventsByShift.get(sid) ?? [];
     current.push({
+      id: (event.id as string | null) ?? null,
       event_type: (event.event_type as string | null) ?? null,
       timestamp: (event.timestamp as string | null) ?? null,
     });
@@ -231,35 +318,34 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
     row.attendance_minutes += duration;
 
     const events = punchEventsByShift.get(shift.id) ?? [];
-    if (events.length > 0) {
-      let activeBreakStart: string | null = null;
+    const rest = parsePayrollRestEvents({ events, shiftStart: shift.start_time, shiftEnd: endTime, policy });
+    row.unpaid_break_minutes += rest.unpaidBreakMinutes;
+    row.paid_break_minutes += rest.paidBreakMinutes;
 
-      for (const event of events) {
-        const eventType = String(event.event_type ?? "").toLowerCase();
-        if (!event.timestamp) continue;
-        const eventTs = clampIso(event.timestamp, shift.start_time, endTime);
+    const snapshot = row.source_snapshot as Record<string, unknown>;
+    const parserWarnings = Array.isArray(snapshot.parser_warnings) ? (snapshot.parser_warnings as unknown[]) : [];
+    parserWarnings.push(...rest.warnings);
+    snapshot.parser_warnings = parserWarnings;
 
-        if (eventType === "break_start" || eventType === "lunch_start") {
-          if (activeBreakStart) {
-            row.unpaid_break_minutes += dateDiffMinutes(activeBreakStart, eventTs);
-          }
-          activeBreakStart = eventTs;
-          continue;
-        }
+    const addWarning = (code: string, message: string, sourceRef: Record<string, unknown>) => {
+      row.warnings += 1;
+      exceptions.push({ user_id: shift.user_id, work_date: workDate, severity: "warning", code, message, source_type: "attendance", source_ref: sourceRef });
+    };
 
-        if (eventType === "break_end" || eventType === "lunch_end") {
-          if (activeBreakStart) {
-            row.unpaid_break_minutes += dateDiffMinutes(activeBreakStart, eventTs);
-            activeBreakStart = null;
-          }
-        }
-      }
-
-      if (activeBreakStart) {
-        row.unpaid_break_minutes += dateDiffMinutes(activeBreakStart, endTime);
-      }
+    for (const warning of rest.warnings) addWarning(warning.code, warning.message, { shift_id: shift.id, ...warning });
+    if (rest.breakPairs.length < policy.paid_breaks_per_day) {
+      addWarning("missing_expected_break", `Recorded ${rest.breakPairs.length} regular breaks; policy expects ${policy.paid_breaks_per_day}.`, { shift_id: shift.id, break_count: rest.breakPairs.length, expected_breaks: policy.paid_breaks_per_day });
     }
-
+    if (rest.breakPairs.length > policy.paid_breaks_per_day) {
+      addWarning("excess_break_count", `Recorded ${rest.breakPairs.length} regular breaks; policy expects ${policy.paid_breaks_per_day}.`, { shift_id: shift.id, break_count: rest.breakPairs.length, expected_breaks: policy.paid_breaks_per_day });
+    }
+    if (duration >= policy.lunch_required_after_minutes && rest.lunchPairs.length === 0) {
+      addWarning("missing_lunch", `Shift exceeded ${policy.lunch_required_after_minutes} minutes with no lunch punch.`, { shift_id: shift.id, duration, threshold: policy.lunch_required_after_minutes });
+    }
+    const longLunchThreshold = policy.default_lunch_duration_minutes + 15;
+    for (const lunch of rest.lunchPairs) {
+      if (lunch.minutes > longLunchThreshold) addWarning("long_lunch", `Lunch length ${lunch.minutes} minutes exceeds expected ${policy.default_lunch_duration_minutes} minutes.`, { shift_id: shift.id, lunch });
+    }
     const ids = Array.isArray(row.source_snapshot.shift_ids)
       ? (row.source_snapshot.shift_ids as string[])
       : [];
@@ -269,6 +355,13 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
       ...row.source_snapshot,
       break_source: events.length > 0 ? "punch_events" : "none_recorded",
       punch_event_count: events.length,
+      break_count: rest.breakPairs.length,
+      lunch_count: rest.lunchPairs.length,
+      break_pairs: rest.breakPairs,
+      lunch_pairs: rest.lunchPairs,
+      paid_break_minutes: row.paid_break_minutes,
+      unpaid_lunch_minutes: policy.lunch_is_paid ? 0 : rest.lunchMinutes,
+      policy_snapshot: policy,
     };
 
     if (!shift.end_time) {
@@ -282,7 +375,7 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
         user_id: shift.user_id,
         work_date: workDate,
         severity: "blocking",
-        code: "open_punch",
+        code: "open_shift",
         message: "Shift is still open and missing clock-out.",
         source_type: "attendance",
         source_ref: { shift_id: shift.id },
@@ -358,8 +451,22 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
     rowsByKey.set(key, row);
   }
 
+
+  const { data: existingEntries } = await admin.from("payroll_time_entries").select("user_id, work_date, adjustment_minutes, approval_state").eq("shop_id", shopId).eq("period_id", periodId);
+  const adjustmentByKey = new Map((existingEntries ?? []).map((e: any) => [`${e.user_id}:${e.work_date}`, Number(e.adjustment_minutes ?? 0)]));
+  for (const row of rowsByKey.values()) { (row.source_snapshot as any).preserved_adjustment_minutes = adjustmentByKey.get(`${row.user_id}:${row.work_date}`) ?? 0; }
+
   const upserts = Array.from(rowsByKey.values()).map((row) => {
-    const netWorked = Math.max(0, row.attendance_minutes - row.unpaid_break_minutes);
+    if (row.job_minutes > row.attendance_minutes - row.unpaid_break_minutes) {
+      row.warnings += 1;
+      exceptions.push({ user_id: row.user_id, work_date: row.work_date, severity: "warning", code: "job_time_exceeds_worked_time", message: "Productive job time exceeds payroll worked time.", source_type: "job_time", source_ref: { job_minutes: row.job_minutes, worked_minutes: row.attendance_minutes - row.unpaid_break_minutes } });
+    }
+    if (row.attendance_minutes > 0 && row.job_minutes === 0) {
+      row.warnings += 1;
+      exceptions.push({ user_id: row.user_id, work_date: row.work_date, severity: "warning", code: "attendance_without_job_time", message: "Attendance was recorded with no completed job labor segments.", source_type: "job_time", source_ref: { attendance_minutes: row.attendance_minutes } });
+    }
+    const adjustment = Number((row.source_snapshot as any).preserved_adjustment_minutes ?? 0);
+    const netWorked = Math.max(0, row.attendance_minutes - row.unpaid_break_minutes + adjustment);
     const overtime = Math.max(0, netWorked - dailyOvertimeAfter);
     const regular = Math.max(0, netWorked - overtime);
 
@@ -375,7 +482,7 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
       regular_minutes: regular,
       overtime_minutes: overtime,
       job_minutes: row.job_minutes,
-      adjustment_minutes: 0,
+      adjustment_minutes: adjustment,
       has_exceptions: row.warnings + row.blocking > 0,
       warning_exception_count: row.warnings,
       blocking_exception_count: row.blocking,

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -14981,8 +14981,14 @@ export type Database = {
           cadence: string
           created_at: string
           daily_overtime_after_minutes: number
+          default_lunch_duration_minutes: number
           enabled: boolean
           id: string
+          lunch_is_paid: boolean
+          lunch_required_after_minutes: number
+          paid_break_duration_minutes: number
+          paid_breaks_per_day: number
+          breaks_are_paid: boolean
           shop_id: string
           suspicious_shift_minutes: number
           updated_at: string
@@ -14993,8 +14999,14 @@ export type Database = {
           cadence?: string
           created_at?: string
           daily_overtime_after_minutes?: number
+          default_lunch_duration_minutes?: number
           enabled?: boolean
           id?: string
+          lunch_is_paid?: boolean
+          lunch_required_after_minutes?: number
+          paid_break_duration_minutes?: number
+          paid_breaks_per_day?: number
+          breaks_are_paid?: boolean
           shop_id: string
           suspicious_shift_minutes?: number
           updated_at?: string
@@ -15005,8 +15017,14 @@ export type Database = {
           cadence?: string
           created_at?: string
           daily_overtime_after_minutes?: number
+          default_lunch_duration_minutes?: number
           enabled?: boolean
           id?: string
+          lunch_is_paid?: boolean
+          lunch_required_after_minutes?: number
+          paid_break_duration_minutes?: number
+          paid_breaks_per_day?: number
+          breaks_are_paid?: boolean
           shop_id?: string
           suspicious_shift_minutes?: number
           updated_at?: string

--- a/tests/payroll-time-rest-policy.test.ts
+++ b/tests/payroll-time-rest-policy.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { parsePayrollRestEvents, type PayrollPolicySnapshot } from "../features/payroll-time/server/payrollTime";
+
+const basePolicy: PayrollPolicySnapshot = {
+  paid_breaks_per_day: 2,
+  paid_break_duration_minutes: 15,
+  breaks_are_paid: true,
+  lunch_is_paid: false,
+  default_lunch_duration_minutes: 30,
+  lunch_required_after_minutes: 300,
+  daily_overtime_after_minutes: 480,
+  suspicious_shift_minutes: 960,
+};
+
+const shiftStart = "2026-07-01T08:00:00.000Z";
+const shiftEnd = "2026-07-01T16:30:00.000Z";
+
+describe("payroll rest event policy parser", () => {
+  it("keeps two regular breaks paid and deducts lunch only", () => {
+    const rest = parsePayrollRestEvents({
+      shiftStart,
+      shiftEnd,
+      policy: basePolicy,
+      events: [
+        { id: "b1s", event_type: "break_start", timestamp: "2026-07-01T10:00:00.000Z" },
+        { id: "b1e", event_type: "break_end", timestamp: "2026-07-01T10:15:00.000Z" },
+        { id: "ls", event_type: "lunch_start", timestamp: "2026-07-01T12:00:00.000Z" },
+        { id: "le", event_type: "lunch_end", timestamp: "2026-07-01T12:30:00.000Z" },
+        { id: "b2s", event_type: "break_start", timestamp: "2026-07-01T15:00:00.000Z" },
+        { id: "b2e", event_type: "break_end", timestamp: "2026-07-01T15:15:00.000Z" },
+      ],
+    });
+    expect(rest.paidBreakMinutes).toBe(30);
+    expect(rest.unpaidBreakMinutes).toBe(30);
+    expect(510 - rest.unpaidBreakMinutes).toBe(480);
+  });
+
+  it("does not add fake break time when no break is punched", () => {
+    const rest = parsePayrollRestEvents({ shiftStart, shiftEnd, policy: basePolicy, events: [] });
+    expect(rest.paidBreakMinutes).toBe(0);
+    expect(rest.unpaidBreakMinutes).toBe(0);
+  });
+
+  it("does not cross-match break starts with lunch ends", () => {
+    const rest = parsePayrollRestEvents({
+      shiftStart,
+      shiftEnd,
+      policy: basePolicy,
+      events: [
+        { id: "b1s", event_type: "break_start", timestamp: "2026-07-01T10:00:00.000Z" },
+        { id: "le", event_type: "lunch_end", timestamp: "2026-07-01T10:30:00.000Z" },
+      ],
+    });
+    expect(rest.lunchPairs).toHaveLength(0);
+    expect(rest.breakPairs[0].end_event_id).toBe("auto_closed_shift_end");
+    expect(rest.warnings.map((w) => w.code)).toContain("unclosed_lunch");
+    expect(rest.warnings.map((w) => w.code)).toContain("unclosed_break");
+  });
+
+  it("supports paid lunch and unpaid regular break policy switches", () => {
+    const policy = { ...basePolicy, breaks_are_paid: false, lunch_is_paid: true };
+    const rest = parsePayrollRestEvents({
+      shiftStart,
+      shiftEnd,
+      policy,
+      events: [
+        { event_type: "break_start", timestamp: "2026-07-01T10:00:00.000Z" },
+        { event_type: "break_end", timestamp: "2026-07-01T10:15:00.000Z" },
+        { event_type: "lunch_start", timestamp: "2026-07-01T12:00:00.000Z" },
+        { event_type: "lunch_end", timestamp: "2026-07-01T12:30:00.000Z" },
+      ],
+    });
+    expect(rest.paidBreakMinutes).toBe(30);
+    expect(rest.unpaidBreakMinutes).toBe(15);
+  });
+});


### PR DESCRIPTION
### Motivation
- Payroll Time Tracking showed no employees and the rebuild incorrectly deducted both regular breaks and lunch from payroll hours; the change implements owner-controlled policy (paid regular breaks, unpaid lunch) and ensures roster visibility even before payroll entries exist. 

### Description
- Add a safe, additive DB migration `db/sql/2026-07-12_payroll_timekeeping_policy.sql` to extend `shop_payroll_settings` with payroll policy fields and validation constraints (paid breaks, durations, lunch policy, lunch threshold). 
- Replace the generic rest parsing with `parsePayrollRestEvents` and `resolvePayrollPolicy` in `features/payroll-time/server/payrollTime.ts`, and update `rebuildPeriod` to compute `attendance_minutes`, `paid_break_minutes`, `unpaid_break_minutes`, `worked_minutes = attendance - unpaid + adjustments`, preserve manual adjustments, emit new warnings/blocking exceptions, and enrich `source_snapshot`. 
- Surface payroll-eligible roster rows by left-joining `people_workforce_profiles` (payroll_ready + active) in `app/api/payroll-time/periods/route.ts` so employees appear even with no `payroll_time_entries`. 
- Add Owner Settings UI and a scoped API at `app/api/payroll-time/settings/route.ts` (Owner/admin + Owner PIN protection) to read/save payroll policy values; add the UI panel in `features/dashboard/app/dashboard/owner/settings/page.tsx`. 
- Trigger a safe open-period rebuild after End Day in `app/api/time/shift/end/route.ts` without failing shift closure if rebuild fails. 
- Update payroll review UI columns and labels in `features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx` to show shift attendance, paid breaks, unpaid lunch, payroll hours, job time, other paid shop time, and exceptions. 
- Add unit tests `tests/payroll-time-rest-policy.test.ts` for the rest-event parser and update Supabase types in `features/shared/types/types/supabase.ts`. 
- Files changed (not exhaustive): `features/payroll-time/server/payrollTime.ts`, `app/api/payroll-time/periods/route.ts`, `app/api/payroll-time/settings/route.ts` (new), `app/api/time/shift/end/route.ts`, `features/dashboard/.../PayrollTimeClient.tsx`, `features/dashboard/.../owner/settings/page.tsx`, `features/shared/types/types/supabase.ts`, `db/sql/2026-07-12_payroll_timekeeping_policy.sql`, `tests/payroll-time-rest-policy.test.ts`.

### Testing
- Ran `npm run typecheck` and it passed with no type errors. 
- Ran ESLint for the touched areas and received only non-blocking warnings. 
- Ran unit tests with `npx vitest run tests/*payroll* tests/*shift* tests/*punch* tests/*workforce*` and all tests passed (9 files, 90 tests). 
- Attempted `pnpm build` and the build failed due to inability to fetch Google Fonts (`Inter`, `Black Ops One`) from fonts.googleapis.com in this environment, which is an external-network artifact and not related to the code changes. 

Commit: `616836dee9847aed1f7be41c22f4b77883904596`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52ee28bcac8328b80c5298faaa2316)