### PR TITLE
Fix parts request handoff type safety

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -401,7 +401,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       const linkedWorkOrderId = requestById?.work_order_id
         ? String(requestById.work_order_id)
         : "";
-      if (linkedWorkOrderId) {
+      if (linkedWorkOrderId && requestById) {
         woRow = await resolveWorkOrder(linkedWorkOrderId);
         requestIdFilter = String(requestById.id);
       }


### PR DESCRIPTION
## Summary
- narrow the nullable parts-request lookup before reading its id
- restore the TypeScript gate inherited by the merged PWA foundation
- preserve the existing request-id routing and work-order scoping behavior

## Verification
- `tsc --noEmit`
- 19 focused tests covering parts handoffs, PWA contracts, offline mutations, and job-punch idempotency