### PR TITLE
feat: add durable offline mutation receipts

### DIFF
--- a/app/api/offline/mutations/route.ts
+++ b/app/api/offline/mutations/route.ts
@@ -1,0 +1,140 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+type SupportedAction =
+  | "update_work_order_line_notes"
+  | "save_story_draft"
+  | "upload_job_photo";
+
+type RequestBody = {
+  actionType?: unknown;
+  payload?: unknown;
+};
+
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+const ACTIONS = new Set<SupportedAction>([
+  "update_work_order_line_notes",
+  "save_story_draft",
+  "upload_job_photo",
+]);
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function statusFor(message: string): number {
+  const normalized = message.toLowerCase();
+  if (normalized.includes("not found")) return 404;
+  if (
+    normalized.includes("not available") ||
+    normalized.includes("not assigned") ||
+    normalized.includes("authenticated actor") ||
+    normalized.includes("cannot add")
+  )
+    return 403;
+  if (
+    normalized.includes("idempotency_key_reuse") ||
+    normalized.includes("already completed") ||
+    normalized.includes("approved job notes")
+  ) {
+    return 409;
+  }
+  return 400;
+}
+
+export async function POST(request: NextRequest) {
+  const operationKey = request.headers.get("Idempotency-Key")?.trim() ?? "";
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
+
+  const body = (await request.json().catch(() => null)) as RequestBody | null;
+  const actionType = clean(body?.actionType) as SupportedAction;
+  const payload =
+    body?.payload && typeof body.payload === "object"
+      ? (body.payload as Record<string, unknown>)
+      : null;
+  if (!ACTIONS.has(actionType) || !payload) {
+    return NextResponse.json(
+      { error: "Unsupported offline mutation." },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null }>();
+  if (profileError || !profile?.shop_id) {
+    return NextResponse.json({ error: "Missing shop" }, { status: 403 });
+  }
+
+  const workOrderLineId =
+    clean(payload.workOrderLineId) || clean(payload.lineId);
+  if (!workOrderLineId) {
+    return NextResponse.json(
+      { error: "Missing work-order line." },
+      { status: 400 },
+    );
+  }
+
+  const rpc = supabase as unknown as RpcClient;
+  const rpcName =
+    actionType === "upload_job_photo"
+      ? "record_offline_photo_receipt_atomic"
+      : "apply_offline_line_mutation_atomic";
+  const rpcArgs =
+    actionType === "upload_job_photo"
+      ? {
+          p_shop_id: profile.shop_id,
+          p_actor_user_id: user.id,
+          p_operation_key: operationKey,
+          p_work_order_line_id: workOrderLineId,
+          p_payload: payload,
+        }
+      : {
+          p_shop_id: profile.shop_id,
+          p_actor_user_id: user.id,
+          p_operation_key: operationKey,
+          p_action_type: actionType,
+          p_work_order_line_id: workOrderLineId,
+          p_payload: payload,
+        };
+  const { data, error } = await rpc.rpc(rpcName, rpcArgs);
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return NextResponse.json(
+      { error: message },
+      { status: statusFor(message) },
+    );
+  }
+
+  return NextResponse.json(data ?? { ok: true });
+}

--- a/app/api/scheduling/punches/route.ts
+++ b/app/api/scheduling/punches/route.ts
@@ -1,14 +1,9 @@
 import { NextResponse, type NextRequest } from "next/server";
-import {
-  createAdminSupabase,
-  createServerSupabaseRoute,
-} from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import {
   isPunchEventType,
   type PunchEventType,
 } from "@/features/workforce/lib/shift-status";
-import { closeAllActiveTechnicianJobLabor } from "@/features/work-orders/server/technicianJobLabor";
 
 type Caller = {
   id: string;
@@ -56,9 +51,7 @@ async function authz() {
     };
   }
 
