### PR TITLE
Fix work order canonical parts display

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -415,6 +415,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
 
     const reqList = (reqs ?? []) as RequestRow[];
     const reqIds = reqList.map((r) => r.id);
+    const shopId = woRow.shop_id ?? null;
 
     const itemsByRequest: Record<string, ItemRow[]> = {};
     if (reqIds.length) {
@@ -459,6 +460,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
         .from("work_order_parts")
         .select("source_parts_request_item_id")
         .in("source_parts_request_item_id", requestItemIds)
+        .eq("shop_id", shopId)
         .eq("is_active", true);
       if (attachedError) {
         toast.warning(attachedError.message);
@@ -493,7 +495,6 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       }
     }
 
-    const shopId = woRow.shop_id ?? null;
     if (shopId) {
       const [{ data: ps }, { data: locs }, { data: poRows }, { data: supRows }, { data: vendorRows }] =
         await Promise.all([

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -33,6 +33,7 @@ import { cn } from "@shared/lib/utils";
 import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import { deriveEventsFromWorkOrder } from "@/features/shared/lib/decisionEvents";
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
 
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
@@ -660,8 +661,9 @@ export default function WorkOrderIdClient(): JSX.Element {
             // ✅ staged/quoted parts from menu quick add (NOT allocated inventory)
             supabase
               .from("work_order_parts")
-              .select("*, parts(name, sku, part_number, manufacturer)")
+              .select("*, parts(name, sku, part_number, manufacturer, supplier)")
               .eq("work_order_id", woRow.id)
+              .eq("shop_id", woRow.shop_id)
               .eq("is_active", true)
               .in(
                 "work_order_line_id",
@@ -923,7 +925,7 @@ export default function WorkOrderIdClient(): JSX.Element {
         quote,
         shopLaborRate,
         stagedParts: stagedPartsByLine[line.id] ?? [],
-        allocatedParts: allocsByLine[line.id] ?? [],
+        allocatedParts: filterAllocationsNotBackedByCanonicalParts(allocsByLine[line.id] ?? [], stagedPartsByLine[line.id] ?? []),
       });
       byLine[line.id] = {
         laborTotal: resolved.laborTotal,

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -25,6 +25,14 @@ import {
   resolvePrimaryTechDisplay,
 } from "@/features/work-orders/lib/display/linePresentation";
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+import {
+  filterAllocationsNotBackedByCanonicalParts,
+  getCanonicalPartDescription,
+  getCanonicalPartManufacturer,
+  getCanonicalPartNumber,
+  getCanonicalPartQuantity,
+  getCanonicalPartUnitPrice,
+} from "@/features/work-orders/lib/display/workOrderParts";
 import VehicleHistoryModal from "@/features/work-orders/components/workorders/VehicleHistoryModal";
 import DtcSuggestionModal from "@/features/work-orders/components/workorders/DtcSuggestionPopup";
 
@@ -94,6 +102,7 @@ type RequiredPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"] & {
   part_number_snapshot?: string | null;
   unit_sell_price_snapshot?: number | null;
   lifecycle_status?: string | null;
+  source_parts_request_item_id?: string | null;
   parts?: { name: string | null; part_number?: string | null; manufacturer?: string | null } | null;
 };
 
@@ -373,18 +382,27 @@ export default function FocusedJobModal(props: {
     if (!workOrderLineId) return;
     setAllocsLoading(true);
     try {
+      let allocBuilder = supabase
+        .from("work_order_part_allocations")
+        .select("*, parts(name)")
+        .eq("work_order_line_id", workOrderLineId);
+      let requiredBuilder = supabase
+        .from("work_order_parts")
+        .select("*, parts(name, part_number, sku, manufacturer, supplier)")
+        .eq("work_order_line_id", workOrderLineId)
+        .eq("is_active", true);
+      if (workOrder?.id) {
+        allocBuilder = allocBuilder.eq("work_order_id", workOrder.id);
+        requiredBuilder = requiredBuilder.eq("work_order_id", workOrder.id);
+      }
+      if (workOrder?.shop_id) {
+        allocBuilder = allocBuilder.eq("shop_id", workOrder.shop_id);
+        requiredBuilder = requiredBuilder.eq("shop_id", workOrder.shop_id);
+      }
+
       const [allocQuery, requiredQuery] = await Promise.all([
-        supabase
-          .from("work_order_part_allocations")
-          .select("*, parts(name)")
-          .eq("work_order_line_id", workOrderLineId)
-          .order("created_at", { ascending: true }),
-        supabase
-          .from("work_order_parts")
-          .select("*, parts(name, part_number, manufacturer)")
-          .eq("work_order_line_id", workOrderLineId)
-          .eq("is_active", true)
-          .order("created_at", { ascending: true }),
+        allocBuilder.order("created_at", { ascending: true }),
+        requiredBuilder.order("created_at", { ascending: true }),
       ]);
       if (allocQuery.error) throw allocQuery.error;
       if (requiredQuery.error) throw requiredQuery.error;
@@ -395,7 +413,7 @@ export default function FocusedJobModal(props: {
     } finally {
       setAllocsLoading(false);
     }
-  }, [supabase, workOrderLineId]);
+  }, [supabase, workOrder?.id, workOrder?.shop_id, workOrderLineId]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -413,6 +431,16 @@ export default function FocusedJobModal(props: {
           event: "*",
           schema: "public",
           table: "work_order_part_allocations",
+          filter: `work_order_line_id=eq.${workOrderLineId}`,
+        },
+        () => void loadAllocations(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "work_order_parts",
           filter: `work_order_line_id=eq.${workOrderLineId}`,
         },
         () => void loadAllocations(),
@@ -589,7 +617,7 @@ export default function FocusedJobModal(props: {
   const isPanelVariant = variant === "panel";
   const isExpandedPanel = isPanelVariant;
   const pricing = line
-    ? resolveWorkOrderLinePricing({ line, shopLaborRate: null, allocatedParts: allocs, stagedParts: requiredParts })
+    ? resolveWorkOrderLinePricing({ line, shopLaborRate: null, allocatedParts: filterAllocationsNotBackedByCanonicalParts(allocs, requiredParts), stagedParts: requiredParts })
     : null;
   const laborDisplay = formatLaborSummary(pricing?.laborHours, Number(pricing?.laborTotal ?? 0));
   const lineTotal = Number(pricing?.lineTotal ?? 0);
@@ -965,13 +993,13 @@ export default function FocusedJobModal(props: {
                     </div>
                     <ul className="max-h-56 overflow-auto divide-y divide-white/5">
                       {requiredParts.map((p) => {
-                        const qty = Number(p.quantity ?? 0);
-                        const unit = Number(p.unit_sell_price_snapshot ?? p.unit_price ?? 0);
+                        const qty = getCanonicalPartQuantity(p);
+                        const unit = getCanonicalPartUnitPrice(p);
                         return (
                           <li key={`required-${p.id}`} className="grid grid-cols-12 items-center gap-2 px-3 py-2 text-sm">
                             <div className="col-span-7 min-w-0 break-words text-neutral-100">
-                              {p.description_snapshot ?? p.parts?.name ?? "Required part"}
-                              <div className="text-[11px] text-neutral-400">{[p.part_number_snapshot ?? p.parts?.part_number, p.manufacturer_snapshot ?? p.parts?.manufacturer, p.lifecycle_status ?? "requested"].filter(Boolean).join(" • ")}</div>
+                              {getCanonicalPartDescription(p) ?? "—"}
+                              <div className="text-[11px] text-neutral-400">{[getCanonicalPartNumber(p), getCanonicalPartManufacturer(p), p.lifecycle_status ?? "requested"].filter(Boolean).join(" • ")}</div>
                             </div>
                             <div className="col-span-3 truncate text-neutral-400">{unit > 0 ? money(unit) : "—"}</div>
                             <div className="col-span-2 text-right font-semibold text-neutral-100">{qty}</div>

--- a/features/work-orders/lib/display/linePresentation.test.ts
+++ b/features/work-orders/lib/display/linePresentation.test.ts
@@ -5,6 +5,12 @@ import {
   resolvePartsBottleneckDisplay,
   resolvePrimaryTechDisplay,
 } from "./linePresentation";
+import {
+  activeCanonicalWorkOrderParts,
+  filterAllocationsNotBackedByCanonicalParts,
+  getCanonicalPartDescription,
+  getCanonicalPartTotal,
+} from "./workOrderParts";
 import { resolveWorkOrderLinePricing } from "../pricing/resolveWorkOrderLinePricing";
 
 describe("linePresentation", () => {
@@ -32,17 +38,20 @@ describe("linePresentation", () => {
     expect(formatLaborSummary(2.2, 319)).toContain("$319.00");
   });
 
-  it("adds active canonical parts to a labor-only line estimate", () => {
+  it("adds active canonical parts to a labor-only line estimate using saved package snapshots", () => {
     const pricing = resolveWorkOrderLinePricing({
-      line: { labor_time: 2.2, price_estimate: 319 },
+      line: { labor_time: 1, price_estimate: 140 },
       shopLaborRate: null,
-      stagedParts: [{ quantity: 1, unit_price: 525, total_price: 525 }],
+      stagedParts: [
+        { quantity: 1, quantity_requested: 1, unit_price: null, unit_sell_price_snapshot: 260.47, total_price: 260.47, is_active: true },
+        { quantity: 6, quantity_requested: 6, unit_price: null, unit_sell_price_snapshot: 229.39, total_price: 1376.34, is_active: true },
+      ],
     });
-    expect(pricing.laborHours).toBe(2.2);
-    expect(pricing.partsTotal).toBe(525);
-    expect(pricing.laborTotal).toBe(319);
-    expect(pricing.lineTotal).toBe(844);
-    expect(formatLaborSummary(pricing.laborHours, pricing.laborTotal)).toContain("$319.00");
+    expect(pricing.partsCount).toBe(2);
+    expect(pricing.partsTotal).toBeCloseTo(1636.81, 2);
+    expect(pricing.laborTotal).toBe(140);
+    expect(pricing.lineTotal).toBeCloseTo(1776.81, 2);
+    expect(formatLaborSummary(pricing.laborHours, pricing.laborTotal)).toContain("$140.00");
   });
 
   it("does not collapse to zero labor when line total exists without parts", () => {
@@ -56,21 +65,49 @@ describe("linePresentation", () => {
     expect(formatLaborSummary(pricing.laborHours, pricing.laborTotal)).toContain("$87.00");
   });
 
-  it("formats parts summary with requested estimate", () => {
-    const summary = formatPartsSummary({ partsCount: 1, partsTotal: 525 });
-    expect(summary).toContain("1 requested");
-    expect(summary).toContain("$525.00");
+  it("formats parts summary with required count even when the saved estimate is zero", () => {
+    const summary = formatPartsSummary({ partsCount: 2, partsTotal: 1636.81 });
+    expect(summary).toContain("2 required");
+    expect(summary).toContain("$1,636.81");
+    expect(formatPartsSummary({ partsCount: 1, partsTotal: 0 })).not.toBe("No parts estimate");
   });
 
-  it("returns requested/backordered parts bottleneck display", () => {
+  it("returns requested/backordered parts bottleneck display without hard-coded product data", () => {
     const display = resolvePartsBottleneckDisplay({
       hasRequestedMarker: true,
-      holdReason: "Waiting for backordered ABS wheel speed sensor",
+      holdReason: "Waiting for backordered parts",
       partsTotal: 295,
     });
     expect(display?.heading).toBe("Parts Waiting");
-    expect(display?.detail).toContain("ABS wheel speed sensor");
-    expect(display?.detail).toContain("Backordered");
+    expect(display?.detail).toContain("Parts backordered");
     expect(display?.detail).toContain("$295.00");
+    expect(display?.detail).not.toContain("ABS wheel speed sensor");
+  });
+
+  it("loads only active canonical work-order parts for the selected line before allocation", () => {
+    const activeParts = activeCanonicalWorkOrderParts([
+      { id: "filter", work_order_id: "wo", work_order_line_id: "line-a", shop_id: "shop", part_id: "p1", quantity: 1, quantity_requested: 1, unit_price: null, unit_sell_price_snapshot: 260.47, total_price: 260.47, description_snapshot: "ACDelco Oil Filter", is_active: true, created_at: null },
+      { id: "oil", work_order_id: "wo", work_order_line_id: "line-a", shop_id: "shop", part_id: "p2", quantity: 6, quantity_requested: 6, unit_price: null, unit_sell_price_snapshot: 229.39, total_price: 1376.34, description_snapshot: "ACDelco 5W30 Oil", is_active: true, created_at: null },
+      { id: "inactive", work_order_id: "wo", work_order_line_id: "line-a", shop_id: "shop", part_id: "p3", quantity: 1, unit_price: 10, total_price: 10, description_snapshot: "Inactive", is_active: false, created_at: null },
+      { id: "other-line", work_order_id: "wo", work_order_line_id: "line-b", shop_id: "shop", part_id: "p4", quantity: 1, unit_price: 999, total_price: 999, description_snapshot: "Other line", is_active: true, created_at: null },
+    ]).filter((part) => part.work_order_line_id === "line-a");
+
+    expect(activeParts.map(getCanonicalPartDescription)).toEqual(["ACDelco Oil Filter", "ACDelco 5W30 Oil"]);
+    expect(activeParts.reduce((sum, part) => sum + getCanonicalPartTotal(part), 0)).toBeCloseTo(1636.81, 2);
+  });
+
+  it("does not double-count allocations backed by canonical request items and does not require allocation for display", () => {
+    const canonicalParts = [
+      { source_parts_request_item_id: "request-item-1" },
+      { source_parts_request_item_id: "request-item-2" },
+    ];
+    const allocations = [
+      { source_request_item_id: "request-item-1", qty: 1, unit_cost: 260.47 },
+      { source_request_item_id: null, qty: 1, unit_cost: 20 },
+    ];
+
+    expect(filterAllocationsNotBackedByCanonicalParts(allocations, canonicalParts)).toEqual([
+      { source_request_item_id: null, qty: 1, unit_cost: 20 },
+    ]);
   });
 });

--- a/features/work-orders/lib/display/linePresentation.ts
+++ b/features/work-orders/lib/display/linePresentation.ts
@@ -28,8 +28,9 @@ export function formatLaborSummary(hours: number | null | undefined, laborTotal:
 
 export function formatPartsSummary(args: { partsCount: number; partsTotal: number }): string {
   const { partsCount, partsTotal } = args;
-  if (partsTotal > 0 && partsCount > 0) {
-    return `${partsCount} requested · ${new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD" }).format(partsTotal)} est.`;
+  if (partsCount > 0) {
+    const total = new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD" }).format(partsTotal);
+    return `${partsCount} required · ${total} est.`;
   }
   if (partsTotal > 0) {
     return `Parts ${new Intl.NumberFormat("en-CA", { style: "currency", currency: "CAD" }).format(partsTotal)} est.`;
@@ -49,6 +50,6 @@ export function resolvePartsBottleneckDisplay(args: {
     : "";
   return {
     heading: status === "Backordered" ? "Parts Waiting" : "Parts Requested",
-    detail: `ABS wheel speed sensor — ${status}${estimate}`,
+    detail: `Parts ${status.toLowerCase()}${estimate}`,
   };
 }

--- a/features/work-orders/lib/display/workOrderParts.ts
+++ b/features/work-orders/lib/display/workOrderParts.ts
@@ -1,0 +1,78 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type WorkOrderPart = DB["public"]["Tables"]["work_order_parts"]["Row"];
+type WorkOrderPartAllocation = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
+
+export type CanonicalWorkOrderPart = WorkOrderPart & {
+  id: string;
+  source_parts_request_item_id?: string | null;
+  part_id: string | null;
+  description_snapshot?: string | null;
+  part_number_snapshot?: string | null;
+  manufacturer_snapshot?: string | null;
+  quantity_requested?: number | null;
+  quantity: number;
+  unit_sell_price_snapshot?: number | null;
+  unit_price: number | null;
+  total_price: number | null;
+  lifecycle_status?: string | null;
+  is_active?: boolean | null;
+  parts?: { name?: string | null; part_number?: string | null; sku?: string | null; manufacturer?: string | null; supplier?: string | null } | null;
+};
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+export function getCanonicalPartQuantity(part: Pick<CanonicalWorkOrderPart, "quantity" | "quantity_requested">): number {
+  return toNumber(part.quantity_requested) ?? toNumber(part.quantity) ?? 0;
+}
+
+export function getCanonicalPartUnitPrice(part: Pick<CanonicalWorkOrderPart, "unit_sell_price_snapshot" | "unit_price">): number {
+  return toNumber(part.unit_sell_price_snapshot) ?? toNumber(part.unit_price) ?? 0;
+}
+
+export function getCanonicalPartTotal(part: Pick<CanonicalWorkOrderPart, "quantity" | "quantity_requested" | "unit_sell_price_snapshot" | "unit_price" | "total_price">): number {
+  return toNumber(part.total_price) ?? getCanonicalPartQuantity(part) * getCanonicalPartUnitPrice(part);
+}
+
+export function getCanonicalPartDescription(part: Pick<CanonicalWorkOrderPart, "description_snapshot" | "parts">): string | null {
+  const snapshot = part.description_snapshot?.trim();
+  if (snapshot) return snapshot;
+  const catalogName = part.parts?.name?.trim();
+  return catalogName || null;
+}
+
+export function getCanonicalPartNumber(part: Pick<CanonicalWorkOrderPart, "part_number_snapshot" | "parts">): string | null {
+  return part.part_number_snapshot?.trim() || part.parts?.part_number?.trim() || part.parts?.sku?.trim() || null;
+}
+
+export function getCanonicalPartManufacturer(part: Pick<CanonicalWorkOrderPart, "manufacturer_snapshot" | "parts">): string | null {
+  return part.manufacturer_snapshot?.trim() || part.parts?.manufacturer?.trim() || part.parts?.supplier?.trim() || null;
+}
+
+export function activeCanonicalWorkOrderParts(parts: CanonicalWorkOrderPart[]): CanonicalWorkOrderPart[] {
+  return parts.filter((part) => part.is_active !== false);
+}
+
+export function filterAllocationsNotBackedByCanonicalParts<T extends Pick<WorkOrderPartAllocation, "source_request_item_id">>(
+  allocations: T[],
+  canonicalParts: Array<{ source_parts_request_item_id?: string | null }>,
+): T[] {
+  const canonicalSourceItemIds = new Set(
+    canonicalParts
+      .map((part) => part.source_parts_request_item_id ?? null)
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
+  );
+  if (canonicalSourceItemIds.size === 0) return allocations;
+  return allocations.filter((allocation) => {
+    const sourceItemId = allocation.source_request_item_id ?? null;
+    return !sourceItemId || !canonicalSourceItemIds.has(sourceItemId);
+  });
+}

--- a/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
+++ b/features/work-orders/lib/pricing/resolveWorkOrderLinePricing.ts
@@ -28,7 +28,7 @@ export function resolveWorkOrderLinePricing(args: {
   line: Pick<WorkOrderLine, "labor_time"> & { id?: string; price_estimate?: number | null; labor_total?: number | null; labor_rate?: number | null };
   quote?: Partial<WorkOrderQuoteLine> | null;
   shopLaborRate: number | null;
-  stagedParts?: Array<Pick<WorkOrderPart, "quantity" | "unit_price" | "total_price">>;
+  stagedParts?: Array<Pick<WorkOrderPart, "quantity" | "unit_price" | "total_price"> & { quantity_requested?: number | null; unit_sell_price_snapshot?: number | null; is_active?: boolean | null }>;
   allocatedParts?: Array<
     Pick<WorkOrderPartAllocation, "qty" | "unit_cost"> & {
       quantity?: number | null;
@@ -68,10 +68,11 @@ export function resolveWorkOrderLinePricing(args: {
   const laborRate = explicitLineLaborRate != null && explicitLineLaborRate > 0 ? explicitLineLaborRate : toNum(shopLaborRate) ?? 0;
   const quotedLaborTotal = toNum(quote?.labor_total);
 
-  const stagedPartsTotal = stagedParts.reduce((sum, part) => {
+  const activeStagedParts = stagedParts.filter((part) => part.is_active !== false);
+  const stagedPartsTotal = activeStagedParts.reduce((sum, part) => {
     const total = toNum(part.total_price);
     if (total != null) return sum + total;
-    return sum + (toNum(part.quantity) ?? 0) * (toNum(part.unit_price) ?? 0);
+    return sum + (toNum(part.quantity_requested) ?? toNum(part.quantity) ?? 0) * (toNum(part.unit_sell_price_snapshot) ?? toNum(part.unit_price) ?? 0);
   }, 0);
 
   const allocPartsTotal = allocatedParts.reduce((sum, part) => {
@@ -82,7 +83,7 @@ export function resolveWorkOrderLinePricing(args: {
 
   const hasQuotePartsTotal = toNum(quote?.parts_total) != null;
   const partsTotal = hasQuotePartsTotal ? (toNum(quote?.parts_total) ?? 0) : stagedPartsTotal + allocPartsTotal;
-  const partsCount = stagedParts.length + allocatedParts.length;
+  const partsCount = activeStagedParts.length + allocatedParts.length;
   const explicitLineLaborTotal = toNum(line.labor_total) ?? (partsTotal > 0 ? linePriceEstimate : null);
   const computedLaborForLineTotal = explicitLineLaborTotal != null && explicitLineLaborTotal > 0 ? explicitLineLaborTotal : laborHours * laborRate;
   const computedLineTotal = computedLaborForLineTotal + partsTotal;

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -30,6 +30,12 @@ import AIAssistantModal from "@work-orders/components/workorders/AiAssistantModa
 import NewChatModal from "@/features/ai/components/chat/NewChatModal";
 import SuggestedQuickAdd from "@work-orders/components/SuggestedQuickAdd";
 import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
+import {
+  getCanonicalPartDescription,
+  getCanonicalPartManufacturer,
+  getCanonicalPartNumber,
+  getCanonicalPartQuantity,
+} from "@/features/work-orders/lib/display/workOrderParts";
 
 import VehicleHistoryModal from "@/features/work-orders/components/workorders/VehicleHistoryModal";
 
@@ -85,6 +91,7 @@ type RequiredPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"] & {
   part_number_snapshot?: string | null;
   unit_sell_price_snapshot?: number | null;
   lifecycle_status?: string | null;
+  source_parts_request_item_id?: string | null;
   parts?: { name: string | null; part_number?: string | null; manufacturer?: string | null } | null;
 };
 
@@ -314,18 +321,27 @@ export default function MobileFocusedJob(props: {
     if (!workOrderLineId) return;
     setAllocsLoading(true);
     try {
+      let allocBuilder = supabase
+        .from("work_order_part_allocations")
+        .select("*, parts(name)")
+        .eq("work_order_line_id", workOrderLineId);
+      let requiredBuilder = supabase
+        .from("work_order_parts")
+        .select("*, parts(name, part_number, sku, manufacturer, supplier)")
+        .eq("work_order_line_id", workOrderLineId)
+        .eq("is_active", true);
+      if (workOrder?.id) {
+        allocBuilder = allocBuilder.eq("work_order_id", workOrder.id);
+        requiredBuilder = requiredBuilder.eq("work_order_id", workOrder.id);
+      }
+      if (workOrder?.shop_id) {
+        allocBuilder = allocBuilder.eq("shop_id", workOrder.shop_id);
+        requiredBuilder = requiredBuilder.eq("shop_id", workOrder.shop_id);
+      }
+
       const [allocQuery, requiredQuery] = await Promise.all([
-        supabase
-          .from("work_order_part_allocations")
-          .select("*, parts(name)")
-          .eq("work_order_line_id", workOrderLineId)
-          .order("created_at", { ascending: true }),
-        supabase
-          .from("work_order_parts")
-          .select("*, parts(name, part_number, manufacturer)")
-          .eq("work_order_line_id", workOrderLineId)
-          .eq("is_active", true)
-          .order("created_at", { ascending: true }),
+        allocBuilder.order("created_at", { ascending: true }),
+        requiredBuilder.order("created_at", { ascending: true }),
       ]);
       if (allocQuery.error) throw allocQuery.error;
       if (requiredQuery.error) throw requiredQuery.error;
@@ -337,7 +353,7 @@ export default function MobileFocusedJob(props: {
     } finally {
       setAllocsLoading(false);
     }
-  }, [supabase, workOrderLineId]);
+  }, [supabase, workOrder?.id, workOrder?.shop_id, workOrderLineId]);
 
   const refresh = useCallback(async () => {
     if (!workOrderLineId) return;
@@ -533,6 +549,16 @@ export default function MobileFocusedJob(props: {
           event: "*",
           schema: "public",
           table: "work_order_part_allocations",
+          filter: `work_order_line_id=eq.${workOrderLineId}`,
+        },
+        () => void loadAllocations(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "work_order_parts",
           filter: `work_order_line_id=eq.${workOrderLineId}`,
         },
         () => void loadAllocations(),
@@ -1245,13 +1271,13 @@ export default function MobileFocusedJob(props: {
                             className="grid grid-cols-12 items-center px-3 py-2 text-sm"
                           >
                             <div className="col-span-7 truncate text-neutral-100">
-                              {p.description_snapshot ?? p.parts?.name ?? "Required part"}
+                              {getCanonicalPartDescription(p) ?? "—"}
                             </div>
                             <div className="col-span-3 truncate text-neutral-400">
-                              {[p.part_number_snapshot ?? p.parts?.part_number, p.lifecycle_status ?? "requested"].filter(Boolean).join(" • ") || "—"}
+                              {[getCanonicalPartNumber(p), getCanonicalPartManufacturer(p), p.lifecycle_status ?? "requested"].filter(Boolean).join(" • ") || "—"}
                             </div>
                             <div className="col-span-2 text-right font-semibold text-neutral-100">
-                              {p.quantity}
+                              {getCanonicalPartQuantity(p)}
                             </div>
                           </li>
                         ))}


### PR DESCRIPTION
### Motivation
- Work-order lines were not reliably showing canonical saved required parts: committed `work_order_parts` snapshots were not consumed for UI/pricing, producing "No parts estimate" and a hard-coded "ABS wheel speed sensor — Requested" placeholder.
- The display must present committed package snapshots (quantity, description, unit sell price) and not fabricate or fall back to live catalog pricing or demo text.

### Description
- Add a small canonical helper `features/work-orders/lib/display/workOrderParts.ts` to read and interpret active `work_order_parts` snapshots (quantity_requested, unit_sell_price_snapshot, total_price, description_snapshot, part_number_snapshot, manufacturer_snapshot) and helpers for unit/total/description extraction and allocation de-duplication. 
- Update pricing to prefer active staged/canonical part snapshots in `resolveWorkOrderLinePricing` so `partsTotal` and `partsCount` come from saved package rows (use `quantity_requested` / `unit_sell_price_snapshot` when present). 
- Load active `work_order_parts` scoped by `work_order_id` / `work_order_line_id` / `shop_id` in the Work Order client and in focused views, add realtime subscriptions for `work_order_parts`, and render snapshot fields in `FocusedJobModal` and `MobileFocusedJob` rather than hard-coded or placeholder text. 
- Avoid double-counting allocations backed by canonical `work_order_parts` by filtering allocations that reference the same `source_parts_request_item_id`. 
- Remove the hard-coded product string from `resolvePartsBottleneckDisplay` and change `formatPartsSummary` to show required parts count and snapshot totals when committed. 
- Ensure Parts Request page hydrates `addedToWorkOrder` from active `work_order_parts` with `shop_id` scope so package-committed rows survive reload. 
- No changes were made to package commit behavior, inventory allocation, purchase orders, RFQ flows, or accounting logic.

### Testing
- Ran focused unit tests: `pnpm exec vitest run features/work-orders/lib/display/linePresentation.test.ts tests/parts/parts-package-handoffs-source.test.ts features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx features/parts/components/request-workbench/partsPackageCommit.test.ts tests/mobile-work-order-detail-operational-state.test.ts` — all selected test files passed (40 tests across 5 files passed).
- Type checks: `pnpm typecheck` — succeeded (TS compile with `--noEmit`).
- Lint: `pnpm exec eslint` on modified files — exited 0 with two existing warnings in `MobileFocusedJob.tsx` (no new errors).
- Attempted `pnpm build` but the environment build was blocked by Google Fonts fetch failures (network font fetch), so a full production build could not be completed in this environment; this is an environment issue and not related to the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54ff3ec9f8832886a7d4340b062b23)