### PR TITLE
feat: add offline inspection recovery

### DIFF
--- a/features/inspections/components/inspection/SaveInspectionButton.tsx
+++ b/features/inspections/components/inspection/SaveInspectionButton.tsx
@@ -7,12 +7,24 @@ import { toast } from "sonner";
 import { saveInspectionSession } from "@inspections/lib/inspection/save";
 import type { InspectionSession } from "@inspections/lib/inspection/types";
 import { Button } from "@shared/components/ui/Button";
-import { getOfflineSyncSummary, subscribeOfflineMutations } from "@/features/shared/lib/offline/mutations";
+import {
+  getOfflineSyncSummary,
+  subscribeOfflineMutations,
+} from "@/features/shared/lib/offline/mutations";
+import {
+  saveInspectionOfflineDraft,
+  type InspectionDraftRecoveryState,
+} from "@inspections/lib/inspection/offlineDrafts";
 
 type Props = {
   session: InspectionSession;
   workOrderLineId: string;
   disabled?: boolean;
+  draftKey?: string;
+  onRecoveryState?: (
+    state: InspectionDraftRecoveryState,
+    operationKey?: string,
+  ) => void;
 };
 
 function errorMessage(err: unknown): string {
@@ -21,7 +33,13 @@ function errorMessage(err: unknown): string {
   return "Failed to save inspection.";
 }
 
-export function SaveInspectionButton({ session, workOrderLineId, disabled = false }: Props) {
+export function SaveInspectionButton({
+  session,
+  workOrderLineId,
+  disabled = false,
+  draftKey,
+  onRecoveryState,
+}: Props) {
   const [syncSummary, setSyncSummary] = useState(() => getOfflineSyncSummary());
 
   useEffect(() => {
@@ -40,6 +58,26 @@ export function SaveInspectionButton({ session, workOrderLineId, disabled = fals
     try {
       if (!workOrderLineId) throw new Error("Missing workOrderLineId");
       const result = await saveInspectionSession(session, workOrderLineId);
+      const recoveryState: InspectionDraftRecoveryState = result.conflicted
+        ? "conflicted"
+        : result.queued
+          ? "queued"
+          : "editing";
+      if (draftKey) {
+        await saveInspectionOfflineDraft({
+          draftKey,
+          session,
+          state: recoveryState,
+          operationKey:
+            result.queued || result.conflicted
+              ? result.operationKey
+              : undefined,
+        });
+      }
+      onRecoveryState?.(
+        recoveryState,
+        result.queued || result.conflicted ? result.operationKey : undefined,
+      );
       if (result.conflicted) {
         toast.error("Inspection save conflicted. Review sync queue status.");
       } else if (result.queued) {
@@ -66,9 +104,13 @@ export function SaveInspectionButton({ session, workOrderLineId, disabled = fals
       >
         Save Progress
       </Button>
-      {(syncSummary.queued > 0 || syncSummary.syncing > 0 || syncSummary.failed > 0 || syncSummary.conflicted > 0) && (
+      {(syncSummary.queued > 0 ||
+        syncSummary.syncing > 0 ||
+        syncSummary.failed > 0 ||
+        syncSummary.conflicted > 0) && (
         <p className="text-[10px] text-[color:var(--theme-text-secondary)]">
-          Sync queue: pending {syncSummary.queued + syncSummary.syncing} • failed {syncSummary.failed} • conflicted {syncSummary.conflicted}
+          Sync queue: pending {syncSummary.queued + syncSummary.syncing} •
+          failed {syncSummary.failed} • conflicted {syncSummary.conflicted}
         </p>
       )}
     </div>

--- a/features/inspections/lib/inspection/offlineDrafts.ts
+++ b/features/inspections/lib/inspection/offlineDrafts.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import type { InspectionSession } from "@inspections/lib/inspection/types";
+import {
+  getOfflineSnapshot,
+  removeOfflineSnapshots,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import {
+  hydrateOfflineMutationQueue,
+  listOfflineMutations,
+  resolveOfflineMutationScope,
+  type OfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+
+const KIND = "inspection-draft";
+const MAX_AGE_MS = 1000 * 60 * 60 * 24 * 14;
+
+export type InspectionDraftRecoveryState = "editing" | "queued" | "conflicted";
+
+export type InspectionOfflineDraft = {
+  draftKey: string;
+  session: InspectionSession;
+  savedAt: string;
+  state: InspectionDraftRecoveryState;
+  operationKey?: string;
+};
+
+async function scopeFor(
+  session: InspectionSession | Partial<InspectionSession>,
+): Promise<OfflineMutationScope | null> {
+  return resolveOfflineMutationScope({
+    workOrderId: session.workOrderId,
+    workOrderLineId: (
+      session as InspectionSession & { workOrderLineId?: string | null }
+    ).workOrderLineId,
+  });
+}
+
+export async function saveInspectionOfflineDraft(args: {
+  draftKey: string;
+  session: InspectionSession;
+  state?: InspectionDraftRecoveryState;
+  operationKey?: string;
+}): Promise<InspectionOfflineDraft | null> {
+  const scope = await scopeFor(args.session);
+  if (!scope) return null;
+  const draft: InspectionOfflineDraft = {
+    draftKey: args.draftKey,
+    session: args.session,
+    savedAt: new Date().toISOString(),
+    state: args.state ?? "editing",
+    operationKey: args.operationKey,
+  };
+  await saveOfflineSnapshot({
+    scope,
+    kind: KIND,
+    entityId: args.draftKey,
+    data: draft,
+    maxAgeMs: MAX_AGE_MS,
+  });
+  return draft;
+}
+
+export async function getInspectionOfflineDraft(args: {
+  draftKey: string;
+  sessionHint: Partial<InspectionSession>;
+}): Promise<InspectionOfflineDraft | null> {
+  const scope = await scopeFor(args.sessionHint);
+  if (!scope) return null;
+  const snapshot = await getOfflineSnapshot<InspectionOfflineDraft>({
+    scope,
+    kind: KIND,
+    entityId: args.draftKey,
+  });
+  if (!snapshot) return null;
+
+  const draft = snapshot.data;
+  if (draft.operationKey) {
+    await hydrateOfflineMutationQueue();
+    const queued = listOfflineMutations(scope).find(
+      (mutation) => mutation.clientMutationId === draft.operationKey,
+    );
+    if (!queued || queued.status === "synced") {
+      const reconciled = {
+        ...draft,
+        state: "editing" as const,
+        operationKey: undefined,
+      };
+      await saveInspectionOfflineDraft(reconciled);
+      return reconciled;
+    }
+    if (queued.status === "conflicted") {
+      return { ...draft, state: "conflicted" };
+    }
+  }
+  return draft;
+}
+
+export async function removeInspectionOfflineDraft(args: {
+  draftKey: string;
+  session: Partial<InspectionSession>;
+}): Promise<void> {
+  const scope = await scopeFor(args.session);
+  if (!scope) return;
+  await removeOfflineSnapshots({
+    scope,
+    kind: KIND,
+    entityIds: [args.draftKey],
+  });
+}

--- a/features/inspections/lib/inspection/save.ts
+++ b/features/inspections/lib/inspection/save.ts
@@ -2,9 +2,7 @@
 "use client";
 
 import type { InspectionSession } from "@inspections/lib/inspection/types";
-import {
-  runMutationWithOfflineQueue,
-} from "@/features/shared/lib/offline/mutations";
+import { runMutationWithOfflineQueue } from "@/features/shared/lib/offline/mutations";
 import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
 
 const ACTION_SAVE_INSPECTION = "inspection:save-session";
@@ -30,9 +28,9 @@ async function postInspectionSave(payload: InspectionSavePayload) {
   });
 
   if (!res.ok) {
-    const json = (await res.json().catch(() => null)) as
-      | { error?: string }
-      | null;
+    const json = (await res.json().catch(() => null)) as {
+      error?: string;
+    } | null;
     const error = new Error(json?.error || "Save failed") as Error & {
       status?: number;
     };
@@ -48,7 +46,7 @@ export async function replayQueuedInspectionSaves(): Promise<void> {
 export async function saveInspectionSession(
   session: InspectionSession,
   workOrderLineId: string,
-): Promise<{ queued: boolean; conflicted: boolean }> {
+): Promise<{ queued: boolean; conflicted: boolean; operationKey: string }> {
   if (!workOrderLineId) {
     throw new Error("Missing workOrderLineId");
   }
@@ -75,5 +73,5 @@ export async function saveInspectionSession(
     await replayQueuedInspectionSaves();
   }
 
-  return result;
+  return { ...result, operationKey };
 }

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -50,6 +50,12 @@ import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
 import { cn } from "@shared/lib/utils";
+import {
+  getInspectionOfflineDraft,
+  removeInspectionOfflineDraft,
+  saveInspectionOfflineDraft,
+  type InspectionDraftRecoveryState,
+} from "@inspections/lib/inspection/offlineDrafts";
 
 /* -------------------------- helpers -------------------------- */
 
@@ -320,6 +326,14 @@ function inspectionDraftKey(args: {
     return `inspection-draft:line:${args.workOrderLineId}`;
   if (args.workOrderId) return `inspection-draft:wo:${args.workOrderId}:${t}`;
   return `inspection-draft:template:${t}:${args.inspectionId}`;
+}
+
+function inspectionDraftTimestamp(
+  session: Partial<InspectionSession> | null,
+): number {
+  const value = session?.lastUpdated;
+  const parsed = value ? new Date(value).getTime() : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function buildCauseCorrectionFromSession(s: unknown): {
@@ -822,6 +836,15 @@ type SmartMatchRow = {
   const [voicePulse, setVoicePulse] = useState(false);
   const pulseTimerRef = useRef<number | null>(null);
   const [serverBootLoaded, setServerBootLoaded] = useState(false);
+  const [draftBootLoaded, setDraftBootLoaded] = useState(false);
+  const [recoveryState, setRecoveryState] =
+    useState<InspectionDraftRecoveryState>("editing");
+  const [recoveryMessage, setRecoveryMessage] = useState<string | null>(null);
+  const recoveryOperationKeyRef = useRef<string | undefined>(undefined);
+  const inspectionCompletedRef = useRef(false);
+  const localDraftUpdatedAtRef = useRef(
+    inspectionDraftTimestamp(persistedSession),
+  );
   const serverStartedRef = useRef<string | null>(null);
 
   const triggerVoicePulse = (): void => {
@@ -870,6 +893,60 @@ type SmartMatchRow = {
     addQuoteLine,
     updateQuoteLine,
   } = useInspectionSession(persistedSession ?? initialSession);
+
+  useEffect(() => {
+    let cancelled = false;
+    inspectionCompletedRef.current = false;
+    const recoverDraft = async () => {
+      try {
+        const recovered = await getInspectionOfflineDraft({
+          draftKey,
+          sessionHint: persistedSession ?? initialSession,
+        });
+        if (cancelled) return;
+        if (recovered) {
+          const recoveredAt = inspectionDraftTimestamp(recovered.session);
+          const legacyAt = inspectionDraftTimestamp(persistedSession);
+          const preferred =
+            recoveredAt >= legacyAt ? recovered.session : persistedSession;
+          if (preferred) {
+            startSession(preferred);
+            localDraftUpdatedAtRef.current = inspectionDraftTimestamp(preferred);
+          }
+          setRecoveryState(recovered.state);
+          recoveryOperationKeyRef.current = recovered.operationKey;
+          setRecoveryMessage(
+            recovered.state === "queued"
+              ? "Recovered inspection · server save is queued."
+              : recovered.state === "conflicted"
+                ? "Recovered inspection · sync needs review."
+                : `Recovered inspection saved ${new Date(recovered.savedAt).toLocaleString()}.`,
+          );
+        } else if (persistedSession) {
+          const migrated = await saveInspectionOfflineDraft({
+            draftKey,
+            session: persistedSession,
+          });
+          if (!cancelled && migrated) {
+            setRecoveryMessage(
+              "Existing inspection draft moved into offline recovery.",
+            );
+          }
+        }
+      } catch (error) {
+        console.warn("[inspection] offline recovery unavailable", error);
+      } finally {
+        if (!cancelled) setDraftBootLoaded(true);
+      }
+    };
+    void recoverDraft();
+    return () => {
+      cancelled = true;
+    };
+    // Recovery is intentionally keyed to the draft identity. Including startSession
+    // would restart this effect on every render because the hook returns a new function.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftKey]);
 
   const fetchSmartMatch = async (
     sectionIndex: number,
@@ -1324,6 +1401,7 @@ type SmartMatchRow = {
     let cancelled = false;
 
     const loadSavedInspection = async () => {
+      if (!draftBootLoaded) return;
       if (!inspectionId && !workOrderLineId) {
         setServerBootLoaded(true);
         return;
@@ -1356,17 +1434,25 @@ type SmartMatchRow = {
           Array.isArray(loaded.sections) &&
           loaded.sections.length > 0
         ) {
-          startSession(loaded);
+          const serverUpdatedAt = inspectionDraftTimestamp(loaded);
+          if (serverUpdatedAt >= localDraftUpdatedAtRef.current) {
+            startSession(loaded);
+            localDraftUpdatedAtRef.current = serverUpdatedAt;
 
-          try {
-            localStorage.setItem(draftKey, JSON.stringify(loaded));
-          } catch {
-            // noop
+            try {
+              localStorage.setItem(draftKey, JSON.stringify(loaded));
+            } catch {
+              // noop
+            }
+
+            serverStartedRef.current = String(
+              loaded.id ?? inspectionId ?? workOrderLineId ?? "loaded",
+            );
+          } else {
+            setRecoveryMessage(
+              "Recovered a newer device draft; the older server copy was not applied.",
+            );
           }
-
-          serverStartedRef.current = String(
-            loaded.id ?? inspectionId ?? workOrderLineId ?? "loaded",
-          );
         }
         setIsLocked(Boolean(data?.inspectionMeta?.locked));
       } catch (err) {
@@ -1383,7 +1469,9 @@ type SmartMatchRow = {
     return () => {
       cancelled = true;
     };
-  }, [inspectionId, workOrderLineId, draftKey, startSession]);
+    // startSession is intentionally omitted; this fetch should run once per identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inspectionId, workOrderLineId, draftKey, draftBootLoaded]);
 
   useEffect(() => {
     if (session && (session.sections?.length ?? 0) === 0) {
@@ -1392,24 +1480,33 @@ type SmartMatchRow = {
   }, [session, bootSections, updateInspection]);
 
   useEffect(() => {
-  if (!session) return;
+    if (!session || !draftBootLoaded || inspectionCompletedRef.current) return;
 
-  try {
-    localStorage.setItem(draftKey, JSON.stringify(session));
-
-    // ✅ ADD THIS — broadcast update to findings page
-    if (typeof window !== "undefined") {
+    localDraftUpdatedAtRef.current = inspectionDraftTimestamp(session);
+    try {
+      localStorage.setItem(draftKey, JSON.stringify(session));
       window.dispatchEvent(
         new CustomEvent("inspection:draft-updated", {
           detail: { draftKey },
         }),
       );
-    }
-  } catch {}
-}, [session, draftKey]);
+    } catch {}
+
+    const timer = window.setTimeout(() => {
+      if (inspectionCompletedRef.current) return;
+      void saveInspectionOfflineDraft({
+        draftKey,
+        session,
+        state: recoveryState,
+        operationKey: recoveryOperationKeyRef.current,
+      });
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [session, draftKey, draftBootLoaded, recoveryState]);
 
   useEffect(() => {
     const persistNow = () => {
+      if (inspectionCompletedRef.current) return;
       try {
         const payload = {
           ...(session ?? initialSession),
@@ -1439,7 +1536,7 @@ type SmartMatchRow = {
       window.removeEventListener("pagehide", persistNow);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [session, draftKey, initialSession]);
+  }, [session, draftKey, initialSession, workOrderId, workOrderLineId]);
 
   useEffect(() => {
     const handler = (evt: Event) => {
@@ -1475,6 +1572,13 @@ type SmartMatchRow = {
         localStorage.removeItem(draftKey);
         localStorage.removeItem(lockKey);
       } catch {}
+      inspectionCompletedRef.current = true;
+      void removeInspectionOfflineDraft({
+        draftKey,
+        session: session ?? initialSession,
+      });
+      recoveryOperationKeyRef.current = undefined;
+      setRecoveryMessage(null);
     };
 
     window.addEventListener("inspection:completed", handler as EventListener);
@@ -1483,7 +1587,7 @@ type SmartMatchRow = {
         "inspection:completed",
         handler as EventListener,
       );
-  }, [session, draftKey, lockKey]);
+  }, [session, draftKey, lockKey, initialSession]);
 
   // ✅ TS-safe label for ParsedCommand (no ".command" assumption)
   const commandLabel = (c: ParsedCommand): string => {
@@ -2570,6 +2674,18 @@ type SmartMatchRow = {
         session={session}
         workOrderLineId={workOrderLineId}
         disabled={isLocked}
+        draftKey={draftKey}
+        onRecoveryState={(state, operationKey) => {
+          setRecoveryState(state);
+          recoveryOperationKeyRef.current = operationKey;
+          setRecoveryMessage(
+            state === "queued"
+              ? "Inspection is safe on this device and queued for server sync."
+              : state === "conflicted"
+                ? "Inspection is safe on this device, but sync needs review."
+                : "Inspection progress is saved on this device and the server.",
+          );
+        }}
       />
 
       <Button
@@ -2606,6 +2722,7 @@ type SmartMatchRow = {
   );
 
   if (
+    !draftBootLoaded ||
     !serverBootLoaded ||
     !session ||
     (session.sections?.length ?? 0) === 0
@@ -2634,6 +2751,21 @@ type SmartMatchRow = {
       )}
 
       <div className="relative space-y-3">
+        {recoveryMessage && (
+          <div
+            role="status"
+            className={cn(
+              "rounded-xl border px-3 py-2 text-xs",
+              recoveryState === "conflicted"
+                ? "border-red-400/40 bg-red-950/20 text-red-100"
+                : recoveryState === "queued"
+                  ? "border-amber-400/40 bg-amber-950/20 text-amber-100"
+                  : "border-emerald-400/40 bg-emerald-950/20 text-emerald-100",
+            )}
+          >
+            {recoveryMessage}
+          </div>
+        )}
         <div className={headerCard}>
           <div className="mb-2 flex flex-wrap items-center justify-between gap-2 border-b border-[var(--theme-card-border,var(--theme-border-soft))] pb-2">
             <div>

--- a/features/shared/lib/offline/mutations.ts
+++ b/features/shared/lib/offline/mutations.ts
@@ -114,7 +114,7 @@ function scopeMatches(
   );
 }
 
-async function resolveMutationScope(
+export async function resolveOfflineMutationScope(
   payload: unknown,
   supplied?: OfflineMutationScope | null,
 ): Promise<OfflineMutationScope | null> {
@@ -620,7 +620,7 @@ export async function runMutationWithOfflineQueue<T>(args: {
 }): Promise<{ queued: boolean; conflicted: boolean }> {
   await hydrateOfflineMutationQueue();
   const queueOnOffline = args.queueOnOffline !== false;
-  const scope = await resolveMutationScope(args.payload, args.scope);
+  const scope = await resolveOfflineMutationScope(args.payload, args.scope);
   if (!scope) {
     throw new Error(
       "Authenticated user and shop scope could not be resolved for offline sync.",

--- a/tests/inspection-offline-recovery.test.ts
+++ b/tests/inspection-offline-recovery.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const drafts = read("features/inspections/lib/inspection/offlineDrafts.ts");
+const screen = read("features/inspections/screens/GenericInspectionScreen.tsx");
+const saveButton = read(
+  "features/inspections/components/inspection/SaveInspectionButton.tsx",
+);
+const save = read("features/inspections/lib/inspection/save.ts");
+
+describe("technician inspection offline recovery", () => {
+  it("stores expiring drafts under the authenticated user and shop scope", () => {
+    expect(drafts).toContain('const KIND = "inspection-draft"');
+    expect(drafts).toContain("resolveOfflineMutationScope");
+    expect(drafts).toContain("saveOfflineSnapshot");
+    expect(drafts).toContain("MAX_AGE_MS");
+    expect(drafts).toContain("entityId: args.draftKey");
+  });
+
+  it("hydrates the durable mutation queue before reconciling recovery state", () => {
+    expect(drafts).toContain("await hydrateOfflineMutationQueue()");
+    expect(drafts).toContain(
+      "mutation.clientMutationId === draft.operationKey",
+    );
+    expect(drafts).toContain('queued.status === "conflicted"');
+    expect(drafts).toContain('state: "editing" as const');
+  });
+
+  it("recovers before server boot and refuses to replace a newer device draft", () => {
+    expect(screen).toContain("getInspectionOfflineDraft");
+    expect(screen).toContain("if (!draftBootLoaded) return");
+    expect(screen).toContain(
+      "serverUpdatedAt >= localDraftUpdatedAtRef.current",
+    );
+    expect(screen).toContain("the older server copy was not applied");
+    expect(screen).toContain("!draftBootLoaded ||");
+  });
+
+  it("persists edits, surfaces queued saves, and clears only on completion", () => {
+    expect(screen).toContain("saveInspectionOfflineDraft");
+    expect(screen).toContain("state: recoveryState");
+    expect(screen).toContain("operationKey: recoveryOperationKeyRef.current");
+    expect(screen).toContain('window.addEventListener("inspection:completed"');
+    expect(screen).toContain("inspectionCompletedRef.current = true");
+    expect(screen).toContain("removeInspectionOfflineDraft");
+    expect(saveButton).toContain("? result.operationKey");
+    expect(save).toContain("return { ...result, operationKey }");
+  });
+});


### PR DESCRIPTION
## What changed

- add a user/shop-scoped IndexedDB repository for inspection recovery drafts with a 14-day retention window
- recover the newest device draft before loading server state, preventing an older server snapshot from overwriting newer technician work
- preserve queued/conflicted inspection save metadata and show recovery/sync status in the inspection UI
- keep the existing localStorage draft as a compatibility mirror for the findings flow
- clear recovery data only after the confirmed inspection completion event, with guards against unload/autosave resurrection
- return the inspection save operation key so recovery state can reconcile against the durable mutation queue

## Why

Technicians can now continue inspection entry through weak connectivity and recover work after reloads or browser/app interruptions. This is the offline inspections and recovery slice of Phase 3; photo staging and fully offline findings submission remain separate follow-up slices.

## Validation

- `npm run typecheck`
- focused ESLint on all changed files
- `npx vitest run tests/inspection-offline-recovery.test.ts tests/phase6-inspection-progress-route.test.ts tests/technician-offline-download.test.ts` (12 passing)
- full `npm test`: new recovery coverage passes; repository baseline still has 38 unrelated failures across existing financial, parts, import, and OpenAI contract suites

No database migration is required.