-  const actor = getActorCapabilities({ role: me.role });
-  const isAdmin = actor.isKnownRole && actor.canManageScheduling;
-  return { ok: true as const, me, isAdmin };
+  return { ok: true as const, me };
 }
 
 type PunchCreateBody = {
@@ -69,6 +62,13 @@ type PunchCreateBody = {
 };
 
 export async function POST(req: NextRequest) {
+  const operationKey = req.headers.get("Idempotency-Key")?.trim() ?? "";
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
   const a = await authz();
   if (!a.ok) return a.res;
 
@@ -86,80 +86,48 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid timestamp" }, { status: 400 });
   }
 
-  const admin = createAdminSupabase();
-
-  // Verify shift exists + belongs to caller shop
-  const { data: shift, error: sErr } = await admin
-    .from("tech_shifts")
-    .select("id, shop_id, user_id")
-    .eq("id", body.shift_id)
-    .maybeSingle<{
-      id: string;
-      shop_id: string | null;
-      user_id: string | null;
-    }>();
-
-  if (sErr) return NextResponse.json({ error: sErr.message }, { status: 500 });
-  if (!shift)
-    return NextResponse.json({ error: "Shift not found" }, { status: 404 });
-  if (shift.shop_id !== a.me.shop_id) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  // Rule A: punches belong to the shift owner unless admin
-  if (!a.isAdmin && shift.user_id !== a.me.id) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  if (body.event_type === "end_shift" && shift.user_id) {
-    const closed = await closeAllActiveTechnicianJobLabor({
-      supabase: admin,
-      shopId: a.me.shop_id as string,
-      technicianId: shift.user_id,
-      endedAtIso: body.timestamp,
-      reason: "shift_end",
-      event: "job_stopped_at_end_day",
-    });
-
-    if (!closed.ok) {
-      return NextResponse.json(
-        {
-          error: `Unable to stop active job timers before ending shift: ${closed.error}`,
-        },
-        { status: closed.status },
-      );
-    }
-  }
-
   const note =
     typeof body.note === "string" && body.note.trim().length > 0
       ? body.note.trim()
       : null;
 
-  const payload = {
-    shop_id: a.me.shop_id,
-    shift_id: body.shift_id,
-    user_id: shift.user_id ?? a.me.id,
-    profile_id: shift.user_id ?? a.me.id,
-    event_type: body.event_type,
-    timestamp: body.timestamp,
-    note,
+  const rpc = createServerSupabaseRoute() as unknown as {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => PromiseLike<{
+      data: unknown;
+      error: {
+        message: string;
+        details?: string | null;
+        hint?: string | null;
+      } | null;
+    }>;
   };
-  const { error } = await admin.from("punch_events").insert(payload as never);
-  if (error && error.message.includes("shop_id")) {
-    const withoutShopId = { ...payload };
-    delete (withoutShopId as { shop_id?: string | null }).shop_id;
-    const retry = await admin
-      .from("punch_events")
-      .insert(withoutShopId as never);
-    if (retry.error)
-      return NextResponse.json({ error: retry.error.message }, { status: 500 });
-    return NextResponse.json({ ok: true });
-  }
-
+  const { data, error } = await rpc.rpc("apply_offline_shift_punch_atomic", {
+    p_shop_id: a.me.shop_id,
+    p_actor_user_id: a.me.id,
+    p_operation_key: operationKey,
+    p_shift_id: body.shift_id,
+    p_event_type: body.event_type,
+    p_timestamp: body.timestamp,
+    p_note: note,
+  });
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    const normalized = message.toLowerCase();
+    const status = normalized.includes("not found")
+      ? 404
+      : normalized.includes("cannot add") ||
+          normalized.includes("not available") ||
+          normalized.includes("authenticated actor")
+        ? 403
+        : normalized.includes("idempotency_key_reuse")
+          ? 409
+          : 400;
+    return NextResponse.json({ error: message }, { status });
   }
-
-  return NextResponse.json({ ok: true });
+  return NextResponse.json(data ?? { ok: true });
 }

