### PR TITLE
Phase 4: add offline parts-request drafts

### DIFF
--- a/app/api/offline/parts-request-drafts/route.ts
+++ b/app/api/offline/parts-request-drafts/route.ts
@@ -1,0 +1,128 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import type { OfflinePartsRequestDraft } from "@/features/parts/offline/partsRequestDrafts";
+
+function statusFor(message: string): number {
+  const value = message.toLowerCase();
+  if (value.includes("not authenticated")) return 401;
+  if (value.includes("not allowed") || value.includes("different user"))
+    return 403;
+  if (value.includes("not found")) return 404;
+  if (value.includes("idempotency") || value.includes("conflict")) return 409;
+  return 400;
+}
+
+export async function POST(request: NextRequest) {
+  const operationKey = request.headers.get("Idempotency-Key")?.trim() ?? "";
+  const draft = (await request
+    .json()
+    .catch(() => null)) as OfflinePartsRequestDraft | null;
+  if (
+    !operationKey ||
+    !draft ||
+    draft.operationKey !== operationKey ||
+    !draft.workOrderId ||
+    !draft.workOrderLineId ||
+    !Array.isArray(draft.items) ||
+    draft.items.length < 1 ||
+    draft.items.length > 100
+  ) {
+    return NextResponse.json(
+      { error: "A valid parts draft and stable Idempotency-Key are required." },
+      { status: 400 },
+    );
+  }
+  if (
+    draft.items.some(
+      (item) =>
+        !item.description?.trim() ||
+        !Number.isFinite(Number(item.qty)) ||
+        Number(item.qty) < 1 ||
+        Number(item.qty) > 10000,
+    )
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "Every part requires a description and quantity from 1 to 10,000.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("shop_id,role")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null; role: string | null }>();
+  const capabilities = getActorCapabilities({ role: profile?.role });
+  if (
+    !profile?.shop_id ||
+    (!capabilities.canManageParts &&
+      !capabilities.canManageWorkOrders &&
+      !capabilities.canPerformAssignedWork)
+  ) {
+    return NextResponse.json(
+      { error: "Not allowed to request parts." },
+      { status: 403 },
+    );
+  }
+  if (draft.userId !== user.id || draft.shopId !== profile.shop_id) {
+    return NextResponse.json(
+      { error: "Draft belongs to a different user or shop." },
+      { status: 403 },
+    );
+  }
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: profile.shop_id,
+  });
+  if (contextError) {
+    return NextResponse.json(
+      { error: "Shop security context could not be initialized." },
+      { status: 500 },
+    );
+  }
+  const rpc = supabase as unknown as {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => PromiseLike<{
+      data: unknown;
+      error: {
+        message: string;
+        details?: string | null;
+        hint?: string | null;
+      } | null;
+    }>;
+  };
+  const { data, error } = await rpc.rpc(
+    "materialize_offline_parts_request_draft_atomic",
+    {
+      p_shop_id: profile.shop_id,
+      p_actor_user_id: user.id,
+      p_operation_key: operationKey,
+      p_work_order_id: draft.workOrderId,
+      p_work_order_line_id: draft.workOrderLineId,
+      p_payload: draft,
+    },
+  );
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return NextResponse.json(
+      { error: message },
+      { status: statusFor(message) },
+    );
+  }
+  return NextResponse.json(data);
+}

--- a/app/mobile/work-orders/create/page.tsx
+++ b/app/mobile/work-orders/create/page.tsx
@@ -52,6 +52,11 @@ import type {
   AdvisorWorkOrderDraftLine,
 } from "@/features/work-orders/mobile/advisorOfflineTypes";
 import { AdvisorDraftLines } from "@/features/work-orders/mobile/AdvisorDraftLines";
+import { AdvisorPartsDraftEditor } from "@/features/parts/offline/AdvisorPartsDraftEditor";
+import {
+  pruneDependentPartsRequestDrafts,
+  resolveAndSubmitDependentPartsDrafts,
+} from "@/features/parts/offline/partsRequestDrafts";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -572,6 +577,7 @@ export default function MobileCreateWorkOrderPage() {
   const [offlineCustomers, setOfflineCustomers] = useState<CustomerPick[]>([]);
   const [offlineVehicles, setOfflineVehicles] = useState<VehiclePick[]>([]);
   const [draftRestored, setDraftRestored] = useState(false);
+  const [workOrderDraftId, setWorkOrderDraftId] = useState<string | null>(null);
   const [online, setOnline] = useState(
     () => typeof navigator !== "undefined" && navigator.onLine,
   );
@@ -610,6 +616,7 @@ export default function MobileCreateWorkOrderPage() {
                 id: storedDraft.id,
                 operationKey: storedDraft.operationKey,
               };
+              setWorkOrderDraftId(storedDraft.id);
               setDraftLines(storedDraft.lines);
               setIsWaiter(storedDraft.isWaiter);
               const savedCustomer = bundle?.customers.find(
@@ -662,6 +669,18 @@ export default function MobileCreateWorkOrderPage() {
     })();
   }, [supabase]);
 
