### PR TITLE
Harden technician offline reconciliation and conflicts

### DIFF
--- a/app/api/offline/mutations/route.ts
+++ b/app/api/offline/mutations/route.ts
@@ -47,6 +47,7 @@ function statusFor(message: string): number {
     return 403;
   if (
     normalized.includes("idempotency_key_reuse") ||
+    normalized.includes("offline_version_conflict") ||
     normalized.includes("already completed") ||
     normalized.includes("approved job notes")
   ) {

--- a/app/offline/page.tsx
+++ b/app/offline/page.tsx
@@ -8,7 +8,7 @@ import {
   subscribeOfflineMutations,
 } from "@/features/shared/lib/offline/mutations";
 import { listOfflineSnapshots } from "@/features/shared/lib/offline/database";
-import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
+import { replayAndReconcileOfflineMutations } from "@/features/shared/lib/offline/replay";
 
 type WorkOrderSummary = {
   id?: string;
@@ -98,7 +98,7 @@ export default function OfflinePage() {
 
   const reconnect = async () => {
     if (!navigator.onLine) return;
-    await replayAllOfflineMutations();
+    await replayAndReconcileOfflineMutations();
     window.location.assign("/");
   };
 

--- a/app/offline/sync/page.tsx
+++ b/app/offline/sync/page.tsx
@@ -9,7 +9,6 @@ import {
   hydrateOfflineMutationQueue,
   listOfflineMutations,
   pruneOfflineState,
-  retryOfflineMutation,
   subscribeOfflineMutations,
   type PendingMutation,
 } from "@/features/shared/lib/offline/mutations";
@@ -17,7 +16,13 @@ import {
   getOfflineDatabaseStats,
   type OfflineDatabaseStats,
 } from "@/features/shared/lib/offline/database";
-import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
+import { replayAndReconcileOfflineMutations } from "@/features/shared/lib/offline/replay";
+import { reconcileOfflineTechnicianState } from "@/features/shared/lib/offline/reconciliation";
+import {
+  offlineMutationDeviceValue,
+  offlineMutationTarget,
+  prepareOfflineMutationRetry,
+} from "@/features/shared/lib/offline/conflicts";
 
 type BrowserStorage = {
   usage: number;
@@ -123,8 +128,13 @@ export default function OfflineSyncPage() {
 
   const syncNow = () =>
     run(async () => {
-      const result = await replayAllOfflineMutations();
-      return `Synced ${result.replayed}; ${result.failed} failed; ${result.conflicted} need review.`;
+      const result = await replayAndReconcileOfflineMutations();
+      const cacheWarning = Object.values(result.reconciliation).includes(
+        "failed",
+      )
+        ? " Server sync finished, but one saved view could not be refreshed."
+        : "";
+      return `Synced ${result.replayed}; ${result.failed} failed; ${result.conflicted} need review.${cacheWarning}`;
     }, "Sync complete.");
 
   const requestPersistence = () =>
@@ -212,68 +222,110 @@ export default function OfflineSyncPage() {
               No offline updates are stored for this user and shop.
             </div>
           ) : (
-            mutations.map((mutation) => (
-              <article
-                key={mutation.clientMutationId}
-                className="rounded-2xl border border-slate-800 bg-slate-900 p-4"
-              >
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <p className="font-medium">
-                      {ACTION_LABELS[mutation.actionType] ??
-                        mutation.actionType}
-                    </p>
-                    <p className="mt-1 text-xs text-slate-400">
-                      {new Date(mutation.createdAt).toLocaleString()} ·{" "}
-                      {mutation.retryCount} retries
-                    </p>
+            mutations.map((mutation) => {
+              const target = offlineMutationTarget(mutation);
+              const deviceValue = offlineMutationDeviceValue(mutation);
+              return (
+                <article
+                  key={mutation.clientMutationId}
+                  className="rounded-2xl border border-slate-800 bg-slate-900 p-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium">
+                        {ACTION_LABELS[mutation.actionType] ??
+                          mutation.actionType}
+                      </p>
+                      <p className="mt-1 text-xs text-slate-400">
+                        {new Date(mutation.createdAt).toLocaleString()} ·{" "}
+                        {mutation.retryCount} retries
+                      </p>
+                    </div>
+                    <span
+                      className={`rounded-full border px-2.5 py-1 text-xs uppercase tracking-wider ${statusTone(mutation.status)}`}
+                    >
+                      {mutation.status}
+                    </span>
                   </div>
-                  <span
-                    className={`rounded-full border px-2.5 py-1 text-xs uppercase tracking-wider ${statusTone(mutation.status)}`}
-                  >
-                    {mutation.status}
-                  </span>
-                </div>
-                {(mutation.conflictReason || mutation.lastError) && (
-                  <p className="mt-3 rounded-lg bg-slate-950/70 px-3 py-2 text-sm text-slate-300">
-                    {mutation.conflictReason || mutation.lastError}
-                  </p>
-                )}
-                <div className="mt-3 flex gap-2">
-                  {["failed", "conflicted"].includes(mutation.status) && (
-                    <button
-                      type="button"
-                      disabled={busy}
-                      onClick={() =>
-                        void run(
-                          () => retryOfflineMutation(mutation.clientMutationId),
-                          "Update queued for retry.",
-                        )
-                      }
-                      className="rounded-lg border border-sky-500/50 px-3 py-1.5 text-xs font-semibold text-sky-200 disabled:opacity-40"
-                    >
-                      Retry
-                    </button>
+                  {(mutation.conflictReason || mutation.lastError) && (
+                    <p className="mt-3 rounded-lg bg-slate-950/70 px-3 py-2 text-sm text-slate-300">
+                      {mutation.conflictReason || mutation.lastError}
+                    </p>
                   )}
-                  {mutation.status !== "syncing" && (
-                    <button
-                      type="button"
-                      disabled={busy}
-                      onClick={() =>
-                        void run(
-                          () =>
-                            dismissOfflineMutation(mutation.clientMutationId),
-                          "Update removed from this device.",
-                        )
-                      }
-                      className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs text-slate-300 disabled:opacity-40"
-                    >
-                      Remove
-                    </button>
+                  {mutation.status === "conflicted" && deviceValue && (
+                    <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-950/20 px-3 py-2 text-sm text-slate-300">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-amber-200">
+                        Saved on this device
+                      </p>
+                      <p className="mt-1 line-clamp-3 whitespace-pre-wrap">
+                        {deviceValue}
+                      </p>
+                    </div>
                   )}
-                </div>
-              </article>
-            ))
+                  <div className="mt-3 flex gap-2">
+                    {["failed", "conflicted"].includes(mutation.status) && (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() =>
+                          void run(async () => {
+                            await prepareOfflineMutationRetry(mutation);
+                            await replayAndReconcileOfflineMutations();
+                          }, "Device update retried and saved views refreshed.")
+                        }
+                        className="rounded-lg border border-sky-500/50 px-3 py-1.5 text-xs font-semibold text-sky-200 disabled:opacity-40"
+                      >
+                        Retry device update
+                      </button>
+                    )}
+                    {mutation.status === "conflicted" && (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() =>
+                          void run(async () => {
+                            await dismissOfflineMutation(
+                              mutation.clientMutationId,
+                            );
+                            await reconcileOfflineTechnicianState([mutation]);
+                          }, "Server state kept and this device's update removed.")
+                        }
+                        className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs text-slate-300 disabled:opacity-40"
+                      >
+                        Use server state
+                      </button>
+                    )}
+                    {mutation.status !== "syncing" &&
+                      mutation.status !== "conflicted" && (
+                        <button
+                          type="button"
+                          disabled={busy}
+                          onClick={() =>
+                            void run(
+                              () =>
+                                dismissOfflineMutation(
+                                  mutation.clientMutationId,
+                                ),
+                              "Update removed from this device.",
+                            )
+                          }
+                          className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs text-slate-300 disabled:opacity-40"
+                        >
+                          Remove
+                        </button>
+                      )}
+                    {target && (
+                      <Link
+                        href={target}
+                        className="rounded-lg border border-slate-700 px-3 py-1.5 text-xs text-slate-300"
+                      >
+                        Open record
+                      </Link>
+                    )}
+                  </div>
+                </article>
+              );
+            })
           )}
         </section>
 

--- a/features/mobile/components/MobileShiftTracker.tsx
+++ b/features/mobile/components/MobileShiftTracker.tsx
@@ -7,7 +7,7 @@ import {
   getOfflineSyncSummary,
   subscribeOfflineMutations,
 } from "@/features/shared/lib/offline/mutations";
-import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
+import { replayAndReconcileOfflineMutations } from "@/features/shared/lib/offline/replay";
 import {
   fetchMobileShiftState,
   type MobileShiftState,
@@ -45,7 +45,7 @@ export default function MobileShiftTracker({ userId }: Props) {
   }, [refreshOfflineSummary]);
 
   const replayOfflineMutations = useCallback(async () => {
-    const result = await replayAllOfflineMutations();
+    const result = await replayAndReconcileOfflineMutations();
 
     if (result.failed > 0) {
       setErr(`${result.failed} queued punch event(s) still failing to sync.`);

--- a/features/shared/lib/offline/conflicts.ts
+++ b/features/shared/lib/offline/conflicts.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  getOfflineMutationScope,
+  retryOfflineMutation,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+import { downloadAssignedTechnicianWork } from "@/features/work-orders/mobile/technicianOfflineDownload";
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function offlineMutationTarget(
+  mutation: PendingMutation,
+): string | null {
+  const payload = record(mutation.payload);
+  const lineId =
+    text(payload.workOrderLineId) ||
+    text(payload.lineId) ||
+    text(payload.work_order_line_id);
+  if (lineId) return `/mobile/jobs/${encodeURIComponent(lineId)}`;
+  if (mutation.actionType === "shift:punch-event") return "/mobile/tech/queue";
+  return null;
+}
+
+export function offlineMutationDeviceValue(
+  mutation: PendingMutation,
+): string | null {
+  const payload = record(mutation.payload);
+  if (mutation.actionType === "update_work_order_line_notes") {
+    return text(payload.notes) || "Empty notes";
+  }
+  if (mutation.actionType === "save_story_draft") {
+    return (
+      [text(payload.cause), text(payload.correction)]
+        .filter(Boolean)
+        .join(" · ") || "Empty cause and correction"
+    );
+  }
+  if (mutation.actionType === "job:punch-transition") {
+    return text(payload.action) || null;
+  }
+  return null;
+}
+
+export async function prepareOfflineMutationRetry(
+  mutation: PendingMutation,
+): Promise<void> {
+  if (
+    mutation.actionType !== "update_work_order_line_notes" &&
+    mutation.actionType !== "save_story_draft"
+  ) {
+    await retryOfflineMutation(mutation.clientMutationId);
+    return;
+  }
+
+  const scope = getOfflineMutationScope();
+  if (!scope) throw new Error("Offline user and shop scope is unavailable.");
+  const payload = record(mutation.payload);
+  const lineId = text(payload.workOrderLineId) || text(payload.lineId);
+  if (!lineId) throw new Error("This update is missing its job.");
+  const bundle = await downloadAssignedTechnicianWork({ scope });
+  const line = bundle.workOrders
+    .flatMap((item) => item.lines)
+    .find((item) => item.id === lineId);
+  if (!line?.updated_at) {
+    throw new Error("The latest server version of this job is unavailable.");
+  }
+  await retryOfflineMutation(mutation.clientMutationId, {
+    baseUpdatedAt: line.updated_at,
+  });
+}

--- a/features/shared/lib/offline/mutations.ts
+++ b/features/shared/lib/offline/mutations.ts
@@ -182,7 +182,7 @@ export async function resolveOfflineMutationScope(
   return scope;
 }
 
-function parseMutation(raw: unknown): PendingMutation | null {
+export function restoreOfflineMutation(raw: unknown): PendingMutation | null {
   if (!raw || typeof raw !== "object") return null;
   const item = raw as Partial<PendingMutation> & {
     id?: unknown;
@@ -229,7 +229,9 @@ function parseMutation(raw: unknown): PendingMutation | null {
   };
 }
 
-function normalizeQueue(queue: PendingMutation[]): PendingMutation[] {
+export function normalizeOfflineMutationQueue(
+  queue: PendingMutation[],
+): PendingMutation[] {
   const byId = new Map<string, PendingMutation>();
   for (const item of queue) byId.set(item.clientMutationId, item);
   const now = Date.now();
@@ -254,7 +256,7 @@ export async function hydrateOfflineMutationQueue(): Promise<void> {
   if (hydrationPromise) return hydrationPromise;
   hydrationPromise = (async () => {
     const stored = (await readStoredMutations())
-      .map(parseMutation)
+      .map(restoreOfflineMutation)
       .filter((item): item is PendingMutation => Boolean(item));
     const legacy: PendingMutation[] = [];
     for (const key of LEGACY_KEYS) {
@@ -263,7 +265,7 @@ export async function hydrateOfflineMutationQueue(): Promise<void> {
         if (Array.isArray(raw)) {
           legacy.push(
             ...raw
-              .map(parseMutation)
+              .map(restoreOfflineMutation)
               .filter((item): item is PendingMutation => Boolean(item)),
           );
         }
@@ -272,7 +274,7 @@ export async function hydrateOfflineMutationQueue(): Promise<void> {
       }
       localStorage.removeItem(key);
     }
-    queueCache = normalizeQueue([...stored, ...legacy]);
+    queueCache = normalizeOfflineMutationQueue([...stored, ...legacy]);
     await replaceStoredMutations(queueCache);
     emitQueueUpdate();
   })().catch((error) => {
@@ -283,12 +285,14 @@ export async function hydrateOfflineMutationQueue(): Promise<void> {
 }
 
 async function writeQueue(queue: PendingMutation[]): Promise<void> {
-  queueCache = normalizeQueue(queue);
+  queueCache = normalizeOfflineMutationQueue(queue);
   await replaceStoredMutations(queueCache);
   emitQueueUpdate();
 }
 
-function sortForReplay(queue: PendingMutation[]): PendingMutation[] {
+export function sortOfflineMutationsForReplay(
+  queue: PendingMutation[],
+): PendingMutation[] {
   return [...queue].sort((a, b) => {
     const time =
       new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
@@ -372,7 +376,9 @@ export function listOfflineMutations(
   scope: OfflineMutationScope | null = getOfflineMutationScope(),
 ): PendingMutation[] {
   void hydrateOfflineMutationQueue();
-  return sortForReplay(queueCache.filter((item) => scopeMatches(item, scope)));
+  return sortOfflineMutationsForReplay(
+    queueCache.filter((item) => scopeMatches(item, scope)),
+  );
 }
 
 export function getOfflineSyncSummary(
@@ -407,6 +413,7 @@ export function subscribeOfflineMutations(listener: () => void): () => void {
 
 export async function retryOfflineMutation(
   clientMutationId: string,
+  payloadPatch?: Record<string, unknown>,
 ): Promise<void> {
   await hydrateOfflineMutationQueue();
   const scope = getOfflineMutationScope();
@@ -422,6 +429,10 @@ export async function retryOfflineMutation(
     return;
   await upsertMutation({
     ...mutation,
+    payload:
+      payloadPatch && mutation.payload && typeof mutation.payload === "object"
+        ? { ...(mutation.payload as Record<string, unknown>), ...payloadPatch }
+        : mutation.payload,
     status: "queued",
     lastError: undefined,
     conflictReason: undefined,
@@ -544,7 +555,7 @@ export async function replayQueuedMutations(args: {
   const scope = args.scope ?? getOfflineMutationScope();
   if (!scope || !navigator.onLine)
     return { replayed: 0, failed: 0, conflicted: 0 };
-  const queue = sortForReplay(
+  const queue = sortOfflineMutationsForReplay(
     queueCache.filter(
       (item) =>
         ["queued", "failed"].includes(item.status) && scopeMatches(item, scope),

--- a/features/shared/lib/offline/reconciliation.ts
+++ b/features/shared/lib/offline/reconciliation.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+  getOfflineMutationScope,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+import { fetchMobileShiftState } from "@/features/mobile/shifts/client";
+import { saveCachedMobileShiftState } from "@/features/mobile/shifts/offline";
+import { downloadAssignedTechnicianWork } from "@/features/work-orders/mobile/technicianOfflineDownload";
+
+const WORK_ORDER_ACTIONS = new Set([
+  "update_work_order_line_notes",
+  "save_story_draft",
+  "upload_job_photo",
+  "job:punch-transition",
+  "inspection:save-session",
+  "inspection:upload-photo",
+]);
+
+export type OfflineReconciliationResult = {
+  workOrders: "skipped" | "refreshed" | "failed";
+  shift: "skipped" | "refreshed" | "failed";
+};
+
+/** Refreshes authoritative device snapshots after mutations reach the server. */
+export async function reconcileOfflineTechnicianState(
+  mutations: Array<Pick<PendingMutation, "actionType">>,
+): Promise<OfflineReconciliationResult> {
+  const scope = getOfflineMutationScope();
+  const result: OfflineReconciliationResult = {
+    workOrders: "skipped",
+    shift: "skipped",
+  };
+  if (!scope || typeof navigator === "undefined" || !navigator.onLine) {
+    return result;
+  }
+
+  if (
+    mutations.some((mutation) => WORK_ORDER_ACTIONS.has(mutation.actionType))
+  ) {
+    try {
+      await downloadAssignedTechnicianWork({ scope });
+      result.workOrders = "refreshed";
+    } catch {
+      result.workOrders = "failed";
+    }
+  }
+
+  if (
+    mutations.some((mutation) => mutation.actionType === "shift:punch-event")
+  ) {
+    try {
+      const state = await fetchMobileShiftState();
+      await saveCachedMobileShiftState({ scope, state });
+      result.shift = "refreshed";
+    } catch {
+      result.shift = "failed";
+    }
+  }
+
+  return result;
+}

--- a/features/shared/lib/offline/replay.ts
+++ b/features/shared/lib/offline/replay.ts
@@ -6,11 +6,17 @@ import {
   removeOfflineBlob,
 } from "@/features/shared/lib/offline/database";
 import {
+  listPendingMutations,
   replayQueuedMutations,
   type OfflineMutationRunner,
+  type PendingMutation,
 } from "@/features/shared/lib/offline/mutations";
 import { postOfflineServerMutation } from "@/features/shared/lib/offline/server-mutations";
 import { replayInspectionPhotoMutation } from "@inspections/lib/inspection/inspectionPhotoStaging";
+import {
+  reconcileOfflineTechnicianState,
+  type OfflineReconciliationResult,
+} from "@/features/shared/lib/offline/reconciliation";
 
 type ReplayPayload = Record<string, unknown>;
 
@@ -155,4 +161,33 @@ export function replayAllOfflineMutations() {
     replayPromise = null;
   });
   return replayPromise;
+}
+
+let replayAndReconcilePromise: Promise<{
+  replayed: number;
+  failed: number;
+  conflicted: number;
+  reconciliation: OfflineReconciliationResult;
+}> | null = null;
+
+export function replayAndReconcileOfflineMutations() {
+  replayAndReconcilePromise ??= (async () => {
+    const before = listPendingMutations();
+    const beforeById = new Map(
+      before.map((mutation) => [mutation.clientMutationId, mutation]),
+    );
+    const replay = await replayAllOfflineMutations();
+    const remaining = new Set(
+      listPendingMutations().map((mutation) => mutation.clientMutationId),
+    );
+    const synced: PendingMutation[] = [];
+    for (const [id, mutation] of beforeById) {
+      if (!remaining.has(id)) synced.push(mutation);
+    }
+    const reconciliation = await reconcileOfflineTechnicianState(synced);
+    return { ...replay, reconciliation };
+  })().finally(() => {
+    replayAndReconcilePromise = null;
+  });
+  return replayAndReconcilePromise;
 }

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -17,7 +17,7 @@ import {
   runMutationWithOfflineQueue,
   subscribeOfflineMutations,
 } from "@/features/shared/lib/offline/mutations";
-import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
+import { replayAndReconcileOfflineMutations } from "@/features/shared/lib/offline/replay";
 import { postOfflineServerMutation } from "@/features/shared/lib/offline/server-mutations";
 import {
   removeOfflineBlob,
@@ -445,7 +445,7 @@ export default function MobileFocusedJob(props: {
   }, [workOrderLineId, loadLine, onChanged, loadAllocations]);
 
   const replayOfflineMutations = useCallback(async () => {
-    const result = await replayAllOfflineMutations();
+    const result = await replayAndReconcileOfflineMutations();
     refreshSyncState();
     setStagedPhotos((prev) =>
       prev.filter((photo) => {
@@ -779,17 +779,22 @@ export default function MobileFocusedJob(props: {
     setSavingNotes(true);
     try {
       const mutationId = `${workOrderLineId}:notes:${Date.now()}`;
+      const payload = {
+        workOrderLineId,
+        notes: techNotes,
+        baseUpdatedAt: line?.updated_at ?? null,
+      };
       const result = await runMutationWithOfflineQueue({
         clientMutationId: mutationId,
         actionType: "update_work_order_line_notes",
-        payload: { workOrderLineId, notes: techNotes },
+        payload,
         orderKey: `${workOrderLineId}:001:notes`,
         conflictCheck: () => getLineConflict(workOrderLineId, "notes"),
         runner: async () => {
           await postOfflineServerMutation({
             actionType: "update_work_order_line_notes",
             operationKey: mutationId,
-            payload: { workOrderLineId, notes: techNotes },
+            payload,
           });
         },
       });
@@ -1501,17 +1506,23 @@ export default function MobileFocusedJob(props: {
           }}
           onSaveDraft={async (cause: string, correction: string) => {
             const mutationId = `${line.id}:story:${Date.now()}`;
+            const payload = {
+              lineId: line.id,
+              cause,
+              correction,
+              baseUpdatedAt: line.updated_at,
+            };
             const result = await runMutationWithOfflineQueue({
               clientMutationId: mutationId,
               actionType: "save_story_draft",
-              payload: { lineId: line.id, cause, correction },
+              payload,
               orderKey: `${line.id}:002:story`,
               conflictCheck: () => getLineConflict(line.id, "story"),
               runner: async () => {
                 await postOfflineServerMutation({
                   actionType: "save_story_draft",
                   operationKey: mutationId,
-                  payload: { lineId: line.id, cause, correction },
+                  payload,
                 });
               },
             });

--- a/supabase/migrations/20260716230000_offline_line_version_conflicts.sql
+++ b/supabase/migrations/20260716230000_offline_line_version_conflicts.sql
@@ -1,0 +1,133 @@
+begin;
+
+create or replace function public.apply_offline_line_mutation_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_action_type text,
+  p_work_order_line_id uuid,
+  p_payload jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_role text;
+  v_existing public.offline_mutation_receipts%rowtype;
+  v_receipt_id uuid;
+  v_payload jsonb := coalesce(p_payload, '{}'::jsonb);
+  v_payload_hash text := encode(digest(coalesce(p_payload, '{}'::jsonb)::text, 'sha256'), 'hex');
+  v_base_updated_at timestamptz;
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor does not match the mutation actor.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null or length(p_operation_key) > 240 then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+  if p_action_type not in ('update_work_order_line_notes', 'save_story_draft') then
+    raise exception using errcode = 'P0001', message = 'Unsupported offline line mutation.';
+  end if;
+
+  select * into v_existing
+  from public.offline_mutation_receipts r
+  where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+  if found then
+    if v_existing.action_type <> p_action_type or v_existing.payload_hash <> v_payload_hash then
+      raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+    end if;
+    return v_existing.result || jsonb_build_object('idempotent', true, 'receipt_id', v_existing.id);
+  end if;
+
+  select lower(coalesce(p.role::text, '')) into v_role
+  from public.profiles p
+  where p.id = p_actor_user_id and p.shop_id = p_shop_id;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Actor is not available for this shop.';
+  end if;
+
+  select * into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id and wol.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for shop.';
+  end if;
+  if lower(coalesce(v_line.status::text, '')) = 'completed' then
+    raise exception using errcode = 'P0001', message = 'Work-order line is already completed.';
+  end if;
+  if v_role not in ('owner','admin','manager','advisor','service','lead_hand','lead hand','leadhand','foreman')
+     and v_line.assigned_tech_id is distinct from p_actor_user_id
+     and not exists (
+       select 1 from public.work_order_line_technicians wolt
+       where wolt.work_order_line_id = p_work_order_line_id
+         and wolt.technician_id = p_actor_user_id
+     ) then
+    raise exception using errcode = 'P0001', message = 'Actor is not assigned to this work-order line.';
+  end if;
+
+  if nullif(trim(v_payload->>'baseUpdatedAt'), '') is not null then
+    begin
+      v_base_updated_at := (v_payload->>'baseUpdatedAt')::timestamptz;
+    exception when invalid_datetime_format then
+      raise exception using errcode = 'P0001', message = 'Invalid offline base version.';
+    end;
+    if v_line.updated_at is distinct from v_base_updated_at then
+      raise exception using
+        errcode = 'P0001',
+        message = 'OFFLINE_VERSION_CONFLICT: this job changed on another device. Review the server state before retrying.';
+    end if;
+  end if;
+
+  if p_action_type = 'update_work_order_line_notes' then
+    if lower(coalesce(v_line.approval_state::text, '')) = 'approved' then
+      raise exception using errcode = 'P0001', message = 'Approved job notes require review before editing.';
+    end if;
+    update public.work_order_lines
+    set notes = coalesce(v_payload->>'notes', ''), updated_at = now()
+    where id = p_work_order_line_id and shop_id = p_shop_id;
+  else
+    update public.work_order_lines
+    set cause = coalesce(v_payload->>'cause', ''),
+        correction = coalesce(v_payload->>'correction', ''),
+        updated_at = now()
+    where id = p_work_order_line_id and shop_id = p_shop_id;
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'action_type', p_action_type,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'completed_at', now()
+  );
+
+  insert into public.offline_mutation_receipts(
+    shop_id, actor_user_id, operation_key, action_type, payload_hash,
+    entity_type, entity_id, result
+  ) values (
+    p_shop_id, p_actor_user_id, p_operation_key, p_action_type, v_payload_hash,
+    'work_order_line', p_work_order_line_id, v_result
+  ) returning id into v_receipt_id;
+
+  return v_result || jsonb_build_object('receipt_id', v_receipt_id);
+exception
+  when unique_violation then
+    select * into v_existing
+    from public.offline_mutation_receipts r
+    where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+    if found and v_existing.action_type = p_action_type and v_existing.payload_hash = v_payload_hash then
+      return v_existing.result || jsonb_build_object('idempotent', true, 'receipt_id', v_existing.id);
+    end if;
+    raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+end;
+$$;
+
+revoke all on function public.apply_offline_line_mutation_atomic(uuid,uuid,text,text,uuid,jsonb) from public, anon;
+grant execute on function public.apply_offline_line_mutation_atomic(uuid,uuid,text,text,uuid,jsonb) to authenticated, service_role;
+
+commit;

--- a/tests/technician-offline-hardening.test.ts
+++ b/tests/technician-offline-hardening.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  normalizeOfflineMutationQueue,
+  restoreOfflineMutation,
+  sortOfflineMutationsForReplay,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+import {
+  offlineMutationDeviceValue,
+  offlineMutationTarget,
+} from "@/features/shared/lib/offline/conflicts";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+function mutation(
+  id: string,
+  actionType: string,
+  createdAt: string,
+  orderKey?: string,
+): PendingMutation {
+  return {
+    clientMutationId: id,
+    actionType,
+    payload: { lineId: "line-1" },
+    createdAt,
+    retryCount: 0,
+    userId: "user-1",
+    shopId: "shop-1",
+    orderKey,
+    status: "queued",
+  };
+}
+
+describe("technician offline hardening", () => {
+  it("recovers an interrupted sync as retryable after an app restart", () => {
+    const restored = restoreOfflineMutation({
+      ...mutation("restart-1", "job:punch-transition", "2026-07-16T10:00:00Z"),
+      status: "syncing",
+    });
+    expect(restored?.status).toBe("failed");
+    expect(restored?.clientMutationId).toBe("restart-1");
+  });
+
+  it("collapses repeated actions with the same stable mutation id", () => {
+    const first = mutation(
+      "same-id",
+      "save_story_draft",
+      "2026-07-16T10:00:00Z",
+    );
+    const repeated = { ...first, retryCount: 2, status: "failed" as const };
+    expect(normalizeOfflineMutationQueue([first, repeated])).toEqual([
+      repeated,
+    ]);
+  });
+
+  it("replays reconnect work chronologically and deterministically", () => {
+    const sorted = sortOfflineMutationsForReplay([
+      mutation("third", "save_story_draft", "2026-07-16T10:01:00Z", "line:002"),
+      mutation(
+        "second",
+        "update_work_order_line_notes",
+        "2026-07-16T10:00:00Z",
+        "line:002",
+      ),
+      mutation(
+        "first",
+        "job:punch-transition",
+        "2026-07-16T10:00:00Z",
+        "line:001",
+      ),
+    ]);
+    expect(sorted.map((item) => item.clientMutationId)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("keeps the device value visible and links conflicts to their job", () => {
+    const conflicted = {
+      ...mutation(
+        "notes-1",
+        "update_work_order_line_notes",
+        "2026-07-16T10:00:00Z",
+      ),
+      payload: { workOrderLineId: "line/1", notes: "Device diagnosis" },
+      status: "conflicted" as const,
+    };
+    expect(offlineMutationTarget(conflicted)).toBe("/mobile/jobs/line%2F1");
+    expect(offlineMutationDeviceValue(conflicted)).toBe("Device diagnosis");
+  });
+
+  it("atomically rejects stale notes and story writes from a second device", () => {
+    const migration = read(
+      "supabase/migrations/20260716230000_offline_line_version_conflicts.sql",
+    );
+    const editor = read("features/work-orders/mobile/MobileFocusedJob.tsx");
+    const route = read("app/api/offline/mutations/route.ts");
+    expect(editor).toContain("baseUpdatedAt: line?.updated_at ?? null");
+    expect(editor).toContain("baseUpdatedAt: line.updated_at");
+    expect(migration).toContain("for update");
+    expect(migration).toContain(
+      "v_line.updated_at is distinct from v_base_updated_at",
+    );
+    expect(migration).toContain("OFFLINE_VERSION_CONFLICT");
+    expect(route).toContain('normalized.includes("idempotency_key_reuse")');
+    expect(route).toContain("return 409");
+  });
+
+  it("refreshes authoritative work-order and shift snapshots after replay", () => {
+    const replay = read("features/shared/lib/offline/replay.ts");
+    const reconciliation = read(
+      "features/shared/lib/offline/reconciliation.ts",
+    );
+    const syncCenter = read("app/offline/sync/page.tsx");
+    expect(replay).toContain("replayAndReconcileOfflineMutations");
+    expect(reconciliation).toContain("downloadAssignedTechnicianWork");
+    expect(reconciliation).toContain("fetchMobileShiftState");
+    expect(syncCenter).toContain("Retry device update");
+    expect(syncCenter).toContain("prepareOfflineMutationRetry");
+    expect(reconciliation).toContain("downloadAssignedTechnicianWork");
+    expect(syncCenter).toContain("Use server state");
+    expect(syncCenter).toContain("Open record");
+  });
+});


### PR DESCRIPTION
## What changed

- reconcile assigned work-order and shift snapshots after queued mutations reach the server
- route all automatic/manual replay entry points through the reconciliation wrapper
- expose conflict context, saved device values, record links, and explicit **Retry device update** / **Use server state** actions
- rebase an intentional device retry against the latest server line version while retaining atomic race protection
- add optimistic base timestamps to offline notes and cause/correction writes
- atomically reject stale two-device line mutations with HTTP 409
- add regression coverage for app restart recovery, repeated mutation IDs, reconnect ordering, conflict UI, two-device version checks, and snapshot reconciliation

## Why

A mutation could be marked synced before IndexedDB snapshots were refreshed, leaving stale or optimistic state after reconnect. Notes and story drafts also lacked an atomic server version check, allowing a second device to overwrite newer edits.

## Validation

- `pnpm exec vitest run tests/technician-offline-hardening.test.ts tests/technician-offline-execution.test.ts tests/offline-mutation-receipts.test.ts tests/pwa-sync-center.test.ts tests/technician-offline-download.test.ts tests/inspection-offline-recovery.test.ts tests/inspection-offline-photo-staging.test.ts` — 34 tests passed
- `pnpm exec tsc --noEmit` — passed
- focused ESLint — 0 errors; 2 existing warnings in `MobileFocusedJob.tsx`

## Migration

Run `supabase/migrations/20260716230000_offline_line_version_conflicts.sql` after merge. It replaces `apply_offline_line_mutation_atomic` with a row-locked base-version check while keeping backward compatibility for already-queued payloads without `baseUpdatedAt`.