### PR TITLE
Fix Parts Package SQL quantity precedence

### DIFF
--- a/db/sql/2026-07-11_parts_lifecycle_completion.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_completion.sql
@@ -155,7 +155,7 @@ begin
   where id = p_work_order_part_id;
 end $$;
 
-create or replace function public.parts_ensure_work_order_part(p_request_item_id uuid)
+create or replace function public.parts_attach_request_item(p_request_item_id uuid)
 returns uuid language plpgsql security definer set search_path = public as $$
 declare v_item public.part_request_items%rowtype; v_request public.part_requests%rowtype; v_part public.parts%rowtype; v_line record; v_wop uuid; v_qty numeric;
 begin
@@ -172,7 +172,14 @@ begin
   if not found then raise exception 'Work-order line not found.'; end if;
   if v_line.shop_id is distinct from v_item.shop_id then raise exception 'Work-order line belongs to a different shop.'; end if;
   if v_request.work_order_id is not null and v_request.work_order_id <> v_line.work_order_id then raise exception 'Work-order line does not belong to the request work order.'; end if;
-  v_qty := coalesce(v_item.qty_requested, v_item.qty, 0);
+  v_qty := case
+    when coalesce(v_item.qty_requested, 0) > 0
+      then v_item.qty_requested
+    when coalesce(v_item.qty, 0) > 0
+      then v_item.qty
+    else 0
+  end;
+  if v_qty <= 0 then raise exception 'Quantity must be greater than 0.'; end if;
   select id into v_wop from public.work_order_parts where source_parts_request_item_id = p_request_item_id and is_active for update;
   if found then return v_wop; end if;
   insert into public.work_order_parts(work_order_id, work_order_line_id, shop_id, part_id, quantity, unit_price, total_price, source_parts_request_id, source_parts_request_item_id, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_received, quantity_consumed, unit_cost_snapshot, unit_sell_price_snapshot, lifecycle_status, updated_at, is_active)
@@ -180,6 +187,11 @@ begin
   returning id into v_wop;
   return v_wop;
 end $$;
+
+create or replace function public.parts_ensure_work_order_part(p_request_item_id uuid)
+returns uuid language sql security definer set search_path = public as $$
+  select public.parts_attach_request_item(p_request_item_id);
+$$;
 
 create or replace function public.parts_allocate_request_item(p_request_item_id uuid, p_location_id uuid, p_qty numeric, p_idempotency_key text)
 returns jsonb language plpgsql security definer set search_path = public as $$
@@ -274,7 +286,13 @@ begin
     if coalesce(v_line.received_qty,0) + p_qty > coalesce(v_line.qty,0) then raise exception 'Receipt exceeds ordered quantity.'; end if;
     update public.purchase_order_lines set received_qty = coalesce(received_qty,0) + p_qty where id=p_po_line_id;
   else
-    select coalesce(sum(qty), coalesce(v_item.qty_requested, v_item.qty, 0)) into v_ordered_limit from public.purchase_order_lines where part_request_item_id=p_request_item_id;
+    select coalesce(sum(qty), case
+    when coalesce(v_item.qty_requested, 0) > 0
+      then v_item.qty_requested
+    when coalesce(v_item.qty, 0) > 0
+      then v_item.qty
+    else 0
+  end) into v_ordered_limit from public.purchase_order_lines where part_request_item_id=p_request_item_id;
     if coalesce(v_item.qty_received,0) + p_qty > greatest(v_ordered_limit, coalesce(v_item.qty_requested, v_item.qty,0)) then raise exception 'Receipt exceeds requested quantity.'; end if;
   end if;
   insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, purchase_order_line_id, metadata, lifecycle_quantity)
@@ -404,6 +422,8 @@ end $$;
 -- Security hardening: lifecycle RPCs are callable by authenticated users only;
 -- each SECURITY DEFINER function validates shop/work-order scope internally and
 -- API routes additionally require canManageWorkOrders.
