### PR TITLE
fix: harden offline recovery and assigned work

### DIFF
--- a/app/api/offline/technician-work-orders/route.ts
+++ b/app/api/offline/technician-work-orders/route.ts
@@ -19,6 +19,14 @@ type QuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
 
+function chunks<T>(items: T[], size = 100): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result;
+}
+
 export async function GET() {
   const authClient = createServerSupabaseRoute();
   const {
@@ -41,6 +49,17 @@ export async function GET() {
     return NextResponse.json(
       { error: "Assigned technician work is not available for this role." },
       { status: 403 },
+    );
+  }
+
+  const { error: shopContextError } = await authClient.rpc(
+    "set_current_shop_id",
+    { p_shop_id: profile.shop_id },
+  );
+  if (shopContextError) {
+    return NextResponse.json(
+      { error: "Shop security context could not be initialized." },
+      { status: 500 },
     );
   }
 
@@ -108,14 +127,19 @@ export async function GET() {
 
   // Use the authenticated client for every downloaded business record so the
   // normal table policies remain the final authorization boundary.
-  const { data: workOrdersData, error: workOrdersError } = await authClient
-    .from("work_orders")
-    .select("*")
-    .eq("shop_id", profile.shop_id)
-    .in("id", workOrderIds)
-    .neq("type", "historical_import")
-    .order("created_at", { ascending: false })
-    .limit(50);
+  const workOrderResults = await Promise.all(
+    chunks(workOrderIds).map((ids) =>
+      authClient
+        .from("work_orders")
+        .select("*")
+        .eq("shop_id", profile.shop_id)
+        .in("id", ids)
+        .neq("type", "historical_import"),
+    ),
+  );
+  const workOrdersError = workOrderResults.find(
+    (result) => result.error,
+  )?.error;
   if (workOrdersError) {
     return NextResponse.json(
       { error: workOrdersError.message },
@@ -123,7 +147,13 @@ export async function GET() {
     );
   }
 
-  const workOrders = (workOrdersData ?? []) as WorkOrder[];
+  const workOrders = workOrderResults
+    .flatMap((result) => (result.data ?? []) as WorkOrder[])
+    .sort(
+      (a, b) =>
+        new Date(b.created_at ?? 0).getTime() -
+        new Date(a.created_at ?? 0).getTime(),
+    );
   if (workOrders.length === 0) {
     const empty: TechnicianOfflineBundle = {
       scope: { userId: user.id, shopId: profile.shop_id },
@@ -169,33 +199,38 @@ export async function GET() {
             .in("id", customerIds)
         : Promise.resolve({ data: [], error: null }),
     ]);
-  if (linesResult.error) {
+  const supportingReadError =
+    linesResult.error ??
+    quotesResult.error ??
+    vehiclesResult.error ??
+    customersResult.error;
+  if (supportingReadError) {
     return NextResponse.json(
-      { error: linesResult.error.message },
+      { error: supportingReadError.message },
       { status: 500 },
     );
   }
 
   const lines = (linesResult.data ?? []) as WorkOrderLine[];
-  const quoteLines = (
-    quotesResult.error ? [] : (quotesResult.data ?? [])
-  ) as QuoteLine[];
-  const vehicles = (
-    vehiclesResult.error ? [] : (vehiclesResult.data ?? [])
-  ) as Vehicle[];
-  const customers = (
-    customersResult.error ? [] : (customersResult.data ?? [])
-  ) as Customer[];
+  const quoteLines = (quotesResult.data ?? []) as QuoteLine[];
+  const vehicles = (vehiclesResult.data ?? []) as Vehicle[];
+  const customers = (customersResult.data ?? []) as Customer[];
   const techIds = [
     ...new Set(lines.map((line) => line.assigned_tech_id).filter(Boolean)),
   ] as string[];
-  const { data: technicians } = techIds.length
+  const { data: technicians, error: techniciansError } = techIds.length
     ? await authClient
         .from("profiles")
         .select("id, full_name")
         .eq("shop_id", profile.shop_id)
         .in("id", techIds)
-    : { data: [] };
+    : { data: [], error: null };
+  if (techniciansError) {
+    return NextResponse.json(
+      { error: techniciansError.message },
+      { status: 500 },
+    );
+  }
   const techNamesById = Object.fromEntries(
     (technicians ?? []).map((technician) => [
       technician.id,

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -1,6 +1,7 @@
 import {
   CacheFirst,
   ExpirationPlugin,
+  NetworkFirst,
   NetworkOnly,
   Serwist,
   StaleWhileRevalidate,
@@ -19,8 +20,23 @@ const serwist = new Serwist({
   disableDevLogs: true,
   runtimeCaching: [
     {
-      matcher: ({ url }) => url.origin === self.location.origin && url.pathname.startsWith("/api/"),
+      matcher: ({ url }) =>
+        url.origin === self.location.origin && url.pathname.startsWith("/api/"),
       handler: new NetworkOnly(),
+    },
+    {
+      matcher: ({ request, url }) =>
+        request.mode === "navigate" && url.pathname === "/mobile/tech/queue",
+      handler: new NetworkFirst({
+        cacheName: "profixiq-technician-shell-v1",
+        networkTimeoutSeconds: 4,
+        plugins: [
+          new ExpirationPlugin({
+            maxEntries: 4,
+            maxAgeSeconds: 60 * 60 * 24 * 14,
+          }),
+        ],
+      }),
     },
     {
       matcher: ({ request }) => request.mode === "navigate",
@@ -28,10 +44,16 @@ const serwist = new Serwist({
     },
     {
       matcher: ({ url }) =>
-        url.origin === self.location.origin && url.pathname.startsWith("/_next/static/"),
+        url.origin === self.location.origin &&
+        url.pathname.startsWith("/_next/static/"),
       handler: new CacheFirst({
         cacheName: "profixiq-static-v1",
-        plugins: [new ExpirationPlugin({ maxEntries: 160, maxAgeSeconds: 60 * 60 * 24 * 30 })],
+        plugins: [
+          new ExpirationPlugin({
+            maxEntries: 160,
+            maxAgeSeconds: 60 * 60 * 24 * 30,
+          }),
+        ],
       }),
     },
     {
@@ -40,7 +62,12 @@ const serwist = new Serwist({
         ["style", "script", "font", "image"].includes(request.destination),
       handler: new StaleWhileRevalidate({
         cacheName: "profixiq-assets-v1",
-        plugins: [new ExpirationPlugin({ maxEntries: 100, maxAgeSeconds: 60 * 60 * 24 * 14 })],
+        plugins: [
+          new ExpirationPlugin({
+            maxEntries: 100,
+            maxAgeSeconds: 60 * 60 * 24 * 14,
+          }),
+        ],
       }),
     },
   ],

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -25,6 +25,7 @@ import { deriveEventsFromFindings } from "@/features/shared/lib/decisionEvents";
 import { requestQuoteSuggestion } from "@inspections/lib/inspection/aiQuote";
 import { cn } from "@shared/lib/utils";
 import { getPendingInspectionPhotoCount } from "@inspections/lib/inspection/inspectionPhotoStaging";
+import { removeInspectionOfflineDraft } from "@inspections/lib/inspection/offlineDrafts";
 
 type FindingRow = {
   sectionIndex: number;
@@ -957,6 +958,17 @@ export default function InspectionFindingsPage(): JSX.Element {
         bestEffortWarning =
           bestEffortWarning ??
           (pdfJson?.error || "Findings submitted, but PDF finalize failed.");
+      }
+
+      await removeInspectionOfflineDraft({
+        draftKey,
+        session: nextSession,
+      });
+      try {
+        localStorage.removeItem(draftKey);
+        localStorage.removeItem(`${draftKey}:locked`);
+      } catch {
+        // IndexedDB is authoritative; localStorage cleanup is best effort.
       }
 
       window.dispatchEvent(

--- a/features/inspections/lib/inspection/offlineDrafts.ts
+++ b/features/inspections/lib/inspection/offlineDrafts.ts
@@ -16,6 +16,13 @@ import {
 const KIND = "inspection-draft";
 const MAX_AGE_MS = 1000 * 60 * 60 * 24 * 14;
 
+function sessionTimestamp(session: Partial<InspectionSession> | null): number {
+  const parsed = session?.lastUpdated
+    ? new Date(session.lastUpdated).getTime()
+    : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 export type InspectionDraftRecoveryState = "editing" | "queued" | "conflicted";
 
 export type InspectionOfflineDraft = {
@@ -82,6 +89,19 @@ export async function getInspectionOfflineDraft(args: {
       (mutation) => mutation.clientMutationId === draft.operationKey,
     );
     if (!queued || queued.status === "synced") {
+      const reconciled = {
+        ...draft,
+        state: "editing" as const,
+        operationKey: undefined,
+      };
+      await saveInspectionOfflineDraft(reconciled);
+      return reconciled;
+    }
+    const queuedSession =
+      (queued.payload && typeof queued.payload === "object"
+        ? (queued.payload as { session?: Partial<InspectionSession> }).session
+        : null) ?? null;
+    if (sessionTimestamp(draft.session) > sessionTimestamp(queuedSession)) {
       const reconciled = {
         ...draft,
         state: "editing" as const,

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -841,10 +841,10 @@ type SmartMatchRow = {
     useState<InspectionDraftRecoveryState>("editing");
   const [recoveryMessage, setRecoveryMessage] = useState<string | null>(null);
   const recoveryOperationKeyRef = useRef<string | undefined>(undefined);
+  const queuedSessionRef = useRef<InspectionSession | null>(null);
+  const skipNextQueuedEditCheckRef = useRef(false);
   const inspectionCompletedRef = useRef(false);
-  const localDraftUpdatedAtRef = useRef(
-    inspectionDraftTimestamp(persistedSession),
-  );
+  const localDraftUpdatedAtRef = useRef(0);
   const serverStartedRef = useRef<string | null>(null);
 
   const triggerVoicePulse = (): void => {
@@ -915,6 +915,10 @@ type SmartMatchRow = {
           }
           setRecoveryState(recovered.state);
           recoveryOperationKeyRef.current = recovered.operationKey;
+          queuedSessionRef.current = null;
+          skipNextQueuedEditCheckRef.current = Boolean(
+            recovered.operationKey && recovered.state !== "editing",
+          );
           setRecoveryMessage(
             recovered.state === "queued"
               ? "Recovered inspection · server save is queued."
@@ -922,16 +926,6 @@ type SmartMatchRow = {
                 ? "Recovered inspection · sync needs review."
                 : `Recovered inspection saved ${new Date(recovered.savedAt).toLocaleString()}.`,
           );
-        } else if (persistedSession) {
-          const migrated = await saveInspectionOfflineDraft({
-            draftKey,
-            session: persistedSession,
-          });
-          if (!cancelled && migrated) {
-            setRecoveryMessage(
-              "Existing inspection draft moved into offline recovery.",
-            );
-          }
         }
       } catch (error) {
         console.warn("[inspection] offline recovery unavailable", error);
@@ -1480,7 +1474,33 @@ type SmartMatchRow = {
   }, [session, bootSections, updateInspection]);
 
   useEffect(() => {
-    if (!session || !draftBootLoaded || inspectionCompletedRef.current) return;
+    if (
+      !session ||
+      !draftBootLoaded ||
+      !serverBootLoaded ||
+      inspectionCompletedRef.current
+    )
+      return;
+
+    let draftState = recoveryState;
+    let operationKey = recoveryOperationKeyRef.current;
+    let skipDraftWrite = false;
+    if (operationKey && recoveryState !== "editing") {
+      if (skipNextQueuedEditCheckRef.current) {
+        skipNextQueuedEditCheckRef.current = false;
+        queuedSessionRef.current = session;
+        skipDraftWrite = true;
+      } else if (queuedSessionRef.current !== session) {
+        draftState = "editing";
+        operationKey = undefined;
+        recoveryOperationKeyRef.current = undefined;
+        queuedSessionRef.current = null;
+        setRecoveryState("editing");
+        setRecoveryMessage(
+          "Newer edits are safe on this device. Save Progress again to queue them for server sync.",
+        );
+      }
+    }
 
     localDraftUpdatedAtRef.current = inspectionDraftTimestamp(session);
     try {
@@ -1492,21 +1512,23 @@ type SmartMatchRow = {
       );
     } catch {}
 
+    if (skipDraftWrite) return;
+
     const timer = window.setTimeout(() => {
       if (inspectionCompletedRef.current) return;
       void saveInspectionOfflineDraft({
         draftKey,
         session,
-        state: recoveryState,
-        operationKey: recoveryOperationKeyRef.current,
+        state: draftState,
+        operationKey,
       });
     }, 250);
     return () => window.clearTimeout(timer);
-  }, [session, draftKey, draftBootLoaded, recoveryState]);
+  }, [session, draftKey, draftBootLoaded, serverBootLoaded, recoveryState]);
 
   useEffect(() => {
     const persistNow = () => {
-      if (inspectionCompletedRef.current) return;
+      if (inspectionCompletedRef.current || !serverBootLoaded) return;
       try {
         const payload = {
           ...(session ?? initialSession),
@@ -1536,7 +1558,14 @@ type SmartMatchRow = {
       window.removeEventListener("pagehide", persistNow);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [session, draftKey, initialSession, workOrderId, workOrderLineId]);
+  }, [
+    session,
+    draftKey,
+    initialSession,
+    workOrderId,
+    workOrderLineId,
+    serverBootLoaded,
+  ]);
 
   useEffect(() => {
     const handler = (evt: Event) => {
@@ -2678,6 +2707,8 @@ type SmartMatchRow = {
         onRecoveryState={(state, operationKey) => {
           setRecoveryState(state);
           recoveryOperationKeyRef.current = operationKey;
+          queuedSessionRef.current = operationKey ? session : null;
+          skipNextQueuedEditCheckRef.current = false;
           setRecoveryMessage(
             state === "queued"
               ? "Inspection is safe on this device and queued for server sync."

--- a/features/work-orders/mobile/technicianOfflineDownload.ts
+++ b/features/work-orders/mobile/technicianOfflineDownload.ts
@@ -2,6 +2,7 @@
 
 import {
   getOfflineSnapshot,
+  listOfflineSnapshots,
   removeOfflineSnapshots,
   saveOfflineSnapshot,
   type OfflineSnapshot,
@@ -14,7 +15,10 @@ const BUNDLE_ID = "current";
 export async function cacheTechnicianOfflineBundle(
   bundle: TechnicianOfflineBundle,
 ): Promise<void> {
-  const previous = await getCachedTechnicianWork({ scope: bundle.scope });
+  const existingDetails = await listOfflineSnapshots({
+    scope: bundle.scope,
+    kind: "mobile-work-order-detail",
+  });
   const currentAliases = new Set(
     bundle.workOrders.flatMap((item) =>
       [item.workOrder.id, item.workOrder.custom_id].filter((id): id is string =>
@@ -22,11 +26,9 @@ export async function cacheTechnicianOfflineBundle(
       ),
     ),
   );
-  const staleAliases = (previous?.data.workOrders ?? [])
-    .flatMap((item) => [item.workOrder.id, item.workOrder.custom_id])
-    .filter(
-      (id): id is string => Boolean(id) && !currentAliases.has(id as string),
-    );
+  const staleAliases = existingDetails
+    .map((snapshot) => snapshot.entityId)
+    .filter((entityId) => !currentAliases.has(entityId));
   const detailWrites = bundle.workOrders.flatMap((item) => {
     const ids = new Set(
       [item.workOrder.id, item.workOrder.custom_id].filter(Boolean),

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ const withSerwist = withSerwistInit({
   additionalPrecacheEntries: [
     { url: "/offline", revision: null },
     { url: "/offline/sync", revision: null },
+    { url: "/mobile/tech/queue", revision: null },
   ],
 });
 

--- a/tests/inspection-offline-recovery.test.ts
+++ b/tests/inspection-offline-recovery.test.ts
@@ -8,6 +8,7 @@ const saveButton = read(
   "features/inspections/components/inspection/SaveInspectionButton.tsx",
 );
 const save = read("features/inspections/lib/inspection/save.ts");
+const findings = read("features/inspections/lib/inspection/findings/page.tsx");
 
 describe("technician inspection offline recovery", () => {
   it("stores expiring drafts under the authenticated user and shop scope", () => {
@@ -35,15 +36,33 @@ describe("technician inspection offline recovery", () => {
     );
     expect(screen).toContain("the older server copy was not applied");
     expect(screen).toContain("!draftBootLoaded ||");
+    expect(screen).toContain("!serverBootLoaded ||");
+    expect(screen).toContain("const localDraftUpdatedAtRef = useRef(0)");
+    expect(screen).toContain(
+      "inspectionCompletedRef.current || !serverBootLoaded",
+    );
   });
 
-  it("persists edits, surfaces queued saves, and clears only on completion", () => {
+  it("detaches newer edits from an older queued save", () => {
     expect(screen).toContain("saveInspectionOfflineDraft");
-    expect(screen).toContain("state: recoveryState");
-    expect(screen).toContain("operationKey: recoveryOperationKeyRef.current");
+    expect(screen).toContain("queuedSessionRef.current !== session");
+    expect(screen).toContain('draftState = "editing"');
+    expect(screen).toContain("operationKey = undefined");
+    expect(screen).toContain("state: draftState");
+    expect(drafts).toContain(
+      "sessionTimestamp(draft.session) > sessionTimestamp(queuedSession)",
+    );
+    expect(drafts).toContain('state: "editing" as const');
+  });
+
+  it("clears durable and legacy drafts from the mounted findings flow", () => {
     expect(screen).toContain('window.addEventListener("inspection:completed"');
     expect(screen).toContain("inspectionCompletedRef.current = true");
-    expect(screen).toContain("removeInspectionOfflineDraft");
+    expect(findings).toContain("await removeInspectionOfflineDraft");
+    expect(findings).toContain("localStorage.removeItem(draftKey)");
+    expect(findings.indexOf("await removeInspectionOfflineDraft")).toBeLessThan(
+      findings.indexOf('new CustomEvent("inspection:completed"'),
+    );
     expect(saveButton).toContain("? result.operationKey");
     expect(save).toContain("return { ...result, operationKey }");
   });

--- a/tests/pwa-offline-foundation.test.ts
+++ b/tests/pwa-offline-foundation.test.ts
@@ -18,6 +18,21 @@ describe("installable offline foundation", () => {
     expect(source).not.toContain("profixiq-api");
   });
 
+  it("keeps the downloaded technician queue reachable after an offline restart", () => {
+    const serviceWorker = read("app/sw.ts");
+    const config = read("next.config.ts");
+    expect(serviceWorker).toContain('url.pathname === "/mobile/tech/queue"');
+    expect(serviceWorker).toContain("handler: new NetworkFirst");
+    expect(
+      serviceWorker.indexOf('url.pathname === "/mobile/tech/queue"'),
+    ).toBeLessThan(
+      serviceWorker.indexOf(
+        'request.mode === "navigate",\n      handler: new NetworkOnly()',
+      ),
+    );
+    expect(config).toContain('{ url: "/mobile/tech/queue", revision: null }');
+  });
+
   it("stores queues, snapshots, and blobs in shop-scoped IndexedDB stores", () => {
     const source = read("features/shared/lib/offline/database.ts");
     expect(source).toContain("[userId+shopId]");

--- a/tests/technician-offline-download.test.ts
+++ b/tests/technician-offline-download.test.ts
@@ -23,10 +23,16 @@ describe("technician assigned-work offline download", () => {
     expect(route).toContain(
       "normal table policies remain the final authorization boundary",
     );
-    expect(route).toContain("const { data: workOrdersData");
+    expect(route).toContain('authClient.rpc(\n    "set_current_shop_id"');
+    expect(route.indexOf('"set_current_shop_id"')).toBeLessThan(
+      route.indexOf('.from("work_orders")'),
+    );
+    expect(route).toContain("chunks(workOrderIds)");
+    expect(route).not.toContain(".limit(50)");
     expect(route).toContain("await authClient");
     expect(route).toMatch(/authClient\s*\.from\("work_order_lines"\)/);
     expect(route).toMatch(/authClient\s*\.from\("work_order_quote_lines"\)/);
+    expect(route).toContain("quotesResult.error");
     expect(route).toContain('"Cache-Control": "private, no-store"');
   });
 
@@ -37,6 +43,8 @@ describe("technician assigned-work offline download", () => {
     expect(download).toContain('kind: "mobile-work-order-detail"');
     expect(download).toContain("item.workOrder.custom_id");
     expect(download).toContain("await cacheTechnicianOfflineBundle(result)");
+    expect(download).toContain("listOfflineSnapshots");
+    expect(download).toContain("existingDetails");
     expect(download).toContain("staleAliases");
     expect(download).toContain("removeOfflineSnapshots");
   });


### PR DESCRIPTION
## Summary

Hardens the Phase 3 offline inspection and assigned-work foundation by addressing all eight Codex review findings from PRs #1063 and #1064. This branch is rebased onto the merged offline photo-staging work from PR #1065.

### Inspection recovery

- delay autosave and unload persistence until server boot reconciliation completes
- treat only a real recovered device draft as newer than server state
- detach newer edits from an older queued inspection payload, including reload reconciliation
- delete IndexedDB and legacy localStorage drafts from the mounted findings submission path

### Technician assigned-work download

- initialize the authenticated RLS shop context before protected business reads
- fetch all assigned work orders in chunks instead of silently limiting the bundle to 50
- fail incomplete supporting reads, including quote lines, instead of caching partial success
- prune every stale scoped work-order detail snapshot
- precache and network-first cache the technician queue shell for offline PWA restarts

## Validation

- `tsc --noEmit`
- focused ESLint: no errors (one pre-existing `next.config.ts` explicit-any warning)
- 21 focused Vitest assertions, including the merged photo-staging coverage
- `git diff --check`

No database migration is included.