### PR TITLE
Fix payroll time open-period visibility and auto-refresh from source records

### DIFF
--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import { getOrCreateCurrentPeriod } from "@/features/payroll-time/server/payrollTime";
+import { getOrCreateCurrentPeriod, refreshOpenPeriodIfStale } from "@/features/payroll-time/server/payrollTime";
 import { requirePayrollReviewer } from "../_lib/auth";
 type AdminClient = ReturnType<typeof createAdminSupabase>;
 
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const periodId = url.searchParams.get("period_id");
 
-  await getOrCreateCurrentPeriod(me.shop_id!, me.id);
+  const current = await getOrCreateCurrentPeriod(me.shop_id!, me.id);
 
   const { data: periods, error: periodErr } = await admin
     .from("payroll_pay_periods")
@@ -24,8 +24,10 @@ export async function GET(req: NextRequest) {
 
   if (periodErr) return NextResponse.json({ error: periodErr.message }, { status: 500 });
 
-  const activePeriodId = periodId ?? periods?.[0]?.id ?? null;
+  const activePeriodId = periodId ?? current.period?.id ?? periods?.[0]?.id ?? null;
   if (!activePeriodId) return NextResponse.json({ periods: [], entries: [], exceptions: [] });
+
+  const refreshState = await refreshOpenPeriodIfStale({ shopId: me.shop_id!, actorId: me.id, periodId: activePeriodId });
 
   const [{ data: entries, error: entriesErr }, { data: exceptions, error: exErr }, { data: roster }] = await Promise.all([
     admin
@@ -110,11 +112,35 @@ export async function GET(req: NextRequest) {
       payroll_status_label: "No recorded shifts",
     }));
 
+  const missingProfileUserIds = entryRows
+    .filter((entry) => entry.user_id && !entry.profiles)
+    .map((entry) => entry.user_id);
+  const { data: fallbackProfiles } = missingProfileUserIds.length
+    ? await admin.from("profiles").select("id, full_name, email").eq("shop_id", me.shop_id).in("id", missingProfileUserIds)
+    : { data: [] };
+  const fallbackProfileById = new Map((fallbackProfiles ?? []).map((profile: any) => [profile.id, profile]));
+
   const enrichedEntries = [...entryRows, ...rosterEntries].map((entry) => ({
     ...entry,
+    profiles: entry.profiles ?? fallbackProfileById.get(entry.user_id) ?? null,
     scheduled_minutes: scheduleMap.get(`${entry.user_id}|${entry.work_date}`) ?? 0,
     approved_time_away_minutes_in_period: awayMap.get(entry.user_id) ?? 0,
   }));
 
-  return NextResponse.json({ periods: periods ?? [], activePeriodId, entries: enrichedEntries, exceptions: exceptions ?? [] });
+  const trueZero = enrichedEntries.length === 0 && !refreshState.hasSourceTime;
+  return NextResponse.json({
+    periods: periods ?? [],
+    activePeriodId,
+    entries: enrichedEntries,
+    exceptions: exceptions ?? [],
+    refresh: refreshState,
+    zeroState: {
+      trueZero,
+      message: trueZero
+        ? "No employee time has been recorded for this pay period."
+        : refreshState.refreshError
+          ? "Time records exist, but payroll totals could not be refreshed."
+          : null,
+    },
+  });
 }

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -35,6 +35,7 @@ type Entry = {
   paid_break_minutes: number;
   attendance_minutes: number;
   job_minutes: number;
+  source_snapshot?: { shifts?: Array<{ start_time?: string | null; end_time?: string | null }> } | null;
   roster_only?: boolean;
   payroll_status_label?: string;
   has_exceptions: boolean;
@@ -95,6 +96,8 @@ export default function PayrollTimeClient() {
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [csvPreview, setCsvPreview] = useState<string | null>(null);
   const [exportHistory, setExportHistory] = useState<ExportBatch[]>([]);
+  const [zeroState, setZeroState] = useState<{ trueZero?: boolean; message?: string | null } | null>(null);
+  const [refreshState, setRefreshState] = useState<{ reason?: string; refreshError?: string | null; hasSourceTime?: boolean } | null>(null);
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [downloadingBatchId, setDownloadingBatchId] = useState<string | null>(null);
   const [employeeSearch, setEmployeeSearch] = useState("");
@@ -155,6 +158,8 @@ export default function PayrollTimeClient() {
     setActivePeriodId((body?.activePeriodId as string | null) ?? null);
     setEntries((body?.entries ?? []) as Entry[]);
     setExceptions((body?.exceptions ?? []) as Exception[]);
+    setZeroState(body?.zeroState ?? null);
+    setRefreshState(body?.refresh ?? null);
     setLoading(false);
   }, []);
 
@@ -196,6 +201,8 @@ export default function PayrollTimeClient() {
 
   async function handleApprove() {
     if (!activePeriodId) return;
+    const confirmed = window.confirm(`Approve Payroll?\n\nEmployees: ${summary.employees}\nPayroll hours: ${summary.totalHours}\nOvertime hours: ${summary.overtimeHours}\nUnresolved blocking issues: ${summary.blocking}\nAdvisory warnings: ${summary.warnings}\n\nAdvisory warnings can be acknowledged without changing valid hours. Only blocking integrity issues prevent approval.`);
+    if (!confirmed) return;
     const result = await runAction("/api/payroll-time/approve", "approve", { period_id: activePeriodId });
     if (result) await load(activePeriodId);
   }
@@ -251,9 +258,9 @@ export default function PayrollTimeClient() {
   return (
     <AdminPageShell>
       <AdminPageHeader
-        eyebrow="Workforce Payroll-Ready Time"
-        title="Payroll Time Tracking"
-        subtitle="Attendance-first payroll-hour review and export readiness by pay period with exception triage, approval locking, and export snapshots."
+        eyebrow="Payroll"
+        title="Payroll Time"
+        subtitle="Review employee hours for the current pay period."
       />
       {workforceSeverity ? (
         <div className="mb-4 flex items-center justify-between rounded-lg border border-orange-400/40 bg-orange-500/10 px-4 py-2 text-xs text-orange-200">
@@ -264,39 +271,34 @@ export default function PayrollTimeClient() {
 
       <AdminPanel>
         <AdminPanelTitle
-          title="Current Period Signals"
-          description="Trust posture before approval/export. Blocking exceptions should be cleared before lock."
+          title="Current-period summary"
+          description="Recorded attendance is refreshed automatically for open periods. Overtime and warnings are advisory unless a blocking integrity issue remains."
         />
         <AdminStatGrid>
-          <AdminStatCard label="Employees in period" value={summary.employees} />
-          <AdminStatCard label="Worked hours" value={summary.totalHours} />
-          <AdminStatCard label="Overtime-ready hours" value={summary.overtimeHours} />
-          <AdminStatCard label="Blocking exceptions" value={summary.blocking} />
-          <AdminStatCard label="Warnings" value={summary.warnings} />
+          <AdminStatCard label="Employees" value={summary.employees} />
+          <AdminStatCard label="Payroll hours" value={summary.totalHours} />
+          <AdminStatCard label="Regular hours" value={fmtHours(entries.reduce((acc, entry) => acc + Number(entry.regular_minutes ?? 0), 0))} />
+          <AdminStatCard label="Overtime" value={summary.overtimeHours} />
+          <AdminStatCard label="Needs review" value={summary.blocking + summary.warnings} />
         </AdminStatGrid>
       </AdminPanel>
 
       <AdminPanel>
         <AdminPanelTitle
-          title="Connected Workforce Context"
-          description="Payroll review stays aligned with employee identity/workforce posture."
+          title="Payroll Assistant"
+          description="Deterministic review aid only. It cannot change payroll records, approval state, or blocking status."
         />
-        <div className="flex flex-wrap items-center gap-3 p-4 text-xs">
-          <Link href="/dashboard/admin/employees" className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">
-            Open People & Staff
-          </Link>
-          <Link href="/dashboard/admin/people" className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">
-            Open People Directory
-          </Link>
-          <Link href="/dashboard/admin/scheduling" className="rounded-lg border border-white/15 bg-black/30 px-3 py-2 font-medium text-orange-300 hover:text-orange-200">
-            Open Scheduling Board
-          </Link>
-          <span className="text-neutral-400">Use People for all person-level governance, certifications, profile setup, and workforce updates.</span>
+        <div className="space-y-2 p-4 text-sm text-neutral-200">
+          {summary.blocking > 0 ? <p>{summary.blocking} blocking integrity issue{summary.blocking === 1 ? "" : "s"} must be resolved before payroll can be finalized.</p> : null}
+          {Number(summary.overtimeHours) > 0 ? <p>{entries.filter((entry) => entry.overtime_minutes > 0).length} employee day{entries.filter((entry) => entry.overtime_minutes > 0).length === 1 ? "" : "s"} recorded overtime this period.</p> : null}
+          {summary.warnings > 0 ? <p>{summary.warnings} advisory warning{summary.warnings === 1 ? "" : "s"} may need owner review, but do not remove recorded payable hours.</p> : null}
+          {summary.blocking === 0 && summary.warnings === 0 ? <p>Payroll totals are ready for review.</p> : null}
+          <p className="text-xs text-neutral-500">Overtime, long shifts, missing lunch, and job-time ratio flags are advisory. Valid recorded attendance remains visible and payable for owner/admin decisions.</p>
         </div>
       </AdminPanel>
 
       <AdminPanel>
-        <AdminPanelTitle title="Pay Period Review" description="Rebuild while open, approve to lock, then export to a payroll-provider-ready CSV snapshot." />
+        <AdminPanelTitle title="Pay Period Review" description="Open periods refresh from time records automatically. Approved, locked, and exported periods show their durable snapshot." />
         <AdminToolbar>
           <select
             className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none md:w-80"
@@ -314,21 +316,21 @@ export default function PayrollTimeClient() {
             onClick={() => void handleRebuild()}
             disabled={!activePeriodId || busyAction !== null || activePeriod?.status === "approved" || activePeriod?.status === "exported"}
           >
-            {busyAction === "rebuild" ? "Rebuilding…" : "Rebuild from source"}
+            {busyAction === "rebuild" ? "Recalculating…" : "Recalculate"}
           </button>
           <button
             className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs uppercase tracking-[0.12em] text-emerald-200 disabled:opacity-50"
             onClick={() => void handleApprove()}
             disabled={!activePeriodId || busyAction !== null || activePeriod?.status === "approved" || activePeriod?.status === "exported"}
           >
-            {busyAction === "approve" ? "Approving…" : "Approve + lock"}
+            {busyAction === "approve" ? "Approving…" : "Approve Payroll"}
           </button>
           <button
             className="rounded-lg border border-sky-500/40 bg-sky-500/10 px-3 py-2 text-xs uppercase tracking-[0.12em] text-sky-200 disabled:opacity-50"
             onClick={() => void handleExport()}
             disabled={!activePeriodId || busyAction !== null || activePeriod?.status !== "approved"}
           >
-            {busyAction === "export" ? "Exporting…" : "Export CSV snapshot"}
+            {busyAction === "export" ? "Exporting…" : "Export Payroll"}
           </button>
         </AdminToolbar>
 
@@ -342,12 +344,18 @@ export default function PayrollTimeClient() {
         ) : null}
 
         {error ? <p className="px-4 pb-4 text-xs text-red-300">{error}</p> : null}
+        {refreshState?.refreshError ? (
+          <div className="mx-4 mb-4 rounded-lg border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-200">
+            <p>Time records exist, but payroll totals could not be refreshed.</p>
+            <button className="mt-2 rounded-lg border border-red-300/40 px-3 py-1 text-xs" onClick={() => void handleRebuild()}>Retry refresh</button>
+          </div>
+        ) : null}
       </AdminPanel>
 
       <AdminPanel>
         <AdminPanelTitle
-          title="Employee Daily Payroll Entries"
-          description="Attendance is payroll base truth; job time is supplemental visibility for productivity context."
+          title="Employee hours"
+          description="Attendance determines payroll hours; productive job time is shown separately from other paid shop time."
         />
         <AdminToolbar>
           {personIdFilter ? <p className="text-xs text-orange-300">Filtered to person: {personIdFilter.slice(0, 8)}</p> : null}
@@ -359,16 +367,16 @@ export default function PayrollTimeClient() {
           />
         </AdminToolbar>
         {loading ? (
-          <AdminEmptyState title="Loading payroll period" body="Collecting derived payroll-ready rows." />
+          <AdminEmptyState title="Loading payroll period" body="Refreshing employee time records." />
         ) : filteredEntries.length === 0 ? (
-          <AdminEmptyState title="No derived entries" body="Payroll-eligible employees appear here even before recorded shifts; open periods can be rebuilt from attendance and job source layers." />
+          <AdminEmptyState title={zeroState?.message ?? "No employee time has been recorded for this pay period."} body={activePeriod ? `${activePeriod.period_start} → ${activePeriod.period_end}` : "Open Attendance or Scheduling to record employee time."} />
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
               <thead className="bg-black/30 text-xs uppercase tracking-[0.12em] text-neutral-400">
                 <tr>
                   <th className="px-4 py-2.5 text-left">Employee</th>
-                  <th className="px-4 py-2.5 text-left">Date</th>
+                  <th className="px-4 py-2.5 text-left">Date / clock</th>
                   <th className="px-4 py-2.5 text-right">Shift duration</th>
                   <th className="px-4 py-2.5 text-right">Paid breaks</th>
                   <th className="px-4 py-2.5 text-right">Unpaid lunch</th>
@@ -379,7 +387,8 @@ export default function PayrollTimeClient() {
                   <th className="px-4 py-2.5 text-right">Other paid shop time</th>
                   <th className="px-4 py-2.5 text-right">Scheduled</th>
                   <th className="px-4 py-2.5 text-right">Approved away</th>
-                  <th className="px-4 py-2.5 text-left">Exceptions</th>
+                  <th className="px-4 py-2.5 text-left">Status</th>
+                  <th className="px-4 py-2.5 text-left">Action</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-white/10">
@@ -389,7 +398,10 @@ export default function PayrollTimeClient() {
                       <p className="font-medium text-neutral-100"><Link href={`/dashboard/admin/people/${entry.user_id}`} className="font-medium text-neutral-100 hover:text-orange-300">{entry.profiles?.full_name ?? entry.user_id}</Link></p>
                       <p className="text-xs text-neutral-500">{entry.profiles?.email ?? ""}</p>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-2.5">{entry.work_date}</td>
+                    <td className="whitespace-nowrap px-4 py-2.5">
+                      <p>{entry.work_date}</p>
+                      <p className="text-xs text-neutral-500">{entry.source_snapshot?.shifts?.[0]?.start_time ? new Date(entry.source_snapshot.shifts[0].start_time).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }) : "—"} → {entry.source_snapshot?.shifts?.[0]?.end_time ? new Date(entry.source_snapshot.shifts[0].end_time).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }) : "In progress"}</p>
+                    </td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.attendance_minutes)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.paid_break_minutes)}h</td>
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.unpaid_break_minutes)}h</td>
@@ -402,13 +414,14 @@ export default function PayrollTimeClient() {
                     <td className="whitespace-nowrap px-4 py-2.5 text-right">{fmtHours(entry.approved_time_away_minutes_in_period ?? 0)}h</td>
                     <td className="px-4 py-2.5">
                       {entry.blocking_exception_count > 0 ? (
-                        <AdminBadge>{entry.blocking_exception_count} blocking</AdminBadge>
+                        <AdminBadge>Shift still open</AdminBadge>
                       ) : entry.warning_exception_count > 0 ? (
-                        <AdminBadge>{entry.warning_exception_count} warning</AdminBadge>
+                        <AdminBadge>Needs review</AdminBadge>
                       ) : (
-                        <span className="text-xs text-neutral-500">{entry.payroll_status_label ?? "Clean"}</span>
+                        <span className="text-xs text-emerald-300">{entry.payroll_status_label ?? "Ready"}</span>
                       )}
                     </td>
+                    <td className="px-4 py-2.5"><Link className="text-xs font-medium text-orange-300 hover:text-orange-200" href={`/dashboard/workforce/attendance?person_id=${entry.user_id}`}>Review time</Link></td>
                   </tr>
                 ))}
               </tbody>
@@ -417,8 +430,10 @@ export default function PayrollTimeClient() {
         )}
       </AdminPanel>
 
