### PR TITLE
Fix quote-to-parts request handoffs

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -383,7 +383,30 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
     const preserveContent = options.preserveContent === true;
     if (!preserveContent) setLoading(true);
 
-    const woRow = await resolveWorkOrder(routeId);
+    let requestIdFilter: string | null = null;
+    let woRow = await resolveWorkOrder(routeId);
+
+    // Quote Review links to the canonical request id. Keep supporting the
+    // older work-order id/custom-id route while resolving a request id to its
+    // owning work order and limiting the page to that request.
+    if (!woRow && isUuid(routeId)) {
+      const { data: requestById, error: requestLookupError } = await supabase
+        .from("part_requests")
+        .select("id, work_order_id")
+        .eq("id", routeId)
+        .maybeSingle();
+
+      if (requestLookupError) toast.error(requestLookupError.message);
+
+      const linkedWorkOrderId = requestById?.work_order_id
+        ? String(requestById.work_order_id)
+        : "";
+      if (linkedWorkOrderId) {
+        woRow = await resolveWorkOrder(linkedWorkOrderId);
+        requestIdFilter = String(requestById.id);
+      }
+    }
+
     if (!woRow) {
       setWo(null);
       setLineById(new Map());
@@ -405,11 +428,16 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
 
     setWo(woRow);
 
-    const { data: reqs, error: reqErr } = await supabase
+    const requestsForWorkOrder = supabase
       .from("part_requests")
       .select("*")
-      .eq("work_order_id", woRow.id)
-      .order("created_at", { ascending: false });
+      .eq("work_order_id", woRow.id);
+    const requestQuery = requestIdFilter
+      ? requestsForWorkOrder.eq("id", requestIdFilter)
+      : requestsForWorkOrder;
+    const { data: reqs, error: reqErr } = await requestQuery.order("created_at", {
+      ascending: false,
+    });
 
     if (reqErr) toast.error(reqErr.message);
 
@@ -1730,7 +1758,26 @@ if (!lineId || !isUuid(lineId)) {
   async function commitPartsPackage(requestId: string): Promise<void> {
     setSavingReqId(requestId);
     try {
-      const res = await fetch(`/api/parts/requests/${requestId}/commit-package`, { method: "POST" });
+      const request = requests.find((candidate) => candidate.req.id === requestId);
+      const packageFingerprint = (request?.items ?? [])
+        .slice()
+        .sort((a, b) => String(a.id).localeCompare(String(b.id)))
+        .map((item) =>
+          [
+            item.id,
+            item.part_id ?? "",
+            item.work_order_line_id ?? "",
+            item.qty ?? "",
+            item.quoted_price ?? "",
+          ].join(":"),
+        )
+        .join("|");
+      const idempotencyKey = `parts-package:${requestId}:${packageFingerprint}`;
+      const res = await fetch(`/api/parts/requests/${requestId}/commit-package`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ idempotencyKey }),
+      });
       const body = (await res.json().catch(() => null)) as {
         ok?: boolean;
         committedCount?: number;

--- a/tests/parts/parts-package-handoffs-source.test.ts
+++ b/tests/parts/parts-package-handoffs-source.test.ts
@@ -41,6 +41,19 @@ describe("parts package handoff source contracts", () => {
     expect(focusedJob).toContain('.eq("is_active", true)');
   });
 
+  it("resolves canonical parts-request ids to their owning work order and scopes the result", () => {
+    expect(requestPage).toContain("const { data: requestById, error: requestLookupError }");
+    expect(requestPage).toContain('.eq("id", routeId)');
+    expect(requestPage).toContain("requestIdFilter = String(requestById.id)");
+    expect(requestPage).toContain('requestsForWorkOrder.eq("id", requestIdFilter)');
+  });
+
+  it("sends a stable content-derived idempotency key when committing a parts package", () => {
+    expect(requestPage).toContain("const packageFingerprint = (request?.items ?? [])");
+    expect(requestPage).toContain("const idempotencyKey =");
+    expect(requestPage).toContain('body: JSON.stringify({ idempotencyKey })');
+  });
+
   it("does not render a second Sonner toaster inside the app shell", () => {
     expect(appShell).not.toContain("<Toaster");
   });


### PR DESCRIPTION
## What changed

- lets `/parts/requests/[id]` resolve either a legacy work-order ID/custom ID or a canonical parts-request UUID
- when the route receives a request UUID, resolves its owning work order and renders only that request
- sends a deterministic, content-derived idempotency key when saving a parts package to the work order
- adds source-contract regression coverage for both handoffs

## Root cause

Quote Review correctly linked to `/parts/requests/{request.id}`, but the destination page treated every route ID as a work-order identifier. That produced “Work order not found / not visible” for valid request IDs.

The package commit endpoint requires a stable idempotency key, but the request-detail UI sent an empty POST with no key, so the API rejected it before committing any package rows.

## Behavior after this change

- “View Parts Request” opens the selected request instead of an empty work-order error state.
- Existing links that pass a work-order ID still render all requests for that work order.
- “Save Parts Package to Work Order” supplies a stable key that remains identical for retries of the same package and changes when package content changes.

## Validation

- branch is based on current `main`
- comparison is limited to 2 files, +65/-5
- verified request-ID fallback, request scoping, idempotency payload, and regression assertions in branch source
- full typecheck/test/build delegated to CI because this workspace has connector-only repository access