### PR TITLE
Repair part_request_items UPDATE RLS and reconcile legacy inventory triggers

### DIFF
--- a/app/api/parts/requests/items/[itemId]/inventory/route.ts
+++ b/app/api/parts/requests/items/[itemId]/inventory/route.ts
@@ -134,6 +134,9 @@ export async function POST(req: Request, ctx: { params: Promise<{ itemId: string
   if (!updatedItem) {
     return NextResponse.json({ ok: false, error: "Inventory selection did not persist. The item may have changed or your shop access was blocked." }, { status: 409 });
   }
+  if (updatedItem.part_id !== partId) {
+    return NextResponse.json({ ok: false, error: "Inventory selection verification failed. Reload and try again." }, { status: 409 });
+  }
 
   return NextResponse.json({
     ok: true,

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -1988,16 +1988,6 @@ if (!lineId || !isUuid(lineId)) {
                             matchedPart: selectedPart,
                           });
 
-                          updateItem(r.req.id, input.itemId, {
-                            ui_part_id: input.partId,
-                            ui_price:
-                              typeof selectedRecord?.price === "number"
-                                ? selectedRecord.price
-                                : selectedRecord?.price == null
-                                  ? undefined
-                                  : Number(selectedRecord.price),
-                          });
-
                           if (conflict && !input.warningAccepted) {
                             setConflictWarningByItemId((prev) => ({ ...prev, [input.itemId]: conflict.message }));
                             toast.warning("Possible mismatch. Review the selected inventory part before attaching.");

--- a/db/sql/2026-07-13_parts_request_legacy_trigger_reconciliation_audit.sql
+++ b/db/sql/2026-07-13_parts_request_legacy_trigger_reconciliation_audit.sql
@@ -1,0 +1,53 @@
+-- Read-only diagnostics for legacy parts-request trigger reconciliation.
+-- This script intentionally performs no writes and should be reviewed before any historical repair.
+with movement_rollup as (
+  select
+    sm.shop_id,
+    coalesce(sm.part_request_item_id, case when sm.reference_kind = 'part_request_item' then sm.reference_id end) as request_item_id,
+    count(*) filter (where sm.qty_change < 0) as negative_moves,
+    count(*) filter (where sm.qty_change < 0 and sm.reason = 'wo_allocate') as negative_wo_allocate_moves,
+    count(*) filter (where sm.qty_change < 0 and sm.reason = 'consume') as negative_consume_moves,
+    coalesce(sum(sm.qty_change) filter (where sm.reason not in ('wo_allocate','wo_release')), 0) as physical_delta
+  from public.stock_moves sm
+  where coalesce(sm.part_request_item_id, case when sm.reference_kind = 'part_request_item' then sm.reference_id end) is not null
+  group by sm.shop_id, coalesce(sm.part_request_item_id, case when sm.reference_kind = 'part_request_item' then sm.reference_id end)
+), stock_move_on_hand as (
+  select shop_id, part_id, location_id,
+    coalesce(sum(qty_change) filter (where reason not in ('wo_allocate','wo_release')), 0) as stock_move_on_hand
+  from public.stock_moves
+  group by shop_id, part_id, location_id
+), allocation_rollup as (
+  select source_request_item_id as request_item_id, coalesce(sum(qty), 0) as allocated_qty
+  from public.work_order_part_allocations
+  where source_request_item_id is not null
+  group by source_request_item_id
+), findings as (
+  select 'consumed_items_with_multiple_negative_stock_movements' as finding, count(*)::bigint as count
+  from public.part_request_items i
+  join movement_rollup mr on mr.request_item_id = i.id
+  where i.status = 'consumed' and mr.negative_moves > 1
+  union all
+  select 'items_with_negative_wo_allocate_and_negative_consume_movements', count(*)
+  from movement_rollup
+  where negative_wo_allocate_moves > 0 and negative_consume_moves > 0
+  union all
+  select 'items_with_duplicate_physical_deductions', count(*)
+  from movement_rollup
+  where negative_moves > 1 and physical_delta < 0
+  union all
+  select 'part_stock_mismatches_stock_move_on_hand', count(*)
+  from public.part_stock ps
+  full join stock_move_on_hand sm
+    on sm.shop_id = ps.shop_id and sm.part_id = ps.part_id and sm.location_id = ps.location_id
+  where coalesce(ps.qty_on_hand, 0) <> coalesce(sm.stock_move_on_hand, 0)
+  union all
+  select 'allocations_inconsistent_with_request_item_reserved_quantities', count(*)
+  from public.part_request_items i
+  left join allocation_rollup ar on ar.request_item_id = i.id
+  where coalesce(i.qty_reserved, 0) <> coalesce(ar.allocated_qty, 0)
+  union all
+  select 'request_items_consumed_quantity_exceeds_required_quantity', count(*)
+  from public.part_request_items
+  where coalesce(qty_consumed, 0) > coalesce(qty_requested, qty, 0)
+)
+select * from findings order by finding;

--- a/supabase/migrations/202607130001_parts_request_rls_and_legacy_trigger_reconciliation.sql
+++ b/supabase/migrations/202607130001_parts_request_rls_and_legacy_trigger_reconciliation.sql
@@ -3,6 +3,28 @@
 
 begin;
 
+-- No existing DB helper mirrors the application canManageWorkOrders/canonical parts role set
+-- without also admitting technician/advisor roles. Keep this predicate narrow to roles
+-- that own parts request fulfillment operations in the product navigation.
+create or replace function public.can_update_part_request_items(p_shop_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = p_shop_id
+      and lower(coalesce(p.role, '')) in ('owner', 'admin', 'manager', 'parts')
+  );
+$$;
+
+comment on function public.can_update_part_request_items(uuid) is
+  'Narrow database authorization predicate for direct part_request_items updates: same-shop owner/admin/manager/parts users only.';
+
 -- Replace requester-only UPDATE policy with same-shop policy aligned to SELECT/DELETE.
 -- Dynamic drop is intentional because the live requester-only policy name has drifted
 -- between environments; the table should have exactly one UPDATE policy after this migration.
@@ -32,6 +54,7 @@ using (
     join public.profiles p on p.id = auth.uid()
     where pr.id = part_request_items.request_id
       and pr.shop_id = p.shop_id
+      and public.can_update_part_request_items(pr.shop_id)
       and (part_request_items.shop_id is null or part_request_items.shop_id = pr.shop_id)
   )
 )
@@ -42,12 +65,49 @@ with check (
     join public.profiles p on p.id = auth.uid()
     where pr.id = part_request_items.request_id
       and pr.shop_id = p.shop_id
+      and public.can_update_part_request_items(pr.shop_id)
       and (part_request_items.shop_id is null or part_request_items.shop_id = pr.shop_id)
   )
 );
 
 comment on policy part_request_items_update_same_shop_parent_request on public.part_request_items is
-  'Allows authenticated users to update request items only when the parent part request belongs to their profile shop; prevents cross-shop request_id/shop_id changes.';
+  'Allows authenticated owner/admin/manager/parts users to update request items only when the parent part request belongs to their profile shop; prevents cross-shop request_id/shop_id changes.';
+
+
+-- Block direct PostgREST/client UPDATE attempts from reassigning immutable tenant and
+-- durable linkage anchors. Canonical lifecycle commands should create new durable
+-- relationships rather than moving an existing request item across these boundaries.
+create or replace function public.prevent_part_request_item_anchor_changes()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.shop_id is distinct from old.shop_id then
+    raise exception 'part_request_items.shop_id cannot be changed';
+  end if;
+  if new.request_id is distinct from old.request_id then
+    raise exception 'part_request_items.request_id cannot be changed';
+  end if;
+  if new.work_order_id is distinct from old.work_order_id then
+    raise exception 'part_request_items.work_order_id cannot be changed';
+  end if;
+  if new.work_order_line_id is distinct from old.work_order_line_id then
+    raise exception 'part_request_items.work_order_line_id cannot be changed';
+  end if;
+  if new.quote_line_id is distinct from old.quote_line_id then
+    raise exception 'part_request_items.quote_line_id cannot be changed';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_prevent_part_request_item_anchor_changes on public.part_request_items;
+create trigger trg_prevent_part_request_item_anchor_changes
+before update on public.part_request_items
+for each row
+execute function public.prevent_part_request_item_anchor_changes();
 
 -- Legacy trigger reconciliation:
 -- * trg_pri_approved_reserve_stock auto-allocated on approval and moved items to reserved.

--- a/supabase/migrations/202607130001_parts_request_rls_and_legacy_trigger_reconciliation.sql
+++ b/supabase/migrations/202607130001_parts_request_rls_and_legacy_trigger_reconciliation.sql
@@ -1,0 +1,73 @@
+-- Repair part_request_items RLS for same-shop Parts users and remove legacy automatic
+-- inventory side effects that predate the canonical explicit parts lifecycle.
+
+begin;
+
+-- Replace requester-only UPDATE policy with same-shop policy aligned to SELECT/DELETE.
+-- Dynamic drop is intentional because the live requester-only policy name has drifted
+-- between environments; the table should have exactly one UPDATE policy after this migration.
+do $$
+declare
+  policy_record record;
+begin
+  for policy_record in
+    select policyname
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'part_request_items'
+      and cmd = 'UPDATE'
+  loop
+    execute format('drop policy if exists %I on public.part_request_items', policy_record.policyname);
+  end loop;
+end $$;
+
+create policy part_request_items_update_same_shop_parent_request
+on public.part_request_items
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.part_requests pr
+    join public.profiles p on p.id = auth.uid()
+    where pr.id = part_request_items.request_id
+      and pr.shop_id = p.shop_id
+      and (part_request_items.shop_id is null or part_request_items.shop_id = pr.shop_id)
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.part_requests pr
+    join public.profiles p on p.id = auth.uid()
+    where pr.id = part_request_items.request_id
+      and pr.shop_id = p.shop_id
+      and (part_request_items.shop_id is null or part_request_items.shop_id = pr.shop_id)
+  )
+);
+
+comment on policy part_request_items_update_same_shop_parent_request on public.part_request_items is
+  'Allows authenticated users to update request items only when the parent part request belongs to their profile shop; prevents cross-shop request_id/shop_id changes.';
+
+-- Legacy trigger reconciliation:
+-- * trg_pri_approved_reserve_stock auto-allocated on approval and moved items to reserved.
+--   Approval fulfillment is now explicit via parts_allocate_request_item.
+-- * trg_pri_reserved_autopick physically decremented stock and marked picked/picking.
+--   Physical issue is now explicit via parts_issue_work_order_part.
+-- * trg_pri_picked_consume inserted another consume movement and marked consumed.
+--   This could double-deduct with reserved autopick; explicit issue is the canonical single deduction.
+-- * trg_pri_auto_unreserve inserted positive physical release movements on status changes.
+--   Canonical release is zero-quantity allocation release; physical return is explicit return-to-stock.
+-- * trg_pri_recheck_line_hold called legacy reservation/order functions after part_id updates.
+--   Inventory selection must only persist part_id and must not reserve/order/pick/consume.
+drop trigger if exists trg_pri_approved_reserve_stock on public.part_request_items;
+drop trigger if exists trg_pri_reserved_autopick on public.part_request_items;
+drop trigger if exists trg_pri_picked_consume on public.part_request_items;
+drop trigger if exists trg_pri_auto_unreserve on public.part_request_items;
+drop trigger if exists trg_pri_recheck_line_hold on public.part_request_items;
+
+-- Preserve updated-at and request-item linkage triggers by not touching any other triggers on part_request_items.
+-- Preserve canonical explicit lifecycle functions; this migration intentionally does not drop legacy functions
+-- because historical RPC callers and manual reconciliation scripts may still reference them.
+
+commit;

--- a/tests/parts/parts-request-rls-trigger-reconciliation-sql.test.ts
+++ b/tests/parts/parts-request-rls-trigger-reconciliation-sql.test.ts
@@ -14,6 +14,8 @@ const lifecycleSql = readFileSync("db/sql/2026-07-11_parts_lifecycle_completion.
 describe("parts request RLS and legacy trigger reconciliation", () => {
   it("replaces requester-only UPDATE RLS with same-shop parent request USING and WITH CHECK", () => {
     expect(migration).toContain("cmd = 'UPDATE'");
+    expect(migration).toContain("create or replace function public.can_update_part_request_items");
+    expect(migration).toContain("lower(coalesce(p.role, '')) in ('owner', 'admin', 'manager', 'parts')");
     expect(migration).toContain("create policy part_request_items_update_same_shop_parent_request");
     expect(migration).toContain("for update");
     expect(migration).toContain("using (");
@@ -22,7 +24,29 @@ describe("parts request RLS and legacy trigger reconciliation", () => {
     expect(migration).toContain("join public.profiles p on p.id = auth.uid()");
     expect(migration).toContain("pr.id = part_request_items.request_id");
     expect(migration).toContain("pr.shop_id = p.shop_id");
+    expect(migration).toContain("public.can_update_part_request_items(pr.shop_id)");
     expect(migration).toContain("part_request_items.shop_id = pr.shop_id");
+  });
+
+  it("does not admit unauthorized same-shop technician or advisor roles to direct updates", () => {
+    expect(migration).toContain("in ('owner', 'admin', 'manager', 'parts')");
+    expect(migration).not.toContain("'mechanic'");
+    expect(migration).not.toContain("'advisor'");
+  });
+
+  it("blocks ordinary updates from moving immutable ownership and linkage anchors", () => {
+    expect(migration).toContain("create or replace function public.prevent_part_request_item_anchor_changes()");
+    for (const column of ["shop_id", "request_id", "work_order_id", "work_order_line_id", "quote_line_id"]) {
+      expect(migration).toContain(`new.${column} is distinct from old.${column}`);
+    }
+    expect(migration).toContain("create trigger trg_prevent_part_request_item_anchor_changes");
+    expect(migration).toContain("before update on public.part_request_items");
+  });
+
+  it("allows canonical inventory selection route to persist through authorized server path", () => {
+    expect(inventoryRoute).toContain("requireShopScopedApiAccess({ requiredCapability: \"canManageWorkOrders\" })");
+    expect(inventoryRoute).toContain("part_id: partId");
+    expect(inventoryRoute).toContain("updatedItem.part_id !== partId");
   });
 
   it("does not broaden INSERT policy in this migration", () => {

--- a/tests/parts/parts-request-rls-trigger-reconciliation-sql.test.ts
+++ b/tests/parts/parts-request-rls-trigger-reconciliation-sql.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/202607130001_parts_request_rls_and_legacy_trigger_reconciliation.sql",
+  "utf8",
+);
+const audit = readFileSync("db/sql/2026-07-13_parts_request_legacy_trigger_reconciliation_audit.sql", "utf8");
+const inventoryRoute = readFileSync("app/api/parts/requests/items/[itemId]/inventory/route.ts", "utf8");
+const requestPage = readFileSync("app/parts/requests/[id]/page.tsx", "utf8");
+const commitRoute = readFileSync("app/api/parts/requests/[requestId]/commit-package/route.ts", "utf8");
+const lifecycleSql = readFileSync("db/sql/2026-07-11_parts_lifecycle_completion.sql", "utf8");
+
+describe("parts request RLS and legacy trigger reconciliation", () => {
+  it("replaces requester-only UPDATE RLS with same-shop parent request USING and WITH CHECK", () => {
+    expect(migration).toContain("cmd = 'UPDATE'");
+    expect(migration).toContain("create policy part_request_items_update_same_shop_parent_request");
+    expect(migration).toContain("for update");
+    expect(migration).toContain("using (");
+    expect(migration).toContain("with check (");
+    expect(migration).toContain("from public.part_requests pr");
+    expect(migration).toContain("join public.profiles p on p.id = auth.uid()");
+    expect(migration).toContain("pr.id = part_request_items.request_id");
+    expect(migration).toContain("pr.shop_id = p.shop_id");
+    expect(migration).toContain("part_request_items.shop_id = pr.shop_id");
+  });
+
+  it("does not broaden INSERT policy in this migration", () => {
+    expect(migration).not.toMatch(/for\s+insert/i);
+    expect(migration).not.toMatch(/part_request_items_insert/i);
+  });
+
+  it("drops legacy automatic allocation, pick, consume, unreserve, and recheck triggers only", () => {
+    for (const trigger of [
+      "trg_pri_approved_reserve_stock",
+      "trg_pri_reserved_autopick",
+      "trg_pri_picked_consume",
+      "trg_pri_auto_unreserve",
+      "trg_pri_recheck_line_hold",
+    ]) {
+      expect(migration).toContain(`drop trigger if exists ${trigger} on public.part_request_items`);
+    }
+    expect(migration).not.toMatch(/drop\s+trigger[^;]*(updated|linkage)/i);
+    expect(migration).not.toMatch(/drop\s+function/i);
+  });
+
+  it("ships read-only anomaly diagnostics for duplicate legacy physical movements and stock mismatches", () => {
+    expect(audit).toContain("consumed_items_with_multiple_negative_stock_movements");
+    expect(audit).toContain("items_with_negative_wo_allocate_and_negative_consume_movements");
+    expect(audit).toContain("items_with_duplicate_physical_deductions");
+    expect(audit).toContain("part_stock_mismatches_stock_move_on_hand");
+    expect(audit).toContain("allocations_inconsistent_with_request_item_reserved_quantities");
+    expect(audit).toContain("request_items_consumed_quantity_exceeds_required_quantity");
+    expect(audit).not.toMatch(/\b(insert|update|delete|alter|drop|create)\b/i);
+  });
+});
+
+describe("parts request inventory selection regression", () => {
+  it("retains application capability authorization and verifies persisted selected part", () => {
+    expect(inventoryRoute).toContain("requireShopScopedApiAccess({ requiredCapability: \"canManageWorkOrders\" })");
+    expect(inventoryRoute).toContain(".eq(\"shop_id\", shopId)");
+    expect(inventoryRoute).toContain("part_id: partId");
+    expect(inventoryRoute).toContain("updatedItem.part_id !== partId");
+    expect(inventoryRoute).not.toContain("upsert_part_allocation_from_request_item");
+    expect(inventoryRoute).not.toContain("parts_allocate_request_item");
+  });
+
+  it("does not leave optimistic selected state when inventory persistence fails", () => {
+    const attachHandlerStart = requestPage.indexOf("onAttachInventory={async (");
+    const fetchStart = requestPage.indexOf("/api/parts/requests/items/${input.itemId}/inventory", attachHandlerStart);
+    const beforePersist = requestPage.slice(attachHandlerStart, fetchStart);
+    expect(beforePersist).not.toContain("updateItem(r.req.id, input.itemId");
+    expect(beforePersist).toContain("toast.warning(\"Possible mismatch");
+  });
+
+  it("keeps package save and approval separate from automatic allocation or consumption", () => {
+    expect(commitRoute).toContain("parts_ensure_work_order_part");
+    expect(commitRoute).not.toContain("parts_allocate_request_item");
+    expect(commitRoute).not.toContain("parts_issue_work_order_part");
+    expect(lifecycleSql).toContain("values (v_wop.part_id, p_location_id, 0, 'wo_allocate'");
+    expect(lifecycleSql).toContain("values (v_wop.part_id, p_location_id, -p_qty, 'consume'");
+    expect(lifecycleSql).toContain("select * into v_existing from public.stock_moves where shop_id=v_wop.shop_id and idempotency_key=p_idempotency_key");
+  });
+});


### PR DESCRIPTION
### Motivation
- Fix live 406 on `PATCH /rest/v1/part_request_items` by correcting an overly-restrictive UPDATE RLS that allowed SELECT but blocked updates for same-shop Parts/owner/admin users. 
- Stop legacy triggers from causing automatic physical stock picks/consumes or implicit allocations during simple `part_id` selection, and align behavior to the newer canonical explicit lifecycle (`parts_allocate_request_item` / `parts_issue_work_order_part`).
- Provide safe diagnostics for any historical anomalies that could result from the legacy trigger chain before performing any destructive reconciliation.

### Description
- Add a forward-only Supabase migration `supabase/migrations/202607130001_parts_request_rls_and_legacy_trigger_reconciliation.sql` that drops existing UPDATE policies on `part_request_items` and creates `part_request_items_update_same_shop_parent_request` which enforces same-shop access via both `USING` and `WITH CHECK` against the parent `part_requests` and `profiles.shop_id`.
- Drop five legacy automatic triggers on `public.part_request_items`: `trg_pri_approved_reserve_stock`, `trg_pri_reserved_autopick`, `trg_pri_picked_consume`, `trg_pri_auto_unreserve`, and `trg_pri_recheck_line_hold` so ordinary `part_id` updates cannot auto-reserve/pick/consume/unreserve; leave underlying legacy functions in place for manual/compatibility usage.
- Add a read-only audit SQL `db/sql/2026-07-13_parts_request_legacy_trigger_reconciliation_audit.sql` that reports duplicate negative movements, mixed `wo_allocate` + `consume` cases, duplicate deductions, `part_stock` vs stock-move mismatches, allocation vs reserved-qty mismatches, and consumed > requested findings.
- Harden the inventory-selection flow: verify persisted selection in `app/api/parts/requests/items/[itemId]/inventory/route.ts` by checking `updatedItem.part_id === partId` before returning success; remove the optimistic pre-persist UI update in `app/parts/requests/[id]/page.tsx` so the UI only updates after the server confirms persistence.
- Add a focused regression test `tests/parts/parts-request-rls-trigger-reconciliation-sql.test.ts` that asserts the migration content, trigger drops, audit script presence, and the route/page separation/behaviour expectations.

### Testing
- Ran focused parts validation suite: `pnpm vitest run tests/parts/parts-request-rls-trigger-reconciliation-sql.test.ts features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts tests/parts/parts-lifecycle-sql.test.ts tests/parts/parts-lifecycle-manual-sql.test.ts` and those targeted tests passed locally (all assertions in the added parts tests succeeded).
- Ran repository checks: `pnpm typecheck` passed, `pnpm exec eslint app/api/parts/requests/items/[itemId]/inventory/route.ts app/parts/requests/[id]/page.tsx tests/parts/parts-request-rls-trigger-reconciliation-sql.test.ts` passed, and `pnpm audit:api-routes` completed; full `pnpm lint` and full `pnpm test` surfaced unrelated pre-existing failures in other areas and are recorded as unrelated to this change.
- Build was attempted with `pnpm build` and failed in this environment due to external font fetches from `next/font` (network/font fetch issue), not due to the migration or code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a543a5351f08328a583203c8386457d)