### PR TITLE
Add offline pilot resilience diagnostics

### DIFF
--- a/app/offline/sync/page.tsx
+++ b/app/offline/sync/page.tsx
@@ -4,13 +4,17 @@ import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import {
   clearSyncedOfflineMutations,
+  auditOfflineMutationAttachments,
   dismissOfflineMutation,
   getOfflineMutationScope,
+  getOfflinePersistenceHealth,
   hydrateOfflineMutationQueue,
   listOfflineMutations,
   pruneOfflineState,
   subscribeOfflineMutations,
   type PendingMutation,
+  type OfflineAttachmentAudit,
+  type OfflinePersistenceHealth,
 } from "@/features/shared/lib/offline/mutations";
 import {
   getOfflineDatabaseStats,
@@ -31,6 +35,10 @@ import {
   assessOfflineStorage,
   type OfflineStorageHealth,
 } from "@/features/shared/lib/offline/storage-health";
+import {
+  buildOfflinePilotDiagnostics,
+  downloadOfflinePilotDiagnostics,
+} from "@/features/shared/lib/offline/diagnostics";
 
 type BrowserStorage = {
   usage: number;
@@ -44,6 +52,19 @@ const EMPTY_DATABASE_STATS: OfflineDatabaseStats = {
   blobs: 0,
   blobBytes: 0,
 };
+const EMPTY_ATTACHMENT_AUDIT: OfflineAttachmentAudit = {
+  checked: 0,
+  missing: 0,
+  invalid: 0,
+};
+const EMPTY_PERSISTENCE_HEALTH: OfflinePersistenceHealth = {
+  expectedPendingMutations: 0,
+  storedPendingMutations: 0,
+  expectedPendingAttachments: 0,
+  suspectedEviction: false,
+};
+const APP_VERSION =
+  process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA?.slice(0, 12) ?? "development";
 
 const ACTION_LABELS: Record<string, string> = {
   "inspection:save-session": "Inspection progress",
@@ -89,10 +110,24 @@ export default function OfflineSyncPage() {
     message: "Session verification has not run yet.",
   });
   const [updateWaiting, setUpdateWaiting] = useState(false);
+  const [attachmentAudit, setAttachmentAudit] = useState(
+    EMPTY_ATTACHMENT_AUDIT,
+  );
+  const [persistenceHealth, setPersistenceHealth] = useState(
+    EMPTY_PERSISTENCE_HEALTH,
+  );
 
   const refresh = useCallback(async () => {
     await hydrateOfflineMutationQueue();
     const scope = getOfflineMutationScope();
+    const [nextAttachmentAudit, nextPersistenceHealth] = scope
+      ? await Promise.all([
+          auditOfflineMutationAttachments(scope),
+          getOfflinePersistenceHealth(scope),
+        ])
+      : [EMPTY_ATTACHMENT_AUDIT, EMPTY_PERSISTENCE_HEALTH];
+    setAttachmentAudit(nextAttachmentAudit);
+    setPersistenceHealth(nextPersistenceHealth);
     setMutations(listOfflineMutations(scope));
     setDatabaseStats(
       scope ? await getOfflineDatabaseStats(scope) : EMPTY_DATABASE_STATS,
@@ -174,6 +209,32 @@ export default function OfflineSyncPage() {
     pendingBlobCount: databaseStats.blobs,
   });
   const pendingCount = mutations.filter((item) => item.status !== "synced").length;
+  const stagedFilesReady =
+    !persistenceHealth.suspectedEviction &&
+    attachmentAudit.missing === 0 &&
+    attachmentAudit.invalid === 0;
+
+  const exportDiagnostics = () => {
+    const installed =
+      window.matchMedia("(display-mode: standalone)").matches ||
+      Boolean((navigator as Navigator & { standalone?: boolean }).standalone);
+    downloadOfflinePilotDiagnostics(
+      buildOfflinePilotDiagnostics({
+        appVersion: APP_VERSION,
+        online,
+        installed,
+        sessionHealth,
+        browserStorage,
+        storageHealth,
+        databaseStats,
+        attachmentAudit,
+        persistenceHealth,
+        updateWaiting,
+        mutations,
+      }),
+    );
+    setMessage("Privacy-safe pilot diagnostics exported.");
+  };
 
   return (
     <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100">
@@ -225,7 +286,7 @@ export default function OfflineSyncPage() {
 
         <section className="rounded-2xl border border-slate-700 bg-slate-900 p-5">
           <h2 className="font-semibold">Pilot readiness</h2>
-          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <ReadinessItem
               label="Session"
               ready={sessionHealth.status === "verified"}
@@ -254,8 +315,40 @@ export default function OfflineSyncPage() {
                   : "No version-skew risk is currently detected."
               }
             />
+            <ReadinessItem
+              label="Staged files"
+              ready={stagedFilesReady}
+              value={
+                persistenceHealth.suspectedEviction
+                  ? "Storage cleared"
+                  : stagedFilesReady
+                    ? "Files verified"
+                    : `${attachmentAudit.missing + attachmentAudit.invalid} unavailable`
+              }
+              detail={
+                persistenceHealth.suspectedEviction
+                  ? `${persistenceHealth.expectedPendingMutations} saved updates were expected but are no longer in device storage.`
+                  : stagedFilesReady
+                    ? `${attachmentAudit.checked} pending photo files checked.`
+                    : "Open the affected queue item, capture the photo again, then remove the unavailable update."
+              }
+            />
           </div>
         </section>
+
+        {persistenceHealth.suspectedEviction && (
+          <section className="rounded-2xl border border-red-500/50 bg-red-950/30 p-5">
+            <h2 className="font-semibold text-red-100">
+              Device storage may have been cleared
+            </h2>
+            <p className="mt-2 text-sm text-red-100/80">
+              This device previously recorded {persistenceHealth.expectedPendingMutations}{" "}
+              pending update{persistenceHealth.expectedPendingMutations === 1 ? "" : "s"},
+              but the offline database is now empty. Reconnect, verify the server record,
+              and re-enter any missing work before continuing.
+            </p>
+          </section>
+        )}
 
         <section className="space-y-3">
           <div className="flex items-center justify-between gap-3">
@@ -445,7 +538,19 @@ export default function OfflineSyncPage() {
             >
               Clean expired data
             </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={exportDiagnostics}
+              className="rounded-lg border border-slate-700 px-3 py-2 text-xs text-slate-300 disabled:opacity-40"
+            >
+              Export pilot diagnostics
+            </button>
           </div>
+          <p className="mt-3 text-xs text-slate-500">
+            Diagnostics contain aggregate device and queue health only—no customer,
+            vehicle, message, note, user, or shop data.
+          </p>
         </section>
       </div>
     </main>

--- a/docs/offline-shop-pilot.md
+++ b/docs/offline-shop-pilot.md
@@ -21,6 +21,7 @@ Run this matrix against the production-like pilot shop before general offline re
 8. Lose the network during every server mutation and immediately after the server commits; verify retries do not duplicate records.
 9. Deploy an app update while work is queued; verify activation is held until the queue is synced or reviewed.
 10. Evict browser storage where the platform allows it; verify missing staged files become explicit conflicts rather than silent success.
+11. Export pilot diagnostics from Sync Center after each failure test; verify the report contains aggregate health only and no customer, vehicle, message, note, user, shop, or mutation identifiers.
 
 ## Release gate
 

--- a/features/shared/lib/offline/diagnostics.ts
+++ b/features/shared/lib/offline/diagnostics.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import type { OfflineDatabaseStats } from "@/features/shared/lib/offline/database";
+import type {
+  OfflineAttachmentAudit,
+  OfflinePersistenceHealth,
+  PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+import type { OfflineSessionHealth } from "@/features/shared/lib/offline/session";
+import type { OfflineStorageHealth } from "@/features/shared/lib/offline/storage-health";
+
+type StorageSummary = {
+  usage: number;
+  quota: number;
+  persistent: boolean;
+};
+
+export type OfflinePilotDiagnostics = {
+  schemaVersion: 1;
+  generatedAt: string;
+  appVersion: string;
+  connectivity: "online" | "offline";
+  installed: boolean;
+  sessionStatus: OfflineSessionHealth["status"];
+  storage: StorageSummary & {
+    level: OfflineStorageHealth["level"];
+    database: OfflineDatabaseStats;
+    suspectedEviction: boolean;
+  };
+  attachments: OfflineAttachmentAudit & {
+    expectedBeforeEviction: number;
+  };
+  updateWaiting: boolean;
+  queue: {
+    total: number;
+    byStatus: Record<string, number>;
+    byAction: Record<string, number>;
+    maximumRetryCount: number;
+    oldestPendingMinutes: number | null;
+  };
+};
+
+export function buildOfflinePilotDiagnostics(args: {
+  now?: Date;
+  appVersion: string;
+  online: boolean;
+  installed: boolean;
+  sessionHealth: OfflineSessionHealth;
+  browserStorage: StorageSummary;
+  storageHealth: OfflineStorageHealth;
+  databaseStats: OfflineDatabaseStats;
+  attachmentAudit: OfflineAttachmentAudit;
+  persistenceHealth: OfflinePersistenceHealth;
+  updateWaiting: boolean;
+  mutations: PendingMutation[];
+}): OfflinePilotDiagnostics {
+  const now = args.now ?? new Date();
+  const pending = args.mutations.filter((item) => item.status !== "synced");
+  const byStatus: Record<string, number> = {};
+  const byAction: Record<string, number> = {};
+  for (const mutation of args.mutations) {
+    byStatus[mutation.status] = (byStatus[mutation.status] ?? 0) + 1;
+    byAction[mutation.actionType] =
+      (byAction[mutation.actionType] ?? 0) + 1;
+  }
+  const oldest = pending.reduce<number | null>((value, mutation) => {
+    const created = new Date(mutation.createdAt).getTime();
+    return Number.isFinite(created) && (value == null || created < value)
+      ? created
+      : value;
+  }, null);
+  return {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    appVersion: args.appVersion || "unknown",
+    connectivity: args.online ? "online" : "offline",
+    installed: args.installed,
+    sessionStatus: args.sessionHealth.status,
+    storage: {
+      ...args.browserStorage,
+      level: args.storageHealth.level,
+      database: args.databaseStats,
+      suspectedEviction: args.persistenceHealth.suspectedEviction,
+    },
+    attachments: {
+      ...args.attachmentAudit,
+      expectedBeforeEviction:
+        args.persistenceHealth.expectedPendingAttachments,
+    },
+    updateWaiting: args.updateWaiting,
+    queue: {
+      total: args.mutations.length,
+      byStatus,
+      byAction,
+      maximumRetryCount: args.mutations.reduce(
+        (value, mutation) => Math.max(value, mutation.retryCount),
+        0,
+      ),
+      oldestPendingMinutes:
+        oldest == null
+          ? null
+          : Math.max(0, Math.round((now.getTime() - oldest) / 60000)),
+    },
+  };
+}
+
+export function downloadOfflinePilotDiagnostics(
+  diagnostics: OfflinePilotDiagnostics,
+): void {
+  const blob = new Blob([JSON.stringify(diagnostics, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `profixiq-offline-diagnostics-${diagnostics.generatedAt.replace(/[:.]/g, "-")}.json`;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/features/shared/lib/offline/mutations.ts
+++ b/features/shared/lib/offline/mutations.ts
@@ -3,6 +3,7 @@
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   clearOfflineDatabase,
+  getOfflineBlob,
   pruneOfflineDatabase,
   readStoredMutations,
   removeOfflineBlob,
@@ -46,6 +47,7 @@ const LEGACY_KEYS = [
   "profixiq.pending_mutations.v1",
 ];
 const SCOPE_KEY = "profixiq.pending_mutations.scope.v1";
+const PERSISTENCE_MARKER_KEY = "profixiq.offline.persistence.v1";
 const EVENT_NAME = "offline-mutations:updated";
 const MAX_HISTORY = 300;
 const TERMINAL_RETENTION_MS = 1000 * 60 * 60 * 24 * 7;
@@ -56,6 +58,27 @@ const PERMANENT_STATUS_CODES = new Set([
 
 let queueCache: PendingMutation[] = [];
 let hydrationPromise: Promise<void> | null = null;
+
+type OfflinePersistenceMarker = {
+  userId: string;
+  shopId: string;
+  pendingMutations: number;
+  pendingAttachments: number;
+  updatedAt: string;
+};
+
+export type OfflinePersistenceHealth = {
+  expectedPendingMutations: number;
+  storedPendingMutations: number;
+  expectedPendingAttachments: number;
+  suspectedEviction: boolean;
+};
+
+export type OfflineAttachmentAudit = {
+  checked: number;
+  missing: number;
+  invalid: number;
+};
 
 function clean(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -68,6 +91,59 @@ function browserReady(): boolean {
 function emitQueueUpdate(): void {
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent(EVENT_NAME));
+  }
+}
+
+function isAttachmentMutation(mutation: Pick<PendingMutation, "actionType">) {
+  return (
+    mutation.actionType === "upload_job_photo" ||
+    mutation.actionType === "inspection:upload-photo"
+  );
+}
+
+function updatePersistenceMarker(queue: PendingMutation[]): void {
+  if (!browserReady()) return;
+  const scope = getOfflineMutationScope();
+  if (!scope) return;
+  const pending = queue.filter(
+    (item) => item.status !== "synced" && scopeMatches(item, scope),
+  );
+  const marker: OfflinePersistenceMarker = {
+    userId: scope.userId,
+    shopId: scope.shopId,
+    pendingMutations: pending.length,
+    pendingAttachments: pending.filter(isAttachmentMutation).length,
+    updatedAt: new Date().toISOString(),
+  };
+  try {
+    localStorage.setItem(PERSISTENCE_MARKER_KEY, JSON.stringify(marker));
+  } catch {
+    // IndexedDB remains authoritative when localStorage is unavailable.
+  }
+}
+
+function readPersistenceMarker(): OfflinePersistenceMarker | null {
+  if (!browserReady()) return null;
+  try {
+    const value = JSON.parse(
+      localStorage.getItem(PERSISTENCE_MARKER_KEY) ?? "null",
+    ) as Partial<OfflinePersistenceMarker> | null;
+    const userId = clean(value?.userId);
+    const shopId = clean(value?.shopId);
+    return userId && shopId
+      ? {
+          userId,
+          shopId,
+          pendingMutations: Math.max(0, Number(value?.pendingMutations) || 0),
+          pendingAttachments: Math.max(
+            0,
+            Number(value?.pendingAttachments) || 0,
+          ),
+          updatedAt: clean(value?.updatedAt),
+        }
+      : null;
+  } catch {
+    return null;
   }
 }
 
@@ -287,7 +363,88 @@ export async function hydrateOfflineMutationQueue(): Promise<void> {
 async function writeQueue(queue: PendingMutation[]): Promise<void> {
   queueCache = normalizeOfflineMutationQueue(queue);
   await replaceStoredMutations(queueCache);
+  updatePersistenceMarker(queueCache);
   emitQueueUpdate();
+}
+
+export async function getOfflinePersistenceHealth(
+  scope: OfflineMutationScope | null = getOfflineMutationScope(),
+): Promise<OfflinePersistenceHealth> {
+  await hydrateOfflineMutationQueue();
+  const storedPendingMutations = scope
+    ? queueCache.filter(
+        (item) => item.status !== "synced" && scopeMatches(item, scope),
+      ).length
+    : 0;
+  const marker = readPersistenceMarker();
+  const matches = Boolean(
+    scope &&
+      marker &&
+      marker.userId === scope.userId &&
+      marker.shopId === scope.shopId,
+  );
+  const expectedPendingMutations = matches ? marker!.pendingMutations : 0;
+  const expectedPendingAttachments = matches ? marker!.pendingAttachments : 0;
+  return {
+    expectedPendingMutations,
+    storedPendingMutations,
+    expectedPendingAttachments,
+    suspectedEviction:
+      expectedPendingMutations > 0 && storedPendingMutations === 0,
+  };
+}
+
+export async function auditOfflineMutationAttachments(
+  scope: OfflineMutationScope | null = getOfflineMutationScope(),
+): Promise<OfflineAttachmentAudit> {
+  await hydrateOfflineMutationQueue();
+  if (!scope) return { checked: 0, missing: 0, invalid: 0 };
+  const attachments = queueCache.filter(
+    (item) =>
+      item.status !== "synced" &&
+      scopeMatches(item, scope) &&
+      isAttachmentMutation(item),
+  );
+  let missing = 0;
+  let invalid = 0;
+  for (const mutation of attachments) {
+    const payload = mutation.payload as { blobId?: unknown } | null;
+    const blobId = clean(payload?.blobId);
+    const record = blobId ? await getOfflineBlob(blobId) : null;
+    const scopeMismatch = Boolean(
+      record &&
+        (record.userId !== mutation.userId || record.shopId !== mutation.shopId),
+    );
+    const invalidBlob = Boolean(
+      record &&
+        (!record.blob ||
+          typeof record.blob.size !== "number" ||
+          record.blob.size <= 0),
+    );
+    const reason = !blobId
+      ? "The staged file reference is missing. Capture the photo again, then remove this update."
+      : !record
+        ? "Browser storage removed the staged photo. Capture it again, then remove this update."
+        : scopeMismatch
+          ? "The staged photo belongs to a different user or shop and cannot be uploaded."
+          : invalidBlob
+            ? "The staged photo is empty or corrupted. Capture it again, then remove this update."
+            : null;
+    if (!reason) continue;
+    if (!record) missing += 1;
+    else invalid += 1;
+    if (
+      mutation.status !== "conflicted" ||
+      mutation.conflictReason !== reason
+    ) {
+      await markMutationStatus({
+        clientMutationId: mutation.clientMutationId,
+        status: "conflicted",
+        conflictReason: reason,
+      });
+    }
+  }
+  return { checked: attachments.length, missing, invalid };
 }
 
 export function sortOfflineMutationsForReplay(
@@ -555,6 +712,7 @@ export async function replayQueuedMutations(args: {
   const scope = args.scope ?? getOfflineMutationScope();
   if (!scope || !navigator.onLine)
     return { replayed: 0, failed: 0, conflicted: 0 };
+  await auditOfflineMutationAttachments(scope);
   const queue = sortOfflineMutationsForReplay(
     queueCache.filter(
       (item) =>
@@ -705,6 +863,7 @@ export async function clearOfflineState(): Promise<void> {
   hydrationPromise = null;
   setOfflineMutationScope(null);
   for (const key of LEGACY_KEYS) localStorage.removeItem(key);
+  localStorage.removeItem(PERSISTENCE_MARKER_KEY);
   await clearOfflineDatabase();
   emitQueueUpdate();
 }

--- a/supabase/migrations/20260717120000_offline_advisor_lead_alias.sql
+++ b/supabase/migrations/20260717120000_offline_advisor_lead_alias.sql
@@ -1,5 +1,7 @@
 begin;
 
+-- Re-apply the advisor draft materializer so databases that already ran the
+-- original migration accept the canonical legacy `lead` role alias.
 create or replace function public.materialize_offline_work_order_draft_atomic(
   p_shop_id uuid,
   p_actor_user_id uuid,

--- a/tests/offline-pilot-resilience.test.ts
+++ b/tests/offline-pilot-resilience.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { buildOfflinePilotDiagnostics } from "@/features/shared/lib/offline/diagnostics";
+import type { PendingMutation } from "@/features/shared/lib/offline/mutations";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const mutation: PendingMutation = {
+  clientMutationId: "secret-mutation-id",
+  actionType: "upload_job_photo",
+  payload: {
+    customerName: "Private Customer",
+    notes: "Private technician notes",
+  },
+  createdAt: "2026-07-16T18:00:00.000Z",
+  retryCount: 2,
+  userId: "secret-user-id",
+  shopId: "secret-shop-id",
+  status: "failed",
+};
+
+describe("offline pilot resilience", () => {
+  it("exports aggregate diagnostics without tenant IDs or mutation payloads", () => {
+    const diagnostics = buildOfflinePilotDiagnostics({
+      now: new Date("2026-07-16T19:00:00.000Z"),
+      appVersion: "abc123",
+      online: true,
+      installed: true,
+      sessionHealth: {
+        status: "verified",
+        message: "Verified",
+        verifiedAt: "2026-07-16T19:00:00.000Z",
+      },
+      browserStorage: { usage: 100, quota: 1000, persistent: true },
+      storageHealth: {
+        level: "ready",
+        label: "Storage ready",
+        message: "Ready",
+        usagePercent: 10,
+        availableBytes: 900,
+      },
+      databaseStats: { mutations: 1, snapshots: 2, blobs: 1, blobBytes: 50 },
+      attachmentAudit: { checked: 1, missing: 1, invalid: 0 },
+      persistenceHealth: {
+        expectedPendingMutations: 1,
+        storedPendingMutations: 1,
+        expectedPendingAttachments: 1,
+        suspectedEviction: false,
+      },
+      updateWaiting: false,
+      mutations: [mutation],
+    });
+    const json = JSON.stringify(diagnostics);
+    expect(diagnostics.queue.byAction.upload_job_photo).toBe(1);
+    expect(diagnostics.queue.oldestPendingMinutes).toBe(60);
+    for (const secret of [
+      "secret-mutation-id",
+      "secret-user-id",
+      "secret-shop-id",
+      "Private Customer",
+      "Private technician notes",
+    ]) {
+      expect(json).not.toContain(secret);
+    }
+  });
+
+  it("marks unavailable staged files as actionable conflicts before replay", () => {
+    const mutations = read("features/shared/lib/offline/mutations.ts");
+    const syncCenter = read("app/offline/sync/page.tsx");
+    expect(mutations).toContain("auditOfflineMutationAttachments");
+    expect(mutations).toContain("await auditOfflineMutationAttachments(scope)");
+    expect(mutations).toContain("Browser storage removed the staged photo");
+    expect(mutations).toContain('status: "conflicted"');
+    expect(syncCenter).toContain("auditOfflineMutationAttachments(scope)");
+    expect(syncCenter.toLowerCase()).toContain("capture the photo again");
+  });
+
+  it("detects a missing offline database using only aggregate persistence markers", () => {
+    const mutations = read("features/shared/lib/offline/mutations.ts");
+    expect(mutations).toContain('const PERSISTENCE_MARKER_KEY = "profixiq.offline.persistence.v1"');
+    expect(mutations).toContain("pendingMutations: pending.length");
+    expect(mutations).toContain("expectedPendingMutations > 0");
+    expect(mutations).toContain("storedPendingMutations === 0");
+    expect(mutations).not.toContain("payload: marker");
+  });
+
+  it("repairs the advisor materializer legacy lead alias for existing databases", () => {
+    const original = read(
+      "supabase/migrations/20260717090000_offline_advisor_work_order_drafts.sql",
+    );
+    const repair = read(
+      "supabase/migrations/20260717120000_offline_advisor_lead_alias.sql",
+    );
+    for (const source of [original, repair]) {
+      expect(source).toContain("'leadhand','lead','foreman'");
+      expect(source).toContain("materialize_offline_work_order_draft_atomic");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- audit queued job and inspection photo blobs before replay and convert missing, empty, corrupted, or cross-scope files into actionable Sync Center conflicts
- detect likely full IndexedDB eviction with a minimal scoped aggregate persistence marker
- add a privacy-safe pilot diagnostics export containing aggregate queue, storage, session, update, and attachment health only
- extend the real-shop pilot checklist with diagnostics review
- repair the advisor work-order materializer so the legacy `lead` role alias is accepted in databases that already ran the original migration

## Why

The offline pilot needs visible recovery paths for browser storage loss and staged-file eviction. Support also needs enough device health information to diagnose pilot failures without exporting user/shop IDs, mutation IDs, payloads, or customer, vehicle, message, and note content.

## Validation

- `eslint` on the changed TypeScript/TSX files
- `tsc --noEmit`
- 8 focused Vitest files: 41 tests passed
- `git diff --check`

## Migration

After merging, run:

`supabase/migrations/20260717120000_offline_advisor_lead_alias.sql`
