### PR TITLE
Phase 5: Atomic quote approval and inspection import lifecycle

### DIFF
--- a/.github/workflows/phase-5-quote-lifecycle-validation.yml
+++ b/.github/workflows/phase-5-quote-lifecycle-validation.yml
@@ -1,0 +1,32 @@
+name: Phase 5 Quote Lifecycle Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/work-orders/quotes/**"
+      - "app/api/work-orders/import-from-inspection/**"
+      - "app/api/work-orders/[id]/_lib/reviewWorkOrder.ts"
+      - "features/work-orders/server/workOrderQuoteLineApproval.ts"
+      - "features/work-orders/lib/work-orders/**"
+      - "supabase/migrations/20260715060*.sql"
+      - "tests/phase5-*.test.ts"
+      - ".github/workflows/phase-5-quote-lifecycle-validation.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm exec eslint 'app/api/work-orders/quotes/[id]/approval-decision/route.ts' app/api/work-orders/import-from-inspection/route.ts 'app/api/work-orders/[id]/_lib/reviewWorkOrder.ts' features/work-orders/server/workOrderQuoteLineApproval.ts features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts features/work-orders/lib/work-orders/inspectionFindingEligibility.ts tests/phase5-quote-lifecycle-sql-contract.test.ts tests/phase5-quote-lifecycle-routes.test.ts
+      - run: pnpm exec vitest run tests/phase5-quote-lifecycle-sql-contract.test.ts tests/phase5-quote-lifecycle-routes.test.ts

--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -7,7 +7,6 @@ import { isReviewableQuoteLine } from "@/features/work-orders/lib/quotes/reviewa
 type DB = Database;
 
 export type ReviewIssue = { kind: string; lineId?: string; message: string };
-
 export type ReviewKind = "ai_review" | "invoice_review";
 
 type Args = {
@@ -33,32 +32,48 @@ const BILLABLE_PART_REQUEST_ITEM_STATUSES = new Set([
 function numericValue(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string") {
-    const n = Number(value);
-    return Number.isFinite(n) ? n : null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
   }
   return null;
 }
 
-
 function hasMeaningfulJson(value: unknown): boolean {
   if (value == null) return false;
   if (Array.isArray(value)) return value.length > 0;
-  if (typeof value === "object") return Object.keys(value as Record<string, unknown>).length > 0;
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
   if (typeof value === "string") return value.trim().length > 0;
   return Boolean(value);
 }
 
+function isInfoLine(line: Record<string, unknown>): boolean {
+  const lineType = String(line.line_type ?? "").trim().toLowerCase();
+  const jobType = String(line.job_type ?? "").trim().toLowerCase();
+  return lineType === "info" || lineType === "note" || jobType === "info";
+}
+
 function lineRequiresParts(line: Record<string, unknown>): boolean {
-  if (line.no_parts_required === true) return false;
+  if (line.no_parts_required === true || isInfoLine(line)) return false;
   const jobType = String(line.job_type ?? "").trim().toLowerCase();
   const lineType = String(line.line_type ?? "").trim().toLowerCase();
-  if (jobType === "inspection" || jobType === "diagnosis" || lineType === "inspection" || lineType === "diagnostic") {
-    return line.parts_required === true || hasMeaningfulJson(line.parts_required) || hasMeaningfulJson(line.parts_needed);
+  if (
+    jobType === "inspection" ||
+    jobType === "diagnosis" ||
+    lineType === "inspection" ||
+    lineType === "diagnostic"
+  ) {
+    return (
+      line.parts_required === true ||
+      hasMeaningfulJson(line.parts_required) ||
+      hasMeaningfulJson(line.parts_needed)
+    );
   }
   if (line.parts_required === true) return true;
   if (hasMeaningfulJson(line.parts_required)) return true;
   if (hasMeaningfulJson(line.parts_needed)) return true;
-  if (typeof line.parts === "string" && line.parts.trim().length > 0) return true;
+  if (typeof line.parts === "string" && line.parts.trim()) return true;
   if (line.parts_verification_required === true) return true;
 
   const text = [
@@ -70,25 +85,26 @@ function lineRequiresParts(line: Record<string, unknown>): boolean {
     line.job_type,
     line.service_code,
   ]
-    .map((v) => String(v ?? "").toLowerCase())
+    .map((value) => String(value ?? "").toLowerCase())
     .join(" ");
 
-  const serviceNeedsParts =
+  if (
     /\b(oil|filter|air filter|cabin filter|fuel filter|brake|pads?|rotors?|battery|tire|spark plug|belt|hose|coolant|transmission fluid|differential fluid|wiper)\b/.test(
       text,
-    );
-
-  if (serviceNeedsParts) return true;
+    )
+  ) {
+    return true;
+  }
 
   const status = String(line.status ?? "").trim().toLowerCase();
   return status === "pending_parts" || status === "awaiting_parts";
 }
 
 function partRequestItemHasBillablePrice(row: Record<string, unknown>): boolean {
-  const quotedPrice = numericValue(row.quoted_price);
-  const unitPrice = numericValue(row.unit_price);
-  const unitCost = numericValue(row.unit_cost);
-  const price = quotedPrice ?? unitPrice ?? unitCost;
+  const price =
+    numericValue(row.quoted_price) ??
+    numericValue(row.unit_price) ??
+    numericValue(row.unit_cost);
   return price != null && price > 0;
 }
 
@@ -107,85 +123,77 @@ export async function reviewWorkOrder({
   shopId,
   kind,
 }: Args): Promise<{ ok: boolean; issues: ReviewIssue[] }> {
-  const { data: allocRows } = await supabase
+  const hasBillablePartsByLine = new Map<string, boolean>();
+
+  const { data: allocationRows } = await supabase
     .from("work_order_part_allocations")
     .select("work_order_line_id, qty, unit_cost")
     .eq("work_order_id", workOrderId)
     .eq("shop_id", shopId);
-  const hasBillablePartsByLine = new Map<string, boolean>();
-  for (const row of allocRows ?? []) {
+  for (const row of allocationRows ?? []) {
     const lineId = typeof row.work_order_line_id === "string" ? row.work_order_line_id : "";
-    const qty = Number(row.qty ?? 0);
-    const unitCostRaw = (row as Record<string, unknown>).unit_cost;
-    const unitCost =
-      typeof unitCostRaw === "number"
-        ? unitCostRaw
-        : typeof unitCostRaw === "string"
-          ? Number(unitCostRaw)
-          : null;
-    // Fallback behavior: if unit_cost is unavailable/non-numeric in this row,
-    // preserve existing qty-only billable detection to avoid false negatives.
-    const billableByQtyAndUnitCost =
-      qty > 0 && unitCost !== null && Number.isFinite(unitCost) && unitCost > 0;
-    const billableByQtyFallback = qty > 0 && unitCost === null;
-    if (lineId && (billableByQtyAndUnitCost || billableByQtyFallback)) {
+    const qty = numericValue(row.qty) ?? 0;
+    const unitCost = numericValue(
+      (row as Record<string, unknown>).unit_cost,
+    );
+    if (lineId && qty > 0 && (unitCost == null || unitCost > 0)) {
       hasBillablePartsByLine.set(lineId, true);
     }
   }
-
 
   const { data: stagedPartRows } = await supabase
     .from("work_order_parts")
     .select("work_order_line_id, quantity, unit_price, total_price")
     .eq("work_order_id", workOrderId)
     .eq("shop_id", shopId);
-
   for (const row of stagedPartRows ?? []) {
     const record = row as Record<string, unknown>;
     const lineId = typeof row.work_order_line_id === "string" ? row.work_order_line_id : "";
-    const qty = numericValue(record.quantity) ?? 0;
+    const quantity = numericValue(record.quantity) ?? 0;
     const unitPrice = numericValue(record.unit_price);
     const totalPrice = numericValue(record.total_price);
-    if (lineId && qty > 0 && ((unitPrice != null && unitPrice > 0) || (totalPrice != null && totalPrice > 0))) {
+    if (
+      lineId &&
+      quantity > 0 &&
+      ((unitPrice != null && unitPrice > 0) ||
+        (totalPrice != null && totalPrice > 0))
+    ) {
       hasBillablePartsByLine.set(lineId, true);
     }
   }
 
-  const { data: linkedPartRequestRows } = await supabase
+  const { data: requestItemRows } = await supabase
     .from("part_request_items")
-    .select("work_order_line_id, quote_line_id, status, approved, qty, qty_requested, qty_approved, quoted_price, unit_price, unit_cost")
+    .select(
+      "work_order_line_id, quote_line_id, status, approved, qty, qty_requested, qty_approved, quoted_price, unit_price, unit_cost",
+    )
     .eq("shop_id", shopId)
     .eq("work_order_id", workOrderId)
     .not("work_order_line_id", "is", null);
-
-  for (const row of linkedPartRequestRows ?? []) {
+  for (const row of requestItemRows ?? []) {
     const record = row as Record<string, unknown>;
     const lineId = typeof row.work_order_line_id === "string" ? row.work_order_line_id : "";
     const quoteLineId = typeof row.quote_line_id === "string" ? row.quote_line_id : "";
     const status = String(row.status ?? "").trim().toLowerCase();
-    const statusIsBillable = BILLABLE_PART_REQUEST_ITEM_STATUSES.has(status);
-    const approved = row.approved === true;
-
     if (
       lineId &&
       quoteLineId &&
-      (statusIsBillable || approved) &&
+      (BILLABLE_PART_REQUEST_ITEM_STATUSES.has(status) || row.approved === true) &&
       partRequestItemQuantity(record) > 0 &&
       partRequestItemHasBillablePrice(record)
     ) {
       hasBillablePartsByLine.set(lineId, true);
     }
   }
-  const { data: wo, error: woErr } = await supabase
+
+  const { data: workOrder, error: workOrderError } = await supabase
     .from("work_orders")
     .select("*")
     .eq("id", workOrderId)
     .eq("shop_id", shopId)
     .maybeSingle();
-
-  if (woErr) throw woErr;
-
-  if (!wo) {
+  if (workOrderError) throw workOrderError;
+  if (!workOrder) {
     return {
       ok: false,
       issues: [{ kind: "missing_wo", message: "WO not found" }],
@@ -199,28 +207,28 @@ export async function reviewWorkOrder({
     .maybeSingle<{ labor_rate: number | null }>();
   const shopLaborRate = numericValue(shop?.labor_rate);
 
-  const { data: lines, error: lnErr } = await supabase
+  const { data: lines, error: lineError } = await supabase
     .from("work_order_lines")
     .select("*")
-    .eq("work_order_id", wo.id)
+    .eq("work_order_id", workOrder.id)
     .eq("shop_id", shopId);
-
-  if (lnErr) throw lnErr;
+  if (lineError) throw lineError;
 
   const issues: ReviewIssue[] = [];
-
-  const { data: quoteLines, error: quoteErr } = await supabase
+  const { data: quoteLines, error: quoteError } = await supabase
     .from("work_order_quote_lines")
     .select("id,status,stage,approved_at,declined_at,work_order_line_id")
-    .eq("work_order_id", wo.id)
+    .eq("work_order_id", workOrder.id)
     .eq("shop_id", shopId);
-  if (quoteErr) throw quoteErr;
+  if (quoteError) throw quoteError;
 
-  const activePendingQuoteCount = (quoteLines ?? []).filter((line) => isReviewableQuoteLine(line)).length;
-  if (activePendingQuoteCount > 0) {
+  const pendingQuoteCount = (quoteLines ?? []).filter((line) =>
+    isReviewableQuoteLine(line),
+  ).length;
+  if (pendingQuoteCount > 0) {
     issues.push({
       kind: "pending_quote_lines",
-      message: `${activePendingQuoteCount} pending quote line(s) must be resolved before invoicing.`,
+      message: `${pendingQuoteCount} pending quote line(s) must be resolved before invoicing.`,
     });
   }
 
@@ -228,59 +236,65 @@ export async function reviewWorkOrder({
     issues.push({ kind: "no_lines", message: "Work order has no lines" });
   }
 
-  for (const ln of lines ?? []) {
-    const st = String(ln.status ?? "awaiting").toLowerCase();
+  const actionableLines = (lines ?? []).filter(
+    (line) => !isInfoLine(line as Record<string, unknown>),
+  );
+  if ((lines?.length ?? 0) > 0 && actionableLines.length === 0) {
+    issues.push({
+      kind: "no_billable_lines",
+      message: "Work order has no billable or actionable lines.",
+    });
+  }
 
-    // invoice: allow completed-like statuses
-    // ai-review: keep stricter if you want (right now they match)
+  for (const line of actionableLines) {
+    const record = line as Record<string, unknown>;
+    const status = String(line.status ?? "awaiting").toLowerCase();
     const completedLike =
-      st === "completed" || st === "ready_to_invoice" || st === "invoiced";
-
+      status === "completed" ||
+      status === "ready_to_invoice" ||
+      status === "invoiced";
     if (!completedLike) {
       issues.push({
         kind: "line_not_completed",
-        lineId: ln.id,
-        message: `Line not completed: ${ln.description ?? ln.complaint ?? "job"}`,
+        lineId: line.id,
+        message: `Line not completed: ${line.description ?? line.complaint ?? "job"}`,
       });
     }
 
-    // Optional “marked N/A” booleans if you add them later
-    const causeNA = (ln as Record<string, unknown>)["cause_marked_na"] === true;
-    const correctionNA =
-      (ln as Record<string, unknown>)["correction_marked_na"] === true;
-
-    if (!ln.cause && !causeNA) {
+    const causeNA = record.cause_marked_na === true;
+    const correctionNA = record.correction_marked_na === true;
+    if (!line.cause && !causeNA) {
       issues.push({
         kind: "missing_cause",
-        lineId: ln.id,
-        message: `Missing cause: ${ln.description ?? "job"}`,
+        lineId: line.id,
+        message: `Missing cause: ${line.description ?? "job"}`,
       });
     }
-
-    if (!ln.correction && !correctionNA) {
+    if (!line.correction && !correctionNA) {
       issues.push({
         kind: "missing_correction",
-        lineId: ln.id,
-        message: `Missing correction: ${ln.description ?? "job"}`,
+        lineId: line.id,
+        message: `Missing correction: ${line.description ?? "job"}`,
       });
     }
 
-    const noCharge = (ln as Record<string, unknown>)["no_charge"] === true;
-    const laborNA = (ln as Record<string, unknown>)["labor_marked_na"] === true;
-    const hasBillableParts = hasBillablePartsByLine.get(String(ln.id)) === true;
-    if (lineRequiresParts(ln as Record<string, unknown>) && !hasBillableParts) {
+    const noCharge = record.no_charge === true;
+    const laborNA = record.labor_marked_na === true;
+    const hasBillableParts = hasBillablePartsByLine.get(String(line.id)) === true;
+    if (lineRequiresParts(record) && !hasBillableParts) {
       issues.push({
         kind: "missing_required_parts",
-        lineId: ln.id,
-        message: `Required parts are missing from line: ${ln.description ?? ln.complaint ?? "job"}`,
+        lineId: line.id,
+        message: `Required parts are missing from line: ${line.description ?? line.complaint ?? "job"}`,
       });
     }
 
-    const laborHours = numericValue(ln.labor_time) ?? 0;
-    const lineLaborRate = numericValue((ln as Record<string, unknown>)["labor_rate"]);
-    const effectiveLaborRate = lineLaborRate && lineLaborRate > 0 ? lineLaborRate : shopLaborRate ?? 0;
-    const explicitLaborTotal = numericValue((ln as Record<string, unknown>)["labor_total"]);
-    const priceEstimate = numericValue((ln as Record<string, unknown>)["price_estimate"]);
+    const laborHours = numericValue(line.labor_time) ?? 0;
+    const lineLaborRate = numericValue(record.labor_rate);
+    const effectiveLaborRate =
+      lineLaborRate && lineLaborRate > 0 ? lineLaborRate : shopLaborRate ?? 0;
+    const explicitLaborTotal = numericValue(record.labor_total);
+    const priceEstimate = numericValue(record.price_estimate);
     const laborTotal =
       explicitLaborTotal != null && explicitLaborTotal > 0
         ? explicitLaborTotal
@@ -288,17 +302,30 @@ export async function reviewWorkOrder({
           ? priceEstimate
           : laborHours * effectiveLaborRate;
 
-    if (!noCharge && !laborNA && laborHours > 0 && !(laborTotal > 0) && !hasBillableParts) {
+    if (
+      !noCharge &&
+      !laborNA &&
+      laborHours > 0 &&
+      !(laborTotal > 0) &&
+      !hasBillableParts
+    ) {
       issues.push({
         kind: "invalid_labor_total",
-        lineId: ln.id,
-        message: `Labor pricing is missing or invalid for line: ${ln.description ?? ln.complaint ?? "job"}`,
+        lineId: line.id,
+        message: `Labor pricing is missing or invalid for line: ${line.description ?? line.complaint ?? "job"}`,
       });
-    } else if (!noCharge && !laborNA && laborHours >= 1 && laborTotal > 0 && laborTotal <= laborHours + 0.01 && effectiveLaborRate <= 1) {
+    } else if (
+      !noCharge &&
+      !laborNA &&
+      laborHours >= 1 &&
+      laborTotal > 0 &&
+      laborTotal <= laborHours + 0.01 &&
+      effectiveLaborRate <= 1
+    ) {
       issues.push({
         kind: "suspicious_labor_total",
-        lineId: ln.id,
-        message: `Labor total looks like hours were used as dollars for line: ${ln.description ?? ln.complaint ?? "job"}`,
+        lineId: line.id,
+        message: `Labor total looks like hours were used as dollars for line: ${line.description ?? line.complaint ?? "job"}`,
       });
     }
 
@@ -306,72 +333,62 @@ export async function reviewWorkOrder({
     if (laborRequired && !(laborHours > 0)) {
       issues.push({
         kind: "no_labor_time",
-        lineId: ln.id,
-        message: `No labor time set: ${ln.description ?? "job"}`,
+        lineId: line.id,
+        message: `No labor time set: ${line.description ?? "job"}`,
       });
     }
   }
 
-  if (!wo.customer_id) {
+  if (!workOrder.customer_id) {
     issues.push({ kind: "missing_customer", message: "Missing customer on WO" });
   } else {
-    const { data: cust, error: cErr } = await supabase
+    const { data: customer, error: customerError } = await supabase
       .from("customers")
       .select("email")
-      .eq("id", wo.customer_id)
+      .eq("id", workOrder.customer_id)
       .eq("shop_id", shopId)
       .maybeSingle();
-
-    if (cErr) throw cErr;
-
-    if (!cust?.email) {
+    if (customerError) throw customerError;
+    if (!customer?.email) {
       issues.push({ kind: "missing_email", message: "Customer has no email" });
     }
   }
 
   const ok = issues.length === 0;
-
   if (ok) {
     try {
       let vehicle = null;
-      if (wo.vehicle_id) {
+      if (workOrder.vehicle_id) {
         const { data: vehicleRow } = await supabase
           .from("vehicles")
           .select("id, year, make, model")
-          .eq("id", wo.vehicle_id)
+          .eq("id", workOrder.vehicle_id)
           .eq("shop_id", shopId)
           .maybeSingle();
         vehicle = vehicleRow ?? null;
       }
-
       await seedWorkOrderIntelligenceFromReview({
         supabase,
-        workOrder: wo,
+        workOrder,
         lines,
         vehicle,
         source: kind,
       });
-    } catch (intelligenceErr) {
-      console.warn("[reviewWorkOrder] intelligence seed failed:", intelligenceErr);
+    } catch (error) {
+      console.warn("[reviewWorkOrder] intelligence seed failed:", error);
     }
   }
 
-  // Training hook (never block)
-  if (wo.shop_id) {
+  if (workOrder.shop_id) {
     try {
       await recordWorkOrderTraining({
-        shopId: wo.shop_id,
-        workOrderId: wo.id,
+        shopId: workOrder.shop_id,
+        workOrderId: workOrder.id,
         vehicleYmm: null,
-        payload: {
-          kind,
-          ok,
-          issue_count: issues.length,
-          issues,
-        },
+        payload: { kind, ok, issue_count: issues.length, issues },
       });
-    } catch (trainErr) {
-      console.warn(`AI training (${kind}) failed:`, trainErr);
+    } catch (error) {
+      console.warn(`AI training (${kind}) failed:`, error);
     }
   }
 

--- a/app/api/work-orders/import-from-inspection/route.ts
+++ b/app/api/work-orders/import-from-inspection/route.ts
@@ -1,4 +1,3 @@
-// /app/api/work-orders/import-from-inspection/route.ts (FULL FILE REPLACEMENT)
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
@@ -8,131 +7,169 @@ import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { insertPrioritizedJobsFromInspection } from "@/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection";
 
-
 type ImportBody = {
-  workOrderId: string;
-  inspectionId: string;
+  workOrderId?: string;
+  inspectionId?: string;
   vehicleId?: string | null;
   autoGenerateParts?: boolean;
+  operationKey?: string;
+  idempotencyKey?: string;
 };
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
 
 export async function POST(req: Request) {
   const supabase = createServerSupabaseRoute();
 
   try {
-    const body = (await req.json()) as Partial<ImportBody>;
-    const { workOrderId, inspectionId, vehicleId, autoGenerateParts } = body;
+    const body = (await req.json().catch(() => null)) as ImportBody | null;
+    const workOrderId = clean(body?.workOrderId);
+    const inspectionId = clean(body?.inspectionId);
+    const requestedVehicleId = clean(body?.vehicleId) || null;
+    const operationKey =
+      req.headers.get("Idempotency-Key")?.trim() ||
+      body?.operationKey?.trim() ||
+      body?.idempotencyKey?.trim() ||
+      "";
 
     if (!workOrderId || !inspectionId) {
-      return NextResponse.json({ error: "Missing workOrderId or inspectionId" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Missing workOrderId or inspectionId" },
+        { status: 400 },
+      );
+    }
+    if (!operationKey) {
+      return NextResponse.json(
+        { error: "A stable Idempotency-Key is required." },
+        { status: 400 },
+      );
     }
 
     const {
       data: { user },
-      error: authErr,
+      error: authError,
     } = await supabase.auth.getUser();
-
-    if (authErr || !user) {
+    if (authError || !user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { data: profile, error: profileErr } = await supabase
+    const { data: profile, error: profileError } = await supabase
       .from("profiles")
       .select("shop_id")
       .eq("id", user.id)
       .maybeSingle<{ shop_id: string | null }>();
-
-    if (profileErr || !profile?.shop_id) {
-      return NextResponse.json({ error: "Profile for current user not found." }, { status: 403 });
+    if (profileError || !profile?.shop_id) {
+      return NextResponse.json(
+        { error: "Profile for current user not found." },
+        { status: 403 },
+      );
     }
 
-    // Ensure requester can see the WO (RLS enforced) and the WO is scoped to the current shop.
-    const { data: wo, error: woErr } = await supabase
+    const { data: workOrder, error: workOrderError } = await supabase
       .from("work_orders")
       .select("id, shop_id, vehicle_id, status")
       .eq("id", workOrderId)
       .eq("shop_id", profile.shop_id)
-      .maybeSingle<{ id: string; shop_id: string | null; vehicle_id: string | null; status: string | null }>();
-
-    if (woErr) {
+      .maybeSingle<{
+        id: string;
+        shop_id: string | null;
+        vehicle_id: string | null;
+        status: string | null;
+      }>();
+    if (workOrderError) {
       return NextResponse.json(
-        { error: `Failed to load work order: ${woErr.message}` },
+        { error: `Failed to load work order: ${workOrderError.message}` },
         { status: 400 },
       );
     }
-    if (!wo) {
+    if (!workOrder) {
       return NextResponse.json({ error: "Work order not found." }, { status: 404 });
     }
 
-    const { data: inspection, error: inspectionErr } = await supabase
+    const { data: inspection, error: inspectionError } = await supabase
       .from("inspections")
-      .select("id, shop_id")
+      .select("id, shop_id, work_order_id, work_order_line_id")
       .eq("id", inspectionId)
-      .maybeSingle<{ id: string; shop_id: string | null }>();
-
-    if (inspectionErr) {
+      .eq("shop_id", profile.shop_id)
+      .maybeSingle<{
+        id: string;
+        shop_id: string | null;
+        work_order_id: string | null;
+        work_order_line_id: string | null;
+      }>();
+    if (inspectionError) {
       return NextResponse.json(
-        { error: `Failed to load inspection: ${inspectionErr.message}` },
+        { error: `Failed to load inspection: ${inspectionError.message}` },
         { status: 400 },
       );
     }
-
     if (!inspection) {
       return NextResponse.json({ error: "Inspection not found." }, { status: 404 });
     }
-
-    if (wo.shop_id !== profile.shop_id) {
+    if (!inspection.work_order_id || !inspection.work_order_line_id) {
       return NextResponse.json(
-        { error: "Work order does not belong to the current user's shop." },
-        { status: 403 },
+        {
+          error:
+            "Inspection is not anchored to a work order and requires administrative reconciliation.",
+        },
+        { status: 409 },
       );
     }
-
-    const blockedStatuses = new Set(["cancelled", "canceled", "invoiced", "closed"]);
-    if (blockedStatuses.has((wo.status ?? "").toLowerCase())) {
+    if (inspection.work_order_id !== workOrder.id) {
       return NextResponse.json(
-        { error: "Cannot import inspection findings into a cancelled, closed, or invoiced work order." },
+        { error: "Inspection belongs to a different work order." },
+        { status: 409 },
+      );
+    }
+    if (
+      requestedVehicleId &&
+      requestedVehicleId !== workOrder.vehicle_id
+    ) {
+      return NextResponse.json(
+        { error: "Requested vehicle does not match the work order." },
         { status: 409 },
       );
     }
 
-    if (!inspection.shop_id || inspection.shop_id !== wo.shop_id) {
-      return NextResponse.json(
-        { error: "Inspection does not belong to this work order's shop." },
-        { status: 403 },
-      );
-    }
-
-    const res = await insertPrioritizedJobsFromInspection({
+    const result = await insertPrioritizedJobsFromInspection({
       supabase,
       inspectionId,
       workOrderId,
-      vehicleId: vehicleId || wo.vehicle_id || null,
+      vehicleId: requestedVehicleId,
       userId: user.id,
-      autoGenerateParts: autoGenerateParts ?? true,
+      autoGenerateParts: body?.autoGenerateParts ?? true,
+      operationKey,
     });
 
-    if (!res.ok) {
-      return NextResponse.json({ error: res.error }, { status: 400 });
+    if (!result.ok) {
+      const status =
+        result.error.includes("MISMATCH") ||
+        result.error.includes("UNANCHORED") ||
+        result.error.includes("FINANCIALLY_LOCKED")
+          ? 409
+          : 400;
+      return NextResponse.json({ error: result.error }, { status });
     }
 
     return NextResponse.json({
       ok: true,
-      message: res.message,
-      quoteLineIds: res.quoteLineIds,
-      createdQuoteLines: res.createdQuoteLines,
-      skippedDuplicates: res.skippedDuplicates,
-      createdPartRequestIds: res.createdPartRequestIds,
-      insertedCount: res.insertedCount,
-      partsRequestsCount: res.partsRequestsCount,
-      skippedCount: res.skippedCount,
-      skippedPartsRequestsCount: res.skippedPartsRequestsCount,
-      insertedJobIds: res.insertedJobIds,
-      workOrderLineIds: res.workOrderLineIds,
+      message: result.message,
+      quoteLineIds: result.quoteLineIds,
+      createdQuoteLines: result.createdQuoteLines,
+      skippedDuplicates: result.skippedDuplicates,
+      createdPartRequestIds: result.createdPartRequestIds,
+      insertedCount: result.insertedCount,
+      partsRequestsCount: result.partsRequestsCount,
+      skippedCount: result.skippedCount,
+      skippedPartsRequestsCount: result.skippedPartsRequestsCount,
+      insertedJobIds: result.insertedJobIds,
+      workOrderLineIds: result.workOrderLineIds,
+      idempotent: result.idempotent === true,
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    // eslint-disable-next-line no-console
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
     console.error("import-from-inspection error:", message);
     return NextResponse.json(
       { error: "Failed to import inspection jobs." },

--- a/app/api/work-orders/quotes/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/quotes/[id]/approval-decision/route.ts
@@ -18,10 +18,12 @@ type Body = {
   lineIds?: string[];
   workOrderId?: string | null;
   declineRemaining?: boolean;
+  operationKey?: string;
+  idempotencyKey?: string;
 };
 
-function safeTrim(v: unknown): string {
-  return typeof v === "string" ? v.trim() : "";
+function safeTrim(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function serviceSupabase() {
@@ -31,21 +33,18 @@ function serviceSupabase() {
   );
 }
 
-export async function POST(req: NextRequest, ctx: RouteContext) {
+export async function POST(req: NextRequest, context: RouteContext) {
   const routeSupabase = createServerSupabaseRoute();
-  const { id } = await ctx.params;
+  const { id } = await context.params;
   const routeQuoteLineId = safeTrim(id);
 
   const {
     data: { user },
-    error: userErr,
+    error: userError,
   } = await routeSupabase.auth.getUser();
 
-  if (userErr || !user) {
-    return NextResponse.json(
-      { ok: false, error: "Unauthorized" },
-      { status: 401 },
-    );
+  if (userError || !user) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
   }
 
   const body = (await req.json().catch(() => null)) as Body | null;
@@ -57,6 +56,11 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
   const quoteLineIds = [
     ...new Set([routeQuoteLineId, ...requestedLineIds].filter(Boolean)),
   ];
+  const operationKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    body?.operationKey?.trim() ||
+    body?.idempotencyKey?.trim() ||
+    "";
 
   if (
     !workOrderId ||
@@ -68,20 +72,25 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
       { status: 400 },
     );
   }
+  if (!operationKey) {
+    return NextResponse.json(
+      { ok: false, error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
 
-  const { data: customer, error: customerErr } = await routeSupabase
+  const { data: customer, error: customerError } = await routeSupabase
     .from("customers")
     .select("id")
     .eq("user_id", user.id)
     .maybeSingle();
 
-  if (customerErr) {
+  if (customerError) {
     return NextResponse.json(
-      { ok: false, error: customerErr.message },
+      { ok: false, error: customerError.message },
       { status: 400 },
     );
   }
-
   if (!customer?.id) {
     return NextResponse.json(
       { ok: false, error: "Customer profile not found" },
@@ -89,110 +98,54 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
     );
   }
 
-  const { data: workOrder, error: workOrderErr } = await routeSupabase
+  const { data: workOrder, error: workOrderError } = await routeSupabase
     .from("work_orders")
     .select("id, shop_id, customer_id")
     .eq("id", workOrderId)
     .eq("customer_id", customer.id)
     .maybeSingle();
 
-  if (workOrderErr) {
+  if (workOrderError) {
     return NextResponse.json(
-      { ok: false, error: workOrderErr.message },
+      { ok: false, error: workOrderError.message },
       { status: 400 },
     );
   }
-
   if (
     !workOrder?.id ||
     !workOrder.shop_id ||
     workOrder.customer_id !== customer.id
   ) {
-    return NextResponse.json(
-      { ok: false, error: "Quote not found" },
-      { status: 404 },
-    );
+    return NextResponse.json({ ok: false, error: "Quote not found" }, { status: 404 });
   }
 
-  const supabaseAdmin = serviceSupabase();
   const result = await applyWorkOrderQuoteLineDecision({
-    supabase: supabaseAdmin,
+    supabase: serviceSupabase(),
     quoteLineIds,
     workOrderId: workOrder.id,
     shopId: workOrder.shop_id,
     customerId: customer.id,
     actorUserId: user.id,
     decision,
+    declineRemaining: body?.declineRemaining === true,
+    operationKey,
   });
 
   if (!result.ok) {
+    const status = result.error?.includes("FINANCIALLY_LOCKED") ? 409 : 400;
     return NextResponse.json(
       { ok: false, error: result.error ?? "Unable to update quote decision" },
-      { status: 400 },
+      { status },
     );
-  }
-
-  if (body?.declineRemaining && decision === "approve") {
-    const { data: remaining, error: remainingErr } = await supabaseAdmin
-      .from("work_order_quote_lines")
-      .select("id, status")
-      .eq("shop_id", workOrder.shop_id)
-      .eq("work_order_id", workOrder.id);
-
-    if (remainingErr) {
-      return NextResponse.json(
-        { ok: false, error: remainingErr.message },
-        { status: 400 },
-      );
-    }
-
-    const selectedIds = new Set(quoteLineIds);
-    const remainingIds = (remaining ?? [])
-      .filter(
-        (line) =>
-          !selectedIds.has(line.id) &&
-          safeTrim(line.status).toLowerCase() === "sent",
-      )
-      .map((line) => line.id)
-      .filter(Boolean);
-    if (remainingIds.length > 0) {
-      const declineResult = await applyWorkOrderQuoteLineDecision({
-        supabase: supabaseAdmin,
-        quoteLineIds: remainingIds,
-        workOrderId: workOrder.id,
-        shopId: workOrder.shop_id,
-        customerId: customer.id,
-        actorUserId: user.id,
-        decision: "decline",
-      });
-
-      if (!declineResult.ok) {
-        return NextResponse.json(
-          {
-            ok: false,
-            error:
-              declineResult.error ?? "Unable to decline remaining quote lines",
-          },
-          { status: 400 },
-        );
-      }
-
-      return NextResponse.json({
-        ok: true,
-        quoteLineIds,
-        workOrderLineIds: result.workOrderLineIds,
-        declinedRemainingQuoteLineIds: remainingIds,
-        approvalState: declineResult.approvalState,
-        partRelink: result.partRelink,
-      });
-    }
   }
 
   return NextResponse.json({
     ok: true,
     quoteLineIds,
     workOrderLineIds: result.workOrderLineIds,
+    declinedRemainingQuoteLineIds: result.declinedRemainingQuoteLineIds,
     approvalState: result.approvalState,
     partRelink: result.partRelink,
+    idempotent: result.idempotent === true,
   });
 }

--- a/docs/phase-5-quote-approval-runbook.md
+++ b/docs/phase-5-quote-approval-runbook.md
@@ -1,0 +1,44 @@
+# Phase 5 Quote and Inspection Lifecycle Runbook
+
+## Migration order
+
+1. `supabase/migrations/20260715060000_phase5_atomic_quote_decisions.sql`
+2. `supabase/migrations/20260715060100_phase5_atomic_inspection_quote_import.sql`
+3. `supabase/migrations/20260715060200_phase5_quote_lifecycle_postcheck.sql`
+
+Deploy the application changes only after all three migrations succeed.
+
+The final migration must print:
+
+```text
+Phase 5 quote and inspection lifecycle postcheck passed.
+```
+
+## Required foundation
+
+- Phase 2 financial lifecycle protection is applied.
+- Phase 3 canonical parts lifecycle is applied.
+- Phase 4 technician labor lifecycle is applied.
+- Inspection work-order anchor columns exist.
+- Quote-to-parts linkage columns exist.
+
+## Validation checklist
+
+1. Send a quote containing at least two customer-visible quote lines.
+2. Approve one selected line and decline the remaining sent lines.
+3. Confirm the approved repair is created with `status = awaiting` and `approval_state = approved`.
+4. Confirm no active labor segment or active punch timestamp is created by customer approval.
+5. Confirm the remaining sent quote lines are declined in the same response.
+6. Confirm linked parts requests and items point to the materialized repair line.
+7. Retry with the same operation key and confirm no duplicate repair line is created.
+8. Confirm an invoiced work order rejects the decision with `FINANCIALLY_LOCKED`.
+9. Import an inspection anchored to the same work order and confirm quote lines and required parts appear together.
+10. Retry the import with the same operation key and confirm the same committed IDs are returned.
+11. Confirm imports are rejected for a different work order, an unanchored inspection, or a conflicting vehicle ID.
+12. Confirm OK and N/A observations do not enter Quote Review from keyword matching.
+13. Confirm completed billable work plus an info line can pass readiness.
+14. Confirm an info-only work order fails with `no_billable_lines`.
+
+## Application fallback
+
+The migrations are additive. A previous application build can be redeployed while the new functions and operation records remain in place. Operation records should be retained because they provide retry safety and audit history.

--- a/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
+++ b/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
@@ -5,6 +5,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database, Json } from "@shared/types/types/supabase";
 import { estimateLabor } from "@ai/lib/ai/estimateLabor";
 import { normalizeLaborHoursInput } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+import { isInspectionFindingEligible } from "@/features/work-orders/lib/work-orders/inspectionFindingEligibility";
 import {
   createCanonicalQuoteLines,
   type CanonicalQuoteItem,
@@ -12,7 +13,6 @@ import {
 } from "@/features/work-orders/lib/work-orders/canonicalQuoteLines";
 
 type DB = Database;
-
 type InspectionRow = DB["public"]["Tables"]["inspections"]["Row"];
 
 type InspectionItem = {
@@ -78,9 +78,7 @@ export type ImportFromInspectionResult =
       createdPartRequestIds: string[];
       skippedPartsRequestsCount: number;
       message: string;
-      /** @deprecated Legacy work_order_lines are no longer created by inspection import. */
       insertedJobIds: null;
