### PR TITLE
Fix mobile work-order detail status derivation and stale cached state

### DIFF
--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -29,6 +29,10 @@ import MobileFocusedJob from "@/features/work-orders/mobile/MobileFocusedJob";
 import AskAssistantEntry from "@/features/assistant/components/AskAssistantEntry";
 import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
 import {
+  applyFetchedMobileDetailSnapshot,
+  deriveMobileDetailOperationalState,
+} from "@/features/work-orders/mobile/detailOperationalState";
+import {
   getOfflineSyncSummary,
   subscribeOfflineMutations,
 } from "@/features/shared/lib/offline/mutations";
@@ -90,8 +94,9 @@ function extractInspectionTemplateId(
 
 type KnownStatus =
   | "awaiting_approval"
-  | "parts_waiting"
+  | "waiting_parts"
   | "awaiting"
+  | "assigned"
   | "queued"
   | "in_progress"
   | "on_hold"
@@ -108,7 +113,7 @@ const BASE_BADGE =
 const BADGE: Record<KnownStatus, string> = {
   awaiting_approval:
     "bg-amber-500/12 border-amber-300/65 text-amber-100 shadow-[0_0_18px_rgba(251,191,36,0.24)]",
-  parts_waiting:
+  waiting_parts:
     "bg-indigo-500/12 border-indigo-300/65 text-indigo-100 shadow-[0_0_18px_rgba(129,140,248,0.24)]",
   awaiting:
     "bg-slate-900/40 border-slate-400/60 text-slate-200 shadow-[0_0_18px_rgba(148,163,184,0.25)]",
@@ -118,6 +123,8 @@ const BADGE: Record<KnownStatus, string> = {
     "border-cyan-300/70 bg-cyan-500/14 text-cyan-100 shadow-[0_0_22px_rgba(34,211,238,0.30)]",
   on_hold:
     "bg-amber-500/12 border-amber-300/65 text-amber-100 shadow-[0_0_18px_rgba(251,191,36,0.24)]",
+  assigned:
+    "bg-sky-900/30 border-sky-400/60 text-sky-200 shadow-[0_0_18px_rgba(56,189,248,0.35)]",
   unassigned:
     "bg-slate-800/65 border-slate-400/60 text-slate-200 shadow-[0_0_14px_rgba(148,163,184,0.20)]",
   planned:
@@ -150,64 +157,7 @@ const APPROVAL_ROLES = new Set([
   "leadhand",
 ]);
 
-type MobileOperationalState =
-  | "in_progress"
-  | "awaiting_approval"
-  | "parts_waiting"
-  | "on_hold"
-  | "unassigned"
-  | "completed";
-
-function normalizeStatus(status: string | null | undefined): string {
-  return String(status ?? "").trim().toLowerCase().replaceAll("-", "_");
-}
-
-function isCompletedLine(line: WorkOrderLine): boolean {
-  const status = normalizeStatus(line.status);
-  return (
-    status === "completed" ||
-    status === "ready_to_invoice" ||
-    status === "invoiced" ||
-    Boolean(line.punched_out_at)
-  );
-}
-
-function isApprovalPendingLine(line: WorkOrderLine): boolean {
-  const approval = normalizeStatus(line.approval_state);
-  const status = normalizeStatus(line.status);
-  return (
-    approval === "pending" ||
-    status === "awaiting_approval" ||
-    status === "needs_approval"
-  );
-}
-
-function isPartsWaitingLine(line: WorkOrderLine): boolean {
-  const status = normalizeStatus(line.status);
-  const holdReason = normalizeStatus(line.hold_reason);
-  return (
-    status === "waiting_parts" ||
-    status === "pending_parts" ||
-    holdReason.includes("part") ||
-    holdReason.includes("quote")
-  );
-}
-
-function isInProgressLine(line: WorkOrderLine): boolean {
-  const status = normalizeStatus(line.status);
-  const punchedIn = Boolean(line.punched_in_at);
-  const punchedOut = Boolean(line.punched_out_at);
-  return status === "in_progress" || (punchedIn && !punchedOut);
-}
-
-function getOperationalState(line: WorkOrderLine): MobileOperationalState {
-  if (isCompletedLine(line)) return "completed";
-  if (isInProgressLine(line)) return "in_progress";
-  if (isApprovalPendingLine(line)) return "awaiting_approval";
-  if (isPartsWaitingLine(line)) return "parts_waiting";
-  if (normalizeStatus(line.status) === "on_hold") return "on_hold";
-  return "unassigned";
-}
+/* Mobile detail operational status is derived in detailOperationalState.ts. */
 
 /* ------------------------------------------------------------------------- */
 
@@ -440,8 +390,6 @@ export default function MobileWorkOrderClient({
           return;
         }
 
-        setWo(woRow);
-
         if (!warnedMissing && (!woRow.vehicle_id || !woRow.customer_id)) {
           toast.error(
             "This work order is missing vehicle and/or customer. Open the Create form to set them.",
@@ -478,7 +426,14 @@ export default function MobileWorkOrderClient({
 
         if (linesRes.error) throw linesRes.error;
         const lineRows = (linesRes.data ?? []) as WorkOrderLine[];
-        setLines(lineRows);
+        const freshCore = applyFetchedMobileDetailSnapshot({
+          cachedWorkOrder: null,
+          cachedLines: [],
+          fetchedWorkOrder: woRow,
+          fetchedLines: lineRows,
+        });
+        setWo(freshCore.workOrder);
+        setLines(freshCore.lines);
 
         // 🔹 populate tech names from assigned_tech_id
         const techIds = Array.from(
@@ -508,16 +463,26 @@ export default function MobileWorkOrderClient({
           setTechNamesById({});
         }
 
-        if (quotesRes.error) throw quotesRes.error;
-        setQuoteLines(
-          (quotesRes.data as WorkOrderQuoteLine[] | null) ?? [],
-        );
+        if (quotesRes.error) {
+          setQuoteLines([]);
+          console.error("[Mobile WO id page] quote lines load error:", quotesRes.error);
+        } else {
+          setQuoteLines((quotesRes.data as WorkOrderQuoteLine[] | null) ?? []);
+        }
 
-        if (vehRes?.error) throw vehRes.error;
-        setVehicle((vehRes?.data as Vehicle | null) ?? null);
+        if (vehRes?.error) {
+          setVehicle(null);
+          console.error("[Mobile WO id page] vehicle load error:", vehRes.error);
+        } else {
+          setVehicle((vehRes?.data as Vehicle | null) ?? null);
+        }
 
-        if (custRes?.error) throw custRes.error;
-        setCustomer((custRes?.data as Customer | null) ?? null);
+        if (custRes?.error) {
+          setCustomer(null);
+          console.error("[Mobile WO id page] customer load error:", custRes.error);
+        } else {
+          setCustomer((custRes?.data as Customer | null) ?? null);
+        }
       } catch (e: unknown) {
         const msg =
           e instanceof Error ? e.message : "Failed to load work order.";
@@ -658,13 +623,22 @@ export default function MobileWorkOrderClient({
     return m;
   }, [quoteLines]);
 
+  const mobileOperationalState = useMemo(
+    () => deriveMobileDetailOperationalState(wo, lines),
+    [wo, lines],
+  );
+
+  const visibleLineState = useCallback(
+    (line: WorkOrderLine) => mobileOperationalState.lineStates.get(line) ?? "awaiting",
+    [mobileOperationalState],
+  );
+
   const approvalPending = useMemo(
     () =>
-      lines.filter(
-        (l) =>
-          getOperationalState(l) === "awaiting_approval" && !isCompletedLine(l),
+      mobileOperationalState.visibleLines.filter(
+        (l) => visibleLineState(l) === "awaiting_approval",
       ),
-    [lines],
+    [mobileOperationalState.visibleLines, visibleLineState],
   );
 
   const quotePending = useMemo(
@@ -676,42 +650,15 @@ export default function MobileWorkOrderClient({
     [quoteLines],
   );
 
-  const linesByOperationalState = useMemo(() => {
-    const grouped: Record<MobileOperationalState, WorkOrderLine[]> = {
-      in_progress: [],
-      awaiting_approval: [],
-      parts_waiting: [],
-      on_hold: [],
-      unassigned: [],
-      completed: [],
-    };
-    lines.forEach((line) => {
-      grouped[getOperationalState(line)].push(line);
-    });
-    return grouped;
-  }, [lines]);
-
-  const createdSortedLines = useMemo(() => {
-    return [...lines].sort((a, b) => {
-      const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
-      const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
-      return ta - tb;
-    });
-  }, [lines]);
-
   const actionableLines = useMemo(() => {
-    return [
-      ...linesByOperationalState.in_progress,
-      ...linesByOperationalState.awaiting_approval,
-      ...linesByOperationalState.parts_waiting,
-      ...linesByOperationalState.on_hold,
-      ...linesByOperationalState.unassigned,
-    ].sort((a, b) => {
-      const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
-      const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
-      return ta - tb;
-    });
-  }, [linesByOperationalState]);
+    return mobileOperationalState.visibleLines
+      .filter((line) => visibleLineState(line) !== "completed")
+      .sort((a, b) => {
+        const ta = a.created_at ? new Date(a.created_at).getTime() : 0;
+        const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
+        return ta - tb;
+      });
+  }, [mobileOperationalState.visibleLines, visibleLineState]);
 
   const displayLines = useMemo(() => {
     const pr: Record<string, number> = {
@@ -720,17 +667,18 @@ export default function MobileWorkOrderClient({
       maintenance: 3,
       repair: 4,
     };
-    const statePriority: Record<MobileOperationalState, number> = {
+    const statePriority: Record<string, number> = {
       in_progress: 1,
       awaiting_approval: 2,
-      parts_waiting: 3,
-      on_hold: 4,
-      unassigned: 5,
-      completed: 6,
+      on_hold: 3,
+      waiting_parts: 4,
+      assigned: 5,
+      awaiting: 6,
+      completed: 7,
     };
-    return [...createdSortedLines].sort((a, b) => {
-      const sa = statePriority[getOperationalState(a)];
-      const sb = statePriority[getOperationalState(b)];
+    return [...mobileOperationalState.visibleLines].sort((a, b) => {
+      const sa = statePriority[visibleLineState(a)] ?? 999;
+      const sb = statePriority[visibleLineState(b)] ?? 999;
       if (sa !== sb) return sa - sb;
 
       const pa = pr[String(a.job_type ?? "repair").toLowerCase()] ?? 999;
@@ -740,7 +688,7 @@ export default function MobileWorkOrderClient({
       const tb = b.created_at ? new Date(b.created_at).getTime() : 0;
       return ta - tb;
     });
-  }, [createdSortedLines]);
+  }, [mobileOperationalState.visibleLines, visibleLineState]);
 
   const createdAt = wo?.created_at ? new Date(wo.created_at) : null;
   const createdAtText =
@@ -771,32 +719,24 @@ export default function MobileWorkOrderClient({
         waiterFlagSource.customer_waiting)
     );
 
-  const canonicalHeaderStatus = useMemo<MobileOperationalState>(() => {
-    if (linesByOperationalState.in_progress.length > 0) return "in_progress";
-    if (linesByOperationalState.awaiting_approval.length > 0)
-      return "awaiting_approval";
-    if (linesByOperationalState.parts_waiting.length > 0) return "parts_waiting";
-    if (linesByOperationalState.on_hold.length > 0) return "on_hold";
-    if (linesByOperationalState.unassigned.length > 0) return "unassigned";
-    return "completed";
-  }, [linesByOperationalState]);
+  const canonicalHeaderStatus = mobileOperationalState.headerStatus;
 
   const hasAnyPending = approvalPending.length > 0 || quotePending.length > 0;
-  const inProgressCount = linesByOperationalState.in_progress.length;
-  const unassignedCount = linesByOperationalState.unassigned.length;
-  const awaitingPartsCount = linesByOperationalState.parts_waiting.length;
+  const inProgressCount = mobileOperationalState.counters.in_progress;
+  const unassignedCount = mobileOperationalState.counters.awaiting + mobileOperationalState.counters.assigned;
+  const awaitingPartsCount = mobileOperationalState.counters.waiting_parts;
   const nextActionText = useMemo(() => {
     if (inProgressCount > 0) return "Continue active job punches.";
     if (approvalPending.length > 0) return "Review pending approvals.";
     if (awaitingPartsCount > 0) return "Release parts-blocked jobs.";
-    if (linesByOperationalState.on_hold.length > 0) return "Resolve held jobs.";
+    if (mobileOperationalState.counters.on_hold > 0) return "Resolve held jobs.";
     if (unassignedCount > 0) return "Assign unassigned jobs.";
     return "All lines are complete.";
   }, [
     approvalPending.length,
     awaitingPartsCount,
     inProgressCount,
-    linesByOperationalState.on_hold.length,
+    mobileOperationalState.counters.on_hold,
     unassignedCount,
   ]);
 
@@ -818,10 +758,10 @@ export default function MobileWorkOrderClient({
     el.scrollIntoView({ block: "start", behavior: "auto" });
   }, []);
 
-  const firstInProgressLineId = linesByOperationalState.in_progress[0]?.id ?? null;
-  const firstOnHoldLineId = linesByOperationalState.on_hold[0]?.id ?? null;
-  const firstPartsWaitingLineId = linesByOperationalState.parts_waiting[0]?.id ?? null;
-  const firstUnassignedLineId = linesByOperationalState.unassigned[0]?.id ?? null;
+  const firstInProgressLineId = mobileOperationalState.visibleLines.find((line) => visibleLineState(line) === "in_progress")?.id ?? null;
+  const firstOnHoldLineId = mobileOperationalState.visibleLines.find((line) => visibleLineState(line) === "on_hold")?.id ?? null;
+  const firstPartsWaitingLineId = mobileOperationalState.visibleLines.find((line) => visibleLineState(line) === "waiting_parts" || Boolean(line.hold_reason?.toLowerCase().includes("part")))?.id ?? null;
+  const firstUnassignedLineId = mobileOperationalState.visibleLines.find((line) => visibleLineState(line) === "awaiting" || visibleLineState(line) === "assigned")?.id ?? null;
 
   const primaryActionLine = actionableLines[0] ?? null;
 
@@ -842,7 +782,7 @@ export default function MobileWorkOrderClient({
       { title: "In progress", count: inProgressCount, targetLineId: firstInProgressLineId },
       {
         title: "On hold",
-        count: linesByOperationalState.on_hold.length,
+        count: mobileOperationalState.counters.on_hold,
         targetLineId: firstOnHoldLineId,
       },
       { title: "Parts waiting", count: awaitingPartsCount, targetLineId: firstPartsWaitingLineId },
@@ -855,7 +795,7 @@ export default function MobileWorkOrderClient({
       firstPartsWaitingLineId,
       firstUnassignedLineId,
       inProgressCount,
-      linesByOperationalState.on_hold.length,
+      mobileOperationalState.counters.on_hold,
       unassignedCount,
     ],
   );

--- a/features/work-orders/mobile/detailOperationalState.ts
+++ b/features/work-orders/mobile/detailOperationalState.ts
@@ -1,0 +1,134 @@
+import { normalizeWorkOrderLineStatus, type WorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
+
+type DetailLine = {
+  status?: string | null;
+  approval_state?: string | null;
+  hold_reason?: string | null;
+  punched_in_at?: string | null;
+  punched_out_at?: string | null;
+  assigned_tech_id?: string | null;
+  voided_at?: string | null;
+  deleted_at?: string | null;
+};
+
+type DetailWorkOrder = {
+  status?: string | null;
+};
+
+export type MobileDetailHeaderStatus =
+  | "in_progress"
+  | "awaiting_approval"
+  | "waiting_parts"
+  | "on_hold"
+  | "assigned"
+  | "awaiting"
+  | "ready_to_invoice"
+  | "invoiced"
+  | "completed";
+
+export type MobileDetailLineState =
+  | "in_progress"
+  | "awaiting_approval"
+  | "waiting_parts"
+  | "on_hold"
+  | "assigned"
+  | "awaiting"
+  | "completed";
+
+export type MobileDetailCounters = {
+  in_progress: number;
+  awaiting_approval: number;
+  waiting_parts: number;
+  on_hold: number;
+  assigned: number;
+  awaiting: number;
+  completed: number;
+};
+
+export type MobileDetailOperationalState<TLine extends DetailLine> = {
+  visibleLines: TLine[];
+  lineStates: Map<TLine, MobileDetailLineState>;
+  counters: MobileDetailCounters;
+  headerStatus: MobileDetailHeaderStatus;
+};
+
+const ACTIONABLE_PARENT_STATUSES = new Set(["ready_to_invoice", "invoiced"]);
+
+function normalizeRaw(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase().replaceAll(" ", "_").replaceAll("-", "_");
+}
+
+export function isMobileDetailVisibleLine(line: DetailLine): boolean {
+  return !line.voided_at && !line.deleted_at;
+}
+
+export function isPartsWaitingAdvisory(line: DetailLine): boolean {
+  const status = normalizeWorkOrderLineStatus(line.status);
+  const holdReason = normalizeRaw(line.hold_reason);
+  return status === "waiting_parts" || holdReason.includes("part") || holdReason.includes("quote");
+}
+
+function isLineInProgress(line: DetailLine, status: WorkOrderLineStatus): boolean {
+  return status === "in_progress" || (Boolean(line.punched_in_at) && !line.punched_out_at);
+}
+
+export function deriveMobileDetailLineState(line: DetailLine): MobileDetailLineState {
+  const status = normalizeWorkOrderLineStatus(line.status);
+  const approval = normalizeRaw(line.approval_state);
+
+  if (isLineInProgress(line, status)) return "in_progress";
+  if (approval === "pending" || status === "awaiting_approval") return "awaiting_approval";
+  if (status === "on_hold") return "on_hold";
+  if (status === "waiting_parts" || isPartsWaitingAdvisory(line)) return "waiting_parts";
+  if (status === "completed" || status === "ready_to_invoice" || status === "invoiced") return "completed";
+  if (line.assigned_tech_id || status === "approved") return "assigned";
+  return "awaiting";
+}
+
+export function deriveMobileDetailOperationalState<TLine extends DetailLine>(
+  workOrder: DetailWorkOrder | null | undefined,
+  lines: readonly TLine[],
+): MobileDetailOperationalState<TLine> {
+  const visibleLines = lines.filter(isMobileDetailVisibleLine);
+  const counters: MobileDetailCounters = {
+    in_progress: 0,
+    awaiting_approval: 0,
+    waiting_parts: 0,
+    on_hold: 0,
+    assigned: 0,
+    awaiting: 0,
+    completed: 0,
+  };
+  const lineStates = new Map<TLine, MobileDetailLineState>();
+
+  for (const line of visibleLines) {
+    const state = deriveMobileDetailLineState(line);
+    lineStates.set(line, state);
+    counters[state] += 1;
+    if (isPartsWaitingAdvisory(line)) counters.waiting_parts += state === "waiting_parts" ? 0 : 1;
+  }
+
+  const parentStatus = normalizeRaw(workOrder?.status);
+  let headerStatus: MobileDetailHeaderStatus;
+  if (counters.in_progress > 0) headerStatus = "in_progress";
+  else if (counters.on_hold > 0) headerStatus = "on_hold";
+  else if (counters.awaiting_approval > 0) headerStatus = "awaiting_approval";
+  else if (counters.waiting_parts > 0) headerStatus = "waiting_parts";
+  else if (counters.assigned > 0) headerStatus = "assigned";
+  else if (counters.awaiting > 0) headerStatus = "awaiting";
+  else if (ACTIONABLE_PARENT_STATUSES.has(parentStatus)) headerStatus = parentStatus as "ready_to_invoice" | "invoiced";
+  else headerStatus = "completed";
+
+  return { visibleLines, lineStates, counters, headerStatus };
+}
+
+export function applyFetchedMobileDetailSnapshot<TWorkOrder, TLine>(args: {
+  cachedWorkOrder: TWorkOrder | null;
+  cachedLines: readonly TLine[];
+  fetchedWorkOrder: TWorkOrder;
+  fetchedLines: readonly TLine[];
+}): { workOrder: TWorkOrder; lines: TLine[] } {
+  void args.cachedWorkOrder;
+  void args.cachedLines;
+  return { workOrder: args.fetchedWorkOrder, lines: [...args.fetchedLines] };
+}

--- a/tests/mobile-work-order-detail-operational-state.test.ts
+++ b/tests/mobile-work-order-detail-operational-state.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyFetchedMobileDetailSnapshot,
+  deriveMobileDetailLineState,
+  deriveMobileDetailOperationalState,
+} from "@/features/work-orders/mobile/detailOperationalState";
+
+type TestWorkOrder = { status: string | null };
+type TestLine = {
+  id: string;
+  status: string | null;
+  approval_state?: string | null;
+  hold_reason?: string | null;
+  assigned_tech_id?: string | null;
+  voided_at?: string | null;
+};
+
+const wo = (status: string): TestWorkOrder => ({ status });
+const line = (overrides: Partial<TestLine> = {}): TestLine => ({
+  id: overrides.id ?? "line-1",
+  status: overrides.status ?? "awaiting",
+  approval_state: overrides.approval_state ?? "approved",
+  hold_reason: overrides.hold_reason ?? null,
+  assigned_tech_id: overrides.assigned_tech_id ?? null,
+  voided_at: overrides.voided_at ?? null,
+});
+
+describe("mobile work-order detail operational state", () => {
+  it("derives an on-hold header and on-hold count from a visible on-hold line", () => {
+    const state = deriveMobileDetailOperationalState(wo("on_hold"), [line({ status: "on_hold" })]);
+
+    expect(state.headerStatus).toBe("on_hold");
+    expect(state.counters.on_hold).toBe(1);
+  });
+
+  it("replaces stale cached completed state with fetched on-hold state", () => {
+    const snapshot = applyFetchedMobileDetailSnapshot({
+      cachedWorkOrder: wo("completed"),
+      cachedLines: [line({ id: "stale", status: "completed" })],
+      fetchedWorkOrder: wo("on_hold"),
+      fetchedLines: [line({ id: "fresh", status: "on_hold" })],
+    });
+    const state = deriveMobileDetailOperationalState(snapshot.workOrder, snapshot.lines);
+
+    expect(state.headerStatus).toBe("on_hold");
+    expect(state.counters.on_hold).toBe(1);
+    expect(snapshot.lines).toHaveLength(1);
+    expect(snapshot.lines[0]?.id).toBe("fresh");
+  });
+
+  it("counts parts waiting as an advisory without replacing the general on-hold count", () => {
+    const state = deriveMobileDetailOperationalState(wo("on_hold"), [
+      line({ status: "on_hold", hold_reason: "Awaiting parts" }),
+    ]);
+
+    expect(state.counters.on_hold).toBe(1);
+    expect(state.counters.waiting_parts).toBe(1);
+    expect(state.headerStatus).toBe("on_hold");
+  });
+
+  it("cannot render an on-hold visible job while reporting on-hold zero for the same input", () => {
+    const heldLine = line({ status: "on_hold" });
+    const state = deriveMobileDetailOperationalState(wo("on_hold"), [heldLine]);
+
+    expect(deriveMobileDetailLineState(heldLine)).toBe("on_hold");
+    expect(state.lineStates.get(heldLine)).toBe("on_hold");
+    expect(state.counters.on_hold).toBeGreaterThan(0);
+  });
+
+  it("keeps ready_to_invoice distinct from generic completed when all lines are completed", () => {
+    const state = deriveMobileDetailOperationalState(wo("ready_to_invoice"), [
+      line({ status: "completed" }),
+    ]);
+
+    expect(state.headerStatus).toBe("ready_to_invoice");
+    expect(state.headerStatus).not.toBe("completed");
+  });
+
+  it("keeps invoiced distinct from generic completed when all lines are completed", () => {
+    const state = deriveMobileDetailOperationalState(wo("invoiced"), [line({ status: "completed" })]);
+
+    expect(state.headerStatus).toBe("invoiced");
+    expect(state.headerStatus).not.toBe("completed");
+  });
+
+  it("excludes voided on-hold lines from operational counters", () => {
+    const state = deriveMobileDetailOperationalState(wo("on_hold"), [
+      line({ status: "on_hold", voided_at: "2026-07-13T00:00:00.000Z" }),
+    ]);
+
+    expect(state.counters.on_hold).toBe(0);
+    expect(state.visibleLines).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Motivation
- The mobile work-order detail UI could render a stale parent/header snapshot (e.g. "completed") while job cards and counters were freshly rendered from updated lines, producing inconsistent status and counter values. 
- Root cause: cached/tab-scoped `wo` and `lines` were hydrated/committed independently and header/counters used a separate derivation path than the visible job list, allowing mixed snapshots to appear.

### Description
- Add a pure derivation module `features/work-orders/mobile/detailOperationalState.ts` that computes visible lines, per-line normalized operational state, counters, and a single canonical header status (parts-waiting is treated as an advisory that can increment alongside on-hold). 
- Update `MobileWorkOrderClient` to use that single source-of-truth: commit fetched work-order and line arrays together, derive header, counters, actionable/display ordering, and job-target ids from the same visible-line array, and avoid letting stale cached parent/header persist after a successful fetch. 
- Make non-core fetches (quoteLines, vehicle, customer) non-blocking for the core state refresh and log errors rather than throwing so core work-order + lines always refresh when available. 
- Add focused tests `tests/mobile-work-order-detail-operational-state.test.ts` that assert on-hold counting, parts-waiting advisory behavior, stale-cached replacement, voided-line exclusion, and parent lifecycle distinctions (ready_to_invoice / invoiced remain distinct). 

### Testing
- Ran targeted unit tests: `pnpm exec vitest run tests/mobile-work-order-detail-operational-state.test.ts` — passed (7 tests passed). 
- Type check: `pnpm typecheck` — passed. 
- Full test run: `pnpm test` — new targeted tests passed but the repository full suite reported unrelated failures (5 failing tests) outside the changed files; these failures are pre-existing and not caused by this change. 
- Lint: `pnpm lint` — failed on unrelated repository lint issues outside this change. 
- Build: `pnpm build` — failed due to environment/network font fetch errors (Google Fonts) and did not reach a repository-related build failure.

Files changed: `features/work-orders/mobile/detailOperationalState.ts`, `features/work-orders/mobile/MobileWorkOrderClient.tsx`, `tests/mobile-work-order-detail-operational-state.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f80c0cb88328b6b765fa91f5a456)