### PR TITLE
Fix Parts Workbench inventory picker mobile/modal layout

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -2001,7 +2001,7 @@ if (!lineId || !isUuid(lineId)) {
                           if (conflict && !input.warningAccepted) {
                             setConflictWarningByItemId((prev) => ({ ...prev, [input.itemId]: conflict.message }));
                             toast.warning("Possible mismatch. Review the selected inventory part before attaching.");
-                            return;
+                            throw new Error(conflict.message);
                           }
 
                           const res = await fetch(`/api/parts/requests/items/${input.itemId}/inventory`, {
@@ -2011,8 +2011,9 @@ if (!lineId || !isUuid(lineId)) {
                           });
                           const body = await res.json().catch(() => null) as { ok?: boolean; error?: string; item?: ItemRow } | null;
                           if (!res.ok || !body?.ok) {
-                            toast.error(body?.error || "Could not attach inventory part.");
-                            return;
+                            const message = body?.error || "Could not attach inventory part.";
+                            toast.error(message);
+                            throw new Error(message);
                           }
 
                           if (body.item) {

--- a/features/parts/components/request-workbench/InventoryPickerModal.tsx
+++ b/features/parts/components/request-workbench/InventoryPickerModal.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { WorkbenchOption } from "./types";
-import { WorkbenchModalFrame, modalButton, modalInput, modalPrimaryButton } from "./WorkbenchModalFrame";
+import { modalButton, modalInput, modalPrimaryButton } from "./WorkbenchModalFrame";
+
+const INVENTORY_PICKER_RESULT_LIMIT = 50;
 
 export type InventoryPickerResult = {
   partId: string;
@@ -34,76 +36,198 @@ export function InventoryPickerModal({
   onQueryChange?: (query: string) => void;
   selectedPartId?: string | null;
   onSelectedPartChange?: (partId: string) => void;
-  onAttach?: (result: InventoryPickerResult) => void;
+  onAttach?: (result: InventoryPickerResult) => Promise<void> | void;
   onClose?: () => void;
 }): JSX.Element | null {
+  const titleId = useId();
+  const descriptionId = useId();
+  const searchRef = useRef<HTMLInputElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const selected = results.find((result) => result.value === selectedPartId) ?? null;
   const selectedOnHand = selected?.onHandQty;
   const onHand = Number(selectedOnHand ?? 0);
   const stockUnknown = selectedOnHand == null;
   const zeroStock = !!selected && !stockUnknown && onHand <= 0;
+  const displayedResults = useMemo(
+    () => results.slice(0, INVENTORY_PICKER_RESULT_LIMIT),
+    [results],
+  );
+  const resultCountSummary = results.length > displayedResults.length
+    ? `Showing ${displayedResults.length} of ${results.length} results. Refine search to narrow matches.`
+    : `${results.length} result${results.length === 1 ? "" : "s"}`;
+
+  useEffect(() => {
+    if (!open) return;
+    submittingRef.current = false;
+    setSubmitting(false);
+    setSubmitError(null);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const focusTimer = window.setTimeout(() => searchRef.current?.focus(), 0);
+
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose?.();
+        return;
+      }
+
+      if (event.key !== "Tab" || !dialogRef.current) return;
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), [href], select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((element) => !element.hasAttribute("disabled") && element.offsetParent !== null);
+
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, open]);
+
+  if (!open) return null;
+
+  async function handleAttach(): Promise<void> {
+    if (!selectedPartId || submittingRef.current) return;
+    submittingRef.current = true;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onAttach?.({ partId: selectedPartId, warningAccepted: zeroStock });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Could not attach inventory part.";
+      setSubmitError(message);
+      submittingRef.current = false;
+      setSubmitting(false);
+    }
+  }
 
   return (
-    <WorkbenchModalFrame
-      open={open}
-      title={title}
-      onClose={onClose}
-      footer={
-        <div className="flex items-center justify-end gap-2">
-          <button type="button" className={modalButton} onClick={onClose}>Cancel</button>
-          <button
-            type="button"
-            className={modalPrimaryButton}
-            disabled={!selectedPartId}
-            onClick={() => selectedPartId && onAttach?.({ partId: selectedPartId, warningAccepted: zeroStock })}
-          >
-            Attach Part
-          </button>
-        </div>
-      }
-    >
-      <div className="space-y-4 text-sm text-neutral-300">
-        <p>Search existing parts by description, SKU, part number, or manufacturer.</p>
-        <input
-          className={modalInput}
-          value={query ?? ""}
-          placeholder="Search inventory..."
-          onChange={(event) => onQueryChange?.(event.target.value)}
-        />
-
-        {zeroStock ? (
-          <div className="rounded-xl border border-amber-400/30 bg-amber-950/25 p-3 text-amber-100">
-            This part has zero stock. You can still attach it to preserve the match and order/receive later.
-          </div>
-        ) : null}
-
-        <div className="space-y-2">
-          {results.length ? results.map((result) => (
-            <label key={result.value} className="block rounded-xl border border-white/10 bg-white/[0.03] p-3">
-              <div className="flex gap-3">
-                <input
-                  type="radio"
-                  checked={selectedPartId === result.value}
-                  onChange={() => onSelectedPartChange?.(result.value)}
-                />
-                <div className="min-w-0">
-                  <div className="font-medium text-white">{result.label}</div>
-                  <div className="mt-1 text-xs text-neutral-400">
-                    {[result.sku, result.partNumber, result.manufacturer].filter(Boolean).join(" • ") || "No part metadata"}
-                  </div>
-                  <div className="mt-1 text-xs text-neutral-300">
-                    On hand: {result.onHandQty == null ? "Unavailable" : Number(result.onHandQty)}
-                  </div>
-                </div>
-              </div>
-            </label>
-          )) : (
-            <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 text-neutral-400">
-              No inventory results loaded yet.
+    <>
+      <div className="fixed inset-0 z-[70] bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="fixed left-1/2 top-1/2 z-[71] flex max-h-[calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-1rem)] w-[min(920px,calc(100vw-env(safe-area-inset-left)-env(safe-area-inset-right)-1rem))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-2xl border border-white/10 bg-neutral-950/95 shadow-2xl supports-[height:100dvh]:max-h-[calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-1rem)]"
+      >
+        <div className="shrink-0 border-b border-white/10 bg-neutral-950/98 px-4 py-3 sm:px-5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-xs uppercase tracking-[0.18em] text-neutral-500">Parts Workbench</div>
+              <h2 id={titleId} className="mt-1 truncate text-lg font-semibold text-white">{title}</h2>
             </div>
-          )}
+            <button type="button" onClick={onClose} className="min-h-11 shrink-0 rounded-lg border border-white/10 px-3 py-2 text-sm text-white hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-sky-500/50">
+              Close
+            </button>
+          </div>
+          <p id={descriptionId} className="mt-2 text-sm text-neutral-300">Search existing parts by description, SKU, part number, or manufacturer.</p>
+          <input
+            ref={searchRef}
+            className={`${modalInput} mt-3 min-h-11`}
+            value={query ?? ""}
+            placeholder="Search inventory..."
+            aria-label="Search inventory"
+            onChange={(event) => onQueryChange?.(event.target.value)}
+          />
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-neutral-400">
+            <span>{resultCountSummary}</span>
+            {selected ? <span className="rounded-full border border-orange-400/30 bg-orange-500/10 px-2 py-1 text-orange-100">Selected: {selected.label}</span> : null}
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-3 sm:px-5" data-testid="inventory-picker-results-body">
+          {zeroStock ? (
+            <div className="mb-3 rounded-xl border border-amber-400/30 bg-amber-950/25 p-3 text-sm text-amber-100">
+              This part has zero stock. You can still attach it to preserve the match and order/receive later.
+            </div>
+          ) : null}
+          {submitError ? (
+            <div role="alert" className="mb-3 rounded-xl border border-red-400/30 bg-red-950/25 p-3 text-sm text-red-100">
+              {submitError}
+            </div>
+          ) : null}
+
+          <div className="space-y-1.5">
+            {displayedResults.length ? displayedResults.map((result) => {
+              const checked = selectedPartId === result.value;
+              const metadata = [result.partNumber || result.sku, result.manufacturer].filter(Boolean).join(" • ") || "No part metadata";
+              const onHandText = result.onHandQty == null ? "On hand unavailable" : `${Number(result.onHandQty)} on hand`;
+              return (
+                <label
+                  key={result.value}
+                  className={`block min-h-11 cursor-pointer rounded-xl border px-3 py-2 focus-within:ring-2 focus-within:ring-sky-500/50 ${checked ? "border-orange-400/70 bg-orange-500/15 shadow-[0_0_0_1px_rgba(251,146,60,0.35)]" : "border-white/10 bg-white/[0.03] hover:bg-white/[0.06]"}`}
+                >
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="radio"
+                      name="inventory-picker-part"
+                      className="h-4 w-4 shrink-0 accent-orange-500"
+                      checked={checked}
+                      aria-label={`${result.label}. ${metadata}. ${onHandText}`}
+                      onChange={() => onSelectedPartChange?.(result.value)}
+                    />
+                    <div className="grid min-w-0 flex-1 gap-0.5 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-x-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-white">{result.label}</div>
+                        <div className="truncate text-xs text-neutral-400">{metadata}</div>
+                      </div>
+                      <div className="text-xs font-medium text-neutral-200 sm:text-right">{onHandText}</div>
+                    </div>
+                    {checked ? <span className="text-xs font-semibold text-orange-100">Selected</span> : null}
+                  </div>
+                </label>
+              );
+            }) : (
+              <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 text-sm text-neutral-400">
+                No inventory results loaded yet.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="shrink-0 border-t border-white/10 bg-neutral-950/98 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] sm:px-5">
+          <div className="mb-2 min-h-5 text-xs text-neutral-300">
+            {selected ? <>Ready to attach <span className="font-semibold text-white">{selected.label}</span>{selected.partNumber || selected.sku ? <> · {selected.partNumber || selected.sku}</> : null}</> : "Select an inventory part to enable attachment."}
+          </div>
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-end">
+            <button type="button" className={`${modalButton} min-h-11`} onClick={onClose}>Cancel</button>
+            <button
+              type="button"
+              className={`${modalPrimaryButton} min-h-11 disabled:cursor-not-allowed disabled:opacity-50`}
+              disabled={!selectedPartId || submitting}
+              onClick={() => void handleAttach()}
+            >
+              {submitting ? "Attaching…" : "Attach Selected Part"}
+            </button>
+          </div>
         </div>
       </div>
-    </WorkbenchModalFrame>
+    </>
   );
 }

--- a/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
@@ -68,7 +68,7 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
 
     await user.click(screen.getByRole("button", { name: "Attach Part" }));
     await user.click(screen.getByLabelText(/ACDelco Oil Filter/i));
-    await user.click(screen.getAllByRole("button", { name: "Attach Part" }).at(-1)!);
+    await user.click(screen.getByRole("button", { name: "Attach Selected Part" }));
 
     await waitFor(() => expect(onAttachInventory).toHaveBeenCalledWith({
       itemId: "item-1",
@@ -94,7 +94,7 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
 
     await user.click(screen.getByRole("button", { name: "Attach Part" }));
     await user.click(screen.getByLabelText(/ACDelco Oil Filter/i));
-    await user.click(screen.getAllByRole("button", { name: "Attach Part" }).at(-1)!);
+    await user.click(screen.getByRole("button", { name: "Attach Selected Part" }));
 
     await waitFor(() => expect(onAttachInventory).toHaveBeenCalledTimes(1));
     expect(onCommitPackage).not.toHaveBeenCalled();
@@ -174,5 +174,97 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
       availableStockByItemId: { "item-1": 0 },
     });
     expect(attached.items[0]?.insights?.some((insight) => insight.kind === "no_stock")).toBe(true);
+  });
+});
+
+describe("PartsRequestWorkbench inventory picker mobile layout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses a viewport-constrained dialog with sticky header/footer and an independently scrolling results body", async () => {
+    const user = userEvent.setup();
+    render(<PartsRequestWorkbench model={model(null)} />);
+
+    await user.click(screen.getByRole("button", { name: "Attach Part" }));
+
+    const dialog = screen.getByRole("dialog", { name: /Attach Part — Oil filter/i });
+    expect(dialog).toHaveClass("max-h-[calc(100dvh-env(safe-area-inset-top)-env(safe-area-inset-bottom)-1rem)]");
+    expect(dialog).toHaveClass("flex-col");
+    expect(dialog).toHaveClass("overflow-hidden");
+    expect(screen.getByRole("heading", { name: /Attach Part — Oil filter/i }).parentElement?.parentElement?.parentElement).toHaveClass("shrink-0");
+    expect(screen.getByTestId("inventory-picker-results-body")).toHaveClass("flex-1", "overflow-y-auto", "overscroll-contain");
+    expect(screen.getByRole("button", { name: "Attach Selected Part" }).closest("div")?.parentElement).toHaveClass("shrink-0");
+    expect(screen.getByRole("button", { name: "Attach Selected Part" })).toBeVisible();
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("keeps the search visible, focused, and caps the displayed result count deterministically", async () => {
+    const user = userEvent.setup();
+    const denseModel = model(null);
+    denseModel.inventoryResults = Array.from({ length: 75 }, (_, index) => ({
+      value: `part-${index}`,
+      label: `Inventory part ${String(index).padStart(2, "0")}`,
+      sku: `SKU-${index}`,
+      partNumber: `PN-${index}`,
+      manufacturer: index % 2 === 0 ? "Fleetguard" : "ACDelco",
+      onHandQty: index,
+    }));
+
+    render(<PartsRequestWorkbench model={denseModel} />);
+    await user.click(screen.getByRole("button", { name: "Attach Part" }));
+
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "Search inventory" })).toHaveFocus());
+    expect(screen.getByText("Showing 50 of 75 results. Refine search to narrow matches.")).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(50);
+
+    await user.type(screen.getByRole("textbox", { name: "Search inventory" }), "SKU-74");
+    expect(screen.getByText("1 result")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Inventory part 74/i)).toBeInTheDocument();
+  });
+
+  it("disables confirm until row selection, selects by row click, and submits the selected part once", async () => {
+    const user = userEvent.setup();
+    const onAttachInventory = vi.fn(async () => ({ partId: "part-2", addedToWorkOrder: false }));
+
+    render(<PartsRequestWorkbench model={model(null)} onAttachInventory={onAttachInventory} />);
+    await user.click(screen.getByRole("button", { name: "Attach Part" }));
+
+    const confirm = screen.getByRole("button", { name: "Attach Selected Part" });
+    expect(confirm).toBeDisabled();
+    await user.click(screen.getByText("ACDelco Oil Filter"));
+    expect(screen.getByLabelText(/ACDelco Oil Filter/i)).toBeChecked();
+    expect(confirm).toBeEnabled();
+
+    await Promise.all([user.click(confirm), user.click(confirm)]);
+
+    await waitFor(() => expect(onAttachInventory).toHaveBeenCalledTimes(1));
+    expect(onAttachInventory).toHaveBeenCalledWith({ itemId: "item-1", partId: "part-2", warningAccepted: false });
+  });
+
+  it("keeps the modal open on failure and closes it on success without emitting extra notifications", async () => {
+    const user = userEvent.setup();
+    const onAttachInventory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Attach failed"))
+      .mockResolvedValueOnce({ partId: "part-2", addedToWorkOrder: false });
+
+    render(<PartsRequestWorkbench model={model(null)} onAttachInventory={onAttachInventory} />);
+    await user.click(screen.getByRole("button", { name: "Attach Part" }));
+    await user.click(screen.getByText("ACDelco Oil Filter"));
+    await user.click(screen.getByRole("button", { name: "Attach Selected Part" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Attach failed");
+    expect(screen.getByRole("dialog", { name: /Attach Part — Oil filter/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/ACDelco Oil Filter/i)).toBeChecked();
+    expect(screen.getByRole("button", { name: "Attach Selected Part" })).toBeEnabled();
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Attach Selected Part" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: /Attach Part — Oil filter/i })).not.toBeInTheDocument());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation
- The existing Attach Part modal behaved like a long page on tablet/mobile so the inventory list extended past the viewport and the confirm action became unreachable (notably on iPad Safari). The picker needed to be viewport-constrained with fixed header/footer and an independently scrolling results body.

### Description
- Reimplemented the inventory picker as a viewport-constrained flex dialog using `100dvh` safe-area insets and `overflow-hidden` so the dialog never exceeds the viewport and background scrolling is locked while open.
- Split the modal into three regions: a sticky header (title, close, search, selected summary), a scrollable results body (`min-h-0 flex-1 overflow-y-auto overscroll-contain`), and a sticky footer with Cancel + `Attach Selected Part` that remains visible at all times.
- Reduced per-row vertical density while preserving part name, part number/SKU, manufacturer, on-hand quantity, and selected state; rows are full-row clickable and synchronized with radio controls and accessible labels.
- Added deterministic result capping (50 displayed rows) to avoid rendering huge lists by default, initial search focus when opened, Tab focus wrapping, Escape-to-close, body-scroll lock, and a submit guard to avoid double-submit; failures are shown inline and keep the modal open with selection preserved.
- Kept server/API surface unchanged; the attach flow still calls the same inventory-selection API and RLS, and Parts Package commit and inventory accounting behavior were not modified; the page handler was adjusted to throw after existing toast so the modal can detect and display inline errors without duplicating notifications.

### Testing
- Ran focused picker/workbench unit tests: `pnpm test features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx` — all tests passed (11 tests).
- Type checking: `pnpm typecheck` — passed.
- ESLint: linted modified files — passed.
- Production build: `pnpm build` attempted but failed due to Google Fonts fetch errors for `Inter` and `Black Ops One` in `app/layout.tsx` (network/font fetch issue unrelated to the picker changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a545372ef688328af697249cdb54bb2)