### PR TITLE
Fix Quote Review parts hydration and totals

### DIFF
--- a/features/parts/server/syncQuoteLinePartsStatus.test.ts
+++ b/features/parts/server/syncQuoteLinePartsStatus.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("syncQuoteLinePartsStatus contract", () => {
+  const source = readFileSync("features/parts/server/syncQuoteLinePartsStatus.ts", "utf8");
+
+  it("keeps quote-line part item hydration scoped by shop, work order, and quote line", () => {
+    expect(source).toMatch(/from\("part_request_items"\)[\s\S]*\.eq\("shop_id", shopId\)[\s\S]*\.eq\("work_order_id", line\.work_order_id\)[\s\S]*\.eq\("quote_line_id", quoteLineId\)/);
+  });
+
+  it("persists displayable parts_quote items without requiring inventory selection", () => {
+    expect(source).toContain("required_count");
+    expect(source).toContain("quoted_count");
+    expect(source).toContain("pending_count");
+    expect(source).toContain("description: item.description");
+    expect(source).toContain("qty,");
+    expect(source).toContain("part_id: item.part_id");
+    expect(source).toContain("vendor: item.vendor");
+  });
+});

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -16,6 +16,7 @@ import {
   resolveShopSuppliesSettings,
   shopSuppliesSummaryText,
 } from "@/features/work-orders/lib/shopSupplies";
+import { quoteLineTotalResolved, resolveQuoteLineParts, type CatalogPart, type PartRequest, type PartRequestItem, type ResolvedQuotePart } from "./partsModel";
 
 const COPPER = "#C57A4A";
 const SEND_READY_STAGES = new Set(["advisor_pending", "ready_to_send"]);
@@ -38,6 +39,8 @@ type Customer = DB["public"]["Tables"]["customers"]["Row"];
 type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
 type QuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 type QuoteLineUpdate = DB["public"]["Tables"]["work_order_quote_lines"]["Update"];
+type PartsByQuoteLine = Record<string, ResolvedQuotePart[]>;
+type RequestByQuoteLine = Record<string, PartRequest[]>;
 
 type EditableQuoteLine = QuoteLine & {
   _dirty?: boolean;
@@ -162,11 +165,12 @@ function quoteLinePartsTotal(line: Pick<QuoteLine, "parts_total" | "metadata">):
 }
 
 function quoteLineTotal(line: EditableQuoteLine, shopLaborRate: number): number {
-  return (
-    asNumber(line.grand_total) ??
-    asNumber(line.subtotal) ??
-    quoteLineLaborTotal(line, shopLaborRate) + quoteLinePartsTotal(line)
-  );
+  return quoteLineTotalResolved({
+    persistedGrandTotal: line.grand_total,
+    persistedSubtotal: line.subtotal,
+    calculatedLabor: quoteLineLaborTotal(line, shopLaborRate),
+    calculatedParts: quoteLinePartsTotal(line),
+  });
 }
 
 function hasPartsPrice(line: Pick<QuoteLine, "parts_total" | "metadata">): boolean {
@@ -306,6 +310,22 @@ function sourceSummary(line: Pick<QuoteLine, "metadata" | "suggested_by">): stri
   return values;
 }
 
