### PR TITLE
Add advisor offline day packs and work-order drafts

### DIFF
--- a/app/api/offline/advisor-day/route.ts
+++ b/app/api/offline/advisor-day/route.ts
@@ -1,0 +1,172 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import type { Database } from "@shared/types/types/supabase";
+import type { AdvisorOfflineBundle } from "@/features/work-orders/mobile/advisorOfflineTypes";
+
+type DB = Database;
+type Customer = DB["public"]["Tables"]["customers"]["Row"];
+type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
+type BookingJoined = Pick<
+  DB["public"]["Tables"]["bookings"]["Row"],
+  | "id"
+  | "starts_at"
+  | "ends_at"
+  | "customer_id"
+  | "vehicle_id"
+  | "work_order_id"
+  | "notes"
+  | "status"
+> & {
+  customers:
+    | Pick<Customer, "first_name" | "last_name" | "email" | "phone">
+    | Array<Pick<Customer, "first_name" | "last_name" | "email" | "phone">>
+    | null;
+};
+const PAGE_SIZE = 500;
+const MAX_ROWS = 5000;
+
+function validDay(value: string): boolean {
+  return (
+    /^\d{4}-\d{2}-\d{2}$/.test(value) &&
+    !Number.isNaN(Date.parse(`${value}T00:00:00Z`))
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const day = request.nextUrl.searchParams.get("day")?.trim() ?? "";
+  if (!validDay(day)) {
+    return NextResponse.json(
+      { error: "A valid day is required." },
+      { status: 400 },
+    );
+  }
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id, role")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null; role: string | null }>();
+  if (profileError || !profile?.shop_id) {
+    return NextResponse.json({ error: "Missing shop" }, { status: 403 });
+  }
+  const capabilities = getActorCapabilities({ role: profile.role });
+  if (!capabilities.canManageScheduling && !capabilities.canManageWorkOrders) {
+    return NextResponse.json(
+      { error: "Advisor offline access is unavailable for this role." },
+      { status: 403 },
+    );
+  }
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: profile.shop_id,
+  });
+  if (contextError) {
+    return NextResponse.json(
+      { error: "Shop security context could not be initialized." },
+      { status: 500 },
+    );
+  }
+  const { data: shop, error: shopError } = await supabase
+    .from("shops")
+    .select("id,name,slug")
+    .eq("id", profile.shop_id)
+    .single();
+  if (shopError || !shop?.slug) {
+    return NextResponse.json(
+      { error: "Shop could not be loaded." },
+      { status: 500 },
+    );
+  }
+
+  const start = new Date(`${day}T00:00:00.000Z`);
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 1);
+  const { data: bookingRows, error: bookingError } = await supabase
+    .from("bookings")
+    .select(
+      "id,starts_at,ends_at,customer_id,vehicle_id,work_order_id,notes,status,customers:customer_id(first_name,last_name,email,phone)",
+    )
+    .eq("shop_id", profile.shop_id)
+    .gte("starts_at", start.toISOString())
+    .lt("starts_at", end.toISOString())
+    .order("starts_at");
+  if (bookingError) {
+    return NextResponse.json({ error: bookingError.message }, { status: 500 });
+  }
+
+  const customers: Customer[] = [];
+  const vehicles: Vehicle[] = [];
+  let customersTruncated = false;
+  let vehiclesTruncated = false;
+  for (let offset = 0; offset < MAX_ROWS; offset += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from("customers")
+      .select("*")
+      .eq("shop_id", profile.shop_id)
+      .order("created_at", { ascending: false })
+      .range(offset, offset + PAGE_SIZE - 1);
+    if (error)
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    customers.push(...((data ?? []) as Customer[]));
+    if ((data ?? []).length < PAGE_SIZE) break;
+    if (offset + PAGE_SIZE >= MAX_ROWS) customersTruncated = true;
+  }
+  for (let offset = 0; offset < MAX_ROWS; offset += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from("vehicles")
+      .select("*")
+      .eq("shop_id", profile.shop_id)
+      .order("created_at", { ascending: false })
+      .range(offset, offset + PAGE_SIZE - 1);
+    if (error)
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    vehicles.push(...((data ?? []) as Vehicle[]));
+    if ((data ?? []).length < PAGE_SIZE) break;
+    if (offset + PAGE_SIZE >= MAX_ROWS) vehiclesTruncated = true;
+  }
+
+  const bookings = ((bookingRows ?? []) as unknown as BookingJoined[]).map(
+    (row) => {
+      const customer = Array.isArray(row.customers)
+        ? row.customers[0]
+        : row.customers;
+      return {
+        id: row.id,
+        starts_at: row.starts_at,
+        ends_at: row.ends_at,
+        customer_id: row.customer_id,
+        vehicle_id: row.vehicle_id,
+        work_order_id: row.work_order_id,
+        notes: row.notes,
+        status: row.status,
+        shop_slug: shop.slug,
+        customer_name:
+          [customer?.first_name, customer?.last_name]
+            .filter(Boolean)
+            .join(" ") || null,
+        customer_email: customer?.email ?? null,
+        customer_phone: customer?.phone ?? null,
+      };
+    },
+  );
+  const bundle: AdvisorOfflineBundle = {
+    scope: { userId: user.id, shopId: profile.shop_id },
+    downloadedAt: new Date().toISOString(),
+    day,
+    shop,
+    bookings,
+    customers,
+    vehicles,
+    truncated: { customers: customersTruncated, vehicles: vehiclesTruncated },
+  };
+  return NextResponse.json(bundle, {
+    headers: { "Cache-Control": "private, no-store" },
+  });
+}

--- a/app/api/offline/advisor-work-order-drafts/route.ts
+++ b/app/api/offline/advisor-work-order-drafts/route.ts
@@ -1,0 +1,122 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import type { AdvisorWorkOrderDraft } from "@/features/work-orders/mobile/advisorOfflineTypes";
+
+function statusFor(message: string): number {
+  const value = message.toLowerCase();
+  if (value.includes("not authenticated")) return 401;
+  if (value.includes("not allowed") || value.includes("different shop"))
+    return 403;
+  if (value.includes("not found")) return 404;
+  if (value.includes("idempotency") || value.includes("conflict")) return 409;
+  return 400;
+}
+
+export async function POST(request: NextRequest) {
+  const operationKey = request.headers.get("Idempotency-Key")?.trim() ?? "";
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable Idempotency-Key is required." },
+      { status: 400 },
+    );
+  }
+  const draft = (await request
+    .json()
+    .catch(() => null)) as AdvisorWorkOrderDraft | null;
+  if (
+    !draft ||
+    draft.operationKey !== operationKey ||
+    !draft.customerId ||
+    !draft.vehicleId
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "A canonical customer, vehicle, and matching operation key are required.",
+      },
+      { status: 400 },
+    );
+  }
+  if (
+    !Array.isArray(draft.lines) ||
+    draft.lines.length === 0 ||
+    draft.lines.length > 50
+  ) {
+    return NextResponse.json(
+      { error: "A draft requires between 1 and 50 job lines." },
+      { status: 400 },
+    );
+  }
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("shop_id,role")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null; role: string | null }>();
+  if (
+    !profile?.shop_id ||
+    !getActorCapabilities({ role: profile.role }).canManageWorkOrders
+  ) {
+    return NextResponse.json(
+      { error: "Not allowed to create work orders." },
+      { status: 403 },
+    );
+  }
+  if (draft.userId !== user.id || draft.shopId !== profile.shop_id) {
+    return NextResponse.json(
+      { error: "Draft belongs to a different user or shop." },
+      { status: 403 },
+    );
+  }
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: profile.shop_id,
+  });
+  if (contextError)
+    return NextResponse.json(
+      { error: "Shop security context could not be initialized." },
+      { status: 500 },
+    );
+
+  const rpc = supabase as unknown as {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => PromiseLike<{
+      data: unknown;
+      error: {
+        message: string;
+        details?: string | null;
+        hint?: string | null;
+      } | null;
+    }>;
+  };
+  const { data, error } = await rpc.rpc(
+    "materialize_offline_work_order_draft_atomic",
+    {
+      p_shop_id: profile.shop_id,
+      p_actor_user_id: user.id,
+      p_operation_key: operationKey,
+      p_customer_id: draft.customerId,
+      p_vehicle_id: draft.vehicleId,
+      p_payload: draft,
+    },
+  );
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return NextResponse.json(
+      { error: message },
+      { status: statusFor(message) },
+    );
+  }
+  return NextResponse.json(data);
+}