+revoke all on function public.parts_attach_request_item(uuid) from public, anon;
+revoke all on function public.parts_ensure_work_order_part(uuid) from public, anon;
 revoke all on function public.parts_allocate_request_item(uuid, uuid, numeric, text) from public, anon;
 revoke all on function public.parts_release_allocation(uuid, uuid, numeric, text) from public, anon;
 revoke all on function public.parts_create_po_line_for_request(uuid, uuid, numeric, numeric, uuid, text) from public, anon;
@@ -412,6 +432,8 @@ revoke all on function public.parts_issue_work_order_part(uuid, uuid, numeric, t
 revoke all on function public.parts_return_to_stock(uuid, uuid, numeric, text) from public, anon;
 revoke all on function public.parts_cancel_request_item(uuid, text) from public, anon;
 revoke all on function public.parts_replace_request_item(uuid, uuid, uuid, numeric, text) from public, anon;
+grant execute on function public.parts_attach_request_item(uuid) to authenticated, service_role;
+grant execute on function public.parts_ensure_work_order_part(uuid) to authenticated, service_role;
 grant execute on function public.parts_allocate_request_item(uuid, uuid, numeric, text) to authenticated, service_role;
 grant execute on function public.parts_release_allocation(uuid, uuid, numeric, text) to authenticated, service_role;
 grant execute on function public.parts_create_po_line_for_request(uuid, uuid, numeric, numeric, uuid, text) to authenticated, service_role;

--- a/db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql
+++ b/db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql
@@ -406,7 +406,13 @@ begin
   if v_line.wo_shop_id is distinct from v_item.shop_id or v_line.line_shop_id is distinct from v_item.shop_id then raise exception 'Work-order line belongs to a different shop.'; end if;
   if v_item.work_order_id is not null and v_item.work_order_id <> v_line.work_order_id then raise exception 'Request item work order does not match line.'; end if;
   if v_request.work_order_id is not null and v_request.work_order_id <> v_line.work_order_id then raise exception 'Work-order line does not belong to the request work order.'; end if;
-  v_qty := coalesce(v_item.qty_requested, v_item.qty, 0);
+  v_qty := case
+    when coalesce(v_item.qty_requested, 0) > 0
+      then v_item.qty_requested
+    when coalesce(v_item.qty, 0) > 0
+      then v_item.qty
+    else 0
+  end;
   if v_qty <= 0 then raise exception 'Quantity must be greater than 0.'; end if;
   select id into v_wop from public.work_order_parts where source_parts_request_item_id = p_request_item_id and coalesce(is_active,true) for update;
   if found then return v_wop; end if;
@@ -524,7 +530,13 @@ begin
     if coalesce(v_line.received_qty,0) + p_qty > coalesce(v_line.qty,0) then raise exception 'Receipt exceeds ordered quantity.'; end if;
     update public.purchase_order_lines set received_qty = coalesce(received_qty,0) + p_qty where id=p_po_line_id;
   else
-    select coalesce(sum(qty), coalesce(v_item.qty_requested, v_item.qty, 0)) into v_ordered_limit from public.purchase_order_lines where part_request_item_id=p_request_item_id;
+    select coalesce(sum(qty), case
+    when coalesce(v_item.qty_requested, 0) > 0
+      then v_item.qty_requested
+    when coalesce(v_item.qty, 0) > 0
+      then v_item.qty
+    else 0
+  end) into v_ordered_limit from public.purchase_order_lines where part_request_item_id=p_request_item_id;
     if coalesce(v_item.qty_received,0) + p_qty > greatest(v_ordered_limit, coalesce(v_item.qty_requested, v_item.qty,0)) then raise exception 'Receipt exceeds requested quantity.'; end if;
   end if;
   insert into public.stock_moves(part_id, location_id, qty_change, reason, reference_kind, reference_id, created_by, shop_id, idempotency_key, work_order_part_id, part_request_item_id, purchase_order_line_id, metadata, lifecycle_quantity)

--- a/db/sql/2026-07-11_parts_request_workflow_repair.sql
+++ b/db/sql/2026-07-11_parts_request_workflow_repair.sql
@@ -127,7 +127,13 @@ begin
     raise exception 'Work-order line does not belong to the request work order.';
   end if;
 
-  v_qty := coalesce(v_item.qty_requested, v_item.qty, 0);
+  v_qty := case
+    when coalesce(v_item.qty_requested, 0) > 0
+      then v_item.qty_requested
+    when coalesce(v_item.qty, 0) > 0
+      then v_item.qty
+    else 0
+  end;
 
   insert into public.work_order_parts(
     work_order_id, work_order_line_id, shop_id, part_id, quantity, unit_price, total_price,

--- a/supabase/migrations/202607130002_fix_parts_attach_positive_quantity.sql
+++ b/supabase/migrations/202607130002_fix_parts_attach_positive_quantity.sql
@@ -1,0 +1,49 @@
+-- Fix Parts Package materialization quantity resolution for legacy rows.
+-- Forward-only migration: replaces RPC definitions only; it does not backfill or mutate historical rows.
+
+create or replace function public.parts_attach_request_item(p_request_item_id uuid)
+returns uuid language plpgsql security definer set search_path = public as $$
+declare v_item public.part_request_items%rowtype; v_request public.part_requests%rowtype; v_part public.parts%rowtype; v_line record; v_wop uuid; v_qty numeric;
+begin
+  if auth.uid() is null and current_user <> 'service_role' then raise exception 'Authentication required.'; end if;
+  select * into v_item from public.part_request_items where id = p_request_item_id for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+  if v_item.work_order_line_id is null then raise exception 'Request item must be linked to a work-order line.'; end if;
+  if v_item.part_id is null then raise exception 'Request item has no selected inventory part.'; end if;
+  select * into v_request from public.part_requests where id = v_item.request_id for update;
+  if not found then raise exception 'Parent parts request not found.'; end if;
+  select * into v_part from public.parts where id = v_item.part_id;
+  if not found then raise exception 'Selected part not found.'; end if;
+  if v_part.shop_id is distinct from v_item.shop_id then raise exception 'Selected part belongs to a different shop.'; end if;
+  select wl.id, wl.work_order_id, wl.shop_id line_shop_id, wo.shop_id wo_shop_id into v_line
+  from public.work_order_lines wl join public.work_orders wo on wo.id = wl.work_order_id where wl.id = v_item.work_order_line_id;
+  if not found then raise exception 'Work-order line not found.'; end if;
+  if v_line.wo_shop_id is distinct from v_item.shop_id or v_line.line_shop_id is distinct from v_item.shop_id then raise exception 'Work-order line belongs to a different shop.'; end if;
+  if v_item.work_order_id is not null and v_item.work_order_id <> v_line.work_order_id then raise exception 'Request item work order does not match line.'; end if;
+  if v_request.work_order_id is not null and v_request.work_order_id <> v_line.work_order_id then raise exception 'Work-order line does not belong to the request work order.'; end if;
+  v_qty := case
+    when coalesce(v_item.qty_requested, 0) > 0
+      then v_item.qty_requested
+    when coalesce(v_item.qty, 0) > 0
+      then v_item.qty
+    else 0
+  end;
+  if v_qty <= 0 then raise exception 'Quantity must be greater than 0.'; end if;
+  select id into v_wop from public.work_order_parts where source_parts_request_item_id = p_request_item_id and coalesce(is_active,true) for update;
+  if found then return v_wop; end if;
+  insert into public.work_order_parts(work_order_id, work_order_line_id, shop_id, part_id, quantity, unit_price, total_price, source_parts_request_id, source_parts_request_item_id, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_received, quantity_consumed, unit_cost_snapshot, unit_sell_price_snapshot, lifecycle_status, updated_at, is_active)
+  values (v_line.work_order_id, v_item.work_order_line_id, v_item.shop_id, v_item.part_id, v_qty, coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price, 0) * v_qty, v_item.request_id, v_item.id, coalesce(v_part.name, v_item.description), coalesce(v_part.supplier, v_item.vendor), v_part.part_number, v_qty, coalesce(v_item.qty_received,0), coalesce(v_item.qty_consumed,0), coalesce(v_item.unit_cost, v_part.cost), coalesce(v_item.unit_price, v_item.quoted_price, v_part.price), 'requested', now(), true)
+  returning id into v_wop;
+  return v_wop;
+end $$;
+
+create or replace function public.parts_ensure_work_order_part(p_request_item_id uuid)
+returns uuid language sql security definer set search_path = public as $$
+  select public.parts_attach_request_item(p_request_item_id);
+$$;
+
+revoke all on function public.parts_attach_request_item(uuid) from public, anon;
+revoke all on function public.parts_ensure_work_order_part(uuid) from public, anon;
+grant execute on function public.parts_attach_request_item(uuid) to authenticated, service_role;
+grant execute on function public.parts_ensure_work_order_part(uuid) to authenticated, service_role;

--- a/tests/parts/parts-lifecycle-sql.test.ts
+++ b/tests/parts/parts-lifecycle-sql.test.ts
@@ -52,3 +52,60 @@ describe("parts lifecycle read-only audit", () => {
     expect(audit).not.toMatch(/\b(insert|update|delete|alter|drop|create)\b/i);
   });
 });