+function partsRequestLabel(line: Pick<QuoteLine, "description">, index: number): string {
+  const description = safeTrim(line.description);
+  return description ? `Request for ${description}` : `Parts request for quote line ${index + 1}`;
+}
+
+function partPricingLabel(part: ResolvedQuotePart): string {
+  if (part.pricingState === "unresolved") return "Pricing unresolved";
+  if (part.unitPrice != null) return `Unit price: ${fmt(part.unitPrice)}`;
+  return "Price entered";
+}
+
+function selectedPartLabel(part: ResolvedQuotePart): string | null {
+  const identity = [part.selectedPartName, part.selectedPartNumber].filter(Boolean).join(" • ");
+  return identity || null;
+}
+
 export default function QuoteReviewView(props: {
   workOrderId: string;
   embedded?: boolean;
@@ -321,6 +341,8 @@ export default function QuoteReviewView(props: {
   const [shop, setShop] = useState<Shop | null>(null);
   const [customer, setCustomer] = useState<Customer | null>(null);
   const [quoteLines, setQuoteLines] = useState<EditableQuoteLine[]>([]);
+  const [partsByQuoteLine, setPartsByQuoteLine] = useState<PartsByQuoteLine>({});
+  const [requestsByQuoteLine, setRequestsByQuoteLine] = useState<RequestByQuoteLine>({});
   const [workLines, setWorkLines] = useState<WorkOrderLine[]>([]);
   const [openDetails, setOpenDetails] = useState<Record<string, boolean>>({});
   const [saving, setSaving] = useState(false);
@@ -353,6 +375,8 @@ export default function QuoteReviewView(props: {
         setShop(null);
         setCustomer(null);
         setQuoteLines([]);
+        setPartsByQuoteLine({});
+        setRequestsByQuoteLine({});
         setWorkLines([]);
       }
       setLoading(false);
@@ -387,11 +411,61 @@ export default function QuoteReviewView(props: {
       if (qErr) toast.error(qErr.message);
       if (wlErr) toast.error(wlErr.message);
       setShop(shopRow ?? null);
-      setQuoteLines(((qRows ?? []) as QuoteLine[]).map((line) => ({ ...line, _dirty: false, _laborRateDraft: jsonNumber(quoteMetadata(line).labor_rate) })));
+      const loadedQuoteLines = ((qRows ?? []) as QuoteLine[]).map((line) => ({ ...line, _dirty: false, _laborRateDraft: jsonNumber(quoteMetadata(line).labor_rate) }));
+      const quoteLineIds = loadedQuoteLines.map((line) => line.id).filter(Boolean);
+      let liveRequests: PartRequest[] = [];
+      let liveItems: PartRequestItem[] = [];
+      let selectedParts = new Map<string, CatalogPart>();
+
+      if (quoteLineIds.length > 0) {
+        const [{ data: requestRows, error: requestErr }, { data: itemRows, error: itemErr }] = await Promise.all([
+          supabase
+            .from("part_requests")
+            .select("*")
+            .eq("shop_id", shopId)
+            .eq("work_order_id", woId)
+            .in("quote_line_id", quoteLineIds),
+          supabase
+            .from("part_request_items")
+            .select("*")
+            .eq("shop_id", shopId)
+            .eq("work_order_id", woId)
+            .in("quote_line_id", quoteLineIds)
+            .order("created_at", { ascending: true }),
+        ]);
+        if (requestErr) toast.error(requestErr.message);
+        if (itemErr) toast.error(itemErr.message);
+        liveRequests = (requestRows ?? []) as PartRequest[];
+        liveItems = (itemRows ?? []) as PartRequestItem[];
+
+        const selectedPartIds = [...new Set(liveItems.map((item) => safeTrim(item.part_id ?? "")).filter(Boolean))];
+        if (selectedPartIds.length > 0) {
+          const { data: partRows, error: partErr } = await supabase
+            .from("parts")
+            .select("id,name,sku,part_number,supplier")
+            .eq("shop_id", shopId)
+            .in("id", selectedPartIds);
+          if (partErr) toast.error(partErr.message);
+          selectedParts = new Map(((partRows ?? []) as CatalogPart[]).map((part) => [part.id, part]));
+        }
+      }
+
+      const nextPartsByLine: PartsByQuoteLine = {};
+      const nextRequestsByLine: RequestByQuoteLine = {};
+      for (const line of loadedQuoteLines) {
+        nextPartsByLine[line.id] = resolveQuoteLineParts({ line, liveItems, requests: liveRequests, selectedParts });
+        nextRequestsByLine[line.id] = liveRequests.filter((request) => request.quote_line_id === line.id);
+      }
+
+      setQuoteLines(loadedQuoteLines);
+      setPartsByQuoteLine(nextPartsByLine);
+      setRequestsByQuoteLine(nextRequestsByLine);
       setWorkLines(((wlRows ?? []) as WorkOrderLine[]).filter(activeWorkLine));
     } else {
       setShop(null);
       setQuoteLines([]);
+      setPartsByQuoteLine({});
+      setRequestsByQuoteLine({});
       setWorkLines([]);
     }
 
@@ -792,11 +866,54 @@ export default function QuoteReviewView(props: {
                             <div>Labor rate: <span className="text-neutral-200">{fmt(lineLaborRate)}/hr</span></div>
                           </div>
 
-                          {partsSummary ? (
-                            <div className="mt-3 rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3 text-xs text-neutral-400">
-                              Parts quote sync: <span className="text-neutral-200">{partsSummary.pendingCount > 0 ? "pending" : "quoted"} • {partsSummary.quotedCount}/{partsSummary.requiredCount} quoted • {fmt(partsSummary.partsTotal)}</span>
+                          <div className="mt-3 rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3 text-xs text-neutral-300">
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <div className="font-semibold uppercase tracking-[0.16em] text-neutral-400">Required parts</div>
+                              {partsSummary ? (
+                                <div className="text-neutral-400">
+                                  Sync: <span className="text-neutral-200">{partsSummary.pendingCount > 0 ? "pending" : "quoted"} • {partsSummary.quotedCount}/{partsSummary.requiredCount} quoted • {fmt(partsSummary.partsTotal)}</span>
+                                </div>
+                              ) : null}
                             </div>
-                          ) : null}
+                            {(partsByQuoteLine[line.id] ?? []).length > 0 ? (
+                              <div className="mt-2 space-y-2">
+                                {(partsByQuoteLine[line.id] ?? []).map((part) => {
+                                  const request = part.requestId ? (requestsByQuoteLine[line.id] ?? []).find((candidate) => candidate.id === part.requestId) ?? null : null;
+                                  const selected = selectedPartLabel(part);
+                                  return (
+                                    <div key={`${part.source}:${part.requestItemId ?? part.requestId ?? part.description}`} className="rounded-lg border border-[color:var(--desktop-border)] bg-black/20 p-2">
+                                      {selected ? (
+                                        <>
+                                          <div className="text-neutral-200">Requested: <span className="font-semibold text-white">{part.description} × {part.quantity}</span></div>
+                                          <div className="mt-1 text-neutral-300">Selected: <span className="text-white">{selected}</span></div>
+                                        </>
+                                      ) : (
+                                        <div className="font-semibold text-white">{part.description} × {part.quantity}</div>
+                                      )}
+                                      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-neutral-400">
+                                        {part.requestedPartNumber ? <span>Requested part #: <span className="text-neutral-200">{part.requestedPartNumber}</span></span> : null}
+                                        {part.manufacturer ? <span>Manufacturer: <span className="text-neutral-200">{part.manufacturer}</span></span> : null}
+                                        {part.supplier ?? part.vendor ? <span>Supplier: <span className="text-neutral-200">{part.supplier ?? part.vendor}</span></span> : null}
+                                        <span>{partPricingLabel(part)}</span>
+                                        {part.lineTotal != null ? <span>Line: <span className="text-neutral-200">{fmt(part.lineTotal)}</span></span> : null}
+                                        {part.status ? <span>Status: <span className="text-neutral-200">{statusLabel(part.status)}</span></span> : null}
+                                      </div>
+                                      {request ? (
+                                        <a href={`/parts/requests/${request.id}`} className="mt-2 inline-flex rounded-lg border border-sky-300/35 bg-sky-400/10 px-2.5 py-1.5 text-xs font-semibold text-sky-100 hover:bg-sky-400/15">
+                                          View Parts Request — {partsRequestLabel(line, index)}
+                                        </a>
+                                      ) : null}
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            ) : (
+                              <div className="mt-2 rounded-lg border border-[color:var(--desktop-border)] bg-black/20 p-2 text-neutral-400">
+                                <div>Parts: <span className="text-neutral-200">None</span></div>
+                                <div>Parts Request: <span className="text-neutral-200">Not required</span></div>
+                              </div>
+                            )}
+                          </div>
 
                           {sources.length > 0 ? (
                             <div className="mt-3 rounded-xl border border-[color:var(--desktop-border)] bg-black/20 p-3 text-xs text-neutral-400">

--- a/features/work-orders/quote-review/partsModel.test.ts
+++ b/features/work-orders/quote-review/partsModel.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolveQuoteLineParts, quoteLineTotalResolved, type CatalogPart, type PartRequestItem, type QuoteLine } from "./partsModel";
+import type { Json } from "@shared/types/types/supabase";
+
+const quoteLine = (metadata: Json | null = null): Pick<QuoteLine, "id" | "metadata"> => ({ id: "ql-1", metadata });
+
+const liveItem = (overrides: Partial<PartRequestItem> = {}): PartRequestItem => ({
+  id: "pri-1",
+  request_id: "pr-1",
+  shop_id: "shop-1",
+  work_order_id: "wo-1",
+  quote_line_id: "ql-1",
+  description: "Brake fluid",
+  qty: 1,
+  qty_requested: 1,
+  qty_approved: 0,
+  qty_consumed: 0,
+  qty_picked: 0,
+  qty_received: 0,
+  qty_reserved: 0,
+  approved: false,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+  location_id: null,
+  markup_pct: null,
+  menu_item_id: null,
+  part_id: null,
+  po_id: null,
+  quoted_price: null,
+  requested_manufacturer: null,
+  requested_part_number: null,
+  status: "requested",
+  unit_cost: null,
+  unit_price: null,
+  vendor: null,
+  vendor_id: null,
+  work_order_line_id: null,
+  ...overrides,
+});
+
+describe("Quote Review parts model", () => {
+  it("renders live linked request item description and quantity", () => {
+    const parts = resolveQuoteLineParts({ line: quoteLine(), liveItems: [liveItem()] });
+    expect(parts).toMatchObject([{ description: "Brake fluid", quantity: 1, source: "live_request_item" }]);
+  });
+
+  it("renders generic required part with null part_id and null price", () => {
+    const parts = resolveQuoteLineParts({ line: quoteLine(), liveItems: [liveItem({ part_id: null, unit_price: null, quoted_price: null })] });
+    expect(parts[0]).toMatchObject({ selectedPartId: null, pricingState: "unresolved" });
+  });
+
+  it("displays selected inventory identity separately from requested description", () => {
+    const selected: CatalogPart = { id: "part-1", name: "Motorcraft BRF-1847", sku: "BRF-1847", part_number: "BRF1847", supplier: "Ford Dealer" };
+    const parts = resolveQuoteLineParts({
+      line: quoteLine(),
+      liveItems: [liveItem({ description: "Front brake pads", part_id: "part-1" })],
+      selectedParts: new Map([[selected.id, selected]]),
+    });
+    expect(parts[0]).toMatchObject({ description: "Front brake pads", selectedPartName: "Motorcraft BRF-1847", selectedPartNumber: "BRF1847", supplier: "Ford Dealer" });
+  });
+
+  it("uses metadata.parts_quote.items when live item hydration is unavailable", () => {
+    const parts = resolveQuoteLineParts({ line: quoteLine({ parts_quote: { items: [{ id: "pri-1", request_id: "pr-1", description: "Brake fluid", qty: 1, status: "requested" }] } }) });
+    expect(parts).toMatchObject([{ requestItemId: "pri-1", requestId: "pr-1", description: "Brake fluid", source: "synced_metadata" }]);
+  });
+
+  it("uses metadata.parts as final technician-truth fallback", () => {
+    const parts = resolveQuoteLineParts({ line: quoteLine({ parts: [{ description: "Front brake pads", qty: 1 }] }) });
+    expect(parts).toMatchObject([{ description: "Front brake pads", quantity: 1, source: "technician_snapshot" }]);
+  });
+
+  it("live request item takes precedence over metadata fallbacks", () => {
+    const parts = resolveQuoteLineParts({
+      line: quoteLine({ parts_quote: { items: [{ id: "pri-1", request_id: "pr-1", description: "Old", qty: 1 }] }, parts: [{ description: "Older", qty: 1 }] }),
+      liveItems: [liveItem({ description: "Live" })],
+    });
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toMatchObject({ description: "Live", source: "live_request_item" });
+  });
+
+  it("duplicate fallback representations produce one displayed part", () => {
+    const parts = resolveQuoteLineParts({ line: quoteLine({ parts_quote: { items: [
+      { id: "pri-1", request_id: "pr-1", description: "Brake fluid", qty: 1 },
+      { id: "pri-1", request_id: "pr-1", description: "Brake fluid", qty: 1 },
+    ] } }) });
+    expect(parts).toHaveLength(1);
+  });
+
+  it("no-parts diagnosis resolves no required parts", () => {
+    expect(resolveQuoteLineParts({ line: quoteLine({ parts: [] }) })).toEqual([]);
+  });
+
+  it("does not create AI part fallback", () => {
+    expect(resolveQuoteLineParts({ line: quoteLine({ ai_parts: [{ description: "AI part", qty: 1 }] } as Json) })).toEqual([]);
+  });
+});
+
+describe("Quote Review total resolution", () => {
+  it("one-hour line at $140 with persisted grand_total = 0 displays $140", () => {
+    expect(quoteLineTotalResolved({ persistedGrandTotal: 0, persistedSubtotal: null, calculatedLabor: 140, calculatedParts: 0 })).toBe(140);
+  });
+
+  it("1.5-hour line at $140 with persisted subtotal = 0 displays $210", () => {
+    expect(quoteLineTotalResolved({ persistedGrandTotal: null, persistedSubtotal: 0, calculatedLabor: 210, calculatedParts: 0 })).toBe(210);
+  });
+
+  it("truly zero labor/no-parts line stays $0", () => {
+    expect(quoteLineTotalResolved({ persistedGrandTotal: 0, persistedSubtotal: 0, calculatedLabor: 0, calculatedParts: 0 })).toBe(0);
+  });
+
+  it("quote totals include known labor while parts remain pending", () => {
+    const totals = [140, 210, 140].reduce((sum, labor) => sum + quoteLineTotalResolved({ persistedGrandTotal: 0, persistedSubtotal: 0, calculatedLabor: labor, calculatedParts: 0 }), 0);
+    expect(totals).toBe(490);
+  });
+});
+
+describe("QuoteReviewView linked parts queries and persistence boundaries", () => {
+  const source = readFileSync("features/work-orders/quote-review/QuoteReviewView.tsx", "utf8");
+
+  it("scopes linked parts queries by shop, work order, and quote line ids", () => {
+    expect(source).toMatch(/from\("part_requests"\)[\s\S]*\.eq\("shop_id", shopId\)[\s\S]*\.eq\("work_order_id", woId\)[\s\S]*\.in\("quote_line_id", quoteLineIds\)/);
+    expect(source).toMatch(/from\("part_request_items"\)[\s\S]*\.eq\("shop_id", shopId\)[\s\S]*\.eq\("work_order_id", woId\)[\s\S]*\.in\("quote_line_id", quoteLineIds\)/);
+  });
+
+  it("saving a quote line does not write part request data", () => {
+    const saveBody = source.slice(source.indexOf("async function saveAllDirty"), source.indexOf("async function updateQuoteLineState"));
+    expect(saveBody).not.toContain("part_request_items");
+    expect(saveBody).not.toContain("part_requests");
+  });
+
+  it("View Parts Request uses linked request_id", () => {
+    expect(source).toContain("href={`/parts/requests/${request.id}`}");
+  });
+});

--- a/features/work-orders/quote-review/partsModel.ts
+++ b/features/work-orders/quote-review/partsModel.ts
@@ -1,0 +1,192 @@
+import type { Database, Json } from "@shared/types/types/supabase";
+
+type DB = Database;
+export type QuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+export type PartRequest = DB["public"]["Tables"]["part_requests"]["Row"];
+export type PartRequestItem = DB["public"]["Tables"]["part_request_items"]["Row"];
+export type CatalogPart = Pick<DB["public"]["Tables"]["parts"]["Row"], "id" | "name" | "sku" | "part_number" | "supplier">;
+
+export type ResolvedQuotePartSource = "live_request_item" | "synced_metadata" | "technician_snapshot";
+export type ResolvedQuotePartPricingState = "unresolved" | "priced";
+
+export type ResolvedQuotePart = {
+  requestItemId: string | null;
+  requestId: string | null;
+  description: string;
+  quantity: number;
+  requestedPartNumber: string | null;
+  selectedPartId: string | null;
+  selectedPartNumber: string | null;
+  selectedPartName: string | null;
+  manufacturer: string | null;
+  supplier: string | null;
+  vendor: string | null;
+  unitPrice: number | null;
+  lineTotal: number | null;
+  status: string | null;
+  pricingState: ResolvedQuotePartPricingState;
+  source: ResolvedQuotePartSource;
+};
+
+export type QuoteLinePartsInput = {
+  line: Pick<QuoteLine, "id" | "metadata">;
+  liveItems?: PartRequestItem[];
+  requests?: PartRequest[];
+  selectedParts?: Map<string, CatalogPart>;
+};
+
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function metadataRecord(metadata: Json | null): Record<string, Json> {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return {};
+  return metadata as Record<string, Json>;
+}
+
+function recordFromJson(value: Json): Record<string, Json> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, Json>) : null;
+}
+
+function quantityFrom(value: unknown, fallback = 1): number {
+  const n = asNumber(value);
+  return n != null && n > 0 ? n : fallback;
+}
+
+function priceState(unitPrice: number | null, lineTotal: number | null): ResolvedQuotePartPricingState {
+  return unitPrice != null || lineTotal != null ? "priced" : "unresolved";
+}
+
+function durableKey(part: Pick<ResolvedQuotePart, "requestItemId" | "requestId" | "description" | "quantity" | "source">): string {
+  if (part.requestItemId) return `item:${part.requestItemId}`;
+  if (part.requestId && part.description) return `request:${part.requestId}:${part.description.toLowerCase()}:${part.quantity}`;
+  return `snapshot:${part.description.toLowerCase()}:${part.quantity}`;
+}
+
+function fromLiveItem(item: PartRequestItem, selectedPart: CatalogPart | null): ResolvedQuotePart | null {
+  const description = safeString(item.description) || safeString(selectedPart?.name);
+  const quantity = quantityFrom(item.qty, quantityFrom(item.qty_requested, quantityFrom(item.qty_approved, 0)));
+  if (!description || quantity <= 0) return null;
+  const unitPrice = asNumber(item.quoted_price) ?? asNumber(item.unit_price) ?? asNumber(item.unit_cost);
+  const lineTotal = unitPrice == null ? null : Math.round((quantity * unitPrice + Number.EPSILON) * 100) / 100;
+  return {
+    requestItemId: item.id,
+    requestId: item.request_id,
+    description,
+    quantity,
+    requestedPartNumber: safeString(item.requested_part_number) || null,
+    selectedPartId: safeString(item.part_id) || null,
+    selectedPartNumber: safeString(selectedPart?.part_number) || safeString(selectedPart?.sku) || null,
+    selectedPartName: safeString(selectedPart?.name) || null,
+    manufacturer: safeString(item.requested_manufacturer) || null,
+    supplier: safeString(selectedPart?.supplier) || null,
+    vendor: safeString(item.vendor) || null,
+    unitPrice,
+    lineTotal,
+    status: safeString(item.status) || null,
+    pricingState: priceState(unitPrice, lineTotal),
+    source: "live_request_item",
+  };
+}
+
+function fromSyncedMetadata(item: Record<string, Json>): ResolvedQuotePart | null {
+  const description = safeString(item.description);
+  const quantity = quantityFrom(item.qty, 0);
+  if (!description || quantity <= 0) return null;
+  const unitPrice = asNumber(item.unit_price);
+  const lineTotal = asNumber(item.line_total) ?? (unitPrice == null ? null : Math.round((quantity * unitPrice + Number.EPSILON) * 100) / 100);
+  return {
+    requestItemId: safeString(item.id) || null,
+    requestId: safeString(item.request_id) || null,
+    description,
+    quantity,
+    requestedPartNumber: safeString(item.requested_part_number) || null,
+    selectedPartId: safeString(item.part_id) || null,
+    selectedPartNumber: null,
+    selectedPartName: null,
+    manufacturer: safeString(item.manufacturer) || null,
+    supplier: null,
+    vendor: safeString(item.vendor) || null,
+    unitPrice,
+    lineTotal,
+    status: safeString(item.status) || null,
+    pricingState: priceState(unitPrice, lineTotal),
+    source: "synced_metadata",
+  };
+}
+
+function fromTechnicianSnapshot(item: Record<string, Json>): ResolvedQuotePart | null {
+  const description = safeString(item.description) || safeString(item.name) || safeString(item.part) || safeString(item.part_name);
+  const quantity = quantityFrom(item.qty ?? item.quantity, 0);
+  if (!description || quantity <= 0) return null;
+  const unitPrice = asNumber(item.unitPrice) ?? asNumber(item.unit_price) ?? asNumber(item.unitCost) ?? asNumber(item.unit_cost);
+  const lineTotal = unitPrice == null ? null : Math.round((quantity * unitPrice + Number.EPSILON) * 100) / 100;
+  return {
+    requestItemId: null,
+    requestId: null,
+    description,
+    quantity,
+    requestedPartNumber: safeString(item.part_number) || safeString(item.partNumber) || null,
+    selectedPartId: null,
+    selectedPartNumber: null,
+    selectedPartName: null,
+    manufacturer: safeString(item.manufacturer) || null,
+    supplier: safeString(item.supplier) || null,
+    vendor: safeString(item.vendor) || null,
+    unitPrice,
+    lineTotal,
+    status: null,
+    pricingState: priceState(unitPrice, lineTotal),
+    source: "technician_snapshot",
+  };
+}
+
+export function resolveQuoteLineParts(input: QuoteLinePartsInput): ResolvedQuotePart[] {
+  const selectedParts = input.selectedParts ?? new Map<string, CatalogPart>();
+  const live = (input.liveItems ?? [])
+    .filter((item) => item.quote_line_id === input.line.id)
+    .map((item) => fromLiveItem(item, item.part_id ? selectedParts.get(item.part_id) ?? null : null))
+    .filter((item): item is ResolvedQuotePart => Boolean(item));
+
+  const result = new Map<string, ResolvedQuotePart>();
+  for (const item of live) result.set(durableKey(item), item);
+  if (result.size > 0) return [...result.values()];
+
+  const metadata = metadataRecord(input.line.metadata);
+  const partsQuote = recordFromJson(metadata.parts_quote ?? null);
+  const syncedItems = Array.isArray(partsQuote?.items) ? partsQuote.items : [];
+  for (const raw of syncedItems) {
+    const record = recordFromJson(raw);
+    if (!record) continue;
+    const item = fromSyncedMetadata(record);
+    if (item) result.set(durableKey(item), item);
+  }
+  if (result.size > 0) return [...result.values()];
+
+  const techItems = Array.isArray(metadata.parts) ? metadata.parts : [];
+  for (const raw of techItems) {
+    const record = recordFromJson(raw);
+    if (!record) continue;
+    const item = fromTechnicianSnapshot(record);
+    if (item) result.set(durableKey(item), item);
+  }
+  return [...result.values()];
+}
+
+export function quoteLineTotalResolved(input: { persistedGrandTotal: unknown; persistedSubtotal: unknown; calculatedLabor: number; calculatedParts: number }): number {
+  const calculated = input.calculatedLabor + input.calculatedParts;
+  const grand = asNumber(input.persistedGrandTotal);
+  if (grand != null && (grand !== 0 || calculated === 0)) return grand;
+  const subtotal = asNumber(input.persistedSubtotal);
+  if (subtotal != null && (subtotal !== 0 || calculated === 0)) return subtotal;
+  return calculated;
+}


### PR DESCRIPTION
### Motivation
- Quote Review UI did not hydrate live parts data (part_requests, part_request_items, selected catalog parts) and therefore could not show technician-entered part descriptions/quantities or correct per-line totals. 
- Line total logic favored persisted zeros (grand_total/subtotal) over calculated labor/parts, hiding known labor amounts when persisted totals were uninitialized.

### Description
- Add a typed parts model `partsModel.ts` implementing deterministic precedence: live `part_request_items` → `metadata.parts_quote.items` → `metadata.parts`, with durable de-duplication and explicit pricing state.
- Hydrate Quote Review in `QuoteReviewView.tsx` with bounded, shop/work-order/quote-line scoped queries for `part_requests` and `part_request_items`, and load selected `parts` only when `part_id` exists.
- Render a visible "Required parts" section per quote line that shows requested description × quantity, pricing state (e.g. “Pricing unresolved”), selected inventory identity, supplier/vendor, and a friendly "View Parts Request" link using the real request id, while preserving the no-parts diagnosis state.
- Replace the previous total resolution with `quoteLineTotalResolved` so persisted zero totals do not override positive calculated labor or parts, preserving legitimate zero-value diagnosis lines.
- Add focused tests that assert live item precedence, metadata fallbacks, technician snapshot fallback, deduplication, pricing state, scoped queries, save boundaries (no writes to part tables), and the corrected total resolution.

### Testing
- Ran focused tests: `pnpm exec vitest run features/work-orders/quote-review/partsModel.test.ts features/parts/server/syncQuoteLinePartsStatus.test.ts` and both test files passed (18 tests total).
- Ran type checking: `pnpm typecheck` passed with no errors.
- Ran ESLint on changed files: `pnpm exec eslint ...` passed with no issues.
- Attempted full build: `pnpm build` failed due to environment/network font fetch errors for Google fonts (`Inter`, `Black Ops One`) and is unrelated to the code changes.
- Note: an earlier unscoped test run executed the full suite and surfaced unrelated existing failures; the focused Quote Review tests added by this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5562ac5e8c8328afb4842e22a475a1)