### PR TITLE
Harden SendGrid delivery tracking

### DIFF
--- a/app/api/email/logs/route.ts
+++ b/app/api/email/logs/route.ts
@@ -2,41 +2,12 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-
-
-const ALLOWED_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
 export async function GET(req: Request) {
   try {
-    const supabase = createServerSupabaseRoute();
-
-    const {
-      data: { user },
-      error: userErr,
-    } = await supabase.auth.getUser();
-
-    if (userErr || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { data: me, error: meErr } = await supabase
-      .from("profiles")
-      .select("id, role, shop_id")
-      .eq("id", user.id)
-      .maybeSingle();
-
-    if (meErr || !me?.shop_id) {
-      return NextResponse.json(
-        { error: meErr?.message ?? "Profile not found" },
-        { status: 403 },
-      );
-    }
-
-    const role = String(me.role ?? "").toLowerCase();
-    if (!ALLOWED_ROLES.has(role)) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+    if (!access.ok) return access.response;
 
     const url = new URL(req.url);
     const limitRaw = Number(url.searchParams.get("limit") ?? "25");
@@ -44,12 +15,12 @@ export async function GET(req: Request) {
       ? Math.min(Math.max(limitRaw, 1), 100)
       : 25;
 
-    const { data, error } = await supabase
+    const { data, error } = await access.supabase
       .from("email_logs")
       .select(
         "id, to_email, subject, template_key, status, provider, provider_message_id, error_text, created_at, sent_at, metadata",
       )
-      .eq("shop_id", me.shop_id)
+      .eq("shop_id", access.profile.shop_id)
       .order("created_at", { ascending: false })
       .limit(limit);
 

--- a/app/api/webhooks/sendgrid/events/route.ts
+++ b/app/api/webhooks/sendgrid/events/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  normalizeSendGridEvent,
+  parseSendGridEvents,
+  shouldSuppressEmail,
+  verifySendGridWebhookSignature,
+} from "@/features/email/server/sendgridWebhook";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required env: ${name}`);
+  return value.replaceAll("\\n", "\n");
+}
+
+export async function POST(req: Request) {
+  const rawBody = await req.text();
+  const timestamp = req.headers.get("x-twilio-email-event-webhook-timestamp") ?? "";
+  const signature = req.headers.get("x-twilio-email-event-webhook-signature") ?? "";
+
+  if (!timestamp || !signature) {
+    return NextResponse.json({ error: "Missing webhook signature" }, { status: 401 });
+  }
+
+  if (!verifySendGridWebhookSignature({
+    rawBody,
+    timestamp,
+    signature,
+    publicKey: requiredEnv("SENDGRID_EVENT_WEBHOOK_PUBLIC_KEY"),
+  })) {
+    return NextResponse.json({ error: "Invalid webhook signature" }, { status: 401 });
+  }
+
+  let events;
+  try {
+    events = parseSendGridEvents(rawBody).map(normalizeSendGridEvent);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Invalid webhook payload" },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminSupabase();
+  const rpc = admin as unknown as {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => PromiseLike<{ data: boolean | null; error: { message: string } | null }>;
+  };
+  let processed = 0;
+
+  for (const event of events) {
+    if (!event.providerEventId) continue;
+
+    const suppress = Boolean(event.email && shouldSuppressEmail(event.eventType));
+    const { data: inserted, error: eventError } = await rpc.rpc(
+      "process_sendgrid_delivery_event",
+      {
+        p_email_log_id: event.emailLogId,
+        p_provider_event_id: event.providerEventId,
+        p_provider_message_id: event.providerMessageId,
+        p_event_type: event.eventType,
+        p_event_at: event.eventAt,
+        p_error_text: ["bounce", "dropped", "deferred"].includes(event.eventType)
+          ? event.errorText
+          : null,
+        p_payload: event.safePayload,
+        p_suppression_email: suppress ? event.email : null,
+      },
+    );
+    if (eventError) throw new Error(eventError.message);
+    if (inserted) processed += 1;
+  }
+
+  return NextResponse.json({ ok: true, processed });
+}

--- a/docs/ops/sendgrid-delivery-webhook.md
+++ b/docs/ops/sendgrid-delivery-webhook.md
@@ -1,0 +1,29 @@
+# SendGrid delivery webhook
+
+ProFixIQ records SendGrid acceptance synchronously and records final delivery
+events through a signed webhook.
+
+## Required configuration
+
+1. Apply `20260716120000_sendgrid_delivery_events.sql`.
+2. In SendGrid, create an Event Webhook with this production URL:
+   `https://profixiq.com/api/webhooks/sendgrid/events`.
+3. Enable signature verification.
+4. Subscribe to processed, delivered, deferred, bounce, dropped, open, click,
+   spam report, and unsubscribe events.
+5. Store SendGrid's verification public key in the deployment environment as
+   `SENDGRID_EVENT_WEBHOOK_PUBLIC_KEY`. PEM and base64 DER forms are accepted.
+6. Send a SendGrid test event and confirm the endpoint returns HTTP 200.
+
+## Operational behavior
+
+- A successful Mail Send API response is recorded as `accepted`, not delivered.
+- Signed webhook events advance the delivery status and are deduplicated by
+  SendGrid event ID.
+- Bounce, spam-report, and global unsubscribe events add the recipient to
+  `email_suppressions`.
+- Suppressed recipients are not sent another dynamic-template email.
+- Email-log metadata is scrubbed of links, tokens, passwords, and cookies.
+
+Do not place customer data, URLs, access tokens, or message content in SendGrid
+custom arguments. ProFixIQ sends only the opaque email-log ID for correlation.

--- a/features/email/server/emailEvents.ts
+++ b/features/email/server/emailEvents.ts
@@ -19,7 +19,6 @@ export async function sendPortalInviteEmail(input: {
     createdBy: input.createdBy,
     metadata: {
       kind: "portal_invite",
-      portal_link: input.portalLink,
     } as Json,
     dynamicTemplateData: {
       portal_link: input.portalLink,
@@ -52,7 +51,6 @@ export async function sendQuoteReadyEmail(input: {
     createdBy: input.createdBy,
     metadata: {
       kind: "quote_ready",
-      quote_url: input.quoteUrl,
     } as Json,
     dynamicTemplateData: {
       quote_url: input.quoteUrl,
@@ -91,7 +89,6 @@ export async function sendInvoiceReadyEmail(input: {
     metadata: {
       kind: "invoice_ready",
       work_order_id: input.workOrderId,
-      portal_url: input.portalUrl,
     } as Json,
     dynamicTemplateData: {
       portalUrl: input.portalUrl,
@@ -132,8 +129,6 @@ export async function sendUserInviteEmail(input: {
     createdBy: input.createdBy,
     metadata: {
       kind: "user_invite",
-      login_url: input.loginUrl,
-      username: input.username,
       resend: input.resend ?? false,
     } as Json,
     dynamicTemplateData: {

--- a/features/email/server/sendDynamicTemplateEmail.ts
+++ b/features/email/server/sendDynamicTemplateEmail.ts
@@ -2,6 +2,7 @@ import sgMail from "@sendgrid/mail";
 import { createClient } from "@supabase/supabase-js";
 import type { Database, Json } from "@shared/types/types/supabase";
 import { getTemplateId, type EmailTemplateKey } from "./templateIds";
+import { sanitizeEmailMetadata } from "./sendgridWebhook";
 
 type DB = Database;
 
@@ -46,6 +47,18 @@ export async function sendDynamicTemplateEmail(
   const supabase = getAdminClient();
   const templateId = getTemplateId(input.templateKey);
   const fromEmail = requiredEnv("SENDGRID_FROM_EMAIL");
+  const to = input.to.trim().toLowerCase();
+
+  const { data: suppression, error: suppressionError } = await supabase
+    .from("email_suppressions")
+    .select("reason")
+    .eq("email", to)
+    .eq("suppressed", true)
+    .maybeSingle<{ reason: string | null }>();
+
+  if (suppressionError) {
+    throw new Error(`Failed to verify email suppression: ${suppressionError.message}`);
+  }
 
   const { data: logRow, error: insertError } = await supabase
     .from("email_logs")
@@ -53,11 +66,13 @@ export async function sendDynamicTemplateEmail(
       shop_id: input.shopId,
       template_key: input.templateKey,
       template_id: templateId,
-      to_email: input.to,
+      to_email: to,
       subject: input.subject ?? null,
       status: "queued",
       provider: "sendgrid",
-      metadata: (input.metadata ?? {}) as Json,
+      metadata: sanitizeEmailMetadata(
+        (input.metadata ?? {}) as Record<string, unknown>,
+      ) as Json,
       created_by: input.createdBy ?? null,
     })
     .select("id")
@@ -67,12 +82,27 @@ export async function sendDynamicTemplateEmail(
     throw new Error(insertError.message);
   }
 
+  if (suppression) {
+    const { error: suppressedLogError } = await supabase
+      .from("email_logs")
+      .update({
+        status: "suppressed",
+        error_text: suppression.reason ?? "Recipient is suppressed",
+      })
+      .eq("id", logRow.id);
+    if (suppressedLogError) throw new Error(suppressedLogError.message);
+    return;
+  }
+
   try {
     const [response] = await sgMail.send({
-      to: input.to,
+      to,
       from: fromEmail,
       templateId,
       dynamicTemplateData: input.dynamicTemplateData ?? {},
+      customArgs: {
+        email_log_id: logRow.id,
+      },
       ...(input.subject ? { subject: input.subject } : {}),
     });
 
@@ -86,7 +116,7 @@ export async function sendDynamicTemplateEmail(
     const { error: updateError } = await supabase
       .from("email_logs")
       .update({
-        status: "sent",
+        status: "accepted",
         provider_message_id: providerMessageId,
         sent_at: new Date().toISOString(),
       })
@@ -98,7 +128,7 @@ export async function sendDynamicTemplateEmail(
         {
           emailLogId: logRow.id,
           templateKey: input.templateKey,
-          to: input.to,
+          to,
           error: updateError.message,
         },
       );

--- a/features/email/server/sendgridWebhook.ts
+++ b/features/email/server/sendgridWebhook.ts
@@ -1,0 +1,108 @@
+import { createVerify } from "node:crypto";
+
+export type SendGridEvent = {
+  email?: unknown;
+  event?: unknown;
+  timestamp?: unknown;
+  sg_event_id?: unknown;
+  sg_message_id?: unknown;
+  email_log_id?: unknown;
+  reason?: unknown;
+  response?: unknown;
+  status?: unknown;
+  attempt?: unknown;
+  type?: unknown;
+};
+
+const MAX_WEBHOOK_BYTES = 1_000_000;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function cleanString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function verifySendGridWebhookSignature(input: {
+  rawBody: string;
+  timestamp: string;
+  signature: string;
+  publicKey: string;
+}): boolean {
+  if (Buffer.byteLength(input.rawBody, "utf8") > MAX_WEBHOOK_BYTES) return false;
+
+  try {
+    const trimmedKey = input.publicKey.trim();
+    const publicKey = trimmedKey.includes("BEGIN PUBLIC KEY")
+      ? trimmedKey
+      : `-----BEGIN PUBLIC KEY-----\n${trimmedKey.match(/.{1,64}/g)?.join("\n") ?? trimmedKey}\n-----END PUBLIC KEY-----`;
+    const verifier = createVerify("sha256");
+    verifier.update(input.timestamp + input.rawBody, "utf8");
+    verifier.end();
+    return verifier.verify(publicKey, input.signature, "base64");
+  } catch {
+    return false;
+  }
+}
+
+export function parseSendGridEvents(rawBody: string): SendGridEvent[] {
+  if (Buffer.byteLength(rawBody, "utf8") > MAX_WEBHOOK_BYTES) {
+    throw new Error("Webhook payload is too large");
+  }
+
+  const parsed = JSON.parse(rawBody) as unknown;
+  if (!Array.isArray(parsed)) throw new Error("Webhook payload must be an array");
+  return parsed.filter(
+    (event): event is SendGridEvent => typeof event === "object" && event !== null,
+  );
+}
+
+export function normalizeSendGridEvent(event: SendGridEvent) {
+  const eventType = cleanString(event.event)?.toLowerCase() ?? "unknown";
+  const timestamp = Number(event.timestamp);
+  const eventAt = Number.isFinite(timestamp) && timestamp > 0
+    ? new Date(timestamp * 1000).toISOString()
+    : new Date().toISOString();
+
+  return {
+    eventType,
+    eventAt,
+    providerEventId: cleanString(event.sg_event_id),
+    providerMessageId: cleanString(event.sg_message_id),
+    emailLogId: UUID_RE.test(cleanString(event.email_log_id) ?? "")
+      ? cleanString(event.email_log_id)
+      : null,
+    email: cleanString(event.email)?.toLowerCase() ?? null,
+    errorText:
+      cleanString(event.reason) ??
+      cleanString(event.response) ??
+      cleanString(event.status),
+    safePayload: {
+      reason: cleanString(event.reason),
+      response: cleanString(event.response),
+      status: cleanString(event.status),
+      attempt: typeof event.attempt === "number" ? event.attempt : null,
+      type: cleanString(event.type),
+    },
+  };
+}
+
+export function shouldSuppressEmail(eventType: string): boolean {
+  return eventType === "bounce" || eventType === "spamreport" || eventType === "unsubscribe";
+}
+
+export function sanitizeEmailMetadata(
+  metadata: Record<string, unknown>,
+): Record<string, unknown> {
+  const blocked = /(password|secret|token|magic|link|url|authorization|cookie)/i;
+
+  const sanitizeValue = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(sanitizeValue);
+    if (typeof value !== "object" || value === null) return value;
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => !blocked.test(key))
+        .map(([key, child]) => [key, sanitizeValue(child)]),
+    );
+  };
+
+  return sanitizeValue(metadata) as Record<string, unknown>;
+}

--- a/supabase/migrations/20260716120000_sendgrid_delivery_events.sql
+++ b/supabase/migrations/20260716120000_sendgrid_delivery_events.sql
@@ -1,0 +1,133 @@
+begin;
+
+alter table public.email_logs
+  add column if not exists last_event_at timestamptz,
+  add column if not exists last_event_type text,
+  add column if not exists delivered_at timestamptz;
+
+-- Remove bearer links and credentials written by legacy application versions.
+update public.email_logs
+set metadata = coalesce(metadata, '{}'::jsonb)
+  - 'portal_link'
+  - 'portal_url'
+  - 'quote_url'
+  - 'login_url'
+  - 'username'
+  - 'password'
+  - 'temp_password'
+  - 'token';
+
+create table if not exists public.email_delivery_events (
+  id uuid primary key default gen_random_uuid(),
+  email_log_id uuid references public.email_logs(id) on delete set null,
+  provider text not null default 'sendgrid',
+  provider_event_id text not null,
+  provider_message_id text,
+  event_type text not null,
+  event_at timestamptz not null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (provider, provider_event_id)
+);
+
+create index if not exists email_delivery_events_log_idx
+  on public.email_delivery_events(email_log_id, event_at desc);
+
+alter table public.email_delivery_events enable row level security;
+revoke all on table public.email_delivery_events from anon, authenticated;
+grant all on table public.email_delivery_events to service_role;
+
+alter table public.email_suppressions enable row level security;
+revoke all on table public.email_suppressions from anon, authenticated;
+grant all on table public.email_suppressions to service_role;
+
+create or replace function public.process_sendgrid_delivery_event(
+  p_email_log_id uuid,
+  p_provider_event_id text,
+  p_provider_message_id text,
+  p_event_type text,
+  p_event_at timestamptz,
+  p_error_text text,
+  p_payload jsonb,
+  p_suppression_email text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_event_id uuid;
+  v_email_log_id uuid;
+begin
+  select id
+  into v_email_log_id
+  from public.email_logs
+  where id = p_email_log_id;
+
+  insert into public.email_delivery_events (
+    email_log_id,
+    provider,
+    provider_event_id,
+    provider_message_id,
+    event_type,
+    event_at,
+    payload
+  )
+  values (
+    v_email_log_id,
+    'sendgrid',
+    p_provider_event_id,
+    p_provider_message_id,
+    p_event_type,
+    p_event_at,
+    coalesce(p_payload, '{}'::jsonb)
+  )
+  on conflict (provider, provider_event_id) do nothing
+  returning id into v_event_id;
+
+  if v_event_id is null then
+    return false;
+  end if;
+
+  if v_email_log_id is not null then
+    update public.email_logs
+    set status = p_event_type,
+        error_text = p_error_text,
+        provider_message_id = coalesce(p_provider_message_id, provider_message_id),
+        last_event_at = p_event_at,
+        last_event_type = p_event_type,
+        delivered_at = case
+          when p_event_type = 'delivered' then p_event_at
+          else delivered_at
+        end
+    where id = v_email_log_id
+      and (last_event_at is null or last_event_at <= p_event_at);
+  end if;
+
+  if nullif(lower(btrim(p_suppression_email)), '') is not null then
+    insert into public.email_suppressions (email, suppressed, reason, updated_at)
+    values (
+      lower(btrim(p_suppression_email)),
+      true,
+      'sendgrid:' || p_event_type || coalesce(':' || nullif(p_error_text, ''), ''),
+      p_event_at
+    )
+    on conflict (email) do update
+      set suppressed = true,
+          reason = excluded.reason,
+          updated_at = excluded.updated_at;
+  end if;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.process_sendgrid_delivery_event(
+  uuid, text, text, text, timestamptz, text, jsonb, text
+) from public, anon, authenticated;
+grant execute on function public.process_sendgrid_delivery_event(
+  uuid, text, text, text, timestamptz, text, jsonb, text
+) to service_role;
+
+commit;

--- a/tests/sendgrid-webhook-security.test.ts
+++ b/tests/sendgrid-webhook-security.test.ts
@@ -1,0 +1,89 @@
+import { generateKeyPairSync, createSign } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  normalizeSendGridEvent,
+  parseSendGridEvents,
+  sanitizeEmailMetadata,
+  shouldSuppressEmail,
+  verifySendGridWebhookSignature,
+} from "@/features/email/server/sendgridWebhook";
+
+describe("SendGrid webhook security", () => {
+  it("accepts authentic payloads and rejects tampering", () => {
+    const { privateKey, publicKey } = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+    });
+    const rawBody = JSON.stringify([{ event: "delivered", sg_event_id: "event-1" }]);
+    const timestamp = "1770000000";
+    const signer = createSign("sha256");
+    signer.update(timestamp + rawBody, "utf8");
+    signer.end();
+    const signature = signer.sign(privateKey, "base64");
+    const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+    const publicKeyBase64 = publicKeyPem
+      .replace("-----BEGIN PUBLIC KEY-----", "")
+      .replace("-----END PUBLIC KEY-----", "")
+      .replaceAll(/\s/g, "");
+
+    expect(verifySendGridWebhookSignature({ rawBody, timestamp, signature, publicKey: publicKeyPem })).toBe(true);
+    expect(verifySendGridWebhookSignature({ rawBody, timestamp, signature, publicKey: publicKeyBase64 })).toBe(true);
+    expect(verifySendGridWebhookSignature({ rawBody: `${rawBody} `, timestamp, signature, publicKey: publicKeyPem })).toBe(false);
+  });
+
+  it("normalizes provider events without retaining recipient data in payload", () => {
+    const [raw] = parseSendGridEvents(JSON.stringify([{
+      email: "CUSTOMER@EXAMPLE.COM",
+      event: "bounce",
+      timestamp: 1770000000,
+      sg_event_id: "event-1",
+      sg_message_id: "message-1",
+      email_log_id: "log-1",
+      reason: "Mailbox unavailable",
+    }]));
+    const event = normalizeSendGridEvent(raw);
+
+    expect(event.email).toBe("customer@example.com");
+    expect(event.eventType).toBe("bounce");
+    expect(event.safePayload).not.toHaveProperty("email");
+    expect(shouldSuppressEmail(event.eventType)).toBe(true);
+    expect(shouldSuppressEmail("deferred")).toBe(false);
+  });
+
+  it("removes secrets and links from log metadata", () => {
+    expect(sanitizeEmailMetadata({
+      kind: "portal_invite",
+      portal_link: "https://example.com/token",
+      resetToken: "secret",
+      nested: { magicUrl: "https://example.com/secret", safe: "value" },
+      work_order_id: "wo-1",
+    })).toEqual({
+      kind: "portal_invite",
+      nested: { safe: "value" },
+      work_order_id: "wo-1",
+    });
+  });
+
+  it("correlates sends without exposing shop or customer data", () => {
+    const sender = readFileSync(
+      "features/email/server/sendDynamicTemplateEmail.ts",
+      "utf8",
+    );
+    expect(sender).toContain('status: "accepted"');
+    expect(sender).toContain("email_log_id: logRow.id");
+    expect(sender).not.toContain("customArgs: {\n        shop_id");
+    expect(sender).toContain('.from("email_suppressions")');
+  });
+
+  it("ships idempotent event storage and legacy metadata cleanup", () => {
+    const migration = readFileSync(
+      "supabase/migrations/20260716120000_sendgrid_delivery_events.sql",
+      "utf8",
+    );
+    expect(migration).toContain("unique (provider, provider_event_id)");
+    expect(migration).toContain("process_sendgrid_delivery_event");
+    expect(migration).toContain("on conflict (provider, provider_event_id) do nothing");
+    expect(migration).toContain("- 'portal_link'");
+    expect(migration).toContain("revoke all on table public.email_suppressions from anon, authenticated");
+  });
+});


### PR DESCRIPTION
## Summary

- add a signed SendGrid Event Webhook endpoint for delivery-state tracking
- distinguish SendGrid API acceptance from actual delivery
- process webhook events atomically and replay-safely in the database
- suppress recipients after bounce, spam-report, or unsubscribe events
- remove sensitive links and credentials from email-log metadata
- restrict email-log access to owner and admin roles
- document SendGrid webhook deployment and verification

SMS/text messaging is intentionally deferred to a later update.

## Validation

- `tsc --noEmit`
- targeted ESLint
- 15 targeted Vitest tests (email webhook security and role-gating contracts)
- API authorization boundary audit across 344 routes
- `git diff --check`

## Deployment

1. Apply `supabase/migrations/20260716120000_sendgrid_delivery_events.sql`.
2. Set `SENDGRID_EVENT_WEBHOOK_PUBLIC_KEY` to the SendGrid Event Webhook verification public key.
3. Configure SendGrid's Event Webhook URL as `https://profixiq.com/api/webhooks/sendgrid/events`.
4. Enable signature verification and subscribe to processed, delivered, deferred, bounce, dropped, open, click, spam-report, and unsubscribe events.
5. Send a SendGrid test event and confirm the delivery event is recorded.

## Scope note

This update covers ProFixIQ's central Dynamic Template sender. Direct or legacy SendGrid call paths and a generalized notification outbox can be handled in later email phases.