### PR TITLE
Fix invalid route export by moving resolvePackageCommitQuantity to a non-route helper

### DIFF
--- a/app/api/parts/requests/[requestId]/commit-package/route.ts
+++ b/app/api/parts/requests/[requestId]/commit-package/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { resolvePackageCommitQuantity } from "@/features/parts/server/resolvePackageCommitQuantity";
 
 type DB = Database;
 type PartRequestItem = DB["public"]["Tables"]["part_request_items"]["Row"];
@@ -13,16 +14,6 @@ type ItemResult =
 
 function isUuid(value: unknown): value is string {
   return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.trim());
-}
-
-type CommitQuantitySource = Pick<PartRequestItem, "qty_requested" | "qty">;
-
-export function resolvePackageCommitQuantity(item: CommitQuantitySource): number {
-  const requested = typeof item.qty_requested === "number" ? item.qty_requested : Number(item.qty_requested);
-  if (Number.isFinite(requested) && requested > 0) return requested;
-  const legacy = typeof item.qty === "number" ? item.qty : Number(item.qty);
-  if (Number.isFinite(legacy) && legacy > 0) return legacy;
-  return 0;
 }
 
 function positiveQuantity(item: PartRequestItem): number {

--- a/features/parts/components/request-workbench/partsPackageCommit.test.ts
+++ b/features/parts/components/request-workbench/partsPackageCommit.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { resolvePackageCommitQuantity } from "../../../../app/api/parts/requests/[requestId]/commit-package/route";
+import { resolvePackageCommitQuantity } from "@/features/parts/server/resolvePackageCommitQuantity";
 
 type QuantityItem = Parameters<typeof resolvePackageCommitQuantity>[0];
 

--- a/features/parts/server/resolvePackageCommitQuantity.ts
+++ b/features/parts/server/resolvePackageCommitQuantity.ts
@@ -1,0 +1,13 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type PartRequestItem = Database["public"]["Tables"]["part_request_items"]["Row"];
+
+type CommitQuantitySource = Pick<PartRequestItem, "qty_requested" | "qty">;
+
+export function resolvePackageCommitQuantity(item: CommitQuantitySource): number {
+  const requested = typeof item.qty_requested === "number" ? item.qty_requested : Number(item.qty_requested);
+  if (Number.isFinite(requested) && requested > 0) return requested;
+  const legacy = typeof item.qty === "number" ? item.qty : Number(item.qty);
+  if (Number.isFinite(legacy) && legacy > 0) return legacy;
+  return 0;
+}


### PR DESCRIPTION
### Motivation
- Vercel production build fails because `app/api/parts/requests/[requestId]/commit-package/route.ts` exported `resolvePackageCommitQuantity`, and App Router route modules may only export route handlers/configuration fields.

### Description
- Move `resolvePackageCommitQuantity` to `features/parts/server/resolvePackageCommitQuantity.ts` preserving exact precedence (positive `qty_requested`, otherwise positive `qty`, otherwise `0`).
- Update `app/api/parts/requests/[requestId]/commit-package/route.ts` to import the helper and ensure the route module exports only valid Next.js route handlers (only `POST`).
- Update tests to import the helper from `@/features/parts/server/resolvePackageCommitQuantity` instead of the route file.
- Scan `app/**/route.ts` for unsupported exported value helpers and make no other changes because none were found.

### Testing
- Ran focused tests: `pnpm test features/parts/components/request-workbench/partsPackageCommit.test.ts features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts tests/parts/parts-request-rls-trigger-reconciliation-sql.test.ts` — passed (3 files, 21 tests).
- Ran typecheck: `pnpm typecheck` — passed.
- Ran targeted ESLint: `pnpm exec eslint app/api/parts/requests/[requestId]/commit-package/route.ts features/parts/server/resolvePackageCommitQuantity.ts features/parts/components/request-workbench/partsPackageCommit.test.ts` — passed for the targeted files.
- Ran production build: `pnpm build` — build progressed past the route-export validation; remaining failure in this environment was `next/font` unable to fetch Google Fonts (`Inter` and `Black Ops One`), which is unrelated to the invalid route export and indicates an external network/font-fetch limitation rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a545b29be1083289ced340c4814704b)