### PR TITLE
Harden offline message draft delivery

### DIFF
--- a/features/ai/components/chat/ChatWindow.tsx
+++ b/features/ai/components/chat/ChatWindow.tsx
@@ -79,7 +79,13 @@ export default function ChatWindow({
     let cancelled = false;
     setDraftReady(false);
     void resolveMessagingDraftScope(userId).then(async (scope) => {
-      if (!scope || cancelled) return;
+      if (cancelled) return;
+      if (!scope) {
+        setError(
+          "Messaging storage could not verify your shop. Reconnect or sign in again.",
+        );
+        return;
+      }
       const stored = await getOfflineMessageDraft({ scope, targetId: draftTargetId });
       if (cancelled) return;
       const next = stored ?? createMessageDraft({ scope, targetId: draftTargetId });
@@ -244,13 +250,30 @@ export default function ChatWindow({
   const sendMessage = useCallback(async () => {
     const content = newMessage.trim();
     if (!content || sending) return;
-
-    if (!navigator.onLine) {
-      setError("Offline — this message is saved as a draft and has not been sent.");
+    if (!draftReady || !draftScope || !draft) {
+      setError("Wait for secure draft storage to finish loading.");
       return;
     }
 
-    const clientMessageId = draft?.clientMessageId ?? crypto.randomUUID();
+    if (!navigator.onLine) {
+      const savedDraft = {
+        ...draft,
+        content,
+        updatedAt: new Date().toISOString(),
+      };
+      try {
+        await saveOfflineMessageDraft(savedDraft);
+        setDraft(savedDraft);
+        setDraftSaved(true);
+        setError("Offline — this message is saved as a draft and has not been sent.");
+      } catch {
+        setDraftSaved(false);
+        setError("Offline draft could not be saved. Keep this window open and try again.");
+      }
+      return;
+    }
+
+    const clientMessageId = draft.clientMessageId;
     const tempId = `temp-${clientMessageId}`;
     const optimistic: Message = {
       id: tempId,
@@ -312,7 +335,7 @@ export default function ChatWindow({
     } finally {
       setSending(false);
     }
-  }, [conversationId, draft, draftScope, draftTargetId, newMessage, sending, userId]);
+  }, [conversationId, draft, draftReady, draftScope, draftTargetId, newMessage, sending, userId]);
 
   const deleteMessage = useCallback(
     async (id: string) => {
@@ -483,13 +506,18 @@ export default function ChatWindow({
           value={newMessage}
           onChange={(e) => setNewMessage(e.target.value)}
           onKeyDown={handleKeyDown}
+          disabled={!draftReady || sending}
           rows={1}
-          placeholder="Type a message… (Enter to send, Shift+Enter for new line)"
+          placeholder={
+            draftReady
+              ? "Type a message… (Enter to send, Shift+Enter for new line)"
+              : "Loading saved draft…"
+          }
           className="flex-1 resize-none rounded bg-[color:var(--theme-surface-overlay)] border border-[var(--metal-border-soft)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)] focus:outline-none"
         />
         <button
           onClick={() => void sendMessage()}
-          disabled={sending || !newMessage.trim()}
+          disabled={sending || !draftReady || !newMessage.trim()}
           className="rounded-full border border-[var(--accent-copper-soft)] bg-[color:var(--theme-surface-overlay)] px-4 py-2 text-sm font-semibold text-[var(--accent-copper-soft)] shadow-[var(--theme-shadow-medium)] hover:bg-[color:var(--theme-surface-overlay)] disabled:opacity-50"
         >
           {sending ? "Sending…" : "Send"}

--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -160,6 +160,31 @@ export default function InboxModal({
   const draftTargetId = activeConversationId
     ? `conversation:${activeConversationId}`
     : `staff:new:${composeAudience}:${context.context_type ?? "general"}:${context.context_id ?? "none"}`;
+  const draftReady = Boolean(
+    draftScope &&
+      messageDraft &&
+      loadedDraftTarget === draftTargetId &&
+      messageDraft.targetId === draftTargetId,
+  );
+  const newConversationFingerprint = useMemo(
+    () =>
+      JSON.stringify({
+        audience: composeAudience,
+        customerId: composeAudience === "customer" ? selectedCustomerId : null,
+        recipientIds:
+          composeAudience === "internal" ? [...selectedRecipients].sort() : [],
+        contextType: useContext ? context.context_type : null,
+        contextId: useContext ? context.context_id : null,
+      }),
+    [
+      composeAudience,
+      context.context_id,
+      context.context_type,
+      selectedCustomerId,
+      selectedRecipients,
+      useContext,
+    ],
+  );
 
   const loadConversations = useCallback(async () => {
     const res = await fetch("/api/chat/my-conversations", { credentials: "include" });
@@ -193,11 +218,26 @@ export default function InboxModal({
   }, [open, supabase, loadConversations]);
 
   useEffect(() => {
-    if (!open || !me) return;
+    if (!open || !me) {
+      setDraftScope(null);
+      setMessageDraft(null);
+      setLoadedDraftTarget(null);
+      return;
+    }
     let cancelled = false;
+    setDraftScope(null);
+    setMessageDraft(null);
+    setLoadedDraftTarget(null);
     void resolveMessagingDraftScope(me).then(async (scope) => {
-      if (!scope || cancelled) return;
+      if (cancelled) return;
+      if (!scope) {
+        setSendError(
+          "Messaging storage could not verify your shop. Reconnect or sign in again.",
+        );
+        return;
+      }
       setDraftScope(scope);
+      setSendError(null);
       if (navigator.onLine) void warmMessagingRouteShells();
     });
     return () => {
@@ -228,6 +268,36 @@ export default function InboxModal({
       cancelled = true;
     };
   }, [activeConversationId, draftScope, draftTargetId, open]);
+
+  useEffect(() => {
+    if (
+      activeConversationId ||
+      !draftReady ||
+      !messageDraft?.conversationRequestFingerprint ||
+      messageDraft.conversationRequestFingerprint === newConversationFingerprint
+    ) {
+      return;
+    }
+
+    setMessageDraft((current) =>
+      current && current.targetId === draftTargetId
+        ? {
+            ...current,
+            conversationRequestId: crypto.randomUUID(),
+            conversationRequestFingerprint: null,
+            clientMessageId: crypto.randomUUID(),
+            updatedAt: new Date().toISOString(),
+          }
+        : current,
+    );
+    setDraftSaved(false);
+  }, [
+    activeConversationId,
+    draftReady,
+    draftTargetId,
+    messageDraft?.conversationRequestFingerprint,
+    newConversationFingerprint,
+  ]);
 
   useEffect(() => {
     if (
@@ -344,21 +414,59 @@ export default function InboxModal({
   const sendMessage = useCallback(async () => {
     const content = compose.trim();
     if (!content || sending || !me) return;
+    if (!draftReady || !draftScope || !messageDraft) {
+      setSendError("Wait for secure draft storage to finish loading.");
+      return;
+    }
 
     setSending(true);
     setSendError(null);
 
     if (!navigator.onLine) {
-      setSending(false);
-      setDraftSaved(true);
-      setSendError("Offline — this message is saved as a draft and has not been sent.");
+      const savedDraft: OfflineMessageDraft = {
+        ...messageDraft,
+        content,
+        audience: composeAudience,
+        recipientIds: selectedRecipients,
+        customerId: selectedCustomerId,
+        useContext,
+        updatedAt: new Date().toISOString(),
+      };
+      try {
+        await saveOfflineMessageDraft(savedDraft);
+        setMessageDraft(savedDraft);
+        setDraftSaved(true);
+        setSendError(
+          "Offline — this message is saved as a draft and has not been sent.",
+        );
+      } catch {
+        setDraftSaved(false);
+        setSendError(
+          "Offline draft could not be saved. Keep this window open and try again.",
+        );
+      } finally {
+        setSending(false);
+      }
       return;
     }
 
     try {
       let conversationId = activeConversationId;
+      let deliveryDraft = messageDraft;
 
       if (!conversationId) {
+        deliveryDraft = {
+          ...messageDraft,
+          content,
+          audience: composeAudience,
+          recipientIds: selectedRecipients,
+          customerId: selectedCustomerId,
+          useContext,
+          conversationRequestFingerprint: newConversationFingerprint,
+          updatedAt: new Date().toISOString(),
+        };
+        await saveOfflineMessageDraft(deliveryDraft);
+        setMessageDraft(deliveryDraft);
         const res = await fetch("/api/chat/start-conversation", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -373,7 +481,7 @@ export default function InboxModal({
                 ? context.context_label
                 : null,
             is_broadcast: composeAudience === "internal" && selectedRecipients.length > 3,
-            request_id: messageDraft?.conversationRequestId ?? crypto.randomUUID(),
+            request_id: deliveryDraft.conversationRequestId,
           }),
         });
 
@@ -390,7 +498,7 @@ export default function InboxModal({
           conversationId,
           senderId: me,
           content,
-          clientMessageId: messageDraft?.clientMessageId ?? crypto.randomUUID(),
+          clientMessageId: deliveryDraft.clientMessageId,
           metadata: {
             deep_link: useContext ? context.deep_link : null,
             context_type: context.context_type,
@@ -432,6 +540,8 @@ export default function InboxModal({
     messageDraft,
     draftScope,
     draftTargetId,
+    draftReady,
+    newConversationFingerprint,
   ]);
 
   if (!open) return null;
@@ -472,6 +582,7 @@ export default function InboxModal({
                 <button
                   key={audience}
                   type="button"
+                  disabled={!draftReady || sending}
                   onClick={() => {
                     setComposeAudience(audience);
                     setActiveConversationId(null);
@@ -596,6 +707,7 @@ export default function InboxModal({
                 </select>
                 <button
                   type="button"
+                  disabled={!draftReady || sending}
                   className="h-8 rounded border border-[color:var(--theme-border-soft)] px-2"
                   onClick={() => setSelectedRecipients(recipientOptions.map((u) => u.id))}
                 >
@@ -608,6 +720,7 @@ export default function InboxModal({
                   <label key={u.id} className="mb-1 flex items-center gap-2">
                     <input
                       type="checkbox"
+                      disabled={!draftReady || sending}
                       checked={selectedRecipients.includes(u.id)}
                       onChange={(e) =>
                         setSelectedRecipients((prev) =>
@@ -632,7 +745,7 @@ export default function InboxModal({
                     <button
                       key={customer.id}
                       type="button"
-                      disabled={!customer.can_message}
+                      disabled={!draftReady || sending || !customer.can_message}
                       onClick={() => setSelectedCustomerId(customer.id)}
                       className={`mb-1 flex w-full items-center justify-between rounded px-2 py-1.5 text-left ${
                         selectedCustomerId === customer.id
@@ -655,6 +768,7 @@ export default function InboxModal({
                 <label className="flex items-center gap-2">
                   <input
                     type="checkbox"
+                    disabled={!draftReady || sending}
                     checked={useContext}
                     onChange={(e) => setUseContext(e.target.checked)}
                   />
@@ -668,7 +782,14 @@ export default function InboxModal({
             <textarea
               value={compose}
               onChange={(e) => setCompose(e.target.value)}
-              placeholder={activeConversationId ? "Reply…" : "Compose…"}
+              disabled={!draftReady || sending}
+              placeholder={
+                draftReady
+                  ? activeConversationId
+                    ? "Reply…"
+                    : "Compose…"
+                  : "Loading saved draft…"
+              }
               className="h-14 flex-1 rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-2 py-1.5 text-xs"
             />
             <button
@@ -676,6 +797,7 @@ export default function InboxModal({
               onClick={() => void sendMessage()}
               disabled={
                 sending ||
+                !draftReady ||
                 (!activeConversationId &&
                   (composeAudience === "customer"
                     ? !selectedCustomerId

--- a/features/chat/offline/messageDrafts.ts
+++ b/features/chat/offline/messageDrafts.ts
@@ -27,6 +27,7 @@ export type OfflineMessageDraft = {
   customerId?: string | null;
   useContext?: boolean;
   conversationRequestId: string;
+  conversationRequestFingerprint?: string | null;
   clientMessageId: string;
   updatedAt: string;
 };
@@ -51,8 +52,11 @@ export async function resolveMessagingDraftScope(
   expectedUserId?: string | null,
 ): Promise<OfflineMutationScope | null> {
   const cached = getOfflineMutationScope();
-  if (cached && (!expectedUserId || cached.userId === expectedUserId)) return cached;
-  if (typeof navigator !== "undefined" && !navigator.onLine) return null;
+  if (typeof navigator !== "undefined" && !navigator.onLine) {
+    return cached && (!expectedUserId || cached.userId === expectedUserId)
+      ? cached
+      : null;
+  }
 
   try {
     const response = await fetch("/api/chat/offline-scope", {

--- a/tests/offline-message-drafts.test.ts
+++ b/tests/offline-message-drafts.test.ts
@@ -25,6 +25,12 @@ describe("offline messaging drafts", () => {
     expect(scopeRoute).toContain("resolveMessagingActor");
     expect(scopeRoute).toContain("shopId: actor.actor.shopId");
     expect(scopeRoute).not.toContain("req.json");
+    expect(repository.indexOf("!navigator.onLine")).toBeLessThan(
+      repository.indexOf("return cached"),
+    );
+    expect(repository.indexOf('fetch("/api/chat/offline-scope"')).toBeLessThan(
+      repository.indexOf("setOfflineMutationScope(scope)"),
+    );
   });
 
   it("restores and autosaves staff, customer, and reply composers", () => {
@@ -43,14 +49,29 @@ describe("offline messaging drafts", () => {
   it("uses stable delivery identities but does not queue or auto-send drafts", () => {
     expect(repository).toContain("conversationRequestId: crypto.randomUUID()");
     expect(repository).toContain("clientMessageId: crypto.randomUUID()");
-    expect(staffInbox).toContain("messageDraft?.conversationRequestId");
-    expect(staffInbox).toContain("messageDraft?.clientMessageId");
+    expect(staffInbox).toContain("request_id: deliveryDraft.conversationRequestId");
+    expect(staffInbox).toContain("clientMessageId: deliveryDraft.clientMessageId");
+    expect(repository).toContain("conversationRequestFingerprint?: string | null");
+    expect(staffInbox).toContain("conversationRequestFingerprint: newConversationFingerprint");
+    expect(staffInbox).toContain("newConversationFingerprint");
     expect(portal).toContain("newThreadDraft?.conversationRequestId");
-    expect(chatWindow).toContain("draft?.clientMessageId");
+    expect(chatWindow).toContain("const clientMessageId = draft.clientMessageId");
     expect(repository).not.toContain("runMutationWithOfflineQueue");
     expect(repository).not.toContain("replayAllOfflineMutations");
     for (const source of [staffInbox, portal, chatWindow]) {
       expect(source).toContain("!navigator.onLine");
+    }
+  });
+
+  it("waits for draft hydration and confirms offline persistence before claiming success", () => {
+    expect(staffInbox).toContain("disabled={!draftReady || sending}");
+    expect(chatWindow).toContain("disabled={!draftReady || sending}");
+    for (const source of [staffInbox, chatWindow]) {
+      const offlineBranch = source.indexOf("if (!navigator.onLine)");
+      const confirmedSave = source.indexOf("await saveOfflineMessageDraft", offlineBranch);
+      const savedState = source.indexOf("setDraftSaved(true)", confirmedSave);
+      expect(confirmedSave).toBeGreaterThan(offlineBranch);
+      expect(savedState).toBeGreaterThan(confirmedSave);
     }
   });
 


### PR DESCRIPTION
## What changed

Addresses every actionable finding from the Codex review on #1071:

- refresh messaging draft scope from the authenticated server actor whenever online; cached scope is now offline-only fallback
- keep staff and conversation composers disabled until draft hydration and stable delivery identities are ready
- persist a new-conversation target fingerprint before the first create attempt
- retain the same request identity for safe retries against the same target, including after app restart
- rotate both conversation and message identities if recipients, customer, audience, or attached context changes after an attempted create
- explicitly await IndexedDB persistence before showing an offline draft as saved
- remove in-flight random UUID fallbacks from message sends

## Validation

- `node_modules/.bin/tsc --noEmit`
- focused ESLint: clean
- offline messaging/PWA suite: 15 tests passed

No database migration is required.