### PR TITLE
Add offline pilot safeguards

### DIFF
--- a/app/api/offline/session-check/route.ts
+++ b/app/api/offline/session-check/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<NextResponse> {
+  const supabase = createServerSupabaseRoute();
+  const actor = await resolveCurrentActor(supabase);
+  if (!actor.user) {
+    return NextResponse.json(
+      { error: "Sign in again before syncing saved work." },
+      { status: 401 },
+    );
+  }
+  if (!actor.profile || !actor.shopId) {
+    return NextResponse.json(
+      { error: "Your shop access is no longer available." },
+      { status: 403 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      userId: actor.user.id,
+      shopId: actor.shopId,
+      role: actor.role,
+      verifiedAt: new Date().toISOString(),
+    },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/app/offline/sync/page.tsx
+++ b/app/offline/sync/page.tsx
@@ -23,6 +23,14 @@ import {
   offlineMutationTarget,
   prepareOfflineMutationRetry,
 } from "@/features/shared/lib/offline/conflicts";
+import {
+  checkOfflineReplaySession,
+  type OfflineSessionHealth,
+} from "@/features/shared/lib/offline/session";
+import {
+  assessOfflineStorage,
+  type OfflineStorageHealth,
+} from "@/features/shared/lib/offline/storage-health";
 
 type BrowserStorage = {
   usage: number;
@@ -76,6 +84,11 @@ export default function OfflineSyncPage() {
   );
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
+  const [sessionHealth, setSessionHealth] = useState<OfflineSessionHealth>({
+    status: "offline",
+    message: "Session verification has not run yet.",
+  });
+  const [updateWaiting, setUpdateWaiting] = useState(false);
 
   const refresh = useCallback(async () => {
     await hydrateOfflineMutationQueue();
@@ -91,6 +104,9 @@ export default function OfflineSyncPage() {
       quota: estimate?.quota ?? 0,
       persistent,
     });
+    setSessionHealth(await checkOfflineReplaySession(scope));
+    const registration = await navigator.serviceWorker?.getRegistration?.();
+    setUpdateWaiting(Boolean(registration?.waiting));
   }, []);
 
   useEffect(() => {
@@ -152,6 +168,12 @@ export default function OfflineSyncPage() {
   const quotaPercent = browserStorage.quota
     ? Math.min(100, (browserStorage.usage / browserStorage.quota) * 100)
     : 0;
+  const storageHealth: OfflineStorageHealth = assessOfflineStorage({
+    ...browserStorage,
+    pendingBlobBytes: databaseStats.blobBytes,
+    pendingBlobCount: databaseStats.blobs,
+  });
+  const pendingCount = mutations.filter((item) => item.status !== "synced").length;
 
   return (
     <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100">
@@ -199,6 +221,40 @@ export default function OfflineSyncPage() {
               {message}
             </p>
           )}
+        </section>
+
+        <section className="rounded-2xl border border-slate-700 bg-slate-900 p-5">
+          <h2 className="font-semibold">Pilot readiness</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <ReadinessItem
+              label="Session"
+              ready={sessionHealth.status === "verified"}
+              value={
+                sessionHealth.status === "verified"
+                  ? "Verified"
+                  : sessionHealth.status === "offline"
+                    ? "Verify on reconnect"
+                    : "Sign-in required"
+              }
+              detail={sessionHealth.message}
+            />
+            <ReadinessItem
+              label="Storage"
+              ready={storageHealth.level === "ready"}
+              value={storageHealth.label}
+              detail={storageHealth.message}
+            />
+            <ReadinessItem
+              label="App update"
+              ready={!updateWaiting || pendingCount === 0}
+              value={updateWaiting ? "Update waiting" : "Current"}
+              detail={
+                updateWaiting && pendingCount > 0
+                  ? "Sync saved work before activating the update."
+                  : "No version-skew risk is currently detected."
+              }
+            />
+          </div>
         </section>
 
         <section className="space-y-3">
@@ -393,5 +449,22 @@ export default function OfflineSyncPage() {
         </section>
       </div>
     </main>
+  );
+}
+
+function ReadinessItem(props: {
+  label: string;
+  ready: boolean;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-3">
+      <p className="text-xs uppercase tracking-wider text-slate-400">{props.label}</p>
+      <p className={props.ready ? "mt-1 font-semibold text-emerald-300" : "mt-1 font-semibold text-amber-300"}>
+        {props.value}
+      </p>
+      <p className="mt-1 text-xs text-slate-400">{props.detail}</p>
+    </div>
   );
 }

--- a/docs/offline-shop-pilot.md
+++ b/docs/offline-shop-pilot.md
@@ -1,0 +1,27 @@
+# Offline shop pilot
+
+Run this matrix against the production-like pilot shop before general offline release. Record device, OS/browser version, installed-app version, user/shop, test time, result, and evidence for every row.
+
+## Required devices
+
+- Current iPhone and iPad installed from Safari
+- Current Android phone and tablet installed from Chrome
+- Windows desktop or shop tablet installed from Edge or Chrome
+- Two devices signed into separate technician/advisor accounts in the same shop
+
+## Test matrix
+
+1. Download assigned work, close the app completely, disable networking, reopen, and verify the queue and job details load.
+2. Repeat notes, cause/correction, inspection, shift, and job-punch actions twice; verify one stable receipt per action.
+3. Queue several dependent actions offline, reconnect, and verify chronological replay and authoritative cache refresh.
+4. Edit the same job from two devices, reconnect the older device, and verify an actionable conflict preserves both server and device values.
+5. Expire or revoke the session while work is queued; reconnect and verify nothing replays until the original user/shop is re-verified.
+6. Sign out and sign in as another user; verify the previous user's snapshots, drafts, photos, and queue are unavailable and removed by logout cleanup.
+7. Stage at least 40 photos and repeat near the browser quota; verify the Sync Center warns before capture becomes unsafe.
+8. Lose the network during every server mutation and immediately after the server commits; verify retries do not duplicate records.
+9. Deploy an app update while work is queued; verify activation is held until the queue is synced or reviewed.
+10. Evict browser storage where the platform allows it; verify missing staged files become explicit conflicts rather than silent success.
+
+## Release gate
+
+Do not expand beyond the pilot until every critical workflow passes on every required device, no cross-user/shop data is visible, duplicate mutations remain idempotent, and all conflicts give the user a safe recovery action.

--- a/features/shared/components/pwa/PwaRuntime.tsx
+++ b/features/shared/components/pwa/PwaRuntime.tsx
@@ -26,6 +26,7 @@ export default function PwaRuntime() {
   const [iosInstallAvailable, setIosInstallAvailable] = useState(false);
   const [showIosInstructions, setShowIosInstructions] = useState(false);
   const [activatingUpdate, setActivatingUpdate] = useState(false);
+  const [syncBlocked, setSyncBlocked] = useState<string | null>(null);
   const updateReloading = useRef(false);
   const pending = summary.queued + summary.syncing + summary.failed;
 
@@ -69,7 +70,17 @@ export default function PwaRuntime() {
     );
     const sync = () => {
       setOnline(navigator.onLine);
-      if (navigator.onLine) void replayAllOfflineMutations();
+      if (navigator.onLine) {
+        void replayAllOfflineMutations()
+          .then(() => setSyncBlocked(null))
+          .catch((cause: unknown) => {
+            setSyncBlocked(
+              cause instanceof Error
+                ? cause.message
+                : "Saved work could not be verified for sync.",
+            );
+          });
+      }
     };
     window.addEventListener("online", sync);
     window.addEventListener("offline", sync);
@@ -140,7 +151,8 @@ export default function PwaRuntime() {
     pending === 0 &&
     !installPrompt &&
     !iosInstallAvailable &&
-    !updateReady
+    !updateReady &&
+    !syncBlocked
   ) {
     return null;
   }
@@ -151,12 +163,15 @@ export default function PwaRuntime() {
         className={`h-2 w-2 rounded-full ${online ? "bg-emerald-400" : "bg-amber-400"}`}
       />
       <span>
-        {online
+        {syncBlocked
+          ? "Sync needs attention"
+          : online
           ? pending
             ? `Syncing ${pending}`
             : "Online"
           : `Offline · ${pending} pending`}
       </span>
+      {syncBlocked && <span className="sr-only">{syncBlocked}</span>}
       {installPrompt && (
         <button
           type="button"
@@ -175,7 +190,7 @@ export default function PwaRuntime() {
           Install
         </button>
       )}
-      {(pending > 0 || !online) && (
+      {(pending > 0 || !online || syncBlocked) && (
         <button
           type="button"
           onClick={() => window.location.assign("/offline/sync")}
@@ -188,10 +203,14 @@ export default function PwaRuntime() {
         <button
           type="button"
           onClick={activateUpdate}
-          disabled={activatingUpdate}
+          disabled={activatingUpdate || pending > 0}
           className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
         >
-          {activatingUpdate ? "Updating…" : "Update"}
+          {activatingUpdate
+            ? "Updating…"
+            : pending > 0
+              ? "Sync before update"
+              : "Update"}
         </button>
       )}
       {showIosInstructions && (

--- a/features/shared/lib/offline/replay.ts
+++ b/features/shared/lib/offline/replay.ts
@@ -7,6 +7,8 @@ import {
 } from "@/features/shared/lib/offline/database";
 import {
   listPendingMutations,
+  getOfflineMutationScope,
+  hydrateOfflineMutationQueue,
   replayQueuedMutations,
   type OfflineMutationRunner,
   type PendingMutation,
@@ -22,6 +24,7 @@ import {
   reconcileOfflineTechnicianState,
   type OfflineReconciliationResult,
 } from "@/features/shared/lib/offline/reconciliation";
+import { assertOfflineReplaySession } from "@/features/shared/lib/offline/session";
 
 type ReplayPayload = Record<string, unknown>;
 
@@ -173,7 +176,14 @@ const handlers: Record<string, OfflineMutationRunner> = {
 let replayPromise: ReturnType<typeof replayQueuedMutations> | null = null;
 
 export function replayAllOfflineMutations() {
-  replayPromise ??= replayQueuedMutations({ handlers }).finally(() => {
+  replayPromise ??= (async () => {
+    await hydrateOfflineMutationQueue();
+    if (!navigator.onLine || listPendingMutations().length === 0) {
+      return replayQueuedMutations({ handlers });
+    }
+    await assertOfflineReplaySession(getOfflineMutationScope());
+    return replayQueuedMutations({ handlers });
+  })().finally(() => {
     replayPromise = null;
   });
   return replayPromise;

--- a/features/shared/lib/offline/session.ts
+++ b/features/shared/lib/offline/session.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+
+export type OfflineReplayBlockCode =
+  | "reauthenticate"
+  | "access_revoked"
+  | "scope_changed"
+  | "verification_unavailable";
+
+export type OfflineSessionHealth =
+  | { status: "offline"; message: string }
+  | { status: "verified"; message: string; verifiedAt: string }
+  | { status: "blocked"; code: OfflineReplayBlockCode; message: string };
+
+export class OfflineReplayBlockedError extends Error {
+  readonly code: OfflineReplayBlockCode;
+
+  constructor(code: OfflineReplayBlockCode, message: string) {
+    super(message);
+    this.name = "OfflineReplayBlockedError";
+    this.code = code;
+  }
+}
+
+export async function checkOfflineReplaySession(
+  scope: OfflineMutationScope | null,
+): Promise<OfflineSessionHealth> {
+  if (typeof navigator !== "undefined" && !navigator.onLine) {
+    return {
+      status: "offline",
+      message: "Session verification will run after reconnection.",
+    };
+  }
+  if (!scope) {
+    return {
+      status: "blocked",
+      code: "reauthenticate",
+      message: "Sign in again to identify the saved work on this device.",
+    };
+  }
+
+  try {
+    const response = await fetch("/api/offline/session-check", {
+      credentials: "include",
+      cache: "no-store",
+      headers: { Accept: "application/json" },
+    });
+    const body = (await response.json().catch(() => null)) as {
+      userId?: string;
+      shopId?: string;
+      verifiedAt?: string;
+      error?: string;
+    } | null;
+    if (response.status === 401) {
+      return {
+        status: "blocked",
+        code: "reauthenticate",
+        message: body?.error ?? "Sign in again before syncing saved work.",
+      };
+    }
+    if (response.status === 403) {
+      return {
+        status: "blocked",
+        code: "access_revoked",
+        message: body?.error ?? "Your shop access is no longer available.",
+      };
+    }
+    if (!response.ok || !body?.userId || !body.shopId) {
+      return {
+        status: "blocked",
+        code: "verification_unavailable",
+        message: "The server could not verify this device. Saved work was not sent.",
+      };
+    }
+    if (body.userId !== scope.userId || body.shopId !== scope.shopId) {
+      return {
+        status: "blocked",
+        code: "scope_changed",
+        message:
+          "This device's saved work belongs to a different user or shop. Sign in with the original account.",
+      };
+    }
+    return {
+      status: "verified",
+      message: "User and shop access verified for sync.",
+      verifiedAt: body.verifiedAt ?? new Date().toISOString(),
+    };
+  } catch {
+    return {
+      status: "blocked",
+      code: "verification_unavailable",
+      message: "The server could not verify this device. Saved work was not sent.",
+    };
+  }
+}
+
+export async function assertOfflineReplaySession(
+  scope: OfflineMutationScope | null,
+): Promise<void> {
+  const health = await checkOfflineReplaySession(scope);
+  if (health.status === "blocked") {
+    throw new OfflineReplayBlockedError(health.code, health.message);
+  }
+}

--- a/features/shared/lib/offline/storage-health.ts
+++ b/features/shared/lib/offline/storage-health.ts
@@ -1,0 +1,73 @@
+export type OfflineStorageHealth = {
+  level: "unknown" | "ready" | "warning" | "critical";
+  label: string;
+  message: string;
+  usagePercent: number | null;
+  availableBytes: number | null;
+};
+
+const MIB = 1024 * 1024;
+
+export function assessOfflineStorage(args: {
+  usage: number;
+  quota: number;
+  persistent: boolean;
+  pendingBlobBytes: number;
+  pendingBlobCount: number;
+}): OfflineStorageHealth {
+  if (!Number.isFinite(args.quota) || args.quota <= 0) {
+    return {
+      level: "unknown",
+      label: "Storage unknown",
+      message: "This browser did not report an offline storage limit.",
+      usagePercent: null,
+      availableBytes: null,
+    };
+  }
+  const usage = Math.max(0, args.usage);
+  const availableBytes = Math.max(0, args.quota - usage);
+  const usagePercent = Math.min(100, (usage / args.quota) * 100);
+  const photoHeadroom = Math.max(50 * MIB, args.pendingBlobBytes * 2);
+
+  if (usagePercent >= 90 || availableBytes < photoHeadroom) {
+    return {
+      level: "critical",
+      label: "Storage critical",
+      message:
+        "Sync photos now and clean expired data before capturing more offline files.",
+      usagePercent,
+      availableBytes,
+    };
+  }
+  if (
+    usagePercent >= 75 ||
+    availableBytes < 200 * MIB ||
+    args.pendingBlobCount >= 40 ||
+    args.pendingBlobBytes >= 250 * MIB
+  ) {
+    return {
+      level: "warning",
+      label: "Storage needs attention",
+      message:
+        "A large offline queue or limited free space could interrupt photo capture. Sync when practical.",
+      usagePercent,
+      availableBytes,
+    };
+  }
+  if (!args.persistent) {
+    return {
+      level: "warning",
+      label: "Best-effort storage",
+      message: "Protect offline storage to reduce the chance of browser eviction.",
+      usagePercent,
+      availableBytes,
+    };
+  }
+  return {
+    level: "ready",
+    label: "Storage ready",
+    message: "Offline storage has sufficient protected capacity.",
+    usagePercent,
+    availableBytes,
+  };
+}

--- a/tests/offline-pilot-hardening.test.ts
+++ b/tests/offline-pilot-hardening.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { assessOfflineStorage } from "@/features/shared/lib/offline/storage-health";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("offline shop-pilot hardening", () => {
+  it("blocks replay until the server verifies the same authenticated user and shop", () => {
+    const route = read("app/api/offline/session-check/route.ts");
+    const session = read("features/shared/lib/offline/session.ts");
+    const replay = read("features/shared/lib/offline/replay.ts");
+    expect(route).toContain("resolveCurrentActor");
+    expect(route).toContain("actor.user.id");
+    expect(route).toContain("actor.shopId");
+    expect(session).toContain("body.userId !== scope.userId");
+    expect(session).toContain("body.shopId !== scope.shopId");
+    expect(replay).toContain("assertOfflineReplaySession");
+    expect(replay.indexOf("assertOfflineReplaySession")).toBeLessThan(
+      replay.lastIndexOf("replayQueuedMutations({ handlers })"),
+    );
+  });
+
+  it("gives expired, revoked, mismatched, and unavailable verification distinct outcomes", () => {
+    const session = read("features/shared/lib/offline/session.ts");
+    expect(session).toContain('"reauthenticate"');
+    expect(session).toContain('"access_revoked"');
+    expect(session).toContain('"scope_changed"');
+    expect(session).toContain('"verification_unavailable"');
+  });
+
+  it("marks low capacity and large photo queues before capture becomes unsafe", () => {
+    expect(
+      assessOfflineStorage({
+        usage: 950,
+        quota: 1000,
+        persistent: true,
+        pendingBlobBytes: 0,
+        pendingBlobCount: 0,
+      }).level,
+    ).toBe("critical");
+    expect(
+      assessOfflineStorage({
+        usage: 100 * 1024 * 1024,
+        quota: 1024 * 1024 * 1024,
+        persistent: true,
+        pendingBlobBytes: 300 * 1024 * 1024,
+        pendingBlobCount: 45,
+      }).level,
+    ).toBe("warning");
+    expect(
+      assessOfflineStorage({
+        usage: 100 * 1024 * 1024,
+        quota: 2 * 1024 * 1024 * 1024,
+        persistent: true,
+        pendingBlobBytes: 10 * 1024 * 1024,
+        pendingBlobCount: 2,
+      }).level,
+    ).toBe("ready");
+  });
+
+  it("prevents an app update from activating over pending device work", () => {
+    const runtime = read("features/shared/components/pwa/PwaRuntime.tsx");
+    const syncCenter = read("app/offline/sync/page.tsx");
+    expect(runtime).toContain("activatingUpdate || pending > 0");
+    expect(runtime).toContain("Sync before update");
+    expect(syncCenter).toContain("navigator.serviceWorker?.getRegistration?.()");
+    expect(syncCenter).toContain("No version-skew risk is currently detected.");
+  });
+});


### PR DESCRIPTION
## What changed

- verify the authenticated user and shop with the server before any queued offline mutation replays
- leave saved work untouched and surface actionable states for expired sessions, revoked shop access, scope changes, and verification outages
- add Sync Center pilot-readiness indicators for session health, storage pressure, large photo queues, persistence, and waiting app updates
- prevent service-worker updates from activating while device work is still pending
- add a production-like shop pilot matrix covering restart, repeated actions, replay ordering, two-device conflicts, revoked sessions, large photo queues, network-loss timing, version skew, and storage eviction
- add focused hardening contract and storage-threshold tests

## Validation

- `node_modules/.bin/tsc --noEmit`
- focused ESLint on all changed TypeScript/TSX files
- 7 focused test files: 33 tests passed
- `next build` compiled successfully; the existing environment then stopped page-data collection because `supabaseUrl` is unavailable for `/api/agent/requests`

No database migration is required.