### PR TITLE
Expand the QR editor live preview

### DIFF
--- a/features/portal/components/CustomerPortalQrBuilder.tsx
+++ b/features/portal/components/CustomerPortalQrBuilder.tsx
@@ -674,7 +674,7 @@ export default function CustomerPortalQrBuilder() {
           </section>
         </aside>
 
-        <main className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-soft)] print:border-0 print:bg-white print:p-0 print:shadow-none sm:p-6">
+        <main className="min-h-[760px] rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-soft)] print:min-h-0 print:border-0 print:bg-white print:p-0 print:shadow-none sm:min-h-[880px] sm:p-6">
           <div className="mb-5 flex flex-wrap items-center justify-between gap-3 print:hidden">
             <div>
               <div className="flex items-center gap-2 font-semibold">
@@ -690,10 +690,10 @@ export default function CustomerPortalQrBuilder() {
             </span>
           </div>
 
-          <div className="grid place-items-center overflow-auto rounded-2xl bg-[color:var(--theme-surface-inset)] p-4 print:block print:bg-white print:p-0 sm:p-8">
+          <div className="grid min-h-[680px] place-items-center overflow-auto rounded-2xl bg-[color:var(--theme-surface-inset)] p-4 print:min-h-0 print:block print:bg-white print:p-0 sm:min-h-[800px] sm:p-8">
             <div
               ref={cardRef}
-              className="relative w-full max-w-[430px] overflow-hidden border border-black/15 text-center shadow-2xl transition-all print:max-w-none print:rounded-none print:border-0 print:shadow-none"
+              className="relative min-h-[640px] w-full max-w-[430px] overflow-hidden border border-black/15 text-center shadow-2xl transition-all print:min-h-0 print:max-w-none print:rounded-none print:border-0 print:shadow-none sm:min-h-[720px]"
               style={{
                 aspectRatio: printSize.ratio,
                 backgroundColor: paper.color,

--- a/tests/portal-qr-print-editor.test.ts
+++ b/tests/portal-qr-print-editor.test.ts
@@ -71,6 +71,9 @@ describe("customer portal QR print editor", () => {
     expect(builder).toContain("Download preview");
     expect(builder).toContain('import("html2canvas")');
     expect(builder).toContain("beforeunload");
+    expect(builder).toContain("sm:min-h-[800px]");
+    expect(builder).toContain("sm:min-h-[720px]");
+    expect(builder).toContain("print:min-h-0");
   });
 
   it("persists validated settings in a tenant-scoped campaign update", () => {


### PR DESCRIPTION
## Summary

- increases the live preview canvas to a responsive 680–800px minimum height
- increases the editable card to a responsive 640–720px minimum height so the QR code, instruction, and footer remain visible
- keeps the center editor panel tall enough to show the complete design while scrolling the page
- removes all preview-only minimum heights in print mode so Letter, 5×7, and counter-card output ratios remain unchanged
- adds a regression contract for the expanded preview and print overrides

## Validation

- focused QR print editor regression contract added
- GitHub customer portal validation will run on this PR
- no database or environment changes