### PR TITLE
Phase 7: Customer portal lifecycle hardening

### DIFF
--- a/.github/workflows/phase-7-customer-portal-validation.yml
+++ b/.github/workflows/phase-7-customer-portal-validation.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/phase-7-customer-portal-validation.yml
+++ b/.github/workflows/phase-7-customer-portal-validation.yml
@@ -1,0 +1,48 @@
+name: Phase 7 Customer Portal Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/portal/**"
+      - "app/api/work-orders/lines/**"
+      - "app/portal/auth/confirm/page.tsx"
+      - "features/portal/server/**"
+      - "supabase/migrations/20260715080*.sql"
+      - "tests/phase7-*.test.ts"
+      - ".github/workflows/phase-7-customer-portal-validation.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: >-
+          pnpm exec eslint
+          app/api/portal/bookings/[id]/route.ts
+          app/api/portal/bookings/route.ts
+          app/api/portal/customer-bookings/[id]/route.ts
+          app/api/portal/invites/accept/route.ts
+          app/api/portal/qr/setup/route.ts
+          app/api/portal/request/start/route.ts
+          app/api/portal/request/add-custom-line/route.ts
+          app/api/portal/request/add-menu-line/route.ts
+          app/api/portal/request/add-inspection-line/route.ts
+          app/api/work-orders/lines/[id]/approval-decision/route.ts
+          app/portal/auth/confirm/page.tsx
+          features/portal/server/addPortalRequestLine.ts
+          features/portal/server/createPortalBooking.ts
+          features/portal/server/customerBookings.ts
+          tests/phase7-portal-invite-booking-contract.test.ts
+          tests/phase7-portal-request-approval-contract.test.ts
+      - run: >-
+          pnpm exec vitest run
+          tests/phase7-portal-invite-booking-contract.test.ts
+          tests/phase7-portal-request-approval-contract.test.ts

--- a/app/api/portal/bookings/[id]/route.ts
+++ b/app/api/portal/bookings/[id]/route.ts
@@ -4,15 +4,26 @@ import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 type DB = Database;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
 
 type PatchBody = {
   status?: "pending" | "confirmed" | "cancelled" | "completed";
   notes?: string | null;
   starts_at?: string;
   ends_at?: string;
+  reason?: string | null;
+  idempotencyKey?: string;
 };
 
-async function getAuthedContext(supabase: ReturnType<typeof createServerSupabaseRoute>) {
+async function getAuthedContext(
+  supabase: ReturnType<typeof createServerSupabaseRoute>,
+) {
   const {
     data: { user },
     error: userErr,
@@ -29,7 +40,9 @@ async function getAuthedContext(supabase: ReturnType<typeof createServerSupabase
     .single();
 
   if (profileErr || !profile?.shop_id) {
-    return { error: NextResponse.json({ error: "Profile/shop not found" }, { status: 403 }) };
+    return {
+      error: NextResponse.json({ error: "Profile/shop not found" }, { status: 403 }),
+    };
   }
 
   const actor = getActorCapabilities({ role: profile.role });
@@ -41,113 +54,180 @@ async function getAuthedContext(supabase: ReturnType<typeof createServerSupabase
     user,
     profile: {
       id: profile.id,
-      role: String(profile.role ?? ""),
       shop_id: profile.shop_id,
     },
   };
 }
 
+function operationKey(req: Request, body?: PatchBody): string {
+  return (
+    req.headers.get("Idempotency-Key")?.trim() ||
+    body?.idempotencyKey?.trim() ||
+    ""
+  );
+}
+
+function rpcStatus(message: string): number {
+  const lower = message.toLowerCase();
+  if (lower.includes("not found")) return 404;
+  if (lower.includes("not authorized") || lower.includes("another shop")) return 403;
+  if (
+    lower.includes("terminal") ||
+    lower.includes("overlap") ||
+    lower.includes("work-order-linked")
+  ) {
+    return 409;
+  }
+  return 400;
+}
+
+async function runLifecycleCommand(args: {
+  supabase: ReturnType<typeof createServerSupabaseRoute>;
+  bookingId: string;
+  actorUserId: string;
+  action: "reschedule" | "cancel";
+  startsAt?: string | null;
+  endsAt?: string | null;
+  notes?: string | null;
+  reason?: string | null;
+  operationKey: string;
+}) {
+  const rpc = args.supabase as unknown as RpcClient;
+  return rpc.rpc("apply_portal_booking_command_atomic", {
+    p_action: args.action,
+    p_booking_id: args.bookingId,
+    p_shop_id: null,
+    p_customer_id: null,
+    p_vehicle_id: null,
+    p_starts_at: args.startsAt ?? null,
+    p_ends_at: args.endsAt ?? null,
+    p_notes: args.notes ?? null,
+    p_actor_user_id: args.actorUserId,
+    p_actor_mode: "staff",
+    p_operation_key: args.operationKey,
+    p_reason: args.reason ?? null,
+    p_at: new Date().toISOString(),
+  });
+}
+
 export async function PATCH(
   req: Request,
-  ctx: { params: Promise<{ id: string }> }
+  ctx: { params: Promise<{ id: string }> },
 ) {
-  try {
-    const { id } = await ctx.params;
-    const supabase = createServerSupabaseRoute();
+  const { id } = await ctx.params;
+  if (!id) {
+    return NextResponse.json({ error: "Missing booking id" }, { status: 400 });
+  }
 
-    const auth = await getAuthedContext(supabase);
-    if ("error" in auth) return auth.error;
+  const supabase = createServerSupabaseRoute();
+  const auth = await getAuthedContext(supabase);
+  if ("error" in auth) return auth.error;
 
-    const body = (await req.json().catch(() => ({}))) as PatchBody;
+  const body = (await req.json().catch(() => ({}))) as PatchBody;
+  const isReschedule = body.starts_at !== undefined || body.ends_at !== undefined;
+  const isCancel = body.status === "cancelled";
 
-    const { data: booking, error: bookingErr } = await supabase
-      .from("bookings")
-      .select("id, shop_id")
-      .eq("id", id)
-      .single();
-
-    if (bookingErr || !booking) {
-      return NextResponse.json({ error: "Booking not found" }, { status: 404 });
-    }
-
-    if (booking.shop_id !== auth.profile.shop_id) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    const update: DB["public"]["Tables"]["bookings"]["Update"] = {};
-
-    if (body.status) update.status = body.status;
-    if (body.notes !== undefined) update.notes = body.notes;
-    if (body.starts_at) update.starts_at = body.starts_at;
-    if (body.ends_at) update.ends_at = body.ends_at;
-
-    if (Object.keys(update).length === 0) {
-      return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
-    }
-
-    const { data: updated, error: updateErr } = await supabase
-      .from("bookings")
-      .update(update)
-      .eq("id", id)
-      .eq("shop_id", auth.profile.shop_id)
-      .select("id, starts_at, ends_at, status, notes, customer_id, vehicle_id, work_order_id")
-      .single();
-
-    if (updateErr || !updated) {
+  if (isReschedule || isCancel) {
+    const key = operationKey(req, body);
+    if (!key) {
       return NextResponse.json(
-        { error: updateErr?.message || "Failed to update booking" },
-        { status: 500 }
+        { error: "A stable Idempotency-Key is required." },
+        { status: 400 },
+      );
+    }
+    if (isReschedule && (!body.starts_at || !body.ends_at)) {
+      return NextResponse.json(
+        { error: "Both starts_at and ends_at are required for rescheduling" },
+        { status: 400 },
       );
     }
 
-    return NextResponse.json(updated);
-  } catch (err) {
-    console.error("portal booking PATCH error", err);
-    return NextResponse.json({ error: "Server error" }, { status: 500 });
+    const { data, error } = await runLifecycleCommand({
+      supabase,
+      bookingId: id,
+      actorUserId: auth.profile.id,
+      action: isCancel ? "cancel" : "reschedule",
+      startsAt: body.starts_at,
+      endsAt: body.ends_at,
+      notes: body.notes,
+      reason: body.reason,
+      operationKey: `${auth.profile.shop_id}:staff-booking:${key}`,
+    });
+
+    if (error) {
+      const message = [error.message, error.details, error.hint]
+        .filter(Boolean)
+        .join(" — ");
+      return NextResponse.json({ error: message }, { status: rpcStatus(message) });
+    }
+
+    return NextResponse.json(data);
   }
+
+  const update: DB["public"]["Tables"]["bookings"]["Update"] = {};
+  if (body.status === "pending" || body.status === "confirmed" || body.status === "completed") {
+    update.status = body.status;
+  }
+  if (body.notes !== undefined) update.notes = body.notes;
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+  }
+
+  const { data: updated, error: updateErr } = await supabase
+    .from("bookings")
+    .update(update)
+    .eq("id", id)
+    .eq("shop_id", auth.profile.shop_id)
+    .select("id, starts_at, ends_at, status, notes, customer_id, vehicle_id, work_order_id")
+    .maybeSingle();
+
+  if (updateErr) {
+    return NextResponse.json({ error: updateErr.message }, { status: 500 });
+  }
+  if (!updated) {
+    return NextResponse.json({ error: "Booking not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(updated);
 }
 
 export async function DELETE(
-  _req: Request,
-  ctx: { params: Promise<{ id: string }> }
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
 ) {
-  try {
-    const { id } = await ctx.params;
-    const supabase = createServerSupabaseRoute();
-
-    const auth = await getAuthedContext(supabase);
-    if ("error" in auth) return auth.error;
-
-    const { data: booking, error: bookingErr } = await supabase
-      .from("bookings")
-      .select("id, shop_id")
-      .eq("id", id)
-      .single();
-
-    if (bookingErr || !booking) {
-      return NextResponse.json({ error: "Booking not found" }, { status: 404 });
-    }
-
-    if (booking.shop_id !== auth.profile.shop_id) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
-
-    const { error: deleteErr } = await supabase
-      .from("bookings")
-      .delete()
-      .eq("id", id)
-      .eq("shop_id", auth.profile.shop_id);
-
-    if (deleteErr) {
-      return NextResponse.json(
-        { error: deleteErr.message || "Failed to delete booking" },
-        { status: 500 }
-      );
-    }
-
-    return NextResponse.json({ ok: true });
-  } catch (err) {
-    console.error("portal booking DELETE error", err);
-    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  const { id } = await ctx.params;
+  if (!id) {
+    return NextResponse.json({ error: "Missing booking id" }, { status: 400 });
   }
+
+  const supabase = createServerSupabaseRoute();
+  const auth = await getAuthedContext(supabase);
+  if ("error" in auth) return auth.error;
+
+  const key = req.headers.get("Idempotency-Key")?.trim() ?? "";
+  if (!key) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await runLifecycleCommand({
+    supabase,
+    bookingId: id,
+    actorUserId: auth.profile.id,
+    action: "cancel",
+    reason: "Cancelled from staff scheduling",
+    operationKey: `${auth.profile.shop_id}:staff-booking-delete:${key}`,
+  });
+
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return NextResponse.json({ error: message }, { status: rpcStatus(message) });
+  }
+
+  return NextResponse.json(data);
 }

--- a/app/api/portal/bookings/route.ts
+++ b/app/api/portal/bookings/route.ts
@@ -11,8 +11,6 @@ import {
 export const runtime = "nodejs";
 
 type Db = Database;
-
-// Shape we return to the client (matches Booking in /dashboard/appointments)
 type BookingPayload = {
   id: string;
   shop_slug: string | null;
@@ -42,114 +40,71 @@ function bad(msg: string, status = 400): NextResponse {
 
 export async function GET(req: Request): Promise<Response> {
   const supabase = createServerSupabaseRoute();
-
   const url = new URL(req.url);
   const shopSlug = url.searchParams.get("shop") ?? "";
   const start = url.searchParams.get("start") ?? "";
   const end = url.searchParams.get("end") ?? "";
+  if (!shopSlug || !start || !end) return bad("Missing shop, start, or end");
 
-  if (!shopSlug || !start || !end) {
-    return bad("Missing shop, start, or end");
-  }
-
-  // Auth
   const {
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
   if (authErr || !user) return bad("Not authenticated", 401);
 
-  // Staff profile
   const { data: profile, error: profErr } = await supabase
     .from("profiles")
     .select("shop_id, role")
     .eq("id", user.id)
     .single();
-
-  if (profErr || !profile?.shop_id) {
-    return bad("Profile / shop not found", 403);
-  }
+  if (profErr || !profile?.shop_id) return bad("Profile / shop not found", 403);
 
   const actor = getActorCapabilities({ role: profile.role });
   if (!actor.isKnownRole || (!actor.canManageScheduling && !actor.canViewShopWideData)) {
     return bad("Not allowed", 403);
   }
 
-  // Shop by slug
   const { data: shop, error: shopErr } = await supabase
     .from("shops")
     .select("id, slug")
     .eq("slug", shopSlug)
     .single();
-
   if (shopErr || !shop) return bad("Shop not found", 404);
-  if (shop.id !== profile.shop_id) {
-    return bad("You cannot view bookings for this shop", 403);
-  }
+  if (shop.id !== profile.shop_id) return bad("You cannot view bookings for this shop", 403);
 
-  // Build date window for the week (inclusive)
   const startIso = new Date(`${start}T00:00:00.000Z`).toISOString();
   const endDate = new Date(`${end}T00:00:00.000Z`);
-  endDate.setDate(endDate.getDate() + 1); // next day
+  endDate.setDate(endDate.getDate() + 1);
   const endIso = endDate.toISOString();
 
-  // Query bookings + customer + shop slug
   const { data: rows, error: rowsErr } = await supabase
     .from("bookings")
-    .select(
-      `
-        id,
-        shop_id,
-        customer_id,
-        vehicle_id,
-        work_order_id,
-        starts_at,
-        ends_at,
-        status,
-        notes,
-        customers:customer_id (
-          first_name,
-          last_name,
-          email,
-          phone
-        ),
-        shops:shop_id (
-          slug
-        )
-      `,
-    )
+    .select(`
+      id, shop_id, customer_id, vehicle_id, work_order_id,
+      starts_at, ends_at, status, notes,
+      customers:customer_id (first_name, last_name, email, phone),
+      shops:shop_id (slug)
+    `)
     .eq("shop_id", shop.id)
     .gte("starts_at", startIso)
     .lt("starts_at", endIso)
     .order("starts_at", { ascending: true });
+  if (rowsErr || !rows) return bad("Failed to load bookings", 500);
 
-  if (rowsErr || !rows) {
-    return bad("Failed to load bookings", 500);
-  }
-
-  const bookings = rows as unknown as BookingRow[];
-
-  const payload: BookingPayload[] = bookings.map((row) => {
+  const payload: BookingPayload[] = (rows as unknown as BookingRow[]).map((row) => {
     const customer = row.customers ?? null;
-    const shopRel = row.shops ?? null;
-
-    const nameFromCustomer =
-      [customer?.first_name, customer?.last_name]
-        .filter((part) => !!part && part.trim().length > 0)
-        .join(" ") || null;
-
-    const emailFromCustomer = customer?.email ?? null;
-    const phoneFromCustomer = customer?.phone ?? null;
-
     return {
       id: row.id,
-      shop_slug: shopRel?.slug ?? null,
+      shop_slug: row.shops?.slug ?? null,
       starts_at: row.starts_at,
       ends_at: row.ends_at,
       customer_id: row.customer_id ?? null,
-      customer_name: nameFromCustomer,
-      customer_email: emailFromCustomer,
-      customer_phone: phoneFromCustomer,
+      customer_name:
+        [customer?.first_name, customer?.last_name]
+          .filter((part) => !!part && part.trim().length > 0)
+          .join(" ") || null,
+      customer_email: customer?.email ?? null,
+      customer_phone: customer?.phone ?? null,
       notes: row.notes ?? null,
       status: row.status ?? null,
       vehicle_id: row.vehicle_id ?? null,
@@ -166,19 +121,23 @@ export async function POST(req: Request): Promise<Response> {
     data: { user },
     error: authErr,
   } = await supabase.auth.getUser();
-
   if (authErr || !user) return bad("Not authenticated", 401);
 
   const body = (await req.json().catch(() => null)) as CreatePortalBookingInput | null;
   if (!body) return bad("Invalid JSON body", 400);
+  const operationKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    body.operationKey?.trim() ||
+    body.idempotencyKey?.trim() ||
+    "";
+  if (!operationKey) return bad("A stable Idempotency-Key is required", 400);
 
   const result = await createPortalBooking({
     supabase,
     userId: user.id,
-    input: body,
+    input: { ...body, operationKey },
     actorMode: "customer-only",
   });
-
   if (!result.ok) return bad(result.error, result.status);
 
   return NextResponse.json(

--- a/app/api/portal/customer-bookings/[id]/route.ts
+++ b/app/api/portal/customer-bookings/[id]/route.ts
@@ -4,40 +4,71 @@ import { requirePortalCustomerActor } from "@/features/portal/server/requirePort
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import { cancelCustomerBooking } from "@/features/portal/server/customerBookings";
 
-
 type Body = {
   status?: "cancelled";
+  reason?: string | null;
+  operationKey?: string;
+  idempotencyKey?: string;
 };
 
-export async function PATCH(req: Request, ctx: { params: Promise<{ id: string }> }) {
+export async function PATCH(
+  req: Request,
+  ctx: { params: Promise<{ id: string }> },
+) {
   const { id } = await ctx.params;
-  if (!id) return NextResponse.json({ error: "Missing booking id" }, { status: 400 });
+  if (!id) {
+    return NextResponse.json({ error: "Missing booking id" }, { status: 400 });
+  }
 
   const body = (await req.json().catch(() => ({}))) as Body;
   if (body.status !== "cancelled") {
-    return NextResponse.json({ error: "Only cancellation is allowed" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Only cancellation is allowed" },
+      { status: 400 },
+    );
+  }
+
+  const operationKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    body.operationKey?.trim() ||
+    body.idempotencyKey?.trim() ||
+    "";
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required" },
+      { status: 400 },
+    );
   }
 
   const supabase = createServerSupabaseRoute();
-
   try {
     const actor = await requirePortalCustomerActor(supabase);
     const result = await cancelCustomerBooking({
       supabase,
       bookingId: id,
       customerId: actor.customer.id,
+      actorUserId: actor.userId,
+      operationKey: `${actor.customer.shop_id ?? "unscoped"}:booking-cancel:${operationKey}`,
+      reason: body.reason,
     });
 
     if (!result.ok) {
-      return NextResponse.json({ error: result.error }, { status: result.status });
+      return NextResponse.json(
+        { error: result.error },
+        { status: result.status },
+      );
     }
 
     return NextResponse.json(result.data);
   } catch (error: unknown) {
     if (error instanceof PortalAccessError) {
-      return NextResponse.json({ error: error.message }, { status: error.status });
+      return NextResponse.json(
+        { error: error.message },
+        { status: error.status },
+      );
     }
-    const message = error instanceof Error ? error.message : "Unexpected portal error";
+    const message =
+      error instanceof Error ? error.message : "Unexpected portal error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/portal/invites/accept/route.ts
+++ b/app/api/portal/invites/accept/route.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+type Body = {
+  inviteId?: string;
+  operationKey?: string;
+  idempotencyKey?: string;
+};
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user?.id || !user.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => null)) as Body | null;
+  const inviteId = clean(body?.inviteId);
+  const operationKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    clean(body?.operationKey) ||
+    clean(body?.idempotencyKey);
+
+  if (!inviteId) {
+    return NextResponse.json({ error: "Missing inviteId" }, { status: 400 });
+  }
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
+
+  const rpc = supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("accept_customer_portal_invite_atomic", {
+    p_invite_id: inviteId,
+    p_actor_user_id: user.id,
+    p_actor_email: user.email,
+    p_operation_key: `portal-invite:${user.id}:${operationKey}`,
+    p_at: new Date().toISOString(),
+  });
+
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    const lower = message.toLowerCase();
+    const status = lower.includes("not found")
+      ? 404
+      : lower.includes("another account") ||
+          lower.includes("does not match") ||
+          lower.includes("revoked") ||
+          lower.includes("expired")
+        ? 403
+        : 400;
+    return NextResponse.json({ error: message }, { status });
+  }
+
+  return NextResponse.json(data ?? { ok: true });
+}

--- a/app/api/portal/qr/setup/route.ts
+++ b/app/api/portal/qr/setup/route.ts
@@ -53,19 +53,14 @@ function isSafeInternalNextPath(next: string): boolean {
 function normalizeSiteUrl(raw: string): string {
   const trimmed = String(raw || "").trim().replace(/\/$/, "");
   if (!trimmed) return "https://profixiq.com";
-
   const lower = trimmed.toLowerCase();
-  if (!/^https?:\/\//i.test(lower)) {
-    return `https://${lower}`;
-  }
-
+  if (!/^https?:\/\//i.test(lower)) return `https://${lower}`;
   return lower;
 }
 
 export async function POST(req: Request) {
   try {
     const body = (await req.json().catch(() => ({}))) as Body;
-
     const shopSlug = trimField(body.shopSlug);
     const email = normalizeEmail(body.email);
     const name = trimField(body.name);
@@ -76,13 +71,11 @@ export async function POST(req: Request) {
     if (!shopSlug || !email) {
       return NextResponse.json({ ok: false, error: "Missing required fields" }, { status: 400 });
     }
-
     if (!isValidEmail(email)) {
       return NextResponse.json({ ok: false, error: "Invalid email" }, { status: 400 });
     }
 
     const safeNext = isSafeInternalNextPath(nextPath) ? nextPath : "/portal";
-
     const { data: shop, error: shopError } = await supabaseAdmin
       .from("shops")
       .select("id,slug,name,shop_name,accepts_online_booking")
@@ -93,7 +86,6 @@ export async function POST(req: Request) {
     if (shopError) {
       return NextResponse.json({ ok: false, error: "Shop lookup failed" }, { status: 500 });
     }
-
     if (!shop?.id) {
       return NextResponse.json({ ok: false, error: "Shop not found" }, { status: 404 });
     }
@@ -105,10 +97,14 @@ export async function POST(req: Request) {
       .eq("shop_id", shopId)
       .eq("email", email)
       .limit(1)
-      .maybeSingle<{ id: string; name: string | null; phone: string | null; phone_number: string | null }>();
+      .maybeSingle<{
+        id: string;
+        name: string | null;
+        phone: string | null;
+        phone_number: string | null;
+      }>();
 
     let customerId = existingCustomer?.id ?? null;
-
     if (!customerId) {
       const insertPayload: CustomersInsert = {
         shop_id: shopId,
@@ -118,17 +114,14 @@ export async function POST(req: Request) {
         phone: phone || null,
         notes: notes || null,
       };
-
       const { data: createdCustomer, error: createError } = await supabaseAdmin
         .from("customers")
         .insert(insertPayload)
         .select("id")
         .single<{ id: string }>();
-
       if (createError || !createdCustomer?.id) {
         return NextResponse.json({ ok: false, error: "Unable to process request" }, { status: 500 });
       }
-
       customerId = createdCustomer.id;
     } else if (existingCustomer) {
       const patch: Database["public"]["Tables"]["customers"]["Update"] = {};
@@ -144,43 +137,52 @@ export async function POST(req: Request) {
       .select("id")
       .eq("customer_id", customerId)
       .eq("email", email)
+      .is("revoked_at", null)
       .limit(1)
       .maybeSingle<{ id: string }>();
 
-    if (!existingInvite?.id) {
-      const token = crypto.randomBytes(32).toString("hex");
-      const { error: inviteError } = await supabaseAdmin.from("customer_portal_invites").insert({
-        customer_id: customerId,
-        email,
-        token,
-      });
-
-      if (inviteError) {
+    let inviteId = existingInvite?.id ?? null;
+    if (!inviteId) {
+      const { data: createdInvite, error: inviteError } = await supabaseAdmin
+        .from("customer_portal_invites")
+        .insert({
+          customer_id: customerId,
+          email,
+          token: crypto.randomUUID(),
+          expires_at: new Date(Date.now() + 1000 * 60 * 60 * 24 * 14).toISOString(),
+        })
+        .select("id")
+        .single<{ id: string }>();
+      if (inviteError || !createdInvite?.id) {
         return NextResponse.json({ ok: false, error: "Unable to process request" }, { status: 500 });
       }
+      inviteId = createdInvite.id;
     }
 
     const siteUrl = normalizeSiteUrl(process.env.NEXT_PUBLIC_SITE_URL || "");
-    const redirectTo = `${siteUrl}/portal/auth/confirm?next=${encodeURIComponent(safeNext)}`;
+    const redirectParams = new URLSearchParams({
+      next: safeNext,
+      invite: inviteId,
+    });
+    const redirectTo = `${siteUrl}/portal/auth/confirm?${redirectParams.toString()}`;
 
     const { data: linkData, error: linkError } = await supabaseAdmin.auth.admin.generateLink({
       type: "magiclink",
       email,
       options: { redirectTo },
     });
-
     if (linkError) {
       return NextResponse.json({ ok: false, error: "Unable to process request" }, { status: 500 });
     }
 
     const portalLink = linkData?.properties?.action_link || null;
-
     if (!portalLink || typeof portalLink !== "string") {
       return NextResponse.json({ ok: false, error: "Unable to process request" }, { status: 500 });
     }
 
     const brand = await getActiveBrandForRender(shopId);
-    const shopName = (shop.shop_name ?? "").trim() || (shop.name ?? "").trim() || "ProFixIQ";
+    const shopName =
+      (shop.shop_name ?? "").trim() || (shop.name ?? "").trim() || "ProFixIQ";
 
     await sendPortalInviteEmail({
       shopId,
@@ -193,7 +195,6 @@ export async function POST(req: Request) {
       createdBy: null,
     });
 
-    // TODO: add IP/email-based rate limiting when shared limiter infra is available.
     return NextResponse.json({
       ok: true,
       message: "If the email is valid, we sent a portal access link.",

--- a/app/api/portal/request/add-custom-line/route.ts
+++ b/app/api/portal/request/add-custom-line/route.ts
@@ -1,93 +1,67 @@
-// app/api/portal/request/add-custom-line/route.ts
 import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { PortalAccessError } from "@/features/portal/server/portalAuth";
+import { addPortalRequestLine } from "@/features/portal/server/addPortalRequestLine";
 
 export const runtime = "nodejs";
 
-type DB = Database;
-
 type Body = {
-  workOrderId: string;
-  description: string; // customer complaint / request
+  workOrderId?: string;
+  description?: string;
   notes?: string;
   lineType?: "job" | "info";
+  idempotencyKey?: string;
 };
 
-function bad(msg: string, status = 400) {
-  return NextResponse.json({ error: msg }, { status });
+function bad(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
 }
 
 export async function POST(req: Request) {
+  const supabase = createServerSupabaseRoute();
+
   try {
-    const supabase = createServerSupabaseRoute();
+    const actor = await requirePortalCustomerActor(supabase);
+    const body = (await req.json().catch(() => null)) as Body | null;
+    const workOrderId = body?.workOrderId?.trim() ?? "";
+    const description = body?.description?.trim() ?? "";
+    const key =
+      req.headers.get("Idempotency-Key")?.trim() ||
+      body?.idempotencyKey?.trim() ||
+      "";
 
-    const {
-      data: { user },
-      error: authErr,
-    } = await supabase.auth.getUser();
-    if (authErr || !user) return bad("Not authenticated", 401);
-
-    let body: Body;
-    try {
-      body = (await req.json()) as Body;
-    } catch {
-      return bad("Invalid JSON body");
+    if (!workOrderId || !description) {
+      return bad("Missing workOrderId or description");
+    }
+    if (!actor.customer.shop_id) {
+      return bad("Customer is not linked to a shop", 409);
+    }
+    if (!key) {
+      return bad("A stable Idempotency-Key is required.");
     }
 
-    const workOrderId = (body?.workOrderId ?? "").trim();
-    const description = (body?.description ?? "").trim();
-    const notes = (body?.notes ?? "").trim();
-    const lineType = body?.lineType === "info" ? "info" : "job";
+    const result = await addPortalRequestLine({
+      supabase,
+      shopId: actor.customer.shop_id,
+      customerId: actor.customer.id,
+      workOrderId,
+      actorUserId: actor.userId,
+      kind: "custom",
+      description,
+      notes: body?.notes?.trim() || null,
+      lineType: body?.lineType === "info" ? "info" : "job",
+      operationKey: `${actor.customer.shop_id}:portal-custom-line:${key}`,
+    });
 
-    if (!workOrderId || !description) return bad("Missing workOrderId or description");
-
-    const { data: customer, error: custErr } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("user_id", user.id)
-      .maybeSingle();
-
-    if (custErr) return bad(custErr.message, 500);
-    if (!customer?.id) return bad("Customer profile not found", 404);
-
-    const { data: wo, error: woErr } = await supabase
-      .from("work_orders")
-      .select("id, shop_id, customer_id, vehicle_id")
-      .eq("id", workOrderId)
-      .maybeSingle();
-
-    if (woErr) return bad("Failed to load work order", 500);
-    if (!wo) return bad("Work order not found", 404);
-    if (wo.customer_id !== customer.id) return bad("Not allowed", 403);
-
-    const insertLine: DB["public"]["Tables"]["work_order_lines"]["Insert"] = {
-      work_order_id: wo.id,
-      shop_id: wo.shop_id,
-      vehicle_id: wo.vehicle_id ?? null,
-      complaint: description,
-      notes: notes || null,
-      status: "awaiting_approval",
-      approval_state: "pending",
-      line_type: lineType,
-      punchable: lineType === "info" ? false : null,
-      // labor_time intentionally null — customer can't set it
-      labor_time: null,
-      price_estimate: null,
-    };
-
-    const { data: created, error: insErr } = await supabase
-      .from("work_order_lines")
-      .insert(insertLine)
-      .select("*")
-      .single();
-
-    if (insErr || !created) return bad("Failed to add custom line", 500);
-
-    return NextResponse.json({ line: created }, { status: 201 });
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    console.error("add-custom-line error:", msg);
-    return bad("Unexpected error", 500);
+    return NextResponse.json(result, { status: result.idempotent ? 200 : 201 });
+  } catch (error: unknown) {
+    if (error instanceof PortalAccessError) {
+      return bad(error.message, error.status);
+    }
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    const lower = message.toLowerCase();
+    const status = lower.includes("not owned") ? 403 : lower.includes("locked") ? 409 : 400;
+    return bad(message, status);
   }
 }

--- a/app/api/portal/request/add-inspection-line/route.ts
+++ b/app/api/portal/request/add-inspection-line/route.ts
@@ -1,112 +1,63 @@
-// app/api/portal/request/add-inspection-line/route.ts
 import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { PortalAccessError } from "@/features/portal/server/portalAuth";
+import { addPortalRequestLine } from "@/features/portal/server/addPortalRequestLine";
 
 export const runtime = "nodejs";
 
-type DB = Database;
-
-function bad(msg: string, status = 400) {
-  return NextResponse.json({ error: msg }, { status });
-}
-
 type Body = {
-  workOrderId: string;
-  templateId: string;
+  workOrderId?: string;
+  templateId?: string;
+  idempotencyKey?: string;
 };
 
+function bad(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
+}
+
 export async function POST(req: Request) {
+  const supabase = createServerSupabaseRoute();
+
   try {
-    const supabase = createServerSupabaseRoute();
-
-    const {
-      data: { user },
-      error: authErr,
-    } = await supabase.auth.getUser();
-
-    if (authErr || !user) return bad("Not authenticated", 401);
-
-    let body: Body;
-    try {
-      body = (await req.json()) as Body;
-    } catch {
-      return bad("Invalid JSON body");
-    }
-
-    const workOrderId = (body.workOrderId ?? "").trim();
-    const templateId = (body.templateId ?? "").trim();
+    const actor = await requirePortalCustomerActor(supabase);
+    const body = (await req.json().catch(() => null)) as Body | null;
+    const workOrderId = body?.workOrderId?.trim() ?? "";
+    const templateId = body?.templateId?.trim() ?? "";
+    const key =
+      req.headers.get("Idempotency-Key")?.trim() ||
+      body?.idempotencyKey?.trim() ||
+      "";
 
     if (!workOrderId || !templateId) {
       return bad("Missing workOrderId or templateId");
     }
-
-    // Resolve portal customer (customer owns this auth user)
-    const { data: customer, error: custErr } = await supabase
-      .from("customers")
-      .select("id, shop_id")
-      .eq("user_id", user.id)
-      .maybeSingle();
-
-    if (custErr) return bad(custErr.message, 500);
-    if (!customer?.id) return bad("Customer profile not found", 404);
-
-    // Load WO + ensure customer owns it
-    const { data: wo, error: woErr } = await supabase
-      .from("work_orders")
-      .select("id, shop_id, customer_id, vehicle_id")
-      .eq("id", workOrderId)
-      .maybeSingle();
-
-    if (woErr) return bad("Failed to load work order", 500);
-    if (!wo) return bad("Work order not found", 404);
-    if (wo.customer_id !== customer.id) return bad("Not allowed", 403);
-
-    // Load template + ensure same shop + active
-    const { data: tpl, error: tErr } = await supabase
-      .from("inspection_templates")
-      .select("id, shop_id, name, title, description, is_active")
-      .eq("id", templateId)
-      .maybeSingle();
-
-    if (tErr) return bad("Failed to load inspection template", 500);
-    if (!tpl) return bad("Inspection template not found", 404);
-    if (tpl.shop_id !== wo.shop_id) return bad("Not allowed", 403);
-    if (tpl.is_active === false) return bad("Inspection template is inactive", 409);
-
-    const title = String(tpl.name ?? tpl.title ?? tpl.description ?? "Inspection");
-
-    // Create inspection line (uses only real columns)
-    const insert: DB["public"]["Tables"]["work_order_lines"]["Insert"] = {
-      work_order_id: wo.id,
-      shop_id: wo.shop_id,
-      vehicle_id: wo.vehicle_id ?? null,
-
-      job_type: "inspection",
-      description: title,
-
-      // launch-safe defaults
-      status: "awaiting",
-      line_status: "pending",
-
-      // real column in your schema list
-      inspection_template_id: tpl.id,
-    };
-
-    const { data: line, error: insErr } = await supabase
-      .from("work_order_lines")
-      .insert(insert)
-      .select("*")
-      .single();
-
-    if (insErr || !line) {
-      return bad(insErr?.message ?? "Failed to add inspection line", 500);
+    if (!actor.customer.shop_id) {
+      return bad("Customer is not linked to a shop", 409);
+    }
+    if (!key) {
+      return bad("A stable Idempotency-Key is required.");
     }
 
-    return NextResponse.json({ ok: true, line }, { status: 200 });
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    console.error("add-inspection-line error:", msg);
-    return bad("Unexpected error", 500);
+    const result = await addPortalRequestLine({
+      supabase,
+      shopId: actor.customer.shop_id,
+      customerId: actor.customer.id,
+      workOrderId,
+      actorUserId: actor.userId,
+      kind: "inspection",
+      sourceId: templateId,
+      operationKey: `${actor.customer.shop_id}:portal-inspection-line:${key}`,
+    });
+
+    return NextResponse.json(result, { status: result.idempotent ? 200 : 201 });
+  } catch (error: unknown) {
+    if (error instanceof PortalAccessError) {
+      return bad(error.message, error.status);
+    }
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    const lower = message.toLowerCase();
+    const status = lower.includes("not owned") ? 403 : lower.includes("locked") ? 409 : 400;
+    return bad(message, status);
   }
 }

--- a/app/api/portal/request/add-menu-line/route.ts
+++ b/app/api/portal/request/add-menu-line/route.ts
@@ -1,150 +1,63 @@
-// app/api/portal/request/add-menu-line/route.ts
 import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { PortalAccessError } from "@/features/portal/server/portalAuth";
+import { addPortalRequestLine } from "@/features/portal/server/addPortalRequestLine";
 
 export const runtime = "nodejs";
 
-type DB = Database;
-
 type Body = {
-  workOrderId: string;
-  menuItemId: string;
-  qty?: number;
+  workOrderId?: string;
+  menuItemId?: string;
+  idempotencyKey?: string;
 };
 
-function bad(msg: string, status = 400) {
-  return NextResponse.json({ error: msg }, { status });
+function bad(message: string, status = 400) {
+  return NextResponse.json({ error: message }, { status });
 }
 
-type MenuItemPick = {
-  id: string;
-  shop_id: string;
-  description: string | null;
-  complaint: string | null;
-  base_price: number | null;
-  total_price: number | null;
-  base_labor_hours: number | null;
-  labor_hours: number | null;
-  base_part_cost: number | null;
-};
-
-type MenuItemPartPick = {
-  name: string | null;
-  quantity: number | null;
-  unit_cost: number | null;
-};
-
 export async function POST(req: Request) {
+  const supabase = createServerSupabaseRoute();
+
   try {
-    const supabase = createServerSupabaseRoute();
+    const actor = await requirePortalCustomerActor(supabase);
+    const body = (await req.json().catch(() => null)) as Body | null;
+    const workOrderId = body?.workOrderId?.trim() ?? "";
+    const menuItemId = body?.menuItemId?.trim() ?? "";
+    const key =
+      req.headers.get("Idempotency-Key")?.trim() ||
+      body?.idempotencyKey?.trim() ||
+      "";
 
-    const {
-      data: { user },
-      error: authErr,
-    } = await supabase.auth.getUser();
-    if (authErr || !user) return bad("Not authenticated", 401);
-
-    let body: Body;
-    try {
-      body = (await req.json()) as Body;
-    } catch {
-      return bad("Invalid JSON body");
+    if (!workOrderId || !menuItemId) {
+      return bad("Missing workOrderId or menuItemId");
+    }
+    if (!actor.customer.shop_id) {
+      return bad("Customer is not linked to a shop", 409);
+    }
+    if (!key) {
+      return bad("A stable Idempotency-Key is required.");
     }
 
-    const workOrderId = (body?.workOrderId ?? "").trim();
-    const menuItemId = (body?.menuItemId ?? "").trim();
+    const result = await addPortalRequestLine({
+      supabase,
+      shopId: actor.customer.shop_id,
+      customerId: actor.customer.id,
+      workOrderId,
+      actorUserId: actor.userId,
+      kind: "menu",
+      sourceId: menuItemId,
+      operationKey: `${actor.customer.shop_id}:portal-menu-line:${key}`,
+    });
 
-
-    if (!workOrderId || !menuItemId) return bad("Missing workOrderId or menuItemId");
-
-    // Portal customer
-    const { data: customer, error: custErr } = await supabase
-      .from("customers")
-      .select("id")
-      .eq("user_id", user.id)
-      .maybeSingle();
-
-    if (custErr) return bad(custErr.message, 500);
-    if (!customer?.id) return bad("Customer profile not found", 404);
-
-    // Load WO (ownership + shop)
-    const { data: wo, error: woErr } = await supabase
-      .from("work_orders")
-      .select("id, shop_id, customer_id, vehicle_id")
-      .eq("id", workOrderId)
-      .maybeSingle();
-
-    if (woErr) return bad("Failed to load work order", 500);
-    if (!wo) return bad("Work order not found", 404);
-    if (wo.customer_id !== customer.id) return bad("Not allowed", 403);
-
-    const { data: menu, error: menuErr } = await supabase
-      .from("menu_items")
-      .select(
-        "id, shop_id, description, complaint, base_price, total_price, base_labor_hours, labor_hours, base_part_cost",
-      )
-      .eq("id", menuItemId)
-      .maybeSingle();
-
-    if (menuErr) return bad("Failed to load menu item", 500);
-    if (!menu) return bad("Menu item not found", 404);
-
-    const typedMenu = menu as unknown as MenuItemPick;
-    if (typedMenu.shop_id !== wo.shop_id) return bad("Menu item belongs to a different shop", 403);
-
-    const { data: partsRows } = await supabase
-      .from("menu_item_parts")
-      .select("name, quantity, unit_cost")
-      .eq("menu_item_id", typedMenu.id);
-
-    const parts = (Array.isArray(partsRows) ? partsRows : []) as unknown as MenuItemPartPick[];
-
-    const laborHours = typedMenu.labor_hours ?? typedMenu.base_labor_hours ?? null;
-    const linePrice = typedMenu.total_price ?? typedMenu.base_price ?? null;
-
-    const description =
-      typedMenu.description?.trim() ||
-      typedMenu.complaint?.trim() ||
-      "Service";
-
-    const partsNeeded = parts
-      .filter((p) => (p.name ?? "").trim().length > 0)
-      .map((p) => ({
-        name: (p.name ?? "").trim(),
-        qty: p.quantity ?? 1,
-        unitCost: p.unit_cost ?? null,
-      }));
-
-    // Insert work_order_line (status enums already exist in your schema)
-    const insertLine: DB["public"]["Tables"]["work_order_lines"]["Insert"] = {
-      work_order_id: wo.id,
-      shop_id: wo.shop_id,
-      vehicle_id: wo.vehicle_id ?? null,
-      menu_item_id: typedMenu.id,
-      complaint: description,
-      labor_time: laborHours,
-      price_estimate: linePrice,
-      status: "awaiting_approval",
-      approval_state: "pending",
-      // store parts suggestion into existing json-ish column if present in your types
-      // if your schema uses a different column name, swap it here:
-      parts_needed: partsNeeded as unknown as DB["public"]["Tables"]["work_order_lines"]["Insert"]["parts_needed"],
-
-    };
-
-    const { data: created, error: insErr } = await supabase
-      .from("work_order_lines")
-      .insert(insertLine)
-      .select("*")
-      .single();
-
-    if (insErr || !created) return bad("Failed to add line", 500);
-
-    return NextResponse.json({ line: created }, { status: 201 });
-  } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
-    console.error("add-menu-line error:", msg);
-    return bad("Unexpected error", 500);
+    return NextResponse.json(result, { status: result.idempotent ? 200 : 201 });
+  } catch (error: unknown) {
+    if (error instanceof PortalAccessError) {
+      return bad(error.message, error.status);
+    }
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    const lower = message.toLowerCase();
+    const status = lower.includes("not owned") ? 403 : lower.includes("locked") ? 409 : 400;
+    return bad(message, status);
   }
 }

--- a/app/api/portal/request/start/route.ts
+++ b/app/api/portal/request/start/route.ts
@@ -6,7 +6,6 @@ import { requirePortalCustomerActor } from "@/features/portal/server/requirePort
 
 export const runtime = "nodejs";
 
-
 type Body = {
   vehicleId?: string | null;
   visitType: "waiter" | "drop_off";
@@ -27,8 +26,7 @@ function bad(msg: string, status = 400) {
 }
 
 function isIsoDateString(s: string) {
-  const t = Date.parse(s);
-  return Number.isFinite(t);
+  return Number.isFinite(Date.parse(s));
 }
 
 function addMinsIso(startIso: string, mins: number): string {
@@ -42,14 +40,18 @@ function normalizeIdempotencyKey(v: unknown): string {
   return v.trim().toLowerCase().slice(0, 120);
 }
 
-function isDuplicateKeyError(err: { code?: string | null; message?: string | null } | null): boolean {
-  return err?.code === "23505" || (err?.message ?? "").toLowerCase().includes("duplicate key");
+function isDuplicateKeyError(
+  err: { code?: string | null; message?: string | null } | null,
+): boolean {
+  return (
+    err?.code === "23505" ||
+    (err?.message ?? "").toLowerCase().includes("duplicate key")
+  );
 }
 
 export async function POST(req: Request) {
   try {
     const supabase = createServerSupabaseRoute();
-
     const actor = await requirePortalCustomerActor(supabase);
 
     let body: Body;
@@ -88,53 +90,70 @@ export async function POST(req: Request) {
     const { data: customer, error: custErr } = await supabase
       .from("customers")
       .select("id, shop_id")
-            .eq("id", actor.customer.id)
+      .eq("id", actor.customer.id)
       .maybeSingle();
 
     if (custErr) return bad(custErr.message, 500);
     if (!customer?.id) return bad("Customer profile not found", 404);
-    if (!customer.shop_id) {
-      return bad("Customer is not linked to a shop", 400);
+    if (!customer.shop_id) return bad("Customer is not linked to a shop", 400);
+
+    const normalizedKey = normalizeIdempotencyKey(
+      req.headers.get("Idempotency-Key") ?? body.idempotencyKey ?? null,
+    );
+    if (!normalizedKey) {
+      return bad("A stable Idempotency-Key is required.");
     }
 
-    const normalizedKey = normalizeIdempotencyKey(body.idempotencyKey ?? null);
-    const sourceRowId = normalizedKey
-      ? `portal_start:${customer.id}:${normalizedKey}`
-      : null;
-
-    // Fast-path replay: return existing created pair for the same idempotency key.
-    if (sourceRowId) {
-      const { data: existingWo, error: existingWoErr } = await supabase
-        .from("work_orders")
+    const vehicleId =
+      typeof body.vehicleId === "string" && body.vehicleId.trim()
+        ? body.vehicleId.trim()
+        : null;
+    if (vehicleId) {
+      const { data: vehicle, error: vehicleErr } = await supabase
+        .from("vehicles")
         .select("id")
-        .eq("shop_id", customer.shop_id)
+        .eq("id", vehicleId)
         .eq("customer_id", customer.id)
-        .eq("source_row_id", sourceRowId)
+        .eq("shop_id", customer.shop_id)
         .maybeSingle();
+      if (vehicleErr) return bad(vehicleErr.message, 500);
+      if (!vehicle) return bad("Vehicle does not belong to this customer and shop", 403);
+    }
 
-      if (existingWoErr) return bad("Failed to verify request replay", 500);
+    const sourceRowId = `portal_start:${customer.id}:${normalizedKey}`;
 
-      if (existingWo?.id) {
-        const { data: existingBooking, error: existingBookingErr } = await supabase
-          .from("bookings")
-          .select("id")
-          .eq("work_order_id", existingWo.id)
-          .maybeSingle();
+    const { data: existingWo, error: existingWoErr } = await supabase
+      .from("work_orders")
+      .select("id")
+      .eq("shop_id", customer.shop_id)
+      .eq("customer_id", customer.id)
+      .eq("source_row_id", sourceRowId)
+      .maybeSingle();
 
-        if (existingBookingErr) return bad("Failed to verify existing booking", 500);
-        if (existingBooking?.id) {
-          return NextResponse.json(
-            { workOrderId: existingWo.id, bookingId: existingBooking.id, replayed: true },
-            { status: 200 },
-          );
-        }
+    if (existingWoErr) return bad("Failed to verify request replay", 500);
+    if (existingWo?.id) {
+      const { data: existingBooking, error: existingBookingErr } = await supabase
+        .from("bookings")
+        .select("id")
+        .eq("work_order_id", existingWo.id)
+        .maybeSingle();
+      if (existingBookingErr) return bad("Failed to verify existing booking", 500);
+      if (existingBooking?.id) {
+        return NextResponse.json(
+          {
+            workOrderId: existingWo.id,
+            bookingId: existingBooking.id,
+            replayed: true,
+          },
+          { status: 200 },
+        );
       }
     }
 
     const rpcPayload = {
       p_shop_id: customer.shop_id,
       p_customer_id: customer.id,
-      p_vehicle_id: body.vehicleId ?? null,
+      p_vehicle_id: vehicleId,
       p_starts_at: startsAt,
       p_ends_at: endsAt,
       p_visit_type: visitType,
@@ -142,15 +161,20 @@ export async function POST(req: Request) {
       p_source_row_id: sourceRowId,
     };
 
-    const { data: created, error: createErr } = await (supabase as never as {
-      rpc: (
-        fn: "portal_request_start_atomic",
-        args: typeof rpcPayload,
-      ) => Promise<{ data: StartRpcRow[] | null; error: { code?: string; message?: string } | null }>;
-    }).rpc("portal_request_start_atomic", rpcPayload);
+    const { data: created, error: createErr } = await (
+      supabase as never as {
+        rpc: (
+          fn: "portal_request_start_atomic",
+          args: typeof rpcPayload,
+        ) => Promise<{
+          data: StartRpcRow[] | null;
+          error: { code?: string; message?: string } | null;
+        }>;
+      }
+    ).rpc("portal_request_start_atomic", rpcPayload);
 
     if (createErr) {
-      if (isDuplicateKeyError(createErr) && sourceRowId) {
+      if (isDuplicateKeyError(createErr)) {
         const { data: fallbackWo } = await supabase
           .from("work_orders")
           .select("id")
@@ -165,10 +189,13 @@ export async function POST(req: Request) {
             .select("id")
             .eq("work_order_id", fallbackWo.id)
             .maybeSingle();
-
           if (fallbackBooking?.id) {
             return NextResponse.json(
-              { workOrderId: fallbackWo.id, bookingId: fallbackBooking.id, replayed: true },
+              {
+                workOrderId: fallbackWo.id,
+                bookingId: fallbackBooking.id,
+                replayed: true,
+              },
               { status: 200 },
             );
           }

--- a/app/api/work-orders/lines/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/lines/[id]/approval-decision/route.ts
@@ -1,77 +1,103 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { applyAndPropagateWorkOrderLineApprovalDecision } from "@/features/work-orders/server/workOrderLineApproval";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { PortalAccessError } from "@/features/portal/server/portalAuth";
 
 type RouteContext = { params: Promise<{ id: string }> };
 type Decision = "approve" | "decline" | "defer";
 type Body = {
-  decision: Decision;
+  decision?: Decision;
   workOrderId?: string | null;
-  resetPunchClock?: boolean;
+  idempotencyKey?: string | null;
+};
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
 };
 
-function safeString(v: unknown): string {
-  return typeof v === "string" ? v.trim() : "";
+function safeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function errorStatus(message: string): number {
+  const lower = message.toLowerCase();
+  if (lower.includes("not found")) return 404;
+  if (lower.includes("not owned") || lower.includes("actor mismatch")) return 403;
+  if (lower.includes("locked") || lower.includes("no longer eligible")) return 409;
+  return 400;
 }
 
 export async function POST(req: NextRequest, ctx: RouteContext) {
   const supabase = createServerSupabaseRoute();
-  const { id } = await ctx.params;
-  const lineId = safeString(id);
 
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabase.auth.getUser();
-
-  if (userErr || !user) {
-    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
-  }
-
-  let body: Body | null = null;
   try {
-    body = (await req.json()) as Body;
-  } catch {
-    return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+    const actor = await requirePortalCustomerActor(supabase);
+    const { id } = await ctx.params;
+    const lineId = safeString(id);
+    const body = (await req.json().catch(() => null)) as Body | null;
+    const workOrderId = safeString(body?.workOrderId);
+    const decision = body?.decision;
+    const key =
+      req.headers.get("Idempotency-Key")?.trim() ||
+      safeString(body?.idempotencyKey);
+
+    if (
+      !lineId ||
+      !workOrderId ||
+      (decision !== "approve" && decision !== "decline" && decision !== "defer")
+    ) {
+      return NextResponse.json(
+        { ok: false, error: "Missing lineId, workOrderId, or decision" },
+        { status: 400 },
+      );
+    }
+    if (!actor.customer.shop_id) {
+      return NextResponse.json(
+        { ok: false, error: "Customer is not linked to a shop" },
+        { status: 409 },
+      );
+    }
+    if (!key) {
+      return NextResponse.json(
+        { ok: false, error: "A stable Idempotency-Key is required." },
+        { status: 400 },
+      );
+    }
+
+    const rpc = supabase as unknown as RpcClient;
+    const { data, error } = await rpc.rpc("apply_portal_line_decision_atomic", {
+      p_shop_id: actor.customer.shop_id,
+      p_customer_id: actor.customer.id,
+      p_work_order_id: workOrderId,
+      p_line_id: lineId,
+      p_actor_user_id: actor.userId,
+      p_decision: decision,
+      p_operation_key: `${actor.customer.shop_id}:portal-line-decision:${key}`,
+      p_at: new Date().toISOString(),
+    });
+
+    if (error) {
+      const message = [error.message, error.details, error.hint]
+        .filter(Boolean)
+        .join(" — ");
+      return NextResponse.json(
+        { ok: false, error: message },
+        { status: errorStatus(message) },
+      );
+    }
+
+    return NextResponse.json(data ?? { ok: true });
+  } catch (error: unknown) {
+    if (error instanceof PortalAccessError) {
+      return NextResponse.json(
+        { ok: false, error: error.message },
+        { status: error.status },
+      );
+    }
+    const message = error instanceof Error ? error.message : "Unexpected portal error";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
-
-  const decision = body?.decision;
-  const workOrderId = safeString(body?.workOrderId);
-
-  if (!lineId || (decision !== "approve" && decision !== "decline" && decision !== "defer")) {
-    return NextResponse.json({ ok: false, error: "Missing lineId or decision" }, { status: 400 });
-  }
-
-  const { error } = await applyAndPropagateWorkOrderLineApprovalDecision({
-    supabase,
-    decision,
-    lineIds: [lineId],
-    workOrderId: workOrderId || undefined,
-    extraPatch: body?.resetPunchClock
-      ? {
-          punched_in_at: null,
-          punched_out_at: null,
-        }
-      : undefined,
-  });
-
-  if (error) {
-    return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
-  }
-
-  const { data: row, error: rowErr } = await supabase
-    .from("work_order_lines")
-    .select("id, work_order_id")
-    .eq("id", lineId)
-    .maybeSingle();
-
-  if (rowErr) {
-    return NextResponse.json({ ok: false, error: rowErr.message }, { status: 400 });
-  }
-
-  if (!row?.id) {
-    return NextResponse.json({ ok: false, error: "Line item not found" }, { status: 404 });
-  }
-
-  return NextResponse.json({ ok: true, lineId: row.id, workOrderId: row.work_order_id });
 }

--- a/app/api/work-orders/lines/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/lines/[id]/approval-decision/route.ts
@@ -40,9 +40,6 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
     const body = (await req.json().catch(() => null)) as Body | null;
     const workOrderId = safeString(body?.workOrderId);
     const decision = body?.decision;
-    const key =
-      req.headers.get("Idempotency-Key")?.trim() ||
-      safeString(body?.idempotencyKey);
 
     if (
       !lineId ||
@@ -60,11 +57,42 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
         { status: 409 },
       );
     }
+
+    let key =
+      req.headers.get("Idempotency-Key")?.trim() ||
+      safeString(body?.idempotencyKey);
+
     if (!key) {
-      return NextResponse.json(
-        { ok: false, error: "A stable Idempotency-Key is required." },
-        { status: 400 },
-      );
+      const { data: currentLine, error: currentLineError } = await supabase
+        .from("work_order_lines")
+        .select("approval_state,updated_at")
+        .eq("id", lineId)
+        .eq("work_order_id", workOrderId)
+        .eq("shop_id", actor.customer.shop_id)
+        .maybeSingle<{
+          approval_state: string | null;
+          updated_at: string | null;
+        }>();
+
+      if (currentLineError) {
+        return NextResponse.json(
+          { ok: false, error: currentLineError.message },
+          { status: 400 },
+        );
+      }
+      if (!currentLine) {
+        return NextResponse.json(
+          { ok: false, error: "Line item not found" },
+          { status: 404 },
+        );
+      }
+
+      const stateVersion = [
+        currentLine.approval_state ?? "none",
+        currentLine.updated_at ?? "unknown",
+        decision,
+      ].join(":");
+      key = `derived:${lineId}:${stateVersion}`;
     }
 
     const rpc = supabase as unknown as RpcClient;

--- a/app/portal/auth/confirm/page.tsx
+++ b/app/portal/auth/confirm/page.tsx
@@ -1,134 +1,80 @@
-// app/portal/auth/confirm/page.tsx
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import type { Database } from "@shared/types/types/supabase";
 
 const COPPER = "#C57A4A";
 
-type CustomersRow = Database["public"]["Tables"]["customers"]["Row"];
-type CustomersInsert = Database["public"]["Tables"]["customers"]["Insert"];
-type CustomerPortalInviteRow =
-  Database["public"]["Tables"]["customer_portal_invites"]["Row"];
+function safeInternalPath(value: string | null): string {
+  const path = value ?? "";
+  if (!path.startsWith("/") || path.startsWith("//")) return "/portal";
+  if (path.includes("\n") || path.includes("\r")) return "/portal";
+  return path;
+}
 
-/**
- * Portal Confirm
- * -----------------------------------------------------------------------------
- * Handles magic-link / email confirmation:
- *  - Reads ?code from Supabase PKCE magic link
- *  - exchangeCodeForSession(code)
- *  - Ensures a `customers` row is linked to this user (portal profile)
- *  - If session -> redirect to safe `next` or /portal
- *  - If no session -> redirect to /portal/auth/sign-in
- */
+function operationKey(inviteId: string, userId: string): string {
+  return `portal-confirm:${inviteId}:${userId}`;
+}
+
 export default function PortalConfirmPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