--- a/app/mobile/appointments/page.tsx
+++ b/app/mobile/appointments/page.tsx
@@ -8,6 +8,12 @@ import { Toaster, toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
+import { getOfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+import {
+  downloadAdvisorOfflineDay,
+  getCachedAdvisorDay,
+  getLatestCachedAdvisorDay,
+} from "@/features/work-orders/mobile/advisorOffline";
 
 type DB = Database;
 type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
@@ -57,6 +63,12 @@ export default function MobileAppointmentsPage() {
   // data
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [loadingBookings, setLoadingBookings] = useState(false);
+  const [online, setOnline] = useState(
+    () => typeof navigator !== "undefined" && navigator.onLine,
+  );
+  const [downloadingOffline, setDownloadingOffline] = useState(false);
+  const [offlineSavedAt, setOfflineSavedAt] = useState<string | null>(null);
+  const [usingOfflineData, setUsingOfflineData] = useState(false);
 
   // form state
   const [editing, setEditing] = useState<Booking | null>(null);
@@ -74,7 +86,16 @@ export default function MobileAppointmentsPage() {
       if (error) {
         // eslint-disable-next-line no-console
         console.error(error);
-        toast.error("Unable to load shops.");
+        const scope = getOfflineMutationScope();
+        const cached = scope ? await getLatestCachedAdvisorDay(scope) : null;
+        if (cached) {
+          setShops([cached.shop as ShopRow]);
+          setShopSlug(cached.shop.slug ?? "");
+          setOfflineSavedAt(cached.downloadedAt);
+          setUsingOfflineData(true);
+        } else {
+          toast.error("Unable to load shops.");
+        }
         return;
       }
 
@@ -93,6 +114,16 @@ export default function MobileAppointmentsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine);
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+    return () => {
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
   // selected shop row
   const selectedShop = useMemo(
     () => shops.find((s) => (s.slug as string | null) === shopSlug) ?? null,
@@ -107,6 +138,18 @@ export default function MobileAppointmentsPage() {
     (async () => {
       setLoadingCustomers(true);
       try {
+        if (!navigator.onLine) {
+          const scope = getOfflineMutationScope();
+          const cached = scope
+            ? await getCachedAdvisorDay({ scope, day })
+            : null;
+          setCustomers(cached?.customers ?? []);
+          if (cached) {
+            setOfflineSavedAt(cached.downloadedAt);
+            setUsingOfflineData(true);
+          }
+          return;
+        }
         const { data, error } = await supabase
           .from("customers")
           .select("*")
@@ -131,7 +174,7 @@ export default function MobileAppointmentsPage() {
         setLoadingCustomers(false);
       }
     })();
-  }, [supabase, selectedShop]);
+  }, [supabase, selectedShop, day]);
 
   /* ------------------------------ Bookings --------------------------------- */
 
@@ -151,10 +194,21 @@ export default function MobileAppointmentsPage() {
         if (!res.ok) throw new Error("Failed to load appointments.");
         const j = (await res.json().catch(() => [])) as Booking[];
         setBookings(j ?? []);
+        setUsingOfflineData(false);
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error(err);
-        toast.error("Failed to load appointments.");
+        const scope = getOfflineMutationScope();
+        const cached = scope ? await getCachedAdvisorDay({ scope, day }) : null;
+        if (cached && cached.shop.slug === shopSlug) {
+          setBookings(cached.bookings);
+          setCustomers(cached.customers);
+          setOfflineSavedAt(cached.downloadedAt);
+          setUsingOfflineData(true);
+          toast.warning("Showing appointments saved on this device.");
+        } else {
+          toast.error("Failed to load appointments.");
+        }
       } finally {
         setLoadingBookings(false);
       }
@@ -213,9 +267,10 @@ export default function MobileAppointmentsPage() {
         }),
       });
 
