### PR TITLE
feat: add PWA sync center and install hardening

### DIFF
--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -1,10 +1,40 @@
 "use client";
 
 import { useEffect } from "react";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { resolveInstalledLaunchPath } from "@/features/shared/lib/pwa/launch";
 
 export default function LaunchPage() {
   useEffect(() => {
-    window.location.replace(navigator.onLine ? "/" : "/offline");
+    let active = true;
+    const launch = async () => {
+      if (!navigator.onLine) {
+        window.location.replace("/offline");
+        return;
+      }
+      const supabase = createBrowserSupabase();
+      const { data: sessionData } = await supabase.auth.getSession();
+      const userId = sessionData.session?.user.id;
+      if (!active) return;
+      if (!userId) {
+        window.location.replace("/sign-in?next=/launch");
+        return;
+      }
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("role")
+        .eq("id", userId)
+        .maybeSingle();
+      if (!active) return;
+      const compactViewport = window.matchMedia("(max-width: 900px)").matches;
+      window.location.replace(
+        resolveInstalledLaunchPath(profile?.role, compactViewport),
+      );
+    };
+    void launch();
+    return () => {
+      active = false;
+    };
   }, []);
   return (
     <main className="grid min-h-screen place-items-center bg-slate-950 text-slate-100">

--- a/app/offline/page.tsx
+++ b/app/offline/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
   getOfflineMutationScope,
@@ -14,24 +15,39 @@ type WorkOrderSummary = {
   work_order_number?: string | number | null;
   status?: string | null;
   customers?: { first_name?: string | null; last_name?: string | null } | null;
-  vehicles?: { year?: string | number | null; make?: string | null; model?: string | null } | null;
+  vehicles?: {
+    year?: string | number | null;
+    make?: string | null;
+    model?: string | null;
+  } | null;
 };
 type WorkOrderListSnapshot = { rows: WorkOrderSummary[] };
 type WorkOrderDetailSnapshot = {
   workOrder: WorkOrderSummary & { custom_id?: string | null };
   customer?: { first_name?: string | null; last_name?: string | null } | null;
-  vehicle?: { year?: string | number | null; make?: string | null; model?: string | null } | null;
-  lines: Array<{ id?: string; description?: string | null; status?: string | null }>;
+  vehicle?: {
+    year?: string | number | null;
+    make?: string | null;
+    model?: string | null;
+  } | null;
+  lines: Array<{
+    id?: string;
+    description?: string | null;
+    status?: string | null;
+  }>;
 };
 
 export default function OfflinePage() {
-  const [online, setOnline] = useState(() => typeof navigator !== "undefined" && navigator.onLine);
+  const [online, setOnline] = useState(
+    () => typeof navigator !== "undefined" && navigator.onLine,
+  );
   const [summary, setSummary] = useState(() => getOfflineSyncSummary());
   const [orders, setOrders] = useState<WorkOrderSummary[]>([]);
   const [details, setDetails] = useState<WorkOrderDetailSnapshot[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const pending = summary.queued + summary.syncing + summary.failed;
-  const selected = details.find((detail) => detail.workOrder.id === selectedId) ?? null;
+  const selected =
+    details.find((detail) => detail.workOrder.id === selectedId) ?? null;
 
   useEffect(() => {
     const refresh = () => {
@@ -53,8 +69,24 @@ export default function OfflinePage() {
           kind: "mobile-work-order-detail",
         }),
       ]).then(([listRows, detailRows]) => {
-        setOrders(listRows.flatMap((row) => row.data.rows).filter((row, index, all) => all.findIndex((item) => item.id === row.id) === index));
-        setDetails(detailRows.map((row) => row.data).filter((detail, index, all) => all.findIndex((item) => item.workOrder.id === detail.workOrder.id) === index));
+        setOrders(
+          listRows
+            .flatMap((row) => row.data.rows)
+            .filter(
+              (row, index, all) =>
+                all.findIndex((item) => item.id === row.id) === index,
+            ),
+        );
+        setDetails(
+          detailRows
+            .map((row) => row.data)
+            .filter(
+              (detail, index, all) =>
+                all.findIndex(
+                  (item) => item.workOrder.id === detail.workOrder.id,
+                ) === index,
+            ),
+        );
       });
     }
     return () => {
@@ -74,15 +106,27 @@ export default function OfflinePage() {
     <main className="min-h-screen bg-slate-950 px-5 py-10 text-slate-100">
       <div className="mx-auto max-w-2xl space-y-6">
         <section className="rounded-2xl border border-slate-700 bg-slate-900 p-6 shadow-2xl">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">ProFixIQ offline</p>
-          <h1 className="mt-2 text-2xl font-semibold">Your saved work is still available.</h1>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">
+            ProFixIQ offline
+          </p>
+          <h1 className="mt-2 text-2xl font-semibold">
+            Your saved work is still available.
+          </h1>
           <p className="mt-3 text-sm text-slate-300">
-            {online ? "Connection restored. Sync your queued updates now." : "Updates are stored on this device and will sync after reconnecting."}
+            {online
+              ? "Connection restored. Sync your queued updates now."
+              : "Updates are stored on this device and will sync after reconnecting."}
           </p>
           <div className="mt-5 flex flex-wrap gap-3 text-sm">
-            <span className="rounded-full bg-slate-800 px-3 py-1">{pending} pending</span>
-            <span className="rounded-full bg-slate-800 px-3 py-1">{summary.failed} need retry</span>
-            <span className="rounded-full bg-slate-800 px-3 py-1">{summary.conflicted} conflicts</span>
+            <span className="rounded-full bg-slate-800 px-3 py-1">
+              {pending} pending
+            </span>
+            <span className="rounded-full bg-slate-800 px-3 py-1">
+              {summary.failed} need retry
+            </span>
+            <span className="rounded-full bg-slate-800 px-3 py-1">
+              {summary.conflicted} conflicts
+            </span>
           </div>
           <button
             type="button"
@@ -92,22 +136,49 @@ export default function OfflinePage() {
           >
             Reconnect and sync
           </button>
+          <Link
+            href="/offline/sync"
+            className="ml-3 inline-flex rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200"
+          >
+            Open Sync Center
+          </Link>
         </section>
 
         {orders.length > 0 && (
           <section className="space-y-3">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-300">Recently saved work orders</h2>
+            <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-300">
+              Recently saved work orders
+            </h2>
             {orders.map((order, index) => (
-              <article key={order.id ?? index} className="rounded-xl border border-slate-800 bg-slate-900/80 p-4">
-                <p className="font-semibold">Work order {order.work_order_number ?? "—"}</p>
-                <p className="mt-1 text-sm text-slate-300">
-                  {[order.customers?.first_name, order.customers?.last_name].filter(Boolean).join(" ") || "Customer"}
-                  {" · "}
-                  {[order.vehicles?.year, order.vehicles?.make, order.vehicles?.model].filter(Boolean).join(" ") || "Vehicle"}
+              <article
+                key={order.id ?? index}
+                className="rounded-xl border border-slate-800 bg-slate-900/80 p-4"
+              >
+                <p className="font-semibold">
+                  Work order {order.work_order_number ?? "—"}
                 </p>
-                <p className="mt-2 text-xs uppercase tracking-wider text-sky-300">{order.status ?? "active"}</p>
+                <p className="mt-1 text-sm text-slate-300">
+                  {[order.customers?.first_name, order.customers?.last_name]
+                    .filter(Boolean)
+                    .join(" ") || "Customer"}
+                  {" · "}
+                  {[
+                    order.vehicles?.year,
+                    order.vehicles?.make,
+                    order.vehicles?.model,
+                  ]
+                    .filter(Boolean)
+                    .join(" ") || "Vehicle"}
+                </p>
+                <p className="mt-2 text-xs uppercase tracking-wider text-sky-300">
+                  {order.status ?? "active"}
+                </p>
                 {details.some((detail) => detail.workOrder.id === order.id) && (
-                  <button type="button" onClick={() => setSelectedId(order.id ?? null)} className="mt-3 rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-semibold text-sky-200">
+                  <button
+                    type="button"
+                    onClick={() => setSelectedId(order.id ?? null)}
+                    className="mt-3 rounded-lg border border-slate-700 px-3 py-1.5 text-xs font-semibold text-sky-200"
+                  >
                     View saved details
                   </button>
                 )}
@@ -120,21 +191,48 @@ export default function OfflinePage() {
           <section className="rounded-2xl border border-slate-700 bg-slate-900 p-5">
             <div className="flex items-start justify-between gap-3">
               <div>
-                <p className="text-xs uppercase tracking-[0.16em] text-sky-300">Saved work order</p>
-                <h2 className="mt-1 text-xl font-semibold">{selected.workOrder.custom_id ?? selected.workOrder.work_order_number ?? "Details"}</h2>
+                <p className="text-xs uppercase tracking-[0.16em] text-sky-300">
+                  Saved work order
+                </p>
+                <h2 className="mt-1 text-xl font-semibold">
+                  {selected.workOrder.custom_id ??
+                    selected.workOrder.work_order_number ??
+                    "Details"}
+                </h2>
               </div>
-              <button type="button" onClick={() => setSelectedId(null)} className="text-sm text-slate-300">Close</button>
+              <button
+                type="button"
+                onClick={() => setSelectedId(null)}
+                className="text-sm text-slate-300"
+              >
+                Close
+              </button>
             </div>
             <p className="mt-2 text-sm text-slate-300">
-              {[selected.customer?.first_name, selected.customer?.last_name].filter(Boolean).join(" ") || "Customer"}
+              {[selected.customer?.first_name, selected.customer?.last_name]
+                .filter(Boolean)
+                .join(" ") || "Customer"}
               {" · "}
-              {[selected.vehicle?.year, selected.vehicle?.make, selected.vehicle?.model].filter(Boolean).join(" ") || "Vehicle"}
+              {[
+                selected.vehicle?.year,
+                selected.vehicle?.make,
+                selected.vehicle?.model,
+              ]
+                .filter(Boolean)
+                .join(" ") || "Vehicle"}
             </p>
             <div className="mt-5 space-y-2">
               {selected.lines.map((line, index) => (
-                <div key={line.id ?? index} className="rounded-xl bg-slate-950/70 p-3">
-                  <p className="text-sm font-medium">{line.description ?? "Job line"}</p>
-                  <p className="mt-1 text-xs uppercase tracking-wider text-slate-400">{line.status ?? "awaiting"}</p>
+                <div
+                  key={line.id ?? index}
+                  className="rounded-xl bg-slate-950/70 p-3"
+                >
+                  <p className="text-sm font-medium">
+                    {line.description ?? "Job line"}
+                  </p>
+                  <p className="mt-1 text-xs uppercase tracking-wider text-slate-400">
+                    {line.status ?? "awaiting"}
+                  </p>
                 </div>
               ))}
             </div>

--- a/app/offline/sync/page.tsx
+++ b/app/offline/sync/page.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import {
+  clearSyncedOfflineMutations,
+  dismissOfflineMutation,
+  getOfflineMutationScope,
+  hydrateOfflineMutationQueue,
+  listOfflineMutations,
+  pruneOfflineState,
+  retryOfflineMutation,
+  subscribeOfflineMutations,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+import {
+  getOfflineDatabaseStats,
+  type OfflineDatabaseStats,
+} from "@/features/shared/lib/offline/database";
+import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
+
+type BrowserStorage = {
+  usage: number;
+  quota: number;
+  persistent: boolean;
+};
+
+const EMPTY_DATABASE_STATS: OfflineDatabaseStats = {
+  mutations: 0,
+  snapshots: 0,
+  blobs: 0,
+  blobBytes: 0,
+};
+
+const ACTION_LABELS: Record<string, string> = {
+  "inspection:save-session": "Inspection progress",
+  "shift:punch-event": "Shift punch",
+  update_work_order_line_notes: "Job notes",
+  upload_job_photo: "Job photo",
+  save_story_draft: "Cause and correction",
+  "job:punch-transition": "Job status",
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function statusTone(status: PendingMutation["status"]): string {
+  if (status === "synced") return "border-emerald-500/40 text-emerald-200";
+  if (status === "failed" || status === "conflicted") {
+    return "border-red-500/40 text-red-200";
+  }
+  if (status === "syncing") return "border-sky-500/40 text-sky-200";
+  return "border-amber-500/40 text-amber-200";
+}
+
+export default function OfflineSyncPage() {
+  const [mutations, setMutations] = useState<PendingMutation[]>([]);
+  const [databaseStats, setDatabaseStats] = useState(EMPTY_DATABASE_STATS);
+  const [browserStorage, setBrowserStorage] = useState<BrowserStorage>({
+    usage: 0,
+    quota: 0,
+    persistent: false,
+  });
+  const [online, setOnline] = useState(
+    () => typeof navigator !== "undefined" && navigator.onLine,
+  );
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    await hydrateOfflineMutationQueue();
+    const scope = getOfflineMutationScope();
+    setMutations(listOfflineMutations(scope));
+    setDatabaseStats(
+      scope ? await getOfflineDatabaseStats(scope) : EMPTY_DATABASE_STATS,
+    );
+    const estimate = await navigator.storage?.estimate?.();
+    const persistent = (await navigator.storage?.persisted?.()) ?? false;
+    setBrowserStorage({
+      usage: estimate?.usage ?? 0,
+      quota: estimate?.quota ?? 0,
+      persistent,
+    });
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const unsubscribe = subscribeOfflineMutations(() => void refresh());
+    const updateOnline = () => setOnline(navigator.onLine);
+    window.addEventListener("online", updateOnline);
+    window.addEventListener("offline", updateOnline);
+    return () => {
+      unsubscribe();
+      window.removeEventListener("online", updateOnline);
+      window.removeEventListener("offline", updateOnline);
+    };
+  }, [refresh]);
+
+  const run = async (
+    action: () => Promise<string | void>,
+    fallbackSuccess: string,
+  ) => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const success = await action();
+      await refresh();
+      setMessage(success ?? fallbackSuccess);
+    } catch (error) {
+      setMessage(
+        error instanceof Error
+          ? error.message
+          : "That action could not be completed.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const syncNow = () =>
+    run(async () => {
+      const result = await replayAllOfflineMutations();
+      return `Synced ${result.replayed}; ${result.failed} failed; ${result.conflicted} need review.`;
+    }, "Sync complete.");
+
+  const requestPersistence = () =>
+    run(async () => {
+      await navigator.storage?.persist?.();
+    }, "Storage protection preference updated.");
+
+  const cleanStorage = () =>
+    run(async () => {
+      const result = await pruneOfflineState();
+      return `Removed ${result.mutationsRemoved} completed updates, ${result.snapshotsRemoved} expired views, and ${result.blobsRemoved} unused files.`;
+    }, "Offline storage cleaned.");
+
+  const quotaPercent = browserStorage.quota
+    ? Math.min(100, (browserStorage.usage / browserStorage.quota) * 100)
+    : 0;
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100">
+      <div className="mx-auto max-w-3xl space-y-5">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">
+              ProFixIQ offline
+            </p>
+            <h1 className="mt-2 text-2xl font-semibold">Sync Center</h1>
+            <p className="mt-2 text-sm text-slate-300">
+              Review work stored for the active user and shop on this device.
+            </p>
+          </div>
+          <Link
+            href="/offline"
+            className="rounded-lg border border-slate-700 px-3 py-2 text-sm"
+          >
+            Back
+          </Link>
+        </header>
+
+        <section className="rounded-2xl border border-slate-700 bg-slate-900 p-5">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="font-semibold">
+                {online ? "Connected" : "Offline"}
+              </p>
+              <p className="text-sm text-slate-400">
+                {mutations.filter((item) => item.status !== "synced").length}{" "}
+                updates require attention
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={!online || busy}
+              onClick={() => void syncNow()}
+              className="rounded-xl bg-sky-400 px-4 py-2 font-semibold text-slate-950 disabled:opacity-40"
+            >
+              Sync now
+            </button>
+          </div>
+          {message && (
+            <p className="mt-3 rounded-lg bg-slate-950/70 px-3 py-2 text-sm text-slate-200">
+              {message}
+            </p>
+          )}
+        </section>
+
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="font-semibold">Device queue</h2>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() =>
+                void run(
+                  clearSyncedOfflineMutations,
+                  "Completed history cleared.",
+                )
+              }
+              className="text-xs font-semibold text-sky-300 disabled:opacity-40"
+            >
+              Clear completed
+            </button>
+          </div>
+          {mutations.length === 0 ? (
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/70 p-5 text-sm text-slate-400">
+              No offline updates are stored for this user and shop.
+            </div>
+          ) : (
+            mutations.map((mutation) => (
+              <article
+                key={mutation.clientMutationId}
+                className="rounded-2xl border border-slate-800 bg-slate-900 p-4"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium">
+                      {ACTION_LABELS[mutation.actionType] ??
+                        mutation.actionType}
+                    </p>
+                    <p className="mt-1 text-xs text-slate-400">
+                      {new Date(mutation.createdAt).toLocaleString()} ·{" "}
+                      {mutation.retryCount} retries
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-full border px-2.5 py-1 text-xs uppercase tracking-wider ${statusTone(mutation.status)}`}
+                  >
+                    {mutation.status}
+                  </span>
+                </div>
+                {(mutation.conflictReason || mutation.lastError) && (
+                  <p className="mt-3 rounded-lg bg-slate-950/70 px-3 py-2 text-sm text-slate-300">
+                    {mutation.conflictReason || mutation.lastError}
+                  </p>
+                )}
+                <div className="mt-3 flex gap-2">
+                  {["failed", "conflicted"].includes(mutation.status) && (
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() =>
+                        void run(
+                          () => retryOfflineMutation(mutation.clientMutationId),
+                          "Update queued for retry.",
+                        )
+                      }
+                      className="rounded-lg border border-sky-500/50 px-3 py-1.5 text-xs font-semibold text-sky-200 disabled:opacity-40"
+                    >
+                      Retry
+                    </button>
+                  )}
+                  {mutation.status !== "syncing" && (
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() =>
+                        void run(
+                          () =>
+                            dismissOfflineMutation(mutation.clientMutationId),
+                          "Update removed from this device.",
+                        )
+                      }
+                      className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs text-slate-300 disabled:opacity-40"
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              </article>
+            ))
+          )}
+        </section>
+
+        <section className="rounded-2xl border border-slate-700 bg-slate-900 p-5">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="font-semibold">Storage</h2>
+              <p className="mt-1 text-sm text-slate-400">
+                {formatBytes(browserStorage.usage)} used of{" "}
+                {browserStorage.quota
+                  ? formatBytes(browserStorage.quota)
+                  : "unknown quota"}
+              </p>
+            </div>
+            <span
+              className={`rounded-full border px-2.5 py-1 text-xs ${browserStorage.persistent ? "border-emerald-500/40 text-emerald-200" : "border-amber-500/40 text-amber-200"}`}
+            >
+              {browserStorage.persistent ? "Protected" : "Best effort"}
+            </span>
+          </div>
+          <div className="mt-4 h-2 overflow-hidden rounded-full bg-slate-800">
+            <div
+              className="h-full bg-sky-400"
+              style={{ width: `${quotaPercent}%` }}
+            />
+          </div>
+          <div className="mt-4 grid grid-cols-3 gap-2 text-center text-xs text-slate-300">
+            <div className="rounded-lg bg-slate-950/70 p-2">
+              {databaseStats.snapshots}
+              <br />
+              saved views
+            </div>
+            <div className="rounded-lg bg-slate-950/70 p-2">
+              {databaseStats.blobs}
+              <br />
+              files
+            </div>
+            <div className="rounded-lg bg-slate-950/70 p-2">
+              {formatBytes(databaseStats.blobBytes)}
+              <br />
+              photos
+            </div>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {!browserStorage.persistent && (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void requestPersistence()}
+                className="rounded-lg border border-sky-500/50 px-3 py-2 text-xs font-semibold text-sky-200 disabled:opacity-40"
+              >
+                Protect offline storage
+              </button>
+            )}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void cleanStorage()}
+              className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 disabled:opacity-40"
+            >
+              Clean expired data
+            </button>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/features/shared/components/pwa/PwaRuntime.tsx
+++ b/features/shared/components/pwa/PwaRuntime.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   clearOfflineState,
@@ -19,12 +19,25 @@ type InstallPromptEvent = Event & {
 export default function PwaRuntime() {
   const [online, setOnline] = useState(true);
   const [summary, setSummary] = useState(() => getOfflineSyncSummary());
-  const [installPrompt, setInstallPrompt] = useState<InstallPromptEvent | null>(null);
+  const [installPrompt, setInstallPrompt] = useState<InstallPromptEvent | null>(
+    null,
+  );
   const [updateReady, setUpdateReady] = useState<ServiceWorker | null>(null);
+  const [iosInstallAvailable, setIosInstallAvailable] = useState(false);
+  const [showIosInstructions, setShowIosInstructions] = useState(false);
+  const [activatingUpdate, setActivatingUpdate] = useState(false);
+  const updateReloading = useRef(false);
   const pending = summary.queued + summary.syncing + summary.failed;
 
   useEffect(() => {
     setOnline(navigator.onLine);
+    const iosDevice =
+      /iphone|ipad|ipod/i.test(navigator.userAgent) ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+    const standalone =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      Boolean((navigator as Navigator & { standalone?: boolean }).standalone);
+    setIosInstallAvailable(iosDevice && !standalone);
     void hydrateOfflineMutationQueue();
     void navigator.storage?.persist?.().catch(() => false);
 
@@ -36,18 +49,24 @@ export default function PwaRuntime() {
         .select("shop_id")
         .eq("id", userId)
         .maybeSingle();
-      if (profile?.shop_id) setOfflineMutationScope({ userId, shopId: profile.shop_id });
+      if (profile?.shop_id)
+        setOfflineMutationScope({ userId, shopId: profile.shop_id });
     };
     void supabase.auth.getSession().then(async ({ data }) => {
       const userId = data.session?.user.id;
       if (userId) await resolveScope(userId);
     });
 
-    const { data: authSubscription } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event === "SIGNED_OUT") void clearOfflineState();
-      if (session?.user.id) window.setTimeout(() => void resolveScope(session.user.id), 0);
-    });
-    const unsubscribe = subscribeOfflineMutations(() => setSummary(getOfflineSyncSummary()));
+    const { data: authSubscription } = supabase.auth.onAuthStateChange(
+      (event, session) => {
+        if (event === "SIGNED_OUT") void clearOfflineState();
+        if (session?.user.id)
+          window.setTimeout(() => void resolveScope(session.user.id), 0);
+      },
+    );
+    const unsubscribe = subscribeOfflineMutations(() =>
+      setSummary(getOfflineSyncSummary()),
+    );
     const sync = () => {
       setOnline(navigator.onLine);
       if (navigator.onLine) void replayAllOfflineMutations();
@@ -64,16 +83,18 @@ export default function PwaRuntime() {
     window.addEventListener("beforeinstallprompt", beforeInstall);
 
     if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
-      void navigator.serviceWorker.register("/sw.js", { scope: "/" }).then((registration) => {
-        if (registration.waiting) setUpdateReady(registration.waiting);
-        registration.addEventListener("updatefound", () => {
-          registration.installing?.addEventListener("statechange", () => {
-            if (registration.waiting && navigator.serviceWorker.controller) {
-              setUpdateReady(registration.waiting);
-            }
+      void navigator.serviceWorker
+        .register("/sw.js", { scope: "/" })
+        .then((registration) => {
+          if (registration.waiting) setUpdateReady(registration.waiting);
+          registration.addEventListener("updatefound", () => {
+            registration.installing?.addEventListener("statechange", () => {
+              if (registration.waiting && navigator.serviceWorker.controller) {
+                setUpdateReady(registration.waiting);
+              }
+            });
           });
         });
-      });
     }
     sync();
 
@@ -95,24 +116,121 @@ export default function PwaRuntime() {
     setInstallPrompt(null);
   };
 
-  if (online && pending === 0 && !installPrompt && !updateReady) return null;
+  const activateUpdate = () => {
+    if (!updateReady || activatingUpdate) return;
+    setActivatingUpdate(true);
+    const reloadWhenControlled = () => {
+      if (updateReloading.current) return;
+      updateReloading.current = true;
+      window.location.reload();
+    };
+    navigator.serviceWorker.addEventListener(
+      "controllerchange",
+      reloadWhenControlled,
+      {
+        once: true,
+      },
+    );
+    updateReady.postMessage({ type: "SKIP_WAITING" });
+    window.setTimeout(reloadWhenControlled, 8_000);
+  };
+
+  if (
+    online &&
+    pending === 0 &&
+    !installPrompt &&
+    !iosInstallAvailable &&
+    !updateReady
+  ) {
+    return null;
+  }
 
   return (
     <div className="fixed bottom-4 right-4 z-[100] flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full border border-slate-700 bg-slate-950/95 px-3 py-2 text-xs font-semibold text-slate-100 shadow-xl backdrop-blur">
-      <span className={`h-2 w-2 rounded-full ${online ? "bg-emerald-400" : "bg-amber-400"}`} />
-      <span>{online ? (pending ? `Syncing ${pending}` : "Online") : `Offline · ${pending} pending`}</span>
-      {installPrompt && <button type="button" onClick={() => void install()} className="rounded-full bg-sky-400 px-3 py-1 text-slate-950">Install</button>}
+      <span
+        className={`h-2 w-2 rounded-full ${online ? "bg-emerald-400" : "bg-amber-400"}`}
+      />
+      <span>
+        {online
+          ? pending
+            ? `Syncing ${pending}`
+            : "Online"
+          : `Offline · ${pending} pending`}
+      </span>
+      {installPrompt && (
+        <button
+          type="button"
+          onClick={() => void install()}
+          className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
+        >
+          Install
+        </button>
+      )}
+      {!installPrompt && iosInstallAvailable && (
+        <button
+          type="button"
+          onClick={() => setShowIosInstructions(true)}
+          className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
+        >
+          Install
+        </button>
+      )}
+      {(pending > 0 || !online) && (
+        <button
+          type="button"
+          onClick={() => window.location.assign("/offline/sync")}
+          className="rounded-full border border-slate-600 px-3 py-1"
+        >
+          Details
+        </button>
+      )}
       {updateReady && (
         <button
           type="button"
-          onClick={() => {
-            updateReady.postMessage({ type: "SKIP_WAITING" });
-            window.location.reload();
-          }}
+          onClick={activateUpdate}
+          disabled={activatingUpdate}
           className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
         >
-          Update
+          {activatingUpdate ? "Updating…" : "Update"}
         </button>
+      )}
+      {showIosInstructions && (
+        <div className="fixed inset-0 z-[110] grid place-items-center bg-slate-950/80 p-4 backdrop-blur-sm">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="ios-install-title"
+            className="w-full max-w-sm rounded-2xl border border-slate-700 bg-slate-900 p-5 text-left shadow-2xl"
+          >
+            <h2 id="ios-install-title" className="text-lg font-semibold">
+              Install ProFixIQ on iPhone or iPad
+            </h2>
+            <ol className="mt-4 space-y-3 text-sm font-normal text-slate-300">
+              <li>
+                <span className="font-semibold text-slate-100">1.</span> Open
+                this page in Safari.
+              </li>
+              <li>
+                <span className="font-semibold text-slate-100">2.</span> Tap the
+                Share button in Safari.
+              </li>
+              <li>
+                <span className="font-semibold text-slate-100">3.</span> Choose{" "}
+                <span className="font-semibold text-slate-100">
+                  Add to Home Screen
+                </span>
+                , then tap Add.
+              </li>
+            </ol>
+            <button
+              type="button"
+              onClick={() => setShowIosInstructions(false)}
+              className="mt-5 w-full rounded-xl bg-sky-400 px-4 py-2 font-semibold text-slate-950"
+            >
+              Done
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/features/shared/lib/offline/database.ts
+++ b/features/shared/lib/offline/database.ts
@@ -39,6 +39,13 @@ export type OfflineBlobRecord = {
   blob: Blob;
 };
 
+export type OfflineDatabaseStats = {
+  mutations: number;
+  snapshots: number;
+  blobs: number;
+  blobBytes: number;
+};
+
 class ProFixIQOfflineDatabase extends Dexie {
   mutations!: Table<StoredOfflineMutation, string>;
   snapshots!: Table<OfflineSnapshot, string>;
@@ -156,7 +163,8 @@ export async function saveOfflineBlob(
   record: OfflineBlobRecord,
 ): Promise<void> {
   const db = getDatabase();
-  if (!db) throw new Error("Offline file storage is unavailable on this device.");
+  if (!db)
+    throw new Error("Offline file storage is unavailable on this device.");
   await db.blobs.put(record);
 }
 
@@ -164,12 +172,71 @@ export async function getOfflineBlob(
   id: string,
 ): Promise<OfflineBlobRecord | null> {
   const db = getDatabase();
-  return db ? (await db.blobs.get(id)) ?? null : null;
+  return db ? ((await db.blobs.get(id)) ?? null) : null;
 }
 
 export async function removeOfflineBlob(id: string): Promise<void> {
   const db = getDatabase();
   if (db) await db.blobs.delete(id);
+}
+
+export async function getOfflineDatabaseStats(scope: {
+  userId: string;
+  shopId: string;
+}): Promise<OfflineDatabaseStats> {
+  const db = getDatabase();
+  if (!db) return { mutations: 0, snapshots: 0, blobs: 0, blobBytes: 0 };
+  const compoundScope: [string, string] = [scope.userId, scope.shopId];
+  const [mutations, snapshots, blobs] = await Promise.all([
+    db.mutations.where("[userId+shopId]").equals(compoundScope).count(),
+    db.snapshots.where("[userId+shopId]").equals(compoundScope).count(),
+    db.blobs.where("[userId+shopId]").equals(compoundScope).toArray(),
+  ]);
+  return {
+    mutations,
+    snapshots,
+    blobs: blobs.length,
+    blobBytes: blobs.reduce((total, row) => total + row.blob.size, 0),
+  };
+}
+
+export async function pruneOfflineDatabase(args: {
+  scope: { userId: string; shopId: string };
+  retainedBlobIds: Set<string>;
+}): Promise<{ snapshotsRemoved: number; blobsRemoved: number }> {
+  const db = getDatabase();
+  if (!db) return { snapshotsRemoved: 0, blobsRemoved: 0 };
+  const compoundScope: [string, string] = [
+    args.scope.userId,
+    args.scope.shopId,
+  ];
+  const [snapshots, blobs] = await Promise.all([
+    db.snapshots.where("[userId+shopId]").equals(compoundScope).toArray(),
+    db.blobs.where("[userId+shopId]").equals(compoundScope).toArray(),
+  ]);
+  const now = Date.now();
+  const expiredSnapshotKeys = snapshots
+    .filter((row) => new Date(row.expiresAt).getTime() <= now)
+    .map((row) => row.key);
+  const orphanBlobIds = blobs
+    .filter(
+      (row) =>
+        !args.retainedBlobIds.has(row.id) &&
+        now - new Date(row.createdAt).getTime() > 1000 * 60 * 60,
+    )
+    .map((row) => row.id);
+  await Promise.all([
+    expiredSnapshotKeys.length
+      ? db.snapshots.bulkDelete(expiredSnapshotKeys)
+      : Promise.resolve(),
+    orphanBlobIds.length
+      ? db.blobs.bulkDelete(orphanBlobIds)
+      : Promise.resolve(),
+  ]);
+  return {
+    snapshotsRemoved: expiredSnapshotKeys.length,
+    blobsRemoved: orphanBlobIds.length,
+  };
 }
 
 export async function clearOfflineDatabase(): Promise<void> {

--- a/features/shared/lib/offline/mutations.ts
+++ b/features/shared/lib/offline/mutations.ts
@@ -3,7 +3,9 @@
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   clearOfflineDatabase,
+  pruneOfflineDatabase,
   readStoredMutations,
+  removeOfflineBlob,
   replaceStoredMutations,
   type StoredOfflineMutation,
 } from "@/features/shared/lib/offline/database";
@@ -48,7 +50,9 @@ const EVENT_NAME = "offline-mutations:updated";
 const MAX_HISTORY = 300;
 const TERMINAL_RETENTION_MS = 1000 * 60 * 60 * 24 * 7;
 const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
-const PERMANENT_STATUS_CODES = new Set([400, 401, 403, 404, 409, 410, 412, 422]);
+const PERMANENT_STATUS_CODES = new Set([
+  400, 401, 403, 404, 409, 410, 412, 422,
+]);
 
 let queueCache: PendingMutation[] = [];
 let hydrationPromise: Promise<void> | null = null;
@@ -67,14 +71,19 @@ function emitQueueUpdate(): void {
   }
 }
 
-export function setOfflineMutationScope(scope: OfflineMutationScope | null): void {
+export function setOfflineMutationScope(
+  scope: OfflineMutationScope | null,
+): void {
   if (!browserReady()) return;
   if (!scope?.userId.trim() || !scope.shopId.trim()) {
     localStorage.removeItem(SCOPE_KEY);
   } else {
     localStorage.setItem(
       SCOPE_KEY,
-      JSON.stringify({ userId: scope.userId.trim(), shopId: scope.shopId.trim() }),
+      JSON.stringify({
+        userId: scope.userId.trim(),
+        shopId: scope.shopId.trim(),
+      }),
     );
   }
   emitQueueUpdate();
@@ -83,9 +92,9 @@ export function setOfflineMutationScope(scope: OfflineMutationScope | null): voi
 export function getOfflineMutationScope(): OfflineMutationScope | null {
   if (!browserReady()) return null;
   try {
-    const value = JSON.parse(localStorage.getItem(SCOPE_KEY) ?? "null") as
-      | Partial<OfflineMutationScope>
-      | null;
+    const value = JSON.parse(
+      localStorage.getItem(SCOPE_KEY) ?? "null",
+    ) as Partial<OfflineMutationScope> | null;
     const userId = clean(value?.userId);
     const shopId = clean(value?.shopId);
     return userId && shopId ? { userId, shopId } : null;
@@ -99,7 +108,9 @@ function scopeMatches(
   scope: OfflineMutationScope | null,
 ): boolean {
   return Boolean(
-    scope && mutation.userId === scope.userId && mutation.shopId === scope.shopId,
+    scope &&
+    mutation.userId === scope.userId &&
+    mutation.shopId === scope.shopId,
   );
 }
 
@@ -108,13 +119,18 @@ async function resolveMutationScope(
   supplied?: OfflineMutationScope | null,
 ): Promise<OfflineMutationScope | null> {
   if (supplied?.userId.trim() && supplied.shopId.trim()) {
-    const scope = { userId: supplied.userId.trim(), shopId: supplied.shopId.trim() };
+    const scope = {
+      userId: supplied.userId.trim(),
+      shopId: supplied.shopId.trim(),
+    };
     setOfflineMutationScope(scope);
     return scope;
   }
 
   const cached = getOfflineMutationScope();
-  const candidate = (payload && typeof payload === "object" ? payload : {}) as ScopePayload;
+  const candidate = (
+    payload && typeof payload === "object" ? payload : {}
+  ) as ScopePayload;
   const explicitUserId = clean(candidate.userId) || clean(candidate.user_id);
   const explicitShopId = clean(candidate.shopId) || clean(candidate.shop_id);
 
@@ -132,7 +148,8 @@ async function resolveMutationScope(
     clean(candidate.workOrderLineId) ||
     clean(candidate.lineId) ||
     clean(candidate.work_order_line_id);
-  const workOrderId = clean(candidate.workOrderId) || clean(candidate.work_order_id);
+  const workOrderId =
+    clean(candidate.workOrderId) || clean(candidate.work_order_id);
 
   if (!shopId && workOrderLineId && navigator.onLine) {
     const { data } = await supabase
@@ -167,7 +184,10 @@ async function resolveMutationScope(
 
 function parseMutation(raw: unknown): PendingMutation | null {
   if (!raw || typeof raw !== "object") return null;
-  const item = raw as Partial<PendingMutation> & { id?: unknown; action?: unknown };
+  const item = raw as Partial<PendingMutation> & {
+    id?: unknown;
+    action?: unknown;
+  };
   const clientMutationId = clean(item.clientMutationId) || clean(item.id);
   const actionType = clean(item.actionType) || clean(item.action);
   const createdAt = clean(item.createdAt);
@@ -175,10 +195,16 @@ function parseMutation(raw: unknown): PendingMutation | null {
 
   const userId = clean(item.userId);
   const shopId = clean(item.shopId);
-  const validStatus = ["queued", "syncing", "failed", "synced", "conflicted"].includes(
-    String(item.status),
-  );
-  const parsedStatus = (validStatus ? item.status : "queued") as OfflineMutationStatus;
+  const validStatus = [
+    "queued",
+    "syncing",
+    "failed",
+    "synced",
+    "conflicted",
+  ].includes(String(item.status));
+  const parsedStatus = (
+    validStatus ? item.status : "queued"
+  ) as OfflineMutationStatus;
   const status = parsedStatus === "syncing" ? "failed" : parsedStatus;
   const missingScope = !userId || !shopId;
 
@@ -190,7 +216,9 @@ function parseMutation(raw: unknown): PendingMutation | null {
     retryCount: typeof item.retryCount === "number" ? item.retryCount : 0,
     userId,
     shopId,
-    dependsOn: Array.isArray(item.dependsOn) ? item.dependsOn.map(String) : undefined,
+    dependsOn: Array.isArray(item.dependsOn)
+      ? item.dependsOn.map(String)
+      : undefined,
     orderKey: clean(item.orderKey) || undefined,
     status: missingScope && status !== "synced" ? "conflicted" : status,
     lastError: clean(item.lastError) || undefined,
@@ -208,12 +236,16 @@ function normalizeQueue(queue: PendingMutation[]): PendingMutation[] {
   const retained = [...byId.values()].filter((item) => {
     if (item.status !== "synced") return true;
     return Boolean(
-      item.syncedAt && now - new Date(item.syncedAt).getTime() < TERMINAL_RETENTION_MS,
+      item.syncedAt &&
+      now - new Date(item.syncedAt).getTime() < TERMINAL_RETENTION_MS,
     );
   });
   if (retained.length <= MAX_HISTORY) return retained;
   return retained
-    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .sort(
+      (a, b) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    )
     .slice(retained.length - MAX_HISTORY);
 }
 
@@ -230,7 +262,9 @@ export async function hydrateOfflineMutationQueue(): Promise<void> {
         const raw = JSON.parse(localStorage.getItem(key) ?? "[]") as unknown;
         if (Array.isArray(raw)) {
           legacy.push(
-            ...raw.map(parseMutation).filter((item): item is PendingMutation => Boolean(item)),
+            ...raw
+              .map(parseMutation)
+              .filter((item): item is PendingMutation => Boolean(item)),
           );
         }
       } catch {
@@ -256,7 +290,8 @@ async function writeQueue(queue: PendingMutation[]): Promise<void> {
 
 function sortForReplay(queue: PendingMutation[]): PendingMutation[] {
   return [...queue].sort((a, b) => {
-    const time = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    const time =
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
     if (time) return time;
     const order = (a.orderKey ?? "").localeCompare(b.orderKey ?? "");
     return order || a.clientMutationId.localeCompare(b.clientMutationId);
@@ -265,7 +300,9 @@ function sortForReplay(queue: PendingMutation[]): PendingMutation[] {
 
 async function upsertMutation(next: PendingMutation): Promise<void> {
   const queue = [...queueCache];
-  const index = queue.findIndex((item) => item.clientMutationId === next.clientMutationId);
+  const index = queue.findIndex(
+    (item) => item.clientMutationId === next.clientMutationId,
+  );
   if (index >= 0) queue[index] = next;
   else queue.push(next);
   await writeQueue(queue);
@@ -311,11 +348,14 @@ async function markMutationStatus(args: {
   if (!existing) return;
   await upsertMutation({
     ...existing,
-    retryCount: args.incrementRetry ? existing.retryCount + 1 : existing.retryCount,
+    retryCount: args.incrementRetry
+      ? existing.retryCount + 1
+      : existing.retryCount,
     status: args.status,
     lastError: args.error,
     conflictReason: args.conflictReason,
-    syncedAt: args.status === "synced" ? new Date().toISOString() : existing.syncedAt,
+    syncedAt:
+      args.status === "synced" ? new Date().toISOString() : existing.syncedAt,
   });
 }
 
@@ -323,7 +363,9 @@ export function listPendingMutations(
   scope: OfflineMutationScope | null = getOfflineMutationScope(),
 ): PendingMutation[] {
   void hydrateOfflineMutationQueue();
-  return queueCache.filter((item) => item.status !== "synced" && scopeMatches(item, scope));
+  return queueCache.filter(
+    (item) => item.status !== "synced" && scopeMatches(item, scope),
+  );
 }
 
 export function listOfflineMutations(
@@ -337,7 +379,14 @@ export function getOfflineSyncSummary(
   scope: OfflineMutationScope | null = getOfflineMutationScope(),
 ) {
   void hydrateOfflineMutationQueue();
-  const summary = { queued: 0, syncing: 0, failed: 0, conflicted: 0, synced: 0, total: 0 };
+  const summary = {
+    queued: 0,
+    syncing: 0,
+    failed: 0,
+    conflicted: 0,
+    synced: 0,
+    total: 0,
+  };
   for (const item of queueCache.filter((entry) => scopeMatches(entry, scope))) {
     summary[item.status] += 1;
     summary.total += 1;
@@ -353,6 +402,98 @@ export function subscribeOfflineMutations(listener: () => void): () => void {
   return () => {
     window.removeEventListener(EVENT_NAME, listener);
     window.removeEventListener("storage", listener);
+  };
+}
+
+export async function retryOfflineMutation(
+  clientMutationId: string,
+): Promise<void> {
+  await hydrateOfflineMutationQueue();
+  const scope = getOfflineMutationScope();
+  const mutation = queueCache.find(
+    (item) =>
+      item.clientMutationId === clientMutationId && scopeMatches(item, scope),
+  );
+  if (
+    !mutation ||
+    mutation.status === "syncing" ||
+    mutation.status === "synced"
+  )
+    return;
+  await upsertMutation({
+    ...mutation,
+    status: "queued",
+    lastError: undefined,
+    conflictReason: undefined,
+  });
+}
+
+export async function dismissOfflineMutation(
+  clientMutationId: string,
+): Promise<void> {
+  await hydrateOfflineMutationQueue();
+  const scope = getOfflineMutationScope();
+  const mutation = queueCache.find(
+    (item) =>
+      item.clientMutationId === clientMutationId && scopeMatches(item, scope),
+  );
+  if (!mutation || mutation.status === "syncing") return;
+  const dependent = queueCache.find(
+    (item) =>
+      scopeMatches(item, scope) &&
+      item.status !== "synced" &&
+      item.dependsOn?.includes(clientMutationId),
+  );
+  if (dependent) {
+    throw new Error("Remove the dependent offline update first.");
+  }
+  if (mutation.actionType === "upload_job_photo") {
+    const payload = mutation.payload as { blobId?: unknown } | null;
+    if (typeof payload?.blobId === "string")
+      await removeOfflineBlob(payload.blobId);
+  }
+  await writeQueue(
+    queueCache.filter((item) => item.clientMutationId !== clientMutationId),
+  );
+}
+
+export async function clearSyncedOfflineMutations(): Promise<void> {
+  await hydrateOfflineMutationQueue();
+  const scope = getOfflineMutationScope();
+  await writeQueue(
+    queueCache.filter(
+      (item) => item.status !== "synced" || !scopeMatches(item, scope),
+    ),
+  );
+}
+
+export async function pruneOfflineState(): Promise<{
+  mutationsRemoved: number;
+  snapshotsRemoved: number;
+  blobsRemoved: number;
+}> {
+  await hydrateOfflineMutationQueue();
+  const scope = getOfflineMutationScope();
+  if (!scope)
+    return { mutationsRemoved: 0, snapshotsRemoved: 0, blobsRemoved: 0 };
+  const before = queueCache.length;
+  const retainedBlobIds = new Set(
+    queueCache
+      .filter(
+        (item) =>
+          scopeMatches(item, scope) &&
+          item.actionType === "upload_job_photo" &&
+          item.status !== "synced",
+      )
+      .map((item) => (item.payload as { blobId?: unknown } | null)?.blobId)
+      .filter((id): id is string => typeof id === "string"),
+  );
+  await clearSyncedOfflineMutations();
+  const removed = await pruneOfflineDatabase({ scope, retainedBlobIds });
+  return {
+    mutationsRemoved: before - queueCache.length,
+    snapshotsRemoved: removed.snapshotsRemoved,
+    blobsRemoved: removed.blobsRemoved,
   };
 }
 
@@ -373,7 +514,8 @@ export function isRetryableOfflineError(error: unknown): boolean {
   }
   const source = (error && typeof error === "object" ? error : {}) as ErrorLike;
   const code = clean(source.code).toUpperCase();
-  if (["PGRST301", "42501", "23503", "23505", "22P02"].includes(code)) return false;
+  if (["PGRST301", "42501", "23503", "23505", "22P02"].includes(code))
+    return false;
   const message = clean(source.message ?? error).toLowerCase();
   if (
     /unauthorized|forbidden|validation|invalid|not found|financially_locked|conflict|already completed|cannot/.test(
@@ -396,10 +538,12 @@ export async function replayQueuedMutations(args: {
 }): Promise<{ replayed: number; failed: number; conflicted: number }> {
   await hydrateOfflineMutationQueue();
   const scope = args.scope ?? getOfflineMutationScope();
-  if (!scope || !navigator.onLine) return { replayed: 0, failed: 0, conflicted: 0 };
+  if (!scope || !navigator.onLine)
+    return { replayed: 0, failed: 0, conflicted: 0 };
   const queue = sortForReplay(
     queueCache.filter(
-      (item) => ["queued", "failed"].includes(item.status) && scopeMatches(item, scope),
+      (item) =>
+        ["queued", "failed"].includes(item.status) && scopeMatches(item, scope),
     ),
   );
   let replayed = 0;
@@ -409,7 +553,9 @@ export async function replayQueuedMutations(args: {
   for (const mutation of queue) {
     const dependencyPending =
       mutation.dependsOn?.some(
-        (id) => queueCache.find((item) => item.clientMutationId === id)?.status !== "synced",
+        (id) =>
+          queueCache.find((item) => item.clientMutationId === id)?.status !==
+          "synced",
       ) ?? false;
     if (dependencyPending) continue;
     const handler = args.handlers[mutation.actionType];

--- a/features/shared/lib/pwa/launch.ts
+++ b/features/shared/lib/pwa/launch.ts
@@ -1,0 +1,14 @@
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
+
+export function resolveInstalledLaunchPath(
+  role: string | null | undefined,
+  compactViewport: boolean,
+): string {
+  const canonicalRole = canonicalizeRole(role);
+  if (canonicalRole === "customer") return "/portal";
+  if (["fleet_manager", "dispatcher", "driver"].includes(canonicalRole)) {
+    return "/fleet";
+  }
+  if (compactViewport) return "/mobile";
+  return "/dashboard";
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,10 @@ const withSerwist = withSerwistInit({
   swDest: "public/sw.js",
   register: false,
   disable: process.env.NODE_ENV !== "production",
-  additionalPrecacheEntries: [{ url: "/offline", revision: null }],
+  additionalPrecacheEntries: [
+    { url: "/offline", revision: null },
+    { url: "/offline/sync", revision: null },
+  ],
 });
 
 const nextConfig: NextConfig = {

--- a/tests/phase6-inspection-progress-route.test.ts
+++ b/tests/phase6-inspection-progress-route.test.ts
@@ -6,6 +6,10 @@ const client = readFileSync(
   "features/inspections/lib/inspection/save.ts",
   "utf8",
 );
+const replay = readFileSync(
+  "features/shared/lib/offline/replay.ts",
+  "utf8",
+);
 
 describe("Phase 6 inspection progress route", () => {
   it("requires and forwards one stable operation key", () => {
@@ -23,8 +27,9 @@ describe("Phase 6 inspection progress route", () => {
 
   it("preserves the operation key in queued replay payloads", () => {
     expect(client).toContain("operationKey: string");
-    expect(client).toContain("!payload.operationKey");
-    expect(client).toContain("await postInspectionSave(payload as InspectionSavePayload)");
+    expect(replay).toContain("!workOrderLineId || !operationKey || !payload.session");
+    expect(replay).toContain("{ ...payload, idempotencyKey: operationKey }");
+    expect(replay).toContain("operationKey,");
   });
 
   it("preserves HTTP status for permanent-error classification", () => {

--- a/tests/pwa-sync-center.test.ts
+++ b/tests/pwa-sync-center.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { resolveInstalledLaunchPath } from "@/features/shared/lib/pwa/launch";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("PWA install and sync center", () => {
+  it("launches installed sessions into the correct role and viewport experience", () => {
+    expect(resolveInstalledLaunchPath("customer", false)).toBe("/portal");
+    expect(resolveInstalledLaunchPath("fleet_manager", false)).toBe("/fleet");
+    expect(resolveInstalledLaunchPath("technician", true)).toBe("/mobile");
+    expect(resolveInstalledLaunchPath("service_advisor", false)).toBe(
+      "/dashboard",
+    );
+  });
+
+  it("precaches the offline fallback and sync center", () => {
+    const source = read("next.config.ts");
+    expect(source).toContain('{ url: "/offline", revision: null }');
+    expect(source).toContain('{ url: "/offline/sync", revision: null }');
+  });
+
+  it("waits for service worker control before reloading an update", () => {
+    const source = read("features/shared/components/pwa/PwaRuntime.tsx");
+    expect(source).toContain('"controllerchange"');
+    expect(source).toContain('postMessage({ type: "SKIP_WAITING" })');
+    expect(source).toContain("Add to Home Screen");
+  });
+
+  it("exposes tenant-scoped queue and storage controls", () => {
+    const queueSource = read("features/shared/lib/offline/mutations.ts");
+    const pageSource = read("app/offline/sync/page.tsx");
+    expect(queueSource).toContain("scopeMatches(item, scope)");
+    expect(queueSource).toContain("retryOfflineMutation");
+    expect(queueSource).toContain("dismissOfflineMutation");
+    expect(pageSource).toContain("navigator.storage?.estimate?.()");
+    expect(pageSource).toContain("Protect offline storage");
+  });
+});


### PR DESCRIPTION
## Summary

Continues Phase 1 and Phase 2 together on top of the merged installable/offline foundation.

- route installed launches by authenticated role and viewport
- add iPhone/iPad installation guidance and reliable service-worker update activation
- add a precached, tenant-scoped Sync Center at `/offline/sync`
- let users inspect, retry, or remove queued updates and clear completed history
- surface storage usage/persistence status and safely prune expired snapshots/orphaned blobs
- preserve dependent mutation ordering and active user/shop isolation

## Validation

- `tsc --noEmit --pretty false`
- focused ESLint: no errors (one existing `next.config.ts` `no-explicit-any` warning)
- `vitest run tests/pwa-offline-foundation.test.ts tests/pwa-sync-center.test.ts tests/phase6-offline-mutations.test.ts` — 13/13 passing
- `git diff --check`
- local production build reached Serwist service-worker bundling; the workspace native runtime then stalled with the known `fatal library error, lookup self` environment issue, so Vercel is the authoritative production-build check

## Scope boundary

This advances the Phase 1 install experience and Phase 2 client foundation. Server-side mutation receipts/idempotency and real-device install/offline testing remain follow-up work.