### PR TITLE
Phase 4: Atomic technician assignment and labor lifecycle

### DIFF
--- a/.github/workflows/phase-4-technician-labor-validation.yml
+++ b/.github/workflows/phase-4-technician-labor-validation.yml
@@ -1,0 +1,29 @@
+name: Phase 4 Technician Labor Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/work-orders/**"
+      - "features/work-orders/server/**"
+      - "supabase/migrations/20260714050*.sql"
+      - "tests/phase4-*.test.ts"
+      - ".github/workflows/phase-4-technician-labor-validation.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm exec eslint app/api/work-orders/assign-line/route.ts 'app/api/work-orders/lines/[id]/start/route.ts' 'app/api/work-orders/lines/[id]/pause/route.ts' 'app/api/work-orders/lines/[id]/resume/route.ts' 'app/api/work-orders/lines/[id]/finish/route.ts' features/work-orders/server/applyJobPunchTransition.ts features/work-orders/server/technicianJobLabor.ts tests/phase4-technician-labor-sql-contract.test.ts tests/phase4-technician-labor-routes.test.ts
+      - run: pnpm exec vitest run tests/phase4-technician-labor-sql-contract.test.ts tests/phase4-technician-labor-routes.test.ts

--- a/app/api/work-orders/assign-line/route.ts
+++ b/app/api/work-orders/assign-line/route.ts
@@ -1,111 +1,85 @@
-// app/api/work-orders/assign-line/route.ts
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 type DB = Database;
-
-const ASSIGNABLE_TECH_ROLES = ["mechanic", "tech", "foreman", "lead_hand"] as const;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
 
 function must(name: string): string {
-  const v = process.env[name];
-  if (!v) throw new Error(`Missing env ${name}`);
-  return v;
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing env ${name}`);
+  return value;
 }
 
 export async function POST(req: Request) {
   try {
-    const body = (await req.json()) as {
+    const body = (await req.json().catch(() => null)) as {
       work_order_line_id?: string;
       tech_id?: string;
-    };
+      operationKey?: string;
+      idempotencyKey?: string;
+    } | null;
 
-    const lineId = body.work_order_line_id;
-    const techId = body.tech_id;
-    const access = await requireShopScopedApiAccess({ requiredCapability: "canManageWorkOrders" });
+    const lineId = body?.work_order_line_id?.trim() ?? "";
+    const techId = body?.tech_id?.trim() ?? "";
+    const rawOperationKey =
+      req.headers.get("Idempotency-Key")?.trim() ||
+      body?.operationKey?.trim() ||
+      body?.idempotencyKey?.trim() ||
+      "";
+
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canManageWorkOrders",
+    });
     if (!access.ok) return access.response;
-    const assignedBy = access.profile.id;
-    const shopId = access.profile.shop_id;
 
     if (!lineId || !techId) {
       return NextResponse.json(
         { error: "work_order_line_id and tech_id are required" },
-        { status: 400 }
+        { status: 400 },
+      );
+    }
+    if (!rawOperationKey) {
+      return NextResponse.json(
+        { error: "A stable Idempotency-Key is required." },
+        { status: 400 },
       );
     }
 
-    const url = must("NEXT_PUBLIC_SUPABASE_URL");
-    const service = must("SUPABASE_SERVICE_ROLE_KEY");
-    const supabase = createClient<DB>(url, service);
+    const admin = createClient<DB>(
+      must("NEXT_PUBLIC_SUPABASE_URL"),
+      must("SUPABASE_SERVICE_ROLE_KEY"),
+    ) as unknown as RpcClient;
 
-    const { data: line, error: lineReadErr } = await supabase
-      .from("work_order_lines")
-      .select("id, line_type, work_order_id, work_orders!inner(id, shop_id)")
-      .eq("id", lineId)
-      .eq("work_orders.shop_id", shopId)
-      .maybeSingle();
+    const { data, error } = await admin.rpc(
+      "assign_work_order_line_technician_atomic",
+      {
+        p_shop_id: access.profile.shop_id,
+        p_work_order_line_id: lineId,
+        p_technician_id: techId,
+        p_assigned_by: access.profile.id,
+        p_operation_key: `${access.profile.shop_id}:assign-line:${rawOperationKey}`,
+      },
+    );
 
-    if (lineReadErr) {
-      return NextResponse.json({ error: lineReadErr.message }, { status: 400 });
-    }
-    if (!line) {
-      return NextResponse.json({ error: "Line not found" }, { status: 404 });
-    }
-    if ((line.line_type ?? "job") === "info") {
-      return NextResponse.json({ error: "Info lines cannot be technician-assigned." }, { status: 409 });
-    }
-
-    const { data: technician, error: technicianErr } = await supabase
-      .from("profiles")
-      .select("id, role")
-      .eq("id", techId)
-      .eq("shop_id", shopId)
-      .maybeSingle();
-    if (technicianErr) {
-      return NextResponse.json({ error: technicianErr.message }, { status: 400 });
-    }
-    if (!technician) {
-      return NextResponse.json({ error: "Technician not found" }, { status: 404 });
-    }
-    if (!technician.role || !ASSIGNABLE_TECH_ROLES.includes(technician.role as (typeof ASSIGNABLE_TECH_ROLES)[number])) {
-      return NextResponse.json({ error: "Technician not found" }, { status: 404 });
+    if (error) {
+      const message = [error.message, error.details, error.hint]
+        .filter(Boolean)
+        .join(" — ");
+      const status = message.includes("FINANCIALLY_LOCKED") ? 409 : 400;
+      return NextResponse.json({ error: message }, { status });
     }
 
-    // 1) keep the simple column up to date
-    const { error: lineErr } = await supabase
-      .from("work_order_lines")
-      .update({ assigned_tech_id: techId })
-      .eq("id", lineId)
-      .eq("work_order_id", line.work_order_id);
-
-    if (lineErr) {
-      return NextResponse.json({ error: lineErr.message }, { status: 400 });
-    }
-
-    // 2) also record in the 1..n table (ignore duplicates)
-    const { error: relErr } = await supabase
-      .from("work_order_line_technicians")
-      .upsert(
-        {
-          work_order_line_id: lineId,
-          technician_id: techId,
-          assigned_by: assignedBy,
-        },
-        {
-          // because you declared unique (work_order_line_id, technician_id)
-          onConflict: "work_order_line_id,technician_id",
-        }
-      );
-
-    if (relErr) {
-      // not fatal for UI
-      console.warn("assign-line: technician link failed:", relErr.message);
-    }
-
-    return NextResponse.json({ ok: true });
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : "Unexpected error";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    return NextResponse.json(data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/work-orders/lines/[id]/finish/route.ts
+++ b/app/api/work-orders/lines/[id]/finish/route.ts
@@ -7,11 +7,15 @@ import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobP
 type Body = {
   cause?: string | null;
   correction?: string | null;
+  operationKey?: string;
+  idempotencyKey?: string;
 };
 
 function extractLineId(req: NextRequest): string | null {
-  const m = req.nextUrl.pathname.match(/\/api\/work-orders\/lines\/([^/]+)\/finish$/);
-  return m?.[1] ?? null;
+  const match = req.nextUrl.pathname.match(
+    /\/api\/work-orders\/lines\/([^/]+)\/finish$/,
+  );
+  return match?.[1] ?? null;
 }
 
 export async function POST(req: NextRequest) {
@@ -21,7 +25,6 @@ export async function POST(req: NextRequest) {
   }
 
   const supabase = createServerSupabaseRoute();
-
   const {
     data: { user },
     error: userErr,
@@ -30,12 +33,22 @@ export async function POST(req: NextRequest) {
   if (userErr) {
     return NextResponse.json({ error: userErr.message }, { status: 500 });
   }
-
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const body = (await req.json().catch(() => ({}))) as Body;
+  const operationKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    body.operationKey?.trim() ||
+    body.idempotencyKey?.trim() ||
+    "";
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
 
   const result = await applyJobPunchTransition({
     supabase,
@@ -43,6 +56,7 @@ export async function POST(req: NextRequest) {
     action: "finish",
     technicianId: user.id,
     options: {
+      operationKey,
       finish: {
         cause: body.cause,
         correction: body.correction,

--- a/app/api/work-orders/lines/[id]/pause/route.ts
+++ b/app/api/work-orders/lines/[id]/pause/route.ts
@@ -25,12 +25,26 @@ export async function POST(req: NextRequest) {
   const body = (await req.json().catch(() => null)) as {
     holdReason?: string;
     notes?: string | null;
+    operationKey?: string;
+    idempotencyKey?: string;
   } | null;
+  const operationKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    body?.operationKey?.trim() ||
+    body?.idempotencyKey?.trim() ||
+    "";
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
 
   const result = await stopTechnicianJobLabor({
     supabase,
     lineId: id,
     technicianId: auth.user.id,
+    operationKey,
     reason: body?.holdReason,
   });
 

--- a/app/api/work-orders/lines/[id]/resume/route.ts
+++ b/app/api/work-orders/lines/[id]/resume/route.ts
@@ -5,8 +5,10 @@ import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server
 import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
 
 function getId(req: NextRequest) {
-  const m = req.nextUrl.pathname.match(/\/api\/work-orders\/lines\/([^/]+)\/resume$/);
-  return m?.[1] ?? null;
+  const match = req.nextUrl.pathname.match(
+    /\/api\/work-orders\/lines\/([^/]+)\/resume$/,
+  );
+  return match?.[1] ?? null;
 }
 
 export async function POST(req: NextRequest) {
@@ -15,12 +17,30 @@ export async function POST(req: NextRequest) {
 
   const supabase = createServerSupabaseRoute();
   const { data: auth, error: authErr } = await supabase.auth.getUser();
-  if (authErr) return NextResponse.json({ error: authErr.message }, { status: 500 });
-  if (!auth?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (authErr)
+    return NextResponse.json({ error: authErr.message }, { status: 500 });
+  if (!auth?.user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = (await req.json().catch(() => null)) as
-    | { allowConcurrentJobPunches?: boolean; toAwaiting?: boolean }
+    | {
+        allowConcurrentJobPunches?: boolean;
+        toAwaiting?: boolean;
+        operationKey?: string;
+        idempotencyKey?: string;
+      }
     | null;
+  const operationKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    body?.operationKey?.trim() ||
+    body?.idempotencyKey?.trim() ||
+    "";
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
 
   const result = await applyJobPunchTransition({
     supabase,
@@ -28,6 +48,7 @@ export async function POST(req: NextRequest) {
     action: "resume",
     technicianId: auth.user.id,
     options: {
+      operationKey,
       allowConcurrentJobPunches: body?.allowConcurrentJobPunches === true,
       resume: {
         toAwaiting: body?.toAwaiting === true,

--- a/app/api/work-orders/lines/[id]/start/route.ts
+++ b/app/api/work-orders/lines/[id]/start/route.ts
@@ -24,12 +24,26 @@ export async function POST(req: NextRequest) {
 
   const body = (await req.json().catch(() => null)) as {
     allowConcurrentJobPunches?: boolean;
+    operationKey?: string;
+    idempotencyKey?: string;
   } | null;
+  const operationKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    body?.operationKey?.trim() ||
+    body?.idempotencyKey?.trim() ||
+    "";
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
 
   const result = await startTechnicianJobLabor({
     supabase,
     lineId: id,
     technicianId: auth.user.id,
+    operationKey,
     allowConcurrentJobPunches: body?.allowConcurrentJobPunches === true,
   });
 

--- a/docs/phase-4-technician-labor-runbook.md
+++ b/docs/phase-4-technician-labor-runbook.md
@@ -1,0 +1,48 @@
+# Phase 4 technician labor lifecycle rollout
+
+## Scope
+
+Phase 4 makes technician assignment and job labor transitions transactional while preserving the existing work-order, workforce, payroll, and multi-technician architecture.
+
+## Canonical ownership
+
+- `work_order_line_technicians` is the canonical multi-technician assignment set.
+- `work_order_lines.assigned_tech_id` is the synchronized primary-technician mirror.
+- `work_order_line_labor_segments` is the canonical actual-job-time ledger.
+- `work_order_lines.punched_in_at` and `punched_out_at` are derived mirrors maintained in the same transaction.
+- `tech_shifts` is the shop-scoped shift authorization envelope.
+
+## Migration order
+
+Run in this order:
+
+1. `supabase/migrations/20260714050000_phase4_atomic_technician_labor.sql`
+2. `supabase/migrations/20260714050100_phase4_coordinated_labor_and_postcheck.sql`
+
+The final migration must print:
+
+```text
+Phase 4 technician labor lifecycle postcheck passed.
+```
+
+## Validation scenarios
+
+1. Assign the first technician to a line and verify both the relationship row and primary mirror are updated.
+2. Add a second technician and verify both assignments remain while the newest assignment becomes the primary mirror.
+3. Start a job with a same-shop active shift and verify one open labor segment and matching line mirrors.
+4. Retry the start with the same key and verify no duplicate segment is created.
+5. Attempt a start with only a different-shop or null-shop open shift and verify it is rejected.
+6. Pause for hold and verify the segment close and line `on_hold` state commit together.
+7. Release hold to `awaiting` and verify no labor segment is created.
+8. Resume and verify a new segment is created.
+9. Finish with valid cause, correction, and labor time and verify segment close, line completion, inspection finalization, mirrors, and activity log.
+10. Start break/lunch or End Day with active job time and verify all active job segments close through the coordinated RPC.
+11. Attempt assignment or labor mutation on a financially locked work order and verify `FINANCIALLY_LOCKED`.
+
+## Rollback behavior
+
+Every RPC runs inside one PostgreSQL transaction. Any validation, constraint, segment, mirror, line, inspection, assignment, or audit failure rolls back all writes made by that operation.
+
+## No new environment variables
+
+Phase 4 uses the existing Supabase authentication and service-role configuration.

--- a/features/work-orders/server/applyJobPunchTransition.ts
+++ b/features/work-orders/server/applyJobPunchTransition.ts
@@ -1,17 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
-import {
-  canTransitionWorkOrderLineStatus,
-  getWorkOrderLineTransitionError,
-  normalizeWorkOrderLineStatus,
-} from "@/features/work-orders/lib/line-status";
-import {
-  closeActiveLaborSegments,
-  startLaborSegment,
-  syncLinePunchMirrorFromSegments,
-} from "@/features/work-orders/server/laborSegments";
-import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
-import { SHIFT_STATUSES } from "@/features/workforce/lib/shift-status";
+import type { Database, Json } from "@shared/types/types/supabase";
 
 type DB = Database;
 
@@ -35,6 +23,7 @@ type ResumeOptions = {
 };
 
 type TransitionOptions = {
+  operationKey?: string;
   allowConcurrentJobPunches?: boolean;
   nowIso?: string;
   startSource?: string;
@@ -55,23 +44,13 @@ type TransitionResult =
   | { ok: true; payload?: unknown }
   | { ok: false; status: number; error: string };
 
-type LineRow = Pick<
-  DB["public"]["Tables"]["work_order_lines"]["Row"],
-  | "id"
-  | "work_order_id"
-  | "status"
-  | "approval_state"
-  | "punchable"
-  | "assigned_tech_id"
-  | "shop_id"
-  | "punched_in_at"
-  | "punched_out_at"
-  | "hold_reason"
-  | "cause"
-  | "correction"
-  | "labor_time"
-  | "line_type"
->;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
 
 function cleanString(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -79,8 +58,20 @@ function cleanString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function err(status: number, error: string): TransitionResult {
-  return { ok: false, status, error };
+function errorStatus(message: string): number {
+  const normalized = message.toLowerCase();
+  if (normalized.includes("not found")) return 404;
+  if (
+    normalized.includes("financially_locked") ||
+    normalized.includes("shift_shop_mismatch") ||
+    normalized.includes("already has") ||
+    normalized.includes("cannot") ||
+    normalized.includes("requires") ||
+    normalized.includes("need an active shift")
+  ) {
+    return 409;
+  }
+  return 400;
 }
 
 export async function applyJobPunchTransition({
@@ -90,471 +81,55 @@ export async function applyJobPunchTransition({
   technicianId,
   options,
 }: ApplyJobPunchTransitionParams): Promise<TransitionResult> {
-  const allowConcurrentJobPunches = options?.allowConcurrentJobPunches === true;
+  const operationKey = cleanString(options?.operationKey);
+  if (!operationKey) {
+    return {
+      ok: false,
+      status: 400,
+      error: "A stable operation key is required for job punch transitions.",
+    };
+  }
 
-  const { data: line, error: lineErr } = await supabase
+  const { data: line, error: lineError } = await supabase
     .from("work_order_lines")
-    .select(
-      "id, work_order_id, status, approval_state, punchable, assigned_tech_id, shop_id, punched_in_at, punched_out_at, hold_reason, cause, correction, labor_time, line_type",
-    )
+    .select("id, shop_id")
     .eq("id", lineId)
-    .maybeSingle<LineRow>();
+    .maybeSingle<{ id: string; shop_id: string | null }>();
 
-  if (lineErr) {
-    return err(action === "finish" ? 500 : 400, lineErr.message);
+  if (lineError) return { ok: false, status: 400, error: lineError.message };
+  if (!line?.shop_id) {
+    return { ok: false, status: 404, error: "Work-order line not found for shop." };
   }
 
-  if (!line) return err(404, "Line not found");
-  if ((line.line_type ?? "job") === "info")
-    return err(409, "Info lines are non-actionable.");
-
-  const status = normalizeWorkOrderLineStatus(line.status);
-
-  if (action === "start" || action === "resume") {
-    const resumeToAwaiting =
-      action === "resume" && options?.resume?.toAwaiting === true;
-
-    if (resumeToAwaiting) {
-      if (status === "completed" || status === "invoiced") {
-        return err(409, "Cannot release hold on a closed line.");
-      }
-
-      if (!canTransitionWorkOrderLineStatus(status, "awaiting")) {
-        return err(409, getWorkOrderLineTransitionError(status, "awaiting"));
-      }
-
-      const now = new Date().toISOString();
-      const { error: releaseErr } = await supabase
-        .from("work_order_lines")
-        .update({
-          status: "awaiting",
-          hold_reason: null,
-        } as DB["public"]["Tables"]["work_order_lines"]["Update"])
-        .eq("id", lineId)
-        .single();
-
-      if (releaseErr) return err(400, releaseErr.message);
-
-      await logOperationalEvent({
-        supabase,
-        event: "resume",
-        actorId: technicianId,
-        entityType: "work_order_line",
-        entityId: lineId,
-        at: now,
-      });
-
-      return { ok: true, payload: { ok: true } };
-    }
-
-    const approvalState = String(line.approval_state ?? "").toLowerCase();
-    const punchable = Boolean(line.punchable);
-
-    if (status === "completed" || status === "invoiced") {
-      return err(
-        409,
-        action === "start"
-          ? "Cannot start a closed line."
-          : "Cannot resume a closed line.",
-      );
-    }
-
-    if (!canTransitionWorkOrderLineStatus(status, "in_progress")) {
-      return err(409, getWorkOrderLineTransitionError(status, "in_progress"));
-    }
-
-    if (
-      status === "awaiting_approval" &&
-      approvalState !== "approved" &&
-      !punchable
-    ) {
-      return err(
-        409,
-        action === "start"
-          ? "Line is awaiting approval and cannot be started yet."
-          : "Line is awaiting approval and cannot be resumed yet.",
-      );
-    }
-
-    const lineTechId = technicianId;
-
-    let openShiftQuery = supabase
-      .from("tech_shifts")
-      .select("id, shop_id, status, start_time, end_time")
-      .eq("user_id", lineTechId)
-      .eq("status", SHIFT_STATUSES.active)
-      .order("start_time", { ascending: false })
-      .limit(1);
-
-    if (line.shop_id) {
-      openShiftQuery = openShiftQuery.eq("shop_id", line.shop_id);
-    }
-
-    let openShift: {
-      id: string;
-      shop_id: string | null;
-      status: string | null;
-      start_time: string | null;
-      end_time: string | null;
-    } | null = null;
-
-    const { data: firstOpenShift, error: firstOpenShiftErr } =
-      await openShiftQuery.maybeSingle();
-
-    if (firstOpenShiftErr) return err(400, firstOpenShiftErr.message);
-    openShift = firstOpenShift;
-
-    if (!openShift) {
-      let fallbackQuery = supabase
-        .from("tech_shifts")
-        .select("id, shop_id, status, start_time, end_time")
-        .eq("user_id", lineTechId)
-        .is("end_time", null)
-        .order("start_time", { ascending: false })
-        .limit(1);
-
-      if (line.shop_id) {
-        fallbackQuery = fallbackQuery.eq("shop_id", line.shop_id);
-      }
-
-      const { data: fallbackOpenShift, error: fallbackOpenShiftErr } =
-        await fallbackQuery.maybeSingle();
-      if (fallbackOpenShiftErr) return err(400, fallbackOpenShiftErr.message);
-      openShift = fallbackOpenShift;
-    }
-
-    if (!openShift) {
-      const { data: anyShopOpenShift, error: anyShopOpenShiftErr } =
-        await supabase
-          .from("tech_shifts")
-          .select("id, shop_id, status, start_time, end_time")
-          .eq("user_id", lineTechId)
-          .eq("status", SHIFT_STATUSES.active)
-          .order("start_time", { ascending: false })
-          .limit(1)
-          .maybeSingle();
-
-      if (anyShopOpenShiftErr) return err(400, anyShopOpenShiftErr.message);
-      openShift = anyShopOpenShift;
-    }
-
-    if (!openShift) {
-      const { data: anyShopLegacyOpenShift, error: anyShopLegacyOpenShiftErr } =
-        await supabase
-          .from("tech_shifts")
-          .select("id, shop_id, status, start_time, end_time")
-          .eq("user_id", lineTechId)
-          .is("end_time", null)
-          .order("start_time", { ascending: false })
-          .limit(1)
-          .maybeSingle();
-
-      if (anyShopLegacyOpenShiftErr)
-        return err(400, anyShopLegacyOpenShiftErr.message);
-      openShift = anyShopLegacyOpenShift;
-    }
-
-    if (!openShift) {
-      return err(
-        409,
-        action === "start"
-          ? "You need to clock in before starting this job."
-          : "You need to clock in before resuming this job.",
-      );
-    }
-
-    const { data: driftedRows, error: driftErr } = await supabase
-      .from("work_order_lines")
-      .select("id")
-      .eq("assigned_tech_id", lineTechId)
-      .not("punched_in_at", "is", null)
-      .is("punched_out_at", null)
-      .in("status", ["on_hold", "completed", "invoiced"]);
-
-    if (driftErr) return err(400, driftErr.message);
-
-    if ((driftedRows?.length ?? 0) > 0) {
-      return err(
-        409,
-        action === "start"
-          ? "Detected stale active labor punches on on-hold/completed jobs. Resolve those punches before starting a new job."
-          : "Detected stale active labor punches on on-hold/completed jobs. Resolve those punches before resuming a job.",
-      );
-    }
-
-    if (!allowConcurrentJobPunches) {
-      let activeSegmentQuery = supabase
-        .from("work_order_line_labor_segments")
-        .select("id")
-        .eq("technician_id", lineTechId)
-        .is("ended_at", null)
-        .neq("work_order_line_id", lineId)
-        .limit(1);
-
-      if (line.shop_id) {
-        activeSegmentQuery = activeSegmentQuery.eq("shop_id", line.shop_id);
-      }
-
-      const { data: activeSegments, error: activeSegmentErr } =
-        await activeSegmentQuery;
-
-      if (activeSegmentErr) return err(400, activeSegmentErr.message);
-
-      if ((activeSegments?.length ?? 0) > 0) {
-        return err(
-          409,
-          "Technician already has an active job punch. Complete/pause it first or retry with allowConcurrentJobPunches=true.",
-        );
-      }
-    }
-
-    const now = options?.nowIso ?? new Date().toISOString();
-    const shouldResetPunchClock =
-      action === "start" ||
-      status === "on_hold" ||
-      Boolean(line.punched_out_at);
-
-    if (!line.shop_id || !line.work_order_id) {
-      return err(
-        409,
-        "Cannot start labor segment until line has shop_id and work_order_id.",
-      );
-    }
-
-    const { error: updateErr } = await supabase
-      .from("work_order_lines")
-      .update({
-        status: "in_progress",
-        hold_reason: null,
-        ...(shouldResetPunchClock
-          ? {
-              punched_in_at: now,
-              punched_out_at: null,
-            }
-          : {}),
-      } as DB["public"]["Tables"]["work_order_lines"]["Update"])
-      .eq("id", lineId)
-      .single();
-
-    if (updateErr) return err(400, updateErr.message);
-
-    const { error: segmentErr } = await startLaborSegment({
-      supabase,
-      shopId: line.shop_id,
-      workOrderId: line.work_order_id,
-      workOrderLineId: lineId,
-      technicianId: lineTechId,
-      actorId: technicianId,
-      startedAtIso: now,
-      source:
-        options?.startSource ??
-        (action === "start" ? "job_start" : "job_resume"),
-    });
-
-    if (segmentErr) {
-      const message = segmentErr.message.toLowerCase();
-      if (
-        message.includes("uq_wolls_active_by_tech") ||
-        message.includes("ex_wolls_no_overlap")
-      ) {
-        return err(
-          409,
-          "Technician already has overlapping active labor. Pause/finish current job first.",
-        );
-      }
-      return err(400, segmentErr.message);
-    }
-
-    const { error: syncErr } = await syncLinePunchMirrorFromSegments({
-      supabase,
-      workOrderLineId: lineId,
-    });
-
-    if (syncErr) return err(400, syncErr.message);
-
-    await logOperationalEvent({
-      supabase,
-      event: action,
-      actorId: technicianId,
-      entityType: "work_order_line",
-      entityId: lineId,
-      at: now,
-    });
-
-    return { ok: true, payload: { ok: true } };
-  }
-
-  if (action === "pause") {
-    if (status === "completed" || status === "invoiced") {
-      return err(409, "Cannot pause a closed line.");
-    }
-
-    if (!canTransitionWorkOrderLineStatus(status, "on_hold")) {
-      return err(409, getWorkOrderLineTransitionError(status, "on_hold"));
-    }
-
-    const now = options?.nowIso ?? new Date().toISOString();
-    const shouldCloseActivePunch =
-      Boolean(line.punched_in_at) && !line.punched_out_at;
-
-    const preserveLineStatus = options?.pause?.preserveLineStatus === true;
-    const { error: updateErr } = await supabase
-      .from("work_order_lines")
-      .update({
-        ...(preserveLineStatus
-          ? {}
-          : {
-              status: "on_hold",
-              hold_reason:
-                cleanString(options?.pause?.holdReason) ??
-                "Paused by technician",
-              notes: options?.pause?.notes ?? undefined,
-            }),
-        ...(shouldCloseActivePunch ? { punched_out_at: now } : {}),
-      } as DB["public"]["Tables"]["work_order_lines"]["Update"])
-      .eq("id", lineId)
-      .single();
-
-    if (updateErr) return err(400, updateErr.message);
-
-    const pauseTechId = technicianId;
-    const { error: closeErr } = await closeActiveLaborSegments({
-      supabase,
-      workOrderLineId: lineId,
-      technicianId: pauseTechId,
-      endedAtIso: now,
-      pauseReason: preserveLineStatus
-        ? (cleanString(options?.pause?.holdReason) ?? "labor_pause")
-        : cleanString(options?.pause?.holdReason)
-          ? `hold:${cleanString(options?.pause?.holdReason)}`
-          : "hold",
-    });
-
-    if (closeErr) return err(400, closeErr.message);
-
-    const { error: syncErr } = await syncLinePunchMirrorFromSegments({
-      supabase,
-      workOrderLineId: lineId,
-    });
-    if (syncErr) return err(400, syncErr.message);
-
-    await logOperationalEvent({
-      supabase,
-      event: options?.pause?.event ?? "pause",
-      actorId: technicianId,
-      entityType: "work_order_line",
-      entityId: lineId,
-      details: options?.pause?.details,
-      at: now,
-    });
-
-    return { ok: true, payload: { ok: true } };
-  }
-
-  const incomingCause = cleanString(options?.finish?.cause);
-  const incomingCorrection = cleanString(options?.finish?.correction);
-
-  if (!canTransitionWorkOrderLineStatus(status, "completed")) {
-    return err(409, getWorkOrderLineTransitionError(status, "completed"));
-  }
-
-  const finalCause = incomingCause ?? cleanString(line.cause);
-  const finalCorrection = incomingCorrection ?? cleanString(line.correction);
-  const laborTime = typeof line.labor_time === "number" ? line.labor_time : 0;
-
-  if (!finalCause) {
-    return err(400, "Cause is required before finishing this job.");
-  }
-
-  if (!finalCorrection) {
-    return err(400, "Correction is required before finishing this job.");
-  }
-
-  if (laborTime <= 0) {
-    return err(
-      400,
-      "Labor time must be greater than 0 before finishing this job.",
-    );
-  }
-
-  const nowIso = new Date().toISOString();
-
-  const finishTechId = technicianId;
-  const { error: closeErr } = await closeActiveLaborSegments({
-    supabase,
-    workOrderLineId: lineId,
-    technicianId: finishTechId,
-    endedAtIso: nowIso,
-    pauseReason: "completed",
+  const details = (options?.pause?.details ?? {}) as Json;
+  const rpc = supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("apply_job_punch_transition_atomic", {
+    p_shop_id: line.shop_id,
+    p_work_order_line_id: lineId,
+    p_action: action,
+    p_technician_id: technicianId,
+    p_actor_user_id: technicianId,
+    p_operation_key: `${line.shop_id}:job-punch:${operationKey}`,
+    p_allow_concurrent: options?.allowConcurrentJobPunches === true,
+    p_at: options?.nowIso ?? new Date().toISOString(),
+    p_start_source: cleanString(options?.startSource),
+    p_hold_reason: cleanString(options?.pause?.holdReason),
+    p_notes: options?.pause?.notes ?? null,
+    p_preserve_line_status: options?.pause?.preserveLineStatus === true,
+    p_release_to_awaiting:
+      action === "resume" && options?.resume?.toAwaiting === true,
+    p_cause: cleanString(options?.finish?.cause),
+    p_correction: cleanString(options?.finish?.correction),
+    p_event: cleanString(options?.pause?.event),
+    p_details: details,
   });
 
-  if (closeErr) return err(400, closeErr.message);
-
-  const { error: syncErr } = await syncLinePunchMirrorFromSegments({
-    supabase,
-    workOrderLineId: lineId,
-  });
-  if (syncErr) return err(400, syncErr.message);
-
-  const updatePayload: DB["public"]["Tables"]["work_order_lines"]["Update"] = {
-    status: "completed",
-    punched_out_at: nowIso,
-    cause: finalCause,
-    correction: finalCorrection,
-    updated_at: nowIso,
-  };
-
-  const { data: updatedLine, error: updateErr } = await supabase
-    .from("work_order_lines")
-    .update(updatePayload)
-    .eq("id", lineId)
-    .select(
-      "id, work_order_id, status, cause, correction, labor_time, punched_in_at, punched_out_at",
-    )
-    .single();
-
-  if (updateErr) return err(400, updateErr.message);
-
-  const inspectionUpdate: DB["public"]["Tables"]["inspections"]["Update"] = {
-    completed: true,
-    is_draft: false,
-    locked: true,
-    status: "completed",
-    finalized_at: nowIso,
-    finalized_by: technicianId,
-    updated_at: nowIso,
-  };
-
-  const { error: inspectionErr } = await supabase
-    .from("inspections")
-    .update(inspectionUpdate)
-    .eq("work_order_line_id", lineId);
-
-  if (inspectionErr) {
-    console.warn(
-      "[finish] inspections finalize failed:",
-      inspectionErr.message,
-    );
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return { ok: false, status: errorStatus(message), error: message };
   }
 
-  try {
-    await logOperationalEvent({
-      supabase,
-      event: "finish",
-      actorId: technicianId,
-      entityType: "work_order_line",
-      entityId: lineId,
-      at: nowIso,
-    });
-  } catch (error) {
-    console.warn("[finish] activity log insert failed", error);
-  }
-
-  return {
-    ok: true,
-    payload: {
-      success: true,
-      line: updatedLine,
-    },
-  };
+  return { ok: true, payload: data };
 }

--- a/features/work-orders/server/technicianJobLabor.ts
+++ b/features/work-orders/server/technicianJobLabor.ts
@@ -24,22 +24,37 @@ type JobLaborResult =
   | { ok: true; payload?: unknown }
   | { ok: false; status: number; error: string };
 
+function internalOperationKey(parts: Array<string | null | undefined>): string {
+  return parts.map((part) => String(part ?? "").trim()).filter(Boolean).join(":");
+}
+
 export async function startTechnicianJobLabor(params: {
   supabase: SupabaseClient<DB>;
   lineId: string;
   technicianId: string;
-  operationKey: string;
+  operationKey?: string;
+  sourceEventId?: string | null;
   startedAtIso?: string;
   source?: "manual" | "break_resume" | "lunch_resume";
   allowConcurrentJobPunches?: boolean;
 }): Promise<JobLaborResult> {
+  const operationKey =
+    params.operationKey?.trim() ||
+    internalOperationKey([
+      "internal-start",
+      params.sourceEventId,
+      params.lineId,
+      params.technicianId,
+      params.startedAtIso,
+      params.source,
+    ]);
   return applyJobPunchTransition({
     supabase: params.supabase,
     lineId: params.lineId,
     action: "start",
     technicianId: params.technicianId,
     options: {
-      operationKey: params.operationKey,
+      operationKey,
       allowConcurrentJobPunches: params.allowConcurrentJobPunches === true,
       nowIso: params.startedAtIso,
       startSource:
@@ -56,20 +71,31 @@ export async function stopTechnicianJobLabor(params: {
   supabase: SupabaseClient<DB>;
   lineId: string;
   technicianId: string;
-  operationKey: string;
+  operationKey?: string;
+  sourceEventId?: string | null;
   endedAtIso?: string;
   reason?: string;
   preserveLineStatus?: boolean;
   event?: string;
   details?: Json;
 }): Promise<JobLaborResult> {
+  const operationKey =
+    params.operationKey?.trim() ||
+    internalOperationKey([
+      "internal-stop",
+      params.sourceEventId,
+      params.lineId,
+      params.technicianId,
+      params.endedAtIso,
+      params.reason,
+    ]);
   return applyJobPunchTransition({
     supabase: params.supabase,
     lineId: params.lineId,
     action: "pause",
     technicianId: params.technicianId,
     options: {
-      operationKey: params.operationKey,
+      operationKey,
       nowIso: params.endedAtIso,
       pause: {
         holdReason: params.reason,
@@ -103,23 +129,35 @@ export async function closeAllActiveTechnicianJobLabor(params: {
   supabase: SupabaseClient<DB>;
   shopId: string;
   technicianId: string;
-  operationKey: string;
+  operationKey?: string;
   endedAtIso: string;
   reason: string;
   event?: string;
   sourceEventId?: string | null;
+  breakPunchId?: string | null;
   details?: Json;
 }) {
+  const sourceEventId = params.sourceEventId ?? params.breakPunchId ?? null;
+  const operationKey =
+    params.operationKey?.trim() ||
+    internalOperationKey([
+      "coordinated-labor-stop",
+      sourceEventId,
+      params.shopId,
+      params.technicianId,
+      params.endedAtIso,
+      params.reason,
+    ]);
   const rpc = params.supabase as unknown as RpcClient;
   const { data, error } = await rpc.rpc("pause_all_active_technician_labor_atomic", {
     p_shop_id: params.shopId,
     p_technician_id: params.technicianId,
     p_actor_user_id: params.technicianId,
-    p_operation_key: params.operationKey,
+    p_operation_key: operationKey,
     p_at: params.endedAtIso,
     p_reason: params.reason,
     p_event: params.event ?? "job_stopped_at_end_day",
-    p_source_event_id: params.sourceEventId ?? null,
+    p_source_event_id: sourceEventId,
     p_details: params.details ?? {},
   });
 

--- a/features/work-orders/server/technicianJobLabor.ts
+++ b/features/work-orders/server/technicianJobLabor.ts
@@ -1,13 +1,15 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database, Json } from "@shared/types/types/supabase";
 import { applyJobPunchTransition } from "@/features/work-orders/server/applyJobPunchTransition";
-import {
-  closeActiveLaborSegments,
-  syncLinePunchMirrorFromSegments,
-} from "@/features/work-orders/server/laborSegments";
-import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
 
 type DB = Database;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
 
 type ActiveLaborSegment = {
   id: string;
@@ -101,93 +103,48 @@ export async function closeAllActiveTechnicianJobLabor(params: {
   supabase: SupabaseClient<DB>;
   shopId: string;
   technicianId: string;
+  operationKey: string;
   endedAtIso: string;
   reason: string;
   event?: string;
-  breakPunchId?: string | null;
+  sourceEventId?: string | null;
+  details?: Json;
 }) {
-  const { data: active, error } = await getActiveTechnicianJobLabor(params);
-  if (error)
+  const rpc = params.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("pause_all_active_technician_labor_atomic", {
+    p_shop_id: params.shopId,
+    p_technician_id: params.technicianId,
+    p_actor_user_id: params.technicianId,
+    p_operation_key: params.operationKey,
+    p_at: params.endedAtIso,
+    p_reason: params.reason,
+    p_event: params.event ?? "job_stopped_at_end_day",
+    p_source_event_id: params.sourceEventId ?? null,
+    p_details: params.details ?? {},
+  });
+
+  if (error) {
+    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
     return {
       ok: false as const,
-      status: 500,
-      error: error.message,
+      status: message.includes("FINANCIALLY_LOCKED") ? 409 : 400,
+      error: message,
       closed: [] as ActiveLaborSegment[],
     };
-
-  if (active.length > 1) {
-    await logOperationalEvent({
-      supabase: params.supabase,
-      event: "integrity_warning_multiple_active_jobs",
-      actorId: params.technicianId,
-      entityType: "technician",
-      entityId: params.technicianId,
-      at: params.endedAtIso,
-      details: {
-        shop_id: params.shopId,
-        technician_id: params.technicianId,
-        active_segment_ids: active.map((segment) => segment.id),
-        reason: params.reason,
-        break_punch_id: params.breakPunchId ?? null,
-      } as Json,
-    });
   }
 
-  const lineIds = [
-    ...new Set(
-      active
-        .map((segment) => segment.work_order_line_id)
-        .filter((id): id is string => Boolean(id)),
-    ),
-  ];
-  for (const lineId of lineIds) {
-    const { error: closeErr } = await closeActiveLaborSegments({
-      supabase: params.supabase,
-      workOrderLineId: lineId,
-      technicianId: params.technicianId,
-      endedAtIso: params.endedAtIso,
-      pauseReason: params.reason,
-    });
-    if (closeErr)
-      return {
-        ok: false as const,
-        status: 500,
-        error: closeErr.message,
-        closed: active,
-      };
-
-    const { error: syncErr } = await syncLinePunchMirrorFromSegments({
-      supabase: params.supabase,
-      workOrderLineId: lineId,
-    });
-    if (syncErr)
-      return {
-        ok: false as const,
-        status: 500,
-        error: syncErr.message,
-        closed: active,
-      };
-  }
-
-  for (const segment of active) {
-    await logOperationalEvent({
-      supabase: params.supabase,
-      event: params.event ?? "job_stopped_at_end_day",
-      actorId: params.technicianId,
-      entityType: "work_order_line",
-      entityId: segment.work_order_line_id,
-      at: params.endedAtIso,
-      details: {
-        shop_id: params.shopId,
-        technician_id: params.technicianId,
-        work_order_id: segment.work_order_id,
-        work_order_line_id: segment.work_order_line_id,
-        source_session_id: segment.id,
-        reason: params.reason,
-        break_punch_id: params.breakPunchId ?? null,
-      } as Json,
-    });
-  }
-
-  return { ok: true as const, closed: active };
+  const result = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+  const count = Number(result.closed_line_count ?? 0);
+  return {
+    ok: true as const,
+    closed: Array.from({ length: Number.isFinite(count) ? count : 0 }, () => ({
+      id: "",
+      shop_id: params.shopId,
+      work_order_id: null,
+      work_order_line_id: null,
+      technician_id: params.technicianId,
+      started_at: null,
+    })) as ActiveLaborSegment[],
+    payload: result,
+  };
 }

--- a/features/work-orders/server/technicianJobLabor.ts
+++ b/features/work-orders/server/technicianJobLabor.ts
@@ -26,6 +26,7 @@ export async function startTechnicianJobLabor(params: {
   supabase: SupabaseClient<DB>;
   lineId: string;
   technicianId: string;
+  operationKey: string;
   startedAtIso?: string;
   source?: "manual" | "break_resume" | "lunch_resume";
   allowConcurrentJobPunches?: boolean;
@@ -36,6 +37,7 @@ export async function startTechnicianJobLabor(params: {
     action: "start",
     technicianId: params.technicianId,
     options: {
+      operationKey: params.operationKey,
       allowConcurrentJobPunches: params.allowConcurrentJobPunches === true,
       nowIso: params.startedAtIso,
       startSource:
@@ -52,6 +54,7 @@ export async function stopTechnicianJobLabor(params: {
   supabase: SupabaseClient<DB>;
   lineId: string;
   technicianId: string;
+  operationKey: string;
   endedAtIso?: string;
   reason?: string;
   preserveLineStatus?: boolean;
@@ -64,6 +67,7 @@ export async function stopTechnicianJobLabor(params: {
     action: "pause",
     technicianId: params.technicianId,
     options: {
+      operationKey: params.operationKey,
       nowIso: params.endedAtIso,
       pause: {
         holdReason: params.reason,

--- a/supabase/migrations/20260714050000_phase4_atomic_technician_labor.sql
+++ b/supabase/migrations/20260714050000_phase4_atomic_technician_labor.sql
@@ -1,0 +1,498 @@
+begin;
+
+create table if not exists public.workforce_operation_keys (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  operation_name text not null,
+  operation_key text not null,
+  actor_user_id uuid references auth.users(id) on delete set null,
+  work_order_id uuid references public.work_orders(id) on delete cascade,
+  work_order_line_id uuid references public.work_order_lines(id) on delete cascade,
+  result jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (shop_id, operation_name, operation_key)
+);
+
+create index if not exists workforce_operation_keys_line_idx
+  on public.workforce_operation_keys(shop_id, work_order_line_id, created_at desc);
+
+alter table public.workforce_operation_keys enable row level security;
+
+drop policy if exists workforce_operation_keys_shop_select on public.workforce_operation_keys;
+create policy workforce_operation_keys_shop_select
+  on public.workforce_operation_keys
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = workforce_operation_keys.shop_id
+    )
+  );
+
+create or replace function public.assign_work_order_line_technician_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_technician_id uuid,
+  p_assigned_by uuid,
+  p_operation_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_role text;
+  v_existing jsonb;
+  v_result jsonb;
+begin
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  select wok.result
+    into v_existing
+  from public.workforce_operation_keys wok
+  where wok.shop_id = p_shop_id
+    and wok.operation_name = 'assign_line_technician'
+    and wok.operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  perform 1
+  from public.profiles p
+  where p.id = p_assigned_by
+    and p.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Assigning user is not available for this shop.';
+  end if;
+
+  select *
+    into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for shop.';
+  end if;
+  if coalesce(v_line.line_type::text, 'job') = 'info' then
+    raise exception using errcode = 'P0001', message = 'Info lines cannot be technician-assigned.';
+  end if;
+  if public.work_order_is_financially_locked(p_shop_id, v_line.work_order_id) then
+    raise exception using errcode = 'P0001', message = 'FINANCIALLY_LOCKED: assignment cannot change after invoice finalization.';
+  end if;
+
+  select lower(coalesce(p.role::text, ''))
+    into v_role
+  from public.profiles p
+  where p.id = p_technician_id
+    and p.shop_id = p_shop_id
+  for update;
+  if not found or v_role not in ('mechanic','tech','technician','foreman','lead_hand','lead hand','leadhand') then
+    raise exception using errcode = 'P0001', message = 'Technician is not assignable for this shop.';
+  end if;
+
+  insert into public.work_order_line_technicians(
+    work_order_line_id,
+    technician_id,
+    assigned_by
+  ) values (
+    p_work_order_line_id,
+    p_technician_id,
+    p_assigned_by
+  )
+  on conflict (work_order_line_id, technician_id)
+  do update set assigned_by = excluded.assigned_by;
+
+  update public.work_order_lines
+  set assigned_tech_id = p_technician_id,
+      updated_at = now()
+  where id = p_work_order_line_id
+    and shop_id = p_shop_id;
+
+  select jsonb_build_object(
+    'ok', true,
+    'shop_id', p_shop_id,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'primary_technician_id', p_technician_id,
+    'technician_ids', coalesce(
+      (
+        select jsonb_agg(wolt.technician_id order by wolt.technician_id)
+        from public.work_order_line_technicians wolt
+        where wolt.work_order_line_id = p_work_order_line_id
+      ),
+      '[]'::jsonb
+    ),
+    'assignment_mode', 'additive_multi_tech_primary_mirror',
+    'idempotent', false
+  ) into v_result;
+
+  insert into public.workforce_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id,
+    work_order_id, work_order_line_id, result
+  ) values (
+    p_shop_id, 'assign_line_technician', p_operation_key, p_assigned_by,
+    v_line.work_order_id, p_work_order_line_id, v_result
+  );
+
+  insert into public.activity_logs(action, user_id, timestamp, target_table, target_id, context)
+  values (
+    'technician_assigned', p_assigned_by, now(), 'work_order_line', p_work_order_line_id,
+    jsonb_build_object(
+      'shop_id', p_shop_id,
+      'work_order_id', v_line.work_order_id,
+      'technician_id', p_technician_id,
+      'assignment_mode', 'additive_multi_tech_primary_mirror'
+    )
+  );
+
+  return v_result;
+end;
+$$;
+
+create or replace function public.apply_job_punch_transition_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_action text,
+  p_technician_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_allow_concurrent boolean default false,
+  p_at timestamptz default now(),
+  p_start_source text default null,
+  p_hold_reason text default null,
+  p_notes text default null,
+  p_preserve_line_status boolean default false,
+  p_release_to_awaiting boolean default false,
+  p_cause text default null,
+  p_correction text default null,
+  p_event text default null,
+  p_details jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_shift public.tech_shifts%rowtype;
+  v_status text;
+  v_approval text;
+  v_action text := lower(trim(coalesce(p_action, '')));
+  v_now timestamptz := coalesce(p_at, now());
+  v_existing jsonb;
+  v_result jsonb;
+  v_final_cause text;
+  v_final_correction text;
+  v_segment_id uuid;
+  v_earliest timestamptz;
+  v_latest timestamptz;
+  v_has_open boolean;
+  v_closed_count integer := 0;
+begin
+  if v_action not in ('start','resume','pause','finish') then
+    raise exception using errcode = 'P0001', message = 'Unsupported job punch action.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  select wok.result
+    into v_existing
+  from public.workforce_operation_keys wok
+  where wok.shop_id = p_shop_id
+    and wok.operation_name = 'job_punch:' || v_action
+    and wok.operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  perform 1
+  from public.profiles p
+  where p.id = p_actor_user_id
+    and p.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Actor is not available for this shop.';
+  end if;
+
+  perform 1
+  from public.profiles p
+  where p.id = p_technician_id
+    and p.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Technician is not available for this shop.';
+  end if;
+
+  select *
+    into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for shop.';
+  end if;
+  if v_line.work_order_id is null then
+    raise exception using errcode = 'P0001', message = 'Work-order line is missing its work-order anchor.';
+  end if;
+  if coalesce(v_line.line_type::text, 'job') = 'info' then
+    raise exception using errcode = 'P0001', message = 'Info lines are non-actionable.';
+  end if;
+  if public.work_order_is_financially_locked(p_shop_id, v_line.work_order_id) then
+    raise exception using errcode = 'P0001', message = 'FINANCIALLY_LOCKED: job labor cannot change after invoice finalization.';
+  end if;
+
+  v_status := lower(coalesce(v_line.status::text, 'awaiting'));
+  v_approval := lower(coalesce(v_line.approval_state::text, ''));
+
+  perform 1
+  from public.work_order_line_technicians wolt
+  where wolt.work_order_line_id = p_work_order_line_id
+  for update;
+
+  perform 1
+  from public.work_order_line_labor_segments seg
+  where seg.shop_id = p_shop_id
+    and (
+      seg.work_order_line_id = p_work_order_line_id
+      or (seg.technician_id = p_technician_id and seg.ended_at is null)
+    )
+  for update;
+
+  if v_action in ('start','resume') and p_release_to_awaiting then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot release hold on a closed line.';
+    end if;
+
+    update public.work_order_lines
+    set status = 'awaiting',
+        hold_reason = null,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+  elsif v_action in ('start','resume') then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot start or resume a closed line.';
+    end if;
+    if v_status = 'awaiting_approval'
+       and v_approval <> 'approved'
+       and not coalesce(v_line.punchable, false) then
+      raise exception using errcode = 'P0001', message = 'Line is awaiting approval and cannot be started.';
+    end if;
+
+    select *
+      into v_shift
+    from public.tech_shifts ts
+    where ts.user_id = p_technician_id
+      and ts.shop_id = p_shop_id
+      and ts.status::text = 'active'
+      and ts.end_time is null
+    order by ts.start_time desc, ts.id desc
+    limit 1
+    for update;
+    if not found then
+      if exists (
+        select 1
+        from public.tech_shifts ts
+        where ts.user_id = p_technician_id
+          and ts.end_time is null
+          and (ts.shop_id is null or ts.shop_id <> p_shop_id)
+      ) then
+        raise exception using errcode = 'P0001', message = 'SHIFT_SHOP_MISMATCH: an open shift exists outside this shop and cannot authorize job labor.';
+      end if;
+      raise exception using errcode = 'P0001', message = 'You need an active shift in this shop before starting job labor.';
+    end if;
+
+    if exists (
+      select 1
+      from public.work_order_line_labor_segments seg
+      where seg.shop_id = p_shop_id
+        and seg.technician_id = p_technician_id
+        and seg.work_order_line_id = p_work_order_line_id
+        and seg.ended_at is null
+    ) then
+      raise exception using errcode = 'P0001', message = 'Technician already has active labor on this line.';
+    end if;
+
+    if not p_allow_concurrent and exists (
+      select 1
+      from public.work_order_line_labor_segments seg
+      where seg.shop_id = p_shop_id
+        and seg.technician_id = p_technician_id
+        and seg.work_order_line_id <> p_work_order_line_id
+        and seg.ended_at is null
+    ) then
+      raise exception using errcode = 'P0001', message = 'Technician already has an active job punch.';
+    end if;
+
+    insert into public.work_order_line_technicians(
+      work_order_line_id, technician_id, assigned_by
+    ) values (
+      p_work_order_line_id, p_technician_id, p_actor_user_id
+    )
+    on conflict (work_order_line_id, technician_id)
+    do update set assigned_by = excluded.assigned_by;
+
+    update public.work_order_lines
+    set assigned_tech_id = coalesce(assigned_tech_id, p_technician_id),
+        status = 'in_progress',
+        hold_reason = null,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+    insert into public.work_order_line_labor_segments(
+      shop_id, work_order_id, work_order_line_id, technician_id,
+      created_by, started_at, source
+    ) values (
+      p_shop_id, v_line.work_order_id, p_work_order_line_id, p_technician_id,
+      p_actor_user_id, v_now,
+      coalesce(nullif(trim(p_start_source), ''), case when v_action = 'start' then 'job_start' else 'job_resume' end)
+    ) returning id into v_segment_id;
+
+  elsif v_action = 'pause' then
+    if v_status in ('completed','invoiced') then
+      raise exception using errcode = 'P0001', message = 'Cannot pause a closed line.';
+    end if;
+
+    update public.work_order_line_labor_segments
+    set ended_at = v_now,
+        pause_reason = case
+          when p_preserve_line_status then coalesce(nullif(trim(p_hold_reason), ''), 'labor_pause')
+          when nullif(trim(p_hold_reason), '') is not null then 'hold:' || trim(p_hold_reason)
+          else 'hold'
+        end
+    where shop_id = p_shop_id
+      and work_order_line_id = p_work_order_line_id
+      and technician_id = p_technician_id
+      and ended_at is null;
+    get diagnostics v_closed_count = row_count;
+
+    update public.work_order_lines
+    set status = case when p_preserve_line_status then status else 'on_hold' end,
+        hold_reason = case
+          when p_preserve_line_status then hold_reason
+          else coalesce(nullif(trim(p_hold_reason), ''), 'Paused by technician')
+        end,
+        notes = case when p_preserve_line_status then notes else coalesce(p_notes, notes) end,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+  else
+    if v_status = 'invoiced' then
+      raise exception using errcode = 'P0001', message = 'Cannot finish an invoiced line.';
+    end if;
+
+    v_final_cause := coalesce(nullif(trim(p_cause), ''), nullif(trim(v_line.cause), ''));
+    v_final_correction := coalesce(nullif(trim(p_correction), ''), nullif(trim(v_line.correction), ''));
+    if v_final_cause is null then
+      raise exception using errcode = 'P0001', message = 'Cause is required before finishing this job.';
+    end if;
+    if v_final_correction is null then
+      raise exception using errcode = 'P0001', message = 'Correction is required before finishing this job.';
+    end if;
+    if coalesce(v_line.labor_time, 0) <= 0 then
+      raise exception using errcode = 'P0001', message = 'Labor time must be greater than 0 before finishing this job.';
+    end if;
+
+    update public.work_order_line_labor_segments
+    set ended_at = v_now,
+        pause_reason = 'completed'
+    where shop_id = p_shop_id
+      and work_order_line_id = p_work_order_line_id
+      and technician_id = p_technician_id
+      and ended_at is null;
+    get diagnostics v_closed_count = row_count;
+
+    update public.work_order_lines
+    set status = 'completed',
+        cause = v_final_cause,
+        correction = v_final_correction,
+        hold_reason = null,
+        updated_at = v_now
+    where id = p_work_order_line_id;
+
+    update public.inspections
+    set completed = true,
+        is_draft = false,
+        locked = true,
+        status = 'completed',
+        finalized_at = v_now,
+        finalized_by = p_technician_id,
+        updated_at = v_now
+    where work_order_line_id = p_work_order_line_id;
+  end if;
+
+  select min(seg.started_at),
+         max(seg.ended_at) filter (where seg.ended_at is not null),
+         bool_or(seg.ended_at is null)
+    into v_earliest, v_latest, v_has_open
+  from public.work_order_line_labor_segments seg
+  where seg.work_order_line_id = p_work_order_line_id;
+
+  update public.work_order_lines
+  set punched_in_at = v_earliest,
+      punched_out_at = case when coalesce(v_has_open, false) then null else v_latest end,
+      updated_at = v_now
+  where id = p_work_order_line_id;
+
+  select jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'action', v_action,
+    'shop_id', p_shop_id,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'technician_id', p_technician_id,
+    'shift_id', v_shift.id,
+    'labor_segment_id', v_segment_id,
+    'closed_segment_count', v_closed_count,
+    'line', (
+      select to_jsonb(wol)
+      from public.work_order_lines wol
+      where wol.id = p_work_order_line_id
+    )
+  ) into v_result;
+
+  insert into public.activity_logs(action, user_id, timestamp, target_table, target_id, context)
+  values (
+    coalesce(nullif(trim(p_event), ''), v_action),
+    p_actor_user_id,
+    v_now,
+    'work_order_line',
+    p_work_order_line_id,
+    coalesce(p_details, '{}'::jsonb) || jsonb_build_object(
+      'shop_id', p_shop_id,
+      'work_order_id', v_line.work_order_id,
+      'technician_id', p_technician_id,
+      'shift_id', v_shift.id,
+      'operation_key', p_operation_key
+    )
+  );
+
+  insert into public.workforce_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id,
+    work_order_id, work_order_line_id, result
+  ) values (
+    p_shop_id, 'job_punch:' || v_action, p_operation_key, p_actor_user_id,
+    v_line.work_order_id, p_work_order_line_id, v_result
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.assign_work_order_line_technician_atomic(uuid,uuid,uuid,uuid,text) from public, anon;
+revoke all on function public.apply_job_punch_transition_atomic(uuid,uuid,text,uuid,uuid,text,boolean,timestamptz,text,text,text,boolean,boolean,text,text,text,jsonb) from public, anon;
+grant execute on function public.assign_work_order_line_technician_atomic(uuid,uuid,uuid,uuid,text) to authenticated, service_role;
+grant execute on function public.apply_job_punch_transition_atomic(uuid,uuid,text,uuid,uuid,text,boolean,timestamptz,text,text,text,boolean,boolean,text,text,text,jsonb) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260714050100_phase4_coordinated_labor_and_postcheck.sql
+++ b/supabase/migrations/20260714050100_phase4_coordinated_labor_and_postcheck.sql
@@ -1,0 +1,160 @@
+begin;
+
+create or replace function public.pause_all_active_technician_labor_atomic(
+  p_shop_id uuid,
+  p_technician_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_at timestamptz,
+  p_reason text,
+  p_event text,
+  p_source_event_id uuid default null,
+  p_details jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_existing jsonb;
+  v_result jsonb;
+  v_line_id uuid;
+  v_child jsonb;
+  v_children jsonb := '[]'::jsonb;
+  v_count integer := 0;
+begin
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  select result into v_existing
+  from public.workforce_operation_keys
+  where shop_id = p_shop_id
+    and operation_name = 'pause_all_active_labor'
+    and operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  perform 1
+  from public.profiles p
+  where p.id = p_actor_user_id and p.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Actor is not available for this shop.';
+  end if;
+
+  perform 1
+  from public.profiles p
+  where p.id = p_technician_id and p.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Technician is not available for this shop.';
+  end if;
+
+  perform 1
+  from public.work_order_line_labor_segments seg
+  where seg.shop_id = p_shop_id
+    and seg.technician_id = p_technician_id
+    and seg.ended_at is null
+  for update;
+
+  for v_line_id in
+    select distinct seg.work_order_line_id
+    from public.work_order_line_labor_segments seg
+    where seg.shop_id = p_shop_id
+      and seg.technician_id = p_technician_id
+      and seg.ended_at is null
+      and seg.work_order_line_id is not null
+    order by seg.work_order_line_id
+  loop
+    v_child := public.apply_job_punch_transition_atomic(
+      p_shop_id,
+      v_line_id,
+      'pause',
+      p_technician_id,
+      p_actor_user_id,
+      p_operation_key || ':' || v_line_id::text,
+      true,
+      coalesce(p_at, now()),
+      null,
+      p_reason,
+      null,
+      true,
+      false,
+      null,
+      null,
+      p_event,
+      coalesce(p_details, '{}'::jsonb) || jsonb_build_object('source_event_id', p_source_event_id)
+    );
+    v_children := v_children || jsonb_build_array(v_child);
+    v_count := v_count + 1;
+  end loop;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'shop_id', p_shop_id,
+    'technician_id', p_technician_id,
+    'closed_line_count', v_count,
+    'source_event_id', p_source_event_id,
+    'transitions', v_children
+  );
+
+  insert into public.workforce_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id, result
+  ) values (
+    p_shop_id, 'pause_all_active_labor', p_operation_key, p_actor_user_id, v_result
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.pause_all_active_technician_labor_atomic(uuid,uuid,uuid,text,timestamptz,text,text,uuid,jsonb) from public, anon;
+grant execute on function public.pause_all_active_technician_labor_atomic(uuid,uuid,uuid,text,timestamptz,text,text,uuid,jsonb) to authenticated, service_role;
+
+do $$
+declare
+  v_missing text[] := array[]::text[];
+begin
+  if to_regclass('public.workforce_operation_keys') is null then
+    v_missing := array_append(v_missing, 'workforce_operation_keys');
+  end if;
+  if to_regprocedure('public.assign_work_order_line_technician_atomic(uuid,uuid,uuid,uuid,text)') is null then
+    v_missing := array_append(v_missing, 'assign_work_order_line_technician_atomic');
+  end if;
+  if to_regprocedure('public.apply_job_punch_transition_atomic(uuid,uuid,text,uuid,uuid,text,boolean,timestamptz,text,text,text,boolean,boolean,text,text,text,jsonb)') is null then
+    v_missing := array_append(v_missing, 'apply_job_punch_transition_atomic');
+  end if;
+  if to_regprocedure('public.pause_all_active_technician_labor_atomic(uuid,uuid,uuid,text,timestamptz,text,text,uuid,jsonb)') is null then
+    v_missing := array_append(v_missing, 'pause_all_active_technician_labor_atomic');
+  end if;
+  if to_regprocedure('public.work_order_is_financially_locked(uuid,uuid)') is null then
+    v_missing := array_append(v_missing, 'Phase 2 financial lock function');
+  end if;
+  if not exists (
+    select 1 from pg_indexes
+    where schemaname = 'public'
+      and tablename = 'workforce_operation_keys'
+      and indexdef ilike '%unique%shop_id%operation_name%operation_key%'
+  ) then
+    v_missing := array_append(v_missing, 'tenant operation-key uniqueness');
+  end if;
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public' and table_name = 'work_order_line_labor_segments'
+      and column_name in ('shop_id','work_order_id','work_order_line_id','technician_id','started_at','ended_at','pause_reason')
+    group by table_schema, table_name
+    having count(*) = 7
+  ) then
+    v_missing := array_append(v_missing, 'labor segment column contract');
+  end if;
+  if cardinality(v_missing) > 0 then
+    raise exception 'Phase 4 technician labor postcheck failed. Missing: %', array_to_string(v_missing, ', ');
+  end if;
+  raise notice 'Phase 4 technician labor lifecycle postcheck passed.';
+end;
+$$;
+
+notify pgrst, 'reload schema';
+commit;

--- a/tests/phase4-technician-labor-routes.test.ts
+++ b/tests/phase4-technician-labor-routes.test.ts
@@ -13,21 +13,21 @@ describe("Phase 4 technician labor route contract", () => {
       "app/api/work-orders/lines/[id]/finish/route.ts",
     ]) {
       const source = read(path);
-      expect(source).toContain("idempotency-key");
-      expect(source).toContain("stable idempotency key is required");
+      expect(source.toLowerCase()).toContain("idempotency-key");
+      expect(source.toLowerCase()).toMatch(/stable idempotency-key is required/);
     }
   });
 
   it("routes every job transition through the shared atomic command", () => {
     const helper = read("features/work-orders/server/applyJobPunchTransition.ts");
-    expect(helper).toContain('rpc("apply_job_punch_transition_atomic"');
+    expect(helper).toMatch(/\.rpc\(\s*"apply_job_punch_transition_atomic"/);
     expect(helper).not.toContain('.from("work_order_line_labor_segments").insert');
     expect(helper).not.toContain('.from("work_order_lines").update');
   });
 
   it("routes assignment through one canonical RPC with no follow-up edits", () => {
     const source = read("app/api/work-orders/assign-line/route.ts");
-    expect(source).toContain('rpc("assign_work_order_line_technician_atomic"');
+    expect(source).toMatch(/\.rpc\(\s*"assign_work_order_line_technician_atomic"/);
     expect(source).not.toContain('.from("work_order_lines").update');
     expect(source).not.toContain('.from("work_order_line_technicians").upsert');
     expect(source).not.toContain("not fatal for UI");
@@ -35,7 +35,7 @@ describe("Phase 4 technician labor route contract", () => {
 
   it("routes coordinated labor stopping through one RPC", () => {
     const source = read("features/work-orders/server/technicianJobLabor.ts");
-    expect(source).toContain('rpc("pause_all_active_technician_labor_atomic"');
+    expect(source).toMatch(/\.rpc\(\s*"pause_all_active_technician_labor_atomic"/);
     expect(source).not.toContain("closeActiveLaborSegments");
     expect(source).not.toContain("syncLinePunchMirrorFromSegments");
   });

--- a/tests/phase4-technician-labor-routes.test.ts
+++ b/tests/phase4-technician-labor-routes.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), "utf8");
+
+describe("Phase 4 technician labor route contract", () => {
+  it("requires stable operation keys on public punch routes", () => {
+    for (const path of [
+      "app/api/work-orders/lines/[id]/start/route.ts",
+      "app/api/work-orders/lines/[id]/pause/route.ts",
+      "app/api/work-orders/lines/[id]/resume/route.ts",
+      "app/api/work-orders/lines/[id]/finish/route.ts",
+    ]) {
+      const source = read(path);
+      expect(source).toContain("idempotency-key");
+      expect(source).toContain("stable idempotency key is required");
+    }
+  });
+
+  it("routes every job transition through the shared atomic command", () => {
+    const helper = read("features/work-orders/server/applyJobPunchTransition.ts");
+    expect(helper).toContain('rpc("apply_job_punch_transition_atomic"');
+    expect(helper).not.toContain('.from("work_order_line_labor_segments").insert');
+    expect(helper).not.toContain('.from("work_order_lines").update');
+  });
+
+  it("routes assignment through one canonical RPC with no follow-up edits", () => {
+    const source = read("app/api/work-orders/assign-line/route.ts");
+    expect(source).toContain('rpc("assign_work_order_line_technician_atomic"');
+    expect(source).not.toContain('.from("work_order_lines").update');
+    expect(source).not.toContain('.from("work_order_line_technicians").upsert');
+    expect(source).not.toContain("not fatal for UI");
+  });
+
+  it("routes coordinated labor stopping through one RPC", () => {
+    const source = read("features/work-orders/server/technicianJobLabor.ts");
+    expect(source).toContain('rpc("pause_all_active_technician_labor_atomic"');
+    expect(source).not.toContain("closeActiveLaborSegments");
+    expect(source).not.toContain("syncLinePunchMirrorFromSegments");
+  });
+
+  it("supports persisted event identities for coordinated retries", () => {
+    const source = read("features/work-orders/server/technicianJobLabor.ts");
+    expect(source).toContain("sourceEventId");
+    expect(source).toContain("breakPunchId");
+    expect(source).toContain("coordinated-labor-stop");
+  });
+});

--- a/tests/phase4-technician-labor-sql-contract.test.ts
+++ b/tests/phase4-technician-labor-sql-contract.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const read = (path: string) => readFileSync(resolve(process.cwd(), path), "utf8");
+const core = read("supabase/migrations/20260714050000_phase4_atomic_technician_labor.sql");
+const coordinated = read("supabase/migrations/20260714050100_phase4_coordinated_labor_and_postcheck.sql");
+
+describe("Phase 4 technician labor SQL contract", () => {
+  it("uses tenant-scoped operation-key uniqueness", () => {
+    expect(core).toContain("unique (shop_id, operation_name, operation_key)");
+    expect(core).toContain("workforce_operation_keys");
+  });
+
+  it("locks line, technician, shift, assignments, and labor rows before mutation", () => {
+    expect(core).toContain("from public.work_order_lines wol");
+    expect(core).toContain("for update");
+    expect(core).toContain("from public.work_order_line_technicians wolt");
+    expect(core).toContain("from public.work_order_line_labor_segments seg");
+    expect(core).toContain("from public.tech_shifts ts");
+  });
+
+  it("rejects cross-shop and null-shop open shifts", () => {
+    expect(core).toContain("SHIFT_SHOP_MISMATCH");
+    expect(core).toContain("ts.shop_id is null or ts.shop_id <> p_shop_id");
+    expect(core).toContain("ts.shop_id = p_shop_id");
+  });
+
+  it("enforces Phase 2 financial locks for assignment and labor", () => {
+    expect(core.match(/work_order_is_financially_locked/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(core).toContain("FINANCIALLY_LOCKED");
+  });
+
+  it("keeps the multi-tech table canonical and the primary column synchronized", () => {
+    expect(core).toContain("insert into public.work_order_line_technicians");
+    expect(core).toContain("assigned_tech_id = p_technician_id");
+    expect(core).toContain("additive_multi_tech_primary_mirror");
+  });
+
+  it("makes line state, labor segments, mirrors, inspection finalization, and audit one transaction", () => {
+    expect(core).toContain("create or replace function public.apply_job_punch_transition_atomic");
+    expect(core).toContain("insert into public.work_order_line_labor_segments");
+    expect(core).toContain("update public.work_order_line_labor_segments");
+    expect(core).toContain("punched_in_at = v_earliest");
+    expect(core).toContain("update public.inspections");
+    expect(core).toContain("insert into public.activity_logs");
+  });
+
+  it("serializes concurrent starts and prevents overlapping labor", () => {
+    expect(core).toContain("Technician already has active labor on this line");
+    expect(core).toContain("Technician already has an active job punch");
+    expect(core).toContain("p_allow_concurrent");
+  });
+
+  it("pauses all coordinated labor inside one database transaction", () => {
+    expect(coordinated).toContain("pause_all_active_technician_labor_atomic");
+    expect(coordinated).toContain("perform 1");
+    expect(coordinated).toContain("apply_job_punch_transition_atomic");
+    expect(coordinated).toContain("source_event_id");
+  });
+
+  it("installs a fail-fast compatibility postcheck", () => {
+    expect(coordinated).toContain("labor segment column contract");
+    expect(coordinated).toContain("Phase 4 technician labor postcheck failed");
+    expect(coordinated).toContain("Phase 4 technician labor lifecycle postcheck passed");
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 4 of the system-flow audit for technician assignment, shift eligibility, job punch transitions, labor-segment consistency, and coordinated break/lunch/end-day labor stopping.

### Core guarantees
- `work_order_line_technicians` is the canonical multi-tech assignment set
- `work_order_lines.assigned_tech_id` is synchronized as the primary-tech mirror
- Assignment writes are atomic and idempotent
- Start, resume, release hold, pause, and finish are one transactional RPC each
- Same-shop active shifts are required for start/resume
- Cross-shop and null-shop open shifts are rejected
- Line, shift, assignment, and labor rows are locked before recalculation
- Line status, labor segments, punch mirrors, inspections, assignments, and activity logs commit together
- Coordinated break/lunch/end-day labor stopping uses one database orchestrator
- Phase 2 financial locks remain enforced

### Migration order
1. `supabase/migrations/20260714050000_phase4_atomic_technician_labor.sql`
2. `supabase/migrations/20260714050100_phase4_coordinated_labor_and_postcheck.sql`

Do not run migrations until Vercel and GitHub validation are green.

Closes #993
Closes #994
Closes #995
Related: #992