### PR TITLE
Reconcile premium UI foundation onto main

### DIFF
--- a/app/api/portal/availability/route.ts
+++ b/app/api/portal/availability/route.ts
@@ -67,7 +67,9 @@ const addMinutes = (date: Date, mins: number) =>
 const overlaps = (aStart: Date, aEnd: Date, bStart: Date, bEnd: Date) =>
   aStart < bEnd && bStart < aEnd;
 
-function parseHm(time: string | null | undefined): { h: number; m: number } | null {
+function parseHm(
+  time: string | null | undefined,
+): { h: number; m: number } | null {
   if (!time) return null;
 
   // accept "HH:MM" or "HH:MM:SS" and tolerate suffixes like "+00"
@@ -88,9 +90,17 @@ function parseHm(time: string | null | undefined): { h: number; m: number } | nu
  * We probe at local noon to avoid DST/offset edge weirdness.
  * Returns 0..6 (Sun..Sat).
  */
-function weekdayForLocalYMD(tz: string, y: number, m: number, d: number): number {
+function weekdayForLocalYMD(
+  tz: string,
+  y: number,
+  m: number,
+  d: number,
+): number {
   const probe = makeZonedDate(tz, y, m, d, 12, 0);
-  const fmt = new Intl.DateTimeFormat("en-US", { timeZone: tz, weekday: "short" });
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    weekday: "short",
+  });
   const w = fmt.format(probe);
   const idx = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].indexOf(w);
   return idx >= 0 ? idx : probe.getUTCDay();
@@ -120,7 +130,12 @@ function weekdayCandidates(raw: unknown): number[] {
 type ShopsRow = Database["public"]["Tables"]["shops"]["Row"];
 type ShopPick = Pick<
   ShopsRow,
-  "id" | "slug" | "timezone" | "accepts_online_booking"
+  | "id"
+  | "slug"
+  | "timezone"
+  | "accepts_online_booking"
+  | "min_notice_minutes"
+  | "max_lead_days"
 >;
 
 type ShopHoursRow = Database["public"]["Tables"]["shop_hours"]["Row"];
@@ -140,7 +155,10 @@ export async function GET(req: NextRequest) {
     const slug = searchParams.get("shop") || "";
     const startYMD = searchParams.get("start") || "";
     const endYMD = searchParams.get("end") || "";
-    const slotMins = Math.max(5, Math.min(180, Number(searchParams.get("slotMins") || 30)));
+    const slotMins = Math.max(
+      5,
+      Math.min(180, Number(searchParams.get("slotMins") || 30)),
+    );
 
     if (!slug || !startYMD || !endYMD) {
       return NextResponse.json(
@@ -152,12 +170,15 @@ export async function GET(req: NextRequest) {
     // 1) Load shop config
     const shopRes = await supabase
       .from("shops")
-      .select("id, slug, timezone, accepts_online_booking")
+      .select(
+        "id, slug, timezone, accepts_online_booking, min_notice_minutes, max_lead_days",
+      )
       .eq("slug", slug)
       .maybeSingle();
 
     const shop = shopRes.data as ShopPick | null;
-    if (!shop) return NextResponse.json({ error: "Shop not found" }, { status: 404 });
+    if (!shop)
+      return NextResponse.json({ error: "Shop not found" }, { status: 404 });
 
     const tz = shop.timezone || "UTC";
 
@@ -166,8 +187,8 @@ export async function GET(req: NextRequest) {
     }
 
     // Defaults
-    const MIN_NOTICE_MIN = 120; // 2 hours
-    const MAX_LEAD_DAYS = 30;   // 30 days
+    const MIN_NOTICE_MIN = shop.min_notice_minutes ?? 120;
+    const MAX_LEAD_DAYS = shop.max_lead_days ?? 30;
     const now = new Date();
     const maxLeadUntil = addMinutes(now, MAX_LEAD_DAYS * 24 * 60);
 
@@ -184,7 +205,10 @@ export async function GET(req: NextRequest) {
     const e = parseYMD(endYMD);
 
     const windowStartUtc = makeZonedDate(tz, s.y, s.m, s.d, 0, 0);
-    const windowEndUtc = addMinutes(makeZonedDate(tz, e.y, e.m, e.d, 23, 59), 1);
+    const windowEndUtc = addMinutes(
+      makeZonedDate(tz, e.y, e.m, e.d, 23, 59),
+      1,
+    );
 
     const timeOffRes = await supabase
       .from("shop_time_off")
@@ -263,7 +287,8 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ tz, slots });
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : "Failed to compute availability";
+    const message =
+      err instanceof Error ? err.message : "Failed to compute availability";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/portal/bookings/[id]/route.ts
+++ b/app/api/portal/bookings/[id]/route.ts
@@ -2,9 +2,14 @@ import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { notifyBookingConfirmation } from "@/features/portal/server/notifyBookingConfirmation";
 
 type DB = Database;
-type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
 type RpcClient = {
   rpc: (
     name: string,
@@ -18,6 +23,7 @@ type PatchBody = {
   starts_at?: string;
   ends_at?: string;
   reason?: string | null;
+  customer_id?: string | null;
   idempotencyKey?: string;
 };
 
@@ -30,7 +36,9 @@ async function getAuthedContext(
   } = await supabase.auth.getUser();
 
   if (userErr || !user) {
-    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+    return {
+      error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
   }
 
   const { data: profile, error: profileErr } = await supabase
@@ -41,13 +49,18 @@ async function getAuthedContext(
 
   if (profileErr || !profile?.shop_id) {
     return {
-      error: NextResponse.json({ error: "Profile/shop not found" }, { status: 403 }),
+      error: NextResponse.json(
+        { error: "Profile/shop not found" },
+        { status: 403 },
+      ),
     };
   }
 
   const actor = getActorCapabilities({ role: profile.role });
   if (!actor.isKnownRole || !actor.canManageScheduling) {
-    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+    return {
+      error: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
   }
 
   return {
@@ -70,7 +83,8 @@ function operationKey(req: Request, body?: PatchBody): string {
 function rpcStatus(message: string): number {
   const lower = message.toLowerCase();
   if (lower.includes("not found")) return 404;
-  if (lower.includes("not authorized") || lower.includes("another shop")) return 403;
+  if (lower.includes("not authorized") || lower.includes("another shop"))
+    return 403;
   if (
     lower.includes("terminal") ||
     lower.includes("overlap") ||
@@ -124,7 +138,8 @@ export async function PATCH(
   if ("error" in auth) return auth.error;
 
   const body = (await req.json().catch(() => ({}))) as PatchBody;
-  const isReschedule = body.starts_at !== undefined || body.ends_at !== undefined;
+  const isReschedule =
+    body.starts_at !== undefined || body.ends_at !== undefined;
   const isCancel = body.status === "cancelled";
 
   if (isReschedule || isCancel) {
@@ -158,20 +173,83 @@ export async function PATCH(
       const message = [error.message, error.details, error.hint]
         .filter(Boolean)
         .join(" — ");
-      return NextResponse.json({ error: message }, { status: rpcStatus(message) });
+      return NextResponse.json(
+        { error: message },
+        { status: rpcStatus(message) },
+      );
     }
 
     return NextResponse.json(data);
   }
 
+  const { data: existing, error: existingErr } = await supabase
+    .from("bookings")
+    .select("id,status")
+    .eq("id", id)
+    .eq("shop_id", auth.profile.shop_id)
+    .maybeSingle();
+  if (existingErr) {
+    return NextResponse.json({ error: existingErr.message }, { status: 500 });
+  }
+  if (!existing) {
+    return NextResponse.json({ error: "Booking not found" }, { status: 404 });
+  }
+
+  const currentStatus = existing.status ?? "pending";
+  const requestedStatus = body.status;
+  const transitionAllowed =
+    !requestedStatus ||
+    requestedStatus === currentStatus ||
+    (currentStatus === "pending" && requestedStatus === "confirmed") ||
+    (currentStatus === "confirmed" && requestedStatus === "completed");
+  if (!transitionAllowed) {
+    return NextResponse.json(
+      {
+        error: `Cannot move appointment from ${currentStatus} to ${requestedStatus}`,
+      },
+      { status: 409 },
+    );
+  }
+
   const update: DB["public"]["Tables"]["bookings"]["Update"] = {};
-  if (body.status === "pending" || body.status === "confirmed" || body.status === "completed") {
+  if (
+    body.status === "pending" ||
+    body.status === "confirmed" ||
+    body.status === "completed"
+  ) {
     update.status = body.status;
   }
   if (body.notes !== undefined) update.notes = body.notes;
+  if (body.customer_id !== undefined) {
+    if (!body.customer_id) {
+      return NextResponse.json(
+        { error: "A canonical customer is required" },
+        { status: 400 },
+      );
+    }
+    const { data: customer, error: customerErr } = await supabase
+      .from("customers")
+      .select("id")
+      .eq("id", body.customer_id)
+      .eq("shop_id", auth.profile.shop_id)
+      .maybeSingle();
+    if (customerErr) {
+      return NextResponse.json({ error: customerErr.message }, { status: 500 });
+    }
+    if (!customer) {
+      return NextResponse.json(
+        { error: "Customer does not belong to this shop" },
+        { status: 403 },
+      );
+    }
+    update.customer_id = body.customer_id;
+  }
 
   if (Object.keys(update).length === 0) {
-    return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+    return NextResponse.json(
+      { error: "No valid fields to update" },
+      { status: 400 },
+    );
   }
 
   const { data: updated, error: updateErr } = await supabase
@@ -179,7 +257,9 @@ export async function PATCH(
     .update(update)
     .eq("id", id)
     .eq("shop_id", auth.profile.shop_id)
-    .select("id, starts_at, ends_at, status, notes, customer_id, vehicle_id, work_order_id")
+    .select(
+      "id, shop_id, starts_at, ends_at, status, notes, customer_id, vehicle_id, work_order_id",
+    )
     .maybeSingle();
 
   if (updateErr) {
@@ -189,7 +269,29 @@ export async function PATCH(
     return NextResponse.json({ error: "Booking not found" }, { status: 404 });
   }
 
-  return NextResponse.json(updated);
+  let confirmationNotification: "not_requested" | "sent" | "skipped" =
+    "not_requested";
+  if (body.status === "confirmed" && currentStatus !== "confirmed") {
+    try {
+      confirmationNotification = (await notifyBookingConfirmation(
+        supabase,
+        updated,
+      ))
+        ? "sent"
+        : "skipped";
+    } catch (notificationError) {
+      confirmationNotification = "skipped";
+      console.error(
+        "booking confirmation notification failed",
+        notificationError,
+      );
+    }
+  }
+
+  return NextResponse.json({
+    ...updated,
+    confirmation_notification: confirmationNotification,
+  });
 }
 
 export async function DELETE(
@@ -226,7 +328,10 @@ export async function DELETE(
     const message = [error.message, error.details, error.hint]
       .filter(Boolean)
       .join(" — ");
-    return NextResponse.json({ error: message }, { status: rpcStatus(message) });
+    return NextResponse.json(
+      { error: message },
+      { status: rpcStatus(message) },
+    );
   }
 
   return NextResponse.json(data);

--- a/app/api/portal/bookings/route.ts
+++ b/app/api/portal/bookings/route.ts
@@ -44,7 +44,12 @@ export async function GET(req: Request): Promise<Response> {
   const shopSlug = url.searchParams.get("shop") ?? "";
   const start = url.searchParams.get("start") ?? "";
   const end = url.searchParams.get("end") ?? "";
-  if (!shopSlug || !start || !end) return bad("Missing shop, start, or end");
+  const status = url.searchParams.get("status") ?? "";
+  const pendingQueue = status === "pending";
+
+  if (!shopSlug || (!pendingQueue && (!start || !end))) {
+    return bad("Missing shop or date range");
+  }
 
   const {
     data: { user },
@@ -60,7 +65,10 @@ export async function GET(req: Request): Promise<Response> {
   if (profErr || !profile?.shop_id) return bad("Profile / shop not found", 403);
 
   const actor = getActorCapabilities({ role: profile.role });
-  if (!actor.isKnownRole || (!actor.canManageScheduling && !actor.canViewShopWideData)) {
+  if (
+    !actor.isKnownRole ||
+    (!actor.canManageScheduling && !actor.canViewShopWideData)
+  ) {
     return bad("Not allowed", 403);
   }
 
@@ -70,28 +78,49 @@ export async function GET(req: Request): Promise<Response> {
     .eq("slug", shopSlug)
     .single();
   if (shopErr || !shop) return bad("Shop not found", 404);
-  if (shop.id !== profile.shop_id) return bad("You cannot view bookings for this shop", 403);
+  if (shop.id !== profile.shop_id)
+    return bad("You cannot view bookings for this shop", 403);
 
-  const startIso = new Date(`${start}T00:00:00.000Z`).toISOString();
-  const endDate = new Date(`${end}T00:00:00.000Z`);
-  endDate.setDate(endDate.getDate() + 1);
-  const endIso = endDate.toISOString();
-
-  const { data: rows, error: rowsErr } = await supabase
+  let bookingsQuery = supabase
     .from("bookings")
-    .select(`
+    .select(
+      `
       id, shop_id, customer_id, vehicle_id, work_order_id,
       starts_at, ends_at, status, notes,
       customers:customer_id (first_name, last_name, email, phone),
       shops:shop_id (slug)
-    `)
+    `,
+    )
     .eq("shop_id", shop.id)
-    .gte("starts_at", startIso)
-    .lt("starts_at", endIso)
     .order("starts_at", { ascending: true });
-  if (rowsErr || !rows) return bad("Failed to load bookings", 500);
 
-  const payload: BookingPayload[] = (rows as unknown as BookingRow[]).map((row) => {
+  if (pendingQueue) {
+    bookingsQuery = bookingsQuery.eq("status", "pending");
+  } else {
+    const startIso = new Date(`${start}T00:00:00.000Z`).toISOString();
+    const endDate = new Date(`${end}T00:00:00.000Z`);
+    endDate.setDate(endDate.getDate() + 1);
+    const endIso = endDate.toISOString();
+    bookingsQuery = bookingsQuery
+      .gte("starts_at", startIso)
+      .lt("starts_at", endIso);
+  }
+
+  const { data: rows, error: rowsErr } = await bookingsQuery;
+
+  if (rowsErr || !rows) {
+    console.error("appointments GET failed", {
+      shopId: shop.id,
+      pendingQueue,
+      message: rowsErr?.message,
+      code: rowsErr?.code,
+    });
+    return bad(rowsErr?.message || "Failed to load bookings", 500);
+  }
+
+  const bookings = rows as unknown as BookingRow[];
+
+  const payload: BookingPayload[] = bookings.map((row) => {
     const customer = row.customers ?? null;
     return {
       id: row.id,
@@ -123,7 +152,9 @@ export async function POST(req: Request): Promise<Response> {
   } = await supabase.auth.getUser();
   if (authErr || !user) return bad("Not authenticated", 401);
 
-  const body = (await req.json().catch(() => null)) as CreatePortalBookingInput | null;
+  const body = (await req
+    .json()
+    .catch(() => null)) as CreatePortalBookingInput | null;
   if (!body) return bad("Invalid JSON body", 400);
   const operationKey =
     req.headers.get("Idempotency-Key")?.trim() ||

--- a/app/api/portal/request/submit/route.ts
+++ b/app/api/portal/request/submit/route.ts
@@ -63,12 +63,16 @@ export async function POST(req: Request) {
 
     const workOrderId = (body?.workOrderId ?? "").trim();
     const bookingId = (body?.bookingId ?? "").trim();
-    if (!workOrderId || !bookingId) return bad("Missing workOrderId or bookingId");
+    if (!workOrderId || !bookingId)
+      return bad("Missing workOrderId or bookingId");
 
     const customerAgreedAt = parseIsoDate(body?.customerAgreedAt ?? null);
-    if (!customerAgreedAt) return bad("You must agree to the terms before submitting.", 400);
+    if (!customerAgreedAt)
+      return bad("You must agree to the terms before submitting.", 400);
 
-    const customerSignatureUrl = toNonEmptyString(body?.customerSignatureUrl ?? null);
+    const customerSignatureUrl = toNonEmptyString(
+      body?.customerSignatureUrl ?? null,
+    );
 
     // Resolve portal customer
     const { data: customer, error: custErr } = await supabase
@@ -94,7 +98,9 @@ export async function POST(req: Request) {
     // Load booking + ensure same shop
     const { data: booking, error: bErr } = await supabase
       .from("bookings")
-      .select("id, shop_id, customer_id, work_order_id, starts_at, ends_at, status")
+      .select(
+        "id, shop_id, customer_id, work_order_id, starts_at, ends_at, status",
+      )
       .eq("id", bookingId)
       .maybeSingle();
 
@@ -105,7 +111,8 @@ export async function POST(req: Request) {
 
     const warnings: string[] = [];
     const alreadySubmitted = Boolean(wo.portal_submitted_at);
-    const alreadyFinalized = booking.status === "confirmed" && booking.work_order_id === wo.id;
+    const alreadyFinalized =
+      booking.status === "pending" && booking.work_order_id === wo.id;
     if (alreadySubmitted && alreadyFinalized) {
       return NextResponse.json(
         {
@@ -130,15 +137,21 @@ export async function POST(req: Request) {
       portal_submitted_at: wo.portal_submitted_at ?? new Date().toISOString(),
     };
 
-    const { error: woUpdErr } = await supabase.from("work_orders").update(woUpdate).eq("id", wo.id);
+    const { error: woUpdErr } = await supabase
+      .from("work_orders")
+      .update(woUpdate)
+      .eq("id", wo.id);
     if (woUpdErr) return bad("Failed to save agreement/signature", 500);
 
     const bookingUpdate: DB["public"]["Tables"]["bookings"]["Update"] = {
-      status: "confirmed",
+      status: "pending",
       work_order_id: wo.id,
     };
 
-    const { error: updErr } = await supabase.from("bookings").update(bookingUpdate).eq("id", booking.id);
+    const { error: updErr } = await supabase
+      .from("bookings")
+      .update(bookingUpdate)
+      .eq("id", booking.id);
     if (updErr) return bad("Failed to finalize booking", 500);
 
     const concern = extractPortalIntakeConcern(wo.notes);
@@ -155,19 +168,22 @@ export async function POST(req: Request) {
         .limit(1);
 
       if (!exErr && (!existing || existing.length === 0)) {
-        const insertLine: DB["public"]["Tables"]["work_order_lines"]["Insert"] = {
-          work_order_id: wo.id,
-          shop_id: wo.shop_id,
+        const insertLine: DB["public"]["Tables"]["work_order_lines"]["Insert"] =
+          {
+            work_order_id: wo.id,
+            shop_id: wo.shop_id,
 
-          // Make the intake visible in the workflow immediately:
-          job_type: "diagnostic",
-          status: "awaiting",
-          description: desc,
-          complaint: concern,
-          notes: "Auto-created from portal intake on submit.",
-        };
+            // Make the intake visible in the workflow immediately:
+            job_type: "diagnostic",
+            status: "awaiting",
+            description: desc,
+            complaint: concern,
+            notes: "Auto-created from portal intake on submit.",
+          };
 
-        const { error: insertErr } = await supabase.from("work_order_lines").insert(insertLine);
+        const { error: insertErr } = await supabase
+          .from("work_order_lines")
+          .insert(insertLine);
         if (insertErr) {
           warnings.push("portal_intake_line_insert_failed");
           console.warn("portal submit: failed to insert intake line", {
@@ -201,7 +217,13 @@ export async function POST(req: Request) {
       });
 
       return NextResponse.json(
-        { ok: true, workOrderId: wo.id, bookingId: booking.id, partsRequestId: null, warnings },
+        {
+          ok: true,
+          workOrderId: wo.id,
+          bookingId: booking.id,
+          partsRequestId: null,
+          warnings,
+        },
         { status: 200 },
       );
     }
@@ -228,12 +250,19 @@ export async function POST(req: Request) {
 
     if (items.length === 0) {
       return NextResponse.json(
-        { ok: true, workOrderId: wo.id, bookingId: booking.id, partsRequestId: null, warnings },
+        {
+          ok: true,
+          workOrderId: wo.id,
+          bookingId: booking.id,
+          partsRequestId: null,
+          warnings,
+        },
         { status: 200 },
       );
     }
 
-    type RpcArgs = DB["public"]["Functions"]["create_part_request_with_items"]["Args"];
+    type RpcArgs =
+      DB["public"]["Functions"]["create_part_request_with_items"]["Args"];
 
     const rpcArgs: RpcArgs = {
       p_work_order_id: wo.id,
@@ -241,7 +270,10 @@ export async function POST(req: Request) {
       p_notes: "Portal request submit: auto parts quote",
     };
 
-    const { data: partsRequestId, error: prErr } = await supabase.rpc("create_part_request_with_items", rpcArgs);
+    const { data: partsRequestId, error: prErr } = await supabase.rpc(
+      "create_part_request_with_items",
+      rpcArgs,
+    );
 
     if (prErr) {
       warnings.push("parts_request_create_failed");
@@ -251,13 +283,25 @@ export async function POST(req: Request) {
         message: prErr.message,
       });
       return NextResponse.json(
-        { ok: true, workOrderId: wo.id, bookingId: booking.id, partsRequestId: null, warnings },
+        {
+          ok: true,
+          workOrderId: wo.id,
+          bookingId: booking.id,
+          partsRequestId: null,
+          warnings,
+        },
         { status: 200 },
       );
     }
 
     return NextResponse.json(
-      { ok: true, workOrderId: wo.id, bookingId: booking.id, partsRequestId, warnings },
+      {
+        ok: true,
+        workOrderId: wo.id,
+        bookingId: booking.id,
+        partsRequestId,
+        warnings,
+      },
       { status: 200 },
     );
   } catch (e: unknown) {

--- a/app/dashboard/appointments/FullCalendarModal.tsx
+++ b/app/dashboard/appointments/FullCalendarModal.tsx
@@ -1,0 +1,602 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Booking } from "./page";
+import { Button } from "@shared/components/ui/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@shared/components/ui/dialog";
+
+type Props = {
+  open: boolean;
+  shopSlug: string;
+  initialDate: Date;
+  onOpenChange: (open: boolean) => void;
+  onCreate: (dayIso: string) => void;
+  onEdit: (booking: Booking) => void;
+  onApprove: (booking: Booking) => Promise<boolean>;
+  onDecline: (booking: Booking) => Promise<boolean>;
+  onOpenWorkOrder: (booking: Booking) => void;
+  onCreateWorkOrder: (booking: Booking) => void;
+};
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function dayKey(date: Date): string {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+function addDays(date: Date, amount: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + amount);
+  return next;
+}
+
+function monthStart(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function calendarStart(date: Date): Date {
+  const first = monthStart(date);
+  return addDays(first, -first.getDay());
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function statusOf(booking: Booking): string {
+  return (booking.status || "pending").toLowerCase();
+}
+
+function statusClass(status?: string | null): string {
+  const normalized = (status || "pending").toLowerCase();
+  if (normalized === "confirmed") {
+    return "border-emerald-500/25 bg-emerald-50 text-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-200";
+  }
+  if (normalized === "cancelled") {
+    return "border-red-500/25 bg-red-50 text-red-800 dark:bg-red-950/30 dark:text-red-200";
+  }
+  return "border-amber-500/30 bg-amber-50 text-amber-900 dark:bg-amber-950/30 dark:text-amber-200";
+}
+
+function canCreateWorkOrder(booking: Booking): boolean {
+  return (
+    statusOf(booking) !== "cancelled" &&
+    !booking.work_order_id &&
+    Boolean(
+      booking.customer_id ||
+      booking.customer_name?.trim() ||
+      booking.customer_email?.trim() ||
+      booking.customer_phone?.trim(),
+    )
+  );
+}
+
+export default function FullCalendarModal({
+  open,
+  shopSlug,
+  initialDate,
+  onOpenChange,
+  onCreate,
+  onEdit,
+  onApprove,
+  onDecline,
+  onOpenWorkOrder,
+  onCreateWorkOrder,
+}: Props) {
+  const [cursor, setCursor] = useState(() => monthStart(initialDate));
+  const [selectedDay, setSelectedDay] = useState(() => dayKey(initialDate));
+  const [selectedBookingId, setSelectedBookingId] = useState<string | null>(
+    null,
+  );
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [acting, setActing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setCursor(monthStart(initialDate));
+    setSelectedDay(dayKey(initialDate));
+    setSelectedBookingId(null);
+  }, [initialDate, open]);
+
+  const gridDays = useMemo(() => {
+    const start = calendarStart(cursor);
+    return Array.from({ length: 42 }, (_, index) => addDays(start, index));
+  }, [cursor]);
+
+  const fetchBookings = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!shopSlug) return;
+      const start = dayKey(gridDays[0]);
+      const end = dayKey(gridDays[gridDays.length - 1]);
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(
+          `/api/portal/bookings?shop=${encodeURIComponent(shopSlug)}&start=${start}&end=${end}`,
+          { cache: "no-store", signal },
+        );
+        const body = (await response.json().catch(() => null)) as
+          | Booking[]
+          | { error?: string }
+          | null;
+        if (!response.ok) {
+          throw new Error(
+            body && !Array.isArray(body)
+              ? body.error || "Unable to load calendar."
+              : "Unable to load calendar.",
+          );
+        }
+        setBookings(Array.isArray(body) ? body : []);
+      } catch (caught: unknown) {
+        if (caught instanceof DOMException && caught.name === "AbortError")
+          return;
+        setError(
+          caught instanceof Error ? caught.message : "Unable to load calendar.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [gridDays, shopSlug],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    void fetchBookings(controller.signal);
+    return () => controller.abort();
+  }, [fetchBookings, open]);
+
+  const grouped = useMemo(() => {
+    const result = new Map<string, Booking[]>();
+    for (const booking of bookings) {
+      const key = dayKey(new Date(booking.starts_at));
+      const current = result.get(key) || [];
+      current.push(booking);
+      result.set(key, current);
+    }
+    result.forEach((items) =>
+      items.sort((a, b) => +new Date(a.starts_at) - +new Date(b.starts_at)),
+    );
+    return result;
+  }, [bookings]);
+
+  const dayBookings = grouped.get(selectedDay) || [];
+  const selectedBooking =
+    bookings.find((booking) => booking.id === selectedBookingId) || null;
+  const today = dayKey(new Date());
+
+  function moveMonth(amount: number) {
+    setCursor(
+      (current) =>
+        new Date(current.getFullYear(), current.getMonth() + amount, 1),
+    );
+    setSelectedBookingId(null);
+  }
+
+  async function changeStatus(
+    booking: Booking,
+    nextStatus: "confirmed" | "cancelled",
+  ) {
+    setActing(true);
+    const succeeded =
+      nextStatus === "confirmed"
+        ? await onApprove(booking)
+        : await onDecline(booking);
+    if (succeeded) {
+      setBookings((current) =>
+        current.map((item) =>
+          item.id === booking.id ? { ...item, status: nextStatus } : item,
+        ),
+      );
+    }
+    setActing(false);
+  }
+
+  function closeThen(action: () => void) {
+    onOpenChange(false);
+    action();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[min(92vh,920px)] w-[min(96vw,1500px)] max-w-none flex-col overflow-hidden bg-[color:var(--theme-surface-page)] p-0">
+        <DialogHeader className="shrink-0 px-5 py-4 sm:px-6">
+          <div className="flex flex-wrap items-center justify-between gap-3 pr-8">
+            <div>
+              <DialogTitle className="text-base normal-case tracking-normal sm:text-xl">
+                Full calendar
+              </DialogTitle>
+              <DialogDescription>
+                Review capacity by month, then open any day or appointment.
+              </DialogDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => closeThen(() => onCreate(selectedDay))}
+              >
+                New appointment
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+              >
+                Close
+              </Button>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="grid min-h-0 flex-1 overflow-auto lg:grid-cols-[minmax(0,1fr)_380px] lg:overflow-hidden">
+          <section className="flex min-h-0 flex-col border-b border-[color:var(--theme-border-soft)] lg:border-b-0 lg:border-r">
+            <div className="flex shrink-0 items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-4 py-3 sm:px-6">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => moveMonth(-1)}
+                aria-label="Previous month"
+              >
+                ←
+              </Button>
+              <div className="text-center">
+                <div className="text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                  {cursor.toLocaleDateString([], {
+                    month: "long",
+                    year: "numeric",
+                  })}
+                </div>
+                {loading ? (
+                  <div className="text-xs text-[color:var(--theme-text-muted)]">
+                    Updating calendar…
+                  </div>
+                ) : null}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    const current = new Date();
+                    setCursor(monthStart(current));
+                    setSelectedDay(dayKey(current));
+                    setSelectedBookingId(null);
+                  }}
+                >
+                  Today
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => moveMonth(1)}
+                  aria-label="Next month"
+                >
+                  →
+                </Button>
+              </div>
+            </div>
+
+            {error ? (
+              <div className="m-4 flex items-center justify-between gap-3 rounded-xl border border-red-500/25 bg-red-50 px-3 py-2 text-sm text-red-800 dark:bg-red-950/25 dark:text-red-200">
+                <span>{error}</span>
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outline"
+                  onClick={() => void fetchBookings()}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : null}
+
+            <div className="grid grid-cols-7 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-center text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)] sm:px-5">
+              {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map(
+                (label) => (
+                  <div key={label}>{label}</div>
+                ),
+              )}
+            </div>
+
+            <div className="grid min-h-[430px] flex-1 grid-cols-7 grid-rows-6 gap-px overflow-auto bg-[color:var(--theme-border-soft)]">
+              {gridDays.map((date) => {
+                const key = dayKey(date);
+                const items = grouped.get(key) || [];
+                const active = items.filter(
+                  (item) => statusOf(item) !== "cancelled",
+                );
+                const pending = items.filter(
+                  (item) => statusOf(item) === "pending",
+                ).length;
+                const confirmed = items.filter(
+                  (item) => statusOf(item) === "confirmed",
+                ).length;
+                const inMonth = date.getMonth() === cursor.getMonth();
+                const selected = key === selectedDay;
+
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => {
+                      setSelectedDay(key);
+                      setSelectedBookingId(null);
+                    }}
+                    className={[
+                      "min-h-[76px] p-1.5 text-left transition sm:min-h-[92px] sm:p-2",
+                      selected
+                        ? "bg-[color:var(--theme-surface-panel-strong)] ring-2 ring-inset ring-[rgba(184,115,51,0.7)]"
+                        : "bg-[color:var(--theme-surface-page)] hover:bg-[color:var(--theme-surface-subtle)]",
+                      inMonth ? "" : "opacity-45",
+                    ].join(" ")}
+                  >
+                    <div className="flex items-center justify-between gap-1">
+                      <span
+                        className={[
+                          "flex h-6 min-w-6 items-center justify-center rounded-full text-xs font-semibold",
+                          key === today
+                            ? "bg-[color:var(--theme-accent,var(--pfq-copper,#b87333))] text-white"
+                            : "text-[color:var(--theme-text-primary)]",
+                        ].join(" ")}
+                      >
+                        {date.getDate()}
+                      </span>
+                      {active.length ? (
+                        <span className="text-[0.65rem] font-semibold text-[color:var(--theme-text-secondary)]">
+                          {active.length}
+                        </span>
+                      ) : null}
+                    </div>
+                    <div className="mt-2 hidden space-y-1 sm:block">
+                      {confirmed ? (
+                        <div className="truncate rounded bg-emerald-50 px-1.5 py-0.5 text-[0.6rem] font-medium text-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-200">
+                          {confirmed} confirmed
+                        </div>
+                      ) : null}
+                      {pending ? (
+                        <div className="truncate rounded bg-amber-50 px-1.5 py-0.5 text-[0.6rem] font-medium text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                          {pending} pending
+                        </div>
+                      ) : null}
+                    </div>
+                    {active.length ? (
+                      <div className="mt-2 h-1 rounded-full bg-[rgba(184,115,51,0.28)] sm:hidden" />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <aside className="min-h-0 overflow-auto bg-[color:var(--theme-surface-inset)] p-4 sm:p-5">
+            {selectedBooking ? (
+              <div className="space-y-4">
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="ghost"
+                  onClick={() => setSelectedBookingId(null)}
+                >
+                  ← Day agenda
+                </Button>
+                <div>
+                  <div className="mb-2 flex flex-wrap items-center gap-2">
+                    <h3 className="text-xl font-semibold text-[color:var(--theme-text-primary)]">
+                      {selectedBooking.customer_name || "Customer"}
+                    </h3>
+                    <span
+                      className={`rounded-full border px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-[0.12em] ${statusClass(selectedBooking.status)}`}
+                    >
+                      {selectedBooking.status || "pending"}
+                    </span>
+                  </div>
+                  <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                    {new Date(selectedBooking.starts_at).toLocaleDateString(
+                      [],
+                      {
+                        weekday: "long",
+                        month: "long",
+                        day: "numeric",
+                        year: "numeric",
+                      },
+                    )}
+                  </p>
+                  <p className="font-semibold text-[color:var(--theme-text-primary)]">
+                    {formatTime(selectedBooking.starts_at)} –{" "}
+                    {formatTime(selectedBooking.ends_at)}
+                  </p>
+                </div>
+
+                <div className="space-y-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-4 text-sm">
+                  <Detail
+                    label="Phone"
+                    value={selectedBooking.customer_phone}
+                  />
+                  <Detail
+                    label="Email"
+                    value={selectedBooking.customer_email}
+                  />
+                  <Detail label="Notes" value={selectedBooking.notes} />
+                  <Detail
+                    label="Work order"
+                    value={
+                      selectedBooking.work_order_id ? "Linked" : "Not created"
+                    }
+                  />
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {statusOf(selectedBooking) === "pending" ? (
+                    <>
+                      <Button
+                        type="button"
+                        disabled={acting}
+                        onClick={() =>
+                          void changeStatus(selectedBooking, "confirmed")
+                        }
+                      >
+                        Approve request
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={acting}
+                        className="border-red-500/35 text-red-700 dark:text-red-200"
+                        onClick={() =>
+                          void changeStatus(selectedBooking, "cancelled")
+                        }
+                      >
+                        Decline
+                      </Button>
+                    </>
+                  ) : null}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => closeThen(() => onEdit(selectedBooking))}
+                  >
+                    Edit
+                  </Button>
+                  {selectedBooking.work_order_id ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() =>
+                        closeThen(() => onOpenWorkOrder(selectedBooking))
+                      }
+                    >
+                      Open work order
+                    </Button>
+                  ) : canCreateWorkOrder(selectedBooking) ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() =>
+                        closeThen(() => onCreateWorkOrder(selectedBooking))
+                      }
+                    >
+                      Create work order
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
+                      Day agenda
+                    </div>
+                    <h3 className="mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]">
+                      {new Date(`${selectedDay}T12:00:00`).toLocaleDateString(
+                        [],
+                        { weekday: "long", month: "long", day: "numeric" },
+                      )}
+                    </h3>
+                  </div>
+                  <Button
+                    type="button"
+                    size="xs"
+                    onClick={() => closeThen(() => onCreate(selectedDay))}
+                  >
+                    Add
+                  </Button>
+                </div>
+
+                <div className="flex gap-2 text-xs text-[color:var(--theme-text-secondary)]">
+                  <span>
+                    {
+                      dayBookings.filter(
+                        (item) => statusOf(item) !== "cancelled",
+                      ).length
+                    }{" "}
+                    active
+                  </span>
+                  <span>•</span>
+                  <span>
+                    {
+                      dayBookings.filter((item) => statusOf(item) === "pending")
+                        .length
+                    }{" "}
+                    pending
+                  </span>
+                </div>
+
+                {dayBookings.length === 0 ? (
+                  <div className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-6 text-center text-sm text-[color:var(--theme-text-muted)]">
+                    No appointments scheduled for this day.
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {dayBookings.map((booking) => (
+                      <button
+                        key={booking.id}
+                        type="button"
+                        onClick={() => setSelectedBookingId(booking.id)}
+                        className="w-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-3 text-left transition hover:border-[rgba(184,115,51,0.45)] hover:shadow-sm"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="font-semibold text-[color:var(--theme-text-primary)]">
+                              {booking.customer_name || "Customer"}
+                            </div>
+                            <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                              {formatTime(booking.starts_at)} –{" "}
+                              {formatTime(booking.ends_at)}
+                            </div>
+                          </div>
+                          <span
+                            className={`rounded-full border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.1em] ${statusClass(booking.status)}`}
+                          >
+                            {booking.status || "pending"}
+                          </span>
+                        </div>
+                        {booking.notes ? (
+                          <p className="mt-2 line-clamp-2 text-xs text-[color:var(--theme-text-muted)]">
+                            {booking.notes}
+                          </p>
+                        ) : null}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </aside>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Detail({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <div>
+      <div className="text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-0.5 break-words text-[color:var(--theme-text-primary)]">
+        {value || "Not provided"}
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/appointments/WeeklyCalendar.tsx
+++ b/app/dashboard/appointments/WeeklyCalendar.tsx
@@ -25,7 +25,10 @@ function dayKeyLocal(d: Date) {
 function timeLabel(startsAtIso: string, endsAtIso: string) {
   const start = new Date(startsAtIso);
   const end = new Date(endsAtIso);
-  const s = start.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  const s = start.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
   const e = end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   return `${s} – ${e}`;
 }
@@ -47,9 +50,11 @@ function displayCustomerName(b: Booking): string {
 
 function statusPill(status?: string | null) {
   const s = (status || "pending").toLowerCase();
-  if (s === "confirmed") return "border-emerald-500/30 bg-emerald-900/15 text-emerald-200";
-  if (s === "cancelled") return "border-red-500/30 bg-red-900/15 text-red-200";
-  return "border-sky-400/30 bg-sky-900/20 text-sky-100";
+  if (s === "confirmed")
+    return "border-emerald-500/30 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-200";
+  if (s === "cancelled")
+    return "border-red-500/30 bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-200";
+  return "border-amber-500/30 bg-amber-50 text-amber-800 dark:bg-amber-950/30 dark:text-amber-200";
 }
 
 function bookingCardStyle(status?: string | null) {
@@ -58,10 +63,10 @@ function bookingCardStyle(status?: string | null) {
     return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-inset)]";
   }
   if (s === "confirmed") {
-    return "border-emerald-400/25 bg-emerald-500/10 hover:bg-emerald-500/15";
+    return "border-emerald-500/25 bg-emerald-50/70 hover:bg-emerald-50 dark:bg-emerald-950/20 dark:hover:bg-emerald-950/30";
   }
   // pending
-  return "border-sky-400/30 bg-sky-500/10 hover:bg-sky-500/20";
+  return "border-amber-500/30 bg-amber-50/70 hover:bg-amber-50 dark:bg-amber-950/20 dark:hover:bg-amber-950/30";
 }
 
 export default function WeeklyCalendar({
@@ -72,7 +77,7 @@ export default function WeeklyCalendar({
   loading = false,
 }: Props) {
   const days = useMemo(() => {
-    return Array.from({ length: 7 }, (_, i) => {
+    return Array.from({ length: 5 }, (_, i) => {
       const d = new Date(weekStart);
       d.setHours(0, 0, 0, 0);
       d.setDate(d.getDate() + i);
@@ -101,7 +106,7 @@ export default function WeeklyCalendar({
   const todayKey = dayKeyLocal(new Date());
 
   return (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-7">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-5">
       {days.map((d) => {
         const k = dayKeyLocal(d);
         const dayBookings = grouped.get(k) ?? [];
@@ -114,7 +119,7 @@ export default function WeeklyCalendar({
         return (
           <div
             key={k}
-            className="flex min-h-[160px] flex-col gap-2 rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 text-xs text-[color:var(--theme-text-primary)] shadow-card backdrop-blur-md overflow-hidden"
+            className="flex min-h-[240px] min-w-0 flex-col gap-2 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-primary)] shadow-sm"
           >
             {/* Day header */}
             <div className="flex items-center gap-2">
@@ -176,7 +181,14 @@ export default function WeeklyCalendar({
                       }
                     >
                       <div className="flex w-full items-center justify-between gap-2">
-                        <div className={"truncate font-semibold " + (isCancelled ? "text-[color:var(--theme-text-secondary)] line-through" : "text-[color:var(--theme-text-primary)]")}>
+                        <div
+                          className={
+                            "truncate font-semibold " +
+                            (isCancelled
+                              ? "text-[color:var(--theme-text-secondary)] line-through"
+                              : "text-[color:var(--theme-text-primary)]")
+                          }
+                        >
                           {displayCustomerName(b)}
                         </div>
 
@@ -190,7 +202,14 @@ export default function WeeklyCalendar({
                             {b.status || "pending"}
                           </span>
 
-                          <span className={"whitespace-nowrap text-[0.6rem] " + (isCancelled ? "text-[color:var(--theme-text-secondary)]" : "text-[color:var(--theme-text-primary)]")}>
+                          <span
+                            className={
+                              "whitespace-nowrap text-[0.6rem] " +
+                              (isCancelled
+                                ? "text-[color:var(--theme-text-secondary)]"
+                                : "text-[color:var(--theme-text-primary)]")
+                            }
+                          >
                             {timeLabel(b.starts_at, b.ends_at)}
                           </span>
                         </div>

--- a/app/dashboard/appointments/page.tsx
+++ b/app/dashboard/appointments/page.tsx
@@ -34,6 +34,7 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast, Toaster } from "sonner";
 
 import WeeklyCalendar from "./WeeklyCalendar";
+import FullCalendarModal from "./FullCalendarModal";
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
 
@@ -59,6 +60,10 @@ export type Booking = {
 
 const isoDate = (d: Date) => d.toISOString().slice(0, 10);
 
+function operationKey(action: string, bookingId?: string): string {
+  return `${action}:${bookingId ?? "new"}:${crypto.randomUUID()}`;
+}
+
 function startOfToday(): Date {
   const d = new Date();
   d.setHours(0, 0, 0, 0);
@@ -77,7 +82,6 @@ function toLocalTimeInput(d: Date): string {
   return `${hh}:${mm}`;
 }
 
-
 /* ----------------------------- ui helpers ----------------------------- */
 
 const COPPER_FOCUS =
@@ -86,9 +90,8 @@ const COPPER_FOCUS =
 function cardClass() {
   return [
     "rounded-2xl border border-[color:var(--theme-border-soft)]",
-    "bg-[var(--theme-gradient-panel)]",
-    "shadow-[var(--theme-shadow-medium)]",
-    "backdrop-blur-xl",
+    "bg-[color:var(--theme-surface-panel-strong)]",
+    "shadow-[var(--theme-shadow-soft)]",
     "p-4",
   ].join(" ");
 }
@@ -114,10 +117,10 @@ function subtleButtonClass() {
 function pillClass(status?: string | null) {
   const s = (status || "pending").toLowerCase();
   if (s === "confirmed")
-    return "border-emerald-500/25 bg-emerald-500/10 text-emerald-200";
+    return "border-emerald-500/25 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-200";
   if (s === "cancelled")
-    return "border-red-500/25 bg-red-500/10 text-red-200";
-  return "border-sky-400/30 bg-sky-500/10 text-sky-100";
+    return "border-red-500/25 bg-red-50 text-red-700 dark:bg-red-950/30 dark:text-red-200";
+  return "border-amber-500/30 bg-amber-50 text-amber-800 dark:bg-amber-950/30 dark:text-amber-200";
 }
 
 function safeString(v: unknown): string {
@@ -129,7 +132,8 @@ function customerLabel(c: CustomerRow): string {
   const first = safeString(rec["first_name"]);
   const last = safeString(rec["last_name"]);
   const full = safeString(rec["full_name"]) || safeString(rec["name"]);
-  const name = full || `${first} ${last}`.trim() || safeString(rec["email"]) || "Customer";
+  const name =
+    full || `${first} ${last}`.trim() || safeString(rec["email"]) || "Customer";
   const phone = safeString(rec["phone"]) || safeString(rec["mobile"]);
   return phone ? `${name} (${phone})` : name;
 }
@@ -182,9 +186,9 @@ function canCreateWorkOrderFromBooking(b: Booking): boolean {
   if (b.work_order_id) return false;
   return Boolean(
     b.customer_id ||
-      b.customer_name?.trim() ||
-      b.customer_email?.trim() ||
-      b.customer_phone?.trim(),
+    b.customer_name?.trim() ||
+    b.customer_email?.trim() ||
+    b.customer_phone?.trim(),
   );
 }
 
@@ -202,10 +206,13 @@ export default function PortalAppointmentsPage(): JSX.Element {
   const [loadingCustomers, setLoadingCustomers] = useState(false);
 
   const [weekStart, setWeekStart] = useState<Date>(() => startOfToday());
-  const weekEnd = useMemo(() => addDays(weekStart, 6), [weekStart]);
+  const weekEnd = useMemo(() => addDays(weekStart, 4), [weekStart]);
 
   const [bookings, setBookings] = useState<Booking[]>([]);
+  const [pendingRequests, setPendingRequests] = useState<Booking[]>([]);
   const [loadingBookings, setLoadingBookings] = useState(false);
+  const [loadingRequests, setLoadingRequests] = useState(false);
+  const [bookingsError, setBookingsError] = useState<string | null>(null);
 
   const [panelMode, setPanelMode] = useState<PanelMode>(null);
   const [editing, setEditing] = useState<Booking | null>(null);
@@ -213,8 +220,10 @@ export default function PortalAppointmentsPage(): JSX.Element {
 
   const [query, setQuery] = useState<string>("");
   const [listTab, setListTab] = useState<ListTab>("all");
+  const [calendarOpen, setCalendarOpen] = useState(false);
 
   const bookingsAbortRef = useRef<AbortController | null>(null);
+  const requestsAbortRef = useRef<AbortController | null>(null);
 
   // "..." menu state
   const [menuOpenFor, setMenuOpenFor] = useState<string | null>(null);
@@ -232,16 +241,35 @@ export default function PortalAppointmentsPage(): JSX.Element {
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [menuOpenFor]);
 
-  // load shops
+  // Resolve the signed-in staff member's shop. Internal scheduling must not
+  // depend on whether that shop currently accepts public online bookings.
   useEffect(() => {
     let mounted = true;
 
     (async () => {
+      const { data: auth } = await supabase.auth.getUser();
+      const userId = auth.user?.id;
+      if (!userId) {
+        if (mounted) toast.error("Sign in to manage appointments.");
+        return;
+      }
+
+      const { data: profile, error: profileError } = await supabase
+        .from("profiles")
+        .select("shop_id")
+        .eq("id", userId)
+        .maybeSingle<{ shop_id: string | null }>();
+
+      if (profileError || !profile?.shop_id) {
+        if (mounted) toast.error("Your profile is not linked to a shop.");
+        return;
+      }
+
       const { data, error } = await supabase
         .from("shops")
         .select("id,name,slug,accepts_online_booking")
-        .eq("accepts_online_booking", true)
-        .order("name", { ascending: true });
+        .eq("id", profile.shop_id)
+        .maybeSingle();
 
       if (!mounted) return;
 
@@ -252,13 +280,17 @@ export default function PortalAppointmentsPage(): JSX.Element {
         return;
       }
 
-      const rows = (data ?? []) as ShopRow[];
+      const rows = data ? [data as ShopRow] : [];
       setShops(rows);
 
-      if (!shopSlug && rows.length > 0) {
-        const first = rows[0].slug as string;
-        setShopSlug(first);
-        router.replace(`/dashboard/appointments?shop=${encodeURIComponent(first)}`);
+      if (rows.length > 0) {
+        const authorizedSlug = rows[0].slug as string;
+        setShopSlug(authorizedSlug);
+        if (shopSlug !== authorizedSlug) {
+          router.replace(
+            `/dashboard/appointments?shop=${encodeURIComponent(authorizedSlug)}`,
+          );
+        }
       }
     })();
 
@@ -313,33 +345,77 @@ export default function PortalAppointmentsPage(): JSX.Element {
     };
   }, [supabase, selectedShop]);
 
-  const refreshBookings = useCallback(async (slug: string, ws: Date, we: Date) => {
+  const refreshBookings = useCallback(
+    async (slug: string, ws: Date, we: Date) => {
+      if (!slug) return;
+
+      bookingsAbortRef.current?.abort();
+      const ac = new AbortController();
+      bookingsAbortRef.current = ac;
+
+      setLoadingBookings(true);
+      setBookingsError(null);
+      try {
+        const start = isoDate(ws);
+        const end = isoDate(we);
+
+        const res = await fetch(
+          `/api/portal/bookings?shop=${encodeURIComponent(slug)}&start=${start}&end=${end}`,
+          { cache: "no-store", signal: ac.signal },
+        );
+
+        const body = (await res.json().catch(() => null)) as
+          | Booking[]
+          | { error?: string }
+          | null;
+        if (!res.ok) {
+          const message = body && !Array.isArray(body) ? body.error : null;
+          throw new Error(message || "Failed to load appointments.");
+        }
+        setBookings(Array.isArray(body) ? body : []);
+      } catch (err: unknown) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        // eslint-disable-next-line no-console
+        console.error(err);
+        setBookingsError(
+          err instanceof Error ? err.message : "Failed to load appointments.",
+        );
+      } finally {
+        setLoadingBookings(false);
+      }
+    },
+    [],
+  );
+
+  const refreshPendingRequests = useCallback(async (slug: string) => {
     if (!slug) return;
-
-    bookingsAbortRef.current?.abort();
+    requestsAbortRef.current?.abort();
     const ac = new AbortController();
-    bookingsAbortRef.current = ac;
-
-    setLoadingBookings(true);
+    requestsAbortRef.current = ac;
+    setLoadingRequests(true);
     try {
-      const start = isoDate(ws);
-      const end = isoDate(we);
-
       const res = await fetch(
-        `/api/portal/bookings?shop=${encodeURIComponent(slug)}&start=${start}&end=${end}`,
+        `/api/portal/bookings?shop=${encodeURIComponent(slug)}&status=pending`,
         { cache: "no-store", signal: ac.signal },
       );
-
-      if (!res.ok) throw new Error("Failed to load appointments.");
-      const j = (await res.json().catch(() => [])) as Booking[];
-      setBookings(j ?? []);
+      const body = (await res.json().catch(() => null)) as
+        | Booking[]
+        | { error?: string }
+        | null;
+      if (!res.ok) {
+        const message = body && !Array.isArray(body) ? body.error : null;
+        throw new Error(message || "Failed to load appointment requests.");
+      }
+      setPendingRequests(Array.isArray(body) ? body : []);
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === "AbortError") return;
-      // eslint-disable-next-line no-console
-      console.error(err);
-      toast.error("Failed to load appointments.");
+      setBookingsError(
+        err instanceof Error
+          ? err.message
+          : "Failed to load appointment requests.",
+      );
     } finally {
-      setLoadingBookings(false);
+      setLoadingRequests(false);
     }
   }, []);
 
@@ -347,13 +423,23 @@ export default function PortalAppointmentsPage(): JSX.Element {
   useEffect(() => {
     if (!shopSlug) return;
     void refreshBookings(shopSlug, weekStart, weekEnd);
-    return () => bookingsAbortRef.current?.abort();
-  }, [shopSlug, weekStart, weekEnd, refreshBookings]);
+    void refreshPendingRequests(shopSlug);
+    return () => {
+      bookingsAbortRef.current?.abort();
+      requestsAbortRef.current?.abort();
+    };
+  }, [shopSlug, weekStart, weekEnd, refreshBookings, refreshPendingRequests]);
 
   // derived groups
-  const pending = useMemo(() => bookings.filter((b) => statusOf(b) === "pending"), [bookings]);
-  const confirmed = useMemo(() => bookings.filter((b) => statusOf(b) === "confirmed"), [bookings]);
-  const cancelled = useMemo(() => bookings.filter((b) => statusOf(b) === "cancelled"), [bookings]);
+  const pending = pendingRequests;
+  const confirmed = useMemo(
+    () => bookings.filter((b) => statusOf(b) === "confirmed"),
+    [bookings],
+  );
+  const cancelled = useMemo(
+    () => bookings.filter((b) => statusOf(b) === "cancelled"),
+    [bookings],
+  );
 
   const totalForWeek = bookings.length;
 
@@ -422,10 +508,14 @@ export default function PortalAppointmentsPage(): JSX.Element {
     try {
       const startIso = new Date(`${form.date}T${form.startsAt}`).toISOString();
       const endIso = new Date(`${form.date}T${form.endsAt}`).toISOString();
+      const createKey = operationKey("staff-create");
 
       const res = await fetch("/api/portal/book", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": createKey,
+        },
         body: JSON.stringify({
           shopSlug,
           startsAt: startIso,
@@ -435,6 +525,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
           customerName: form.customerName,
           customerEmail: form.customerEmail,
           customerPhone: form.customerPhone,
+          operationKey: createKey,
         }),
       });
 
@@ -443,57 +534,126 @@ export default function PortalAppointmentsPage(): JSX.Element {
         error?: string;
       };
 
-      if (!res.ok || !j.booking) throw new Error(j?.error || "Unable to create appointment.");
+      if (!res.ok || !j.booking)
+        throw new Error(j?.error || "Unable to create appointment.");
 
-      toast.success("Appointment created.");
+      const created = j.booking;
+      const confirmRes = await fetch(`/api/portal/bookings/${created.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "confirmed" }),
+      });
+      if (!confirmRes.ok)
+        throw new Error("Appointment was created but could not be confirmed.");
+
+      toast.success("Appointment created and confirmed.");
       closePanel();
-      await refreshBookings(shopSlug, weekStart, weekEnd);
+      await Promise.all([
+        refreshBookings(shopSlug, weekStart, weekEnd),
+        refreshPendingRequests(shopSlug),
+      ]);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Create failed";
       toast.error(message);
     }
   }
 
-  async function handleUpdate(id: string, patch: Partial<Booking>) {
+  async function handleUpdate(
+    id: string,
+    patch: Partial<Booking>,
+  ): Promise<boolean> {
     try {
-      const res = await fetch(`/api/portal/bookings/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(patch),
-      });
+      const sendPatch = async (body: Record<string, unknown>, key?: string) => {
+        const res = await fetch(`/api/portal/bookings/${id}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            ...(key ? { "Idempotency-Key": key } : {}),
+          },
+          body: JSON.stringify(key ? { ...body, idempotencyKey: key } : body),
+        });
+        const responseBody = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        if (!res.ok) throw new Error(responseBody.error || "Update failed");
+      };
 
-      const j = (await res.json().catch(() => ({}))) as { error?: string };
-      if (!res.ok) throw new Error(j?.error || "Update failed");
+      const isReschedule =
+        patch.starts_at !== undefined || patch.ends_at !== undefined;
+      const isCancellation = patch.status === "cancelled";
+
+      if (isCancellation) {
+        await sendPatch(
+          { status: "cancelled", notes: patch.notes },
+          operationKey("staff-cancel", id),
+        );
+      } else {
+        if (isReschedule) {
+          await sendPatch(
+            {
+              starts_at: patch.starts_at,
+              ends_at: patch.ends_at,
+              notes: patch.notes,
+            },
+            operationKey("staff-reschedule", id),
+          );
+        }
+
+        const metadataPatch: Record<string, unknown> = {};
+        if (patch.status !== undefined) metadataPatch.status = patch.status;
+        if (patch.customer_id !== undefined)
+          metadataPatch.customer_id = patch.customer_id;
+        if (!isReschedule && patch.notes !== undefined)
+          metadataPatch.notes = patch.notes;
+        if (Object.keys(metadataPatch).length > 0) {
+          await sendPatch(metadataPatch);
+        }
+      }
 
       toast.success("Appointment updated.");
       closePanel();
-      await refreshBookings(shopSlug, weekStart, weekEnd);
+      await Promise.all([
+        refreshBookings(shopSlug, weekStart, weekEnd),
+        refreshPendingRequests(shopSlug),
+      ]);
+      return true;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Update failed";
       toast.error(message);
+      return false;
     }
   }
 
   async function handleDelete(id: string) {
-    if (!confirm("Delete this appointment?")) return;
+    if (!confirm("Cancel this appointment? Its history will be preserved."))
+      return;
     try {
-      const res = await fetch(`/api/portal/bookings/${id}`, { method: "DELETE" });
-      if (!res.ok) throw new Error("Delete failed.");
-      toast.success("Appointment deleted.");
-      setBookings((prev) => prev.filter((b) => b.id !== id));
-      if (editing?.id === id) closePanel();
+      const cancelKey = operationKey("staff-cancel", id);
+      const res = await fetch(`/api/portal/bookings/${id}`, {
+        method: "DELETE",
+        headers: { "Idempotency-Key": cancelKey },
+      });
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(body.error || "Cancellation failed.");
+      toast.success("Appointment cancelled.");
+      closePanel();
+      await Promise.all([
+        refreshBookings(shopSlug, weekStart, weekEnd),
+        refreshPendingRequests(shopSlug),
+      ]);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Delete failed";
+      const message =
+        err instanceof Error ? err.message : "Cancellation failed";
       toast.error(message);
     }
   }
 
-  async function approveBooking(b: Booking) {
-    await handleUpdate(b.id, { status: "confirmed" });
+  async function approveBooking(b: Booking): Promise<boolean> {
+    return handleUpdate(b.id, { status: "confirmed" });
   }
 
-  async function declineBooking(b: Booking) {
-    await handleUpdate(b.id, { status: "cancelled" });
+  async function declineBooking(b: Booking): Promise<boolean> {
+    return handleUpdate(b.id, { status: "cancelled" });
   }
 
   function buildWorkOrderCreateHref(b: Booking): string {
@@ -529,37 +689,32 @@ export default function PortalAppointmentsPage(): JSX.Element {
     <div className="space-y-6">
       <Toaster position="top-center" />
 
-      <header className="space-y-1">
-        <h1 className="text-2xl font-blackops text-[color:var(--theme-text-primary)]">Appointments</h1>
-        <p className="text-sm text-[color:var(--theme-text-secondary)]">
-          Admin / manager view of customer bookings for the week.
-        </p>
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-[-0.03em] text-[color:var(--theme-text-primary)]">
+            Appointments
+          </h1>
+          <p className="text-sm text-[color:var(--theme-text-secondary)]">
+            Review customer requests, protect shop capacity, and move approved
+            visits into work.
+          </p>
+        </div>
+        <Button type="button" onClick={() => openCreate(isoDate(weekStart))}>
+          New appointment
+        </Button>
       </header>
 
       {/* Top: Shop + Stats + Search */}
       <div className={cardClass()}>
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2">
               <div className="text-[0.7rem] uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
                 Shop
               </div>
-              <select
-                value={shopSlug}
-                onChange={(e) => {
-                  const slug = e.target.value;
-                  setShopSlug(slug);
-                  router.replace(`/dashboard/appointments?shop=${encodeURIComponent(slug)}`);
-                  closePanel();
-                }}
-                className={fieldClass() + " min-w-[220px]"}
-              >
-                {shops.map((s) => (
-                  <option key={s.slug as string} value={s.slug as string}>
-                    {s.name}
-                  </option>
-                ))}
-              </select>
+              <div className="min-w-[180px] text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                {selectedShop?.name ?? "Loading shop…"}
+              </div>
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
@@ -567,37 +722,45 @@ export default function PortalAppointmentsPage(): JSX.Element {
                 <div className="text-[0.65rem] uppercase tracking-[0.13em] text-[color:var(--theme-text-muted)]">
                   Week
                 </div>
-                <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">{weekLabel}</div>
+                <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  {weekLabel}
+                </div>
               </div>
 
               <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-2">
                 <div className="text-[0.65rem] uppercase tracking-[0.13em] text-[color:var(--theme-text-muted)]">
-                  This week
+                  Five-day view
                 </div>
                 <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
                   {totalForWeek} booking{totalForWeek === 1 ? "" : "s"}
                 </div>
               </div>
 
-              <div className="rounded-xl border border-sky-500/25 bg-sky-950/20 px-3 py-2">
-                <div className="text-[0.65rem] uppercase tracking-[0.13em] text-sky-200/80">
-                  Requests
+              <div className="rounded-xl border border-amber-500/25 bg-amber-50 px-3 py-2 dark:bg-amber-950/25">
+                <div className="text-[0.65rem] uppercase tracking-[0.13em] text-amber-700 dark:text-amber-200">
+                  Pending review
                 </div>
-                <div className="text-sm font-semibold text-sky-100">{pending.length}</div>
+                <div className="text-sm font-semibold text-amber-900 dark:text-amber-100">
+                  {pending.length}
+                </div>
               </div>
 
-              <div className="rounded-xl border border-emerald-500/20 bg-emerald-950/10 px-3 py-2">
-                <div className="text-[0.65rem] uppercase tracking-[0.13em] text-emerald-200/80">
+              <div className="rounded-xl border border-emerald-500/20 bg-emerald-50 px-3 py-2 dark:bg-emerald-950/25">
+                <div className="text-[0.65rem] uppercase tracking-[0.13em] text-emerald-700 dark:text-emerald-200">
                   Confirmed
                 </div>
-                <div className="text-sm font-semibold text-emerald-100">{confirmed.length}</div>
+                <div className="text-sm font-semibold text-emerald-900 dark:text-emerald-100">
+                  {confirmed.length}
+                </div>
               </div>
 
-              <div className="rounded-xl border border-red-500/20 bg-red-950/10 px-3 py-2">
-                <div className="text-[0.65rem] uppercase tracking-[0.13em] text-red-200/80">
+              <div className="rounded-xl border border-red-500/20 bg-red-50 px-3 py-2 dark:bg-red-950/25">
+                <div className="text-[0.65rem] uppercase tracking-[0.13em] text-red-700 dark:text-red-200">
                   Cancelled
                 </div>
-                <div className="text-sm font-semibold text-red-100">{cancelled.length}</div>
+                <div className="text-sm font-semibold text-red-900 dark:text-red-100">
+                  {cancelled.length}
+                </div>
               </div>
             </div>
           </div>
@@ -622,7 +785,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
                 size="sm"
                 onClick={() => {
                   const d = new Date(weekStart);
-                  d.setDate(d.getDate() - 7);
+                  d.setDate(d.getDate() - 5);
                   setWeekStart(d);
                   closePanel();
                 }}
@@ -646,7 +809,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
                 size="sm"
                 onClick={() => {
                   const d = new Date(weekStart);
-                  d.setDate(d.getDate() + 7);
+                  d.setDate(d.getDate() + 5);
                   setWeekStart(d);
                   closePanel();
                 }}
@@ -659,17 +822,53 @@ export default function PortalAppointmentsPage(): JSX.Element {
       </div>
 
       {/* Main 2-column layout */}
-      <div className="grid gap-6 lg:grid-cols-[1fr_420px]">
+      <div className="grid gap-6 2xl:grid-cols-[minmax(0,1fr)_420px]">
         {/* Left: Calendar big */}
         <div className={cardClass()}>
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Weekly calendar</h2>
-            {loadingBookings ? (
-              <span className="text-[0.75rem] text-[color:var(--theme-text-muted)]">Loading…</span>
-            ) : null}
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                Five-day schedule
+              </h2>
+              <p className="mt-0.5 text-[0.75rem] text-[color:var(--theme-text-muted)]">
+                A focused view of the shop&apos;s next operating window.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {loadingBookings ? (
+                <span className="text-[0.75rem] text-[color:var(--theme-text-muted)]">
+                  Loading…
+                </span>
+              ) : null}
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => setCalendarOpen(true)}
+              >
+                Full calendar
+              </Button>
+            </div>
           </div>
 
-          <div className="overflow-x-auto pb-2">
+          {bookingsError ? (
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-red-500/25 bg-red-50 px-3 py-2 text-sm text-red-800 dark:bg-red-950/25 dark:text-red-200">
+              <span>{bookingsError}</span>
+              <Button
+                type="button"
+                size="xs"
+                variant="outline"
+                onClick={() => {
+                  void refreshBookings(shopSlug, weekStart, weekEnd);
+                  void refreshPendingRequests(shopSlug);
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : null}
+
+          <div>
             <WeeklyCalendar
               weekStart={weekStart}
               bookings={filteredBookings}
@@ -680,32 +879,36 @@ export default function PortalAppointmentsPage(): JSX.Element {
           </div>
 
           <p className="mt-3 text-[0.75rem] text-[color:var(--theme-text-muted)]">
-            Click a day to create. Click an appointment to edit.
+            Select a day to create an appointment, or open the full calendar for
+            month and day views.
           </p>
         </div>
 
         {/* Right: Sticky Requests + Panel */}
-        <div className="lg:sticky lg:top-6 space-y-6">
+        <div className="space-y-6 2xl:sticky 2xl:top-6 2xl:self-start">
           {/* Requests (pending) */}
           <div className={cardClass()}>
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                Requests (pending)
+                Customer requests
               </h2>
               <div className="text-[0.75rem] text-[color:var(--theme-text-muted)]">
-                {filteredPending.length}
+                {loadingRequests ? "Loading…" : filteredPending.length}
               </div>
             </div>
 
             {filteredPending.length === 0 ? (
               <div className="rounded-xl border border-dashed border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-3 text-sm text-[color:var(--theme-text-muted)]">
-                No pending requests{query.trim() ? " matching your search." : " for this week."}
+                No pending requests
+                {query.trim() ? " matching your search." : "."}
               </div>
             ) : (
               <ul className="divide-y divide-[color:var(--theme-border-soft)]">
                 {filteredPending
                   .slice()
-                  .sort((a, b) => +new Date(a.starts_at) - +new Date(b.starts_at))
+                  .sort(
+                    (a, b) => +new Date(a.starts_at) - +new Date(b.starts_at),
+                  )
                   .map((b) => (
                     <li
                       key={b.id}
@@ -713,7 +916,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
                         "py-3 text-sm",
                         // subtle "actionable" highlight
                         "rounded-xl px-2 -mx-2",
-                        "bg-sky-500/[0.05] hover:bg-sky-500/[0.1]",
+                        "border border-amber-500/15 bg-amber-50/70 hover:bg-amber-50 dark:bg-amber-950/15 dark:hover:bg-amber-950/25",
                       ].join(" ")}
                     >
                       <div className="flex items-start gap-3">
@@ -737,8 +940,12 @@ export default function PortalAppointmentsPage(): JSX.Element {
                           </div>
 
                           <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[0.75rem] text-[color:var(--theme-text-muted)]">
-                            {b.customer_phone ? <span>{b.customer_phone}</span> : null}
-                            {b.customer_email ? <span>{b.customer_email}</span> : null}
+                            {b.customer_phone ? (
+                              <span>{b.customer_phone}</span>
+                            ) : null}
+                            {b.customer_email ? (
+                              <span>{b.customer_email}</span>
+                            ) : null}
                           </div>
 
                           {b.notes ? (
@@ -761,7 +968,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
                             type="button"
                             size="xs"
                             variant="outline"
-                            className="border-red-500/40 text-red-200 hover:bg-red-900/20"
+                            className="border-red-500/35 text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/25"
                             onClick={() => void declineBooking(b)}
                           >
                             Decline
@@ -788,11 +995,18 @@ export default function PortalAppointmentsPage(): JSX.Element {
                           ) : null}
 
                           {/* "..." menu */}
-                          <div className="relative" ref={menuOpenFor === b.id ? menuRef : undefined}>
+                          <div
+                            className="relative"
+                            ref={menuOpenFor === b.id ? menuRef : undefined}
+                          >
                             <button
                               type="button"
                               className={subtleButtonClass()}
-                              onClick={() => setMenuOpenFor((prev) => (prev === b.id ? null : b.id))}
+                              onClick={() =>
+                                setMenuOpenFor((prev) =>
+                                  prev === b.id ? null : b.id,
+                                )
+                              }
                               aria-label="More actions"
                             >
                               …
@@ -812,13 +1026,13 @@ export default function PortalAppointmentsPage(): JSX.Element {
                                 </button>
                                 <button
                                   type="button"
-                                  className="w-full px-3 py-2 text-left text-sm text-red-200 hover:bg-red-500/10"
+                                  className="w-full px-3 py-2 text-left text-sm text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/25"
                                   onClick={() => {
                                     setMenuOpenFor(null);
                                     void handleDelete(b.id);
                                   }}
                                 >
-                                  Delete
+                                  Cancel appointment
                                 </button>
                               </div>
                             ) : null}
@@ -832,7 +1046,7 @@ export default function PortalAppointmentsPage(): JSX.Element {
           </div>
 
           {/* Create / Edit panel (desktop card) */}
-          <div className={cardClass() + " hidden lg:block"}>
+          <div className={cardClass() + " hidden 2xl:block"}>
             {panelMode === "edit" && editing ? (
               <EditForm
                 booking={editing}
@@ -876,35 +1090,55 @@ export default function PortalAppointmentsPage(): JSX.Element {
       <div className={cardClass()}>
         <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
-            This week ({filteredBookings.length})
+            Five-day agenda ({filteredBookings.length})
           </h2>
 
           <div className="flex flex-wrap items-center gap-2">
-            <TabButton active={listTab === "all"} onClick={() => setListTab("all")}>
+            <TabButton
+              active={listTab === "all"}
+              onClick={() => setListTab("all")}
+            >
               All
             </TabButton>
-            <TabButton active={listTab === "pending"} onClick={() => setListTab("pending")}>
+            <TabButton
+              active={listTab === "pending"}
+              onClick={() => setListTab("pending")}
+            >
               Pending
             </TabButton>
-            <TabButton active={listTab === "confirmed"} onClick={() => setListTab("confirmed")}>
+            <TabButton
+              active={listTab === "confirmed"}
+              onClick={() => setListTab("confirmed")}
+            >
               Confirmed
             </TabButton>
-            <TabButton active={listTab === "cancelled"} onClick={() => setListTab("cancelled")}>
+            <TabButton
+              active={listTab === "cancelled"}
+              onClick={() => setListTab("cancelled")}
+            >
               Cancelled
             </TabButton>
           </div>
         </div>
 
         {loadingBookings ? (
-          <p className="text-sm text-[color:var(--theme-text-muted)]">Fetching appointments…</p>
+          <p className="text-sm text-[color:var(--theme-text-muted)]">
+            Fetching appointments…
+          </p>
         ) : filteredListByTab.length === 0 ? (
           <p className="text-sm text-[color:var(--theme-text-muted)]">
-            No appointments{query.trim() ? " matching your search." : " for this week."}
+            No appointments
+            {query.trim()
+              ? " matching your search."
+              : " in this five-day view."}
           </p>
         ) : (
           <ul className="divide-y divide-[color:var(--theme-border-soft)]">
             {filteredListByTab.map((b) => (
-              <li key={b.id} className="flex flex-wrap items-start gap-3 py-3 text-sm">
+              <li
+                key={b.id}
+                className="flex flex-wrap items-start gap-3 py-3 text-sm"
+              >
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
                     <div className="font-medium text-[color:var(--theme-text-primary)]">
@@ -925,21 +1159,27 @@ export default function PortalAppointmentsPage(): JSX.Element {
                   </div>
 
                   {b.notes ? (
-                    <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-muted)]">{b.notes}</div>
+                    <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-muted)]">
+                      {b.notes}
+                    </div>
                   ) : null}
                 </div>
 
                 <div className="flex items-center gap-2">
                   {statusOf(b) === "pending" ? (
                     <>
-                      <Button type="button" size="xs" onClick={() => void approveBooking(b)}>
+                      <Button
+                        type="button"
+                        size="xs"
+                        onClick={() => void approveBooking(b)}
+                      >
                         Approve
                       </Button>
                       <Button
                         type="button"
                         size="xs"
                         variant="outline"
-                        className="border-red-500/40 text-red-200 hover:bg-red-900/20"
+                        className="border-red-500/35 text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/25"
                         onClick={() => void declineBooking(b)}
                       >
                         Decline
@@ -967,17 +1207,22 @@ export default function PortalAppointmentsPage(): JSX.Element {
                     </Button>
                   ) : null}
 
-                  <Button type="button" size="xs" variant="outline" onClick={() => openEdit(b)}>
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="outline"
+                    onClick={() => openEdit(b)}
+                  >
                     Edit
                   </Button>
                   <Button
                     type="button"
                     size="xs"
                     variant="ghost"
-                    className="text-red-300 hover:bg-red-900/25"
+                    className="text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/25"
                     onClick={() => void handleDelete(b.id)}
                   >
-                    Delete
+                    Cancel appointment
                   </Button>
                 </div>
               </li>
@@ -986,9 +1231,22 @@ export default function PortalAppointmentsPage(): JSX.Element {
         )}
       </div>
 
+      <FullCalendarModal
+        open={calendarOpen}
+        shopSlug={shopSlug}
+        initialDate={weekStart}
+        onOpenChange={setCalendarOpen}
+        onCreate={openCreate}
+        onEdit={openEdit}
+        onApprove={approveBooking}
+        onDecline={declineBooking}
+        onOpenWorkOrder={openLinkedWorkOrder}
+        onCreateWorkOrder={openWorkOrderCreate}
+      />
+
       {/* Mobile drawer */}
       {panelMode ? (
-        <div className="lg:hidden">
+        <div className="2xl:hidden">
           <div
             className="fixed inset-0 z-40 bg-[color:var(--theme-surface-overlay)]"
             onClick={closePanel}
@@ -999,9 +1257,16 @@ export default function PortalAppointmentsPage(): JSX.Element {
           <div className="fixed inset-x-0 bottom-0 z-50 max-h-[85vh] overflow-auto rounded-t-3xl border border-[color:var(--desktop-border)] bg-[var(--desktop-panel-bg)] p-4 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
             <div className="mb-3 flex items-center justify-between">
               <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                {panelMode === "edit" ? "Edit appointment" : "Create appointment"}
+                {panelMode === "edit"
+                  ? "Edit appointment"
+                  : "Create appointment"}
               </div>
-              <Button type="button" size="xs" variant="outline" onClick={closePanel}>
+              <Button
+                type="button"
+                size="xs"
+                variant="outline"
+                onClick={closePanel}
+              >
                 Close
               </Button>
             </div>
@@ -1050,7 +1315,7 @@ function TabButton({
         "rounded-full border px-3 py-1 text-xs font-semibold",
         "transition",
         active
-          ? "border-sky-400/35 bg-sky-500/10 text-sky-100"
+          ? "border-sky-500/30 bg-sky-50 text-sky-700 dark:bg-sky-950/30 dark:text-sky-200"
           : "border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-subtle)]",
       ].join(" ")}
     >
@@ -1110,7 +1375,9 @@ function CreateForm({
     const name = full || `${first} ${last}`.trim();
 
     setCustomerName(name || "");
-    setCustomerEmail(safeString(rec["email"]) || safeString(rec["contact_email"]));
+    setCustomerEmail(
+      safeString(rec["email"]) || safeString(rec["contact_email"]),
+    );
     setCustomerPhone(safeString(rec["phone"]) || safeString(rec["mobile"]));
   };
 
@@ -1131,7 +1398,9 @@ function CreateForm({
         });
       }}
     >
-      <h3 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Create appointment</h3>
+      <h3 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+        Create appointment
+      </h3>
 
       <div className="grid gap-2 sm:grid-cols-2">
         <label className="text-xs text-[color:var(--theme-text-secondary)]">
@@ -1253,8 +1522,12 @@ function EditForm({
   const start = useMemo(() => new Date(booking.starts_at), [booking.starts_at]);
   const end = useMemo(() => new Date(booking.ends_at), [booking.ends_at]);
 
-  const [date, setDate] = useState<string>(() => booking.starts_at.slice(0, 10));
-  const [startsAt, setStartsAt] = useState<string>(() => toLocalTimeInput(start));
+  const [date, setDate] = useState<string>(() =>
+    booking.starts_at.slice(0, 10),
+  );
+  const [startsAt, setStartsAt] = useState<string>(() =>
+    toLocalTimeInput(start),
+  );
   const [endsAt, setEndsAt] = useState<string>(() => toLocalTimeInput(end));
 
   useEffect(() => {
@@ -1264,10 +1537,16 @@ function EditForm({
     setEndsAt(toLocalTimeInput(new Date(booking.ends_at)));
   }, [booking.id, booking.starts_at, booking.ends_at]);
 
-  const [customerId, setCustomerId] = useState<string>(booking.customer_id ?? "");
+  const [customerId, setCustomerId] = useState<string>(
+    booking.customer_id ?? "",
+  );
   const [customerName, setCustomerName] = useState(booking.customer_name ?? "");
-  const [customerEmail, setCustomerEmail] = useState(booking.customer_email ?? "");
-  const [customerPhone, setCustomerPhone] = useState(booking.customer_phone ?? "");
+  const [customerEmail, setCustomerEmail] = useState(
+    booking.customer_email ?? "",
+  );
+  const [customerPhone, setCustomerPhone] = useState(
+    booking.customer_phone ?? "",
+  );
   const [notes, setNotes] = useState(booking.notes ?? "");
   const [status, setStatus] = useState(booking.status ?? "pending");
 
@@ -1283,7 +1562,9 @@ function EditForm({
     const name = full || `${first} ${last}`.trim();
 
     setCustomerName(name || "");
-    setCustomerEmail(safeString(rec["email"]) || safeString(rec["contact_email"]));
+    setCustomerEmail(
+      safeString(rec["email"]) || safeString(rec["contact_email"]),
+    );
     setCustomerPhone(safeString(rec["phone"]) || safeString(rec["mobile"]));
   };
 
@@ -1308,7 +1589,9 @@ function EditForm({
         });
       }}
     >
-      <h3 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Edit appointment</h3>
+      <h3 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+        Edit appointment
+      </h3>
 
       <div className="grid gap-2 sm:grid-cols-2">
         <label className="text-xs text-[color:var(--theme-text-secondary)]">
@@ -1361,11 +1644,7 @@ function EditForm({
 
       <label className="text-xs text-[color:var(--theme-text-secondary)]">
         Customer name
-        <input
-          value={customerName}
-          onChange={(e) => setCustomerName(e.target.value)}
-          className={fieldClass()}
-        />
+        <input value={customerName} disabled className={fieldClass()} />
       </label>
 
       <div className="grid gap-2 sm:grid-cols-2">
@@ -1374,19 +1653,20 @@ function EditForm({
           <input
             type="email"
             value={customerEmail}
-            onChange={(e) => setCustomerEmail(e.target.value)}
+            disabled
             className={fieldClass()}
           />
         </label>
         <label className="text-xs text-[color:var(--theme-text-secondary)]">
           Phone
-          <input
-            value={customerPhone}
-            onChange={(e) => setCustomerPhone(e.target.value)}
-            className={fieldClass()}
-          />
+          <input value={customerPhone} disabled className={fieldClass()} />
         </label>
       </div>
+
+      <p className="text-xs text-[color:var(--theme-text-muted)]">
+        Contact details come from the customer profile. Select a different
+        customer above to reassign this appointment.
+      </p>
 
       <label className="text-xs text-[color:var(--theme-text-secondary)]">
         Notes
@@ -1400,7 +1680,11 @@ function EditForm({
 
       <label className="text-xs text-[color:var(--theme-text-secondary)]">
         Status
-        <select value={status} onChange={(e) => setStatus(e.target.value)} className={fieldClass()}>
+        <select
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          className={fieldClass()}
+        >
           <option value="pending">Pending</option>
           <option value="confirmed">Confirmed</option>
           <option value="cancelled">Cancelled</option>
@@ -1418,18 +1702,23 @@ function EditForm({
           type="button"
           size="sm"
           variant="ghost"
-          className="text-red-300 hover:bg-red-900/25"
+          className="text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/25"
           onClick={onDelete}
         >
-          Delete
+          Cancel appointment
         </Button>
       </div>
 
       <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-[0.75rem] text-[color:var(--theme-text-muted)]">
-        <div className="font-semibold text-[color:var(--theme-text-secondary)]">Current time window</div>
-        <div className="mt-1">{formatRange(booking.starts_at, booking.ends_at)}</div>
+        <div className="font-semibold text-[color:var(--theme-text-secondary)]">
+          Current time window
+        </div>
+        <div className="mt-1">
+          {formatRange(booking.starts_at, booking.ends_at)}
+        </div>
         <div className="mt-2 text-[color:var(--theme-text-muted)]">
-          Tip: If times looked “shifted” before, that was UTC slicing. This form now uses local time.
+          Tip: If times looked “shifted” before, that was UTC slicing. This form
+          now uses local time.
         </div>
       </div>
     </form>

--- a/app/globals.css
+++ b/app/globals.css
@@ -106,6 +106,66 @@ html {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* The public marketing site has a deliberate light presentation independent
+   of the signed-in application's saved theme preference. */
+.pfq-marketing {
+  --marketing-bg: #f7f5f1;
+  --marketing-surface: #ffffff;
+  --marketing-stone: #f0ece6;
+  --marketing-ink: #17202a;
+  --marketing-muted: #5f6b76;
+  --marketing-border: #ddd8d0;
+  --marketing-border-strong: #c9c2b8;
+  --marketing-copper: #c1663b;
+  --marketing-copper-dark: #8f4528;
+  --marketing-copper-light: #e7a57c;
+  --marketing-copper-soft: #f7e3d7;
+  --marketing-steel: #355b75;
+
+  --pfq-copper: var(--marketing-copper);
+  --accent-copper: var(--marketing-copper);
+  --accent-copper-soft: var(--marketing-copper-dark);
+  --accent-copper-light: var(--marketing-copper-dark);
+  --theme-surface-page: var(--marketing-bg);
+  --theme-surface-panel: #ffffff;
+  --theme-surface-panel-strong: #ffffff;
+  --theme-surface-inset: var(--marketing-stone);
+  --theme-surface-subtle: rgba(95, 107, 118, 0.09);
+  --theme-surface-hover: rgba(95, 107, 118, 0.14);
+  --theme-surface-overlay: rgba(255, 255, 255, 0.98);
+  --theme-backdrop: rgba(23, 32, 42, 0.36);
+  --theme-border-soft: var(--marketing-border);
+  --theme-border-strong: var(--marketing-border-strong);
+  --theme-text-primary: var(--marketing-ink);
+  --theme-text-secondary: var(--marketing-muted);
+  --theme-text-muted: #78838d;
+  --theme-text-on-accent: #ffffff;
+  --theme-card-bg: #ffffff;
+  --theme-card-border: var(--marketing-border);
+  --theme-input-bg: #ffffff;
+  --theme-input-border: var(--marketing-border-strong);
+  --theme-input-text: var(--marketing-ink);
+  --theme-shadow-soft: 0 12px 30px rgba(23, 32, 42, 0.08);
+  --theme-shadow-medium: 0 22px 55px rgba(23, 32, 42, 0.11);
+  color-scheme: light;
+}
+
+.marketing-eyebrow {
+  color: var(--marketing-copper-dark);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.marketing-heading {
+  color: var(--marketing-ink);
+  font-size: clamp(2.25rem, 4.4vw, 3.5rem);
+  font-weight: 600;
+  letter-spacing: -0.045em;
+  line-height: 1.06;
+}
+
 html[data-theme-mode="light"] {
   /* BrandThemeBoot writes brand values inline, so mode tokens intentionally
      use !important to remain authoritative when the mode changes. */
@@ -179,6 +239,88 @@ html[data-theme-mode="light"] {
   --app-shell-bg:
     radial-gradient(circle at top, color-mix(in srgb, var(--brand-primary) 12%, transparent), transparent 55%),
     linear-gradient(180deg, var(--theme-app-bg), var(--theme-app-bg-secondary)) !important;
+}
+
+/* Keep pastel status pills readable against light surfaces without changing
+   their existing dark-mode colors or non-pill accent text. */
+html[data-theme-mode="light"] [class*="rounded"][class~="text-red-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-red-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-red-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-red-400"] {
+  color: #b91c1c;
+}
+
+html[data-theme-mode="light"] [class*="rounded"][class~="text-amber-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-amber-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-amber-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-amber-400"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-yellow-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-yellow-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-yellow-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-yellow-400"] {
+  color: #92400e;
+}
+
+html[data-theme-mode="light"] [class*="rounded"][class~="text-green-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-green-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-green-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-green-400"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-emerald-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-emerald-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-emerald-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-emerald-400"] {
+  color: #047857;
+}
+
+html[data-theme-mode="light"] [class*="rounded"][class~="text-cyan-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-cyan-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-cyan-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-cyan-400"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-sky-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-sky-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-sky-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-sky-400"] {
+  color: #0369a1;
+}
+
+html[data-theme-mode="light"] [class*="rounded"][class~="text-blue-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-blue-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-blue-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-blue-400"] {
+  color: #1d4ed8;
+}
+
+html[data-theme-mode="light"] [class*="rounded"][class~="text-violet-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-violet-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-violet-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-violet-400"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-purple-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-purple-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-purple-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-purple-400"] {
+  color: #6d28d9;
+}
+
+html[data-theme-mode="light"] [class*="rounded"][class~="text-orange-50"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-orange-100"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-orange-200"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-orange-300"],
+html[data-theme-mode="light"] [class*="rounded"][class~="text-orange-400"],
+html[data-theme-mode="light"] [class*="rounded"][class*="text-[var(--accent-copper"],
+html[data-theme-mode="light"] [class*="rounded"][class*="text-[color:var(--accent-copper"],
+html[data-theme-mode="light"] .accent-chip {
+  color: #9a4b2b;
+}
+
+/* Header action controls are not status pills. Give them an explicit mode-aware
+   text contract so translucent header surfaces cannot wash out their labels. */
+.app-shell-action {
+  color: var(--theme-text-primary) !important;
+}
+
+html[data-theme-mode="light"] .app-shell-action {
+  background: rgba(255, 255, 255, 0.92) !important;
+  color: #0f172a !important;
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,8 +25,9 @@ const blackOps = Black_Ops_One({
 });
 
 export const metadata = {
-  title: "ProFixIQ",
-  description: "Tech tools for modern shops",
+  title: "ProFixIQ | The operating system for modern repair shops",
+  description:
+    "Voice inspections, technician-built repairs, approvals, parts workflows, workforce operations, and fleet transparency—connected in one repair shop operating system.",
 };
 
 export default async function RootLayout({

--- a/app/portal/booking/BookingPageClient.tsx
+++ b/app/portal/booking/BookingPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Toaster, toast } from "sonner";
@@ -48,7 +48,9 @@ export default function PortalBookingPage() {
 
   const initialRequestedDate = dateFromSearch(search.get("requestedDate"));
   const [month, setMonth] = useState(() => initialRequestedDate ?? new Date());
-  const [selectedDate, setSelectedDate] = useState<Date | undefined>(initialRequestedDate);
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(
+    initialRequestedDate,
+  );
 
   const [loading, setLoading] = useState(false);
   const [shops, setShops] = useState<ShopOption[]>([]);
@@ -64,6 +66,7 @@ export default function PortalBookingPage() {
     type: "success" | "error";
     text: string;
   } | null>(null);
+  const bookingAttemptRef = useRef<{ slot: string; key: string } | null>(null);
 
   useEffect(() => {
     const urlShop = search.get("shop") || "";
@@ -213,20 +216,34 @@ export default function PortalBookingPage() {
 
   async function book(startIso: string, endIso: string) {
     try {
+      if (bookingAttemptRef.current?.slot !== startIso) {
+        bookingAttemptRef.current = {
+          slot: startIso,
+          key: crypto.randomUUID(),
+        };
+      }
+      const operationKey = bookingAttemptRef.current.key;
       const res = await fetch("/api/portal/bookings", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": operationKey,
+        },
         body: JSON.stringify({
           shopSlug,
           startsAt: startIso,
           endsAt: endIso,
           notes: "",
+          operationKey,
         }),
       });
       const j = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(j?.error || "Booking failed");
 
-      toast.success("Appointment requested! We’ll email you when it’s confirmed.");
+      toast.success(
+        "Appointment requested! We’ll email you when it’s confirmed.",
+      );
+      bookingAttemptRef.current = null;
       setSlots((prev) => prev.filter((s) => s.start !== startIso));
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "Could not book.";
@@ -300,7 +317,9 @@ export default function PortalBookingPage() {
         <div>
           <h1
             className="text-lg tracking-[0.18em] text-[var(--accent-copper-light)]"
-            style={{ fontFamily: "var(--font-blackops), system-ui, sans-serif" }}
+            style={{
+              fontFamily: "var(--font-blackops), system-ui, sans-serif",
+            }}
           >
             Book service appointment
           </h1>
@@ -319,7 +338,9 @@ export default function PortalBookingPage() {
               const slug = e.target.value;
               setShopSlug(slug);
               setSelectedDate(undefined);
-              router.replace(`/portal/booking?shop=${encodeURIComponent(slug)}`);
+              router.replace(
+                `/portal/booking?shop=${encodeURIComponent(slug)}`,
+              );
             }}
             className="min-w-[200px] rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-sm text-[color:var(--theme-text-primary)] outline-none"
           >
@@ -337,11 +358,17 @@ export default function PortalBookingPage() {
       </div>
 
       <div className="mb-6 rounded-2xl border border-[rgba(197,122,74,0.22)] bg-[var(--theme-gradient-panel)] p-4 backdrop-blur-xl">
-        <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Send me my portal link</h2>
+        <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+          Send me my portal link
+        </h2>
         <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-          Need to book or view service? Send yourself a secure portal link first.
+          Need to book or view service? Send yourself a secure portal link
+          first.
         </p>
-        <form className="mt-3 grid gap-2 sm:grid-cols-2" onSubmit={requestPortalAccess}>
+        <form
+          className="mt-3 grid gap-2 sm:grid-cols-2"
+          onSubmit={requestPortalAccess}
+        >
           <input
             type="email"
             required
@@ -375,7 +402,9 @@ export default function PortalBookingPage() {
         {portalMessage && (
           <p
             className={`mt-2 text-xs ${
-              portalMessage.type === "success" ? "text-emerald-300" : "text-rose-300"
+              portalMessage.type === "success"
+                ? "text-emerald-300"
+                : "text-rose-300"
             }`}
           >
             {portalMessage.text}
@@ -396,7 +425,9 @@ export default function PortalBookingPage() {
         </div>
 
         <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 backdrop-blur-xl">
-          <h2 className="mb-1 font-semibold text-[color:var(--theme-text-primary)]">Step 3 • Select time</h2>
+          <h2 className="mb-1 font-semibold text-[color:var(--theme-text-primary)]">
+            Step 3 • Select time
+          </h2>
           <p className="mb-3 text-xs text-[color:var(--theme-text-secondary)]">
             Times shown in <span className="font-medium">{tz}</span>.
             {closedLabel && (
@@ -415,10 +446,14 @@ export default function PortalBookingPage() {
               Pick a date in Step 2 to see time slots.
             </p>
           ) : loading ? (
-            <p className="text-sm text-[color:var(--theme-text-secondary)]">Loading available times…</p>
+            <p className="text-sm text-[color:var(--theme-text-secondary)]">
+              Loading available times…
+            </p>
           ) : daySlots.length === 0 ? (
             isSelectedClosed ? (
-              <p className="text-sm text-[color:var(--theme-text-secondary)]">Shop is closed on this day.</p>
+              <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                Shop is closed on this day.
+              </p>
             ) : (
               <p className="text-sm text-[color:var(--theme-text-secondary)]">
                 No available slots on this date. Try another day.

--- a/app/portal/customer-appointments/page.tsx
+++ b/app/portal/customer-appointments/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Toaster, toast } from "sonner";
@@ -21,7 +21,6 @@ type PortalBooking = {
   status?: string | null;
 };
 
-
 function cardClass() {
   return "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 backdrop-blur-md shadow-card";
 }
@@ -29,9 +28,9 @@ function cardClass() {
 function pillClass(status?: string | null) {
   const s = (status || "pending").toLowerCase();
   if (s === "confirmed")
-    return "border-emerald-500/30 bg-emerald-900/15 text-emerald-200";
+    return "border-emerald-500/30 bg-emerald-50 text-emerald-800 dark:bg-emerald-950/30 dark:text-emerald-200";
   if (s === "cancelled")
-    return "border-red-500/30 bg-red-900/15 text-red-200";
+    return "border-red-500/30 bg-red-50 text-red-800 dark:bg-red-950/30 dark:text-red-200";
   return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]";
 }
 
@@ -67,6 +66,7 @@ export default function PortalCustomerAppointmentsPage() {
 
   const [bookings, setBookings] = useState<PortalBooking[]>([]);
   const [loadingBookings, setLoadingBookings] = useState(false);
+  const cancellationKeys = useRef<Record<string, string>>({});
 
   useEffect(() => {
     let cancelled = false;
@@ -115,7 +115,9 @@ export default function PortalCustomerAppointmentsPage() {
     (async () => {
       setLoadingBookings(true);
       try {
-        const res = await fetch("/api/portal/customer-bookings", { cache: "no-store" });
+        const res = await fetch("/api/portal/customer-bookings", {
+          cache: "no-store",
+        });
 
         if (!res.ok) throw new Error("Failed to load your appointments.");
 
@@ -157,16 +159,22 @@ export default function PortalCustomerAppointmentsPage() {
     if (!confirm("Cancel this appointment?")) return;
 
     try {
+      const operationKey = cancellationKeys.current[id] ?? crypto.randomUUID();
+      cancellationKeys.current[id] = operationKey;
       const res = await fetch(`/api/portal/customer-bookings/${id}`, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "cancelled" }),
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": operationKey,
+        },
+        body: JSON.stringify({ status: "cancelled", operationKey }),
       });
 
       const j = (await res.json().catch(() => ({}))) as { error?: string };
       if (!res.ok) throw new Error(j?.error || "Cancel failed");
 
       toast.success("Appointment cancelled.");
+      delete cancellationKeys.current[id];
       setBookings((prev) =>
         prev.map((b) => (b.id === id ? { ...b, status: "cancelled" } : b)),
       );
@@ -179,7 +187,11 @@ export default function PortalCustomerAppointmentsPage() {
   if (loading) {
     return (
       <div className="mx-auto max-w-xl">
-        <div className={cardClass() + " text-sm text-[color:var(--theme-text-primary)]"}>
+        <div
+          className={
+            cardClass() + " text-sm text-[color:var(--theme-text-primary)]"
+          }
+        >
           Loading your portal…
         </div>
       </div>
@@ -237,14 +249,20 @@ export default function PortalCustomerAppointmentsPage() {
             Upcoming ({upcoming.length})
           </h2>
           {loadingBookings ? (
-            <span className="text-[0.75rem] text-[color:var(--theme-text-secondary)]">Loading…</span>
+            <span className="text-[0.75rem] text-[color:var(--theme-text-secondary)]">
+              Loading…
+            </span>
           ) : null}
         </div>
 
         {loadingBookings ? (
-          <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">Fetching your bookings…</p>
+          <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">
+            Fetching your bookings…
+          </p>
         ) : upcoming.length === 0 ? (
-          <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">No upcoming appointments.</p>
+          <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">
+            No upcoming appointments.
+          </p>
         ) : (
           <ul className="mt-3 space-y-2">
             {upcoming.map((b) => {
@@ -259,7 +277,9 @@ export default function PortalCustomerAppointmentsPage() {
                       <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
                         {date}
                       </div>
-                      <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">{time}</div>
+                      <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
+                        {time}
+                      </div>
 
                       {b.notes ? (
                         <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
@@ -283,7 +303,7 @@ export default function PortalCustomerAppointmentsPage() {
                         size="xs"
                         variant="outline"
                         onClick={() => void cancelBooking(b.id)}
-                        className="border-red-500/40 text-red-200 hover:bg-red-900/20"
+                        className="border-red-500/40 text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/30"
                       >
                         Cancel
                       </Button>
@@ -302,9 +322,13 @@ export default function PortalCustomerAppointmentsPage() {
         </h2>
 
         {loadingBookings ? (
-          <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">Loading…</p>
+          <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">
+            Loading…
+          </p>
         ) : past.length === 0 ? (
-          <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">No past appointments.</p>
+          <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">
+            No past appointments.
+          </p>
         ) : (
           <ul className="mt-3 space-y-2">
             {past.slice(0, 25).map((b) => {
@@ -319,7 +343,9 @@ export default function PortalCustomerAppointmentsPage() {
                       <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
                         {date}
                       </div>
-                      <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">{time}</div>
+                      <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
+                        {time}
+                      </div>
                     </div>
 
                     <span
@@ -333,7 +359,9 @@ export default function PortalCustomerAppointmentsPage() {
                   </div>
 
                   {b.notes ? (
-                    <div className="mt-2 text-xs text-[color:var(--theme-text-muted)]">{b.notes}</div>
+                    <div className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
+                      {b.notes}
+                    </div>
                   ) : null}
                 </li>
               );

--- a/features/dashboard/components/OperationalViewSwitcher.tsx
+++ b/features/dashboard/components/OperationalViewSwitcher.tsx
@@ -77,7 +77,7 @@ export function OperationalViewSwitcher({
             aria-current={active ? "page" : undefined}
             className={cn(
               "whitespace-nowrap rounded-xl px-3 py-2 font-medium text-[color:var(--theme-text-secondary)] transition hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/70",
-              active && "bg-orange-500/20 text-orange-100 shadow-[inset_0_0_0_1px_rgba(251,146,60,0.35)]",
+              active && "bg-orange-500/20 text-orange-900 shadow-[inset_0_0_0_1px_rgba(251,146,60,0.35)] dark:text-orange-100",
             )}
           >
             {view.label}

--- a/features/inspections/components/InspectionModal.tsx
+++ b/features/inspections/components/InspectionModal.tsx
@@ -227,41 +227,40 @@ export default function InspectionModal({
     };
   }, [open]);
 
-  const panelWidth = compact ? "max-w-4xl" : "max-w-6xl";
-  const bodyHeight = compact ? "max-h-[80vh]" : "max-h-[92vh]";
+  const panelWidth = compact ? "max-w-6xl" : "max-w-[1440px]";
+  const bodyHeight = compact ? "h-[78vh]" : "h-[calc(94vh-64px)]";
 
   const cardBase =
-    "rounded-2xl border border-[color:var(--theme-border-soft)] " +
-    "bg-[var(--theme-gradient-panel)] " +
-    "shadow-[var(--theme-shadow-medium)] backdrop-blur-xl";
+    "overflow-hidden rounded-[1.5rem] border border-[color:var(--theme-border-strong)] " +
+    "bg-[color:var(--theme-surface-panel-strong)] " +
+    "shadow-[0_32px_90px_rgba(15,23,42,0.28)]";
 
-  const innerShell = "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)]";
+  const innerShell = "bg-[color:var(--theme-surface-page)]";
 
   return (
     <Dialog
       open={open}
       // ✅ Backdrop click + Esc will call close()
       onClose={close}
-      className="fixed inset-0 z-[300] flex items-center justify-center px-2 py-6 sm:px-4"
+      className="pfq-inspection-modal fixed inset-0 z-[300] flex items-center justify-center px-2 py-3 sm:px-4 sm:py-5"
     >
       {/* clickable dimmed backdrop */}
-      <div className="fixed inset-0 z-[290] bg-[color:var(--theme-surface-overlay)] backdrop-blur-sm" aria-hidden />
+      <div className="fixed inset-0 z-[290] bg-slate-950/55 backdrop-blur-[3px]" aria-hidden />
 
       <Dialog.Panel
         className={`relative z-[310] mx-auto w-full ${panelWidth} ${cardBase}`}
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-start justify-between gap-3 rounded-t-2xl border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-4 py-2.5">
-          <div className="space-y-1">
-            <Dialog.Title className="text-base font-semibold tracking-wide text-foreground sm:text-lg">
+        <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] px-4 py-3 sm:px-5">
+          <div className="min-w-0">
+            <Dialog.Title className="text-base font-semibold tracking-[-0.02em] text-[color:var(--theme-text-primary)] sm:text-lg">
               {title}
             </Dialog.Title>
 
             {derived.displayTemplate && (
-              <p className="text-[10px] text-muted-foreground">
-                Template:{" "}
-                <span className="font-mono text-[rgba(184,115,51,0.95)]">
+              <p className="mt-0.5 truncate text-xs text-[color:var(--theme-text-secondary)]">
+                <span className="font-medium text-[color:var(--brand-primary)]">
                   {derived.displayTemplate}
                 </span>
               </p>
@@ -272,14 +271,14 @@ export default function InspectionModal({
             <button
               type="button"
               onClick={() => setCompact((v) => !v)}
-              className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 py-1.5 text-[11px] text-foreground hover:border-[rgba(184,115,51,0.9)] hover:bg-[color:var(--theme-surface-panel)]"
+              className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--brand-primary)]"
             >
               {compact ? "Expand" : "Shrink"}
             </button>
             <button
               type="button"
               onClick={close}
-              className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-2 py-1 text-xs text-muted-foreground hover:bg-[color:var(--theme-surface-panel-strong)]"
+              className="grid h-9 w-9 place-items-center rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-sm text-[color:var(--theme-text-secondary)] transition hover:border-[color:var(--brand-primary)] hover:text-[color:var(--theme-text-primary)]"
               aria-label="Close inspection"
             >
               ✕
@@ -290,14 +289,14 @@ export default function InspectionModal({
         {/* Body */}
         <div
           ref={scrollRef}
-          className={`${bodyHeight} overflow-y-auto overscroll-contain ${innerShell} rounded-b-2xl p-4 text-foreground`}
+          className={`${bodyHeight} overflow-y-auto overscroll-contain ${innerShell} text-[color:var(--theme-text-primary)]`}
           style={{
             WebkitOverflowScrolling: "touch",
             scrollbarGutter: "stable both-edges",
           }}
         >
           {derived.missingWOLine && (
-            <div className="mb-3 rounded-xl border border-amber-500/40 bg-amber-950/40 px-3 py-2 text-xs text-amber-100">
+            <div className="m-4 rounded-xl border border-amber-400/50 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:bg-amber-950/40 dark:text-amber-100">
               <strong>Heads up:</strong>{" "}
               <code className="font-mono text-amber-50">workOrderLineId</code> is
               missing; save/finish will be blocked.
@@ -309,30 +308,10 @@ export default function InspectionModal({
               No inspection selected.
             </div>
           ) : (
-            <div className="mx-auto w-full max-w-5xl">
+            <div className="mx-auto w-full">
               <InspectionHost template={derived.screenTemplate} embed params={derived.params} />
             </div>
           )}
-
-          {/* Footer actions */}
-          <div className="sticky bottom-0 mt-4 flex flex-col gap-2 border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] pt-3 sm:flex-row sm:items-center sm:justify-between">
-            <button
-              type="button"
-              onClick={() => setCompact((v) => !v)}
-              className="inline-flex items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 py-1.5 text-xs text-muted-foreground hover:border-[rgba(184,115,51,0.9)] hover:text-foreground hover:bg-[color:var(--theme-surface-panel)] sm:text-[11px]"
-            >
-              {compact ? "Expand view" : "Shrink view"}
-            </button>
-            <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={close}
-                className="rounded-full border border-[rgba(184,115,51,0.9)] bg-[rgba(184,115,51,0.12)] px-4 py-1.5 text-xs font-medium text-[rgba(252,211,77,0.98)] hover:bg-[rgba(184,115,51,0.22)] sm:text-sm"
-              >
-                Close inspection
-              </button>
-            </div>
-          </div>
         </div>
       </Dialog.Panel>
     </Dialog>

--- a/features/inspections/components/inspection/InspectionSignaturePanel.tsx
+++ b/features/inspections/components/inspection/InspectionSignaturePanel.tsx
@@ -241,18 +241,18 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-2 rounded-md border border-zinc-800 bg-[color:var(--theme-surface-overlay)] p-3 text-xs text-zinc-200">
+    <div className="flex flex-col gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-4 text-xs text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-soft)]">
       <div className="flex items-center justify-between gap-2">
         <div>
-          <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-400">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
             {header}
           </div>
-          <div className="text-[11px] text-zinc-500">{roleSubtext(role)}</div>
+          <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-secondary)]">{roleSubtext(role)}</div>
         </div>
       </div>
 
       <label
-        className="mt-1 text-[11px] text-zinc-300"
+        className="mt-1 text-[11px] font-medium text-[color:var(--theme-text-secondary)]"
         onClick={() => {
           if (!nameLocked) nameInputRef.current?.focus();
         }}
@@ -265,44 +265,44 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           onChange={(e) => setName(e.target.value)}
           disabled={nameLocked}
           className={[
-            "mt-1 w-full rounded border px-2 py-1 text-xs outline-none",
+            "mt-1 h-10 w-full rounded-lg border px-3 py-2 text-sm outline-none transition",
             nameLocked
-              ? "border-zinc-800 bg-zinc-950 text-zinc-300 opacity-90"
-              : "border-zinc-700 bg-zinc-900 text-zinc-100 focus:border-orange-500",
+              ? "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-secondary)]"
+              : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)] focus:border-[color:var(--brand-primary)] focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-primary)_24%,transparent)]",
           ].join(" ")}
           placeholder={role === "technician" ? "Loading your name…" : "Type your full legal name"}
         />
         {role === "technician" && nameLocked ? (
-          <div className="mt-1 text-[10px] text-zinc-500">
+          <div className="mt-1.5 text-[10px] text-[color:var(--theme-text-secondary)]">
             Tech name is pulled from your profile (edit in your account settings if needed).
           </div>
         ) : null}
       </label>
 
-      <label className="flex items-start gap-2 text-[11px] text-zinc-300">
+      <label className="flex items-start gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2.5 text-[11px] text-[color:var(--theme-text-secondary)]">
         <input
           type="checkbox"
           checked={confirm}
           onChange={(e) => setConfirm(e.target.checked)}
-          className="mt-[1px] h-3 w-3 rounded border border-zinc-600 bg-zinc-900 text-orange-500"
+          className="mt-[1px] h-3.5 w-3.5 rounded border border-[color:var(--theme-border-strong)] bg-[color:var(--theme-surface-page)] text-[color:var(--brand-primary)]"
         />
         <span>{confirmText(role)}</span>
       </label>
 
       {!inspectionId && (
-        <p className="text-[11px] text-amber-300">
+        <p className="rounded-xl border border-amber-500/30 bg-amber-50 px-3 py-2 text-[11px] text-amber-800 dark:bg-amber-950/35 dark:text-amber-200">
           This inspection has not been saved to the database yet. Once it has a persistent{" "}
           <code>inspection_id</code>, this panel will allow signing.
         </p>
       )}
 
       {role === "technician" ? (
-        <p className="text-[11px] text-zinc-400">
+        <p className="text-[11px] text-[color:var(--theme-text-secondary)]">
           If signing fails, it usually means no saved signature exists yet.
           {techSettingsHref ? (
             <>
               {" "}
-              Add one in <span className="text-zinc-300">Tech Settings</span>.
+              Add one in <span className="font-medium text-[color:var(--theme-text-primary)]">Tech Settings</span>.
             </>
           ) : null}
         </p>
@@ -313,7 +313,7 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           type="button"
           onClick={handleSign}
           disabled={busy || !inspectionId}
-          className="inline-flex items-center rounded-full border border-orange-500/80 bg-orange-500/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-orange-100 shadow-[0_0_18px_rgba(248,113,113,0.65)] hover:bg-orange-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex items-center rounded-lg border border-[color:var(--brand-primary)] bg-[color:var(--brand-primary)] px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {busy ? "Signing…" : "Sign"}
         </button>

--- a/features/inspections/lib/inspection/InspectionItemCard.tsx
+++ b/features/inspections/lib/inspection/InspectionItemCard.tsx
@@ -157,7 +157,7 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
                 ref={labelRef}
                 className={[
                   "block min-w-0",
-                  expanded ? "whitespace-normal break-words" : "line-clamp-2 lg:truncate",
+                  expanded ? "whitespace-normal break-words" : "line-clamp-2",
                   expandEnabled && !expanded ? "cursor-help" : "",
                 ].join(" ")}
                 onMouseEnter={onMouseEnter}

--- a/features/inspections/lib/inspection/PauseResume.tsx
+++ b/features/inspections/lib/inspection/PauseResume.tsx
@@ -15,13 +15,13 @@ export default function PauseResumeButton({
   disabled,
 }: PauseResumeButtonProps) {
   return (
-    <div className="mt-2 text-center">
+    <div className="text-center">
       {isPaused ? (
         <button
           type="button"
           onClick={onResume}
           disabled={disabled}
-          className="rounded bg-green-600 px-4 py-2 font-bold text-[color:var(--theme-text-primary)] hover:bg-green-700 disabled:opacity-50"
+          className="rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold text-white hover:bg-white/15 disabled:opacity-50"
         >
           Resume
         </button>
@@ -30,7 +30,7 @@ export default function PauseResumeButton({
           type="button"
           onClick={onPause}
           disabled={disabled}
-          className="rounded bg-yellow-600 px-4 py-2 font-bold text-[color:var(--theme-text-primary)] hover:bg-yellow-700 disabled:opacity-50"
+          className="rounded-lg border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold text-white hover:bg-white/15 disabled:opacity-50"
         >
           Pause
         </button>

--- a/features/inspections/lib/inspection/ProgressTracker.tsx
+++ b/features/inspections/lib/inspection/ProgressTracker.tsx
@@ -15,10 +15,22 @@ const ProgressTracker = ({
   totalSections,
   totalItems,
 }: ProgressTrackerProps) => {
+  const sectionProgress = totalSections > 0 ? currentSection / totalSections : 0;
+  const itemProgress = totalItems > 0 ? currentItem / totalItems / Math.max(totalSections, 1) : 0;
+  const progress = Math.min(100, Math.max(2, (sectionProgress + itemProgress) * 100));
+
   return (
-    <div className="text-xs text-[color:var(--theme-text-secondary)] text-center mb-2">
-      Section {currentSection + 1} of {totalSections} • Item {currentItem + 1}{" "}
-      of {totalItems}
+    <div className="min-w-[180px] sm:min-w-[240px]">
+      <div className="flex items-center justify-between gap-3 text-xs text-[color:var(--theme-text-secondary)]">
+        <span>Section {currentSection + 1} of {totalSections}</span>
+        <span>Item {Math.min(currentItem + 1, Math.max(totalItems, 1))} of {totalItems}</span>
+      </div>
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[color:var(--theme-surface-inset)]">
+        <div
+          className="h-full rounded-full bg-[color:var(--brand-primary)] transition-[width] duration-300"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
     </div>
   );
 };

--- a/features/inspections/lib/inspection/SectionDisplay.tsx
+++ b/features/inspections/lib/inspection/SectionDisplay.tsx
@@ -10,7 +10,6 @@ import type {
 } from "@inspections/lib/inspection/types";
 import InspectionItemCard from "./InspectionItemCard";
 import { Button } from "@shared/components/ui/Button";
-import Card from "@/features/shared/components/ui/Card";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { pricingStatusClass, pricingStatusText } from "@/features/menu-repair-items/lib/pricingStatus";
 
@@ -253,17 +252,17 @@ export default function SectionDisplay(props: SectionDisplayProps) {
   };
 
   return (
-    <Card className="mb-6 px-4 py-3 md:px-5 md:py-4">
+    <div>
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--theme-card-border,var(--theme-border-soft))] pb-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--theme-card-border,var(--theme-border-soft))] pb-4">
         {gridSection ? (
-          <div className="text-left text-base font-semibold tracking-[0.08em] text-[var(--theme-text-primary,var(--theme-text-primary))] transition-opacity hover:opacity-80 md:text-lg">
+          <div className="text-left text-lg font-semibold tracking-[-0.02em] text-[var(--theme-text-primary,var(--theme-text-primary))] md:text-xl">
             {resolvedTitle}
           </div>
         ) : (
           <button
             onClick={toggleOpen}
-            className="text-left text-base font-semibold tracking-[0.08em] text-[var(--theme-text-primary,var(--theme-text-primary))] transition-opacity hover:opacity-80 md:text-lg"
+            className="text-left text-lg font-semibold tracking-[-0.02em] text-[var(--theme-text-primary,var(--theme-text-primary))] transition-opacity hover:opacity-80 md:text-xl"
             aria-expanded={open}
             type="button"
           >
@@ -285,7 +284,7 @@ export default function SectionDisplay(props: SectionDisplayProps) {
               <Button
                 variant="outline"
                 size="sm"
-                className="h-7 px-2 text-[11px]"
+                className="h-7 border-emerald-500/35 bg-emerald-50 px-2 text-[11px] text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/25 dark:text-emerald-200"
                 onClick={() => markAll("ok")}
                 type="button"
               >
@@ -294,7 +293,7 @@ export default function SectionDisplay(props: SectionDisplayProps) {
               <Button
                 variant="outline"
                 size="sm"
-                className="h-7 px-2 text-[11px]"
+                className="h-7 border-red-500/30 px-2 text-[11px] text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/25"
                 onClick={() => markAll("fail")}
                 type="button"
               >
@@ -303,7 +302,7 @@ export default function SectionDisplay(props: SectionDisplayProps) {
               <Button
                 variant="outline"
                 size="sm"
-                className="h-7 px-2 text-[11px]"
+                className="h-7 border-sky-500/30 px-2 text-[11px] text-sky-700 hover:bg-sky-50 dark:text-sky-200 dark:hover:bg-sky-950/25"
                 onClick={() => markAll("na")}
                 type="button"
               >
@@ -312,7 +311,7 @@ export default function SectionDisplay(props: SectionDisplayProps) {
               <Button
                 variant="outline"
                 size="sm"
-                className="h-7 px-2 text-[11px]"
+                className="h-7 border-amber-500/35 px-2 text-[11px] text-amber-800 hover:bg-amber-50 dark:text-amber-200 dark:hover:bg-amber-950/25"
                 onClick={() => markAll("recommend")}
                 type="button"
               >
@@ -341,9 +340,9 @@ export default function SectionDisplay(props: SectionDisplayProps) {
           {gridSection ? (
             <div />
           ) : (
-            <div className="overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[var(--theme-shadow-medium)]">
+            <div className="overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)]">
               {/* Desktop header row — desktop only */}
-              <div className="hidden border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-2 lg:block">
+              <div className="hidden border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-2.5 lg:block">
                 <div className="grid grid-cols-2 gap-3">
                   <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
                     Item · Status · Notes
@@ -357,25 +356,14 @@ export default function SectionDisplay(props: SectionDisplayProps) {
               {/* Mobile/Tablet: 1 col. Desktop: 2-up on lg+ */}
               <div
                 className={[
-                  "grid gap-2 p-2",
-                  "lg:grid-cols-2 lg:gap-[2px] lg:bg-[color:var(--theme-surface-subtle)] lg:p-[2px]",
-                  "[&>*]:rounded-lg",
+                  "grid gap-2 p-2.5",
+                  "lg:grid-cols-2 lg:gap-3 lg:p-3",
+                  "[&>*]:rounded-xl",
                   "[&>*]:border [&>*]:border-[color:var(--theme-border-soft)]",
-                  "[&>*]:bg-[var(--theme-gradient-panel)]",
-                  "[&>*]:shadow-[var(--theme-shadow-medium)]",
-                  "[&>*]:backdrop-blur-md",
+                  "[&>*]:bg-[color:var(--theme-surface-panel-strong)]",
                   "[&>*]:relative [&>*]:overflow-hidden",
-                  "[&>*]:before:absolute [&>*]:before:inset-x-0 [&>*]:before:top-0 [&>*]:before:h-[2px] [&>*]:before:content-['']",
-                  "[&>*]:before:bg-[linear-gradient(90deg,transparent,rgba(197,122,74,0.85),transparent)]",
                   "[&>*]:transition [&>*]:duration-150",
-                  "[&>*]:hover:-translate-y-[1px]",
-                  "[&>*]:hover:border-[rgba(197,122,74,0.45)]",
-                  "[&>*]:hover:shadow-[var(--theme-shadow-medium)]",
-                  "[&>*]:hover:bg-[var(--theme-gradient-panel)]",
-                  "[&>*:nth-child(odd)]:brightness-[1.02]",
-                  "[&>*:nth-child(even)]:brightness-[0.98]",
-                  "lg:[&>*:nth-child(4n+1)]:brightness-[1.02] lg:[&>*:nth-child(4n+2)]:brightness-[1.02]",
-                  "lg:[&>*:nth-child(4n+3)]:brightness-[0.98] lg:[&>*:nth-child(4n+4)]:brightness-[0.98]",
+                  "[&>*]:hover:border-[color:var(--theme-border-strong)]",
                 ].join(" ")}
               >
                 {items.map((item, itemIndex) => {
@@ -430,7 +418,8 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                     <div
                       key={keyBase}
                       className={[
-                        "relative px-3 py-3",
+                        "relative px-3 py-3.5",
+                        isFailOrRec ? "lg:col-span-2" : "",
                         "before:absolute before:left-0 before:top-0 before:h-full before:w-[3px] before:content-['']",
                         rail,
                         submitted ? "ring-1 ring-emerald-500/35" : "",
@@ -937,6 +926,6 @@ export default function SectionDisplay(props: SectionDisplayProps) {
           )}
         </div>
       )}
-    </Card>
+    </div>
   );
 }

--- a/features/inspections/lib/inspection/StartListeningButton.tsx
+++ b/features/inspections/lib/inspection/StartListeningButton.tsx
@@ -41,17 +41,17 @@ export default function StartListeningButton({
       size="sm"
       aria-pressed={isListening}
       aria-label={isListening ? "Voice listening active" : "Start voice listening"}
-      className={`inline-flex items-center gap-2 rounded-full text-[11px] font-semibold uppercase tracking-[0.18em] ${
+      className={`inline-flex items-center gap-2 rounded-lg border-white/20 text-[11px] font-semibold tracking-[0.04em] ${
         isListening
-          ? "border-[color:var(--accent-copper-soft,#f97316)] bg-[color:var(--theme-surface-overlay)] text-[color:var(--accent-copper,#f97316)]"
-          : "bg-[linear-gradient(to_right,var(--accent-copper-soft,#fb923c),var(--accent-copper,#ea580c))] text-[color:var(--theme-text-on-accent)] shadow-[0_0_18px_rgba(234,88,12,0.6)]"
+          ? "bg-white/10 text-white"
+          : "bg-[color:var(--brand-primary)] text-white shadow-none"
       }`}
     >
       <span
         className={`inline-block h-2 w-2 rounded-full ${
           isListening
-            ? "bg-[color:var(--accent-copper,#f97316)] animate-pulse"
-            : "bg-[color:var(--theme-surface-overlay)]"
+            ? "bg-orange-300 animate-pulse"
+            : "bg-white"
         }`}
       />
       {isListening ? "Listening…" : "Start Listening"}

--- a/features/inspections/lib/inspection/StatusButtons.tsx
+++ b/features/inspections/lib/inspection/StatusButtons.tsx
@@ -40,7 +40,7 @@ type StatusButtonsProps = {
  * - Uses gap instead of mr/mb (cleaner wrapping)
  * - Supports compact mode
  */
-export default function StatusButtons(_props: any) {
+export default function StatusButtons(_props: StatusButtonsProps) {
   const {
     item,
     sectionIndex,
@@ -54,21 +54,21 @@ export default function StatusButtons(_props: any) {
   const selected = item.status;
 
   const size = compact
-    ? "h-7 px-2.5 text-[10px]"
-    : "h-8 px-3 text-[11px]";
+    ? "h-8 px-2.5 text-[10px]"
+    : "h-9 px-3 text-[11px]";
 
   const container = wrap
-    ? "mt-1 flex flex-wrap items-center gap-2"
-    : "mt-1 flex items-center gap-2 overflow-x-auto";
+    ? "mt-1 grid grid-cols-4 gap-1"
+    : "mt-1 flex items-center gap-1 overflow-x-auto";
 
   const base =
-    "inline-flex items-center justify-center rounded-md " +
+    "inline-flex min-w-0 items-center justify-center rounded-lg " +
     size +
     " " +
     "select-none " +
     "font-semibold uppercase tracking-[0.16em] " +
-    "border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)] " +
-    "backdrop-blur-sm transition-colors duration-150 " +
+    "border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] text-[color:var(--theme-text-primary)] " +
+    "transition-colors duration-150 " +
     "focus:outline-none focus:ring-2 focus:ring-[rgba(184,115,51,0.55)] " + // copper focus ring
     "focus:ring-offset-2 focus:ring-offset-[color:var(--theme-surface-page)]";
 
@@ -78,38 +78,34 @@ export default function StatusButtons(_props: any) {
     switch (key) {
       case "ok": {
         const selectedClasses =
-          " border-emerald-400/90 text-emerald-50 " +
-          "bg-emerald-900/40 shadow-[0_0_0_1px_rgba(52,211,153,0.7)]";
+          " border-emerald-400/80 bg-emerald-50 text-emerald-800 dark:bg-emerald-950/45 dark:text-emerald-100";
         const hover =
-          " hover:border-emerald-400/80 hover:text-emerald-100 hover:bg-emerald-900/30";
+          " hover:border-emerald-400/80 hover:bg-emerald-50 hover:text-emerald-800 dark:hover:bg-emerald-950/35 dark:hover:text-emerald-100";
         return base + hover + (isSel ? " " + selectedClasses : "");
       }
 
       case "fail": {
         const selectedClasses =
-          " border-red-500/90 text-red-50 " +
-          "bg-red-950/50 shadow-[0_0_0_1px_rgba(248,113,113,0.8)]";
+          " border-red-400/80 bg-red-50 text-red-800 dark:bg-red-950/45 dark:text-red-100";
         const hover =
-          " hover:border-red-500/80 hover:text-red-100 hover:bg-red-950/40";
+          " hover:border-red-400/80 hover:bg-red-50 hover:text-red-800 dark:hover:bg-red-950/35 dark:hover:text-red-100";
         return base + hover + (isSel ? " " + selectedClasses : "");
       }
 
       case "recommend": {
         const selectedClasses =
-          " border-amber-400/90 text-amber-50 " +
-          "bg-amber-950/40 shadow-[0_0_0_1px_rgba(251,191,36,0.85)]";
+          " border-amber-400/80 bg-amber-50 text-amber-900 dark:bg-amber-950/45 dark:text-amber-100";
         const hover =
-          " hover:border-amber-400/80 hover:text-amber-100 hover:bg-amber-950/30";
+          " hover:border-amber-400/80 hover:bg-amber-50 hover:text-amber-900 dark:hover:bg-amber-950/35 dark:hover:text-amber-100";
         return base + hover + (isSel ? " " + selectedClasses : "");
       }
 
       case "na":
       default: {
         const selectedClasses =
-          " border-sky-400/90 text-sky-50 " +
-          "bg-sky-950/40 shadow-[0_0_0_1px_rgba(56,189,248,0.8)]";
+          " border-sky-400/80 bg-sky-50 text-sky-800 dark:bg-sky-950/45 dark:text-sky-100";
         const hover =
-          " hover:border-sky-400/80 hover:text-sky-100 hover:bg-sky-950/30";
+          " hover:border-sky-400/80 hover:bg-sky-50 hover:text-sky-800 dark:hover:bg-sky-950/35 dark:hover:text-sky-100";
         return base + hover + (isSel ? " " + selectedClasses : "");
       }
     }

--- a/features/inspections/lib/inspection/ui/CustomerVehicleHeader.tsx
+++ b/features/inspections/lib/inspection/ui/CustomerVehicleHeader.tsx
@@ -62,28 +62,30 @@ export default function CustomerVehicleHeader({
   ].filter(Boolean) as string[];
 
   return (
-    <div className="mb-4 rounded-lg border border-zinc-800 bg-zinc-900 p-3">
+    <div className="mt-3 border-t border-[color:var(--theme-border-soft)] pt-3">
+      {(templateName || rightSlot) && (
       <div className="mb-2 flex items-start justify-between gap-3">
-        <h1 className="text-xl font-bold text-orange-400">{templateName}</h1>
+        {templateName ? <h1 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">{templateName}</h1> : <span />}
         {rightSlot ? <div className="shrink-0">{rightSlot}</div> : null}
       </div>
+      )}
 
-      <div className="grid gap-2 text-sm text-zinc-200 md:grid-cols-2">
+      <div className="grid gap-3 text-sm md:grid-cols-2">
         {/* Customer */}
-        <div className="rounded border border-zinc-800 bg-zinc-950 p-2">
-          <div className="text-zinc-400">Customer</div>
-          <div className="font-medium">{fullName}</div>
-          <div className="text-zinc-400">
+        <div className="rounded-xl bg-[color:var(--theme-surface-inset)] px-3 py-2.5">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Customer / Fleet</div>
+          <div className="mt-1 font-semibold text-[color:var(--theme-text-primary)]">{fullName}</div>
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">
             {[customer?.phone, customer?.email].filter(Boolean).join(" · ") || "—"}
           </div>
-          {addr ? <div className="text-zinc-400">{addr}</div> : null}
+          {addr ? <div className="text-xs text-[color:var(--theme-text-secondary)]">{addr}</div> : null}
         </div>
 
         {/* Vehicle */}
-        <div className="rounded border border-zinc-800 bg-zinc-950 p-2">
-          <div className="text-zinc-400">Vehicle</div>
-          <div className="font-medium">{vehicleLabel}</div>
-          <div className="text-zinc-400">{subBits.join(" · ") || "—"}</div>
+        <div className="rounded-xl bg-[color:var(--theme-surface-inset)] px-3 py-2.5">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Vehicle</div>
+          <div className="mt-1 font-semibold text-[color:var(--theme-text-primary)]">{vehicleLabel}</div>
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">{subBits.join(" · ") || "—"}</div>
         </div>
       </div>
     </div>

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -48,7 +48,6 @@ import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicl
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
-import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 import { cn } from "@shared/lib/utils";
 
@@ -2525,19 +2524,19 @@ type SmartMatchRow = {
   };
 
   const shell = isEmbed
-    ? "relative mx-auto max-w-[1100px] px-3 py-4 pb-[calc(9rem+env(safe-area-inset-bottom))]"
+    ? "relative mx-auto max-w-[1280px] px-3 py-4 pb-6 md:px-5 md:py-5"
     : "relative mx-auto max-w-5xl px-3 md:px-4 py-6 pb-[calc(9.5rem+env(safe-area-inset-bottom))]";
 
-  const headerCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-5 md:py-4 mb-3 md:mb-4`;
-  const sectionCard = `${PANEL_VARIANTS.primary} px-3 py-3 md:px-5 md:py-5 mb-4 md:mb-6`;
-  const supportCard = `${PANEL_VARIANTS.secondary} px-3 py-2 md:px-4 md:py-2.5`;
-  const passiveCard = `${PANEL_VARIANTS.passive} px-3 py-2.5 md:px-4 md:py-3`;
+  const headerCard = `${PANEL_VARIANTS.primary} rounded-2xl px-4 py-4 md:px-5 md:py-5 mb-3`;
+  const sectionCard = `${PANEL_VARIANTS.primary} rounded-2xl px-3 py-3 md:px-5 md:py-5 mb-4`;
+  const supportCard = "space-y-3";
+  const passiveCard = `${PANEL_VARIANTS.passive} rounded-xl px-3 py-2.5 md:px-4 md:py-3`;
 
   const sectionTitle =
-    "text-base md:text-lg font-semibold text-[var(--theme-text-primary,var(--theme-text-primary))] text-center tracking-[0.12em] uppercase";
+    "text-lg md:text-xl font-semibold text-[var(--theme-text-primary,var(--theme-text-primary))] tracking-[-0.02em]";
 
   const hint =
-    "mt-1 block text-center text-[11px] uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]";
+    "mt-1 block text-xs text-[color:var(--theme-text-secondary)]";
 
 
   const findingsHref = useMemo(() => {
@@ -2627,10 +2626,12 @@ type SmartMatchRow = {
         `}</style>
       )}
 
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 -z-10 bg-[var(--theme-gradient-panel)]"
-      />
+      {!isEmbed && (
+        <div
+          aria-hidden
+          className="pointer-events-none fixed inset-0 -z-10 bg-[var(--theme-gradient-panel)]"
+        />
+      )}
 
       <div className="relative space-y-3">
         <div className={headerCard}>
@@ -2659,93 +2660,68 @@ type SmartMatchRow = {
         </div>
 
         <div className={supportCard}>
-          <div className="flex flex-wrap items-center gap-2">
-            <div className={voicePulse ? "rounded-full shadow-[0_0_0_6px_rgba(16,185,129,0.12)]" : ""}>
-              <StatusBadge
-                variant={
-                  voiceState === "listening"
-                    ? "success"
+          <div className="flex flex-col gap-3 rounded-2xl bg-[#17202a] px-4 py-3 text-white shadow-[0_16px_36px_rgba(15,23,42,0.16)] sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className={cn("grid h-10 w-10 shrink-0 place-items-center rounded-full bg-[color:var(--brand-primary)]", voicePulse && "ring-4 ring-orange-300/20")}>
+                <span className={cn("h-2.5 w-2.5 rounded-full bg-white", voiceState === "listening" && "animate-pulse")} />
+              </div>
+              <div className="min-w-0">
+                <div className="text-sm font-semibold sm:text-base">
+                  {voiceState === "listening"
+                    ? "Listening for the next finding…"
                     : voiceState === "connecting"
-                      ? "warning"
+                      ? "Connecting voice capture…"
                       : voiceState === "error"
-                        ? "danger"
-                        : "neutral"
-                }
-                size="md"
-                className="inline-flex items-center gap-2 px-3 py-1"
-              >
-                <span
-                  className={[
-                    "h-2 w-2 rounded-full",
-                    voiceState === "listening"
-                      ? "bg-emerald-400"
-                      : voiceState === "connecting"
-                        ? "bg-amber-400"
-                        : voiceState === "error"
-                          ? "bg-red-400"
-                          : "bg-[color:var(--theme-surface-subtle)]",
-                    voiceState === "listening" ? "animate-pulse" : "",
-                  ].join(" ")}
-                />
-                {voiceState === "listening"
-                  ? "Listening…"
-                  : voiceState === "connecting"
-                    ? "Connecting…"
-                    : voiceState === "error"
-                      ? "Voice error"
-                      : "Voice idle"}
-                {voicePulse && <span className="text-emerald-200/80">• audio</span>}
-              </StatusBadge>
+                        ? "Voice capture needs attention"
+                        : isPaused
+                          ? "Voice capture paused"
+                          : "Voice capture ready"}
+                </div>
+                <div className="mt-1 flex h-3 items-center gap-0.5" aria-hidden>
+                  {[4, 8, 6, 11, 7, 13, 9, 5, 10, 6, 12, 8, 4, 9, 5, 7].map((height, index) => (
+                    <span key={`${height}-${index}`} className={cn("w-0.5 rounded-full bg-orange-300/80", !isListening && "opacity-25")} style={{ height }} />
+                  ))}
+                  {wakeActive ? <span className="ml-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-orange-200">Ready</span> : null}
+                </div>
+              </div>
             </div>
 
-            {wakeActive && (
-              <div className="rounded-full border border-orange-400/60 bg-orange-500/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-orange-200">
-                Ready
-              </div>
-            )}
+            <div className="flex shrink-0 flex-wrap items-center gap-2">
+              {!isLocked && <StartListeningButton isListening={isListening} onStart={startListening} />}
+              {!isLocked && (isListening || isPaused) && (
+                <PauseResumeButton
+                  isPaused={isPaused}
+                  onPause={() => {
+                    setIsPaused(true);
+                    pauseSession();
+                    stopListening();
+                  }}
+                  onResume={() => {
+                    setIsPaused(false);
+                    resumeSession();
+                    void startListening();
+                  }}
+                />
+              )}
+            </div>
+          </div>
 
-            {!isLocked && (
-              <StartListeningButton isListening={isListening} onStart={startListening} />
-            )}
-
-            {!isLocked && (isListening || isPaused) && (
-              <PauseResumeButton
-                isPaused={isPaused}
-                onPause={() => {
-                  setIsPaused(true);
-                  pauseSession();
-                  stopListening();
-                }}
-                onResume={() => {
-                  setIsPaused(false);
-                  resumeSession();
-                  void startListening();
-                }}
-              />
-            )}
-
+          <div className="flex flex-col gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] px-3 py-3 shadow-[var(--theme-shadow-soft)] sm:flex-row sm:items-center sm:justify-between">
             <Button
               type="button"
               variant="outline"
-              className="w-full justify-center border-orange-300/70 bg-[color:var(--theme-surface-overlay)] text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)] hover:border-orange-400 hover:bg-[color:var(--theme-surface-overlay)] sm:w-auto"
+              size="sm"
+              className="justify-center text-xs font-semibold sm:justify-start"
               onClick={(): void => setUnit(unit === "metric" ? "imperial" : "metric")}
             >
-              Unit: {unit === "metric" ? "Metric (mm / kPa)" : "Imperial (in / psi)"}
+              {unit === "metric" ? "Metric (mm / kPa)" : "Imperial (in / psi)"}
             </Button>
 
-            <div className="ml-auto flex items-center gap-2 text-[11px]">
-              <span className="rounded-full border border-red-500/35 bg-red-500/10 px-2 py-0.5 text-red-100">
-                Fail {failed.length}
-              </span>
-              <span className="rounded-full border border-amber-500/35 bg-amber-500/10 px-2 py-0.5 text-amber-100">
-                Rec {recommended.length}
-              </span>
-              <span className="rounded-full border border-emerald-500/35 bg-emerald-500/10 px-2 py-0.5 text-emerald-100">
-                OK/NA {otherOkNa.length}
-              </span>
-              <span className="rounded-full border border-sky-500/35 bg-sky-500/10 px-2 py-0.5 text-sky-100">
-                WO lines {linesAdded}
-              </span>
+            <div className="grid grid-cols-2 gap-2 text-xs sm:flex sm:items-center">
+              <span className="rounded-full bg-red-50 px-3 py-1.5 font-semibold text-red-700 dark:bg-red-950/35 dark:text-red-200">{failed.length} Fail</span>
+              <span className="rounded-full bg-amber-50 px-3 py-1.5 font-semibold text-amber-800 dark:bg-amber-950/35 dark:text-amber-200">{recommended.length} Recommend</span>
+              <span className="rounded-full bg-emerald-50 px-3 py-1.5 font-semibold text-emerald-700 dark:bg-emerald-950/35 dark:text-emerald-200">{otherOkNa.length} Pass / N/A</span>
+              <span className="rounded-full bg-sky-50 px-3 py-1.5 font-semibold text-sky-700 dark:bg-sky-950/35 dark:text-sky-200">{linesAdded} WO lines</span>
             </div>
           </div>
 
@@ -2860,7 +2836,7 @@ type SmartMatchRow = {
                         <button
                           type="button"
                           disabled={isLocked}
-                          className="rounded-full border border-emerald-500/60 bg-emerald-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-emerald-200 hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded-lg border border-emerald-300 bg-emerald-50 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-emerald-800 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-emerald-500/60 dark:bg-emerald-950/35 dark:text-emerald-100"
                           onClick={() => applyStatusToSection(sectionIndex, "ok")}
                         >
                           All OK
@@ -2868,7 +2844,7 @@ type SmartMatchRow = {
                         <button
                           type="button"
                           disabled={isLocked}
-                          className="rounded-full border border-red-500/60 bg-red-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-red-200 hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded-lg border border-red-300 bg-red-50 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-red-800 hover:bg-red-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-500/60 dark:bg-red-950/35 dark:text-red-100"
                           onClick={() => applyStatusToSection(sectionIndex, "fail")}
                         >
                           All Fail
@@ -2876,7 +2852,7 @@ type SmartMatchRow = {
                         <button
                           type="button"
                           disabled={isLocked}
-                          className="rounded-full border border-zinc-500/60 bg-zinc-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-zinc-200 hover:bg-zinc-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded-lg border border-sky-300 bg-sky-50 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-sky-800 hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-sky-500/60 dark:bg-sky-950/35 dark:text-sky-100"
                           onClick={() => applyStatusToSection(sectionIndex, "na")}
                         >
                           All NA
@@ -2884,7 +2860,7 @@ type SmartMatchRow = {
                         <button
                           type="button"
                           disabled={isLocked}
-                          className="rounded-full border border-amber-500/60 bg-amber-500/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-200 hover:bg-amber-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                          className="rounded-lg border border-amber-300 bg-amber-50 px-2.5 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-amber-900 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-500/60 dark:bg-amber-950/35 dark:text-amber-100"
                           onClick={() =>
                             applyStatusToSection(sectionIndex, "recommend")
                           }
@@ -2893,7 +2869,7 @@ type SmartMatchRow = {
                         </button>
                         <button
                           type="button"
-                          className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-hover)]"
+                          className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] px-2.5 py-1.5 text-[10px] font-semibold tracking-[0.04em] text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-hover)]"
                           onClick={() => toggleSectionCollapsed(sectionIndex)}
                         >
                           {collapsed ? "Expand" : "Collapse"}
@@ -2902,7 +2878,7 @@ type SmartMatchRow = {
                     ) : (
                       <button
                         type="button"
-                        className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-panel-strong)]"
+                        className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] px-3 py-1.5 text-[10px] font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-hover)]"
                         onClick={() => toggleSectionCollapsed(sectionIndex)}
                       >
                         {collapsed ? "Expand" : "Collapse"}
@@ -3187,17 +3163,20 @@ type SmartMatchRow = {
         )}
       </div>
 
-      <div className="fixed inset-x-0 bottom-0 z-40 border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] backdrop-blur">
-        <div className="mx-auto flex max-w-[1100px] flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div className="grid grid-cols-1 gap-2 sm:flex sm:flex-wrap sm:items-center">{actions}</div>
-          <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+      <div className={cn(
+        "z-40 border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] px-3 pt-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] shadow-[0_-12px_30px_rgba(15,23,42,0.08)]",
+        isEmbed ? "sticky bottom-0 -mx-3 md:-mx-5" : "fixed inset-x-0 bottom-0",
+      )}>
+        <div className="mx-auto flex max-w-[1240px] flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="grid grid-cols-2 gap-2 [&>*]:w-full [&>*:last-child:nth-child(odd)]:col-span-2 sm:flex sm:flex-wrap sm:items-center sm:[&>*]:w-auto">{actions}</div>
+          <div className="order-first text-[10px] font-medium text-[color:var(--theme-text-secondary)] sm:order-none">
             Draft auto-saves locally
           </div>
         </div>
       </div>
 
       {showMissingLineWarning && (
-        <div className="fixed inset-x-0 bottom-[52px] z-50 px-3">
+        <div className={cn("inset-x-0 z-50 px-3", isEmbed ? "sticky bottom-[76px]" : "fixed bottom-[52px]")}>
           <div className="mx-auto max-w-[1100px] rounded-xl border border-red-500/40 bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-xs text-red-200 shadow-[var(--theme-shadow-medium)]">
             Missing <code>workOrderLineId</code> — save/finish will be blocked.
           </div>

--- a/features/portal/server/notifyBookingConfirmation.ts
+++ b/features/portal/server/notifyBookingConfirmation.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { sendBookingConfirmation } from "@/features/shared/lib/email/sendEmail";
+
+type BookingForNotification = Pick<
+  Database["public"]["Tables"]["bookings"]["Row"],
+  | "starts_at"
+  | "ends_at"
+  | "customer_id"
+  | "vehicle_id"
+  | "work_order_id"
+  | "shop_id"
+>;
+
+export async function notifyBookingConfirmation(
+  supabase: SupabaseClient<Database>,
+  booking: BookingForNotification,
+): Promise<boolean> {
+  if (!booking.customer_id) return false;
+
+  const [{ data: customer }, { data: vehicle }, { data: shop }] =
+    await Promise.all([
+      supabase
+        .from("customers")
+        .select("first_name,last_name,email")
+        .eq("id", booking.customer_id)
+        .maybeSingle(),
+      booking.vehicle_id
+        ? supabase
+            .from("vehicles")
+            .select("year,make,model")
+            .eq("id", booking.vehicle_id)
+            .maybeSingle()
+        : Promise.resolve({ data: null }),
+      supabase
+        .from("shops")
+        .select("timezone")
+        .eq("id", booking.shop_id)
+        .maybeSingle(),
+    ]);
+
+  if (!customer?.email) return false;
+
+  const { data: lines } = booking.work_order_id
+    ? await supabase
+        .from("work_order_lines")
+        .select("description,complaint")
+        .eq("work_order_id", booking.work_order_id)
+        .limit(12)
+    : { data: null };
+
+  const services = (lines ?? [])
+    .map((line) => line.description || line.complaint || "")
+    .filter((value): value is string => Boolean(value?.trim()));
+
+  const timezone = shop?.timezone || "UTC";
+  const appointmentTime = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    dateStyle: "full",
+    timeStyle: "short",
+  }).format(new Date(booking.starts_at));
+
+  const customerName =
+    [customer.first_name, customer.last_name]
+      .filter(Boolean)
+      .join(" ")
+      .trim() || "Customer";
+  const vehicleLabel = vehicle
+    ? [vehicle.year, vehicle.make, vehicle.model].filter(Boolean).join(" ")
+    : "Vehicle details on file";
+
+  await sendBookingConfirmation({
+    customerEmail: customer.email,
+    customerName,
+    vehicle: vehicleLabel,
+    services: services.length ? services : ["Service appointment"],
+    estimatedTotal: "Estimate pending",
+    appointmentTime,
+  });
+
+  return true;
+}

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -46,12 +46,12 @@ const ActionButton = ({
     type="button"
     onClick={onClick}
     title={title}
-    className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border px-2.5 text-xs font-medium shadow-sm backdrop-blur-md transition-colors"
+    className="app-shell-action inline-flex h-8 items-center justify-center gap-1.5 rounded-md border px-2.5 text-xs font-medium shadow-sm backdrop-blur-md transition-colors"
     style={{
-      borderColor: "rgba(148,163,184,0.22)",
+      borderColor: "var(--theme-border-soft)",
       background:
         "var(--theme-gradient-panel)",
-      color: "rgb(226,232,240)",
+      color: "var(--theme-text-primary)",
     }}
   >
     {children}

--- a/features/shared/components/ProFixIQLanding.tsx
+++ b/features/shared/components/ProFixIQLanding.tsx
@@ -1,330 +1,228 @@
-// app/page.tsx
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Toaster } from "sonner";
+import {
+  ArrowRight,
+  BarChart3,
+  Building2,
+  Check,
+  ClipboardCheck,
+  FileCheck2,
+  Menu,
+  MessageSquareText,
+  Mic,
+  PackageCheck,
+  ShieldCheck,
+  Sparkles,
+  Upload,
+  Users,
+  Wrench,
+  X,
+} from "lucide-react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-
 import LandingHero from "@shared/components/ui/LandingHero";
-import LandingShopBoost from "@shared/components/ui/LandingShopBoost";
-import RealShopDayFlow from "@shared/components/ui/RealShopDayFlow";
-import FeaturesSection from "@shared/components/ui/FeaturesSection";
-import WhySection from "@shared/components/ui/WhySection";
 import PricingSection from "@shared/components/ui/PricingSection";
 import Footer from "@shared/components/ui/Footer";
-import Container from "@shared/components/ui/Container";
 import LandingChatbot from "@/features/landing/LandingChatbot";
-import LandingReviews from "@shared/components/ui/LandingReviews";
+import type { PlanKey } from "@/features/stripe/lib/stripe/constants";
 
 type Interval = "monthly" | "yearly";
 
+const workflow = [
+  { number: "01", title: "Capture", body: "Technicians document voice notes, measurements, photos, and findings once.", icon: Mic },
+  { number: "02", title: "Build", body: "Findings become complete repair lines with labor, parts, and evidence attached.", icon: Wrench },
+  { number: "03", title: "Approve", body: "Customers and fleets make clear decisions from a live, evidence-backed portal.", icon: FileCheck2 },
+  { number: "04", title: "Fulfill", body: "Approved work moves directly into parts, technician, and scheduling workflows.", icon: PackageCheck },
+  { number: "05", title: "Complete", body: "Invoice, history, reporting, and fleet visibility close the loop cleanly.", icon: ClipboardCheck },
+];
+
+const stories = [
+  {
+    eyebrow: "Voice inspections",
+    title: "Capture the real condition of the vehicle without slowing the technician down.",
+    body: "Voice-guided inspections keep technicians working naturally. Photos, videos, notes, and measurements remain connected to the exact repair they support.",
+    points: ["Hands-free inspection flow", "Evidence attached to durable records", "Custom automotive and heavy-duty templates"],
+    icon: Mic,
+    visual: "inspection",
+  },
+  {
+    eyebrow: "Connected decisions",
+    title: "Turn a technician’s finding into approved work without rebuilding the job.",
+    body: "Advisors review one complete repair line. Customers and fleets see the evidence, approve the work, and trigger the next operational step.",
+    points: ["Technician-built repairs", "Customer and fleet approvals", "No duplicate data entry"],
+    icon: MessageSquareText,
+    visual: "approval",
+  },
+  {
+    eyebrow: "End-to-end operations",
+    title: "Keep parts, people, billing, and history tied to the same source of truth.",
+    body: "Every team works from the same job state—from request and receiving through completion, invoicing, reporting, and future service history.",
+    points: ["Parts requests and receiving", "Workforce and dispatch visibility", "Clean billing and vehicle history"],
+    icon: BarChart3,
+    visual: "operations",
+  },
+] as const;
+
+const roles = [
+  { title: "Technicians", body: "Less typing, fewer interruptions, and one place to build the repair correctly.", icon: Wrench },
+  { title: "Advisors", body: "Review evidence, send clear approvals, and see what is blocking every job.", icon: MessageSquareText },
+  { title: "Parts", body: "Requests, quotes, orders, receiving, and allocations stay tied to the work.", icon: PackageCheck },
+  { title: "Owners", body: "See operational readiness, workforce activity, and missed opportunity across the shop.", icon: BarChart3 },
+  { title: "Customers & fleets", body: "Get evidence, decisions, live status, documents, and history through dedicated portals.", icon: Users },
+];
+
+const modules = [
+  { title: "Repair Operations", items: "Work orders, quotes, inspections, approvals, invoicing", icon: Wrench },
+  { title: "Parts & Inventory", items: "Requests, purchasing, receiving, allocations, inventory", icon: PackageCheck },
+  { title: "Workforce Command", items: "Scheduling, attendance, readiness, documents, certifications", icon: Users },
+  { title: "Portals & Intelligence", items: "Customer and fleet portals, history, AI assistance, reporting", icon: Building2 },
+];
+
+function ProductVisual({ type }: { type: (typeof stories)[number]["visual"] }) {
+  if (type === "inspection") {
+    return (
+      <div className="rounded-[1.5rem] border border-[color:var(--marketing-border)] bg-white p-5 shadow-[0_24px_60px_rgba(23,32,42,0.1)]">
+        <div className="flex items-center justify-between border-b border-[color:var(--marketing-border)] pb-4">
+          <div><div className="text-sm font-bold">Heavy-duty PM inspection</div><div className="mt-1 text-xs text-[color:var(--marketing-muted)]">Unit 47 • 12 sections</div></div>
+          <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-bold text-emerald-700">Live</span>
+        </div>
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          {["Steering", "Brakes", "Suspension", "Tires"].map((item, index) => (
+            <div key={item} className={`rounded-xl border p-3 ${index === 1 ? "border-amber-200 bg-amber-50" : "border-[color:var(--marketing-border)] bg-[color:var(--marketing-stone)]"}`}>
+              <div className="text-xs text-[color:var(--marketing-muted)]">Section {index + 1}</div>
+              <div className="mt-1 text-sm font-bold text-[color:var(--marketing-ink)]">{item}</div>
+              <div className={`mt-3 h-1.5 rounded-full ${index === 1 ? "bg-amber-400" : "bg-emerald-500"}`} />
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 flex items-center gap-3 rounded-xl bg-[color:var(--marketing-ink)] p-3.5 text-white"><Mic size={17} /><div className="text-sm font-semibold">Listening for the next finding…</div></div>
+      </div>
+    );
+  }
+
+  if (type === "approval") {
+    return (
+      <div className="rounded-[1.5rem] border border-[color:var(--marketing-border)] bg-white p-5 shadow-[0_24px_60px_rgba(23,32,42,0.1)]">
+        <div className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--marketing-muted)]">Customer approval</div>
+        <div className="mt-4 rounded-2xl border border-[color:var(--marketing-border)] p-4">
+          <div className="flex items-start justify-between gap-3"><div><div className="font-bold text-[color:var(--marketing-ink)]">Replace front brake pads & rotors</div><div className="mt-1 text-xs text-[color:var(--marketing-muted)]">Safety • Recommended today</div></div><div className="font-bold text-[color:var(--marketing-ink)]">$1,284</div></div>
+          <div className="mt-4 grid grid-cols-3 gap-2">
+            {["Photo", "Measurement", "Tech note"].map((item) => <div key={item} className="rounded-lg bg-[color:var(--marketing-stone)] p-2.5 text-center text-[11px] font-semibold text-[color:var(--marketing-muted)]">{item}</div>)}
+          </div>
+          <div className="mt-4 grid grid-cols-2 gap-2"><div className="rounded-lg border border-[color:var(--marketing-border)] px-3 py-2 text-center text-xs font-bold">Decline</div><div className="rounded-lg bg-[color:var(--marketing-copper)] px-3 py-2 text-center text-xs font-bold text-white">Approve repair</div></div>
+        </div>
+        <div className="mt-3 flex items-center gap-2 text-xs font-semibold text-emerald-700"><ShieldCheck size={15} /> Decision recorded with a complete audit trail</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-[1.5rem] border border-[color:var(--marketing-border)] bg-white p-5 shadow-[0_24px_60px_rgba(23,32,42,0.1)]">
+      <div className="flex items-center justify-between"><div><div className="text-sm font-bold text-[color:var(--marketing-ink)]">Today’s operation</div><div className="mt-1 text-xs text-[color:var(--marketing-muted)]">One live view across the shop</div></div><span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-bold text-blue-700">24 active</span></div>
+      <div className="mt-5 grid grid-cols-3 gap-3">
+        {[{ n: "8", l: "In progress" }, { n: "5", l: "Awaiting parts" }, { n: "11", l: "Ready" }].map((stat) => <div key={stat.l} className="rounded-xl bg-[color:var(--marketing-stone)] p-3"><div className="text-2xl font-bold text-[color:var(--marketing-ink)]">{stat.n}</div><div className="mt-1 text-[10px] font-semibold text-[color:var(--marketing-muted)]">{stat.l}</div></div>)}
+      </div>
+      <div className="mt-4 space-y-2.5">
+        {[{ label: "Parts fulfillment", value: "82%", width: "82%" }, { label: "Technician capacity", value: "74%", width: "74%" }, { label: "Approval completion", value: "91%", width: "91%" }].map((row) => <div key={row.label}><div className="flex justify-between text-xs"><span className="font-semibold text-[color:var(--marketing-muted)]">{row.label}</span><span className="font-bold text-[color:var(--marketing-ink)]">{row.value}</span></div><div className="mt-1.5 h-2 rounded-full bg-[color:var(--marketing-stone)]"><div className="h-full rounded-full bg-[color:var(--marketing-steel)]" style={{ width: row.width }} /></div></div>)}
+      </div>
+    </div>
+  );
+}
+
 export default function ProFixIQLanding() {
-  const supabase = createBrowserSupabase();
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [sessionExists, setSessionExists] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
-    let unsub: (() => void) | null = null;
-
-    (async () => {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-      setSessionExists(!!session);
-
-      const { data } = supabase.auth.onAuthStateChange((_event, sess) => {
-        setSessionExists(!!sess);
-      });
-
-      unsub = () => data.subscription.unsubscribe();
-    })();
-
-    return () => {
-      unsub?.();
-    };
+    let unsubscribe: (() => void) | null = null;
+    void supabase.auth.getSession().then(({ data }) => setSessionExists(Boolean(data.session)));
+    const { data } = supabase.auth.onAuthStateChange((_event, session) => setSessionExists(Boolean(session)));
+    unsubscribe = () => data.subscription.unsubscribe();
+    return () => unsubscribe?.();
   }, [supabase]);
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();
-    setSessionExists(false);
     window.location.href = "/";
   };
 
-  const startCheckout = async ({ planKey, interval }: { planKey: string; interval: Interval }) => {
-    const res = await fetch("/api/stripe/checkout", {
+  const startCheckout = async ({ planKey, interval }: { planKey: PlanKey; interval: Interval }) => {
+    const response = await fetch("/api/stripe/checkout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        source: "pricing_cta",
-        planKey,
-        interval,
-        enableTrial: true,
-        applyFoundingDiscount: true,
-        cancelPath: "/compare-plans",
-      }),
+      body: JSON.stringify({ source: "pricing_cta", planKey, interval, enableTrial: true, applyFoundingDiscount: true, cancelPath: "/compare-plans" }),
     });
-
-    const data = await res.json().catch(() => ({}));
-    if (!res.ok || !data?.url) {
-      throw new Error(String(data?.error ?? data?.details ?? "Unable to start checkout"));
-    }
-
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok || !data?.url) throw new Error(String(data?.error ?? data?.details ?? "Unable to start checkout"));
     window.location.href = data.url;
   };
 
   return (
-    <div className="relative min-h-screen text-[color:var(--theme-text-primary)]">
-      <Toaster position="top-center" />
+    <div className="pfq-marketing min-h-screen bg-[color:var(--marketing-bg)] text-[color:var(--marketing-ink)]">
+      <header className="sticky top-0 z-40 border-b border-[color:var(--marketing-border)] bg-[rgba(247,245,241,0.92)] backdrop-blur-xl">
+        <div className="mx-auto flex h-[72px] max-w-[1400px] items-center justify-between px-5 sm:px-8">
+          <Link href="/" className="flex items-center gap-3" aria-label="ProFixIQ home">
+            <span className="grid h-10 w-10 place-items-center rounded-xl bg-[color:var(--marketing-ink)] text-[10px] font-blackops tracking-[0.12em] text-white">PFQ</span>
+            <span><span className="block text-base font-bold tracking-[-0.02em]">ProFixIQ</span><span className="block text-[10px] font-bold uppercase tracking-[0.15em] text-[color:var(--marketing-muted)]">Shop operating system</span></span>
+          </Link>
 
-      {/* Dark steel + copper signal background */}
-      <div
-        className="pointer-events-none absolute inset-0 -z-10"
-        style={{
-          backgroundImage: [
-            // base steel falloff
-            "radial-gradient(1200px 700px at 20% -10%, rgba(148,163,184,0.18), transparent 55%)",
-            "radial-gradient(1000px 650px at 85% 0%, var(--theme-surface-inset), transparent 60%)",
-            "var(--theme-gradient-panel)",
-            // copper “signal” sources
-            "radial-gradient(550px 250px at 18% 18%, rgba(197,122,74,0.22), transparent 65%)",
-            "radial-gradient(500px 240px at 80% 65%, rgba(197,122,74,0.14), transparent 70%)",
-            // steel scanlines / texture
-            "var(--theme-gradient-panel)",
-            // subtle diagonal steel grain
-            "var(--theme-gradient-panel)",
-          ].join(", "),
-          backgroundColor: "var(--theme-surface-panel)",
-        }}
-      />
+          <nav className="hidden items-center gap-7 lg:flex" aria-label="Primary navigation">
+            {[{ href: "#workflow", label: "Workflow" }, { href: "#product", label: "Product" }, { href: "#shop-boost", label: "Shop Boost" }, { href: "#pricing", label: "Pricing" }].map((item) => <Link key={item.href} href={item.href} className="text-sm font-semibold text-[color:var(--marketing-muted)] transition hover:text-[color:var(--marketing-ink)]">{item.label}</Link>)}
+          </nav>
 
-      {/* Top bar (ops header) */}
-      <div className="sticky top-0 z-30 w-full border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] backdrop-blur-xl">
-        <Container>
-          <div className="flex items-center justify-between gap-3 py-3">
-            <Link href="/" className="flex items-center gap-3">
-              <div
-                className="grid h-9 w-9 place-items-center rounded-xl border bg-[color:var(--theme-surface-inset)]"
-                style={{
-                  borderColor: "rgba(255,255,255,0.10)",
-                  boxShadow: "0 0 0 1px rgba(255,255,255,0.04) inset",
-                }}
-              >
-                <span
-                  className="text-[11px] font-blackops tracking-[0.14em]"
-                  style={{ color: "var(--pfq-copper)" }}
-                >
-                  PFQ
-                </span>
-              </div>
+          <div className="hidden items-center gap-3 sm:flex">
+            <Link href="/portal" className="text-sm font-semibold text-[color:var(--marketing-muted)] hover:text-[color:var(--marketing-ink)]">Portal sign-in</Link>
+            {sessionExists ? <><Link href="/dashboard" className="rounded-xl border border-[color:var(--marketing-border-strong)] bg-white px-4 py-2.5 text-sm font-bold">Dashboard</Link><button type="button" onClick={() => void handleSignOut()} className="text-sm font-semibold text-[color:var(--marketing-muted)]">Sign out</button></> : <><Link href="/sign-in" className="px-2 text-sm font-semibold text-[color:var(--marketing-ink)]">Sign in</Link><Link href="/compare-plans" className="rounded-xl bg-[color:var(--marketing-copper)] px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-[color:var(--marketing-copper-dark)]">Start free trial</Link></>}
+          </div>
 
-              <div className="leading-tight">
-                <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">ProFixIQ</div>
-                <div className="flex items-center gap-2 text-[11px] text-[color:var(--theme-text-secondary)]">
-                  {/* ✅ wording tweak: match your “Shop OS / modern repair shops” positioning */}
-                  <span>Shop OS for Heavy-Duty • Automotive • Fleet</span>
-                  <span className="text-[color:var(--theme-text-muted)]">•</span>
-                  <span className="inline-flex items-center gap-1">
-                    <span
-                      className="h-1.5 w-1.5 rounded-full"
-                      style={{ background: "rgba(197,122,74,0.9)" }}
-                    />
-                    <span className="text-[color:var(--theme-text-muted)]">Signal</span>
-                  </span>
-                </div>
-              </div>
-            </Link>
+          <button type="button" className="grid h-10 w-10 place-items-center rounded-lg border border-[color:var(--marketing-border)] bg-white sm:hidden" onClick={() => setMenuOpen((value) => !value)} aria-expanded={menuOpen} aria-label="Toggle navigation">{menuOpen ? <X size={19} /> : <Menu size={19} />}</button>
+        </div>
+        {menuOpen ? <div className="border-t border-[color:var(--marketing-border)] bg-white px-5 py-5 sm:hidden"><div className="flex flex-col gap-4">{[{ href: "#workflow", label: "Workflow" }, { href: "#product", label: "Product" }, { href: "#shop-boost", label: "Shop Boost" }, { href: "#pricing", label: "Pricing" }, { href: "/portal", label: "Portal sign-in" }, { href: sessionExists ? "/dashboard" : "/sign-in", label: sessionExists ? "Dashboard" : "Sign in" }].map((item) => <Link key={item.href} href={item.href} onClick={() => setMenuOpen(false)} className="text-sm font-bold">{item.label}</Link>)}<Link href="/compare-plans" className="mt-2 rounded-xl bg-[color:var(--marketing-copper)] px-4 py-3 text-center text-sm font-bold text-white">Start free trial</Link></div></div> : null}
+      </header>
 
-            <div className="flex items-center gap-2">
-              {/* Always visible portal entry */}
-              <Link
-                href="/portal"
-                className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-sm font-extrabold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-panel)]"
-                style={{
-                  boxShadow: "0 0 0 1px rgba(197,122,74,0.08) inset",
-                }}
-              >
-                Portal Sign In
-              </Link>
+      <main>
+        <LandingHero />
 
-              <Link
-                href="/portal/fleet"
-                className="hidden sm:inline-flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-panel)]"
-              >
-                Fleet Portal
-              </Link>
-
-              {sessionExists ? (
-                <>
-                  <Link
-                    href="/dashboard"
-                    className="hidden sm:inline-flex rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-sm text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-panel)]"
-                  >
-                    Dashboard
-                  </Link>
-
-                  <button
-                    onClick={handleSignOut}
-                    className="inline-flex rounded-xl px-3 py-1.5 text-sm font-extrabold text-[color:var(--theme-text-on-accent)] transition"
-                    style={{
-                      background: "var(--pfq-copper)",
-                      border: "1px solid rgba(255,255,255,0.10)",
-                    }}
-                  >
-                    Sign Out
-                  </button>
-                </>
-              ) : (
-                <Link
-                  href="/sign-in"
-                  className="inline-flex rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-panel)]"
-                >
-                  Sign In
-                </Link>
-              )}
+        <section id="workflow" className="scroll-mt-24 border-b border-[color:var(--marketing-border)] bg-white py-20 sm:py-28">
+          <div className="mx-auto max-w-[1400px] px-5 sm:px-8">
+            <div className="grid gap-8 lg:grid-cols-[0.75fr_1.25fr] lg:items-end">
+              <div><div className="marketing-eyebrow">Connected workflow</div><h2 className="marketing-heading mt-4 max-w-xl">One job. One truth. Every team connected.</h2></div>
+              <p className="max-w-2xl text-lg leading-8 text-[color:var(--marketing-muted)] lg:justify-self-end">ProFixIQ carries the work forward instead of asking each department to recreate it. Evidence, decisions, parts, labor, and status remain attached from first inspection to final invoice.</p>
+            </div>
+            <div className="mt-14 grid gap-px overflow-hidden rounded-[1.5rem] border border-[color:var(--marketing-border)] bg-[color:var(--marketing-border)] md:grid-cols-5">
+              {workflow.map(({ number, title, body, icon: Icon }) => <div key={number} className="bg-white p-6 md:min-h-[250px]"><div className="flex items-center justify-between"><span className="text-xs font-bold tracking-[0.18em] text-[color:var(--marketing-copper-dark)]">{number}</span><Icon size={19} className="text-[color:var(--marketing-steel)]" /></div><h3 className="mt-10 text-xl font-bold tracking-[-0.025em]">{title}</h3><p className="mt-3 text-sm leading-6 text-[color:var(--marketing-muted)]">{body}</p></div>)}
             </div>
           </div>
-        </Container>
-      </div>
+        </section>
 
-      {/* HERO (full-bleed) */}
-      <LandingHero />
-
-      {/* SHOP BOOST */}
-      <div id="shop-boost">
-        <LandingShopBoost />
-      </div>
-
-      {/* ✅ REAL SHOP DAY FLOW (NEW) */}
-      <section id="real-shop-day" className="relative py-16 md:py-20">
-        <Container>
-          <RealShopDayFlow />
-        </Container>
-      </section>
-
-      {/* FEATURES */}
-      <section id="features" className="relative py-16 md:py-20">
-        <Container>
-          <div className="mx-auto max-w-3xl text-center">
-            <div
-              className="text-xs font-semibold uppercase tracking-[0.22em]"
-              style={{ color: "var(--pfq-copper)" }}
-            >
-              Included
-            </div>
-            <h2
-              className="mt-2 text-3xl text-[color:var(--theme-text-primary)] md:text-5xl"
-              style={{ fontFamily: "var(--font-blackops)" }}
-            >
-              Everything included. One workflow.
-            </h2>
-            <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)] md:text-base">
-              Fleet-first tools that also work great for automotive — built to
-              reduce screen time and keep work moving.
-            </p>
-          </div>
-
-          <div className="mt-12">
-            <FeaturesSection showHeading={false} />
-          </div>
-        </Container>
-      </section>
-
-      {/* WHY */}
-      <section id="why" className="relative py-16 md:py-20">
-        <Container>
-          <WhySection />
-        </Container>
-      </section>
-
-      {/* REVIEWS */}
-      <section id="reviews" className="relative py-16 md:py-20">
-        <LandingReviews />
-      </section>
-
-      {/* PRICING */}
-      <section id="plans" className="relative py-16 md:py-20">
-        <Container>
-          <div className="mx-auto max-w-3xl text-center">
-            <div
-              className="text-xs font-semibold uppercase tracking-[0.22em]"
-              style={{ color: "var(--pfq-copper)" }}
-            >
-              Plans
-            </div>
-            <h2
-              className="mt-2 text-3xl text-[color:var(--theme-text-primary)] md:text-5xl"
-              style={{ fontFamily: "var(--font-blackops)" }}
-            >
-              One complete product. No feature tax.
-            </h2>
-            <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)] md:text-base">
-              Every Complete plan includes repair ops plus workforce scheduling, attendance, documents, certifications, readiness, and Payroll Connect foundation for payroll review/export readiness.
-            </p>
-          </div>
-
-                    <div className="mt-10">
-            <PricingSection
-              onCheckout={async ({
-                planKey,
-                interval,
-              }: {
-                planKey: string;
-                interval: Interval;
-              }) => {
-                await startCheckout({ planKey, interval });
-              }}
-              onStartFree={() => {
-                window.location.href = "/compare-plans";
-              }}
-            />
-          </div>
-
-          {/* CTA band */}
-          <div className="mt-10 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-6 py-6 backdrop-blur">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <div>
-                <div className="text-lg font-extrabold text-[color:var(--theme-text-primary)]">
-                  Ready to see it in motion?
-                </div>
-                <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-                  Create a work order, run an inspection, or let AI scan your
-                  shop&apos;s history.
-                </div>
-              </div>
-
-              <div className="flex flex-wrap gap-3">
-                <Link
-                  href="/work-orders/create"
-                  className="rounded-xl px-4 py-2 text-sm font-extrabold text-[color:var(--theme-text-on-accent)]"
-                  style={{
-                    background: "var(--pfq-copper)",
-                    border: "1px solid rgba(255,255,255,0.10)",
-                    boxShadow: "0 0 26px rgba(197,122,74,0.25)",
-                  }}
-                >
-                  Start a work order
-                </Link>
-                <Link
-                  href="/demo/instant-shop-analysis"
-                  className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-panel)]"
-                >
-                  Run Instant Shop Analysis
-                </Link>
-              </div>
+        <section id="product" className="scroll-mt-24 py-20 sm:py-28">
+          <div className="mx-auto max-w-[1400px] px-5 sm:px-8">
+            <div className="mx-auto max-w-3xl text-center"><div className="marketing-eyebrow">Built around the repair</div><h2 className="marketing-heading mt-4">From technician evidence to a complete business record.</h2><p className="mt-5 text-lg leading-8 text-[color:var(--marketing-muted)]">The product follows how a real shop works—then removes the re-entry, blind spots, and disconnected handoffs.</p></div>
+            <div className="mt-16 space-y-24">
+              {stories.map((story, index) => <div key={story.eyebrow} className="grid items-center gap-12 lg:grid-cols-2 lg:gap-20"><div className={index % 2 === 1 ? "lg:order-2" : ""}><div className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-[color:var(--marketing-border)] bg-white text-[color:var(--marketing-copper-dark)] shadow-sm"><story.icon size={20} /></div><div className="marketing-eyebrow mt-6">{story.eyebrow}</div><h3 className="mt-3 text-3xl font-semibold leading-tight tracking-[-0.035em] sm:text-4xl">{story.title}</h3><p className="mt-5 text-base leading-7 text-[color:var(--marketing-muted)]">{story.body}</p><ul className="mt-6 space-y-3">{story.points.map((point) => <li key={point} className="flex items-center gap-3 text-sm font-semibold"><span className="grid h-5 w-5 place-items-center rounded-full bg-[color:var(--marketing-copper-soft)] text-[color:var(--marketing-copper-dark)]"><Check size={12} /></span>{point}</li>)}</ul></div><div className={index % 2 === 1 ? "lg:order-1" : ""}><ProductVisual type={story.visual} /></div></div>)}
             </div>
           </div>
-        </Container>
-      </section>
+        </section>
 
-      {/* Chatbot */}
-      <div className="relative">
-        <LandingChatbot />
-      </div>
+        <section className="border-y border-[color:var(--marketing-border)] bg-[color:var(--marketing-ink)] py-20 text-white sm:py-24">
+          <div className="mx-auto max-w-[1400px] px-5 sm:px-8"><div className="max-w-3xl"><div className="text-xs font-bold uppercase tracking-[0.2em] text-[color:var(--marketing-copper-light)]">One platform, every role</div><h2 className="mt-4 text-4xl font-semibold tracking-[-0.045em] sm:text-5xl">Built for the people doing the work—and the people waiting on it.</h2></div><div className="mt-12 grid gap-px overflow-hidden rounded-2xl border border-white/10 bg-white/10 md:grid-cols-5">{roles.map(({ title, body, icon: Icon }) => <div key={title} className="bg-[color:var(--marketing-ink)] p-6"><Icon size={21} className="text-[color:var(--marketing-copper-light)]" /><h3 className="mt-8 text-lg font-bold">{title}</h3><p className="mt-3 text-sm leading-6 text-slate-400">{body}</p></div>)}</div></div>
+        </section>
 
-      {/* Footer */}
-      <div className="relative">
-        <Footer />
-      </div>
+        <section id="shop-boost" className="scroll-mt-24 bg-white py-20 sm:py-28">
+          <div className="mx-auto max-w-[1400px] px-5 sm:px-8"><div className="grid gap-12 lg:grid-cols-[0.8fr_1.2fr] lg:items-center"><div><div className="marketing-eyebrow">Shop Boost onboarding</div><h2 className="marketing-heading mt-4">Bring the shop you already have. Start with a system built around it.</h2><p className="mt-5 text-lg leading-8 text-[color:var(--marketing-muted)]">Import your existing data, preview what ProFixIQ understands, and activate a clean operational foundation with guided review at every important decision.</p><Link href="/demo/instant-shop-analysis" className="mt-7 inline-flex items-center gap-2 text-sm font-bold text-[color:var(--marketing-copper-dark)]">Run Instant Shop Analysis <ArrowRight size={15} /></Link></div><div className="grid gap-4 sm:grid-cols-3">{[{ n: "01", t: "Profile", b: "Tell us how your bays, people, and workflow operate.", icon: Building2 }, { n: "02", t: "Import", b: "Upload customers, vehicles, history, parts, and services.", icon: Upload }, { n: "03", t: "Preview", b: "Review the shop blueprint before anything is activated.", icon: Sparkles }].map(({ n, t, b, icon: Icon }) => <div key={n} className="rounded-2xl border border-[color:var(--marketing-border)] bg-[color:var(--marketing-stone)] p-5"><div className="flex items-center justify-between"><span className="text-xs font-bold text-[color:var(--marketing-copper-dark)]">{n}</span><Icon size={18} className="text-[color:var(--marketing-steel)]" /></div><h3 className="mt-10 text-xl font-bold">{t}</h3><p className="mt-3 text-sm leading-6 text-[color:var(--marketing-muted)]">{b}</p></div>)}</div></div></div>
+        </section>
+
+        <section id="modules" className="border-y border-[color:var(--marketing-border)] py-20 sm:py-24">
+          <div className="mx-auto max-w-[1400px] px-5 sm:px-8"><div className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between"><div><div className="marketing-eyebrow">Complete platform</div><h2 className="marketing-heading mt-4 max-w-2xl">Everything included. No feature tax.</h2></div><p className="max-w-lg text-base leading-7 text-[color:var(--marketing-muted)]">Choose a plan by team size. The operating system stays complete at every level.</p></div><div className="mt-12 grid gap-4 md:grid-cols-2 xl:grid-cols-4">{modules.map(({ title, items, icon: Icon }) => <div key={title} className="rounded-2xl border border-[color:var(--marketing-border)] bg-white p-6 shadow-sm"><Icon size={21} className="text-[color:var(--marketing-copper-dark)]" /><h3 className="mt-8 text-lg font-bold">{title}</h3><p className="mt-3 text-sm leading-6 text-[color:var(--marketing-muted)]">{items}</p></div>)}</div></div>
+        </section>
+
+        <section id="pricing" className="scroll-mt-24 bg-white py-20 sm:py-28"><div className="mx-auto max-w-[1400px] px-5 sm:px-8"><div className="mx-auto max-w-3xl text-center"><div className="marketing-eyebrow">Simple pricing</div><h2 className="marketing-heading mt-4">One complete product. Sized for your shop.</h2><p className="mt-5 text-lg leading-8 text-[color:var(--marketing-muted)]">All core features are included. Plans scale by the number of active users at each location.</p></div><div className="mt-12"><PricingSection onCheckout={startCheckout} onStartFree={() => { window.location.href = "/compare-plans"; }} /></div></div></section>
+      </main>
+
+      <LandingChatbot />
+      <Footer />
     </div>
   );
 }

--- a/features/shared/components/ui/Footer.tsx
+++ b/features/shared/components/ui/Footer.tsx
@@ -1,89 +1,60 @@
 "use client";
 
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { cn } from "@shared/lib/utils";
 
-const COPPER_LIGHT = "var(--accent-copper-light)";
+const groups = [
+  {
+    title: "Product",
+    links: [
+      { label: "Workflow", href: "/#workflow" },
+      { label: "Platform", href: "/#product" },
+      { label: "Shop Boost", href: "/#shop-boost" },
+      { label: "Pricing", href: "/#pricing" },
+    ],
+  },
+  {
+    title: "Access",
+    links: [
+      { label: "Shop sign-in", href: "/sign-in" },
+      { label: "Customer portal", href: "/portal" },
+      { label: "Fleet portal", href: "/portal/fleet" },
+      { label: "Compare plans", href: "/compare-plans" },
+    ],
+  },
+];
 
 export default function Footer({ className }: { className?: string }) {
   return (
-    <div className={cn("w-full", className)}>
-      <div className="mx-auto max-w-6xl px-4">
-        <div className="relative mb-6 overflow-hidden rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6 backdrop-blur-xl">
-          <div
-            className="pointer-events-none absolute -right-24 -top-24 h-80 w-80 rounded-full blur-3xl"
-            style={{ background: "rgba(197,122,74,0.12)" }}
-          />
-          <div
-            className="pointer-events-none absolute -left-28 -bottom-28 h-96 w-96 rounded-full blur-3xl"
-            style={{ background: "var(--theme-surface-inset)" }}
-          />
-          <div
-            className="pointer-events-none absolute inset-0 opacity-[0.10]"
-            style={{
-              backgroundImage:
-                "var(--theme-gradient-panel)",
-            }}
-          />
-
-          <div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-secondary)]">
-                Quick truth
-              </div>
-              <div className="mt-2 text-base font-extrabold text-[color:var(--theme-text-primary)] sm:text-lg">
-                If you’re still reading, you’re already wasting time. Let ProFixIQ set the shop up for you.
-              </div>
-              <div className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
-                Get a workflow that fits fleet reality — inspections → quotes → parts → approvals → portal.
-              </div>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-2">
-              <a
-                href="#"
-                className="inline-flex items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-5 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-inset)]"
-              >
-                See what’s included
-              </a>
-              <a
-                href="#"
-                className="inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-extrabold text-[color:var(--theme-text-on-accent)] transition hover:brightness-110"
-                style={{
-                  backgroundColor: "rgba(197,122,74,0.95)",
-                  boxShadow: "0 0 30px rgba(197,122,74,0.25)",
-                }}
-              >
-                Run Instant Shop Analysis
-              </a>
-            </div>
+    <footer className={cn("border-t border-[color:var(--marketing-border)] bg-[color:var(--marketing-ink)] text-white", className)}>
+      <div className="mx-auto max-w-[1400px] px-5 py-16 sm:px-8 sm:py-20">
+        <div className="grid gap-12 lg:grid-cols-[1.35fr_0.65fr_0.65fr]">
+          <div className="max-w-xl">
+            <Link href="/" className="flex items-center gap-3">
+              <span className="grid h-10 w-10 place-items-center rounded-xl bg-white text-[10px] font-blackops tracking-[0.12em] text-[color:var(--marketing-ink)]">PFQ</span>
+              <span className="text-lg font-bold">ProFixIQ</span>
+            </Link>
+            <h2 className="mt-8 text-3xl font-semibold leading-tight tracking-[-0.04em] sm:text-4xl">See how ProFixIQ fits your shop.</h2>
+            <p className="mt-4 max-w-lg text-base leading-7 text-slate-400">Bring inspections, repair building, approvals, parts, workforce operations, invoicing, and portals into one connected system.</p>
+            <Link href="/compare-plans" className="mt-7 inline-flex items-center gap-2 rounded-xl bg-[color:var(--marketing-copper)] px-5 py-3 text-sm font-bold text-white transition hover:bg-[color:var(--marketing-copper-dark)]">Start 14-day free trial <ArrowRight size={15} /></Link>
           </div>
 
-          <div className="relative mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] pt-4">
-            <div className="text-xs text-[color:var(--theme-text-muted)]">
-              Next: social links + verified shop reviews
+          {groups.map((group) => (
+            <div key={group.title}>
+              <div className="text-xs font-bold uppercase tracking-[0.18em] text-slate-500">{group.title}</div>
+              <ul className="mt-5 space-y-3">
+                {group.links.map((link) => <li key={link.href}><Link href={link.href} className="text-sm text-slate-300 transition hover:text-white">{link.label}</Link></li>)}
+              </ul>
             </div>
-            <div className="text-xs text-[color:var(--theme-text-muted)]">
-              <span style={{ color: COPPER_LIGHT }}>ProFixIQ</span> • Heavy-duty &amp; fleet shop OS
-            </div>
-          </div>
+          ))}
+        </div>
+
+        <div className="mt-16 flex flex-col gap-3 border-t border-white/10 pt-6 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+          <span>© {new Date().getFullYear()} ProFixIQ Technologies. All rights reserved.</span>
+          <span>Heavy-Duty • Automotive • Fleet</span>
         </div>
       </div>
-
-      <footer
-        className={cn(
-          "w-full border-t border-[color:var(--theme-border-soft)] px-4 py-8 text-center",
-          "bg-[color:var(--theme-surface-inset)] text-sm text-[color:var(--theme-text-secondary)] backdrop-blur-xl transition-all",
-          "hover:text-[color:var(--theme-text-primary)]",
-        )}
-      >
-        <p className="font-mono text-xs tracking-wide sm:text-sm">
-          © {new Date().getFullYear()}{" "}
-          <span className="font-semibold" style={{ color: COPPER_LIGHT }}>
-            ProFixIQ
-          </span>
-          . Built for pros, powered by AI.
-        </p>
-      </footer>
-    </div>
+    </footer>
   );
 }

--- a/features/shared/components/ui/LandingHero.tsx
+++ b/features/shared/components/ui/LandingHero.tsx
@@ -1,361 +1,163 @@
 "use client";
 
 import Link from "next/link";
+import {
+  ArrowRight,
+  Camera,
+  Check,
+  ChevronRight,
+  Clock3,
+  Mic,
+  PackageCheck,
+  ShieldCheck,
+  Wrench,
+} from "lucide-react";
 
-const COPPER = "var(--pfq-copper)";
-const COPPER_LIGHT = "var(--accent-copper-light)";
-
-type RailStep = {
-  key: string;
-  label: string;
-  hint: string;
-};
-
-const RAIL: RailStep[] = [
-  { key: "inspect", label: "Inspect", hint: "Evidence + measurements" },
-  { key: "quote", label: "Quote", hint: "Lines built automatically" },
-  { key: "approve", label: "Approve", hint: "Fleet/customer portals" },
-  { key: "parts", label: "Parts", hint: "Requests → receiving" },
-  { key: "invoice", label: "Invoice", hint: "Clean billing trail" },
-  { key: "portal", label: "Portal", hint: "Live status + history" },
+const workflow = [
+  { label: "Inspect", icon: Mic },
+  { label: "Build", icon: Wrench },
+  { label: "Approve", icon: Check },
+  { label: "Fulfill", icon: PackageCheck },
 ];
-
-function SignalDot() {
-  return (
-    <span
-      className="inline-block h-2 w-2 rounded-full"
-      style={{
-        background: COPPER,
-        boxShadow: "0 0 18px rgba(197,122,74,0.55)",
-      }}
-      aria-hidden
-    />
-  );
-}
 
 export default function LandingHero() {
   return (
-    <section className="relative overflow-x-hidden">
-      <style jsx>{`
-        @keyframes pfqSweep {
-          0% {
-            transform: translateX(-30%);
-            opacity: 0;
-          }
-          12% {
-            opacity: 0.65;
-          }
-          50% {
-            opacity: 0.95;
-          }
-          88% {
-            opacity: 0.65;
-          }
-          100% {
-            transform: translateX(130%);
-            opacity: 0;
-          }
-        }
+    <section className="relative overflow-hidden border-b border-[color:var(--marketing-border)]">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_82%_14%,rgba(193,102,59,0.12),transparent_30%),radial-gradient(circle_at_10%_30%,rgba(53,91,117,0.08),transparent_28%)]" />
 
-        @keyframes pfqHop6 {
-          0% {
-            transform: translateX(0%);
-          }
-          16.66% {
-            transform: translateX(0%);
-          }
-          16.67% {
-            transform: translateX(100%);
-          }
-          33.33% {
-            transform: translateX(100%);
-          }
-          33.34% {
-            transform: translateX(200%);
-          }
-          50% {
-            transform: translateX(200%);
-          }
-          50.01% {
-            transform: translateX(300%);
-          }
-          66.66% {
-            transform: translateX(300%);
-          }
-          66.67% {
-            transform: translateX(400%);
-          }
-          83.33% {
-            transform: translateX(400%);
-          }
-          83.34% {
-            transform: translateX(500%);
-          }
-          100% {
-            transform: translateX(500%);
-          }
-        }
-
-        @keyframes pfqBreathe {
-          0% {
-            transform: scale(1);
-            opacity: 0.95;
-          }
-          50% {
-            transform: scale(1.08);
-            opacity: 1;
-          }
-          100% {
-            transform: scale(1);
-            opacity: 0.95;
-          }
-        }
-      `}</style>
-
-      <div className="mx-auto w-full max-w-[1400px] px-4 pb-10 pt-14 sm:pt-16 md:pt-20">
-        <div className="grid gap-10 lg:grid-cols-[1.15fr_0.85fr] lg:items-start">
-          <div className="relative">
-            <div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--theme-text-secondary)]">
-              <SignalDot />
-              <span style={{ color: COPPER_LIGHT }}>
-                Heavy-Duty &amp; Fleet Shop OS
-              </span>
-              <span className="text-[color:var(--theme-text-muted)]">•</span>
-              <span className="text-[color:var(--theme-text-secondary)]">
-                Built for the floor — not forms
-              </span>
-            </div>
-
-            <h1
-              className="mt-4 text-4xl leading-[1.03] text-[color:var(--theme-text-primary)] sm:text-6xl md:text-7xl"
-              style={{
-                fontFamily: "var(--font-blackops)",
-                boxShadow: "var(--theme-shadow-medium)",
-              }}
-            >
-              <span className="block">The</span>
-              <span
-                className="block"
-                style={{
-                  color: COPPER_LIGHT,
-                  textShadow: "0 0 30px rgba(197,122,74,0.22)",
-                }}
-              >
-                operating system
-              </span>
-              <span className="block">for modern repair shops.</span>
-            </h1>
-
-            <p className="mt-4 max-w-2xl text-sm font-semibold text-[color:var(--theme-text-primary)] sm:text-base">
-              Built for heavy-duty, automotive, and fleet repair operations.
-            </p>
-
-            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-[color:var(--theme-text-secondary)] sm:text-base md:text-lg">
-              Technicians capture evidence once. Quotes build automatically.
-              Customers approve instantly. Parts and invoices stay in sync.
-            </p>
-
-            <div
-              className="mt-5 text-lg font-extrabold uppercase tracking-[0.18em] sm:text-xl md:text-2xl"
-              style={{
-                color: COPPER_LIGHT,
-                textShadow: "0 0 26px rgba(197,122,74,0.35)",
-              }}
-            >
-              Heavy-Duty • Automotive • Fleet
-            </div>
-
-            <div className="mt-8 flex flex-wrap items-center gap-3">
-              <Link
-                href="/demo/instant-shop-analysis"
-                className="rounded-xl px-5 py-3 text-sm font-extrabold text-[color:var(--theme-text-on-accent)] transition hover:brightness-110 active:scale-[0.99]"
-                style={{
-                  background:
-                    "linear-gradient(to right, var(--accent-copper-soft), var(--accent-copper))",
-                  border: "1px solid rgba(255,255,255,0.10)",
-                  boxShadow: "0 0 34px rgba(197,122,74,0.26)",
-                }}
-              >
-                Run Instant Shop Analysis
-              </Link>
-
-              <Link
-                href="#features"
-                className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-5 py-3 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-inset)]"
-              >
-                See what’s included
-              </Link>
-            </div>
-
-            <div className="mt-8 grid gap-3 sm:grid-cols-3">
-              <div className="flex items-start gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 backdrop-blur-sm">
-                <SignalDot />
-                <div>
-                  <div className="text-sm font-extrabold text-[color:var(--theme-text-primary)]">
-                    Evidence-first inspections
-                  </div>
-                  <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
-                    Photos + notes + measurements stay attached.
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex items-start gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 backdrop-blur-sm">
-                <SignalDot />
-                <div>
-                  <div className="text-sm font-extrabold text-[color:var(--theme-text-primary)]">
-                    Build the job once
-                  </div>
-                  <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
-                    Parts + labor flow forward — no re-entry.
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex items-start gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 backdrop-blur-sm">
-                <SignalDot />
-                <div>
-                  <div className="text-sm font-extrabold text-[color:var(--theme-text-primary)]">
-                    Approvals that move work
-                  </div>
-                  <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
-                    Portal decisions trigger the next step.
-                  </div>
-                </div>
-              </div>
-            </div>
+      <div className="relative mx-auto grid w-full max-w-[1400px] gap-14 px-5 pb-20 pt-16 sm:px-8 sm:pt-20 lg:grid-cols-[0.92fr_1.08fr] lg:items-center lg:pb-28 lg:pt-24">
+        <div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-[color:var(--marketing-border)] bg-white px-3.5 py-2 text-[11px] font-bold uppercase tracking-[0.2em] text-[color:var(--marketing-copper-dark)] shadow-sm">
+            <span className="h-1.5 w-1.5 rounded-full bg-[color:var(--marketing-copper)]" />
+            Heavy-Duty • Automotive • Fleet
           </div>
 
-          <div className="relative">
-            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 backdrop-blur-xl shadow-[var(--theme-shadow-medium)]">
-              <div className="flex items-center justify-between gap-3">
+          <h1 className="mt-7 max-w-3xl text-5xl font-semibold leading-[0.98] tracking-[-0.055em] text-[color:var(--marketing-ink)] sm:text-6xl lg:text-[4.65rem]">
+            The operating system for modern repair shops.
+          </h1>
+
+          <p className="mt-7 max-w-2xl text-lg leading-8 text-[color:var(--marketing-muted)] sm:text-xl">
+            Voice inspections, technician-built repairs, automated approvals,
+            parts workflows, workforce operations, and fleet transparency—connected
+            in one system.
+          </p>
+
+          <div className="mt-9 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Link
+              href="/compare-plans"
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-[color:var(--marketing-copper)] px-5 py-3.5 text-sm font-bold text-white shadow-[0_12px_30px_rgba(143,69,40,0.2)] transition hover:-translate-y-0.5 hover:bg-[color:var(--marketing-copper-dark)]"
+            >
+              Start 14-day free trial
+              <ArrowRight size={16} />
+            </Link>
+            <Link
+              href="#workflow"
+              className="inline-flex items-center justify-center gap-2 rounded-xl border border-[color:var(--marketing-border-strong)] bg-white px-5 py-3.5 text-sm font-bold text-[color:var(--marketing-ink)] transition hover:border-[color:var(--marketing-steel)] hover:bg-[color:var(--marketing-stone)]"
+            >
+              See the workflow
+              <ChevronRight size={16} />
+            </Link>
+          </div>
+
+          <div className="mt-9 flex flex-wrap gap-x-6 gap-y-3 text-sm text-[color:var(--marketing-muted)]">
+            {["Full platform included", "No feature gating", "Built for real shop flow"].map((item) => (
+              <span key={item} className="inline-flex items-center gap-2">
+                <Check size={15} className="text-[color:var(--marketing-copper)]" />
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="relative lg:pl-4">
+          <div className="absolute -inset-8 -z-10 rounded-full bg-[radial-gradient(circle,rgba(193,102,59,0.11),transparent_67%)]" />
+          <div className="overflow-hidden rounded-[1.75rem] border border-[color:var(--marketing-border-strong)] bg-white shadow-[0_32px_80px_rgba(23,32,42,0.14)]">
+            <div className="flex items-center justify-between border-b border-[color:var(--marketing-border)] bg-[color:var(--marketing-stone)] px-5 py-4">
+              <div className="flex items-center gap-3">
+                <div className="grid h-9 w-9 place-items-center rounded-lg bg-[color:var(--marketing-ink)] text-[10px] font-blackops tracking-widest text-white">
+                  PFQ
+                </div>
                 <div>
-                  <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-secondary)]">
-                    System Snapshot
-                  </div>
-                  <div className="mt-1 text-lg font-extrabold text-[color:var(--theme-text-primary)]">
-                    One workflow, end-to-end
-                  </div>
-                </div>
-
-                <div
-                  className="rounded-full border px-3 py-1 text-[11px] font-extrabold uppercase tracking-[0.18em]"
-                  style={{
-                    borderColor: "rgba(255,255,255,0.14)",
-                    backgroundColor: "rgba(197,122,74,0.10)",
-                    color: COPPER_LIGHT,
-                  }}
-                >
-                  Live ops feel
+                  <div className="text-sm font-bold text-[color:var(--marketing-ink)]">Work order EL000284</div>
+                  <div className="text-xs text-[color:var(--marketing-muted)]">2019 Ford F-550 • Unit 47</div>
                 </div>
               </div>
+              <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-bold text-amber-800">In progress</span>
+            </div>
 
-              <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">
-                ProFixIQ ties together inspections, parts, approvals, and portals
-                — so fleets and customers see the same truth your bay sees.
-              </p>
-
-              <div className="mt-5">
-                <div className="flex items-center justify-between text-[11px] text-[color:var(--theme-text-secondary)]">
-                  <span className="font-semibold uppercase tracking-[0.18em]">
-                    Workflow rail
-                  </span>
-                  <span className="text-[color:var(--theme-text-muted)]">Inspect → Portal</span>
+            <div className="grid md:grid-cols-[0.9fr_1.1fr]">
+              <div className="border-b border-[color:var(--marketing-border)] p-5 md:border-b-0 md:border-r">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--marketing-muted)]">Inspection</span>
+                  <span className="text-xs font-semibold text-[color:var(--marketing-steel)]">12 of 16 complete</span>
+                </div>
+                <div className="mt-4 rounded-2xl bg-[color:var(--marketing-stone)] p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="grid h-10 w-10 place-items-center rounded-full bg-[color:var(--marketing-copper)] text-white">
+                      <Mic size={18} />
+                    </div>
+                    <div>
+                      <div className="text-sm font-bold text-[color:var(--marketing-ink)]">Voice capture active</div>
+                      <div className="text-xs text-[color:var(--marketing-muted)]">Evidence stays with the repair</div>
+                    </div>
+                  </div>
+                  <div className="mt-4 flex h-8 items-center gap-1" aria-hidden>
+                    {[8, 16, 11, 23, 15, 28, 18, 10, 22, 14, 25, 9, 17, 12, 20].map((height, index) => (
+                      <span key={`${height}-${index}`} className="w-1 flex-1 rounded-full bg-[color:var(--marketing-copper)] opacity-70" style={{ height }} />
+                    ))}
+                  </div>
                 </div>
 
-                <div className="mt-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
-                  <div className="relative">
-                    <div className="absolute left-2 right-2 top-[13px] h-px bg-[color:var(--theme-surface-subtle)]" />
-
-                    <div className="pointer-events-none absolute left-2 right-2 top-[12px] h-[3px] overflow-hidden">
-                      <div
-                        className="h-full w-[30%] rounded-full"
-                        style={{
-                          background:
-                            "linear-gradient(90deg, rgba(197,122,74,0) 0%, rgba(197,122,74,0.95) 45%, rgba(197,122,74,0) 100%)",
-                          filter:
-                            "drop-shadow(0 0 18px rgba(197,122,74,0.55))",
-                          animation: "pfqSweep 6s linear infinite",
-                        }}
-                      />
-                    </div>
-
-                    <div className="pointer-events-none absolute left-0 right-0 top-[2px]">
-                      <div
-                        className="grid grid-cols-6 gap-2"
-                        style={{
-                          animation: "pfqHop6 6s steps(1) infinite",
-                        }}
-                      >
-                        <div className="col-span-1 flex justify-center">
-                          <div
-                            className="mt-[2px] flex h-7 w-7 items-center justify-center rounded-full"
-                            style={{
-                              boxShadow:
-                                "0 0 0 1px rgba(197,122,74,0.25) inset, 0 0 26px rgba(197,122,74,0.22)",
-                            }}
-                          >
-                            <span
-                              className="h-2.5 w-2.5 rounded-full"
-                              style={{
-                                backgroundColor: "rgba(197,122,74,0.98)",
-                                boxShadow:
-                                  "0 0 22px rgba(197,122,74,0.60)",
-                                animation: "pfqBreathe 1.2s ease-in-out infinite",
-                              }}
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="relative grid grid-cols-6 gap-2">
-                      {RAIL.map((step) => (
-                        <div key={step.key} className="flex flex-col items-center text-center">
-                          <div className="flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[11px] font-extrabold text-[color:var(--theme-text-primary)]">
-                            {step.label.charAt(0)}
-                          </div>
-                          <div className="mt-2 text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
-                            {step.label}
-                          </div>
-                          <div className="mt-1 text-[10px] leading-tight text-[color:var(--theme-text-muted)]">
-                            {step.hint}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
+                <div className="mt-4 space-y-3">
+                  <div className="flex items-center justify-between rounded-xl border border-[color:var(--marketing-border)] px-3.5 py-3">
+                    <span className="flex items-center gap-2 text-sm font-semibold text-[color:var(--marketing-ink)]"><ShieldCheck size={16} className="text-emerald-700" /> Front brakes</span>
+                    <span className="text-xs font-bold text-emerald-700">Pass</span>
+                  </div>
+                  <div className="flex items-center justify-between rounded-xl border border-red-200 bg-red-50 px-3.5 py-3">
+                    <span className="flex items-center gap-2 text-sm font-semibold text-[color:var(--marketing-ink)]"><Camera size={16} className="text-red-700" /> Left outer tie rod</span>
+                    <span className="text-xs font-bold text-red-700">Repair</span>
                   </div>
                 </div>
               </div>
 
-              <div className="mt-5 grid gap-3 sm:grid-cols-3">
-                <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
-                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
-                    Less screen time
-                  </div>
-                  <div className="mt-1 text-sm text-[color:var(--theme-text-primary)]">
-                    Techs stay in flow.
+              <div className="p-5">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-bold uppercase tracking-[0.16em] text-[color:var(--marketing-muted)]">Repair line</span>
+                  <span className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-bold text-blue-700">Evidence attached</span>
+                </div>
+                <div className="mt-4 rounded-2xl border border-[color:var(--marketing-border)] p-4">
+                  <div className="text-sm font-bold text-[color:var(--marketing-ink)]">Replace left outer tie rod end</div>
+                  <p className="mt-1 text-xs leading-5 text-[color:var(--marketing-muted)]">Excessive play confirmed during steering inspection. Photo and technician note included.</p>
+                  <div className="mt-4 grid grid-cols-2 gap-3">
+                    <div className="rounded-xl bg-[color:var(--marketing-stone)] p-3">
+                      <div className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--marketing-muted)]">Labor</div>
+                      <div className="mt-1 text-sm font-bold text-[color:var(--marketing-ink)]">1.4 hours</div>
+                    </div>
+                    <div className="rounded-xl bg-[color:var(--marketing-stone)] p-3">
+                      <div className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--marketing-muted)]">Parts</div>
+                      <div className="mt-1 text-sm font-bold text-[color:var(--marketing-ink)]">Requested</div>
+                    </div>
                   </div>
                 </div>
 
-                <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
-                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
-                    Faster approvals
+                <div className="mt-4 flex items-center justify-between rounded-2xl bg-[color:var(--marketing-ink)] p-4 text-white">
+                  <div>
+                    <div className="flex items-center gap-2 text-xs text-slate-300"><Clock3 size={14} /> Customer decision</div>
+                    <div className="mt-1 text-sm font-bold">Approval link ready</div>
                   </div>
-                  <div className="mt-1 text-sm text-[color:var(--theme-text-primary)]">
-                    Proof moves decisions.
-                  </div>
-                </div>
-
-                <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
-                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
-                    One truth
-                  </div>
-                  <div className="mt-1 text-sm text-[color:var(--theme-text-primary)]">
-                    Inspection to invoice.
-                  </div>
+                  <div className="rounded-lg bg-white px-3 py-2 text-xs font-bold text-[color:var(--marketing-ink)]">Send</div>
                 </div>
               </div>
+            </div>
+
+            <div className="grid grid-cols-4 border-t border-[color:var(--marketing-border)] bg-[color:var(--marketing-stone)] px-4 py-4">
+              {workflow.map(({ label, icon: Icon }, index) => (
+                <div key={label} className="relative flex flex-col items-center gap-2 text-center">
+                  {index < workflow.length - 1 ? <span className="absolute left-[62%] top-4 h-px w-[76%] bg-[color:var(--marketing-border-strong)]" /> : null}
+                  <span className="relative z-10 grid h-8 w-8 place-items-center rounded-full border border-[color:var(--marketing-border-strong)] bg-white text-[color:var(--marketing-copper-dark)]"><Icon size={14} /></span>
+                  <span className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--marketing-muted)]">{label}</span>
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/features/shared/components/ui/PricingSection.tsx
+++ b/features/shared/components/ui/PricingSection.tsx
@@ -1,15 +1,8 @@
-// features/shared/components/ui/PricingSection.tsx
-
 "use client";
 
-import type { FC } from "react";
-import { useMemo, useState } from "react";
-import { Check, Sparkles, Timer } from "lucide-react";
-import type { PlanKey } from "@/features/stripe/lib/stripe/constants";
-
-/* -------------------------------------------------------------------------- */
-/* Types                                                                      */
-/* -------------------------------------------------------------------------- */
+import { useState } from "react";
+import { Check } from "lucide-react";
+import { PLAN_PRICING, type PlanKey } from "@/features/stripe/lib/stripe/constants";
 
 export type BillingInterval = "monthly" | "yearly";
 
@@ -23,328 +16,124 @@ export type PricingSectionProps = {
   onStartFree: () => void;
 };
 
-type CheckoutPricingPlan = {
+const sharedFeatures = [
+  "Work orders, inspections, quotes, and invoicing",
+  "Customer and fleet portals",
+  "Parts, purchasing, and receiving workflows",
+  "Workforce scheduling, attendance, and readiness",
+  "AI assistance and guided Shop Boost onboarding",
+];
+
+const plans: Array<{
   key: PlanKey;
-  checkoutEnabled: true;
-  title: string;
-  desc: string;
-  priceLabel: string;
-  subLabel: string;
-  features: string[];
-  cta: string;
-  featured: boolean;
-  badge?: string;
-};
+  name: string;
+  price: string;
+  users: string;
+  description: string;
+  featured?: boolean;
+}> = [
+  {
+    key: "starter",
+    name: "Complete 10",
+    price: `$${PLAN_PRICING.starter}`,
+    users: "Up to 10 active users",
+    description: "A complete operating system for independent and smaller repair teams.",
+  },
+  {
+    key: "pro",
+    name: "Complete 50",
+    price: `$${PLAN_PRICING.pro}`,
+    users: "Up to 50 active users",
+    description: "Full platform access for growing shops with larger operational teams.",
+    featured: true,
+  },
+  {
+    key: "unlimited",
+    name: "Complete Unlimited",
+    price: `$${PLAN_PRICING.unlimited}`,
+    users: "Unlimited active users",
+    description: "Unlimited users per location for high-volume and multi-team operations.",
+  },
+];
 
-type ContactPricingPlan = {
-  key: string;
-  checkoutEnabled: false;
-  title: string;
-  desc: string;
-  priceLabel: string;
-  subLabel: string;
-  features: string[];
-  cta: string;
-  featured: boolean;
-  badge?: string;
-};
-
-type PricingPlan = CheckoutPricingPlan | ContactPricingPlan;
-
-/* -------------------------------------------------------------------------- */
-/* Component                                                                  */
-/* -------------------------------------------------------------------------- */
-
-const PricingSection: FC<PricingSectionProps> = ({ onCheckout, onStartFree }) => {
-  const interval: BillingInterval = "monthly";
+export default function PricingSection({ onCheckout }: PricingSectionProps) {
   const [busyKey, setBusyKey] = useState<PlanKey | null>(null);
 
-  const COPPER = "var(--pfq-copper)";
-  const COPPER_LIGHT = "var(--accent-copper-light)";
-
-  const plans: PricingPlan[] = useMemo(
-    () => [
-      {
-        key: "starter",
-        checkoutEnabled: true,
-        title: "Complete 10",
-        desc: "One complete shop operating system for smaller teams. Full platform access with pricing sized for up to 10 active users.",
-        priceLabel: "$299 / month",
-        subLabel: "Up to 10 active users",
-        features: [
-          "14-day free trial included",
-          "Up to 10 active users (techs, advisors, parts, admin)",
-          "Full repair operations: work orders, inspections, approvals, parts, and invoicing",
-          "Workforce Command: scheduling + attendance",
-          "Documents/certifications + Required Document Matrix readiness",
-          "Payroll review and export readiness with provider-ready export workflows",
-        ],
-        featured: false,
-        cta: "Start free trial",
-      },
-      {
-        key: "pro",
-        checkoutEnabled: true,
-        title: "Complete 50",
-        desc: "One complete shop operating system for growing shops. Full platform access with pricing sized for up to 50 active users.",
-        priceLabel: "$399 / month",
-        subLabel: "Up to 50 active users",
-        features: [
-          "14-day free trial included",
-          "Up to 50 active users (techs, advisors, parts, admin)",
-          "Everything in Complete 10 + expanded implementation support",
-          "Customer + fleet portal workflows included",
-          "Priority support",
-          "Payroll Connect foundation + review/export readiness",
-        ],
-        featured: true,
-        badge: "Most popular",
-        cta: "Start free trial",
-      },
-      {
-        key: "complete-100",
-        checkoutEnabled: false,
-        title: "Complete 100",
-        desc: "Complete platform for high-capacity shops scaling toward 100 active users. Contact-only rollout with guided implementation.",
-        priceLabel: "Talk to us",
-        subLabel: "Up to 100 active users",
-        features: [
-          "Everything in Complete plans",
-          "Sized for up to 100 active users",
-          "Implementation planning and rollout guidance",
-          "Payroll Connect foundation + provider-ready export workflows",
-          "Contact-only rollout: Talk to us for implementation planning",
-        ],
-        featured: false,
-        badge: "Coming soon",
-        cta: "Talk to us",
-      },
-      {
-        key: "unlimited",
-        checkoutEnabled: true,
-        title: "Complete Unlimited",
-        desc: "One complete shop operating system for larger operations with unlimited active users per location.",
-        priceLabel: "$599 / month / location",
-        subLabel: "Unlimited users",
-        features: [
-          "14-day free trial included",
-          "Unlimited active users per location",
-          "Everything in Complete plans with enterprise-scale operations",
-          "High-volume fleet + municipality readiness",
-          "Priority support with implementation coordination",
-          "Provider-ready payroll export workflows",
-        ],
-        featured: false,
-        cta: "Start free trial",
-      },
-    ],
-    [],
-  );
-
-  async function handlePlanClick(key: PlanKey): Promise<void> {
+  const startCheckout = async (planKey: PlanKey) => {
     if (busyKey) return;
-    setBusyKey(key);
-
+    setBusyKey(planKey);
     try {
-      await onCheckout({
-        planKey: key,
-        interval,
-      });
-    } catch (err) {
-      // Make failures visible during testing instead of “nothing happens”
-      console.error("[PricingSection] checkout failed", err);
-      alert("Checkout failed. Check console/network for details.");
+      await onCheckout({ planKey, interval: "monthly" });
+    } catch (error) {
+      console.error("[PricingSection] checkout failed", error);
+      window.alert("Checkout could not be started. Please try again.");
     } finally {
       setBusyKey(null);
     }
-  }
+  };
 
   return (
-    <div className="w-full">
-      {/* Offer Bar */}
-      <div className="mx-auto mb-8 max-w-3xl text-center">
-        <div className="inline-flex flex-col items-center gap-3">
-          <div
-            className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em]"
-            style={{
-              borderColor: "rgba(255,255,255,0.14)",
-              backgroundColor: "rgba(193,102,59,0.16)",
-              color: "var(--accent-copper-light)",
-            }}
-          >
-            <Timer size={14} />
-            <span>14-day free trial</span>
-            <span className="mx-1 text-[color:var(--theme-text-muted)]">•</span>
-            <Sparkles size={14} />
-            <span>Founding Shop offer (6 months discounted)</span>
-          </div>
-
-          <p className="text-sm text-[color:var(--theme-text-secondary)]">
-            Every Complete plan includes the full ProFixIQ platform. Pricing scales by shop size, not by feature access.
-          </p>
-
-          <p className="text-xs text-[color:var(--theme-text-secondary)]">
-            One complete product. No feature tax. Repair operations, workforce scheduling, attendance, documents, certifications, readiness, customer/fleet portals, and Payroll Connect foundation are included.
-          </p>
-
-          <button
-            type="button"
-            onClick={onStartFree}
-            className={[
-              "mt-1 inline-flex items-center justify-center rounded-xl px-5 py-2.5 text-sm font-extrabold text-[color:var(--theme-text-on-accent)]",
-              "shadow-[0_0_24px_rgba(212,118,49,0.35)] transition",
-              "hover:brightness-110 active:scale-[0.99]",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-copper)]/60",
-            ].join(" ")}
-            style={{
-              background: "linear-gradient(to right, var(--accent-copper-soft), var(--accent-copper))",
-              border: "1px solid rgba(255,255,255,0.10)",
-            }}
-          >
-            Start 14-day free trial
-          </button>
-        </div>
-      </div>
-
-      {/* Plans */}
-      <div
-        className="mt-5 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 text-xs text-[color:var(--theme-text-secondary)]"
-      >
-        SMS, payment processing, heavy AI usage, storage overages, and custom integrations may be billed separately.
-      </div>
-
-      <div className="mt-5 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 text-xs text-[color:var(--theme-text-secondary)]">
-        Payroll Connect supports operational payroll review and export readiness. Payroll processing, tax filing/remittance, benefits administration, and legal compliance services remain handled by your payroll/HR providers.
-      </div>
-
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
-        {plans.map((p) => {
-          const isBusy = p.checkoutEnabled ? busyKey === p.key : false;
-
+    <div>
+      <div className="grid gap-5 lg:grid-cols-3">
+        {plans.map((plan) => {
+          const isBusy = busyKey === plan.key;
           return (
-            <button
-              key={`${p.key}-${p.title}`}
-              type="button"
-              onClick={() => (p.checkoutEnabled ? void handlePlanClick(p.key) : (window.location.href = "/#contact"))}
-              disabled={Boolean(busyKey) || !p.checkoutEnabled}
-              className={[
-                "group relative text-left",
-                "rounded-3xl border bg-[color:var(--theme-surface-inset)] p-6 backdrop-blur-xl transition",
-                "shadow-[var(--theme-shadow-medium)]",
-                "hover:bg-[color:var(--theme-surface-inset)] hover:-translate-y-[2px]",
-                "active:translate-y-0 active:brightness-95",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-copper)]/60",
-                "disabled:opacity-70 disabled:cursor-not-allowed disabled:hover:translate-y-0",
-                p.featured
-                  ? "border-[color:var(--accent-copper)]/55 shadow-[0_0_44px_rgba(212,118,49,0.22)]"
-                  : "border-[color:var(--metal-border-soft)]",
-              ].join(" ")}
-              style={{
-                cursor: busyKey ? "not-allowed" : "pointer",
-              }}
-              aria-busy={isBusy}
+            <article
+              key={plan.key}
+              className={`relative flex flex-col rounded-[1.5rem] border bg-white p-7 transition sm:p-8 ${
+                plan.featured
+                  ? "border-[color:var(--marketing-copper)] shadow-[0_22px_55px_rgba(143,69,40,0.13)]"
+                  : "border-[color:var(--marketing-border)] shadow-sm"
+              }`}
             >
-              {/* Glow accent */}
-              <div
-                className={[
-                  "pointer-events-none absolute inset-0 rounded-3xl opacity-0 transition",
-                  "group-hover:opacity-100",
-                ].join(" ")}
-                style={{
-                  boxShadow: p.featured
-                    ? "0 0 0 1px rgba(212,118,49,0.25) inset, 0 0 60px rgba(212,118,49,0.18)"
-                    : "0 0 0 1px rgba(255,255,255,0.06) inset",
-                }}
-              />
-
-              {/* Header */}
-              <div className="relative flex items-start justify-between gap-4">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <h3
-                      className="text-2xl text-[color:var(--theme-text-primary)]"
-                      style={{ fontFamily: "var(--font-blackops)" }}
-                    >
-                      {p.title}
-                    </h3>
-
-                    {p.badge ? (
-                      <span
-                        className="rounded-full border px-2.5 py-1 text-[11px] font-extrabold uppercase tracking-[0.16em]"
-                        style={{
-                          borderColor: "rgba(255,255,255,0.14)",
-                          backgroundColor: "rgba(193,102,59,0.16)",
-                          color: "var(--accent-copper-light)",
-                        }}
-                      >
-                        {p.badge}
-                      </span>
-                    ) : null}
-                  </div>
-
-                  <div className="mt-1 text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-secondary)]">
-                    {p.subLabel}
-                  </div>
-
-                  <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">{p.desc}</p>
+              {plan.featured ? (
+                <div className="absolute right-6 top-0 -translate-y-1/2 rounded-full bg-[color:var(--marketing-copper)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.15em] text-white">
+                  Most popular
                 </div>
+              ) : null}
+
+              <div className="text-sm font-bold text-[color:var(--marketing-copper-dark)]">{plan.name}</div>
+              <div className="mt-5 flex items-end gap-2">
+                <span className="text-5xl font-semibold tracking-[-0.05em] text-[color:var(--marketing-ink)]">{plan.price}</span>
+                <span className="pb-1.5 text-sm text-[color:var(--marketing-muted)]">/ month / location</span>
               </div>
+              <div className="mt-3 text-sm font-bold text-[color:var(--marketing-ink)]">{plan.users}</div>
+              <p className="mt-3 min-h-[48px] text-sm leading-6 text-[color:var(--marketing-muted)]">{plan.description}</p>
 
-              {/* Price */}
-              <div className="relative mt-6">
-                <div
-                  className={[
-                    "text-4xl font-extrabold",
-                    p.featured ? "" : "",
-                  ].join(" ")}
-                  style={{ color: COPPER_LIGHT }}
-                >
-                  {p.priceLabel}
-                </div>
-                <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
-                  Includes <span className="text-[color:var(--theme-text-primary)]">full platform access</span> •
-                  Founding discount at checkout
-                </div>
-              </div>
+              <button
+                type="button"
+                onClick={() => void startCheckout(plan.key)}
+                disabled={Boolean(busyKey)}
+                className={`mt-7 rounded-xl px-4 py-3 text-sm font-bold transition disabled:cursor-wait disabled:opacity-60 ${
+                  plan.featured
+                    ? "bg-[color:var(--marketing-copper)] text-white hover:bg-[color:var(--marketing-copper-dark)]"
+                    : "border border-[color:var(--marketing-border-strong)] bg-[color:var(--marketing-stone)] text-[color:var(--marketing-ink)] hover:border-[color:var(--marketing-steel)]"
+                }`}
+              >
+                {isBusy ? "Starting…" : "Start 14-day free trial"}
+              </button>
 
-              {/* Features */}
-              <ul className="relative mt-6 space-y-2.5 text-sm text-[color:var(--theme-text-primary)]">
-                {p.features.map((f) => (
-                  <li key={f} className="flex items-start gap-2">
-                    <Check size={16} className="mt-0.5" style={{ color: COPPER }} />
-                    <span className="text-[color:var(--theme-text-primary)]">{f}</span>
+              <div className="my-7 h-px bg-[color:var(--marketing-border)]" />
+              <div className="text-xs font-bold uppercase tracking-[0.15em] text-[color:var(--marketing-muted)]">Everything included</div>
+              <ul className="mt-4 space-y-3">
+                {sharedFeatures.map((feature) => (
+                  <li key={feature} className="flex items-start gap-3 text-sm leading-6 text-[color:var(--marketing-ink)]">
+                    <span className="mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full bg-[color:var(--marketing-copper-soft)] text-[color:var(--marketing-copper-dark)]">
+                      <Check size={12} />
+                    </span>
+                    {feature}
                   </li>
                 ))}
               </ul>
-
-              {/* CTA (visual only — card itself is clickable) */}
-              <div className="relative mt-7">
-                <div
-                  className={[
-                    "w-full rounded-xl px-4 py-3 text-center text-sm font-extrabold text-[color:var(--theme-text-on-accent)]",
-                    "shadow-[0_0_24px_rgba(212,118,49,0.35)] transition",
-                    "group-hover:brightness-110",
-                    "disabled:opacity-60",
-                  ].join(" ")}
-                  style={{
-                    background:
-                      "linear-gradient(to right, var(--accent-copper-soft), var(--accent-copper))",
-                    border: "1px solid rgba(255,255,255,0.10)",
-                  }}
-                >
-                  {isBusy ? "Starting…" : p.cta}
-                </div>
-
-                <div className="mt-3 text-[11px] text-[color:var(--theme-text-secondary)]">
-                  Cancel anytime • Secure checkout by Stripe
-                </div>
-              </div>
-            </button>
+            </article>
           );
         })}
       </div>
+
+      <div className="mt-6 flex flex-col gap-2 rounded-2xl border border-[color:var(--marketing-border)] bg-[color:var(--marketing-stone)] px-5 py-4 text-xs leading-5 text-[color:var(--marketing-muted)] sm:flex-row sm:items-center sm:justify-between">
+        <span>All plans include the complete core platform. Cancel anytime.</span>
+        <span>Payment processing, SMS, storage overages, and unusually heavy AI usage may be billed separately.</span>
+      </div>
     </div>
   );
-};
-
-export default PricingSection;
+}

--- a/tests/ui-foundation-regression-contract.test.ts
+++ b/tests/ui-foundation-regression-contract.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const globals = read("app/globals.css");
+const appShell = read("features/shared/components/AppShell.tsx");
+const operationalSwitcher = read(
+  "features/dashboard/components/OperationalViewSwitcher.tsx",
+);
+const appointmentsPage = read("app/dashboard/appointments/page.tsx");
+const weeklyCalendar = read("app/dashboard/appointments/WeeklyCalendar.tsx");
+const fullCalendar = read("app/dashboard/appointments/FullCalendarModal.tsx");
+const staffBookingsRoute = read("app/api/portal/bookings/route.ts");
+const staffBookingRoute = read("app/api/portal/bookings/[id]/route.ts");
+const requestSubmitRoute = read("app/api/portal/request/submit/route.ts");
+const customerBookingPage = read("app/portal/booking/BookingPageClient.tsx");
+const customerAppointmentsPage = read(
+  "app/portal/customer-appointments/page.tsx",
+);
+
+describe("premium UI foundation regressions", () => {
+  it("keeps light-mode pill text readable without changing dark-mode tokens", () => {
+    for (const color of [
+      "red",
+      "amber",
+      "yellow",
+      "green",
+      "emerald",
+      "cyan",
+      "sky",
+      "blue",
+      "violet",
+      "purple",
+      "orange",
+    ]) {
+      expect(globals).toContain(
+        `html[data-theme-mode="light"] [class*="rounded"][class~="text-${color}`,
+      );
+    }
+
+    expect(globals).toContain('html[data-theme-mode="light"] .accent-chip');
+    expect(globals).toContain(
+      'html[data-theme-mode="light"] .app-shell-action',
+    );
+    expect(appShell).toContain("app-shell-action");
+    expect(operationalSwitcher).toContain("text-orange-900");
+    expect(operationalSwitcher).toContain("dark:text-orange-100");
+  });
+
+  it("keeps the compact five-day schedule and the detailed calendar modal", () => {
+    expect(weeklyCalendar).toContain("Array.from({ length: 5 }");
+    expect(appointmentsPage).toContain("<FullCalendarModal");
+    expect(appointmentsPage).toContain("Full calendar");
+    expect(fullCalendar).toContain("Array.from({ length: 42 }");
+    expect(fullCalendar).toContain("Review capacity by month");
+  });
+
+  it("keeps appointment mutations compatible with the atomic lifecycle", () => {
+    expect(appointmentsPage).toContain('"Idempotency-Key"');
+    expect(customerBookingPage).toContain('"Idempotency-Key"');
+    expect(customerAppointmentsPage).toContain('"Idempotency-Key"');
+    expect(staffBookingRoute).toContain('action: "cancel"');
+    expect(staffBookingRoute).not.toContain('.from("bookings").delete');
+    expect(appointmentsPage).toContain("Cancel appointment");
+  });
+
+  it("keeps customer requests pending until staff approval", () => {
+    expect(requestSubmitRoute).toMatch(
+      /const bookingUpdate:[\s\S]*?status: "pending"/,
+    );
+    expect(appointmentsPage).toContain("status=pending");
+    expect(staffBookingsRoute).toContain('status === "pending"');
+    expect(staffBookingRoute).toContain("notifyBookingConfirmation");
+  });
+});


### PR DESCRIPTION
## Summary

- Restores the premium light marketing foundation, inspection modal polish, app-shell navigation contrast, and durable light-mode pill contrast.
- Refactors appointments to a compact five-day view plus a full calendar modal with per-day counts, day agenda, and appointment detail selection.
- Preserves the current Phase 7/8 atomic appointment lifecycle while hardening customer-request approval, availability rules, idempotency, audited cancellation, reassignment validation, status transitions, and booking confirmation notifications.
- Adds regression contract coverage for the visual foundation and customer-request-to-shop-approval handoff.

## Validation

- TypeScript typecheck: passed
- ESLint on all touched files: passed
- Focused regression/lifecycle tests: 10/10 passed
- Next.js production build: passed with placeholder build-time environment variables
- Full repository test suite: 676 passed, 38 unrelated baseline failures across existing financial, parts, vehicle-import, and legacy contract tests
- Full repository lint: existing unrelated baseline errors remain; changed files are clean

## Review notes

This is intentionally a single reconciliation commit based on `main`. It replaces the divergent feature-branch history with one reviewable change and adds regression guards so future feature deployments do not silently remove the shared contrast and scheduling behavior.