### PR TITLE
feat: complete offline technician execution

### DIFF
--- a/app/mobile/tech/queue/page.tsx
+++ b/app/mobile/tech/queue/page.tsx
@@ -668,7 +668,9 @@ export default function MobileTechQueuePage() {
 
             // ✅ always use UUID route (mobile expects UUID)
             const woId = wo?.id ?? line.work_order_id ?? "";
-            const href = woId ? `/mobile/work-orders/${woId}?mode=tech` : "";
+            const href = woId
+              ? `/mobile/work-orders/${woId}?mode=tech&focus=${line.id}`
+              : "";
 
             return (
               <button

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -26,13 +26,16 @@ const serwist = new Serwist({
     },
     {
       matcher: ({ request, url }) =>
-        request.mode === "navigate" && url.pathname === "/mobile/tech/queue",
+        request.mode === "navigate" &&
+        (url.pathname === "/mobile/tech/queue" ||
+          url.pathname.startsWith("/mobile/work-orders/") ||
+          url.pathname.startsWith("/mobile/jobs/")),
       handler: new NetworkFirst({
         cacheName: "profixiq-technician-shell-v1",
         networkTimeoutSeconds: 4,
         plugins: [
           new ExpirationPlugin({
-            maxEntries: 4,
+            maxEntries: 120,
             maxAgeSeconds: 60 * 60 * 24 * 14,
           }),
         ],

--- a/features/mobile/components/MobileShiftTracker.tsx
+++ b/features/mobile/components/MobileShiftTracker.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { formatDistanceToNow } from "date-fns";
 import {
+  getOfflineMutationScope,
   getOfflineSyncSummary,
   subscribeOfflineMutations,
 } from "@/features/shared/lib/offline/mutations";
@@ -11,16 +12,14 @@ import {
   fetchMobileShiftState,
   type MobileShiftState,
 } from "@/features/mobile/shifts/client";
+import {
+  getCachedMobileShiftState,
+  runMobileShiftAction,
+  saveCachedMobileShiftState,
+  type MobileShiftAction,
+} from "@/features/mobile/shifts/offline";
 
 type Props = { userId: string };
-
-function modeFromActivity(activity: MobileShiftState["activity"] | undefined, shiftStatus?: MobileShiftState["shiftStatus"]): MobileShiftState["mode"] {
-  if (shiftStatus === "completed") return "ended";
-  if (activity === "working") return "shift";
-  if (activity === "on_break") return "break";
-  if (activity === "on_lunch") return "lunch";
-  return "none";
-}
 
 export default function MobileShiftTracker({ userId }: Props) {
   const [shiftId, setShiftId] = useState<string | null>(null);
@@ -28,7 +27,14 @@ export default function MobileShiftTracker({ userId }: Props) {
   const [shiftState, setShiftState] = useState<MobileShiftState | null>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [online, setOnline] = useState(true);
   const [syncSummary, setSyncSummary] = useState(() => getOfflineSyncSummary());
+
+  const applyState = useCallback((state: MobileShiftState | null) => {
+    setShiftId(state?.shiftId ?? null);
+    setStartTime(state?.startTime ?? null);
+    setShiftState(state);
+  }, []);
 
   const refreshOfflineSummary = useCallback(() => {
     setSyncSummary(getOfflineSyncSummary());
@@ -50,25 +56,30 @@ export default function MobileShiftTracker({ userId }: Props) {
     if (!userId) return;
     setErr(null);
 
-    try {
-      const shiftState = await fetchMobileShiftState();
-      if (!shiftState.shiftId) {
-        setShiftId(null);
-        setStartTime(null);
-        setShiftState(null);
-        return;
-      }
-
-      setShiftId(shiftState.shiftId);
-      setStartTime(shiftState.startTime ?? null);
-      setShiftState(shiftState);
-    } catch (error) {
-      setErr(error instanceof Error ? error.message : "Failed to load shift state");
-      setShiftId(null);
-      setStartTime(null);
-      setShiftState(null);
+    const scope = getOfflineMutationScope();
+    if (!navigator.onLine && scope) {
+      applyState(await getCachedMobileShiftState(scope));
+      return;
     }
-  }, [userId]);
+
+    try {
+      const next = await fetchMobileShiftState();
+      applyState(next.shiftId ? next : null);
+      if (scope && next.shiftId)
+        await saveCachedMobileShiftState({ scope, state: next });
+    } catch (error) {
+      const cached = scope ? await getCachedMobileShiftState(scope) : null;
+      if (cached) {
+        applyState(cached);
+        setErr("Using the shift state saved on this device.");
+      } else {
+        setErr(
+          error instanceof Error ? error.message : "Failed to load shift state",
+        );
+        applyState(null);
+      }
+    }
+  }, [userId, applyState]);
 
   useEffect(() => {
     void loadOpenShift();
@@ -76,117 +87,84 @@ export default function MobileShiftTracker({ userId }: Props) {
 
   useEffect(() => {
     if (typeof navigator === "undefined") return;
+    setOnline(navigator.onLine);
     if (navigator.onLine) {
-      void replayOfflineMutations();
+      void replayOfflineMutations().then(loadOpenShift);
     }
-    const onOnline = () => void replayOfflineMutations();
+    const onOnline = () => {
+      setOnline(true);
+      void replayOfflineMutations().then(loadOpenShift);
+    };
+    const onOffline = () => setOnline(false);
     window.addEventListener("online", onOnline);
-    return () => window.removeEventListener("online", onOnline);
-  }, [replayOfflineMutations]);
+    window.addEventListener("offline", onOffline);
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+    };
+  }, [replayOfflineMutations, loadOpenShift]);
 
-  const startShift = useCallback(async () => {
-    if (busy || !userId) return;
-    setBusy(true);
-    setErr(null);
+  const performAction = useCallback(
+    async (action: MobileShiftAction) => {
+      if (busy || !userId) return;
+      setBusy(true);
+      setErr(null);
 
-    try {
-      const res = await fetch("/api/mobile/shifts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "start_shift" }),
-      });
-      const body = (await res.json().catch(() => null)) as
-        | ({ ok?: boolean; error?: string } & Partial<MobileShiftState>)
-        | null;
-      if (!res.ok || !body?.ok) throw new Error(body?.error ?? "Failed to start shift");
+      try {
+        const result = await runMobileShiftAction({
+          action,
+          current: shiftState,
+        });
+        applyState(result.state);
+        if (result.queued)
+          setErr("Shift update saved on this device and queued.");
+        if (action === "end_shift")
+          window.dispatchEvent(new CustomEvent("wol:refresh"));
+      } catch (error) {
+        setErr(
+          error instanceof Error ? error.message : "Failed to update shift",
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, userId, shiftState, applyState],
+  );
 
-      setShiftId(body.shiftId ?? null);
-      setStartTime(body.startTime ?? null);
-      setShiftState({ shiftId: body.shiftId ?? null, shiftStatus: body.shiftStatus ?? null, activity: body.activity ?? "working", startTime: body.startTime ?? null, endTime: body.endTime ?? null, latestEventType: body.latestEventType ?? null, latestEventAt: body.latestEventAt ?? null, mode: body.mode ?? modeFromActivity(body.activity, body.shiftStatus) });
-    } catch (e: any) {
-      setErr(`${e?.code ? e.code + ": " : ""}${e?.message ?? "Failed to start shift"}`);
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, userId]);
+  const startShift = useCallback(
+    () => performAction("start_shift"),
+    [performAction],
+  );
 
   const endShift = useCallback(async () => {
     if (busy || !shiftId) return;
-    setBusy(true);
-    setErr(null);
-
-    try {
-      const res = await fetch("/api/mobile/shifts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "end_shift" }),
-      });
-      const body = (await res.json().catch(() => null)) as
-        | ({ ok?: boolean; error?: string } & Partial<MobileShiftState>)
-        | null;
-      if (!res.ok || !body?.ok) throw new Error(body?.error ?? "Failed to end shift");
-      window.dispatchEvent(new CustomEvent("wol:refresh"));
-
-      setShiftId(body.shiftId ?? null);
-      setStartTime(body.startTime ?? null);
-      setShiftState({ shiftId: body.shiftId ?? null, shiftStatus: body.shiftStatus ?? "completed", activity: body.activity ?? "off_shift", startTime: body.startTime ?? null, endTime: body.endTime ?? null, latestEventType: body.latestEventType ?? "end_shift", latestEventAt: body.latestEventAt ?? null, mode: body.mode ?? modeFromActivity(body.activity, body.shiftStatus) });
-    } catch (e: any) {
-      setErr(`${e?.code ? e.code + ": " : ""}${e?.message ?? "Failed to end shift"}`);
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, shiftId]);
+    await performAction("end_shift");
+  }, [busy, shiftId, performAction]);
 
   const toggleBreak = useCallback(async () => {
     if (busy || !shiftId) return;
-    setBusy(true);
-    setErr(null);
-
-    try {
-      const res = await fetch("/api/mobile/shifts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: shiftState?.activity === "on_break" ? "end_break" : "start_break" }),
-      });
-      const body = (await res.json().catch(() => null)) as
-        | ({ ok?: boolean; error?: string } & Partial<MobileShiftState>)
-        | null;
-      if (!res.ok || !body?.ok) throw new Error(body?.error ?? "Failed to toggle break");
-      setShiftState({ shiftId: body.shiftId ?? null, shiftStatus: body.shiftStatus ?? null, activity: body.activity ?? "working", startTime: body.startTime ?? null, endTime: body.endTime ?? null, latestEventType: body.latestEventType ?? null, latestEventAt: body.latestEventAt ?? null, mode: body.mode ?? modeFromActivity(body.activity, body.shiftStatus) });
-    } catch (e: any) {
-      setErr(`${e?.code ? e.code + ": " : ""}${e?.message ?? "Failed to toggle break"}`);
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, shiftId, shiftState?.activity]);
+    await performAction(
+      shiftState?.activity === "on_break" ? "end_break" : "start_break",
+    );
+  }, [busy, shiftId, shiftState?.activity, performAction]);
 
   const toggleLunch = useCallback(async () => {
     if (busy || !shiftId) return;
-    setBusy(true);
-    setErr(null);
-
-    try {
-      const res = await fetch("/api/mobile/shifts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: shiftState?.activity === "on_lunch" ? "end_lunch" : "start_lunch" }),
-      });
-      const body = (await res.json().catch(() => null)) as
-        | ({ ok?: boolean; error?: string } & Partial<MobileShiftState>)
-        | null;
-      if (!res.ok || !body?.ok) throw new Error(body?.error ?? "Failed to toggle lunch");
-      setShiftState({ shiftId: body.shiftId ?? null, shiftStatus: body.shiftStatus ?? null, activity: body.activity ?? "working", startTime: body.startTime ?? null, endTime: body.endTime ?? null, latestEventType: body.latestEventType ?? null, latestEventAt: body.latestEventAt ?? null, mode: body.mode ?? modeFromActivity(body.activity, body.shiftStatus) });
-    } catch (e: any) {
-      setErr(`${e?.code ? e.code + ": " : ""}${e?.message ?? "Failed to toggle lunch"}`);
-    } finally {
-      setBusy(false);
-    }
-  }, [busy, shiftId, shiftState?.activity]);
+    await performAction(
+      shiftState?.activity === "on_lunch" ? "end_lunch" : "start_lunch",
+    );
+  }, [busy, shiftId, shiftState?.activity, performAction]);
 
   const activity = shiftState?.activity ?? "off_shift";
   const mode = shiftState?.mode ?? "none";
   const niceStatus =
-    activity === "off_shift" ? "Off shift" : activity === "working" ? "Working" : activity === "on_break" ? "On break" : "On lunch";
+    activity === "off_shift"
+      ? "Off shift"
+      : activity === "working"
+        ? "Working"
+        : activity === "on_break"
+          ? "On break"
+          : "On lunch";
 
   const btnBase =
     "rounded-xl px-3 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.18em] transition-colors disabled:opacity-60 disabled:cursor-not-allowed";
@@ -206,8 +184,8 @@ export default function MobileShiftTracker({ userId }: Props) {
         syncSummary.syncing > 0 ||
         syncSummary.conflicted > 0) && (
         <div className="rounded-md border border-amber-400/35 bg-amber-500/10 px-2 py-1 text-[0.65rem] text-amber-100">
-          Sync queue • Pending {syncSummary.queued + syncSummary.syncing} • Failed{" "}
-          {syncSummary.failed} • Conflicted {syncSummary.conflicted}
+          Sync queue • Pending {syncSummary.queued + syncSummary.syncing} •
+          Failed {syncSummary.failed} • Conflicted {syncSummary.conflicted}
         </div>
       )}
 
@@ -220,12 +198,25 @@ export default function MobileShiftTracker({ userId }: Props) {
       {mode !== "none" && startTime && mode !== "ended" && (
         <div className="space-y-1 text-[0.65rem] text-[color:var(--theme-text-secondary)]">
           <p>
-            Started <span className="font-mono text-[color:var(--theme-text-primary)]">{new Date(startTime).toLocaleTimeString()}</span>
+            Started{" "}
+            <span className="font-mono text-[color:var(--theme-text-primary)]">
+              {new Date(startTime).toLocaleTimeString()}
+            </span>
           </p>
           <p>
-            Elapsed <span className="font-mono text-[color:var(--theme-text-primary)]">{formatDistanceToNow(new Date(startTime), { includeSeconds: true })}</span>
+            Elapsed{" "}
+            <span className="font-mono text-[color:var(--theme-text-primary)]">
+              {formatDistanceToNow(new Date(startTime), {
+                includeSeconds: true,
+              })}
+            </span>
           </p>
-          <p>Activity <span className="text-[color:var(--theme-text-primary)]">{niceStatus}</span></p>
+          <p>
+            Activity{" "}
+            <span className="text-[color:var(--theme-text-primary)]">
+              {niceStatus}
+            </span>
+          </p>
         </div>
       )}
 
@@ -233,7 +224,7 @@ export default function MobileShiftTracker({ userId }: Props) {
         <button
           type="button"
           onClick={startShift}
-          disabled={busy}
+          disabled={busy || !online}
           className={
             btnBase +
             " w-full border border-[var(--accent-copper-soft)] " +
@@ -241,7 +232,11 @@ export default function MobileShiftTracker({ userId }: Props) {
             "text-[color:var(--theme-text-primary)] shadow-[0_0_22px_rgba(248,113,22,0.55)] hover:bg-[rgba(248,113,22,0.25)]"
           }
         >
-          {busy ? "Starting…" : "Start shift"}
+          {busy
+            ? "Starting…"
+            : online
+              ? "Start shift"
+              : "Connect to start shift"}
         </button>
       )}
 

--- a/features/mobile/shifts/offline.ts
+++ b/features/mobile/shifts/offline.ts
@@ -1,0 +1,186 @@
+"use client";
+
+import {
+  getOfflineSnapshot,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import {
+  getOfflineMutationScope,
+  runMutationWithOfflineQueue,
+  type OfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+import type { MobileShiftState } from "@/features/mobile/shifts/client";
+
+export type MobileShiftAction =
+  | "start_shift"
+  | "end_shift"
+  | "start_break"
+  | "end_break"
+  | "start_lunch"
+  | "end_lunch";
+
+const KIND = "mobile-shift-state";
+const ENTITY_ID = "current";
+
+function eventType(action: MobileShiftAction): string {
+  const events: Record<MobileShiftAction, string> = {
+    start_shift: "start_shift",
+    end_shift: "end_shift",
+    start_break: "break_start",
+    end_break: "break_end",
+    start_lunch: "lunch_start",
+    end_lunch: "lunch_end",
+  };
+  return events[action];
+}
+
+function operationKey(action: MobileShiftAction): string {
+  const id =
+    typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `shift:${action}:${id}`;
+}
+
+function optimisticState(
+  current: MobileShiftState,
+  action: MobileShiftAction,
+  occurredAt: string,
+): MobileShiftState {
+  if (action === "end_shift") {
+    return {
+      ...current,
+      shiftStatus: "completed",
+      activity: "off_shift",
+      endTime: occurredAt,
+      latestEventType: "end_shift",
+      latestEventAt: occurredAt,
+      mode: "ended",
+    };
+  }
+  if (action === "start_break" || action === "end_break") {
+    const starting = action === "start_break";
+    return {
+      ...current,
+      activity: starting ? "on_break" : "working",
+      latestEventType: starting ? "break_start" : "break_end",
+      latestEventAt: occurredAt,
+      mode: starting ? "break" : "shift",
+    };
+  }
+  if (action === "start_lunch" || action === "end_lunch") {
+    const starting = action === "start_lunch";
+    return {
+      ...current,
+      activity: starting ? "on_lunch" : "working",
+      latestEventType: starting ? "lunch_start" : "lunch_end",
+      latestEventAt: occurredAt,
+      mode: starting ? "lunch" : "shift",
+    };
+  }
+  return current;
+}
+
+export async function saveCachedMobileShiftState(args: {
+  scope: OfflineMutationScope;
+  state: MobileShiftState;
+}): Promise<void> {
+  await saveOfflineSnapshot({
+    scope: args.scope,
+    kind: KIND,
+    entityId: ENTITY_ID,
+    data: args.state,
+  });
+}
+
+export async function getCachedMobileShiftState(
+  scope: OfflineMutationScope,
+): Promise<MobileShiftState | null> {
+  const snapshot = await getOfflineSnapshot<MobileShiftState>({
+    scope,
+    kind: KIND,
+    entityId: ENTITY_ID,
+  });
+  return snapshot?.data ?? null;
+}
+
+async function postShiftAction(
+  action: MobileShiftAction,
+  key: string,
+): Promise<MobileShiftState> {
+  const response = await fetch("/api/mobile/shifts", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": key,
+    },
+    body: JSON.stringify({ action, operationKey: key }),
+  });
+  const body = (await response.json().catch(() => null)) as
+    | ({ ok?: boolean; error?: string } & Partial<MobileShiftState>)
+    | null;
+  if (!response.ok || !body?.ok) {
+    const error = new Error(
+      body?.error ?? "Failed to update shift",
+    ) as Error & {
+      status?: number;
+    };
+    error.status = response.status;
+    throw error;
+  }
+  return {
+    shiftId: body.shiftId ?? null,
+    shiftStatus: body.shiftStatus ?? null,
+    activity: body.activity ?? "off_shift",
+    startTime: body.startTime ?? null,
+    endTime: body.endTime ?? null,
+    latestEventType: body.latestEventType ?? null,
+    latestEventAt: body.latestEventAt ?? null,
+    mode: body.mode ?? "none",
+  };
+}
+
+export async function runMobileShiftAction(args: {
+  action: MobileShiftAction;
+  current: MobileShiftState | null;
+}): Promise<{
+  state: MobileShiftState;
+  queued: boolean;
+  conflicted: boolean;
+}> {
+  const scope = getOfflineMutationScope();
+  const key = operationKey(args.action);
+
+  if (args.action === "start_shift") {
+    if (!navigator.onLine) {
+      throw new Error("Starting a new shift requires a connection.");
+    }
+    const state = await postShiftAction(args.action, key);
+    if (scope) await saveCachedMobileShiftState({ scope, state });
+    return { state, queued: false, conflicted: false };
+  }
+  if (!scope) throw new Error("Offline shop scope is unavailable.");
+  if (!args.current?.shiftId) throw new Error("No active shift is available.");
+
+  const occurredAt = new Date().toISOString();
+  let serverState: MobileShiftState | null = null;
+  const result = await runMutationWithOfflineQueue({
+    clientMutationId: key,
+    actionType: "shift:punch-event",
+    payload: {
+      shift_id: args.current.shiftId,
+      event_type: eventType(args.action),
+      timestamp: occurredAt,
+      operationKey: key,
+    },
+    orderKey: `${args.current.shiftId}:shift:${occurredAt}:${key}`,
+    scope,
+    runner: async () => {
+      serverState = await postShiftAction(args.action, key);
+    },
+  });
+  const state =
+    serverState ?? optimisticState(args.current, args.action, occurredAt);
+  await saveCachedMobileShiftState({ scope, state });
+  return { state, ...result };
+}

--- a/features/work-orders/components/workorders/CauseCorrectionModal.tsx
+++ b/features/work-orders/components/workorders/CauseCorrectionModal.tsx
@@ -18,6 +18,7 @@ interface CauseCorrectionModalProps {
 
   /** ✅ Draft save (cause/correction can be partial) */
   onSaveDraft?: (cause: string, correction: string) => Promise<void>;
+  onDraftChange?: (cause: string, correction: string) => void;
 
   initialCause?: string;
   initialCorrection?: string;
@@ -30,6 +31,7 @@ export default function CauseCorrectionModal({
   lineLabel,
   onSubmit,
   onSaveDraft,
+  onDraftChange,
   initialCause = "",
   initialCorrection = "",
 }: CauseCorrectionModalProps) {
@@ -124,7 +126,8 @@ export default function CauseCorrectionModal({
             Job completion story
           </div>
           <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Capture what failed and exactly what was done so this line is complete, searchable, and useful later.
+            Capture what failed and exactly what was done so this line is
+            complete, searchable, and useful later.
           </div>
         </div>
         <div className="flex items-center justify-between text-[0.7rem] text-[color:var(--theme-text-secondary)]">
@@ -177,7 +180,9 @@ export default function CauseCorrectionModal({
             className="w-full rounded-lg border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] outline-none transition focus:border-[var(--accent-copper-soft)] focus:ring-2 focus:ring-[var(--accent-copper-soft)]/60"
             value={cause}
             onChange={(e) => {
-              setCause(e.target.value);
+              const next = e.target.value;
+              setCause(next);
+              onDraftChange?.(next, correction);
               if (error) setError(null);
               if (ok) setOk(null);
             }}
@@ -194,7 +199,9 @@ export default function CauseCorrectionModal({
             className="w-full rounded-lg border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] outline-none transition focus:border-[var(--accent-copper-soft)] focus:ring-2 focus:ring-[var(--accent-copper-soft)]/60"
             value={correction}
             onChange={(e) => {
-              setCorrection(e.target.value);
+              const next = e.target.value;
+              setCorrection(next);
+              onDraftChange?.(cause, next);
               if (error) setError(null);
               if (ok) setOk(null);
             }}

--- a/features/work-orders/lib/jobPunchTransitionsClient.ts
+++ b/features/work-orders/lib/jobPunchTransitionsClient.ts
@@ -42,11 +42,14 @@ export async function runJobPunchTransition(
   options?: JobPunchTransitionOptions,
 ): Promise<void> {
   const suppliedKey = options?.operationKey?.trim();
-  const operationKey = suppliedKey || createJobPunchOperationKey(lineId, action);
+  const operationKey =
+    suppliedKey || createJobPunchOperationKey(lineId, action);
+  const occurredAt = new Date().toISOString();
   const payload = {
     ...(body ?? {}),
     operationKey,
     idempotencyKey: operationKey,
+    occurredAt,
   };
 
   const post = async () => {
@@ -59,8 +62,12 @@ export async function runJobPunchTransition(
       body: JSON.stringify(payload),
     });
     if (res.ok) return;
-    const responsePayload = (await res.json().catch(() => null)) as ApiError | null;
-    const error = new Error(responsePayload?.error ?? `Failed to ${action} job`) as Error & {
+    const responsePayload = (await res
+      .json()
+      .catch(() => null)) as ApiError | null;
+    const error = new Error(
+      responsePayload?.error ?? `Failed to ${action} job`,
+    ) as Error & {
       status?: number;
     };
     error.status = res.status;
@@ -75,7 +82,7 @@ export async function runJobPunchTransition(
   await runMutationWithOfflineQueue({
     clientMutationId: operationKey,
     actionType: "job:punch-transition",
-    payload: { lineId, action, body: payload, operationKey },
+    payload: { lineId, action, body: payload, operationKey, occurredAt },
     orderKey: `${lineId}:job-punch:${operationKey}`,
     scope,
     runner: post,

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -43,6 +43,12 @@ import {
 } from "@/features/work-orders/lib/display/workOrderParts";
 
 import VehicleHistoryModal from "@/features/work-orders/components/workorders/VehicleHistoryModal";
+import {
+  clearTechnicianJobEditorDraftFields,
+  findProjectedTechnicianJob,
+  getTechnicianJobEditorDraft,
+  saveTechnicianJobEditorDraft,
+} from "@/features/work-orders/mobile/technicianOfflineExecution";
 
 import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
@@ -301,14 +307,54 @@ export default function MobileFocusedJob(props: {
     [supabase, loadVehicle, loadCustomer],
   );
 
+  const loadOfflineJob = useCallback(
+    async (id: string): Promise<boolean> => {
+      const scope = getOfflineMutationScope();
+      if (!scope) return false;
+      const cached = await findProjectedTechnicianJob({ scope, lineId: id });
+      if (!cached) return false;
+
+      setLine(cached.line);
+      setWorkOrder(cached.snapshot.workOrder);
+      setVehicle(cached.snapshot.vehicle);
+      setCustomer(cached.snapshot.customer);
+      const editorDraft = await getTechnicianJobEditorDraft({
+        scope,
+        lineId: id,
+      });
+      if (editorDraft?.notes != null) {
+        setTechNotes(editorDraft.notes);
+        setNotesDirty(true);
+      } else if (!notesDirty) {
+        setTechNotes(cached.line.notes ?? "");
+      }
+      if (editorDraft?.cause != null) setPrefillCause(editorDraft.cause);
+      else setPrefillCause(cached.line.cause ?? "");
+      if (editorDraft?.correction != null)
+        setPrefillCorrection(editorDraft.correction);
+      else setPrefillCorrection(cached.line.correction ?? "");
+      return true;
+    },
+    [notesDirty],
+  );
+
   const loadLine = useCallback(
     async (id: string) => {
+      if (!navigator.onLine) {
+        if (!(await loadOfflineJob(id))) {
+          throw new Error("No downloaded copy of this job is available.");
+        }
+        return;
+      }
       const { data: l, error: le } = await supabase
         .from("work_order_lines")
         .select("*")
         .eq("id", id)
         .maybeSingle<WorkOrderLine>();
-      if (le) throw le;
+      if (le) {
+        if (await loadOfflineJob(id)) return;
+        throw le;
+      }
 
       setLine(l ?? null);
 
@@ -319,11 +365,16 @@ export default function MobileFocusedJob(props: {
 
       await loadWorkOrder(l?.work_order_id ?? null);
     },
-    [supabase, loadWorkOrder, notesDirty],
+    [supabase, loadWorkOrder, loadOfflineJob, notesDirty],
   );
 
   const loadAllocations = useCallback(async () => {
     if (!workOrderLineId) return;
+    if (!navigator.onLine) {
+      setAllocs([]);
+      setRequiredParts([]);
+      return;
+    }
     setAllocsLoading(true);
     try {
       let allocBuilder = supabase
@@ -359,6 +410,27 @@ export default function MobileFocusedJob(props: {
       setAllocsLoading(false);
     }
   }, [supabase, workOrder?.id, workOrder?.shop_id, workOrderLineId]);
+
+  useEffect(() => {
+    if (!notesDirty || !workOrderLineId) return;
+    const scope = getOfflineMutationScope();
+    if (!scope) return;
+    const timer = window.setTimeout(() => {
+      void getTechnicianJobEditorDraft({ scope, lineId: workOrderLineId }).then(
+        (existing) =>
+          saveTechnicianJobEditorDraft({
+            scope,
+            draft: {
+              ...existing,
+              lineId: workOrderLineId,
+              notes: techNotes,
+              updatedAt: new Date().toISOString(),
+            },
+          }),
+      );
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [notesDirty, techNotes, workOrderLineId]);
 
   const refresh = useCallback(async () => {
     if (!workOrderLineId) return;
@@ -728,11 +800,27 @@ export default function MobileFocusedJob(props: {
         return;
       }
       if (result.queued) {
+        const scope = getOfflineMutationScope();
+        if (scope)
+          await clearTechnicianJobEditorDraftFields({
+            scope,
+            lineId: workOrderLineId,
+            fields: ["notes"],
+          });
+        setNotesDirty(false);
+        await loadOfflineJob(workOrderLineId);
         toast.warning("Notes queued for retry when back online.");
         return;
       }
 
       toast.success("Notes saved");
+      const scope = getOfflineMutationScope();
+      if (scope)
+        await clearTechnicianJobEditorDraftFields({
+          scope,
+          lineId: workOrderLineId,
+          fields: ["notes"],
+        });
       setNotesDirty(false);
       await refresh();
     } catch (error) {
@@ -1357,9 +1445,30 @@ export default function MobileFocusedJob(props: {
           lineLabel={lineLabel}
           initialCause={prefillCause}
           initialCorrection={prefillCorrection}
+          onDraftChange={(cause, correction) => {
+            const scope = getOfflineMutationScope();
+            if (!scope) return;
+            void getTechnicianJobEditorDraft({
+              scope,
+              lineId: line.id,
+            }).then((existing) =>
+              saveTechnicianJobEditorDraft({
+                scope,
+                draft: {
+                  ...existing,
+                  lineId: line.id,
+                  cause,
+                  correction,
+                  updatedAt: new Date().toISOString(),
+                },
+              }),
+            );
+          }}
           onSubmit={async (cause: string, correction: string) => {
             try {
-              const conflict = await getLineConflict(line.id, "finish");
+              const conflict = navigator.onLine
+                ? await getLineConflict(line.id, "finish")
+                : null;
               if (conflict) {
                 toast.error(conflict);
                 return;
@@ -1368,6 +1477,13 @@ export default function MobileFocusedJob(props: {
                 cause,
                 correction,
               });
+              const scope = getOfflineMutationScope();
+              if (scope)
+                await clearTechnicianJobEditorDraftFields({
+                  scope,
+                  lineId: line.id,
+                  fields: ["cause", "correction"],
+                });
             } catch (error) {
               return showErr("Complete job failed", error as { message?: string });
             }
@@ -1406,10 +1522,25 @@ export default function MobileFocusedJob(props: {
               return;
             }
             if (result.queued) {
+              const scope = getOfflineMutationScope();
+              if (scope)
+                await clearTechnicianJobEditorDraftFields({
+                  scope,
+                  lineId: line.id,
+                  fields: ["cause", "correction"],
+                });
+              await loadOfflineJob(line.id);
               toast.warning("Story queued for sync when back online.");
               return;
             }
 
+            const scope = getOfflineMutationScope();
+            if (scope)
+              await clearTechnicianJobEditorDraftFields({
+                scope,
+                lineId: line.id,
+                fields: ["cause", "correction"],
+              });
             toast.success("Story saved");
             await refresh();
           }}

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -39,10 +39,11 @@ import {
   setOfflineMutationScope,
   subscribeOfflineMutations,
 } from "@/features/shared/lib/offline/mutations";
+import { saveOfflineSnapshot } from "@/features/shared/lib/offline/database";
 import {
-  getOfflineSnapshot,
-  saveOfflineSnapshot,
-} from "@/features/shared/lib/offline/database";
+  loadProjectedWorkOrderSnapshot,
+  type MobileWorkOrderSnapshot,
+} from "@/features/work-orders/mobile/technicianOfflineExecution";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -54,15 +55,6 @@ type WorkOrderQuoteLine =
 type WorkOrderQuoteLineWithLineId = WorkOrderQuoteLine & {
   work_order_line_id?: string | null;
 };
-type MobileWorkOrderSnapshot = {
-  workOrder: WorkOrder;
-  lines: WorkOrderLine[];
-  quoteLines: WorkOrderQuoteLine[];
-  vehicle: Vehicle | null;
-  customer: Customer | null;
-  techNamesById: Record<string, string>;
-};
-
 // 🔹 Extra metadata shape for inspection template ids (mirrors desktop logic)
 type WorkOrderLineWithInspectionMeta = WorkOrderLine & {
   inspection_template_id?: string | null;
@@ -334,18 +326,17 @@ export default function MobileWorkOrderClient({
       const scope = currentUserId && shopId ? { userId: currentUserId, shopId } : null;
       const loadCached = async (): Promise<boolean> => {
         if (!scope) return false;
-        const cached = await getOfflineSnapshot<MobileWorkOrderSnapshot>({
+        const cached = await loadProjectedWorkOrderSnapshot({
           scope,
-          kind: "mobile-work-order-detail",
           entityId: routeId,
         });
         if (!cached) return false;
-        setWo(cached.data.workOrder);
-        setLines(cached.data.lines);
-        setQuoteLines(cached.data.quoteLines);
-        setVehicle(cached.data.vehicle);
-        setCustomer(cached.data.customer);
-        setTechNamesById(cached.data.techNamesById);
+        setWo(cached.workOrder);
+        setLines(cached.lines);
+        setQuoteLines(cached.quoteLines);
+        setVehicle(cached.vehicle);
+        setCustomer(cached.customer);
+        setTechNamesById(cached.techNamesById);
         setViewError("Offline copy · changes may be newer on the server.");
         return true;
       };
@@ -492,7 +483,7 @@ export default function MobileWorkOrderClient({
           ),
         );
 
-        let techMap: Record<string, string> = {};
+        const techMap: Record<string, string> = {};
         if (techIds.length > 0) {
           const { data: techProfiles, error: techErr } = await supabase
             .from("profiles")
@@ -578,6 +569,11 @@ export default function MobileWorkOrderClient({
   useEffect(() => {
     if (!routeId || !currentUserId) return;
     void fetchAll();
+  }, [fetchAll, routeId, currentUserId]);
+
+  useEffect(() => {
+    if (!routeId || !currentUserId) return;
+    return subscribeOfflineMutations(() => void fetchAll());
   }, [fetchAll, routeId, currentUserId]);
 
   /* ---------------------- REALTIME ---------------------- */

--- a/features/work-orders/mobile/technicianOfflineDownload.ts
+++ b/features/work-orders/mobile/technicianOfflineDownload.ts
@@ -11,6 +11,32 @@ import type { TechnicianOfflineBundle } from "@/features/work-orders/mobile/tech
 
 const BUNDLE_KIND = "technician-assigned-work";
 const BUNDLE_ID = "current";
+const TECHNICIAN_SHELL_CACHE = "profixiq-technician-shell-v1";
+
+async function cacheTechnicianRouteShells(
+  bundle: TechnicianOfflineBundle,
+): Promise<void> {
+  if (typeof caches === "undefined" || !navigator.serviceWorker?.controller)
+    return;
+  const cache = await caches.open(TECHNICIAN_SHELL_CACHE);
+  const urls = bundle.workOrders.flatMap((item) => [
+    `/mobile/work-orders/${item.workOrder.id}?mode=tech`,
+    ...item.assignedLineIds.map(
+      (lineId) =>
+        `/mobile/work-orders/${item.workOrder.id}?mode=tech&focus=${lineId}`,
+    ),
+    ...item.assignedLineIds.map((lineId) => `/mobile/jobs/${lineId}`),
+  ]);
+  await Promise.all(
+    urls.map(async (url) => {
+      const response = await fetch(url, {
+        credentials: "include",
+        headers: { Accept: "text/html" },
+      });
+      if (response.ok) await cache.put(url, response.clone());
+    }),
+  );
+}
 
 export async function cacheTechnicianOfflineBundle(
   bundle: TechnicianOfflineBundle,
@@ -90,6 +116,7 @@ export async function downloadAssignedTechnicianWork(args: {
     throw new Error("Downloaded work does not match the active user and shop.");
   }
   await cacheTechnicianOfflineBundle(result);
+  await cacheTechnicianRouteShells(result);
   return result;
 }
 

--- a/features/work-orders/mobile/technicianOfflineExecution.ts
+++ b/features/work-orders/mobile/technicianOfflineExecution.ts
@@ -1,0 +1,218 @@
+"use client";
+
+import {
+  getOfflineSnapshot,
+  listOfflineSnapshots,
+  removeOfflineSnapshots,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import {
+  hydrateOfflineMutationQueue,
+  listPendingMutations,
+  type OfflineMutationScope,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type QuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
+type Customer = DB["public"]["Tables"]["customers"]["Row"];
+
+export type MobileWorkOrderSnapshot = {
+  workOrder: WorkOrder;
+  lines: WorkOrderLine[];
+  quoteLines: QuoteLine[];
+  vehicle: Vehicle | null;
+  customer: Customer | null;
+  techNamesById: Record<string, string>;
+};
+
+export type TechnicianJobEditorDraft = {
+  lineId: string;
+  notes?: string;
+  cause?: string;
+  correction?: string;
+  updatedAt: string;
+};
+
+const DETAIL_KIND = "mobile-work-order-detail";
+const DRAFT_KIND = "technician-job-draft";
+const DRAFT_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 14;
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function text(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function projectLine(
+  line: WorkOrderLine,
+  mutation: PendingMutation,
+): WorkOrderLine {
+  const payload = record(mutation.payload);
+  if (
+    mutation.actionType === "update_work_order_line_notes" &&
+    text(payload.workOrderLineId) === line.id
+  ) {
+    return { ...line, notes: text(payload.notes) ?? "" };
+  }
+  if (
+    mutation.actionType === "save_story_draft" &&
+    text(payload.lineId) === line.id
+  ) {
+    return {
+      ...line,
+      cause: text(payload.cause) ?? "",
+      correction: text(payload.correction) ?? "",
+    };
+  }
+  if (
+    mutation.actionType !== "job:punch-transition" ||
+    text(payload.lineId) !== line.id
+  ) {
+    return line;
+  }
+
+  const action = text(payload.action);
+  const body = record(payload.body);
+  const occurredAt =
+    text(payload.occurredAt) ?? text(body.occurredAt) ?? mutation.createdAt;
+  if (action === "start" || action === "resume") {
+    return {
+      ...line,
+      status: "in_progress",
+      punched_in_at: occurredAt,
+      punched_out_at: null,
+      hold_reason: null,
+    };
+  }
+  if (action === "pause") {
+    return {
+      ...line,
+      status: "on_hold",
+      punched_out_at: occurredAt,
+      hold_reason: text(body.holdReason) ?? line.hold_reason,
+    };
+  }
+  if (action === "finish") {
+    return {
+      ...line,
+      status: "completed",
+      punched_out_at: occurredAt,
+      cause: text(body.cause) ?? line.cause,
+      correction: text(body.correction) ?? line.correction,
+    };
+  }
+  return line;
+}
+
+export function projectTechnicianWorkOrderSnapshot(
+  snapshot: MobileWorkOrderSnapshot,
+  mutations: PendingMutation[],
+): MobileWorkOrderSnapshot {
+  return {
+    ...snapshot,
+    lines: snapshot.lines.map((line) => mutations.reduce(projectLine, line)),
+  };
+}
+
+export async function loadProjectedWorkOrderSnapshot(args: {
+  scope: OfflineMutationScope;
+  entityId: string;
+}): Promise<MobileWorkOrderSnapshot | null> {
+  await hydrateOfflineMutationQueue();
+  const snapshot = await getOfflineSnapshot<MobileWorkOrderSnapshot>({
+    scope: args.scope,
+    kind: DETAIL_KIND,
+    entityId: args.entityId,
+  });
+  return snapshot
+    ? projectTechnicianWorkOrderSnapshot(
+        snapshot.data,
+        listPendingMutations(args.scope),
+      )
+    : null;
+}
+
+export async function findProjectedTechnicianJob(args: {
+  scope: OfflineMutationScope;
+  lineId: string;
+}): Promise<{
+  snapshot: MobileWorkOrderSnapshot;
+  line: WorkOrderLine;
+} | null> {
+  await hydrateOfflineMutationQueue();
+  const snapshots = await listOfflineSnapshots<MobileWorkOrderSnapshot>({
+    scope: args.scope,
+    kind: DETAIL_KIND,
+  });
+  const pending = listPendingMutations(args.scope);
+  for (const stored of snapshots) {
+    const projected = projectTechnicianWorkOrderSnapshot(stored.data, pending);
+    const line = projected.lines.find((item) => item.id === args.lineId);
+    if (line) return { snapshot: projected, line };
+  }
+  return null;
+}
+
+export async function getTechnicianJobEditorDraft(args: {
+  scope: OfflineMutationScope;
+  lineId: string;
+}): Promise<TechnicianJobEditorDraft | null> {
+  const stored = await getOfflineSnapshot<TechnicianJobEditorDraft>({
+    scope: args.scope,
+    kind: DRAFT_KIND,
+    entityId: args.lineId,
+  });
+  return stored?.data ?? null;
+}
+
+export async function saveTechnicianJobEditorDraft(args: {
+  scope: OfflineMutationScope;
+  draft: TechnicianJobEditorDraft;
+}): Promise<void> {
+  await saveOfflineSnapshot({
+    scope: args.scope,
+    kind: DRAFT_KIND,
+    entityId: args.draft.lineId,
+    data: args.draft,
+    maxAgeMs: DRAFT_MAX_AGE_MS,
+  });
+}
+
+export async function removeTechnicianJobEditorDraft(args: {
+  scope: OfflineMutationScope;
+  lineId: string;
+}): Promise<void> {
+  await removeOfflineSnapshots({
+    scope: args.scope,
+    kind: DRAFT_KIND,
+    entityIds: [args.lineId],
+  });
+}
+
+export async function clearTechnicianJobEditorDraftFields(args: {
+  scope: OfflineMutationScope;
+  lineId: string;
+  fields: Array<"notes" | "cause" | "correction">;
+}): Promise<void> {
+  const existing = await getTechnicianJobEditorDraft(args);
+  if (!existing) return;
+  const next = { ...existing };
+  for (const field of args.fields) delete next[field];
+  if (next.notes == null && next.cause == null && next.correction == null) {
+    await removeTechnicianJobEditorDraft(args);
+    return;
+  }
+  await saveTechnicianJobEditorDraft({
+    scope: args.scope,
+    draft: { ...next, updatedAt: new Date().toISOString() },
+  });
+}

--- a/supabase/migrations/20260716220000_offline_shift_end_state.sql
+++ b/supabase/migrations/20260716220000_offline_shift_end_state.sql
@@ -1,0 +1,41 @@
+create or replace function public.finalize_shift_from_end_punch()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.event_type::text = 'end_shift' then
+    update public.tech_shifts
+    set status = 'completed',
+        end_time = coalesce(end_time, new.timestamp)
+    where id = new.shift_id
+      and (status <> 'completed' or end_time is null);
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists punch_events_finalize_shift on public.punch_events;
+create trigger punch_events_finalize_shift
+after insert on public.punch_events
+for each row
+when (new.event_type::text = 'end_shift')
+execute function public.finalize_shift_from_end_punch();
+
+revoke all on function public.finalize_shift_from_end_punch() from public, anon;
+grant execute on function public.finalize_shift_from_end_punch() to authenticated, service_role;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgname = 'punch_events_finalize_shift'
+      and tgrelid = 'public.punch_events'::regclass
+      and not tgisinternal
+  ) then
+    raise exception 'punch_events_finalize_shift trigger was not created';
+  end if;
+end;
+$$;

--- a/tests/technician-offline-execution.test.ts
+++ b/tests/technician-offline-execution.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { projectTechnicianWorkOrderSnapshot } from "@/features/work-orders/mobile/technicianOfflineExecution";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("technician offline execution", () => {
+  it("projects queued notes, story, and punch state over the downloaded line", () => {
+    const snapshot = {
+      workOrder: { id: "wo-1" },
+      lines: [
+        {
+          id: "line-1",
+          notes: "server notes",
+          cause: null,
+          correction: null,
+          status: "awaiting",
+          punched_in_at: null,
+          punched_out_at: null,
+          hold_reason: null,
+        },
+      ],
+      quoteLines: [],
+      vehicle: null,
+      customer: null,
+      techNamesById: {},
+    } as never;
+    const base = {
+      createdAt: "2026-07-16T10:00:00.000Z",
+      retryCount: 0,
+      userId: "user-1",
+      shopId: "shop-1",
+      status: "queued",
+    };
+    const projected = projectTechnicianWorkOrderSnapshot(snapshot, [
+      {
+        ...base,
+        clientMutationId: "notes",
+        actionType: "update_work_order_line_notes",
+        payload: { workOrderLineId: "line-1", notes: "device notes" },
+      },
+      {
+        ...base,
+        clientMutationId: "story",
+        actionType: "save_story_draft",
+        payload: {
+          lineId: "line-1",
+          cause: "failed seal",
+          correction: "replaced seal",
+        },
+      },
+      {
+        ...base,
+        clientMutationId: "finish",
+        actionType: "job:punch-transition",
+        payload: {
+          lineId: "line-1",
+          action: "finish",
+          occurredAt: "2026-07-16T11:00:00.000Z",
+          body: {
+            cause: "failed seal",
+            correction: "replaced seal",
+          },
+        },
+      },
+    ] as never);
+
+    expect(projected.lines[0]).toMatchObject({
+      notes: "device notes",
+      cause: "failed seal",
+      correction: "replaced seal",
+      status: "completed",
+      punched_out_at: "2026-07-16T11:00:00.000Z",
+    });
+  });
+
+  it("warms and caches work-order and focused-job navigation shells", () => {
+    const worker = read("app/sw.ts");
+    const download = read(
+      "features/work-orders/mobile/technicianOfflineDownload.ts",
+    );
+    expect(worker).toContain('url.pathname.startsWith("/mobile/work-orders/")');
+    expect(worker).toContain('url.pathname.startsWith("/mobile/jobs/")');
+    expect(download).toContain("cacheTechnicianRouteShells");
+    expect(download).toContain("...item.assignedLineIds.map");
+    expect(download).toContain("?mode=tech&focus=${lineId}");
+    expect(download).toContain("await cache.put(url, response.clone())");
+  });
+
+  it("recovers focused jobs and unsaved editor fields from scoped IndexedDB", () => {
+    const execution = read(
+      "features/work-orders/mobile/technicianOfflineExecution.ts",
+    );
+    const focused = read("features/work-orders/mobile/MobileFocusedJob.tsx");
+    const modal = read(
+      "features/work-orders/components/workorders/CauseCorrectionModal.tsx",
+    );
+    expect(execution).toContain('const DRAFT_KIND = "technician-job-draft"');
+    expect(execution).toContain(
+      "listOfflineSnapshots<MobileWorkOrderSnapshot>",
+    );
+    expect(focused).toContain("await loadOfflineJob(id)");
+    expect(focused).toContain("saveTechnicianJobEditorDraft");
+    expect(focused).toContain("clearTechnicianJobEditorDraftFields");
+    expect(modal).toContain("onDraftChange?.(next, correction)");
+    expect(modal).toContain("onDraftChange?.(cause, next)");
+  });
+
+  it("queues active-shift punches and persists their optimistic state", () => {
+    const shift = read("features/mobile/shifts/offline.ts");
+    const tracker = read("features/mobile/components/MobileShiftTracker.tsx");
+    expect(shift).toContain('actionType: "shift:punch-event"');
+    expect(shift).toContain("kind: KIND");
+    expect(shift).toContain("optimisticState(args.current");
+    expect(shift).toContain(
+      'throw new Error("Starting a new shift requires a connection.")',
+    );
+    expect(tracker).toContain("getCachedMobileShiftState");
+    expect(tracker).toContain("runMobileShiftAction");
+    expect(tracker).toContain('performAction("end_shift")');
+    const migration = read(
+      "supabase/migrations/20260716220000_offline_shift_end_state.sql",
+    );
+    expect(migration).toContain("punch_events_finalize_shift");
+    expect(migration).toContain("set status = 'completed'");
+  });
+});


### PR DESCRIPTION
## Summary

Completes Phase 3 technician execution items 1–5 on top of merged PR #1066.

### Offline technician workspace

- caches and warms work-order and focused-job navigation shells during assigned-work download
- opens queue entries directly into their assigned focused job
- falls back to scoped IndexedDB snapshots when focused-job reads are offline
- projects pending notes, cause/correction, and job punch mutations over cached work-order lines
- persists unsaved notes and cause/correction editor drafts for restart recovery
- records a stable occurrence timestamp for optimistic job start, pause, resume, and finish state

### Offline shifts

- caches the last active shift under the authenticated user/shop scope
- queues end-shift, break, and lunch punches through the existing mutation engine
- applies the queued punch to local shift state immediately and reconciles after reconnect
- keeps starting a brand-new shift online-only because it requires canonical server shift creation
- finalizes the shift record when an offline end-shift punch is replayed

## Migration

Run:

`supabase/migrations/20260716220000_offline_shift_end_state.sql`

This installs the end-punch trigger that marks the corresponding shift completed.

## Validation

- `tsc --noEmit`
- 25 focused Vitest assertions across technician execution, assigned downloads, PWA routing, inspection recovery, and photo staging
- focused ESLint: no errors; two pre-existing warnings remain in `MobileFocusedJob.tsx`
- `git diff --check`