### PR TITLE
Phase 3: Canonical atomic parts transaction engine

### DIFF
--- a/.github/workflows/phase3-parts-validation.yml
+++ b/.github/workflows/phase3-parts-validation.yml
@@ -1,0 +1,31 @@
+name: Phase 3 Parts Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/parts/**"
+      - "app/api/work-orders/lines/**"
+      - "app/api/invoices/send/route.ts"
+      - "features/invoices/server/getIssuableInvoiceSnapshot.ts"
+      - "supabase/migrations/20260714039*.sql"
+      - "supabase/migrations/20260714040*.sql"
+      - "tests/phase3-parts-*.test.ts"
+      - ".github/workflows/phase3-parts-validation.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm lint -- app/api/parts app/api/work-orders/lines app/api/invoices/send/route.ts features/invoices/server/getIssuableInvoiceSnapshot.ts tests/phase3-parts-atomic-routes.test.ts tests/phase3-parts-sql-contract.test.ts
+      - run: pnpm vitest run tests/phase3-parts-atomic-routes.test.ts tests/phase3-parts-sql-contract.test.ts

--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -3,7 +3,7 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { runPostSendPersistence, sendInvoiceReadyEmail } from "@/features/email/server";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
-import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
+import { getIssuableInvoiceSnapshot } from "@/features/invoices/server/getIssuableInvoiceSnapshot";
 import { finalizeInvoiceVersion } from "@/features/invoices/server/financialLifecycle";
 import { reviewWorkOrder } from "../../work-orders/[id]/_lib/reviewWorkOrder";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
@@ -89,7 +89,11 @@ export async function POST(req: Request) {
       );
     }
 
-    const snapshot = await getInvoiceSnapshotForWorkOrder({ supabase: admin, workOrderId });
+    const snapshot = await getIssuableInvoiceSnapshot({
+      supabase: admin,
+      workOrderId,
+      shopId: workOrder.shop_id,
+    });
     const total = Number(snapshot.total ?? 0);
     if (!Number.isFinite(total) || total <= 0) {
       return NextResponse.json({ error: "Cannot issue a zero-total invoice." }, { status: 400 });

--- a/app/api/parts/_lib/lifecycleCommand.ts
+++ b/app/api/parts/_lib/lifecycleCommand.ts
@@ -2,7 +2,12 @@ import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 export function isUuid(value: unknown): value is string {
-  return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i.test(value.trim());
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.trim(),
+    )
+  );
 }
 
 export function positiveNumber(value: unknown): number | null {
@@ -10,16 +15,52 @@ export function positiveNumber(value: unknown): number | null {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
-export function idempotencyKey(req: Request, body: Record<string, unknown>, fallback: string): string {
+export function idempotencyKey(
+  req: Request,
+  body: Record<string, unknown>,
+): string | null {
   const header = req.headers.get("Idempotency-Key")?.trim();
-  const fromBody = typeof body.idempotencyKey === "string" ? body.idempotencyKey.trim() : "";
-  return header || fromBody || fallback;
+  const camel = typeof body.idempotencyKey === "string" ? body.idempotencyKey.trim() : "";
+  const snake = typeof body.idempotency_key === "string" ? body.idempotency_key.trim() : "";
+  return header || camel || snake || null;
 }
 
-export async function runPartsLifecycleRpc(_req: Request, rpc: string, args: Record<string, unknown>) {
-  const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+export async function runPartsLifecycleRpc(
+  _req: Request,
+  rpcName: string,
+  args: Record<string, unknown>,
+) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
   if (!access.ok) return access.response;
-  const { data, error } = await access.supabase.rpc(rpc as never, args as never);
-  if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 409 });
+
+  const rawKey =
+    typeof args.p_idempotency_key === "string" ? args.p_idempotency_key.trim() : "";
+  if (!rawKey) {
+    return NextResponse.json(
+      { ok: false, error: "A stable idempotency key is required." },
+      { status: 400 },
+    );
+  }
+
+  const scopedArgs = {
+    ...args,
+    p_idempotency_key: `${access.profile.shop_id}:${rpcName}:${rawKey}`,
+  };
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc(rpcName, scopedArgs);
+  if (error) {
+    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+    return NextResponse.json({ ok: false, error: message }, { status: 409 });
+  }
   return NextResponse.json({ ok: true, result: data });
 }

--- a/app/api/parts/_lib/receivePartRequestItem.ts
+++ b/app/api/parts/_lib/receivePartRequestItem.ts
@@ -1,9 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
-import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
-
-type DB = Database;
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type ReceivePayload = {
   itemId: string;
@@ -22,98 +18,99 @@ type LegacyBody = {
   idempotency_key?: unknown;
 };
 
-function isUuid(v: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i.test(v);
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
 }
 
 function normalizeBody(input: LegacyBody | null): Omit<ReceivePayload, "itemId"> | null {
   if (!input) return null;
-
   const locationId = String(input.location_id ?? "").trim();
   const qty = typeof input.qty === "number" ? input.qty : Number(input.qty);
-  const poId = typeof input.po_id === "string" && input.po_id.trim().length > 0 ? input.po_id.trim() : null;
+  const poId =
+    typeof input.po_id === "string" && input.po_id.trim() ? input.po_id.trim() : null;
+  const idempotencyKey =
+    typeof input.idempotencyKey === "string" && input.idempotencyKey.trim()
+      ? input.idempotencyKey.trim()
+      : typeof input.idempotency_key === "string" && input.idempotency_key.trim()
+        ? input.idempotency_key.trim()
+        : null;
 
   if (!locationId || !isUuid(locationId)) return null;
   if (!Number.isFinite(qty) || qty <= 0) return null;
   if (poId && !isUuid(poId)) return null;
-
-  const idempotencyKey = typeof input.idempotencyKey === "string" && input.idempotencyKey.trim() ? input.idempotencyKey.trim() : typeof input.idempotency_key === "string" && input.idempotency_key.trim() ? input.idempotency_key.trim() : null;
+  if (!idempotencyKey) return null;
   return { locationId, qty, poId, idempotencyKey };
 }
 
 export async function receivePartRequestItem(payload: ReceivePayload): Promise<NextResponse> {
-  try {
-    if (!isUuid(payload.itemId)) {
-      return NextResponse.json({ error: "Invalid itemId (must be UUID)" }, { status: 400 });
-    }
-
-    if (!isUuid(payload.locationId)) {
-      return NextResponse.json({ error: "Invalid location_id (must be UUID)" }, { status: 400 });
-    }
-
-    if (!Number.isFinite(payload.qty) || payload.qty <= 0) {
-      return NextResponse.json({ error: "Invalid qty (must be > 0)" }, { status: 400 });
-    }
-
-    if (payload.poId && !isUuid(payload.poId)) {
-      return NextResponse.json({ error: "Invalid po_id (must be UUID when provided)" }, { status: 400 });
-    }
-
-    const supabase = createServerSupabaseRoute();
-
-    const {
-      data: { user },
-      error: userErr,
-    } = await supabase.auth.getUser();
-
-    if (userErr) return NextResponse.json({ error: userErr.message }, { status: 401 });
-    if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-
-    type RpcArgs = DB["public"]["Functions"]["receive_part_request_item"]["Args"];
-
-    const args: RpcArgs = {
-      p_item_id: payload.itemId,
-      p_location_id: payload.locationId,
-      p_qty: payload.qty,
-      ...(payload.poId ? { p_po_id: payload.poId } : {}),
-      ...(payload.idempotencyKey ? { p_idempotency_key: payload.idempotencyKey } : {}),
-    } as RpcArgs;
-
-    const { data, error } = await supabase.rpc("receive_part_request_item", args);
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-    const { data: linkedItem } = await supabase
-      .from("part_request_items")
-      .select("shop_id, quote_line_id")
-      .eq("id", payload.itemId)
-      .maybeSingle();
-
-    const quoteLineSync = linkedItem?.shop_id && linkedItem.quote_line_id
-      ? await syncQuoteLinePartsStatus(supabase, {
-          shopId: linkedItem.shop_id,
-          quoteLineId: linkedItem.quote_line_id,
-        })
-      : null;
-
-    const row = Array.isArray(data) ? data[0] : data;
-    return NextResponse.json({ ok: true, result: row, quoteLineSync });
-  } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : typeof e === "string" ? e : "Server error";
-    return NextResponse.json({ error: message }, { status: 500 });
+  if (!isUuid(payload.itemId) || !isUuid(payload.locationId)) {
+    return NextResponse.json({ error: "Invalid item or location id." }, { status: 400 });
   }
+  if (!Number.isFinite(payload.qty) || payload.qty <= 0) {
+    return NextResponse.json({ error: "Receipt quantity must be greater than zero." }, { status: 400 });
+  }
+  if (payload.poId && !isUuid(payload.poId)) {
+    return NextResponse.json({ error: "Invalid purchase order id." }, { status: 400 });
+  }
+  const rawKey = payload.idempotencyKey?.trim() ?? "";
+  if (!rawKey) {
+    return NextResponse.json({ error: "A stable idempotency key is required." }, { status: 400 });
+  }
+
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
+
+  const { data: item, error: itemError } = await access.supabase
+    .from("part_request_items")
+    .select("id, shop_id")
+    .eq("id", payload.itemId)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+  if (itemError) return NextResponse.json({ error: itemError.message }, { status: 500 });
+  if (!item) return NextResponse.json({ error: "Request item not found for shop." }, { status: 404 });
+
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("receive_part_request_item", {
+    p_item_id: payload.itemId,
+    p_location_id: payload.locationId,
+    p_qty: payload.qty,
+    p_po_id: payload.poId ?? null,
+    p_idempotency_key: `${access.profile.shop_id}:receive:${rawKey}`,
+  });
+
+  if (error) {
+    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+    const status = error.message.includes("FINANCIALLY_LOCKED") ? 409 : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+
+  return NextResponse.json({ ok: true, result: Array.isArray(data) ? data[0] : data });
 }
 
-export async function receiveFromCanonicalBody(req: Request, itemId: string): Promise<NextResponse> {
+export async function receiveFromCanonicalBody(
+  req: Request,
+  itemId: string,
+): Promise<NextResponse> {
   const body = (await req.json().catch(() => null)) as LegacyBody | null;
   const normalized = normalizeBody(body);
-
   if (!normalized) {
     return NextResponse.json(
-      { error: "Invalid body. Expect { location_id, qty, po_id? } with UUID ids and qty > 0." },
+      { error: "Invalid body. A stable idempotency key, location UUID, and qty > 0 are required." },
       { status: 400 },
     );
   }
-
   return receivePartRequestItem({ itemId, ...normalized });
 }
 
@@ -121,17 +118,11 @@ export async function receiveFromLegacyBody(req: Request): Promise<NextResponse>
   const body = (await req.json().catch(() => null)) as LegacyBody | null;
   const itemId = String(body?.part_request_item_id ?? "").trim();
   const normalized = normalizeBody(body);
-
-  if (!itemId || !isUuid(itemId)) {
-    return NextResponse.json({ error: "Invalid part_request_item_id (must be UUID)" }, { status: 400 });
-  }
-
-  if (!normalized) {
+  if (!itemId || !isUuid(itemId) || !normalized) {
     return NextResponse.json(
-      { error: "Invalid body. Expect { part_request_item_id, location_id, qty, po_id? } with UUID ids and qty > 0." },
+      { error: "Invalid body. Item, location, qty, and a stable idempotency key are required." },
       { status: 400 },
     );
   }
-
   return receivePartRequestItem({ itemId, ...normalized });
 }

--- a/app/api/parts/consume/route.ts
+++ b/app/api/parts/consume/route.ts
@@ -1,45 +1,66 @@
-// app/api/parts/consume/route.ts
 export const runtime = "nodejs";
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { z } from "zod";
-import { consumePart } from "@work-orders/lib/parts/consumePart";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
-// Strict payload schema (no anys)
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
 const Payload = z.object({
-  work_order_line_id: z.string().min(1),
-  part_id: z.string().min(1),
-  qty: z.number().positive(),
-  location_id: z.string().min(1).optional(),
+  work_order_line_id: z.string().uuid(),
+  part_id: z.string().uuid(),
+  qty: z.coerce.number().positive(),
+  location_id: z.string().uuid(),
+  idempotency_key: z.string().trim().min(1).optional(),
 });
 
-type Payload = z.infer<typeof Payload>;
+export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
 
-export async function POST(req: NextRequest) {
-  try {
-    const json: unknown = await req.json();
-    const parsed = Payload.safeParse(json);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { error: "Invalid payload", issues: parsed.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const body: Payload = parsed.data;
-
-    const result = await consumePart({
-      work_order_line_id: body.work_order_line_id,
-      part_id: body.part_id,
-      qty: body.qty,
-      location_id: body.location_id,
-    });
-
-    return NextResponse.json({ ok: true, result });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Failed to consume part";
-    return NextResponse.json({ error: message }, { status: 500 });
+  const json: unknown = await req.json().catch(() => null);
+  const parsed = Payload.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid payload", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
   }
+
+  const body = parsed.data;
+  const rawKey =
+    body.idempotency_key || req.headers.get("idempotency-key")?.trim() || "";
+  if (!rawKey) {
+    return NextResponse.json(
+      { error: "A stable idempotency key is required." },
+      { status: 400 },
+    );
+  }
+
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("parts_issue_by_line_part_atomic", {
+    p_shop_id: access.profile.shop_id,
+    p_work_order_line_id: body.work_order_line_id,
+    p_part_id: body.part_id,
+    p_location_id: body.location_id,
+    p_qty: body.qty,
+    p_operation_key: `${access.profile.shop_id}:legacy-consume:${rawKey}`,
+    p_actor_user_id: access.profile.id,
+  });
+
+  if (error) {
+    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+    const status = error.message.includes("FINANCIALLY_LOCKED") ? 409 : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+
+  return NextResponse.json({ ok: true, result: data });
 }
-
-

--- a/app/api/parts/requests/[requestId]/commit-package/route.ts
+++ b/app/api/parts/requests/[requestId]/commit-package/route.ts
@@ -1,164 +1,67 @@
 import { NextResponse } from "next/server";
-import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import { resolvePackageCommitQuantity } from "@/features/parts/server/resolvePackageCommitQuantity";
 
 type DB = Database;
-type PartRequestItem = DB["public"]["Tables"]["part_request_items"]["Row"];
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
 
-type ItemResult =
-  | { itemId: string; status: "committed" | "already_committed"; workOrderPartId: string }
-  | { itemId: string; status: "skipped"; reason: string }
-  | { itemId: string; status: "error"; error: string };
+type Body = {
+  idempotencyKey?: string;
+};
 
 function isUuid(value: unknown): value is string {
-  return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.trim());
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.trim(),
+    )
+  );
 }
 
-function positiveQuantity(item: PartRequestItem): number {
-  const parsed = resolvePackageCommitQuantity(item);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const { requestId } = await context.params;
+  if (!isUuid(requestId)) {
+    return NextResponse.json({ ok: false, error: "Invalid requestId." }, { status: 400 });
+  }
 
-function descriptionFor(item: PartRequestItem): string {
-  return String(item.description ?? "").trim();
-}
-
-async function ensureWorkOrderPart(
-  supabase: SupabaseClient<DB>,
-  itemId: string,
-): Promise<string> {
-  const { data, error } = await supabase.rpc("parts_ensure_work_order_part" as never, {
-    p_request_item_id: itemId,
-  } as never);
-  if (error) throw new Error(error.message);
-  if (!isUuid(data)) throw new Error("Canonical parts package helper did not return a work-order part id.");
-  return data;
-}
-
-export async function POST(_req: Request, ctx: { params: Promise<{ requestId: string }> }) {
-  const { requestId } = await ctx.params;
-  if (!isUuid(requestId)) return NextResponse.json({ ok: false, error: "Invalid requestId." }, { status: 400 });
-
-  const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
   if (!access.ok) return access.response;
 
-  const supabase = access.supabase;
-  const shopId = access.profile.shop_id;
-
-  const { data: request, error: requestError } = await supabase
-    .from("part_requests")
-    .select("id, shop_id, work_order_id, status")
-    .eq("id", requestId)
-    .eq("shop_id", shopId)
-    .maybeSingle();
-
-  if (requestError) return NextResponse.json({ ok: false, error: requestError.message }, { status: 500 });
-  if (!request) return NextResponse.json({ ok: false, error: "Parts request not found for this shop." }, { status: 404 });
-  if (!request.work_order_id) {
-    return NextResponse.json({ ok: false, error: "Parts request is not linked to a work order." }, { status: 409 });
+  const body = (await req.json().catch(() => null)) as Body | null;
+  const rawKey =
+    body?.idempotencyKey?.trim() || req.headers.get("idempotency-key")?.trim() || "";
+  if (!rawKey) {
+    return NextResponse.json(
+      { ok: false, error: "A stable idempotency key is required." },
+      { status: 400 },
+    );
   }
 
-  const { data: workOrder, error: workOrderError } = await supabase
-    .from("work_orders")
-    .select("id, shop_id")
-    .eq("id", request.work_order_id)
-    .eq("shop_id", shopId)
-    .maybeSingle();
-  if (workOrderError) return NextResponse.json({ ok: false, error: workOrderError.message }, { status: 500 });
-  if (!workOrder) return NextResponse.json({ ok: false, error: "Related work order is not available for this shop." }, { status: 403 });
+  const operationKey = `${access.profile.shop_id}:commit-package:${rawKey}`;
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("parts_commit_request_package_atomic", {
+    p_shop_id: access.profile.shop_id,
+    p_request_id: requestId,
+    p_operation_key: operationKey,
+    p_actor_user_id: access.profile.id,
+  });
 
-  const { data: itemsData, error: itemsError } = await supabase
-    .from("part_request_items")
-    .select("*")
-    .eq("request_id", requestId)
-    .eq("shop_id", shopId)
-    .order("created_at", { ascending: true });
-  if (itemsError) return NextResponse.json({ ok: false, error: itemsError.message }, { status: 500 });
-
-  const items = (itemsData ?? []) as PartRequestItem[];
-  const itemIds = items.map((item) => item.id);
-  const existingByItemId = new Map<string, string>();
-  if (itemIds.length > 0) {
-    const { data: existingRows, error: existingError } = await supabase
-      .from("work_order_parts")
-      .select("id, source_parts_request_item_id")
-      .in("source_parts_request_item_id", itemIds)
-      .eq("shop_id", shopId)
-      .eq("is_active", true);
-    if (existingError) return NextResponse.json({ ok: false, error: existingError.message }, { status: 500 });
-    for (const row of (existingRows ?? []) as Array<{ id: string; source_parts_request_item_id: string | null }>) {
-      if (row.source_parts_request_item_id) existingByItemId.set(row.source_parts_request_item_id, row.id);
-    }
+  if (error) {
+    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+    const status = error.message.includes("FINANCIALLY_LOCKED") ? 409 : 400;
+    return NextResponse.json({ ok: false, error: message }, { status });
   }
 
-  const results: ItemResult[] = [];
-  for (const item of items) {
-    const itemId = String(item.id);
-    const existingId = existingByItemId.get(itemId);
-    if (existingId) {
-      results.push({ itemId, status: "already_committed", workOrderPartId: existingId });
-      continue;
-    }
-
-    if (!item.part_id) {
-      results.push({ itemId, status: "skipped", reason: "Select an inventory part before saving this item to the work order." });
-      continue;
-    }
-    if (!item.work_order_line_id) {
-      results.push({ itemId, status: "skipped", reason: "Item is not linked to a work-order repair line." });
-      continue;
-    }
-    if (item.work_order_id && item.work_order_id !== request.work_order_id) {
-      results.push({ itemId, status: "error", error: "Item work order does not match the parent request." });
-      continue;
-    }
-    if (positiveQuantity(item) <= 0) {
-      results.push({ itemId, status: "skipped", reason: "Quantity must be greater than zero." });
-      continue;
-    }
-    if (!descriptionFor(item)) {
-      results.push({ itemId, status: "skipped", reason: "Description is required." });
-      continue;
-    }
-
-    const { data: line, error: lineError } = await supabase
-      .from("work_order_lines")
-      .select("id, work_order_id, shop_id")
-      .eq("id", item.work_order_line_id)
-      .eq("work_order_id", request.work_order_id)
-      .eq("shop_id", shopId)
-      .maybeSingle();
-    if (lineError) {
-      results.push({ itemId, status: "error", error: lineError.message });
-      continue;
-    }
-    if (!line) {
-      results.push({ itemId, status: "error", error: "Work-order line is not available for this shop or request." });
-      continue;
-    }
-
-    try {
-      const workOrderPartId = await ensureWorkOrderPart(supabase, itemId);
-      results.push({ itemId, status: "committed", workOrderPartId });
-    } catch (error) {
-      results.push({ itemId, status: "error", error: error instanceof Error ? error.message : "Could not save item to work order." });
-    }
-  }
-
-  const committed = results.filter((result): result is Extract<ItemResult, { workOrderPartId: string }> => result.status === "committed" || result.status === "already_committed");
-  const errors = results.filter((result) => result.status === "error");
-  const skipped = results.filter((result) => result.status === "skipped");
-  const ok = errors.length === 0 && skipped.length === 0;
-
-  return NextResponse.json({
-    ok,
-    requestId,
-    committedCount: committed.length,
-    skippedCount: skipped.length,
-    results,
-    workOrderPartIds: committed.map((result) => result.workOrderPartId),
-    errorsRequiringReview: [...errors, ...skipped],
-  }, { status: errors.length > 0 ? 409 : 200 });
+  return NextResponse.json(data);
 }

--- a/app/api/parts/requests/[requestId]/commit-package/route.ts
+++ b/app/api/parts/requests/[requestId]/commit-package/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
-import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
-type DB = Database;
 type RpcError = { message: string; details?: string | null; hint?: string | null };
 type RpcClient = {
   rpc: (

--- a/app/api/parts/requests/items/[itemId]/add/route.ts
+++ b/app/api/parts/requests/items/[itemId]/add/route.ts
@@ -1,242 +1,106 @@
 import { NextResponse } from "next/server";
-import type { Database } from "@shared/types/types/supabase";
+import { z } from "zod";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
-type DB = Database;
-type ItemUpdate = DB["public"]["Tables"]["part_request_items"]["Update"] & {
-  requested_part_number?: string | null;
-  requested_manufacturer?: string | null;
-};
-type ItemRow = DB["public"]["Tables"]["part_request_items"]["Row"] & {
-  requested_part_number?: string | null;
-  requested_manufacturer?: string | null;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
 };
 
-type Body = {
-  partId?: string | null;
-  description?: string | null;
-  qty?: number | string | null;
-  quotedPrice?: number | string | null;
-  requestedPartNumber?: string | null;
-  requestedManufacturer?: string | null;
-  workOrderLineId?: string | null;
-  poId?: string | null;
-  locationId?: string | null;
-  createAllocation?: boolean;
-  warningAccepted?: boolean;
-  warningReason?: string | null;
-};
+const nullableUuid = z.string().uuid().nullable().optional();
+const Payload = z.object({
+  partId: z.string().uuid(),
+  description: z.string().trim().min(1),
+  qty: z.coerce.number().positive(),
+  quotedPrice: z.coerce.number().nonnegative(),
+  requestedPartNumber: z.string().trim().nullable().optional(),
+  requestedManufacturer: z.string().trim().nullable().optional(),
+  workOrderLineId: z.string().uuid(),
+  poId: nullableUuid,
+  locationId: nullableUuid,
+  createAllocation: z.boolean().optional().default(false),
+  warningAccepted: z.boolean().optional().default(false),
+  warningReason: z.string().trim().nullable().optional(),
+  idempotencyKey: z.string().trim().min(1).optional(),
+});
 
-function cleanString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
-}
-
-function isUuid(value: unknown): value is string {
-  if (typeof value !== "string") return false;
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value.trim());
-}
-
-function nullableUuid(value: unknown, label: string): string | null {
-  const cleaned = cleanString(value);
-  if (!cleaned) return null;
-  if (!isUuid(cleaned)) throw new Error(`${label} must be a valid UUID.`);
-  return cleaned;
-}
-
-function finiteNumber(value: unknown, label: string): number {
-  const parsed = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(parsed)) throw new Error(`${label} must be a number.`);
-  return parsed;
-}
+type Payload = z.infer<typeof Payload>;
 
 export async function POST(
   req: Request,
-  ctx: { params: Promise<{ itemId: string }> },
+  context: { params: Promise<{ itemId: string }> },
 ) {
-  const { itemId: rawItemId } = await ctx.params;
-  const itemId = cleanString(rawItemId);
-  if (!itemId || !isUuid(itemId)) {
+  const { itemId } = await context.params;
+  if (!z.string().uuid().safeParse(itemId).success) {
     return NextResponse.json({ ok: false, error: "Invalid itemId." }, { status: 400 });
   }
 
-  const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
   if (!access.ok) return access.response;
 
-  const supabase = access.supabase;
-  const shopId = access.profile.shop_id;
-
-  const body = (await req.json().catch(() => null)) as Body | null;
-  if (!body) {
-    return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 });
-  }
-
-  let partId: string | null;
-  let workOrderLineId: string | null;
-  let poId: string | null;
-  let locationId: string | null;
-  let qty: number;
-  let quotedPrice: number;
-  try {
-    partId = nullableUuid(body.partId, "partId");
-    workOrderLineId = nullableUuid(body.workOrderLineId, "workOrderLineId");
-    poId = nullableUuid(body.poId, "poId");
-    locationId = nullableUuid(body.locationId, "locationId");
-    qty = finiteNumber(body.qty, "qty");
-    quotedPrice = finiteNumber(body.quotedPrice, "quotedPrice");
-  } catch (error) {
+  const json: unknown = await req.json().catch(() => null);
+  const parsed = Payload.safeParse(json);
+  if (!parsed.success) {
     return NextResponse.json(
-      { ok: false, error: error instanceof Error ? error.message : "Invalid request body." },
+      { ok: false, error: "Invalid request body.", issues: parsed.error.flatten() },
       { status: 400 },
     );
   }
 
-  if (qty <= 0) {
-    return NextResponse.json({ ok: false, error: "Quantity must be greater than 0." }, { status: 400 });
-  }
-  if (quotedPrice < 0) {
-    return NextResponse.json({ ok: false, error: "Quoted price must be 0 or greater." }, { status: 400 });
-  }
-
-  const { data: item, error: itemError } = await supabase
-    .from("part_request_items")
-    .select("*")
-    .eq("id", itemId)
-    .maybeSingle<ItemRow>();
-
-  if (itemError) return NextResponse.json({ ok: false, error: itemError.message }, { status: 500 });
-  if (!item) return NextResponse.json({ ok: false, error: "Request item not found or blocked by shop access." }, { status: 404 });
-
-  const { data: partRequest, error: requestError } = await supabase
-    .from("part_requests")
-    .select("id, shop_id, work_order_id, status")
-    .eq("id", item.request_id)
-    .eq("shop_id", shopId)
-    .maybeSingle();
-
-  if (requestError) return NextResponse.json({ ok: false, error: requestError.message }, { status: 500 });
-  if (!partRequest) return NextResponse.json({ ok: false, error: "Parent parts request is not available for this shop." }, { status: 403 });
-  if (!partRequest.work_order_id) {
-    return NextResponse.json({ ok: false, error: "Parent parts request is not linked to a work order." }, { status: 409 });
-  }
-
-  const { data: workOrder, error: workOrderError } = await supabase
-    .from("work_orders")
-    .select("id, shop_id")
-    .eq("id", partRequest.work_order_id)
-    .eq("shop_id", shopId)
-    .maybeSingle();
-  if (workOrderError) return NextResponse.json({ ok: false, error: workOrderError.message }, { status: 500 });
-  if (!workOrder) return NextResponse.json({ ok: false, error: "Related work order is not available for this shop." }, { status: 403 });
-
-  if (partId) {
-    const { data: part, error: partError } = await supabase
-      .from("parts")
-      .select("id")
-      .eq("id", partId)
-      .eq("shop_id", shopId)
-      .maybeSingle();
-    if (partError) return NextResponse.json({ ok: false, error: partError.message }, { status: 500 });
-    if (!part) return NextResponse.json({ ok: false, error: "Selected part is not available for this shop." }, { status: 403 });
-  }
-
-  if (!workOrderLineId) {
-    return NextResponse.json({ ok: false, error: "A work order line is required before attaching this part." }, { status: 409 });
-  }
-
-  const { data: line, error: lineError } = await supabase
-    .from("work_order_lines")
-    .select("id, work_order_id, shop_id")
-    .eq("id", workOrderLineId)
-    .eq("work_order_id", partRequest.work_order_id)
-    .eq("shop_id", shopId)
-    .maybeSingle();
-  if (lineError) return NextResponse.json({ ok: false, error: lineError.message }, { status: 500 });
-  if (!line) return NextResponse.json({ ok: false, error: "Work order line is not available for this shop or request." }, { status: 403 });
-
-  if (poId) {
-    const { data: po, error: poError } = await supabase
-      .from("purchase_orders")
-      .select("id")
-      .eq("id", poId)
-      .eq("shop_id", shopId)
-      .maybeSingle();
-    if (poError) return NextResponse.json({ ok: false, error: poError.message }, { status: 500 });
-    if (!po) return NextResponse.json({ ok: false, error: "Purchase order is not available for this shop." }, { status: 403 });
-  }
-
-  const warningAccepted = body.warningAccepted === true;
-  const warningReason = cleanString(body.warningReason);
-
-  const update: ItemUpdate = {
-    part_id: partId,
-    description: cleanString(body.description) ?? item.description ?? "Part",
-    qty,
-    qty_requested: qty,
-    quoted_price: quotedPrice,
-    unit_price: quotedPrice,
-    requested_part_number: body.requestedPartNumber === undefined ? item.requested_part_number ?? null : cleanString(body.requestedPartNumber),
-    requested_manufacturer: body.requestedManufacturer === undefined ? item.requested_manufacturer ?? null : cleanString(body.requestedManufacturer),
-    work_order_id: partRequest.work_order_id,
-    work_order_line_id: workOrderLineId,
-    po_id: poId,
-    updated_at: new Date().toISOString(),
-  };
-
-  const { data: updatedItem, error: updateError } = await supabase
-    .from("part_request_items")
-    .update(update as DB["public"]["Tables"]["part_request_items"]["Update"])
-    .eq("id", itemId)
-    .eq("request_id", item.request_id)
-    .eq("shop_id", shopId)
-    .select("*")
-    .maybeSingle<ItemRow>();
-
-  if (updateError) return NextResponse.json({ ok: false, error: updateError.message }, { status: 500 });
-  if (!updatedItem) {
-    return NextResponse.json({ ok: false, error: "Update did not apply. The item may have changed or your shop access was blocked." }, { status: 409 });
-  }
-
-  const { data: workOrderPartId, error: workOrderPartError } = await supabase.rpc(
-    "parts_ensure_work_order_part" as never,
-    { p_request_item_id: itemId } as never,
-  );
-  if (workOrderPartError) {
+  const body: Payload = parsed.data;
+  if (body.createAllocation && !body.locationId) {
     return NextResponse.json(
-      { ok: false, item: updatedItem, error: workOrderPartError.message },
-      { status: 500 },
+      { ok: false, error: "A stock location is required when creating an allocation." },
+      { status: 400 },
     );
   }
-  if (!isUuid(workOrderPartId)) {
+  if (body.warningAccepted && !body.warningReason) {
     return NextResponse.json(
-      { ok: false, item: updatedItem, error: "Canonical work-order part was not created." },
-      { status: 500 },
+      { ok: false, error: "A mismatch acknowledgement reason is required." },
+      { status: 400 },
     );
   }
 
-  let allocation: { ok: true; result?: unknown } | { ok: false; error: string } | null = null;
-  if (body.createAllocation && locationId) {
-    const { data: allocationResult, error: allocationError } = await supabase.rpc("upsert_part_allocation_from_request_item", {
-      p_request_item_id: itemId,
-      p_location_id: locationId,
-      p_create_stock_move: true,
-    });
-    allocation = allocationError ? { ok: false, error: allocationError.message } : { ok: true, result: allocationResult };
-    if (allocationError) {
-      return NextResponse.json({ ok: false, item: updatedItem, workOrderPartId, allocation, error: allocationError.message }, { status: 500 });
-    }
+  const rawKey =
+    body.idempotencyKey || req.headers.get("idempotency-key")?.trim() || "";
+  if (!rawKey) {
+    return NextResponse.json(
+      { ok: false, error: "A stable idempotency key is required." },
+      { status: 400 },
+    );
   }
 
-  if (warningAccepted && warningReason) {
-    await supabase
-      .from("work_order_parts")
-      .update({
-        mismatch_acknowledged_at: new Date().toISOString(),
-        mismatch_acknowledged_by: access.profile.id,
-        mismatch_warning_reason: warningReason,
-      } as never)
-      .eq("id", workOrderPartId)
-      .eq("shop_id", shopId);
+  const operationKey = `${access.profile.shop_id}:item-attach:${rawKey}`;
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("parts_update_attach_allocate_item_atomic", {
+    p_shop_id: access.profile.shop_id,
+    p_request_item_id: itemId,
+    p_part_id: body.partId,
+    p_description: body.description,
+    p_qty: body.qty,
+    p_unit_sell_price: body.quotedPrice,
+    p_requested_part_number: body.requestedPartNumber ?? null,
+    p_requested_manufacturer: body.requestedManufacturer ?? null,
+    p_work_order_line_id: body.workOrderLineId,
+    p_po_id: body.poId ?? null,
+    p_location_id: body.locationId ?? null,
+    p_create_allocation: body.createAllocation,
+    p_warning_accepted: body.warningAccepted,
+    p_warning_reason: body.warningReason ?? null,
+    p_operation_key: operationKey,
+    p_actor_user_id: access.profile.id,
+  });
+
+  if (error) {
+    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+    const status = error.message.includes("FINANCIALLY_LOCKED") ? 409 : 400;
+    return NextResponse.json({ ok: false, error: message }, { status });
   }
 
-  return NextResponse.json({ ok: true, item: updatedItem, workOrderPartId, allocation });
+  return NextResponse.json(data);
 }

--- a/app/api/parts/work-order-parts/[partId]/issue/route.ts
+++ b/app/api/parts/work-order-parts/[partId]/issue/route.ts
@@ -1,11 +1,43 @@
 import { NextResponse } from "next/server";
-import { idempotencyKey, isUuid, positiveNumber, runPartsLifecycleRpc } from "../../../_lib/lifecycleCommand";
+import {
+  idempotencyKey,
+  isUuid,
+  positiveNumber,
+  runPartsLifecycleRpc,
+} from "../../../_lib/lifecycleCommand";
 
-export async function POST(req: Request, ctx: { params: Promise<{ partId: string }> }) {
-  const { partId } = await ctx.params;
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ partId: string }> },
+) {
+  const { partId } = await context.params;
   const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
-  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : "";
+  const locationId =
+    typeof body?.locationId === "string"
+      ? body.locationId
+      : typeof body?.location_id === "string"
+        ? body.location_id
+        : "";
   const qty = positiveNumber(body?.qty);
-  if (!isUuid(partId) || !isUuid(locationId) || qty == null) return NextResponse.json({ ok: false, error: "Invalid work-order part, location, or quantity." }, { status: 400 });
-  return runPartsLifecycleRpc(req, "parts_issue_work_order_part", { p_work_order_part_id: partId, p_location_id: locationId, p_qty: qty, p_idempotency_key: idempotencyKey(req, body ?? {}, `issue:${partId}:${locationId}:${qty}`) });
+  const operationKey = idempotencyKey(req, body ?? {});
+
+  if (!isUuid(partId) || !isUuid(locationId) || qty == null) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid work-order part, location, or quantity." },
+      { status: 400 },
+    );
+  }
+  if (!operationKey) {
+    return NextResponse.json(
+      { ok: false, error: "A stable idempotency key is required." },
+      { status: 400 },
+    );
+  }
+
+  return runPartsLifecycleRpc(req, "parts_issue_work_order_part", {
+    p_work_order_part_id: partId,
+    p_location_id: locationId,
+    p_qty: qty,
+    p_idempotency_key: operationKey,
+  });
 }

--- a/app/api/parts/work-order-parts/[partId]/return/route.ts
+++ b/app/api/parts/work-order-parts/[partId]/return/route.ts
@@ -1,11 +1,43 @@
 import { NextResponse } from "next/server";
-import { idempotencyKey, isUuid, positiveNumber, runPartsLifecycleRpc } from "../../../_lib/lifecycleCommand";
+import {
+  idempotencyKey,
+  isUuid,
+  positiveNumber,
+  runPartsLifecycleRpc,
+} from "../../../_lib/lifecycleCommand";
 
-export async function POST(req: Request, ctx: { params: Promise<{ partId: string }> }) {
-  const { partId } = await ctx.params;
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ partId: string }> },
+) {
+  const { partId } = await context.params;
   const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
-  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : "";
+  const locationId =
+    typeof body?.locationId === "string"
+      ? body.locationId
+      : typeof body?.location_id === "string"
+        ? body.location_id
+        : "";
   const qty = positiveNumber(body?.qty);
-  if (!isUuid(partId) || !isUuid(locationId) || qty == null) return NextResponse.json({ ok: false, error: "Invalid work-order part, location, or quantity." }, { status: 400 });
-  return runPartsLifecycleRpc(req, "parts_return_to_stock", { p_work_order_part_id: partId, p_location_id: locationId, p_qty: qty, p_idempotency_key: idempotencyKey(req, body ?? {}, `return:${partId}:${locationId}:${qty}`) });
+  const operationKey = idempotencyKey(req, body ?? {});
+
+  if (!isUuid(partId) || !isUuid(locationId) || qty == null) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid work-order part, location, or quantity." },
+      { status: 400 },
+    );
+  }
+  if (!operationKey) {
+    return NextResponse.json(
+      { ok: false, error: "A stable idempotency key is required." },
+      { status: 400 },
+    );
+  }
+
+  return runPartsLifecycleRpc(req, "parts_return_to_stock", {
+    p_work_order_part_id: partId,
+    p_location_id: locationId,
+    p_qty: qty,
+    p_idempotency_key: operationKey,
+  });
 }

--- a/app/api/work-orders/lines/[id]/delete-or-void/route.ts
+++ b/app/api/work-orders/lines/[id]/delete-or-void/route.ts
@@ -1,237 +1,96 @@
-// /app/api/work-orders/lines/[id]/delete-or-void/route.ts
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
+import { z } from "zod";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
-type DB = Database;
-
-type Disposition = "return_to_stock" | "keep_consumed" | "scrap";
-type Mode = "delete" | "void";
-
-type Body = {
-  mode: Mode;
-  disposition?: Disposition; // required when allocations exist
-  reason: string;
-  note?: string | null;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
 };
 
-function safeTrim(x: unknown): string {
-  return typeof x === "string" ? x.trim() : "";
-}
-
-function asNumber(v: unknown): number {
-  const n = typeof v === "number" ? v : Number(v);
-  return Number.isFinite(n) ? n : 0;
-}
+const Payload = z.object({
+  mode: z.enum(["delete", "void"]),
+  disposition: z.enum(["return_to_stock", "keep_consumed", "scrap"]).optional(),
+  reservedDisposition: z.literal("release").optional().default("release"),
+  orderedDisposition: z
+    .enum(["cancel_open_order", "retain_open_order"])
+    .optional()
+    .default("cancel_open_order"),
+  receivedDisposition: z
+    .enum(["retain_for_other_work", "return_to_vendor"])
+    .optional()
+    .default("retain_for_other_work"),
+  consumedDisposition: z
+    .enum(["return_to_stock", "keep_consumed", "scrap"])
+    .optional(),
+  reason: z.string().trim().min(1),
+  note: z.string().trim().nullable().optional(),
+  idempotencyKey: z.string().trim().min(1).optional(),
+});
 
 export async function POST(
   req: Request,
-  ctx: { params: Promise<{ id: string }> }, // ✅ folder is [id]
+  context: { params: Promise<{ id: string }> },
 ) {
-  try {
-    const supabase = createServerSupabaseRoute();
-
-    const { id: rawId } = await ctx.params; // ✅ params key is "id"
-    const id = safeTrim(rawId);
-
-    const body = (await req.json().catch(() => null)) as Body | null;
-
-    const mode = safeTrim(body?.mode) as Mode;
-    const disposition = safeTrim(body?.disposition) as Disposition;
-    const reason = safeTrim(body?.reason);
-    const note = body?.note ?? null;
-
-    if (!id) {
-      return NextResponse.json({ error: "Missing id" }, { status: 400 });
-    }
-    if (mode !== "delete" && mode !== "void") {
-      return NextResponse.json({ error: "Invalid mode" }, { status: 400 });
-    }
-    if (!reason) {
-      return NextResponse.json({ error: "Reason is required" }, { status: 400 });
-    }
-
-    const {
-      data: { user },
-      error: userErr,
-    } = await supabase.auth.getUser();
-
-    if (userErr) {
-      return NextResponse.json({ error: userErr.message }, { status: 401 });
-    }
-    if (!user) {
-      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-    }
-
-    // Load line + WO status (block if invoiced)
-    const { data: lineRow, error: lineErr } = await supabase
-      .from("work_order_lines")
-      .select("id, work_order_id, shop_id, status, voided_at")
-      .eq("id", id)
-      .maybeSingle();
-
-    if (lineErr) {
-      return NextResponse.json({ error: lineErr.message }, { status: 500 });
-    }
-    if (!lineRow) {
-      return NextResponse.json({ error: "Line not found" }, { status: 404 });
-    }
-
-    if (lineRow.voided_at) {
-      return NextResponse.json(
-        { error: "This line is already voided." },
-        { status: 409 },
-      );
-    }
-
-    const workOrderId = lineRow.work_order_id;
-    const shopId = lineRow.shop_id;
-
-    if (!workOrderId || !shopId) {
-      return NextResponse.json(
-        { error: "Line is missing work_order_id or shop_id" },
-        { status: 500 },
-      );
-    }
-
-    const { data: woRow, error: woErr } = await supabase
-      .from("work_orders")
-      .select("id, status")
-      .eq("id", workOrderId)
-      .maybeSingle();
-
-    if (woErr) {
-      return NextResponse.json({ error: woErr.message }, { status: 500 });
-    }
-
-    const woStatus = safeTrim(woRow?.status).toLowerCase();
-    const lineStatus = safeTrim(lineRow.status).toLowerCase();
-
-    if (woStatus === "invoiced" || lineStatus === "invoiced") {
-      return NextResponse.json(
-        { error: "Cannot delete/void an invoiced line." },
-        { status: 409 },
-      );
-    }
-
-    // Set shop context for RLS (server session)
-    const { error: ctxErr } = await supabase.rpc("set_current_shop_id", {
-      p_shop_id: shopId,
-    });
-    if (ctxErr) {
-      return NextResponse.json(
-        { error: ctxErr.message || "Failed to set current_shop_id" },
-        { status: 500 },
-      );
-    }
-
-    // Load allocations for this line
-    const { data: allocs, error: aErr } = await supabase
-      .from("work_order_part_allocations")
-      .select("id, part_id, location_id, qty, stock_move_id")
-      .eq("work_order_line_id", id);
-
-    if (aErr) {
-      return NextResponse.json({ error: aErr.message }, { status: 500 });
-    }
-
-    const allocations = Array.isArray(allocs) ? allocs : [];
-    const hasAllocs = allocations.length > 0;
-
-    if (hasAllocs) {
-      if (
-        disposition !== "return_to_stock" &&
-        disposition !== "keep_consumed" &&
-        disposition !== "scrap"
-      ) {
-        return NextResponse.json(
-          { error: "Disposition is required when parts are on the line." },
-          { status: 400 },
-        );
-      }
-    }
-
-    const hardDeleteAllowed =
-      mode === "delete" &&
-      !hasAllocs &&
-      !["completed", "ready_to_invoice", "invoiced"].includes(lineStatus);
-
-    if (hardDeleteAllowed) {
-      const { error: delErr } = await supabase
-        .from("work_order_lines")
-        .delete()
-        .eq("id", id);
-
-      if (delErr) {
-        return NextResponse.json({ error: delErr.message }, { status: 500 });
-      }
-
-      return NextResponse.json({ ok: true, mode: "deleted" });
-    }
-
-    // Otherwise: VOID (soft delete)
-    if (hasAllocs) {
-      if (disposition === "return_to_stock") {
-        for (const a of allocations) {
-          const partId = a.part_id;
-          const locId = a.location_id;
-          const qty = asNumber(a.qty);
-
-          if (!partId || !locId || qty <= 0) continue;
-
-          const { error: mvErr } = await supabase.rpc("apply_stock_move", {
-            p_part: partId,
-            p_loc: locId,
-            p_qty: qty,
-            p_reason: "return_in",
-            p_ref_kind: "work_order_line_void",
-            p_ref_id: id,
-          });
-
-          if (mvErr) {
-            return NextResponse.json({ error: mvErr.message }, { status: 500 });
-          }
-        }
-      }
-
-      const { error: daErr } = await supabase
-        .from("work_order_part_allocations")
-        .delete()
-        .eq("work_order_line_id", id);
-
-      if (daErr) {
-        return NextResponse.json({ error: daErr.message }, { status: 500 });
-      }
-    }
-
-    const { error: vErr } = await supabase
-      .from("work_order_lines")
-      .update({
-        voided_at: new Date().toISOString(),
-        voided_by: user.id,
-        void_reason: reason,
-        void_note: note,
-      } as DB["public"]["Tables"]["work_order_lines"]["Update"])
-      .eq("id", id);
-
-    if (vErr) {
-      return NextResponse.json(
-        {
-          error:
-            vErr.message +
-            " (Did you run the migration to add voided_at/void_reason/etc?)",
-        },
-        { status: 500 },
-      );
-    }
-
-    return NextResponse.json({
-      ok: true,
-      mode: "voided",
-      disposition: hasAllocs ? disposition : null,
-    });
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : "Server error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+  const { id } = await context.params;
+  if (!z.string().uuid().safeParse(id).success) {
+    return NextResponse.json({ error: "Invalid work-order line id." }, { status: 400 });
   }
+
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
+
+  const json: unknown = await req.json().catch(() => null);
+  const parsed = Payload.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid line disposition payload.", issues: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const body = parsed.data;
+  const consumedDisposition = body.consumedDisposition ?? body.disposition;
+  if (!consumedDisposition) {
+    return NextResponse.json(
+      { error: "Consumed-parts disposition is required." },
+      { status: 400 },
+    );
+  }
+
+  const rawKey =
+    body.idempotencyKey || req.headers.get("idempotency-key")?.trim() || "";
+  if (!rawKey) {
+    return NextResponse.json(
+      { error: "A stable idempotency key is required." },
+      { status: 400 },
+    );
+  }
+
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("parts_void_work_order_line_atomic", {
+    p_shop_id: access.profile.shop_id,
+    p_work_order_line_id: id,
+    p_mode: body.mode,
+    p_reserved_disposition: body.reservedDisposition,
+    p_ordered_disposition: body.orderedDisposition,
+    p_received_disposition: body.receivedDisposition,
+    p_consumed_disposition: consumedDisposition,
+    p_reason: body.reason,
+    p_note: body.note ?? null,
+    p_operation_key: `${access.profile.shop_id}:line-void:${rawKey}`,
+    p_actor_user_id: access.profile.id,
+  });
+
+  if (error) {
+    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+    const status = error.message.includes("FINANCIALLY_LOCKED") ? 409 : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+
+  return NextResponse.json(data);
 }

--- a/docs/phase-3-parts-transaction-contract.md
+++ b/docs/phase-3-parts-transaction-contract.md
@@ -1,0 +1,72 @@
+# Phase 3 canonical parts transaction contract
+
+Parent audit: #992
+
+## Non-negotiable rules
+
+1. Existing canonical parts RPCs remain the lifecycle source of truth.
+2. Every retryable operation requires a stable shop-prefixed operation key.
+3. One RPC owns all writes for an operation; failures roll back every related row.
+4. Quantity-changing commands lock their request, request item, work-order part, allocation, PO line, and work-order anchors before recalculating.
+5. Phase 2 financial locks apply inside each quantity-changing RPC.
+6. Manufacturer, supplier, vendor, part number, SKU, cost, and sell-price snapshots remain distinct.
+7. Invoice quantity is always `quantity_consumed - quantity_returned`.
+
+## Canonical quantity meanings
+
+| Quantity | Meaning |
+|---|---|
+| requested | Customer/repair requirement |
+| assigned | Quantity assigned to a supplier or purchasing workflow |
+| ordered | Quantity committed on purchase-order lines |
+| received | Physical quantity received into stock |
+| allocated | On-hand quantity reserved to a work-order part |
+| consumed | Gross quantity issued to the repair |
+| returned | Gross issued quantity returned to stock |
+| net issued | `consumed - returned` |
+| cancelled | Requested quantity explicitly cancelled before use |
+
+Assigned, ordered, and received quantities must never be inferred from one another.
+
+## Line-void disposition contract
+
+A line cannot be voided until every attached part quantity has an explicit disposition.
+
+### Reserved or picked
+
+- `release`: call canonical allocation release for every locked allocation.
+- No allocation row may be deleted directly by the route.
+
+### Ordered but not received
+
+- `cancel_open_order`: cancel the unreceived PO-line remainder through the canonical PO cancellation command.
+- `retain_open_order`: reject line void because the order remains operationally attached.
+
+### Received but not issued
+
+- `return_to_inventory`: retain physical stock and cancel only the work-order demand.
+- `return_to_vendor`: requires a canonical vendor-return command and stock movement.
+- `retain_for_other_work`: release allocation and cancel the work-order demand.
+
+### Consumed and not returned
+
+- `return_to_stock`: call canonical return for the complete net-issued quantity.
+- `keep_consumed`: retain the issue ledger and record an explicit non-billable/internal disposition.
+- `scrap`: retain the physical deduction and record a scrap disposition event.
+
+The line is marked void only after every disposition succeeds in the same transaction.
+
+## Implemented command boundaries
+
+- `parts_commit_request_package_atomic`
+- `parts_update_attach_allocate_item_atomic`
+- `parts_issue_by_line_part_atomic` compatibility bridge into `parts_issue_work_order_part`
+- Hardened `parts_create_po_line_for_request`
+- Hardened `parts_receive_request_item` / `receive_part_request_item`
+- Hardened `parts_issue_work_order_part`
+- Hardened `parts_return_to_stock`
+- Hardened `parts_replace_request_item`
+
+## Legacy paths
+
+Routes may validate and normalize input, but they must not update lifecycle tables before or after the canonical RPC. Compatibility endpoints must delegate to the same canonical command and require the same operation key.

--- a/docs/phase-3-parts-transaction-runbook.md
+++ b/docs/phase-3-parts-transaction-runbook.md
@@ -1,0 +1,40 @@
+# Phase 3 parts transaction rollout
+
+## Migration order
+
+Run only after PR validation is green:
+
+1. `20260714039900_phase3_part_request_statuses.sql`
+2. `20260714040000_phase3_parts_atomic_commands.sql`
+3. `20260714040100_phase3_parts_quantity_reconciliation.sql`
+4. `20260714040200_phase3_atomic_line_void.sql`
+5. `20260714040300_phase3_part_identity_snapshots.sql`
+6. `20260714040400_phase3_invoice_net_issued_rpc.sql`
+7. `20260714040500_phase3_parts_reconciliation_and_postcheck.sql`
+
+Expected final notice:
+
+```text
+Phase 3 canonical parts transaction postcheck passed.
+```
+
+## Controlled validation
+
+Use a non-invoiced test work order.
+
+1. Add a priced request item to a repair line with an explicit idempotency key.
+2. Retry with the same key and confirm no duplicate work-order part/allocation.
+3. Partially order the item and confirm requested, ordered, and received quantities remain separate.
+4. Partially receive using a stable receipt key; retry and confirm no duplicate receipt.
+5. Allocate and partially issue the part.
+6. Return part of the issued quantity and confirm both request-item and work-order-part returned quantities reconcile.
+7. Confirm invoice preview/issuance includes only net issued quantity.
+8. Attempt a quantity change after invoice finalization and confirm `WORK_ORDER_FINANCIALLY_LOCKED`.
+9. Void an uninvoiced line and confirm reservations, open-order remainder, received stock, and issued quantity follow the selected dispositions atomically.
+
+## Rollout cautions
+
+- Client callers must now provide stable idempotency keys for package commit, item attach, receiving, issuing, returning, and line void.
+- The old timestamp-derived receipt fallback is intentionally removed.
+- Replacement with net issued quantity is rejected until issued stock is fully returned.
+- Vendor return is not silently simulated; it requires its own canonical vendor-return command.

--- a/features/invoices/server/getIssuableInvoiceSnapshot.ts
+++ b/features/invoices/server/getIssuableInvoiceSnapshot.ts
@@ -1,0 +1,118 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import {
+  getInvoiceSnapshotForWorkOrder,
+  type InvoiceSnapshot,
+  type InvoiceSnapshotPart,
+} from "@/features/invoices/server/getInvoiceSnapshot";
+
+type DB = Database;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+type NetIssuedPart = InvoiceSnapshotPart & {
+  manufacturer?: string;
+  supplier?: string;
+  unitCost?: number;
+};
+
+function finite(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function money(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function normalizeParts(value: unknown): NetIssuedPart[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry): NetIssuedPart[] => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const row = entry as Record<string, unknown>;
+    const id = typeof row.id === "string" ? row.id : "";
+    const name = typeof row.name === "string" ? row.name.trim() : "";
+    const qty = finite(row.qty);
+    const unitPrice = finite(row.unitPrice);
+    if (!id || !name || qty <= 0 || unitPrice < 0) return [];
+
+    return [
+      {
+        id,
+        lineId: typeof row.lineId === "string" ? row.lineId : undefined,
+        name,
+        qty,
+        unitPrice,
+        totalPrice: money(finite(row.totalPrice) || qty * unitPrice),
+        sku: typeof row.sku === "string" && row.sku.trim() ? row.sku.trim() : undefined,
+        partNumber:
+          typeof row.partNumber === "string" && row.partNumber.trim()
+            ? row.partNumber.trim()
+            : undefined,
+        vendor:
+          typeof row.vendor === "string" && row.vendor.trim() ? row.vendor.trim() : undefined,
+        manufacturer:
+          typeof row.manufacturer === "string" && row.manufacturer.trim()
+            ? row.manufacturer.trim()
+            : undefined,
+        supplier:
+          typeof row.supplier === "string" && row.supplier.trim()
+            ? row.supplier.trim()
+            : undefined,
+        unitCost: finite(row.unitCost),
+        source: "work_order_part",
+      },
+    ];
+  });
+}
+
+export async function getIssuableInvoiceSnapshot(input: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+}): Promise<InvoiceSnapshot> {
+  const base = await getInvoiceSnapshotForWorkOrder({
+    supabase: input.supabase,
+    workOrderId: input.workOrderId,
+  });
+
+  const rpc = input.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("get_invoice_net_issued_parts", {
+    p_shop_id: input.shopId,
+    p_work_order_id: input.workOrderId,
+  });
+  if (error) {
+    throw new Error([error.message, error.details, error.hint].filter(Boolean).join(" — "));
+  }
+
+  const parts = normalizeParts(data);
+  const partsCost = money(parts.reduce((sum, part) => sum + finite(part.totalPrice), 0));
+  const laborCost = money(finite(base.laborCost));
+  const supplies = money(finite(base.shopSuppliesTotal));
+  const discount = money(finite(base.discountTotal));
+
+  // Preserve the canonical tax treatment chosen by the existing snapshot builder by
+  // inferring its effective rate, then apply that rate to the corrected taxable base.
+  const previousSubtotal = finite(base.subtotal);
+  const previousTaxableBase = Math.max(previousSubtotal - discount, 0);
+  const effectiveTaxRate = previousTaxableBase > 0 ? finite(base.taxTotal) / previousTaxableBase : 0;
+
+  const subtotal = money(laborCost + partsCost + supplies);
+  const taxableBase = Math.max(subtotal - discount, 0);
+  const taxTotal = money(taxableBase * effectiveTaxRate);
+  const total = money(taxableBase + taxTotal);
+
+  return {
+    ...base,
+    parts,
+    partsCost,
+    subtotal,
+    taxTotal,
+    total,
+  };
+}

--- a/features/invoices/server/getIssuableInvoiceSnapshot.ts
+++ b/features/invoices/server/getIssuableInvoiceSnapshot.ts
@@ -30,42 +30,43 @@ function money(value: number): number {
   return Math.round((value + Number.EPSILON) * 100) / 100;
 }
 
+function optionalText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
 function normalizeParts(value: unknown): NetIssuedPart[] {
   if (!Array.isArray(value)) return [];
   return value.flatMap((entry): NetIssuedPart[] => {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
     const row = entry as Record<string, unknown>;
-    const id = typeof row.id === "string" ? row.id : "";
-    const name = typeof row.name === "string" ? row.name.trim() : "";
+    const id = optionalText(row.id) ?? "";
+    const name = optionalText(row.name) ?? "";
     const qty = finite(row.qty);
     const unitPrice = finite(row.unitPrice);
     if (!id || !name || qty <= 0 || unitPrice < 0) return [];
 
+    const lineId = optionalText(row.lineId);
+    const sku = optionalText(row.sku);
+    const partNumber = optionalText(row.partNumber);
+    const vendor = optionalText(row.vendor);
+    const manufacturer = optionalText(row.manufacturer);
+    const supplier = optionalText(row.supplier);
+
     return [
       {
         id,
-        lineId: typeof row.lineId === "string" ? row.lineId : undefined,
         name,
         qty,
         unitPrice,
         totalPrice: money(finite(row.totalPrice) || qty * unitPrice),
-        sku: typeof row.sku === "string" && row.sku.trim() ? row.sku.trim() : undefined,
-        partNumber:
-          typeof row.partNumber === "string" && row.partNumber.trim()
-            ? row.partNumber.trim()
-            : undefined,
-        vendor:
-          typeof row.vendor === "string" && row.vendor.trim() ? row.vendor.trim() : undefined,
-        manufacturer:
-          typeof row.manufacturer === "string" && row.manufacturer.trim()
-            ? row.manufacturer.trim()
-            : undefined,
-        supplier:
-          typeof row.supplier === "string" && row.supplier.trim()
-            ? row.supplier.trim()
-            : undefined,
         unitCost: finite(row.unitCost),
         source: "work_order_part",
+        ...(lineId ? { lineId } : {}),
+        ...(sku ? { sku } : {}),
+        ...(partNumber ? { partNumber } : {}),
+        ...(vendor ? { vendor } : {}),
+        ...(manufacturer ? { manufacturer } : {}),
+        ...(supplier ? { supplier } : {}),
       },
     ];
   });
@@ -95,13 +96,10 @@ export async function getIssuableInvoiceSnapshot(input: {
   const laborCost = money(finite(base.laborCost));
   const supplies = money(finite(base.shopSuppliesTotal));
   const discount = money(finite(base.discountTotal));
-
-  // Preserve the canonical tax treatment chosen by the existing snapshot builder by
-  // inferring its effective rate, then apply that rate to the corrected taxable base.
   const previousSubtotal = finite(base.subtotal);
   const previousTaxableBase = Math.max(previousSubtotal - discount, 0);
-  const effectiveTaxRate = previousTaxableBase > 0 ? finite(base.taxTotal) / previousTaxableBase : 0;
-
+  const effectiveTaxRate =
+    previousTaxableBase > 0 ? finite(base.taxTotal) / previousTaxableBase : 0;
   const subtotal = money(laborCost + partsCost + supplies);
   const taxableBase = Math.max(subtotal - discount, 0);
   const taxTotal = money(taxableBase * effectiveTaxRate);

--- a/supabase/migrations/20260714039900_phase3_part_request_statuses.sql
+++ b/supabase/migrations/20260714039900_phase3_part_request_statuses.sql
@@ -1,0 +1,7 @@
+-- Enum values must be committed before later migrations use them.
+-- Keep this migration outside an explicit transaction.
+
+alter type public.part_request_status add value if not exists 'partially_ordered';
+alter type public.part_request_status add value if not exists 'partially_consumed';
+alter type public.part_request_status add value if not exists 'partially_returned';
+alter type public.part_request_status add value if not exists 'returned';

--- a/supabase/migrations/20260714040000_phase3_parts_atomic_commands.sql
+++ b/supabase/migrations/20260714040000_phase3_parts_atomic_commands.sql
@@ -1,0 +1,424 @@
+begin;
+
+create table if not exists public.parts_operation_keys (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete restrict,
+  operation_key text not null,
+  operation_type text not null,
+  aggregate_type text not null,
+  aggregate_id uuid not null,
+  result jsonb,
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz,
+  unique (shop_id, operation_key)
+);
+
+create index if not exists parts_operation_keys_aggregate_idx
+  on public.parts_operation_keys(shop_id, aggregate_type, aggregate_id, created_at desc);
+
+alter table public.parts_operation_keys enable row level security;
+
+create policy parts_operation_keys_shop_select
+  on public.parts_operation_keys
+  for select
+  to authenticated
+  using (
+    shop_id = nullif(current_setting('app.current_shop_id', true), '')::uuid
+    or exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid() and p.shop_id = parts_operation_keys.shop_id
+    )
+  );
+
+create or replace function public.parts_assert_work_order_mutable(
+  p_shop_id uuid,
+  p_work_order_id uuid
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if public.work_order_is_financially_locked(p_shop_id, p_work_order_id) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_FINANCIALLY_LOCKED',
+      detail = format('Quantity-changing parts operation is blocked for finalized work order %s', p_work_order_id),
+      hint = 'Use an audited Phase 2 correction session before changing finalized parts quantities.';
+  end if;
+end;
+$$;
+
+create or replace function public.parts_begin_operation(
+  p_shop_id uuid,
+  p_operation_key text,
+  p_operation_type text,
+  p_aggregate_type text,
+  p_aggregate_id uuid,
+  p_actor_user_id uuid
+) returns public.parts_operation_keys
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_operation public.parts_operation_keys;
+begin
+  if coalesce(trim(p_operation_key), '') = '' then
+    raise exception 'A stable operation key is required.';
+  end if;
+  if position(p_shop_id::text || ':' in p_operation_key) <> 1 then
+    raise exception 'Operation key must be tenant scoped with the shop id prefix.';
+  end if;
+
+  select * into v_operation
+  from public.parts_operation_keys
+  where shop_id = p_shop_id and operation_key = p_operation_key
+  for update;
+
+  if found then
+    if v_operation.operation_type <> p_operation_type
+       or v_operation.aggregate_type <> p_aggregate_type
+       or v_operation.aggregate_id <> p_aggregate_id then
+      raise exception 'Operation key is already used for a different parts operation.';
+    end if;
+    return v_operation;
+  end if;
+
+  insert into public.parts_operation_keys(
+    shop_id, operation_key, operation_type, aggregate_type, aggregate_id, created_by
+  ) values (
+    p_shop_id, trim(p_operation_key), p_operation_type, p_aggregate_type, p_aggregate_id, p_actor_user_id
+  ) returning * into v_operation;
+
+  return v_operation;
+end;
+$$;
+
+create or replace function public.parts_complete_operation(
+  p_operation_id uuid,
+  p_result jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.parts_operation_keys
+  set result = coalesce(p_result, '{}'::jsonb), completed_at = coalesce(completed_at, now())
+  where id = p_operation_id;
+  return coalesce(p_result, '{}'::jsonb);
+end;
+$$;
+
+create or replace function public.parts_commit_request_package_atomic(
+  p_shop_id uuid,
+  p_request_id uuid,
+  p_operation_key text,
+  p_actor_user_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_request public.part_requests%rowtype;
+  v_operation public.parts_operation_keys;
+  v_item public.part_request_items%rowtype;
+  v_line record;
+  v_part record;
+  v_work_order_part_id uuid;
+  v_ids jsonb := '[]'::jsonb;
+  v_count integer := 0;
+  v_qty numeric;
+begin
+  v_operation := public.parts_begin_operation(
+    p_shop_id,
+    p_operation_key,
+    'commit_request_package',
+    'part_request',
+    p_request_id,
+    p_actor_user_id
+  );
+  if v_operation.completed_at is not null then
+    return coalesce(v_operation.result, '{}'::jsonb) || jsonb_build_object('idempotent', true);
+  end if;
+
+  select * into v_request
+  from public.part_requests
+  where id = p_request_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Parts request not found for shop.'; end if;
+  if v_request.work_order_id is null then raise exception 'Parts request is not linked to a work order.'; end if;
+
+  perform 1 from public.work_orders
+  where id = v_request.work_order_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Work order not found for shop.'; end if;
+  perform public.parts_assert_work_order_mutable(p_shop_id, v_request.work_order_id);
+
+  -- Lock the complete package before validation or attachment.
+  perform 1 from public.part_request_items
+  where request_id = p_request_id and shop_id = p_shop_id
+  order by id
+  for update;
+
+  if not exists (
+    select 1 from public.part_request_items
+    where request_id = p_request_id and shop_id = p_shop_id
+  ) then
+    raise exception 'Parts request contains no items.';
+  end if;
+
+  -- Validate every item before creating any work-order part.
+  for v_item in
+    select * from public.part_request_items
+    where request_id = p_request_id and shop_id = p_shop_id
+    order by id
+  loop
+    if v_item.part_id is null then raise exception 'Request item % has no selected inventory part.', v_item.id; end if;
+    if v_item.work_order_line_id is null then raise exception 'Request item % is not linked to a repair line.', v_item.id; end if;
+    if v_item.work_order_id is not null and v_item.work_order_id <> v_request.work_order_id then
+      raise exception 'Request item % belongs to a different work order.', v_item.id;
+    end if;
+    v_qty := greatest(coalesce(v_item.qty_requested, v_item.qty, 0), 0);
+    if v_qty <= 0 then raise exception 'Request item % quantity must be greater than zero.', v_item.id; end if;
+    if coalesce(trim(v_item.description), '') = '' then raise exception 'Request item % requires a description.', v_item.id; end if;
+
+    select id, work_order_id, shop_id into v_line
+    from public.work_order_lines
+    where id = v_item.work_order_line_id
+    for update;
+    if not found or v_line.shop_id <> p_shop_id or v_line.work_order_id <> v_request.work_order_id then
+      raise exception 'Request item % repair line is outside the request work order/shop.', v_item.id;
+    end if;
+
+    select id, shop_id into v_part
+    from public.parts
+    where id = v_item.part_id
+    for share;
+    if not found or v_part.shop_id <> p_shop_id then
+      raise exception 'Request item % selected part belongs to another shop.', v_item.id;
+    end if;
+  end loop;
+
+  for v_item in
+    select * from public.part_request_items
+    where request_id = p_request_id and shop_id = p_shop_id
+    order by id
+  loop
+    v_work_order_part_id := public.parts_ensure_work_order_part(v_item.id);
+    v_ids := v_ids || jsonb_build_array(jsonb_build_object(
+      'requestItemId', v_item.id,
+      'workOrderPartId', v_work_order_part_id
+    ));
+    v_count := v_count + 1;
+  end loop;
+
+  return public.parts_complete_operation(
+    v_operation.id,
+    jsonb_build_object(
+      'ok', true,
+      'idempotent', false,
+      'requestId', p_request_id,
+      'committedCount', v_count,
+      'items', v_ids
+    )
+  );
+end;
+$$;
+
+create or replace function public.parts_update_attach_allocate_item_atomic(
+  p_shop_id uuid,
+  p_request_item_id uuid,
+  p_part_id uuid,
+  p_description text,
+  p_qty numeric,
+  p_unit_sell_price numeric,
+  p_requested_part_number text,
+  p_requested_manufacturer text,
+  p_work_order_line_id uuid,
+  p_po_id uuid,
+  p_location_id uuid,
+  p_create_allocation boolean,
+  p_warning_accepted boolean,
+  p_warning_reason text,
+  p_operation_key text,
+  p_actor_user_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_operation public.parts_operation_keys;
+  v_item public.part_request_items%rowtype;
+  v_request public.part_requests%rowtype;
+  v_part public.parts%rowtype;
+  v_line public.work_order_lines%rowtype;
+  v_wop_id uuid;
+  v_allocation jsonb;
+  v_result jsonb;
+begin
+  if p_qty <= 0 then raise exception 'Quantity must be greater than zero.'; end if;
+  if p_unit_sell_price < 0 then raise exception 'Sell price cannot be negative.'; end if;
+  if p_part_id is null then raise exception 'A selected inventory part is required.'; end if;
+  if p_work_order_line_id is null then raise exception 'A work-order line is required.'; end if;
+  if p_create_allocation and p_location_id is null then raise exception 'A location is required when allocating stock.'; end if;
+
+  v_operation := public.parts_begin_operation(
+    p_shop_id,
+    p_operation_key,
+    'update_attach_allocate_item',
+    'part_request_item',
+    p_request_item_id,
+    p_actor_user_id
+  );
+  if v_operation.completed_at is not null then
+    return coalesce(v_operation.result, '{}'::jsonb) || jsonb_build_object('idempotent', true);
+  end if;
+
+  select * into v_item from public.part_request_items
+  where id = p_request_item_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Request item not found for shop.'; end if;
+
+  select * into v_request from public.part_requests
+  where id = v_item.request_id and shop_id = p_shop_id
+  for update;
+  if not found or v_request.work_order_id is null then raise exception 'Parent request is not linked to a work order.'; end if;
+
+  perform 1 from public.work_orders
+  where id = v_request.work_order_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Work order not found for shop.'; end if;
+  perform public.parts_assert_work_order_mutable(p_shop_id, v_request.work_order_id);
+
+  select * into v_line from public.work_order_lines
+  where id = p_work_order_line_id and work_order_id = v_request.work_order_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Work-order line is outside the request work order/shop.'; end if;
+
+  select * into v_part from public.parts
+  where id = p_part_id and shop_id = p_shop_id
+  for share;
+  if not found then raise exception 'Selected part is outside the shop.'; end if;
+
+  if p_po_id is not null then
+    perform 1 from public.purchase_orders
+    where id = p_po_id and shop_id = p_shop_id
+    for update;
+    if not found then raise exception 'Purchase order is outside the shop.'; end if;
+  end if;
+
+  update public.part_request_items
+  set part_id = p_part_id,
+      description = coalesce(nullif(trim(p_description), ''), description, v_part.name, 'Part'),
+      qty = p_qty,
+      qty_requested = p_qty,
+      quoted_price = p_unit_sell_price,
+      unit_price = p_unit_sell_price,
+      requested_part_number = nullif(trim(p_requested_part_number), ''),
+      requested_manufacturer = nullif(trim(p_requested_manufacturer), ''),
+      work_order_id = v_request.work_order_id,
+      work_order_line_id = p_work_order_line_id,
+      po_id = p_po_id,
+      updated_at = now()
+  where id = p_request_item_id and shop_id = p_shop_id;
+
+  v_wop_id := public.parts_ensure_work_order_part(p_request_item_id);
+
+  if p_create_allocation then
+    v_allocation := public.parts_allocate_request_item(
+      p_request_item_id,
+      p_location_id,
+      p_qty,
+      p_shop_id::text || ':allocate:' || trim(p_operation_key)
+    );
+  end if;
+
+  if p_warning_accepted then
+    if coalesce(trim(p_warning_reason), '') = '' then
+      raise exception 'Mismatch acknowledgement reason is required.';
+    end if;
+    update public.work_order_parts
+    set mismatch_acknowledged_at = now(),
+        mismatch_acknowledged_by = p_actor_user_id,
+        mismatch_warning_reason = trim(p_warning_reason),
+        updated_at = now()
+    where id = v_wop_id and shop_id = p_shop_id;
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'requestItemId', p_request_item_id,
+    'workOrderPartId', v_wop_id,
+    'allocation', v_allocation
+  );
+  return public.parts_complete_operation(v_operation.id, v_result);
+end;
+$$;
+
+create or replace function public.parts_issue_by_line_part_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_operation_key text,
+  p_actor_user_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_wop public.work_order_parts%rowtype;
+  v_key text;
+begin
+  if p_qty <= 0 then raise exception 'Issue quantity must be greater than zero.'; end if;
+  if coalesce(trim(p_operation_key), '') = '' then raise exception 'A stable operation key is required.'; end if;
+  if position(p_shop_id::text || ':' in p_operation_key) <> 1 then
+    raise exception 'Operation key must be tenant scoped with the shop id prefix.';
+  end if;
+
+  select * into v_line from public.work_order_lines
+  where id = p_work_order_line_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Work-order line not found for shop.'; end if;
+  perform public.parts_assert_work_order_mutable(p_shop_id, v_line.work_order_id);
+
+  select * into v_wop
+  from public.work_order_parts
+  where shop_id = p_shop_id
+    and work_order_id = v_line.work_order_id
+    and work_order_line_id = p_work_order_line_id
+    and part_id = p_part_id
+    and is_active
+  order by updated_at desc, id desc
+  limit 1
+  for update;
+  if not found then raise exception 'No active canonical work-order part exists for this line and part.'; end if;
+
+  v_key := p_shop_id::text || ':issue:' || trim(p_operation_key);
+  return public.parts_issue_work_order_part(v_wop.id, p_location_id, p_qty, v_key);
+end;
+$$;
+
+revoke all on function public.parts_assert_work_order_mutable(uuid,uuid) from public;
+revoke all on function public.parts_begin_operation(uuid,text,text,text,uuid,uuid) from public;
+revoke all on function public.parts_complete_operation(uuid,jsonb) from public;
+revoke all on function public.parts_commit_request_package_atomic(uuid,uuid,text,uuid) from public;
+revoke all on function public.parts_update_attach_allocate_item_atomic(uuid,uuid,uuid,text,numeric,numeric,text,text,uuid,uuid,uuid,boolean,boolean,text,text,uuid) from public;
+revoke all on function public.parts_issue_by_line_part_atomic(uuid,uuid,uuid,uuid,numeric,text,uuid) from public;
+
+grant execute on function public.parts_commit_request_package_atomic(uuid,uuid,text,uuid) to authenticated, service_role;
+grant execute on function public.parts_update_attach_allocate_item_atomic(uuid,uuid,uuid,text,numeric,numeric,text,text,uuid,uuid,uuid,boolean,boolean,text,text,uuid) to authenticated, service_role;
+grant execute on function public.parts_issue_by_line_part_atomic(uuid,uuid,uuid,uuid,numeric,text,uuid) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260714040100_phase3_parts_quantity_reconciliation.sql
+++ b/supabase/migrations/20260714040100_phase3_parts_quantity_reconciliation.sql
@@ -1,0 +1,559 @@
+begin;
+
+alter table public.part_request_items
+  add column if not exists qty_assigned numeric(12,2) not null default 0,
+  add column if not exists qty_ordered numeric(12,2) not null default 0,
+  add column if not exists qty_returned numeric(12,2) not null default 0;
+
+alter table public.part_request_items
+  drop constraint if exists part_request_items_nonnegative_phase3;
+alter table public.part_request_items
+  add constraint part_request_items_nonnegative_phase3 check (
+    coalesce(qty, 0) >= 0
+    and coalesce(qty_requested, 0) >= 0
+    and coalesce(qty_assigned, 0) >= 0
+    and coalesce(qty_ordered, 0) >= 0
+    and coalesce(qty_received, 0) >= 0
+    and coalesce(qty_reserved, 0) >= 0
+    and coalesce(qty_consumed, 0) >= 0
+    and coalesce(qty_returned, 0) >= 0
+    and coalesce(qty_returned, 0) <= coalesce(qty_consumed, 0)
+  ) not valid;
+
+alter table public.work_order_parts
+  drop constraint if exists work_order_parts_nonnegative_phase3;
+alter table public.work_order_parts
+  add constraint work_order_parts_nonnegative_phase3 check (
+    coalesce(quantity_requested, 0) >= 0
+    and coalesce(quantity_ordered, 0) >= 0
+    and coalesce(quantity_received, 0) >= 0
+    and coalesce(quantity_allocated, 0) >= 0
+    and coalesce(quantity_consumed, 0) >= 0
+    and coalesce(quantity_returned, 0) >= 0
+    and coalesce(quantity_cancelled, 0) >= 0
+    and coalesce(quantity_returned, 0) <= coalesce(quantity_consumed, 0)
+  ) not valid;
+
+create or replace function public.parts_create_po_line_for_request(
+  p_po_id uuid,
+  p_request_item_id uuid,
+  p_qty numeric,
+  p_unit_cost numeric default null,
+  p_location_id uuid default null,
+  p_idempotency_key text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item public.part_request_items%rowtype;
+  v_po public.purchase_orders%rowtype;
+  v_wop public.work_order_parts%rowtype;
+  v_line_id uuid;
+  v_total_ordered numeric;
+  v_requested numeric;
+  v_status text;
+begin
+  if p_qty <= 0 then raise exception 'PO quantity must be greater than zero.'; end if;
+  if coalesce(trim(p_idempotency_key), '') = '' then raise exception 'A stable idempotency key is required.'; end if;
+
+  select * into v_item from public.part_request_items
+  where id = p_request_item_id
+  for update;
+  if not found then raise exception 'Request item not found.'; end if;
+
+  select * into v_po from public.purchase_orders
+  where id = p_po_id
+  for update;
+  if not found then raise exception 'Purchase order not found.'; end if;
+  if v_po.shop_id is distinct from v_item.shop_id then raise exception 'Purchase order belongs to a different shop.'; end if;
+
+  perform public.parts_assert_work_order_mutable(v_item.shop_id, v_item.work_order_id);
+
+  select * into v_wop from public.work_order_parts
+  where id = public.parts_ensure_work_order_part(p_request_item_id)
+  for update;
+
+  insert into public.purchase_order_lines(
+    po_id, part_id, description, qty, unit_cost, location_id,
+    part_request_item_id, work_order_part_id, idempotency_key
+  ) values (
+    p_po_id, v_item.part_id, v_item.description, p_qty,
+    coalesce(p_unit_cost, v_item.unit_cost, 0), p_location_id,
+    p_request_item_id, v_wop.id, p_idempotency_key
+  )
+  on conflict (po_id, idempotency_key) where idempotency_key is not null
+  do update set id = public.purchase_order_lines.id
+  returning id into v_line_id;
+
+  select coalesce(sum(qty), 0) into v_total_ordered
+  from public.purchase_order_lines
+  where part_request_item_id = p_request_item_id;
+
+  v_requested := greatest(coalesce(v_item.qty_requested, v_item.qty, 0), 0);
+  if v_total_ordered > v_requested then
+    raise exception 'Ordered quantity % exceeds requested quantity %.', v_total_ordered, v_requested;
+  end if;
+  v_status := case
+    when v_total_ordered <= 0 then 'requested'
+    when v_total_ordered < v_requested then 'partially_ordered'
+    else 'ordered'
+  end;
+
+  update public.part_request_items
+  set po_id = p_po_id,
+      qty_ordered = v_total_ordered,
+      status = v_status,
+      updated_at = now()
+  where id = p_request_item_id;
+
+  update public.work_order_parts
+  set quantity_ordered = v_total_ordered,
+      updated_at = now()
+  where id = v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+
+  return jsonb_build_object(
+    'ok', true,
+    'purchase_order_line_id', v_line_id,
+    'work_order_part_id', v_wop.id,
+    'requested_qty', v_requested,
+    'ordered_qty', v_total_ordered,
+    'remaining_to_order', greatest(v_requested - v_total_ordered, 0),
+    'status', v_status
+  );
+end;
+$$;
+
+create or replace function public.parts_receive_request_item(
+  p_request_item_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_po_line_id uuid default null,
+  p_unit_cost numeric default null,
+  p_idempotency_key text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item public.part_request_items%rowtype;
+  v_wop public.work_order_parts%rowtype;
+  v_line public.purchase_order_lines%rowtype;
+  v_existing public.stock_moves%rowtype;
+  v_received_total numeric;
+  v_move_id uuid;
+  v_limit numeric;
+  v_status text;
+begin
+  if p_qty <= 0 then raise exception 'Receive quantity must be greater than zero.'; end if;
+  if coalesce(trim(p_idempotency_key), '') = '' then raise exception 'A stable idempotency key is required.'; end if;
+
+  select * into v_item from public.part_request_items
+  where id = p_request_item_id
+  for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_assert_work_order_mutable(v_item.shop_id, v_item.work_order_id);
+
+  select * into v_existing from public.stock_moves
+  where shop_id = v_item.shop_id and idempotency_key = p_idempotency_key
+  for update;
+  if found then
+    return coalesce(v_existing.metadata, '{}'::jsonb)
+      || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id);
+  end if;
+
+  select * into v_wop from public.work_order_parts
+  where id = public.parts_ensure_work_order_part(p_request_item_id)
+  for update;
+
+  if p_po_line_id is not null then
+    select * into v_line from public.purchase_order_lines
+    where id = p_po_line_id
+    for update;
+    if not found then raise exception 'Purchase order line not found.'; end if;
+    if v_line.part_request_item_id is distinct from p_request_item_id then
+      raise exception 'PO line is not linked to this request item.';
+    end if;
+    if coalesce(v_line.received_qty, 0) + p_qty > coalesce(v_line.qty, 0) then
+      raise exception 'Receipt exceeds ordered quantity.';
+    end if;
+    update public.purchase_order_lines
+    set received_qty = coalesce(received_qty, 0) + p_qty
+    where id = p_po_line_id;
+    v_limit := coalesce(v_line.qty, 0);
+  else
+    v_limit := greatest(coalesce(v_item.qty_ordered, 0), coalesce(v_item.qty_requested, v_item.qty, 0));
+    if coalesce(v_item.qty_received, 0) + p_qty > v_limit then
+      raise exception 'Receipt exceeds assigned/ordered/requested quantity.';
+    end if;
+  end if;
+
+  insert into public.stock_moves(
+    part_id, location_id, qty_change, reason, reference_kind, reference_id,
+    created_by, shop_id, idempotency_key, work_order_part_id,
+    part_request_item_id, purchase_order_line_id, metadata, lifecycle_quantity
+  ) values (
+    v_wop.part_id, p_location_id, p_qty, 'receive',
+    case when p_po_line_id is null then 'part_request_item' else 'purchase_order_line' end,
+    coalesce(p_po_line_id, p_request_item_id), auth.uid(), v_wop.shop_id,
+    p_idempotency_key, v_wop.id, p_request_item_id, p_po_line_id,
+    jsonb_build_object('qty_received', p_qty, 'operation', 'receive'), p_qty
+  ) returning id into v_move_id;
+
+  v_received_total := coalesce(v_item.qty_received, 0) + p_qty;
+  v_status := case
+    when v_received_total < greatest(coalesce(v_item.qty_ordered, 0), coalesce(v_item.qty_requested, v_item.qty, 0)) then 'partially_received'
+    else 'received'
+  end;
+
+  update public.part_request_items
+  set qty_received = v_received_total,
+      location_id = coalesce(location_id, p_location_id),
+      unit_cost = coalesce(p_unit_cost, unit_cost),
+      status = v_status,
+      updated_at = now()
+  where id = p_request_item_id;
+
+  update public.work_order_parts
+  set quantity_received = coalesce(quantity_received, 0) + p_qty,
+      unit_cost_snapshot = coalesce(p_unit_cost, unit_cost_snapshot),
+      updated_at = now()
+  where id = v_wop.id;
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'work_order_part_id', v_wop.id,
+    'stock_move_id', v_move_id,
+    'received_qty', v_received_total,
+    'status', v_status,
+    'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id)
+  );
+end;
+$$;
+
+create or replace function public.receive_part_request_item(
+  p_item_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_po_id uuid default null,
+  p_idempotency_key text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line_id uuid;
+begin
+  if coalesce(trim(p_idempotency_key), '') = '' then
+    raise exception 'A stable idempotency key is required.';
+  end if;
+
+  select pol.id into v_line_id
+  from public.purchase_order_lines pol
+  where pol.part_request_item_id = p_item_id
+    and (p_po_id is null or pol.po_id = p_po_id)
+    and coalesce(pol.received_qty, 0) < coalesce(pol.qty, 0)
+  order by pol.created_at asc, pol.id asc
+  limit 1
+  for update;
+
+  return public.parts_receive_request_item(
+    p_item_id, p_location_id, p_qty, v_line_id, null, p_idempotency_key
+  );
+end;
+$$;
+
+create or replace function public.parts_issue_work_order_part(
+  p_work_order_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_wop public.work_order_parts%rowtype;
+  v_existing public.stock_moves%rowtype;
+  v_alloc public.work_order_part_allocations%rowtype;
+  v_move_id uuid;
+  v_item public.part_request_items%rowtype;
+  v_net_issued numeric;
+  v_status text;
+begin
+  if p_qty <= 0 then raise exception 'Issue quantity must be greater than zero.'; end if;
+  if coalesce(trim(p_idempotency_key), '') = '' then raise exception 'A stable idempotency key is required.'; end if;
+
+  select * into v_wop from public.work_order_parts
+  where id = p_work_order_part_id and is_active
+  for update;
+  if not found then raise exception 'Active work-order part not found.'; end if;
+  perform public.parts_assert_work_order_mutable(v_wop.shop_id, v_wop.work_order_id);
+
+  select * into v_existing from public.stock_moves
+  where shop_id = v_wop.shop_id and idempotency_key = p_idempotency_key
+  for update;
+  if found then
+    return coalesce(v_existing.metadata, '{}'::jsonb)
+      || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id);
+  end if;
+
+  select * into v_alloc from public.work_order_part_allocations
+  where work_order_part_id = v_wop.id and location_id = p_location_id
+  for update;
+  if not found or v_alloc.qty < p_qty then raise exception 'Allocation is insufficient for issue.'; end if;
+  if coalesce(v_wop.quantity_allocated, 0) < p_qty then raise exception 'Cannot issue more than allocated quantity.'; end if;
+  if public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id) < p_qty then
+    raise exception 'Cannot issue more than physical on-hand quantity.';
+  end if;
+
+  if v_wop.source_parts_request_item_id is not null then
+    select * into v_item from public.part_request_items
+    where id = v_wop.source_parts_request_item_id
+    for update;
+  end if;
+
+  insert into public.stock_moves(
+    part_id, location_id, qty_change, reason, reference_kind, reference_id,
+    created_by, shop_id, idempotency_key, work_order_part_id,
+    part_request_item_id, metadata, lifecycle_quantity
+  ) values (
+    v_wop.part_id, p_location_id, -p_qty, 'consume', 'work_order_part', v_wop.id,
+    auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id,
+    v_wop.source_parts_request_item_id,
+    jsonb_build_object('qty_issued', p_qty, 'operation', 'issue'), p_qty
+  ) returning id into v_move_id;
+
+  update public.work_order_part_allocations
+  set qty = qty - p_qty, stock_move_id = v_move_id
+  where id = v_alloc.id;
+  delete from public.work_order_part_allocations where id = v_alloc.id and qty <= 0;
+
+  update public.work_order_parts
+  set quantity_allocated = greatest(coalesce(quantity_allocated, 0) - p_qty, 0),
+      quantity_consumed = coalesce(quantity_consumed, 0) + p_qty,
+      updated_at = now()
+  where id = v_wop.id;
+
+  if v_wop.source_parts_request_item_id is not null then
+    v_net_issued := coalesce(v_item.qty_consumed, 0) + p_qty - coalesce(v_item.qty_returned, 0);
+    v_status := case
+      when v_net_issued < greatest(coalesce(v_item.qty_requested, v_item.qty, 0), 0) then 'partially_consumed'
+      else 'consumed'
+    end;
+    update public.part_request_items
+    set qty_reserved = greatest(coalesce(qty_reserved, 0) - p_qty, 0),
+        qty_consumed = coalesce(qty_consumed, 0) + p_qty,
+        status = v_status,
+        updated_at = now()
+    where id = v_wop.source_parts_request_item_id;
+  end if;
+
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object(
+    'ok', true, 'idempotent', false,
+    'work_order_part_id', v_wop.id,
+    'stock_move_id', v_move_id,
+    'issued_qty', p_qty,
+    'net_issued_qty', coalesce(v_wop.quantity_consumed, 0) + p_qty - coalesce(v_wop.quantity_returned, 0),
+    'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id)
+  );
+end;
+$$;
+
+create or replace function public.parts_return_to_stock(
+  p_work_order_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_wop public.work_order_parts%rowtype;
+  v_existing public.stock_moves%rowtype;
+  v_move_id uuid;
+  v_item public.part_request_items%rowtype;
+  v_new_returned numeric;
+  v_net_issued numeric;
+  v_status text;
+begin
+  if p_qty <= 0 then raise exception 'Return quantity must be greater than zero.'; end if;
+  if coalesce(trim(p_idempotency_key), '') = '' then raise exception 'A stable idempotency key is required.'; end if;
+
+  select * into v_wop from public.work_order_parts
+  where id = p_work_order_part_id and is_active
+  for update;
+  if not found then raise exception 'Active work-order part not found.'; end if;
+  perform public.parts_assert_work_order_mutable(v_wop.shop_id, v_wop.work_order_id);
+
+  select * into v_existing from public.stock_moves
+  where shop_id = v_wop.shop_id and idempotency_key = p_idempotency_key
+  for update;
+  if found then
+    return coalesce(v_existing.metadata, '{}'::jsonb)
+      || jsonb_build_object('ok', true, 'idempotent', true, 'stock_move_id', v_existing.id);
+  end if;
+
+  if coalesce(v_wop.quantity_consumed, 0) - coalesce(v_wop.quantity_returned, 0) < p_qty then
+    raise exception 'Cannot return more than consumed and not-yet-returned quantity.';
+  end if;
+
+  if v_wop.source_parts_request_item_id is not null then
+    select * into v_item from public.part_request_items
+    where id = v_wop.source_parts_request_item_id
+    for update;
+    if coalesce(v_item.qty_consumed, 0) - coalesce(v_item.qty_returned, 0) < p_qty then
+      raise exception 'Request-item return exceeds its net consumed quantity.';
+    end if;
+  end if;
+
+  insert into public.stock_moves(
+    part_id, location_id, qty_change, reason, reference_kind, reference_id,
+    created_by, shop_id, idempotency_key, work_order_part_id,
+    part_request_item_id, metadata, lifecycle_quantity
+  ) values (
+    v_wop.part_id, p_location_id, p_qty, 'return', 'work_order_part', v_wop.id,
+    auth.uid(), v_wop.shop_id, p_idempotency_key, v_wop.id,
+    v_wop.source_parts_request_item_id,
+    jsonb_build_object('qty_returned', p_qty, 'operation', 'return_to_stock'), p_qty
+  ) returning id into v_move_id;
+
+  v_new_returned := coalesce(v_wop.quantity_returned, 0) + p_qty;
+  update public.work_order_parts
+  set quantity_returned = v_new_returned, updated_at = now()
+  where id = v_wop.id;
+
+  if v_wop.source_parts_request_item_id is not null then
+    v_net_issued := coalesce(v_item.qty_consumed, 0) - (coalesce(v_item.qty_returned, 0) + p_qty);
+    v_status := case
+      when v_net_issued <= 0 then 'returned'
+      else 'partially_returned'
+    end;
+    update public.part_request_items
+    set qty_returned = coalesce(qty_returned, 0) + p_qty,
+        status = v_status,
+        updated_at = now()
+    where id = v_wop.source_parts_request_item_id;
+  end if;
+
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+  return jsonb_build_object(
+    'ok', true, 'idempotent', false,
+    'work_order_part_id', v_wop.id,
+    'stock_move_id', v_move_id,
+    'returned_qty', p_qty,
+    'net_issued_qty', coalesce(v_wop.quantity_consumed, 0) - v_new_returned,
+    'on_hand_after', public.parts_on_hand(v_wop.shop_id, v_wop.part_id, p_location_id)
+  );
+end;
+$$;
+
+create or replace function public.parts_replace_request_item(
+  p_request_item_id uuid,
+  p_new_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item public.part_request_items%rowtype;
+  v_old public.work_order_parts%rowtype;
+  v_new_part public.parts%rowtype;
+  v_new_wop_id uuid;
+  v_result jsonb;
+begin
+  if p_qty <= 0 then raise exception 'Replacement quantity must be greater than zero.'; end if;
+  if coalesce(trim(p_idempotency_key), '') = '' then raise exception 'A stable idempotency key is required.'; end if;
+
+  select * into v_item from public.part_request_items
+  where id = p_request_item_id
+  for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_assert_work_order_mutable(v_item.shop_id, v_item.work_order_id);
+
+  select * into v_new_part from public.parts
+  where id = p_new_part_id and shop_id = v_item.shop_id
+  for share;
+  if not found then raise exception 'Replacement part is not available for this shop.'; end if;
+
+  select * into v_old from public.work_order_parts
+  where source_parts_request_item_id = p_request_item_id and is_active
+  order by updated_at desc, id desc
+  limit 1
+  for update;
+
+  if found then
+    perform 1 from public.work_order_part_allocations
+    where work_order_part_id = v_old.id
+    order by id
+    for update;
+
+    if coalesce(v_old.quantity_consumed, 0) - coalesce(v_old.quantity_returned, 0) > 0 then
+      raise exception 'Consumed replacement source must be fully returned before replacement.';
+    end if;
+    if coalesce(v_old.quantity_received, 0) > coalesce(v_old.quantity_returned, 0)
+       and coalesce(v_old.quantity_allocated, 0) <= 0 then
+      raise exception 'Received replacement source requires explicit inventory disposition.';
+    end if;
+
+    perform public.parts_cancel_request_item(p_request_item_id, p_idempotency_key || ':cancel-old');
+    update public.work_order_parts
+    set lifecycle_status = 'replaced', is_active = false, updated_at = now()
+    where id = v_old.id;
+  end if;
+
+  update public.part_request_items
+  set part_id = p_new_part_id,
+      status = 'requested',
+      qty = p_qty,
+      qty_requested = p_qty,
+      qty_assigned = 0,
+      qty_ordered = 0,
+      qty_received = 0,
+      qty_reserved = 0,
+      qty_consumed = 0,
+      qty_returned = 0,
+      po_id = null,
+      updated_at = now()
+  where id = p_request_item_id;
+
+  v_new_wop_id := public.parts_ensure_work_order_part(p_request_item_id);
+  update public.work_order_parts
+  set replaced_from_work_order_part_id = case when v_old.id is null then null else v_old.id end
+  where id = v_new_wop_id;
+  if v_old.id is not null then
+    update public.work_order_parts
+    set replaced_by_work_order_part_id = v_new_wop_id
+    where id = v_old.id;
+  end if;
+
+  v_result := public.parts_allocate_request_item(
+    p_request_item_id, p_location_id, p_qty, p_idempotency_key || ':allocate-new'
+  );
+  return v_result || jsonb_build_object(
+    'ok', true,
+    'old_work_order_part_id', v_old.id,
+    'new_work_order_part_id', v_new_wop_id,
+    'old_part_id', v_old.part_id,
+    'new_part_id', p_new_part_id
+  );
+end;
+$$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260714040200_phase3_atomic_line_void.sql
+++ b/supabase/migrations/20260714040200_phase3_atomic_line_void.sql
@@ -1,0 +1,374 @@
+begin;
+
+alter table public.purchase_order_lines
+  add column if not exists cancelled_qty numeric(12,2) not null default 0;
+
+alter table public.purchase_order_lines
+  drop constraint if exists purchase_order_lines_cancelled_qty_phase3;
+alter table public.purchase_order_lines
+  add constraint purchase_order_lines_cancelled_qty_phase3 check (
+    coalesce(cancelled_qty, 0) >= 0
+    and coalesce(cancelled_qty, 0) <= greatest(coalesce(qty, 0) - coalesce(received_qty, 0), 0)
+  ) not valid;
+
+create table if not exists public.parts_disposition_events (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete restrict,
+  work_order_id uuid not null references public.work_orders(id) on delete restrict,
+  work_order_line_id uuid not null references public.work_order_lines(id) on delete restrict,
+  work_order_part_id uuid references public.work_order_parts(id) on delete restrict,
+  part_request_item_id uuid references public.part_request_items(id) on delete set null,
+  disposition_kind text not null check (
+    disposition_kind in (
+      'allocation_released',
+      'open_order_cancelled',
+      'received_retained_for_inventory',
+      'consumed_returned_to_stock',
+      'consumed_kept_internal',
+      'consumed_scrapped',
+      'line_voided'
+    )
+  ),
+  quantity numeric(12,2) not null default 0 check (quantity >= 0),
+  operation_key text not null,
+  actor_user_id uuid references auth.users(id) on delete set null,
+  reason text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (shop_id, operation_key)
+);
+
+create index if not exists parts_disposition_events_line_idx
+  on public.parts_disposition_events(shop_id, work_order_line_id, created_at);
+
+alter table public.parts_disposition_events enable row level security;
+create policy parts_disposition_events_shop_select
+  on public.parts_disposition_events
+  for select
+  to authenticated
+  using (
+    shop_id = nullif(current_setting('app.current_shop_id', true), '')::uuid
+    or exists (
+      select 1 from public.profiles p
+      where p.id = auth.uid() and p.shop_id = parts_disposition_events.shop_id
+    )
+  );
+
+create or replace function public.parts_void_work_order_line_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_mode text,
+  p_reserved_disposition text,
+  p_ordered_disposition text,
+  p_received_disposition text,
+  p_consumed_disposition text,
+  p_reason text,
+  p_note text,
+  p_operation_key text,
+  p_actor_user_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_operation public.parts_operation_keys;
+  v_wop public.work_order_parts%rowtype;
+  v_alloc public.work_order_part_allocations%rowtype;
+  v_po_line public.purchase_order_lines%rowtype;
+  v_location record;
+  v_open_order numeric;
+  v_net_consumed numeric;
+  v_remaining numeric;
+  v_item_id uuid;
+  v_part_count integer := 0;
+  v_released numeric := 0;
+  v_returned numeric := 0;
+  v_cancelled_order numeric := 0;
+  v_hard_delete boolean := false;
+  v_result jsonb;
+begin
+  if p_mode not in ('delete', 'void') then raise exception 'Invalid line removal mode.'; end if;
+  if coalesce(trim(p_reason), '') = '' then raise exception 'A line removal reason is required.'; end if;
+  if p_reserved_disposition <> 'release' then raise exception 'Reserved parts must be released.'; end if;
+  if p_ordered_disposition not in ('cancel_open_order', 'retain_open_order') then
+    raise exception 'Invalid ordered-parts disposition.';
+  end if;
+  if p_received_disposition not in ('retain_for_other_work', 'return_to_vendor') then
+    raise exception 'Invalid received-parts disposition.';
+  end if;
+  if p_consumed_disposition not in ('return_to_stock', 'keep_consumed', 'scrap') then
+    raise exception 'Invalid consumed-parts disposition.';
+  end if;
+  if p_received_disposition = 'return_to_vendor' then
+    raise exception 'Vendor return requires the canonical vendor-return command before line void.';
+  end if;
+
+  v_operation := public.parts_begin_operation(
+    p_shop_id,
+    p_operation_key,
+    'void_work_order_line',
+    'work_order_line',
+    p_work_order_line_id,
+    p_actor_user_id
+  );
+  if v_operation.completed_at is not null then
+    return coalesce(v_operation.result, '{}'::jsonb) || jsonb_build_object('idempotent', true);
+  end if;
+
+  select * into v_line from public.work_order_lines
+  where id = p_work_order_line_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Work-order line not found for shop.'; end if;
+  if v_line.voided_at is not null then
+    return public.parts_complete_operation(
+      v_operation.id,
+      jsonb_build_object('ok', true, 'idempotent', true, 'mode', 'voided')
+    );
+  end if;
+
+  perform 1 from public.work_orders
+  where id = v_line.work_order_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Work order not found for shop.'; end if;
+  perform public.parts_assert_work_order_mutable(p_shop_id, v_line.work_order_id);
+
+  -- Lock the complete line parts graph before calculating any disposition.
+  perform 1 from public.work_order_parts
+  where work_order_line_id = p_work_order_line_id and shop_id = p_shop_id
+  order by id
+  for update;
+  perform 1 from public.work_order_part_allocations
+  where work_order_line_id = p_work_order_line_id and shop_id = p_shop_id
+  order by id
+  for update;
+  perform 1 from public.part_request_items
+  where work_order_line_id = p_work_order_line_id and shop_id = p_shop_id
+  order by id
+  for update;
+  perform 1 from public.purchase_order_lines pol
+  where pol.work_order_part_id in (
+    select id from public.work_order_parts
+    where work_order_line_id = p_work_order_line_id and shop_id = p_shop_id
+  )
+  order by pol.id
+  for update;
+
+  select count(*) into v_part_count
+  from public.work_order_parts
+  where work_order_line_id = p_work_order_line_id and shop_id = p_shop_id and is_active;
+
+  v_hard_delete := p_mode = 'delete'
+    and v_part_count = 0
+    and lower(coalesce(v_line.status::text, '')) not in ('completed', 'ready_to_invoice', 'invoiced');
+
+  if v_hard_delete then
+    delete from public.work_order_lines
+    where id = p_work_order_line_id and shop_id = p_shop_id;
+    return public.parts_complete_operation(
+      v_operation.id,
+      jsonb_build_object('ok', true, 'idempotent', false, 'mode', 'deleted')
+    );
+  end if;
+
+  for v_wop in
+    select * from public.work_order_parts
+    where work_order_line_id = p_work_order_line_id and shop_id = p_shop_id and is_active
+    order by id
+  loop
+    v_item_id := v_wop.source_parts_request_item_id;
+
+    for v_alloc in
+      select * from public.work_order_part_allocations
+      where work_order_part_id = v_wop.id
+      order by id
+    loop
+      if coalesce(v_alloc.qty, 0) > 0 then
+        perform public.parts_release_allocation(
+          v_item_id,
+          v_alloc.location_id,
+          v_alloc.qty,
+          p_operation_key || ':release:' || v_alloc.id::text
+        );
+        v_released := v_released + v_alloc.qty;
+        insert into public.parts_disposition_events(
+          shop_id, work_order_id, work_order_line_id, work_order_part_id,
+          part_request_item_id, disposition_kind, quantity, operation_key,
+          actor_user_id, reason, metadata
+        ) values (
+          p_shop_id, v_line.work_order_id, p_work_order_line_id, v_wop.id,
+          v_item_id, 'allocation_released', v_alloc.qty,
+          p_operation_key || ':event:release:' || v_alloc.id::text,
+          p_actor_user_id, trim(p_reason), jsonb_build_object('location_id', v_alloc.location_id)
+        ) on conflict do nothing;
+      end if;
+    end loop;
+
+    for v_po_line in
+      select * from public.purchase_order_lines
+      where work_order_part_id = v_wop.id
+      order by id
+    loop
+      v_open_order := greatest(
+        coalesce(v_po_line.qty, 0)
+          - coalesce(v_po_line.received_qty, 0)
+          - coalesce(v_po_line.cancelled_qty, 0),
+        0
+      );
+      if v_open_order > 0 then
+        if p_ordered_disposition = 'retain_open_order' then
+          raise exception 'Open purchase-order quantity must be cancelled before line void.';
+        end if;
+        update public.purchase_order_lines
+        set cancelled_qty = coalesce(cancelled_qty, 0) + v_open_order
+        where id = v_po_line.id;
+        v_cancelled_order := v_cancelled_order + v_open_order;
+        insert into public.parts_disposition_events(
+          shop_id, work_order_id, work_order_line_id, work_order_part_id,
+          part_request_item_id, disposition_kind, quantity, operation_key,
+          actor_user_id, reason, metadata
+        ) values (
+          p_shop_id, v_line.work_order_id, p_work_order_line_id, v_wop.id,
+          v_item_id, 'open_order_cancelled', v_open_order,
+          p_operation_key || ':event:po-cancel:' || v_po_line.id::text,
+          p_actor_user_id, trim(p_reason), jsonb_build_object('purchase_order_line_id', v_po_line.id)
+        ) on conflict do nothing;
+      end if;
+    end loop;
+
+    v_net_consumed := greatest(
+      coalesce(v_wop.quantity_consumed, 0) - coalesce(v_wop.quantity_returned, 0),
+      0
+    );
+
+    if v_net_consumed > 0 and p_consumed_disposition = 'return_to_stock' then
+      for v_location in
+        with issued as (
+          select location_id, coalesce(sum(lifecycle_quantity), 0) as qty
+          from public.stock_moves
+          where work_order_part_id = v_wop.id and reason = 'consume'
+          group by location_id
+        ), returned as (
+          select location_id, coalesce(sum(lifecycle_quantity), 0) as qty
+          from public.stock_moves
+          where work_order_part_id = v_wop.id and reason = 'return'
+          group by location_id
+        )
+        select issued.location_id,
+               greatest(issued.qty - coalesce(returned.qty, 0), 0) as qty
+        from issued
+        left join returned using (location_id)
+        where greatest(issued.qty - coalesce(returned.qty, 0), 0) > 0
+        order by issued.location_id
+      loop
+        perform public.parts_return_to_stock(
+          v_wop.id,
+          v_location.location_id,
+          v_location.qty,
+          p_operation_key || ':return:' || v_wop.id::text || ':' || v_location.location_id::text
+        );
+        v_returned := v_returned + v_location.qty;
+      end loop;
+      insert into public.parts_disposition_events(
+        shop_id, work_order_id, work_order_line_id, work_order_part_id,
+        part_request_item_id, disposition_kind, quantity, operation_key,
+        actor_user_id, reason
+      ) values (
+        p_shop_id, v_line.work_order_id, p_work_order_line_id, v_wop.id,
+        v_item_id, 'consumed_returned_to_stock', v_net_consumed,
+        p_operation_key || ':event:return:' || v_wop.id::text,
+        p_actor_user_id, trim(p_reason)
+      ) on conflict do nothing;
+    elsif v_net_consumed > 0 then
+      insert into public.parts_disposition_events(
+        shop_id, work_order_id, work_order_line_id, work_order_part_id,
+        part_request_item_id, disposition_kind, quantity, operation_key,
+        actor_user_id, reason
+      ) values (
+        p_shop_id, v_line.work_order_id, p_work_order_line_id, v_wop.id,
+        v_item_id,
+        case when p_consumed_disposition = 'scrap' then 'consumed_scrapped' else 'consumed_kept_internal' end,
+        v_net_consumed,
+        p_operation_key || ':event:consumed:' || v_wop.id::text,
+        p_actor_user_id, trim(p_reason)
+      ) on conflict do nothing;
+    end if;
+
+    if coalesce(v_wop.quantity_received, 0) > coalesce(v_wop.quantity_consumed, 0) then
+      insert into public.parts_disposition_events(
+        shop_id, work_order_id, work_order_line_id, work_order_part_id,
+        part_request_item_id, disposition_kind, quantity, operation_key,
+        actor_user_id, reason
+      ) values (
+        p_shop_id, v_line.work_order_id, p_work_order_line_id, v_wop.id,
+        v_item_id, 'received_retained_for_inventory',
+        greatest(coalesce(v_wop.quantity_received, 0) - coalesce(v_wop.quantity_consumed, 0), 0),
+        p_operation_key || ':event:received:' || v_wop.id::text,
+        p_actor_user_id, trim(p_reason)
+      ) on conflict do nothing;
+    end if;
+
+    v_remaining := greatest(
+      coalesce(v_wop.quantity_requested, 0)
+        - coalesce(v_wop.quantity_consumed, 0)
+        - coalesce(v_wop.quantity_cancelled, 0),
+      0
+    );
+    update public.work_order_parts
+    set quantity_cancelled = coalesce(quantity_cancelled, 0) + v_remaining,
+        is_active = false,
+        updated_at = now()
+    where id = v_wop.id;
+    perform public.parts_reconcile_work_order_part(v_wop.id);
+
+    if v_item_id is not null then
+      update public.part_request_items
+      set status = 'cancelled', updated_at = now()
+      where id = v_item_id;
+    end if;
+  end loop;
+
+  update public.work_order_lines
+  set voided_at = now(),
+      voided_by = p_actor_user_id,
+      void_reason = trim(p_reason),
+      void_note = nullif(trim(p_note), '')
+  where id = p_work_order_line_id and shop_id = p_shop_id;
+
+  insert into public.parts_disposition_events(
+    shop_id, work_order_id, work_order_line_id, disposition_kind,
+    quantity, operation_key, actor_user_id, reason, metadata
+  ) values (
+    p_shop_id, v_line.work_order_id, p_work_order_line_id, 'line_voided',
+    0, p_operation_key || ':event:line', p_actor_user_id, trim(p_reason),
+    jsonb_build_object(
+      'reserved_disposition', p_reserved_disposition,
+      'ordered_disposition', p_ordered_disposition,
+      'received_disposition', p_received_disposition,
+      'consumed_disposition', p_consumed_disposition,
+      'released_qty', v_released,
+      'returned_qty', v_returned,
+      'cancelled_order_qty', v_cancelled_order
+    )
+  ) on conflict do nothing;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'mode', 'voided',
+    'workOrderLineId', p_work_order_line_id,
+    'releasedQty', v_released,
+    'returnedQty', v_returned,
+    'cancelledOrderQty', v_cancelled_order
+  );
+  return public.parts_complete_operation(v_operation.id, v_result);
+end;
+$$;
+
+revoke all on function public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid) from public;
+grant execute on function public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260714040300_phase3_part_identity_snapshots.sql
+++ b/supabase/migrations/20260714040300_phase3_part_identity_snapshots.sql
@@ -1,0 +1,197 @@
+begin;
+
+alter table public.work_order_parts
+  add column if not exists supplier_snapshot text,
+  add column if not exists vendor_snapshot text,
+  add column if not exists sku_snapshot text;
+
+create or replace function public.parts_attach_request_item(
+  p_request_item_id uuid
+) returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item public.part_request_items%rowtype;
+  v_request public.part_requests%rowtype;
+  v_part public.parts%rowtype;
+  v_line record;
+  v_wop public.work_order_parts%rowtype;
+  v_qty numeric;
+  v_sell numeric;
+  v_cost numeric;
+begin
+  select * into v_item
+  from public.part_request_items
+  where id = p_request_item_id
+  for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  if v_item.work_order_line_id is null then raise exception 'Request item must be linked to a work-order line.'; end if;
+  if v_item.part_id is null then raise exception 'Request item has no selected inventory part.'; end if;
+
+  select * into v_request
+  from public.part_requests
+  where id = v_item.request_id
+  for update;
+  if not found then raise exception 'Parent parts request not found.'; end if;
+
+  select * into v_part
+  from public.parts
+  where id = v_item.part_id
+  for share;
+  if not found then raise exception 'Selected part not found.'; end if;
+  if v_part.shop_id is distinct from v_item.shop_id then
+    raise exception 'Selected part belongs to a different shop.';
+  end if;
+
+  select wl.id, wl.work_order_id, wl.shop_id
+    into v_line
+  from public.work_order_lines wl
+  where wl.id = v_item.work_order_line_id
+  for update;
+  if not found then raise exception 'Work-order line not found.'; end if;
+  if v_line.shop_id is distinct from v_item.shop_id then
+    raise exception 'Work-order line belongs to a different shop.';
+  end if;
+  if v_request.work_order_id is not null and v_request.work_order_id <> v_line.work_order_id then
+    raise exception 'Work-order line does not belong to the request work order.';
+  end if;
+
+  perform public.parts_assert_work_order_mutable(v_item.shop_id, v_line.work_order_id);
+
+  v_qty := greatest(coalesce(v_item.qty_requested, v_item.qty, 0), 0);
+  if v_qty <= 0 then raise exception 'Quantity must be greater than zero.'; end if;
+  v_sell := coalesce(v_item.quoted_price, v_item.unit_price, v_part.price, 0);
+  v_cost := coalesce(v_item.unit_cost, v_part.cost, v_part.default_cost, 0);
+
+  select * into v_wop
+  from public.work_order_parts
+  where source_parts_request_item_id = p_request_item_id and is_active
+  order by updated_at desc, id desc
+  limit 1
+  for update;
+
+  if found then
+    if v_wop.part_id is distinct from v_item.part_id then
+      if coalesce(v_wop.quantity_ordered, 0) > 0
+         or coalesce(v_wop.quantity_received, 0) > 0
+         or coalesce(v_wop.quantity_allocated, 0) > 0
+         or coalesce(v_wop.quantity_consumed, 0) > 0
+         or coalesce(v_wop.quantity_returned, 0) > 0 then
+        raise exception 'Selected part changed after lifecycle activity. Use the canonical replacement command.';
+      end if;
+    end if;
+
+    update public.work_order_parts
+    set work_order_id = v_line.work_order_id,
+        work_order_line_id = v_item.work_order_line_id,
+        part_id = v_item.part_id,
+        quantity = v_qty,
+        quantity_requested = v_qty,
+        unit_price = v_sell,
+        total_price = round(v_qty * v_sell, 2),
+        description_snapshot = coalesce(nullif(trim(v_part.name), ''), nullif(trim(v_item.description), ''), 'Part'),
+        manufacturer_snapshot = coalesce(nullif(trim(v_part.manufacturer), ''), nullif(trim(v_item.requested_manufacturer), '')),
+        supplier_snapshot = nullif(trim(v_part.supplier), ''),
+        vendor_snapshot = nullif(trim(v_item.vendor), ''),
+        part_number_snapshot = coalesce(nullif(trim(v_part.part_number), ''), nullif(trim(v_item.requested_part_number), '')),
+        sku_snapshot = nullif(trim(v_part.sku), ''),
+        unit_cost_snapshot = v_cost,
+        unit_sell_price_snapshot = v_sell,
+        updated_at = now()
+    where id = v_wop.id
+    returning * into v_wop;
+    return v_wop.id;
+  end if;
+
+  insert into public.work_order_parts(
+    work_order_id,
+    work_order_line_id,
+    shop_id,
+    part_id,
+    quantity,
+    unit_price,
+    total_price,
+    source_parts_request_id,
+    source_parts_request_item_id,
+    description_snapshot,
+    manufacturer_snapshot,
+    supplier_snapshot,
+    vendor_snapshot,
+    part_number_snapshot,
+    sku_snapshot,
+    quantity_requested,
+    quantity_received,
+    quantity_consumed,
+    quantity_returned,
+    unit_cost_snapshot,
+    unit_sell_price_snapshot,
+    lifecycle_status,
+    updated_at,
+    is_active
+  ) values (
+    v_line.work_order_id,
+    v_item.work_order_line_id,
+    v_item.shop_id,
+    v_item.part_id,
+    v_qty,
+    v_sell,
+    round(v_qty * v_sell, 2),
+    v_item.request_id,
+    v_item.id,
+    coalesce(nullif(trim(v_part.name), ''), nullif(trim(v_item.description), ''), 'Part'),
+    coalesce(nullif(trim(v_part.manufacturer), ''), nullif(trim(v_item.requested_manufacturer), '')),
+    nullif(trim(v_part.supplier), ''),
+    nullif(trim(v_item.vendor), ''),
+    coalesce(nullif(trim(v_part.part_number), ''), nullif(trim(v_item.requested_part_number), '')),
+    nullif(trim(v_part.sku), ''),
+    v_qty,
+    coalesce(v_item.qty_received, 0),
+    coalesce(v_item.qty_consumed, 0),
+    coalesce(v_item.qty_returned, 0),
+    v_cost,
+    v_sell,
+    'requested',
+    now(),
+    true
+  ) returning * into v_wop;
+
+  return v_wop.id;
+end;
+$$;
+
+create or replace view public.invoice_net_issued_parts as
+select
+  wop.id,
+  wop.shop_id,
+  wop.work_order_id,
+  wop.work_order_line_id,
+  wop.part_id,
+  greatest(coalesce(wop.quantity_consumed, 0) - coalesce(wop.quantity_returned, 0), 0) as net_issued_quantity,
+  coalesce(wop.unit_sell_price_snapshot, wop.unit_price, 0) as unit_sell_price,
+  round(
+    greatest(coalesce(wop.quantity_consumed, 0) - coalesce(wop.quantity_returned, 0), 0)
+      * coalesce(wop.unit_sell_price_snapshot, wop.unit_price, 0),
+    2
+  ) as line_total,
+  wop.description_snapshot,
+  wop.manufacturer_snapshot,
+  wop.supplier_snapshot,
+  wop.vendor_snapshot,
+  wop.part_number_snapshot,
+  wop.sku_snapshot,
+  wop.unit_cost_snapshot
+from public.work_order_parts wop
+join public.work_order_lines wol
+  on wol.id = wop.work_order_line_id
+ and wol.work_order_id = wop.work_order_id
+ and wol.shop_id = wop.shop_id
+where wol.voided_at is null
+  and greatest(coalesce(wop.quantity_consumed, 0) - coalesce(wop.quantity_returned, 0), 0) > 0;
+
+grant select on public.invoice_net_issued_parts to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260714040400_phase3_invoice_net_issued_rpc.sql
+++ b/supabase/migrations/20260714040400_phase3_invoice_net_issued_rpc.sql
@@ -1,0 +1,43 @@
+begin;
+
+create or replace function public.get_invoice_net_issued_parts(
+  p_shop_id uuid,
+  p_work_order_id uuid
+) returns jsonb
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', p.id,
+        'lineId', p.work_order_line_id,
+        'partId', p.part_id,
+        'name', coalesce(nullif(trim(p.description_snapshot), ''), 'Part'),
+        'qty', p.net_issued_quantity,
+        'unitPrice', p.unit_sell_price,
+        'totalPrice', p.line_total,
+        'manufacturer', p.manufacturer_snapshot,
+        'supplier', p.supplier_snapshot,
+        'vendor', p.vendor_snapshot,
+        'partNumber', p.part_number_snapshot,
+        'sku', p.sku_snapshot,
+        'unitCost', p.unit_cost_snapshot,
+        'source', 'work_order_part'
+      ) order by p.work_order_line_id, p.id
+    ),
+    '[]'::jsonb
+  )
+  from public.invoice_net_issued_parts p
+  where p.shop_id = p_shop_id
+    and p.work_order_id = p_work_order_id;
+$$;
+
+revoke all on function public.get_invoice_net_issued_parts(uuid,uuid) from public;
+grant execute on function public.get_invoice_net_issued_parts(uuid,uuid) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260714040500_phase3_parts_reconciliation_and_postcheck.sql
+++ b/supabase/migrations/20260714040500_phase3_parts_reconciliation_and_postcheck.sql
@@ -53,21 +53,29 @@ set quantity_requested = greatest(coalesce(quantity_requested, 0), 0),
     ),
     quantity_cancelled = greatest(coalesce(quantity_cancelled, 0), 0);
 
--- Backfill distinct identity snapshots without overwriting existing immutable values.
+-- Backfill immutable identity snapshots in two deterministic passes.
 update public.work_order_parts wop
-set manufacturer_snapshot = coalesce(wop.manufacturer_snapshot, p.manufacturer, pri.requested_manufacturer),
+set manufacturer_snapshot = coalesce(wop.manufacturer_snapshot, p.manufacturer),
     supplier_snapshot = coalesce(wop.supplier_snapshot, p.supplier),
-    vendor_snapshot = coalesce(wop.vendor_snapshot, pri.vendor),
-    part_number_snapshot = coalesce(wop.part_number_snapshot, p.part_number, pri.requested_part_number),
+    part_number_snapshot = coalesce(wop.part_number_snapshot, p.part_number),
     sku_snapshot = coalesce(wop.sku_snapshot, p.sku),
-    unit_cost_snapshot = coalesce(wop.unit_cost_snapshot, pri.unit_cost, p.cost, p.default_cost),
-    unit_sell_price_snapshot = coalesce(wop.unit_sell_price_snapshot, pri.quoted_price, pri.unit_price, p.price),
+    unit_cost_snapshot = coalesce(wop.unit_cost_snapshot, p.cost, p.default_cost),
+    unit_sell_price_snapshot = coalesce(wop.unit_sell_price_snapshot, p.price),
     updated_at = wop.updated_at
 from public.parts p
-left join public.part_request_items pri
-  on pri.id = wop.source_parts_request_item_id
 where p.id = wop.part_id
   and p.shop_id = wop.shop_id;
+
+update public.work_order_parts wop
+set manufacturer_snapshot = coalesce(wop.manufacturer_snapshot, pri.requested_manufacturer),
+    vendor_snapshot = coalesce(wop.vendor_snapshot, pri.vendor),
+    part_number_snapshot = coalesce(wop.part_number_snapshot, pri.requested_part_number),
+    unit_cost_snapshot = coalesce(wop.unit_cost_snapshot, pri.unit_cost),
+    unit_sell_price_snapshot = coalesce(wop.unit_sell_price_snapshot, pri.quoted_price, pri.unit_price),
+    updated_at = wop.updated_at
+from public.part_request_items pri
+where pri.id = wop.source_parts_request_item_id
+  and pri.shop_id = wop.shop_id;
 
 alter table public.part_request_items
   validate constraint part_request_items_nonnegative_phase3;

--- a/supabase/migrations/20260714040500_phase3_parts_reconciliation_and_postcheck.sql
+++ b/supabase/migrations/20260714040500_phase3_parts_reconciliation_and_postcheck.sql
@@ -1,0 +1,125 @@
+begin;
+
+-- Backfill separated ordered and returned quantities from canonical ledgers.
+with ordered as (
+  select part_request_item_id, coalesce(sum(qty), 0) as qty_ordered
+  from public.purchase_order_lines
+  where part_request_item_id is not null
+  group by part_request_item_id
+)
+update public.part_request_items pri
+set qty_ordered = greatest(ordered.qty_ordered, 0)
+from ordered
+where pri.id = ordered.part_request_item_id;
+
+with returned as (
+  select source_parts_request_item_id,
+         coalesce(sum(quantity_returned), 0) as qty_returned
+  from public.work_order_parts
+  where source_parts_request_item_id is not null
+  group by source_parts_request_item_id
+)
+update public.part_request_items pri
+set qty_returned = least(
+      greatest(returned.qty_returned, 0),
+      greatest(coalesce(pri.qty_consumed, 0), 0)
+    )
+from returned
+where pri.id = returned.source_parts_request_item_id;
+
+-- Repair negative legacy counters before validating the new invariants.
+update public.part_request_items
+set qty = greatest(coalesce(qty, 0), 0),
+    qty_requested = greatest(coalesce(qty_requested, 0), 0),
+    qty_assigned = greatest(coalesce(qty_assigned, 0), 0),
+    qty_ordered = greatest(coalesce(qty_ordered, 0), 0),
+    qty_received = greatest(coalesce(qty_received, 0), 0),
+    qty_reserved = greatest(coalesce(qty_reserved, 0), 0),
+    qty_consumed = greatest(coalesce(qty_consumed, 0), 0),
+    qty_returned = least(
+      greatest(coalesce(qty_returned, 0), 0),
+      greatest(coalesce(qty_consumed, 0), 0)
+    );
+
+update public.work_order_parts
+set quantity_requested = greatest(coalesce(quantity_requested, 0), 0),
+    quantity_ordered = greatest(coalesce(quantity_ordered, 0), 0),
+    quantity_received = greatest(coalesce(quantity_received, 0), 0),
+    quantity_allocated = greatest(coalesce(quantity_allocated, 0), 0),
+    quantity_consumed = greatest(coalesce(quantity_consumed, 0), 0),
+    quantity_returned = least(
+      greatest(coalesce(quantity_returned, 0), 0),
+      greatest(coalesce(quantity_consumed, 0), 0)
+    ),
+    quantity_cancelled = greatest(coalesce(quantity_cancelled, 0), 0);
+
+-- Backfill distinct identity snapshots without overwriting existing immutable values.
+update public.work_order_parts wop
+set manufacturer_snapshot = coalesce(wop.manufacturer_snapshot, p.manufacturer, pri.requested_manufacturer),
+    supplier_snapshot = coalesce(wop.supplier_snapshot, p.supplier),
+    vendor_snapshot = coalesce(wop.vendor_snapshot, pri.vendor),
+    part_number_snapshot = coalesce(wop.part_number_snapshot, p.part_number, pri.requested_part_number),
+    sku_snapshot = coalesce(wop.sku_snapshot, p.sku),
+    unit_cost_snapshot = coalesce(wop.unit_cost_snapshot, pri.unit_cost, p.cost, p.default_cost),
+    unit_sell_price_snapshot = coalesce(wop.unit_sell_price_snapshot, pri.quoted_price, pri.unit_price, p.price),
+    updated_at = wop.updated_at
+from public.parts p
+left join public.part_request_items pri
+  on pri.id = wop.source_parts_request_item_id
+where p.id = wop.part_id
+  and p.shop_id = wop.shop_id;
+
+alter table public.part_request_items
+  validate constraint part_request_items_nonnegative_phase3;
+alter table public.work_order_parts
+  validate constraint work_order_parts_nonnegative_phase3;
+alter table public.purchase_order_lines
+  validate constraint purchase_order_lines_cancelled_qty_phase3;
+
+do $$
+declare
+  v_missing text[] := array[]::text[];
+begin
+  if to_regclass('public.parts_operation_keys') is null then
+    v_missing := array_append(v_missing, 'parts_operation_keys');
+  end if;
+  if to_regclass('public.parts_disposition_events') is null then
+    v_missing := array_append(v_missing, 'parts_disposition_events');
+  end if;
+  if to_regclass('public.invoice_net_issued_parts') is null then
+    v_missing := array_append(v_missing, 'invoice_net_issued_parts');
+  end if;
+
+  if to_regprocedure('public.parts_commit_request_package_atomic(uuid,uuid,text,uuid)') is null then
+    v_missing := array_append(v_missing, 'parts_commit_request_package_atomic');
+  end if;
+  if to_regprocedure('public.parts_update_attach_allocate_item_atomic(uuid,uuid,uuid,text,numeric,numeric,text,text,uuid,uuid,uuid,boolean,boolean,text,text,uuid)') is null then
+    v_missing := array_append(v_missing, 'parts_update_attach_allocate_item_atomic');
+  end if;
+  if to_regprocedure('public.parts_void_work_order_line_atomic(uuid,uuid,text,text,text,text,text,text,text,text,uuid)') is null then
+    v_missing := array_append(v_missing, 'parts_void_work_order_line_atomic');
+  end if;
+  if to_regprocedure('public.get_invoice_net_issued_parts(uuid,uuid)') is null then
+    v_missing := array_append(v_missing, 'get_invoice_net_issued_parts');
+  end if;
+
+  if not exists (
+    select 1 from pg_indexes
+    where schemaname = 'public'
+      and tablename = 'parts_operation_keys'
+      and indexdef ilike '%unique%shop_id%operation_key%'
+  ) then
+    v_missing := array_append(v_missing, 'tenant operation key uniqueness');
+  end if;
+
+  if cardinality(v_missing) > 0 then
+    raise exception 'Phase 3 parts postcheck failed. Missing: %', array_to_string(v_missing, ', ');
+  end if;
+
+  raise notice 'Phase 3 canonical parts transaction postcheck passed.';
+end;
+$$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/phase3-parts-atomic-routes.test.ts
+++ b/tests/phase3-parts-atomic-routes.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+}
+
+describe("phase 3 atomic parts routes", () => {
+  it("uses one package command", () => {
+    const route = source("app/api/parts/requests/[requestId]/commit-package/route.ts");
+    expect(route).toContain("parts_commit_request_package_atomic");
+    expect(route).not.toContain("for (const item");
+    expect(route).not.toContain('from("work_order_parts")');
+  });
+
+  it("uses one item attach command", () => {
+    const route = source("app/api/parts/requests/items/[itemId]/add/route.ts");
+    expect(route).toContain("parts_update_attach_allocate_item_atomic");
+    expect(route).not.toContain('from("part_request_items").update');
+    expect(route).not.toContain("upsert_part_allocation_from_request_item");
+  });
+
+  it("requires explicit operation keys", () => {
+    const helper = source("app/api/parts/_lib/lifecycleCommand.ts");
+    const receiving = source("app/api/parts/_lib/receivePartRequestItem.ts");
+    expect(helper).toContain("A stable idempotency key is required");
+    expect(receiving).toContain("A stable idempotency key is required");
+    expect(helper).not.toContain("|| fallback");
+  });
+
+  it("uses one line disposition command", () => {
+    const route = source("app/api/work-orders/lines/[id]/delete-or-void/route.ts");
+    expect(route).toContain("parts_void_work_order_line_atomic");
+    expect(route).not.toContain("apply_stock_move");
+    expect(route).not.toContain('from("work_order_part_allocations")');
+  });
+
+  it("uses canonical issued quantity for invoice creation", () => {
+    expect(source("app/api/invoices/send/route.ts")).toContain(
+      "getIssuableInvoiceSnapshot",
+    );
+    expect(source("features/invoices/server/getIssuableInvoiceSnapshot.ts")).toContain(
+      "get_invoice_net_issued_parts",
+    );
+  });
+});

--- a/tests/phase3-parts-sql-contract.test.ts
+++ b/tests/phase3-parts-sql-contract.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+}
+
+describe("phase 3 parts SQL contract", () => {
+  const atomic = source(
+    "supabase/migrations/20260714040000_phase3_parts_atomic_commands.sql",
+  );
+  const quantities = source(
+    "supabase/migrations/20260714040100_phase3_parts_quantity_reconciliation.sql",
+  );
+  const lineDisposition = source(
+    "supabase/migrations/20260714040200_phase3_atomic_line_void.sql",
+  );
+  const snapshots = source(
+    "supabase/migrations/20260714040300_phase3_part_identity_snapshots.sql",
+  );
+
+  it("enforces tenant operation uniqueness", () => {
+    expect(atomic).toContain("unique (shop_id, operation_key)");
+    expect(atomic).toContain("Operation key must be tenant scoped");
+  });
+
+  it("locks affected rows and checks financial state", () => {
+    for (const sql of [atomic, quantities, lineDisposition, snapshots]) {
+      expect(sql).toContain("for update");
+      expect(sql).toContain("parts_assert_work_order_mutable");
+    }
+  });
+
+  it("protects quantity ceilings", () => {
+    expect(quantities).toContain("Receipt exceeds ordered quantity");
+    expect(quantities).toContain("Cannot return more than consumed");
+    expect(quantities).toContain("Cannot issue more than allocated quantity");
+    expect(quantities).toContain("Ordered quantity % exceeds requested quantity %");
+  });
+
+  it("keeps purchasing and fulfillment quantities distinct", () => {
+    expect(quantities).toContain("add column if not exists qty_assigned");
+    expect(quantities).toContain("add column if not exists qty_ordered");
+    expect(quantities).toContain("add column if not exists qty_returned");
+    expect(quantities).not.toContain("qty_approved=greatest");
+  });
+
+  it("rereads replacement state under locks", () => {
+    expect(quantities).toContain(
+      "where source_parts_request_item_id = p_request_item_id and is_active",
+    );
+    expect(quantities).toContain(
+      "must be fully returned before replacement",
+    );
+  });
+
+  it("records every line disposition category", () => {
+    expect(lineDisposition).toContain("allocation_released");
+    expect(lineDisposition).toContain("open_order_cancelled");
+    expect(lineDisposition).toContain("received_retained_for_inventory");
+    expect(lineDisposition).toContain("consumed_returned_to_stock");
+    expect(lineDisposition).toContain("consumed_kept_internal");
+    expect(lineDisposition).toContain("consumed_scrapped");
+  });
+
+  it("uses net issued quantity and separate identity snapshots", () => {
+    expect(snapshots).toContain(
+      "quantity_consumed, 0) - coalesce(wop.quantity_returned, 0)",
+    );
+    for (const field of [
+      "manufacturer_snapshot",
+      "supplier_snapshot",
+      "vendor_snapshot",
+      "part_number_snapshot",
+      "sku_snapshot",
+      "unit_cost_snapshot",
+      "unit_sell_price_snapshot",
+    ]) {
+      expect(snapshots).toContain(field);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 3 of the repository-wide system audit using the existing canonical parts lifecycle RPCs.

### Core guarantees
- Stable shop-scoped operation keys for every retryable parts command
- One RPC owns every operation's writes
- Full rollback on failure
- Row locking before quantity recalculation
- Phase 2 financial-lock enforcement inside quantity-changing RPCs
- Separate requested, assigned, ordered, received, allocated, consumed, returned, and cancelled quantities
- Net issued invoice quantity: `quantity_consumed - quantity_returned`
- Distinct manufacturer, supplier, vendor, part number, SKU, cost, and sell-price snapshots

### Converted routes
- Request package commit
- Request-item edit/attach/allocation
- Receiving helper
- Issue and return
- Legacy consume compatibility route
- Work-order-line delete/void
- Invoice issuance

### Canonical SQL changes
- Atomic package and item commands
- Hardened existing PO, receive, issue, return, and replacement RPCs
- Atomic parts-aware line void with explicit disposition events
- Canonical net-issued invoice projection/RPC
- Legacy-data reconciliation and postcheck

### Migration order
1. `20260714039900_phase3_part_request_statuses.sql`
2. `20260714040000_phase3_parts_atomic_commands.sql`
3. `20260714040100_phase3_parts_quantity_reconciliation.sql`
4. `20260714040200_phase3_atomic_line_void.sql`
5. `20260714040300_phase3_part_identity_snapshots.sql`
6. `20260714040400_phase3_invoice_net_issued_rpc.sql`
7. `20260714040500_phase3_parts_reconciliation_and_postcheck.sql`

Do not run migrations until Vercel and GitHub validation are green.

Closes #1002
Closes #1003
Closes #1004
Closes #1005
Closes #1006
Closes #1007
Closes #1008
Closes #1009
Closes #1020
Related: #992