### PR TITLE
Harden offline parts draft submission

### DIFF
--- a/app/api/offline/parts-request-drafts/route.ts
+++ b/app/api/offline/parts-request-drafts/route.ts
@@ -15,6 +15,20 @@ function statusFor(message: string): number {
   return 400;
 }
 
+function isValidDraftItem(item: unknown): boolean {
+  if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+  const value = item as Record<string, unknown>;
+  const description =
+    typeof value.description === "string" ? value.description.trim() : "";
+  const qty = Number(value.qty);
+  return (
+    description.length > 0 &&
+    Number.isFinite(qty) &&
+    qty >= 1 &&
+    qty <= 10000
+  );
+}
+
 export async function POST(request: NextRequest) {
   const operationKey = request.headers.get("Idempotency-Key")?.trim() ?? "";
   const draft = (await request
@@ -35,15 +49,7 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
-  if (
-    draft.items.some(
-      (item) =>
-        !item.description?.trim() ||
-        !Number.isFinite(Number(item.qty)) ||
-        Number(item.qty) < 1 ||
-        Number(item.qty) > 10000,
-    )
-  ) {
+  if ((draft.items as unknown[]).some((item) => !isValidDraftItem(item))) {
     return NextResponse.json(
       {
         error:

--- a/app/mobile/work-orders/create/page.tsx
+++ b/app/mobile/work-orders/create/page.tsx
@@ -36,7 +36,6 @@ import NewWorkOrderLineForm from "@/features/work-orders/components/NewWorkOrder
 import { useWorkOrderDraft } from "app/work-orders/state/useWorkOrderDraft";
 import VinCaptureModal from "app/vehicle/VinCaptureModal";
 import {
-  getOfflineMutationScope,
   setOfflineMutationScope,
 } from "@/features/shared/lib/offline/mutations";
 import {
@@ -1071,6 +1070,12 @@ export default function MobileCreateWorkOrderPage() {
           customerId: cust.id,
           vehicleId: veh.id,
         };
+        const advisorScope = { userId: currentUserId, shopId };
+        await pruneDependentPartsRequestDrafts({
+          scope: advisorScope,
+          workOrderDraftId: prepared.id,
+          activeTempLineIds: prepared.lines.map((line) => line.tempId),
+        });
         await saveCurrentAdvisorWorkOrderDraft(submissionDraft);
         const materialization =
           await materializeAdvisorWorkOrderDraft(submissionDraft);
@@ -1085,21 +1090,18 @@ export default function MobileCreateWorkOrderPage() {
             createdError?.message ?? "Created work order could not be loaded.",
           );
         }
-        const scope = getOfflineMutationScope();
-        if (scope) {
-          const parts = await resolveAndSubmitDependentPartsDrafts({
-            scope,
-            workOrderDraftId: prepared.id,
-            workOrderId: materialization.workOrderId,
-            lineIdMap: materialization.lineIdMap,
-          });
-          if (parts.queued > 0) {
-            setError(
-              `${parts.queued} parts request${parts.queued === 1 ? "" : "s"} queued for sync.`,
-            );
-          }
-          await removeCurrentAdvisorWorkOrderDraft(scope);
+        const parts = await resolveAndSubmitDependentPartsDrafts({
+          scope: advisorScope,
+          workOrderDraftId: prepared.id,
+          workOrderId: materialization.workOrderId,
+          lineIdMap: materialization.lineIdMap,
+        });
+        if (parts.queued > 0) {
+          setError(
+            `${parts.queued} parts request${parts.queued === 1 ? "" : "s"} queued for sync.`,
+          );
         }
+        await removeCurrentAdvisorWorkOrderDraft(advisorScope);
         setWo(createdRow as WorkOrderRow);
         setDraftLines([]);
         draftIdentityRef.current = null;

--- a/features/parts/offline/partsRequestDrafts.ts
+++ b/features/parts/offline/partsRequestDrafts.ts
@@ -181,7 +181,16 @@ export async function submitOfflinePartsRequestDraft(
   if (!draft.workOrderId || !draft.workOrderLineId) {
     throw new Error("Parts request is still waiting for its work-order line.");
   }
-  await saveOfflinePartsRequestDraft(draft);
+  if (typeof navigator !== "undefined" && navigator.onLine) {
+    try {
+      await saveOfflinePartsRequestDraft(draft);
+    } catch {
+      // Online delivery must not depend on IndexedDB availability or quota.
+    }
+  } else {
+    // Do not claim an offline queue is durable until device persistence succeeds.
+    await saveOfflinePartsRequestDraft(draft);
+  }
   let requestId: string | null = null;
   const result = await runMutationWithOfflineQueue({
     clientMutationId: draft.operationKey,
@@ -189,15 +198,20 @@ export async function submitOfflinePartsRequestDraft(
     payload: draft,
     scope: { userId: draft.userId, shopId: draft.shopId },
     orderKey: `${draft.workOrderId}:${draft.workOrderLineId}:parts:${draft.operationKey}`,
+    bestEffortOnlineHistory: true,
     runner: async () => {
       requestId = (await postOfflinePartsRequestDraft(draft)).requestId;
     },
   });
   if (!result.conflicted) {
-    await removeOfflinePartsRequestDraft({
-      scope: { userId: draft.userId, shopId: draft.shopId },
-      draftId: draft.id,
-    });
+    try {
+      await removeOfflinePartsRequestDraft({
+        scope: { userId: draft.userId, shopId: draft.shopId },
+        draftId: draft.id,
+      });
+    } catch {
+      // Cleanup is best-effort once the request was submitted or durably queued.
+    }
   }
   return { ...result, requestId };
 }
@@ -228,7 +242,6 @@ export async function resolveAndSubmitDependentPartsDrafts(args: {
       workOrderLineId: lineId,
       updatedAt: new Date().toISOString(),
     };
-    await saveOfflinePartsRequestDraft(resolved);
     const result = await submitOfflinePartsRequestDraft(resolved);
     if (result.queued) queued += 1;
     else if (!result.conflicted) submitted += 1;

--- a/features/shared/lib/offline/mutations.ts
+++ b/features/shared/lib/offline/mutations.ts
@@ -632,6 +632,7 @@ export async function runMutationWithOfflineQueue<T>(args: {
   dependsOn?: string[];
   orderKey?: string;
   conflictCheck?: () => Promise<string | null>;
+  bestEffortOnlineHistory?: boolean;
 }): Promise<{ queued: boolean; conflicted: boolean }> {
   await hydrateOfflineMutationQueue();
   const queueOnOffline = args.queueOnOffline !== false;
@@ -679,7 +680,16 @@ export async function runMutationWithOfflineQueue<T>(args: {
       }
     }
     await args.runner();
-    await queueEntry("synced");
+    if (args.bestEffortOnlineHistory) {
+      try {
+        await queueEntry("synced");
+      } catch {
+        // The server commit succeeded; unavailable device history must not
+        // turn an online mutation into an apparent submission failure.
+      }
+    } else {
+      await queueEntry("synced");
+    }
     return { queued: false, conflicted: false };
   } catch (error) {
     if (queueOnOffline && isRetryableOfflineError(error)) {

--- a/features/work-orders/components/workorders/PartsRequestModal.tsx
+++ b/features/work-orders/components/workorders/PartsRequestModal.tsx
@@ -13,7 +13,6 @@ import {
 import {
   createOfflinePartsRequestDraft,
   getOfflinePartsRequestDraft,
-  saveOfflinePartsRequestDraft,
   submitOfflinePartsRequestDraft,
 } from "@/features/parts/offline/partsRequestDrafts";
 
@@ -206,7 +205,6 @@ export default function PartsRequestModal({
         })),
         updatedAt: new Date().toISOString(),
       };
-      await saveOfflinePartsRequestDraft(draft);
       const result = await submitOfflinePartsRequestDraft(draft);
       if (result.conflicted) {
         toast.error("Parts request needs review in Sync Center.");

--- a/supabase/migrations/20260717110000_offline_parts_request_lead_alias.sql
+++ b/supabase/migrations/20260717110000_offline_parts_request_lead_alias.sql
@@ -1,5 +1,7 @@
 begin;
 
+-- Re-apply the parts draft materializer so production databases that already
+-- ran 20260717100000 accept the canonical legacy `lead` role alias.
 create or replace function public.materialize_offline_parts_request_draft_atomic(
   p_shop_id uuid,
   p_actor_user_id uuid,

--- a/tests/offline-parts-request-drafts.test.ts
+++ b/tests/offline-parts-request-drafts.test.ts
@@ -9,9 +9,13 @@ const modal = read(
   "features/work-orders/components/workorders/PartsRequestModal.tsx",
 );
 const replay = read("features/shared/lib/offline/replay.ts");
+const mutations = read("features/shared/lib/offline/mutations.ts");
 const route = read("app/api/offline/parts-request-drafts/route.ts");
 const migration = read(
   "supabase/migrations/20260717100000_offline_parts_request_drafts.sql",
+);
+const leadAliasMigration = read(
+  "supabase/migrations/20260717110000_offline_parts_request_lead_alias.sql",
 );
 
 describe("offline parts-request drafts", () => {
@@ -34,11 +38,16 @@ describe("offline parts-request drafts", () => {
     expect(createPage).toContain("<AdvisorPartsDraftEditor");
     expect(createPage).toContain("materialization.lineIdMap");
     expect(createPage).toContain("resolveAndSubmitDependentPartsDrafts");
+    expect(createPage).toContain("const advisorScope = { userId: currentUserId, shopId }");
+    expect(createPage).not.toContain("const scope = getOfflineMutationScope()");
     expect(repository).toContain("args.lineIdMap[draft.tempLineId]");
     expect(repository).toContain(
       "A parts-request draft could not be matched to its saved job line.",
     );
     expect(createPage).toContain("pruneDependentPartsRequestDrafts");
+    expect(createPage.indexOf("await pruneDependentPartsRequestDrafts")).toBeLessThan(
+      createPage.indexOf("await materializeAdvisorWorkOrderDraft"),
+    );
   });
 
   it("uses the global ordered mutation queue for both advisor and technician requests", () => {
@@ -47,6 +56,11 @@ describe("offline parts-request drafts", () => {
     expect(repository).toContain("clientMutationId: draft.operationKey");
     expect(repository).toContain("orderKey:");
     expect(modal).toContain("submitOfflinePartsRequestDraft");
+    expect(modal).not.toContain("await saveOfflinePartsRequestDraft(draft)");
+    expect(repository).toContain("Online delivery must not depend on IndexedDB");
+    expect(repository).toContain("bestEffortOnlineHistory: true");
+    expect(mutations).toContain("if (args.bestEffortOnlineHistory)");
+    expect(repository).not.toContain("await saveOfflinePartsRequestDraft(resolved)");
     expect(modal).not.toContain('fetch("/api/parts/requests/create"');
     expect(replay).toContain('"parts-request:create-draft"');
     expect(replay).toContain("postOfflinePartsRequestDraft(draft)");
@@ -60,6 +74,8 @@ describe("offline parts-request drafts", () => {
     expect(route).toContain("draft.shopId !== profile.shop_id");
     expect(route).toContain('rpc("set_current_shop_id"');
     expect(route).toContain("materialize_offline_parts_request_draft_atomic");
+    expect(route).toContain("function isValidDraftItem(item: unknown)");
+    expect(route).toContain('typeof item !== "object"');
   });
 
   it("materializes through the canonical parts RPC with receipt-backed idempotency", () => {
@@ -74,5 +90,10 @@ describe("offline parts-request drafts", () => {
     expect(migration).toContain("wol.work_order_id = p_work_order_id");
     expect(migration).toContain("wolt.technician_id = p_actor_user_id");
     expect(migration).toContain("when unique_violation then");
+    expect(migration).toContain("'leadhand','lead','foreman'");
+    expect(leadAliasMigration).toContain(
+      "create or replace function public.materialize_offline_parts_request_draft_atomic",
+    );
+    expect(leadAliasMigration).toContain("'leadhand','lead','foreman'");
   });
 });


### PR DESCRIPTION
## What changed

Addresses all five actionable findings from the Codex review on #1070:

- makes device draft snapshots and synced-history writes best-effort after a successful online parts request, so IndexedDB availability or quota cannot block server delivery
- continues to require durable device persistence before claiming an offline request is queued
- uses the already verified advisor `{ userId, shopId }` scope when resolving parts drafts after work-order materialization
- synchronously prunes drafts for removed temporary lines before creating the work order
- rejects null, arrays, and other malformed item values with a permanent 400 response before dereferencing
- adds the legacy `lead` role alias to fresh installs and reapplies the corrected SECURITY DEFINER function through a new migration for existing databases

## Validation

- `node_modules/.bin/tsc --noEmit`
- focused ESLint: clean
- 5 focused offline test files: 26 tests passed

## Migration

Run `20260717110000_offline_parts_request_lead_alias.sql` after merging.