+  const ensureDraftIdentity = useCallback(() => {
+    if (!draftIdentityRef.current) {
+      const id = createAdvisorDraftId();
+      draftIdentityRef.current = {
+        id,
+        operationKey: `${id}:materialize`,
+      };
+      setWorkOrderDraftId(id);
+    }
+    return draftIdentityRef.current;
+  }, []);
+
   useEffect(() => {
     const update = () => setOnline(navigator.onLine);
     window.addEventListener("online", update);
@@ -674,12 +693,9 @@ export default function MobileCreateWorkOrderPage() {
 
   const buildAdvisorDraft = useCallback((): AdvisorWorkOrderDraft | null => {
     if (!currentUserId || !shopId) return null;
-    draftIdentityRef.current ??= (() => {
-      const id = createAdvisorDraftId();
-      return { id, operationKey: `${id}:materialize` };
-    })();
+    const identity = ensureDraftIdentity();
     return {
-      ...draftIdentityRef.current,
+      ...identity,
       userId: currentUserId,
       shopId,
       customerId: customer.id,
@@ -692,7 +708,15 @@ export default function MobileCreateWorkOrderPage() {
       lines: draftLines,
       updatedAt: new Date().toISOString(),
     };
-  }, [currentUserId, shopId, customer, vehicle, isWaiter, draftLines]);
+  }, [
+    currentUserId,
+    shopId,
+    customer,
+    vehicle,
+    isWaiter,
+    draftLines,
+    ensureDraftIdentity,
+  ]);
 
   useEffect(() => {
     if (wo?.id || creatingWo || !currentUserId || !shopId) return;
@@ -1061,11 +1085,25 @@ export default function MobileCreateWorkOrderPage() {
             createdError?.message ?? "Created work order could not be loaded.",
           );
         }
+        const scope = getOfflineMutationScope();
+        if (scope) {
+          const parts = await resolveAndSubmitDependentPartsDrafts({
+            scope,
+            workOrderDraftId: prepared.id,
+            workOrderId: materialization.workOrderId,
+            lineIdMap: materialization.lineIdMap,
+          });
+          if (parts.queued > 0) {
+            setError(
+              `${parts.queued} parts request${parts.queued === 1 ? "" : "s"} queued for sync.`,
+            );
+          }
+          await removeCurrentAdvisorWorkOrderDraft(scope);
+        }
         setWo(createdRow as WorkOrderRow);
         setDraftLines([]);
-        const scope = getOfflineMutationScope();
-        if (scope) await removeCurrentAdvisorWorkOrderDraft(scope);
         draftIdentityRef.current = null;
+        setWorkOrderDraftId(null);
         return;
       }
 
@@ -1581,8 +1619,32 @@ export default function MobileCreateWorkOrderPage() {
             <div className="mt-4">
               <AdvisorDraftLines
                 lines={draftLines}
-                onChange={setDraftLines}
+                onChange={(next) => {
+                  const identity = ensureDraftIdentity();
+                  setDraftLines(next);
+                  if (currentUserId && shopId) {
+                    void pruneDependentPartsRequestDrafts({
+                      scope: { userId: currentUserId, shopId },
+                      workOrderDraftId: identity.id,
+                      activeTempLineIds: next.map((line) => line.tempId),
+                    });
+                  }
+                }}
                 disabled={creatingWo}
+              />
+            </div>
+          )}
+
+          {!wo?.id && (
+            <div className="mt-4">
+              <AdvisorPartsDraftEditor
+                scope={
+                  currentUserId && shopId
+                    ? { userId: currentUserId, shopId }
+                    : null
+                }
+                workOrderDraftId={workOrderDraftId}
+                lines={draftLines}
               />
             </div>
           )}

--- a/app/offline/sync/page.tsx
+++ b/app/offline/sync/page.tsx
@@ -45,6 +45,7 @@ const ACTION_LABELS: Record<string, string> = {
   "inspection:upload-photo": "Inspection photo",
   save_story_draft: "Cause and correction",
   "job:punch-transition": "Job status",
+  "parts-request:create-draft": "Parts request",
 };
 
 function formatBytes(bytes: number): string {

--- a/features/parts/offline/AdvisorPartsDraftEditor.tsx
+++ b/features/parts/offline/AdvisorPartsDraftEditor.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+import type { AdvisorWorkOrderDraftLine } from "@/features/work-orders/mobile/advisorOfflineTypes";
+import {
+  createOfflinePartsRequestDraft,
+  createOfflinePartsRequestItem,
+  getOfflinePartsRequestDraft,
+  saveOfflinePartsRequestDraft,
+  type OfflinePartsRequestDraft,
+} from "@/features/parts/offline/partsRequestDrafts";
+
+export function AdvisorPartsDraftEditor({
+  scope,
+  workOrderDraftId,
+  lines,
+}: {
+  scope: OfflineMutationScope | null;
+  workOrderDraftId: string | null;
+  lines: AdvisorWorkOrderDraftLine[];
+}) {
+  const [selectedLineId, setSelectedLineId] = useState("");
+  const [draft, setDraft] = useState<OfflinePartsRequestDraft | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const selectedLine = useMemo(
+    () => lines.find((line) => line.tempId === selectedLineId) ?? null,
+    [lines, selectedLineId],
+  );
+
+  useEffect(() => {
+    if (!selectedLineId && lines[0]) setSelectedLineId(lines[0].tempId);
+    if (
+      selectedLineId &&
+      !lines.some((line) => line.tempId === selectedLineId)
+    ) {
+      setSelectedLineId(lines[0]?.tempId ?? "");
+    }
+  }, [lines, selectedLineId]);
+
+  useEffect(() => {
+    if (!scope || !workOrderDraftId || !selectedLineId) {
+      setDraft(null);
+      return;
+    }
+    void (async () => {
+      const existing = await getOfflinePartsRequestDraft({
+        scope,
+        workOrderDraftId,
+        tempLineId: selectedLineId,
+      });
+      setDraft(
+        existing ?? {
+          ...createOfflinePartsRequestDraft({
+            scope,
+            workOrderDraftId,
+            tempLineId: selectedLineId,
+          }),
+          items: [createOfflinePartsRequestItem()],
+        },
+      );
+      setMessage(null);
+    })();
+  }, [scope, workOrderDraftId, selectedLineId]);
+
+  if (!scope || !workOrderDraftId || lines.length === 0 || !draft) return null;
+
+  const updateItem = (
+    tempId: string,
+    patch: Partial<OfflinePartsRequestDraft["items"][number]>,
+  ) => {
+    setDraft((current) =>
+      current
+        ? {
+            ...current,
+            items: current.items.map((item) =>
+              item.tempId === tempId ? { ...item, ...patch } : item,
+            ),
+            updatedAt: new Date().toISOString(),
+          }
+        : current,
+    );
+  };
+
+  const save = async () => {
+    const items = draft.items.filter(
+      (item) => item.description.trim() && item.qty > 0,
+    );
+    if (items.length === 0) {
+      setMessage("Add at least one part description and quantity.");
+      return;
+    }
+    await saveOfflinePartsRequestDraft({
+      ...draft,
+      items,
+      updatedAt: new Date().toISOString(),
+    });
+    setMessage("Parts request draft saved on this device.");
+  };
+
+  return (
+    <section className="glass-card rounded-2xl border border-[color:var(--theme-border-soft)] px-3 py-3 text-[color:var(--theme-text-primary)]">
+      <div>
+        <p className="text-[0.68rem] font-medium uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+          Parts request drafts
+        </p>
+        <p className="mt-1 text-[0.7rem] text-[color:var(--theme-text-muted)]">
+          These requests wait for their temporary job line, then submit after
+          the work order reconnects.
+        </p>
+      </div>
+      <label className="mt-3 block text-[0.65rem] uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)]">
+        Job line
+        <select
+          className="input mt-1 w-full"
+          value={selectedLineId}
+          onChange={(event) => setSelectedLineId(event.target.value)}
+        >
+          {lines.map((line, index) => (
+            <option key={line.tempId} value={line.tempId}>
+              {index + 1}. {line.complaint}
+            </option>
+          ))}
+        </select>
+      </label>
+      {selectedLine && (
+        <p className="mt-2 text-[0.7rem] text-[color:var(--theme-text-muted)]">
+          Requesting for: {selectedLine.complaint}
+        </p>
+      )}
+      <textarea
+        className="input mt-3 w-full"
+        rows={2}
+        placeholder="Note to parts (optional)"
+        value={draft.notes}
+        onChange={(event) =>
+          setDraft({
+            ...draft,
+            notes: event.target.value,
+            updatedAt: new Date().toISOString(),
+          })
+        }
+      />
+      <div className="mt-3 space-y-2">
+        {draft.items.map((item) => (
+          <div key={item.tempId} className="grid grid-cols-12 gap-2">
+            <input
+              className="input col-span-7"
+              placeholder="Part description"
+              value={item.description}
+              onChange={(event) =>
+                updateItem(item.tempId, { description: event.target.value })
+              }
+            />
+            <input
+              className="input col-span-3"
+              type="number"
+              min="1"
+              max="10000"
+              value={item.qty}
+              onChange={(event) =>
+                updateItem(item.tempId, {
+                  qty: Math.max(1, Number(event.target.value) || 1),
+                })
+              }
+            />
+            <button
+              type="button"
+              className="col-span-2 text-xs text-red-300 disabled:opacity-40"
+              disabled={draft.items.length === 1}
+              onClick={() =>
+                setDraft({
+                  ...draft,
+                  items: draft.items.filter(
+                    (row) => row.tempId !== item.tempId,
+                  ),
+                  updatedAt: new Date().toISOString(),
+                })
+              }
+            >
+              Remove
+            </button>
+            <input
+              className="input col-span-6"
+              placeholder="Part number (optional)"
+              value={item.partNumber ?? ""}
+              onChange={(event) =>
+                updateItem(item.tempId, {
+                  partNumber: event.target.value || null,
+                })
+              }
+            />
+            <input
+              className="input col-span-6"
+              placeholder="Manufacturer (optional)"
+              value={item.manufacturer ?? ""}
+              onChange={(event) =>
+                updateItem(item.tempId, {
+                  manufacturer: event.target.value || null,
+                })
+              }
+            />
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs"
+          onClick={() =>
+            setDraft({
+              ...draft,
+              items: [...draft.items, createOfflinePartsRequestItem()],
+              updatedAt: new Date().toISOString(),
+            })
+          }
+        >
+          Add part
+        </button>
+        <button
+          type="button"
+          className="rounded-full bg-[var(--accent-copper)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-on-accent)]"
+          onClick={() => void save()}
+        >
+          Save parts draft
+        </button>
+      </div>
+      {message && <p className="mt-2 text-[0.7rem] text-sky-200">{message}</p>}
+    </section>
+  );
+}

--- a/features/parts/offline/partsRequestDrafts.ts
+++ b/features/parts/offline/partsRequestDrafts.ts
@@ -1,0 +1,237 @@
+"use client";
+
+import {
+  listOfflineSnapshots,
+  removeOfflineSnapshots,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import {
+  runMutationWithOfflineQueue,
+  type OfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+
+const KIND = "parts-request-draft";
+const MAX_AGE_MS = 1000 * 60 * 60 * 24 * 30;
+
+export type OfflinePartsRequestItem = {
+  tempId: string;
+  description: string;
+  qty: number;
+  partNumber?: string | null;
+  manufacturer?: string | null;
+};
+
+export type OfflinePartsRequestDraft = {
+  id: string;
+  operationKey: string;
+  userId: string;
+  shopId: string;
+  workOrderId: string | null;
+  workOrderLineId: string | null;
+  workOrderDraftId: string | null;
+  tempLineId: string | null;
+  notes: string;
+  items: OfflinePartsRequestItem[];
+  updatedAt: string;
+};
+
+export function createOfflinePartsRequestDraft(args: {
+  scope: OfflineMutationScope;
+  workOrderId?: string | null;
+  workOrderLineId?: string | null;
+  workOrderDraftId?: string | null;
+  tempLineId?: string | null;
+}): OfflinePartsRequestDraft {
+  const id = crypto.randomUUID();
+  return {
+    id: `parts-draft:${id}`,
+    operationKey: `parts-draft:${id}:materialize`,
+    userId: args.scope.userId,
+    shopId: args.scope.shopId,
+    workOrderId: args.workOrderId ?? null,
+    workOrderLineId: args.workOrderLineId ?? null,
+    workOrderDraftId: args.workOrderDraftId ?? null,
+    tempLineId: args.tempLineId ?? null,
+    notes: "",
+    items: [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function createOfflinePartsRequestItem(): OfflinePartsRequestItem {
+  return {
+    tempId: `temp-part:${crypto.randomUUID()}`,
+    description: "",
+    qty: 1,
+    partNumber: null,
+    manufacturer: null,
+  };
+}
+
+export async function saveOfflinePartsRequestDraft(
+  draft: OfflinePartsRequestDraft,
+): Promise<void> {
+  await saveOfflineSnapshot({
+    scope: { userId: draft.userId, shopId: draft.shopId },
+    kind: KIND,
+    entityId: draft.id,
+    data: draft,
+    maxAgeMs: MAX_AGE_MS,
+  });
+}
+
+export async function listOfflinePartsRequestDrafts(
+  scope: OfflineMutationScope,
+): Promise<OfflinePartsRequestDraft[]> {
+  const stored = await listOfflineSnapshots<OfflinePartsRequestDraft>({
+    scope,
+    kind: KIND,
+  });
+  return stored.map((item) => item.data);
+}
+
+export async function getOfflinePartsRequestDraft(args: {
+  scope: OfflineMutationScope;
+  workOrderId?: string | null;
+  workOrderLineId?: string | null;
+  workOrderDraftId?: string | null;
+  tempLineId?: string | null;
+}): Promise<OfflinePartsRequestDraft | null> {
+  const drafts = await listOfflinePartsRequestDrafts(args.scope);
+  return (
+    drafts.find(
+      (draft) =>
+        (args.workOrderId == null || draft.workOrderId === args.workOrderId) &&
+        (args.workOrderLineId == null ||
+          draft.workOrderLineId === args.workOrderLineId) &&
+        (args.workOrderDraftId == null ||
+          draft.workOrderDraftId === args.workOrderDraftId) &&
+        (args.tempLineId == null || draft.tempLineId === args.tempLineId),
+    ) ?? null
+  );
+}
+
+export async function removeOfflinePartsRequestDraft(args: {
+  scope: OfflineMutationScope;
+  draftId: string;
+}): Promise<void> {
+  await removeOfflineSnapshots({
+    scope: args.scope,
+    kind: KIND,
+    entityIds: [args.draftId],
+  });
+}
+
+export async function pruneDependentPartsRequestDrafts(args: {
+  scope: OfflineMutationScope;
+  workOrderDraftId: string;
+  activeTempLineIds: string[];
+}): Promise<void> {
+  const active = new Set(args.activeTempLineIds);
+  const stale = (await listOfflinePartsRequestDrafts(args.scope)).filter(
+    (draft) =>
+      draft.workOrderDraftId === args.workOrderDraftId &&
+      draft.tempLineId != null &&
+      !active.has(draft.tempLineId),
+  );
+  await Promise.all(
+    stale.map((draft) =>
+      removeOfflinePartsRequestDraft({
+        scope: args.scope,
+        draftId: draft.id,
+      }),
+    ),
+  );
+}
+
+export async function postOfflinePartsRequestDraft(
+  draft: OfflinePartsRequestDraft,
+): Promise<{ requestId: string; idempotent: boolean }> {
+  const response = await fetch("/api/offline/parts-request-drafts", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": draft.operationKey,
+    },
+    body: JSON.stringify(draft),
+  });
+  const body = (await response.json().catch(() => null)) as {
+    requestId?: string;
+    idempotent?: boolean;
+    error?: string;
+  } | null;
+  if (!response.ok || !body?.requestId) {
+    const error = new Error(
+      body?.error ?? "Parts-request draft could not be submitted.",
+    ) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+  return { requestId: body.requestId, idempotent: body.idempotent === true };
+}
+
+export async function submitOfflinePartsRequestDraft(
+  draft: OfflinePartsRequestDraft,
+): Promise<{
+  queued: boolean;
+  conflicted: boolean;
+  requestId: string | null;
+}> {
+  if (!draft.workOrderId || !draft.workOrderLineId) {
+    throw new Error("Parts request is still waiting for its work-order line.");
+  }
+  await saveOfflinePartsRequestDraft(draft);
+  let requestId: string | null = null;
+  const result = await runMutationWithOfflineQueue({
+    clientMutationId: draft.operationKey,
+    actionType: "parts-request:create-draft",
+    payload: draft,
+    scope: { userId: draft.userId, shopId: draft.shopId },
+    orderKey: `${draft.workOrderId}:${draft.workOrderLineId}:parts:${draft.operationKey}`,
+    runner: async () => {
+      requestId = (await postOfflinePartsRequestDraft(draft)).requestId;
+    },
+  });
+  if (!result.conflicted) {
+    await removeOfflinePartsRequestDraft({
+      scope: { userId: draft.userId, shopId: draft.shopId },
+      draftId: draft.id,
+    });
+  }
+  return { ...result, requestId };
+}
+
+export async function resolveAndSubmitDependentPartsDrafts(args: {
+  scope: OfflineMutationScope;
+  workOrderDraftId: string;
+  workOrderId: string;
+  lineIdMap: Record<string, string>;
+}): Promise<{ submitted: number; queued: number }> {
+  const drafts = (await listOfflinePartsRequestDrafts(args.scope)).filter(
+    (draft) => draft.workOrderDraftId === args.workOrderDraftId,
+  );
+  let submitted = 0;
+  let queued = 0;
+  for (const draft of drafts) {
+    const lineId = draft.tempLineId
+      ? args.lineIdMap[draft.tempLineId]
+      : draft.workOrderLineId;
+    if (!lineId) {
+      throw new Error(
+        "A parts-request draft could not be matched to its saved job line.",
+      );
+    }
+    const resolved: OfflinePartsRequestDraft = {
+      ...draft,
+      workOrderId: args.workOrderId,
+      workOrderLineId: lineId,
+      updatedAt: new Date().toISOString(),
+    };
+    await saveOfflinePartsRequestDraft(resolved);
+    const result = await submitOfflinePartsRequestDraft(resolved);
+    if (result.queued) queued += 1;
+    else if (!result.conflicted) submitted += 1;
+  }
+  return { submitted, queued };
+}

--- a/features/shared/lib/offline/conflicts.ts
+++ b/features/shared/lib/offline/conflicts.ts
@@ -47,6 +47,10 @@ export function offlineMutationDeviceValue(
   if (mutation.actionType === "job:punch-transition") {
     return text(payload.action) || null;
   }
+  if (mutation.actionType === "parts-request:create-draft") {
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    return `${items.length} requested part${items.length === 1 ? "" : "s"}`;
+  }
   return null;
 }
 

--- a/features/shared/lib/offline/replay.ts
+++ b/features/shared/lib/offline/replay.ts
@@ -14,6 +14,11 @@ import {
 import { postOfflineServerMutation } from "@/features/shared/lib/offline/server-mutations";
 import { replayInspectionPhotoMutation } from "@inspections/lib/inspection/inspectionPhotoStaging";
 import {
+  postOfflinePartsRequestDraft,
+  removeOfflinePartsRequestDraft,
+  type OfflinePartsRequestDraft,
+} from "@/features/parts/offline/partsRequestDrafts";
+import {
   reconcileOfflineTechnicianState,
   type OfflineReconciliationResult,
 } from "@/features/shared/lib/offline/reconciliation";
@@ -48,6 +53,17 @@ async function apiPost(path: string, body: unknown, operationKey?: string) {
 }
 
 const handlers: Record<string, OfflineMutationRunner> = {
+  "parts-request:create-draft": async (mutation) => {
+    const draft = mutation.payload as OfflinePartsRequestDraft;
+    if (!draft?.id || !draft.workOrderId || !draft.workOrderLineId) {
+      return { conflicted: "Parts request is missing its work-order line." };
+    }
+    await postOfflinePartsRequestDraft(draft);
+    await removeOfflinePartsRequestDraft({
+      scope: { userId: mutation.userId, shopId: mutation.shopId },
+      draftId: draft.id,
+    });
+  },
   "inspection:upload-photo": replayInspectionPhotoMutation,
   "inspection:save-session": async (mutation) => {
     const payload = mutation.payload as ReplayPayload;

--- a/features/work-orders/components/workorders/PartsRequestModal.tsx
+++ b/features/work-orders/components/workorders/PartsRequestModal.tsx
@@ -6,6 +6,16 @@ import { toast } from "sonner";
 import ModalShell from "@/features/shared/components/ModalShell";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  getOfflineMutationScope,
+  resolveOfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+import {
+  createOfflinePartsRequestDraft,
+  getOfflinePartsRequestDraft,
+  saveOfflinePartsRequestDraft,
+  submitOfflinePartsRequestDraft,
+} from "@/features/parts/offline/partsRequestDrafts";
 
 type DB = Database;
 
@@ -71,6 +81,24 @@ export default function PartsRequestModal({
     setJobLabel("");
 
     (async () => {
+      const scope = getOfflineMutationScope();
+      const recovered = scope
+        ? await getOfflinePartsRequestDraft({
+            scope,
+            workOrderId,
+            workOrderLineId: jobId,
+          })
+        : null;
+      if (recovered) {
+        setHeaderNotes(recovered.notes);
+        setRows(
+          recovered.items.map((item) => ({
+            id: item.tempId,
+            description: item.description,
+            qty: String(item.qty),
+          })),
+        );
+      }
       // Work order custom id
       if (workOrderId) {
         const { data } = await supabase
@@ -103,7 +131,10 @@ export default function PartsRequestModal({
   }, [isOpen, requestNote, supabase, workOrderId, jobId]);
 
   const addRow = () =>
-    setRows((r) => [...r, { id: crypto.randomUUID(), description: "", qty: "1" }]);
+    setRows((r) => [
+      ...r,
+      { id: crypto.randomUUID(), description: "", qty: "1" },
+    ]);
 
   const removeRow = (id: string) =>
     setRows((r) => (r.length > 1 ? r.filter((x) => x.id !== id) : r));
@@ -117,7 +148,7 @@ export default function PartsRequestModal({
       const description = r.description.trim();
       const n = Number.parseInt(r.qty, 10);
       const qty = Number.isFinite(n) ? n : 0;
-      return { description, qty };
+      return { tempId: r.id, description, qty };
     })
     .filter((i) => i.description && i.qty > 0);
 
@@ -145,37 +176,52 @@ export default function PartsRequestModal({
     setSubmitting(true);
 
     try {
-      const res = await fetch("/api/parts/requests/create", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          workOrderId,
-          jobId,
-          notes: headerNotes || undefined,
-          items: validItems,
-        }),
+      const scope = await resolveOfflineMutationScope({
+        workOrderId,
+        workOrderLineId: jobId,
       });
-
-      const raw = await res.text();
-      let json: { requestId?: string; error?: string } | null = null;
-      try {
-        json = raw
-          ? (JSON.parse(raw) as { requestId?: string; error?: string })
-          : null;
-      } catch {
-        /* ignore */
+      if (!scope)
+        throw new Error("Offline user and shop scope is unavailable.");
+      const existing = await getOfflinePartsRequestDraft({
+        scope,
+        workOrderId,
+        workOrderLineId: jobId,
+      });
+      const base =
+        existing ??
+        createOfflinePartsRequestDraft({
+          scope,
+          workOrderId,
+          workOrderLineId: jobId,
+        });
+      const draft = {
+        ...base,
+        notes: headerNotes,
+        items: validItems.map((item) => ({
+          tempId: item.tempId,
+          description: item.description,
+          qty: item.qty,
+          partNumber: null,
+          manufacturer: null,
+        })),
+        updatedAt: new Date().toISOString(),
+      };
+      await saveOfflinePartsRequestDraft(draft);
+      const result = await submitOfflinePartsRequestDraft(draft);
+      if (result.conflicted) {
+        toast.error("Parts request needs review in Sync Center.");
+        return;
       }
-
-      if (!res.ok || !json?.requestId) {
-        const msg = json?.error || raw || `Request failed with status ${res.status}`;
-        toast.error(`Parts request failed: ${msg}`);
+      if (result.queued) {
+        toast.warning("Parts request saved on this device and queued.");
+        emit(closeEventName);
         return;
       }
 
       toast.success("Parts request sent.");
 
       const detail: SubmittedDetail = {
-        requestId: json.requestId,
+        requestId: result.requestId ?? draft.operationKey,
         workOrderId,
         jobId,
       };
@@ -183,7 +229,9 @@ export default function PartsRequestModal({
       emit(submittedEventName, detail);
       emit(closeEventName);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Unable to submit request");
+      toast.error(
+        err instanceof Error ? err.message : "Unable to submit request",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -209,7 +257,8 @@ export default function PartsRequestModal({
             Parts request
           </div>
           <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Send a clean request to parts without losing the work order and job context.
+            Send a clean request to parts without losing the work order and job
+            context.
           </div>
         </div>
 
@@ -273,7 +322,9 @@ export default function PartsRequestModal({
                 <input
                   className="col-span-8 rounded-md border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-2 py-1 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] outline-none transition focus:border-[var(--accent-copper-soft)] focus:ring-1 focus:ring-[var(--accent-copper-soft)]/60"
                   value={r.description}
-                  onChange={(e) => setCell(r.id, { description: e.target.value })}
+                  onChange={(e) =>
+                    setCell(r.id, { description: e.target.value })
+                  }
                   placeholder="e.g. rear pads, serp belt…"
                 />
 
@@ -291,7 +342,8 @@ export default function PartsRequestModal({
                   onBlur={() => {
                     // normalize on blur
                     const n = Number.parseInt(r.qty, 10);
-                    const normalized = Number.isFinite(n) && n > 0 ? String(n) : "1";
+                    const normalized =
+                      Number.isFinite(n) && n > 0 ? String(n) : "1";
                     setCell(r.id, { qty: normalized });
                   }}
                   aria-label="Quantity"
@@ -302,7 +354,11 @@ export default function PartsRequestModal({
                     className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] text-[0.7rem] text-[color:var(--theme-text-secondary)] transition hover:bg-red-500/20 hover:text-red-200 disabled:opacity-40 disabled:hover:bg-[color:var(--theme-surface-overlay)] disabled:hover:text-[color:var(--theme-text-secondary)]"
                     onClick={() => removeRow(r.id)}
                     disabled={rows.length <= 1}
-                    title={rows.length <= 1 ? "At least one row is required" : "Remove row"}
+                    title={
+                      rows.length <= 1
+                        ? "At least one row is required"
+                        : "Remove row"
+                    }
                     type="button"
                   >
                     ✕

--- a/supabase/migrations/20260717100000_offline_parts_request_drafts.sql
+++ b/supabase/migrations/20260717100000_offline_parts_request_drafts.sql
@@ -1,0 +1,142 @@
+begin;
+
+create or replace function public.materialize_offline_parts_request_draft_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_work_order_id uuid,
+  p_work_order_line_id uuid,
+  p_payload jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_existing public.offline_mutation_receipts%rowtype;
+  v_role text;
+  v_request_id uuid;
+  v_item jsonb;
+  v_payload jsonb := coalesce(p_payload, '{}'::jsonb);
+  v_payload_hash text := encode(digest(coalesce(p_payload, '{}'::jsonb)::text, 'sha256'), 'hex');
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor does not match the parts draft actor.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null or length(p_operation_key) > 240 then
+    raise exception using errcode = 'P0001', message = 'A stable idempotency key is required.';
+  end if;
+
+  select * into v_existing
+  from public.offline_mutation_receipts r
+  where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+  if found then
+    if v_existing.action_type <> 'materialize_parts_request_draft' or v_existing.payload_hash <> v_payload_hash then
+      raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different parts draft data.';
+    end if;
+    return v_existing.result || jsonb_build_object('idempotent', true);
+  end if;
+
+  select lower(coalesce(p.role::text, '')) into v_role
+  from public.profiles p
+  where p.id = p_actor_user_id and p.shop_id = p_shop_id;
+  if not found or v_role not in (
+    'owner','admin','manager','advisor','service','parts','mechanic',
+    'technician','tech','lead_hand','lead hand','leadhand','foreman'
+  ) then
+    raise exception using errcode = 'P0001', message = 'Actor is not allowed to request parts for this shop.';
+  end if;
+  if not exists (
+    select 1 from public.work_orders wo
+    where wo.id = p_work_order_id and wo.shop_id = p_shop_id
+  ) then
+    raise exception using errcode = 'P0001', message = 'Work order not found for this shop.';
+  end if;
+  if not exists (
+    select 1 from public.work_order_lines wol
+    where wol.id = p_work_order_line_id
+      and wol.work_order_id = p_work_order_id
+      and wol.shop_id = p_shop_id
+  ) then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for this work order and shop.';
+  end if;
+  if v_role in ('mechanic','technician','tech') and not exists (
+    select 1 from public.work_order_lines wol
+    where wol.id = p_work_order_line_id
+      and (
+        wol.assigned_tech_id = p_actor_user_id
+        or wol.assigned_to = p_actor_user_id
+        or exists (
+          select 1 from public.work_order_line_technicians wolt
+          where wolt.work_order_line_id = wol.id
+            and wolt.technician_id = p_actor_user_id
+        )
+      )
+  ) then
+    raise exception using errcode = 'P0001', message = 'Technician is not assigned to this work-order line.';
+  end if;
+  if jsonb_typeof(v_payload->'items') <> 'array'
+     or jsonb_array_length(v_payload->'items') < 1
+     or jsonb_array_length(v_payload->'items') > 100 then
+    raise exception using errcode = 'P0001', message = 'Parts draft requires between 1 and 100 items.';
+  end if;
+  for v_item in select value from jsonb_array_elements(v_payload->'items')
+  loop
+    if nullif(trim(v_item->>'description'), '') is null then
+      raise exception using errcode = 'P0001', message = 'Every requested part requires a description.';
+    end if;
+    if nullif(v_item->>'qty', '') is null
+       or (v_item->>'qty') !~ '^[0-9]+([.][0-9]+)?$'
+       or (v_item->>'qty')::numeric < 1
+       or (v_item->>'qty')::numeric > 10000 then
+      raise exception using errcode = 'P0001', message = 'Every requested part quantity must be from 1 to 10,000.';
+    end if;
+  end loop;
+
+  v_request_id := public.create_part_request_with_items(
+    p_work_order_id,
+    v_payload->'items',
+    p_work_order_line_id::text,
+    nullif(trim(v_payload->>'notes'), '')
+  );
+  if v_request_id is null then
+    raise exception using errcode = 'P0001', message = 'Parts request could not be created.';
+  end if;
+  update public.part_request_items
+  set work_order_line_id = p_work_order_line_id
+  where request_id = v_request_id
+    and work_order_id = p_work_order_id
+    and (shop_id is null or shop_id = p_shop_id);
+
+  v_result := jsonb_build_object(
+    'requestId', v_request_id,
+    'workOrderId', p_work_order_id,
+    'workOrderLineId', p_work_order_line_id,
+    'idempotent', false
+  );
+  insert into public.offline_mutation_receipts(
+    shop_id, actor_user_id, operation_key, action_type, payload_hash,
+    entity_type, entity_id, result
+  ) values (
+    p_shop_id, p_actor_user_id, p_operation_key,
+    'materialize_parts_request_draft', v_payload_hash,
+    'parts_request', v_request_id, v_result
+  );
+  return v_result;
+exception
+  when unique_violation then
+    select * into v_existing
+    from public.offline_mutation_receipts r
+    where r.shop_id = p_shop_id and r.operation_key = p_operation_key;
+    if found and v_existing.action_type = 'materialize_parts_request_draft' and v_existing.payload_hash = v_payload_hash then
+      return v_existing.result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = 'P0001', message = 'IDEMPOTENCY_KEY_REUSE: operation key belongs to different parts draft data.';
+end;
+$$;
+
+revoke all on function public.materialize_offline_parts_request_draft_atomic(uuid,uuid,text,uuid,uuid,jsonb) from public, anon;
+grant execute on function public.materialize_offline_parts_request_draft_atomic(uuid,uuid,text,uuid,uuid,jsonb) to authenticated, service_role;
+
+commit;

--- a/tests/offline-parts-request-drafts.test.ts
+++ b/tests/offline-parts-request-drafts.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const repository = read("features/parts/offline/partsRequestDrafts.ts");
+const editor = read("features/parts/offline/AdvisorPartsDraftEditor.tsx");
+const createPage = read("app/mobile/work-orders/create/page.tsx");
+const modal = read(
+  "features/work-orders/components/workorders/PartsRequestModal.tsx",
+);
+const replay = read("features/shared/lib/offline/replay.ts");
+const route = read("app/api/offline/parts-request-drafts/route.ts");
+const migration = read(
+  "supabase/migrations/20260717100000_offline_parts_request_drafts.sql",
+);
+
+describe("offline parts-request drafts", () => {
+  it("stores drafts in tenant-scoped IndexedDB with stable operation identities", () => {
+    expect(repository).toContain('const KIND = "parts-request-draft"');
+    expect(repository).toContain("listOfflineSnapshots");
+    expect(repository).toContain("saveOfflineSnapshot");
+    expect(repository).toContain("userId: draft.userId");
+    expect(repository).toContain("shopId: draft.shopId");
+    expect(repository).toContain(
+      "operationKey: `parts-draft:${id}:materialize`",
+    );
+    expect(repository).not.toContain("localStorage");
+  });
+
+  it("attaches advisor drafts to temporary lines and resolves them after work-order creation", () => {
+    expect(editor).toContain("workOrderDraftId");
+    expect(editor).toContain("tempLineId: selectedLineId");
+    expect(editor).toContain("Save parts draft");
+    expect(createPage).toContain("<AdvisorPartsDraftEditor");
+    expect(createPage).toContain("materialization.lineIdMap");
+    expect(createPage).toContain("resolveAndSubmitDependentPartsDrafts");
+    expect(repository).toContain("args.lineIdMap[draft.tempLineId]");
+    expect(repository).toContain(
+      "A parts-request draft could not be matched to its saved job line.",
+    );
+    expect(createPage).toContain("pruneDependentPartsRequestDrafts");
+  });
+
+  it("uses the global ordered mutation queue for both advisor and technician requests", () => {
+    expect(repository).toContain("runMutationWithOfflineQueue");
+    expect(repository).toContain('actionType: "parts-request:create-draft"');
+    expect(repository).toContain("clientMutationId: draft.operationKey");
+    expect(repository).toContain("orderKey:");
+    expect(modal).toContain("submitOfflinePartsRequestDraft");
+    expect(modal).not.toContain('fetch("/api/parts/requests/create"');
+    expect(replay).toContain('"parts-request:create-draft"');
+    expect(replay).toContain("postOfflinePartsRequestDraft(draft)");
+    expect(replay).toContain("removeOfflinePartsRequestDraft");
+  });
+
+  it("derives server scope from the actor and initializes the RLS shop context", () => {
+    expect(route).toContain("auth.getUser()");
+    expect(route).toContain("getActorCapabilities");
+    expect(route).toContain("draft.userId !== user.id");
+    expect(route).toContain("draft.shopId !== profile.shop_id");
+    expect(route).toContain('rpc("set_current_shop_id"');
+    expect(route).toContain("materialize_offline_parts_request_draft_atomic");
+  });
+
+  it("materializes through the canonical parts RPC with receipt-backed idempotency", () => {
+    expect(migration).toContain("offline_mutation_receipts");
+    expect(migration).toContain("IDEMPOTENCY_KEY_REUSE");
+    expect(migration).toContain("create_part_request_with_items");
+    expect(migration).toContain("update public.part_request_items");
+    expect(migration).toContain(
+      "set work_order_line_id = p_work_order_line_id",
+    );
+    expect(migration).toContain("wo.shop_id = p_shop_id");
+    expect(migration).toContain("wol.work_order_id = p_work_order_id");
+    expect(migration).toContain("wolt.technician_id = p_actor_user_id");
+    expect(migration).toContain("when unique_violation then");
+  });
+});


### PR DESCRIPTION
## Summary

- add tenant-scoped IndexedDB parts-request drafts for canonical and temporary work-order lines
- map temporary advisor line IDs to canonical IDs after atomic work-order creation
- submit and replay parts drafts through the global ordered mutation queue
- add receipt-backed, idempotent server materialization with shop, role, work-order, line, and technician-assignment validation
- surface parts mutations in Sync Center and keep dependent drafts recoverable until submitted or durably queued

Sensitive inventory commits, invoicing, approvals, and payment remain online-only.

## Migration required

Run:

`supabase/migrations/20260717100000_offline_parts_request_drafts.sql`

This adds `materialize_offline_parts_request_draft_atomic`, reusing the existing offline mutation receipt table and canonical parts-request RPC.

## Validation

- `pnpm exec tsc --noEmit`
- focused ESLint on all touched TypeScript/TSX files
- `git diff --check`
- 20 focused regression tests passed across offline parts drafts, advisor foundation, mutation ordering, and mutation receipts
- `pnpm build` reached Next.js/service-worker compilation but stalled without a diagnostic in this container and was stopped; CI should run the full production build
