### PR TITLE
feat: download assigned technician work offline

### DIFF
--- a/app/api/offline/technician-work-orders/route.ts
+++ b/app/api/offline/technician-work-orders/route.ts
@@ -1,0 +1,233 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import type { Database } from "@shared/types/types/supabase";
+import type {
+  TechnicianOfflineBundle,
+  TechnicianOfflineWorkOrder,
+} from "@/features/work-orders/mobile/technicianOfflineTypes";
+
+type DB = Database;
+type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type QuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
+type Customer = DB["public"]["Tables"]["customers"]["Row"];
+
+export async function GET() {
+  const authClient = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error: userError,
+  } = await authClient.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { data: profile, error: profileError } = await authClient
+    .from("profiles")
+    .select("shop_id, role")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null; role: string | null }>();
+  if (profileError || !profile?.shop_id) {
+    return NextResponse.json({ error: "Missing shop" }, { status: 403 });
+  }
+  if (!getActorCapabilities({ role: profile.role }).canPerformAssignedWork) {
+    return NextResponse.json(
+      { error: "Assigned technician work is not available for this role." },
+      { status: 403 },
+    );
+  }
+
+  const admin = createAdminSupabase();
+  const [
+    { data: directlyAssigned, error: directError },
+    { data: sharedAssigned, error: sharedError },
+  ] = await Promise.all([
+    admin
+      .from("work_order_lines")
+      .select("id, work_order_id")
+      .eq("shop_id", profile.shop_id)
+      .eq("line_type", "job")
+      .or(`assigned_tech_id.eq.${user.id},assigned_to.eq.${user.id}`),
+    admin
+      .from("work_order_line_technicians")
+      .select("work_order_line_id")
+      .eq("technician_id", user.id),
+  ]);
+  if (directError || sharedError) {
+    return NextResponse.json(
+      {
+        error:
+          directError?.message ??
+          sharedError?.message ??
+          "Assignments could not be loaded.",
+      },
+      { status: 500 },
+    );
+  }
+
+  const sharedLineIds = (sharedAssigned ?? []).map(
+    (row) => row.work_order_line_id,
+  );
+  const { data: sharedLines, error: sharedLinesError } = sharedLineIds.length
+    ? await admin
+        .from("work_order_lines")
+        .select("id, work_order_id")
+        .eq("shop_id", profile.shop_id)
+        .eq("line_type", "job")
+        .in("id", sharedLineIds)
+    : { data: [], error: null };
+  if (sharedLinesError) {
+    return NextResponse.json(
+      { error: sharedLinesError.message },
+      { status: 500 },
+    );
+  }
+
+  const assignedRows = [...(directlyAssigned ?? []), ...(sharedLines ?? [])];
+  const assignedLineIds = new Set(assignedRows.map((row) => row.id));
+  const workOrderIds = [
+    ...new Set(assignedRows.map((row) => row.work_order_id).filter(Boolean)),
+  ] as string[];
+  if (workOrderIds.length === 0) {
+    const empty: TechnicianOfflineBundle = {
+      scope: { userId: user.id, shopId: profile.shop_id },
+      downloadedAt: new Date().toISOString(),
+      workOrders: [],
+    };
+    return NextResponse.json(empty, {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  }
+
+  // Use the authenticated client for every downloaded business record so the
+  // normal table policies remain the final authorization boundary.
+  const { data: workOrdersData, error: workOrdersError } = await authClient
+    .from("work_orders")
+    .select("*")
+    .eq("shop_id", profile.shop_id)
+    .in("id", workOrderIds)
+    .neq("type", "historical_import")
+    .order("created_at", { ascending: false })
+    .limit(50);
+  if (workOrdersError) {
+    return NextResponse.json(
+      { error: workOrdersError.message },
+      { status: 500 },
+    );
+  }
+
+  const workOrders = (workOrdersData ?? []) as WorkOrder[];
+  if (workOrders.length === 0) {
+    const empty: TechnicianOfflineBundle = {
+      scope: { userId: user.id, shopId: profile.shop_id },
+      downloadedAt: new Date().toISOString(),
+      workOrders: [],
+    };
+    return NextResponse.json(empty, {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  }
+  const allowedWorkOrderIds = workOrders.map((row) => row.id);
+  const vehicleIds = [
+    ...new Set(workOrders.map((row) => row.vehicle_id).filter(Boolean)),
+  ] as string[];
+  const customerIds = [
+    ...new Set(workOrders.map((row) => row.customer_id).filter(Boolean)),
+  ] as string[];
+  const [linesResult, quotesResult, vehiclesResult, customersResult] =
+    await Promise.all([
+      authClient
+        .from("work_order_lines")
+        .select("*")
+        .eq("shop_id", profile.shop_id)
+        .in("work_order_id", allowedWorkOrderIds)
+        .order("created_at"),
+      authClient
+        .from("work_order_quote_lines")
+        .select("*")
+        .in("work_order_id", allowedWorkOrderIds)
+        .order("created_at"),
+      vehicleIds.length
+        ? authClient
+            .from("vehicles")
+            .select("*")
+            .eq("shop_id", profile.shop_id)
+            .in("id", vehicleIds)
+        : Promise.resolve({ data: [], error: null }),
+      customerIds.length
+        ? authClient
+            .from("customers")
+            .select("*")
+            .eq("shop_id", profile.shop_id)
+            .in("id", customerIds)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
+  if (linesResult.error) {
+    return NextResponse.json(
+      { error: linesResult.error.message },
+      { status: 500 },
+    );
+  }
+
+  const lines = (linesResult.data ?? []) as WorkOrderLine[];
+  const quoteLines = (
+    quotesResult.error ? [] : (quotesResult.data ?? [])
+  ) as QuoteLine[];
+  const vehicles = (
+    vehiclesResult.error ? [] : (vehiclesResult.data ?? [])
+  ) as Vehicle[];
+  const customers = (
+    customersResult.error ? [] : (customersResult.data ?? [])
+  ) as Customer[];
+  const techIds = [
+    ...new Set(lines.map((line) => line.assigned_tech_id).filter(Boolean)),
+  ] as string[];
+  const { data: technicians } = techIds.length
+    ? await authClient
+        .from("profiles")
+        .select("id, full_name")
+        .eq("shop_id", profile.shop_id)
+        .in("id", techIds)
+    : { data: [] };
+  const techNamesById = Object.fromEntries(
+    (technicians ?? []).map((technician) => [
+      technician.id,
+      technician.full_name ?? "Technician",
+    ]),
+  );
+
+  const bundle: TechnicianOfflineBundle = {
+    scope: { userId: user.id, shopId: profile.shop_id },
+    downloadedAt: new Date().toISOString(),
+    workOrders: workOrders.map<TechnicianOfflineWorkOrder>((workOrder) => ({
+      workOrder,
+      lines: lines.filter((line) => line.work_order_id === workOrder.id),
+      quoteLines: quoteLines.filter(
+        (line) => line.work_order_id === workOrder.id,
+      ),
+      vehicle:
+        vehicles.find((vehicle) => vehicle.id === workOrder.vehicle_id) ?? null,
+      customer:
+        customers.find((customer) => customer.id === workOrder.customer_id) ??
+        null,
+      techNamesById,
+      assignedLineIds: lines
+        .filter(
+          (line) =>
+            line.work_order_id === workOrder.id && assignedLineIds.has(line.id),
+        )
+        .map((line) => line.id),
+    })),
+  };
+
+  return NextResponse.json(bundle, {
+    headers: { "Cache-Control": "private, no-store" },
+  });
+}

--- a/app/mobile/tech/queue/page.tsx
+++ b/app/mobile/tech/queue/page.tsx
@@ -7,11 +7,21 @@
 
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
-import { getOfflineSyncSummary, subscribeOfflineMutations } from "@/features/shared/lib/offline/mutations";
+import {
+  getOfflineMutationScope,
+  getOfflineSyncSummary,
+  setOfflineMutationScope,
+  subscribeOfflineMutations,
+} from "@/features/shared/lib/offline/mutations";
+import {
+  downloadAssignedTechnicianWork,
+  getCachedTechnicianWork,
+} from "@/features/work-orders/mobile/technicianOfflineDownload";
+import type { TechnicianOfflineBundle } from "@/features/work-orders/mobile/technicianOfflineTypes";
 
 type DB = Database;
 type Line = DB["public"]["Tables"]["work_order_lines"]["Row"];
@@ -66,7 +76,8 @@ function toBucket(line: Line): RollupStatus {
   if (punchedIn) return "in_progress";
 
   const s = (line.status ?? "").toLowerCase().replaceAll(" ", "_");
-  if (s === "in_progress" || s === "in-progress" || s === "active") return "in_progress";
+  if (s === "in_progress" || s === "in-progress" || s === "active")
+    return "in_progress";
   if (s === "on_hold") return "on_hold";
   if (s === "completed") return "completed";
   return "awaiting";
@@ -81,15 +92,20 @@ const STATUS_RANK: Record<RollupStatus, number> = {
 };
 
 function toPriority(line: Line): JobPriority {
-  const raw = String((line as Line & { job_priority?: string | null }).job_priority ?? "normal")
+  const raw = String(
+    (line as Line & { job_priority?: string | null }).job_priority ?? "normal",
+  )
     .toLowerCase()
     .trim();
-  if (raw === "urgent" || raw === "high" || raw === "normal" || raw === "low") return raw;
+  if (raw === "urgent" || raw === "high" || raw === "normal" || raw === "low")
+    return raw;
   return "normal";
 }
 
 function cleanText(v: string | null | undefined): string {
-  return String(v ?? "").trim().replace(/\s+/g, " ");
+  return String(v ?? "")
+    .trim()
+    .replace(/\s+/g, " ");
 }
 
 function nextActionLabel(status: RollupStatus): string {
@@ -122,15 +138,66 @@ type WorkOrderMapRow = {
   vehicleLabel: string | null;
 };
 
+function queueViewFromBundle(bundle: TechnicianOfflineBundle): {
+  lines: Line[];
+  workOrderMap: Record<string, WorkOrderMapRow>;
+  lineNumberMap: Record<string, number>;
+} {
+  const assignedIds = new Set(
+    bundle.workOrders.flatMap((item) => item.assignedLineIds),
+  );
+  const lines = bundle.workOrders
+    .flatMap((item) => item.lines)
+    .filter((line) => assignedIds.has(line.id));
+  const workOrderMap: Record<string, WorkOrderMapRow> = {};
+  const lineNumberMap: Record<string, number> = {};
+  const jobTypePriority: Record<string, number> = {
+    diagnosis: 1,
+    inspection: 2,
+    maintenance: 3,
+    repair: 4,
+  };
+
+  for (const item of bundle.workOrders) {
+    workOrderMap[item.workOrder.id] = {
+      id: item.workOrder.id,
+      custom_id: item.workOrder.custom_id,
+      vehicle_id: item.workOrder.vehicle_id,
+      vehicleLabel: formatVehicle(item.vehicle),
+    };
+    item.lines
+      .filter(
+        (line) =>
+          (line.line_type ?? "job") === "job" &&
+          (line.approval_state ?? "").toLowerCase() !== "pending",
+      )
+      .sort((a, b) => {
+        const priority =
+          (jobTypePriority[String(a.job_type ?? "repair")] ?? 999) -
+          (jobTypePriority[String(b.job_type ?? "repair")] ?? 999);
+        if (priority) return priority;
+        return (
+          new Date(a.created_at ?? 0).getTime() -
+          new Date(b.created_at ?? 0).getTime()
+        );
+      })
+      .forEach((line, index) => {
+        lineNumberMap[line.id] = index + 1;
+      });
+  }
+
+  return { lines, workOrderMap, lineNumberMap };
+}
+
 export default function MobileTechQueuePage() {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const router = useRouter();
 
   const [lines, setLines] = useState<Line[]>([]);
 
-  const [workOrderMap, setWorkOrderMap] = useState<Record<string, WorkOrderMapRow>>(
-    {},
-  );
+  const [workOrderMap, setWorkOrderMap] = useState<
+    Record<string, WorkOrderMapRow>
+  >({});
 
   // line.id -> 1-based “client view” line number
   const [lineNumberMap, setLineNumberMap] = useState<Record<string, number>>(
@@ -141,7 +208,20 @@ export default function MobileTechQueuePage() {
   const [err, setErr] = useState<string | null>(null);
   const [activeFilter, setActiveFilter] = useState<RollupStatus | null>(null);
   const [syncSummary, setSyncSummary] = useState(() => getOfflineSyncSummary());
+  const [scope, setScope] = useState<{ userId: string; shopId: string } | null>(
+    null,
+  );
+  const [downloading, setDownloading] = useState(false);
+  const [offlineMessage, setOfflineMessage] = useState<string | null>(null);
+  const [offlineUpdatedAt, setOfflineUpdatedAt] = useState<string | null>(null);
+  const [online, setOnline] = useState(true);
 
+  const applyOfflineBundle = useCallback((bundle: TechnicianOfflineBundle) => {
+    const view = queueViewFromBundle(bundle);
+    setLines(view.lines);
+    setWorkOrderMap(view.workOrderMap);
+    setLineNumberMap(view.lineNumberMap);
+  }, []);
 
   useEffect(() => {
     const refresh = () => setSyncSummary(getOfflineSyncSummary());
@@ -150,9 +230,41 @@ export default function MobileTechQueuePage() {
   }, []);
 
   useEffect(() => {
+    const refresh = () => setOnline(navigator.onLine);
+    refresh();
+    window.addEventListener("online", refresh);
+    window.addEventListener("offline", refresh);
+    return () => {
+      window.removeEventListener("online", refresh);
+      window.removeEventListener("offline", refresh);
+    };
+  }, []);
+
+  useEffect(() => {
     (async () => {
       setLoading(true);
       setErr(null);
+
+      if (!navigator.onLine) {
+        const cachedScope = getOfflineMutationScope();
+        if (!cachedScope) {
+          setErr("No offline user and shop scope is available on this device.");
+          setLoading(false);
+          return;
+        }
+        setScope(cachedScope);
+        const cached = await getCachedTechnicianWork({ scope: cachedScope });
+        if (!cached) {
+          setErr("No assigned work has been downloaded to this device yet.");
+          setLoading(false);
+          return;
+        }
+        applyOfflineBundle(cached.data);
+        setOfflineUpdatedAt(cached.updatedAt);
+        setOfflineMessage("Showing the assigned work saved on this device.");
+        setLoading(false);
+        return;
+      }
 
       // 1) auth
       const {
@@ -182,6 +294,11 @@ export default function MobileTechQueuePage() {
         setLoading(false);
         return;
       }
+      const activeScope = { userId: user.id, shopId: prof.shop_id };
+      setScope(activeScope);
+      setOfflineMutationScope(activeScope);
+      const cached = await getCachedTechnicianWork({ scope: activeScope });
+      setOfflineUpdatedAt(cached?.updatedAt ?? null);
 
       // 3) lines assigned to this tech
       const { data: techLines, error: linesErr } = await supabase
@@ -216,14 +333,21 @@ export default function MobileTechQueuePage() {
             .neq("type", "historical_import"),
           supabase
             .from("work_order_lines")
-            .select("id, work_order_id, created_at, job_type, approval_state, line_type")
+            .select(
+              "id, work_order_id, created_at, job_type, approval_state, line_type",
+            )
             .eq("line_type", "job")
             .in("work_order_id", woIds),
         ]);
 
         const wos = (wosRes.data ?? []) as WorkOrderPick[];
         const allowedWorkOrderIds = new Set(wos.map((wo) => wo.id));
-        setLines(assignedLines.filter((line) => line.work_order_id && allowedWorkOrderIds.has(line.work_order_id)));
+        setLines(
+          assignedLines.filter(
+            (line) =>
+              line.work_order_id && allowedWorkOrderIds.has(line.work_order_id),
+          ),
+        );
 
         // vehicles lookup (batch)
         const vehicleIds = Array.from(
@@ -315,7 +439,30 @@ export default function MobileTechQueuePage() {
 
       setLoading(false);
     })();
-  }, [supabase]);
+  }, [supabase, applyOfflineBundle]);
+
+  const downloadForOffline = useCallback(async () => {
+    if (!scope || !navigator.onLine) return;
+    setDownloading(true);
+    setOfflineMessage(null);
+    try {
+      const bundle = await downloadAssignedTechnicianWork({ scope });
+      applyOfflineBundle(bundle);
+      setOfflineUpdatedAt(bundle.downloadedAt);
+      await navigator.storage?.persist?.();
+      setOfflineMessage(
+        `${bundle.workOrders.length} assigned work order${bundle.workOrders.length === 1 ? " is" : "s are"} available offline.`,
+      );
+    } catch (error) {
+      setOfflineMessage(
+        error instanceof Error
+          ? error.message
+          : "Assigned work could not be downloaded.",
+      );
+    } finally {
+      setDownloading(false);
+    }
+  }, [scope, applyOfflineBundle]);
 
   // counts per bucket
   const counts = useMemo(() => {
@@ -388,11 +535,42 @@ export default function MobileTechQueuePage() {
   return (
     <main className="min-h-screen bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
       <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 pb-8 pt-4">
-        {(syncSummary.queued > 0 || syncSummary.syncing > 0 || syncSummary.failed > 0 || syncSummary.conflicted > 0) && (
+        {(syncSummary.queued > 0 ||
+          syncSummary.syncing > 0 ||
+          syncSummary.failed > 0 ||
+          syncSummary.conflicted > 0) && (
           <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-xs text-amber-100">
-            Sync status: pending {syncSummary.queued + syncSummary.syncing} • failed {syncSummary.failed} • conflicted {syncSummary.conflicted}
+            Sync status: pending {syncSummary.queued + syncSummary.syncing} •
+            failed {syncSummary.failed} • conflicted {syncSummary.conflicted}
           </div>
         )}
+        <section className="metal-card rounded-2xl border border-[var(--metal-border-soft)] p-4 shadow-[var(--theme-shadow-medium)]">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                Offline availability
+              </h2>
+              <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                {offlineUpdatedAt
+                  ? `Saved ${new Date(offlineUpdatedAt).toLocaleString()}`
+                  : "Assigned work has not been downloaded on this device."}
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={downloading || !scope || !online}
+              onClick={() => void downloadForOffline()}
+              className="rounded-xl border border-[var(--accent-copper-soft)]/70 bg-[rgba(212,118,49,0.18)] px-4 py-2 text-xs font-semibold text-[var(--accent-copper-soft)] disabled:cursor-not-allowed disabled:opacity-45"
+            >
+              {downloading ? "Downloading…" : "Download assigned work"}
+            </button>
+          </div>
+          {offlineMessage ? (
+            <p className="mt-3 text-xs text-[color:var(--theme-text-secondary)]">
+              {offlineMessage}
+            </p>
+          ) : null}
+        </section>
         {/* HERO (match MobileTechHome vibe) */}
         <section className="metal-panel metal-panel--hero rounded-2xl border border-[var(--metal-border-soft)] px-4 py-4 shadow-[var(--theme-shadow-medium)]">
           <div className="space-y-1">
@@ -417,7 +595,12 @@ export default function MobileTechQueuePage() {
         {/* FILTER CARDS (desktop-style vibes) */}
         <section className="grid grid-cols-2 gap-3 text-xs md:grid-cols-4">
           {(
-            ["awaiting", "in_progress", "on_hold", "completed"] as RollupStatus[]
+            [
+              "awaiting",
+              "in_progress",
+              "on_hold",
+              "completed",
+            ] as RollupStatus[]
           ).map((s) => {
             const isActive = activeFilter === s;
 
@@ -455,7 +638,9 @@ export default function MobileTechQueuePage() {
           {filteredLines.map((line) => {
             const bucket = toBucket(line);
 
-            const wo = line.work_order_id ? workOrderMap[line.work_order_id] : null;
+            const wo = line.work_order_id
+              ? workOrderMap[line.work_order_id]
+              : null;
 
             const woLabel = wo?.custom_id
               ? wo.custom_id
@@ -473,8 +658,11 @@ export default function MobileTechQueuePage() {
             );
 
             const vehicleLabel = wo?.vehicleLabel ?? null;
-            const approvalState = (line.approval_state ?? "approved").replaceAll("_", " ");
-            const isAwaitingApproval = (line.approval_state ?? "").toLowerCase() === "pending";
+            const approvalState = (
+              line.approval_state ?? "approved"
+            ).replaceAll("_", " ");
+            const isAwaitingApproval =
+              (line.approval_state ?? "").toLowerCase() === "pending";
             const isPunchedIn = !!line.punched_in_at && !line.punched_out_at;
             const priority = toPriority(line);
 
@@ -584,7 +772,9 @@ function MiniStat({
       <div className="text-[0.6rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
         {label}
       </div>
-      <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{value}</div>
+      <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+        {value}
+      </div>
     </div>
   );
 }

--- a/features/shared/lib/offline/database.ts
+++ b/features/shared/lib/offline/database.ts
@@ -135,6 +135,20 @@ export async function getOfflineSnapshot<T>(args: {
   return row;
 }
 
+export async function removeOfflineSnapshots(args: {
+  scope: { userId: string; shopId: string };
+  kind: string;
+  entityIds: string[];
+}): Promise<void> {
+  const db = getDatabase();
+  if (!db || args.entityIds.length === 0) return;
+  await db.snapshots.bulkDelete(
+    args.entityIds.map((entityId) =>
+      snapshotKey(args.scope, args.kind, entityId),
+    ),
+  );
+}
+
 export async function listOfflineSnapshots<T>(args: {
   scope: { userId: string; shopId: string };
   kind: string;

--- a/features/work-orders/mobile/technicianOfflineDownload.ts
+++ b/features/work-orders/mobile/technicianOfflineDownload.ts
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+  getOfflineSnapshot,
+  removeOfflineSnapshots,
+  saveOfflineSnapshot,
+  type OfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import type { TechnicianOfflineBundle } from "@/features/work-orders/mobile/technicianOfflineTypes";
+
+const BUNDLE_KIND = "technician-assigned-work";
+const BUNDLE_ID = "current";
+
+export async function cacheTechnicianOfflineBundle(
+  bundle: TechnicianOfflineBundle,
+): Promise<void> {
+  const previous = await getCachedTechnicianWork({ scope: bundle.scope });
+  const currentAliases = new Set(
+    bundle.workOrders.flatMap((item) =>
+      [item.workOrder.id, item.workOrder.custom_id].filter((id): id is string =>
+        Boolean(id),
+      ),
+    ),
+  );
+  const staleAliases = (previous?.data.workOrders ?? [])
+    .flatMap((item) => [item.workOrder.id, item.workOrder.custom_id])
+    .filter(
+      (id): id is string => Boolean(id) && !currentAliases.has(id as string),
+    );
+  const detailWrites = bundle.workOrders.flatMap((item) => {
+    const ids = new Set(
+      [item.workOrder.id, item.workOrder.custom_id].filter(Boolean),
+    );
+    return [...ids].map((entityId) =>
+      saveOfflineSnapshot({
+        scope: bundle.scope,
+        kind: "mobile-work-order-detail",
+        entityId: entityId as string,
+        data: {
+          workOrder: item.workOrder,
+          lines: item.lines,
+          quoteLines: item.quoteLines,
+          vehicle: item.vehicle,
+          customer: item.customer,
+          techNamesById: item.techNamesById,
+        },
+      }),
+    );
+  });
+
+  await Promise.all([
+    ...detailWrites,
+    removeOfflineSnapshots({
+      scope: bundle.scope,
+      kind: "mobile-work-order-detail",
+      entityIds: staleAliases,
+    }),
+    saveOfflineSnapshot({
+      scope: bundle.scope,
+      kind: BUNDLE_KIND,
+      entityId: BUNDLE_ID,
+      data: bundle,
+    }),
+  ]);
+}
+
+export async function downloadAssignedTechnicianWork(args: {
+  scope: { userId: string; shopId: string };
+}): Promise<TechnicianOfflineBundle> {
+  const response = await fetch("/api/offline/technician-work-orders", {
+    credentials: "include",
+    cache: "no-store",
+  });
+  const result = (await response.json().catch(() => null)) as
+    | TechnicianOfflineBundle
+    | { error?: string }
+    | null;
+  if (!response.ok || !result || !("scope" in result)) {
+    throw new Error(
+      (result && "error" in result && result.error) ||
+        "Assigned work could not be downloaded.",
+    );
+  }
+  if (
+    result.scope.userId !== args.scope.userId ||
+    result.scope.shopId !== args.scope.shopId
+  ) {
+    throw new Error("Downloaded work does not match the active user and shop.");
+  }
+  await cacheTechnicianOfflineBundle(result);
+  return result;
+}
+
+export async function getCachedTechnicianWork(args: {
+  scope: { userId: string; shopId: string };
+}): Promise<OfflineSnapshot<TechnicianOfflineBundle> | null> {
+  return getOfflineSnapshot<TechnicianOfflineBundle>({
+    scope: args.scope,
+    kind: BUNDLE_KIND,
+    entityId: BUNDLE_ID,
+  });
+}

--- a/features/work-orders/mobile/technicianOfflineTypes.ts
+++ b/features/work-orders/mobile/technicianOfflineTypes.ts
@@ -1,0 +1,19 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+
+export type TechnicianOfflineWorkOrder = {
+  workOrder: DB["public"]["Tables"]["work_orders"]["Row"];
+  lines: DB["public"]["Tables"]["work_order_lines"]["Row"][];
+  quoteLines: DB["public"]["Tables"]["work_order_quote_lines"]["Row"][];
+  vehicle: DB["public"]["Tables"]["vehicles"]["Row"] | null;
+  customer: DB["public"]["Tables"]["customers"]["Row"] | null;
+  techNamesById: Record<string, string>;
+  assignedLineIds: string[];
+};
+
+export type TechnicianOfflineBundle = {
+  scope: { userId: string; shopId: string };
+  downloadedAt: string;
+  workOrders: TechnicianOfflineWorkOrder[];
+};

--- a/tests/technician-offline-download.test.ts
+++ b/tests/technician-offline-download.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const route = read("app/api/offline/technician-work-orders/route.ts");
+const download = read(
+  "features/work-orders/mobile/technicianOfflineDownload.ts",
+);
+const queue = read("app/mobile/tech/queue/page.tsx");
+
+describe("technician assigned-work offline download", () => {
+  it("authenticates the actor and resolves only their shop assignments", () => {
+    expect(route).toContain("auth.getUser()");
+    expect(route).toContain("canPerformAssignedWork");
+    expect(route).toContain("assigned_tech_id.eq.${user.id}");
+    expect(route).toContain("assigned_to.eq.${user.id}");
+    expect(route).toContain('from("work_order_line_technicians")');
+    expect(route).toContain('.eq("technician_id", user.id)');
+    expect(route).toContain('.eq("shop_id", profile.shop_id)');
+  });
+
+  it("keeps authenticated table policies around downloaded business records", () => {
+    expect(route).toContain(
+      "normal table policies remain the final authorization boundary",
+    );
+    expect(route).toContain("const { data: workOrdersData");
+    expect(route).toContain("await authClient");
+    expect(route).toMatch(/authClient\s*\.from\("work_order_lines"\)/);
+    expect(route).toMatch(/authClient\s*\.from\("work_order_quote_lines"\)/);
+    expect(route).toContain('"Cache-Control": "private, no-store"');
+  });
+
+  it("writes the bundle and every detail alias under one tenant scope", () => {
+    expect(download).toContain("result.scope.userId !== args.scope.userId");
+    expect(download).toContain("result.scope.shopId !== args.scope.shopId");
+    expect(download).toContain('BUNDLE_KIND = "technician-assigned-work"');
+    expect(download).toContain('kind: "mobile-work-order-detail"');
+    expect(download).toContain("item.workOrder.custom_id");
+    expect(download).toContain("await cacheTechnicianOfflineBundle(result)");
+    expect(download).toContain("staleAliases");
+    expect(download).toContain("removeOfflineSnapshots");
+  });
+
+  it("loads the assigned queue from IndexedDB and exposes an explicit download", () => {
+    expect(queue).toContain("getCachedTechnicianWork");
+    expect(queue).toContain("applyOfflineBundle(cached.data)");
+    expect(queue).toContain("Download assigned work");
+    expect(queue).toContain("navigator.storage?.persist?.()");
+    expect(queue).toContain("No assigned work has been downloaded");
+  });
+});


### PR DESCRIPTION
## Summary

- add an authenticated endpoint that bundles the current technician's assigned work orders
- download queue context and complete mobile work-order details into tenant-scoped IndexedDB snapshots
- add an explicit **Download assigned work** control with saved timestamp and storage persistence request
- reopen the technician queue and downloaded work-order details while offline
- include primary, legacy, and multi-technician assignments
- keep authenticated RLS as the final authorization boundary for downloaded business records
- remove cached detail aliases as soon as a refreshed assignment bundle no longer contains them

## Why

Before this change, work-order details became available offline only after a technician opened each one individually, and the assigned queue had no offline read path. This is the first Phase 3 technician-beta slice: deliberate assigned-work download with predictable queue and detail availability.

## Validation

- `pnpm typecheck`
- focused ESLint: no errors or warnings
- 24 focused Vitest tests across assigned download, PWA, detail operational state, receipts, and replay
- `git diff --check`

## Scope

This PR covers assigned-work download and cached queue/detail reads. Offline inspection editing, photo staging, notes/story mutations, and job/shift replay continue to use the Phase 2 queue foundation and will be hardened in subsequent Phase 3 slices.