### PR TITLE
Add offline messaging drafts

### DIFF
--- a/app/api/chat/offline-scope/route.ts
+++ b/app/api/chat/offline-scope/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import { resolveMessagingActor } from "@/features/ai/lib/chat/authorization";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<NextResponse> {
+  const userClient = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await userClient.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+
+  const actor = await resolveMessagingActor({
+    supabase: createAdminSupabase(),
+    actorUserId: user.id,
+  });
+  if (!actor.ok) {
+    return NextResponse.json({ error: actor.error }, { status: actor.status });
+  }
+
+  return NextResponse.json({
+    userId: user.id,
+    shopId: actor.actor.shopId,
+    actorKind: actor.actor.kind,
+  });
+}

--- a/app/sw.ts
+++ b/app/sw.ts
@@ -27,6 +27,21 @@ const serwist = new Serwist({
     {
       matcher: ({ request, url }) =>
         request.mode === "navigate" &&
+        (url.pathname === "/portal/messages" || url.pathname === "/chat"),
+      handler: new NetworkFirst({
+        cacheName: "profixiq-messaging-shell-v1",
+        networkTimeoutSeconds: 4,
+        plugins: [
+          new ExpirationPlugin({
+            maxEntries: 10,
+            maxAgeSeconds: 60 * 60 * 24 * 14,
+          }),
+        ],
+      }),
+    },
+    {
+      matcher: ({ request, url }) =>
+        request.mode === "navigate" &&
         (url.pathname === "/mobile/appointments" ||
           url.pathname === "/mobile/work-orders/create"),
       handler: new NetworkFirst({

--- a/features/ai/components/chat/ChatWindow.tsx
+++ b/features/ai/components/chat/ChatWindow.tsx
@@ -10,6 +10,15 @@ import {
 } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  createMessageDraft,
+  getOfflineMessageDraft,
+  removeOfflineMessageDraft,
+  resolveMessagingDraftScope,
+  saveOfflineMessageDraft,
+  type OfflineMessageDraft,
+} from "@/features/chat/offline/messageDrafts";
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
 
 type Message = Database["public"]["Tables"]["messages"]["Row"];
 
@@ -57,9 +66,47 @@ export default function ChatWindow({
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(null);
+  const [draft, setDraft] = useState<OfflineMessageDraft | null>(null);
+  const [draftReady, setDraftReady] = useState(false);
+  const [draftSaved, setDraftSaved] = useState(false);
 
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const draftTargetId = `conversation:${conversationId}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    setDraftReady(false);
+    void resolveMessagingDraftScope(userId).then(async (scope) => {
+      if (!scope || cancelled) return;
+      const stored = await getOfflineMessageDraft({ scope, targetId: draftTargetId });
+      if (cancelled) return;
+      const next = stored ?? createMessageDraft({ scope, targetId: draftTargetId });
+      setDraftScope(scope);
+      setDraft(next);
+      setNewMessage(next.content);
+      setDraftSaved(Boolean(stored?.content));
+      setDraftReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [draftTargetId, userId]);
+
+  useEffect(() => {
+    if (!draftReady || !draftScope || !draft || sending) return;
+    const timer = window.setTimeout(() => {
+      if (!newMessage.trim()) {
+        void removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        setDraftSaved(false);
+        return;
+      }
+      const next = { ...draft, content: newMessage, updatedAt: new Date().toISOString() };
+      void saveOfflineMessageDraft(next).then(() => setDraftSaved(true));
+    }, 350);
+    return () => window.clearTimeout(timer);
+  }, [draft, draftReady, draftScope, draftTargetId, newMessage, sending]);
 
   const fetchMessages = useCallback(async () => {
     if (!conversationId) return;
@@ -198,7 +245,12 @@ export default function ChatWindow({
     const content = newMessage.trim();
     if (!content || sending) return;
 
-    const clientMessageId = crypto.randomUUID();
+    if (!navigator.onLine) {
+      setError("Offline — this message is saved as a draft and has not been sent.");
+      return;
+    }
+
+    const clientMessageId = draft?.clientMessageId ?? crypto.randomUUID();
     const tempId = `temp-${clientMessageId}`;
     const optimistic: Message = {
       id: tempId,
@@ -245,6 +297,13 @@ export default function ChatWindow({
         ),
         inserted,
       ]);
+      if (draftScope) {
+        await removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+      }
+      setDraft(
+        draftScope ? createMessageDraft({ scope: draftScope, targetId: draftTargetId }) : null,
+      );
+      setDraftSaved(false);
     } catch (err) {
       console.error("[ChatWindow] sendMessage error:", err);
       setMessages((prev) => prev.filter((message) => message.id !== tempId));
@@ -253,7 +312,7 @@ export default function ChatWindow({
     } finally {
       setSending(false);
     }
-  }, [conversationId, newMessage, sending, userId]);
+  }, [conversationId, draft, draftScope, draftTargetId, newMessage, sending, userId]);
 
   const deleteMessage = useCallback(
     async (id: string) => {
@@ -436,6 +495,11 @@ export default function ChatWindow({
           {sending ? "Sending…" : "Send"}
         </button>
       </div>
+      {draftSaved ? (
+        <div className="px-3 pb-2 text-[10px] text-[color:var(--theme-text-muted)]">
+          Saved on this device · delivery requires a connection
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -7,6 +7,16 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import UserAvatar from "@/features/chat/components/UserAvatar";
 import ModalShell from "@/features/shared/components/ModalShell";
+import {
+  createMessageDraft,
+  getOfflineMessageDraft,
+  removeOfflineMessageDraft,
+  resolveMessagingDraftScope,
+  saveOfflineMessageDraft,
+  warmMessagingRouteShells,
+  type OfflineMessageDraft,
+} from "@/features/chat/offline/messageDrafts";
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
 
 type DB = Database;
 type MessageRow = DB["public"]["Tables"]["messages"]["Row"];
@@ -140,8 +150,16 @@ export default function InboxModal({
   const [composeAudience, setComposeAudience] = useState<"internal" | "customer">("internal");
   const [roleFilter, setRoleFilter] = useState("all");
   const [useContext, setUseContext] = useState(true);
+  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(null);
+  const [messageDraft, setMessageDraft] = useState<OfflineMessageDraft | null>(null);
+  const [loadedDraftTarget, setLoadedDraftTarget] = useState<string | null>(null);
+  const [draftSaved, setDraftSaved] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
 
   const context = useMemo(() => inferContext(pathname), [pathname]);
+  const draftTargetId = activeConversationId
+    ? `conversation:${activeConversationId}`
+    : `staff:new:${composeAudience}:${context.context_type ?? "general"}:${context.context_id ?? "none"}`;
 
   const loadConversations = useCallback(async () => {
     const res = await fetch("/api/chat/my-conversations", { credentials: "include" });
@@ -157,8 +175,8 @@ export default function InboxModal({
   useEffect(() => {
     if (!open) return;
 
-    void supabase.auth.getUser().then(({ data }) => setMe(data.user?.id ?? null));
-    void loadConversations();
+    void supabase.auth.getSession().then(({ data }) => setMe(data.session?.user.id ?? null));
+    void loadConversations().catch(() => undefined);
 
     void fetch("/api/chat/users", { credentials: "include" })
       .then((r) => r.json())
@@ -170,8 +188,72 @@ export default function InboxModal({
           })),
         );
         setCustomers(Array.isArray(json?.customers) ? json.customers : []);
-      });
+      })
+      .catch(() => undefined);
   }, [open, supabase, loadConversations]);
+
+  useEffect(() => {
+    if (!open || !me) return;
+    let cancelled = false;
+    void resolveMessagingDraftScope(me).then(async (scope) => {
+      if (!scope || cancelled) return;
+      setDraftScope(scope);
+      if (navigator.onLine) void warmMessagingRouteShells();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [me, open]);
+
+  useEffect(() => {
+    if (!open || !draftScope) return;
+    let cancelled = false;
+    setLoadedDraftTarget(null);
+    void getOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId }).then(
+      (stored) => {
+        if (cancelled) return;
+        const next = stored ?? createMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        setMessageDraft(next);
+        setCompose(next.content);
+        if (!activeConversationId) {
+          setSelectedRecipients(next.recipientIds ?? []);
+          setSelectedCustomerId(next.customerId ?? null);
+          setUseContext(next.useContext ?? true);
+        }
+        setDraftSaved(Boolean(stored?.content));
+        setLoadedDraftTarget(draftTargetId);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [activeConversationId, draftScope, draftTargetId, open]);
+
+  useEffect(() => {
+    if (
+      !draftScope ||
+      !messageDraft ||
+      loadedDraftTarget !== draftTargetId ||
+      messageDraft.targetId !== draftTargetId
+    ) return;
+    const timer = window.setTimeout(() => {
+      if (!compose.trim()) {
+        void removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        setDraftSaved(false);
+        return;
+      }
+      void saveOfflineMessageDraft({
+        ...messageDraft,
+        content: compose,
+        audience: composeAudience,
+        recipientIds: selectedRecipients,
+        customerId: selectedCustomerId,
+        useContext,
+        updatedAt: new Date().toISOString(),
+      }).then(() => setDraftSaved(true));
+    }, 350);
+    return () => window.clearTimeout(timer);
+  }, [compose, composeAudience, draftScope, draftTargetId, loadedDraftTarget, messageDraft, selectedCustomerId, selectedRecipients, useContext]);
 
   useEffect(() => {
     if (!open || !activeConversationId) return;
@@ -264,6 +346,14 @@ export default function InboxModal({
     if (!content || sending || !me) return;
 
     setSending(true);
+    setSendError(null);
+
+    if (!navigator.onLine) {
+      setSending(false);
+      setDraftSaved(true);
+      setSendError("Offline — this message is saved as a draft and has not been sent.");
+      return;
+    }
 
     try {
       let conversationId = activeConversationId;
@@ -283,7 +373,7 @@ export default function InboxModal({
                 ? context.context_label
                 : null,
             is_broadcast: composeAudience === "internal" && selectedRecipients.length > 3,
-            request_id: crypto.randomUUID(),
+            request_id: messageDraft?.conversationRequestId ?? crypto.randomUUID(),
           }),
         });
 
@@ -291,8 +381,6 @@ export default function InboxModal({
         if (!res.ok) throw new Error(data?.error ?? "Could not start inbox thread");
 
         conversationId = data.id;
-        setActiveConversationId(conversationId);
-        await loadConversations();
       }
 
       const res = await fetch("/api/chat/send-message", {
@@ -302,7 +390,7 @@ export default function InboxModal({
           conversationId,
           senderId: me,
           content,
-          clientMessageId: crypto.randomUUID(),
+          clientMessageId: messageDraft?.clientMessageId ?? crypto.randomUUID(),
           metadata: {
             deep_link: useContext ? context.deep_link : null,
             context_type: context.context_type,
@@ -311,7 +399,22 @@ export default function InboxModal({
         }),
       });
 
-      if (res.ok) setCompose("");
+      if (!res.ok) {
+        const failure = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(failure?.error ?? "Could not send message");
+      }
+      if (draftScope) {
+        await removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+      }
+      setCompose("");
+      setDraftSaved(false);
+      if (draftScope) {
+        setMessageDraft(createMessageDraft({ scope: draftScope, targetId: draftTargetId }));
+      }
+      setActiveConversationId(conversationId);
+      await loadConversations();
+    } catch (cause) {
+      setSendError(cause instanceof Error ? cause.message : "Could not send message");
     } finally {
       setSending(false);
     }
@@ -326,6 +429,9 @@ export default function InboxModal({
     useContext,
     context,
     loadConversations,
+    messageDraft,
+    draftScope,
+    draftTargetId,
   ]);
 
   if (!open) return null;
@@ -580,6 +686,14 @@ export default function InboxModal({
               {sending ? "Sending" : "Send"}
             </button>
           </div>
+          {draftSaved ? (
+            <p className="px-3 pb-2 text-[10px] text-[color:var(--theme-text-muted)]">
+              Saved on this device · delivery requires a connection
+            </p>
+          ) : null}
+          {sendError ? (
+            <p className="px-3 pb-2 text-[10px] text-red-300">{sendError}</p>
+          ) : null}
         </section>
 
         <aside className="hidden rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2.5 text-xs text-[color:var(--theme-text-secondary)] xl:block">

--- a/features/chat/components/PortalMessagesWorkspace.tsx
+++ b/features/chat/components/PortalMessagesWorkspace.tsx
@@ -6,6 +6,16 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import ChatWindow from "@/features/ai/components/chat/ChatWindow";
 import UserAvatar from "@/features/chat/components/UserAvatar";
+import {
+  createMessageDraft,
+  getOfflineMessageDraft,
+  removeOfflineMessageDraft,
+  resolveMessagingDraftScope,
+  saveOfflineMessageDraft,
+  warmMessagingRouteShells,
+  type OfflineMessageDraft,
+} from "@/features/chat/offline/messageDrafts";
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
 
 type ConversationRow = Database["public"]["Tables"]["conversations"]["Row"];
 type MessageRow = Database["public"]["Tables"]["messages"]["Row"];
@@ -49,6 +59,11 @@ export default function PortalMessagesWorkspace(): JSX.Element {
   const [contextOptions, setContextOptions] = useState<ContextOption[]>([]);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(null);
+  const [newThreadDraft, setNewThreadDraft] = useState<OfflineMessageDraft | null>(null);
+  const [draftReady, setDraftReady] = useState(false);
+  const [draftSaved, setDraftSaved] = useState(false);
+  const draftTargetId = "portal:new-conversation";
 
   const loadConversations = useCallback(async () => {
     const response = await fetch("/api/chat/my-conversations", { credentials: "include" });
@@ -59,21 +74,65 @@ export default function PortalMessagesWorkspace(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    void Promise.all([
-      supabase.auth.getUser(),
-      fetch("/api/chat/context-options", { credentials: "include" }).then((response) => response.json()),
-      loadConversations(),
-    ])
-      .then(([auth, contextPayload]) => {
-        setUserId(auth.data.user?.id ?? null);
+    void supabase.auth.getSession().then(({ data }) => {
+      setUserId(data.session?.user.id ?? null);
+    });
+    void fetch("/api/chat/context-options", { credentials: "include" })
+      .then((response) => response.json())
+      .then((contextPayload) => {
         const options = (contextPayload as { options?: ContextOption[] }).options;
         setContextOptions(Array.isArray(options) ? options : []);
       })
+      .catch(() => undefined);
+    void loadConversations()
       .catch((cause: unknown) => {
-        setError(cause instanceof Error ? cause.message : "Could not load messages");
+        if (navigator.onLine) {
+          setError(cause instanceof Error ? cause.message : "Could not load messages");
+        }
       })
       .finally(() => setLoading(false));
   }, [loadConversations, supabase]);
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    void resolveMessagingDraftScope(userId).then(async (scope) => {
+      if (!scope || cancelled) return;
+      const stored = await getOfflineMessageDraft({ scope, targetId: draftTargetId });
+      if (cancelled) return;
+      const next = stored ?? createMessageDraft({ scope, targetId: draftTargetId });
+      setDraftScope(scope);
+      setNewThreadDraft(next);
+      setMessage(next.content);
+      setSubject(next.subject ?? "");
+      setContextKey(next.contextKey ?? "");
+      setDraftSaved(Boolean(stored?.content || stored?.subject));
+      setDraftReady(true);
+      if (navigator.onLine) void warmMessagingRouteShells();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  useEffect(() => {
+    if (!draftReady || !draftScope || !newThreadDraft || !newThread) return;
+    const timer = window.setTimeout(() => {
+      if (!message.trim() && !subject.trim() && !contextKey) {
+        void removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        setDraftSaved(false);
+        return;
+      }
+      void saveOfflineMessageDraft({
+        ...newThreadDraft,
+        content: message,
+        subject,
+        contextKey,
+        updatedAt: new Date().toISOString(),
+      }).then(() => setDraftSaved(true));
+    }, 350);
+    return () => window.clearTimeout(timer);
+  }, [contextKey, draftReady, draftScope, message, newThread, newThreadDraft, subject]);
 
   const active = rows.find((row) => row.conversation.id === activeId) ?? null;
 
@@ -83,10 +142,16 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     setSending(true);
     setError(null);
 
+    if (!navigator.onLine) {
+      setError("Offline — this message is saved as a draft and has not been sent.");
+      setSending(false);
+      return;
+    }
+
     const selectedContext = contextOptions.find(
       (option) => `${option.type}:${option.id}` === contextKey,
     );
-    const requestId = crypto.randomUUID();
+    const requestId = newThreadDraft?.conversationRequestId ?? crypto.randomUUID();
 
     try {
       const createResponse = await fetch("/api/chat/start-conversation", {
@@ -112,7 +177,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
         body: JSON.stringify({
           conversationId: created.id,
           content,
-          clientMessageId: crypto.randomUUID(),
+          clientMessageId: newThreadDraft?.clientMessageId ?? crypto.randomUUID(),
         }),
       });
       if (!messageResponse.ok) {
@@ -125,6 +190,11 @@ export default function PortalMessagesWorkspace(): JSX.Element {
       setContextKey("");
       setNewThread(false);
       setActiveId(created.id);
+      if (draftScope) {
+        await removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        setNewThreadDraft(createMessageDraft({ scope: draftScope, targetId: draftTargetId }));
+      }
+      setDraftSaved(false);
       await loadConversations();
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : "Could not send message");
@@ -273,6 +343,11 @@ export default function PortalMessagesWorkspace(): JSX.Element {
                   {sending ? "Sending…" : "Send message"}
                 </button>
               </div>
+              {draftSaved ? (
+                <p className="text-xs text-[color:var(--theme-text-muted)]">
+                  Saved on this device · delivery requires a connection
+                </p>
+              ) : null}
             </div>
           ) : active && userId ? (
             <>

--- a/features/chat/offline/messageDrafts.ts
+++ b/features/chat/offline/messageDrafts.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  getOfflineSnapshot,
+  removeOfflineSnapshots,
+  saveOfflineSnapshot,
+} from "@/features/shared/lib/offline/database";
+import {
+  getOfflineMutationScope,
+  setOfflineMutationScope,
+  type OfflineMutationScope,
+} from "@/features/shared/lib/offline/mutations";
+
+const KIND = "message-draft";
+const MAX_AGE_MS = 1000 * 60 * 60 * 24 * 30;
+const SHELL_CACHE = "profixiq-messaging-shell-v1";
+
+export type OfflineMessageDraft = {
+  targetId: string;
+  userId: string;
+  shopId: string;
+  content: string;
+  subject?: string;
+  contextKey?: string;
+  audience?: "internal" | "customer";
+  recipientIds?: string[];
+  customerId?: string | null;
+  useContext?: boolean;
+  conversationRequestId: string;
+  clientMessageId: string;
+  updatedAt: string;
+};
+
+export function createMessageDraft(args: {
+  scope: OfflineMutationScope;
+  targetId: string;
+  content?: string;
+}): OfflineMessageDraft {
+  return {
+    targetId: args.targetId,
+    userId: args.scope.userId,
+    shopId: args.scope.shopId,
+    content: args.content ?? "",
+    conversationRequestId: crypto.randomUUID(),
+    clientMessageId: crypto.randomUUID(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export async function resolveMessagingDraftScope(
+  expectedUserId?: string | null,
+): Promise<OfflineMutationScope | null> {
+  const cached = getOfflineMutationScope();
+  if (cached && (!expectedUserId || cached.userId === expectedUserId)) return cached;
+  if (typeof navigator !== "undefined" && !navigator.onLine) return null;
+
+  try {
+    const response = await fetch("/api/chat/offline-scope", {
+      credentials: "include",
+      cache: "no-store",
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as { userId?: string; shopId?: string };
+    if (!body.userId || !body.shopId || (expectedUserId && body.userId !== expectedUserId)) {
+      return null;
+    }
+    const scope = { userId: body.userId, shopId: body.shopId };
+    setOfflineMutationScope(scope);
+    return scope;
+  } catch {
+    return null;
+  }
+}
+
+export async function getOfflineMessageDraft(args: {
+  scope: OfflineMutationScope;
+  targetId: string;
+}): Promise<OfflineMessageDraft | null> {
+  const stored = await getOfflineSnapshot<OfflineMessageDraft>({
+    scope: args.scope,
+    kind: KIND,
+    entityId: args.targetId,
+  });
+  return stored?.data ?? null;
+}
+
+export async function saveOfflineMessageDraft(
+  draft: OfflineMessageDraft,
+): Promise<void> {
+  await saveOfflineSnapshot({
+    scope: { userId: draft.userId, shopId: draft.shopId },
+    kind: KIND,
+    entityId: draft.targetId,
+    data: { ...draft, updatedAt: new Date().toISOString() },
+    maxAgeMs: MAX_AGE_MS,
+  });
+}
+
+export async function removeOfflineMessageDraft(args: {
+  scope: OfflineMutationScope;
+  targetId: string;
+}): Promise<void> {
+  await removeOfflineSnapshots({
+    scope: args.scope,
+    kind: KIND,
+    entityIds: [args.targetId],
+  });
+}
+
+export async function warmMessagingRouteShells(): Promise<void> {
+  if (typeof caches === "undefined" || !navigator.onLine) return;
+  const cache = await caches.open(SHELL_CACHE);
+  await Promise.all(
+    ["/portal/messages", "/chat"].map(async (url) => {
+      try {
+        const response = await fetch(url, {
+          credentials: "include",
+          headers: { Accept: "text/html" },
+        });
+        if (response.ok) await cache.put(url, response.clone());
+      } catch {
+        // A previously warmed shell remains usable when this refresh loses network.
+      }
+    }),
+  );
+}

--- a/tests/offline-message-drafts.test.ts
+++ b/tests/offline-message-drafts.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+const repository = read("features/chat/offline/messageDrafts.ts");
+const scopeRoute = read("app/api/chat/offline-scope/route.ts");
+const staffInbox = read("features/chat/components/InboxModal.tsx");
+const portal = read("features/chat/components/PortalMessagesWorkspace.tsx");
+const chatWindow = read("features/ai/components/chat/ChatWindow.tsx");
+const serviceWorker = read("app/sw.ts");
+
+describe("offline messaging drafts", () => {
+  it("stores drafts in tenant-scoped IndexedDB and never localStorage", () => {
+    expect(repository).toContain('const KIND = "message-draft"');
+    expect(repository).toContain("saveOfflineSnapshot");
+    expect(repository).toContain("getOfflineSnapshot");
+    expect(repository).toContain("removeOfflineSnapshots");
+    expect(repository).toContain("userId: draft.userId");
+    expect(repository).toContain("shopId: draft.shopId");
+    expect(repository).not.toContain("localStorage");
+  });
+
+  it("derives scope from the authenticated canonical messaging actor", () => {
+    expect(scopeRoute).toContain("auth.getUser()");
+    expect(scopeRoute).toContain("resolveMessagingActor");
+    expect(scopeRoute).toContain("shopId: actor.actor.shopId");
+    expect(scopeRoute).not.toContain("req.json");
+  });
+
+  it("restores and autosaves staff, customer, and reply composers", () => {
+    for (const source of [staffInbox, portal, chatWindow]) {
+      expect(source).toContain("getOfflineMessageDraft");
+      expect(source).toContain("saveOfflineMessageDraft");
+      expect(source).toContain("removeOfflineMessageDraft");
+      expect(source).toContain("Saved on this device");
+    }
+    expect(staffInbox).toContain("recipientIds: selectedRecipients");
+    expect(portal).toContain("subject");
+    expect(staffInbox).toContain("auth.getSession()");
+    expect(portal).toContain("auth.getSession()");
+  });
+
+  it("uses stable delivery identities but does not queue or auto-send drafts", () => {
+    expect(repository).toContain("conversationRequestId: crypto.randomUUID()");
+    expect(repository).toContain("clientMessageId: crypto.randomUUID()");
+    expect(staffInbox).toContain("messageDraft?.conversationRequestId");
+    expect(staffInbox).toContain("messageDraft?.clientMessageId");
+    expect(portal).toContain("newThreadDraft?.conversationRequestId");
+    expect(chatWindow).toContain("draft?.clientMessageId");
+    expect(repository).not.toContain("runMutationWithOfflineQueue");
+    expect(repository).not.toContain("replayAllOfflineMutations");
+    for (const source of [staffInbox, portal, chatWindow]) {
+      expect(source).toContain("!navigator.onLine");
+    }
+  });
+
+  it("makes the messaging shell reopenable after an offline restart", () => {
+    expect(repository).toContain('"/portal/messages", "/chat"');
+    expect(serviceWorker).toContain('url.pathname === "/portal/messages"');
+    expect(serviceWorker).toContain('cacheName: "profixiq-messaging-shell-v1"');
+    expect(serviceWorker).toContain("new NetworkFirst");
+  });
+});


### PR DESCRIPTION
## What changed

- adds tenant-scoped IndexedDB drafts for staff inbox replies, new staff/customer conversations, portal conversations, and portal replies
- restores draft content and recipient/context selections after reloads and offline app restarts
- derives the draft scope from the authenticated canonical messaging actor
- assigns stable conversation and client-message UUIDs so a lost response can be retried without duplicating delivery
- keeps delivery explicitly online-only; drafts are not added to the global mutation replay queue
- caches the portal messaging and chat navigation shells for offline reopening
- removes a draft only after the server confirms delivery and rotates identities before the next message

## User impact

Advisors, staff, and portal customers can compose while offline or through an interrupted session without losing text. The UI clearly labels device-saved drafts and does not claim they were sent. Actual thread creation and delivery continue through the existing authorized messaging APIs once online.

## Security and isolation

Drafts are stored under the existing user/shop IndexedDB scope. The client cannot choose the server scope: `/api/chat/offline-scope` resolves it from the authenticated messaging actor. Existing send and conversation authorization remains unchanged.

## Validation

- `node_modules/.bin/tsc --noEmit`
- focused ESLint on all changed TypeScript files
- 34 focused tests across messaging authorization, offline drafts, PWA foundations/sync, advisor offline foundations, and parts drafts
- `next build` compiled successfully and bundled `/sw.js`; page-data collection then stopped on the pre-existing local-environment requirement for `supabaseUrl` in `/api/agent/requests`

No database migration is required for this slice.