### PR TITLE
Fix inspection review submission: add quote_line_id migration, avoid auto-finish, and allow expired pricing to be applied

### DIFF
--- a/features/inspections/lib/inspection/SectionDisplay.tsx
+++ b/features/inspections/lib/inspection/SectionDisplay.tsx
@@ -136,9 +136,9 @@ function submittedAt(item: ItemExtended): string | null {
 function smartPricingText(
   status: "fresh" | "stale" | "expired" | undefined,
 ): string {
-  if (status === "fresh") return "Fresh pricing — safe for auto-add.";
-  if (status === "stale") return "Stale pricing — review before add.";
-  return "Expired pricing — auto-add blocked until pricing is refreshed.";
+  if (status === "fresh") return "Fresh pricing — ready to apply.";
+  if (status === "stale") return "Stale pricing — pricing review required after apply.";
+  return "Expired pricing — pricing review required after apply.";
 }
 
 function smartPricingBadgeClass(
@@ -470,14 +470,12 @@ export default function SectionDisplay(props: SectionDisplayProps) {
 
                         if (!match) return null;
 
-                        const canAutoAdd = match.pricingStatus === "fresh";
+                        const canApplyRepair = Boolean(onAcceptSmartMatch);
                         const statusText = pricingStatusText(match.pricingStatus);
                         const actionText =
                           match.pricingStatus === "fresh"
-                            ? "Auto-add eligible"
-                            : match.pricingStatus === "stale"
-                              ? "Review recommended"
-                              : "Auto-add blocked";
+                            ? "Ready to apply"
+                            : "Pricing review required";
 
                         return (
                           <div className="mt-2 rounded-lg border border-white/10 bg-black/25 p-3">
@@ -520,20 +518,18 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                 </button>
                                 <button
                                   type="button"
-                                  disabled={!canAutoAdd}
+                                  disabled={!canApplyRepair}
                                   className={[
                                     "rounded-full px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em]",
-                                    canAutoAdd
+                                    canApplyRepair
                                       ? "border border-emerald-500/40 bg-emerald-950/30 text-emerald-200 hover:bg-emerald-900/30"
-                                      : "cursor-not-allowed border border-red-500/20 bg-red-950/20 text-red-200/70",
+                                      : "cursor-not-allowed border border-neutral-500/20 bg-neutral-950/20 text-neutral-200/70",
                                   ].join(" ")}
                                   onClick={() => {
-                                    if (canAutoAdd) {
-                                      onAcceptSmartMatch?.(sectionIndex, itemIndex);
-                                    }
+                                    onAcceptSmartMatch?.(sectionIndex, itemIndex);
                                   }}
                                 >
-                                  {canAutoAdd ? "Add matched repair" : "Pricing review required"}
+                                  Apply repair
                                 </button>
                               </div>
                             </div>
@@ -872,9 +868,7 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                     props.onAcceptSmartMatch?.(sectionIndex, itemIndex)
                                   }
                                 >
-                                  {smartMatch.pricingStatus === "fresh"
-                                    ? "Add matched repair"
-                                    : "Review match"}
+                                  Apply repair
                                 </Button>
                               </div>
                             </>

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -860,6 +860,8 @@ export default function InspectionFindingsPage(): JSX.Element {
                   menu_repair_item_id: acceptedMatch.menuRepairItemId ?? null,
                   pricing_status: acceptedMatch.pricingStatus ?? null,
                   pricing_valid_until: acceptedMatch.pricingValidUntil ?? null,
+                  pricing_review_required: acceptedMatch.pricingStatus !== "fresh",
+                  technician_pricing_approved: false,
                   confidence: acceptedMatch.confidence ?? null,
                 }
               : null,
@@ -939,23 +941,6 @@ export default function InspectionFindingsPage(): JSX.Element {
 
       const payload = summarizeFromSections(nextSession);
 
-      const finishRes = await fetch(
-        `/api/work-orders/lines/${resolvedWorkOrderLineId}/finish`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        },
-      );
-
-      const finishJson = (await finishRes.json().catch(() => null)) as
-        | { error?: string }
-        | null;
-
-      if (!finishRes.ok) {
-        throw new Error(finishJson?.error || "Failed to finish inspection");
-      }
-
       const invoiceRefreshRes = await fetch(
         `/api/work-orders/${resolvedWorkOrderId}/invoice`,
         {
@@ -983,7 +968,7 @@ export default function InspectionFindingsPage(): JSX.Element {
         );
         bestEffortWarning =
           invoiceRefreshJson?.issues?.[0]?.message ||
-          "Inspection finished, but invoice refresh failed.";
+          "Findings submitted, but invoice refresh failed.";
       }
 
       const pdfRes = await fetch(`/api/inspections/finalize/pdf`, {
@@ -999,7 +984,7 @@ export default function InspectionFindingsPage(): JSX.Element {
       if (!pdfRes.ok || !pdfJson?.ok) {
         bestEffortWarning =
           bestEffortWarning ??
-          (pdfJson?.error || "Inspection finished, but PDF finalize failed.");
+          (pdfJson?.error || "Findings submitted, but PDF finalize failed.");
       }
 
       window.dispatchEvent(
@@ -1008,6 +993,7 @@ export default function InspectionFindingsPage(): JSX.Element {
             workOrderLineId: resolvedWorkOrderLineId,
             cause: payload.cause,
             correction: payload.correction,
+            reviewSubmitted: true,
           },
         }),
       );

--- a/features/inspections/lib/inspection/inspectionReviewSubmission.test.ts
+++ b/features/inspections/lib/inspection/inspectionReviewSubmission.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const findingsPage = readFileSync(
+  "features/inspections/lib/inspection/findings/page.tsx",
+  "utf8",
+);
+const sectionDisplay = readFileSync(
+  "features/inspections/lib/inspection/SectionDisplay.tsx",
+  "utf8",
+);
+const genericScreen = readFileSync(
+  "features/inspections/screens/GenericInspectionScreen.tsx",
+  "utf8",
+);
+const jobPunchTransition = readFileSync(
+  "features/work-orders/server/applyJobPunchTransition.ts",
+  "utf8",
+);
+
+describe("inspection review submission blockers", () => {
+  it("submits reviewed findings to canonical quote review without finishing the originating line", () => {
+    expect(findingsPage).toContain('/api/work-orders/quotes/add');
+    expect(findingsPage).not.toContain('/api/work-orders/lines/${resolvedWorkOrderLineId}/finish');
+    expect(findingsPage).not.toContain('Failed to finish inspection');
+    expect(findingsPage).toContain('estimateSubmitted: true');
+    expect(findingsPage).toContain('estimateQuoteLineId:');
+    expect(findingsPage).toContain('/api/inspections/finalize/pdf');
+  });
+
+  it("keeps explicit technician job completion in the punch transition flow", () => {
+    expect(jobPunchTransition).toContain('action === "finish"');
+    expect(jobPunchTransition).toContain('status: "completed"');
+    expect(jobPunchTransition).toContain('completed: true');
+    expect(jobPunchTransition).toContain('punched_out_at: nowIso');
+  });
+
+  it("allows technicians to apply expired smart matches as advisory pricing review", () => {
+    expect(sectionDisplay).toContain('Expired pricing — pricing review required after apply.');
+    expect(sectionDisplay).not.toContain('Auto-add blocked');
+    expect(sectionDisplay).toContain('Apply repair');
+    expect(sectionDisplay).toContain('Pricing review required');
+    expect(genericScreen).toContain('pricingStatus: match.pricingStatus ?? null');
+    expect(findingsPage).toContain('pricing_review_required: acceptedMatch.pricingStatus !== "fresh"');
+    expect(findingsPage).toContain('technician_pricing_approved: false');
+  });
+});

--- a/supabase/migrations/202607130003_quote_line_part_request_linkage.sql
+++ b/supabase/migrations/202607130003_quote_line_part_request_linkage.sql
@@ -1,0 +1,54 @@
+-- Forward-only repair for live databases missing durable quote-line linkage.
+-- Additive, nullable, and safe for existing data; no backfill required.
+
+alter table public.part_requests
+  add column if not exists quote_line_id uuid null;
+
+alter table public.part_request_items
+  add column if not exists quote_line_id uuid null;
+
+comment on column public.part_requests.quote_line_id is
+  'Canonical pre-approval work_order_quote_lines row that originated this parts request, when applicable. Nullable for existing/manual requests.';
+
+comment on column public.part_request_items.quote_line_id is
+  'Canonical pre-approval work_order_quote_lines row that originated this parts request item, when applicable. Nullable for existing/manual items.';
+
+do $$
+begin
+  if to_regclass('public.work_order_quote_lines') is not null then
+    if not exists (
+      select 1
+      from pg_constraint
+      where conname = 'part_requests_quote_line_id_fkey'
+        and conrelid = 'public.part_requests'::regclass
+    ) then
+      alter table public.part_requests
+        add constraint part_requests_quote_line_id_fkey
+        foreign key (quote_line_id)
+        references public.work_order_quote_lines(id)
+        on delete set null;
+    end if;
+
+    if not exists (
+      select 1
+      from pg_constraint
+      where conname = 'part_request_items_quote_line_id_fkey'
+        and conrelid = 'public.part_request_items'::regclass
+    ) then
+      alter table public.part_request_items
+        add constraint part_request_items_quote_line_id_fkey
+        foreign key (quote_line_id)
+        references public.work_order_quote_lines(id)
+        on delete set null;
+    end if;
+  end if;
+end $$;
+
+create index if not exists idx_part_requests_shop_quote_line
+  on public.part_requests (shop_id, quote_line_id);
+
+create index if not exists idx_part_request_items_shop_quote_line
+  on public.part_request_items (shop_id, quote_line_id);
+
+create index if not exists idx_part_request_items_work_order_quote_line
+  on public.part_request_items (work_order_id, quote_line_id);

--- a/tests/parts/quote-line-part-request-linkage.test.ts
+++ b/tests/parts/quote-line-part-request-linkage.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/202607130003_quote_line_part_request_linkage.sql",
+  "utf8",
+);
+const canonicalQuoteHelper = readFileSync(
+  "features/work-orders/lib/work-orders/canonicalQuoteLines.ts",
+  "utf8",
+);
+const generatedTypes = readFileSync(
+  "features/shared/types/types/supabase.ts",
+  "utf8",
+);
+
+describe("quote-line part request linkage schema", () => {
+  it("adds nullable quote_line_id columns idempotently without backfill", () => {
+    expect(migration).toContain("alter table public.part_requests");
+    expect(migration).toContain("add column if not exists quote_line_id uuid null");
+    expect(migration).toContain("alter table public.part_request_items");
+    expect(migration).not.toMatch(/update\s+public\.(part_requests|part_request_items)/i);
+  });
+
+  it("adds quote-line foreign keys only when the canonical quote table exists", () => {
+    expect(migration).toContain("to_regclass('public.work_order_quote_lines') is not null");
+    expect(migration).toContain("constraint part_requests_quote_line_id_fkey");
+    expect(migration).toContain("constraint part_request_items_quote_line_id_fkey");
+    expect(migration).toContain("references public.work_order_quote_lines(id)");
+    expect(migration).toContain("on delete set null");
+  });
+
+  it("adds the intended lookup indexes", () => {
+    expect(migration).toContain("idx_part_requests_shop_quote_line");
+    expect(migration).toContain("on public.part_requests (shop_id, quote_line_id)");
+    expect(migration).toContain("idx_part_request_items_shop_quote_line");
+    expect(migration).toContain("on public.part_request_items (shop_id, quote_line_id)");
+    expect(migration).toContain("idx_part_request_items_work_order_quote_line");
+    expect(migration).toContain("on public.part_request_items (work_order_id, quote_line_id)");
+  });
+
+  it("matches the canonical quote helper's selected and inserted quote_line_id columns", () => {
+    expect(canonicalQuoteHelper).toContain('if (!source || parts.length === 0) continue;');
+    expect(canonicalQuoteHelper).toContain('.eq("shop_id", input.shopId)');
+    expect(canonicalQuoteHelper).toContain('.eq("work_order_id", input.workOrderId)');
+    expect(canonicalQuoteHelper).toContain('.eq("quote_line_id", input.quoteLineId)');
+    expect(canonicalQuoteHelper).toContain('quote_line_id: input.quoteLineId');
+    expect(canonicalQuoteHelper).toContain('.eq("quote_line_id", quoteLineId)');
+    expect(canonicalQuoteHelper).toContain('quote_line_id: quoteLineId');
+    expect(canonicalQuoteHelper).toContain('.select("id, description")');
+    expect(generatedTypes).toContain("quote_line_id: string | null");
+    expect(generatedTypes).toContain("quote_line_id?: string | null");
+  });
+});


### PR DESCRIPTION
### Motivation

- Live DB lacked durable quote linkage columns (`quote_line_id`) used by canonical quote/parts flows, causing submission failures.
- Inspection review submission was finishing the originating work-order line as a side effect of sending findings to quote review, which should be an explicit technician action.
- Smart-match pricing that was expired/stale blocked technicians from applying authored repairs; pricing should be advisory and flagged for review instead of hard-blocking the technician.

### Description

- Add forward-only Supabase migration `supabase/migrations/202607130003_quote_line_part_request_linkage.sql` that idempotently adds nullable `quote_line_id` to `part_requests` and `part_request_items`, conditionally creates FKs to `work_order_quote_lines(id)` (ON DELETE SET NULL), and adds the intended indexes (`idx_part_requests_shop_quote_line`, `idx_part_request_items_shop_quote_line`, `idx_part_request_items_work_order_quote_line`).
- Stop the inspection-review flow from calling the work-order line finish endpoint; review submission now creates/reuses canonical quote lines, creates Parts Requests/items when parts exist, persists returned canonical quote IDs to findings, issues invoice refresh and PDF finalize as best-effort, and routes to Quote Review without completing the originating line (`features/inspections/lib/inspection/findings/page.tsx`).
- Make expired/stale smart-match pricing advisory in the technician UI: replace hard-block language and auto-add gating with advisory copy and an enabled "Apply repair" action, while recording pricing-review metadata on the submitted quote items (`pricing_review_required`, `technician_pricing_approved: false`) so advisors/workflows can surface required verification (`features/inspections/lib/inspection/SectionDisplay.tsx`, `features/inspections/lib/inspection/findings/page.tsx`).
- Add focused regression tests covering the migration/script expectations and the inspection review submission behavior: `tests/parts/quote-line-part-request-linkage.test.ts` and `features/inspections/lib/inspection/inspectionReviewSubmission.test.ts`.

### Testing

- Ran the focused test suite: `pnpm test tests/parts/quote-line-part-request-linkage.test.ts features/inspections/lib/inspection/inspectionReviewSubmission.test.ts` — all tests passed locally.
- Ran type checking: `pnpm typecheck` — passed.
- Ran ESLint against affected files: `pnpm exec eslint ...` — completed with no errors and one pre-existing React Hook dependency warning in `GenericInspectionScreen.tsx` (no change made to that logic).
- Attempted a build: `pnpm build` — failed in this environment due to network/font fetch failures from `next/font` for Google Fonts (`Inter`, `Black Ops One`); failures occurred during font fetch and are environmental (no compile errors attributable to these changes were reached).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552cd3b7d083288be9d29363e7f1fb)