### PR TITLE
Fix work-order quote review navigation

### DIFF
--- a/app/quote-review/[id]/page.tsx
+++ b/app/quote-review/[id]/page.tsx
@@ -1,10 +1,21 @@
 // app/quote-review/[id]/page.tsx
-// Standalone wrapper for shared QuoteReviewView.
-// IMPORTANT: In this repo, Next's PageProps typing expects `params` as a Promise.
+// Stable standalone work-order quote review.
+
+import { redirect } from "next/navigation";
 
 import QuoteReviewView from "@/features/work-orders/quote-review/QuoteReviewView";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 export default async function Page(props: { params: Promise<{ id: string }> }) {
   const { id } = await props.params;
+  const supabase = createServerSupabaseRSC();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/sign-in?redirect=${encodeURIComponent(`/quote-review/${id}`)}`);
+  }
+
   return <QuoteReviewView workOrderId={id} />;
 }

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -349,8 +349,8 @@ export default function WorkOrderIdClient(): JSX.Element {
   }, [router, routeId]);
 
   const openQuoteReview = useCallback(() => {
-    router.push(`/work-orders/${routeId}/quote-review`);
-  }, [router, routeId]);
+    router.push(`/quote-review/${wo?.id ?? routeId}`);
+  }, [router, routeId, wo?.id]);
 
   /* ---------------------- AUTH + assignables ---------------------- */
   useEffect(() => {
@@ -2021,7 +2021,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                         Recommended repairs stay here until advisor/customer approval materializes work lines.
                       </p>
                     </div>
-                    <Link href={`/work-orders/${wo?.id ?? routeId}/quote-review`} className="rounded-full border border-sky-400/40 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 hover:bg-sky-500/20">
+                    <Link href={`/quote-review/${wo?.id ?? routeId}`} className="rounded-full border border-sky-400/40 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 hover:bg-sky-500/20">
                       Open Quote Review
                     </Link>
                   </div>
@@ -2064,7 +2064,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                             </div>
                           ) : null}
                           <div className="mt-3 flex flex-wrap gap-2">
-                            <Link href={`/work-orders/${wo?.id ?? routeId}/quote-review`} className="rounded-md border border-sky-400/40 px-2.5 py-1 text-[11px] font-semibold text-sky-100 hover:bg-sky-500/10">
+                            <Link href={`/quote-review/${wo?.id ?? routeId}`} className="rounded-md border border-sky-400/40 px-2.5 py-1 text-[11px] font-semibold text-sky-100 hover:bg-sky-500/10">
                               Review
                             </Link>
                             {partRequests[0]?.id ? (

--- a/app/work-orders/[id]/quote-review/page.tsx
+++ b/app/work-orders/[id]/quote-review/page.tsx
@@ -4,11 +4,9 @@
 // We resolve to the real work_orders.id UUID before embedding quote review.
 
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { redirect } from "next/navigation";
 
 
-import FocusedJobSplitView from "../focused-job/_components/FocusedJobSplitView";
-import WorkOrderIdClient from "../Client"; // adjust ONLY if your filename is actually ../Client
-import QuoteReviewPanelClient from "./_components/QuoteReviewPanelClient";
 
 
 function looksLikeUuid(s: string): boolean {
@@ -19,6 +17,17 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
   const { id: routeId } = await props.params;
 
   const supabase = createServerSupabaseRSC();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(
+      `/sign-in?redirect=${encodeURIComponent(
+        `/work-orders/${routeId}/quote-review`,
+      )}`,
+    );
+  }
 
   // Resolve routeId -> real UUID + custom_id
   let resolved: { id: string; custom_id: string | null } | null = null;
@@ -64,14 +73,5 @@ export default async function Page(props: { params: Promise<{ id: string }> }) {
   }
 
   const woUuid = resolved.id;
-  const woCustomId = resolved.custom_id ?? routeId;
-
-  return (
-    <FocusedJobSplitView
-      left={<WorkOrderIdClient key={routeId} />}
-      right={
-        <QuoteReviewPanelClient workOrderId={woUuid} workOrderLabel={woCustomId} />
-      }
-    />
-  );
+  redirect(`/quote-review/${woUuid}`);
 }

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -959,7 +959,7 @@ export default function InspectionFindingsPage(): JSX.Element {
       } else {
         toast.success("Findings sent to quote review.");
       }
-      router.push(`/work-orders/${resolvedWorkOrderId}/quote-review`);
+      router.push(`/quote-review/${resolvedWorkOrderId}`);
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Unable to submit findings";

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -103,6 +103,14 @@ export const ROUTE_META: Record<string, RouteMeta> = {
     roles: ["owner", "admin", "manager", "advisor"],
   },
 
+  "/quote-review/[id]": {
+    title: (href) =>
+      `Quote Review · ${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
+    icon: "✅",
+    persist: { keyParams: ["id"] },
+    roles: ["owner", "admin", "manager", "advisor"],
+  },
+
   "/work-orders/[id]": {
     title: (href) => `WO #${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
     icon: "🔧",

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -1463,7 +1463,7 @@ export default function MobileWorkOrderClient({
                   <h2 className="text-sm font-semibold text-sky-100 sm:text-base">Pending quote items</h2>
                   <p className="text-[11px] text-[color:var(--theme-text-muted)]">Recommended repairs awaiting quote review or customer decision.</p>
                 </div>
-                <Link href={`/work-orders/${wo?.id ?? routeId}/quote-review`} className="rounded-full border border-sky-400/40 px-3 py-1.5 text-[11px] font-semibold text-sky-100">
+                <Link href={`/quote-review/${wo?.id ?? routeId}`} className="rounded-full border border-sky-400/40 px-3 py-1.5 text-[11px] font-semibold text-sky-100">
                   Review
                 </Link>
               </div>

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -1,7 +1,7 @@
 // features/work-orders/quote-review/QuoteReviewView.tsx
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
@@ -337,6 +337,7 @@ export default function QuoteReviewView(props: {
 
   const [loading, setLoading] = useState(true);
   const [loadedOnce, setLoadedOnce] = useState(false);
+  const loadedOnceRef = useRef(false);
   const [wo, setWo] = useState<WorkOrder | null>(null);
   const [shop, setShop] = useState<Shop | null>(null);
   const [customer, setCustomer] = useState<Customer | null>(null);
@@ -370,7 +371,7 @@ export default function QuoteReviewView(props: {
 
     if (woErr) {
       toast.error(woErr.message);
-      if (!loadedOnce) {
+      if (!loadedOnceRef.current) {
         setWo(null);
         setShop(null);
         setCustomer(null);
@@ -489,10 +490,13 @@ export default function QuoteReviewView(props: {
     }
 
     setLoading(false);
+    loadedOnceRef.current = true;
     setLoadedOnce(true);
-  }, [loadedOnce, supabase, woId]);
+  }, [supabase, woId]);
 
   useEffect(() => {
+    loadedOnceRef.current = false;
+    setLoadedOnce(false);
     void reload();
   }, [reload]);
 


### PR DESCRIPTION
## What changed

- routes desktop, mobile, and inspection quote-review actions to the stable standalone work-order quote review
- replaces the legacy nested split view with an authenticated compatibility redirect
- adds an authentication guard to the standalone quote-review route
- registers the standalone route with the dashboard tab system
- prevents the quote-review loader from immediately running a second time after its first successful load

## Root cause

The nested route mounted the full work-order client and the full quote-review client at the same time. On iPad Safari this produced a high-cost remount/load cycle that showed the quote panel briefly, blanked the workspace, and restored the prior work-order page. The quote loader also recreated its reload callback after setting `loadedOnce`, causing an unnecessary second fetch.

## User impact

Clicking **Open Quote Review** or **Review** now opens one stable, authenticated quote-review screen. Existing nested links remain supported through a safe redirect.

## Validation

- static route contract checks passed for desktop, mobile, and inspection entry points
- verified both standalone and legacy routes enforce authenticated access
- verified the quote loader no longer depends on `loadedOnce`
- branch is based on current `main` and contains only the seven scoped files

Full repository tests were not run because this workspace has connector-only repository access.