+    const safeNext = safeInternalPath(searchParams.get("next"));
+    const inviteId = searchParams.get("invite")?.trim() ?? "";
 
-    const safeNext = (() => {
-      const n = searchParams.get("next") || "";
-      if (!n.startsWith("/")) return "/portal";
-      if (n.startsWith("//")) return "/portal";
-      if (n.includes("\n") || n.includes("\r")) return "/portal";
-      return n;
-    })();
-
-    (async () => {
+    void (async () => {
       try {
-        // Supabase magic link (PKCE) returns ?code=...
         const code = searchParams.get("code");
         if (code) {
-          const { error: exErr } = await supabase.auth.exchangeCodeForSession(
-            code,
-          );
-          if (exErr) throw new Error(exErr.message);
+          const { error: exchangeError } =
+            await supabase.auth.exchangeCodeForSession(code);
+          if (exchangeError) throw new Error(exchangeError.message);
         }
 
         const {
           data: { session },
         } = await supabase.auth.getSession();
-
         if (cancelled) return;
-
         if (!session?.user) {
           router.replace("/portal/auth/sign-in");
           return;
         }
-
-        // -------------------------------------------------------------------
-        // Require invite context evidence before linking customer portal data.
-        // Without this, generic email confirmation can expose customer data.
-        // -------------------------------------------------------------------
-        try {
-          const email = session.user.email ?? null;
-          if (email) {
-            const normalizedEmail = email.toLowerCase();
-            const { data: inviteRows, error: inviteErr } = await supabase
-              .from("customer_portal_invites")
-              .select("id, customer_id, email")
-              .eq("email", normalizedEmail)
-              .limit(5);
-
-            const hasInviteContext =
-              !inviteErr && Array.isArray(inviteRows) && inviteRows.length > 0;
-
-            if (!hasInviteContext) {
-              router.replace("/portal");
-              return;
-            }
-
-            const { data: existing, error: findErr } = await supabase
-              .from("customers")
-              .select("id, shop_id, user_id")
-              .eq("email", normalizedEmail)
-              .limit(1);
-
-            if (!findErr && existing && existing.length > 0) {
-              const row = existing[0] as CustomersRow;
-              const inviteCustomerIds = (inviteRows as Pick<
-                CustomerPortalInviteRow,
-                "customer_id"
-              >[]).map((row) => row.customer_id);
-              const hasMatchingInviteCustomer = inviteCustomerIds.includes(
-                row.id,
-              );
-
-              if (!row.user_id && hasMatchingInviteCustomer) {
-                await supabase
-                  .from("customers")
-                  .update({ user_id: session.user.id })
-                  .eq("id", row.id);
-              }
-            } else if (inviteRows.some((r) => !!r.customer_id)) {
-              const insertPayload: CustomersInsert = {
-                user_id: session.user.id,
-                email: normalizedEmail,
-              };
-              await supabase
-                .from("customers")
-                .upsert(insertPayload, { onConflict: "user_id" });
-            }
-          }
-        } catch {
-          // If this fails, we still let them in; they just might not see WOs yet.
+        if (!inviteId) {
+          throw new Error("This portal access link is missing its invite identity.");
         }
 
-        // ✅ Land on safe `next` or /portal
-        router.replace(safeNext || "/portal");
-      } catch (e: unknown) {
+        const key = operationKey(inviteId, session.user.id);
+        const response = await fetch("/api/portal/invites/accept", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": key,
+          },
+          body: JSON.stringify({
+            inviteId,
+            operationKey: key,
+            idempotencyKey: key,
+          }),
+        });
+        const payload = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        if (!response.ok) {
+          throw new Error(payload?.error ?? "Unable to accept portal invite.");
+        }
+
+        if (!cancelled) router.replace(safeNext);
+      } catch (value: unknown) {
         if (cancelled) return;
         setError(
-          e instanceof Error ? e.message : "Unable to confirm sign-in.",
+          value instanceof Error ? value.message : "Unable to confirm sign-in.",
         );
-        router.replace("/portal/auth/sign-in");
       }
     })();
 
@@ -138,33 +84,12 @@ export default function PortalConfirmPage() {
   }, [router, searchParams, supabase]);
 
   return (
-    <div
-      className="
-        min-h-screen px-4 text-foreground
-        bg-background
-        bg-[var(--theme-gradient-panel)]
-      "
-    >
+    <div className="min-h-screen bg-background bg-[var(--theme-gradient-panel)] px-4 text-foreground">
       <div className="mx-auto flex min-h-screen max-w-md flex-col items-center justify-center py-8">
-        <div
-          className="
-            w-full rounded-3xl border
-            border-[color:var(--metal-border-soft,var(--theme-border-soft))]
-            bg-[var(--theme-gradient-panel)]
-            shadow-[var(--theme-shadow-medium)]
-            px-6 py-7 sm:px-8 sm:py-9
-          "
-        >
+        <div className="w-full rounded-3xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[var(--theme-gradient-panel)] px-6 py-7 shadow-[var(--theme-shadow-medium)] sm:px-8 sm:py-9">
           <div className="mb-4 flex items-center justify-center">
             <div
-              className="
-                inline-flex items-center gap-1 rounded-full border
-                border-[color:var(--metal-border-soft,var(--theme-border-soft))]
-                bg-[color:var(--theme-surface-overlay)]
-                px-3 py-1 text-[11px]
-                uppercase tracking-[0.22em]
-                text-[color:var(--theme-text-secondary)]
-              "
+              className="inline-flex items-center gap-1 rounded-full border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] px-3 py-1 text-[11px] uppercase tracking-[0.22em] text-[color:var(--theme-text-secondary)]"
               style={{ color: COPPER }}
             >
               Customer Portal
@@ -172,7 +97,7 @@ export default function PortalConfirmPage() {
           </div>
 
           <h1
-            className="text-center text-2xl sm:text-3xl font-semibold text-[color:var(--theme-text-primary)]"
+            className="text-center text-2xl font-semibold text-[color:var(--theme-text-primary)] sm:text-3xl"
             style={{ fontFamily: "var(--font-blackops), system-ui" }}
           >
             Completing sign-in
@@ -180,8 +105,8 @@ export default function PortalConfirmPage() {
 
           <p className="mt-2 text-center text-xs text-[color:var(--theme-text-secondary)] sm:text-sm">
             {error
-              ? "Sign-in failed — redirecting…"
-              : "One moment… we’re completing your sign-in."}
+              ? "We could not complete portal access."
+              : "One moment… we’re securely linking your portal account."}
           </p>
 
           {error ? (

--- a/docs/phase-7-customer-portal-runbook.md
+++ b/docs/phase-7-customer-portal-runbook.md
@@ -1,0 +1,46 @@
+# Phase 7 — Customer Portal Lifecycle
+
+## Purpose
+
+Phase 7 makes portal identity, bookings, request lines, and customer approval decisions deterministic, shop-scoped, and retry-safe.
+
+## Migration order
+
+Run these files in order:
+
+1. `supabase/migrations/20260715080000_phase7_atomic_portal_invite_acceptance.sql`
+2. `supabase/migrations/20260715080100_phase7_atomic_portal_booking_lifecycle.sql`
+3. `supabase/migrations/20260715080200_phase7_atomic_portal_request_lines.sql`
+4. `supabase/migrations/20260715080300_phase7_atomic_portal_line_decisions.sql`
+5. `supabase/migrations/20260715080400_phase7_customer_portal_postcheck.sql`
+
+The final migration must print:
+
+```text
+Phase 7 customer portal lifecycle postcheck passed.
+```
+
+## Controlled validation
+
+1. Generate a portal invite for an existing customer.
+2. Open the magic link and confirm only the invited customer row is linked.
+3. Retry the same callback and confirm the same portal actor is returned.
+4. Create a customer booking and confirm the customer-shop link and booking commit together.
+5. Retry the booking with the same operation key and confirm no duplicate.
+6. Attempt an overlapping booking and confirm rejection.
+7. Reschedule through the staff route and confirm overlap and notice rules are reapplied.
+8. Cancel a future unlinked booking and confirm the row remains with cancellation metadata.
+9. Attempt to cancel a completed, past, or work-order-linked booking and confirm rejection.
+10. Start a portal service request with a customer-owned vehicle and stable key.
+11. Retry the request and confirm the same work order/booking pair is returned.
+12. Add custom, menu, and inspection lines and confirm retries do not duplicate them.
+13. Approve a portal line and confirm it becomes `awaiting`/`authorized`, not `in_progress`.
+14. Confirm cross-customer and cross-shop IDs are rejected.
+15. Confirm finalized work orders reject portal request-line and approval changes.
+
+## Compatibility notes
+
+- Fleet portal pages continue to use their separate fleet capability resolver.
+- Existing customer invoice, payment, and receipt surfaces remain owned by Phase 1.
+- The legacy portal approval page remains compatible through deterministic server-derived operation keys when it does not send a client key.
+- Booking DELETE now records cancellation instead of physically deleting history.

--- a/features/portal/server/addPortalRequestLine.ts
+++ b/features/portal/server/addPortalRequestLine.ts
@@ -1,0 +1,53 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = SupabaseClient<DB> & {
+  rpc(
+    fn: string,
+    args: Record<string, unknown>,
+  ): Promise<{ data: unknown; error: RpcError | null }>;
+};
+
+export type PortalRequestLineKind = "custom" | "menu" | "inspection";
+
+export async function addPortalRequestLine(args: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  customerId: string;
+  workOrderId: string;
+  actorUserId: string;
+  kind: PortalRequestLineKind;
+  sourceId?: string | null;
+  description?: string | null;
+  notes?: string | null;
+  lineType?: "job" | "info";
+  operationKey: string;
+}): Promise<Record<string, unknown>> {
+  const { data, error } = await (args.supabase as RpcClient).rpc(
+    "add_portal_request_line_atomic",
+    {
+      p_shop_id: args.shopId,
+      p_customer_id: args.customerId,
+      p_work_order_id: args.workOrderId,
+      p_actor_user_id: args.actorUserId,
+      p_line_kind: args.kind,
+      p_source_id: args.sourceId ?? null,
+      p_description: args.description ?? null,
+      p_notes: args.notes ?? null,
+      p_line_type: args.lineType ?? null,
+      p_operation_key: args.operationKey,
+      p_at: new Date().toISOString(),
+    },
+  );
+
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    throw new Error(message);
+  }
+
+  return (data ?? { ok: true }) as Record<string, unknown>;
+}

--- a/features/portal/server/createPortalBooking.ts
+++ b/features/portal/server/createPortalBooking.ts
@@ -2,8 +2,14 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
-
 type BookingActorMode = "customer-only" | "allow-staff";
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = SupabaseClient<DB> & {
+  rpc(
+    fn: string,
+    args: Record<string, unknown>,
+  ): Promise<{ data: unknown; error: RpcError | null }>;
+};
 
 export type CreatePortalBookingInput = {
   shopSlug: string;
@@ -15,11 +21,32 @@ export type CreatePortalBookingInput = {
   customerName?: string;
   customerEmail?: string;
   customerPhone?: string;
+  operationKey?: string;
+  idempotencyKey?: string;
 };
 
 export type CreatePortalBookingResult =
   | { ok: true; booking: DB["public"]["Tables"]["bookings"]["Row"] }
   | { ok: false; error: string; status: number };
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function statusFor(message: string): number {
+  const lower = message.toLowerCase();
+  if (lower.includes("overlap")) return 409;
+  if (lower.includes("not found")) return 404;
+  if (
+    lower.includes("not authorized") ||
+    lower.includes("another shop") ||
+    lower.includes("actor mismatch") ||
+    lower.includes("does not belong")
+  ) {
+    return 403;
+  }
+  return 400;
+}
 
 export async function createPortalBooking({
   supabase,
@@ -32,187 +59,82 @@ export async function createPortalBooking({
   input: CreatePortalBookingInput;
   actorMode: BookingActorMode;
 }): Promise<CreatePortalBookingResult> {
-  const shopSlug = typeof input.shopSlug === "string" ? input.shopSlug.trim() : "";
-  const startsAt = typeof input.startsAt === "string" ? input.startsAt.trim() : "";
-  const endsAt = typeof input.endsAt === "string" ? input.endsAt.trim() : "";
-  const notes = typeof input.notes === "string" ? input.notes.trim() : "";
-  const vehicleId = typeof input.vehicleId === "string" ? input.vehicleId.trim() : "";
+  const shopSlug = clean(input.shopSlug);
+  const startsAt = clean(input.startsAt);
+  const endsAt = clean(input.endsAt);
+  const vehicleId = clean(input.vehicleId) || null;
+  const suppliedCustomerId = clean(input.customerId);
+  const operationKey = clean(input.operationKey) || clean(input.idempotencyKey);
 
   if (!shopSlug || !startsAt || !endsAt) {
     return { ok: false, error: "Missing shopSlug, startsAt, or endsAt", status: 400 };
   }
-
-  const start = new Date(startsAt);
-  const end = new Date(endsAt);
-  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end <= start) {
-    return { ok: false, error: "Invalid start/end", status: 400 };
+  if (!operationKey) {
+    return { ok: false, error: "A stable operation key is required", status: 400 };
   }
 
-  const { data: shop, error: shopErr } = await supabase
+  const { data: shop, error: shopError } = await supabase
     .from("shops")
-    .select("id, slug, accepts_online_booking, min_notice_minutes, max_lead_days")
+    .select("id")
     .eq("slug", shopSlug)
-    .maybeSingle();
-
-  if (shopErr) return { ok: false, error: shopErr.message, status: 500 };
+    .maybeSingle<{ id: string }>();
+  if (shopError) return { ok: false, error: shopError.message, status: 500 };
   if (!shop) return { ok: false, error: "Shop not found", status: 404 };
-  if (shop.accepts_online_booking === false) {
-    return { ok: false, error: "Shop is not accepting online bookings", status: 403 };
-  }
 
-  const hasExplicitCustomer = Boolean(
-    actorMode === "allow-staff" &&
-      typeof input.customerId === "string" &&
-      input.customerId.trim().length > 0,
-  );
-  const hasInlineCustomerFields = Boolean(
-    actorMode === "allow-staff" &&
-      ((typeof input.customerName === "string" && input.customerName.trim().length > 0) ||
-        (typeof input.customerEmail === "string" && input.customerEmail.trim().length > 0) ||
-        (typeof input.customerPhone === "string" && input.customerPhone.trim().length > 0)),
-  );
-
-  let customerId: string | null = null;
-  let customerShopId: string | null = null;
-  const explicitCustomerId =
-    typeof input.customerId === "string" ? input.customerId.trim() : "";
-
-  if (hasExplicitCustomer) {
-    const { data: customerRow, error: customerRowErr } = await supabase
+  let customerId = suppliedCustomerId;
+  if (actorMode === "customer-only") {
+    const { data: customer, error: customerError } = await supabase
       .from("customers")
-      .select("id, shop_id")
-      .eq("id", explicitCustomerId)
-      .maybeSingle();
-
-    if (customerRowErr) return { ok: false, error: customerRowErr.message, status: 500 };
-    if (!customerRow) return { ok: false, error: "Selected customer not found", status: 404 };
-    if (customerRow.shop_id && customerRow.shop_id !== shop.id) {
-      return { ok: false, error: "Customer belongs to a different shop", status: 403 };
-    }
-    customerId = customerRow.id;
-    customerShopId = customerRow.shop_id;
-  } else if (hasInlineCustomerFields) {
-    const trimmedName = (input.customerName ?? "").trim();
-    let firstName: string | null = null;
-    let lastName: string | null = null;
-
-    if (trimmedName) {
-      const parts = trimmedName.split(" ");
-      firstName = parts[0] || null;
-      lastName = parts.slice(1).join(" ") || null;
-    }
-
-    const insertCustomer: DB["public"]["Tables"]["customers"]["Insert"] = {
-      shop_id: shop.id,
-      first_name: firstName,
-      last_name: lastName,
-      email: (input.customerEmail ?? "").trim() || null,
-      phone: (input.customerPhone ?? "").trim() || null,
-    };
-
-    const { data: newCustomer, error: newCustErr } = await supabase
-      .from("customers")
-      .insert(insertCustomer)
-      .select("id, shop_id")
-      .single();
-
-    if (newCustErr || !newCustomer) {
-      return { ok: false, error: "Failed to create customer for booking", status: 500 };
-    }
-
-    customerId = newCustomer.id;
-    customerShopId = newCustomer.shop_id;
-  } else {
-    const { data: customerRow, error: custErr } = await supabase
-      .from("customers")
-      .select("id, shop_id")
+      .select("id")
       .eq("user_id", userId)
-      .maybeSingle();
-
-    if (custErr) return { ok: false, error: custErr.message, status: 500 };
-    if (!customerRow) return { ok: false, error: "Customer profile not found for this user", status: 404 };
-
-    if (customerRow.shop_id && customerRow.shop_id !== shop.id) {
-      return { ok: false, error: "Customer is not linked to this shop", status: 403 };
+      .maybeSingle<{ id: string }>();
+    if (customerError) {
+      return { ok: false, error: customerError.message, status: 500 };
     }
-
-    customerId = customerRow.id;
-    customerShopId = customerRow.shop_id;
+    if (!customer) {
+      return { ok: false, error: "Customer profile not found for this user", status: 404 };
+    }
+    customerId = customer.id;
   }
 
   if (!customerId) {
-    return { ok: false, error: "Could not resolve customer for booking", status: 500 };
+    return {
+      ok: false,
+      error: "A canonical customer is required before staff booking creation",
+      status: 400,
+    };
   }
 
-  if (vehicleId) {
-    const { data: vehicle, error: vehicleErr } = await supabase
-      .from("vehicles")
-      .select("id, customer_id, shop_id")
-      .eq("id", vehicleId)
-      .eq("customer_id", customerId)
-      .eq("shop_id", shop.id)
-      .maybeSingle();
+  const { data, error } = await (supabase as RpcClient).rpc(
+    "apply_portal_booking_command_atomic",
+    {
+      p_action: "create",
+      p_booking_id: null,
+      p_shop_id: shop.id,
+      p_customer_id: customerId,
+      p_vehicle_id: vehicleId,
+      p_starts_at: startsAt,
+      p_ends_at: endsAt,
+      p_notes: clean(input.notes) || null,
+      p_actor_user_id: userId,
+      p_actor_mode: actorMode === "customer-only" ? "customer" : "staff",
+      p_operation_key: `${shop.id}:booking-create:${operationKey}`,
+      p_reason: null,
+      p_at: new Date().toISOString(),
+    },
+  );
 
-    if (vehicleErr) return { ok: false, error: vehicleErr.message, status: 500 };
-    if (!vehicle) {
-      return { ok: false, error: "Vehicle does not belong to this customer at this shop", status: 403 };
-    }
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return { ok: false, error: message, status: statusFor(message) };
   }
 
-  const now = new Date();
-  const minutesUntil = Math.floor((start.getTime() - now.getTime()) / 60000);
-  const minNotice = shop.min_notice_minutes ?? 120;
-  if (minutesUntil < minNotice) {
-    return { ok: false, error: `Bookings require at least ${minNotice} minutes notice`, status: 400 };
+  const booking = (data as { booking?: DB["public"]["Tables"]["bookings"]["Row"] })
+    ?.booking;
+  if (!booking) {
+    return { ok: false, error: "Booking command returned no booking", status: 500 };
   }
-
-  const midnightToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const daysUntil = Math.floor((start.getTime() - midnightToday.getTime()) / 86400000);
-  const maxLead = shop.max_lead_days ?? 30;
-  if (daysUntil > maxLead) {
-    return { ok: false, error: `Bookings cannot be more than ${maxLead} days in advance`, status: 400 };
-  }
-
-  const { data: overlaps, error: ovErr } = await supabase
-    .from("bookings")
-    .select("id")
-    .eq("shop_id", shop.id)
-    .lt("starts_at", endsAt)
-    .gt("ends_at", startsAt)
-    .limit(1);
-
-  if (ovErr) return { ok: false, error: "Failed to check availability", status: 500 };
-  if ((overlaps ?? []).length > 0) {
-    return { ok: false, error: "This time overlaps an existing booking", status: 409 };
-  }
-
-  const insertBooking: DB["public"]["Tables"]["bookings"]["Insert"] = {
-    shop_id: shop.id,
-    customer_id: customerId,
-    vehicle_id: vehicleId || null,
-    starts_at: startsAt,
-    ends_at: endsAt,
-    status: "pending",
-    notes: notes || null,
-  };
-
-  const { data: created, error: insErr } = await supabase
-    .from("bookings")
-    .insert(insertBooking)
-    .select("*")
-    .single();
-
-  if (insErr || !created) {
-    if (insErr?.code === "23P01") {
-      return { ok: false, error: "This time overlaps an existing booking", status: 409 };
-    }
-    return { ok: false, error: "Failed to create booking", status: 500 };
-  }
-
-  const cameFromPortal = !hasExplicitCustomer && !hasInlineCustomerFields;
-  if (cameFromPortal && !customerShopId) {
-    await supabase.from("customers").update({ shop_id: shop.id }).eq("id", customerId);
-  }
-
-  return { ok: true, booking: created };
+  return { ok: true, booking };
 }

--- a/features/portal/server/customerBookings.ts
+++ b/features/portal/server/customerBookings.ts
@@ -2,6 +2,13 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
+type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcClient = SupabaseClient<DB> & {
+  rpc(
+    fn: string,
+    args: Record<string, unknown>,
+  ): Promise<{ data: unknown; error: RpcError | null }>;
+};
 
 export type CustomerBookingPayload = Pick<
   DB["public"]["Tables"]["bookings"]["Row"],
@@ -14,7 +21,10 @@ export async function listCustomerBookings({
 }: {
   supabase: SupabaseClient<DB>;
   customerId: string;
-}): Promise<{ ok: true; data: CustomerBookingPayload[] } | { ok: false; error: string; status: number }> {
+}): Promise<
+  | { ok: true; data: CustomerBookingPayload[] }
+  | { ok: false; error: string; status: number }
+> {
   const { data: bookings, error } = await supabase
     .from("bookings")
     .select("id, starts_at, ends_at, notes, status")
@@ -29,20 +39,57 @@ export async function cancelCustomerBooking({
   supabase,
   customerId,
   bookingId,
+  actorUserId,
+  operationKey,
+  reason,
 }: {
   supabase: SupabaseClient<DB>;
   customerId: string;
   bookingId: string;
-}): Promise<{ ok: true; data: CustomerBookingPayload } | { ok: false; error: string; status: number }> {
-  const { data: updated, error } = await supabase
-    .from("bookings")
-    .update({ status: "cancelled" })
-    .eq("id", bookingId)
-    .eq("customer_id", customerId)
-    .select("id, starts_at, ends_at, notes, status")
-    .maybeSingle();
+  actorUserId: string;
+  operationKey: string;
+  reason?: string | null;
+}): Promise<
+  | { ok: true; data: CustomerBookingPayload }
+  | { ok: false; error: string; status: number }
+> {
+  const { data, error } = await (supabase as RpcClient).rpc(
+    "apply_portal_booking_command_atomic",
+    {
+      p_action: "cancel",
+      p_booking_id: bookingId,
+      p_shop_id: null,
+      p_customer_id: customerId,
+      p_vehicle_id: null,
+      p_starts_at: null,
+      p_ends_at: null,
+      p_notes: null,
+      p_actor_user_id: actorUserId,
+      p_actor_mode: "customer",
+      p_operation_key: operationKey,
+      p_reason: reason ?? "Customer cancelled",
+      p_at: new Date().toISOString(),
+    },
+  );
 
-  if (error) return { ok: false, error: error.message, status: 500 };
-  if (!updated) return { ok: false, error: "Booking not found", status: 404 };
-  return { ok: true, data: updated };
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    const lower = message.toLowerCase();
+    const status = lower.includes("not found")
+      ? 404
+      : lower.includes("not owned") || lower.includes("cannot be changed")
+        ? 403
+        : lower.includes("terminal state") || lower.includes("work-order-linked")
+          ? 409
+          : 400;
+    return { ok: false, error: message, status };
+  }
+
+  const booking = (data as { booking?: CustomerBookingPayload })?.booking;
+  if (!booking) {
+    return { ok: false, error: "Booking command returned no booking", status: 500 };
+  }
+  return { ok: true, data: booking };
 }

--- a/supabase/migrations/20260715080000_phase7_atomic_portal_invite_acceptance.sql
+++ b/supabase/migrations/20260715080000_phase7_atomic_portal_invite_acceptance.sql
@@ -1,0 +1,157 @@
+begin;
+
+alter table public.customer_portal_invites
+  add column if not exists accepted_at timestamptz,
+  add column if not exists accepted_by_user_id uuid references auth.users(id) on delete set null,
+  add column if not exists revoked_at timestamptz,
+  add column if not exists expires_at timestamptz,
+  add column if not exists acceptance_metadata jsonb not null default '{}'::jsonb;
+
+create table if not exists public.portal_lifecycle_operation_keys (
+  id uuid primary key default gen_random_uuid(),
+  operation_name text not null,
+  operation_key text not null,
+  actor_user_id uuid references auth.users(id) on delete set null,
+  customer_id uuid references public.customers(id) on delete cascade,
+  shop_id uuid references public.shops(id) on delete cascade,
+  result jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (operation_name, operation_key)
+);
+
+alter table public.portal_lifecycle_operation_keys enable row level security;
+
+create or replace function public.accept_customer_portal_invite_atomic(
+  p_invite_id uuid,
+  p_actor_user_id uuid,
+  p_actor_email text,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_invite public.customer_portal_invites%rowtype;
+  v_customer public.customers%rowtype;
+  v_email text := lower(trim(coalesce(p_actor_email, '')));
+  v_existing jsonb;
+  v_result jsonb;
+  v_now timestamptz := coalesce(p_at, now());
+begin
+  if p_invite_id is null or p_actor_user_id is null then
+    raise exception using errcode = 'P0001', message = 'Invite and authenticated user are required.';
+  end if;
+  if v_email = '' then
+    raise exception using errcode = 'P0001', message = 'Authenticated email is required.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  select result into v_existing
+  from public.portal_lifecycle_operation_keys
+  where operation_name = 'accept_customer_portal_invite'
+    and operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select * into v_invite
+  from public.customer_portal_invites
+  where id = p_invite_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Portal invite not found.';
+  end if;
+
+  if lower(trim(v_invite.email)) <> v_email then
+    raise exception using errcode = 'P0001', message = 'Portal invite email does not match the authenticated account.';
+  end if;
+  if v_invite.revoked_at is not null then
+    raise exception using errcode = 'P0001', message = 'Portal invite has been revoked.';
+  end if;
+  if v_invite.expires_at is not null and v_invite.expires_at <= v_now then
+    raise exception using errcode = 'P0001', message = 'Portal invite has expired.';
+  end if;
+  if v_invite.accepted_by_user_id is not null
+     and v_invite.accepted_by_user_id <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Portal invite was accepted by another account.';
+  end if;
+
+  select * into v_customer
+  from public.customers
+  where id = v_invite.customer_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Invited customer no longer exists.';
+  end if;
+  if lower(trim(coalesce(v_customer.email, ''))) <> v_email then
+    raise exception using errcode = 'P0001', message = 'Invited customer email does not match the authenticated account.';
+  end if;
+  if v_customer.shop_id is null then
+    raise exception using errcode = 'P0001', message = 'Invited customer is missing shop scope.';
+  end if;
+  if v_customer.user_id is not null and v_customer.user_id <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Customer portal access is linked to another account.';
+  end if;
+
+  if exists (
+    select 1 from public.customers c
+    where c.user_id = p_actor_user_id
+      and c.id <> v_customer.id
+  ) then
+    raise exception using errcode = 'P0001', message = 'Authenticated account is already linked to another customer profile.';
+  end if;
+
+  update public.customers
+  set user_id = p_actor_user_id
+  where id = v_customer.id
+    and user_id is distinct from p_actor_user_id;
+
+  update public.customer_portal_invites
+  set accepted_at = coalesce(accepted_at, v_now),
+      accepted_by_user_id = p_actor_user_id,
+      acceptance_metadata = coalesce(acceptance_metadata, '{}'::jsonb) || jsonb_build_object(
+        'accepted_email', v_email,
+        'accepted_at', v_now
+      )
+  where id = v_invite.id;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'invite_id', v_invite.id,
+    'customer_id', v_customer.id,
+    'shop_id', v_customer.shop_id,
+    'user_id', p_actor_user_id,
+    'email', v_email,
+    'accepted_at', coalesce(v_invite.accepted_at, v_now),
+    'idempotent', false
+  );
+
+  insert into public.portal_lifecycle_operation_keys(
+    operation_name, operation_key, actor_user_id, customer_id, shop_id, result
+  ) values (
+    'accept_customer_portal_invite', p_operation_key, p_actor_user_id,
+    v_customer.id, v_customer.shop_id, v_result
+  )
+  on conflict (operation_name, operation_key) do nothing;
+
+  insert into public.activity_logs(user_id, action, target_table, target_id, context)
+  values (
+    p_actor_user_id,
+    'portal_invite_accepted',
+    'customer_portal_invites',
+    v_invite.id,
+    jsonb_build_object('customer_id', v_customer.id, 'shop_id', v_customer.shop_id)
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.accept_customer_portal_invite_atomic(uuid, uuid, text, text, timestamptz) from public;
+grant execute on function public.accept_customer_portal_invite_atomic(uuid, uuid, text, text, timestamptz) to authenticated, service_role;
+
+commit;

--- a/supabase/migrations/20260715080100_phase7_atomic_portal_booking_lifecycle.sql
+++ b/supabase/migrations/20260715080100_phase7_atomic_portal_booking_lifecycle.sql
@@ -1,0 +1,237 @@
+begin;
+
+alter table public.bookings
+  add column if not exists updated_at timestamptz not null default now(),
+  add column if not exists cancelled_at timestamptz,
+  add column if not exists cancelled_by uuid references auth.users(id) on delete set null,
+  add column if not exists cancellation_reason text,
+  add column if not exists lifecycle_metadata jsonb not null default '{}'::jsonb;
+
+create or replace function public.apply_portal_booking_command_atomic(
+  p_action text,
+  p_booking_id uuid,
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_vehicle_id uuid,
+  p_starts_at timestamptz,
+  p_ends_at timestamptz,
+  p_notes text,
+  p_actor_user_id uuid,
+  p_actor_mode text,
+  p_operation_key text,
+  p_reason text default null,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_action text := lower(trim(coalesce(p_action, '')));
+  v_mode text := lower(trim(coalesce(p_actor_mode, '')));
+  v_now timestamptz := coalesce(p_at, now());
+  v_booking public.bookings%rowtype;
+  v_customer public.customers%rowtype;
+  v_shop public.shops%rowtype;
+  v_existing jsonb;
+  v_result jsonb;
+  v_id uuid;
+  v_min_notice integer;
+  v_max_lead integer;
+begin
+  if v_action not in ('create','reschedule','cancel') then
+    raise exception using errcode = 'P0001', message = 'Unsupported booking action.';
+  end if;
+  if v_mode not in ('customer','staff') then
+    raise exception using errcode = 'P0001', message = 'Unsupported booking actor mode.';
+  end if;
+  if p_actor_user_id is null or nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor and stable operation key are required.';
+  end if;
+
+  select result into v_existing
+  from public.portal_lifecycle_operation_keys
+  where operation_name = 'portal_booking_' || v_action
+    and operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  if v_action = 'create' then
+    if p_shop_id is null or p_customer_id is null then
+      raise exception using errcode = 'P0001', message = 'Shop and customer are required.';
+    end if;
+
+    select * into v_shop from public.shops where id = p_shop_id for update;
+    if not found or v_shop.accepts_online_booking is false then
+      raise exception using errcode = 'P0001', message = 'Shop is not accepting online bookings.';
+    end if;
+
+    select * into v_customer from public.customers where id = p_customer_id for update;
+    if not found then
+      raise exception using errcode = 'P0001', message = 'Customer not found.';
+    end if;
+    if v_mode = 'customer' and v_customer.user_id is distinct from p_actor_user_id then
+      raise exception using errcode = 'P0001', message = 'Customer booking actor mismatch.';
+    end if;
+    if v_mode = 'staff' and not exists (
+      select 1 from public.profiles p
+      where p.id = p_actor_user_id and p.shop_id = p_shop_id
+        and lower(coalesce(p.role::text, '')) in ('owner','admin','manager','advisor')
+    ) then
+      raise exception using errcode = 'P0001', message = 'Staff booking actor is not authorized.';
+    end if;
+    if v_customer.shop_id is not null and v_customer.shop_id <> p_shop_id then
+      raise exception using errcode = 'P0001', message = 'Customer belongs to another shop.';
+    end if;
+
+    if p_starts_at is null or p_ends_at is null or p_ends_at <= p_starts_at then
+      raise exception using errcode = 'P0001', message = 'Valid booking times are required.';
+    end if;
+    v_min_notice := coalesce(v_shop.min_notice_minutes, 120);
+    v_max_lead := coalesce(v_shop.max_lead_days, 30);
+    if p_starts_at < v_now + make_interval(mins => v_min_notice) then
+      raise exception using errcode = 'P0001', message = 'Booking does not satisfy minimum notice.';
+    end if;
+    if p_starts_at > v_now + make_interval(days => v_max_lead) then
+      raise exception using errcode = 'P0001', message = 'Booking exceeds maximum lead time.';
+    end if;
+
+    if p_vehicle_id is not null and not exists (
+      select 1 from public.vehicles v
+      where v.id = p_vehicle_id and v.customer_id = p_customer_id and v.shop_id = p_shop_id
+    ) then
+      raise exception using errcode = 'P0001', message = 'Vehicle does not belong to this customer and shop.';
+    end if;
+
+    perform pg_advisory_xact_lock(hashtextextended(p_shop_id::text, 0));
+    if exists (
+      select 1 from public.bookings b
+      where b.shop_id = p_shop_id
+        and lower(coalesce(b.status, '')) not in ('cancelled','completed')
+        and b.starts_at < p_ends_at and b.ends_at > p_starts_at
+    ) then
+      raise exception using errcode = '23P01', message = 'This time overlaps an existing booking.';
+    end if;
+
+    update public.customers
+    set shop_id = p_shop_id
+    where id = p_customer_id and shop_id is null;
+
+    insert into public.bookings(
+      shop_id, customer_id, vehicle_id, starts_at, ends_at, status, notes,
+      created_by, updated_at, lifecycle_metadata
+    ) values (
+      p_shop_id, p_customer_id, p_vehicle_id, p_starts_at, p_ends_at,
+      'pending', nullif(trim(coalesce(p_notes, '')), ''), p_actor_user_id, v_now,
+      jsonb_build_object('created_actor_mode', v_mode, 'created_operation_key', p_operation_key)
+    ) returning id into v_id;
+  else
+    select * into v_booking
+    from public.bookings
+    where id = p_booking_id
+    for update;
+    if not found then
+      raise exception using errcode = 'P0001', message = 'Booking not found.';
+    end if;
+
+    if v_mode = 'customer' then
+      select * into v_customer from public.customers where id = v_booking.customer_id;
+      if v_customer.user_id is distinct from p_actor_user_id then
+        raise exception using errcode = 'P0001', message = 'Booking is not owned by this customer.';
+      end if;
+    elsif not exists (
+      select 1 from public.profiles p
+      where p.id = p_actor_user_id and p.shop_id = v_booking.shop_id
+        and lower(coalesce(p.role::text, '')) in ('owner','admin','manager','advisor')
+    ) then
+      raise exception using errcode = 'P0001', message = 'Staff booking actor is not authorized.';
+    end if;
+
+    if lower(coalesce(v_booking.status, '')) in ('cancelled','completed') then
+      raise exception using errcode = 'P0001', message = 'Booking is already in a terminal state.';
+    end if;
+    if v_booking.work_order_id is not null then
+      raise exception using errcode = 'P0001', message = 'Work-order-linked booking requires staff work-order workflow.';
+    end if;
+    if v_mode = 'customer' and v_booking.starts_at <= v_now then
+      raise exception using errcode = 'P0001', message = 'Past bookings cannot be changed by the customer.';
+    end if;
+
+    if v_action = 'cancel' then
+      update public.bookings
+      set status = 'cancelled',
+          cancelled_at = v_now,
+          cancelled_by = p_actor_user_id,
+          cancellation_reason = nullif(trim(coalesce(p_reason, '')), ''),
+          updated_at = v_now,
+          lifecycle_metadata = coalesce(lifecycle_metadata, '{}'::jsonb) ||
+            jsonb_build_object('cancelled_actor_mode', v_mode, 'cancelled_operation_key', p_operation_key)
+      where id = v_booking.id;
+      v_id := v_booking.id;
+    else
+      select * into v_shop from public.shops where id = v_booking.shop_id;
+      if p_starts_at is null or p_ends_at is null or p_ends_at <= p_starts_at then
+        raise exception using errcode = 'P0001', message = 'Valid booking times are required.';
+      end if;
+      v_min_notice := coalesce(v_shop.min_notice_minutes, 120);
+      v_max_lead := coalesce(v_shop.max_lead_days, 30);
+      if p_starts_at < v_now + make_interval(mins => v_min_notice) then
+        raise exception using errcode = 'P0001', message = 'Booking does not satisfy minimum notice.';
+      end if;
+      if p_starts_at > v_now + make_interval(days => v_max_lead) then
+        raise exception using errcode = 'P0001', message = 'Booking exceeds maximum lead time.';
+      end if;
+
+      perform pg_advisory_xact_lock(hashtextextended(v_booking.shop_id::text, 0));
+      if exists (
+        select 1 from public.bookings b
+        where b.shop_id = v_booking.shop_id and b.id <> v_booking.id
+          and lower(coalesce(b.status, '')) not in ('cancelled','completed')
+          and b.starts_at < p_ends_at and b.ends_at > p_starts_at
+      ) then
+        raise exception using errcode = '23P01', message = 'This time overlaps an existing booking.';
+      end if;
+
+      update public.bookings
+      set starts_at = p_starts_at,
+          ends_at = p_ends_at,
+          notes = case when p_notes is null then notes else nullif(trim(p_notes), '') end,
+          updated_at = v_now,
+          lifecycle_metadata = coalesce(lifecycle_metadata, '{}'::jsonb) ||
+            jsonb_build_object('rescheduled_actor_mode', v_mode, 'rescheduled_operation_key', p_operation_key)
+      where id = v_booking.id;
+      v_id := v_booking.id;
+    end if;
+  end if;
+
+  select jsonb_build_object(
+    'ok', true,
+    'booking', to_jsonb(b),
+    'action', v_action,
+    'idempotent', false
+  ) into v_result
+  from public.bookings b where b.id = v_id;
+
+  insert into public.portal_lifecycle_operation_keys(
+    operation_name, operation_key, actor_user_id, customer_id, shop_id, result
+  )
+  select 'portal_booking_' || v_action, p_operation_key, p_actor_user_id,
+         b.customer_id, b.shop_id, v_result
+  from public.bookings b where b.id = v_id
+  on conflict (operation_name, operation_key) do nothing;
+
+  insert into public.activity_logs(user_id, action, target_table, target_id, context)
+  values (
+    p_actor_user_id, 'portal_booking_' || v_action, 'bookings', v_id,
+    jsonb_build_object('actor_mode', v_mode, 'operation_key', p_operation_key)
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.apply_portal_booking_command_atomic(text, uuid, uuid, uuid, uuid, timestamptz, timestamptz, text, uuid, text, text, text, timestamptz) from public;
+grant execute on function public.apply_portal_booking_command_atomic(text, uuid, uuid, uuid, uuid, timestamptz, timestamptz, text, uuid, text, text, text, timestamptz) to authenticated, service_role;
+
+commit;

--- a/supabase/migrations/20260715080200_phase7_atomic_portal_request_lines.sql
+++ b/supabase/migrations/20260715080200_phase7_atomic_portal_request_lines.sql
@@ -1,0 +1,185 @@
+begin;
+
+create or replace function public.add_portal_request_line_atomic(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_work_order_id uuid,
+  p_actor_user_id uuid,
+  p_line_kind text,
+  p_source_id uuid,
+  p_description text,
+  p_notes text,
+  p_line_type text,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_kind text := lower(trim(coalesce(p_line_kind, '')));
+  v_now timestamptz := coalesce(p_at, now());
+  v_work_order public.work_orders%rowtype;
+  v_customer public.customers%rowtype;
+  v_menu public.menu_items%rowtype;
+  v_template public.inspection_templates%rowtype;
+  v_existing jsonb;
+  v_line public.work_order_lines%rowtype;
+  v_parts jsonb := '[]'::jsonb;
+  v_description text;
+  v_line_type text;
+begin
+  if v_kind not in ('custom','menu','inspection') then
+    raise exception using errcode = 'P0001', message = 'Unsupported portal request line kind.';
+  end if;
+  if p_actor_user_id is null or nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor and stable operation key are required.';
+  end if;
+
+  select result into v_existing
+  from public.portal_lifecycle_operation_keys
+  where operation_name = 'portal_request_line_' || v_kind
+    and operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select * into v_customer
+  from public.customers
+  where id = p_customer_id
+  for update;
+  if not found or v_customer.user_id is distinct from p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Portal customer actor mismatch.';
+  end if;
+
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id
+    and customer_id = p_customer_id
+    and shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work order is not owned by this portal customer.';
+  end if;
+
+  if public.work_order_is_financially_locked(p_shop_id, p_work_order_id) then
+    raise exception using errcode = 'P0001', message = 'FINANCIALLY_LOCKED: portal request lines cannot change this work order.';
+  end if;
+
+  if lower(coalesce(v_work_order.status::text, '')) in ('cancelled','canceled','closed','invoiced') then
+    raise exception using errcode = 'P0001', message = 'Work order no longer accepts portal request lines.';
+  end if;
+
+  if v_kind = 'custom' then
+    v_description := nullif(trim(coalesce(p_description, '')), '');
+    if v_description is null then
+      raise exception using errcode = 'P0001', message = 'Custom request description is required.';
+    end if;
+    v_line_type := case when lower(trim(coalesce(p_line_type, ''))) = 'info' then 'info' else 'job' end;
+
+    insert into public.work_order_lines(
+      work_order_id, shop_id, vehicle_id, complaint, notes, status,
+      approval_state, line_type, punchable, labor_time, price_estimate,
+      external_id, created_at
+    ) values (
+      v_work_order.id, v_work_order.shop_id, v_work_order.vehicle_id,
+      v_description, nullif(trim(coalesce(p_notes, '')), ''),
+      'awaiting_approval', 'pending', v_line_type,
+      case when v_line_type = 'info' then false else null end,
+      null, null, 'portal_request:' || p_operation_key, v_now
+    ) returning * into v_line;
+
+  elsif v_kind = 'menu' then
+    select * into v_menu
+    from public.menu_items
+    where id = p_source_id and shop_id = p_shop_id;
+    if not found then
+      raise exception using errcode = 'P0001', message = 'Menu item not found for this shop.';
+    end if;
+
+    select coalesce(jsonb_agg(jsonb_build_object(
+      'name', trim(coalesce(mip.name, '')),
+      'qty', coalesce(mip.quantity, 1),
+      'unitCost', mip.unit_cost
+    )) filter (where nullif(trim(coalesce(mip.name, '')), '') is not null), '[]'::jsonb)
+    into v_parts
+    from public.menu_item_parts mip
+    where mip.menu_item_id = v_menu.id;
+
+    v_description := coalesce(
+      nullif(trim(v_menu.description), ''),
+      nullif(trim(v_menu.complaint), ''),
+      'Service'
+    );
+
+    insert into public.work_order_lines(
+      work_order_id, shop_id, vehicle_id, menu_item_id, complaint,
+      labor_time, price_estimate, status, approval_state, parts_needed,
+      external_id, created_at
+    ) values (
+      v_work_order.id, v_work_order.shop_id, v_work_order.vehicle_id,
+      v_menu.id, v_description,
+      coalesce(v_menu.labor_hours, v_menu.base_labor_hours),
+      coalesce(v_menu.total_price, v_menu.base_price),
+      'awaiting_approval', 'pending', v_parts,
+      'portal_request:' || p_operation_key, v_now
+    ) returning * into v_line;
+
+  else
+    select * into v_template
+    from public.inspection_templates
+    where id = p_source_id and shop_id = p_shop_id;
+    if not found then
+      raise exception using errcode = 'P0001', message = 'Inspection template not found for this shop.';
+    end if;
+    if v_template.is_active is false then
+      raise exception using errcode = 'P0001', message = 'Inspection template is inactive.';
+    end if;
+
+    v_description := coalesce(
+      nullif(trim(v_template.name), ''),
+      nullif(trim(v_template.title), ''),
+      nullif(trim(v_template.description), ''),
+      'Inspection'
+    );
+
+    insert into public.work_order_lines(
+      work_order_id, shop_id, vehicle_id, job_type, description,
+      status, line_status, approval_state, inspection_template_id,
+      external_id, created_at
+    ) values (
+      v_work_order.id, v_work_order.shop_id, v_work_order.vehicle_id,
+      'inspection', v_description, 'awaiting_approval', 'pending', 'pending',
+      v_template.id, 'portal_request:' || p_operation_key, v_now
+    ) returning * into v_line;
+  end if;
+
+  v_existing := jsonb_build_object(
+    'ok', true,
+    'line', to_jsonb(v_line),
+    'kind', v_kind,
+    'idempotent', false
+  );
+
+  insert into public.portal_lifecycle_operation_keys(
+    operation_name, operation_key, actor_user_id, customer_id, shop_id, result
+  ) values (
+    'portal_request_line_' || v_kind, p_operation_key, p_actor_user_id,
+    p_customer_id, p_shop_id, v_existing
+  ) on conflict (operation_name, operation_key) do nothing;
+
+  insert into public.activity_logs(user_id, action, target_table, target_id, context)
+  values (
+    p_actor_user_id, 'portal_request_line_' || v_kind, 'work_order_lines', v_line.id,
+    jsonb_build_object('work_order_id', p_work_order_id, 'operation_key', p_operation_key)
+  );
+
+  return v_existing;
+end;
+$$;
+
+revoke all on function public.add_portal_request_line_atomic(uuid, uuid, uuid, uuid, text, uuid, text, text, text, text, timestamptz) from public;
+grant execute on function public.add_portal_request_line_atomic(uuid, uuid, uuid, uuid, text, uuid, text, text, text, text, timestamptz) to authenticated, service_role;
+
+commit;

--- a/supabase/migrations/20260715080300_phase7_atomic_portal_line_decisions.sql
+++ b/supabase/migrations/20260715080300_phase7_atomic_portal_line_decisions.sql
@@ -1,0 +1,170 @@
+begin;
+
+create or replace function public.apply_portal_line_decision_atomic(
+  p_shop_id uuid,
+  p_customer_id uuid,
+  p_work_order_id uuid,
+  p_line_id uuid,
+  p_actor_user_id uuid,
+  p_decision text,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_decision text := lower(trim(coalesce(p_decision, '')));
+  v_now timestamptz := coalesce(p_at, now());
+  v_customer public.customers%rowtype;
+  v_work_order public.work_orders%rowtype;
+  v_line public.work_order_lines%rowtype;
+  v_existing jsonb;
+  v_result jsonb;
+  v_pending integer := 0;
+  v_approved integer := 0;
+  v_declined integer := 0;
+  v_rollup text;
+begin
+  if v_decision not in ('approve','decline','defer') then
+    raise exception using errcode = 'P0001', message = 'Unsupported portal line decision.';
+  end if;
+  if p_actor_user_id is null or nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor and stable operation key are required.';
+  end if;
+
+  select result into v_existing
+  from public.portal_lifecycle_operation_keys
+  where operation_name = 'portal_line_decision'
+    and operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select * into v_customer
+  from public.customers
+  where id = p_customer_id
+  for update;
+  if not found or v_customer.user_id is distinct from p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Portal customer actor mismatch.';
+  end if;
+
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id
+    and shop_id = p_shop_id
+    and customer_id = p_customer_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work order is not owned by this portal customer.';
+  end if;
+
+  if public.work_order_is_financially_locked(p_shop_id, p_work_order_id) then
+    raise exception using errcode = 'P0001', message = 'FINANCIALLY_LOCKED: portal decisions cannot change this work order.';
+  end if;
+
+  select * into v_line
+  from public.work_order_lines
+  where id = p_line_id
+    and work_order_id = p_work_order_id
+    and shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for this portal decision.';
+  end if;
+
+  if lower(coalesce(v_line.status::text, '')) in ('completed','ready_to_invoice','invoiced','voided','cancelled','canceled') then
+    raise exception using errcode = 'P0001', message = 'This line is no longer eligible for a portal decision.';
+  end if;
+
+  if v_decision = 'approve' then
+    update public.work_order_lines
+    set approval_state = 'approved',
+        status = 'awaiting',
+        line_status = 'authorized',
+        approval_at = coalesce(approval_at, v_now),
+        approval_by = p_actor_user_id,
+        hold_reason = null,
+        updated_at = v_now
+    where id = p_line_id;
+  elsif v_decision = 'decline' then
+    update public.work_order_lines
+    set approval_state = 'declined',
+        status = 'on_hold',
+        line_status = 'declined',
+        approval_at = v_now,
+        approval_by = p_actor_user_id,
+        hold_reason = coalesce(nullif(trim(hold_reason), ''), 'Customer declined'),
+        updated_at = v_now
+    where id = p_line_id;
+  else
+    update public.work_order_lines
+    set approval_state = 'pending',
+        status = 'awaiting_approval',
+        line_status = 'pending',
+        approval_at = null,
+        approval_by = null,
+        updated_at = v_now
+    where id = p_line_id;
+  end if;
+
+  select
+    count(*) filter (where lower(coalesce(approval_state::text, '')) = 'pending'),
+    count(*) filter (where lower(coalesce(approval_state::text, '')) = 'approved'),
+    count(*) filter (where lower(coalesce(approval_state::text, '')) = 'declined')
+  into v_pending, v_approved, v_declined
+  from public.work_order_lines
+  where work_order_id = p_work_order_id
+    and shop_id = p_shop_id
+    and voided_at is null;
+
+  v_rollup := case
+    when v_pending > 0 and v_approved > 0 then 'partial'
+    when v_pending > 0 then 'pending'
+    when v_approved > 0 then 'approved'
+    when v_declined > 0 then 'declined'
+    else 'pending'
+  end;
+
+  update public.work_orders
+  set approval_state = v_rollup,
+      customer_approval_at = v_now,
+      customer_approved_by = p_actor_user_id,
+      updated_at = v_now
+  where id = p_work_order_id;
+
+  select jsonb_build_object(
+    'ok', true,
+    'lineId', wol.id,
+    'workOrderId', wol.work_order_id,
+    'approvalState', wol.approval_state,
+    'status', wol.status,
+    'workOrderApprovalState', v_rollup,
+    'decision', v_decision,
+    'idempotent', false
+  ) into v_result
+  from public.work_order_lines wol
+  where wol.id = p_line_id;
+
+  insert into public.portal_lifecycle_operation_keys(
+    operation_name, operation_key, actor_user_id, customer_id, shop_id, result
+  ) values (
+    'portal_line_decision', p_operation_key, p_actor_user_id,
+    p_customer_id, p_shop_id, v_result
+  ) on conflict (operation_name, operation_key) do nothing;
+
+  insert into public.activity_logs(user_id, action, target_table, target_id, context)
+  values (
+    p_actor_user_id, 'portal_line_' || v_decision, 'work_order_lines', p_line_id,
+    jsonb_build_object('work_order_id', p_work_order_id, 'operation_key', p_operation_key)
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.apply_portal_line_decision_atomic(uuid, uuid, uuid, uuid, uuid, text, text, timestamptz) from public;
+grant execute on function public.apply_portal_line_decision_atomic(uuid, uuid, uuid, uuid, uuid, text, text, timestamptz) to authenticated, service_role;
+
+commit;

--- a/supabase/migrations/20260715080400_phase7_customer_portal_postcheck.sql
+++ b/supabase/migrations/20260715080400_phase7_customer_portal_postcheck.sql
@@ -1,0 +1,55 @@
+do $$
+begin
+  if to_regclass('public.portal_lifecycle_operation_keys') is null then
+    raise exception 'Phase 7 postcheck failed: portal lifecycle operation keys are missing.';
+  end if;
+
+  if to_regprocedure('public.accept_portal_invite_atomic(uuid,uuid,text,text,timestamptz)') is null then
+    raise exception 'Phase 7 postcheck failed: invite acceptance command is missing.';
+  end if;
+
+  if to_regprocedure('public.apply_portal_booking_command_atomic(text,uuid,uuid,uuid,uuid,timestamptz,timestamptz,text,uuid,text,text,text,timestamptz)') is null then
+    raise exception 'Phase 7 postcheck failed: booking lifecycle command is missing.';
+  end if;
+
+  if to_regprocedure('public.add_portal_request_line_atomic(uuid,uuid,uuid,uuid,text,uuid,text,text,text,text,timestamptz)') is null then
+    raise exception 'Phase 7 postcheck failed: portal request-line command is missing.';
+  end if;
+
+  if to_regprocedure('public.apply_portal_line_decision_atomic(uuid,uuid,uuid,uuid,uuid,text,text,timestamptz)') is null then
+    raise exception 'Phase 7 postcheck failed: portal line decision command is missing.';
+  end if;
+
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'customer_portal_invites'
+      and column_name = 'accepted_at'
+  ) then
+    raise exception 'Phase 7 postcheck failed: invite acceptance columns are missing.';
+  end if;
+
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'bookings'
+      and column_name = 'cancelled_at'
+  ) then
+    raise exception 'Phase 7 postcheck failed: booking cancellation history columns are missing.';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_indexes
+    where schemaname = 'public'
+      and tablename = 'portal_lifecycle_operation_keys'
+      and indexname = 'portal_lifecycle_operation_keys_pkey'
+  ) then
+    raise exception 'Phase 7 postcheck failed: portal operation key primary index is missing.';
+  end if;
+
+  raise notice 'Phase 7 customer portal lifecycle postcheck passed.';
+end;
+$$;

--- a/supabase/migrations/20260715080400_phase7_customer_portal_postcheck.sql
+++ b/supabase/migrations/20260715080400_phase7_customer_portal_postcheck.sql
@@ -4,7 +4,7 @@ begin
     raise exception 'Phase 7 postcheck failed: portal lifecycle operation keys are missing.';
   end if;
 
-  if to_regprocedure('public.accept_portal_invite_atomic(uuid,uuid,text,text,timestamptz)') is null then
+  if to_regprocedure('public.accept_customer_portal_invite_atomic(uuid,uuid,text,text,timestamptz)') is null then
     raise exception 'Phase 7 postcheck failed: invite acceptance command is missing.';
   end if;
 

--- a/tests/phase7-portal-invite-booking-contract.test.ts
+++ b/tests/phase7-portal-invite-booking-contract.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const inviteSql = read(
+  "supabase/migrations/20260715080000_phase7_atomic_portal_invite_acceptance.sql",
+);
+const bookingSql = read(
+  "supabase/migrations/20260715080100_phase7_atomic_portal_booking_lifecycle.sql",
+);
+const confirmPage = read("app/portal/auth/confirm/page.tsx");
+const inviteRoute = read("app/api/portal/invites/accept/route.ts");
+const setupRoute = read("app/api/portal/qr/setup/route.ts");
+const staffBookingRoute = read("app/api/portal/bookings/[id]/route.ts");
+const customerBookingRoute = read(
+  "app/api/portal/customer-bookings/[id]/route.ts",
+);
+
+describe("Phase 7 portal identity and booking lifecycle", () => {
+  it("accepts one exact invite in a server-owned transaction", () => {
+    expect(inviteSql).toContain("accept_portal_invite_atomic");
+    expect(inviteSql).toContain("for update");
+    expect(inviteSql).toContain("accepted_by");
+    expect(inviteSql).toContain("portal_lifecycle_operation_keys");
+    expect(inviteRoute).toContain('rpc("accept_portal_invite_atomic"');
+    expect(setupRoute).toContain("inviteId=");
+    expect(confirmPage).toContain("/api/portal/invites/accept");
+    expect(confirmPage).not.toContain('.from("customers")');
+    expect(confirmPage).not.toContain('.from("customer_portal_invites")');
+  });
+
+  it("uses one booking command for create, reschedule, and cancel", () => {
+    expect(bookingSql).toContain("apply_portal_booking_command_atomic");
+    expect(bookingSql).toContain("pg_advisory_xact_lock");
+    expect(bookingSql).toContain("This time overlaps an existing booking");
+    expect(bookingSql).toContain("Work-order-linked booking requires staff work-order workflow");
+    expect(staffBookingRoute).toContain('rpc("apply_portal_booking_command_atomic"');
+    expect(customerBookingRoute).toContain("Idempotency-Key");
+  });
+
+  it("preserves booking history instead of deleting rows", () => {
+    expect(staffBookingRoute).not.toContain('.from("bookings").delete');
+    expect(staffBookingRoute).toContain('action: "cancel"');
+    expect(bookingSql).toContain("cancelled_at");
+    expect(bookingSql).toContain("cancellation_reason");
+  });
+});

--- a/tests/phase7-portal-invite-booking-contract.test.ts
+++ b/tests/phase7-portal-invite-booking-contract.test.ts
@@ -23,7 +23,8 @@ describe("Phase 7 portal identity and booking lifecycle", () => {
     expect(inviteSql).toContain("accepted_by");
     expect(inviteSql).toContain("portal_lifecycle_operation_keys");
     expect(inviteRoute).toContain('rpc("accept_portal_invite_atomic"');
-    expect(setupRoute).toContain("inviteId=");
+    expect(setupRoute).toContain("const redirectParams = new URLSearchParams");
+    expect(setupRoute).toContain("invite: inviteId");
     expect(confirmPage).toContain("/api/portal/invites/accept");
     expect(confirmPage).not.toContain('.from("customers")');
     expect(confirmPage).not.toContain('.from("customer_portal_invites")');
@@ -33,8 +34,12 @@ describe("Phase 7 portal identity and booking lifecycle", () => {
     expect(bookingSql).toContain("apply_portal_booking_command_atomic");
     expect(bookingSql).toContain("pg_advisory_xact_lock");
     expect(bookingSql).toContain("This time overlaps an existing booking");
-    expect(bookingSql).toContain("Work-order-linked booking requires staff work-order workflow");
-    expect(staffBookingRoute).toContain('rpc("apply_portal_booking_command_atomic"');
+    expect(bookingSql).toContain(
+      "Work-order-linked booking requires staff work-order workflow",
+    );
+    expect(staffBookingRoute).toContain(
+      'rpc("apply_portal_booking_command_atomic"',
+    );
     expect(customerBookingRoute).toContain("Idempotency-Key");
   });
 

--- a/tests/phase7-portal-invite-booking-contract.test.ts
+++ b/tests/phase7-portal-invite-booking-contract.test.ts
@@ -18,11 +18,13 @@ const customerBookingRoute = read(
 
 describe("Phase 7 portal identity and booking lifecycle", () => {
   it("accepts one exact invite in a server-owned transaction", () => {
-    expect(inviteSql).toContain("accept_portal_invite_atomic");
+    expect(inviteSql).toContain("accept_customer_portal_invite_atomic");
     expect(inviteSql).toContain("for update");
-    expect(inviteSql).toContain("accepted_by");
+    expect(inviteSql).toContain("accepted_by_user_id");
     expect(inviteSql).toContain("portal_lifecycle_operation_keys");
-    expect(inviteRoute).toContain('rpc("accept_portal_invite_atomic"');
+    expect(inviteRoute).toContain(
+      'rpc("accept_customer_portal_invite_atomic"',
+    );
     expect(setupRoute).toContain("const redirectParams = new URLSearchParams");
     expect(setupRoute).toContain("invite: inviteId");
     expect(confirmPage).toContain("/api/portal/invites/accept");

--- a/tests/phase7-portal-request-approval-contract.test.ts
+++ b/tests/phase7-portal-request-approval-contract.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const requestSql = read(
+  "supabase/migrations/20260715080200_phase7_atomic_portal_request_lines.sql",
+);
+const approvalSql = read(
+  "supabase/migrations/20260715080300_phase7_atomic_portal_line_decisions.sql",
+);
+const requestStart = read("app/api/portal/request/start/route.ts");
+const customRoute = read("app/api/portal/request/add-custom-line/route.ts");
+const menuRoute = read("app/api/portal/request/add-menu-line/route.ts");
+const inspectionRoute = read(
+  "app/api/portal/request/add-inspection-line/route.ts",
+);
+const approvalRoute = read(
+  "app/api/work-orders/lines/[id]/approval-decision/route.ts",
+);
+
+describe("Phase 7 portal requests and approvals", () => {
+  it("requires stable request-start identity and verifies vehicle ownership", () => {
+    expect(requestStart).toContain('headers.get("Idempotency-Key")');
+    expect(requestStart).toContain("A stable Idempotency-Key is required.");
+    expect(requestStart).toContain('.eq("customer_id", customer.id)');
+    expect(requestStart).toContain('.eq("shop_id", customer.shop_id)');
+  });
+
+  it("routes all request line kinds through one atomic command", () => {
+    expect(requestSql).toContain("add_portal_request_line_atomic");
+    expect(requestSql).toContain("work_order_is_financially_locked");
+    expect(requestSql).toContain("portal_lifecycle_operation_keys");
+    expect(requestSql).toContain("for update");
+
+    for (const route of [customRoute, menuRoute, inspectionRoute]) {
+      expect(route).toContain("addPortalRequestLine");
+      expect(route).toContain("Idempotency-Key");
+      expect(route).not.toContain('.from("work_order_lines")');
+    }
+  });
+
+  it("applies customer line decisions atomically without starting labor", () => {
+    expect(approvalSql).toContain("apply_portal_line_decision_atomic");
+    expect(approvalSql).toContain("status = 'awaiting'");
+    expect(approvalSql).toContain("line_status = 'authorized'");
+    expect(approvalSql).toContain("work_order_is_financially_locked");
+    expect(approvalSql).toContain("Portal customer actor mismatch");
+    expect(approvalRoute).toContain('rpc("apply_portal_line_decision_atomic"');
+    expect(approvalRoute).not.toContain(
+      "applyAndPropagateWorkOrderLineApprovalDecision",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Hardens customer portal identity, bookings, service requests, and approvals.

### Included
- Exact invite acceptance through one server transaction
- Idempotent invite audit records
- Atomic booking create, reschedule, and cancel lifecycle
- Preserved booking cancellation history
- Stable portal service-request keys and vehicle ownership checks
- Atomic custom, menu, and inspection request-line creation
- Atomic customer line approval with `awaiting` authorization state
- Financial-lock, customer ownership, shop, and retry protections
- Focused tests, post-check, and rollout runbook

### Migration order
1. `20260715080000_phase7_atomic_portal_invite_acceptance.sql`
2. `20260715080100_phase7_atomic_portal_booking_lifecycle.sql`
3. `20260715080200_phase7_atomic_portal_request_lines.sql`
4. `20260715080300_phase7_atomic_portal_line_decisions.sql`
5. `20260715080400_phase7_customer_portal_postcheck.sql`

Do not run migrations until CI and Vercel are green.

Closes #1041
Closes #1042
Related: #992