### PR TITLE
Harden staff user creation and rollback failures

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -28,18 +28,8 @@ type Body = {
 
 const PRIVILEGED_ROLES = new Set(["owner", "admin"]);
 const PROVISIONABLE_ROLES = new Set([
-  "owner",
-  "admin",
-  "manager",
-  "foreman",
-  "lead_hand",
-  "advisor",
-  "service",
-  "dispatcher",
-  "parts",
-  "mechanic",
-  "fleet_manager",
-  "driver",
+  "owner", "admin", "manager", "foreman", "lead_hand", "advisor", "service",
+  "dispatcher", "parts", "mechanic", "fleet_manager", "driver",
 ]);
 
 function isValidContactEmail(value: string): boolean {
@@ -85,10 +75,7 @@ async function rollbackCreatedAuthUser(args: {
   adminId: string;
   shopId: string;
 }): Promise<boolean> {
-  const { error } = await args.serviceSupabase.auth.admin.deleteUser(
-    args.authUserId,
-  );
-
+  const { error } = await args.serviceSupabase.auth.admin.deleteUser(args.authUserId);
   if (error) {
     logCreateUserError("rollback_auth_user_failed", {
       adminId: args.adminId,
@@ -124,31 +111,21 @@ export async function POST(req: Request) {
           error:
             "Invalid staff role. Allowed roles: owner, admin, manager, foreman, lead_hand, advisor, service, dispatcher, parts, mechanic, fleet_manager, driver.",
         },
-        { status: 400 },
+        { status: 400 }
       );
     }
 
     if (!PROVISIONABLE_ROLES.has(canonicalRole)) {
       return NextResponse.json(
-        {
-          error:
-            "This account type must be created through its dedicated portal or invitation flow.",
-        },
+        { error: "This account type must be created through its dedicated portal or invitation flow." },
         { status: 400 },
       );
     }
-
     if (!full_name) {
-      return NextResponse.json(
-        { error: "Full name is required." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Full name is required." }, { status: 400 });
     }
     if (full_name.length > 120) {
-      return NextResponse.json(
-        { error: "Full name is too long." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Full name is too long." }, { status: 400 });
     }
     if (password.trim().length < 8) {
       return NextResponse.json(
@@ -157,16 +134,10 @@ export async function POST(req: Request) {
       );
     }
     if (inputEmail && !isValidContactEmail(inputEmail)) {
-      return NextResponse.json(
-        { error: "Enter a valid contact email." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Enter a valid contact email." }, { status: 400 });
     }
     if (phone && phone.length > 40) {
-      return NextResponse.json(
-        { error: "Phone number is too long." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Phone number is too long." }, { status: 400 });
     }
 
     const access = await requireShopScopedApiAccess({
@@ -175,10 +146,7 @@ export async function POST(req: Request) {
     });
     if (!access.ok) return access.response;
 
-    if (
-      PRIVILEGED_ROLES.has(canonicalRole) &&
-      access.canonicalRole !== "owner"
-    ) {
+    if (PRIVILEGED_ROLES.has(canonicalRole) && access.canonicalRole !== "owner") {
       return NextResponse.json(
         { error: "Only an owner can create owner or admin accounts." },
         { status: 403 },
@@ -188,10 +156,7 @@ export async function POST(req: Request) {
     // Always force the creator's shop_id to preserve tenant boundaries.
     const effectiveShopId = access.profile.shop_id;
     if (!effectiveShopId) {
-      return NextResponse.json(
-        { error: "Profile for current user not found." },
-        { status: 403 },
-      );
+      return NextResponse.json({ error: "Profile for current user not found." }, { status: 403 });
     }
 
     logCreateUserStep("access_authorized", {
@@ -209,31 +174,22 @@ export async function POST(req: Request) {
       .eq("id", effectiveShopId)
       .maybeSingle<{ name: string | null; shop_name: string | null }>();
 
-    const shopDisplayName =
-      (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || "shop";
+    const shopDisplayName = (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || "shop";
     const shopNamespace = buildShopUsernameNamespace(shopDisplayName);
     const requestedUsername = String(raw.username ?? "").trim();
 
     if (!requestedUsername) {
-      return NextResponse.json(
-        { error: "Username is required." },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Username is required." }, { status: 400 });
     }
 
-    const normalizedInputUsername = requestedUsername
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "");
+    const normalizedInputUsername = requestedUsername.toLowerCase().replace(/[^a-z0-9]+/g, "");
     if (normalizedInputUsername.length < 2) {
       return NextResponse.json(
         { error: "Username must include at least 2 letters or numbers." },
         { status: 400 },
       );
     }
-    const username = normalizeProvisioningUsername(
-      requestedUsername,
-      shopNamespace,
-    );
+    const username = normalizeProvisioningUsername(requestedUsername, shopNamespace);
 
     // ensure username is unique inside the current shop only
     const { data: sameShopProfiles, error: existingErr } = await serviceSupabase
@@ -251,28 +207,22 @@ export async function POST(req: Request) {
         error: existingErr.message,
       });
       return NextResponse.json(
-        {
-          error: "Failed to check existing usernames.",
-          code: "username_lookup_failed",
-        },
-        { status: 500 },
+        { error: "Failed to check existing usernames.", code: "username_lookup_failed" },
+        { status: 500 }
       );
     }
 
     if ((sameShopProfiles ?? []).length > 0) {
       return NextResponse.json(
         { error: "A user with this username already exists in this shop." },
-        { status: 400 },
+        { status: 400 }
       );
     }
 
     try {
       await assertShopHasAvailableSeat(serviceSupabase, effectiveShopId);
     } catch (seatErr) {
-      const msg =
-        seatErr instanceof Error
-          ? seatErr.message
-          : "Shop user limit reached for your current plan.";
+      const msg = seatErr instanceof Error ? seatErr.message : "Shop user limit reached for your current plan.";
       return NextResponse.json({ error: msg }, { status: 400 });
     }
 
@@ -291,20 +241,19 @@ export async function POST(req: Request) {
     });
 
     // create auth user with service client
-    const { data: created, error: createErr } =
-      await serviceSupabase.auth.admin.createUser({
-        email: syntheticEmail,
-        password,
-        email_confirm: true,
-        user_metadata: {
-          full_name,
-          role: canonicalRole,
-          shop_id: effectiveShopId, // force caller's shop
-          phone,
-          username,
-          contact_email: contactEmail,
-        },
-      });
+    const { data: created, error: createErr } = await serviceSupabase.auth.admin.createUser({
+      email: syntheticEmail,
+      password,
+      email_confirm: true,
+      user_metadata: {
+        full_name,
+        role: canonicalRole,
+        shop_id: effectiveShopId, // force caller's shop
+        phone,
+        username,
+        contact_email: contactEmail,
+      },
+    });
 
     if (createErr || !created?.user) {
       logCreateUserError("auth_user_create_failed", {
@@ -313,16 +262,11 @@ export async function POST(req: Request) {
         role: canonicalRole,
         error: createErr?.message ?? "No auth user returned",
       });
-      const safeMessage = createErr?.message
-        ?.toLowerCase()
-        .includes("already been registered")
+      const safeMessage = createErr?.message?.toLowerCase().includes("already been registered")
         ? "Unable to provision this username. Try the suggested shop-prefixed username."
         : (createErr?.message ?? "Failed to create user.");
 
-      return NextResponse.json(
-        { error: safeMessage, code: "auth_user_create_failed" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: safeMessage, code: "auth_user_create_failed" }, { status: 400 });
     }
 
     const newUserId = created.user.id;
@@ -333,29 +277,29 @@ export async function POST(req: Request) {
       authUserId: newUserId,
       normalizedUsername: username,
       hasContactEmail: Boolean(contactEmail),
-      emailConfirmed: Boolean(
-        created.user.email_confirmed_at ?? created.user.confirmed_at,
-      ),
+      emailConfirmed: Boolean(created.user.email_confirmed_at ?? created.user.confirmed_at),
     });
 
     // upsert profile for the new user
-    const { error: profileErr } = await serviceSupabase.from("profiles").upsert(
-      {
-        id: newUserId,
-        email: contactEmail,
-        full_name,
-        phone,
-        role: canonicalRole,
-        shop_id: effectiveShopId,
-        shop_name: null,
-        username,
-        must_change_password: true,
-        updated_at: new Date().toISOString(),
-      } as Database["public"]["Tables"]["profiles"]["Insert"],
-      {
-        onConflict: "id",
-      },
-    );
+    const { error: profileErr } = await serviceSupabase
+      .from("profiles")
+      .upsert(
+        {
+          id: newUserId,
+          email: contactEmail,
+          full_name,
+          phone,
+          role: canonicalRole,
+          shop_id: effectiveShopId,
+          shop_name: null,
+          username,
+          must_change_password: true,
+          updated_at: new Date().toISOString(),
+        } as Database["public"]["Tables"]["profiles"]["Insert"],
+        {
+          onConflict: "id",
+        }
+      );
 
     if (profileErr) {
       const rolledBack = await rollbackCreatedAuthUser({
@@ -364,21 +308,15 @@ export async function POST(req: Request) {
         adminId: access.profile.id,
         shopId: effectiveShopId,
       });
-      if (
-        String(profileErr.message ?? "")
-          .toLowerCase()
-          .includes("shop user limit reached")
-      ) {
+      if (String(profileErr.message ?? "").toLowerCase().includes("shop user limit reached")) {
         return NextResponse.json(
           {
             error: rolledBack
               ? "Shop user limit reached for your current plan. No account was created."
               : "Shop user limit reached, and automatic account cleanup failed. Contact support before retrying.",
-            code: rolledBack
-              ? "shop_user_limit_reached"
-              : "provisioning_rollback_failed",
+            code: rolledBack ? "shop_user_limit_reached" : "provisioning_rollback_failed",
           },
-          { status: 400 },
+          { status: 400 }
         );
       }
       logCreateUserError("profile_upsert_failed", {
@@ -393,11 +331,9 @@ export async function POST(req: Request) {
           error: rolledBack
             ? "User setup could not be completed. No account was created; you can try again."
             : "User setup could not be completed, and automatic cleanup failed. Contact support before retrying.",
-          code: rolledBack
-            ? "profile_upsert_failed"
-            : "provisioning_rollback_failed",
+          code: rolledBack ? "profile_upsert_failed" : "provisioning_rollback_failed",
         },
-        { status: 500 },
+        { status: 500 }
       );
     }
 
@@ -410,10 +346,9 @@ export async function POST(req: Request) {
           user_id: newUserId,
           employment_status: "active",
           payroll_ready: false,
-          notes:
-            "Seeded during account provisioning; complete in People detail.",
+          notes: "Seeded during account provisioning; complete in People detail.",
         },
-        { onConflict: "shop_id,user_id" },
+        { onConflict: "shop_id,user_id" }
       );
 
     if (workforceErr) {
@@ -435,11 +370,9 @@ export async function POST(req: Request) {
           error: rolledBack
             ? "User setup could not be completed. No account was created; you can try again."
             : "User setup could not be completed, and automatic cleanup failed. Contact support before retrying.",
-          code: rolledBack
-            ? "workforce_profile_seed_failed"
-            : "provisioning_rollback_failed",
+          code: rolledBack ? "workforce_profile_seed_failed" : "provisioning_rollback_failed",
         },
-        { status: 500 },
+        { status: 500 }
       );
     }
 
@@ -451,9 +384,7 @@ export async function POST(req: Request) {
       profileId: newUserId,
       normalizedUsername: username,
       hasContactEmail: Boolean(contactEmail),
-      emailConfirmed: Boolean(
-        created.user.email_confirmed_at ?? created.user.confirmed_at,
-      ),
+      emailConfirmed: Boolean(created.user.email_confirmed_at ?? created.user.confirmed_at),
     });
 
     return NextResponse.json({
@@ -470,9 +401,7 @@ export async function POST(req: Request) {
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unexpected error.";
     logCreateUserError("unexpected_error", { error: msg });
-    return NextResponse.json(
-      { error: msg, code: "unexpected_error" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: msg, code: "unexpected_error" }, { status: 500 });
   }
 }
+

--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -26,6 +26,26 @@ type Body = {
   phone?: string | null;
 };
 
+const PRIVILEGED_ROLES = new Set(["owner", "admin"]);
+const PROVISIONABLE_ROLES = new Set([
+  "owner",
+  "admin",
+  "manager",
+  "foreman",
+  "lead_hand",
+  "advisor",
+  "service",
+  "dispatcher",
+  "parts",
+  "mechanic",
+  "fleet_manager",
+  "driver",
+]);
+
+function isValidContactEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
 function logCreateUserStep(
   step: string,
   details: {
@@ -35,8 +55,6 @@ function logCreateUserStep(
     authUserId?: string | null;
     profileId?: string | null;
     normalizedUsername?: string | null;
-    syntheticAuthEmail?: string | null;
-    contactEmail?: string | null;
     hasContactEmail?: boolean;
     emailConfirmed?: boolean | null;
   } = {},
@@ -53,8 +71,6 @@ function logCreateUserError(
     authUserId?: string | null;
     profileId?: string | null;
     normalizedUsername?: string | null;
-    syntheticAuthEmail?: string | null;
-    contactEmail?: string | null;
     hasContactEmail?: boolean;
     emailConfirmed?: boolean | null;
     error?: string | null;
@@ -63,12 +79,40 @@ function logCreateUserError(
   console.warn("[admin/create-user]", { step, ...details });
 }
 
+async function rollbackCreatedAuthUser(args: {
+  serviceSupabase: ReturnType<typeof createAdminSupabase>;
+  authUserId: string;
+  adminId: string;
+  shopId: string;
+}): Promise<boolean> {
+  const { error } = await args.serviceSupabase.auth.admin.deleteUser(
+    args.authUserId,
+  );
+
+  if (error) {
+    logCreateUserError("rollback_auth_user_failed", {
+      adminId: args.adminId,
+      targetShopId: args.shopId,
+      authUserId: args.authUserId,
+      error: error.message,
+    });
+    return false;
+  }
+
+  logCreateUserStep("rollback_auth_user_completed", {
+    adminId: args.adminId,
+    targetShopId: args.shopId,
+    authUserId: args.authUserId,
+  });
+  return true;
+}
+
 export async function POST(req: Request) {
   try {
     const raw = (await req.json()) as Partial<Body>;
 
     const password = raw.password ?? "";
-    const full_name = (raw.full_name ?? null) || null;
+    const full_name = String(raw.full_name ?? "").trim() || null;
     const requestedRole = (raw.role ?? null) || null;
     const canonicalRole = canonicalizeRole(requestedRole);
     const phone = (raw.phone ?? null) || null;
@@ -78,14 +122,51 @@ export async function POST(req: Request) {
       return NextResponse.json(
         {
           error:
-            "Invalid role. Allowed roles: owner, admin, manager, foreman, lead_hand, advisor, service, dispatcher, parts, mechanic, fleet_manager, driver, customer.",
+            "Invalid staff role. Allowed roles: owner, admin, manager, foreman, lead_hand, advisor, service, dispatcher, parts, mechanic, fleet_manager, driver.",
         },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    if (!password) {
-      return NextResponse.json({ error: "Temporary password is required." }, { status: 400 });
+    if (!PROVISIONABLE_ROLES.has(canonicalRole)) {
+      return NextResponse.json(
+        {
+          error:
+            "This account type must be created through its dedicated portal or invitation flow.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (!full_name) {
+      return NextResponse.json(
+        { error: "Full name is required." },
+        { status: 400 },
+      );
+    }
+    if (full_name.length > 120) {
+      return NextResponse.json(
+        { error: "Full name is too long." },
+        { status: 400 },
+      );
+    }
+    if (password.trim().length < 8) {
+      return NextResponse.json(
+        { error: "Temporary password must be at least 8 characters." },
+        { status: 400 },
+      );
+    }
+    if (inputEmail && !isValidContactEmail(inputEmail)) {
+      return NextResponse.json(
+        { error: "Enter a valid contact email." },
+        { status: 400 },
+      );
+    }
+    if (phone && phone.length > 40) {
+      return NextResponse.json(
+        { error: "Phone number is too long." },
+        { status: 400 },
+      );
     }
 
     const access = await requireShopScopedApiAccess({
@@ -94,10 +175,23 @@ export async function POST(req: Request) {
     });
     if (!access.ok) return access.response;
 
+    if (
+      PRIVILEGED_ROLES.has(canonicalRole) &&
+      access.canonicalRole !== "owner"
+    ) {
+      return NextResponse.json(
+        { error: "Only an owner can create owner or admin accounts." },
+        { status: 403 },
+      );
+    }
+
     // Always force the creator's shop_id to preserve tenant boundaries.
     const effectiveShopId = access.profile.shop_id;
     if (!effectiveShopId) {
-      return NextResponse.json({ error: "Profile for current user not found." }, { status: 403 });
+      return NextResponse.json(
+        { error: "Profile for current user not found." },
+        { status: 403 },
+      );
     }
 
     logCreateUserStep("access_authorized", {
@@ -115,15 +209,31 @@ export async function POST(req: Request) {
       .eq("id", effectiveShopId)
       .maybeSingle<{ name: string | null; shop_name: string | null }>();
 
-    const shopDisplayName = (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || "shop";
+    const shopDisplayName =
+      (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || "shop";
     const shopNamespace = buildShopUsernameNamespace(shopDisplayName);
     const requestedUsername = String(raw.username ?? "").trim();
 
     if (!requestedUsername) {
-      return NextResponse.json({ error: "Username is required." }, { status: 400 });
+      return NextResponse.json(
+        { error: "Username is required." },
+        { status: 400 },
+      );
     }
 
-    const username = normalizeProvisioningUsername(requestedUsername, shopNamespace);
+    const normalizedInputUsername = requestedUsername
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "");
+    if (normalizedInputUsername.length < 2) {
+      return NextResponse.json(
+        { error: "Username must include at least 2 letters or numbers." },
+        { status: 400 },
+      );
+    }
+    const username = normalizeProvisioningUsername(
+      requestedUsername,
+      shopNamespace,
+    );
 
     // ensure username is unique inside the current shop only
     const { data: sameShopProfiles, error: existingErr } = await serviceSupabase
@@ -141,22 +251,28 @@ export async function POST(req: Request) {
         error: existingErr.message,
       });
       return NextResponse.json(
-        { error: "Failed to check existing usernames.", code: "username_lookup_failed" },
-        { status: 500 }
+        {
+          error: "Failed to check existing usernames.",
+          code: "username_lookup_failed",
+        },
+        { status: 500 },
       );
     }
 
     if ((sameShopProfiles ?? []).length > 0) {
       return NextResponse.json(
         { error: "A user with this username already exists in this shop." },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
     try {
       await assertShopHasAvailableSeat(serviceSupabase, effectiveShopId);
     } catch (seatErr) {
-      const msg = seatErr instanceof Error ? seatErr.message : "Shop user limit reached for your current plan.";
+      const msg =
+        seatErr instanceof Error
+          ? seatErr.message
+          : "Shop user limit reached for your current plan.";
       return NextResponse.json({ error: msg }, { status: 400 });
     }
 
@@ -171,25 +287,24 @@ export async function POST(req: Request) {
       targetShopId: effectiveShopId,
       role: canonicalRole,
       normalizedUsername: username,
-      syntheticAuthEmail: syntheticEmail,
-      contactEmail,
       hasContactEmail: Boolean(contactEmail),
     });
 
     // create auth user with service client
-    const { data: created, error: createErr } = await serviceSupabase.auth.admin.createUser({
-      email: syntheticEmail,
-      password,
-      email_confirm: true,
-      user_metadata: {
-        full_name,
-        role: canonicalRole,
-        shop_id: effectiveShopId, // force caller's shop
-        phone,
-        username,
-        contact_email: contactEmail,
-      },
-    });
+    const { data: created, error: createErr } =
+      await serviceSupabase.auth.admin.createUser({
+        email: syntheticEmail,
+        password,
+        email_confirm: true,
+        user_metadata: {
+          full_name,
+          role: canonicalRole,
+          shop_id: effectiveShopId, // force caller's shop
+          phone,
+          username,
+          contact_email: contactEmail,
+        },
+      });
 
     if (createErr || !created?.user) {
       logCreateUserError("auth_user_create_failed", {
@@ -198,11 +313,16 @@ export async function POST(req: Request) {
         role: canonicalRole,
         error: createErr?.message ?? "No auth user returned",
       });
-      const safeMessage = createErr?.message?.toLowerCase().includes("already been registered")
+      const safeMessage = createErr?.message
+        ?.toLowerCase()
+        .includes("already been registered")
         ? "Unable to provision this username. Try the suggested shop-prefixed username."
         : (createErr?.message ?? "Failed to create user.");
 
-      return NextResponse.json({ error: safeMessage, code: "auth_user_create_failed" }, { status: 400 });
+      return NextResponse.json(
+        { error: safeMessage, code: "auth_user_create_failed" },
+        { status: 400 },
+      );
     }
 
     const newUserId = created.user.id;
@@ -212,38 +332,53 @@ export async function POST(req: Request) {
       role: canonicalRole,
       authUserId: newUserId,
       normalizedUsername: username,
-      syntheticAuthEmail: syntheticEmail,
-      contactEmail,
       hasContactEmail: Boolean(contactEmail),
-      emailConfirmed: Boolean(created.user.email_confirmed_at ?? created.user.confirmed_at),
+      emailConfirmed: Boolean(
+        created.user.email_confirmed_at ?? created.user.confirmed_at,
+      ),
     });
 
     // upsert profile for the new user
-    const { error: profileErr } = await serviceSupabase
-      .from("profiles")
-      .upsert(
-        {
-          id: newUserId,
-          email: contactEmail,
-          full_name,
-          phone,
-          role: canonicalRole,
-          shop_id: effectiveShopId,
-          shop_name: null,
-          username,
-          must_change_password: true,
-          updated_at: new Date().toISOString(),
-        } as Database["public"]["Tables"]["profiles"]["Insert"],
-        {
-          onConflict: "id",
-        }
-      );
+    const { error: profileErr } = await serviceSupabase.from("profiles").upsert(
+      {
+        id: newUserId,
+        email: contactEmail,
+        full_name,
+        phone,
+        role: canonicalRole,
+        shop_id: effectiveShopId,
+        shop_name: null,
+        username,
+        must_change_password: true,
+        updated_at: new Date().toISOString(),
+      } as Database["public"]["Tables"]["profiles"]["Insert"],
+      {
+        onConflict: "id",
+      },
+    );
 
     if (profileErr) {
-      if (String(profileErr.message ?? "").toLowerCase().includes("shop user limit reached")) {
+      const rolledBack = await rollbackCreatedAuthUser({
+        serviceSupabase,
+        authUserId: newUserId,
+        adminId: access.profile.id,
+        shopId: effectiveShopId,
+      });
+      if (
+        String(profileErr.message ?? "")
+          .toLowerCase()
+          .includes("shop user limit reached")
+      ) {
         return NextResponse.json(
-          { error: "Shop user limit reached for your current plan." },
-          { status: 400 }
+          {
+            error: rolledBack
+              ? "Shop user limit reached for your current plan. No account was created."
+              : "Shop user limit reached, and automatic account cleanup failed. Contact support before retrying.",
+            code: rolledBack
+              ? "shop_user_limit_reached"
+              : "provisioning_rollback_failed",
+          },
+          { status: 400 },
         );
       }
       logCreateUserError("profile_upsert_failed", {
@@ -254,8 +389,15 @@ export async function POST(req: Request) {
         error: profileErr.message,
       });
       return NextResponse.json(
-        { error: "Profile upsert failed.", code: "profile_upsert_failed" },
-        { status: 400 }
+        {
+          error: rolledBack
+            ? "User setup could not be completed. No account was created; you can try again."
+            : "User setup could not be completed, and automatic cleanup failed. Contact support before retrying.",
+          code: rolledBack
+            ? "profile_upsert_failed"
+            : "provisioning_rollback_failed",
+        },
+        { status: 500 },
       );
     }
 
@@ -268,12 +410,19 @@ export async function POST(req: Request) {
           user_id: newUserId,
           employment_status: "active",
           payroll_ready: false,
-          notes: "Seeded during account provisioning; complete in People detail.",
+          notes:
+            "Seeded during account provisioning; complete in People detail.",
         },
-        { onConflict: "shop_id,user_id" }
+        { onConflict: "shop_id,user_id" },
       );
 
     if (workforceErr) {
+      const rolledBack = await rollbackCreatedAuthUser({
+        serviceSupabase,
+        authUserId: newUserId,
+        adminId: access.profile.id,
+        shopId: effectiveShopId,
+      });
       logCreateUserError("workforce_profile_seed_failed", {
         adminId: access.profile.id,
         targetShopId: effectiveShopId,
@@ -282,8 +431,15 @@ export async function POST(req: Request) {
         error: workforceErr.message,
       });
       return NextResponse.json(
-        { error: "Workforce profile seed failed.", code: "workforce_profile_seed_failed" },
-        { status: 400 }
+        {
+          error: rolledBack
+            ? "User setup could not be completed. No account was created; you can try again."
+            : "User setup could not be completed, and automatic cleanup failed. Contact support before retrying.",
+          code: rolledBack
+            ? "workforce_profile_seed_failed"
+            : "provisioning_rollback_failed",
+        },
+        { status: 500 },
       );
     }
 
@@ -294,10 +450,10 @@ export async function POST(req: Request) {
       authUserId: newUserId,
       profileId: newUserId,
       normalizedUsername: username,
-      syntheticAuthEmail: syntheticEmail,
-      contactEmail,
       hasContactEmail: Boolean(contactEmail),
-      emailConfirmed: Boolean(created.user.email_confirmed_at ?? created.user.confirmed_at),
+      emailConfirmed: Boolean(
+        created.user.email_confirmed_at ?? created.user.confirmed_at,
+      ),
     });
 
     return NextResponse.json({
@@ -314,6 +470,9 @@ export async function POST(req: Request) {
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Unexpected error.";
     logCreateUserError("unexpected_error", { error: msg });
-    return NextResponse.json({ error: msg, code: "unexpected_error" }, { status: 500 });
+    return NextResponse.json(
+      { error: msg, code: "unexpected_error" },
+      { status: 500 },
+    );
   }
 }

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -47,9 +47,7 @@ export default function CreateUserPage(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [createdUserId, setCreatedUserId] = useState<string | null>(null);
-  const [createdPersonHref, setCreatedPersonHref] = useState<string | null>(
-    null,
-  );
+  const [createdPersonHref, setCreatedPersonHref] = useState<string | null>(null);
   const [openPeopleAfterCreate, setOpenPeopleAfterCreate] = useState(true);
 
   // force UsersList to re-run its effect
@@ -95,8 +93,7 @@ export default function CreateUserPage(): JSX.Element {
           .eq("id", shopId)
           .maybeSingle<{ name: string | null; shop_name: string | null }>();
 
-        const displayName =
-          (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || null;
+        const displayName = (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || null;
         setCreatorShopName(displayName);
       }
     };
@@ -155,14 +152,9 @@ export default function CreateUserPage(): JSX.Element {
         body: JSON.stringify(body),
       });
 
-      const payload = (await res.json().catch(() => null)) as {
-        error?: string;
-        user_id?: string;
-        username?: string;
-        email?: string | null;
-        auth_email?: string;
-        people_record_href?: string;
-      } | null;
+      const payload = (await res.json().catch(() => null)) as
+        | { error?: string; user_id?: string; username?: string; email?: string | null; auth_email?: string; people_record_href?: string }
+        | null;
 
       if (!res.ok) throw new Error(payload?.error || "Failed to create user.");
 
@@ -256,15 +248,13 @@ export default function CreateUserPage(): JSX.Element {
         {/* LEFT: create user */}
         <div className={`space-y-4 ${PANEL_CLASS}`}>
           <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">
-              New team member
-            </h2>
+            <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">New team member</h2>
             <p className="text-sm text-[color:var(--theme-text-secondary)]">
               This step provisions access only: create login credentials, set an
               initial role, and link the person to your shop. For{" "}
               <span style={{ color: COPPER }}>
-                workforce profile, certifications, payroll readiness, and
-                ongoing staff management
+                workforce profile, certifications, payroll readiness, and ongoing
+                staff management
               </span>
               , continue in People after create.
             </p>
@@ -337,8 +327,7 @@ export default function CreateUserPage(): JSX.Element {
                 onChange={(e) => setForm({ ...form, email: e.target.value })}
               />
               <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-                Stored on the profile for contact only. Username remains the
-                staff sign-in identity.
+                Stored on the profile for contact only. Username remains the staff sign-in identity.
               </p>
             </div>
 
@@ -356,8 +345,7 @@ export default function CreateUserPage(): JSX.Element {
                 }}
               />
               <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-                Username is normalized to letters/numbers and shop-prefixed for
-                collision-safe login.
+                Username is normalized to letters/numbers and shop-prefixed for collision-safe login.
               </p>
             </div>
 
@@ -373,8 +361,7 @@ export default function CreateUserPage(): JSX.Element {
                 onChange={(e) => setForm({ ...form, password: e.target.value })}
               />
               <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-                At least 8 characters. The user must replace it during their
-                first sign-in.
+                At least 8 characters. The user must replace it during their first sign-in.
               </p>
             </div>
 
@@ -389,12 +376,8 @@ export default function CreateUserPage(): JSX.Element {
                   setForm({ ...form, role: e.target.value as UserRole })
                 }
               >
-                {creatorRole === "owner" ? (
-                  <option value="owner">Owner</option>
-                ) : null}
-                {creatorRole === "owner" ? (
-                  <option value="admin">Admin</option>
-                ) : null}
+                {creatorRole === "owner" ? <option value="owner">Owner</option> : null}
+                {creatorRole === "owner" ? <option value="admin">Admin</option> : null}
                 <option value="manager">Manager</option>
                 <option value="foreman">Foreman</option>
                 <option value="lead_hand">Lead Hand</option>
@@ -406,10 +389,9 @@ export default function CreateUserPage(): JSX.Element {
                 <option value="fleet_manager">Fleet manager</option>
               </select>
               <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-                App role controls access and permissions. Workforce
-                title/category is managed separately in the People profile.
-                External customer and fleet portal accounts must use their
-                dedicated invitation flows.
+                App role controls access and permissions. Workforce title/category is managed
+                separately in the People profile. External customer and fleet portal accounts
+                must use their dedicated invitation flows.
               </p>
             </div>
           </div>
@@ -433,8 +415,7 @@ export default function CreateUserPage(): JSX.Element {
             </button>
             <p className="text-xs text-[color:var(--theme-text-muted)]">
               Next step: complete workforce/profile setup in People, then share
-              credentials for first sign-in. Shop access is assigned
-              automatically.
+              credentials for first sign-in. Shop access is assigned automatically.
             </p>
           </div>
         </div>
@@ -478,11 +459,7 @@ export default function CreateUserPage(): JSX.Element {
                 <button
                   type="button"
                   className="text-[var(--accent-copper-soft)] hover:text-[var(--accent-copper)]"
-                  onClick={() =>
-                    router.push(
-                      `/dashboard/admin/people/${createdUserId}?from=create-user`,
-                    )
-                  }
+                  onClick={() => router.push(`/dashboard/admin/people/${createdUserId}?from=create-user`)}
                 >
                   Open workspace
                 </button>
@@ -523,9 +500,7 @@ export default function CreateUserPage(): JSX.Element {
                 {resetBusy ? "Updating…" : "Reset password"}
               </button>
               {resetMsg && (
-                <div className="mt-1 text-xs text-[color:var(--theme-text-primary)]">
-                  {resetMsg}
-                </div>
+                <div className="mt-1 text-xs text-[color:var(--theme-text-primary)]">{resetMsg}</div>
               )}
             </div>
           </div>
@@ -534,27 +509,22 @@ export default function CreateUserPage(): JSX.Element {
 
       {/* PENDING INVITES */}
       <div className={`mt-6 ${PANEL_CLASS}`}>
-        <h2 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">
-          Pending invites
-        </h2>
+        <h2 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">Pending invites</h2>
         <p className="mb-3 text-xs text-[color:var(--theme-text-muted)]">
-          These are staff invite candidates (imported or staged). Create the
-          user + send the invite email.
+          These are staff invite candidates (imported or staged). Create the user + send the invite email.
         </p>
         <InviteCandidatesList />
       </div>
 
       {/* USERS LIST (full width, own card) */}
       <div className={`mt-6 ${PANEL_CLASS}`}>
-        <h2 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">
-          All users
-        </h2>
+        <h2 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">All users</h2>
         <p className="mb-3 text-xs text-[color:var(--theme-text-muted)]">
-          This is the full list of users for your shop. New accounts appear here
-          automatically.
+          This is the full list of users for your shop. New accounts appear here automatically.
         </p>
         <UsersList key={listRefreshKey} />
       </div>
     </PageShell>
   );
 }
+

--- a/features/dashboard/app/dashboard/owner/create-user/page.tsx
+++ b/features/dashboard/app/dashboard/owner/create-user/page.tsx
@@ -23,7 +23,6 @@ type CreatePayload = {
   email?: string | null;
   full_name?: string | null;
   role?: UserRole | null;
-  shop_id?: string | null;
   phone?: string | null;
 };
 
@@ -41,7 +40,6 @@ export default function CreateUserPage(): JSX.Element {
     email: "",
     full_name: "",
     role: "mechanic",
-    shop_id: null,
     phone: "",
   });
 
@@ -49,7 +47,9 @@ export default function CreateUserPage(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [createdUserId, setCreatedUserId] = useState<string | null>(null);
-  const [createdPersonHref, setCreatedPersonHref] = useState<string | null>(null);
+  const [createdPersonHref, setCreatedPersonHref] = useState<string | null>(
+    null,
+  );
   const [openPeopleAfterCreate, setOpenPeopleAfterCreate] = useState(true);
 
   // force UsersList to re-run its effect
@@ -66,9 +66,9 @@ export default function CreateUserPage(): JSX.Element {
   const [resetBusy, setResetBusy] = useState(false);
   const [resetMsg, setResetMsg] = useState<string | null>(null);
 
-  // creator’s shop id (for auto-fill)
-  const [creatorShopId, setCreatorShopId] = useState<string | null>(null);
+  // Creator shop details are display aids only; the API derives tenant scope.
   const [creatorShopName, setCreatorShopName] = useState<string | null>(null);
+  const [creatorRole, setCreatorRole] = useState<string | null>(null);
   const [usernameTouched, setUsernameTouched] = useState(false);
 
   // load current user's shop_id once
@@ -81,12 +81,12 @@ export default function CreateUserPage(): JSX.Element {
 
       const { data: profile } = await supabase
         .from("profiles")
-        .select("shop_id")
+        .select("shop_id, role")
         .eq("id", user.id)
         .maybeSingle();
 
       const shopId = profile?.shop_id ?? null;
-      setCreatorShopId(shopId);
+      setCreatorRole(profile?.role ?? null);
 
       if (shopId) {
         const { data: shop } = await supabase
@@ -95,13 +95,9 @@ export default function CreateUserPage(): JSX.Element {
           .eq("id", shopId)
           .maybeSingle<{ name: string | null; shop_name: string | null }>();
 
-        const displayName = (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || null;
+        const displayName =
+          (shop?.shop_name ?? "").trim() || (shop?.name ?? "").trim() || null;
         setCreatorShopName(displayName);
-
-        setForm((prev) => ({
-          ...prev,
-          shop_id: shopId,
-        }));
       }
     };
 
@@ -140,15 +136,17 @@ export default function CreateUserPage(): JSX.Element {
         email: (form.email ?? "").trim().toLowerCase() || null,
         full_name: (form.full_name ?? "").trim() || null,
         role: form.role ?? null,
-        shop_id: (form.shop_id ?? "")?.trim() || creatorShopId || null,
         phone: (form.phone ?? "")?.trim() || null,
       };
 
       if (!body.username) {
         throw new Error("Username is required.");
       }
-      if (!body.password) {
-        throw new Error("Temporary password is required.");
+      if (!body.full_name) {
+        throw new Error("Full name is required.");
+      }
+      if (body.password.trim().length < 8) {
+        throw new Error("Temporary password must be at least 8 characters.");
       }
 
       const res = await fetch("/api/admin/create-user", {
@@ -157,9 +155,14 @@ export default function CreateUserPage(): JSX.Element {
         body: JSON.stringify(body),
       });
 
-      const payload = (await res.json().catch(() => null)) as
-        | { error?: string; user_id?: string; username?: string; email?: string | null; auth_email?: string; people_record_href?: string }
-        | null;
+      const payload = (await res.json().catch(() => null)) as {
+        error?: string;
+        user_id?: string;
+        username?: string;
+        email?: string | null;
+        auth_email?: string;
+        people_record_href?: string;
+      } | null;
 
       if (!res.ok) throw new Error(payload?.error || "Failed to create user.");
 
@@ -193,7 +196,6 @@ export default function CreateUserPage(): JSX.Element {
         email: "",
         full_name: "",
         phone: "",
-        shop_id: body.shop_id ?? creatorShopId ?? null,
       }));
       setUsernameTouched(false);
 
@@ -254,18 +256,20 @@ export default function CreateUserPage(): JSX.Element {
         {/* LEFT: create user */}
         <div className={`space-y-4 ${PANEL_CLASS}`}>
           <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">New team member</h2>
+            <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">
+              New team member
+            </h2>
             <p className="text-sm text-[color:var(--theme-text-secondary)]">
               This step provisions access only: create login credentials, set an
               initial role, and link the person to your shop. For{" "}
               <span style={{ color: COPPER }}>
-                workforce profile, certifications, payroll readiness, and ongoing
-                staff management
+                workforce profile, certifications, payroll readiness, and
+                ongoing staff management
               </span>
               , continue in People after create.
             </p>
             <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-              If they forget it later, an owner or manager can issue a new
+              If they forget it later, an owner or admin can issue a new
               temporary password from this screen.
             </p>
           </div>
@@ -297,7 +301,7 @@ export default function CreateUserPage(): JSX.Element {
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div className="space-y-1">
               <label className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
-                Full name
+                Full name <span className="text-red-400">*</span>
               </label>
               <input
                 className={INPUT_CLASS}
@@ -333,7 +337,8 @@ export default function CreateUserPage(): JSX.Element {
                 onChange={(e) => setForm({ ...form, email: e.target.value })}
               />
               <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-                Stored on the profile for contact only. Username remains the staff sign-in identity.
+                Stored on the profile for contact only. Username remains the
+                staff sign-in identity.
               </p>
             </div>
 
@@ -351,7 +356,8 @@ export default function CreateUserPage(): JSX.Element {
                 }}
               />
               <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-                Username is normalized to letters/numbers and shop-prefixed for collision-safe login.
+                Username is normalized to letters/numbers and shop-prefixed for
+                collision-safe login.
               </p>
             </div>
 
@@ -367,8 +373,8 @@ export default function CreateUserPage(): JSX.Element {
                 onChange={(e) => setForm({ ...form, password: e.target.value })}
               />
               <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-                Share this directly with the user. They can change it later from
-                the Settings screen if you enable that flow.
+                At least 8 characters. The user must replace it during their
+                first sign-in.
               </p>
             </div>
 
@@ -383,8 +389,12 @@ export default function CreateUserPage(): JSX.Element {
                   setForm({ ...form, role: e.target.value as UserRole })
                 }
               >
-                <option value="owner">Owner</option>
-                <option value="admin">Admin</option>
+                {creatorRole === "owner" ? (
+                  <option value="owner">Owner</option>
+                ) : null}
+                {creatorRole === "owner" ? (
+                  <option value="admin">Admin</option>
+                ) : null}
                 <option value="manager">Manager</option>
                 <option value="foreman">Foreman</option>
                 <option value="lead_hand">Lead Hand</option>
@@ -396,31 +406,11 @@ export default function CreateUserPage(): JSX.Element {
                 <option value="fleet_manager">Fleet manager</option>
               </select>
               <p className="text-[11px] text-[color:var(--theme-text-muted)]">
-                App role controls access and permissions. Workforce title/category is managed
-                separately in the People profile. Use{" "}
-                <span style={{ color: COPPER }}>driver / dispatcher / fleet manager</span> for
-                Fleet Portal accounts.
+                App role controls access and permissions. Workforce
+                title/category is managed separately in the People profile.
+                External customer and fleet portal accounts must use their
+                dedicated invitation flows.
               </p>
-            </div>
-
-            <div className="space-y-1">
-              <label className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
-                Shop ID{" "}
-                <span className="text-[color:var(--theme-text-muted)]">
-                  {creatorShopId ? "(auto from your profile)" : "(optional)"}
-                </span>
-              </label>
-              <input
-                className={INPUT_CLASS}
-                placeholder="Shop ID"
-                value={form.shop_id ?? ""}
-                onChange={(e) =>
-                  setForm({
-                    ...form,
-                    shop_id: e.target.value || null,
-                  })
-                }
-              />
             </div>
           </div>
 
@@ -443,7 +433,8 @@ export default function CreateUserPage(): JSX.Element {
             </button>
             <p className="text-xs text-[color:var(--theme-text-muted)]">
               Next step: complete workforce/profile setup in People, then share
-              credentials for first sign-in.
+              credentials for first sign-in. Shop access is assigned
+              automatically.
             </p>
           </div>
         </div>
@@ -487,7 +478,11 @@ export default function CreateUserPage(): JSX.Element {
                 <button
                   type="button"
                   className="text-[var(--accent-copper-soft)] hover:text-[var(--accent-copper)]"
-                  onClick={() => router.push(`/dashboard/admin/people/${createdUserId}?from=create-user`)}
+                  onClick={() =>
+                    router.push(
+                      `/dashboard/admin/people/${createdUserId}?from=create-user`,
+                    )
+                  }
                 >
                   Open workspace
                 </button>
@@ -528,7 +523,9 @@ export default function CreateUserPage(): JSX.Element {
                 {resetBusy ? "Updating…" : "Reset password"}
               </button>
               {resetMsg && (
-                <div className="mt-1 text-xs text-[color:var(--theme-text-primary)]">{resetMsg}</div>
+                <div className="mt-1 text-xs text-[color:var(--theme-text-primary)]">
+                  {resetMsg}
+                </div>
               )}
             </div>
           </div>
@@ -537,18 +534,24 @@ export default function CreateUserPage(): JSX.Element {
 
       {/* PENDING INVITES */}
       <div className={`mt-6 ${PANEL_CLASS}`}>
-        <h2 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">Pending invites</h2>
+        <h2 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+          Pending invites
+        </h2>
         <p className="mb-3 text-xs text-[color:var(--theme-text-muted)]">
-          These are staff invite candidates (imported or staged). Create the user + send the invite email.
+          These are staff invite candidates (imported or staged). Create the
+          user + send the invite email.
         </p>
         <InviteCandidatesList />
       </div>
 
       {/* USERS LIST (full width, own card) */}
       <div className={`mt-6 ${PANEL_CLASS}`}>
-        <h2 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">All users</h2>
+        <h2 className="mb-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+          All users
+        </h2>
         <p className="mb-3 text-xs text-[color:var(--theme-text-muted)]">
-          This is the full list of users for your shop. New accounts appear here automatically.
+          This is the full list of users for your shop. New accounts appear here
+          automatically.
         </p>
         <UsersList key={listRefreshKey} />
       </div>

--- a/tests/user-auth-normalization.test.ts
+++ b/tests/user-auth-normalization.test.ts
@@ -69,19 +69,13 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
     error: null,
   }));
   const deleteUser = vi.fn(async (_userId: string) => ({
-    error: options.deleteUserError
-      ? { message: options.deleteUserError }
-      : null,
+    error: options.deleteUserError ? { message: options.deleteUserError } : null,
   }));
   const profileUpsert = vi.fn(async (_payload: ProfileUpsertPayload) => ({
-    error: options.profileUpsertError
-      ? { message: options.profileUpsertError }
-      : null,
+    error: options.profileUpsertError ? { message: options.profileUpsertError } : null,
   }));
   const workforceUpsert = vi.fn(async (_payload: Record<string, unknown>) => ({
-    error: options.workforceUpsertError
-      ? { message: options.workforceUpsertError }
-      : null,
+    error: options.workforceUpsertError ? { message: options.workforceUpsertError } : null,
   }));
 
   const adminClient = {
@@ -92,10 +86,7 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
           select: () => ({
             eq: () => ({
               maybeSingle: async () => ({
-                data: {
-                  name: options.shopName ?? "Downtown Diesel",
-                  shop_name: null,
-                },
+                data: { name: options.shopName ?? "Downtown Diesel", shop_name: null },
                 error: null,
               }),
             }),
@@ -108,10 +99,7 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
           select: () => ({
             eq: () => ({
               ilike: () => ({
-                limit: async () => ({
-                  data: options.sameShopProfiles ?? [],
-                  error: null,
-                }),
+                limit: async () => ({ data: options.sameShopProfiles ?? [], error: null }),
               }),
             }),
           }),
@@ -135,15 +123,7 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
   mocks.createAdminSupabase.mockReturnValue(adminClient);
   mocks.assertShopHasAvailableSeat.mockResolvedValue(undefined);
 
-  return {
-    createUser,
-    deleteUser,
-    profileUpsert,
-    workforceUpsert,
-    shopId,
-    adminId,
-    createdUserId,
-  };
+  return { createUser, deleteUser, profileUpsert, workforceUpsert, shopId, adminId, createdUserId };
 }
 
 describe("shop user auth normalization", () => {
@@ -156,9 +136,7 @@ describe("shop user auth normalization", () => {
     const username = normalizeProvisioningUsername(" Sam Tech ", namespace);
 
     expect(username).toBe("downtowndiessamtech");
-    expect(buildShopUserAuthEmail(username)).toBe(
-      "downtowndiessamtech@local.profix-internal",
-    );
+    expect(buildShopUserAuthEmail(username)).toBe("downtowndiessamtech@local.profix-internal");
     expect(normalizeAuthIdentifier(username)).toBe(
       "downtowndiessamtech@local.profix-internal",
     );
@@ -166,15 +144,11 @@ describe("shop user auth normalization", () => {
 
   it("normalizes username-only login exactly like backing auth email creation", () => {
     expect(normalizeLoginUsername(" Shop.User-01 ")).toBe("shopuser01");
-    expect(normalizeAuthIdentifier(" Shop.User-01 ")).toBe(
-      "shopuser01@local.profix-internal",
-    );
+    expect(normalizeAuthIdentifier(" Shop.User-01 ")).toBe("shopuser01@local.profix-internal");
   });
 
   it("preserves explicit email login as lower-case email auth for email users", () => {
-    expect(normalizeAuthIdentifier(" Person@Example.COM ")).toBe(
-      "person@example.com",
-    );
+    expect(normalizeAuthIdentifier(" Person@Example.COM ")).toBe("person@example.com");
     expect(getAuthIdentifierStrategy(" Person@Example.COM ")).toEqual({
       inputKind: "email",
       authEmail: "person@example.com",
@@ -193,29 +167,24 @@ describe("shop user auth normalization", () => {
 
   it("creates username-only staff users with a synthetic auth email", async () => {
     const { POST } = await import("../app/api/admin/create-user/route");
-    const { createUser, profileUpsert, shopId, createdUserId } =
-      buildCreateUserRouteMocks();
+    const { createUser, profileUpsert, shopId, createdUserId } = buildCreateUserRouteMocks();
     const password = " Temp Password 123 ";
 
-    const response = await POST(
-      jsonRequest({
-        username: " Sam Tech ",
-        password,
-        full_name: "Sam Tech",
-        role: "mechanic",
-        shop_id: "client-supplied-shop",
-      }),
-    );
+    const response = await POST(jsonRequest({
+      username: " Sam Tech ",
+      password,
+      full_name: "Sam Tech",
+      role: "mechanic",
+      shop_id: "client-supplied-shop",
+    }));
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(createUser).toHaveBeenCalledWith(
-      expect.objectContaining({
-        email: "downtowndiessamtech@local.profix-internal",
-        password,
-        email_confirm: true,
-      }),
-    );
+    expect(createUser).toHaveBeenCalledWith(expect.objectContaining({
+      email: "downtowndiessamtech@local.profix-internal",
+      password,
+      email_confirm: true,
+    }));
     expect(profileUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         id: createdUserId,
@@ -225,42 +194,36 @@ describe("shop user auth normalization", () => {
       }),
       { onConflict: "id" },
     );
-    expect(payload).toEqual(
-      expect.objectContaining({
-        username: "downtowndiessamtech",
-        email: null,
-        auth_email: "downtowndiessamtech@local.profix-internal",
-        shop_id: shopId,
-      }),
-    );
+    expect(payload).toEqual(expect.objectContaining({
+      username: "downtowndiessamtech",
+      email: null,
+      auth_email: "downtowndiessamtech@local.profix-internal",
+      shop_id: shopId,
+    }));
   });
 
   it("creates username plus contact email staff users with username as auth identity", async () => {
     const { POST } = await import("../app/api/admin/create-user/route");
     const { createUser, profileUpsert } = buildCreateUserRouteMocks();
 
-    const response = await POST(
-      jsonRequest({
-        username: "Sam.Tech",
-        email: " Sam.Tech@Example.COM ",
-        password: "temporary-password",
-        full_name: "Sam Tech",
-        role: "advisor",
-      }),
-    );
+    const response = await POST(jsonRequest({
+      username: "Sam.Tech",
+      email: " Sam.Tech@Example.COM ",
+      password: "temporary-password",
+      full_name: "Sam Tech",
+      role: "advisor",
+    }));
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(createUser).toHaveBeenCalledWith(
-      expect.objectContaining({
-        email: "downtowndiessamtech@local.profix-internal",
-        email_confirm: true,
-        user_metadata: expect.objectContaining({
-          username: "downtowndiessamtech",
-          contact_email: "sam.tech@example.com",
-        }),
+    expect(createUser).toHaveBeenCalledWith(expect.objectContaining({
+      email: "downtowndiessamtech@local.profix-internal",
+      email_confirm: true,
+      user_metadata: expect.objectContaining({
+        username: "downtowndiessamtech",
+        contact_email: "sam.tech@example.com",
       }),
-    );
+    }));
     expect(profileUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         email: "sam.tech@example.com",
@@ -268,37 +231,29 @@ describe("shop user auth normalization", () => {
       }),
       { onConflict: "id" },
     );
-    expect(payload).toEqual(
-      expect.objectContaining({
-        username: "downtowndiessamtech",
-        email: "sam.tech@example.com",
-        auth_email: "downtowndiessamtech@local.profix-internal",
-      }),
-    );
+    expect(payload).toEqual(expect.objectContaining({
+      username: "downtowndiessamtech",
+      email: "sam.tech@example.com",
+      auth_email: "downtowndiessamtech@local.profix-internal",
+    }));
   });
 
   it("blocks duplicate usernames within the same shop before creating auth users", async () => {
     const { POST } = await import("../app/api/admin/create-user/route");
     const { createUser } = buildCreateUserRouteMocks({
-      sameShopProfiles: [
-        { id: "existing-user", username: "downtowndiessamtech" },
-      ],
+      sameShopProfiles: [{ id: "existing-user", username: "downtowndiessamtech" }],
     });
 
-    const response = await POST(
-      jsonRequest({
-        username: "Sam Tech",
-        password: "temporary-password",
-        full_name: "Sam Tech",
-        role: "mechanic",
-      }),
-    );
+    const response = await POST(jsonRequest({
+      username: "Sam Tech",
+      password: "temporary-password",
+      full_name: "Sam Tech",
+      role: "mechanic",
+    }));
     const payload = await response.json();
 
     expect(response.status).toBe(400);
-    expect(payload.error).toBe(
-      "A user with this username already exists in this shop.",
-    );
+    expect(payload.error).toBe("A user with this username already exists in this shop.");
     expect(createUser).not.toHaveBeenCalled();
   });
 
@@ -307,17 +262,10 @@ describe("shop user auth normalization", () => {
     const { deleteUser, createdUserId } = buildCreateUserRouteMocks({
       profileUpsertError: "database unavailable",
     });
-
-    const response = await POST(
-      jsonRequest({
-        username: "Sam Tech",
-        password: "temporary-password",
-        full_name: "Sam Tech",
-        role: "mechanic",
-      }),
-    );
+    const response = await POST(jsonRequest({
+      username: "Sam Tech", password: "temporary-password", full_name: "Sam Tech", role: "mechanic",
+    }));
     const payload = await response.json();
-
     expect(response.status).toBe(500);
     expect(payload.code).toBe("profile_upsert_failed");
     expect(deleteUser).toHaveBeenCalledWith(createdUserId);
@@ -328,17 +276,10 @@ describe("shop user auth normalization", () => {
     const { deleteUser, createdUserId } = buildCreateUserRouteMocks({
       workforceUpsertError: "workforce unavailable",
     });
-
-    const response = await POST(
-      jsonRequest({
-        username: "Sam Tech",
-        password: "temporary-password",
-        full_name: "Sam Tech",
-        role: "mechanic",
-      }),
-    );
+    const response = await POST(jsonRequest({
+      username: "Sam Tech", password: "temporary-password", full_name: "Sam Tech", role: "mechanic",
+    }));
     const payload = await response.json();
-
     expect(response.status).toBe(500);
     expect(payload.code).toBe("workforce_profile_seed_failed");
     expect(deleteUser).toHaveBeenCalledWith(createdUserId);
@@ -350,17 +291,10 @@ describe("shop user auth normalization", () => {
       profileUpsertError: "database unavailable",
       deleteUserError: "auth cleanup unavailable",
     });
-
-    const response = await POST(
-      jsonRequest({
-        username: "Sam Tech",
-        password: "temporary-password",
-        full_name: "Sam Tech",
-        role: "mechanic",
-      }),
-    );
+    const response = await POST(jsonRequest({
+      username: "Sam Tech", password: "temporary-password", full_name: "Sam Tech", role: "mechanic",
+    }));
     const payload = await response.json();
-
     expect(response.status).toBe(500);
     expect(payload.code).toBe("provisioning_rollback_failed");
     expect(payload.error).toContain("Contact support before retrying");
@@ -368,19 +302,10 @@ describe("shop user auth normalization", () => {
 
   it("prevents admins from creating owner or admin accounts", async () => {
     const { POST } = await import("../app/api/admin/create-user/route");
-    const { createUser } = buildCreateUserRouteMocks({
-      canonicalRole: "admin",
-    });
-
-    const response = await POST(
-      jsonRequest({
-        username: "Another Owner",
-        password: "temporary-password",
-        full_name: "Another Owner",
-        role: "owner",
-      }),
-    );
-
+    const { createUser } = buildCreateUserRouteMocks({ canonicalRole: "admin" });
+    const response = await POST(jsonRequest({
+      username: "Another Owner", password: "temporary-password", full_name: "Another Owner", role: "owner",
+    }));
     expect(response.status).toBe(403);
     expect(createUser).not.toHaveBeenCalled();
   });
@@ -388,23 +313,12 @@ describe("shop user auth normalization", () => {
   it("validates required staff identity fields before provisioning", async () => {
     const { POST } = await import("../app/api/admin/create-user/route");
     const { createUser } = buildCreateUserRouteMocks();
-
-    const missingName = await POST(
-      jsonRequest({
-        username: "Sam Tech",
-        password: "temporary-password",
-        role: "mechanic",
-      }),
-    );
-    const shortPassword = await POST(
-      jsonRequest({
-        username: "Sam Tech",
-        password: "short",
-        full_name: "Sam Tech",
-        role: "mechanic",
-      }),
-    );
-
+    const missingName = await POST(jsonRequest({
+      username: "Sam Tech", password: "temporary-password", role: "mechanic",
+    }));
+    const shortPassword = await POST(jsonRequest({
+      username: "Sam Tech", password: "short", full_name: "Sam Tech", role: "mechanic",
+    }));
     expect(missingName.status).toBe(400);
     expect(shortPassword.status).toBe(400);
     expect(createUser).not.toHaveBeenCalled();
@@ -436,4 +350,6 @@ describe("shop user auth normalization", () => {
     expect(payload).not.toHaveProperty("authEmail");
     expect(mocks.createAdminSupabase).not.toHaveBeenCalled();
   });
+
 });
+

--- a/tests/user-auth-normalization.test.ts
+++ b/tests/user-auth-normalization.test.ts
@@ -46,6 +46,10 @@ type MockAdminOptions = {
   shopName?: string;
   sameShopProfiles?: { id: string; username: string | null }[];
   createdUserId?: string;
+  canonicalRole?: "owner" | "admin";
+  profileUpsertError?: string | null;
+  workforceUpsertError?: string | null;
+  deleteUserError?: string | null;
 };
 
 function jsonRequest(body: Record<string, unknown>): Request {
@@ -64,18 +68,34 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
     data: { user: { id: createdUserId } },
     error: null,
   }));
-  const profileUpsert = vi.fn(async (_payload: ProfileUpsertPayload) => ({ error: null }));
-  const workforceUpsert = vi.fn(async (_payload: Record<string, unknown>) => ({ error: null }));
+  const deleteUser = vi.fn(async (_userId: string) => ({
+    error: options.deleteUserError
+      ? { message: options.deleteUserError }
+      : null,
+  }));
+  const profileUpsert = vi.fn(async (_payload: ProfileUpsertPayload) => ({
+    error: options.profileUpsertError
+      ? { message: options.profileUpsertError }
+      : null,
+  }));
+  const workforceUpsert = vi.fn(async (_payload: Record<string, unknown>) => ({
+    error: options.workforceUpsertError
+      ? { message: options.workforceUpsertError }
+      : null,
+  }));
 
   const adminClient = {
-    auth: { admin: { createUser } },
+    auth: { admin: { createUser, deleteUser } },
     from: vi.fn((table: string) => {
       if (table === "shops") {
         return {
           select: () => ({
             eq: () => ({
               maybeSingle: async () => ({
-                data: { name: options.shopName ?? "Downtown Diesel", shop_name: null },
+                data: {
+                  name: options.shopName ?? "Downtown Diesel",
+                  shop_name: null,
+                },
                 error: null,
               }),
             }),
@@ -88,7 +108,10 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
           select: () => ({
             eq: () => ({
               ilike: () => ({
-                limit: async () => ({ data: options.sameShopProfiles ?? [], error: null }),
+                limit: async () => ({
+                  data: options.sameShopProfiles ?? [],
+                  error: null,
+                }),
               }),
             }),
           }),
@@ -107,11 +130,20 @@ function buildCreateUserRouteMocks(options: MockAdminOptions = {}) {
   mocks.requireShopScopedApiAccess.mockResolvedValue({
     ok: true,
     profile: { id: adminId, shop_id: shopId },
+    canonicalRole: options.canonicalRole ?? "owner",
   });
   mocks.createAdminSupabase.mockReturnValue(adminClient);
   mocks.assertShopHasAvailableSeat.mockResolvedValue(undefined);
 
-  return { createUser, profileUpsert, workforceUpsert, shopId, adminId, createdUserId };
+  return {
+    createUser,
+    deleteUser,
+    profileUpsert,
+    workforceUpsert,
+    shopId,
+    adminId,
+    createdUserId,
+  };
 }
 
 describe("shop user auth normalization", () => {
@@ -124,7 +156,9 @@ describe("shop user auth normalization", () => {
     const username = normalizeProvisioningUsername(" Sam Tech ", namespace);
 
     expect(username).toBe("downtowndiessamtech");
-    expect(buildShopUserAuthEmail(username)).toBe("downtowndiessamtech@local.profix-internal");
+    expect(buildShopUserAuthEmail(username)).toBe(
+      "downtowndiessamtech@local.profix-internal",
+    );
     expect(normalizeAuthIdentifier(username)).toBe(
       "downtowndiessamtech@local.profix-internal",
     );
@@ -132,11 +166,15 @@ describe("shop user auth normalization", () => {
 
   it("normalizes username-only login exactly like backing auth email creation", () => {
     expect(normalizeLoginUsername(" Shop.User-01 ")).toBe("shopuser01");
-    expect(normalizeAuthIdentifier(" Shop.User-01 ")).toBe("shopuser01@local.profix-internal");
+    expect(normalizeAuthIdentifier(" Shop.User-01 ")).toBe(
+      "shopuser01@local.profix-internal",
+    );
   });
 
   it("preserves explicit email login as lower-case email auth for email users", () => {
-    expect(normalizeAuthIdentifier(" Person@Example.COM ")).toBe("person@example.com");
+    expect(normalizeAuthIdentifier(" Person@Example.COM ")).toBe(
+      "person@example.com",
+    );
     expect(getAuthIdentifierStrategy(" Person@Example.COM ")).toEqual({
       inputKind: "email",
       authEmail: "person@example.com",
@@ -155,24 +193,29 @@ describe("shop user auth normalization", () => {
 
   it("creates username-only staff users with a synthetic auth email", async () => {
     const { POST } = await import("../app/api/admin/create-user/route");
-    const { createUser, profileUpsert, shopId, createdUserId } = buildCreateUserRouteMocks();
+    const { createUser, profileUpsert, shopId, createdUserId } =
+      buildCreateUserRouteMocks();
     const password = " Temp Password 123 ";
 
-    const response = await POST(jsonRequest({
-      username: " Sam Tech ",
-      password,
-      full_name: "Sam Tech",
-      role: "mechanic",
-      shop_id: "client-supplied-shop",
-    }));
+    const response = await POST(
+      jsonRequest({
+        username: " Sam Tech ",
+        password,
+        full_name: "Sam Tech",
+        role: "mechanic",
+        shop_id: "client-supplied-shop",
+      }),
+    );
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(createUser).toHaveBeenCalledWith(expect.objectContaining({
-      email: "downtowndiessamtech@local.profix-internal",
-      password,
-      email_confirm: true,
-    }));
+    expect(createUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "downtowndiessamtech@local.profix-internal",
+        password,
+        email_confirm: true,
+      }),
+    );
     expect(profileUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         id: createdUserId,
@@ -182,36 +225,42 @@ describe("shop user auth normalization", () => {
       }),
       { onConflict: "id" },
     );
-    expect(payload).toEqual(expect.objectContaining({
-      username: "downtowndiessamtech",
-      email: null,
-      auth_email: "downtowndiessamtech@local.profix-internal",
-      shop_id: shopId,
-    }));
+    expect(payload).toEqual(
+      expect.objectContaining({
+        username: "downtowndiessamtech",
+        email: null,
+        auth_email: "downtowndiessamtech@local.profix-internal",
+        shop_id: shopId,
+      }),
+    );
   });
 
   it("creates username plus contact email staff users with username as auth identity", async () => {
     const { POST } = await import("../app/api/admin/create-user/route");
     const { createUser, profileUpsert } = buildCreateUserRouteMocks();
 
-    const response = await POST(jsonRequest({
-      username: "Sam.Tech",
-      email: " Sam.Tech@Example.COM ",
-      password: "temporary-password",
-      full_name: "Sam Tech",
-      role: "advisor",
-    }));
+    const response = await POST(
+      jsonRequest({
+        username: "Sam.Tech",
+        email: " Sam.Tech@Example.COM ",
+        password: "temporary-password",
+        full_name: "Sam Tech",
+        role: "advisor",
+      }),
+    );
     const payload = await response.json();
 
     expect(response.status).toBe(200);
-    expect(createUser).toHaveBeenCalledWith(expect.objectContaining({
-      email: "downtowndiessamtech@local.profix-internal",
-      email_confirm: true,
-      user_metadata: expect.objectContaining({
-        username: "downtowndiessamtech",
-        contact_email: "sam.tech@example.com",
+    expect(createUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "downtowndiessamtech@local.profix-internal",
+        email_confirm: true,
+        user_metadata: expect.objectContaining({
+          username: "downtowndiessamtech",
+          contact_email: "sam.tech@example.com",
+        }),
       }),
-    }));
+    );
     expect(profileUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         email: "sam.tech@example.com",
@@ -219,28 +268,145 @@ describe("shop user auth normalization", () => {
       }),
       { onConflict: "id" },
     );
-    expect(payload).toEqual(expect.objectContaining({
-      username: "downtowndiessamtech",
-      email: "sam.tech@example.com",
-      auth_email: "downtowndiessamtech@local.profix-internal",
-    }));
+    expect(payload).toEqual(
+      expect.objectContaining({
+        username: "downtowndiessamtech",
+        email: "sam.tech@example.com",
+        auth_email: "downtowndiessamtech@local.profix-internal",
+      }),
+    );
   });
 
   it("blocks duplicate usernames within the same shop before creating auth users", async () => {
     const { POST } = await import("../app/api/admin/create-user/route");
     const { createUser } = buildCreateUserRouteMocks({
-      sameShopProfiles: [{ id: "existing-user", username: "downtowndiessamtech" }],
+      sameShopProfiles: [
+        { id: "existing-user", username: "downtowndiessamtech" },
+      ],
     });
 
-    const response = await POST(jsonRequest({
-      username: "Sam Tech",
-      password: "temporary-password",
-      role: "mechanic",
-    }));
+    const response = await POST(
+      jsonRequest({
+        username: "Sam Tech",
+        password: "temporary-password",
+        full_name: "Sam Tech",
+        role: "mechanic",
+      }),
+    );
     const payload = await response.json();
 
     expect(response.status).toBe(400);
-    expect(payload.error).toBe("A user with this username already exists in this shop.");
+    expect(payload.error).toBe(
+      "A user with this username already exists in this shop.",
+    );
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the auth account when profile provisioning fails", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { deleteUser, createdUserId } = buildCreateUserRouteMocks({
+      profileUpsertError: "database unavailable",
+    });
+
+    const response = await POST(
+      jsonRequest({
+        username: "Sam Tech",
+        password: "temporary-password",
+        full_name: "Sam Tech",
+        role: "mechanic",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.code).toBe("profile_upsert_failed");
+    expect(deleteUser).toHaveBeenCalledWith(createdUserId);
+  });
+
+  it("rolls back the auth account when workforce provisioning fails", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { deleteUser, createdUserId } = buildCreateUserRouteMocks({
+      workforceUpsertError: "workforce unavailable",
+    });
+
+    const response = await POST(
+      jsonRequest({
+        username: "Sam Tech",
+        password: "temporary-password",
+        full_name: "Sam Tech",
+        role: "mechanic",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.code).toBe("workforce_profile_seed_failed");
+    expect(deleteUser).toHaveBeenCalledWith(createdUserId);
+  });
+
+  it("reports an actionable partial-provisioning error when rollback fails", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    buildCreateUserRouteMocks({
+      profileUpsertError: "database unavailable",
+      deleteUserError: "auth cleanup unavailable",
+    });
+
+    const response = await POST(
+      jsonRequest({
+        username: "Sam Tech",
+        password: "temporary-password",
+        full_name: "Sam Tech",
+        role: "mechanic",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(payload.code).toBe("provisioning_rollback_failed");
+    expect(payload.error).toContain("Contact support before retrying");
+  });
+
+  it("prevents admins from creating owner or admin accounts", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser } = buildCreateUserRouteMocks({
+      canonicalRole: "admin",
+    });
+
+    const response = await POST(
+      jsonRequest({
+        username: "Another Owner",
+        password: "temporary-password",
+        full_name: "Another Owner",
+        role: "owner",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  it("validates required staff identity fields before provisioning", async () => {
+    const { POST } = await import("../app/api/admin/create-user/route");
+    const { createUser } = buildCreateUserRouteMocks();
+
+    const missingName = await POST(
+      jsonRequest({
+        username: "Sam Tech",
+        password: "temporary-password",
+        role: "mechanic",
+      }),
+    );
+    const shortPassword = await POST(
+      jsonRequest({
+        username: "Sam Tech",
+        password: "short",
+        full_name: "Sam Tech",
+        role: "mechanic",
+      }),
+    );
+
+    expect(missingName.status).toBe(400);
+    expect(shortPassword.status).toBe(400);
     expect(createUser).not.toHaveBeenCalled();
   });
 
@@ -270,5 +436,4 @@ describe("shop user auth normalization", () => {
     expect(payload).not.toHaveProperty("authEmail");
     expect(mocks.createAdminSupabase).not.toHaveBeenCalled();
   });
-
 });


### PR DESCRIPTION
## What changed

- rolls back the newly created Supabase Auth account when profile or workforce provisioning fails
- returns an explicit support-required error if automatic rollback itself fails
- prevents admins from provisioning owner/admin accounts
- rejects portal-only account roles from the staff provisioning endpoint
- validates full name, username content, contact email, phone length, and temporary password length
- removes contact email and synthetic auth email values from provisioning logs
- removes the editable Shop ID field because tenant scope is derived from the authenticated creator
- requires first-sign-in-ready identity fields in the UI and clarifies the forced password change
- adds regression coverage for profile rollback, workforce rollback, rollback failure, privileged-role denial, and required fields

## Root cause

Staff creation was a three-step process: Auth user, profile, then workforce profile. When either database step failed, the Auth account remained registered. Retrying with the same username then failed as already registered even though the user was not usable in ProFixIQ.

The page also exposed a Shop ID field that the server correctly ignored and allowed admins to select privileged roles that only owners should be able to assign.

## Validation

- `vitest run tests/user-auth-normalization.test.ts`: 14 tests passed
- Prettier check: passed

## Database

No migration required.

## Environment variables

None required.

## Manual verification

Create a mechanic and advisor from Owner Settings, sign in with each temporary password, confirm forced password change, and verify the People workforce record appears.