### PR TITLE
Restore staged parts package commit flow

### DIFF
--- a/app/api/parts/requests/[requestId]/commit-package/route.ts
+++ b/app/api/parts/requests/[requestId]/commit-package/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DB = Database;
+type PartRequestItem = DB["public"]["Tables"]["part_request_items"]["Row"];
+
+type ItemResult =
+  | { itemId: string; status: "committed" | "already_committed"; workOrderPartId: string }
+  | { itemId: string; status: "skipped"; reason: string }
+  | { itemId: string; status: "error"; error: string };
+
+function isUuid(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.trim());
+}
+
+function positiveQuantity(item: PartRequestItem): number {
+  const raw = item.qty_requested ?? item.qty;
+  const parsed = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function descriptionFor(item: PartRequestItem): string {
+  return String(item.description ?? "").trim();
+}
+
+async function ensureWorkOrderPart(
+  supabase: SupabaseClient<DB>,
+  itemId: string,
+): Promise<string> {
+  const { data, error } = await supabase.rpc("parts_ensure_work_order_part" as never, {
+    p_request_item_id: itemId,
+  } as never);
+  if (error) throw new Error(error.message);
+  if (!isUuid(data)) throw new Error("Canonical parts package helper did not return a work-order part id.");
+  return data;
+}
+
+export async function POST(_req: Request, ctx: { params: Promise<{ requestId: string }> }) {
+  const { requestId } = await ctx.params;
+  if (!isUuid(requestId)) return NextResponse.json({ ok: false, error: "Invalid requestId." }, { status: 400 });
+
+  const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+  if (!access.ok) return access.response;
+
+  const supabase = access.supabase;
+  const shopId = access.profile.shop_id;
+
+  const { data: request, error: requestError } = await supabase
+    .from("part_requests")
+    .select("id, shop_id, work_order_id, status")
+    .eq("id", requestId)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (requestError) return NextResponse.json({ ok: false, error: requestError.message }, { status: 500 });
+  if (!request) return NextResponse.json({ ok: false, error: "Parts request not found for this shop." }, { status: 404 });
+  if (!request.work_order_id) {
+    return NextResponse.json({ ok: false, error: "Parts request is not linked to a work order." }, { status: 409 });
+  }
+
+  const { data: workOrder, error: workOrderError } = await supabase
+    .from("work_orders")
+    .select("id, shop_id")
+    .eq("id", request.work_order_id)
+    .eq("shop_id", shopId)
+    .maybeSingle();
+  if (workOrderError) return NextResponse.json({ ok: false, error: workOrderError.message }, { status: 500 });
+  if (!workOrder) return NextResponse.json({ ok: false, error: "Related work order is not available for this shop." }, { status: 403 });
+
+  const { data: itemsData, error: itemsError } = await supabase
+    .from("part_request_items")
+    .select("*")
+    .eq("request_id", requestId)
+    .eq("shop_id", shopId)
+    .order("created_at", { ascending: true });
+  if (itemsError) return NextResponse.json({ ok: false, error: itemsError.message }, { status: 500 });
+
+  const items = (itemsData ?? []) as PartRequestItem[];
+  const itemIds = items.map((item) => item.id);
+  const existingByItemId = new Map<string, string>();
+  if (itemIds.length > 0) {
+    const { data: existingRows, error: existingError } = await supabase
+      .from("work_order_parts")
+      .select("id, source_parts_request_item_id")
+      .in("source_parts_request_item_id", itemIds)
+      .eq("shop_id", shopId)
+      .eq("is_active", true);
+    if (existingError) return NextResponse.json({ ok: false, error: existingError.message }, { status: 500 });
+    for (const row of (existingRows ?? []) as Array<{ id: string; source_parts_request_item_id: string | null }>) {
+      if (row.source_parts_request_item_id) existingByItemId.set(row.source_parts_request_item_id, row.id);
+    }
+  }
+
+  const results: ItemResult[] = [];
+  for (const item of items) {
+    const itemId = String(item.id);
+    const existingId = existingByItemId.get(itemId);
+    if (existingId) {
+      results.push({ itemId, status: "already_committed", workOrderPartId: existingId });
+      continue;
+    }
+
+    if (!item.part_id) {
+      results.push({ itemId, status: "skipped", reason: "Select an inventory part before saving this item to the work order." });
+      continue;
+    }
+    if (!item.work_order_line_id) {
+      results.push({ itemId, status: "skipped", reason: "Item is not linked to a work-order repair line." });
+      continue;
+    }
+    if (item.work_order_id && item.work_order_id !== request.work_order_id) {
+      results.push({ itemId, status: "error", error: "Item work order does not match the parent request." });
+      continue;
+    }
+    if (positiveQuantity(item) <= 0) {
+      results.push({ itemId, status: "skipped", reason: "Quantity must be greater than zero." });
+      continue;
+    }
+    if (!descriptionFor(item)) {
+      results.push({ itemId, status: "skipped", reason: "Description is required." });
+      continue;
+    }
+
+    const { data: line, error: lineError } = await supabase
+      .from("work_order_lines")
+      .select("id, work_order_id, shop_id")
+      .eq("id", item.work_order_line_id)
+      .eq("work_order_id", request.work_order_id)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+    if (lineError) {
+      results.push({ itemId, status: "error", error: lineError.message });
+      continue;
+    }
+    if (!line) {
+      results.push({ itemId, status: "error", error: "Work-order line is not available for this shop or request." });
+      continue;
+    }
+
+    try {
+      const workOrderPartId = await ensureWorkOrderPart(supabase, itemId);
+      results.push({ itemId, status: "committed", workOrderPartId });
+    } catch (error) {
+      results.push({ itemId, status: "error", error: error instanceof Error ? error.message : "Could not save item to work order." });
+    }
+  }
+
+  const committed = results.filter((result): result is Extract<ItemResult, { workOrderPartId: string }> => result.status === "committed" || result.status === "already_committed");
+  const errors = results.filter((result) => result.status === "error");
+  const skipped = results.filter((result) => result.status === "skipped");
+  const ok = errors.length === 0 && skipped.length === 0;
+
+  return NextResponse.json({
+    ok,
+    requestId,
+    committedCount: committed.length,
+    skippedCount: skipped.length,
+    results,
+    workOrderPartIds: committed.map((result) => result.workOrderPartId),
+    errorsRequiringReview: [...errors, ...skipped],
+  }, { status: errors.length > 0 ? 409 : 200 });
+}

--- a/app/api/parts/requests/items/[itemId]/inventory/route.ts
+++ b/app/api/parts/requests/items/[itemId]/inventory/route.ts
@@ -131,6 +131,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ itemId: string
     .maybeSingle();
 
   if (updateError) return NextResponse.json({ ok: false, error: updateError.message }, { status: 500 });
+  if (!updatedItem) {
+    return NextResponse.json({ ok: false, error: "Inventory selection did not persist. The item may have changed or your shop access was blocked." }, { status: 409 });
+  }
 
   return NextResponse.json({
     ok: true,

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -18,7 +18,6 @@ import {
   PARTS_REQUEST_WORKBENCH_V2_LOCAL_FLAG,
   PartsRequestWorkbench,
   mapRequestToWorkbenchModel,
-  type PartsRequestWorkbenchItem,
   type SaveItemInput,
 } from "@/features/parts/components/request-workbench";
 import {
@@ -71,14 +70,6 @@ type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
 type LineLite = Pick<WorkOrderLineRow, "id" | "complaint" | "description">;
 
 type Status = RequestRow["status"];
-
-type UpsertResponse = {
-  ok: boolean;
-  menuItemId?: string;
-  updated?: boolean;
-  error?: string;
-  detail?: string;
-};
 
 type UiItem = ItemRow & {
   ui_part_id: string | null;
@@ -1416,7 +1407,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          quoteLineId,
+          quoteLineId: quoteLineId!,
           description: String(it.description ?? "").trim(),
           qty,
           quotedPrice: price,
@@ -1714,26 +1705,11 @@ if (!lineId || !isUuid(lineId)) {
       window.dispatchEvent(new Event("parts-request:submitted"));
       window.dispatchEvent(new Event("wo:parts-used"));
 
-      try {
-        const res = await fetch("/api/menu-items/upsert-from-line", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ workOrderLineId: safeLineId }),
-        });
+      // Reusable menu learning intentionally does not run from staged parts-package saves.
 
-        const j = (await res.json().catch(() => null)) as UpsertResponse | null;
-
-        if (!res.ok || !j?.ok) {
-          toast.warning(
-            j?.detail || j?.error || "Added, but couldn’t save to menu items.",
-          );
-        }
-      } catch {
-        // ignore
-      }
 
       setAddedToWorkOrderByItemId((prev) => ({ ...prev, [itemId]: true }));
-      toast.success("Part added to work order.");
+      toast.success("Part saved to work order.");
       setConflictWarningByItemId((prev) => {
         const next = { ...prev };
         delete next[itemId];
@@ -1744,6 +1720,49 @@ if (!lineId || !isUuid(lineId)) {
         delete next[itemId];
         return next;
       });
+    } finally {
+      setSavingReqId(null);
+    }
+  }
+
+  async function commitPartsPackage(requestId: string): Promise<void> {
+    setSavingReqId(requestId);
+    try {
+      const res = await fetch(`/api/parts/requests/${requestId}/commit-package`, { method: "POST" });
+      const body = (await res.json().catch(() => null)) as {
+        ok?: boolean;
+        committedCount?: number;
+        skippedCount?: number;
+        errorsRequiringReview?: Array<{ itemId?: string; reason?: string; error?: string }>;
+        results?: Array<{ itemId?: string; status?: string; workOrderPartId?: string }>;
+        error?: string;
+      } | null;
+
+      if (!res.ok || !body) {
+        toast.error(body?.error || "Could not save parts package to work order.");
+        return;
+      }
+
+      const review = body.errorsRequiringReview ?? [];
+      if (!body.ok || review.length > 0) {
+        toast.warning(`Parts package needs review: ${review.length} item${review.length === 1 ? "" : "s"} not saved.`);
+      } else {
+        toast.success(`Parts package saved to work order (${body.committedCount ?? 0} item${body.committedCount === 1 ? "" : "s"}).`);
+      }
+
+      setAddedToWorkOrderByItemId((prev) => {
+        const next = { ...prev };
+        for (const result of body.results ?? []) {
+          if (result.itemId && (result.status === "committed" || result.status === "already_committed")) {
+            next[result.itemId] = true;
+          }
+        }
+        return next;
+      });
+
+      window.dispatchEvent(new Event("parts-request:submitted"));
+      window.dispatchEvent(new Event("wo:parts-used"));
+      await load();
     } finally {
       setSavingReqId(null);
     }
@@ -1870,7 +1889,7 @@ if (!lineId || !isUuid(lineId)) {
                     ? lineLabelFrom(lineById.get(lineId))
                     : "";
 
-                if (PARTS_REQUEST_WORKBENCH_V2_LOCAL_FLAG || searchParams.get("workbenchV2") === "1") {
+                if (PARTS_REQUEST_WORKBENCH_V2_LOCAL_FLAG || searchParams.get("workbenchV2") !== "0") {
                   const model = mapRequestToWorkbenchModel({
                     request: r.req as unknown as Record<string, unknown>,
                     items: r.items as unknown as Record<string, unknown>[],
@@ -2015,7 +2034,6 @@ if (!lineId || !isUuid(lineId)) {
                             return next;
                           });
                           toast.success("Inventory part selected.");
-                          void load();
                           return body.item
                             ? {
                                 partId: body.item.part_id ?? input.partId,
@@ -2056,16 +2074,8 @@ if (!lineId || !isUuid(lineId)) {
                           toast.success("Inventory item created and attached.");
                           await load();
                         }}
-                        onAddToJob={async (item: PartsRequestWorkbenchItem) => {
-                          await addAndAttach(r.req.id, item.id, {
-                            partId: item.partId ?? null,
-                            qty: item.qty,
-                            sellPrice: item.sellPrice,
-                            description: item.description,
-                            requestedPartNumber: item.requestedPartNumber ?? null,
-                            requestedManufacturer: item.requestedManufacturer ?? null,
-                          });
-                          await load();
+                        onCommitPackage={() => {
+                          void commitPartsPackage(r.req.id);
                         }}
                         onSubmitOrder={async (itemId, input) => {
                           updateItem(r.req.id, itemId, {
@@ -2124,11 +2134,11 @@ if (!lineId || !isUuid(lineId)) {
                               ? new Date(r.req.created_at).toLocaleString()
                               : "—"}
                             <span className="mx-2 text-neutral-600">·</span>
-                            Line: {hasValidLineId ? lineId.slice(0, 8) : "Not linked"}
+                            Line: {hasValidLineId && lineId ? String(lineId).slice(0, 8) : "Not linked"}
                             {hasQuoteLineOrigin ? (
                               <>
                                 <span className="mx-2 text-neutral-600">·</span>
-                                Quote line: {quoteLineId.slice(0, 8)}
+                                Quote line: {quoteLineId ? String(quoteLineId).slice(0, 8) : "—"}
                               </>
                             ) : null}
                           </div>
@@ -2749,7 +2759,7 @@ if (!lineId || !isUuid(lineId)) {
                                             ? "Saving…"
                                             : isQuoteOnlyPreApprovalItem
                                               ? "Save Quote"
-                                              : "Add to Job"}
+                                              : "Save to Work Order"}
                                         </button>
 
                                         {isQuoteOnlyPreApprovalItem ? (

--- a/docs/audits/api-route-boundary-inventory.json
+++ b/docs/audits/api-route-boundary-inventory.json
@@ -8,14 +8,32 @@
     "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
-    "hasServiceRolePattern": true,
+    "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "internal",
+    "routeClassGuess": "customer_or_portal",
     "riskFlags": [
-      "service_role_with_shop_identifier_input_or_reference"
+      "has_stronger_boundary_signal"
     ],
-    "riskLevel": "medium"
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/admin/diagnostics/user-auth/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
   },
   {
     "path": "app/api/admin/people/[id]/certifications/[certId]/route.ts",
@@ -225,7 +243,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -257,7 +275,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -273,7 +291,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": true,
     "hasShopReference": false,
@@ -289,7 +307,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -306,7 +324,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -323,7 +341,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": true,
     "hasShopReference": true,
@@ -429,7 +447,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -477,7 +495,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -493,7 +511,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -559,13 +577,31 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/assistant/attachments/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "public_or_token",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -593,7 +629,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -610,7 +646,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -618,6 +654,24 @@
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
     "riskLevel": "low"
+  },
+  {
+    "path": "app/api/auth/resolve-login/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
   },
   {
     "path": "app/api/auth/send-reset-email/route.ts",
@@ -645,6 +699,24 @@
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/billing/work-orders/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -986,6 +1058,24 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/customers/import/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/dashboard/ai-mission-control/route.ts",
     "methods": [
       "GET"
@@ -1047,7 +1137,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1083,7 +1173,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1185,7 +1275,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1201,7 +1291,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1217,7 +1307,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1233,7 +1323,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1249,7 +1339,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1265,7 +1355,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1281,7 +1371,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1299,7 +1389,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1315,7 +1405,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1331,7 +1421,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1348,15 +1438,31 @@
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/import-jobs/[jobId]/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [
-      "mutating_without_obvious_auth_marker"
+      "has_stronger_boundary_signal"
     ],
-    "riskLevel": "high"
+    "riskLevel": "low"
   },
   {
     "path": "app/api/inspections/build-from-prompt/route.ts",
@@ -1366,15 +1472,13 @@
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
+    "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
+    "riskFlags": [],
+    "riskLevel": "low"
   },
   {
     "path": "app/api/inspections/build/route.ts",
@@ -1401,7 +1505,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1417,7 +1521,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1434,15 +1538,13 @@
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
+    "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
+    "riskFlags": [],
+    "riskLevel": "low"
   },
   {
     "path": "app/api/inspections/load/route.ts",
@@ -1451,7 +1553,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1467,7 +1569,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1483,7 +1585,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1499,7 +1601,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1515,7 +1617,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1531,7 +1633,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1547,7 +1649,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1563,7 +1665,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1579,7 +1681,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -1613,7 +1715,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -1730,170 +1832,9 @@
     "riskLevel": "low"
   },
   {
-    "path": "app/api/internal/onboarding-agent/customer-vehicle-links/upsert/route.ts",
+    "path": "app/api/internal/import-jobs/tick/route.ts",
     "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/customers/upsert/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/final-summary/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/history/upsert/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/invoice-history/upsert/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/parts/upsert/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/review-items/create/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/validate-shop/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/vehicles/upsert/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "internal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/internal/onboarding-agent/vendors/upsert/route.ts",
-    "methods": [
+      "GET",
       "POST"
     ],
     "isMutating": true,
@@ -1952,13 +1893,31 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/invoices/import/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -2002,7 +1961,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2019,7 +1978,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2035,7 +1994,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2051,7 +2010,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2085,7 +2044,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -2101,7 +2060,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2117,7 +2076,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2133,7 +2092,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2149,7 +2108,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2165,7 +2124,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -2181,7 +2140,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2197,7 +2156,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2213,7 +2172,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2229,7 +2188,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2245,7 +2204,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -2261,7 +2220,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -2277,7 +2236,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2293,7 +2252,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2311,7 +2270,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2327,7 +2286,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -2343,7 +2302,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -2393,10 +2352,44 @@
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
-    "hasRoleOrCapabilityReference": true,
+    "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [
       "mutating_without_obvious_auth_marker"
@@ -2404,533 +2397,103 @@
     "riskLevel": "high"
   },
   {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/activate-customers-vehicles/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/activate-history/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/activate-parts/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/activate-vendors/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/activate/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/activation-plan/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/analyze/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/rerun/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/resolve-customer-vehicle-link/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "customer_or_portal",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/route.ts",
+    "path": "app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts",
     "methods": [
       "GET",
-      "DELETE"
+      "PATCH"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
+    "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [
-      "has_stronger_boundary_signal"
+      "mutating_without_obvious_auth_marker"
     ],
-    "riskLevel": "low"
+    "riskLevel": "high"
   },
   {
-    "path": "app/api/onboarding-agent/sessions/[sessionId]/upload-files/route.ts",
+    "path": "app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
+    "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [
-      "has_stronger_boundary_signal"
+      "mutating_without_obvious_auth_marker"
     ],
-    "riskLevel": "low"
+    "riskLevel": "high"
   },
   {
-    "path": "app/api/onboarding-agent/sessions/route.ts",
+    "path": "app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/onboarding-v2/guided/sessions/route.ts",
     "methods": [
       "GET",
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/agent-diagnostics/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/agent-readiness/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/activation-summary/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/activation-tick/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/analyze/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/confirm/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/entities/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/events/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/files/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/links/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/materialization-records/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/recommendations/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/review-items/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/[sessionId]/summary/route.ts",
-    "methods": [
-      "GET"
-    ],
-    "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding-v2/sessions/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "has_stronger_boundary_signal"
-    ],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding/bootstrap-owner/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
-    "hasAuthGetUser": true,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/onboarding/shop-boost/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
@@ -2942,22 +2505,6 @@
       "mutating_without_obvious_auth_marker"
     ],
     "riskLevel": "high"
-  },
-  {
-    "path": "app/api/onboarding/shop-defaults/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
-    "hasAuthGetUser": true,
-    "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "public_or_token",
-    "riskFlags": [],
-    "riskLevel": "low"
   },
   {
     "path": "app/api/openai/realtime-token/route.ts",
@@ -3032,7 +2579,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3064,7 +2611,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3128,13 +2675,31 @@
     "riskLevel": "high"
   },
   {
+    "path": "app/api/parts/requests/[requestId]/commit-package/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "public_or_token",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/parts/requests/create/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -3144,7 +2709,219 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/parts/requests/items/[itemId]/add/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "public_or_token",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/allocate/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/cancel/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/edit/route.ts",
+    "methods": [
+      "PATCH"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "public_or_token",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/inventory/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "public_or_token",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/po-line/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/quote-line-sync/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/quote-save/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/parts/requests/items/[itemId]/receive/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/release/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/parts/requests/items/[itemId]/replace/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/parts/work-order-parts/[partId]/issue/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/parts/work-order-parts/[partId]/return/route.ts",
     "methods": [
       "POST"
     ],
@@ -3282,13 +3059,32 @@
     "riskLevel": "high"
   },
   {
+    "path": "app/api/payroll-time/settings/route.ts",
+    "methods": [
+      "GET",
+      "PUT"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
     "path": "app/api/planner/apply/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3304,7 +3100,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3320,7 +3116,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3336,7 +3132,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3352,7 +3148,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3368,7 +3164,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3402,7 +3198,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -3418,7 +3214,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3434,7 +3230,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -3451,7 +3247,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3468,7 +3264,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3484,7 +3280,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -3500,7 +3296,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -3516,7 +3312,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3558,13 +3354,29 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/portal/qr/setup/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/portal/request/add-custom-line/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3580,7 +3392,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3596,7 +3408,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3612,7 +3424,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3628,7 +3440,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3644,7 +3456,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3660,8 +3472,8 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
-    "hasAuthGetUser": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
@@ -3676,8 +3488,8 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
-    "hasAuthGetUser": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
@@ -3692,7 +3504,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -3708,7 +3520,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -3760,14 +3572,16 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
-    "hasServiceRolePattern": false,
+    "hasServiceRolePattern": true,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
-    "riskFlags": [],
-    "riskLevel": "low"
+    "riskFlags": [
+      "service_role_with_shop_identifier_input_or_reference"
+    ],
+    "riskLevel": "medium"
   },
   {
     "path": "app/api/quotes/send-for-approval/route.ts",
@@ -3830,7 +3644,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -3916,7 +3730,7 @@
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "public_or_token",
+    "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -3963,13 +3777,15 @@
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "public_or_token",
-    "riskFlags": [],
-    "riskLevel": "low"
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
   },
   {
     "path": "app/api/scheduling/shifts/route.ts",
@@ -4197,7 +4013,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4213,7 +4029,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4229,7 +4045,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4263,7 +4079,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4279,7 +4095,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4295,7 +4111,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4311,7 +4127,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4327,7 +4143,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4379,7 +4195,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4395,7 +4211,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4465,7 +4281,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4499,7 +4315,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4565,7 +4381,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": true,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4601,7 +4417,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4635,7 +4451,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4761,7 +4577,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": true,
     "hasShopReference": true,
@@ -4805,6 +4621,40 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/vehicles/duplicate-check/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/vehicles/import/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/vin/extract-from-image/route.ts",
     "methods": [
       "POST"
@@ -4812,15 +4662,13 @@
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
+    "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
+    "riskFlags": [],
+    "riskLevel": "low"
   },
   {
     "path": "app/api/vin/route.ts",
@@ -4830,15 +4678,13 @@
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
+    "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
+    "riskFlags": [],
+    "riskLevel": "low"
   },
   {
     "path": "app/api/work-orders/[id]/ai-review/route.ts",
@@ -4978,7 +4824,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -4994,7 +4840,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5011,7 +4857,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5029,7 +4875,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5083,7 +4929,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5116,14 +4962,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
-    "hasAuthGetUser": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -5152,7 +5000,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5162,13 +5010,31 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/work-orders/history/import/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/work-orders/import-from-inspection/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5184,7 +5050,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5200,7 +5066,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5216,7 +5082,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5232,7 +5098,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5248,7 +5114,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5264,7 +5130,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5280,14 +5146,16 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
-    "hasAuthGetUser": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
+    "hasShopReference": false,
     "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "public_or_token",
-    "riskFlags": [],
-    "riskLevel": "low"
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
   },
   {
     "path": "app/api/work-orders/lines/add-from-menu/route.ts",
@@ -5296,7 +5164,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5312,7 +5180,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5346,7 +5214,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5362,7 +5230,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5378,7 +5246,7 @@
     ],
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5388,13 +5256,31 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/work-orders/quotes/[id]/approval-decision/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": true,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "service_role_with_shop_identifier_input_or_reference"
+    ],
+    "riskLevel": "medium"
+  },
+  {
     "path": "app/api/work-orders/quotes/[id]/approval/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5410,12 +5296,12 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
+    "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -5426,7 +5312,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5442,7 +5328,7 @@
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
@@ -5454,7 +5340,7 @@
     "riskLevel": "high"
   },
   {
-    "path": "app/api/work-orders/quotes/add/route.ts",
+    "path": "app/api/work-orders/quotes/add-from-menu-repair/route.ts",
     "methods": [
       "POST"
     ],
@@ -5470,13 +5356,29 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/work-orders/quotes/add/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/work-orders/smart-repair-match/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
@@ -5572,6 +5474,22 @@
       "service_role_with_shop_identifier_input_or_reference"
     ],
     "riskLevel": "medium"
+  },
+  {
+    "path": "app/api/workforce/attendance/corrections/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
   },
   {
     "path": "app/api/workforce/certifications-readiness/route.ts",

--- a/docs/audits/api-route-boundary-inventory.md
+++ b/docs/audits/api-route-boundary-inventory.md
@@ -1,20 +1,21 @@
 # API Route Boundary Inventory (Static Heuristic)
 
-Generated: 2026-05-21T22:52:21.495Z
+Generated: 2026-07-13T00:41:55.425Z
 
 ## Summary
-- Total route count: **335**
-- Routes exporting GET: **102**
-- Routes exporting POST: **240**
-- Routes exporting PUT: **6**
-- Routes exporting PATCH: **17**
-- Routes exporting DELETE: **12**
-- Routes with service-role pattern: **19**
-- Routes using requireShopScopedApiAccess: **82**
-- Routes with auth.getUser references: **147**
+- Total route count: **330**
+- Routes exporting GET: **94**
+- Routes exporting POST: **243**
+- Routes exporting PUT: **7**
+- Routes exporting PATCH: **19**
+- Routes exporting DELETE: **11**
+- Routes with service-role pattern: **20**
+- Routes using requireShopScopedApiAccess: **80**
+- Routes with auth.getUser references: **152**
 
 ## High-Risk Routes
 - `app/api/ai/interpret/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/auth/resolve-login/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/activate/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/archive/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/delete/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -26,30 +27,37 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/diag/log/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/dtc-suggest/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/fleet/service-requests/convert-to-work-order/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/generate-inspection/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/inspections/build-from-prompt/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/inspections/build/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/inspections/generate/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/inspections/submit/pdf/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/connect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/disconnect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/invoice/[id]/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/maintenance/suggestions/dismiss/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/ocr/registration/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/activation-tick/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/analyze/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/confirm/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding/shop-boost/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts` | methods: GET, PATCH | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/parts/consume/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/parts/items/[itemId]/receive/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/parts/receiving/receive-item/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/allocate/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/cancel/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/po-line/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/parts/requests/items/[itemId]/receive/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/release/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/replace/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/work-order-parts/[partId]/issue/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/work-order-parts/[partId]/return/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payments/checkout/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/approve/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/export/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/rebuild/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/payroll-time/settings/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/recalls/fetch/route.ts` | methods: POST | riskFlags: mutating_with_service_role_without_obvious_auth_or_boundary
+- `app/api/scheduling/shifts/[id]/route.ts` | methods: PATCH, DELETE | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop-boost/intakes/run/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop/owner-pin/clear/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shopreel/drafts/[id]/route.ts` | methods: PATCH | riskFlags: mutating_without_obvious_auth_marker
@@ -58,14 +66,12 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/stats/summarize/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/stripe/checkout/link-user/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/stripe/link-user/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/vin/extract-from-image/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/vin/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/[id]/invoice/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/[id]/mark-ready/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/work-orders/lines/add-from-menu-repair/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/quotes/[id]/mark-quoted/route.ts` | methods: PATCH | riskFlags: mutating_without_obvious_auth_marker
 
 ## Medium-Risk Routes
-- `app/api/admin/create-user/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/admin/reset-user-password/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/agent/requests/route.ts` | methods: GET, POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/assignables/route.ts` | methods: GET | riskFlags: service_role_with_shop_identifier_input_or_reference
@@ -73,18 +79,19 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/invoices/send/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/planner/uploads/sign/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/quotes/apply-ai/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
+- `app/api/quotes/approval-webhook/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/quotes/send/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/time/labor-segments/backfill/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/add-line/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/assign-line/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/lines/update-from-inspection/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
+- `app/api/work-orders/quotes/[id]/approval-decision/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/update-status/[id]/route.ts` | methods: GET | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/update-status/create/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/update-status/list/route.ts` | methods: GET | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/update-status/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 
 ## Service-Role Route List
-- `app/api/admin/create-user/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/admin/reset-user-password/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/agent/requests/[id]/notify-discord/route.ts` | methods: POST | riskFlags: none
 - `app/api/agent/requests/route.ts` | methods: GET, POST | riskFlags: service_role_with_shop_identifier_input_or_reference
@@ -93,12 +100,14 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/invoices/send/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/planner/uploads/sign/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/quotes/apply-ai/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
+- `app/api/quotes/approval-webhook/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/quotes/send/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/recalls/fetch/route.ts` | methods: POST | riskFlags: mutating_with_service_role_without_obvious_auth_or_boundary
 - `app/api/time/labor-segments/backfill/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/add-line/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/assign-line/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/lines/update-from-inspection/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
+- `app/api/work-orders/quotes/[id]/approval-decision/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/update-status/[id]/route.ts` | methods: GET | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/update-status/create/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/update-status/list/route.ts` | methods: GET | riskFlags: service_role_with_shop_identifier_input_or_reference
@@ -108,6 +117,7 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/agent/events/route.ts` | methods: GET | riskFlags: none
 - `app/api/ai/interpret/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/ai/suggest/route.ts` | methods: none | riskFlags: none
+- `app/api/auth/resolve-login/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/auth/send-reset-email/route.ts` | methods: none | riskFlags: none
 - `app/api/auth/send-reset/route.ts` | methods: none | riskFlags: none
 - `app/api/branding/active/route.ts` | methods: GET | riskFlags: none
@@ -122,10 +132,7 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/diag/log/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/dtc-suggest/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/fleet/service-requests/convert-to-work-order/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/generate-inspection/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/inspections/build-from-prompt/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/inspections/build/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/inspections/generate/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/inspections/load/route.ts` | methods: GET | riskFlags: none
 - `app/api/inspections/submit/pdf/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/connect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -134,25 +141,24 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/integrations/quickbooks/status/route.ts` | methods: GET | riskFlags: none
 - `app/api/maintenance/suggestions/dismiss/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/mobile/home-payload/route.ts` | methods: GET | riskFlags: none
-- `app/api/ocr/registration/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/activation-summary/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding-v2/sessions/[sessionId]/activation-tick/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/analyze/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/confirm/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/entities/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding-v2/sessions/[sessionId]/events/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding-v2/sessions/[sessionId]/files/content/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/onboarding-v2/sessions/[sessionId]/files/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding-v2/sessions/[sessionId]/links/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding-v2/sessions/[sessionId]/materialization-records/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding-v2/sessions/[sessionId]/recommendations/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding-v2/sessions/[sessionId]/review-items/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding-v2/sessions/[sessionId]/summary/route.ts` | methods: GET | riskFlags: none
-- `app/api/onboarding/shop-boost/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts` | methods: GET, PATCH | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/complete/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/skip/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/status/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/onboarding-v2/guided/sessions/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/parts/consume/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/parts/items/[itemId]/receive/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/parts/receiving/receive-item/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/allocate/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/cancel/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/po-line/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/parts/requests/items/[itemId]/receive/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/release/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/requests/items/[itemId]/replace/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/work-order-parts/[partId]/issue/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/parts/work-order-parts/[partId]/return/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payments/checkout/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/approve/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/export/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -160,6 +166,8 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/payroll-time/exports/route.ts` | methods: GET | riskFlags: none
 - `app/api/payroll-time/periods/route.ts` | methods: GET | riskFlags: none
 - `app/api/payroll-time/rebuild/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/payroll-time/settings/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/scheduling/shifts/[id]/route.ts` | methods: PATCH, DELETE | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/settings/update/shop/owner-pin/set/route.ts` | methods: none | riskFlags: none
 - `app/api/shop-boost/intakes/run/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop/owner-pin/clear/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -170,10 +178,9 @@ Generated: 2026-05-21T22:52:21.495Z
 - `app/api/stats/tech-leaderboard/route.ts` | methods: none | riskFlags: none
 - `app/api/stripe/checkout/link-user/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/stripe/link-user/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/vin/extract-from-image/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/vin/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/[id]/invoice/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/[id]/mark-ready/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/work-orders/lines/add-from-menu-repair/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/work-orders/quotes/[id]/mark-quoted/route.ts` | methods: PATCH | riskFlags: mutating_without_obvious_auth_marker
 
 ## Notes

--- a/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
@@ -84,25 +84,25 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
   });
 
 
-  it("separates inventory selection from Add to Work Order", async () => {
+  it("separates inventory selection from the request-level package save", async () => {
     const user = userEvent.setup();
     const onAttachInventory = vi.fn(async () => ({ partId: "part-2", addedToWorkOrder: false }));
-    const onAddToJob = vi.fn();
+    const onCommitPackage = vi.fn();
 
-    render(<PartsRequestWorkbench model={model(null)} onAttachInventory={onAttachInventory} onAddToJob={onAddToJob} />);
+    render(<PartsRequestWorkbench model={model(null)} onAttachInventory={onAttachInventory} onCommitPackage={onCommitPackage} />);
 
     await user.click(screen.getByRole("button", { name: "Attach Part" }));
     await user.click(screen.getByLabelText(/ACDelco Oil Filter/i));
     await user.click(screen.getAllByRole("button", { name: "Attach Part" }).at(-1)!);
 
     await waitFor(() => expect(onAttachInventory).toHaveBeenCalledTimes(1));
-    expect(onAddToJob).not.toHaveBeenCalled();
+    expect(onCommitPackage).not.toHaveBeenCalled();
     expect(screen.getByText("Selected: ACDelco Oil Filter")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Add to Work Order" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Add to Work Order" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Change Part" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Add to Work Order" }));
-    expect(onAddToJob).toHaveBeenCalledWith(expect.objectContaining({ id: "item-1", partId: "part-2", addedToWorkOrder: false }));
+    await user.click(screen.getByRole("button", { name: "Save Parts Package to Work Order" }));
+    expect(onCommitPackage).toHaveBeenCalledTimes(1);
   });
 
   it("hides Add to Work Order after the durable add state is loaded", () => {
@@ -111,7 +111,7 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
 
     render(<PartsRequestWorkbench model={attachedModel} />);
 
-    expect(screen.getByText("Added to work order")).toBeInTheDocument();
+    expect(screen.getByText("Saved to work order")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Add to Work Order" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Change Part" })).not.toBeInTheDocument();
   });
@@ -119,7 +119,7 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
   it("does not perform Add to Work Order when mismatch acknowledgement is confirmed", async () => {
     const user = userEvent.setup();
     const onConfirmConflict = vi.fn();
-    const onAddToJob = vi.fn();
+    const onCommitPackage = vi.fn();
     const conflictModel = model("part-2");
     conflictModel.items[0] = {
       ...conflictModel.items[0],
@@ -127,13 +127,13 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
       insights: [{ id: "mismatch", kind: "possible_mismatch", label: "Possible mismatch" }],
     };
 
-    render(<PartsRequestWorkbench model={conflictModel} onConfirmConflict={onConfirmConflict} onAddToJob={onAddToJob} />);
+    render(<PartsRequestWorkbench model={conflictModel} onConfirmConflict={onConfirmConflict} onCommitPackage={onCommitPackage} />);
 
     await user.click(screen.getByRole("button", { name: "Attach anyway" }));
     await user.click(screen.getAllByRole("button", { name: "Attach anyway" }).at(-1)!);
 
     expect(onConfirmConflict).toHaveBeenCalledWith("item-1");
-    expect(onAddToJob).not.toHaveBeenCalled();
+    expect(onCommitPackage).not.toHaveBeenCalled();
     expect(toast.success).toHaveBeenCalledWith("Mismatch acknowledged. You can add the selected part now.");
   });
 

--- a/features/parts/components/request-workbench/PartsRequestWorkbench.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbench.tsx
@@ -29,7 +29,7 @@ export function PartsRequestWorkbench({
   onUseInventory,
   onAttachInventory,
   onOrderItem,
-  onAddToJob,
+  onCommitPackage,
   onSubmitOrder,
   onReceiveItem,
   onOpenReceiveDrawer,
@@ -45,7 +45,7 @@ export function PartsRequestWorkbench({
   onUseInventory?: (itemId: string) => Promise<void> | void;
   onAttachInventory?: (input: AttachInventoryInput) => Promise<Partial<PartsRequestWorkbenchItem> | void> | Partial<PartsRequestWorkbenchItem> | void;
   onOrderItem?: (itemId: string) => Promise<void> | void;
-  onAddToJob?: (item: PartsRequestWorkbenchItem) => Promise<void> | void;
+  onCommitPackage?: () => Promise<void> | void;
   onSubmitOrder?: (itemId: string, input: OrderPartInput) => Promise<void> | void;
   onReceiveItem?: (itemId: string) => Promise<void> | void;
   onOpenReceiveDrawer?: (itemId: string) => Promise<void> | void;
@@ -164,6 +164,9 @@ export function PartsRequestWorkbench({
           const firstItem = items[0];
           if (firstItem) setActiveModal({ type: "order", itemId: firstItem.id });
         }}
+        onCommitPackage={onCommitPackage}
+        commitPackageDisabled={items.length === 0}
+        packageCommittedCount={model.packageCommittedCount}
       />
 
       <PartsRequestWorkbenchSummary items={items} />
@@ -177,7 +180,6 @@ export function PartsRequestWorkbench({
           setActiveModal({ type: "inventory", itemId });
           await onUseInventory?.(itemId);
         }}
-        onAddToJob={onAddToJob}
         onConfirmConflict={(itemId) => setActiveModal({ type: "confirmConflict", itemId })}
         onResetConflictOverride={onResetConflictOverride}
         onOrder={async (itemId) => {

--- a/features/parts/components/request-workbench/PartsRequestWorkbenchHeader.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbenchHeader.tsx
@@ -15,6 +15,9 @@ export function PartsRequestWorkbenchHeader({
   supplierOptions,
   onDefaultSupplierChange,
   onCreatePo,
+  onCommitPackage,
+  commitPackageDisabled,
+  packageCommittedCount,
 }: {
   requestLabel: string;
   status?: string | null;
@@ -27,6 +30,9 @@ export function PartsRequestWorkbenchHeader({
   supplierOptions: WorkbenchOption[];
   onDefaultSupplierChange?: (supplierId: string) => void;
   onCreatePo?: () => void;
+  onCommitPackage?: () => void;
+  commitPackageDisabled?: boolean;
+  packageCommittedCount?: number;
 }): JSX.Element {
   const meta = [
     workOrderCustomId ? `Work Order: ${workOrderCustomId}` : null,
@@ -76,6 +82,23 @@ export function PartsRequestWorkbenchHeader({
             </option>
           ))}
         </select>
+
+        {packageCommittedCount && packageCommittedCount > 0 ? (
+          <span className="rounded-lg border border-emerald-400/25 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
+            {packageCommittedCount} saved to work order
+          </span>
+        ) : null}
+
+        {onCommitPackage ? (
+          <button
+            type="button"
+            onClick={onCommitPackage}
+            disabled={commitPackageDisabled}
+            className="rounded-lg border border-emerald-500/40 bg-emerald-600/85 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Save Parts Package to Work Order
+          </button>
+        ) : null}
 
         <button
           type="button"

--- a/features/parts/components/request-workbench/PartsRequestWorkbenchRow.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbenchRow.tsx
@@ -20,7 +20,6 @@ export function PartsRequestWorkbenchRow({
   onSave,
   onUseInventory,
   onOrder,
-  onAddToJob,
   onConfirmConflict,
   onReceive,
   onAddToStock,
@@ -35,7 +34,6 @@ export function PartsRequestWorkbenchRow({
   onSave?: (itemId: string) => void;
   onUseInventory?: (itemId: string) => void;
   onOrder?: (itemId: string) => void;
-  onAddToJob?: (item: PartsRequestWorkbenchItem) => void;
   onConfirmConflict?: (itemId: string) => void;
   onReceive?: (itemId: string) => void;
   onAddToStock?: (itemId: string) => void;
@@ -155,7 +153,6 @@ export function PartsRequestWorkbenchRow({
               event.currentTarget.value = "";
               if (value === "save") onSave?.(item.id);
               if (value === "inventory") onUseInventory?.(item.id);
-              if (value === "add") onAddToJob?.(item);
               if (value === "order") onOrder?.(item.id);
               if (value === "receive") onReceive?.(item.id);
               if (value === "stock") onAddToStock?.(item.id);
@@ -166,7 +163,6 @@ export function PartsRequestWorkbenchRow({
           >
             <option value="">Actions</option>
             <option value="save">Save</option>
-            {hasSelectedPart && !isAddedToWorkOrder ? <option value="add">Add to Work Order</option> : null}
             <option value="inventory">{hasSelectedPart ? "Change Part" : "Attach Part"}</option>
             <option value="order">Order</option>
             {item.poId || item.qtyReceived ? <option value="receive">Receive</option> : null}
@@ -178,10 +174,9 @@ export function PartsRequestWorkbenchRow({
         ) : (
           <div className="flex min-w-[12rem] flex-wrap gap-1.5">
             <button type="button" className={action} onClick={() => onSave?.(item.id)}>Save</button>
-            {hasSelectedPart && !isAddedToWorkOrder ? <button type="button" className={action} onClick={() => onAddToJob?.(item)}>Add to Work Order</button> : null}
             {!isAddedToWorkOrder ? <button type="button" className={action} onClick={() => onUseInventory?.(item.id)}>{hasSelectedPart ? "Change Part" : "Attach Part"}</button> : null}
             {!isAddedToWorkOrder ? <button type="button" className={action} onClick={() => onOrder?.(item.id)}>Order</button> : null}
-            {isAddedToWorkOrder ? <span className="rounded-lg border border-emerald-400/25 bg-emerald-500/10 px-2.5 py-2 text-xs text-emerald-100">Added to work order</span> : null}
+            {isAddedToWorkOrder ? <span className="rounded-lg border border-emerald-400/25 bg-emerald-500/10 px-2.5 py-2 text-xs text-emerald-100">Saved to work order</span> : null}
             {item.poId || item.qtyReceived ? <button type="button" className={action} onClick={() => onReceive?.(item.id)}>Receive</button> : null}
             <select
               className={action}

--- a/features/parts/components/request-workbench/PartsRequestWorkbenchTable.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbenchTable.tsx
@@ -11,7 +11,6 @@ export function PartsRequestWorkbenchTable({
   onSave,
   onUseInventory,
   onOrder,
-  onAddToJob,
   onConfirmConflict,
   onResetConflictOverride,
   onReceive,
@@ -26,7 +25,6 @@ export function PartsRequestWorkbenchTable({
   onSave?: (itemId: string) => void;
   onUseInventory?: (itemId: string) => void;
   onOrder?: (itemId: string) => void;
-  onAddToJob?: (item: PartsRequestWorkbenchItem) => void;
   onConfirmConflict?: (itemId: string) => void;
   onResetConflictOverride?: (itemId: string) => void;
   onReceive?: (itemId: string) => void;
@@ -73,7 +71,6 @@ export function PartsRequestWorkbenchTable({
               onSave={onSave}
               onUseInventory={onUseInventory}
               onOrder={onOrder}
-              onAddToJob={onAddToJob}
               onConfirmConflict={onConfirmConflict}
               onReceive={onReceive}
               onAddToStock={onAddToStock}

--- a/features/parts/components/request-workbench/mapToWorkbenchModel.ts
+++ b/features/parts/components/request-workbench/mapToWorkbenchModel.ts
@@ -109,6 +109,7 @@ export function mapRequestToWorkbenchModel(input: {
           : null,
       };
     }),
+    packageCommittedCount: Object.values(input.addedToWorkOrderByItemId ?? {}).filter(Boolean).length,
     items: input.items.map((item) => {
       const itemId = text(item.id);
       return mapRequestItemToWorkbenchItem({

--- a/features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts
+++ b/features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts
@@ -2,8 +2,9 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const inventoryRoute = readFileSync("app/api/parts/requests/items/[itemId]/inventory/route.ts", "utf8");
-const addRoute = readFileSync("app/api/parts/requests/items/[itemId]/add/route.ts", "utf8");
+const commitRoute = readFileSync("app/api/parts/requests/[requestId]/commit-package/route.ts", "utf8");
 const page = readFileSync("app/parts/requests/[id]/page.tsx", "utf8");
+const header = readFileSync("features/parts/components/request-workbench/PartsRequestWorkbenchHeader.tsx", "utf8");
 
 describe("parts request inventory lifecycle route separation", () => {
   it("keeps inventory selection scoped to persisting part_request_items.part_id", () => {
@@ -16,11 +17,13 @@ describe("parts request inventory lifecycle route separation", () => {
     expect(inventoryRoute).not.toContain("work_order_line_id:");
   });
 
-  it("keeps Add to Work Order on the canonical add route and downstream side effects", () => {
-    expect(addRoute).toContain("upsert_part_allocation_from_request_item");
-    expect(page).toContain("/api/parts/requests/items/${itemId}/add");
-    expect(page).toContain("/api/menu-items/upsert-from-line");
-    expect(page).toContain("Part added to work order.");
+  it("uses a request-level package commit without allocation or menu learning", () => {
+    expect(commitRoute).toContain("parts_ensure_work_order_part");
+    expect(commitRoute).not.toContain("upsert_part_allocation_from_request_item");
+    expect(commitRoute).not.toContain("upsert-from-line");
+    expect(page).toContain("/api/parts/requests/${requestId}/commit-package");
+    expect(header).toContain("Save Parts Package to Work Order");
+    expect(page).not.toContain("Part added to work order.");
   });
 
   it("uses work_order_parts source linkage rather than part_id as the durable added state", () => {

--- a/features/parts/components/request-workbench/types.ts
+++ b/features/parts/components/request-workbench/types.ts
@@ -69,6 +69,7 @@ export type PartsRequestWorkbenchModel = {
   inventoryResults?: PartsRequestInventoryResult[];
   defaultLocationId?: string | null;
   items: PartsRequestWorkbenchItem[];
+  packageCommittedCount?: number;
 };
 
 export type SaveItemInput = {


### PR DESCRIPTION
### Motivation

- Fix a production regression where selecting an inventory part could return `ok: true` without a persisted `part_request_items` row and then be overwritten by a reload, and restore the Parts Request as a durable staging workspace.
- Provide a single request-level action to materialize a complete parts package onto the work order while deferring allocation/PO/receipt lifecycle to later phases.

### Description

- Add request-level route `POST /api/parts/requests/[requestId]/commit-package` that validates shop scope, work-order/line linkage, iterates request items, and calls the canonical DB helper `parts_ensure_work_order_part` to create/reuse `work_order_parts` rows without allocation, PO creation, or menu-learning side effects.
- Make inventory selection route (`app/api/parts/requests/items/[itemId]/inventory/route.ts`) treat a missing updated row (`.maybeSingle()` returning null) as a failed persist and return a 409, preventing the client from showing a false success.
- Update the Parts Request workbench UI to remove per-row “Add to Work Order / Add to Job” actions and add a single request-level button `Save Parts Package to Work Order` in the header, and show durable saved state via `work_order_parts.source_parts_request_item_id` (also surface a `packageCommittedCount`).
- Stop triggering reusable menu-learning from the staged selection flow (do not call `app/api/menu-items/upsert-from-line` from staged selection), and update the workbench model and tests to assert separation between selection and durable commit.

### Testing

- Ran focused unit/UI tests: `pnpm exec vitest run features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts tests/parts/parts-lifecycle-sql.test.ts tests/parts/parts-lifecycle-manual-sql.test.ts tests/parts/parts-request-workflow-migration.test.ts` — all tests passed (23 tests total).
- Type-check: `pnpm typecheck` — passed.
- Lint: `pnpm exec eslint` against changed files (`app/parts/requests/[id]/page.tsx`, `app/api/parts/requests/[requestId]/commit-package/route.ts`, `app/api/parts/requests/items/[itemId]/inventory/route.ts`, and workbench components) — passed.
- Api-route audit: `pnpm audit:api-routes` — ran and refreshed audit output (`docs/audits/api-route-boundary-inventory.*`).
- Production build: `pnpm build` was attempted but failed in this environment due to inability to fetch Google Fonts (`Inter`, `Black Ops One`) from `fonts.googleapis.com`; this is an environment/network issue and not a TypeScript or runtime regression in the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54327ba7d083288ebe0e433bb87117)