--- a/features/dashboard/app/dashboard/admin/SchedulingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/SchedulingClient.tsx
@@ -929,9 +929,13 @@ export default function SchedulingClient(): JSX.Element {
 
     setErr(null);
     try {
+      const operationKey = `schedule-punch:${shiftId}:${crypto.randomUUID()}`;
       await fetchJson<{ ok: true }>("/api/scheduling/punches", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": operationKey,
+        },
         body: JSON.stringify({
           shift_id: shiftId,
           event_type: toDbPunchType(event_type),

--- a/features/shared/lib/offline/replay.ts
+++ b/features/shared/lib/offline/replay.ts
@@ -8,8 +8,8 @@ import {
 import {
   replayQueuedMutations,
   type OfflineMutationRunner,
-  type PendingMutation,
 } from "@/features/shared/lib/offline/mutations";
+import { postOfflineServerMutation } from "@/features/shared/lib/offline/server-mutations";
 
 type ReplayPayload = Record<string, unknown>;
 
@@ -28,33 +28,16 @@ async function apiPost(path: string, body: unknown, operationKey?: string) {
     body: JSON.stringify(body),
   });
   if (response.ok) return;
-  const json = (await response.json().catch(() => null)) as { error?: string } | null;
-  const error = new Error(json?.error ?? "Offline update was rejected") as Error & {
+  const json = (await response.json().catch(() => null)) as {
+    error?: string;
+  } | null;
+  const error = new Error(
+    json?.error ?? "Offline update was rejected",
+  ) as Error & {
     status?: number;
   };
   error.status = response.status;
   throw error;
-}
-
-async function lineConflict(
-  mutation: PendingMutation,
-  lineId: string,
-  action: "notes" | "story",
-): Promise<string | null> {
-  const supabase = createBrowserSupabase();
-  const { data, error } = await supabase
-    .from("work_order_lines")
-    .select("status, approval_state")
-    .eq("id", lineId)
-    .eq("shop_id", mutation.shopId)
-    .maybeSingle();
-  if (error) throw error;
-  if (!data) return "The target job is no longer available in this shop.";
-  if (data.status === "completed") return "The job is already completed.";
-  if (action === "notes" && data.approval_state === "approved") {
-    return "Approved job notes must be reviewed before they can be changed.";
-  }
-  return null;
 }
 
 const handlers: Record<string, OfflineMutationRunner> = {
@@ -63,7 +46,9 @@ const handlers: Record<string, OfflineMutationRunner> = {
     const workOrderLineId = text(payload.workOrderLineId);
     const operationKey = text(payload.operationKey);
     if (!workOrderLineId || !operationKey || !payload.session) {
-      return { conflicted: "Inspection save is missing required offline data." };
+      return {
+        conflicted: "Inspection save is missing required offline data.",
+      };
     }
     await apiPost(
       "/api/inspections/save",
@@ -79,37 +64,36 @@ const handlers: Record<string, OfflineMutationRunner> = {
     if (!shiftId || !eventType || !timestamp) {
       return { conflicted: "Shift punch is missing required offline data." };
     }
-    await apiPost("/api/scheduling/punches", {
-      shift_id: shiftId,
-      event_type: eventType,
-      timestamp,
-    });
+    await apiPost(
+      "/api/scheduling/punches",
+      {
+        shift_id: shiftId,
+        event_type: eventType,
+        timestamp,
+        note: text(payload.note) || undefined,
+      },
+      mutation.clientMutationId,
+    );
   },
   update_work_order_line_notes: async (mutation) => {
     const payload = mutation.payload as ReplayPayload;
     const lineId = text(payload.workOrderLineId);
     if (!lineId) return { conflicted: "Notes update is missing its job." };
-    const conflict = await lineConflict(mutation, lineId, "notes");
-    if (conflict) return { conflicted: conflict };
-    const { error } = await createBrowserSupabase()
-      .from("work_order_lines")
-      .update({ notes: text(payload.notes) })
-      .eq("id", lineId)
-      .eq("shop_id", mutation.shopId);
-    if (error) throw error;
+    await postOfflineServerMutation({
+      actionType: "update_work_order_line_notes",
+      operationKey: mutation.clientMutationId,
+      payload,
+    });
   },
   save_story_draft: async (mutation) => {
     const payload = mutation.payload as ReplayPayload;
     const lineId = text(payload.lineId);
     if (!lineId) return { conflicted: "Story draft is missing its job." };
-    const conflict = await lineConflict(mutation, lineId, "story");
-    if (conflict) return { conflicted: conflict };
-    const { error } = await createBrowserSupabase()
-      .from("work_order_lines")
-      .update({ cause: text(payload.cause), correction: text(payload.correction) })
-      .eq("id", lineId)
-      .eq("shop_id", mutation.shopId);
-    if (error) throw error;
+    await postOfflineServerMutation({
+      actionType: "save_story_draft",
+      operationKey: mutation.clientMutationId,
+      payload,
+    });
   },
   upload_job_photo: async (mutation) => {
     const payload = mutation.payload as ReplayPayload;
@@ -119,16 +103,27 @@ const handlers: Record<string, OfflineMutationRunner> = {
       return { conflicted: "Photo upload is missing its staged file." };
     }
     const record = await getOfflineBlob(blobId);
-    if (!record || record.userId !== mutation.userId || record.shopId !== mutation.shopId) {
-      return { conflicted: "The staged photo is no longer available on this device." };
+    if (
+      !record ||
+      record.userId !== mutation.userId ||
+      record.shopId !== mutation.shopId
+    ) {
+      return {
+        conflicted: "The staged photo is no longer available on this device.",
+      };
     }
-    const { error } = await createBrowserSupabase().storage
-      .from("job-photos")
+    const { error } = await createBrowserSupabase()
+      .storage.from("job-photos")
       .upload(path, record.blob, {
         contentType: record.mimeType || "image/jpeg",
         upsert: true,
       });
     if (error) throw error;
+    await postOfflineServerMutation({
+      actionType: "upload_job_photo",
+      operationKey: mutation.clientMutationId,
+      payload,
+    });
     await removeOfflineBlob(blobId);
   },
   "job:punch-transition": async (mutation) => {
@@ -136,7 +131,11 @@ const handlers: Record<string, OfflineMutationRunner> = {
     const lineId = text(payload.lineId);
     const action = text(payload.action);
     const operationKey = text(payload.operationKey);
-    if (!lineId || !["start", "pause", "resume", "finish"].includes(action) || !operationKey) {
+    if (
+      !lineId ||
+      !["start", "pause", "resume", "finish"].includes(action) ||
+      !operationKey
+    ) {
       return { conflicted: "Job transition is missing required offline data." };
     }
     await apiPost(

--- a/features/shared/lib/offline/server-mutations.ts
+++ b/features/shared/lib/offline/server-mutations.ts
@@ -1,0 +1,38 @@
+"use client";
+
+type OfflineServerMutationAction =
+  | "update_work_order_line_notes"
+  | "save_story_draft"
+  | "upload_job_photo";
+
+type ApiError = { error?: string };
+
+export async function postOfflineServerMutation(args: {
+  actionType: OfflineServerMutationAction;
+  operationKey: string;
+  payload: Record<string, unknown>;
+}): Promise<unknown> {
+  const response = await fetch("/api/offline/mutations", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": args.operationKey,
+    },
+    body: JSON.stringify({
+      actionType: args.actionType,
+      payload: args.payload,
+    }),
+  });
+  const result = (await response.json().catch(() => null)) as ApiError | null;
+  if (!response.ok) {
+    const error = new Error(
+      result?.error ?? "Offline mutation was rejected",
+    ) as Error & {
+      status?: number;
+    };
+    error.status = response.status;
+    throw error;
+  }
+  return result;
+}

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -18,6 +18,7 @@ import {
   subscribeOfflineMutations,
 } from "@/features/shared/lib/offline/mutations";
 import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
+import { postOfflineServerMutation } from "@/features/shared/lib/offline/server-mutations";
 import {
   removeOfflineBlob,
   saveOfflineBlob,
@@ -660,6 +661,17 @@ export default function MobileFocusedJob(props: {
             upsert: true,
           });
           if (error) throw error;
+          await postOfflineServerMutation({
+            actionType: "upload_job_photo",
+            operationKey: clientMutationId,
+            payload: {
+              workOrderLineId,
+              path,
+              fileName: file.name,
+              mimeType: file.type || "image/jpeg",
+              blobId: clientMutationId,
+            },
+          });
         },
       });
     } catch (error) {
@@ -702,13 +714,11 @@ export default function MobileFocusedJob(props: {
         orderKey: `${workOrderLineId}:001:notes`,
         conflictCheck: () => getLineConflict(workOrderLineId, "notes"),
         runner: async () => {
-          const { error } = await supabase
-            .from("work_order_lines")
-            .update({
-              notes: techNotes,
-            } as DB["public"]["Tables"]["work_order_lines"]["Update"])
-            .eq("id", workOrderLineId);
-          if (error) throw error;
+          await postOfflineServerMutation({
+            actionType: "update_work_order_line_notes",
+            operationKey: mutationId,
+            payload: { workOrderLineId, notes: techNotes },
+          });
         },
       });
 
@@ -1382,15 +1392,11 @@ export default function MobileFocusedJob(props: {
               orderKey: `${line.id}:002:story`,
               conflictCheck: () => getLineConflict(line.id, "story"),
               runner: async () => {
-                const { error } = await supabase
-                  .from("work_order_lines")
-                  .update({
-                    cause,
-                    correction,
-                  } as DB["public"]["Tables"]["work_order_lines"]["Update"])
-                  .eq("id", line.id);
-
-                if (error) throw error;
+                await postOfflineServerMutation({
+                  actionType: "save_story_draft",
+                  operationKey: mutationId,
+                  payload: { lineId: line.id, cause, correction },
+                });
               },
             });
 

--- a/supabase/migrations/20260716090000_phase2_offline_mutation_receipts.sql
+++ b/supabase/migrations/20260716090000_phase2_offline_mutation_receipts.sql
@@ -1,0 +1,404 @@
+begin;
+
+create table if not exists public.offline_mutation_receipts (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  actor_user_id uuid not null references auth.users(id) on delete cascade,
+  operation_key text not null,
+  action_type text not null,
+  payload_hash text not null,
+  entity_type text,
+  entity_id uuid,
+  result jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  completed_at timestamptz not null default now(),
+  unique (shop_id, operation_key)
+);
+
+create index if not exists offline_mutation_receipts_actor_idx
+  on public.offline_mutation_receipts(actor_user_id, shop_id, completed_at desc);
+
+alter table public.offline_mutation_receipts enable row level security;
+
+drop policy if exists offline_mutation_receipts_actor_select
+  on public.offline_mutation_receipts;
+create policy offline_mutation_receipts_actor_select
+  on public.offline_mutation_receipts
+  for select
+  to authenticated
+  using (
+    actor_user_id = auth.uid()
+    and exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = offline_mutation_receipts.shop_id
+    )
+  );
+
+create or replace function public.apply_offline_line_mutation_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_action_type text,
+  p_work_order_line_id uuid,
+  p_payload jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_role text;
+  v_existing public.offline_mutation_receipts%rowtype;
+  v_receipt_id uuid;
+  v_payload jsonb := coalesce(p_payload, '{}'::jsonb);
+  v_payload_hash text := encode(digest(coalesce(p_payload, '{}'::jsonb)::text, 'sha256'), 'hex');
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor does not match the mutation actor.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null or length(p_operation_key) > 240 then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+  if p_action_type not in ('update_work_order_line_notes', 'save_story_draft') then
+    raise exception using errcode = 'P0001', message = 'Unsupported offline line mutation.';
+  end if;
+
+  select * into v_existing
+  from public.offline_mutation_receipts r
+  where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+  if found then
+    if v_existing.action_type <> p_action_type or v_existing.payload_hash <> v_payload_hash then
+      raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+    end if;
+    return v_existing.result || jsonb_build_object('idempotent', true, 'receipt_id', v_existing.id);
+  end if;
+
+  select lower(coalesce(p.role::text, '')) into v_role
+  from public.profiles p
+  where p.id = p_actor_user_id and p.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Actor is not available for this shop.';
+  end if;
+
+  select * into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id and wol.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for shop.';
+  end if;
+  if lower(coalesce(v_line.status::text, '')) = 'completed' then
+    raise exception using errcode = 'P0001', message = 'Work-order line is already completed.';
+  end if;
+  if v_role not in ('owner','admin','manager','advisor','service','lead_hand','lead hand','leadhand','foreman')
+     and v_line.assigned_tech_id is distinct from p_actor_user_id
+     and not exists (
+       select 1 from public.work_order_line_technicians wolt
+       where wolt.work_order_line_id = p_work_order_line_id
+         and wolt.technician_id = p_actor_user_id
+     ) then
+    raise exception using errcode = 'P0001', message = 'Actor is not assigned to this work-order line.';
+  end if;
+
+  if p_action_type = 'update_work_order_line_notes' then
+    if lower(coalesce(v_line.approval_state::text, '')) = 'approved' then
+      raise exception using errcode = 'P0001', message = 'Approved job notes require review before editing.';
+    end if;
+    update public.work_order_lines
+    set notes = coalesce(v_payload->>'notes', ''), updated_at = now()
+    where id = p_work_order_line_id and shop_id = p_shop_id;
+  else
+    update public.work_order_lines
+    set cause = coalesce(v_payload->>'cause', ''),
+        correction = coalesce(v_payload->>'correction', ''),
+        updated_at = now()
+    where id = p_work_order_line_id and shop_id = p_shop_id;
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'action_type', p_action_type,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'completed_at', now()
+  );
+
+  insert into public.offline_mutation_receipts(
+    shop_id, actor_user_id, operation_key, action_type, payload_hash,
+    entity_type, entity_id, result
+  ) values (
+    p_shop_id, p_actor_user_id, p_operation_key, p_action_type, v_payload_hash,
+    'work_order_line', p_work_order_line_id, v_result
+  ) returning id into v_receipt_id;
+
+  return v_result || jsonb_build_object('receipt_id', v_receipt_id);
+exception
+  when unique_violation then
+    select * into v_existing
+    from public.offline_mutation_receipts r
+    where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+    if found and v_existing.action_type = p_action_type and v_existing.payload_hash = v_payload_hash then
+      return v_existing.result || jsonb_build_object('idempotent', true, 'receipt_id', v_existing.id);
+    end if;
+    raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+end;
+$$;
+
+create or replace function public.record_offline_photo_receipt_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_work_order_line_id uuid,
+  p_payload jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line record;
+  v_role text;
+  v_existing public.offline_mutation_receipts%rowtype;
+  v_receipt_id uuid;
+  v_payload jsonb := coalesce(p_payload, '{}'::jsonb);
+  v_payload_hash text := encode(digest(coalesce(p_payload, '{}'::jsonb)::text, 'sha256'), 'hex');
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor does not match the mutation actor.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null or length(p_operation_key) > 240 then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  select * into v_existing
+  from public.offline_mutation_receipts r
+  where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+  if found then
+    if v_existing.action_type <> 'upload_job_photo' or v_existing.payload_hash <> v_payload_hash then
+      raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+    end if;
+    return v_existing.result || jsonb_build_object('idempotent', true, 'receipt_id', v_existing.id);
+  end if;
+
+  select lower(coalesce(p.role::text, '')) into v_role
+  from public.profiles p
+  where p.id = p_actor_user_id and p.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Actor is not available for this shop.';
+  end if;
+
+  select wol.work_order_id, wol.shop_id, wol.assigned_tech_id into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id and wol.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for shop.';
+  end if;
+  if v_role not in ('owner','admin','manager','advisor','service','lead_hand','lead hand','leadhand','foreman')
+     and v_line.assigned_tech_id is distinct from p_actor_user_id
+     and not exists (
+       select 1 from public.work_order_line_technicians wolt
+       where wolt.work_order_line_id = p_work_order_line_id
+         and wolt.technician_id = p_actor_user_id
+     ) then
+    raise exception using errcode = 'P0001', message = 'Actor is not assigned to this work-order line.';
+  end if;
+  if nullif(v_payload->>'path', '') is null
+     or position('wo/' || v_line.work_order_id::text || '/lines/' || p_work_order_line_id::text || '/' in (v_payload->>'path')) <> 1 then
+    raise exception using errcode = 'P0001', message = 'Photo storage path does not match the work-order line.';
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'action_type', 'upload_job_photo',
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'path', v_payload->>'path',
+    'completed_at', now()
+  );
+
+  insert into public.offline_mutation_receipts(
+    shop_id, actor_user_id, operation_key, action_type, payload_hash,
+    entity_type, entity_id, result
+  ) values (
+    p_shop_id, p_actor_user_id, p_operation_key, 'upload_job_photo', v_payload_hash,
+    'work_order_line', p_work_order_line_id, v_result
+  ) returning id into v_receipt_id;
+
+  return v_result || jsonb_build_object('receipt_id', v_receipt_id);
+exception
+  when unique_violation then
+    select * into v_existing
+    from public.offline_mutation_receipts r
+    where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+    if found and v_existing.action_type = 'upload_job_photo' and v_existing.payload_hash = v_payload_hash then
+      return v_existing.result || jsonb_build_object('idempotent', true, 'receipt_id', v_existing.id);
+    end if;
+    raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+end;
+$$;
+
+create or replace function public.apply_offline_shift_punch_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_shift_id uuid,
+  p_event_type text,
+  p_timestamp timestamptz,
+  p_note text default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_shift public.tech_shifts%rowtype;
+  v_role text;
+  v_event text := lower(trim(coalesce(p_event_type, '')));
+  v_payload jsonb;
+  v_payload_hash text;
+  v_existing public.offline_mutation_receipts%rowtype;
+  v_receipt_id uuid;
+  v_punch_id uuid;
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor does not match the mutation actor.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null or length(p_operation_key) > 240 then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+  if v_event not in ('start_shift','end_shift','break_start','break_end','lunch_start','lunch_end') then
+    raise exception using errcode = 'P0001', message = 'Invalid shift punch event type.';
+  end if;
+
+  v_payload := jsonb_build_object(
+    'shift_id', p_shift_id,
+    'event_type', v_event,
+    'timestamp', p_timestamp,
+    'note', nullif(trim(coalesce(p_note, '')), '')
+  );
+  v_payload_hash := encode(digest(v_payload::text, 'sha256'), 'hex');
+
+  select * into v_existing
+  from public.offline_mutation_receipts r
+  where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+  if found then
+    if v_existing.action_type <> 'shift:punch-event' or v_existing.payload_hash <> v_payload_hash then
+      raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+    end if;
+    return v_existing.result || jsonb_build_object('idempotent', true, 'receipt_id', v_existing.id);
+  end if;
+
+  select lower(coalesce(p.role::text, '')) into v_role
+  from public.profiles p
+  where p.id = p_actor_user_id and p.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Actor is not available for this shop.';
+  end if;
+
+  select * into v_shift
+  from public.tech_shifts ts
+  where ts.id = p_shift_id and ts.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Shift not found for shop.';
+  end if;
+  if v_shift.user_id <> p_actor_user_id
+     and v_role not in ('owner','admin','manager','advisor','lead_hand','lead hand','leadhand','foreman') then
+    raise exception using errcode = 'P0001', message = 'Actor cannot add a punch for this shift.';
+  end if;
+
+  if v_event = 'end_shift' and v_shift.user_id is not null then
+    perform public.pause_all_active_technician_labor_atomic(
+      p_shop_id,
+      v_shift.user_id,
+      p_actor_user_id,
+      p_shop_id::text || ':offline-shift:' || p_operation_key,
+      p_timestamp,
+      'shift_end',
+      'job_stopped_at_end_day',
+      null,
+      jsonb_build_object('source', 'offline_shift_punch')
+    );
+  end if;
+
+  insert into public.punch_events(
+    shift_id, user_id, profile_id, event_type, timestamp, note
+  ) values (
+    p_shift_id,
+    coalesce(v_shift.user_id, p_actor_user_id),
+    coalesce(v_shift.user_id, p_actor_user_id),
+    v_event::public.punch_event_type,
+    p_timestamp,
+    nullif(trim(coalesce(p_note, '')), '')
+  ) returning id into v_punch_id;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'action_type', 'shift:punch-event',
+    'shift_id', p_shift_id,
+    'punch_event_id', v_punch_id,
+    'completed_at', now()
+  );
+
+  insert into public.offline_mutation_receipts(
+    shop_id, actor_user_id, operation_key, action_type, payload_hash,
+    entity_type, entity_id, result
+  ) values (
+    p_shop_id, p_actor_user_id, p_operation_key, 'shift:punch-event', v_payload_hash,
+    'shift', p_shift_id, v_result
+  ) returning id into v_receipt_id;
+
+  return v_result || jsonb_build_object('receipt_id', v_receipt_id);
+exception
+  when unique_violation then
+    select * into v_existing
+    from public.offline_mutation_receipts r
+    where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+    if found and v_existing.action_type = 'shift:punch-event' and v_existing.payload_hash = v_payload_hash then
+      return v_existing.result || jsonb_build_object('idempotent', true, 'receipt_id', v_existing.id);
+    end if;
+    raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+end;
+$$;
+
+revoke all on function public.apply_offline_line_mutation_atomic(uuid,uuid,text,text,uuid,jsonb) from public, anon;
+revoke all on function public.record_offline_photo_receipt_atomic(uuid,uuid,text,uuid,jsonb) from public, anon;
+revoke all on function public.apply_offline_shift_punch_atomic(uuid,uuid,text,uuid,text,timestamptz,text) from public, anon;
+grant execute on function public.apply_offline_line_mutation_atomic(uuid,uuid,text,text,uuid,jsonb) to authenticated, service_role;
+grant execute on function public.record_offline_photo_receipt_atomic(uuid,uuid,text,uuid,jsonb) to authenticated, service_role;
+grant execute on function public.apply_offline_shift_punch_atomic(uuid,uuid,text,uuid,text,timestamptz,text) to authenticated, service_role;
+
+do $$
+begin
+  if to_regclass('public.offline_mutation_receipts') is null then
+    raise exception 'offline_mutation_receipts table was not created';
+  end if;
+  if not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = 'offline_mutation_receipts'
+      and c.relrowsecurity
+  ) then
+    raise exception 'offline_mutation_receipts RLS was not enabled';
+  end if;
+  if to_regprocedure('public.apply_offline_line_mutation_atomic(uuid,uuid,text,text,uuid,jsonb)') is null
+     or to_regprocedure('public.record_offline_photo_receipt_atomic(uuid,uuid,text,uuid,jsonb)') is null
+     or to_regprocedure('public.apply_offline_shift_punch_atomic(uuid,uuid,text,uuid,text,timestamptz,text)') is null then
+    raise exception 'offline mutation receipt functions were not created';
+  end if;
+end;
+$$;
+
+notify pgrst, 'reload schema';
+commit;

--- a/tests/offline-mutation-receipts.test.ts
+++ b/tests/offline-mutation-receipts.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const migration = read(
+  "supabase/migrations/20260716090000_phase2_offline_mutation_receipts.sql",
+);
+
+describe("offline mutation receipts", () => {
+  it("stores tenant and actor scoped receipts with one operation-key owner", () => {
+    expect(migration).toContain(
+      "create table if not exists public.offline_mutation_receipts",
+    );
+    expect(migration).toContain("unique (shop_id, operation_key)");
+    expect(migration).toContain("actor_user_id = auth.uid()");
+    expect(migration).toContain("payload_hash text not null");
+    expect(migration).toContain("IDEMPOTENCY_KEY_REUSE");
+    expect(migration).toContain("auth.uid() <> p_actor_user_id");
+    expect(migration).toContain("work_order_line_technicians");
+  });
+
+  it("applies line and shift mutations atomically before completing receipts", () => {
+    expect(migration).toContain("apply_offline_line_mutation_atomic");
+    expect(migration).toContain("apply_offline_shift_punch_atomic");
+    expect(migration).toContain("pause_all_active_technician_labor_atomic");
+    expect(migration).toContain("insert into public.punch_events");
+    expect(migration).toContain("insert into public.offline_mutation_receipts");
+  });
+
+  it("requires authenticated idempotency keys at both server entry points", () => {
+    const offlineRoute = read("app/api/offline/mutations/route.ts");
+    const punchRoute = read("app/api/scheduling/punches/route.ts");
+    for (const source of [offlineRoute, punchRoute]) {
+      expect(source).toContain('headers.get("Idempotency-Key")');
+      expect(source).toContain("A stable Idempotency-Key is required.");
+      expect(source).toContain("auth.getUser()");
+    }
+  });
+
+  it("routes every remaining queued write through server receipts", () => {
+    const replay = read("features/shared/lib/offline/replay.ts");
+    const mobileJob = read("features/work-orders/mobile/MobileFocusedJob.tsx");
+    expect(replay).toContain("postOfflineServerMutation");
+    expect(replay).toContain("mutation.clientMutationId");
+    expect(replay).toContain('actionType: "update_work_order_line_notes"');
+    expect(replay).toContain('actionType: "save_story_draft"');
+    expect(replay).toContain('actionType: "upload_job_photo"');
+    expect(mobileJob).toContain("postOfflineServerMutation");
+  });
+});


### PR DESCRIPTION
## Summary

- add a tenant- and actor-scoped `offline_mutation_receipts` ledger
- make job notes, cause/correction drafts, photo completion, and shift punches durably idempotent
- route foreground and replayed technician writes through authenticated server endpoints
- reject reused idempotency keys when action or payload differs
- enforce shop membership, actor identity, technician assignment, and photo-path ownership inside atomic RPCs
- close active job labor atomically when an end-shift punch is applied
- add migration self-checks for the receipt table, RLS, and RPC installation

## Why

Phase 2 already moved the queue to IndexedDB and added a global sync engine, but several replay paths could still perform a write more than once after a response was lost. These server receipts make retries safe and give every queued mutation a durable completion record.

## Validation

- `pnpm typecheck`
- focused ESLint: 0 errors (2 pre-existing warnings in `MobileFocusedJob.tsx`)
- 41 focused Vitest tests across receipt, labor, shift lifecycle, replay, and PWA contracts
- `git diff --check`

## Deployment note

This PR adds a Supabase migration. The database preview/migration check should complete before merging.