+
+
+describe("parts attach positive quantity SQL", () => {
+  const forwardMigration = readFileSync("supabase/migrations/202607130002_fix_parts_attach_positive_quantity.sql", "utf8");
+  const manual = readFileSync("db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql", "utf8");
+  const workflowRepair = readFileSync("db/sql/2026-07-11_parts_request_workflow_repair.sql", "utf8");
+
+  const positiveQuantityCase = /case\s+when coalesce\(v_item\.qty_requested, 0\) > 0\s+then v_item\.qty_requested\s+when coalesce\(v_item\.qty, 0\) > 0\s+then v_item\.qty\s+else 0\s+end/;
+
+  function resolveSqlAttachQuantity(qtyRequested: number | null, qty: number | null): number {
+    if ((qtyRequested ?? 0) > 0) return qtyRequested ?? 0;
+    if ((qty ?? 0) > 0) return qty ?? 0;
+    return 0;
+  }
+
+  it("resolves the production legacy quantity cases the same way as the SQL case expression", () => {
+    expect(resolveSqlAttachQuantity(0, 1)).toBe(1);
+    expect(resolveSqlAttachQuantity(0, 6)).toBe(6);
+    expect(resolveSqlAttachQuantity(2, 6)).toBe(2);
+    expect(resolveSqlAttachQuantity(0, 0)).toBe(0);
+    expect(forwardMigration).toMatch(positiveQuantityCase);
+  });
+
+  it("uses positive qty_requested before positive legacy qty in every canonical SQL copy", () => {
+    for (const source of [sql, manual, workflowRepair, forwardMigration]) {
+      expect(source).toMatch(positiveQuantityCase);
+      expect(source).not.toContain("v_qty := coalesce(v_item.qty_requested, v_item.qty, 0);");
+    }
+  });
+
+  it("keeps zero quantities invalid after positive legacy fallback", () => {
+    expect(forwardMigration).toContain("if v_qty <= 0 then raise exception 'Quantity must be greater than 0.'; end if;");
+  });
+
+  it("keeps parts_attach_request_item idempotent and the ensure wrapper delegated", () => {
+    expect(forwardMigration).toContain("source_parts_request_item_id = p_request_item_id and coalesce(is_active,true) for update");
+    expect(forwardMigration).toContain("select public.parts_attach_request_item(p_request_item_id);");
+  });
+
+  it("does not allocate stock, create purchase orders, insert stock movements, or learn menu items", () => {
+    expect(forwardMigration).not.toContain("upsert_part_allocation_from_request_item");
+    expect(forwardMigration).not.toContain("parts_allocate_request_item");
+    expect(forwardMigration).not.toContain("insert into public.stock_moves");
+    expect(forwardMigration).not.toContain("purchase_order");
+    expect(forwardMigration).not.toMatch(/menu[_ ]?learning|menu_repair|menu_items/i);
+  });
+
+  it("is forward-only and leaves existing work_order_parts rows untouched", () => {
+    expect(forwardMigration).toContain("Forward-only migration");
+    expect(forwardMigration).not.toMatch(/\b(update|delete|truncate)\s+public\.work_order_parts\b/i);
+  });
+
+  it("restores execute permissions for app and service callers", () => {
+    expect(forwardMigration).toContain("grant execute on function public.parts_attach_request_item(uuid) to authenticated, service_role;");
+    expect(forwardMigration).toContain("grant execute on function public.parts_ensure_work_order_part(uuid) to authenticated, service_role;");
+  });
+});


