### PR TITLE
Stop the quote review route retry loop

### DIFF
--- a/app/quote-review/[id]/page.tsx
+++ b/app/quote-review/[id]/page.tsx
@@ -1,21 +1,13 @@
 // app/quote-review/[id]/page.tsx
 // Stable standalone work-order quote review.
-
-import { redirect } from "next/navigation";
+// Authentication is enforced by middleware before this page renders.
 
 import QuoteReviewView from "@/features/work-orders/quote-review/QuoteReviewView";
-import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 export default async function Page(props: { params: Promise<{ id: string }> }) {
   const { id } = await props.params;
-  const supabase = createServerSupabaseRSC();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    redirect(`/sign-in?redirect=${encodeURIComponent(`/quote-review/${id}`)}`);
-  }
-
   return <QuoteReviewView workOrderId={id} />;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -96,10 +96,6 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
-  if (pathname.startsWith("/work-orders/quote-review")) {
-    return NextResponse.next();
-  }
-
   const res = NextResponse.next({ request: { headers: requestHeaders } });
 
   const isPortal = pathname === "/portal" || pathname.startsWith("/portal/");
@@ -346,6 +342,7 @@ export const config = {
     "/dashboard/:path*",
     "/fleet/:path*",
     "/work-orders/:path*",
+    "/quote-review/:path*",
     "/inspections/:path*",
     "/mobile/:path*",
     "/parts/:path*",

--- a/tests/quote-review-route-contract.test.ts
+++ b/tests/quote-review-route-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const middleware = readFileSync("middleware.ts", "utf8");
+const quotePage = readFileSync("app/quote-review/[id]/page.tsx", "utf8");
+
+describe("work-order quote review route", () => {
+  it("uses the shared authenticated middleware boundary", () => {
+    expect(middleware).toContain('"/quote-review/:path*"');
+    expect(middleware).not.toContain(
+      'pathname.startsWith("/work-orders/quote-review")',
+    );
+  });
+
+  it("does not start a second page-level authentication redirect", () => {
+    expect(quotePage).toContain('export const dynamic = "force-dynamic"');
+    expect(quotePage).toContain("<QuoteReviewView workOrderId={id} />");
+    expect(quotePage).not.toContain("auth.getUser()");
+    expect(quotePage).not.toContain("redirect(");
+  });
+});


### PR DESCRIPTION
## What changed

- adds `/quote-review/:path*` to the normal authenticated middleware matcher
- removes the obsolete unauthenticated bypass for `/work-orders/quote-review`
- removes the duplicate page-level `getUser()`/redirect cycle from the standalone quote-review page
- keeps the page dynamic and uncached
- adds a route contract test that prevents the split authentication boundary from returning

## Root cause

PR #1052 moved work-order quote review to the standalone route, but that route was outside the middleware matcher and then performed its own server-component authentication redirect. During a client-side transition, Quote Review therefore authenticated differently from the work-order and app shell. The RSC request could be retried while Next retained the last successfully rendered work-order page, which matches the reported load/flicker/retry/restore behavior.

This change gives Quote Review the same single authentication boundary as the rest of the app.

## Security impact

This also removes the pre-existing early middleware bypass for the batch quote-review route. Both batch and per-work-order quote review now pass through authenticated middleware and Supabase RLS.

## Validation

- confirmed the branch is based on current `main`
- confirmed `/quote-review/:path*` is in the middleware matcher
- confirmed no quote-review middleware bypass remains
- confirmed the page no longer starts a second authentication redirect
- added `tests/quote-review-route-contract.test.ts`

Full repository tests will run in CI/Vercel because this workspace has connector-only repository access.