### PR TITLE
Separate inventory selection from Add-to-Work-Order in Parts Request workbench

### DIFF
--- a/app/api/parts/requests/items/[itemId]/inventory/route.ts
+++ b/app/api/parts/requests/items/[itemId]/inventory/route.ts
@@ -56,6 +56,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ itemId: string
   if (!item) return NextResponse.json({ ok: false, error: "Request item not found." }, { status: 404 });
 
   let partId: string;
+  let selectedPart: DB["public"]["Tables"]["parts"]["Row"] | null = null;
   if (body.mode === "attach") {
     if (!isUuid(body.partId)) return NextResponse.json({ ok: false, error: "Invalid partId." }, { status: 400 });
 
@@ -69,6 +70,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ itemId: string
     if (partError) return NextResponse.json({ ok: false, error: partError.message }, { status: 500 });
     if (!part) return NextResponse.json({ ok: false, error: "Inventory part not found." }, { status: 404 });
     partId = part.id;
+    selectedPart = part as DB["public"]["Tables"]["parts"]["Row"];
   } else {
     const name = clean(body.name);
     if (!name) return NextResponse.json({ ok: false, error: "Name is required." }, { status: 400 });
@@ -97,6 +99,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ itemId: string
 
     if (partError) return NextResponse.json({ ok: false, error: partError.message }, { status: 500 });
     partId = part.id;
+    selectedPart = part as DB["public"]["Tables"]["parts"]["Row"];
 
     const initialQty = num(body.initialQty) ?? 0;
     const locationId = clean(body.locationId);
@@ -129,5 +132,19 @@ export async function POST(req: Request, ctx: { params: Promise<{ itemId: string
 
   if (updateError) return NextResponse.json({ ok: false, error: updateError.message }, { status: 500 });
 
-  return NextResponse.json({ ok: true, item: updatedItem, partId });
+  return NextResponse.json({
+    ok: true,
+    item: updatedItem,
+    partId,
+    part: selectedPart
+      ? {
+          id: selectedPart.id,
+          name: selectedPart.name,
+          sku: selectedPart.sku,
+          part_number: selectedPart.part_number,
+          manufacturer: selectedPart.supplier,
+          sell_price: selectedPart.price ?? selectedPart.default_price ?? null,
+        }
+      : null,
+  });
 }

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -230,6 +230,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
   const [supplierSuggestionAppliedByItemId, setSupplierSuggestionAppliedByItemId] = useState<Record<string, boolean>>({});
   const [conflictWarningByItemId, setConflictWarningByItemId] = useState<Record<string, string>>({});
   const [conflictOverrideByItemId, setConflictOverrideByItemId] = useState<Record<string, boolean>>({});
+  const [addedToWorkOrderByItemId, setAddedToWorkOrderByItemId] = useState<Record<string, boolean>>({});
 
   function clearConflictOverride(itemId: string): void {
     setConflictOverrideByItemId((prev) => {
@@ -404,6 +405,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       setStockAvailableByPartId({});
       setSupplierSuggestionsByItemId({});
       setSupplierSuggestionAppliedByItemId({});
+      setAddedToWorkOrderByItemId({});
       setLoading(false);
       return;
     }
@@ -457,6 +459,27 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     });
 
     setRequests(uiRequests);
+
+    const requestItemIds = uiRequests.flatMap((request) => request.items.map((item) => String(item.id)));
+    if (requestItemIds.length > 0) {
+      const { data: attachedRows, error: attachedError } = await supabase
+        .from("work_order_parts")
+        .select("source_parts_request_item_id")
+        .in("source_parts_request_item_id", requestItemIds)
+        .eq("is_active", true);
+      if (attachedError) {
+        toast.warning(attachedError.message);
+        setAddedToWorkOrderByItemId({});
+      } else {
+        setAddedToWorkOrderByItemId(Object.fromEntries(
+          ((attachedRows ?? []) as Array<{ source_parts_request_item_id: string | null }>).flatMap((row) =>
+            row.source_parts_request_item_id ? [[String(row.source_parts_request_item_id), true] as const] : [],
+          ),
+        ));
+      }
+    } else {
+      setAddedToWorkOrderByItemId({});
+    }
 
     // ✅ Load all line complaint/description for this work order (used for UI + fallback linking)
     {
@@ -1709,7 +1732,8 @@ if (!lineId || !isUuid(lineId)) {
         // ignore
       }
 
-      toast.success("Added to the work order line.");
+      setAddedToWorkOrderByItemId((prev) => ({ ...prev, [itemId]: true }));
+      toast.success("Part added to work order.");
       setConflictWarningByItemId((prev) => {
         const next = { ...prev };
         delete next[itemId];
@@ -1873,6 +1897,7 @@ if (!lineId || !isUuid(lineId)) {
                       ]),
                     ),
                     conflictWarningByItemId,
+                    addedToWorkOrderByItemId,
                   });
 
                   return (
@@ -1965,14 +1990,47 @@ if (!lineId || !isUuid(lineId)) {
                             headers: { "Content-Type": "application/json" },
                             body: JSON.stringify({ mode: "attach", partId: input.partId }),
                           });
-                          const body = await res.json().catch(() => null) as { ok?: boolean; error?: string } | null;
+                          const body = await res.json().catch(() => null) as { ok?: boolean; error?: string; item?: ItemRow } | null;
                           if (!res.ok || !body?.ok) {
                             toast.error(body?.error || "Could not attach inventory part.");
                             return;
                           }
 
-                          toast.success("Inventory part attached.");
-                          await load();
+                          if (body.item) {
+                            updateItem(r.req.id, input.itemId, {
+                              ...body.item,
+                              ui_part_id: body.item.part_id ?? input.partId,
+                              ui_price:
+                                typeof selectedRecord?.price === "number"
+                                  ? selectedRecord.price
+                                  : selectedRecord?.price == null
+                                    ? undefined
+                                    : Number(selectedRecord.price),
+                              ui_added: false,
+                            } as Partial<UiItem>);
+                          }
+                          setAddedToWorkOrderByItemId((prev) => {
+                            const next = { ...prev };
+                            delete next[input.itemId];
+                            return next;
+                          });
+                          toast.success("Inventory part selected.");
+                          void load();
+                          return body.item
+                            ? {
+                                partId: body.item.part_id ?? input.partId,
+                                description: body.item.description ?? existingItem?.description ?? "Part",
+                                requestedPartNumber: body.item.requested_part_number ?? null,
+                                requestedManufacturer: body.item.requested_manufacturer ?? null,
+                                qty: toNum(body.item.qty, existingItem?.ui_qty ?? 1),
+                                sellPrice: body.item.quoted_price == null ? null : toNum(body.item.quoted_price, 0),
+                                status: body.item.status ?? null,
+                                poId: ((body.item as unknown) as { po_id?: string | null }).po_id ?? null,
+                                qtyReceived: toNum(((body.item as unknown) as { qty_received?: unknown }).qty_received, 0),
+                                qtyApproved: toNum(((body.item as unknown) as { qty_approved?: unknown }).qty_approved, 0),
+                                addedToWorkOrder: false,
+                              }
+                            : { partId: input.partId, addedToWorkOrder: false };
                         }}
                         onCreateInventoryItem={async (itemId, input) => {
                           const res = await fetch(`/api/parts/requests/items/${itemId}/inventory`, {
@@ -1990,7 +2048,7 @@ if (!lineId || !isUuid(lineId)) {
                               locationId: resolvedDefaultLocId || defaultLocationId || null,
                             }),
                           });
-                          const body = await res.json().catch(() => null) as { ok?: boolean; error?: string } | null;
+                          const body = await res.json().catch(() => null) as { ok?: boolean; error?: string; item?: ItemRow } | null;
                           if (!res.ok || !body?.ok) {
                             toast.error(body?.error || "Could not create inventory item.");
                             return;

--- a/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
@@ -2,8 +2,9 @@ import React from "react";
 (globalThis as unknown as { React: typeof React }).React = React;
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PartsRequestWorkbench } from "./PartsRequestWorkbench";
+import { toast } from "sonner";
 import { mapRequestToWorkbenchModel } from "./mapToWorkbenchModel";
 import type { PartsRequestWorkbenchModel } from "./types";
 
@@ -45,6 +46,9 @@ function model(partId: string | null = "part-1"): PartsRequestWorkbenchModel {
 }
 
 describe("PartsRequestWorkbench inventory attach flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
   it("uses Attach Part as the primary unattached action and does not show no-stock or permanent suggestion warnings", () => {
     render(<PartsRequestWorkbench model={model(null)} />);
 
@@ -52,7 +56,7 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
     expect(screen.queryByText("Use Inventory")).not.toBeInTheDocument();
     expect(screen.queryByText("No stock")).not.toBeInTheDocument();
     expect(screen.queryByText("Suggested match")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Add to Job" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add to Work Order" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Receive" })).not.toBeInTheDocument();
   });
 
@@ -74,9 +78,63 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
 
     expect(screen.getByDisplayValue("Oil filter")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Part #")).toHaveValue("");
-    expect(screen.getByText("Attached: ACDelco Oil Filter")).toBeInTheDocument();
+    expect(screen.getByText("Selected: ACDelco Oil Filter")).toBeInTheDocument();
     expect(screen.getByText("79 on hand")).toBeInTheDocument();
     expect(screen.queryByText("Possible mismatch")).not.toBeInTheDocument();
+  });
+
+
+  it("separates inventory selection from Add to Work Order", async () => {
+    const user = userEvent.setup();
+    const onAttachInventory = vi.fn(async () => ({ partId: "part-2", addedToWorkOrder: false }));
+    const onAddToJob = vi.fn();
+
+    render(<PartsRequestWorkbench model={model(null)} onAttachInventory={onAttachInventory} onAddToJob={onAddToJob} />);
+
+    await user.click(screen.getByRole("button", { name: "Attach Part" }));
+    await user.click(screen.getByLabelText(/ACDelco Oil Filter/i));
+    await user.click(screen.getAllByRole("button", { name: "Attach Part" }).at(-1)!);
+
+    await waitFor(() => expect(onAttachInventory).toHaveBeenCalledTimes(1));
+    expect(onAddToJob).not.toHaveBeenCalled();
+    expect(screen.getByText("Selected: ACDelco Oil Filter")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add to Work Order" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Change Part" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Add to Work Order" }));
+    expect(onAddToJob).toHaveBeenCalledWith(expect.objectContaining({ id: "item-1", partId: "part-2", addedToWorkOrder: false }));
+  });
+
+  it("hides Add to Work Order after the durable add state is loaded", () => {
+    const attachedModel = model("part-2");
+    attachedModel.items[0] = { ...attachedModel.items[0], addedToWorkOrder: true };
+
+    render(<PartsRequestWorkbench model={attachedModel} />);
+
+    expect(screen.getByText("Added to work order")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add to Work Order" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Change Part" })).not.toBeInTheDocument();
+  });
+
+  it("does not perform Add to Work Order when mismatch acknowledgement is confirmed", async () => {
+    const user = userEvent.setup();
+    const onConfirmConflict = vi.fn();
+    const onAddToJob = vi.fn();
+    const conflictModel = model("part-2");
+    conflictModel.items[0] = {
+      ...conflictModel.items[0],
+      requestedPartNumber: "BRAKE-123",
+      insights: [{ id: "mismatch", kind: "possible_mismatch", label: "Possible mismatch" }],
+    };
+
+    render(<PartsRequestWorkbench model={conflictModel} onConfirmConflict={onConfirmConflict} onAddToJob={onAddToJob} />);
+
+    await user.click(screen.getByRole("button", { name: "Attach anyway" }));
+    await user.click(screen.getAllByRole("button", { name: "Attach anyway" }).at(-1)!);
+
+    expect(onConfirmConflict).toHaveBeenCalledWith("item-1");
+    expect(onAddToJob).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith("Mismatch acknowledged. You can add the selected part now.");
   });
 
   it("shows exact selected part metadata in mismatch confirmation", async () => {

--- a/features/parts/components/request-workbench/PartsRequestWorkbench.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbench.tsx
@@ -43,7 +43,7 @@ export function PartsRequestWorkbench({
   model: PartsRequestWorkbenchModel;
   onSaveItem?: (input: SaveItemInput) => Promise<void> | void;
   onUseInventory?: (itemId: string) => Promise<void> | void;
-  onAttachInventory?: (input: AttachInventoryInput) => Promise<void> | void;
+  onAttachInventory?: (input: AttachInventoryInput) => Promise<Partial<PartsRequestWorkbenchItem> | void> | Partial<PartsRequestWorkbenchItem> | void;
   onOrderItem?: (itemId: string) => Promise<void> | void;
   onAddToJob?: (item: PartsRequestWorkbenchItem) => Promise<void> | void;
   onSubmitOrder?: (itemId: string, input: OrderPartInput) => Promise<void> | void;
@@ -245,11 +245,26 @@ export function PartsRequestWorkbench({
 
           await onResetConflictOverride?.(activeItem.id);
 
-          await onAttachInventory?.({
+          const updated = await onAttachInventory?.({
             itemId: activeItem.id,
             partId: result.partId,
             warningAccepted: result.warningAccepted,
           });
+
+          if (updated) {
+            setItems((current) =>
+              current.map((item) =>
+                item.id === activeItem.id
+                  ? {
+                      ...item,
+                      ...updated,
+                      partId: updated.partId ?? result.partId,
+                      addedToWorkOrder: updated.addedToWorkOrder ?? item.addedToWorkOrder ?? false,
+                    }
+                  : item,
+              ),
+            );
+          }
 
           setSelectedInventoryPartId("");
           setInventoryQuery("");

--- a/features/parts/components/request-workbench/PartsRequestWorkbenchRow.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbenchRow.tsx
@@ -49,6 +49,8 @@ export function PartsRequestWorkbenchRow({
     "rounded-lg border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2.5 py-2 text-xs text-neutral-100 hover:bg-white/5";
 
   const hasPossibleMismatch = item.insights?.some((insight) => insight.kind === "possible_mismatch") ?? false;
+  const hasSelectedPart = !!item.partId && !!selectedPart;
+  const isAddedToWorkOrder = item.addedToWorkOrder === true;
 
   return (
     <tr className="border-t border-[color:var(--desktop-border)] align-top">
@@ -110,7 +112,7 @@ export function PartsRequestWorkbenchRow({
         <div className="space-y-2">
           {selectedPart ? (
             <div className="rounded-xl border border-emerald-400/25 bg-emerald-950/15 p-2 text-xs text-emerald-100">
-              <div className="font-medium">Attached: {selectedPart.label}</div>
+              <div className="font-medium">Selected: {selectedPart.label}</div>
               <div className="mt-1 text-emerald-100/80">
                 {[selectedPart.partNumber || selectedPart.sku, selectedPart.manufacturer].filter(Boolean).join(" • ") || "No part metadata"}
               </div>
@@ -120,6 +122,7 @@ export function PartsRequestWorkbenchRow({
                   : Number(selectedPart.onHandQty) > 0
                     ? `${Number(selectedPart.onHandQty)} on hand`
                     : "No stock"}
+                {selectedPart.sellPrice != null ? ` • Sell price ${money(selectedPart.sellPrice)}` : ""}
               </div>
             </div>
           ) : null}
@@ -152,6 +155,7 @@ export function PartsRequestWorkbenchRow({
               event.currentTarget.value = "";
               if (value === "save") onSave?.(item.id);
               if (value === "inventory") onUseInventory?.(item.id);
+              if (value === "add") onAddToJob?.(item);
               if (value === "order") onOrder?.(item.id);
               if (value === "receive") onReceive?.(item.id);
               if (value === "stock") onAddToStock?.(item.id);
@@ -162,7 +166,8 @@ export function PartsRequestWorkbenchRow({
           >
             <option value="">Actions</option>
             <option value="save">Save</option>
-            <option value="inventory">Attach Part</option>
+            {hasSelectedPart && !isAddedToWorkOrder ? <option value="add">Add to Work Order</option> : null}
+            <option value="inventory">{hasSelectedPart ? "Change Part" : "Attach Part"}</option>
             <option value="order">Order</option>
             {item.poId || item.qtyReceived ? <option value="receive">Receive</option> : null}
             <option value="stock">Add to Stock</option>
@@ -173,9 +178,10 @@ export function PartsRequestWorkbenchRow({
         ) : (
           <div className="flex min-w-[12rem] flex-wrap gap-1.5">
             <button type="button" className={action} onClick={() => onSave?.(item.id)}>Save</button>
-            <button type="button" className={action} onClick={() => onUseInventory?.(item.id)}>Attach Part</button>
-            <button type="button" className={action} onClick={() => onOrder?.(item.id)}>Order</button>
-            {item.partId ? <button type="button" className={action} onClick={() => onAddToJob?.(item)}>Add to Job</button> : null}
+            {hasSelectedPart && !isAddedToWorkOrder ? <button type="button" className={action} onClick={() => onAddToJob?.(item)}>Add to Work Order</button> : null}
+            {!isAddedToWorkOrder ? <button type="button" className={action} onClick={() => onUseInventory?.(item.id)}>{hasSelectedPart ? "Change Part" : "Attach Part"}</button> : null}
+            {!isAddedToWorkOrder ? <button type="button" className={action} onClick={() => onOrder?.(item.id)}>Order</button> : null}
+            {isAddedToWorkOrder ? <span className="rounded-lg border border-emerald-400/25 bg-emerald-500/10 px-2.5 py-2 text-xs text-emerald-100">Added to work order</span> : null}
             {item.poId || item.qtyReceived ? <button type="button" className={action} onClick={() => onReceive?.(item.id)}>Receive</button> : null}
             <select
               className={action}

--- a/features/parts/components/request-workbench/mapToWorkbenchModel.ts
+++ b/features/parts/components/request-workbench/mapToWorkbenchModel.ts
@@ -27,6 +27,7 @@ export function mapRequestItemToWorkbenchItem(input: {
   availableStock?: number | null;
   supplierSuggestionCount?: number;
   conflictWarning?: string | null;
+  addedToWorkOrder?: boolean;
 }): PartsRequestWorkbenchItem {
   const item = input.item;
   const qty = num(item.ui_qty ?? item.qty ?? item.qty_requested, 1);
@@ -47,6 +48,7 @@ export function mapRequestItemToWorkbenchItem(input: {
     poId: nullableText(item.ui_po_id ?? item.po_id),
     qtyReceived,
     qtyApproved,
+    addedToWorkOrder: input.addedToWorkOrder === true,
     insights: buildWorkbenchInsights({
       hasSuggestedMatch: false,
       noStock: Boolean(nullableText(item.ui_part_id ?? item.part_id) && input.availableStock != null && num(input.availableStock, 0) <= 0),
@@ -75,6 +77,7 @@ export function mapRequestToWorkbenchModel(input: {
   availableStockByItemId?: Record<string, number>;
   supplierSuggestionCountByItemId?: Record<string, number>;
   conflictWarningByItemId?: Record<string, string>;
+  addedToWorkOrderByItemId?: Record<string, boolean>;
 }): PartsRequestWorkbenchModel {
   const requestId = text(input.request.id);
   const requestLabel = text(input.request.custom_id, requestId ? requestId.slice(0, 8) : "Request");
@@ -100,6 +103,7 @@ export function mapRequestToWorkbenchModel(input: {
         sku: nullableText(part.sku),
         partNumber: nullableText(part.part_number),
         manufacturer: nullableText(part.manufacturer ?? part.supplier),
+        sellPrice: part.price == null && part.default_price == null ? null : num(part.price ?? part.default_price, 0),
         onHandQty: Object.prototype.hasOwnProperty.call(input.stockAvailableByPartId ?? {}, partId)
           ? input.stockAvailableByPartId?.[partId]
           : null,
@@ -113,6 +117,7 @@ export function mapRequestToWorkbenchModel(input: {
         availableStock: input.availableStockByItemId?.[itemId] ?? null,
         supplierSuggestionCount: input.supplierSuggestionCountByItemId?.[itemId] ?? 0,
         conflictWarning: input.conflictWarningByItemId?.[itemId] ?? null,
+        addedToWorkOrder: input.addedToWorkOrderByItemId?.[itemId] ?? false,
       });
     }),
   };

--- a/features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts
+++ b/features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const inventoryRoute = readFileSync("app/api/parts/requests/items/[itemId]/inventory/route.ts", "utf8");
+const addRoute = readFileSync("app/api/parts/requests/items/[itemId]/add/route.ts", "utf8");
+const page = readFileSync("app/parts/requests/[id]/page.tsx", "utf8");
+
+describe("parts request inventory lifecycle route separation", () => {
+  it("keeps inventory selection scoped to persisting part_request_items.part_id", () => {
+    expect(inventoryRoute).toContain('body.mode === "attach"');
+    expect(inventoryRoute).toContain(".from(\"part_request_items\")");
+    expect(inventoryRoute).toContain("part_id: partId");
+    expect(inventoryRoute).not.toContain("upsert_part_allocation_from_request_item");
+    expect(inventoryRoute).not.toContain("upsert-from-line");
+    expect(inventoryRoute).not.toContain("work_order_parts");
+    expect(inventoryRoute).not.toContain("work_order_line_id:");
+  });
+
+  it("keeps Add to Work Order on the canonical add route and downstream side effects", () => {
+    expect(addRoute).toContain("upsert_part_allocation_from_request_item");
+    expect(page).toContain("/api/parts/requests/items/${itemId}/add");
+    expect(page).toContain("/api/menu-items/upsert-from-line");
+    expect(page).toContain("Part added to work order.");
+  });
+
+  it("uses work_order_parts source linkage rather than part_id as the durable added state", () => {
+    expect(page).toContain("source_parts_request_item_id");
+    expect(page).toContain("setAddedToWorkOrderByItemId");
+    expect(page).toContain("addedToWorkOrderByItemId");
+  });
+});

--- a/features/parts/components/request-workbench/types.ts
+++ b/features/parts/components/request-workbench/types.ts
@@ -41,6 +41,7 @@ export type PartsRequestWorkbenchItem = {
   poId?: string | null;
   qtyReceived?: number | null;
   qtyApproved?: number | null;
+  addedToWorkOrder?: boolean;
   insights?: SmartInsight[];
 };
 
@@ -49,6 +50,7 @@ export type PartsRequestInventoryResult = WorkbenchOption & {
   partNumber?: string | null;
   manufacturer?: string | null;
   onHandQty?: number | null;
+  sellPrice?: number | null;
 };
 
 export type PartsRequestWorkbenchModel = {


### PR DESCRIPTION
### Motivation
- The inventory picker was causing the full add-to-work-order workflow to run when a user clicked `Attach Part`, conflating two distinct lifecycle actions and preventing the expected intermediate state from persisting.
- The UI treated a persisted `part_request_items.part_id` as if the part were already added to the job, which created incorrect actions and toasts.
- The change restores the intended two-step flow: select inventory (persist `part_id`) → then explicitly `Add to Work Order` (perform allocation and downstream side effects).

### Description
- Kept the picker `Attach Part` using the canonical inventory-selection route (`/api/parts/requests/items/[itemId]/inventory`) and updated that route to return the selected part display data without invoking allocation or work-order side effects. (`app/api/parts/requests/items/[itemId]/inventory/route.ts`)
- Added durable tracking of the actual added state using active `work_order_parts.source_parts_request_item_id` and exposed `addedToWorkOrder` into the workbench model instead of inferring added-from-selected. (`app/parts/requests/[id]/page.tsx`, `mapToWorkbenchModel.ts`)
- Updated workbench UI and types to distinguish selection vs final attach: show `Selected:` with stock and sell-price after inventory-selection, show `Add to Work Order` only when a selected part exists and is not yet added, and show an `Added to work order` state once the durable add is confirmed. (`PartsRequestWorkbenchRow.tsx`, `types.ts`, `PartsRequestWorkbench.tsx`)
- Changed success copy to `Inventory part selected.` for selection and `Part added to work order.` for the final add, and ensure the picker updates the row immediately from the inventory-selection response before closing. (`app/parts/requests/[id]/page.tsx`, `PartsRequestWorkbench.tsx`)
- Added focused regression tests proving separation and behavior: `partsRequestInventoryLifecycle.test.ts` plus adjustments to `PartsRequestWorkbench` tests and modal tests. (`features/parts/components/request-workbench/*`)

### Testing
- Ran `pnpm typecheck` which passed successfully.
- Ran the focused test command `pnpm exec vitest run features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx features/parts/components/request-workbench/InventoryPickerModal.test.tsx features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts` and it passed (all related tests succeeded).
- Attempted `pnpm lint` but it failed due to pre-existing unrelated lint errors in other files; these are not introduced by this PR.
- Attempted `pnpm build` but the environment build step was blocked by external Google font fetch failures (network/font fetch issues), so a full production build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5316e8431c8328a7c6858fa4c5ec11)