### PR DESCRIPTION
### Motivation
- Production RPC `public.parts_attach_request_item` resolved quantity with `coalesce(v_item.qty_requested, v_item.qty, 0)`, which treated a legitimate `qty_requested = 0` as final and caused valid legacy rows with `qty > 0` to materialize as zero and fail the `Quantity must be greater than 0.` guard.
- The application-level resolver already uses positive-quantity precedence; the database lifecycle must match that rule to avoid 400 errors from `parts_ensure_work_order_part`.

### Description
- Add forward-only Supabase migration `supabase/migrations/202607130002_fix_parts_attach_positive_quantity.sql` that replaces `public.parts_attach_request_item(uuid)` with the corrected quantity resolution: `case when coalesce(v_item.qty_requested, 0) > 0 then v_item.qty_requested when coalesce(v_item.qty, 0) > 0 then v_item.qty else 0 end` and preserves the explicit guard `if v_qty <= 0 then raise exception 'Quantity must be greater than 0.'; end if;`.
- Preserve existing behavior and safety: authentication check, `parts_lifecycle_assert_shop_access`, request-item and request locking, parent-request and selected-part validation, same-shop checks, idempotent reuse via `source_parts_request_item_id` and `is_active`, snapshot fields, no allocation/stock movement/PO creation/menu-learning side effects, and `parts_ensure_work_order_part` remains a delegating wrapper.
- Update canonical SQL snapshots used for future setup/recovery to the same precedence: `db/sql/2026-07-11_parts_lifecycle_consolidated_manual.sql`, `db/sql/2026-07-11_parts_lifecycle_completion.sql`, and `db/sql/2026-07-11_parts_request_workflow_repair.sql`.
- Add focused SQL contract coverage in `tests/parts/parts-lifecycle-sql.test.ts` to assert the corrected precedence, the production legacy cases (`qty_requested=0, qty=1` and `qty_requested=0, qty=6`), invalid both-zero behavior, idempotency and wrapper delegation, and absence of allocation/stock/PO/menu-learning side effects.

### Testing
- Ran focused SQL and unit tests: `pnpm exec vitest run tests/parts/parts-lifecycle-sql.test.ts features/parts/components/request-workbench/partsPackageCommit.test.ts features/parts/components/request-workbench/partsRequestInventoryLifecycle.test.ts` — all tests passed (these suites: 3 files / 23 tests and related request-workbench suites passed).
- Ran additional SQL migration tests: `pnpm exec vitest run tests/parts/parts-lifecycle-manual-sql.test.ts tests/parts/parts-request-workflow-migration.test.ts` — passed (2 files / 8 tests).
- ESLint on the modified tests and files completed without errors for the targeted files run.
- Typecheck: `pnpm typecheck` — passed.
- Attempted `pnpm build` (Next.js) but build failed in this environment due to inability to fetch Google Fonts (`Inter`, `Black Ops One`) from fonts.googleapis.com; this is an external network/font fetch issue and does not affect the SQL migration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e8e9966c8328a0946da39f0e6890)