### PR TITLE
Fix iPad install prompt positioning

### DIFF
--- a/features/shared/components/pwa/PwaRuntime.tsx
+++ b/features/shared/components/pwa/PwaRuntime.tsx
@@ -27,6 +27,7 @@ export default function PwaRuntime() {
   const [showIosInstructions, setShowIosInstructions] = useState(false);
   const [activatingUpdate, setActivatingUpdate] = useState(false);
   const [syncBlocked, setSyncBlocked] = useState<string | null>(null);
+  const [viewportInsets, setViewportInsets] = useState({ bottom: 0, right: 0 });
   const updateReloading = useRef(false);
   const pending = summary.queued + summary.syncing + summary.failed;
 
@@ -39,6 +40,29 @@ export default function PwaRuntime() {
       window.matchMedia("(display-mode: standalone)").matches ||
       Boolean((navigator as Navigator & { standalone?: boolean }).standalone);
     setIosInstallAvailable(iosDevice && !standalone);
+
+    const updateViewportInsets = () => {
+      const viewport = window.visualViewport;
+      if (!viewport) return;
+      const next = {
+        bottom: Math.max(
+          0,
+          Math.round(window.innerHeight - viewport.height - viewport.offsetTop),
+        ),
+        right: Math.max(
+          0,
+          Math.round(window.innerWidth - viewport.width - viewport.offsetLeft),
+        ),
+      };
+      setViewportInsets((current) =>
+        current.bottom === next.bottom && current.right === next.right
+          ? current
+          : next,
+      );
+    };
+    updateViewportInsets();
+    window.visualViewport?.addEventListener("resize", updateViewportInsets);
+    window.visualViewport?.addEventListener("scroll", updateViewportInsets);
     void hydrateOfflineMutationQueue();
     void navigator.storage?.persist?.().catch(() => false);
 
@@ -117,6 +141,8 @@ export default function PwaRuntime() {
       window.removeEventListener("offline", sync);
       window.removeEventListener("focus", sync);
       window.removeEventListener("beforeinstallprompt", beforeInstall);
+      window.visualViewport?.removeEventListener("resize", updateViewportInsets);
+      window.visualViewport?.removeEventListener("scroll", updateViewportInsets);
     };
   }, []);
 
@@ -158,7 +184,13 @@ export default function PwaRuntime() {
   }
 
   return (
-    <div className="fixed bottom-4 right-4 z-[100] flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full border border-slate-700 bg-slate-950/95 px-3 py-2 text-xs font-semibold text-slate-100 shadow-xl backdrop-blur">
+    <div
+      className="fixed z-[100] flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-end gap-2 rounded-2xl border border-slate-700 bg-slate-950/95 px-3 py-2 text-xs font-semibold text-slate-100 shadow-xl backdrop-blur sm:flex-nowrap sm:rounded-full"
+      style={{
+        bottom: `calc(1rem + env(safe-area-inset-bottom, 0px) + ${viewportInsets.bottom}px)`,
+        right: `calc(1rem + env(safe-area-inset-right, 0px) + ${viewportInsets.right}px)`,
+      }}
+    >
       <span
         className={`h-2 w-2 rounded-full ${online ? "bg-emerald-400" : "bg-amber-400"}`}
       />

--- a/tests/pwa-install-prompt-safe-area.test.ts
+++ b/tests/pwa-install-prompt-safe-area.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("PWA install prompt safe-area positioning", () => {
+  const runtime = readFileSync(
+    "features/shared/components/pwa/PwaRuntime.tsx",
+    "utf8",
+  );
+
+  it("keeps the runtime pill above iOS and iPadOS safe areas", () => {
+    expect(runtime).toContain("safe-area-inset-bottom");
+    expect(runtime).toContain("safe-area-inset-right");
+    expect(runtime).toContain("viewportInsets.bottom");
+    expect(runtime).toContain("viewportInsets.right");
+  });
+
+  it("tracks Safari visual viewport changes and removes its listeners", () => {
+    expect(runtime).toContain('visualViewport?.addEventListener("resize"');
+    expect(runtime).toContain('visualViewport?.addEventListener("scroll"');
+    expect(runtime).toContain('visualViewport?.removeEventListener("resize"');
+    expect(runtime).toContain('visualViewport?.removeEventListener("scroll"');
+  });
+
+  it("allows the compact prompt to wrap on narrow viewports", () => {
+    expect(runtime).toContain("flex-wrap");
+    expect(runtime).toContain("sm:flex-nowrap");
+  });
+});


### PR DESCRIPTION
## Summary

- position the PWA runtime/install pill above iOS and iPadOS safe areas
- account for Safari visual viewport changes caused by browser chrome
- let the compact runtime pill wrap cleanly on narrow viewports
- add regression coverage for safe-area and visual-viewport handling

## Root cause

The runtime pill used a fixed `bottom-4 right-4` position. On iPad Safari with `viewport-fit: cover`, the browser toolbar and safe-area inset could overlap the pill and clip its lower portion.

## Validation

- focused ESLint
- `tsc --noEmit`
- 3 focused PWA test files: 12 tests passed
- `git diff --check`

No database migration is required.
