### PR TITLE
feat: stage inspection photos offline

### DIFF
--- a/app/api/inspections/photos/upload/route.ts
+++ b/app/api/inspections/photos/upload/route.ts
@@ -9,6 +9,7 @@ import crypto from "crypto";
 import { buildInspectionMediaCapturedEvent } from "@/features/integrations/shopreel/server/buildProFixIQStoryEvents";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
 
+const MAX_PHOTO_BYTES = 15 * 1024 * 1024;
 
 function asString(v: FormDataEntryValue | null): string | null {
   if (typeof v !== "string") return null;
@@ -234,6 +235,18 @@ export async function POST(req: NextRequest) {
 
   if (!(file instanceof File)) {
     return NextResponse.json({ error: "Missing file" }, { status: 400 });
+  }
+  if (!file.type.toLowerCase().startsWith("image/")) {
+    return NextResponse.json(
+      { error: "Inspection evidence must be an image." },
+      { status: 415 },
+    );
+  }
+  if (file.size > MAX_PHOTO_BYTES) {
+    return NextResponse.json(
+      { error: "Inspection photos must be 15 MB or smaller." },
+      { status: 413 },
+    );
   }
 
   const resolved = await resolveShopId({

--- a/app/offline/sync/page.tsx
+++ b/app/offline/sync/page.tsx
@@ -37,6 +37,7 @@ const ACTION_LABELS: Record<string, string> = {
   "shift:punch-event": "Shift punch",
   update_work_order_line_notes: "Job notes",
   upload_job_photo: "Job photo",
+  "inspection:upload-photo": "Inspection photo",
   save_story_draft: "Cause and correction",
   "job:punch-transition": "Job status",
 };

--- a/features/inspections/components/inspection/PhotoThumbnail.tsx
+++ b/features/inspections/components/inspection/PhotoThumbnail.tsx
@@ -5,18 +5,25 @@
 interface PhotoThumbnailProps {
   url: string;
   onRemove?: () => void;
+  label?: string;
 }
 
-const PhotoThumbnail: React.FC<PhotoThumbnailProps> = ({ url, onRemove }) => {
+const PhotoThumbnail: React.FC<PhotoThumbnailProps> = ({
+  url,
+  onRemove,
+  label = "Evidence photo",
+}) => {
   return (
     <div className="group relative m-1 w-28 overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[var(--theme-shadow-medium)]">
+      {/* Blob-backed offline previews cannot use the Next image optimizer. */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src={url}
         alt="Inspection evidence"
         className="h-24 w-full object-cover transition duration-200 group-hover:scale-[1.02]"
       />
       <div className="border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
-        Evidence photo
+        {label}
       </div>
       {onRemove && (
         <button

--- a/features/inspections/lib/inspection/InspectionItemCard.tsx
+++ b/features/inspections/lib/inspection/InspectionItemCard.tsx
@@ -21,6 +21,7 @@ interface InspectionItemCardProps {
   inspectionId: string;
   workOrderId?: string | null;
   workOrderLineId?: string | null;
+  draftKey?: string;
   onUpdateNote: (sectionIndex: number, itemIndex: number, note: string) => void;
   onUpload: (photoUrl: string, sectionIndex: number, itemIndex: number) => void;
   onUpdateStatus: (
@@ -28,8 +29,16 @@ interface InspectionItemCardProps {
     itemIndex: number,
     status: InspectionItemStatus,
   ) => void;
-  onUpdateValue?: (sectionIndex: number, itemIndex: number, value: string) => void;
-  onUpdateUnit?: (sectionIndex: number, itemIndex: number, unit: string) => void;
+  onUpdateValue?: (
+    sectionIndex: number,
+    itemIndex: number,
+    value: string,
+  ) => void;
+  onUpdateUnit?: (
+    sectionIndex: number,
+    itemIndex: number,
+    unit: string,
+  ) => void;
   variant?: "card" | "row";
 }
 
@@ -67,6 +76,7 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
     inspectionId,
     workOrderId,
     workOrderLineId,
+    draftKey,
     onUpdateNote,
     onUpload,
     onUpdateStatus,
@@ -205,7 +215,8 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
                   itmIdx: number,
                   updates: Partial<InspectionItem>,
                 ) => {
-                  if (updates.status) onUpdateStatus(secIdx, itmIdx, updates.status);
+                  if (updates.status)
+                    onUpdateStatus(secIdx, itmIdx, updates.status);
                 }}
                 onStatusChange={(s: InspectionItemStatus) =>
                   onUpdateStatus(sectionIndex, itemIndex, s)
@@ -231,37 +242,41 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
           </div>
         ) : null}
 
-        {showPhotos && (item.status === "fail" || item.status === "recommend") && (
-          <div className="mt-1">
-            <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2.5">
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
-                  Photos
+        {showPhotos &&
+          (item.status === "fail" || item.status === "recommend") && (
+            <div className="mt-1">
+              <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2.5">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+                    Photos
+                  </div>
+
+                  <PhotoUploadButton
+                    inspectionId={inspectionId}
+                    workOrderId={workOrderId}
+                    workOrderLineId={workOrderLineId}
+                    draftKey={draftKey}
+                    sectionIndex={sectionIndex}
+                    itemIndex={itemIndex}
+                    itemName={label || null}
+                    photoUrls={item.photoUrls ?? []}
+                    onChange={(urls: string[]) => {
+                      const newUrl = urls[urls.length - 1];
+                      if (newUrl) onUpload(newUrl, sectionIndex, itemIndex);
+                    }}
+                  />
                 </div>
 
-                <PhotoUploadButton
-                  inspectionId={inspectionId}
-                  workOrderId={workOrderId}
-                  workOrderLineId={workOrderLineId}
-                  itemName={label || null}
-                  photoUrls={item.photoUrls ?? []}
-                  onChange={(urls: string[]) => {
-                    const newUrl = urls[urls.length - 1];
-                    if (newUrl) onUpload(newUrl, sectionIndex, itemIndex);
-                  }}
-                />
+                {Array.isArray(item.photoUrls) && item.photoUrls.length > 0 && (
+                  <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
+                    {item.photoUrls.map((url, i) => (
+                      <PhotoThumbnail key={url + i} url={url} />
+                    ))}
+                  </div>
+                )}
               </div>
-
-              {Array.isArray(item.photoUrls) && item.photoUrls.length > 0 && (
-                <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
-                  {item.photoUrls.map((url, i) => (
-                    <PhotoThumbnail key={url + i} url={url} />
-                  ))}
-                </div>
-              )}
             </div>
-          </div>
-        )}
+          )}
       </div>
     );
   }
@@ -269,7 +284,10 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
   return (
     <div className="rounded-md border border-zinc-800 bg-zinc-950 p-3">
       <div className="min-w-0">
-        <h3 className="truncate text-[15px] font-semibold text-[color:var(--theme-text-primary)]" title={label}>
+        <h3
+          className="truncate text-[15px] font-semibold text-[color:var(--theme-text-primary)]"
+          title={label}
+        >
           {label || "—"}
         </h3>
 
@@ -306,7 +324,8 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
                 itmIdx: number,
                 updates: Partial<InspectionItem>,
               ) => {
-                if (updates.status) onUpdateStatus(secIdx, itmIdx, updates.status);
+                if (updates.status)
+                  onUpdateStatus(secIdx, itmIdx, updates.status);
               }}
               onStatusChange={(s: InspectionItemStatus) =>
                 onUpdateStatus(sectionIndex, itemIndex, s)
@@ -329,36 +348,40 @@ export default function InspectionItemCard(props: InspectionItemCardProps) {
         </div>
       )}
 
-      {showPhotos && (item.status === "fail" || item.status === "recommend") && (
-        <div className="mt-2">
-          <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2.5">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
-                Photos
+      {showPhotos &&
+        (item.status === "fail" || item.status === "recommend") && (
+          <div className="mt-2">
+            <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2.5">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+                  Photos
+                </div>
+                <PhotoUploadButton
+                  inspectionId={inspectionId}
+                  workOrderId={workOrderId}
+                  workOrderLineId={workOrderLineId}
+                  draftKey={draftKey}
+                  sectionIndex={sectionIndex}
+                  itemIndex={itemIndex}
+                  itemName={label || null}
+                  photoUrls={item.photoUrls ?? []}
+                  onChange={(urls: string[]) => {
+                    const newUrl = urls[urls.length - 1];
+                    if (newUrl) onUpload(newUrl, sectionIndex, itemIndex);
+                  }}
+                />
               </div>
-              <PhotoUploadButton
-                inspectionId={inspectionId}
-                workOrderId={workOrderId}
-                workOrderLineId={workOrderLineId}
-                itemName={label || null}
-                photoUrls={item.photoUrls ?? []}
-                onChange={(urls: string[]) => {
-                  const newUrl = urls[urls.length - 1];
-                  if (newUrl) onUpload(newUrl, sectionIndex, itemIndex);
-                }}
-              />
-            </div>
 
-            {Array.isArray(item.photoUrls) && item.photoUrls.length > 0 && (
-              <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
-                {item.photoUrls.map((url, i) => (
-                  <PhotoThumbnail key={url + i} url={url} />
-                ))}
-              </div>
-            )}
+              {Array.isArray(item.photoUrls) && item.photoUrls.length > 0 && (
+                <div className="mt-2 flex gap-2 overflow-x-auto pb-1">
+                  {item.photoUrls.map((url, i) => (
+                    <PhotoThumbnail key={url + i} url={url} />
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
     </div>
   );
 }

--- a/features/inspections/lib/inspection/PhotoUploadButton.tsx
+++ b/features/inspections/lib/inspection/PhotoUploadButton.tsx
@@ -1,10 +1,18 @@
-//features/inspections/lib/inspection/PhotoUploadButton.tsx
-
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { toast } from "sonner";
 import PhotoThumbnail from "@inspections/components/inspection/PhotoThumbnail";
+import {
+  INSPECTION_PHOTO_SYNCED_EVENT,
+  listStagedInspectionPhotos,
+  stageInspectionPhoto,
+  type StagedInspectionPhoto,
+} from "@inspections/lib/inspection/inspectionPhotoStaging";
+import {
+  dismissOfflineMutation,
+  subscribeOfflineMutations,
+} from "@/features/shared/lib/offline/mutations";
 
 type PhotoUploadButtonProps = {
   photoUrls: string[];
@@ -13,7 +21,13 @@ type PhotoUploadButtonProps = {
   itemName?: string | null;
   workOrderId?: string | null;
   workOrderLineId?: string | null;
+  draftKey?: string;
+  sectionIndex?: number;
+  itemIndex?: number;
 };
+
+type StagedPreview = StagedInspectionPhoto & { previewUrl: string };
+const MAX_PHOTO_BYTES = 15 * 1024 * 1024;
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
@@ -30,16 +44,97 @@ export default function PhotoUploadButton({
   itemName,
   workOrderId,
   workOrderLineId,
+  draftKey,
+  sectionIndex,
+  itemIndex,
 }: PhotoUploadButtonProps) {
   const [urls, setUrls] = useState<string[]>(photoUrls ?? []);
+  const [staged, setStaged] = useState<StagedPreview[]>([]);
   const [uploading, setUploading] = useState(false);
+  const urlsRef = useRef(urls);
+  const onChangeRef = useRef(onChange);
 
   useEffect(() => {
-    setUrls(photoUrls ?? []);
+    const next = photoUrls ?? [];
+    urlsRef.current = next;
+    setUrls(next);
   }, [photoUrls]);
 
-  const canUpload =
-    typeof inspectionId === "string" && inspectionId.trim().length > 0;
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  const canUpload = Boolean(getString(inspectionId));
+  const canStage = Boolean(
+    canUpload &&
+    getString(draftKey) &&
+    getString(workOrderLineId) &&
+    Number.isInteger(sectionIndex) &&
+    Number.isInteger(itemIndex),
+  );
+
+  useEffect(() => {
+    if (
+      !canStage ||
+      !draftKey ||
+      typeof sectionIndex !== "number" ||
+      typeof itemIndex !== "number"
+    ) {
+      setStaged([]);
+      return;
+    }
+    let cancelled = false;
+    let previews: StagedPreview[] = [];
+    const refresh = async () => {
+      const records = await listStagedInspectionPhotos({
+        draftKey,
+        sectionIndex,
+        itemIndex,
+      });
+      if (cancelled) return;
+      const next = records.map((record) => ({
+        ...record,
+        previewUrl: URL.createObjectURL(record.blob),
+      }));
+      previews.forEach((preview) => URL.revokeObjectURL(preview.previewUrl));
+      previews = next;
+      setStaged(next);
+    };
+    const unsubscribe = subscribeOfflineMutations(() => void refresh());
+    const onSynced = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{
+          draftKey?: string;
+          sectionIndex?: number;
+          itemIndex?: number;
+          url?: string;
+        }>
+      ).detail;
+      if (
+        detail?.draftKey !== draftKey ||
+        detail.sectionIndex !== sectionIndex ||
+        detail.itemIndex !== itemIndex ||
+        !detail.url
+      ) {
+        return;
+      }
+      if (!urlsRef.current.includes(detail.url)) {
+        const next = [...urlsRef.current, detail.url];
+        urlsRef.current = next;
+        setUrls(next);
+        onChangeRef.current(next);
+      }
+      void refresh();
+    };
+    window.addEventListener(INSPECTION_PHOTO_SYNCED_EVENT, onSynced);
+    void refresh();
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      window.removeEventListener(INSPECTION_PHOTO_SYNCED_EVENT, onSynced);
+      previews.forEach((preview) => URL.revokeObjectURL(preview.previewUrl));
+    };
+  }, [canStage, draftKey, sectionIndex, itemIndex]);
 
   async function uploadOne(file: File): Promise<string | null> {
     if (!canUpload) {
@@ -47,89 +142,149 @@ export default function PhotoUploadButton({
       return null;
     }
 
-    const fd = new FormData();
-    fd.set("inspectionId", inspectionId!.trim());
-
+    const form = new FormData();
+    form.set("inspectionId", inspectionId!.trim());
     const safeItem = getString(itemName);
-    if (safeItem) fd.set("itemName", safeItem);
-
+    if (safeItem) form.set("itemName", safeItem);
     const safeWo = getString(workOrderId);
-    if (safeWo) fd.set("workOrderId", safeWo);
-
+    if (safeWo) form.set("workOrderId", safeWo);
     const safeWol = getString(workOrderLineId);
-    if (safeWol) fd.set("workOrderLineId", safeWol);
+    if (safeWol) form.set("workOrderLineId", safeWol);
+    form.set("file", file);
 
-    fd.set("file", file);
-
-    const res = await fetch("/api/inspections/photos/upload", {
+    const response = await fetch("/api/inspections/photos/upload", {
       method: "POST",
-      body: fd,
+      credentials: "include",
+      body: form,
     });
-
-    const json = (await res.json().catch(() => null)) as unknown;
-
-    if (!res.ok) {
-      const msg =
+    const json = (await response.json().catch(() => null)) as unknown;
+    if (!response.ok) {
+      throw new Error(
         isRecord(json) && typeof json.error === "string"
           ? json.error
-          : "Upload failed";
-      throw new Error(msg);
+          : "Upload failed",
+      );
     }
-
-    const url = isRecord(json) && typeof json.url === "string" ? json.url : null;
-    return url;
+    return isRecord(json) && typeof json.url === "string" ? json.url : null;
   }
 
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? []);
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
     if (!files.length) return;
-
     if (!canUpload) {
       toast.error("This screen didn't provide an inspectionId yet.");
-      e.target.value = "";
+      event.target.value = "";
       return;
     }
 
     setUploading(true);
+    let queued = 0;
+    const uploaded: string[] = [];
     try {
-      const uploaded: string[] = [];
-
-      for (const f of files) {
-        const url = await uploadOne(f);
-        if (url) uploaded.push(url);
+      for (const file of files) {
+        if (!file.type.toLowerCase().startsWith("image/")) {
+          throw new Error(`${file.name} is not an image.`);
+        }
+        if (file.size > MAX_PHOTO_BYTES) {
+          throw new Error(`${file.name} is larger than 15 MB.`);
+        }
+        if (
+          canStage &&
+          draftKey &&
+          workOrderLineId &&
+          typeof sectionIndex === "number" &&
+          typeof itemIndex === "number"
+        ) {
+          const result = await stageInspectionPhoto({
+            draftKey,
+            inspectionId: inspectionId!.trim(),
+            workOrderId,
+            workOrderLineId,
+            itemName,
+            sectionIndex,
+            itemIndex,
+            file,
+          });
+          if (result.queued) queued += 1;
+          else if (result.url) uploaded.push(result.url);
+        } else {
+          const url = await uploadOne(file);
+          if (url) uploaded.push(url);
+        }
       }
 
-      const updated = [...urls, ...uploaded];
-      setUrls(updated);
-      onChange(updated);
-
-      toast.success(
-        `Uploaded ${uploaded.length} photo${uploaded.length === 1 ? "" : "s"}`,
+      if (uploaded.length) {
+        const next = [...urlsRef.current, ...uploaded].filter(
+          (url, index, all) => all.indexOf(url) === index,
+        );
+        urlsRef.current = next;
+        setUrls(next);
+        onChangeRef.current(next);
+      }
+      if (queued) {
+        toast.warning(
+          `${queued} photo${queued === 1 ? "" : "s"} safe on this device and queued.`,
+        );
+      }
+      if (uploaded.length) {
+        toast.success(
+          `Uploaded ${uploaded.length} photo${uploaded.length === 1 ? "" : "s"}.`,
+        );
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Photo staging failed",
       );
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Photo upload failed";
-      toast.error(msg);
     } finally {
       setUploading(false);
-      e.target.value = "";
+      event.target.value = "";
     }
   };
 
   const handleRemove = (index: number) => {
-    const updated = urls.filter((_, i) => i !== index);
-    setUrls(updated);
-    onChange(updated);
+    const next = urls.filter((_, current) => current !== index);
+    urlsRef.current = next;
+    setUrls(next);
+    onChangeRef.current(next);
+  };
+
+  const removeStaged = async (preview: StagedPreview) => {
+    await dismissOfflineMutation(preview.clientMutationId);
+    URL.revokeObjectURL(preview.previewUrl);
+    setStaged((current) =>
+      current.filter(
+        (item) => item.clientMutationId !== preview.clientMutationId,
+      ),
+    );
   };
 
   return (
     <div className="mt-2">
       <label className="mb-1 block text-xs font-bold text-[color:var(--theme-text-primary)]">
-        Upload Photos
+        Add photos
       </label>
 
       <div className="flex flex-wrap">
-        {urls.map((url, i) => (
-          <PhotoThumbnail key={url + i} url={url} onRemove={() => handleRemove(i)} />
+        {urls.map((url, index) => (
+          <PhotoThumbnail
+            key={url + index}
+            url={url}
+            onRemove={() => handleRemove(index)}
+          />
+        ))}
+        {staged.map((preview) => (
+          <PhotoThumbnail
+            key={preview.clientMutationId}
+            url={preview.previewUrl}
+            label={
+              preview.status === "conflicted"
+                ? "Sync needs review"
+                : preview.status === "failed"
+                  ? "Waiting to retry"
+                  : "Queued on device"
+            }
+            onRemove={() => void removeStaged(preview)}
+          />
         ))}
       </div>
 
@@ -142,6 +297,11 @@ export default function PhotoUploadButton({
         className="mt-2 block text-sm text-[color:var(--theme-text-secondary)] file:rounded-full file:border-0 file:bg-orange-700 file:text-sm file:font-semibold file:text-[color:var(--theme-text-primary)] hover:file:bg-orange-600 disabled:opacity-60"
       />
 
+      {canStage && (
+        <div className="mt-1 text-[11px] text-[color:var(--theme-text-secondary)]">
+          Photos are kept on this device until upload completes.
+        </div>
+      )}
       {!canUpload && (
         <div className="mt-1 text-[11px] text-amber-200/80">
           Photo upload disabled (missing inspectionId).

--- a/features/inspections/lib/inspection/SectionDisplay.tsx
+++ b/features/inspections/lib/inspection/SectionDisplay.tsx
@@ -11,7 +11,10 @@ import type {
 import InspectionItemCard from "./InspectionItemCard";
 import { Button } from "@shared/components/ui/Button";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
-import { pricingStatusClass, pricingStatusText } from "@/features/menu-repair-items/lib/pricingStatus";
+import {
+  pricingStatusClass,
+  pricingStatusText,
+} from "@/features/menu-repair-items/lib/pricingStatus";
 
 interface SectionDisplayProps {
   title: string;
@@ -24,6 +27,7 @@ interface SectionDisplayProps {
   inspectionId: string;
   workOrderId?: string | null;
   workOrderLineId?: string | null;
+  draftKey?: string;
 
   onUpdateStatus: (
     sectionIndex: number,
@@ -61,7 +65,6 @@ interface SectionDisplayProps {
 }
 
 type PartRow = { description: string; qty: number };
-
 
 type SmartInspectionMatch = {
   id: string;
@@ -108,14 +111,16 @@ function getNote(item: ItemExtended): string {
 function getParts(item: ItemExtended): PartRow[] {
   const v = item.parts;
   if (!Array.isArray(v)) return [];
-  return v
-    .map((p) => ({
-      description: typeof p?.description === "string" ? p.description : "",
-      // ✅ allow "blank" qty behavior by storing 0 (UI will render as empty)
-      qty: typeof p?.qty === "number" && Number.isFinite(p.qty) ? p.qty : 0,
-    }))
-    // ✅ keep draft rows even if qty is 0
-    .filter((p) => p.description.length > 0 || p.qty >= 0);
+  return (
+    v
+      .map((p) => ({
+        description: typeof p?.description === "string" ? p.description : "",
+        // ✅ allow "blank" qty behavior by storing 0 (UI will render as empty)
+        qty: typeof p?.qty === "number" && Number.isFinite(p.qty) ? p.qty : 0,
+      }))
+      // ✅ keep draft rows even if qty is 0
+      .filter((p) => p.description.length > 0 || p.qty >= 0)
+  );
 }
 
 function getLaborHours(item: ItemExtended): number | null {
@@ -136,7 +141,8 @@ function smartPricingText(
   status: "fresh" | "stale" | "expired" | undefined,
 ): string {
   if (status === "fresh") return "Fresh pricing — ready to apply.";
-  if (status === "stale") return "Stale pricing — pricing review required after apply.";
+  if (status === "stale")
+    return "Stale pricing — pricing review required after apply.";
   return "Expired pricing — pricing review required after apply.";
 }
 
@@ -153,7 +159,7 @@ function smartPricingBadgeClass(
 }
 
 export default function SectionDisplay(props: SectionDisplayProps) {
-    const {
+  const {
     title,
     section,
     sectionIndex,
@@ -162,6 +168,7 @@ export default function SectionDisplay(props: SectionDisplayProps) {
     inspectionId,
     workOrderId,
     workOrderLineId,
+    draftKey,
     onUpdateStatus,
     onUpdateNote,
     onUpload,
@@ -388,12 +395,11 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                   const submitting =
                     isSubmittingAI?.(sectionIndex, itemIndex) ?? false;
 
-                  const rail =
-                    isFail
-                      ? "before:bg-red-500/70"
-                      : isRec
-                        ? "before:bg-orange-500/70"
-                        : "before:bg-[color:var(--theme-surface-subtle)]";
+                  const rail = isFail
+                    ? "before:bg-red-500/70"
+                    : isRec
+                      ? "before:bg-orange-500/70"
+                      : "before:bg-[color:var(--theme-surface-subtle)]";
 
                   const submitted = isSubmittedItem(item);
                   const k = `${sectionIndex}:${itemIndex}`;
@@ -437,6 +443,7 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                         inspectionId={inspectionId}
                         workOrderId={workOrderId}
                         workOrderLineId={workOrderLineId}
+                        draftKey={draftKey}
                         onUpdateStatus={onUpdateStatus}
                         onUpdateNote={onUpdateNote}
                         onUpload={onUpload}
@@ -446,7 +453,8 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                       {(() => {
                         const smartKey = `${sectionIndex}:${itemIndex}`;
                         const match = smartMatchByKey?.[smartKey] ?? null;
-                        const loadingMatch = smartMatchLoadingByKey?.[smartKey] ?? false;
+                        const loadingMatch =
+                          smartMatchLoadingByKey?.[smartKey] ?? false;
 
                         if (!isFailOrRec) return null;
                         if (loadingMatch) {
@@ -460,7 +468,9 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                         if (!match) return null;
 
                         const canApplyRepair = Boolean(onAcceptSmartMatch);
-                        const statusText = pricingStatusText(match.pricingStatus);
+                        const statusText = pricingStatusText(
+                          match.pricingStatus,
+                        );
                         const actionText =
                           match.pricingStatus === "fresh"
                             ? "Ready to apply"
@@ -486,7 +496,10 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                   </span>
                                   {match.pricingValidUntil ? (
                                     <span className="text-[10px] text-[color:var(--theme-text-muted)]">
-                                      Valid until {new Date(match.pricingValidUntil).toLocaleDateString()}
+                                      Valid until{" "}
+                                      {new Date(
+                                        match.pricingValidUntil,
+                                      ).toLocaleDateString()}
                                     </span>
                                   ) : null}
                                 </div>
@@ -501,7 +514,12 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                 <button
                                   type="button"
                                   className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-subtle)]"
-                                  onClick={() => onDismissSmartMatch?.(sectionIndex, itemIndex)}
+                                  onClick={() =>
+                                    onDismissSmartMatch?.(
+                                      sectionIndex,
+                                      itemIndex,
+                                    )
+                                  }
                                 >
                                   Dismiss
                                 </button>
@@ -515,7 +533,10 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                       : "cursor-not-allowed border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-secondary)]",
                                   ].join(" ")}
                                   onClick={() => {
-                                    onAcceptSmartMatch?.(sectionIndex, itemIndex);
+                                    onAcceptSmartMatch?.(
+                                      sectionIndex,
+                                      itemIndex,
+                                    );
                                   }}
                                 >
                                   Apply repair
@@ -546,10 +567,16 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                           const nextIdx = currentParts.length;
                           const draftKey = `${k}:part:${nextIdx}:qty`;
                           setQtyDraft(draftKey, ""); // ✅ blank filler
-                          handlePartsChange([...currentParts, { description: "", qty: 0 }]);
+                          handlePartsChange([
+                            ...currentParts,
+                            { description: "", qty: 0 },
+                          ]);
                         };
 
-                        const updatePart = (idx: number, patch: Partial<PartRow>) => {
+                        const updatePart = (
+                          idx: number,
+                          patch: Partial<PartRow>,
+                        ) => {
                           const next = currentParts.map((p, i) =>
                             i === idx ? { ...p, ...patch } : p,
                           );
@@ -592,7 +619,9 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                     <button
                                       type="button"
                                       className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]"
-                                      onClick={() => setPartsOpen(k, !partsOpen)}
+                                      onClick={() =>
+                                        setPartsOpen(k, !partsOpen)
+                                      }
                                     >
                                       {partsOpen ? "Collapse" : "Expand"}
                                     </button>
@@ -784,7 +813,9 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                         );
                       })()}
 
-                      {(smartMatchLoading || smartMatch) && isFailOrRec && note.length > 0 ? (
+                      {(smartMatchLoading || smartMatch) &&
+                      isFailOrRec &&
+                      note.length > 0 ? (
                         <div className="mt-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
                           {smartMatchLoading ? (
                             <div className="text-[11px] text-[color:var(--theme-text-secondary)]">
@@ -799,19 +830,27 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                     : "Smart match"}
                                 </span>
 
-                                {typeof smartMatch.acceptanceRate === "number" ? (
+                                {typeof smartMatch.acceptanceRate ===
+                                "number" ? (
                                   <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-0.5 text-[11px] text-[color:var(--theme-text-secondary)]">
-                                    Win rate {Math.round(smartMatch.acceptanceRate * 100)}%
+                                    Win rate{" "}
+                                    {Math.round(
+                                      smartMatch.acceptanceRate * 100,
+                                    )}
+                                    %
                                   </span>
                                 ) : null}
 
-                                {typeof smartMatch.acceptedCount === "number" ? (
+                                {typeof smartMatch.acceptedCount ===
+                                "number" ? (
                                   <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-0.5 text-[11px] text-[color:var(--theme-text-secondary)]">
                                     Accepted {smartMatch.acceptedCount}
                                   </span>
                                 ) : null}
 
-                                <span className={`rounded-full border px-2 py-0.5 text-[11px] ${pricingBadgeClass}`}>
+                                <span
+                                  className={`rounded-full border px-2 py-0.5 text-[11px] ${pricingBadgeClass}`}
+                                >
                                   {smartMatch.pricingStatus ?? "expired"}
                                 </span>
                               </div>
@@ -831,7 +870,9 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                               </div>
 
                               <div className="mt-1 text-[11px] text-[color:var(--theme-text-muted)]">
-                                Pricing valid until: {smartMatch.pricingValidUntil ?? "No active pricing snapshot"}
+                                Pricing valid until:{" "}
+                                {smartMatch.pricingValidUntil ??
+                                  "No active pricing snapshot"}
                               </div>
 
                               <div className="mt-3 flex items-center justify-end gap-2">
@@ -841,7 +882,10 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                   size="sm"
                                   className="px-3"
                                   onClick={() =>
-                                    props.onDismissSmartMatch?.(sectionIndex, itemIndex)
+                                    props.onDismissSmartMatch?.(
+                                      sectionIndex,
+                                      itemIndex,
+                                    )
                                   }
                                 >
                                   Dismiss
@@ -854,7 +898,10 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                   className="px-3"
                                   disabled={!props.onAcceptSmartMatch}
                                   onClick={() =>
-                                    props.onAcceptSmartMatch?.(sectionIndex, itemIndex)
+                                    props.onAcceptSmartMatch?.(
+                                      sectionIndex,
+                                      itemIndex,
+                                    )
                                   }
                                 >
                                   Apply repair

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -24,6 +24,7 @@ import { formatDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import { deriveEventsFromFindings } from "@/features/shared/lib/decisionEvents";
 import { requestQuoteSuggestion } from "@inspections/lib/inspection/aiQuote";
 import { cn } from "@shared/lib/utils";
+import { getPendingInspectionPhotoCount } from "@inspections/lib/inspection/inspectionPhotoStaging";
 
 type FindingRow = {
   sectionIndex: number;
@@ -546,6 +547,22 @@ export default function InspectionFindingsPage(): JSX.Element {
 
   const handleSubmitReviewed = async (): Promise<void> => {
     if (!session) return;
+
+    let pendingPhotoCount: number;
+    try {
+      pendingPhotoCount = await getPendingInspectionPhotoCount(draftKey);
+    } catch {
+      toast.error(
+        "Unable to verify staged inspection photos. Open Sync Center and try again.",
+      );
+      return;
+    }
+    if (pendingPhotoCount > 0) {
+      toast.error(
+        `${pendingPhotoCount} inspection photo${pendingPhotoCount === 1 ? " is" : "s are"} still waiting to sync. Upload or remove them before submitting.`,
+      );
+      return;
+    }
 
     if (!resolvedWorkOrderId) {
       toast.error("Missing work order id.");

--- a/features/inspections/lib/inspection/inspectionPhotoStaging.ts
+++ b/features/inspections/lib/inspection/inspectionPhotoStaging.ts
@@ -1,0 +1,298 @@
+"use client";
+
+import {
+  getOfflineBlob,
+  removeOfflineBlob,
+  saveOfflineBlob,
+  type OfflineBlobRecord,
+} from "@/features/shared/lib/offline/database";
+import {
+  hydrateOfflineMutationQueue,
+  listOfflineMutations,
+  resolveOfflineMutationScope,
+  runMutationWithOfflineQueue,
+  type OfflineMutationScope,
+  type OfflineMutationStatus,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+import { appendInspectionPhotoToOfflineDraft } from "@inspections/lib/inspection/offlineDrafts";
+
+export const INSPECTION_PHOTO_ACTION = "inspection:upload-photo";
+export const INSPECTION_PHOTO_SYNCED_EVENT = "inspection:photo-synced";
+
+export type InspectionPhotoPayload = {
+  blobId: string;
+  draftKey: string;
+  inspectionId: string;
+  workOrderId?: string | null;
+  workOrderLineId: string;
+  itemName?: string | null;
+  sectionIndex: number;
+  itemIndex: number;
+  fileName: string;
+  mimeType: string;
+};
+
+export type StagedInspectionPhoto = {
+  clientMutationId: string;
+  blob: Blob;
+  fileName: string;
+  status: OfflineMutationStatus;
+};
+
+function operationId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `inspection-photo:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+}
+
+function isInspectionPhotoPayload(
+  value: unknown,
+): value is InspectionPhotoPayload {
+  if (!value || typeof value !== "object") return false;
+  const payload = value as Partial<InspectionPhotoPayload>;
+  return Boolean(
+    payload.blobId &&
+    payload.draftKey &&
+    payload.inspectionId &&
+    payload.workOrderLineId &&
+    Number.isInteger(payload.sectionIndex) &&
+    Number.isInteger(payload.itemIndex),
+  );
+}
+
+async function uploadInspectionPhoto(
+  payload: InspectionPhotoPayload,
+  blob: Blob,
+  operationKey: string,
+): Promise<string> {
+  const form = new FormData();
+  form.set("inspectionId", payload.inspectionId);
+  form.set("workOrderLineId", payload.workOrderLineId);
+  if (payload.workOrderId) form.set("workOrderId", payload.workOrderId);
+  if (payload.itemName) form.set("itemName", payload.itemName);
+  form.set(
+    "file",
+    new File([blob], payload.fileName, { type: payload.mimeType }),
+  );
+
+  const response = await fetch("/api/inspections/photos/upload", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Idempotency-Key": operationKey },
+    body: form,
+  });
+  const json = (await response.json().catch(() => null)) as {
+    error?: string;
+    url?: string;
+  } | null;
+  if (!response.ok || !json?.url) {
+    const error = new Error(
+      json?.error ?? "Inspection photo upload failed",
+    ) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+  return json.url;
+}
+
+async function applyUploadedPhoto(args: {
+  payload: InspectionPhotoPayload;
+  scope: OfflineMutationScope;
+  operationKey: string;
+  url: string;
+  notify: boolean;
+}): Promise<void> {
+  await appendInspectionPhotoToOfflineDraft({
+    scope: args.scope,
+    draftKey: args.payload.draftKey,
+    sectionIndex: args.payload.sectionIndex,
+    itemIndex: args.payload.itemIndex,
+    url: args.url,
+  });
+  if (args.notify && typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(INSPECTION_PHOTO_SYNCED_EVENT, {
+        detail: {
+          clientMutationId: args.operationKey,
+          draftKey: args.payload.draftKey,
+          sectionIndex: args.payload.sectionIndex,
+          itemIndex: args.payload.itemIndex,
+          url: args.url,
+        },
+      }),
+    );
+  }
+}
+
+export async function stageInspectionPhoto(args: {
+  draftKey: string;
+  inspectionId: string;
+  workOrderId?: string | null;
+  workOrderLineId: string;
+  itemName?: string | null;
+  sectionIndex: number;
+  itemIndex: number;
+  file: File;
+}): Promise<{
+  clientMutationId: string;
+  queued: boolean;
+  conflicted: boolean;
+  url?: string;
+}> {
+  const scope = await resolveOfflineMutationScope({
+    workOrderId: args.workOrderId,
+    workOrderLineId: args.workOrderLineId,
+  });
+  if (!scope) {
+    throw new Error(
+      "Offline shop scope is unavailable. Reconnect and try again.",
+    );
+  }
+
+  const clientMutationId = operationId();
+  const payload: InspectionPhotoPayload = {
+    blobId: clientMutationId,
+    draftKey: args.draftKey,
+    inspectionId: args.inspectionId,
+    workOrderId: args.workOrderId,
+    workOrderLineId: args.workOrderLineId,
+    itemName: args.itemName,
+    sectionIndex: args.sectionIndex,
+    itemIndex: args.itemIndex,
+    fileName: args.file.name,
+    mimeType: args.file.type || "image/jpeg",
+  };
+  await saveOfflineBlob({
+    id: clientMutationId,
+    userId: scope.userId,
+    shopId: scope.shopId,
+    createdAt: new Date().toISOString(),
+    fileName: payload.fileName,
+    mimeType: payload.mimeType,
+    blob: args.file,
+  });
+
+  let uploadedUrl: string | undefined;
+  try {
+    const result = await runMutationWithOfflineQueue({
+      clientMutationId,
+      actionType: INSPECTION_PHOTO_ACTION,
+      payload,
+      scope,
+      orderKey: `${args.workOrderLineId}:inspection-photo:${clientMutationId}`,
+      runner: async () => {
+        uploadedUrl = await uploadInspectionPhoto(
+          payload,
+          args.file,
+          clientMutationId,
+        );
+      },
+    });
+    if (!result.queued && uploadedUrl) {
+      await applyUploadedPhoto({
+        payload,
+        scope,
+        operationKey: clientMutationId,
+        url: uploadedUrl,
+        notify: false,
+      });
+      await removeOfflineBlob(clientMutationId);
+    }
+    return { clientMutationId, ...result, url: uploadedUrl };
+  } catch (error) {
+    await removeOfflineBlob(clientMutationId);
+    throw error;
+  }
+}
+
+export async function replayInspectionPhotoMutation(
+  mutation: PendingMutation,
+): Promise<{ conflicted?: string } | void> {
+  if (!isInspectionPhotoPayload(mutation.payload)) {
+    return {
+      conflicted: "Inspection photo is missing its item or staged file.",
+    };
+  }
+  const record = await getOfflineBlob(mutation.payload.blobId);
+  if (
+    !record ||
+    record.userId !== mutation.userId ||
+    record.shopId !== mutation.shopId
+  ) {
+    return {
+      conflicted: "The staged inspection photo is no longer available.",
+    };
+  }
+  const url = await uploadInspectionPhoto(
+    mutation.payload,
+    record.blob,
+    mutation.clientMutationId,
+  );
+  await applyUploadedPhoto({
+    payload: mutation.payload,
+    scope: { userId: mutation.userId, shopId: mutation.shopId },
+    operationKey: mutation.clientMutationId,
+    url,
+    notify: true,
+  });
+  await removeOfflineBlob(mutation.payload.blobId);
+}
+
+export async function listStagedInspectionPhotos(args: {
+  draftKey: string;
+  sectionIndex: number;
+  itemIndex: number;
+}): Promise<StagedInspectionPhoto[]> {
+  await hydrateOfflineMutationQueue();
+  const mutations = listOfflineMutations().filter((mutation) => {
+    if (
+      mutation.actionType !== INSPECTION_PHOTO_ACTION ||
+      mutation.status === "synced" ||
+      !isInspectionPhotoPayload(mutation.payload)
+    ) {
+      return false;
+    }
+    return (
+      mutation.payload.draftKey === args.draftKey &&
+      mutation.payload.sectionIndex === args.sectionIndex &&
+      mutation.payload.itemIndex === args.itemIndex
+    );
+  });
+  const records = await Promise.all(
+    mutations.map(async (mutation) => ({
+      mutation,
+      record: await getOfflineBlob(
+        (mutation.payload as InspectionPhotoPayload).blobId,
+      ),
+    })),
+  );
+  return records
+    .filter(
+      (
+        entry,
+      ): entry is {
+        mutation: PendingMutation<InspectionPhotoPayload>;
+        record: OfflineBlobRecord;
+      } => Boolean(entry.record),
+    )
+    .map(({ mutation, record }) => ({
+      clientMutationId: mutation.clientMutationId,
+      blob: record.blob,
+      fileName: record.fileName,
+      status: mutation.status,
+    }));
+}
+
+export async function getPendingInspectionPhotoCount(
+  draftKey: string,
+): Promise<number> {
+  await hydrateOfflineMutationQueue();
+  return listOfflineMutations().filter(
+    (mutation) =>
+      mutation.actionType === INSPECTION_PHOTO_ACTION &&
+      mutation.status !== "synced" &&
+      isInspectionPhotoPayload(mutation.payload) &&
+      mutation.payload.draftKey === draftKey,
+  ).length;
+}

--- a/features/inspections/lib/inspection/offlineDrafts.ts
+++ b/features/inspections/lib/inspection/offlineDrafts.ts
@@ -109,3 +109,41 @@ export async function removeInspectionOfflineDraft(args: {
     entityIds: [args.draftKey],
   });
 }
+
+export async function appendInspectionPhotoToOfflineDraft(args: {
+  scope: OfflineMutationScope;
+  draftKey: string;
+  sectionIndex: number;
+  itemIndex: number;
+  url: string;
+}): Promise<boolean> {
+  const snapshot = await getOfflineSnapshot<InspectionOfflineDraft>({
+    scope: args.scope,
+    kind: KIND,
+    entityId: args.draftKey,
+  });
+  if (!snapshot) return false;
+
+  const sections = [...(snapshot.data.session.sections ?? [])];
+  const section = sections[args.sectionIndex];
+  const item = section?.items?.[args.itemIndex];
+  if (!section || !item) return false;
+  const photoUrls = Array.isArray(item.photoUrls) ? item.photoUrls : [];
+  if (photoUrls.includes(args.url)) return true;
+  const items = [...section.items];
+  items[args.itemIndex] = { ...item, photoUrls: [...photoUrls, args.url] };
+  sections[args.sectionIndex] = { ...section, items };
+  const session = {
+    ...snapshot.data.session,
+    sections,
+    lastUpdated: new Date().toISOString(),
+  };
+  await saveOfflineSnapshot({
+    scope: args.scope,
+    kind: KIND,
+    entityId: args.draftKey,
+    data: { ...snapshot.data, session, savedAt: new Date().toISOString() },
+    maxAgeMs: MAX_AGE_MS,
+  });
+  return true;
+}

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -3148,6 +3148,7 @@ type SmartMatchRow = {
                             inspectionId={inspectionId}
                             workOrderId={workOrderId}
                             workOrderLineId={workOrderLineId || null}
+                            draftKey={draftKey}
                             onUpdateStatus={(
                               secIdx: number,
                               itemIdx: number,

--- a/features/shared/lib/offline/mutations.ts
+++ b/features/shared/lib/offline/mutations.ts
@@ -447,7 +447,10 @@ export async function dismissOfflineMutation(
   if (dependent) {
     throw new Error("Remove the dependent offline update first.");
   }
-  if (mutation.actionType === "upload_job_photo") {
+  if (
+    mutation.actionType === "upload_job_photo" ||
+    mutation.actionType === "inspection:upload-photo"
+  ) {
     const payload = mutation.payload as { blobId?: unknown } | null;
     if (typeof payload?.blobId === "string")
       await removeOfflineBlob(payload.blobId);
@@ -482,7 +485,8 @@ export async function pruneOfflineState(): Promise<{
       .filter(
         (item) =>
           scopeMatches(item, scope) &&
-          item.actionType === "upload_job_photo" &&
+          (item.actionType === "upload_job_photo" ||
+            item.actionType === "inspection:upload-photo") &&
           item.status !== "synced",
       )
       .map((item) => (item.payload as { blobId?: unknown } | null)?.blobId)

--- a/features/shared/lib/offline/replay.ts
+++ b/features/shared/lib/offline/replay.ts
@@ -10,6 +10,7 @@ import {
   type OfflineMutationRunner,
 } from "@/features/shared/lib/offline/mutations";
 import { postOfflineServerMutation } from "@/features/shared/lib/offline/server-mutations";
+import { replayInspectionPhotoMutation } from "@inspections/lib/inspection/inspectionPhotoStaging";
 
 type ReplayPayload = Record<string, unknown>;
 
@@ -41,6 +42,7 @@ async function apiPost(path: string, body: unknown, operationKey?: string) {
 }
 
 const handlers: Record<string, OfflineMutationRunner> = {
+  "inspection:upload-photo": replayInspectionPhotoMutation,
   "inspection:save-session": async (mutation) => {
     const payload = mutation.payload as ReplayPayload;
     const workOrderLineId = text(payload.workOrderLineId);

--- a/tests/inspection-offline-photo-staging.test.ts
+++ b/tests/inspection-offline-photo-staging.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const staging = read(
+  "features/inspections/lib/inspection/inspectionPhotoStaging.ts",
+);
+const upload = read(
+  "features/inspections/lib/inspection/PhotoUploadButton.tsx",
+);
+const drafts = read("features/inspections/lib/inspection/offlineDrafts.ts");
+const replay = read("features/shared/lib/offline/replay.ts");
+const mutations = read("features/shared/lib/offline/mutations.ts");
+const screen = read("features/inspections/screens/GenericInspectionScreen.tsx");
+const route = read("app/api/inspections/photos/upload/route.ts");
+const findings = read("features/inspections/lib/inspection/findings/page.tsx");
+
+describe("technician inspection offline photo staging", () => {
+  it("stores the blob before queueing a scoped inspection photo mutation", () => {
+    expect(staging).toContain("await saveOfflineBlob");
+    expect(staging).toContain("actionType: INSPECTION_PHOTO_ACTION");
+    expect(staging).toContain('"inspection:upload-photo"');
+    expect(staging).toContain("scope,");
+    expect(staging).toContain("workOrderLineId: args.workOrderLineId");
+  });
+
+  it("accepts only bounded image evidence on both client and server", () => {
+    expect(upload).toContain("MAX_PHOTO_BYTES");
+    expect(upload).toContain('startsWith("image/")');
+    expect(route).toContain("MAX_PHOTO_BYTES");
+    expect(route).toContain("Inspection evidence must be an image.");
+    expect(route).toContain("Inspection photos must be 15 MB or smaller.");
+  });
+
+  it("recovers queued previews and exposes their sync state", () => {
+    expect(upload).toContain("listStagedInspectionPhotos");
+    expect(upload).toContain("URL.createObjectURL(record.blob)");
+    expect(upload).toContain("Queued on device");
+    expect(upload).toContain("Waiting to retry");
+    expect(upload).toContain("Sync needs review");
+  });
+
+  it("replays through the authenticated inspection upload route", () => {
+    expect(replay).toContain(
+      '"inspection:upload-photo": replayInspectionPhotoMutation',
+    );
+    expect(staging).toContain('fetch("/api/inspections/photos/upload"');
+    expect(staging).toContain('"Idempotency-Key": operationKey');
+    expect(staging).toContain("record.userId !== mutation.userId");
+    expect(staging).toContain("record.shopId !== mutation.shopId");
+  });
+
+  it("writes the uploaded URL back to the recovered item draft", () => {
+    expect(staging).toContain("appendInspectionPhotoToOfflineDraft");
+    expect(drafts).toContain("photoUrls.includes(args.url)");
+    expect(drafts).toContain("photoUrls: [...photoUrls, args.url]");
+    expect(staging).toContain("INSPECTION_PHOTO_SYNCED_EVENT");
+    expect(screen).toContain("draftKey={draftKey}");
+  });
+
+  it("removes staged bytes after success or dismissal and retains active blobs", () => {
+    expect(staging).toContain("await removeOfflineBlob");
+    expect(upload).toContain("dismissOfflineMutation");
+    expect(mutations).toContain(
+      'mutation.actionType === "inspection:upload-photo"',
+    );
+    expect(mutations).toContain(
+      'item.actionType === "inspection:upload-photo"',
+    );
+  });
+
+  it("does not finalize an inspection while evidence is still staged", () => {
+    expect(staging).toContain("getPendingInspectionPhotoCount");
+    expect(findings).toContain(
+      "await getPendingInspectionPhotoCount(draftKey)",
+    );
+    expect(findings).toContain("still waiting to sync");
+  });
+});


### PR DESCRIPTION
## What changed

- stage technician inspection photos in user/shop-scoped IndexedDB before any network attempt
- queue staged evidence through the global offline sync engine and replay it through the authenticated inspection photo endpoint
- restore queued, retrying, and conflicted photo previews after reload
- write uploaded URLs back into the recovered inspection item draft and update an open inspection through a sync event
- remove staged bytes after upload or user dismissal, while retaining blobs needed by active mutations
- surface inspection photos in Sync Center
- block findings submission while inspection photos are still pending
- enforce image-only, 15 MB client and server limits

## Why

Technicians can capture inspection evidence in weak or absent connectivity without losing the file on navigation, reload, or app interruption. Final findings submission remains online and is protected from completing before staged evidence is resolved.

## Validation

- `npm run typecheck`
- focused ESLint on changed photo, inspection, queue, replay, and route files
- `npx vitest run tests/inspection-offline-photo-staging.test.ts tests/inspection-offline-recovery.test.ts tests/phase6-offline-mutations.test.ts tests/pwa-sync-center.test.ts` (20 passing)

No database migration is required.