### PR TITLE
Redesign shop, work order, and parts dashboards

### DIFF
--- a/app/dashboard/_components/OperationsDashboardView.tsx
+++ b/app/dashboard/_components/OperationsDashboardView.tsx
@@ -1,357 +1,393 @@
 import Link from "next/link";
-import { ActivitySquare, AlertTriangle, ArrowRight, ChevronRight, TriangleAlert } from "lucide-react";
+import {
+  ArrowRight,
+  CalendarDays,
+  Car,
+  CheckCircle2,
+  ChevronRight,
+  ClipboardList,
+  Clock3,
+  Package,
+  Plus,
+  ShieldCheck,
+  UserRound,
+  UsersRound,
+  Wrench,
+} from "lucide-react";
 
-import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
-import { DashboardPanel, DashboardShell, DashboardTopStrip, MetricStrip } from "./DashboardPrimitives";
-import { ShopLoadChart } from "./OperationsCharts";
 import { OperationalViewSwitcher } from "@/features/dashboard/components/OperationalViewSwitcher";
+import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+import { DashboardShell } from "./DashboardPrimitives";
 
-function EmbeddedEmptyState({ label, detail }: { label: string; detail: string }) {
-  return (
-    <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2.5">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">{label}</div>
-      <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">{detail}</div>
-    </div>
-  );
+const iconTone = [
+  [ClipboardList, "bg-blue-600"],
+  [Car, "bg-green-600"],
+  [UserRound, "bg-violet-600"],
+  [Wrench, "bg-orange-600"],
+  [UsersRound, "bg-teal-600"],
+] as const;
+
+function panelClass(className = "") {
+  return `rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] ${className}`;
 }
 
-function getCountSeverity(count: number): "neutral" | "amber" | "red" {
-  if (count > 50) return "red";
-  if (count > 20) return "amber";
-  return "neutral";
+function attentionContext(label: string) {
+  const normalized = label.toLowerCase();
+  if (normalized.includes("part"))
+    return { context: "Parts on order", action: "Review parts" };
+  if (normalized.includes("technician"))
+    return { context: "Available now", action: "Assign job" };
+  if (normalized.includes("customer"))
+    return { context: "Front desk", action: "Notify advisor" };
+  if (normalized.includes("approval"))
+    return { context: "Customer decision", action: "Review approval" };
+  if (normalized.includes("long-running"))
+    return { context: "Active bay", action: "Review job" };
+  return { context: "Workflow blocked", action: "Review work" };
 }
 
 export default async function OperationsDashboardView() {
   const payload = await getOperationsDashboardPayload();
-  const displayName = payload.identity.fullName?.trim() || "Operator";
   const isTechnicianView = payload.viewerScope === "technician";
-  const hasTechnicianActivity = payload.technicianActivity.length > 0;
-  const hasRightRailSignals = payload.blockerStack.length > 0 || payload.alerts.length > 0 || payload.suggestedActions.length > 0;
+  const waiterSignal = payload.immediateAttention.find((item) =>
+    item.label.toLowerCase().includes("customer"),
+  );
+  const metrics = [
+    ...payload.todayOperations.slice(0, 4),
+    {
+      label: "Customers waiting",
+      value: waiterSignal?.value ?? "0",
+      href: "/work-orders/board",
+    },
+  ];
+  const pulse = [
+    {
+      label: "Appointments today",
+      value: payload.topSummary.appointmentsToday,
+      icon: CalendarDays,
+      href: "/dashboard/bookings",
+    },
+    {
+      label: "Approvals pending",
+      value: payload.topSummary.waitingApprovals,
+      icon: ShieldCheck,
+      href: "/work-orders/board?stage=awaiting_approval",
+    },
+    {
+      label: "Parts requests open",
+      value: payload.topSummary.waitingParts,
+      icon: Package,
+      href: "/parts/requests",
+    },
+    {
+      label: "Jobs completed today",
+      value: payload.topSummary.completedToday,
+      icon: CheckCircle2,
+      href: "/work-orders/board?stage=completed",
+    },
+  ];
+  const flow = [
+    [
+      "Awaiting",
+      payload.flowMix.find((item) => item.label.toLowerCase() === "awaiting")
+        ?.value ?? 0,
+      "awaiting",
+    ],
+    [
+      "In progress",
+      payload.flowMix.find((item) => item.label.toLowerCase() === "in progress")
+        ?.value ?? 0,
+      "in_progress",
+    ],
+    [
+      "Awaiting approval",
+      payload.topSummary.waitingApprovals,
+      "awaiting_approval",
+    ],
+    ["Waiting parts", payload.topSummary.blockedJobs, "waiting_parts"],
+    ["Ready to invoice", payload.topSummary.completedToday, "completed"],
+  ] as const;
+
   return (
     <DashboardShell>
       <OperationalViewSwitcher role={payload.identity.role} />
-      <DashboardTopStrip
-        view="operations"
-        title={isTechnicianView ? "Technician Dashboard" : "Operations Dashboard"}
-        name={`Welcome back, ${displayName}`}
-        subtitle={
-          isTechnicianView
-            ? "Your personal workbench for assigned jobs, blockers, and immediate next actions."
-            : "Live command center for active jobs, bottlenecks, and immediate dispatch actions."
-        }
-        actions={[
-          { label: "Create work order", href: "/work-orders/create", tone: "primary" },
-          { label: "Work Order Board", href: "/work-orders/board", tone: "secondary" },
-        ]}
-      />
 
-      <MetricStrip
-        className="mb-0"
-        items={payload.todayOperations.map((item) => ({
-          label: item.label,
-          value: item.value,
-          tone: Number(item.value) > 0 && ["Waiting for parts", "Completed today"].includes(item.label) ? "accent" : "default",
-        }))}
-      />
-
-      <DashboardPanel
-        title="Immediate Attention"
-        eyebrow="Right now"
-        action={<Link href="/work-orders/board" className="inline-flex items-center gap-1 text-xs text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]">Open board <ArrowRight className="h-3 w-3" /></Link>}
-        className="border-amber-300/25 bg-[var(--theme-gradient-panel)]"
-      >
-        {payload.immediateAttention.length > 0 ? (
-          <div data-testid="immediate-attention" className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
-            {payload.immediateAttention.map((item) => (
-              <Link key={item.label} href={item.href ?? "/work-orders/board"} className="group rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 transition hover:border-[var(--brand-accent,#E39A6E)]/50 hover:bg-[color:var(--theme-surface-inset)]">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-sm font-semibold text-[color:var(--theme-text-primary)]">{item.label}</span>
-                  <ChevronRight className="h-4 w-4 text-[color:var(--theme-text-muted)] transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
-                </div>
-                <div className="mt-2 text-2xl font-bold text-[var(--brand-accent,#E39A6E)]">{item.value}</div>
-              </Link>
-            ))}
+      <header className="flex flex-col gap-4 px-1 py-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-[color:var(--theme-text-primary)]">
+            {isTechnicianView ? "Technician Overview" : "Shop Overview"}
+          </h1>
+          <div className="mt-1 flex items-center gap-2 text-sm text-[color:var(--theme-text-secondary)]">
+            <span>
+              {new Intl.DateTimeFormat("en", {
+                weekday: "long",
+                month: "long",
+                day: "numeric",
+              }).format(new Date())}
+            </span>
+            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+            <span>Live operations</span>
           </div>
-        ) : (
-          <EmbeddedEmptyState label="No immediate attention cards" detail="Only active operational issues appear here." />
-        )}
-      </DashboardPanel>
-
-      <DashboardPanel title="Quick Actions" eyebrow="Operational shortcuts">
-        <div data-testid="operations-quick-actions" className="flex flex-wrap gap-2">
-          {payload.quickActions.map((action) => (
-            <Link key={action.href} href={action.href} className={action.tone === "primary" ? "rounded-lg border border-[var(--brand-accent,#E39A6E)]/45 bg-[var(--brand-accent,#E39A6E)]/15 px-3 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)]" : "rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-inset)]"}>
-              {action.label}
-            </Link>
-          ))}
         </div>
-      </DashboardPanel>
+        <Link
+          href="/work-orders/create"
+          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[var(--brand-primary,#C1663B)] px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-110"
+        >
+          <Plus className="h-4 w-4" /> Create work order
+        </Link>
+      </header>
 
-      <div className="grid gap-2 lg:grid-cols-[minmax(0,1.72fr)_minmax(276px,0.9fr)] xl:grid-cols-[minmax(0,1.92fr)_minmax(304px,0.96fr)] 2xl:grid-cols-[minmax(0,2.1fr)_minmax(340px,1fr)]">
-        <section className="space-y-2.5">
-          {payload.sectionErrors.length > 0 ? (
-            <section className="rounded-xl border border-amber-500/30 bg-gradient-to-r from-amber-500/15 via-amber-400/10 to-transparent px-3 py-2.5">
-              <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-300">
-                <ActivitySquare className="h-3.5 w-3.5" />
-                Section warnings
-              </div>
-              <div className="space-y-1 text-xs text-amber-200">
-                {payload.sectionErrors.map((warning) => (
-                  <Link
-                    key={warning}
-                    href="/dashboard/operations"
-                    className="group flex items-start gap-2 rounded-md border border-amber-500/30 bg-[color:var(--theme-surface-inset)] px-2 py-1.5 transition hover:bg-[color:var(--theme-surface-inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/60"
-                  >
-                    <AlertTriangle className="mt-0.5 h-3 w-3" />
-                    <span className="flex-1">{warning}</span>
-                    <ChevronRight className="mt-0.5 h-3 w-3 text-amber-200/70 transition group-hover:text-amber-100" />
-                  </Link>
-                ))}
-              </div>
-            </section>
-          ) : null}
+      {payload.sectionErrors.length > 0 ? (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-200">
+          {payload.sectionErrors.join(" ")}
+        </div>
+      ) : null}
 
-          <div
-            className="space-y-1.5 rounded-[22px] border border-[color:var(--theme-border-soft)] p-2.5 md:p-2.5"
-            style={{
-              background: "var(--theme-gradient-panel)",
-              boxShadow: "var(--theme-shadow-medium)",
-            }}
-          >
-            <div className="grid gap-1.5 md:grid-cols-[minmax(0,1.56fr)_minmax(232px,0.88fr)] xl:grid-cols-[minmax(0,1.66fr)_minmax(256px,0.94fr)]">
-            <DashboardPanel
-              title={isTechnicianView ? "My active assigned jobs" : "Live Work Command Surface"}
-              className="min-h-[300px] border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)]"
-              action={<Link href="/work-orders/board" className="inline-flex items-center gap-1 text-xs text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]">Open board <ArrowRight className="h-3 w-3" /></Link>}
+      <section
+        className={`${panelClass("p-3")} grid gap-2 sm:grid-cols-2 lg:grid-cols-5`}
+      >
+        {metrics.map((item, index) => {
+          const [Icon, tone] = iconTone[index];
+          return (
+            <Link
+              key={item.label}
+              href={item.href ?? "/work-orders/board"}
+              className="group flex min-h-20 items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-3 transition hover:border-[var(--brand-accent,#E39A6E)]/55"
             >
-              <div className="grid h-full gap-2 md:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
-                <div className="space-y-0.5">
-                  {payload.liveWork.length > 0 ? (
-                    payload.liveWork.map((item) => (
-                      <Link
-                        key={item.id}
-                        href={`/work-orders/${item.id}`}
-                        className="group flex items-center justify-between rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-[0.32rem] text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/60 hover:bg-[color:var(--theme-surface-inset)] hover:shadow-[var(--theme-shadow-medium)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
-                      >
-                        <div>
-                          <div className="font-extrabold tracking-wide text-[color:var(--theme-text-primary)]">{item.label}</div>
-                          <div className="text-[color:var(--theme-text-secondary)]">{item.stage}</div>
-                        </div>
-                        <div className="flex items-center gap-1.5">
-                          <div className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-0.5 text-[color:var(--theme-text-primary)]">P{item.priority}</div>
-                          <ChevronRight className="h-3.5 w-3.5 text-[color:var(--theme-text-muted)] transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
-                        </div>
-                      </Link>
-                    ))
-                  ) : (
-                    <EmbeddedEmptyState
-                      label="Live work idle"
-                      detail="No active jobs are currently in motion."
-                    />
-                  )}
-                </div>
-                <div className="space-y-1">
-                  {payload.flowMix.length > 0 ? (
-                    payload.flowMix.map((row) => (
-                      <Link
-                        key={row.label}
-                        href={`/work-orders/board?stage=${encodeURIComponent(row.label.toLowerCase().replaceAll(" ", "_"))}`}
-                        className="group block rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2 transition hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-[color:var(--theme-surface-inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
-                      >
-                        <div className="flex items-center justify-between text-xs">
-                          <span className="text-[color:var(--theme-text-secondary)]">{row.label}</span>
-                          <span className="font-semibold text-[color:var(--theme-text-primary)]">{row.value}</span>
-                        </div>
-                        <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-[color:var(--theme-surface-subtle)]">
-                          <div
-                            className="h-full rounded-full bg-gradient-to-r from-[var(--brand-primary,#C1663B)] to-[var(--brand-accent,#E39A6E)]"
-                            style={{ width: `${Math.min(100, row.value * 12)}%` }}
-                          />
-                        </div>
-                      </Link>
-                    ))
-                  ) : (
-                    <EmbeddedEmptyState
-                      label="Flow signal pending"
-                      detail="Stage mix will appear as work transitions through the board."
-                    />
-                  )}
-                </div>
-              </div>
-            </DashboardPanel>
+              <span
+                className={`grid h-11 w-11 shrink-0 place-items-center rounded-xl text-white ${tone}`}
+              >
+                <Icon className="h-5 w-5" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-xs text-[color:var(--theme-text-secondary)]">
+                  {item.label}
+                </span>
+                <span className="block text-2xl font-bold text-[color:var(--theme-text-primary)]">
+                  {item.value}
+                </span>
+              </span>
+              <ChevronRight className="h-4 w-4 text-[color:var(--theme-text-muted)] transition group-hover:translate-x-0.5" />
+            </Link>
+          );
+        })}
+      </section>
 
-            <DashboardPanel title={isTechnicianView ? "My workload snapshot" : "Active Job Summary"} className="min-h-[300px] border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)]">
-              <div className="space-y-2">
-                {payload.activeJobSummary.map((metric) => (
-                  <div key={metric.label} className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2.5 shadow-[inset_0_1px_0_rgba(148,163,184,0.08)]">
-                    <div className="flex items-center justify-between text-xs">
-                      <span className="text-[color:var(--theme-text-secondary)]">{metric.label}</span>
-                      <span className="text-[13px] font-semibold text-[color:var(--theme-text-primary)]">{metric.value}</span>
-                    </div>
-                    <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-[color:var(--theme-surface-subtle)]">
-                      <div
-                        className="h-full rounded-full bg-[var(--brand-accent,#E39A6E)]"
-                        style={{ width: `${metric.pct}%` }}
-                      />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </DashboardPanel>
-          </div>
-
-            <div className="grid gap-1.5 md:grid-cols-[minmax(0,1.56fr)_minmax(232px,0.88fr)] xl:grid-cols-[minmax(0,1.66fr)_minmax(256px,0.94fr)]">
-            <DashboardPanel title={isTechnicianView ? "My queue mix" : "Live Shop Load"} className="min-h-[236px] border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)]">
-              <ShopLoadChart data={payload.liveShopLoad.map((item) => ({ label: item.label, count: item.count }))} />
-            </DashboardPanel>
-
-            <DashboardPanel
-              title={isTechnicianView ? "My daily summary" : "Today's Operations"}
-              className="border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)]"
-              action={<Link href="/dashboard/bookings" className="text-xs text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]">Open</Link>}
-            >
-              <div className="space-y-1.5">
-                {payload.dailySummary.map((item) => {
-                  const href =
-                    item.href
-                      ? item.href
-                      : item.label === "Today's bookings"
-                      ? "/dashboard/bookings"
-                      : item.label === "Approval queue"
-                        ? "/work-orders/board?stage=awaiting_approval"
-                        : item.label === "Parts waiting"
-                          ? "/parts/requests"
-                          : "/work-orders/board";
+      <div className="grid gap-3 xl:grid-cols-[minmax(0,1.75fr)_minmax(300px,0.95fr)]">
+        <div className="space-y-3">
+          <section className={panelClass("overflow-hidden")}>
+            <div className="p-4">
+              <h2 className="text-xl font-bold text-[color:var(--theme-text-primary)]">
+                Needs attention
+              </h2>
+              <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                Top items requiring focus
+              </p>
+            </div>
+            {payload.immediateAttention.length ? (
+              <div
+                data-testid="immediate-attention"
+                className="divide-y divide-[color:var(--theme-border-soft)] border-y border-[color:var(--theme-border-soft)]"
+              >
+                {payload.immediateAttention.slice(0, 5).map((item, index) => {
+                  const meta = attentionContext(item.label);
                   return (
-                    <Link
-                      key={`${item.label}-${item.value}`}
-                      href={href}
-                      className="group flex items-center justify-between rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-2 text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-[color:var(--theme-surface-inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
+                    <div
+                      key={item.label}
+                      className="grid gap-3 border-l-4 border-l-[var(--brand-accent,#E39A6E)] px-4 py-3 sm:grid-cols-[48px_minmax(0,1.4fr)_minmax(120px,0.8fr)_auto] sm:items-center"
                     >
-                      <span className="text-[color:var(--theme-text-secondary)]">{item.label}</span>
-                      <span className={item.tone === "accent" ? "inline-flex items-center gap-1 font-semibold text-[var(--brand-accent,#E39A6E)]" : "inline-flex items-center gap-1 font-semibold text-[color:var(--theme-text-primary)]"}>
-                        {item.value}
-                        <ChevronRight className="h-3 w-3 text-[color:var(--theme-text-muted)] transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
+                      <span className="grid h-9 w-9 place-items-center rounded-lg bg-[var(--brand-accent,#E39A6E)]/15 font-bold text-[var(--brand-primary,#C1663B)]">
+                        {index + 1}
                       </span>
-                    </Link>
+                      <div>
+                        <div className="font-semibold text-[color:var(--theme-text-primary)]">
+                          <span className="mr-1 text-lg">{item.value}</span>
+                          {item.label}
+                        </div>
+                        <div className="text-xs text-[color:var(--theme-text-muted)]">
+                          Operational priority
+                        </div>
+                      </div>
+                      <div className="text-sm text-[color:var(--theme-text-secondary)]">
+                        <div>{meta.context}</div>
+                        <div className="mt-1 inline-flex items-center gap-1 text-xs text-[var(--brand-primary,#C1663B)]">
+                          <Clock3 className="h-3.5 w-3.5" />
+                          Waiting now
+                        </div>
+                      </div>
+                      <Link
+                        href={item.href ?? "/work-orders/board"}
+                        className="inline-flex min-h-10 items-center justify-center gap-1 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-subtle)]"
+                      >
+                        {meta.action}
+                        <ChevronRight className="h-4 w-4" />
+                      </Link>
+                    </div>
                   );
                 })}
               </div>
-            </DashboardPanel>
-          </div>
-          </div>
-
-          {hasTechnicianActivity ? (
-            <DashboardPanel title={isTechnicianView ? "My activity" : "Technician Activity"} className="min-h-[236px]">
-              <div className="space-y-1.5">
-                {payload.technicianActivity.map((tech) => (
-                  <Link
-                    key={tech.id}
-                    href="/work-orders/board"
-                    className="group grid grid-cols-[minmax(0,1fr)_76px_auto] items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-2 transition hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
-                  >
-                    <div className="min-w-0">
-                      <div className="truncate text-xs font-semibold text-[color:var(--theme-text-primary)]">{tech.name}</div>
-                      <div className="text-[11px] text-[color:var(--theme-text-secondary)]">{tech.stage} · {tech.elapsed}</div>
-                      <div className="mt-1 h-1 overflow-hidden rounded-full bg-[color:var(--theme-surface-subtle)]">
-                        <div className="h-full bg-[var(--brand-accent,#E39A6E)]" style={{ width: `${tech.utilizationPct}%` }} />
-                      </div>
-                    </div>
-                    <div className="text-right text-xs text-[color:var(--theme-text-secondary)]">{tech.activeLines} lines</div>
-                    <div className="inline-flex items-center gap-1 text-[10px] font-semibold text-[color:var(--theme-text-secondary)]">
-                      Open <ChevronRight className="h-3 w-3 text-[color:var(--theme-text-muted)] transition group-hover:text-[var(--brand-accent,#E39A6E)]" />
-                    </div>
-                  </Link>
-                ))}
+            ) : (
+              <div className="border-y border-[color:var(--theme-border-soft)] p-6 text-sm text-[color:var(--theme-text-secondary)]">
+                No urgent operational items right now.
               </div>
-            </DashboardPanel>
-          ) : null}
-          <DashboardPanel title="Recent Operational Activity" className="min-h-[180px]">
-            <div className="space-y-1.5">
-              {payload.recentOperationalActivity.length > 0 ? payload.recentOperationalActivity.map((event) => (
-                <Link key={`${event.label}-${event.value}`} href={event.href ?? "/work-orders/board"} className="group flex items-center justify-between rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-2 text-xs transition hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-inset)]">
-                  <span className="text-[color:var(--theme-text-primary)]">{event.label}</span>
-                  <span className="inline-flex items-center gap-1 text-[color:var(--theme-text-secondary)]">{event.value}<ChevronRight className="h-3 w-3" /></span>
-                </Link>
-              )) : <EmbeddedEmptyState label="No operational events" detail="Recent events appear when canonical work activity updates." />}
-            </div>
-          </DashboardPanel>
-
-        </section>
-
-        {hasRightRailSignals ? (
-          <aside className="space-y-2 lg:sticky lg:top-2.5 lg:self-start">
-            <DashboardPanel
-              title="High Impact Alerts"
-              action={<Link href="/work-orders/board" className="text-xs text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]">View all</Link>}
-              className="border-red-400/45 bg-[linear-gradient(150deg,rgba(32,10,10,0.64),var(--theme-surface-inset))] shadow-[0_0_0_1px_rgba(239,68,68,0.12)]"
+            )}
+            <Link
+              href="/work-orders/board"
+              className="flex items-center justify-center gap-2 px-4 py-3 text-sm font-semibold text-[var(--brand-primary,#C1663B)]"
             >
-              <div className="space-y-1.5">
-                {payload.alerts.map((alert) => (
+              View all needs <ArrowRight className="h-4 w-4" />
+            </Link>
+          </section>
+
+          <section className={panelClass("p-4")}>
+            <h2 className="text-lg font-bold text-[color:var(--theme-text-primary)]">
+              Work in motion
+            </h2>
+            <p className="text-sm text-[color:var(--theme-text-secondary)]">
+              Jobs by current stage
+            </p>
+            <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+              {flow.map(([label, value, stage], index) => (
+                <Link
+                  key={label}
+                  href={`/work-orders/board?stage=${stage}`}
+                  className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3 transition hover:border-[var(--brand-accent,#E39A6E)]/55"
+                >
+                  <div className="flex items-center justify-between text-sm text-[color:var(--theme-text-secondary)]">
+                    <span>{label}</span>
+                    {index < flow.length - 1 ? (
+                      <ChevronRight className="h-4 w-4" />
+                    ) : null}
+                  </div>
+                  <div className="mt-2 text-2xl font-bold text-[color:var(--theme-text-primary)]">
+                    {value}
+                  </div>
+                  <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[color:var(--theme-surface-inset)]">
+                    <div
+                      className="h-full rounded-full bg-[var(--brand-primary,#C1663B)]"
+                      style={{ width: `${Math.min(100, Number(value) * 20)}%` }}
+                    />
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <aside className="space-y-3">
+          <section className={panelClass("p-4")}>
+            <h2 className="text-xl font-bold text-[color:var(--theme-text-primary)]">
+              Today&apos;s pulse
+            </h2>
+            <p className="text-sm text-[color:var(--theme-text-secondary)]">
+              Live snapshot of key activity
+            </p>
+            <div className="mt-3 space-y-2">
+              {pulse.map(({ label, value, icon: Icon, href }) => (
+                <Link
+                  key={label}
+                  href={href}
+                  className="flex items-center gap-3 rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-2.5"
+                >
+                  <Icon className="h-5 w-5 text-[var(--brand-primary,#C1663B)]" />
+                  <span className="flex-1 text-sm text-[color:var(--theme-text-secondary)]">
+                    {label}
+                  </span>
+                  <strong className="text-xl text-[color:var(--theme-text-primary)]">
+                    {value}
+                  </strong>
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          <section className={panelClass("p-4")}>
+            <h2 className="text-xl font-bold text-[color:var(--theme-text-primary)]">
+              Action rail
+            </h2>
+            <p className="text-sm text-[color:var(--theme-text-secondary)]">
+              Shortcuts to keep operations moving
+            </p>
+            <div className="mt-3 space-y-2">
+              {payload.suggestedActions.map((action, index) => {
+                const Icon = [UsersRound, Package, ClipboardList][index % 3];
+                return (
                   <Link
-                    key={alert.label}
-                    href={alert.href}
-                    className="group block rounded-lg border p-2 transition hover:-translate-y-0.5 hover:brightness-[1.14] hover:shadow-[var(--theme-shadow-medium)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60"
-                    style={{
-                      borderColor: alert.tone === "critical" ? "rgba(248,113,113,0.7)" : alert.tone === "warning" ? "rgba(251,191,36,0.48)" : "rgba(148,163,184,0.25)",
-                      background: alert.tone === "critical" ? "linear-gradient(120deg, rgba(127,29,29,0.48), rgba(69,10,10,0.24))" : alert.tone === "warning" ? "rgba(120,53,15,0.24)" : "var(--theme-surface-inset)",
-                      boxShadow: alert.tone === "critical" ? "0 0 0 1px rgba(239,68,68,0.2), inset 0 1px 0 rgba(254,202,202,0.18)" : undefined,
-                    }}
+                    key={`${action.label}-${action.href}`}
+                    href={action.href}
+                    className="group flex items-center gap-3 rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-2.5"
                   >
-                    <div className="flex items-center justify-between gap-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">
-                      <span className="inline-flex items-center gap-2">
-                        {alert.tone === "critical" ? <TriangleAlert className="h-3.5 w-3.5 text-red-300" /> : <AlertTriangle className="h-3.5 w-3.5 text-amber-300" />}
-                        {alert.label}
+                    <span className="grid h-9 w-9 place-items-center rounded-lg bg-[var(--brand-primary,#C1663B)]/12 text-[var(--brand-primary,#C1663B)]">
+                      <Icon className="h-5 w-5" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                        {action.label}
                       </span>
-                      <ChevronRight className="h-3.5 w-3.5 text-[color:var(--theme-text-secondary)] transition duration-200 group-hover:translate-x-1 group-hover:scale-110 group-hover:text-[var(--brand-accent,#E39A6E)]" />
-                    </div>
-                    <div className="mt-1 text-[11px] text-[color:var(--theme-text-secondary)]">{alert.detail}</div>
+                      <span className="block truncate text-xs text-[color:var(--theme-text-muted)]">
+                        {action.detail}
+                      </span>
+                    </span>
+                    <ChevronRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
                   </Link>
-                ))}
-              </div>
-            </DashboardPanel>
+                );
+              })}
+            </div>
+          </section>
 
-            <div className="h-px bg-gradient-to-r from-transparent via-[color:var(--theme-surface-subtle)] to-transparent" />
-
-            <DashboardPanel title="Action Rail" eyebrow="Urgency" className="border-amber-300/30 bg-[var(--theme-gradient-panel)]">
-              <div className="space-y-1.5">
-                {payload.blockerStack.map((blocker) => (
-                  (() => {
-                    const count = Number.parseInt(blocker.value, 10);
-                    const severity = Number.isFinite(count) ? getCountSeverity(count) : "neutral";
-                    const valueClass =
-                      severity === "red"
-                        ? "inline-flex items-center gap-1 font-semibold text-red-300"
-                        : severity === "amber"
-                          ? "inline-flex items-center gap-1 font-semibold text-amber-300"
-                          : blocker.tone === "accent"
-                            ? "inline-flex items-center gap-1 font-semibold text-[var(--brand-accent,#E39A6E)]"
-                            : "inline-flex items-center gap-1 font-semibold text-[color:var(--theme-text-primary)]";
-                    const rowClass =
-                      severity === "red"
-                        ? "group flex items-center justify-between rounded-lg border border-red-400/35 bg-red-950/20 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-red-300/60 hover:bg-red-950/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300/50"
-                        : severity === "amber"
-                          ? "group flex items-center justify-between rounded-lg border border-amber-300/30 bg-amber-950/10 px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-amber-300/55 hover:bg-amber-950/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300/45"
-                          : "group flex items-center justify-between rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-1.5 text-xs transition hover:-translate-y-px hover:border-[var(--brand-accent,#E39A6E)]/45 hover:bg-[color:var(--theme-surface-inset)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-accent,#E39A6E)]/60";
-                    return (
-                      <Link
-                        key={blocker.label}
-                        href={blocker.href ?? "/work-orders/board"}
-                        className={rowClass}
-                      >
-                        <span className="text-[color:var(--theme-text-secondary)]">{blocker.label}</span>
-                        <span className={valueClass}>
-                          {blocker.value}
-                          <ChevronRight className="h-3 w-3 text-[color:var(--theme-text-muted)] transition group-hover:translate-x-0.5 group-hover:text-[var(--brand-accent,#E39A6E)]" />
-                        </span>
-                      </Link>
-                    );
-                  })()
-                ))}
-              </div>
-            </DashboardPanel>
-          </aside>
-        ) : null}
+          <section className={panelClass("overflow-hidden p-4 pb-0")}>
+            <h2 className="text-xl font-bold text-[color:var(--theme-text-primary)]">
+              Technician capacity
+            </h2>
+            <p className="text-sm text-[color:var(--theme-text-secondary)]">
+              Today&apos;s availability
+            </p>
+            <div className="mt-3 space-y-2">
+              {payload.technicianActivity.length ? (
+                payload.technicianActivity.slice(0, 3).map((tech) => (
+                  <div
+                    key={tech.id}
+                    className="flex items-center gap-3 rounded-lg border border-[color:var(--theme-border-soft)] p-3"
+                  >
+                    <span className="grid h-10 w-10 place-items-center rounded-full bg-[color:var(--theme-surface-subtle)] text-sm font-bold">
+                      {tech.name
+                        .split(" ")
+                        .map((part) => part[0])
+                        .join("")
+                        .slice(0, 2)}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-semibold">
+                        {tech.name}
+                      </span>
+                      <span className="text-xs text-[color:var(--theme-text-muted)]">
+                        {tech.activeLines
+                          ? `${tech.activeLines} active lines`
+                          : "Available · no active job"}
+                      </span>
+                    </span>
+                    <Link
+                      href="/work-orders/board"
+                      className="rounded-lg border border-[var(--brand-primary,#C1663B)]/45 px-3 py-2 text-xs font-semibold"
+                    >
+                      {tech.activeLines ? "View" : "Assign job"}
+                    </Link>
+                  </div>
+                ))
+              ) : (
+                <div className="rounded-lg border border-dashed border-[color:var(--theme-border-soft)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+                  No technician activity is available.
+                </div>
+              )}
+            </div>
+            <Link
+              href="/dashboard/workforce/attendance"
+              className="mt-3 flex items-center justify-center gap-2 border-t border-[color:var(--theme-border-soft)] py-3 text-sm font-semibold text-[var(--brand-primary,#C1663B)]"
+            >
+              View all technicians <ArrowRight className="h-4 w-4" />
+            </Link>
+          </section>
+        </aside>
       </div>
     </DashboardShell>
   );

--- a/app/work-orders/board/page.tsx
+++ b/app/work-orders/board/page.tsx
@@ -18,13 +18,12 @@ export default async function WorkOrderBoardPage({
     : params?.stage;
   const initialStage = parseWorkOrderBoardStageFilter(rawStage);
   return (
-    <main className="min-h-screen px-4 py-6 text-[color:var(--theme-text-primary)] md:px-6">
-      <div className="mx-auto max-w-[1500px] space-y-4">
+    <main className="min-h-screen px-4 py-5 text-[color:var(--theme-text-primary)] md:px-6">
+      <div className="mx-auto max-w-[1680px] space-y-4">
         <OperationalViewSwitcher role={identity.role} />
         <WorkOrderBoard
           variant="shop"
-          title="Shop work order board"
-          subtitle="Read-only board for real-time workflow visibility across active work orders."
+          title="Work Order Board"
           initialStage={initialStage}
         />
       </div>

--- a/features/dashboard/components/OperationalViewSwitcher.tsx
+++ b/features/dashboard/components/OperationalViewSwitcher.tsx
@@ -3,7 +3,10 @@
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@/features/shared/utils/cn";
-import { canonicalizeRole, type CanonicalRole } from "@/features/shared/lib/rbac";
+import {
+  canonicalizeRole,
+  type CanonicalRole,
+} from "@/features/shared/lib/rbac";
 
 export type OperationalView = {
   href: string;
@@ -15,12 +18,32 @@ export const OPERATIONAL_VIEWS: OperationalView[] = [
   {
     href: "/dashboard",
     label: "Shop Overview",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "parts", "dispatcher", "driver", "fleet_manager", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "parts",
+      "dispatcher",
+      "driver",
+      "fleet_manager",
+      "lead_hand",
+      "foreman",
+    ],
   },
   {
     href: "/work-orders/board",
     label: "Work Order Board",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "lead_hand",
+      "foreman",
+    ],
   },
   {
     href: "/dashboard/workforce/attendance",
@@ -29,7 +52,9 @@ export const OPERATIONAL_VIEWS: OperationalView[] = [
   },
 ];
 
-export function getOperationalViewsForRole(role?: string | null): OperationalView[] {
+export function getOperationalViewsForRole(
+  role?: string | null,
+): OperationalView[] {
   const normalized = canonicalizeRole(role);
   return OPERATIONAL_VIEWS.filter((view) => view.roles.includes(normalized));
 }
@@ -48,13 +73,13 @@ export function OperationalViewSwitcher({
   role?: string | null;
   className?: string;
 }) {
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
   const searchParams = useSearchParams();
   const views = getOperationalViewsForRole(role);
 
   if (views.length <= 1) return null;
 
-  const currentQuery = searchParams.toString();
+  const currentQuery = searchParams?.toString() ?? "";
 
   return (
     <nav
@@ -66,9 +91,10 @@ export function OperationalViewSwitcher({
     >
       {views.map((view) => {
         const active = isActive(pathname, view.href);
-        const href = active && pathname === "/work-orders/board" && currentQuery
-          ? `${view.href}?${currentQuery}`
-          : view.href;
+        const href =
+          active && pathname === "/work-orders/board" && currentQuery
+            ? `${view.href}?${currentQuery}`
+            : view.href;
 
         return (
           <Link
@@ -77,7 +103,8 @@ export function OperationalViewSwitcher({
             aria-current={active ? "page" : undefined}
             className={cn(
               "whitespace-nowrap rounded-xl px-3 py-2 font-medium text-[color:var(--theme-text-secondary)] transition hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300/70",
-              active && "bg-orange-500/20 text-orange-900 shadow-[inset_0_0_0_1px_rgba(251,146,60,0.35)] dark:text-orange-100",
+              active &&
+                "bg-orange-500/20 text-orange-900 shadow-[inset_0_0_0_1px_rgba(251,146,60,0.35)] dark:text-orange-100",
             )}
           >
             {view.label}

--- a/features/shared/components/workboard/WorkOrderBoard.tsx
+++ b/features/shared/components/workboard/WorkOrderBoard.tsx
@@ -1,28 +1,76 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
-import WorkOrderBoardCard from "./WorkOrderBoardCard";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ClipboardCheck,
+  Clock3,
+  Package,
+  Plus,
+  RefreshCw,
+  Search,
+  UserRound,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
+
 import { useWorkOrderBoard } from "../../hooks/useWorkOrderBoard";
+import type { WorkOrderBoardFilterKey } from "../../lib/workboard/filters";
 import type {
   WorkOrderBoardRow,
+  WorkOrderBoardStage,
   WorkOrderBoardVariant,
 } from "../../lib/workboard/types";
-
-import {
-  WORK_ORDER_BOARD_FILTER_KEYS,
-  type WorkOrderBoardFilterKey,
-} from "../../lib/workboard/filters";
+import { buildBlockers, timeAgoLabel } from "../../lib/workboard/utils";
 
 type FilterKey = WorkOrderBoardFilterKey;
 type WorkOrderBoardHrefMode = "none" | "shop-work-order";
 
-function labelForFilter(key: FilterKey): string {
-  if (key === "all") return "All";
-  return key.replaceAll("_", " ");
-}
+const stages: Array<{
+  key: WorkOrderBoardStage;
+  label: string;
+  icon: typeof Clock3;
+  tone: string;
+}> = [
+  { key: "awaiting", label: "Awaiting", icon: Clock3, tone: "text-blue-600" },
+  {
+    key: "in_progress",
+    label: "In progress",
+    icon: Wrench,
+    tone: "text-violet-600",
+  },
+  {
+    key: "awaiting_approval",
+    label: "Awaiting approval",
+    icon: ClipboardCheck,
+    tone: "text-amber-600",
+  },
+  {
+    key: "waiting_parts",
+    label: "Waiting parts",
+    icon: Package,
+    tone: "text-orange-600",
+  },
+  {
+    key: "completed",
+    label: "Ready to invoice",
+    icon: CheckCircle2,
+    tone: "text-emerald-600",
+  },
+];
 
-function isCompletedStage(row: WorkOrderBoardRow): boolean {
-  return row.overall_stage === "completed";
+function priorityLabel(priority?: number | null) {
+  return priority === 1
+    ? "Urgent"
+    : priority === 2
+      ? "High"
+      : priority === 4
+        ? "Low"
+        : "Normal";
 }
 
 function defaultHrefModeForVariant(
@@ -31,15 +79,132 @@ function defaultHrefModeForVariant(
   return variant === "shop" ? "shop-work-order" : "none";
 }
 
-function resolveWorkOrderBoardHref(
-  row: WorkOrderBoardRow,
-  mode: WorkOrderBoardHrefMode,
-): string | null {
-  if (mode === "shop-work-order") {
-    return `/work-orders/${row.work_order_id}`;
-  }
+function resolveHref(row: WorkOrderBoardRow, mode: WorkOrderBoardHrefMode) {
+  return mode === "shop-work-order"
+    ? `/work-orders/${row.work_order_id}`
+    : null;
+}
 
-  return null;
+function BoardCard({
+  row,
+  href,
+  variant,
+}: {
+  row: WorkOrderBoardRow;
+  href: string | null;
+  variant: WorkOrderBoardVariant;
+}) {
+  const blockers = buildBlockers(row, variant);
+  const tech =
+    row.tech_names?.join(", ") ||
+    row.first_tech_name ||
+    row.assigned_summary ||
+    "Unassigned";
+  const card = (
+    <article className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 shadow-sm transition hover:border-[var(--brand-accent,#E39A6E)]/60 hover:shadow-md">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="font-extrabold text-[color:var(--theme-text-primary)]">
+            {row.custom_id ?? "Work order"}
+          </div>
+          <div className="mt-1 truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            {row.display_name ?? "Customer"}
+          </div>
+        </div>
+        <span
+          className={
+            row.risk_level === "danger"
+              ? "text-xs font-bold text-red-600"
+              : "text-xs text-[color:var(--theme-text-muted)]"
+          }
+        >
+          {timeAgoLabel(row.time_in_stage_seconds ?? null)}
+        </span>
+      </div>
+      <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+        {[row.unit_label ? `Unit ${row.unit_label}` : null, row.vehicle_label]
+          .filter(Boolean)
+          .join(" · ") || "Vehicle not listed"}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5 text-[11px]">
+        <span className="inline-flex items-center gap-1">
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${row.priority === 1 ? "bg-red-500" : "bg-blue-500"}`}
+          />
+          {priorityLabel(row.priority)} priority
+        </span>
+        {row.is_waiter ? (
+          <span className="rounded bg-amber-500/15 px-1.5 py-0.5 font-semibold text-amber-700 dark:text-amber-200">
+            Customer waiting
+          </span>
+        ) : null}
+        {row.overall_stage === "completed" ? (
+          <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 font-semibold text-emerald-700 dark:text-emerald-200">
+            Ready to invoice
+          </span>
+        ) : null}
+      </div>
+      <dl className="mt-3 grid grid-cols-[78px_1fr] gap-x-2 gap-y-1 text-xs">
+        <dt className="text-[color:var(--theme-text-muted)]">Technician</dt>
+        <dd className="truncate text-[color:var(--theme-text-secondary)]">
+          <UserRound className="mr-1 inline h-3.5 w-3.5" />
+          {tech}
+        </dd>
+        {row.parts_blocker_count ? (
+          <>
+            <dt className="text-[color:var(--theme-text-muted)]">Parts</dt>
+            <dd>
+              {row.parts_blocker_count} request
+              {row.parts_blocker_count === 1 ? "" : "s"}
+            </dd>
+          </>
+        ) : null}
+        <dt className="text-[color:var(--theme-text-muted)]">Job progress</dt>
+        <dd>{row.progress_pct}%</dd>
+        <dt className="text-[color:var(--theme-text-muted)]">Blocking</dt>
+        <dd className="truncate">{blockers[0] ?? "—"}</dd>
+      </dl>
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[color:var(--theme-surface-subtle)]">
+        <div
+          className={`h-full rounded-full ${row.overall_stage === "completed" ? "bg-emerald-500" : "bg-[var(--brand-primary,#C1663B)]"}`}
+          style={{ width: `${Math.min(100, Math.max(0, row.progress_pct))}%` }}
+        />
+      </div>
+      <div className="mt-3 flex min-h-9 items-center justify-center gap-2 rounded-lg border border-[var(--brand-primary,#C1663B)]/45 text-xs font-semibold text-[var(--brand-primary,#C1663B)]">
+        {row.overall_stage === "completed"
+          ? "Review invoice"
+          : row.overall_stage === "waiting_parts"
+            ? "Open parts"
+            : row.overall_stage === "awaiting"
+              ? "Assign"
+              : "Open work order"}
+        <ChevronRight className="h-3.5 w-3.5" />
+      </div>
+    </article>
+  );
+  return href ? (
+    <Link href={href} className="block">
+      {card}
+    </Link>
+  ) : (
+    card
+  );
+}
+
+function EmptyColumn({ label }: { label: string }) {
+  return (
+    <div className="grid min-h-64 place-items-center rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-5 text-center">
+      <div>
+        <ClipboardCheck className="mx-auto h-10 w-10 text-[color:var(--theme-text-muted)]" />
+        <div className="mt-3 text-sm font-semibold text-[color:var(--theme-text-secondary)]">
+          No work orders
+        </div>
+        <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+          Work appears here when it moves to {label.toLowerCase()}.
+        </p>
+      </div>
+    </div>
+  );
 }
 
 export default function WorkOrderBoard(props: {
@@ -49,10 +214,6 @@ export default function WorkOrderBoard(props: {
   limit?: number;
   fleetId?: string | null;
   compact?: boolean;
-  /**
-   * Serializable href behavior for Server Component callers. Client Component
-   * callers can still use hrefBuilder when they need custom in-client links.
-   */
   hrefMode?: WorkOrderBoardHrefMode;
   hrefBuilder?: (row: WorkOrderBoardRow) => string | null;
   initialStage?: FilterKey;
@@ -61,324 +222,341 @@ export default function WorkOrderBoard(props: {
     limit: props.limit,
     fleetId: props.fleetId,
   });
-
   const [stageFilter, setStageFilter] = useState<FilterKey>(
     props.initialStage ?? "all",
   );
   const [query, setQuery] = useState("");
+  const [advisor, setAdvisor] = useState("all");
+  const [technician, setTechnician] = useState("all");
+  const [priority, setPriority] = useState("all");
+  const [waiter, setWaiter] = useState("all");
 
-  useEffect(() => {
-    setStageFilter(props.initialStage ?? "all");
-  }, [props.initialStage]);
-
-  const searchedRows = useMemo(() => {
-    const q = query.trim().toLowerCase();
-
-    return rows.filter((row) => {
-      const matchesStage =
-        stageFilter === "all" ? true : row.overall_stage === stageFilter;
-
-      const matchesQuery =
-        q.length === 0
-          ? true
-          : [
-              row.custom_id,
-              row.display_name,
-              row.unit_label,
-              row.vehicle_label,
-              row.assigned_summary,
-              row.advisor_name,
-              row.first_tech_name,
-              ...(row.tech_names ?? []),
-            ]
-              .filter(Boolean)
-              .join(" ")
-              .toLowerCase()
-              .includes(q);
-
-      return matchesStage && matchesQuery;
-    });
-  }, [query, rows, stageFilter]);
-
-  const counts = useMemo(() => {
-    const base: Record<FilterKey, number> = {
-      all: rows.length,
-      awaiting: 0,
-      in_progress: 0,
-      awaiting_approval: 0,
-      waiting_parts: 0,
-      on_hold: 0,
-      completed: 0,
-    };
-
-    for (const row of rows) {
-      const key = row.overall_stage as FilterKey;
-      if (key in base) base[key] += 1;
-    }
-
-    return base;
-  }, [rows]);
-
-  const activeRows = useMemo(
-    () => searchedRows.filter((row) => !isCompletedStage(row)),
-    [searchedRows],
+  useEffect(
+    () => setStageFilter(props.initialStage ?? "all"),
+    [props.initialStage],
   );
 
-  const completedRows = useMemo(
-    () => searchedRows.filter((row) => isCompletedStage(row)),
-    [searchedRows],
-  );
-
-  const showCompletedSection =
-    !props.compact && (stageFilter === "all" || stageFilter === "completed");
-  const hrefMode = props.hrefMode ?? defaultHrefModeForVariant(props.variant);
-  const buildRowHref = (row: WorkOrderBoardRow) =>
-    props.hrefBuilder
-      ? props.hrefBuilder(row)
-      : resolveWorkOrderBoardHref(row, hrefMode);
-
-  const activeCount = useMemo(
-    () => rows.filter((row) => !isCompletedStage(row)).length,
-    [rows],
-  );
-
-  const stalledCount = useMemo(
+  const advisorOptions = useMemo(
     () =>
-      rows.filter(
-        (row) =>
-          row.overall_stage === "on_hold" ||
-          row.overall_stage === "awaiting_approval" ||
-          row.overall_stage === "waiting_parts",
-      ).length,
+      [
+        ...new Set(
+          rows
+            .map((row) => row.advisor_name)
+            .filter((value): value is string => Boolean(value)),
+        ),
+      ].sort(),
     [rows],
   );
-
-  const waiterCount = useMemo(
-    () => rows.filter((row) => !!row.is_waiter).length,
+  const techOptions = useMemo(
+    () =>
+      [
+        ...new Set(
+          rows.flatMap((row) =>
+            row.tech_names?.length
+              ? row.tech_names
+              : row.first_tech_name
+                ? [row.first_tech_name]
+                : [],
+          ),
+        ),
+      ].sort(),
     [rows],
   );
+  const filteredRows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return rows.filter((row) => {
+      const searchable = [
+        row.custom_id,
+        row.display_name,
+        row.unit_label,
+        row.vehicle_label,
+        row.advisor_name,
+        row.first_tech_name,
+        ...(row.tech_names ?? []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return (
+        (stageFilter === "all" || row.overall_stage === stageFilter) &&
+        (!q || searchable.includes(q)) &&
+        (advisor === "all" || row.advisor_name === advisor) &&
+        (technician === "all" ||
+          row.first_tech_name === technician ||
+          row.tech_names?.includes(technician)) &&
+        (priority === "all" || String(row.priority ?? 3) === priority) &&
+        (waiter === "all" || (waiter === "yes") === Boolean(row.is_waiter))
+      );
+    });
+  }, [advisor, priority, query, rows, stageFilter, technician, waiter]);
 
-  const urgentCount = useMemo(
-    () => rows.filter((row) => row.priority === 1).length,
-    [rows],
-  );
-
-  const completedCount = counts.completed;
-  const queueGroups = [
+  const count = (stage: WorkOrderBoardStage) =>
+    rows.filter((row) => row.overall_stage === stage).length;
+  const atRisk = rows.filter(
+    (row) => row.risk_level === "warn" || row.risk_level === "danger",
+  ).length;
+  const hrefMode = props.hrefMode ?? defaultHrefModeForVariant(props.variant);
+  const buildHref = (row: WorkOrderBoardRow) =>
+    props.hrefBuilder ? props.hrefBuilder(row) : resolveHref(row, hrefMode);
+  const visibleStages =
+    stageFilter === "all"
+      ? stages
+      : stageFilter === "on_hold"
+        ? stages.filter((stage) => stage.key === "waiting_parts")
+        : stages.filter((stage) => stage.key === stageFilter);
+  const summaryCards: Array<{
+    label: string;
+    value: number;
+    icon: LucideIcon;
+    tone: string;
+  }> = [
     {
-      label: "At Risk",
-      count: rows.filter(
-        (row) => row.risk_level === "danger" || row.risk_level === "warn",
-      ).length,
+      label: "At risk",
+      value: atRisk,
+      icon: AlertTriangle,
+      tone: "text-orange-600",
     },
     {
-      label: "Blocked",
-      count: rows.filter((row) => row.overall_stage === "on_hold").length,
+      label: "Ready to work",
+      value: count("awaiting"),
+      icon: CheckCircle2,
+      tone: "text-blue-600",
     },
     {
-      label: "Ready to Work",
-      count: rows.filter((row) => row.overall_stage === "awaiting").length,
+      label: "Waiting parts",
+      value: count("waiting_parts"),
+      icon: Clock3,
+      tone: "text-amber-600",
     },
     {
-      label: "Working",
-      count: rows.filter((row) => row.overall_stage === "in_progress").length,
+      label: "Ready to invoice",
+      value: count("completed"),
+      icon: ClipboardCheck,
+      tone: "text-emerald-600",
     },
-    {
-      label: "Awaiting Approval",
-      count: rows.filter((row) => row.overall_stage === "awaiting_approval")
-        .length,
-    },
-    {
-      label: "Waiting Parts",
-      count: rows.filter((row) => row.overall_stage === "waiting_parts").length,
-    },
-    { label: "Completed Today", count: completedCount },
-  ].filter((group) => group.count > 0);
+  ];
 
   return (
-    <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 backdrop-blur md:p-5">
-      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+    <section className="space-y-4">
+      <header className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
         <div>
-          <div className="text-xs font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-muted)]">
-            Board
-          </div>
-          <h2
-            className="mt-1 text-2xl text-[color:var(--theme-text-primary)] md:text-3xl"
-            style={{ fontFamily: "var(--font-blackops)" }}
-          >
+          <h1 className="text-3xl font-bold tracking-tight text-[color:var(--theme-text-primary)]">
             {props.title}
-          </h2>
-
-          {props.subtitle ? (
-            <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">{props.subtitle}</p>
-          ) : null}
-
-          {!loading && !error ? (
-            <div className="mt-3 flex flex-wrap gap-2">
-              <div className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
-                Active: <span className="text-[color:var(--theme-text-primary)]">{activeCount}</span>
-              </div>
-              <div className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
-                Needs attention:{" "}
-                <span className="text-[color:var(--theme-text-primary)]">{stalledCount}</span>
-              </div>
-              <div className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
-                Waiters: <span className="text-[color:var(--theme-text-primary)]">{waiterCount}</span>
-              </div>
-              <div className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
-                Urgent: <span className="text-[color:var(--theme-text-primary)]">{urgentCount}</span>
-              </div>
-              <div className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
-                Completed: <span className="text-[color:var(--theme-text-primary)]">{completedCount}</span>
-              </div>
-            </div>
-          ) : null}
+          </h1>
+          <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+            {rows.length} work orders ·{" "}
+            <span className="font-semibold text-[var(--brand-primary,#C1663B)]">
+              {atRisk} need attention
+            </span>
+          </p>
         </div>
-
-        <div className="flex flex-col gap-2 md:min-w-[380px]">
-          {queueGroups.length > 0 ? (
-            <div
-              data-testid="queue-awareness-groups"
-              className="flex flex-wrap gap-2"
-            >
-              {queueGroups.map((group) => (
-                <div
-                  key={group.label}
-                  className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] font-semibold text-[color:var(--theme-text-primary)]"
-                >
-                  {group.label}:{" "}
-                  <span className="text-[color:var(--theme-text-primary)]">{group.count}</span>
-                </div>
-              ))}
-            </div>
-          ) : null}
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search work order, customer, unit, vehicle, advisor, tech"
-            className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)]"
+        <div className="flex flex-1 flex-wrap items-end gap-2 xl:justify-end">
+          <label className="relative min-w-[240px] flex-1 xl:max-w-[380px]">
+            <span className="sr-only">Search work orders</span>
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--theme-text-muted)]" />
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search work order, customer, unit, advisor..."
+              className="h-11 w-full rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] pl-9 pr-3 text-sm outline-none focus:border-[var(--brand-primary,#C1663B)]"
+            />
+          </label>
+          <Filter
+            label="Advisor"
+            value={advisor}
+            onChange={setAdvisor}
+            options={advisorOptions.map((value) => [value, value])}
           />
-
-          <div className="flex flex-wrap gap-2">
-            {WORK_ORDER_BOARD_FILTER_KEYS.map((key) => (
-              <button
-                key={key}
-                type="button"
-                onClick={() => setStageFilter(key)}
-                className={[
-                  "rounded-full border px-3 py-1.5 text-xs font-semibold capitalize transition",
-                  stageFilter === key
-                    ? "border-[color:var(--pfq-copper)] bg-[color:var(--pfq-copper)]/15 text-[color:var(--accent-copper-light)]"
-                    : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-inset)]",
-                ].join(" ")}
-              >
-                {labelForFilter(key)}{" "}
-                <span className="ml-1 text-[10px] opacity-80">
-                  {counts[key]}
-                </span>
-              </button>
-            ))}
-
-            <button
-              type="button"
-              onClick={refetch}
-              className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-xs font-semibold text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-inset)]"
+          <Filter
+            label="Technician"
+            value={technician}
+            onChange={setTechnician}
+            options={techOptions.map((value) => [value, value])}
+          />
+          <Filter
+            label="Priority"
+            value={priority}
+            onChange={setPriority}
+            options={[
+              ["1", "Urgent"],
+              ["2", "High"],
+              ["3", "Normal"],
+              ["4", "Low"],
+            ]}
+          />
+          <Filter
+            label="Waiter"
+            value={waiter}
+            onChange={setWaiter}
+            options={[
+              ["yes", "Yes"],
+              ["no", "No"],
+            ]}
+          />
+          {props.variant === "shop" ? (
+            <Link
+              href="/work-orders/create"
+              className="inline-flex h-11 items-center gap-2 rounded-lg bg-[var(--brand-primary,#C1663B)] px-4 text-sm font-semibold text-white"
             >
-              Refresh
-            </button>
-          </div>
+              <Plus className="h-4 w-4" />
+              Create work order
+            </Link>
+          ) : null}
+          <button
+            type="button"
+            onClick={refetch}
+            aria-label="Refresh board"
+            className="grid h-11 w-11 place-items-center rounded-lg border border-[color:var(--theme-border-soft)]"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </button>
         </div>
+      </header>
+
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        {summaryCards.map(({ label, value, icon: Icon, tone }) => (
+          <div
+            key={String(label)}
+            className="flex items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3"
+          >
+            <Icon className={`h-5 w-5 ${tone}`} />
+            <span className="flex-1 text-sm font-semibold">{label}</span>
+            <strong className={`text-xl ${tone}`}>{value}</strong>
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="flex gap-1 overflow-x-auto"
+        aria-label="Board stage views"
+      >
+        {(
+          [
+            ["all", "All"],
+            ["awaiting", "Awaiting"],
+            ["in_progress", "In progress"],
+            ["awaiting_approval", "Awaiting approval"],
+            ["waiting_parts", "Waiting parts"],
+            ["on_hold", "On hold"],
+            ["completed", "Ready to invoice"],
+          ] as Array<[FilterKey, string]>
+        ).map(([key, label]) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setStageFilter(key)}
+            className={`whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-semibold ${stageFilter === key ? "border-[var(--brand-primary,#C1663B)] bg-[var(--brand-primary,#C1663B)]/10 text-[var(--brand-primary,#C1663B)]" : "border-[color:var(--theme-border-soft)] text-[color:var(--theme-text-secondary)]"}`}
+          >
+            {label}
+          </button>
+        ))}
       </div>
 
       {loading ? (
-        <div className="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {Array.from({ length: props.compact ? 5 : 9 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-40 animate-pulse rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]"
-            />
-          ))}
+        <div className="grid min-h-96 place-items-center rounded-xl border border-[color:var(--theme-border-soft)] text-sm text-[color:var(--theme-text-secondary)]">
+          Loading work order board…
         </div>
       ) : error ? (
-        <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-700 dark:text-red-200">
           {error}
         </div>
-      ) : searchedRows.length === 0 ? (
-        <div className="mt-6 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6 text-sm text-[color:var(--theme-text-secondary)]">
-          No work orders found for this filter.
-        </div>
       ) : (
-        <div className="mt-6 space-y-6">
-          <div>
-            {!props.compact ? (
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
-                  Active work
-                </div>
-                <div className="text-[11px] text-[color:var(--theme-text-muted)]">
-                  {activeRows.length} visible
-                </div>
-              </div>
-            ) : null}
-
-            {activeRows.length === 0 ? (
-              <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6 text-sm text-[color:var(--theme-text-secondary)]">
-                No active work orders found for this filter.
-              </div>
-            ) : (
-              <div
-                className={[
-                  "grid gap-3",
-                  props.compact
-                    ? "grid-cols-1"
-                    : "md:grid-cols-2 xl:grid-cols-3",
-                ].join(" ")}
-              >
-                {activeRows.map((row) => (
-                  <WorkOrderBoardCard
-                    key={row.work_order_id}
-                    row={row}
-                    variant={props.variant}
-                    compact={props.compact}
-                    href={buildRowHref(row)}
-                  />
-                ))}
-              </div>
-            )}
+        <div className="overflow-x-auto pb-2">
+          <div
+            className={`grid min-w-[1280px] gap-3 ${visibleStages.length === 1 ? "grid-cols-1" : "grid-cols-5"}`}
+          >
+            {visibleStages.map((stage) => {
+              const Icon = stage.icon;
+              const stageRows = filteredRows.filter((row) =>
+                stageFilter === "on_hold"
+                  ? row.overall_stage === "on_hold"
+                  : row.overall_stage === stage.key ||
+                    (stageFilter === "all" &&
+                      stage.key === "waiting_parts" &&
+                      row.overall_stage === "on_hold"),
+              );
+              return (
+                <section
+                  key={stage.key}
+                  className="min-h-[560px] rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3"
+                >
+                  <header className="mb-3 flex items-center gap-2">
+                    <Icon className={`h-4 w-4 ${stage.tone}`} />
+                    <h2 className="text-sm font-bold">{stage.label}</h2>
+                    <span className="rounded-full bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-xs font-bold">
+                      {stageRows.length}
+                    </span>
+                  </header>
+                  <div className="space-y-2">
+                    {stageRows.length ? (
+                      stageRows.map((row) => (
+                        <BoardCard
+                          key={row.work_order_id}
+                          row={row}
+                          variant={props.variant}
+                          href={buildHref(row)}
+                        />
+                      ))
+                    ) : (
+                      <EmptyColumn label={stage.label} />
+                    )}
+                  </div>
+                </section>
+              );
+            })}
           </div>
-
-          {showCompletedSection ? (
-            <div>
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
-                  Completed / history
-                </div>
-                <div className="text-[11px] text-[color:var(--theme-text-muted)]">
-                  {completedRows.length} visible
-                </div>
-              </div>
-
-              {completedRows.length === 0 ? (
-                <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 text-sm text-[color:var(--theme-text-secondary)]">
-                  No completed work orders found for this filter.
-                </div>
-              ) : (
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-                  {completedRows.map((row) => (
-                    <WorkOrderBoardCard
-                      key={row.work_order_id}
-                      row={row}
-                      variant={props.variant}
-                      compact={false}
-                      href={buildRowHref(row)}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          ) : null}
         </div>
       )}
+
+      <button
+        type="button"
+        onClick={() =>
+          setStageFilter(stageFilter === "completed" ? "all" : "completed")
+        }
+        className="flex w-full items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 text-sm"
+      >
+        <Clock3 className="h-4 w-4" />
+        <span>Completed today</span>
+        <strong>{count("completed")}</strong>
+        <span className="text-[color:var(--theme-text-muted)]">
+          · View history
+        </span>
+        <ChevronDown className="ml-auto h-4 w-4" />
+      </button>
     </section>
+  );
+}
+
+function Filter({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: string[][];
+}) {
+  return (
+    <label className="relative">
+      <span className="absolute left-3 top-1.5 text-[9px] font-semibold text-[color:var(--theme-text-muted)]">
+        {label}
+      </span>
+      <select
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-11 min-w-24 appearance-none rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 pb-1 pt-4 pr-7 text-xs outline-none"
+      >
+        <option value="all">All</option>
+        {options.map(([optionValue, optionLabel]) => (
+          <option key={optionValue} value={optionValue}>
+            {optionLabel}
+          </option>
+        ))}
+      </select>
+      <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2" />
+    </label>
   );
 }

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -7,63 +7,77 @@ import type { OperationsDashboardPayload } from "@/features/dashboard/server/get
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
 vi.mock("@/features/dashboard/server/getOperationsDashboardPayload", () => ({
-  getOperationsDashboardPayload: vi.fn(async (): Promise<OperationsDashboardPayload> => ({
-    identity: {
-      userId: "user-1",
-      email: "owner@example.com",
-      shopId: "shop-1",
-      role: "owner",
-      fullName: "Operations Owner",
-      profileExists: true,
-      shopLoaded: true,
-      shop: {
-        id: "shop-1",
-        name: "ProFixIQ Demo Shop",
-        shop_name: null,
-        business_name: null,
+  getOperationsDashboardPayload: vi.fn(
+    async (): Promise<OperationsDashboardPayload> => ({
+      identity: {
+        userId: "user-1",
+        email: "owner@example.com",
+        shopId: "shop-1",
+        role: "owner",
+        fullName: "Operations Owner",
+        profileExists: true,
+        shopLoaded: true,
+        shop: {
+          id: "shop-1",
+          name: "ProFixIQ Demo Shop",
+          shop_name: null,
+          business_name: null,
+        },
       },
-    },
-    viewerScope: "shop",
-    topSummary: {
-      activeJobs: 8,
-      blockedJobs: 2,
-      waitingApprovals: 3,
-      waitingParts: 4,
-      techniciansClockedIn: 5,
-      appointmentsToday: 2,
-      completedToday: 1,
-    },
-    immediateAttention: [
-      { label: "Waiting for customer approval", value: "3", href: "/work-orders/board?stage=awaiting_approval" },
-    ],
-    todayOperations: [
-      { label: "Open work orders", value: "8", href: "/work-orders/board" },
-    ],
-    quickActions: [
-      { label: "Create Work Order", href: "/work-orders/create", tone: "primary" },
-      { label: "Work Order Board", href: "/work-orders/board", tone: "neutral" },
-    ],
-    recentOperationalActivity: [],
-    activeJobSummary: [{ label: "In progress", value: 8, pct: 80 }],
-    liveShopLoad: [{ label: "Today", count: 8, pct: 80 }],
-    dailySummary: [{ label: "Approval queue", value: "3", tone: "accent" }],
-    liveWork: [
-      {
-        id: "work-order-1",
-        label: "WO-1001",
-        stage: "In progress",
-        risk: "normal",
-        priority: 1,
+      viewerScope: "shop",
+      topSummary: {
+        activeJobs: 8,
+        blockedJobs: 2,
+        waitingApprovals: 3,
+        waitingParts: 4,
+        techniciansClockedIn: 5,
+        appointmentsToday: 2,
+        completedToday: 1,
       },
-    ],
-    technicianActivity: [],
-    blockerStack: [],
-    alerts: [],
-    suggestedActions: [],
-    flowMix: [{ label: "In Progress", value: 8 }],
-    sectionErrors: [],
-    fetchAudit: [],
-  })),
+      immediateAttention: [
+        {
+          label: "Waiting for customer approval",
+          value: "3",
+          href: "/work-orders/board?stage=awaiting_approval",
+        },
+      ],
+      todayOperations: [
+        { label: "Open work orders", value: "8", href: "/work-orders/board" },
+      ],
+      quickActions: [
+        {
+          label: "Create Work Order",
+          href: "/work-orders/create",
+          tone: "primary",
+        },
+        {
+          label: "Work Order Board",
+          href: "/work-orders/board",
+          tone: "neutral",
+        },
+      ],
+      recentOperationalActivity: [],
+      activeJobSummary: [{ label: "In progress", value: 8, pct: 80 }],
+      liveShopLoad: [{ label: "Today", count: 8, pct: 80 }],
+      dailySummary: [{ label: "Approval queue", value: "3", tone: "accent" }],
+      liveWork: [
+        {
+          id: "work-order-1",
+          label: "WO-1001",
+          stage: "In progress",
+          risk: "normal",
+          priority: 1,
+        },
+      ],
+      technicianActivity: [],
+      blockerStack: [],
+      alerts: [],
+      suggestedActions: [],
+      flowMix: [{ label: "In Progress", value: 8 }],
+      sectionErrors: [],
+      fetchAudit: [],
+    }),
+  ),
 }));
 
 vi.mock("../app/dashboard/_components/OperationsCharts", () => ({
@@ -76,9 +90,8 @@ describe("smoke", () => {
   });
 
   it("keeps the operations dashboard focused on core command surfaces", async () => {
-    const { default: OperationsDashboardView } = await import(
-      "../app/dashboard/_components/OperationsDashboardView"
-    );
+    const { default: OperationsDashboardView } =
+      await import("../app/dashboard/_components/OperationsDashboardView");
 
     const markup = renderToStaticMarkup(await OperationsDashboardView());
 
@@ -88,9 +101,10 @@ describe("smoke", () => {
     expect(markup).not.toContain("Download migration report");
 
     expect(markup).toMatch(/Open work orders/i);
-    expect(markup).toContain("Immediate Attention");
+    expect(markup).toContain("Needs attention");
     expect(markup).toContain("Waiting for customer approval");
-    expect(markup).toContain("Quick Actions");
-    expect(markup).toContain("Live Work Command Surface");
+    expect(markup).toContain("Today&#x27;s pulse");
+    expect(markup).toContain("Action rail");
+    expect(markup).toContain("Work in motion");
   });
 });


### PR DESCRIPTION
## What changed

- Rebuilt Shop Overview around a focused operations-command-center hierarchy: KPIs, ranked needs-attention work, today's pulse, action rail, work-in-motion stages, and technician capacity.
- Rebuilt Work Order Board as a compact five-column workflow surface with search, advisor/technician/priority/waiter filters, summary signals, contextual card actions, empty states, and completed history.
- Rebuilt Parts Overview with the same visual system, including ranked bottlenecks, today's pulse, an action rail, catalog health, recent inventory movement, and the agreed four-stage parts flow: Needs Quote, Awaiting Approval, Order & Receive, and Ready for Tech.
- Corrected ambiguous parts metrics by showing distinct active work orders, open request records, and individual open items separately. Fulfilled requests stay out of active counts and appear through completed history.
- Kept live payload data, canonical routes, permissions, role-aware navigation, and existing server boundaries.

## Impact

The three primary operations surfaces now share one hierarchy and interaction language. Advisors and parts staff can distinguish workload units correctly, identify the next action faster, and use the dashboards comfortably on tablets.

## Validation

- `npx tsc --noEmit`
- ESLint passed for all changed dashboard files
- Shop/work-order focused suite: 29 tests passed
- Parts dashboard and lifecycle suite: 22 tests passed
- `git diff --check`

One unrelated pre-existing test file, `tests/phase3-parts-atomic-routes.test.ts`, currently fails before assertions because its dynamic file URL resolves to `tests/undefined`; this change does not modify that test or those routes.

No database migration is required.