-      /** @deprecated Legacy work_order_lines are no longer created by inspection import. */
       workOrderLineIds: null;
     }
   | { ok: false; error: string };
@@ -153,7 +151,9 @@ function itemNotes(item: InspectionItem): string {
 
 function itemPhotoUrls(item: InspectionItem): string[] {
   const raw = Array.isArray(item.photoUrls) ? item.photoUrls : item.photo_urls;
-  return Array.isArray(raw) ? raw.filter((url): url is string => typeof url === "string" && url.trim().length > 0) : [];
+  return Array.isArray(raw)
+    ? raw.filter((url): url is string => typeof url === "string" && url.trim().length > 0)
+    : [];
 }
 
 function itemParts(item: InspectionItem): CanonicalQuotePart[] {
@@ -167,10 +167,6 @@ function itemParts(item: InspectionItem): CanonicalQuotePart[] {
       notes: safeString(part.notes) || null,
     }))
     .filter((part) => part.description.length > 0);
-}
-
-function shouldIncludeInspectionItem(item: InspectionItem, jobType: CanonicalQuoteItem["jobType"]): boolean {
-  return item.status === "fail" || item.status === "recommend" || item.recommend === true || jobType !== "repair";
 }
 
 export async function insertPrioritizedJobsFromInspection(
@@ -191,39 +187,39 @@ export async function insertPrioritizedJobsFromInspection(
     .eq("id", inspectionId)
     .maybeSingle<InspectionRow>();
 
-  if (inspErr) {
-    return { ok: false, error: `Failed to fetch inspection: ${inspErr.message}` };
-  }
-  if (!inspection) {
-    return { ok: false, error: "Inspection not found." };
-  }
-  if (!inspection.shop_id) {
-    return { ok: false, error: "Inspection is missing shop_id." };
-  }
+  if (inspErr) return { ok: false, error: `Failed to fetch inspection: ${inspErr.message}` };
+  if (!inspection) return { ok: false, error: "Inspection not found." };
+  if (!inspection.shop_id) return { ok: false, error: "Inspection is missing shop_id." };
 
   const { data: workOrder, error: woErr } = await supabase
     .from("work_orders")
     .select("id, shop_id, vehicle_id, status")
     .eq("id", workOrderId)
-    .maybeSingle<{ id: string; shop_id: string | null; vehicle_id: string | null; status: string | null }>();
+    .maybeSingle<{
+      id: string;
+      shop_id: string | null;
+      vehicle_id: string | null;
+      status: string | null;
+    }>();
 
-  if (woErr) {
-    return { ok: false, error: `Failed to fetch work order: ${woErr.message}` };
-  }
-  if (!workOrder) {
-    return { ok: false, error: "Work order not found." };
-  }
+  if (woErr) return { ok: false, error: `Failed to fetch work order: ${woErr.message}` };
+  if (!workOrder) return { ok: false, error: "Work order not found." };
   if (!workOrder.shop_id || workOrder.shop_id !== inspection.shop_id) {
     return { ok: false, error: "Inspection and work order must belong to the same shop." };
   }
 
   const blockedStatuses = new Set(["cancelled", "canceled", "invoiced", "closed"]);
   if (blockedStatuses.has((workOrder.status ?? "").toLowerCase())) {
-    return { ok: false, error: "Cannot import inspection findings into a cancelled, closed, or invoiced work order." };
+    return {
+      ok: false,
+      error: "Cannot import inspection findings into a cancelled, closed, or invoiced work order.",
+    };
   }
 
   const shopId = inspection.shop_id;
-  const result = (inspection as unknown as { result?: unknown })?.result as InspectionResult | undefined;
+  const result = (inspection as unknown as { result?: unknown })?.result as
+    | InspectionResult
+    | undefined;
 
   if (!result?.sections || !Array.isArray(result.sections)) {
     return { ok: false, error: "Invalid inspection format: missing sections." };
@@ -232,25 +228,31 @@ export async function insertPrioritizedJobsFromInspection(
   const diagnosisKeywords = ["check engine", "diagnose", "misfire", "no start"];
   const maintenanceKeywords = ["oil", "fluid", "filter", "belt", "coolant"];
   const autoPartsKeywords = ["brake", "pads", "rotor", "fluid", "coolant", "filter", "belt"];
-
   const quoteItems: CanonicalQuoteItem[] = [];
 
   for (const [sectionIndex, section] of result.sections.entries()) {
-    const sectionTitle = safeString(section.title) || safeString(section.name) || `Section ${sectionIndex + 1}`;
-    const sectionKey = safeString(section.key) || safeString(section.id) || normalizeTitle(sectionTitle) || `section-${sectionIndex}`;
+    const sectionTitle =
+      safeString(section.title) || safeString(section.name) || `Section ${sectionIndex + 1}`;
+    const sectionKey =
+      safeString(section.key) ||
+      safeString(section.id) ||
+      normalizeTitle(sectionTitle) ||
+      `section-${sectionIndex}`;
 
     for (const [itemIndex, item] of (section.items ?? []).entries()) {
       const title = itemTitle(item);
       if (!title) continue;
+      if (!isInspectionFindingEligible(item)) continue;
 
       const titleLower = title.toLowerCase();
       let jobType: CanonicalQuoteItem["jobType"] = "repair";
-
-      if (diagnosisKeywords.some((keyword) => titleLower.includes(keyword))) jobType = "diagnosis";
-      else if (item.status === "fail") jobType = "inspection-fail";
-      else if (maintenanceKeywords.some((keyword) => titleLower.includes(keyword))) jobType = "maintenance";
-
-      if (!shouldIncludeInspectionItem(item, jobType)) continue;
+      if (diagnosisKeywords.some((keyword) => titleLower.includes(keyword))) {
+        jobType = "diagnosis";
+      } else if (safeString(item.status).toLowerCase() === "fail") {
+        jobType = "inspection-fail";
+      } else if (maintenanceKeywords.some((keyword) => titleLower.includes(keyword))) {
+        jobType = "maintenance";
+      }
 
       const sourceKey = buildInspectionSourceKey({
         inspectionId,
@@ -265,8 +267,9 @@ export async function insertPrioritizedJobsFromInspection(
       const notes = itemNotes(item);
       const value = item.value != null ? String(item.value) : "";
       const measurement = value ? `${value}${item.unit ?? ""}` : "";
-      const descriptionParts = [title, measurement ? `(${measurement})` : "", notes ? `- ${notes}` : ""];
-      const description = descriptionParts.filter(Boolean).join(" ");
+      const description = [title, measurement ? `(${measurement})` : "", notes ? `- ${notes}` : ""]
+        .filter(Boolean)
+        .join(" ");
       const normalizedFindingTitle = normalizeTitle(title);
       const normalizedDescription = normalizeTitle(description);
       const findingIdentity = buildFindingIdentity({
@@ -278,15 +281,38 @@ export async function insertPrioritizedJobsFromInspection(
       });
 
       const explicitLaborHours = finiteNumber(item.laborHours) ?? finiteNumber(item.labor_hours);
-      const laborHours = explicitLaborHours ?? normalizeLaborHoursInput(await estimateLabor(title, jobType ?? "repair"), true);
+      const laborHours =
+        explicitLaborHours ??
+        normalizeLaborHoursInput(await estimateLabor(title, jobType ?? "repair"), true);
       const parts = itemParts(item);
 
-      if (autoGenerateParts && parts.length === 0 && autoPartsKeywords.some((keyword) => description.toLowerCase().includes(keyword))) {
-        parts.push({ description: title, qty: 1, cost: null, unitCost: null, unitPrice: null, notes: "Auto-generated from inspection" });
+      if (
+        autoGenerateParts &&
+        parts.length === 0 &&
+        autoPartsKeywords.some((keyword) => description.toLowerCase().includes(keyword))
+      ) {
+        parts.push({
+          description: title,
+          qty: 1,
+          cost: null,
+          unitCost: null,
+          unitPrice: null,
+          notes: "Auto-generated from inspection",
+        });
       }
 
-      const partsTotal = parts.reduce((sum, part) => sum + (finiteNumber(part.unitCost) ?? finiteNumber(part.cost) ?? 0) * (part.qty ?? 1), 0);
-      const hasUnpricedParts = parts.some((part) => finiteNumber(part.unitPrice) == null && finiteNumber(part.unitCost) == null && finiteNumber(part.cost) == null);
+      const partsTotal = parts.reduce(
+        (sum, part) =>
+          sum +
+          (finiteNumber(part.unitCost) ?? finiteNumber(part.cost) ?? 0) * (part.qty ?? 1),
+        0,
+      );
+      const hasUnpricedParts = parts.some(
+        (part) =>
+          finiteNumber(part.unitPrice) == null &&
+          finiteNumber(part.unitCost) == null &&
+          finiteNumber(part.cost) == null,
+      );
 
       const metadata: Record<string, Json | undefined> = {
         legacy_import_route: "/api/work-orders/import-from-inspection",
@@ -388,7 +414,8 @@ export async function insertPrioritizedJobsFromInspection(
     partsRequestsCount: resultFromQuoteLines.createdPartRequestIds.length,
     createdPartRequestIds: resultFromQuoteLines.createdPartRequestIds,
     skippedPartsRequestsCount: resultFromQuoteLines.skippedPartRequestItemCount,
-    message: "Imported findings to Quote Review. No work order lines were created before customer approval.",
+    message:
+      "Imported findings to Quote Review. No work order lines were created before customer approval.",
     insertedJobIds: null,
     workOrderLineIds: null,
   };

--- a/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
+++ b/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts
@@ -5,11 +5,13 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database, Json } from "@shared/types/types/supabase";
 import { estimateLabor } from "@ai/lib/ai/estimateLabor";
 import { normalizeLaborHoursInput } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
-import { isInspectionFindingEligible } from "@/features/work-orders/lib/work-orders/inspectionFindingEligibility";
 import {
-  createCanonicalQuoteLines,
-  type CanonicalQuoteItem,
-  type CanonicalQuotePart,
+  classifyEligibleInspectionFinding,
+  isExplicitInspectionRecommendation,
+} from "@/features/work-orders/lib/work-orders/inspectionFindingEligibility";
+import type {
+  CanonicalQuoteItem,
+  CanonicalQuotePart,
 } from "@/features/work-orders/lib/work-orders/canonicalQuoteLines";
 
 type DB = Database;
@@ -25,7 +27,7 @@ type InspectionItem = {
   unit?: string | null;
   notes?: string | null;
   note?: string | null;
-  status?: "ok" | "fail" | "na" | "recommend" | string | null;
+  status?: string | null;
   recommend?: boolean | string[] | null;
   parts?: Array<{
     description?: string;
@@ -57,6 +59,32 @@ type InspectionResult = {
   }>;
 };
 
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+type AtomicImportResult = {
+  ok?: boolean;
+  ids?: string[];
+  items?: Array<{
+    requestedId?: string | null;
+    id?: string;
+    created?: boolean;
+    findingIdentity?: string | null;
+  }>;
+  createdCount?: number;
+  skippedDuplicateCount?: number;
+  createdPartRequestIds?: string[];
+  partRequestIds?: string[];
+  createdPartRequestItemCount?: number;
+  skippedPartRequestItemCount?: number;
+  idempotent?: boolean;
+};
+
 export type ImportFromInspectionArgs = {
   supabase: SupabaseClient<DB>;
   inspectionId: string;
@@ -64,6 +92,7 @@ export type ImportFromInspectionArgs = {
   vehicleId?: string | null;
   userId: string;
   autoGenerateParts?: boolean;
+  operationKey?: string;
 };
 
 export type ImportFromInspectionResult =
@@ -80,12 +109,9 @@ export type ImportFromInspectionResult =
       message: string;
       insertedJobIds: null;
       workOrderLineIds: null;
+      idempotent?: boolean;
     }
   | { ok: false; error: string };
-
-function normalizeSourceComponent(value: string | number | null | undefined): string {
-  return String(value ?? "").trim().toLowerCase().replace(/\s+/g, " ");
-}
 
 function safeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -95,44 +121,8 @@ function finiteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function normalizeTitle(value: unknown): string {
+function normalize(value: unknown): string {
   return safeString(value).toLowerCase().replace(/\s+/g, " ");
-}
-
-function buildInspectionSourceKey(args: {
-  inspectionId: string;
-  sectionIndex: number;
-  itemIndex: number;
-  sectionTitle?: string;
-  sectionKey?: string;
-  itemName?: string;
-  itemLabel?: string;
-  unit?: string | null;
-}): string {
-  const normalizedSectionTitle = normalizeSourceComponent(args.sectionTitle);
-  const normalizedSectionKey = normalizeSourceComponent(args.sectionKey);
-  const normalizedItemName = normalizeSourceComponent(args.itemName || args.itemLabel);
-  const normalizedUnit = normalizeSourceComponent(args.unit);
-  const raw = `${args.inspectionId}|${args.sectionIndex}|${args.itemIndex}|${normalizedSectionKey}|${normalizedSectionTitle}|${normalizedItemName}|${normalizedUnit}`;
-  return crypto.createHash("sha256").update(raw).digest("hex");
-}
-
-function buildFindingIdentity(args: {
-  inspectionId: string;
-  sourceKey: string;
-  sectionKey: string;
-  normalizedTitle: string;
-  normalizedDescription: string;
-}): string {
-  return [
-    args.inspectionId,
-    args.sectionKey,
-    args.sourceKey,
-    args.normalizedTitle || args.normalizedDescription,
-    args.normalizedDescription,
-  ]
-    .filter(Boolean)
-    .join(":");
 }
 
 function itemTitle(item: InspectionItem): string {
@@ -152,7 +142,9 @@ function itemNotes(item: InspectionItem): string {
 function itemPhotoUrls(item: InspectionItem): string[] {
   const raw = Array.isArray(item.photoUrls) ? item.photoUrls : item.photo_urls;
   return Array.isArray(raw)
-    ? raw.filter((url): url is string => typeof url === "string" && url.trim().length > 0)
+    ? raw.filter(
+        (url): url is string => typeof url === "string" && url.trim().length > 0,
+      )
     : [];
 }
 
@@ -166,7 +158,63 @@ function itemParts(item: InspectionItem): CanonicalQuotePart[] {
       unitPrice: finiteNumber(part.unitPrice),
       notes: safeString(part.notes) || null,
     }))
-    .filter((part) => part.description.length > 0);
+    .filter((part) => Boolean(part.description));
+}
+
+function sourceKey(input: {
+  inspectionId: string;
+  sectionIndex: number;
+  itemIndex: number;
+  sectionKey: string;
+  sectionTitle: string;
+  title: string;
+  unit?: string | null;
+}): string {
+  const raw = [
+    input.inspectionId,
+    input.sectionIndex,
+    input.itemIndex,
+    normalize(input.sectionKey),
+    normalize(input.sectionTitle),
+    normalize(input.title),
+    normalize(input.unit),
+  ].join("|");
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}
+
+function findingIdentity(input: {
+  inspectionId: string;
+  sectionKey: string;
+  sourceItemKey: string;
+  title: string;
+  description: string;
+}): string {
+  return [
+    input.inspectionId,
+    input.sectionKey,
+    input.sourceItemKey,
+    normalize(input.title) || normalize(input.description),
+    normalize(input.description),
+  ]
+    .filter(Boolean)
+    .join(":");
+}
+
+function stableImportKey(input: {
+  inspectionId: string;
+  workOrderId: string;
+  items: CanonicalQuoteItem[];
+}): string {
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        inspectionId: input.inspectionId,
+        workOrderId: input.workOrderId,
+        identities: input.items.map((item) => item.findingIdentity).sort(),
+      }),
+    )
+    .digest("hex");
 }
 
 export async function insertPrioritizedJobsFromInspection(
@@ -176,120 +224,89 @@ export async function insertPrioritizedJobsFromInspection(
     supabase,
     inspectionId,
     workOrderId,
-    vehicleId,
+    vehicleId = null,
     userId,
     autoGenerateParts = true,
   } = args;
 
-  const { data: inspection, error: inspErr } = await supabase
+  const { data: inspection, error: inspectionError } = await supabase
     .from("inspections")
     .select("*")
     .eq("id", inspectionId)
     .maybeSingle<InspectionRow>();
-
-  if (inspErr) return { ok: false, error: `Failed to fetch inspection: ${inspErr.message}` };
-  if (!inspection) return { ok: false, error: "Inspection not found." };
-  if (!inspection.shop_id) return { ok: false, error: "Inspection is missing shop_id." };
-
-  const { data: workOrder, error: woErr } = await supabase
-    .from("work_orders")
-    .select("id, shop_id, vehicle_id, status")
-    .eq("id", workOrderId)
-    .maybeSingle<{
-      id: string;
-      shop_id: string | null;
-      vehicle_id: string | null;
-      status: string | null;
-    }>();
-
-  if (woErr) return { ok: false, error: `Failed to fetch work order: ${woErr.message}` };
-  if (!workOrder) return { ok: false, error: "Work order not found." };
-  if (!workOrder.shop_id || workOrder.shop_id !== inspection.shop_id) {
-    return { ok: false, error: "Inspection and work order must belong to the same shop." };
+  if (inspectionError) {
+    return { ok: false, error: `Failed to fetch inspection: ${inspectionError.message}` };
+  }
+  if (!inspection?.shop_id) {
+    return { ok: false, error: "Inspection not found or missing shop scope." };
   }
 
-  const blockedStatuses = new Set(["cancelled", "canceled", "invoiced", "closed"]);
-  if (blockedStatuses.has((workOrder.status ?? "").toLowerCase())) {
-    return {
-      ok: false,
-      error: "Cannot import inspection findings into a cancelled, closed, or invoiced work order.",
-    };
-  }
-
-  const shopId = inspection.shop_id;
-  const result = (inspection as unknown as { result?: unknown })?.result as
+  const rawResult = (inspection as unknown as { result?: unknown }).result as
     | InspectionResult
     | undefined;
-
-  if (!result?.sections || !Array.isArray(result.sections)) {
+  if (!rawResult?.sections || !Array.isArray(rawResult.sections)) {
     return { ok: false, error: "Invalid inspection format: missing sections." };
   }
 
-  const diagnosisKeywords = ["check engine", "diagnose", "misfire", "no start"];
-  const maintenanceKeywords = ["oil", "fluid", "filter", "belt", "coolant"];
-  const autoPartsKeywords = ["brake", "pads", "rotor", "fluid", "coolant", "filter", "belt"];
   const quoteItems: CanonicalQuoteItem[] = [];
+  const autoPartKeywords = ["brake", "pads", "rotor", "fluid", "coolant", "filter", "belt"];
 
-  for (const [sectionIndex, section] of result.sections.entries()) {
+  for (const [sectionIndex, section] of rawResult.sections.entries()) {
     const sectionTitle =
       safeString(section.title) || safeString(section.name) || `Section ${sectionIndex + 1}`;
     const sectionKey =
       safeString(section.key) ||
       safeString(section.id) ||
-      normalizeTitle(sectionTitle) ||
+      normalize(sectionTitle) ||
       `section-${sectionIndex}`;
 
     for (const [itemIndex, item] of (section.items ?? []).entries()) {
       const title = itemTitle(item);
-      if (!title) continue;
-      if (!isInspectionFindingEligible(item)) continue;
+      if (!title || !isExplicitInspectionRecommendation(item)) continue;
 
-      const titleLower = title.toLowerCase();
-      let jobType: CanonicalQuoteItem["jobType"] = "repair";
-      if (diagnosisKeywords.some((keyword) => titleLower.includes(keyword))) {
-        jobType = "diagnosis";
-      } else if (safeString(item.status).toLowerCase() === "fail") {
-        jobType = "inspection-fail";
-      } else if (maintenanceKeywords.some((keyword) => titleLower.includes(keyword))) {
-        jobType = "maintenance";
-      }
-
-      const sourceKey = buildInspectionSourceKey({
+      const jobType = classifyEligibleInspectionFinding({
+        title,
+        status: item.status,
+      });
+      const key = sourceKey({
         inspectionId,
         sectionIndex,
         itemIndex,
-        sectionTitle,
         sectionKey,
-        itemName: title,
-        itemLabel: item.label,
+        sectionTitle,
+        title,
         unit: item.unit,
       });
       const notes = itemNotes(item);
-      const value = item.value != null ? String(item.value) : "";
-      const measurement = value ? `${value}${item.unit ?? ""}` : "";
-      const description = [title, measurement ? `(${measurement})` : "", notes ? `- ${notes}` : ""]
+      const measurement =
+        item.value != null ? `${String(item.value)}${item.unit ?? ""}` : "";
+      const description = [
+        title,
+        measurement ? `(${measurement})` : "",
+        notes ? `- ${notes}` : "",
+      ]
         .filter(Boolean)
         .join(" ");
-      const normalizedFindingTitle = normalizeTitle(title);
-      const normalizedDescription = normalizeTitle(description);
-      const findingIdentity = buildFindingIdentity({
+      const identity = findingIdentity({
         inspectionId,
-        sourceKey,
         sectionKey,
-        normalizedTitle: normalizedFindingTitle,
-        normalizedDescription,
+        sourceItemKey: key,
+        title,
+        description,
       });
 
-      const explicitLaborHours = finiteNumber(item.laborHours) ?? finiteNumber(item.labor_hours);
+      const explicitLabor =
+        finiteNumber(item.laborHours) ?? finiteNumber(item.labor_hours);
       const laborHours =
-        explicitLaborHours ??
-        normalizeLaborHoursInput(await estimateLabor(title, jobType ?? "repair"), true);
+        explicitLabor ??
+        normalizeLaborHoursInput(await estimateLabor(title, jobType), true);
       const parts = itemParts(item);
-
       if (
         autoGenerateParts &&
         parts.length === 0 &&
-        autoPartsKeywords.some((keyword) => description.toLowerCase().includes(keyword))
+        autoPartKeywords.some((keyword) =>
+          description.toLowerCase().includes(keyword),
+        )
       ) {
         parts.push({
           description: title,
@@ -304,7 +321,8 @@ export async function insertPrioritizedJobsFromInspection(
       const partsTotal = parts.reduce(
         (sum, part) =>
           sum +
-          (finiteNumber(part.unitCost) ?? finiteNumber(part.cost) ?? 0) * (part.qty ?? 1),
+          (finiteNumber(part.unitCost) ?? finiteNumber(part.cost) ?? 0) *
+            (part.qty ?? 1),
         0,
       );
       const hasUnpricedParts = parts.some(
@@ -316,16 +334,12 @@ export async function insertPrioritizedJobsFromInspection(
 
       const metadata: Record<string, Json | undefined> = {
         legacy_import_route: "/api/work-orders/import-from-inspection",
-        canonicalized_phase: "5E-1",
-        shop_id: shopId,
-        work_order_id: workOrderId,
-        vehicle_id: vehicleId || workOrder.vehicle_id || undefined,
+        canonicalized_phase: "5",
         inspection_id: inspectionId,
-        source_inspection_item_key: sourceKey,
+        source_inspection_item_key: key,
         source_section_key: sectionKey,
         source_section_title: sectionTitle,
         source_item_title: title,
-        source_item_description: safeString(item.description) || undefined,
         technician_notes: notes || undefined,
         measurement: measurement || undefined,
         inspection_status: safeString(item.status) || undefined,
@@ -336,8 +350,6 @@ export async function insertPrioritizedJobsFromInspection(
           recommendationType: item.recommendationType ?? null,
           priority: item.priority ?? null,
         },
-        labor_estimate_hours: laborHours,
-        parts_estimate: parts,
         photo_urls: itemPhotoUrls(item),
       };
 
@@ -346,12 +358,15 @@ export async function insertPrioritizedJobsFromInspection(
         title,
         source: "inspection",
         sourceInspectionId: inspectionId,
+        sourceWorkOrderLineId:
+          (inspection as unknown as { work_order_line_id?: string | null })
+            .work_order_line_id ?? null,
         sourceSectionKey: sectionKey,
         sourceSectionTitle: sectionTitle,
-        sourceItemKey: sourceKey,
+        sourceItemKey: key,
         sourceFindingTitle: title,
-        normalizedFindingTitle,
-        findingIdentity,
+        normalizedFindingTitle: normalize(title),
+        findingIdentity: identity,
         photoUrls: itemPhotoUrls(item),
         jobType,
         estLaborHours: laborHours,
@@ -362,7 +377,10 @@ export async function insertPrioritizedJobsFromInspection(
         notes: notes || null,
         complaint: notes || description,
         aiComplaint: notes || description,
-        status: parts.length > 0 && hasUnpricedParts ? "pending_parts" : "advisor_pending",
+        status:
+          parts.length > 0 && hasUnpricedParts
+            ? "pending_parts"
+            : "advisor_pending",
         stage: "advisor_pending",
         parts,
         metadata,
@@ -387,36 +405,66 @@ export async function insertPrioritizedJobsFromInspection(
     };
   }
 
-  const resultFromQuoteLines = await createCanonicalQuoteLines({
-    supabase,
-    shopId,
-    workOrderId,
-    vehicleId: vehicleId || workOrder.vehicle_id || null,
-    suggestedBy: userId,
-    items: quoteItems,
+  const operationKey =
+    args.operationKey?.trim() ||
+    stableImportKey({ inspectionId, workOrderId, items: quoteItems });
+  const rpc = supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("import_inspection_quote_package_atomic", {
+    p_shop_id: inspection.shop_id,
+    p_work_order_id: workOrderId,
+    p_inspection_id: inspectionId,
+    p_requested_vehicle_id: vehicleId,
+    p_actor_user_id: userId,
+    p_operation_key: `${inspection.shop_id}:inspection-import:${operationKey}`,
+    p_items: quoteItems,
+    p_at: new Date().toISOString(),
   });
 
-  if (!resultFromQuoteLines.ok) {
-    return { ok: false, error: resultFromQuoteLines.error };
+  if (error) {
+    return {
+      ok: false,
+      error: [error.message, error.details, error.hint]
+        .filter(Boolean)
+        .join(" — "),
+    };
   }
 
-  const createdQuoteLines = resultFromQuoteLines.items
-    .filter((item) => item.created)
-    .map((item) => ({ id: item.id, findingIdentity: item.findingIdentity }));
+  const result = data && typeof data === "object" ? (data as AtomicImportResult) : {};
+  const items = Array.isArray(result.items) ? result.items : [];
+  const createdQuoteLines = items
+    .filter((item) => item.created === true && typeof item.id === "string")
+    .map((item) => ({
+      id: item.id as string,
+      findingIdentity:
+        typeof item.findingIdentity === "string" ? item.findingIdentity : null,
+    }));
+  const quoteLineIds = Array.isArray(result.ids)
+    ? result.ids.filter((id): id is string => typeof id === "string")
+    : items
+        .map((item) => item.id)
+        .filter((id): id is string => typeof id === "string");
+  const createdPartRequestIds = Array.isArray(result.createdPartRequestIds)
+    ? result.createdPartRequestIds.filter(
+        (id): id is string => typeof id === "string",
+      )
+    : [];
 
   return {
     ok: true,
-    insertedCount: resultFromQuoteLines.createdCount,
-    quoteLineIds: resultFromQuoteLines.ids,
+    insertedCount: Number(result.createdCount ?? createdQuoteLines.length),
+    quoteLineIds,
     createdQuoteLines,
-    skippedDuplicates: resultFromQuoteLines.skippedDuplicateCount,
-    skippedCount: resultFromQuoteLines.skippedDuplicateCount,
-    partsRequestsCount: resultFromQuoteLines.createdPartRequestIds.length,
-    createdPartRequestIds: resultFromQuoteLines.createdPartRequestIds,
-    skippedPartsRequestsCount: resultFromQuoteLines.skippedPartRequestItemCount,
+    skippedDuplicates: Number(result.skippedDuplicateCount ?? 0),
+    skippedCount: Number(result.skippedDuplicateCount ?? 0),
+    partsRequestsCount: createdPartRequestIds.length,
+    createdPartRequestIds,
+    skippedPartsRequestsCount: Number(
+      result.skippedPartRequestItemCount ?? 0,
+    ),
     message:
       "Imported findings to Quote Review. No work order lines were created before customer approval.",
     insertedJobIds: null,
     workOrderLineIds: null,
+    idempotent: result.idempotent === true,
   };
 }

--- a/features/work-orders/lib/work-orders/inspectionFindingEligibility.ts
+++ b/features/work-orders/lib/work-orders/inspectionFindingEligibility.ts
@@ -5,23 +5,35 @@ export type InspectionFindingEligibilityInput = {
   recommendationType?: string | null;
 };
 
-const ELIGIBLE_STATUSES = new Set(["fail", "failed", "recommend", "recommended"]);
-const INELIGIBLE_STATUSES = new Set(["ok", "pass", "passed", "na", "n/a", "not_applicable"]);
+export type EligibleInspectionJobType =
+  | "diagnosis"
+  | "repair"
+  | "maintenance"
+  | "inspection-fail";
+
+const ELIGIBLE_STATUSES = new Set([
+  "fail",
+  "failed",
+  "recommend",
+  "recommended",
+]);
+const INELIGIBLE_STATUSES = new Set([
+  "ok",
+  "pass",
+  "passed",
+  "na",
+  "n/a",
+  "not_applicable",
+]);
 
 function clean(value: unknown): string {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
-/**
- * Determines whether an inspection observation is eligible to become a
- * customer-visible quote recommendation. Classification keywords must only be
- * applied after this function returns true.
- */
-export function isInspectionFindingEligible(
+export function isExplicitInspectionRecommendation(
   input: InspectionFindingEligibilityInput,
 ): boolean {
   const status = clean(input.status);
-
   if (ELIGIBLE_STATUSES.has(status)) return true;
   if (INELIGIBLE_STATUSES.has(status)) return false;
   if (input.recommend === true) return true;
@@ -30,4 +42,44 @@ export function isInspectionFindingEligible(
   const recommendation = clean(input.recommendation);
   const recommendationType = clean(input.recommendationType);
   return recommendation.length > 0 || recommendationType.length > 0;
+}
+
+/**
+ * Backward-compatible alias used by existing focused tests and callers.
+ */
+export const isInspectionFindingEligible = isExplicitInspectionRecommendation;
+
+/**
+ * Classification is intentionally separate from eligibility. Keyword presence
+ * can describe an already eligible finding, but can never make an OK/NA item
+ * customer-visible.
+ */
+export function classifyEligibleInspectionFinding(input: {
+  title: string;
+  status?: string | null;
+}): EligibleInspectionJobType {
+  const title = clean(input.title);
+  const status = clean(input.status);
+
+  if (
+    ["check engine", "diagnose", "diagnostic", "misfire", "no start"].some(
+      (keyword) => title.includes(keyword),
+    )
+  ) {
+    return "diagnosis";
+  }
+
+  if (status === "fail" || status === "failed") {
+    return "inspection-fail";
+  }
+
+  if (
+    ["oil", "fluid", "filter", "belt", "coolant"].some((keyword) =>
+      title.includes(keyword),
+    )
+  ) {
+    return "maintenance";
+  }
+
+  return "repair";
 }

--- a/features/work-orders/lib/work-orders/inspectionFindingEligibility.ts
+++ b/features/work-orders/lib/work-orders/inspectionFindingEligibility.ts
@@ -1,0 +1,33 @@
+export type InspectionFindingEligibilityInput = {
+  status?: string | null;
+  recommend?: boolean | string[] | null;
+  recommendation?: string | null;
+  recommendationType?: string | null;
+};
+
+const ELIGIBLE_STATUSES = new Set(["fail", "failed", "recommend", "recommended"]);
+const INELIGIBLE_STATUSES = new Set(["ok", "pass", "passed", "na", "n/a", "not_applicable"]);
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+/**
+ * Determines whether an inspection observation is eligible to become a
+ * customer-visible quote recommendation. Classification keywords must only be
+ * applied after this function returns true.
+ */
+export function isInspectionFindingEligible(
+  input: InspectionFindingEligibilityInput,
+): boolean {
+  const status = clean(input.status);
+
+  if (ELIGIBLE_STATUSES.has(status)) return true;
+  if (INELIGIBLE_STATUSES.has(status)) return false;
+  if (input.recommend === true) return true;
+  if (Array.isArray(input.recommend) && input.recommend.length > 0) return true;
+
+  const recommendation = clean(input.recommendation);
+  const recommendationType = clean(input.recommendationType);
+  return recommendation.length > 0 || recommendationType.length > 0;
+}

--- a/features/work-orders/server/workOrderQuoteLineApproval.ts
+++ b/features/work-orders/server/workOrderQuoteLineApproval.ts
@@ -1,21 +1,16 @@
 import "server-only";
 
+import crypto from "node:crypto";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database, TablesInsert } from "@shared/types/types/supabase";
-import {
-  relinkQuoteLinePartsToWorkOrderLine,
-  type RelinkQuoteLinePartsResult,
-} from "@/features/parts/server/relinkQuoteLinePartsToWorkOrderLine";
+import type { Database } from "@shared/types/types/supabase";
 import {
   upsertMenuRepairItemFromQuoteLine,
   type UpsertMenuRepairItemFromQuoteLineResult,
 } from "@/features/menu-repair-items/server/upsertMenuRepairItemFromQuoteLine";
 
 type DB = Database;
-type Json = DB["public"]["Tables"]["work_order_quote_lines"]["Row"]["metadata"];
-type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
-type WorkOrderLineInsert = TablesInsert<"work_order_lines">;
-type WorkOrderUpdate = DB["public"]["Tables"]["work_orders"]["Update"];
+
+export type QuoteApprovalDecision = "approve" | "decline" | "defer";
 
 export type QuoteLineLearningResult = {
   quoteLineId: string;
@@ -24,21 +19,36 @@ export type QuoteLineLearningResult = {
   error: string | null;
 };
 
-export type QuoteApprovalDecision = "approve" | "decline" | "defer";
+export type RelinkQuoteLinePartsResult = {
+  partRequestsRelinked: number;
+  partRequestItemsRelinked: number;
+  partRequestsAlreadyLinked: number;
+  partRequestItemsAlreadyLinked: number;
+  conflicts: Array<{
+    table: "part_requests" | "part_request_items";
+    id: string;
+    currentWorkOrderLineId: string;
+    targetWorkOrderLineId: string;
+  }>;
+};
 
-const APPROVABLE_STATUSES = new Set([
-  "sent",
-  "ready_to_send",
-  "quoted",
-  "approved",
-  "converted",
-]);
-const NON_APPROVABLE_STATUSES = new Set([
-  "declined",
-  "deferred",
-  "rejected",
-  "cancelled",
-]);
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+type RpcResult = {
+  ok?: boolean;
+  quote_line_ids?: string[];
+  work_order_line_ids?: string[];
+  declined_remaining_quote_line_ids?: string[];
+  approval_state?: string | null;
+  part_relink?: Partial<RelinkQuoteLinePartsResult>;
+  idempotent?: boolean;
+};
 
 function emptyPartRelinkResult(): RelinkQuoteLinePartsResult {
   return {
@@ -50,319 +60,29 @@ function emptyPartRelinkResult(): RelinkQuoteLinePartsResult {
   };
 }
 
-function mergePartRelinkResult(
-  target: RelinkQuoteLinePartsResult,
-  source: RelinkQuoteLinePartsResult,
-): void {
-  target.partRequestsRelinked += source.partRequestsRelinked;
-  target.partRequestItemsRelinked += source.partRequestItemsRelinked;
-  target.partRequestsAlreadyLinked += source.partRequestsAlreadyLinked;
-  target.partRequestItemsAlreadyLinked += source.partRequestItemsAlreadyLinked;
-  target.conflicts.push(...source.conflicts);
-}
-
-function safeTrim(v: unknown): string {
-  return typeof v === "string" ? v.trim() : "";
-}
-
-function asNumber(v: unknown): number | null {
-  if (typeof v === "number" && Number.isFinite(v)) return v;
-  if (typeof v === "string") {
-    const n = Number(v);
-    return Number.isFinite(n) ? n : null;
-  }
-  return null;
-}
-
-function quoteMetadata(
-  line: Pick<QuoteLineRow, "metadata">,
-): Record<string, unknown> {
-  if (
-    !line.metadata ||
-    typeof line.metadata !== "object" ||
-    Array.isArray(line.metadata)
-  )
-    return {};
-  return line.metadata as Record<string, unknown>;
-}
-
-function mergeMetadata(
-  line: QuoteLineRow,
-  patch: Record<string, unknown>,
-): Json {
-  return {
-    ...quoteMetadata(line),
-    ...patch,
-  } as Json;
-}
-
-function getPartsFromMetadata(line: QuoteLineRow): unknown[] {
-  const parts = quoteMetadata(line).parts;
-  return Array.isArray(parts) ? parts : [];
-}
-
-function describeParts(parts: unknown[]): string | null {
-  const labels = parts
-    .filter(
-      (part): part is Record<string, unknown> =>
-        Boolean(part) && typeof part === "object" && !Array.isArray(part),
-    )
-    .map(
-      (part) =>
-        safeTrim(part.name) ||
-        safeTrim(part.description) ||
-        safeTrim(part.part_number) ||
-        safeTrim(part.sku),
-    )
-    .filter(Boolean);
-
-  return labels.length > 0 ? labels.join(", ") : null;
-}
-
-function decisionPatch(params: {
-  line: QuoteLineRow;
-  decision: QuoteApprovalDecision;
-  actorUserId: string;
-  customerId: string | null;
-  now: string;
-  materializedWorkOrderLineId?: string | null;
-}): DB["public"]["Tables"]["work_order_quote_lines"]["Update"] {
-  const {
-    line,
-    decision,
-    actorUserId,
-    customerId,
-    now,
-    materializedWorkOrderLineId,
-  } = params;
-  const baseAudit = {
-    customer_decision: decision,
-    customer_decision_at: now,
-    customer_actor_user_id: actorUserId,
-    customer_id: customerId,
-  };
-
-  if (decision === "approve") {
-    return {
-      status: "converted",
-      stage: "customer_approved",
-      approved_at: line.approved_at ?? now,
-      declined_at: null,
-      work_order_line_id:
-        materializedWorkOrderLineId ?? line.work_order_line_id,
-      metadata: mergeMetadata(line, {
-        ...baseAudit,
-        materialized_work_order_line_id:
-          materializedWorkOrderLineId ?? line.work_order_line_id ?? null,
-      }),
-      updated_at: now,
-    };
-  }
-
-  if (decision === "decline") {
-    return {
-      status: "declined",
-      stage: "customer_declined",
-      declined_at: line.declined_at ?? now,
-      metadata: mergeMetadata(line, baseAudit),
-      updated_at: now,
-    };
-  }
-
-  return {
-    status: "deferred",
-    stage: "customer_deferred",
-    declined_at: null,
-    metadata: mergeMetadata(line, baseAudit),
-    updated_at: now,
-  };
-}
-
-async function findExistingMaterializedLine(params: {
-  supabase: SupabaseClient<DB>;
-  line: QuoteLineRow;
-}): Promise<{ id: string | null; error: Error | null }> {
-  const { supabase, line } = params;
-  if (line.work_order_line_id)
-    return { id: line.work_order_line_id, error: null };
-
-  const externalId = `quote_line:${line.id}`;
-  const { data, error } = await supabase
-    .from("work_order_lines")
-    .select("id")
-    .eq("shop_id", line.shop_id)
-    .eq("work_order_id", line.work_order_id)
-    .or(`external_id.eq.${externalId},source_row_id.eq.${line.id}`)
-    .limit(1);
-
-  if (error) return { id: null, error: new Error(error.message) };
-  return { id: data?.[0]?.id ?? null, error: null };
-}
-
-async function materializeQuoteLine(params: {
-  supabase: SupabaseClient<DB>;
-  line: QuoteLineRow;
-  actorUserId: string;
-  now: string;
-}): Promise<{ id: string | null; error: Error | null }> {
-  const { supabase, line, actorUserId, now } = params;
-  const existing = await findExistingMaterializedLine({ supabase, line });
-  if (existing.error || existing.id) return existing;
-
-  const metadata = quoteMetadata(line);
-  const parts = getPartsFromMetadata(line);
-  const lineTotal =
-    asNumber(line.grand_total) ??
-    asNumber(line.subtotal) ??
-    (asNumber(line.labor_total) ?? 0) + (asNumber(line.parts_total) ?? 0);
-  const laborHours =
-    asNumber(line.labor_hours) ?? asNumber(line.est_labor_hours);
-
-  const insertLine: WorkOrderLineInsert = {
-    shop_id: line.shop_id,
-    work_order_id: line.work_order_id,
-    vehicle_id: line.vehicle_id,
-    description:
-      safeTrim(line.description) ||
-      safeTrim(line.ai_complaint) ||
-      "Approved quote line",
-    job_type: safeTrim(line.job_type) || "repair",
-    status: "in_progress",
-    line_status: "authorized",
-    approval_state: "approved",
-    approval_at: now,
-    approval_by: actorUserId,
-    quoted_at: line.sent_to_customer_at ?? line.created_at ?? now,
-    labor_time: laborHours,
-    price_estimate: lineTotal,
-    complaint:
-      safeTrim(line.ai_complaint) ||
-      safeTrim(line.notes) ||
-      safeTrim(line.description) ||
-      null,
-    cause: safeTrim(line.ai_cause) || null,
-    correction: safeTrim(line.ai_correction) || null,
-    notes: safeTrim(line.notes) || null,
-    parts: describeParts(parts),
-    parts_needed:
-      parts.length > 0 ? (parts as WorkOrderLineInsert["parts_needed"]) : null,
-    external_id: `quote_line:${line.id}`,
-    source_row_id: line.id,
-    source_intake_id: safeTrim(metadata.source_inspection_id) || null,
-    intake_json: {
-      source: "work_order_quote_lines",
-      quote_line_id: line.id,
-      quote_line_metadata: metadata,
-      customer_approved_at: now,
-      customer_approved_by: actorUserId,
-      labor_total: line.labor_total,
-      parts_total: line.parts_total,
-      subtotal: line.subtotal,
-      tax_total: line.tax_total,
-      grand_total: line.grand_total,
-    } as WorkOrderLineInsert["intake_json"],
-  };
-
-  const { data: inserted, error } = await supabase
-    .from("work_order_lines")
-    .insert(insertLine)
-    .select("id")
-    .single();
-
-  if (error) return { id: null, error: new Error(error.message) };
-  return { id: inserted?.id ?? null, error: null };
-}
-
-async function rollupWorkOrderQuoteApprovalState(params: {
-  supabase: SupabaseClient<DB>;
+function stableDecisionKey(input: {
+  quoteLineIds: string[];
   workOrderId: string;
   shopId: string;
-  now: string;
+  customerId: string | null;
   actorUserId: string;
-}): Promise<{ state: string | null; error: Error | null }> {
-  const { supabase, workOrderId, shopId, now, actorUserId } = params;
-  const { data, error } = await supabase
-    .from("work_order_quote_lines")
-    .select(
-      "status, stage, approved_at, declined_at, work_order_line_id, sent_to_customer_at",
-    )
-    .eq("shop_id", shopId)
-    .eq("work_order_id", workOrderId);
-
-  if (error) return { state: null, error: new Error(error.message) };
-
-  const customerVisibleLines = (data ?? []).filter((line) => {
-    const status = safeTrim(
-      (line as { status?: unknown }).status,
-    ).toLowerCase();
-    return (
-      Boolean(
-        (line as { sent_to_customer_at?: unknown }).sent_to_customer_at,
-      ) ||
-      status === "sent" ||
-      status === "approved" ||
-      status === "converted" ||
-      status === "declined" ||
-      status === "deferred"
-    );
+  decision: QuoteApprovalDecision;
+  declineRemaining: boolean;
+}): string {
+  const payload = JSON.stringify({
+    shopId: input.shopId,
+    workOrderId: input.workOrderId,
+    quoteLineIds: [...input.quoteLineIds].sort(),
+    customerId: input.customerId,
+    actorUserId: input.actorUserId,
+    decision: input.decision,
+    declineRemaining: input.declineRemaining,
   });
+  return crypto.createHash("sha256").update(payload).digest("hex");
+}
 
-  let approved = 0;
-  let declinedDeferred = 0;
-  let pending = 0;
-
-  for (const line of customerVisibleLines) {
-    const status = safeTrim(
-      (line as { status?: unknown }).status,
-    ).toLowerCase();
-    const stage = safeTrim((line as { stage?: unknown }).stage).toLowerCase();
-    if (
-      status === "approved" ||
-      status === "converted" ||
-      stage === "customer_approved" ||
-      (line as { approved_at?: unknown }).approved_at ||
-      (line as { work_order_line_id?: unknown }).work_order_line_id
-    ) {
-      approved += 1;
-    } else if (
-      status === "declined" ||
-      status === "deferred" ||
-      stage === "customer_declined" ||
-      stage === "customer_deferred" ||
-      (line as { declined_at?: unknown }).declined_at
-    ) {
-      declinedDeferred += 1;
-    } else {
-      pending += 1;
-    }
-  }
-
-  let approvalState: WorkOrderUpdate["approval_state"] = "pending";
-  if (approved > 0 && pending === 0 && declinedDeferred === 0)
-    approvalState = "approved";
-  else if (approved > 0) approvalState = "partial";
-  else if (approved === 0 && pending === 0 && declinedDeferred > 0)
-    approvalState = "declined";
-
-  const patch: WorkOrderUpdate = {
-    approval_state: approvalState,
-    updated_at: now,
-  };
-
-  if (approvalState === "approved" || approvalState === "partial") {
-    patch.customer_approval_at = now;
-    patch.customer_agreed_at = now;
-    patch.customer_approved_by = actorUserId;
-  }
-
-  const { error: updateErr } = await supabase
-    .from("work_orders")
-    .update(patch)
-    .eq("id", workOrderId)
-    .eq("shop_id", shopId);
-
-  if (updateErr) return { state: null, error: new Error(updateErr.message) };
-  return { state: approvalState ?? null, error: null };
+function messageFromRpcError(error: RpcError): string {
+  return [error.message, error.details, error.hint].filter(Boolean).join(" — ");
 }
 
 export async function applyWorkOrderQuoteLineDecision(params: {
@@ -373,28 +93,24 @@ export async function applyWorkOrderQuoteLineDecision(params: {
   customerId: string | null;
   actorUserId: string;
   decision: QuoteApprovalDecision;
+  declineRemaining?: boolean;
+  operationKey?: string;
 }): Promise<{
   ok: boolean;
   workOrderLineIds: string[];
+  declinedRemainingQuoteLineIds: string[];
   approvalState: string | null;
   partRelink: RelinkQuoteLinePartsResult;
   menuRepairLearning: QuoteLineLearningResult[];
+  idempotent?: boolean;
   error?: string;
 }> {
-  const {
-    supabase,
-    quoteLineIds,
-    workOrderId,
-    shopId,
-    customerId,
-    actorUserId,
-    decision,
-  } = params;
-  const ids = [...new Set(quoteLineIds.map((id) => id.trim()).filter(Boolean))];
-  if (ids.length === 0) {
+  const quoteLineIds = [...new Set(params.quoteLineIds.map((id) => id.trim()).filter(Boolean))];
+  if (quoteLineIds.length === 0) {
     return {
       ok: false,
       workOrderLineIds: [],
+      declinedRemainingQuoteLineIds: [],
       approvalState: null,
       partRelink: emptyPartRelinkResult(),
       menuRepairLearning: [],
@@ -402,203 +118,115 @@ export async function applyWorkOrderQuoteLineDecision(params: {
     };
   }
 
-  const { data: rows, error: loadErr } = await supabase
-    .from("work_order_quote_lines")
-    .select("*")
-    .eq("shop_id", shopId)
-    .eq("work_order_id", workOrderId)
-    .in("id", ids);
+  const declineRemaining = params.declineRemaining === true;
+  const rawOperationKey =
+    params.operationKey?.trim() ||
+    stableDecisionKey({
+      quoteLineIds,
+      workOrderId: params.workOrderId,
+      shopId: params.shopId,
+      customerId: params.customerId,
+      actorUserId: params.actorUserId,
+      decision: params.decision,
+      declineRemaining,
+    });
 
-  if (loadErr)
+  const rpc = params.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("apply_customer_quote_decision_atomic", {
+    p_shop_id: params.shopId,
+    p_work_order_id: params.workOrderId,
+    p_quote_line_ids: quoteLineIds,
+    p_decision: params.decision,
+    p_decline_remaining: declineRemaining,
+    p_customer_id: params.customerId,
+    p_actor_user_id: params.actorUserId,
+    p_operation_key: `${params.shopId}:quote-decision:${rawOperationKey}`,
+    p_at: new Date().toISOString(),
+  });
+
+  if (error) {
     return {
       ok: false,
       workOrderLineIds: [],
+      declinedRemainingQuoteLineIds: [],
       approvalState: null,
       partRelink: emptyPartRelinkResult(),
       menuRepairLearning: [],
-      error: loadErr.message,
-    };
-  if ((rows?.length ?? 0) !== ids.length) {
-    return {
-      ok: false,
-      workOrderLineIds: [],
-      approvalState: null,
-      partRelink: emptyPartRelinkResult(),
-      menuRepairLearning: [],
-      error: "One or more quote lines were not found for this work order",
+      error: messageFromRpcError(error),
     };
   }
 
-  const now = new Date().toISOString();
-  const workOrderLineIds: string[] = [];
-  const partRelink = emptyPartRelinkResult();
+  const result = data && typeof data === "object" ? (data as RpcResult) : {};
+  const workOrderLineIds = Array.isArray(result.work_order_line_ids)
+    ? result.work_order_line_ids.filter((id): id is string => typeof id === "string")
+    : [];
+  const committedQuoteLineIds = Array.isArray(result.quote_line_ids)
+    ? result.quote_line_ids.filter((id): id is string => typeof id === "string")
+    : quoteLineIds;
+  const declinedRemainingQuoteLineIds = Array.isArray(
+    result.declined_remaining_quote_line_ids,
+  )
+    ? result.declined_remaining_quote_line_ids.filter(
+        (id): id is string => typeof id === "string",
+      )
+    : [];
+
+  const partRelink: RelinkQuoteLinePartsResult = {
+    ...emptyPartRelinkResult(),
+    ...(result.part_relink ?? {}),
+    conflicts: Array.isArray(result.part_relink?.conflicts)
+      ? result.part_relink.conflicts
+      : [],
+  };
+
   const menuRepairLearning: QuoteLineLearningResult[] = [];
-
-  for (const line of (rows ?? []) as QuoteLineRow[]) {
-    const status = safeTrim(line.status).toLowerCase();
-    if (decision === "approve" && NON_APPROVABLE_STATUSES.has(status)) {
-      return {
-        ok: false,
-        workOrderLineIds,
-        approvalState: null,
-        partRelink,
-        menuRepairLearning,
-        error: `Quote line cannot be approved from status '${line.status}'`,
-      };
-    }
-
-    if (
-      decision === "approve" &&
-      status &&
-      !APPROVABLE_STATUSES.has(status) &&
-      !line.sent_to_customer_at
-    ) {
-      return {
-        ok: false,
-        workOrderLineIds,
-        approvalState: null,
-        partRelink,
-        menuRepairLearning,
-        error: "Quote line has not been sent to the customer",
-      };
-    }
-
-    let materializedLineId: string | null = null;
-    if (decision === "approve") {
-      const materialized = await materializeQuoteLine({
-        supabase,
-        line,
-        actorUserId,
-        now,
-      });
-      if (materialized.error)
-        return {
-          ok: false,
-          workOrderLineIds,
-          approvalState: null,
-          partRelink,
-          menuRepairLearning,
-          error: materialized.error.message,
-        };
-      materializedLineId = materialized.id;
-      if (materializedLineId) workOrderLineIds.push(materializedLineId);
-    }
-
-    const patch = decisionPatch({
-      line,
-      decision,
-      actorUserId,
-      customerId,
-      now,
-      materializedWorkOrderLineId: materializedLineId,
-    });
-
-    const { error: updateErr } = await supabase
+  if (params.decision === "approve" && workOrderLineIds.length > 0) {
+    const { data: mappings } = await params.supabase
       .from("work_order_quote_lines")
-      .update(patch)
-      .eq("id", line.id)
-      .eq("shop_id", shopId)
-      .eq("work_order_id", workOrderId);
+      .select("id, work_order_line_id")
+      .eq("shop_id", params.shopId)
+      .eq("work_order_id", params.workOrderId)
+      .in("id", committedQuoteLineIds);
 
-    if (updateErr)
-      return {
-        ok: false,
-        workOrderLineIds,
-        approvalState: null,
-        partRelink,
-        menuRepairLearning,
-        error: updateErr.message,
-      };
-
-    if (decision === "approve" && materializedLineId) {
-      const relink = await relinkQuoteLinePartsToWorkOrderLine({
-        supabase,
-        shopId,
-        workOrderId,
-        quoteLineId: line.id,
-        workOrderLineId: materializedLineId,
-      });
-
-      if (relink.error)
-        return {
-          ok: false,
-          workOrderLineIds,
-          approvalState: null,
-          partRelink,
-          menuRepairLearning,
-          error: relink.error.message,
-        };
-      mergePartRelinkResult(partRelink, relink.result);
-
-      if (relink.result.conflicts.length > 0) {
-        console.warn(
-          "[quote-line-approval] linked parts conflict while relinking approved quote line",
-          {
-            shopId,
-            workOrderId,
-            quoteLineId: line.id,
-            workOrderLineId: materializedLineId,
-            conflicts: relink.result.conflicts,
-          },
-        );
-      }
-
+    for (const mapping of mappings ?? []) {
+      if (!mapping.work_order_line_id) continue;
       try {
         const learningResult = await upsertMenuRepairItemFromQuoteLine({
-          supabase,
-          shopId,
-          workOrderId,
-          quoteLineId: line.id,
-          workOrderLineId: materializedLineId,
-          actorUserId,
+          supabase: params.supabase,
+          shopId: params.shopId,
+          workOrderId: params.workOrderId,
+          quoteLineId: mapping.id,
+          workOrderLineId: mapping.work_order_line_id,
+          actorUserId: params.actorUserId,
         });
         menuRepairLearning.push({
-          quoteLineId: line.id,
-          workOrderLineId: materializedLineId,
+          quoteLineId: mapping.id,
+          workOrderLineId: mapping.work_order_line_id,
           result: learningResult,
           error: null,
         });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown menu repair learning error";
+      } catch (learningError) {
         menuRepairLearning.push({
-          quoteLineId: line.id,
-          workOrderLineId: materializedLineId,
+          quoteLineId: mapping.id,
+          workOrderLineId: mapping.work_order_line_id,
           result: null,
-          error: message,
-        });
-        console.warn("[quote-line-approval] menu repair learning skipped after approved quote line", {
-          shopId,
-          workOrderId,
-          quoteLineId: line.id,
-          workOrderLineId: materializedLineId,
-          error: message,
+          error:
+            learningError instanceof Error
+              ? learningError.message
+              : "Unknown menu repair learning error",
         });
       }
     }
   }
 
-  const rollup = await rollupWorkOrderQuoteApprovalState({
-    supabase,
-    workOrderId,
-    shopId,
-    now,
-    actorUserId,
-  });
-  if (rollup.error)
-    return {
-      ok: false,
-      workOrderLineIds,
-      approvalState: null,
-      partRelink,
-      menuRepairLearning,
-      error: rollup.error.message,
-    };
-
   return {
-    ok: true,
+    ok: result.ok !== false,
     workOrderLineIds,
-    approvalState: rollup.state,
+    declinedRemainingQuoteLineIds,
+    approvalState:
+      typeof result.approval_state === "string" ? result.approval_state : null,
     partRelink,
     menuRepairLearning,
+    idempotent: result.idempotent === true,
   };
 }

--- a/supabase/migrations/20260715060000_phase5_atomic_quote_decisions.sql
+++ b/supabase/migrations/20260715060000_phase5_atomic_quote_decisions.sql
@@ -1,0 +1,427 @@
+begin;
+
+create table if not exists public.quote_lifecycle_operation_keys (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  operation_name text not null,
+  operation_key text not null,
+  actor_user_id uuid references auth.users(id) on delete set null,
+  work_order_id uuid references public.work_orders(id) on delete cascade,
+  result jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (shop_id, operation_name, operation_key)
+);
+
+alter table public.quote_lifecycle_operation_keys enable row level security;
+
+drop policy if exists quote_lifecycle_operation_keys_shop_select
+  on public.quote_lifecycle_operation_keys;
+create policy quote_lifecycle_operation_keys_shop_select
+  on public.quote_lifecycle_operation_keys
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = quote_lifecycle_operation_keys.shop_id
+    )
+  );
+
+create or replace function public.apply_customer_quote_decision_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_quote_line_ids uuid[],
+  p_decision text,
+  p_decline_remaining boolean,
+  p_customer_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_work_order public.work_orders%rowtype;
+  v_line public.work_order_quote_lines%rowtype;
+  v_existing jsonb;
+  v_result jsonb;
+  v_now timestamptz := coalesce(p_at, now());
+  v_decision text := lower(trim(coalesce(p_decision, '')));
+  v_selected_ids uuid[] := array(
+    select distinct x
+    from unnest(coalesce(p_quote_line_ids, array[]::uuid[])) x
+    where x is not null
+    order by x
+  );
+  v_materialized_ids uuid[] := array[]::uuid[];
+  v_declined_ids uuid[] := array[]::uuid[];
+  v_materialized_id uuid;
+  v_approval_state text := 'pending';
+  v_approved_count integer := 0;
+  v_declined_count integer := 0;
+  v_pending_count integer := 0;
+  v_requests_relinked integer := 0;
+  v_items_relinked integer := 0;
+  v_requests_already integer := 0;
+  v_items_already integer := 0;
+  v_customer_visible_count integer := 0;
+begin
+  if v_decision not in ('approve','decline','defer') then
+    raise exception using errcode = 'P0001', message = 'Unsupported quote decision.';
+  end if;
+  if coalesce(array_length(v_selected_ids, 1), 0) = 0 then
+    raise exception using errcode = 'P0001', message = 'At least one quote line is required.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  select qok.result
+    into v_existing
+  from public.quote_lifecycle_operation_keys qok
+  where qok.shop_id = p_shop_id
+    and qok.operation_name = 'customer_quote_decision'
+    and qok.operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select *
+    into v_work_order
+  from public.work_orders wo
+  where wo.id = p_work_order_id
+    and wo.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work order not found for shop.';
+  end if;
+
+  if p_customer_id is not null and v_work_order.customer_id is distinct from p_customer_id then
+    raise exception using errcode = 'P0001', message = 'Customer does not own this work order.';
+  end if;
+  if public.work_order_is_financially_locked(p_shop_id, p_work_order_id) then
+    raise exception using errcode = 'P0001', message = 'FINANCIALLY_LOCKED: quote decisions cannot change after invoice finalization.';
+  end if;
+
+  perform 1
+  from public.work_order_quote_lines ql
+  where ql.shop_id = p_shop_id
+    and ql.work_order_id = p_work_order_id
+  order by ql.id
+  for update;
+
+  if (
+    select count(*)
+    from public.work_order_quote_lines ql
+    where ql.shop_id = p_shop_id
+      and ql.work_order_id = p_work_order_id
+      and ql.id = any(v_selected_ids)
+  ) <> coalesce(array_length(v_selected_ids, 1), 0) then
+    raise exception using errcode = 'P0001', message = 'One or more quote lines were not found for this work order.';
+  end if;
+
+  for v_line in
+    select *
+    from public.work_order_quote_lines ql
+    where ql.shop_id = p_shop_id
+      and ql.work_order_id = p_work_order_id
+      and ql.id = any(v_selected_ids)
+    order by ql.id
+  loop
+    if v_decision = 'approve' then
+      if lower(coalesce(v_line.status::text, '')) in ('declined','deferred','rejected','cancelled') then
+        raise exception using errcode = 'P0001', message = 'Quote line cannot be approved from its current status.';
+      end if;
+      if lower(coalesce(v_line.status::text, '')) not in ('sent','ready_to_send','quoted','approved','converted')
+         and v_line.sent_to_customer_at is null then
+        raise exception using errcode = 'P0001', message = 'Quote line has not been sent to the customer.';
+      end if;
+
+      v_materialized_id := v_line.work_order_line_id;
+      if v_materialized_id is null then
+        select wol.id
+          into v_materialized_id
+        from public.work_order_lines wol
+        where wol.shop_id = p_shop_id
+          and wol.work_order_id = p_work_order_id
+          and (
+            wol.external_id = 'quote_line:' || v_line.id::text
+            or wol.source_row_id = v_line.id
+          )
+        order by wol.created_at
+        limit 1
+        for update;
+      end if;
+
+      if v_materialized_id is null then
+        insert into public.work_order_lines(
+          shop_id,
+          work_order_id,
+          vehicle_id,
+          description,
+          job_type,
+          status,
+          line_status,
+          approval_state,
+          approval_at,
+          approval_by,
+          quoted_at,
+          labor_time,
+          price_estimate,
+          complaint,
+          cause,
+          correction,
+          notes,
+          external_id,
+          source_row_id,
+          source_intake_id,
+          intake_json
+        ) values (
+          p_shop_id,
+          p_work_order_id,
+          v_line.vehicle_id,
+          coalesce(nullif(trim(v_line.description), ''), nullif(trim(v_line.ai_complaint), ''), 'Approved quote line'),
+          coalesce(nullif(trim(v_line.job_type::text), ''), 'repair'),
+          'awaiting',
+          'authorized',
+          'approved',
+          v_now,
+          p_actor_user_id,
+          coalesce(v_line.sent_to_customer_at, v_line.created_at, v_now),
+          coalesce(v_line.labor_hours, v_line.est_labor_hours),
+          coalesce(v_line.grand_total, v_line.subtotal, coalesce(v_line.labor_total, 0) + coalesce(v_line.parts_total, 0)),
+          coalesce(nullif(trim(v_line.ai_complaint), ''), nullif(trim(v_line.notes), ''), nullif(trim(v_line.description), '')),
+          nullif(trim(v_line.ai_cause), ''),
+          nullif(trim(v_line.ai_correction), ''),
+          nullif(trim(v_line.notes), ''),
+          'quote_line:' || v_line.id::text,
+          v_line.id,
+          nullif(trim(coalesce(v_line.metadata ->> 'source_inspection_id', '')), ''),
+          jsonb_build_object(
+            'source', 'work_order_quote_lines',
+            'quote_line_id', v_line.id,
+            'quote_line_metadata', coalesce(v_line.metadata, '{}'::jsonb),
+            'customer_approved_at', v_now,
+            'customer_approved_by', p_actor_user_id,
+            'labor_total', v_line.labor_total,
+            'parts_total', v_line.parts_total,
+            'subtotal', v_line.subtotal,
+            'tax_total', v_line.tax_total,
+            'grand_total', v_line.grand_total
+          )
+        ) returning id into v_materialized_id;
+      end if;
+
+      if exists (
+        select 1
+        from public.part_requests pr
+        where pr.shop_id = p_shop_id
+          and pr.work_order_id = p_work_order_id
+          and pr.quote_line_id = v_line.id
+          and pr.job_id is not null
+          and pr.job_id <> v_materialized_id
+      ) then
+        raise exception using errcode = 'P0001', message = 'PART_RELINK_CONFLICT: a parts request is linked to another work-order line.';
+      end if;
+      if exists (
+        select 1
+        from public.part_request_items pri
+        where pri.shop_id = p_shop_id
+          and pri.work_order_id = p_work_order_id
+          and pri.quote_line_id = v_line.id
+          and pri.work_order_line_id is not null
+          and pri.work_order_line_id <> v_materialized_id
+      ) then
+        raise exception using errcode = 'P0001', message = 'PART_RELINK_CONFLICT: a parts request item is linked to another work-order line.';
+      end if;
+
+      select count(*) into v_requests_already
+      from public.part_requests pr
+      where pr.shop_id = p_shop_id
+        and pr.work_order_id = p_work_order_id
+        and pr.quote_line_id = v_line.id
+        and pr.job_id = v_materialized_id;
+      select count(*) into v_items_already
+      from public.part_request_items pri
+      where pri.shop_id = p_shop_id
+        and pri.work_order_id = p_work_order_id
+        and pri.quote_line_id = v_line.id
+        and pri.work_order_line_id = v_materialized_id;
+
+      update public.part_requests
+      set job_id = v_materialized_id
+      where shop_id = p_shop_id
+        and work_order_id = p_work_order_id
+        and quote_line_id = v_line.id
+        and job_id is null;
+      get diagnostics v_requests_relinked = v_requests_relinked + row_count;
+
+      update public.part_request_items
+      set work_order_line_id = v_materialized_id
+      where shop_id = p_shop_id
+        and work_order_id = p_work_order_id
+        and quote_line_id = v_line.id
+        and work_order_line_id is null;
+      get diagnostics v_items_relinked = v_items_relinked + row_count;
+
+      update public.work_order_quote_lines
+      set status = 'converted',
+          stage = 'customer_approved',
+          approved_at = coalesce(approved_at, v_now),
+          declined_at = null,
+          work_order_line_id = v_materialized_id,
+          metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+            'customer_decision', 'approve',
+            'customer_decision_at', v_now,
+            'customer_actor_user_id', p_actor_user_id,
+            'customer_id', p_customer_id,
+            'materialized_work_order_line_id', v_materialized_id
+          ),
+          updated_at = v_now
+      where id = v_line.id;
+
+      v_materialized_ids := array_append(v_materialized_ids, v_materialized_id);
+    elsif v_decision = 'decline' then
+      update public.work_order_quote_lines
+      set status = 'declined',
+          stage = 'customer_declined',
+          declined_at = coalesce(declined_at, v_now),
+          metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+            'customer_decision', 'decline',
+            'customer_decision_at', v_now,
+            'customer_actor_user_id', p_actor_user_id,
+            'customer_id', p_customer_id
+          ),
+          updated_at = v_now
+      where id = v_line.id;
+      v_declined_ids := array_append(v_declined_ids, v_line.id);
+    else
+      update public.work_order_quote_lines
+      set status = 'deferred',
+          stage = 'customer_deferred',
+          declined_at = null,
+          metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+            'customer_decision', 'defer',
+            'customer_decision_at', v_now,
+            'customer_actor_user_id', p_actor_user_id,
+            'customer_id', p_customer_id
+          ),
+          updated_at = v_now
+      where id = v_line.id;
+    end if;
+  end loop;
+
+  if p_decline_remaining and v_decision = 'approve' then
+    update public.work_order_quote_lines ql
+    set status = 'declined',
+        stage = 'customer_declined',
+        declined_at = coalesce(ql.declined_at, v_now),
+        metadata = coalesce(ql.metadata, '{}'::jsonb) || jsonb_build_object(
+          'customer_decision', 'decline',
+          'customer_decision_at', v_now,
+          'customer_actor_user_id', p_actor_user_id,
+          'customer_id', p_customer_id,
+          'declined_as_remaining', true
+        ),
+        updated_at = v_now
+    where ql.shop_id = p_shop_id
+      and ql.work_order_id = p_work_order_id
+      and ql.id <> all(v_selected_ids)
+      and lower(coalesce(ql.status::text, '')) = 'sent'
+    returning ql.id into v_materialized_id;
+
+    select coalesce(array_agg(ql.id order by ql.id), array[]::uuid[])
+      into v_declined_ids
+    from public.work_order_quote_lines ql
+    where ql.shop_id = p_shop_id
+      and ql.work_order_id = p_work_order_id
+      and (ql.metadata ->> 'declined_as_remaining')::boolean is true
+      and ql.updated_at = v_now;
+  end if;
+
+  select
+    count(*) filter (
+      where lower(coalesce(ql.status::text, '')) in ('approved','converted')
+         or lower(coalesce(ql.stage::text, '')) = 'customer_approved'
+         or ql.approved_at is not null
+         or ql.work_order_line_id is not null
+    ),
+    count(*) filter (
+      where lower(coalesce(ql.status::text, '')) in ('declined','deferred')
+         or lower(coalesce(ql.stage::text, '')) in ('customer_declined','customer_deferred')
+         or ql.declined_at is not null
+    ),
+    count(*) filter (
+      where not (
+        lower(coalesce(ql.status::text, '')) in ('approved','converted','declined','deferred')
+        or lower(coalesce(ql.stage::text, '')) in ('customer_approved','customer_declined','customer_deferred')
+        or ql.approved_at is not null
+        or ql.declined_at is not null
+        or ql.work_order_line_id is not null
+      )
+    ),
+    count(*)
+  into v_approved_count, v_declined_count, v_pending_count, v_customer_visible_count
+  from public.work_order_quote_lines ql
+  where ql.shop_id = p_shop_id
+    and ql.work_order_id = p_work_order_id
+    and (
+      ql.sent_to_customer_at is not null
+      or lower(coalesce(ql.status::text, '')) in ('sent','approved','converted','declined','deferred')
+    );
+
+  if v_approved_count > 0 and v_pending_count = 0 and v_declined_count = 0 then
+    v_approval_state := 'approved';
+  elsif v_approved_count > 0 then
+    v_approval_state := 'partial';
+  elsif v_approved_count = 0 and v_pending_count = 0 and v_declined_count > 0 then
+    v_approval_state := 'declined';
+  else
+    v_approval_state := 'pending';
+  end if;
+
+  update public.work_orders
+  set approval_state = v_approval_state,
+      customer_approval_at = case when v_approval_state in ('approved','partial') then v_now else customer_approval_at end,
+      customer_agreed_at = case when v_approval_state in ('approved','partial') then v_now else customer_agreed_at end,
+      customer_approved_by = case when v_approval_state in ('approved','partial') then p_actor_user_id else customer_approved_by end,
+      updated_at = v_now
+  where id = p_work_order_id
+    and shop_id = p_shop_id;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'quote_line_ids', to_jsonb(v_selected_ids),
+    'work_order_line_ids', to_jsonb(v_materialized_ids),
+    'declined_remaining_quote_line_ids', to_jsonb(v_declined_ids),
+    'approval_state', v_approval_state,
+    'part_relink', jsonb_build_object(
+      'partRequestsRelinked', v_requests_relinked,
+      'partRequestItemsRelinked', v_items_relinked,
+      'partRequestsAlreadyLinked', v_requests_already,
+      'partRequestItemsAlreadyLinked', v_items_already,
+      'conflicts', '[]'::jsonb
+    )
+  );
+
+  insert into public.quote_lifecycle_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id, work_order_id, result
+  ) values (
+    p_shop_id, 'customer_quote_decision', p_operation_key, p_actor_user_id, p_work_order_id, v_result
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.apply_customer_quote_decision_atomic(uuid,uuid,uuid[],text,boolean,uuid,uuid,text,timestamptz) from public, anon;
+grant execute on function public.apply_customer_quote_decision_atomic(uuid,uuid,uuid[],text,boolean,uuid,uuid,text,timestamptz) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260715060000_phase5_atomic_quote_decisions.sql
+++ b/supabase/migrations/20260715060000_phase5_atomic_quote_decisions.sql
@@ -13,17 +13,13 @@ create table if not exists public.quote_lifecycle_operation_keys (
 );
 
 alter table public.quote_lifecycle_operation_keys enable row level security;
-
-drop policy if exists quote_lifecycle_operation_keys_shop_select
-  on public.quote_lifecycle_operation_keys;
+drop policy if exists quote_lifecycle_operation_keys_shop_select on public.quote_lifecycle_operation_keys;
 create policy quote_lifecycle_operation_keys_shop_select
   on public.quote_lifecycle_operation_keys
-  for select
-  to authenticated
+  for select to authenticated
   using (
     exists (
-      select 1
-      from public.profiles p
+      select 1 from public.profiles p
       where p.id = auth.uid()
         and p.shop_id = quote_lifecycle_operation_keys.shop_id
     )
@@ -46,60 +42,56 @@ set search_path = public
 as $$
 declare
   v_work_order public.work_orders%rowtype;
-  v_line public.work_order_quote_lines%rowtype;
+  v_quote public.work_order_quote_lines%rowtype;
   v_existing jsonb;
   v_result jsonb;
   v_now timestamptz := coalesce(p_at, now());
   v_decision text := lower(trim(coalesce(p_decision, '')));
-  v_selected_ids uuid[] := array(
-    select distinct x
-    from unnest(coalesce(p_quote_line_ids, array[]::uuid[])) x
-    where x is not null
-    order by x
+  v_selected uuid[] := array(
+    select distinct value
+    from unnest(coalesce(p_quote_line_ids, array[]::uuid[])) value
+    where value is not null
+    order by value
   );
-  v_materialized_ids uuid[] := array[]::uuid[];
-  v_declined_ids uuid[] := array[]::uuid[];
-  v_materialized_id uuid;
+  v_materialized uuid[] := array[]::uuid[];
+  v_declined_remaining uuid[] := array[]::uuid[];
+  v_work_order_line_id uuid;
   v_approval_state text := 'pending';
-  v_approved_count integer := 0;
-  v_declined_count integer := 0;
-  v_pending_count integer := 0;
+  v_approved integer := 0;
+  v_declined integer := 0;
+  v_pending integer := 0;
+  v_row_count integer := 0;
   v_requests_relinked integer := 0;
   v_items_relinked integer := 0;
   v_requests_already integer := 0;
   v_items_already integer := 0;
-  v_customer_visible_count integer := 0;
 begin
-  if v_decision not in ('approve','decline','defer') then
+  if v_decision not in ('approve', 'decline', 'defer') then
     raise exception using errcode = 'P0001', message = 'Unsupported quote decision.';
   end if;
-  if coalesce(array_length(v_selected_ids, 1), 0) = 0 then
+  if coalesce(array_length(v_selected, 1), 0) = 0 then
     raise exception using errcode = 'P0001', message = 'At least one quote line is required.';
   end if;
   if nullif(trim(p_operation_key), '') is null then
     raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
   end if;
 
-  select qok.result
-    into v_existing
-  from public.quote_lifecycle_operation_keys qok
-  where qok.shop_id = p_shop_id
-    and qok.operation_name = 'customer_quote_decision'
-    and qok.operation_key = p_operation_key;
+  select result into v_existing
+  from public.quote_lifecycle_operation_keys
+  where shop_id = p_shop_id
+    and operation_name = 'customer_quote_decision'
+    and operation_key = p_operation_key;
   if found then
     return v_existing || jsonb_build_object('idempotent', true);
   end if;
 
-  select *
-    into v_work_order
-  from public.work_orders wo
-  where wo.id = p_work_order_id
-    and wo.shop_id = p_shop_id
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id and shop_id = p_shop_id
   for update;
   if not found then
     raise exception using errcode = 'P0001', message = 'Work order not found for shop.';
   end if;
-
   if p_customer_id is not null and v_work_order.customer_id is distinct from p_customer_id then
     raise exception using errcode = 'P0001', message = 'Customer does not own this work order.';
   end if;
@@ -108,297 +100,227 @@ begin
   end if;
 
   perform 1
-  from public.work_order_quote_lines ql
-  where ql.shop_id = p_shop_id
-    and ql.work_order_id = p_work_order_id
-  order by ql.id
+  from public.work_order_quote_lines
+  where shop_id = p_shop_id and work_order_id = p_work_order_id
+  order by id
   for update;
 
   if (
-    select count(*)
-    from public.work_order_quote_lines ql
-    where ql.shop_id = p_shop_id
-      and ql.work_order_id = p_work_order_id
-      and ql.id = any(v_selected_ids)
-  ) <> coalesce(array_length(v_selected_ids, 1), 0) then
+    select count(*) from public.work_order_quote_lines
+    where shop_id = p_shop_id
+      and work_order_id = p_work_order_id
+      and id = any(v_selected)
+  ) <> cardinality(v_selected) then
     raise exception using errcode = 'P0001', message = 'One or more quote lines were not found for this work order.';
   end if;
 
-  for v_line in
-    select *
-    from public.work_order_quote_lines ql
-    where ql.shop_id = p_shop_id
-      and ql.work_order_id = p_work_order_id
-      and ql.id = any(v_selected_ids)
-    order by ql.id
+  for v_quote in
+    select * from public.work_order_quote_lines
+    where shop_id = p_shop_id
+      and work_order_id = p_work_order_id
+      and id = any(v_selected)
+    order by id
   loop
     if v_decision = 'approve' then
-      if lower(coalesce(v_line.status::text, '')) in ('declined','deferred','rejected','cancelled') then
+      if lower(coalesce(v_quote.status::text, '')) in ('declined', 'deferred', 'rejected', 'cancelled') then
         raise exception using errcode = 'P0001', message = 'Quote line cannot be approved from its current status.';
       end if;
-      if lower(coalesce(v_line.status::text, '')) not in ('sent','ready_to_send','quoted','approved','converted')
-         and v_line.sent_to_customer_at is null then
+      if lower(coalesce(v_quote.status::text, '')) not in ('sent', 'ready_to_send', 'quoted', 'approved', 'converted')
+         and v_quote.sent_to_customer_at is null then
         raise exception using errcode = 'P0001', message = 'Quote line has not been sent to the customer.';
       end if;
 
-      v_materialized_id := v_line.work_order_line_id;
-      if v_materialized_id is null then
-        select wol.id
-          into v_materialized_id
-        from public.work_order_lines wol
-        where wol.shop_id = p_shop_id
-          and wol.work_order_id = p_work_order_id
-          and (
-            wol.external_id = 'quote_line:' || v_line.id::text
-            or wol.source_row_id = v_line.id
-          )
-        order by wol.created_at
+      v_work_order_line_id := v_quote.work_order_line_id;
+      if v_work_order_line_id is null then
+        select id into v_work_order_line_id
+        from public.work_order_lines
+        where shop_id = p_shop_id
+          and work_order_id = p_work_order_id
+          and (external_id = 'quote_line:' || v_quote.id::text or source_row_id = v_quote.id)
+        order by created_at
         limit 1
         for update;
       end if;
 
-      if v_materialized_id is null then
+      if v_work_order_line_id is null then
         insert into public.work_order_lines(
-          shop_id,
-          work_order_id,
-          vehicle_id,
-          description,
-          job_type,
-          status,
-          line_status,
-          approval_state,
-          approval_at,
-          approval_by,
-          quoted_at,
-          labor_time,
-          price_estimate,
-          complaint,
-          cause,
-          correction,
-          notes,
-          external_id,
-          source_row_id,
-          source_intake_id,
-          intake_json
+          shop_id, work_order_id, vehicle_id, description, job_type,
+          status, line_status, approval_state, approval_at, approval_by,
+          quoted_at, labor_time, price_estimate, complaint, cause,
+          correction, notes, external_id, source_row_id, intake_json
         ) values (
           p_shop_id,
           p_work_order_id,
-          v_line.vehicle_id,
-          coalesce(nullif(trim(v_line.description), ''), nullif(trim(v_line.ai_complaint), ''), 'Approved quote line'),
-          coalesce(nullif(trim(v_line.job_type::text), ''), 'repair'),
+          v_quote.vehicle_id,
+          coalesce(nullif(trim(v_quote.description), ''), nullif(trim(v_quote.ai_complaint), ''), 'Approved quote line'),
+          coalesce(nullif(trim(v_quote.job_type::text), ''), 'repair'),
           'awaiting',
           'authorized',
           'approved',
           v_now,
           p_actor_user_id,
-          coalesce(v_line.sent_to_customer_at, v_line.created_at, v_now),
-          coalesce(v_line.labor_hours, v_line.est_labor_hours),
-          coalesce(v_line.grand_total, v_line.subtotal, coalesce(v_line.labor_total, 0) + coalesce(v_line.parts_total, 0)),
-          coalesce(nullif(trim(v_line.ai_complaint), ''), nullif(trim(v_line.notes), ''), nullif(trim(v_line.description), '')),
-          nullif(trim(v_line.ai_cause), ''),
-          nullif(trim(v_line.ai_correction), ''),
-          nullif(trim(v_line.notes), ''),
-          'quote_line:' || v_line.id::text,
-          v_line.id,
-          nullif(trim(coalesce(v_line.metadata ->> 'source_inspection_id', '')), ''),
+          coalesce(v_quote.sent_to_customer_at, v_quote.created_at, v_now),
+          coalesce(v_quote.labor_hours, v_quote.est_labor_hours),
+          coalesce(v_quote.grand_total, v_quote.subtotal, coalesce(v_quote.labor_total, 0) + coalesce(v_quote.parts_total, 0)),
+          coalesce(nullif(trim(v_quote.ai_complaint), ''), nullif(trim(v_quote.notes), ''), nullif(trim(v_quote.description), '')),
+          nullif(trim(v_quote.ai_cause), ''),
+          nullif(trim(v_quote.ai_correction), ''),
+          nullif(trim(v_quote.notes), ''),
+          'quote_line:' || v_quote.id::text,
+          v_quote.id,
           jsonb_build_object(
             'source', 'work_order_quote_lines',
-            'quote_line_id', v_line.id,
-            'quote_line_metadata', coalesce(v_line.metadata, '{}'::jsonb),
+            'quote_line_id', v_quote.id,
+            'quote_line_metadata', coalesce(v_quote.metadata, '{}'::jsonb),
             'customer_approved_at', v_now,
             'customer_approved_by', p_actor_user_id,
-            'labor_total', v_line.labor_total,
-            'parts_total', v_line.parts_total,
-            'subtotal', v_line.subtotal,
-            'tax_total', v_line.tax_total,
-            'grand_total', v_line.grand_total
+            'labor_total', v_quote.labor_total,
+            'parts_total', v_quote.parts_total,
+            'subtotal', v_quote.subtotal,
+            'tax_total', v_quote.tax_total,
+            'grand_total', v_quote.grand_total
           )
-        ) returning id into v_materialized_id;
+        ) returning id into v_work_order_line_id;
       end if;
 
       if exists (
-        select 1
-        from public.part_requests pr
-        where pr.shop_id = p_shop_id
-          and pr.work_order_id = p_work_order_id
-          and pr.quote_line_id = v_line.id
-          and pr.job_id is not null
-          and pr.job_id <> v_materialized_id
+        select 1 from public.part_requests
+        where shop_id = p_shop_id
+          and work_order_id = p_work_order_id
+          and quote_line_id = v_quote.id
+          and job_id is not null
+          and job_id <> v_work_order_line_id
+      ) or exists (
+        select 1 from public.part_request_items
+        where shop_id = p_shop_id
+          and work_order_id = p_work_order_id
+          and quote_line_id = v_quote.id
+          and work_order_line_id is not null
+          and work_order_line_id <> v_work_order_line_id
       ) then
-        raise exception using errcode = 'P0001', message = 'PART_RELINK_CONFLICT: a parts request is linked to another work-order line.';
-      end if;
-      if exists (
-        select 1
-        from public.part_request_items pri
-        where pri.shop_id = p_shop_id
-          and pri.work_order_id = p_work_order_id
-          and pri.quote_line_id = v_line.id
-          and pri.work_order_line_id is not null
-          and pri.work_order_line_id <> v_materialized_id
-      ) then
-        raise exception using errcode = 'P0001', message = 'PART_RELINK_CONFLICT: a parts request item is linked to another work-order line.';
+        raise exception using errcode = 'P0001', message = 'PART_RELINK_CONFLICT: quote parts are linked to another work-order line.';
       end if;
 
-      select count(*) into v_requests_already
-      from public.part_requests pr
-      where pr.shop_id = p_shop_id
-        and pr.work_order_id = p_work_order_id
-        and pr.quote_line_id = v_line.id
-        and pr.job_id = v_materialized_id;
-      select count(*) into v_items_already
-      from public.part_request_items pri
-      where pri.shop_id = p_shop_id
-        and pri.work_order_id = p_work_order_id
-        and pri.quote_line_id = v_line.id
-        and pri.work_order_line_id = v_materialized_id;
+      v_requests_already := v_requests_already + (
+        select count(*) from public.part_requests
+        where shop_id = p_shop_id and work_order_id = p_work_order_id
+          and quote_line_id = v_quote.id and job_id = v_work_order_line_id
+      );
+      v_items_already := v_items_already + (
+        select count(*) from public.part_request_items
+        where shop_id = p_shop_id and work_order_id = p_work_order_id
+          and quote_line_id = v_quote.id and work_order_line_id = v_work_order_line_id
+      );
 
       update public.part_requests
-      set job_id = v_materialized_id
-      where shop_id = p_shop_id
-        and work_order_id = p_work_order_id
-        and quote_line_id = v_line.id
-        and job_id is null;
-      get diagnostics v_requests_relinked = v_requests_relinked + row_count;
+      set job_id = v_work_order_line_id
+      where shop_id = p_shop_id and work_order_id = p_work_order_id
+        and quote_line_id = v_quote.id and job_id is null;
+      get diagnostics v_row_count = row_count;
+      v_requests_relinked := v_requests_relinked + v_row_count;
 
       update public.part_request_items
-      set work_order_line_id = v_materialized_id
-      where shop_id = p_shop_id
-        and work_order_id = p_work_order_id
-        and quote_line_id = v_line.id
-        and work_order_line_id is null;
-      get diagnostics v_items_relinked = v_items_relinked + row_count;
+      set work_order_line_id = v_work_order_line_id
+      where shop_id = p_shop_id and work_order_id = p_work_order_id
+        and quote_line_id = v_quote.id and work_order_line_id is null;
+      get diagnostics v_row_count = row_count;
+      v_items_relinked := v_items_relinked + v_row_count;
 
       update public.work_order_quote_lines
       set status = 'converted',
           stage = 'customer_approved',
           approved_at = coalesce(approved_at, v_now),
           declined_at = null,
-          work_order_line_id = v_materialized_id,
+          work_order_line_id = v_work_order_line_id,
           metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
             'customer_decision', 'approve',
             'customer_decision_at', v_now,
             'customer_actor_user_id', p_actor_user_id,
             'customer_id', p_customer_id,
-            'materialized_work_order_line_id', v_materialized_id
+            'materialized_work_order_line_id', v_work_order_line_id
           ),
           updated_at = v_now
-      where id = v_line.id;
+      where id = v_quote.id;
 
-      v_materialized_ids := array_append(v_materialized_ids, v_materialized_id);
+      v_materialized := array_append(v_materialized, v_work_order_line_id);
     elsif v_decision = 'decline' then
       update public.work_order_quote_lines
-      set status = 'declined',
-          stage = 'customer_declined',
+      set status = 'declined', stage = 'customer_declined',
           declined_at = coalesce(declined_at, v_now),
           metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
-            'customer_decision', 'decline',
-            'customer_decision_at', v_now,
-            'customer_actor_user_id', p_actor_user_id,
-            'customer_id', p_customer_id
+            'customer_decision', 'decline', 'customer_decision_at', v_now,
+            'customer_actor_user_id', p_actor_user_id, 'customer_id', p_customer_id
           ),
           updated_at = v_now
-      where id = v_line.id;
-      v_declined_ids := array_append(v_declined_ids, v_line.id);
+      where id = v_quote.id;
     else
       update public.work_order_quote_lines
-      set status = 'deferred',
-          stage = 'customer_deferred',
-          declined_at = null,
+      set status = 'deferred', stage = 'customer_deferred', declined_at = null,
           metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
-            'customer_decision', 'defer',
-            'customer_decision_at', v_now,
-            'customer_actor_user_id', p_actor_user_id,
-            'customer_id', p_customer_id
+            'customer_decision', 'defer', 'customer_decision_at', v_now,
+            'customer_actor_user_id', p_actor_user_id, 'customer_id', p_customer_id
           ),
           updated_at = v_now
-      where id = v_line.id;
+      where id = v_quote.id;
     end if;
   end loop;
 
   if p_decline_remaining and v_decision = 'approve' then
-    update public.work_order_quote_lines ql
-    set status = 'declined',
-        stage = 'customer_declined',
-        declined_at = coalesce(ql.declined_at, v_now),
-        metadata = coalesce(ql.metadata, '{}'::jsonb) || jsonb_build_object(
-          'customer_decision', 'decline',
-          'customer_decision_at', v_now,
-          'customer_actor_user_id', p_actor_user_id,
-          'customer_id', p_customer_id,
+    select coalesce(array_agg(id order by id), array[]::uuid[])
+      into v_declined_remaining
+    from public.work_order_quote_lines
+    where shop_id = p_shop_id
+      and work_order_id = p_work_order_id
+      and not (id = any(v_selected))
+      and lower(coalesce(status::text, '')) = 'sent';
+
+    update public.work_order_quote_lines
+    set status = 'declined', stage = 'customer_declined',
+        declined_at = coalesce(declined_at, v_now),
+        metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+          'customer_decision', 'decline', 'customer_decision_at', v_now,
+          'customer_actor_user_id', p_actor_user_id, 'customer_id', p_customer_id,
           'declined_as_remaining', true
         ),
         updated_at = v_now
-    where ql.shop_id = p_shop_id
-      and ql.work_order_id = p_work_order_id
-      and ql.id <> all(v_selected_ids)
-      and lower(coalesce(ql.status::text, '')) = 'sent'
-    returning ql.id into v_materialized_id;
-
-    select coalesce(array_agg(ql.id order by ql.id), array[]::uuid[])
-      into v_declined_ids
-    from public.work_order_quote_lines ql
-    where ql.shop_id = p_shop_id
-      and ql.work_order_id = p_work_order_id
-      and (ql.metadata ->> 'declined_as_remaining')::boolean is true
-      and ql.updated_at = v_now;
+    where id = any(v_declined_remaining);
   end if;
 
   select
-    count(*) filter (
-      where lower(coalesce(ql.status::text, '')) in ('approved','converted')
-         or lower(coalesce(ql.stage::text, '')) = 'customer_approved'
-         or ql.approved_at is not null
-         or ql.work_order_line_id is not null
-    ),
-    count(*) filter (
-      where lower(coalesce(ql.status::text, '')) in ('declined','deferred')
-         or lower(coalesce(ql.stage::text, '')) in ('customer_declined','customer_deferred')
-         or ql.declined_at is not null
-    ),
-    count(*) filter (
-      where not (
-        lower(coalesce(ql.status::text, '')) in ('approved','converted','declined','deferred')
-        or lower(coalesce(ql.stage::text, '')) in ('customer_approved','customer_declined','customer_deferred')
-        or ql.approved_at is not null
-        or ql.declined_at is not null
-        or ql.work_order_line_id is not null
-      )
-    ),
-    count(*)
-  into v_approved_count, v_declined_count, v_pending_count, v_customer_visible_count
-  from public.work_order_quote_lines ql
-  where ql.shop_id = p_shop_id
-    and ql.work_order_id = p_work_order_id
-    and (
-      ql.sent_to_customer_at is not null
-      or lower(coalesce(ql.status::text, '')) in ('sent','approved','converted','declined','deferred')
-    );
+    count(*) filter (where lower(coalesce(status::text, '')) in ('approved', 'converted') or stage::text = 'customer_approved' or approved_at is not null or work_order_line_id is not null),
+    count(*) filter (where lower(coalesce(status::text, '')) in ('declined', 'deferred') or stage::text in ('customer_declined', 'customer_deferred') or declined_at is not null),
+    count(*) filter (where not (
+      lower(coalesce(status::text, '')) in ('approved', 'converted', 'declined', 'deferred')
+      or stage::text in ('customer_approved', 'customer_declined', 'customer_deferred')
+      or approved_at is not null or declined_at is not null or work_order_line_id is not null
+    ))
+  into v_approved, v_declined, v_pending
+  from public.work_order_quote_lines
+  where shop_id = p_shop_id and work_order_id = p_work_order_id
+    and (sent_to_customer_at is not null or lower(coalesce(status::text, '')) in ('sent', 'approved', 'converted', 'declined', 'deferred'));
 
-  if v_approved_count > 0 and v_pending_count = 0 and v_declined_count = 0 then
+  if v_approved > 0 and v_pending = 0 and v_declined = 0 then
     v_approval_state := 'approved';
-  elsif v_approved_count > 0 then
+  elsif v_approved > 0 then
     v_approval_state := 'partial';
-  elsif v_approved_count = 0 and v_pending_count = 0 and v_declined_count > 0 then
+  elsif v_approved = 0 and v_pending = 0 and v_declined > 0 then
     v_approval_state := 'declined';
-  else
-    v_approval_state := 'pending';
   end if;
 
   update public.work_orders
   set approval_state = v_approval_state,
-      customer_approval_at = case when v_approval_state in ('approved','partial') then v_now else customer_approval_at end,
-      customer_agreed_at = case when v_approval_state in ('approved','partial') then v_now else customer_agreed_at end,
-      customer_approved_by = case when v_approval_state in ('approved','partial') then p_actor_user_id else customer_approved_by end,
+      customer_approval_at = case when v_approval_state in ('approved', 'partial') then v_now else customer_approval_at end,
+      customer_agreed_at = case when v_approval_state in ('approved', 'partial') then v_now else customer_agreed_at end,
+      customer_approved_by = case when v_approval_state in ('approved', 'partial') then p_actor_user_id else customer_approved_by end,
       updated_at = v_now
-  where id = p_work_order_id
-    and shop_id = p_shop_id;
+  where id = p_work_order_id and shop_id = p_shop_id;
 
   v_result := jsonb_build_object(
     'ok', true,
     'idempotent', false,
-    'quote_line_ids', to_jsonb(v_selected_ids),
-    'work_order_line_ids', to_jsonb(v_materialized_ids),
-    'declined_remaining_quote_line_ids', to_jsonb(v_declined_ids),
+    'quote_line_ids', to_jsonb(v_selected),
+    'work_order_line_ids', to_jsonb(v_materialized),
+    'declined_remaining_quote_line_ids', to_jsonb(v_declined_remaining),
     'approval_state', v_approval_state,
     'part_relink', jsonb_build_object(
       'partRequestsRelinked', v_requests_relinked,
@@ -412,7 +334,8 @@ begin
   insert into public.quote_lifecycle_operation_keys(
     shop_id, operation_name, operation_key, actor_user_id, work_order_id, result
   ) values (
-    p_shop_id, 'customer_quote_decision', p_operation_key, p_actor_user_id, p_work_order_id, v_result
+    p_shop_id, 'customer_quote_decision', p_operation_key,
+    p_actor_user_id, p_work_order_id, v_result
   );
 
   return v_result;
@@ -421,7 +344,6 @@ $$;
 
 revoke all on function public.apply_customer_quote_decision_atomic(uuid,uuid,uuid[],text,boolean,uuid,uuid,text,timestamptz) from public, anon;
 grant execute on function public.apply_customer_quote_decision_atomic(uuid,uuid,uuid[],text,boolean,uuid,uuid,text,timestamptz) to authenticated, service_role;
-
 notify pgrst, 'reload schema';
 
 commit;

--- a/supabase/migrations/20260715060100_phase5_atomic_inspection_quote_import.sql
+++ b/supabase/migrations/20260715060100_phase5_atomic_inspection_quote_import.sql
@@ -1,0 +1,307 @@
+begin;
+
+create or replace function public.import_inspection_quote_package_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_inspection_id uuid,
+  p_requested_vehicle_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_items jsonb,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_work_order public.work_orders%rowtype;
+  v_inspection public.inspections%rowtype;
+  v_source_line public.work_order_lines%rowtype;
+  v_existing jsonb;
+  v_result jsonb;
+  v_now timestamptz := coalesce(p_at, now());
+  v_item jsonb;
+  v_part jsonb;
+  v_quote_id uuid;
+  v_requested_id uuid;
+  v_request_id uuid;
+  v_identity text;
+  v_description text;
+  v_part_description text;
+  v_part_identity text;
+  v_qty numeric;
+  v_created boolean;
+  v_quote_ids uuid[] := array[]::uuid[];
+  v_created_quote_ids uuid[] := array[]::uuid[];
+  v_created_request_ids uuid[] := array[]::uuid[];
+  v_created_quote_count integer := 0;
+  v_skipped_quote_count integer := 0;
+  v_created_item_count integer := 0;
+  v_skipped_item_count integer := 0;
+  v_item_results jsonb := '[]'::jsonb;
+begin
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+  if jsonb_typeof(p_items) <> 'array' then
+    raise exception using errcode = 'P0001', message = 'Inspection import items must be a JSON array.';
+  end if;
+
+  select result into v_existing
+  from public.quote_lifecycle_operation_keys
+  where shop_id = p_shop_id
+    and operation_name = 'inspection_quote_import'
+    and operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id and shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work order not found for shop.';
+  end if;
+  if lower(coalesce(v_work_order.status::text, '')) in ('cancelled', 'canceled', 'closed', 'invoiced') then
+    raise exception using errcode = 'P0001', message = 'Cannot import into a cancelled, closed, or invoiced work order.';
+  end if;
+  if public.work_order_is_financially_locked(p_shop_id, p_work_order_id) then
+    raise exception using errcode = 'P0001', message = 'FINANCIALLY_LOCKED: inspection findings cannot be imported after invoice finalization.';
+  end if;
+  if p_requested_vehicle_id is not null and p_requested_vehicle_id is distinct from v_work_order.vehicle_id then
+    raise exception using errcode = 'P0001', message = 'INSPECTION_VEHICLE_MISMATCH: caller vehicle does not match the work order.';
+  end if;
+
+  select * into v_inspection
+  from public.inspections
+  where id = p_inspection_id and shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Inspection not found for shop.';
+  end if;
+  if v_inspection.work_order_id is null or v_inspection.work_order_line_id is null then
+    raise exception using errcode = 'P0001', message = 'INSPECTION_UNANCHORED: inspection requires administrative reconciliation before import.';
+  end if;
+  if v_inspection.work_order_id <> p_work_order_id then
+    raise exception using errcode = 'P0001', message = 'INSPECTION_WORK_ORDER_MISMATCH: inspection belongs to another work order.';
+  end if;
+
+  select * into v_source_line
+  from public.work_order_lines
+  where id = v_inspection.work_order_line_id
+    and shop_id = p_shop_id
+  for update;
+  if not found or v_source_line.work_order_id <> p_work_order_id then
+    raise exception using errcode = 'P0001', message = 'INSPECTION_SOURCE_LINE_MISMATCH: source line is not anchored to this work order.';
+  end if;
+  if v_source_line.vehicle_id is not null
+     and v_work_order.vehicle_id is not null
+     and v_source_line.vehicle_id <> v_work_order.vehicle_id then
+    raise exception using errcode = 'P0001', message = 'INSPECTION_VEHICLE_MISMATCH: source line vehicle conflicts with the work order.';
+  end if;
+
+  for v_item in select value from jsonb_array_elements(p_items)
+  loop
+    v_description := coalesce(nullif(trim(v_item ->> 'description'), ''), nullif(trim(v_item ->> 'title'), ''));
+    if v_description is null then
+      continue;
+    end if;
+
+    v_identity := nullif(trim(v_item ->> 'findingIdentity'), '');
+    v_requested_id := null;
+    if coalesce(v_item ->> 'id', '') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      v_requested_id := (v_item ->> 'id')::uuid;
+    end if;
+
+    v_quote_id := null;
+    if v_requested_id is not null then
+      select id into v_quote_id
+      from public.work_order_quote_lines
+      where id = v_requested_id
+        and shop_id = p_shop_id
+        and work_order_id = p_work_order_id
+      for update;
+    end if;
+    if v_quote_id is null and v_identity is not null then
+      select id into v_quote_id
+      from public.work_order_quote_lines
+      where shop_id = p_shop_id
+        and work_order_id = p_work_order_id
+        and metadata ->> 'inspection_finding_identity' = v_identity
+      order by created_at
+      limit 1
+      for update;
+    end if;
+
+    v_created := false;
+    if v_quote_id is null then
+      insert into public.work_order_quote_lines(
+        id, work_order_id, work_order_line_id, shop_id, vehicle_id,
+        suggested_by, description, job_type, est_labor_hours, notes,
+        status, ai_complaint, ai_cause, ai_correction, stage, qty,
+        labor_hours, parts_total, labor_total, subtotal, tax_total,
+        grand_total, metadata, group_id, sent_to_customer_at,
+        approved_at, declined_at
+      ) values (
+        coalesce(v_requested_id, gen_random_uuid()),
+        p_work_order_id,
+        null,
+        p_shop_id,
+        v_work_order.vehicle_id,
+        p_actor_user_id,
+        v_description,
+        coalesce(nullif(trim(v_item ->> 'jobType'), ''), 'tech-suggested'),
+        nullif(v_item ->> 'estLaborHours', '')::numeric,
+        coalesce(nullif(trim(v_item ->> 'notes'), ''), nullif(trim(v_item ->> 'complaint'), '')),
+        coalesce(nullif(trim(v_item ->> 'status'), ''), 'advisor_pending'),
+        coalesce(nullif(trim(v_item ->> 'aiComplaint'), ''), nullif(trim(v_item ->> 'complaint'), '')),
+        nullif(trim(v_item ->> 'aiCause'), ''),
+        nullif(trim(v_item ->> 'aiCorrection'), ''),
+        coalesce(nullif(trim(v_item ->> 'stage'), ''), 'advisor_pending'),
+        1,
+        nullif(v_item ->> 'laborHours', '')::numeric,
+        coalesce(nullif(v_item ->> 'partsTotal', '')::numeric, 0),
+        nullif(v_item ->> 'laborTotal', '')::numeric,
+        coalesce(nullif(v_item ->> 'subtotal', '')::numeric, 0),
+        nullif(v_item ->> 'taxTotal', '')::numeric,
+        coalesce(nullif(v_item ->> 'grandTotal', '')::numeric, nullif(v_item ->> 'subtotal', '')::numeric, 0),
+        coalesce(v_item -> 'metadata', '{}'::jsonb) || jsonb_build_object(
+          'source', coalesce(nullif(v_item ->> 'source', ''), 'inspection'),
+          'source_inspection_id', p_inspection_id,
+          'source_work_order_line_id', v_inspection.work_order_line_id,
+          'source_section_key', nullif(v_item ->> 'sourceSectionKey', ''),
+          'source_section_title', nullif(v_item ->> 'sourceSectionTitle', ''),
+          'source_item_key', nullif(v_item ->> 'sourceItemKey', ''),
+          'source_finding_title', coalesce(nullif(v_item ->> 'sourceFindingTitle', ''), v_description),
+          'source_finding_title_normalized', nullif(v_item ->> 'normalizedFindingTitle', ''),
+          'inspection_finding_identity', v_identity,
+          'photo_urls', coalesce(v_item -> 'photoUrls', '[]'::jsonb),
+          'parts', coalesce(v_item -> 'parts', '[]'::jsonb)
+        ),
+        null,
+        null,
+        null,
+        null
+      ) returning id into v_quote_id;
+      v_created := true;
+      v_created_quote_count := v_created_quote_count + 1;
+      v_created_quote_ids := array_append(v_created_quote_ids, v_quote_id);
+    else
+      v_skipped_quote_count := v_skipped_quote_count + 1;
+    end if;
+
+    v_quote_ids := array_append(v_quote_ids, v_quote_id);
+    v_item_results := v_item_results || jsonb_build_array(jsonb_build_object(
+      'requestedId', v_requested_id,
+      'id', v_quote_id,
+      'created', v_created,
+      'findingIdentity', v_identity
+    ));
+
+    if jsonb_typeof(v_item -> 'parts') = 'array'
+       and jsonb_array_length(v_item -> 'parts') > 0 then
+      select id into v_request_id
+      from public.part_requests
+      where shop_id = p_shop_id
+        and work_order_id = p_work_order_id
+        and quote_line_id = v_quote_id
+      order by created_at
+      limit 1
+      for update;
+
+      if v_request_id is null then
+        insert into public.part_requests(
+          shop_id, work_order_id, quote_line_id, job_id,
+          requested_by, notes, status
+        ) values (
+          p_shop_id,
+          p_work_order_id,
+          v_quote_id,
+          null,
+          p_actor_user_id,
+          concat_ws(E'\n', nullif(v_item ->> 'notes', ''), 'Quote line: ' || v_quote_id::text, 'Inspection: ' || p_inspection_id::text),
+          'requested'
+        ) returning id into v_request_id;
+        v_created_request_ids := array_append(v_created_request_ids, v_request_id);
+      end if;
+
+      for v_part in select value from jsonb_array_elements(v_item -> 'parts')
+      loop
+        v_part_description := coalesce(nullif(trim(v_part ->> 'description'), ''), nullif(trim(v_part ->> 'name'), ''));
+        if v_part_description is null then
+          continue;
+        end if;
+        v_part_identity := lower(regexp_replace(v_part_description, '\s+', ' ', 'g'));
+        v_qty := greatest(1, coalesce(nullif(v_part ->> 'qty', '')::numeric, 1));
+
+        if exists (
+          select 1 from public.part_request_items
+          where request_id = v_request_id
+            and quote_line_id = v_quote_id
+            and lower(regexp_replace(coalesce(description, ''), '\s+', ' ', 'g')) = v_part_identity
+        ) then
+          v_skipped_item_count := v_skipped_item_count + 1;
+        else
+          insert into public.part_request_items(
+            request_id, shop_id, work_order_id, quote_line_id,
+            work_order_line_id, description, qty, qty_requested,
+            unit_cost, unit_price, status
+          ) values (
+            v_request_id,
+            p_shop_id,
+            p_work_order_id,
+            v_quote_id,
+            null,
+            v_part_description,
+            v_qty,
+            v_qty,
+            coalesce(nullif(v_part ->> 'unitCost', '')::numeric, nullif(v_part ->> 'cost', '')::numeric),
+            nullif(v_part ->> 'unitPrice', '')::numeric,
+            'requested'
+          );
+          v_created_item_count := v_created_item_count + 1;
+        end if;
+      end loop;
+    end if;
+  end loop;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'ids', to_jsonb(v_quote_ids),
+    'items', v_item_results,
+    'createdCount', v_created_quote_count,
+    'skippedDuplicateCount', v_skipped_quote_count,
+    'createdPartRequestIds', to_jsonb(v_created_request_ids),
+    'partRequestIds', (
+      select coalesce(jsonb_agg(distinct id), '[]'::jsonb)
+      from public.part_requests
+      where shop_id = p_shop_id
+        and work_order_id = p_work_order_id
+        and quote_line_id = any(v_quote_ids)
+    ),
+    'createdPartRequestItemCount', v_created_item_count,
+    'skippedPartRequestItemCount', v_skipped_item_count,
+    'canonicalVehicleId', v_work_order.vehicle_id,
+    'sourceWorkOrderLineId', v_inspection.work_order_line_id
+  );
+
+  insert into public.quote_lifecycle_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id,
+    work_order_id, result
+  ) values (
+    p_shop_id, 'inspection_quote_import', p_operation_key,
+    p_actor_user_id, p_work_order_id, v_result
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.import_inspection_quote_package_atomic(uuid,uuid,uuid,uuid,uuid,text,jsonb,timestamptz) from public, anon;
+grant execute on function public.import_inspection_quote_package_atomic(uuid,uuid,uuid,uuid,uuid,text,jsonb,timestamptz) to authenticated, service_role;
+notify pgrst, 'reload schema';
+
+commit;

--- a/supabase/migrations/20260715060200_phase5_quote_lifecycle_postcheck.sql
+++ b/supabase/migrations/20260715060200_phase5_quote_lifecycle_postcheck.sql
@@ -1,0 +1,86 @@
+begin;
+
+do $$
+declare
+  v_definition text;
+begin
+  if to_regclass('public.quote_lifecycle_operation_keys') is null then
+    raise exception 'Phase 5 postcheck failed: quote_lifecycle_operation_keys is missing';
+  end if;
+
+  if to_regprocedure('public.apply_customer_quote_decision_atomic(uuid,uuid,uuid[],text,boolean,uuid,uuid,text,timestamptz)') is null then
+    raise exception 'Phase 5 postcheck failed: apply_customer_quote_decision_atomic is missing';
+  end if;
+
+  if to_regprocedure('public.import_inspection_quote_package_atomic(uuid,uuid,uuid,uuid,uuid,text,jsonb,timestamptz)') is null then
+    raise exception 'Phase 5 postcheck failed: import_inspection_quote_package_atomic is missing';
+  end if;
+
+  if to_regprocedure('public.work_order_is_financially_locked(uuid,uuid)') is null then
+    raise exception 'Phase 5 postcheck failed: Phase 2 financial lock function is missing';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = 'quote_lifecycle_operation_keys'
+      and c.relrowsecurity
+  ) then
+    raise exception 'Phase 5 postcheck failed: operation-key RLS is not enabled';
+  end if;
+
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'inspections'
+      and column_name = 'work_order_id'
+  ) or not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'inspections'
+      and column_name = 'work_order_line_id'
+  ) then
+    raise exception 'Phase 5 postcheck failed: inspection anchor columns are missing';
+  end if;
+
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'part_requests'
+      and column_name = 'quote_line_id'
+  ) or not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'part_request_items'
+      and column_name = 'quote_line_id'
+  ) then
+    raise exception 'Phase 5 postcheck failed: quote-to-parts linkage columns are missing';
+  end if;
+
+  select pg_get_functiondef(
+    'public.apply_customer_quote_decision_atomic(uuid,uuid,uuid[],text,boolean,uuid,uuid,text,timestamptz)'::regprocedure
+  ) into v_definition;
+  if position('FINANCIALLY_LOCKED' in v_definition) = 0
+     or position('for update' in lower(v_definition)) = 0
+     or position('PART_RELINK_CONFLICT' in v_definition) = 0
+     or position('''awaiting''' in v_definition) = 0 then
+    raise exception 'Phase 5 postcheck failed: quote decision transaction contract is incomplete';
+  end if;
+
+  select pg_get_functiondef(
+    'public.import_inspection_quote_package_atomic(uuid,uuid,uuid,uuid,uuid,text,jsonb,timestamptz)'::regprocedure
+  ) into v_definition;
+  if position('INSPECTION_UNANCHORED' in v_definition) = 0
+     or position('INSPECTION_WORK_ORDER_MISMATCH' in v_definition) = 0
+     or position('INSPECTION_VEHICLE_MISMATCH' in v_definition) = 0
+     or position('for update' in lower(v_definition)) = 0 then
+    raise exception 'Phase 5 postcheck failed: inspection import anchor contract is incomplete';
+  end if;
+
+  raise notice 'Phase 5 quote and inspection lifecycle postcheck passed.';
+end $$;
+
+notify pgrst, 'reload schema';
+commit;

--- a/tests/phase5-inspection-finding-eligibility.test.ts
+++ b/tests/phase5-inspection-finding-eligibility.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isInspectionFindingEligible } from "@/features/work-orders/lib/work-orders/inspectionFindingEligibility";
+
+describe("Phase 5 inspection finding eligibility", () => {
+  it("rejects OK and N/A observations regardless of title classification", () => {
+    expect(isInspectionFindingEligible({ status: "ok" })).toBe(false);
+    expect(isInspectionFindingEligible({ status: "na" })).toBe(false);
+    expect(isInspectionFindingEligible({ status: "N/A" })).toBe(false);
+  });
+
+  it("accepts failed and recommended findings", () => {
+    expect(isInspectionFindingEligible({ status: "fail" })).toBe(true);
+    expect(isInspectionFindingEligible({ status: "recommend" })).toBe(true);
+    expect(isInspectionFindingEligible({ recommend: true })).toBe(true);
+  });
+
+  it("accepts explicit technician recommendation metadata", () => {
+    expect(
+      isInspectionFindingEligible({
+        status: "unknown",
+        recommendation: "Replace during this visit",
+      }),
+    ).toBe(true);
+    expect(
+      isInspectionFindingEligible({
+        status: null,
+        recommendationType: "maintenance",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat an unclassified observation as eligible", () => {
+    expect(isInspectionFindingEligible({ status: null })).toBe(false);
+    expect(isInspectionFindingEligible({ status: "unknown" })).toBe(false);
+  });
+});

--- a/tests/phase5-legacy-inspection-import-contract.test.ts
+++ b/tests/phase5-legacy-inspection-import-contract.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  "features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts",
+  "utf8",
+);
+
+describe("Phase 5 legacy inspection import contract", () => {
+  it("checks eligibility before keyword classification", () => {
+    const eligibilityIndex = source.indexOf("if (!isInspectionFindingEligible(item)) continue;");
+    const diagnosisIndex = source.indexOf("diagnosisKeywords.some");
+    const maintenanceIndex = source.indexOf("maintenanceKeywords.some");
+
+    expect(eligibilityIndex).toBeGreaterThan(-1);
+    expect(diagnosisIndex).toBeGreaterThan(eligibilityIndex);
+    expect(maintenanceIndex).toBeGreaterThan(eligibilityIndex);
+  });
+
+  it("does not retain the old job-type eligibility bypass", () => {
+    expect(source).not.toContain("jobType !== \"repair\"");
+    expect(source).not.toContain("shouldIncludeInspectionItem");
+  });
+
+  it("keeps canonical quote creation as the only write path", () => {
+    expect(source).toContain("createCanonicalQuoteLines");
+    expect(source).not.toContain('.from("work_order_lines").insert');
+  });
+});

--- a/tests/phase5-quote-lifecycle-routes.test.ts
+++ b/tests/phase5-quote-lifecycle-routes.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const approvalRoute = read(
+  "app/api/work-orders/quotes/[id]/approval-decision/route.ts",
+);
+const approvalHelper = read(
+  "features/work-orders/server/workOrderQuoteLineApproval.ts",
+);
+const importRoute = read(
+  "app/api/work-orders/import-from-inspection/route.ts",
+);
+const importer = read(
+  "features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection.ts",
+);
+const readiness = read(
+  "app/api/work-orders/[id]/_lib/reviewWorkOrder.ts",
+);
+
+describe("Phase 5 route and helper contract", () => {
+  it("requires stable public operation keys", () => {
+    expect(approvalRoute).toContain('headers.get("Idempotency-Key")');
+    expect(approvalRoute).toContain("A stable Idempotency-Key is required.");
+    expect(importRoute).toContain('headers.get("Idempotency-Key")');
+    expect(importRoute).toContain("A stable Idempotency-Key is required.");
+  });
+
+  it("performs approve-selected and decline-remaining in one helper call", () => {
+    expect(approvalRoute).toContain(
+      "declineRemaining: body?.declineRemaining === true",
+    );
+    expect(approvalRoute).not.toContain("remainingIds");
+    expect(approvalRoute).not.toContain("declineResult");
+    expect(approvalHelper).toContain(
+      'rpc("apply_customer_quote_decision_atomic"',
+    );
+    expect(approvalHelper).not.toContain(
+      '.from("work_order_lines").insert',
+    );
+    expect(approvalHelper).not.toContain(
+      '.from("work_order_quote_lines").update',
+    );
+  });
+
+  it("keeps menu learning outside the customer-visible transaction", () => {
+    expect(approvalHelper.indexOf("apply_customer_quote_decision_atomic")).toBeLessThan(
+      approvalHelper.indexOf("upsertMenuRepairItemFromQuoteLine"),
+    );
+  });
+
+  it("routes legacy inspection import through the atomic anchored command", () => {
+    expect(importer).toContain(
+      'rpc("import_inspection_quote_package_atomic"',
+    );
+    expect(importer).not.toContain("createCanonicalQuoteLines({");
+    expect(importRoute).toContain(
+      '.select("id, shop_id, work_order_id, work_order_line_id")',
+    );
+    expect(importRoute).toContain(
+      "Inspection is not anchored to a work order",
+    );
+  });
+
+  it("checks explicit recommendation eligibility before classification", () => {
+    const eligibilityIndex = importer.indexOf(
+      "isExplicitInspectionRecommendation(item)",
+    );
+    const classificationIndex = importer.indexOf(
+      "classifyEligibleInspectionFinding",
+      eligibilityIndex,
+    );
+    expect(eligibilityIndex).toBeGreaterThan(-1);
+    expect(classificationIndex).toBeGreaterThan(eligibilityIndex);
+    expect(importer).not.toContain('jobType !== "repair"');
+  });
+
+  it("excludes info lines while rejecting info-only work orders", () => {
+    expect(readiness).toContain("function isInfoLine");
+    expect(readiness).toContain("const actionableLines");
+    expect(readiness).toContain('kind: "no_billable_lines"');
+    expect(readiness).toContain("for (const line of actionableLines)");
+  });
+});

--- a/tests/phase5-quote-lifecycle-routes.test.ts
+++ b/tests/phase5-quote-lifecycle-routes.test.ts
@@ -45,9 +45,14 @@ describe("Phase 5 route and helper contract", () => {
   });
 
   it("keeps menu learning outside the customer-visible transaction", () => {
-    expect(approvalHelper.indexOf("apply_customer_quote_decision_atomic")).toBeLessThan(
-      approvalHelper.indexOf("upsertMenuRepairItemFromQuoteLine"),
+    const decisionCall = approvalHelper.indexOf(
+      'rpc("apply_customer_quote_decision_atomic"',
     );
+    const learningCall = approvalHelper.indexOf(
+      "await upsertMenuRepairItemFromQuoteLine",
+    );
+    expect(decisionCall).toBeGreaterThan(-1);
+    expect(learningCall).toBeGreaterThan(decisionCall);
   });
 
   it("routes legacy inspection import through the atomic anchored command", () => {

--- a/tests/phase5-quote-lifecycle-sql-contract.test.ts
+++ b/tests/phase5-quote-lifecycle-sql-contract.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const approvalSql = read(
+  "supabase/migrations/20260715060000_phase5_atomic_quote_decisions.sql",
+);
+const importSql = read(
+  "supabase/migrations/20260715060100_phase5_atomic_inspection_quote_import.sql",
+);
+const postcheck = read(
+  "supabase/migrations/20260715060200_phase5_quote_lifecycle_postcheck.sql",
+);
+
+describe("Phase 5 quote lifecycle SQL contract", () => {
+  it("makes customer quote decisions one locked idempotent transaction", () => {
+    expect(approvalSql).toContain("apply_customer_quote_decision_atomic");
+    expect(approvalSql).toContain("quote_lifecycle_operation_keys");
+    expect(approvalSql.toLowerCase()).toContain("for update");
+    expect(approvalSql).toContain("FINANCIALLY_LOCKED");
+    expect(approvalSql).toContain("PART_RELINK_CONFLICT");
+    expect(approvalSql).toContain("p_decline_remaining");
+  });
+
+  it("materializes authorization as awaiting rather than active labor", () => {
+    expect(approvalSql).toContain("'awaiting'");
+    expect(approvalSql).toContain("'authorized'");
+    expect(approvalSql).toContain("'approved'");
+    expect(approvalSql).not.toMatch(
+      /insert into public\.work_order_lines[\s\S]{0,2000}'in_progress'/,
+    );
+  });
+
+  it("relinks quote-originated parts inside the same command", () => {
+    expect(approvalSql).toContain("update public.part_requests");
+    expect(approvalSql).toContain("update public.part_request_items");
+    expect(approvalSql).toContain("quote_line_id = v_quote.id");
+  });
+
+  it("anchors inspection imports before any quote or parts writes", () => {
+    expect(importSql).toContain("INSPECTION_UNANCHORED");
+    expect(importSql).toContain("INSPECTION_WORK_ORDER_MISMATCH");
+    expect(importSql).toContain("INSPECTION_SOURCE_LINE_MISMATCH");
+    expect(importSql).toContain("INSPECTION_VEHICLE_MISMATCH");
+    expect(importSql.toLowerCase()).toContain("for update");
+    expect(importSql.indexOf("INSPECTION_UNANCHORED")).toBeLessThan(
+      importSql.indexOf("insert into public.work_order_quote_lines"),
+    );
+  });
+
+  it("creates quote lines and required parts under one RPC", () => {
+    expect(importSql).toContain("insert into public.work_order_quote_lines");
+    expect(importSql).toContain("insert into public.part_requests");
+    expect(importSql).toContain("insert into public.part_request_items");
+    expect(importSql).toContain("inspection_finding_identity");
+  });
+
+  it("has a fail-fast compatibility postcheck", () => {
+    expect(postcheck).toContain("work_order_is_financially_locked");
+    expect(postcheck).toContain("inspection anchor columns are missing");
+    expect(postcheck).toContain(
+      "Phase 5 quote and inspection lifecycle postcheck passed.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements the reduced, revalidated Phase 5 scope against the current repository.

### Included
- Atomic multi-line customer quote decisions
- Approve selected + decline remaining in one transaction
- Stable tenant-scoped operation keys
- Approved repairs materialize as `awaiting`, never `in_progress`
- Quote-originated parts requests/items relink in the same transaction
- Phase 2 financial locks enforced
- Atomic inspection-to-quote and parts import
- Canonical inspection/work-order/source-line/vehicle anchor validation
- Explicit FAIL/RECOMMEND eligibility before keyword classification
- Info lines excluded from billable readiness requirements
- Info-only work orders return `no_billable_lines`
- Menu-repair learning remains best-effort after commit

### Migration order
1. `supabase/migrations/20260715060000_phase5_atomic_quote_decisions.sql`
2. `supabase/migrations/20260715060100_phase5_atomic_inspection_quote_import.sql`
3. `supabase/migrations/20260715060200_phase5_quote_lifecycle_postcheck.sql`

Do not run migrations until Vercel and Phase 5 validation are green.

Closes #996
Closes #997
Closes #998
Closes #999
Closes #1000
Closes #1001
Related: #992