-      const j = (await res
-        .json()
-        .catch(() => ({}))) as { booking?: Booking; error?: string };
+      const j = (await res.json().catch(() => ({}))) as {
+        booking?: Booking;
+        error?: string;
+      };
 
       if (!res.ok || !j.booking) {
         throw new Error(j?.error || "Unable to create appointment.");
@@ -266,6 +321,30 @@ export default function MobileAppointmentsPage() {
 
   const totalForDay = bookings.length;
 
+  async function downloadOfflineDay() {
+    if (!online || downloadingOffline) return;
+    setDownloadingOffline(true);
+    try {
+      const bundle = await downloadAdvisorOfflineDay(day);
+      setBookings(bundle.bookings);
+      setCustomers(bundle.customers);
+      setOfflineSavedAt(bundle.downloadedAt);
+      setUsingOfflineData(false);
+      toast.success("Advisor day and customer lookup saved for offline use.");
+      if (bundle.truncated.customers || bundle.truncated.vehicles) {
+        toast.warning(
+          "The shop lookup is large; only the newest 5,000 records were saved.",
+        );
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Offline download failed.",
+      );
+    } finally {
+      setDownloadingOffline(false);
+    }
+  }
+
   /* -------------------------------- Render --------------------------------- */
 
   return (
@@ -286,6 +365,30 @@ export default function MobileAppointmentsPage() {
             appointments.
           </p>
         </header>
+
+        <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs shadow-card">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="font-semibold text-[color:var(--theme-text-primary)]">
+                {online ? "Connected" : "Offline"}
+                {usingOfflineData ? " · saved device view" : ""}
+              </p>
+              <p className="mt-1 text-[color:var(--theme-text-secondary)]">
+                {offlineSavedAt
+                  ? `Saved ${new Date(offlineSavedAt).toLocaleString()}`
+                  : "This day has not been saved for offline use."}
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="xs"
+              disabled={!online || downloadingOffline}
+              onClick={() => void downloadOfflineDay()}
+            >
+              {downloadingOffline ? "Saving…" : "Download this day"}
+            </Button>
+          </div>
+        </section>
 
         {/* Shop + day picker */}
         <section className="space-y-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 shadow-card backdrop-blur-md">
@@ -370,7 +473,12 @@ export default function MobileAppointmentsPage() {
 
         {/* Create / edit form */}
         <section className="space-y-2 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 shadow-card backdrop-blur-md">
-          {editing ? (
+          {!online ? (
+            <p className="text-xs text-[color:var(--theme-text-secondary)]">
+              Appointment creation and changes require a connection. Saved
+              appointments remain available to review.
+            </p>
+          ) : editing ? (
             <EditForm
               booking={editing}
               customers={customers}
@@ -402,7 +510,9 @@ export default function MobileAppointmentsPage() {
           </div>
 
           {loadingBookings ? (
-            <p className="text-xs text-[color:var(--theme-text-secondary)]">Fetching appointments…</p>
+            <p className="text-xs text-[color:var(--theme-text-secondary)]">
+              Fetching appointments…
+            </p>
           ) : bookings.length === 0 ? (
             <p className="text-xs text-[color:var(--theme-text-secondary)]">
               No appointments for this day.
@@ -411,10 +521,7 @@ export default function MobileAppointmentsPage() {
             <ul className="space-y-2">
               {bookings
                 .slice()
-                .sort(
-                  (a, b) =>
-                    +new Date(a.starts_at) - +new Date(b.starts_at),
-                )
+                .sort((a, b) => +new Date(a.starts_at) - +new Date(b.starts_at))
                 .map((b) => {
                   const start = new Date(b.starts_at);
                   const end = new Date(b.ends_at);
@@ -449,6 +556,7 @@ export default function MobileAppointmentsPage() {
                           type="button"
                           size="xs"
                           variant="outline"
+                          disabled={!online}
                           onClick={() => setEditing(b)}
                         >
                           Edit
@@ -457,6 +565,7 @@ export default function MobileAppointmentsPage() {
                           type="button"
                           size="xs"
                           variant="ghost"
+                          disabled={!online}
                           className="text-red-300 hover:bg-red-900/25"
                           onClick={() => void handleDelete(b.id)}
                         >
@@ -604,9 +713,7 @@ function CreateForm({
           onChange={(e) => handleSelectCustomer(e.target.value)}
           className="mt-1 w-full rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-2 py-1.5 text-xs text-[color:var(--theme-text-primary)] focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
         >
-          <option value="">
-            {loadingCustomers ? "Loading…" : "Select…"}
-          </option>
+          <option value="">{loadingCustomers ? "Loading…" : "Select…"}</option>
           {customers.map((c) => (
             <option key={c.id} value={c.id}>
               {customerLabel(c)}
@@ -685,9 +792,7 @@ function EditForm({
   const [customerId, setCustomerId] = useState<string>(
     booking.customer_id ?? "",
   );
-  const [customerName, setCustomerName] = useState(
-    booking.customer_name ?? "",
-  );
+  const [customerName, setCustomerName] = useState(booking.customer_name ?? "");
   const [customerEmail, setCustomerEmail] = useState(
     booking.customer_email ?? "",
   );
@@ -775,9 +880,7 @@ function EditForm({
           onChange={(e) => handleSelectCustomer(e.target.value)}
           className="mt-1 w-full rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-2 py-1.5 text-xs text-[color:var(--theme-text-primary)]"
         >
-          <option value="">
-            {loadingCustomers ? "Loading…" : "Select…"}
-          </option>
+          <option value="">{loadingCustomers ? "Loading…" : "Select…"}</option>
           {customers.map((c) => (
             <option key={c.id} value={c.id}>
               {customerLabel(c)}

--- a/app/mobile/work-orders/create/page.tsx
+++ b/app/mobile/work-orders/create/page.tsx
@@ -35,6 +35,23 @@ import { MobileJobLineAdd } from "@/features/work-orders/mobile/MobileJobLineAdd
 import NewWorkOrderLineForm from "@/features/work-orders/components/NewWorkOrderLineForm";
 import { useWorkOrderDraft } from "app/work-orders/state/useWorkOrderDraft";
 import VinCaptureModal from "app/vehicle/VinCaptureModal";
+import {
+  getOfflineMutationScope,
+  setOfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+import {
+  createAdvisorDraftId,
+  getCurrentAdvisorWorkOrderDraft,
+  getLatestCachedAdvisorDay,
+  materializeAdvisorWorkOrderDraft,
+  removeCurrentAdvisorWorkOrderDraft,
+  saveCurrentAdvisorWorkOrderDraft,
+} from "@/features/work-orders/mobile/advisorOffline";
+import type {
+  AdvisorWorkOrderDraft,
+  AdvisorWorkOrderDraftLine,
+} from "@/features/work-orders/mobile/advisorOfflineTypes";
+import { AdvisorDraftLines } from "@/features/work-orders/mobile/AdvisorDraftLines";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -90,11 +107,7 @@ function toNumberOrNull(v: unknown): number | null {
 
 function numStringOrNull(v: unknown): string | null {
   const s =
-    typeof v === "string"
-      ? v.trim()
-      : typeof v === "number"
-        ? String(v)
-        : "";
+    typeof v === "string" ? v.trim() : typeof v === "number" ? String(v) : "";
   if (!s) return null;
   return s;
 }
@@ -189,11 +202,13 @@ function CustomerSearch({
   shopId,
   value,
   onPick,
+  offlineRows = [],
 }: {
   supabase: ReturnType<typeof createBrowserSupabase>;
   shopId: string | null;
   value: string;
   onPick: (c: CustomerPick) => void;
+  offlineRows?: CustomerPick[];
 }) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -215,10 +230,35 @@ function CustomerSearch({
     const t = window.setTimeout(async () => {
       setBusy(true);
       try {
+        if (!navigator.onLine) {
+          const normalized = term.toLowerCase();
+          setRows(
+            offlineRows
+              .filter((row) =>
+                [
+                  row.business_name,
+                  row.first_name,
+                  row.last_name,
+                  row.name,
+                  row.phone,
+                  row.phone_number,
+                  row.email,
+                ]
+                  .filter(Boolean)
+                  .some((value) =>
+                    String(value).toLowerCase().includes(normalized),
+                  ),
+              )
+              .slice(0, 12),
+          );
+          return;
+        }
         const like = `%${term}%`;
         const { data, error } = await supabase
           .from("customers")
-          .select("id,business_name,first_name,last_name,name,phone,phone_number,email,created_at")
+          .select(
+            "id,business_name,first_name,last_name,name,phone,phone_number,email,created_at",
+          )
           .eq("shop_id", shopId)
           .or(
             [
@@ -246,8 +286,7 @@ function CustomerSearch({
     }, 150);
 
     return () => window.clearTimeout(t);
-
-  }, [value, shopId, supabase]);
+  }, [value, shopId, supabase, offlineRows]);
 
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
@@ -264,7 +303,9 @@ function CustomerSearch({
     <div ref={wrapRef} className="relative">
       <div className="absolute z-20 mt-1 w-full overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] backdrop-blur-xl shadow-lg shadow-[var(--theme-shadow-medium)]">
         {busy && (
-          <div className="px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">Searching…</div>
+          <div className="px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
+            Searching…
+          </div>
         )}
         {rows.map((c) => (
           <button
@@ -287,7 +328,9 @@ function CustomerSearch({
           </button>
         ))}
         {!busy && rows.length === 0 && (
-          <div className="px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">No matches</div>
+          <div className="px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
+            No matches
+          </div>
         )}
       </div>
     </div>
@@ -300,6 +343,7 @@ function CustomerSearch({
 
 type VehiclePick = {
   id: string;
+  customer_id?: string | null;
   unit_number: string | null;
   license_plate: string | null;
   vin: string | null;
@@ -342,12 +386,14 @@ function VehicleSearch({
   customerId,
   value,
   onPick,
+  offlineRows = [],
 }: {
   supabase: ReturnType<typeof createBrowserSupabase>;
   shopId: string | null;
   customerId: string | null;
   value: string;
   onPick: (v: VehiclePick) => void;
+  offlineRows?: VehiclePick[];
 }) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -369,6 +415,30 @@ function VehicleSearch({
     const t = window.setTimeout(async () => {
       setBusy(true);
       try {
+        if (!navigator.onLine) {
+          const normalized = term.toLowerCase();
+          setRows(
+            offlineRows
+              .filter(
+                (row) => !row.customer_id || row.customer_id === customerId,
+              )
+              .filter((row) =>
+                [
+                  row.unit_number,
+                  row.license_plate,
+                  row.vin,
+                  row.make,
+                  row.model,
+                ]
+                  .filter(Boolean)
+                  .some((value) =>
+                    String(value).toLowerCase().includes(normalized),
+                  ),
+              )
+              .slice(0, 12),
+          );
+          return;
+        }
         const like = `%${term}%`;
         const { data, error } = await supabase
           .from("vehicles")
@@ -401,7 +471,7 @@ function VehicleSearch({
     }, 150);
 
     return () => window.clearTimeout(t);
-  }, [value, shopId, customerId, supabase]);
+  }, [value, shopId, customerId, supabase, offlineRows]);
 
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
@@ -418,7 +488,9 @@ function VehicleSearch({
     <div ref={wrapRef} className="relative">
       <div className="absolute z-20 mt-1 w-full overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] backdrop-blur-xl shadow-lg shadow-[var(--theme-shadow-medium)]">
         {busy && (
-          <div className="px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">Searching…</div>
+          <div className="px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
+            Searching…
+          </div>
         )}
         {rows.map((v) => (
           <button
@@ -432,14 +504,18 @@ function VehicleSearch({
               setOpen(false);
             }}
           >
-            <div className="truncate text-[color:var(--theme-text-primary)]">{formatVehicleTitle(v)}</div>
+            <div className="truncate text-[color:var(--theme-text-primary)]">
+              {formatVehicleTitle(v)}
+            </div>
             <div className="truncate text-xs text-[color:var(--theme-text-secondary)]">
               {formatVehicleSub(v) || "—"}
             </div>
           </button>
         ))}
         {!busy && rows.length === 0 && (
-          <div className="px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">No matches</div>
+          <div className="px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
+            No matches
+          </div>
         )}
       </div>
     </div>
@@ -492,6 +568,16 @@ export default function MobileCreateWorkOrderPage() {
   // lightweight search inputs (keep UI small)
   const [customerSearch, setCustomerSearch] = useState("");
   const [vehicleSearch, setVehicleSearch] = useState("");
+  const [draftLines, setDraftLines] = useState<AdvisorWorkOrderDraftLine[]>([]);
+  const [offlineCustomers, setOfflineCustomers] = useState<CustomerPick[]>([]);
+  const [offlineVehicles, setOfflineVehicles] = useState<VehiclePick[]>([]);
+  const [draftRestored, setDraftRestored] = useState(false);
+  const [online, setOnline] = useState(
+    () => typeof navigator !== "undefined" && navigator.onLine,
+  );
+  const draftIdentityRef = useRef<{ id: string; operationKey: string } | null>(
+    null,
+  );
 
   /* ------------------------------------------------------------------------ */
   /* Resolve current user + shop id                                           */
@@ -508,12 +594,125 @@ export default function MobileCreateWorkOrderPage() {
         try {
           const sid = await getOrLinkShopId(supabase, uid);
           setShopId(sid);
+          if (sid) {
+            const scope = { userId: uid, shopId: sid };
+            setOfflineMutationScope(scope);
+            const [bundle, storedDraft] = await Promise.all([
+              getLatestCachedAdvisorDay(scope),
+              getCurrentAdvisorWorkOrderDraft(scope),
+            ]);
+            if (bundle) {
+              setOfflineCustomers(bundle.customers as CustomerPick[]);
+              setOfflineVehicles(bundle.vehicles as VehiclePick[]);
+            }
+            if (storedDraft) {
+              draftIdentityRef.current = {
+                id: storedDraft.id,
+                operationKey: storedDraft.operationKey,
+              };
+              setDraftLines(storedDraft.lines);
+              setIsWaiter(storedDraft.isWaiter);
+              const savedCustomer = bundle?.customers.find(
+                (item) => item.id === storedDraft.customerId,
+              );
+              const savedVehicle = bundle?.vehicles.find(
+                (item) => item.id === storedDraft.vehicleId,
+              );
+              if (savedCustomer) {
+                setCustomer({
+                  id: savedCustomer.id,
+                  first_name: savedCustomer.first_name,
+                  last_name: savedCustomer.last_name,
+                  phone: savedCustomer.phone,
+                  email: savedCustomer.email,
+                  business_name: savedCustomer.business_name,
+                });
+              }
+              if (!savedCustomer && storedDraft.customer) {
+                setCustomer(storedDraft.customer);
+              }
+              if (savedVehicle) {
+                setVehicle({
+                  id: savedVehicle.id,
+                  vin: savedVehicle.vin,
+                  year: savedVehicle.year,
+                  make: savedVehicle.make,
+                  model: savedVehicle.model,
+                  license_plate: savedVehicle.license_plate,
+                  mileage: savedVehicle.mileage,
+                  color: savedVehicle.color,
+                  unit_number: savedVehicle.unit_number,
+                  engine_hours: savedVehicle.engine_hours,
+                  engine: savedVehicle.engine,
+                  transmission: savedVehicle.transmission,
+                  fuel_type: savedVehicle.fuel_type,
+                  drivetrain: savedVehicle.drivetrain,
+                });
+              }
+              if (!savedVehicle && storedDraft.vehicle) {
+                setVehicle(storedDraft.vehicle);
+              }
+              setDraftRestored(true);
+            }
+          }
         } catch (e) {
           setError(e instanceof Error ? e.message : "Failed to load shop.");
         }
       }
     })();
   }, [supabase]);
+
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine);
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+    return () => {
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
+  const buildAdvisorDraft = useCallback((): AdvisorWorkOrderDraft | null => {
+    if (!currentUserId || !shopId) return null;
+    draftIdentityRef.current ??= (() => {
+      const id = createAdvisorDraftId();
+      return { id, operationKey: `${id}:materialize` };
+    })();
+    return {
+      ...draftIdentityRef.current,
+      userId: currentUserId,
+      shopId,
+      customerId: customer.id,
+      vehicleId: vehicle.id,
+      customer,
+      vehicle,
+      isWaiter,
+      notes: "",
+      priority: 3,
+      lines: draftLines,
+      updatedAt: new Date().toISOString(),
+    };
+  }, [currentUserId, shopId, customer, vehicle, isWaiter, draftLines]);
+
+  useEffect(() => {
+    if (wo?.id || creatingWo || !currentUserId || !shopId) return;
+    if (!customer.id && !vehicle.id && draftLines.length === 0) return;
+    const timer = window.setTimeout(() => {
+      const current = buildAdvisorDraft();
+      if (current) void saveCurrentAdvisorWorkOrderDraft(current);
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [
+    wo?.id,
+    creatingWo,
+    currentUserId,
+    shopId,
+    customer.id,
+    vehicle.id,
+    draftLines,
+    isWaiter,
+    buildAdvisorDraft,
+  ]);
 
   /* ------------------------------------------------------------------------ */
   /* Hydrate from shared VIN / OCR draft (desktop + mobile shared store)      */
@@ -812,6 +1011,22 @@ export default function MobileCreateWorkOrderPage() {
       if (!currentUserId) throw new Error("Not signed in.");
       if (!shopId) throw new Error("Your profile isn’t linked to a shop yet.");
 
+      const deviceDraft = buildAdvisorDraft();
+      if (!navigator.onLine) {
+        if (!deviceDraft || deviceDraft.lines.length === 0) {
+          throw new Error(
+            "Add at least one temporary job line to save this draft.",
+          );
+        }
+        await saveCurrentAdvisorWorkOrderDraft(deviceDraft);
+        setError(
+          customer.id && vehicle.id
+            ? "Draft saved on this device. Create it after reconnecting."
+            : "Draft saved. A connection is required to create the new customer or vehicle before submission.",
+        );
+        return;
+      }
+
       if (
         !customer.first_name &&
         !customer.last_name &&
@@ -823,6 +1038,36 @@ export default function MobileCreateWorkOrderPage() {
 
       const cust = await ensureCustomer();
       const veh = await ensureVehicle(cust);
+
+      if (draftLines.length > 0) {
+        const prepared = buildAdvisorDraft();
+        if (!prepared) throw new Error("Draft scope is unavailable.");
+        const submissionDraft: AdvisorWorkOrderDraft = {
+          ...prepared,
+          customerId: cust.id,
+          vehicleId: veh.id,
+        };
+        await saveCurrentAdvisorWorkOrderDraft(submissionDraft);
+        const materialization =
+          await materializeAdvisorWorkOrderDraft(submissionDraft);
+        const { data: createdRow, error: createdError } = await supabase
+          .from("work_orders")
+          .select("*")
+          .eq("id", materialization.workOrderId)
+          .eq("shop_id", shopId)
+          .single();
+        if (createdError || !createdRow) {
+          throw new Error(
+            createdError?.message ?? "Created work order could not be loaded.",
+          );
+        }
+        setWo(createdRow as WorkOrderRow);
+        setDraftLines([]);
+        const scope = getOfflineMutationScope();
+        if (scope) await removeCurrentAdvisorWorkOrderDraft(scope);
+        draftIdentityRef.current = null;
+        return;
+      }
 
       const { data: created, error: rpcErr } = await supabase.rpc(
         "create_work_order_with_custom_id",
@@ -858,6 +1103,9 @@ export default function MobileCreateWorkOrderPage() {
     currentUserId,
     shopId,
     customer,
+    vehicle.id,
+    draftLines,
+    buildAdvisorDraft,
     ensureCustomer,
     ensureVehicle,
     isWaiter,
@@ -920,7 +1168,9 @@ export default function MobileCreateWorkOrderPage() {
                 type="button"
                 onClick={() => void handleWaiterChange(false)}
                 className={`px-3 py-1.5 font-medium transition ${
-                  !isWaiter ? "bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]" : "text-[color:var(--theme-text-secondary)]"
+                  !isWaiter
+                    ? "bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]"
+                    : "text-[color:var(--theme-text-secondary)]"
                 }`}
               >
                 Drop-off
@@ -971,6 +1221,7 @@ export default function MobileCreateWorkOrderPage() {
                 supabase={supabase}
                 shopId={shopId}
                 value={customerSearch}
+                offlineRows={offlineCustomers}
                 onPick={(c) => {
                   setCustomer({
                     id: c.id,
@@ -1060,6 +1311,7 @@ export default function MobileCreateWorkOrderPage() {
                 shopId={shopId}
                 customerId={customer.id}
                 value={vehicleSearch}
+                offlineRows={offlineVehicles}
                 onPick={(v) => {
                   setVehicle({
                     id: v.id,
@@ -1266,26 +1518,32 @@ export default function MobileCreateWorkOrderPage() {
                 onDecoded={(decoded) => {
                   const v: DraftVehicleShape = {
                     vin: decoded.vin ?? null,
-                    year: (decoded as unknown as { year?: string | number | null })
-                      .year
+                    year: (
+                      decoded as unknown as { year?: string | number | null }
+                    ).year
                       ? String(
-                          (decoded as unknown as { year?: string | number | null })
-                            .year,
+                          (
+                            decoded as unknown as {
+                              year?: string | number | null;
+                            }
+                          ).year,
                         )
                       : null,
-                    make: (decoded as unknown as { make?: string | null }).make ?? null,
+                    make:
+                      (decoded as unknown as { make?: string | null }).make ??
+                      null,
                     model:
                       (decoded as unknown as { model?: string | null }).model ??
                       null,
                     engine:
-                      (decoded as unknown as { engine?: string | null }).engine ??
-                      null,
+                      (decoded as unknown as { engine?: string | null })
+                        .engine ?? null,
                     fuel_type:
-                      (decoded as unknown as { fuelType?: string | null }).fuelType ??
-                      null,
+                      (decoded as unknown as { fuelType?: string | null })
+                        .fuelType ?? null,
                     drivetrain:
-                      (decoded as unknown as { driveType?: string | null }).driveType ??
-                      null,
+                      (decoded as unknown as { driveType?: string | null })
+                        .driveType ?? null,
                     transmission:
                       (decoded as unknown as { transmission?: string | null })
                         .transmission ?? null,
@@ -1313,6 +1571,22 @@ export default function MobileCreateWorkOrderPage() {
             </div>
           </div>
 
+          {draftRestored && !wo?.id && (
+            <p className="mt-3 rounded-lg border border-sky-500/30 bg-sky-950/30 px-3 py-2 text-[0.7rem] text-sky-100">
+              Restored the unfinished work-order draft saved on this device.
+            </p>
+          )}
+
+          {!wo?.id && (
+            <div className="mt-4">
+              <AdvisorDraftLines
+                lines={draftLines}
+                onChange={setDraftLines}
+                disabled={creatingWo}
+              />
+            </div>
+          )}
+
           {/* Create WO button */}
           {!wo?.id ? (
             <button
@@ -1321,7 +1595,13 @@ export default function MobileCreateWorkOrderPage() {
               onClick={() => void handleCreateWorkOrder()}
               className="mt-4 w-full rounded-full bg-[var(--accent-copper)] py-3 text-sm font-semibold text-[color:var(--theme-text-on-accent)] shadow-[var(--theme-shadow-medium)] transition active:opacity-85 disabled:opacity-60"
             >
-              {creatingWo ? "Creating…" : "Create Work Order"}
+              {creatingWo
+                ? "Creating…"
+                : !online
+                  ? "Save offline draft"
+                  : draftLines.length > 0
+                    ? `Create Work Order + ${draftLines.length} line${draftLines.length === 1 ? "" : "s"}`
+                    : "Create Work Order"}
             </button>
           ) : (
             <p className="mt-4 text-center text-[0.7rem] text-[color:var(--theme-text-secondary)]">
@@ -1363,8 +1643,6 @@ export default function MobileCreateWorkOrderPage() {
                   onCreated={fetchLines}
                 />
               </div>
-
-
             </div>
 
             <button

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -27,6 +27,22 @@ const serwist = new Serwist({
     {
       matcher: ({ request, url }) =>
         request.mode === "navigate" &&
+        (url.pathname === "/mobile/appointments" ||
+          url.pathname === "/mobile/work-orders/create"),
+      handler: new NetworkFirst({
+        cacheName: "profixiq-advisor-shell-v1",
+        networkTimeoutSeconds: 4,
+        plugins: [
+          new ExpirationPlugin({
+            maxEntries: 20,
+            maxAgeSeconds: 60 * 60 * 24 * 14,
+          }),
+        ],
+      }),
+    },
+    {
+      matcher: ({ request, url }) =>
+        request.mode === "navigate" &&
         (url.pathname === "/mobile/tech/queue" ||
           url.pathname.startsWith("/mobile/work-orders/") ||
           url.pathname.startsWith("/mobile/jobs/")),

--- a/features/work-orders/mobile/AdvisorDraftLines.tsx
+++ b/features/work-orders/mobile/AdvisorDraftLines.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import { createAdvisorDraftLine } from "@/features/work-orders/mobile/advisorOffline";
+import type { AdvisorWorkOrderDraftLine } from "@/features/work-orders/mobile/advisorOfflineTypes";
+
+export function AdvisorDraftLines({
+  lines,
+  onChange,
+  disabled = false,
+}: {
+  lines: AdvisorWorkOrderDraftLine[];
+  onChange: (lines: AdvisorWorkOrderDraftLine[]) => void;
+  disabled?: boolean;
+}) {
+  const [complaint, setComplaint] = useState("");
+  const [jobType, setJobType] =
+    useState<AdvisorWorkOrderDraftLine["jobType"]>("diagnosis");
+  const [laborTime, setLaborTime] = useState("");
+
+  const add = () => {
+    const value = complaint.trim();
+    if (!value || disabled) return;
+    const labor = laborTime.trim() ? Number(laborTime) : null;
+    onChange([
+      ...lines,
+      createAdvisorDraftLine({
+        lineType: "job",
+        complaint: value,
+        jobType,
+        laborTime: Number.isFinite(labor) ? labor : null,
+      }),
+    ]);
+    setComplaint("");
+    setLaborTime("");
+  };
+
+  return (
+    <section className="glass-card rounded-2xl border border-[color:var(--theme-border-soft)] px-3 py-3 text-[color:var(--theme-text-primary)]">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-[0.68rem] font-medium uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            Draft job lines
+          </p>
+          <p className="mt-1 text-[0.7rem] text-[color:var(--theme-text-muted)]">
+            Temporary lines stay on this device until the draft is created
+            online.
+          </p>
+        </div>
+        <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-1 text-[0.65rem]">
+          {lines.length}
+        </span>
+      </div>
+
+      {lines.length > 0 && (
+        <ul className="mt-3 space-y-2">
+          {lines.map((line, index) => (
+            <li
+              key={line.tempId}
+              className="flex items-start justify-between gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs"
+            >
+              <div className="min-w-0">
+                <p className="font-medium">
+                  {index + 1}. {line.complaint}
+                </p>
+                <p className="mt-1 text-[0.65rem] text-[color:var(--theme-text-muted)]">
+                  {line.jobType ?? "diagnosis"}
+                  {line.laborTime != null ? ` · ${line.laborTime} hr` : ""}
+                </p>
+              </div>
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() =>
+                  onChange(lines.filter((item) => item.tempId !== line.tempId))
+                }
+                className="text-[0.68rem] text-red-300 disabled:opacity-40"
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        <input
+          className="input col-span-2"
+          placeholder="Customer concern or requested work"
+          value={complaint}
+          disabled={disabled}
+          onChange={(event) => setComplaint(event.target.value)}
+        />
+        <select
+          className="input"
+          value={jobType}
+          disabled={disabled}
+          onChange={(event) =>
+            setJobType(
+              event.target.value as AdvisorWorkOrderDraftLine["jobType"],
+            )
+          }
+        >
+          <option value="diagnosis">Diagnosis</option>
+          <option value="inspection">Inspection</option>
+          <option value="maintenance">Maintenance</option>
+          <option value="repair">Repair</option>
+        </select>
+        <input
+          className="input"
+          type="number"
+          min="0"
+          max="1000"
+          step="0.1"
+          placeholder="Labor hours"
+          value={laborTime}
+          disabled={disabled}
+          onChange={(event) => setLaborTime(event.target.value)}
+        />
+        <button
+          type="button"
+          disabled={disabled || !complaint.trim()}
+          onClick={add}
+          className="col-span-2 rounded-full border border-[var(--accent-copper)] px-3 py-2 text-xs font-semibold text-[var(--accent-copper-light)] disabled:opacity-40"
+        >
+          Add temporary line
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/features/work-orders/mobile/advisorOffline.ts
+++ b/features/work-orders/mobile/advisorOffline.ts
@@ -1,0 +1,180 @@
+"use client";
+
+import {
+  getOfflineSnapshot,
+  listOfflineSnapshots,
+  removeOfflineSnapshots,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+import type {
+  AdvisorDraftMaterialization,
+  AdvisorOfflineBundle,
+  AdvisorWorkOrderDraft,
+  AdvisorWorkOrderDraftLine,
+} from "@/features/work-orders/mobile/advisorOfflineTypes";
+
+const DAY_KIND = "advisor-offline-day";
+const DRAFT_KIND = "advisor-work-order-draft";
+const MATERIALIZATION_KIND = "advisor-draft-materialization";
+const CURRENT_DRAFT_ID = "current";
+const ADVISOR_SHELL_CACHE = "profixiq-advisor-shell-v1";
+const DRAFT_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 30;
+
+export function createAdvisorDraftId(): string {
+  const id =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `advisor-draft:${id}`;
+}
+
+export function createAdvisorDraftLine(
+  input: Omit<AdvisorWorkOrderDraftLine, "tempId">,
+): AdvisorWorkOrderDraftLine {
+  const id =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return { ...input, tempId: `temp-line:${id}` };
+}
+
+async function cacheAdvisorRouteShells(bundle: AdvisorOfflineBundle) {
+  if (typeof caches === "undefined" || !navigator.serviceWorker?.controller)
+    return;
+  const cache = await caches.open(ADVISOR_SHELL_CACHE);
+  const urls = [
+    `/mobile/appointments?shop=${encodeURIComponent(bundle.shop.slug ?? "")}`,
+    "/mobile/work-orders/create",
+  ];
+  await Promise.all(
+    urls.map(async (url) => {
+      const response = await fetch(url, {
+        credentials: "include",
+        headers: { Accept: "text/html" },
+      });
+      if (response.ok) await cache.put(url, response.clone());
+    }),
+  );
+}
+
+export async function downloadAdvisorOfflineDay(day: string) {
+  const response = await fetch(
+    `/api/offline/advisor-day?day=${encodeURIComponent(day)}`,
+    { credentials: "include", cache: "no-store" },
+  );
+  const body = (await response.json().catch(() => null)) as
+    | AdvisorOfflineBundle
+    | { error?: string }
+    | null;
+  if (!response.ok || !body || !("scope" in body)) {
+    throw new Error(
+      (body && "error" in body && body.error) ||
+        "Advisor offline data could not be downloaded.",
+    );
+  }
+  await saveOfflineSnapshot({
+    scope: body.scope,
+    kind: DAY_KIND,
+    entityId: body.day,
+    data: body,
+  });
+  await cacheAdvisorRouteShells(body);
+  return body;
+}
+
+export async function getCachedAdvisorDay(args: {
+  scope: OfflineMutationScope;
+  day: string;
+}): Promise<AdvisorOfflineBundle | null> {
+  const stored = await getOfflineSnapshot<AdvisorOfflineBundle>({
+    scope: args.scope,
+    kind: DAY_KIND,
+    entityId: args.day,
+  });
+  return stored?.data ?? null;
+}
+
+export async function getLatestCachedAdvisorDay(
+  scope: OfflineMutationScope,
+): Promise<AdvisorOfflineBundle | null> {
+  const stored = await listOfflineSnapshots<AdvisorOfflineBundle>({
+    scope,
+    kind: DAY_KIND,
+  });
+  return (
+    stored.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0]?.data ??
+    null
+  );
+}
+
+export async function getCurrentAdvisorWorkOrderDraft(
+  scope: OfflineMutationScope,
+): Promise<AdvisorWorkOrderDraft | null> {
+  const stored = await getOfflineSnapshot<AdvisorWorkOrderDraft>({
+    scope,
+    kind: DRAFT_KIND,
+    entityId: CURRENT_DRAFT_ID,
+  });
+  return stored?.data ?? null;
+}
+
+export async function saveCurrentAdvisorWorkOrderDraft(
+  draft: AdvisorWorkOrderDraft,
+): Promise<void> {
+  await saveOfflineSnapshot({
+    scope: { userId: draft.userId, shopId: draft.shopId },
+    kind: DRAFT_KIND,
+    entityId: CURRENT_DRAFT_ID,
+    data: draft,
+    maxAgeMs: DRAFT_MAX_AGE_MS,
+  });
+}
+
+export async function removeCurrentAdvisorWorkOrderDraft(
+  scope: OfflineMutationScope,
+): Promise<void> {
+  await removeOfflineSnapshots({
+    scope,
+    kind: DRAFT_KIND,
+    entityIds: [CURRENT_DRAFT_ID],
+  });
+}
+
+export async function materializeAdvisorWorkOrderDraft(
+  draft: AdvisorWorkOrderDraft,
+): Promise<AdvisorDraftMaterialization> {
+  const response = await fetch("/api/offline/advisor-work-order-drafts", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": draft.operationKey,
+    },
+    body: JSON.stringify(draft),
+  });
+  const body = (await response.json().catch(() => null)) as
+    | AdvisorDraftMaterialization
+    | { error?: string }
+    | null;
+  if (!response.ok || !body || !("workOrderId" in body)) {
+    const error = new Error(
+      (body && "error" in body && body.error) ||
+        "Work-order draft could not be created.",
+    ) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+  await saveOfflineSnapshot({
+    scope: { userId: draft.userId, shopId: draft.shopId },
+    kind: MATERIALIZATION_KIND,
+    entityId: draft.id,
+    data: {
+      draftId: draft.id,
+      operationKey: draft.operationKey,
+      ...body,
+    },
+    maxAgeMs: DRAFT_MAX_AGE_MS,
+  });
+  return body;
+}

--- a/features/work-orders/mobile/advisorOfflineTypes.ts
+++ b/features/work-orders/mobile/advisorOfflineTypes.ts
@@ -1,0 +1,67 @@
+import type { Database } from "@shared/types/types/supabase";
+import type {
+  MobileCustomer,
+  MobileVehicle,
+} from "@/features/work-orders/mobile/types";
+
+type DB = Database;
+
+export type AdvisorOfflineBooking = Pick<
+  DB["public"]["Tables"]["bookings"]["Row"],
+  | "id"
+  | "starts_at"
+  | "ends_at"
+  | "customer_id"
+  | "vehicle_id"
+  | "work_order_id"
+  | "notes"
+  | "status"
+> & {
+  shop_slug: string;
+  customer_name: string | null;
+  customer_email: string | null;
+  customer_phone: string | null;
+};
+
+export type AdvisorOfflineBundle = {
+  scope: { userId: string; shopId: string };
+  downloadedAt: string;
+  day: string;
+  shop: Pick<DB["public"]["Tables"]["shops"]["Row"], "id" | "name" | "slug">;
+  bookings: AdvisorOfflineBooking[];
+  customers: DB["public"]["Tables"]["customers"]["Row"][];
+  vehicles: DB["public"]["Tables"]["vehicles"]["Row"][];
+  truncated: { customers: boolean; vehicles: boolean };
+};
+
+export type AdvisorWorkOrderDraftLine = {
+  tempId: string;
+  lineType: "job" | "info";
+  complaint: string;
+  notes?: string;
+  jobType?: "diagnosis" | "inspection" | "maintenance" | "repair";
+  laborTime?: number | null;
+};
+
+export type AdvisorWorkOrderDraft = {
+  id: string;
+  operationKey: string;
+  userId: string;
+  shopId: string;
+  customerId: string | null;
+  vehicleId: string | null;
+  customer: MobileCustomer;
+  vehicle: MobileVehicle;
+  isWaiter: boolean;
+  notes: string;
+  priority: number;
+  lines: AdvisorWorkOrderDraftLine[];
+  updatedAt: string;
+};
+
+export type AdvisorDraftMaterialization = {
+  workOrderId: string;
+  customId: string | null;
+  lineIdMap: Record<string, string>;
+  idempotent: boolean;
+};

--- a/supabase/migrations/20260717090000_offline_advisor_work_order_drafts.sql
+++ b/supabase/migrations/20260717090000_offline_advisor_work_order_drafts.sql
@@ -1,0 +1,148 @@
+begin;
+
+create or replace function public.materialize_offline_work_order_draft_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_customer_id uuid,
+  p_vehicle_id uuid,
+  p_payload jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_existing public.offline_mutation_receipts%rowtype;
+  v_work_order public.work_orders%rowtype;
+  v_line jsonb;
+  v_line_id uuid;
+  v_temp_id text;
+  v_role text;
+  v_payload jsonb := coalesce(p_payload, '{}'::jsonb);
+  v_payload_hash text := encode(digest(coalesce(p_payload, '{}'::jsonb)::text, 'sha256'), 'hex');
+  v_line_map jsonb := '{}'::jsonb;
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor does not match the draft actor.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null or length(p_operation_key) > 240 then
+    raise exception using errcode = 'P0001', message = 'A stable idempotency key is required.';
+  end if;
+
+  select * into v_existing
+  from public.offline_mutation_receipts r
+  where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+  if found then
+    if v_existing.action_type <> 'materialize_work_order_draft' or v_existing.payload_hash <> v_payload_hash then
+      raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different draft data.';
+    end if;
+    return v_existing.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  select lower(coalesce(p.role::text, '')) into v_role
+  from public.profiles p
+  where p.id = p_actor_user_id and p.shop_id = p_shop_id;
+  if not found or v_role not in ('owner','admin','manager','advisor','service','lead_hand','lead hand','leadhand','foreman') then
+    raise exception using errcode = 'P0001', message = 'Actor is not allowed to create work orders for this shop.';
+  end if;
+  if not exists (select 1 from public.customers c where c.id = p_customer_id and c.shop_id = p_shop_id) then
+    raise exception using errcode = 'P0001', message = 'Customer not found for this shop.';
+  end if;
+  if not exists (
+    select 1 from public.vehicles v
+    where v.id = p_vehicle_id and v.shop_id = p_shop_id and v.customer_id = p_customer_id
+  ) then
+    raise exception using errcode = 'P0001', message = 'Vehicle not found for this customer and shop.';
+  end if;
+  if jsonb_typeof(v_payload->'lines') <> 'array'
+     or jsonb_array_length(v_payload->'lines') < 1
+     or jsonb_array_length(v_payload->'lines') > 50 then
+    raise exception using errcode = 'P0001', message = 'Draft requires between 1 and 50 job lines.';
+  end if;
+
+  select * into v_work_order
+  from public.create_work_order_with_custom_id(
+    p_shop_id => p_shop_id,
+    p_customer_id => p_customer_id,
+    p_vehicle_id => p_vehicle_id,
+    p_notes => coalesce(v_payload->>'notes', ''),
+    p_priority => greatest(1, least(5, coalesce((v_payload->>'priority')::integer, 3))),
+    p_is_waiter => coalesce((v_payload->>'isWaiter')::boolean, false),
+    p_advisor_id => p_actor_user_id
+  );
+  if v_work_order.id is null then
+    raise exception using errcode = 'P0001', message = 'Work order could not be created.';
+  end if;
+
+  for v_line in select value from jsonb_array_elements(v_payload->'lines')
+  loop
+    v_temp_id := nullif(trim(v_line->>'tempId'), '');
+    if v_temp_id is null or v_line_map ? v_temp_id then
+      raise exception using errcode = 'P0001', message = 'Every draft line requires a unique temporary ID.';
+    end if;
+    if coalesce(v_line->>'lineType', 'job') not in ('job', 'info') then
+      raise exception using errcode = 'P0001', message = 'Unsupported draft line type.';
+    end if;
+    if nullif(trim(v_line->>'complaint'), '') is null then
+      raise exception using errcode = 'P0001', message = 'Every draft line requires a description.';
+    end if;
+    if nullif(v_line->>'laborTime', '') is not null
+       and ((v_line->>'laborTime')::numeric < 0 or (v_line->>'laborTime')::numeric > 1000) then
+      raise exception using errcode = 'P0001', message = 'Draft line labor time is outside the allowed range.';
+    end if;
+
+    v_line_id := gen_random_uuid();
+    insert into public.work_order_lines(
+      id, work_order_id, vehicle_id, user_id, shop_id, line_no,
+      line_type, complaint, description, notes, job_type, labor_time, status
+    ) values (
+      v_line_id, v_work_order.id, p_vehicle_id, p_actor_user_id, p_shop_id,
+      jsonb_object_length(v_line_map) + 1,
+      coalesce(v_line->>'lineType', 'job'),
+      nullif(trim(v_line->>'complaint'), ''),
+      case when coalesce(v_line->>'lineType', 'job') = 'info' then nullif(trim(v_line->>'complaint'), '') else null end,
+      nullif(trim(v_line->>'notes'), ''),
+      case
+        when coalesce(v_line->>'lineType', 'job') = 'info' then null
+        when v_line->>'jobType' in ('diagnosis','inspection','maintenance','repair') then v_line->>'jobType'
+        else 'diagnosis'
+      end,
+      nullif(v_line->>'laborTime', '')::numeric,
+      'awaiting'
+    );
+    v_line_map := v_line_map || jsonb_build_object(v_temp_id, v_line_id);
+  end loop;
+
+  v_result := jsonb_build_object(
+    'workOrderId', v_work_order.id,
+    'customId', v_work_order.custom_id,
+    'lineIdMap', v_line_map,
+    'idempotent', false
+  );
+  insert into public.offline_mutation_receipts(
+    shop_id, actor_user_id, operation_key, action_type, payload_hash,
+    entity_type, entity_id, result
+  ) values (
+    p_shop_id, p_actor_user_id, p_operation_key,
+    'materialize_work_order_draft', v_payload_hash,
+    'work_order', v_work_order.id, v_result
+  );
+  return v_result;
+exception
+  when unique_violation then
+    select * into v_existing
+    from public.offline_mutation_receipts r
+    where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+    if found and v_existing.action_type = 'materialize_work_order_draft' and v_existing.payload_hash = v_payload_hash then
+      return v_existing.result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different draft data.';
+end;
+$$;
+
+revoke all on function public.materialize_offline_work_order_draft_atomic(uuid,uuid,text,uuid,uuid,jsonb) from public, anon;
+grant execute on function public.materialize_offline_work_order_draft_atomic(uuid,uuid,text,uuid,uuid,jsonb) to authenticated, service_role;
+
+commit;

--- a/tests/advisor-offline-foundation.test.ts
+++ b/tests/advisor-offline-foundation.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  createAdvisorDraftId,
+  createAdvisorDraftLine,
+} from "@/features/work-orders/mobile/advisorOffline";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("advisor offline foundation", () => {
+  it("downloads a role- and shop-scoped day pack without a silent lookup cap", () => {
+    const route = read("app/api/offline/advisor-day/route.ts");
+    expect(route).toContain("canManageScheduling");
+    expect(route).toContain("canManageWorkOrders");
+    expect(route).toContain('rpc("set_current_shop_id"');
+    expect(route).toContain('.eq("shop_id", profile.shop_id)');
+    expect(route).toContain("MAX_ROWS = 5000");
+    expect(route).toContain("customersTruncated = true");
+    expect(route).toContain("vehiclesTruncated = true");
+  });
+
+  it("stores day packs and work-order drafts under authenticated IndexedDB scope", () => {
+    const source = read("features/work-orders/mobile/advisorOffline.ts");
+    expect(source).toContain('const DAY_KIND = "advisor-offline-day"');
+    expect(source).toContain('const DRAFT_KIND = "advisor-work-order-draft"');
+    expect(source).toContain(
+      'const MATERIALIZATION_KIND = "advisor-draft-materialization"',
+    );
+    expect(source).toContain("scope: body.scope");
+    expect(source).toContain(
+      "scope: { userId: draft.userId, shopId: draft.shopId }",
+    );
+    expect(source).toContain("getLatestCachedAdvisorDay");
+    expect(source).toContain("getCurrentAdvisorWorkOrderDraft");
+    expect(source).toContain("operationKey: draft.operationKey");
+  });
+
+  it("creates stable draft and temporary-line identities while preserving line order", () => {
+    const draftId = createAdvisorDraftId();
+    const first = createAdvisorDraftLine({
+      lineType: "job",
+      complaint: "Brake vibration",
+      jobType: "diagnosis",
+    });
+    const second = createAdvisorDraftLine({
+      lineType: "job",
+      complaint: "Oil service",
+      jobType: "maintenance",
+    });
+    expect(draftId).toMatch(/^advisor-draft:/);
+    expect(first.tempId).toMatch(/^temp-line:/);
+    expect(second.tempId).not.toBe(first.tempId);
+    expect([first, second].map((line) => line.complaint)).toEqual([
+      "Brake vibration",
+      "Oil service",
+    ]);
+  });
+
+  it("restores full customer, vehicle, and temporary line draft state after restart", () => {
+    const page = read("app/mobile/work-orders/create/page.tsx");
+    expect(page).toContain("getCurrentAdvisorWorkOrderDraft(scope)");
+    expect(page).toContain("setCustomer(storedDraft.customer)");
+    expect(page).toContain("setVehicle(storedDraft.vehicle)");
+    expect(page).toContain("setDraftLines(storedDraft.lines)");
+    expect(page).toContain("Restored the unfinished work-order draft");
+    expect(page).toContain("saveCurrentAdvisorWorkOrderDraft(current)");
+  });
+
+  it("materializes a draft and its temporary lines atomically and idempotently", () => {
+    const migration = read(
+      "supabase/migrations/20260717090000_offline_advisor_work_order_drafts.sql",
+    );
+    const route = read("app/api/offline/advisor-work-order-drafts/route.ts");
+    const page = read("app/mobile/work-orders/create/page.tsx");
+    expect(route).toContain("Idempotency-Key");
+    expect(route).toContain("materialize_offline_work_order_draft_atomic");
+    expect(migration).toContain("offline_mutation_receipts");
+    expect(migration).toContain("IDEMPOTENCY_KEY_REUSE");
+    expect(migration).toContain("create_work_order_with_custom_id");
+    expect(migration).toContain("jsonb_array_elements");
+    expect(migration).toContain("v_line_map := v_line_map ||");
+    expect(
+      page.indexOf("saveCurrentAdvisorWorkOrderDraft(submissionDraft)"),
+    ).toBeLessThan(
+      page.indexOf("materializeAdvisorWorkOrderDraft(submissionDraft)"),
+    );
+  });
+
+  it("keeps sensitive scheduling writes online and makes advisor shells reopenable", () => {
+    const appointments = read("app/mobile/appointments/page.tsx");
+    const worker = read("app/sw.ts");
+    const offline = read("features/work-orders/mobile/advisorOffline.ts");
+    expect(appointments).toContain(
+      "Appointment creation and changes require a connection",
+    );
+    expect(appointments).toContain("Download this day");
+    expect(worker).toContain('url.pathname === "/mobile/appointments"');
+    expect(worker).toContain('url.pathname === "/mobile/work-orders/create"');
+    expect(worker).toContain('cacheName: "profixiq-advisor-shell-v1"');
+    expect(offline).toContain("cacheAdvisorRouteShells");
+  });
+});


### PR DESCRIPTION
## Summary

Starts Phase 4 with the advisor offline read pack and durable work-order draft foundation.

### Advisor day pack

- adds an authenticated, capability-gated endpoint for a single shop day
- downloads appointments plus customer and vehicle lookup records under the active user/shop scope
- paginates lookup reads and explicitly reports the 5,000-record device limit
- saves day packs in IndexedDB and warms the appointment/work-order-create route shells
- reopens saved appointments and customer/vehicle lookup after an app restart while offline
- keeps appointment creation, edits, and deletion online-only

### Durable work-order drafts

- auto-saves customer, vehicle, waiter state, and ordered temporary job lines in scoped IndexedDB
- restores unfinished drafts after restart
- supports offline customer/vehicle lookup from the downloaded advisor pack
- persists the exact submission payload before sending so lost responses retry safely
- atomically creates the work order and all draft lines through a receipt-backed RPC
- returns and retains temporary-to-canonical line ID mappings for the upcoming parts-request slice
- keeps final materialization online-only

## Security and integrity

- server routes derive user and shop from the authenticated profile
- advisor access uses canonical RBAC capabilities
- authenticated reads initialize the RLS shop context
- the materialization RPC revalidates actor role, customer, vehicle, customer/vehicle relationship, shop, line count, line types, and labor ranges
- stable operation keys and payload hashes reject changed duplicate submissions

## Validation

- 24 focused assertions passed across advisor and existing technician/PWA offline coverage
- `pnpm exec tsc --noEmit` passed
- focused ESLint passed with no errors or warnings
- `git diff --check` passed
- `next build` compiled successfully, including the service worker; page-data collection then stopped because this local workspace does not define the Supabase URL required by the pre-existing `/api/agent/requests` route

## Migration

Run after merge:

`supabase/migrations/20260717090000_offline_advisor_work_order_drafts.sql`

This installs `materialize_offline_work_order_draft_atomic`.