+      <details className="rounded-2xl border border-white/10 bg-black/20">
+        <summary className="cursor-pointer px-4 py-3 text-sm font-semibold text-neutral-100">Advanced: exceptions, exports, source details</summary>
       <AdminPanel>
-        <AdminPanelTitle title="Exception Queue" description="Exceptions keep traceability; unresolved blocking exceptions prevent period approval." />
+        <AdminPanelTitle title="Exceptions" description="Only unresolved blocking integrity exceptions prevent final approval. Advisory warnings can be acknowledged by owner/admin decision." />
         <AdminToolbar>
           <select
             className="w-full rounded-lg border border-white/15 bg-black/30 px-3 py-2 text-sm text-neutral-100 outline-none md:w-64"
@@ -509,6 +524,7 @@ export default function PayrollTimeClient() {
           </div>
         )}
       </AdminPanel>
+      </details>
 
       {csvPreview ? (
         <AdminPanel>

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -1,5 +1,6 @@
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { createHash } from "crypto";
+import { getShopDayRange } from "@/features/shared/lib/utils/shopDayWindow";
 
 export type PayrollPeriodStatus = "draft" | "open" | "approved" | "exported";
 
@@ -32,6 +33,19 @@ function startOfUtcDay(dateIso: string): Date {
 
 function toIsoDate(d: Date): string {
   return d.toISOString().slice(0, 10);
+}
+
+export function toShopDate(iso: string, timezone: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(iso));
+}
+
+export function localDateToUtcBoundary(dateKey: string, timezone: string): string {
+  return getShopDayRange(timezone, new Date(`${dateKey}T12:00:00.000Z`)).start;
 }
 
 function addDays(d: Date, days: number): Date {
@@ -143,6 +157,9 @@ export async function getOrCreateCurrentPeriod(shopId: string, actorId: string) 
   const admin = createAdminSupabase() as any;
   const today = new Date();
 
+  const { data: shop } = await admin.from("shops").select("timezone").eq("id", shopId).maybeSingle();
+  const timezone = shop?.timezone ?? "UTC";
+
   const { data: settings } = await admin
     .from("shop_payroll_settings")
     .select("*")
@@ -162,7 +179,7 @@ export async function getOrCreateCurrentPeriod(shopId: string, actorId: string) 
   const cadence = payrollSettings?.cadence ?? "biweekly";
   const weekStartsOn = Number(payrollSettings?.week_starts_on ?? 1);
 
-  const todayUtc = startOfUtcDay(today.toISOString());
+  const todayUtc = startOfUtcDay(`${toShopDate(today.toISOString(), timezone)}T00:00:00.000Z`);
   const day = todayUtc.getUTCDay();
   const diffToWeekStart = (day - weekStartsOn + 7) % 7;
   const currentWeekStart = addDays(todayUtc, -diffToWeekStart);
@@ -207,6 +224,58 @@ export async function getOrCreateCurrentPeriod(shopId: string, actorId: string) 
   return { settings: payrollSettings, period: created.data };
 }
 
+async function getPeriodSourceState(admin: any, shopId: string, period: any, timezone: string) {
+  const rangeStart = localDateToUtcBoundary(period.period_start, timezone);
+  const rangeEnd = localDateToUtcBoundary(toIsoDate(addDays(startOfUtcDay(`${period.period_end}T00:00:00.000Z`), 1)), timezone);
+  const [{ data: shifts }, { data: jobs }, { data: settings }, { count: entriesCount }] = await Promise.all([
+    admin.from("tech_shifts").select("id, start_time, end_time, created_at").eq("shop_id", shopId).neq("excluded_from_payroll", true).gte("start_time", rangeStart).lt("start_time", rangeEnd),
+    admin.from("work_order_line_labor_segments").select("id, started_at, ended_at, updated_at, created_at").eq("shop_id", shopId).gte("started_at", rangeStart).lt("started_at", rangeEnd),
+    admin.from("shop_payroll_settings").select("updated_at").eq("shop_id", shopId).maybeSingle(),
+    admin.from("payroll_time_entries").select("id", { count: "exact", head: true }).eq("shop_id", shopId).eq("period_id", period.id),
+  ]);
+  const shiftIds = (shifts ?? []).map((s: any) => s.id).filter(Boolean);
+  const { data: punches } = shiftIds.length
+    ? await admin.from("punch_events").select("id, timestamp, created_at").in("shift_id", shiftIds)
+    : { data: [] };
+  const candidates = [
+    period.created_at,
+    settings?.updated_at,
+    ...(shifts ?? []).flatMap((s: any) => [s.created_at, s.start_time, s.end_time]),
+    ...(jobs ?? []).flatMap((j: any) => [j.created_at, j.updated_at, j.started_at, j.ended_at]),
+    ...(punches ?? []).flatMap((p: any) => [p.created_at, p.timestamp]),
+  ].filter(Boolean).map((v) => new Date(v).getTime()).filter(Number.isFinite);
+  return {
+    entriesCount: entriesCount ?? 0,
+    sourceCount: (shifts?.length ?? 0) + (jobs?.length ?? 0),
+    sourceFreshAt: candidates.length ? new Date(Math.max(...candidates)).toISOString() : null,
+    rangeStart,
+    rangeEnd,
+  };
+}
+
+export async function refreshOpenPeriodIfStale(params: { shopId: string; actorId: string; periodId: string }) {
+  const admin = createAdminSupabase() as any;
+  const { data: period, error } = await admin.from("payroll_pay_periods").select("*").eq("shop_id", params.shopId).eq("id", params.periodId).maybeSingle();
+  if (error || !period) throw new Error(error?.message ?? "Pay period not found");
+  if (!["draft", "open"].includes(String(period.status))) {
+    return { refreshed: false, reason: "locked", hasSourceTime: false, refreshError: null };
+  }
+  const { data: shop } = await admin.from("shops").select("timezone").eq("id", params.shopId).maybeSingle();
+  const state = await getPeriodSourceState(admin, params.shopId, period, shop?.timezone ?? "UTC");
+  const periodUpdated = period.updated_at ? new Date(period.updated_at).getTime() : 0;
+  const sourceUpdated = state.sourceFreshAt ? new Date(state.sourceFreshAt).getTime() : 0;
+  if (state.entriesCount === 0 || sourceUpdated > periodUpdated) {
+    try {
+      await rebuildPeriod(params);
+      return { refreshed: true, reason: state.entriesCount === 0 ? "empty" : "stale", hasSourceTime: state.sourceCount > 0, refreshError: null };
+    } catch (err) {
+      console.error("payroll open-period auto-refresh failed", err);
+      return { refreshed: false, reason: "refresh_failed", hasSourceTime: state.sourceCount > 0, refreshError: err instanceof Error ? err.message : "Payroll refresh failed" };
+    }
+  }
+  return { refreshed: false, reason: "fresh", hasSourceTime: state.sourceCount > 0, refreshError: null };
+}
+
 export async function rebuildPeriod(params: { shopId: string; actorId: string; periodId: string }) {
   const { shopId, periodId } = params;
   const admin = createAdminSupabase() as any;
@@ -233,8 +302,10 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
   const dailyOvertimeAfter = policy.daily_overtime_after_minutes;
   const suspiciousShiftMinutes = policy.suspicious_shift_minutes;
 
-  const rangeStart = `${period.period_start}T00:00:00.000Z`;
-  const rangeEnd = `${period.period_end}T23:59:59.999Z`;
+  const { data: shop } = await admin.from("shops").select("timezone").eq("id", shopId).maybeSingle();
+  const timezone = shop?.timezone ?? "UTC";
+  const rangeStart = localDateToUtcBoundary(period.period_start, timezone);
+  const rangeEnd = localDateToUtcBoundary(toIsoDate(addDays(startOfUtcDay(`${period.period_end}T00:00:00.000Z`), 1)), timezone);
 
   const [{ data: shifts, error: shiftsErr }, { data: jobSegments, error: jobsErr }] = await Promise.all([
     admin
@@ -243,13 +314,13 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
       .eq("shop_id", shopId)
       .neq("excluded_from_payroll", true)
       .gte("start_time", rangeStart)
-      .lte("start_time", rangeEnd),
+      .lt("start_time", rangeEnd),
     admin
       .from("work_order_line_labor_segments")
       .select("id, technician_id, started_at, ended_at")
       .eq("shop_id", shopId)
       .gte("started_at", rangeStart)
-      .lte("started_at", rangeEnd),
+      .lt("started_at", rangeEnd),
   ]);
 
   if (shiftsErr) throw new Error(shiftsErr.message);
@@ -298,7 +369,7 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
 
   for (const shift of shifts ?? []) {
     if (!shift.user_id) continue;
-    const workDate = toIsoDate(startOfUtcDay(shift.start_time));
+    const workDate = toShopDate(shift.start_time, timezone);
     const key = `${shift.user_id}:${workDate}`;
     const row = rowsByKey.get(key) ?? {
       user_id: shift.user_id,
@@ -309,7 +380,7 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
       job_minutes: 0,
       warnings: 0,
       blocking: 0,
-      source_snapshot: { shift_ids: [], open_shift_ids: [] },
+      source_snapshot: { shift_ids: [], open_shift_ids: [], shifts: [] },
     };
 
     const endTime = shift.end_time ?? new Date().toISOString();
@@ -351,6 +422,11 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
       : [];
     ids.push(shift.id);
     row.source_snapshot.shift_ids = ids;
+    const shiftSummaries = Array.isArray(row.source_snapshot.shifts)
+      ? (row.source_snapshot.shifts as Array<Record<string, unknown>>)
+      : [];
+    shiftSummaries.push({ id: shift.id, start_time: shift.start_time, end_time: shift.end_time, status: shift.status });
+    row.source_snapshot.shifts = shiftSummaries;
     row.source_snapshot = {
       ...row.source_snapshot,
       break_source: events.length > 0 ? "punch_events" : "none_recorded",
@@ -413,7 +489,7 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
 
   for (const seg of jobSegments ?? []) {
     if (!seg.technician_id || !seg.started_at) continue;
-    const workDate = toIsoDate(startOfUtcDay(seg.started_at));
+    const workDate = toShopDate(seg.started_at, timezone);
     const key = `${seg.technician_id}:${workDate}`;
     const row = rowsByKey.get(key) ?? {
       user_id: seg.technician_id,
@@ -424,7 +500,7 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
       job_minutes: 0,
       warnings: 0,
       blocking: 0,
-      source_snapshot: { shift_ids: [], open_shift_ids: [], job_segment_ids: [] },
+      source_snapshot: { shift_ids: [], open_shift_ids: [], shifts: [], job_segment_ids: [] },
     };
 
     if (!seg.ended_at) {
@@ -519,7 +595,7 @@ export async function approvePeriod(params: { shopId: string; periodId: string; 
   const admin = createAdminSupabase() as any;
   const { shopId, periodId, actorId } = params;
 
-  const { data: blocking } = await admin
+  const { count: blockingCount, error: blockingErr } = await admin
     .from("payroll_time_exceptions")
     .select("id", { count: "exact", head: true })
     .eq("shop_id", shopId)
@@ -527,7 +603,8 @@ export async function approvePeriod(params: { shopId: string; periodId: string; 
     .eq("severity", "blocking")
     .eq("resolved", false);
 
-  if ((blocking?.length ?? 0) > 0) {
+  if (blockingErr) throw new Error(blockingErr.message);
+  if ((blockingCount ?? 0) > 0) {
     throw new Error("Cannot approve period with unresolved blocking exceptions.");
   }
 

--- a/tests/payroll-time-open-period-refresh.test.ts
+++ b/tests/payroll-time-open-period-refresh.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "fs";
+import { describe, expect, it } from "vitest";
+import { localDateToUtcBoundary, toShopDate } from "../features/payroll-time/server/payrollTime";
+
+const routeSource = readFileSync("app/api/payroll-time/periods/route.ts", "utf8");
+const payrollSource = readFileSync("features/payroll-time/server/payrollTime.ts", "utf8");
+const uiSource = readFileSync("features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx", "utf8");
+
+describe("payroll time open-period visibility contract", () => {
+  it("auto-refreshes open periods before loading entries and distinguishes refresh failure", () => {
+    expect(routeSource).toContain("refreshOpenPeriodIfStale");
+    expect(routeSource.indexOf("refreshOpenPeriodIfStale")).toBeLessThan(routeSource.indexOf('.from("payroll_time_entries")'));
+    expect(routeSource).toContain("Time records exist, but payroll totals could not be refreshed.");
+    expect(routeSource).toContain("No employee time has been recorded for this pay period.");
+  });
+
+  it("does not hide source attendance behind workforce payroll_ready flags", () => {
+    expect(payrollSource).toContain('.from("tech_shifts")');
+    expect(payrollSource).toContain('.from("work_order_line_labor_segments")');
+    expect(payrollSource).not.toMatch(/from\("tech_shifts"\)[\s\S]{0,700}payroll_ready/);
+    expect(payrollSource).not.toMatch(/from\("work_order_line_labor_segments"\)[\s\S]{0,700}payroll_ready/);
+  });
+
+  it("uses profiles fallback for snapshot/source employees without workforce profile rows", () => {
+    expect(routeSource).toContain('.from("profiles")');
+    expect(routeSource).toContain("fallbackProfileById");
+  });
+
+  it("removes derived-entry and rebuild-first terminology from the primary workflow", () => {
+    expect(uiSource).not.toContain("No derived entries");
+    expect(uiSource).not.toContain("Rebuild from source");
+    expect(uiSource).toContain("Approve Payroll");
+    expect(uiSource).toContain("Export Payroll");
+    expect(uiSource).toContain("Recalculate");
+  });
+});
+
+describe("payroll time shop-local period boundaries", () => {
+  it("includes a Calgary evening shift crossing UTC midnight on the local work date", () => {
+    expect(toShopDate("2026-07-02T03:30:00.000Z", "America/Edmonton")).toBe("2026-07-01");
+  });
+
+  it("uses shift-start local date for overnight shift work_date", () => {
+    expect(toShopDate("2026-07-02T05:30:00.000Z", "America/Edmonton")).toBe("2026-07-01");
+  });
+
+  it("builds period boundaries from shop-local calendar days", () => {
+    expect(localDateToUtcBoundary("2026-07-01", "America/Edmonton")).toBe("2026-07-01T06:00:00.000Z");
+    expect(localDateToUtcBoundary("2026-07-01", "UTC")).toBe("2026-07-01T00:00:00.000Z");
+  });
+});


### PR DESCRIPTION
### Motivation
- Owners reported empty Payroll Time even when canonical source shifts exist; investigation showed the UI relied on `payroll_time_entries` snapshots (and UTC day boundaries), so open/draft periods without a built snapshot hid recorded attendance.
- The goal is to auto-rebuild open periods when the durable snapshot is empty or stale, use shop-local day boundaries, and keep roster/roster-only flags from hiding real attendance while preserving existing snapshot/approval/export semantics.

### Description
- Add an automatic open-period refresh: implemented `refreshOpenPeriodIfStale` and call it from `GET /api/payroll-time/periods` so open/draft periods rebuild when empty or stale but never auto-rebuild when `approved`/`exported`.
- Use shop-local date boundaries and shift-start local work_date: added `toShopDate` and `localDateToUtcBoundary` and switched period-source queries and work_date derivation to use the shop timezone.
- Preserve durable snapshot and calculations: `rebuildPeriod` still writes `payroll_time_entries` and `payroll_time_exceptions` with the same calculation model (attendance, paid/unpaid breaks, job time, overtime), and existing manual `rebuild` endpoint remains (renamed label in UI to `Recalculate`).
- Visibility and identity fixes: roster-only rows remain controlled by `people_workforce_profiles.payroll_ready`, but actual source attendance no longer depends on that flag and a profile fallback is used when `people_workforce_profiles` rows are absent.
- UI simplifications and assistant: simplified first-screen copy and actions ("Payroll Time", "Approve Payroll", "Export Payroll", "Recalculate"), added a deterministic non-blocking Payroll Assistant summary, and surfaced a distinct zero vs refresh-failure state returned by the API.
- Small correctness fixes: approval blocking count uses Supabase `count` head query to reliably detect unresolved blocking exceptions.
- Tests and contract: added focused contract tests `tests/payroll-time-open-period-refresh.test.ts` covering auto-refresh ordering, profile fallback, UI copy, and shop-local date behavior.

### Testing
- Ran focused unit tests: `pnpm test tests/payroll-time-rest-policy.test.ts tests/payroll-time-open-period-refresh.test.ts` — both test files passed (all tests green).
- Typecheck: `pnpm typecheck` — passed with no type errors.
- Lint: `pnpm lint` — produced pre-existing repository lint warnings/errors unrelated to payroll changes; touched files only added expected lightweight warnings (no new blocking lint errors introduced in the payroll code-path).
- Full test suite: `pnpm test` — the full suite surfaced unrelated pre-existing failures (smoke test around searchParams mock, vehicle-history import architecture expectations, and an OpenAI structured mock); these failures are outside the scope of this change and the focused payroll tests passed.
- Production build: `pnpm build` — failed in the execution environment because `next/font` could not fetch Google Fonts (`Inter` and `Black Ops One`); this is an environment/network limitation rather than a regression in the payroll changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a530e344120832885e06bb5d92cd2cb)