### PR TITLE
Fix approval signature pad contrast

### DIFF
--- a/features/shared/signaturePad/controller.tsx
+++ b/features/shared/signaturePad/controller.tsx
@@ -3,6 +3,9 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
+const SIGNATURE_INK_COLOR = "#0f172a";
+const SIGNATURE_CANVAS_COLOR = "#ffffff";
+
 type SigCanvasInstance = {
   clear: () => void;
   isEmpty: () => boolean;
@@ -200,17 +203,21 @@ function SignaturePadHost() {
               ref={(inst: SigCanvasInstance | null) => {
                 sigRef.current = inst;
               }}
-              penColor="white"
+              penColor={SIGNATURE_INK_COLOR}
               canvasProps={{
                 width: size.w,
                 height: size.h,
-                className: "w-full rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)]",
+                className: "w-full rounded-md border border-[color:var(--theme-border-soft)]",
+                style: { backgroundColor: SIGNATURE_CANVAS_COLOR },
                 role: "img",
                 "aria-label": "Signature input area",
               }}
             />
           ) : (
-            <div className="h-[220px] w-full animate-pulse rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)]" />
+            <div
+              className="h-[220px] w-full animate-pulse rounded-md border border-[color:var(--theme-border-soft)]"
+              style={{ backgroundColor: SIGNATURE_CANVAS_COLOR }}
+            />
           )}
         </div>
 
@@ -219,8 +226,12 @@ function SignaturePadHost() {
             type="button"
             onClick={handleClear}
             disabled={saving}
-            className="rounded px-4 py-2 text-[color:var(--theme-text-primary)] hover:opacity-90 disabled:opacity-50"
-            style={{ backgroundColor: "var(--theme-text-primary)", fontFamily: "'Black Ops One', Roboto, ui-sans-serif, system-ui" }}
+            className="rounded px-4 py-2 hover:opacity-90 disabled:opacity-50"
+            style={{
+              backgroundColor: SIGNATURE_INK_COLOR,
+              color: SIGNATURE_CANVAS_COLOR,
+              fontFamily: "'Black Ops One', Roboto, ui-sans-serif, system-ui",
+            }}
           >
             Clear
           </button>

--- a/tests/signature-pad-appearance.test.ts
+++ b/tests/signature-pad-appearance.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  "features/shared/signaturePad/controller.tsx",
+  "utf8",
+);
+
+describe("signature pad appearance", () => {
+  it("uses dark ink on a stable white drawing surface", () => {
+    expect(source).toContain('const SIGNATURE_INK_COLOR = "#0f172a"');
+    expect(source).toContain('const SIGNATURE_CANVAS_COLOR = "#ffffff"');
+    expect(source).toContain("penColor={SIGNATURE_INK_COLOR}");
+    expect(source).toContain("style: { backgroundColor: SIGNATURE_CANVAS_COLOR }");
+    expect(source).not.toContain('penColor="white"');
+  });
+
+  it("keeps the clear control readable against the ink-color background", () => {
+    expect(source).toContain("backgroundColor: SIGNATURE_INK_COLOR");
+    expect(source).toContain("color: SIGNATURE_CANVAS_COLOR");
+  });
+});


### PR DESCRIPTION
## Summary

- change the shared signature pad from white ink to high-contrast dark navy ink
- keep the drawing surface consistently white across themes
- restore readable text contrast on the Clear button
- add regression coverage for the signature-pad appearance contract

## Root cause

The shared signature component hard-coded `penColor="white"` while the approval canvas rendered with a light theme surface. On Safari/iPad, the captured stroke was therefore nearly invisible. The Clear control also used the same theme color for its text and background.

## Impact

Customer and technician signatures are now visibly drawn in dark ink on a white surface across every consumer of the shared signature pad, including work-order approval.

## Validation

- `tsc --noEmit`
- targeted ESLint (no errors; two pre-existing `no-explicit-any` warnings in the component)
- `vitest run tests/signature-pad-appearance.test.ts` (2 tests passed)
- `git diff --check`
