### PR TITLE
Collapse inactive CSV import cards

### DIFF
--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -1082,6 +1082,13 @@ export default function InventoryPage(): JSX.Element {
               </p>
             </>
           }
+          guidedActive={guidedQuery?.onboardingStep === "parts"}
+          hasSelectedFile={csvRows.length > 0 || csvHeaders.length > 0}
+          isParsing={csvProgress?.phaseKey === "reading_file" || csvProgress?.phaseKey === "validating" || csvProgress?.phaseKey === "processing"}
+          isImporting={csvImporting || csvCompletingOnboarding}
+          hasValidationIssues={Boolean(csvError || csvReviewRows.length > 0 || (csvResult?.counts.failed ?? 0) > 0 || csvResult?.errors.length)}
+          hasImportResult={Boolean(csvResult || csvProgress)}
+          compactDescription="Add or update parts inventory records in bulk."
           actions={
             <>
               <input

--- a/features/billing/components/InvoiceCsvImportCard.tsx
+++ b/features/billing/components/InvoiceCsvImportCard.tsx
@@ -355,6 +355,13 @@ export function InvoiceCsvImportCard({
           </p>
         </>
       }
+      guidedActive={isOnboarding}
+      hasSelectedFile={Boolean(fileName)}
+      isParsing={progress?.phaseKey === "reading_file" || progress?.phaseKey === "validating" || progress?.phaseKey === "processing"}
+      isImporting={importing || completingOnboarding}
+      hasValidationIssues={Boolean(parseError || importError || rows.length - importableRows.length > 0 || (response?.counts?.failed ?? 0) > 0)}
+      hasImportResult={Boolean(response?.counts || response?.skippedRows?.length || response?.failedRows?.length || progress)}
+      compactDescription="Add historical invoice records in bulk."
       actions={
         <>
           <input

--- a/features/customers/components/CustomerCsvImportCard.tsx
+++ b/features/customers/components/CustomerCsvImportCard.tsx
@@ -3,7 +3,7 @@
 import React, { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Papa from "papaparse";
-import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
+import { CollapsibleCsvImportCard } from "@/features/shared/components/import/CollapsibleCsvImportCard";
 import {
   CsvImportProgress,
   type CsvImportProgressState,
@@ -515,14 +515,10 @@ export function CustomerCsvImportCard({
   }
 
   return (
-    <GuidedSetupCardShell
+    <CollapsibleCsvImportCard
       testId="customer-csv-import-card"
-      eyebrow={
-        isOnboarding ? "Guided onboarding · Customers" : "Customer files"
-      }
-      title={
-        isOnboarding ? "Upload your customer CSV here" : "Import customers"
-      }
+      eyebrow={isOnboarding ? "Guided onboarding · Customers" : "CSV import"}
+      title={isOnboarding ? "Upload your customer CSV here" : "Import customers"}
       description={
         <>
           {isOnboarding ? (
@@ -541,9 +537,14 @@ export function CustomerCsvImportCard({
           </p>
         </>
       }
-      guided={null}
-      variant="workspace"
-      actions={
+      guidedActive={isOnboarding}
+      hasSelectedFile={Boolean(fileName)}
+      isParsing={importProgress?.phaseKey === "reading_file" || importProgress?.phaseKey === "validating"}
+      isImporting={importing || completingOnboarding}
+      hasValidationIssues={Boolean(parseError || importError || skippedPreviewCount > 0 || (counts?.failed ?? 0) > 0)}
+      hasImportResult={Boolean(counts || skippedRows.length || failedRows.length || importProgress)}
+      compactDescription="Add or update customer records in bulk."
+      headerActions={
         <>
           <input
             ref={fileInputRef}
@@ -655,6 +656,6 @@ export function CustomerCsvImportCard({
         skipDisabled={busyAction !== null}
         skipLabel={busyAction === "skip" ? "Skipping…" : "Skip for now"}
       />{" "}
-    </GuidedSetupCardShell>
+    </CollapsibleCsvImportCard>
   );
 }

--- a/features/shared/components/import/CollapsibleCsvImportCard.tsx
+++ b/features/shared/components/import/CollapsibleCsvImportCard.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import React, { useEffect, useId, useMemo, useState } from "react";
+import { OnboardingHighlightFrame } from "@/features/onboarding-v2/components/OnboardingHighlightFrame";
+
+type GuidedHighlight = {
+  active?: boolean;
+  highlightKey?: string;
+  title?: string;
+  description?: string;
+};
+
+export type CollapsibleCsvImportCardProps = {
+  title: string;
+  description: React.ReactNode;
+  guidedActive?: boolean;
+  guided?: GuidedHighlight | null;
+  forceExpanded?: boolean;
+  hasSelectedFile?: boolean;
+  isParsing?: boolean;
+  isImporting?: boolean;
+  hasValidationIssues?: boolean;
+  hasImportResult?: boolean;
+  headerActions?: React.ReactNode;
+  children: React.ReactNode;
+  defaultExpanded?: boolean;
+  testId?: string;
+  eyebrow?: string;
+  compactDescription?: string;
+  variant?: "copper" | "workspace";
+};
+
+export function CollapsibleCsvImportCard({
+  title,
+  description,
+  guidedActive = false,
+  guided,
+  forceExpanded = false,
+  hasSelectedFile = false,
+  isParsing = false,
+  isImporting = false,
+  hasValidationIssues = false,
+  hasImportResult = false,
+  headerActions,
+  children,
+  defaultExpanded = false,
+  testId,
+  eyebrow = "CSV import",
+  compactDescription,
+  variant = "workspace",
+}: CollapsibleCsvImportCardProps) {
+  const contentId = useId();
+  const shouldAutoExpand =
+    guidedActive ||
+    forceExpanded ||
+    hasSelectedFile ||
+    isParsing ||
+    isImporting ||
+    hasValidationIssues ||
+    hasImportResult;
+  const [manuallyExpanded, setManuallyExpanded] = useState(
+    defaultExpanded || shouldAutoExpand,
+  );
+
+  useEffect(() => {
+    if (shouldAutoExpand) setManuallyExpanded(true);
+  }, [shouldAutoExpand]);
+
+  const expanded = shouldAutoExpand || manuallyExpanded;
+  const cardClassName = useMemo(
+    () =>
+      variant === "workspace"
+        ? "rounded-2xl border border-sky-500/20 bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),rgba(15,23,42,0.92)_38%,rgba(2,6,23,0.96))] p-3 shadow-[0_16px_50px_rgba(0,0,0,0.45)] sm:p-4"
+        : "rounded-2xl border border-[color:var(--desktop-border)] bg-[radial-gradient(circle_at_top_left,rgba(197,122,74,0.13),rgba(15,23,42,0.92)_36%,rgba(2,6,23,0.96))] p-3 shadow-[0_16px_50px_rgba(0,0,0,0.45)] sm:p-4",
+    [variant],
+  );
+
+  const card = (
+    <section data-testid={testId} className={cardClassName}>
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0 max-w-3xl">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-orange-200/85">
+            {eyebrow}
+          </div>
+          <h2 className="mt-1 text-lg font-semibold text-white sm:text-xl">
+            {title}
+          </h2>
+          {expanded ? (
+            <div className="mt-2 space-y-2 text-sm text-neutral-300">
+              {description}
+            </div>
+          ) : (
+            <p className="mt-1 text-sm text-neutral-300">
+              {compactDescription ?? "Upload a CSV when you need to add or update records in bulk."}
+            </p>
+          )}
+        </div>
+
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          {headerActions}
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-controls={contentId}
+            onClick={() => setManuallyExpanded((current) => !current)}
+            className="rounded-xl border border-white/10 bg-white/[0.04] px-3 py-2 text-sm font-semibold text-slate-100 hover:bg-white/[0.08]"
+          >
+            {expanded ? "Collapse ▴" : "Expand ▾"}
+          </button>
+        </div>
+      </div>
+
+      {expanded ? (
+        <div id={contentId} className="mt-4">
+          {children}
+        </div>
+      ) : null}
+    </section>
+  );
+
+  if (guided?.active || guidedActive) {
+    return (
+      <OnboardingHighlightFrame
+        active
+        highlightKey={guided?.highlightKey}
+        title={guided?.title ?? title}
+        description={guided?.description ?? "Use this card to complete the guided setup step."}
+      >
+        {card}
+      </OnboardingHighlightFrame>
+    );
+  }
+
+  return card;
+}

--- a/features/shared/components/import/GuidedImportCardLayout.tsx
+++ b/features/shared/components/import/GuidedImportCardLayout.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
+import { CollapsibleCsvImportCard } from "@/features/shared/components/import/CollapsibleCsvImportCard";
 
 type Props = {
   testId: string;
@@ -8,6 +8,14 @@ type Props = {
   description: ReactNode;
   actions?: ReactNode;
   children: ReactNode;
+  guidedActive?: boolean;
+  forceExpanded?: boolean;
+  hasSelectedFile?: boolean;
+  isParsing?: boolean;
+  isImporting?: boolean;
+  hasValidationIssues?: boolean;
+  hasImportResult?: boolean;
+  compactDescription?: string;
 };
 
 export function GuidedImportCardLayout({
@@ -17,18 +25,33 @@ export function GuidedImportCardLayout({
   description,
   actions,
   children,
+  guidedActive,
+  forceExpanded,
+  hasSelectedFile,
+  isParsing,
+  isImporting,
+  hasValidationIssues,
+  hasImportResult,
+  compactDescription,
 }: Props) {
   return (
-    <GuidedSetupCardShell
+    <CollapsibleCsvImportCard
       testId={testId}
       eyebrow={eyebrow}
       title={title}
       description={description}
-      guided={null}
+      guidedActive={guidedActive}
+      forceExpanded={forceExpanded}
+      hasSelectedFile={hasSelectedFile}
+      isParsing={isParsing}
+      isImporting={isImporting}
+      hasValidationIssues={hasValidationIssues}
+      hasImportResult={hasImportResult}
+      compactDescription={compactDescription}
+      headerActions={actions}
       variant="workspace"
-      actions={actions}
     >
       {children}
-    </GuidedSetupCardShell>
+    </CollapsibleCsvImportCard>
   );
 }

--- a/features/vehicles/components/VehicleCsvImportCard.tsx
+++ b/features/vehicles/components/VehicleCsvImportCard.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { GuidedSetupCardShell } from "@/features/onboarding-v2/components/GuidedSetupCardShell";
+import { CollapsibleCsvImportCard } from "@/features/shared/components/import/CollapsibleCsvImportCard";
 import {
   CsvImportProgress,
   type CsvImportProgressState,
@@ -443,9 +443,9 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
 
 
   return (
-    <GuidedSetupCardShell
+    <CollapsibleCsvImportCard
       testId="vehicle-csv-import-card"
-      eyebrow={isOnboarding ? "Guided onboarding · Vehicles" : "Vehicle files"}
+      eyebrow={isOnboarding ? "Guided onboarding · Vehicles" : "CSV import"}
       title={isOnboarding ? "Upload your vehicle CSV here" : "Import vehicles"}
       description={
         <>
@@ -459,6 +459,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
           </p>
         </>
       }
+      guidedActive={isOnboarding}
       guided={
         isOnboarding
           ? {
@@ -470,7 +471,13 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
             }
           : null
       }
-      actions={
+      hasSelectedFile={Boolean(fileName)}
+      isParsing={importProgress?.phaseKey === "reading_file" || importProgress?.phaseKey === "validating"}
+      isImporting={importing || completingOnboarding}
+      hasValidationIssues={Boolean(parseError || importError || skippedPreviewCount > 0 || (counts?.failed ?? 0) > 0)}
+      hasImportResult={Boolean(counts || skippedRows.length || failedRows.length || importProgress)}
+      compactDescription="Add or update vehicle records in bulk."
+      headerActions={
         <>
           <button
             type="button"
@@ -553,7 +560,7 @@ export function VehicleCsvImportCard({ guidedQuery }: Props) {
         importSucceeded={importSucceeded}
         onContinue={() => router.push(guidedQuery!.returnTo)}
       />{" "}
-    </GuidedSetupCardShell>
+    </CollapsibleCsvImportCard>
   );
 }
 

--- a/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
+++ b/features/work-orders/components/VehicleHistoryCsvImportCard.tsx
@@ -366,6 +366,13 @@ export function VehicleHistoryCsvImportCard({
           </p>
         </>
       }
+      guidedActive={isOnboarding}
+      hasSelectedFile={Boolean(fileName)}
+      isParsing={progress?.phaseKey === "reading_file" || progress?.phaseKey === "validating" || progress?.phaseKey === "processing"}
+      isImporting={importing || completingOnboarding}
+      hasValidationIssues={Boolean(parseError || importError || rows.length - importableRows.length > 0 || (response?.counts?.failed ?? 0) > 0)}
+      hasImportResult={Boolean(response?.counts || response?.skippedRows?.length || response?.failedRows?.length || progress)}
+      compactDescription="Add historical service records in bulk."
       actions={
         <>
           <input

--- a/tests/csv-import-collapse.test.ts
+++ b/tests/csv-import-collapse.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("collapsible CSV import cards", () => {
+  it("centralizes compact collapse state and accessibility in a shared shell", () => {
+    const source = read("features/shared/components/import/CollapsibleCsvImportCard.tsx");
+
+    expect(source).toContain("shouldAutoExpand");
+    expect(source).toContain("guidedActive");
+    expect(source).toContain("hasSelectedFile");
+    expect(source).toContain("isParsing");
+    expect(source).toContain("isImporting");
+    expect(source).toContain("hasValidationIssues");
+    expect(source).toContain("hasImportResult");
+    expect(source).toContain("aria-expanded={expanded}");
+    expect(source).toContain("aria-controls={contentId}");
+    expect(source).toContain("CSV import");
+  });
+
+  it("keeps operational customer and vehicle import cards compact until file or lifecycle state exists", () => {
+    const customer = read("features/customers/components/CustomerCsvImportCard.tsx");
+    const vehicle = read("features/vehicles/components/VehicleCsvImportCard.tsx");
+
+    expect(customer).toContain("CollapsibleCsvImportCard");
+    expect(customer).toContain("compactDescription=\"Add or update customer records in bulk.\"");
+    expect(customer).toContain("hasSelectedFile={Boolean(fileName)}");
+    expect(customer).toContain("hasImportResult={Boolean(counts || skippedRows.length || failedRows.length || importProgress)}");
+    expect(vehicle).toContain("CollapsibleCsvImportCard");
+    expect(vehicle).toContain("compactDescription=\"Add or update vehicle records in bulk.\"");
+    expect(vehicle).toContain("hasSelectedFile={Boolean(fileName)}");
+    expect(vehicle).toContain("Choose CSV file");
+  });
+
+  it("collapses invoice, parts, and history layouts outside guided onboarding while preserving guided expansion", () => {
+    const layout = read("features/shared/components/import/GuidedImportCardLayout.tsx");
+    const invoice = read("features/billing/components/InvoiceCsvImportCard.tsx");
+    const parts = read("app/parts/inventory/page.tsx");
+    const history = read("features/work-orders/components/VehicleHistoryCsvImportCard.tsx");
+
+    expect(layout).toContain("CollapsibleCsvImportCard");
+    expect(invoice).toContain("guidedActive={isOnboarding}");
+    expect(invoice).toContain("compactDescription=\"Add historical invoice records in bulk.\"");
+    expect(parts).toContain("guidedActive={guidedQuery?.onboardingStep === \"parts\"}");
+    expect(parts).toContain("compactDescription=\"Add or update parts inventory records in bulk.\"");
+    expect(history).toContain("guidedActive={isOnboarding}");
+    expect(history).toContain("compactDescription=\"Add historical service records in bulk.\"");
+  });
+});


### PR DESCRIPTION
### Motivation
- Large, always-expanded CSV import cards pushed operational lists (Customers, Vehicles, Parts, Invoices, History) far down pages and made day-to-day workflows import-first instead of records-first.  
- The UI needed a shared, compact wrapper that keeps import controls discoverable while collapsing non-active import content by default and still auto-expanding during guided onboarding or active import lifecycle states.

### Description
- Added a reusable `CollapsibleCsvImportCard` wrapper to centralize collapse/auto-expand behavior and accessibility (`aria-expanded` / `aria-controls`) and expose compact header actions like `Choose CSV file` and `Download template` while collapsed (`features/shared/components/import/CollapsibleCsvImportCard.tsx`).
- Routed the shared guided import layout through the new wrapper by replacing `GuidedSetupCardShell` usage with a `GuidedImportCardLayout` that delegates to `CollapsibleCsvImportCard` so invoice, parts, and vehicle-history imports share collapse logic (`features/shared/components/import/GuidedImportCardLayout.tsx`).
- Replaced individual full-size import shells with the collapsible wrapper in Customers and Vehicles and wire up auto-expand signals (guided onboarding, `hasSelectedFile`, parsing/import progress, validation issues, results) while preserving all existing parsing, preview, confirmation, progress, and API logic (`features/customers/components/CustomerCsvImportCard.tsx`, `features/vehicles/components/VehicleCsvImportCard.tsx`).
- Updated Invoice, Vehicle History, and Parts inventory import placements to use the new layout and pass the same auto-expand/compact props so normal pages stay compact outside onboarding (`features/billing/components/InvoiceCsvImportCard.tsx`, `features/work-orders/components/VehicleHistoryCsvImportCard.tsx`, `app/parts/inventory/page.tsx`).
- Kept all importer internals, identity-matching, APIs, progress, and completion summaries unchanged; added a focused regression test that asserts shared wiring and compact defaults (`tests/csv-import-collapse.test.ts`).

### Testing
- Ran `pnpm typecheck` and the TypeScript check completed successfully.  
- Ran ESLint on the changed imports and components and it completed without reported errors.  
- Added and ran a focused unit test `tests/csv-import-collapse.test.ts` with `npx vitest run tests/csv-import-collapse.test.ts` and it passed.  
- Ran the broader Vitest suite (`npx vitest` for relevant import and guided-onboarding tests); the suite passed the new collapse test but some unrelated tests in `vehicle-history-csv-import-architecture.test.ts` failed (pre-existing architecture expectations about worker/insert signatures) which are outside the scope of this UI-only change.  
- Attempted `pnpm build`; build failed in the environment because `next/font` could not fetch Google Fonts (`Inter` and `Black Ops One`), which prevented a full production build in this CI environment (network font fetch issue, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f2284354832899c0adb399549965)