### PR TITLE
Connect Instant Shop Analysis to guided onboarding

### DIFF
--- a/app/api/demo/shop-boost/activate/route.ts
+++ b/app/api/demo/shop-boost/activate/route.ts
@@ -84,12 +84,45 @@ export async function POST(req: NextRequest) {
 
   const { data: demoRow, error: demoErr } = await admin
     .from("demo_shop_boosts")
-    .select("id,snapshot")
+    .select("id,snapshot,shop_id")
     .eq("id", demoId)
     .maybeSingle();
 
   if (demoErr || !demoRow?.snapshot) {
     return NextResponse.json({ ok: false, error: "Preview expired. Please run analysis again." }, { status: 404 });
+  }
+
+  if (demoRow.shop_id && demoRow.shop_id !== shopId) {
+    return NextResponse.json(
+      { ok: false, error: "This analysis has already been activated by another shop." },
+      { status: 403 },
+    );
+  }
+
+  const normalizedUserEmail = user.email?.trim().toLowerCase() ?? "";
+  if (!normalizedUserEmail) {
+    return NextResponse.json(
+      { ok: false, error: "A verified account email is required to activate this analysis." },
+      { status: 403 },
+    );
+  }
+
+  const { data: claimedLead, error: claimedLeadError } = await admin
+    .from("demo_shop_boost_leads")
+    .select("id")
+    .eq("demo_id", demoId)
+    .eq("email", normalizedUserEmail)
+    .maybeSingle();
+
+  if (claimedLeadError || !claimedLead?.id) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          "Sign in with the same email used to unlock this analysis, or return to the report and unlock it first.",
+      },
+      { status: 403 },
+    );
   }
 
   const snapshot = isRecord(demoRow.snapshot) ? demoRow.snapshot : null;

--- a/app/api/demo/shop-boost/activate/route.ts
+++ b/app/api/demo/shop-boost/activate/route.ts
@@ -6,9 +6,10 @@ import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
 import { runShopBoostImport } from "@/features/integrations/imports/runFullImport";
 import { updateIntakeProgress } from "@/features/integrations/shopBoost/status";
 import {
-  SHOP_BOOST_UPLOAD_DATASET_KEYS,
+  INSTANT_SHOP_ANALYSIS_DATASET_KEYS,
   type ShopBoostUploadDatasetKey,
 } from "@/features/integrations/shopBoost/uploadDatasets";
+import { mapInstantAnalysisToGuidedOnboarding } from "@/features/onboarding-v2/guided/instantAnalysisHandoff";
 
 type DB = Database;
 
@@ -34,7 +35,7 @@ function extractPaths(snapshot: unknown): Partial<Record<ShopBoostUploadDatasetK
   const uploadPaths = isRecord(root.activationUploadPaths) ? root.activationUploadPaths : {};
   const result: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
 
-  for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+  for (const key of INSTANT_SHOP_ANALYSIS_DATASET_KEYS) {
     const value = uploadPaths[key];
     if (typeof value === "string" && value.length > 0) {
       result[key] = value;
@@ -98,7 +99,9 @@ export async function POST(req: NextRequest) {
   }
 
   const sourcePaths = extractPaths(snapshot);
-  if (Object.keys(sourcePaths).length === 0) {
+  const questionnaire = isRecord(snapshot.questionnaire) ? snapshot.questionnaire : {};
+  const uploadedDatasets = Object.keys(sourcePaths) as ShopBoostUploadDatasetKey[];
+  if (uploadedDatasets.length === 0) {
     return NextResponse.json({ ok: false, error: "Preview files expired. Please run analysis again." }, { status: 410 });
   }
 
@@ -110,7 +113,21 @@ export async function POST(req: NextRequest) {
     .maybeSingle();
 
   if (existing.data?.id) {
-    return NextResponse.json({ ok: true, intakeId, status: existing.data.status, reused: true });
+    const guided = await mapInstantAnalysisToGuidedOnboarding({
+      shopId,
+      userId: user.id,
+      demoId,
+      intakeId,
+      uploadedDatasets,
+    });
+    return NextResponse.json({
+      ok: true,
+      intakeId,
+      status: existing.data.status,
+      reused: true,
+      guidedSessionId: guided.sessionId,
+      redirectTo: guided.redirectTo,
+    });
   }
 
   const copiedPaths: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
@@ -126,10 +143,26 @@ export async function POST(req: NextRequest) {
     copiedPaths[datasetKey] = targetPath;
   }
 
+  const uploadManifest = Object.fromEntries(
+    uploadedDatasets.map((dataset) => [
+      dataset,
+      {
+        dataset,
+        path: copiedPaths[dataset],
+        fileName: copiedPaths[dataset] ? pathBasename(copiedPaths[dataset]!) : null,
+        contentType: "text/csv",
+        sizeBytes: null,
+        target: dataset,
+        importMode: dataset === "invoices" ? "staging" : "direct",
+      },
+    ]),
+  );
+
   const intakeInsert: DB["public"]["Tables"]["shop_boost_intakes"]["Insert"] = {
     id: intakeId,
     shop_id: shopId,
-    questionnaire: {},
+    questionnaire:
+      questionnaire as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["questionnaire"],
     customers_file_path: copiedPaths.customers ?? null,
     vehicles_file_path: copiedPaths.vehicles ?? null,
     parts_file_path: copiedPaths.parts ?? null,
@@ -140,6 +173,7 @@ export async function POST(req: NextRequest) {
       demoId,
       activatedByUserId: user.id,
       activatedAt: new Date().toISOString(),
+      uploadManifest,
     },
     status: "pending",
   };
@@ -200,5 +234,34 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  return NextResponse.json({ ok: true, intakeId, status: completedStatus });
+  const guided = await mapInstantAnalysisToGuidedOnboarding({
+    shopId,
+    userId: user.id,
+    demoId,
+    intakeId,
+    uploadedDatasets,
+    importSummary,
+  });
+
+  const { error: demoLinkError } = await admin
+    .from("demo_shop_boosts")
+    .update({ shop_id: shopId, intake_id: intakeId })
+    .eq("id", demoId);
+
+  if (demoLinkError) {
+    console.warn("[demo/shop-boost/activate] Failed to persist demo ownership link", {
+      demoId,
+      intakeId,
+      shopId,
+      error: demoLinkError.message,
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    intakeId,
+    status: completedStatus,
+    guidedSessionId: guided.sessionId,
+    redirectTo: guided.redirectTo,
+  });
 }

--- a/app/api/demo/shop-boost/run/route.ts
+++ b/app/api/demo/shop-boost/run/route.ts
@@ -8,7 +8,7 @@ import {
   type ShadowShopSnapshot,
 } from "@/features/integrations/shopBoost/shadowShop";
 import {
-  SHOP_BOOST_UPLOAD_DATASET_KEYS,
+  INSTANT_SHOP_ANALYSIS_DATASET_KEYS,
   type ShopBoostUploadDatasetKey,
 } from "@/features/integrations/shopBoost/uploadDatasets";
 
@@ -71,8 +71,22 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
         ? rawCountry
         : "US";
 
+    const rawQuestionnaire = formData.get("questionnaire");
+    let questionnaire: Record<string, unknown> = {};
+    if (typeof rawQuestionnaire === "string" && rawQuestionnaire.trim()) {
+      try {
+        const parsed = JSON.parse(rawQuestionnaire) as unknown;
+        if (isRecord(parsed)) questionnaire = parsed;
+      } catch {
+        return NextResponse.json(
+          { ok: false, error: "Shop profile answers were invalid. Please try again." },
+          { status: 400 },
+        );
+      }
+    }
+
     const filesByDataset: Partial<Record<ShopBoostUploadDatasetKey, File>> = {};
-    for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
+    for (const key of INSTANT_SHOP_ANALYSIS_DATASET_KEYS) {
       const file = asFile(formData.get(`${key}File`));
       if (file) filesByDataset[key] = file;
     }
@@ -111,6 +125,7 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
     const activationUploadPaths = Object.fromEntries(uploadedPathEntries);
     const snapshotWithActivation = {
       ...snapshot,
+      questionnaire,
       activationUploadPaths,
     };
 

--- a/app/demo/instant-shop-analysis/page.tsx
+++ b/app/demo/instant-shop-analysis/page.tsx
@@ -170,7 +170,7 @@ export default function InstantShopAnalysisPage() {
       : "/compare-plans";
     const signupHref = `/signup?redirect=${encodeURIComponent(next)}${
       demoId ? `&demoId=${encodeURIComponent(demoId)}` : ""
-    }${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}`;
+    }${intakeId ? `&intakeId=${encodeURIComponent(intakeId)}` : ""}${email.trim() ? `&email=${encodeURIComponent(email.trim().toLowerCase())}` : ""}`;
     window.location.href = activationContext
       ? appendActivationContextToHref(signupHref, activationContext)
       : signupHref;

--- a/app/demo/instant-shop-analysis/page.tsx
+++ b/app/demo/instant-shop-analysis/page.tsx
@@ -6,7 +6,7 @@ import { appendActivationContextToHref, type ActivationContext } from "@/feature
 import type { ShopBoostPreflightReport } from "@/features/integrations/shopBoost/preflightAnalysis";
 import type { ShadowShopSnapshot } from "@/features/integrations/shopBoost/shadowShop";
 import {
-  SHOP_BOOST_UPLOAD_DATASETS,
+  INSTANT_SHOP_ANALYSIS_DATASETS,
   type ShopBoostUploadDatasetKey,
 } from "@/features/integrations/shopBoost/uploadDatasets";
 
@@ -441,7 +441,7 @@ export default function InstantShopAnalysisPage() {
               </div>
 
               <div className="space-y-3 text-xs">
-                {SHOP_BOOST_UPLOAD_DATASETS.map((dataset) => (
+                {INSTANT_SHOP_ANALYSIS_DATASETS.map((dataset) => (
                   <FileRow
                     key={dataset.key}
                     id={`demo-${dataset.key}`}

--- a/app/onboarding/shop-boost/page.tsx
+++ b/app/onboarding/shop-boost/page.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { readPersistedActivationContext } from "@/features/integrations/shopBoost/activationContext";
+
+type ActivationResponse =
+  | { ok: true; redirectTo: string; guidedSessionId: string; intakeId: string; status: string }
+  | { ok: false; error: string };
+
+export default function ShopBoostOnboardingHandoffPage() {
+  const [message, setMessage] = useState("Preparing your analyzed shop…");
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  const activate = useCallback(async () => {
+    setError(null);
+    const context = readPersistedActivationContext();
+    if (!context) {
+      setError("Your saved analysis context could not be found. Return to Instant Shop Analysis to resume it.");
+      return;
+    }
+
+    setMessage("Importing your analyzed data and preparing guided setup…");
+
+    try {
+      const response = await fetch("/api/demo/shop-boost/activate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ demoId: context.demoId, intakeId: context.intakeId }),
+      });
+      const payload = (await response.json().catch(() => null)) as ActivationResponse | null;
+
+      if (!response.ok || !payload?.ok) {
+        setError(payload && !payload.ok ? payload.error : "We could not activate this analysis.");
+        return;
+      }
+
+      setMessage("Your data is ready. Opening your personalized setup…");
+      window.location.replace(payload.redirectTo);
+    } catch (activationError) {
+      setError(
+        activationError instanceof Error
+          ? activationError.message
+          : "We could not activate this analysis.",
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    void activate();
+  }, [activate, attempt]);
+
+  return (
+    <main className="grid min-h-screen place-items-center bg-[color:var(--theme-surface-page)] px-4 text-[color:var(--theme-text-primary)]">
+      <section className="w-full max-w-xl rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-7 text-center shadow-[var(--theme-shadow-medium)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Instant Shop Analysis
+        </p>
+        <h1 className="mt-3 text-2xl font-semibold">Building your real ProFixIQ workspace</h1>
+        {!error ? (
+          <>
+            <div className="mx-auto mt-6 h-12 w-12 animate-spin rounded-full border-4 border-[color:var(--theme-border-soft)] border-t-[var(--accent-copper)]" />
+            <p className="mt-5 text-sm text-[color:var(--theme-text-secondary)]">{message}</p>
+            <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
+              Customers, vehicles, history, invoices, and parts are being connected to guided onboarding.
+            </p>
+          </>
+        ) : (
+          <div className="mt-6 rounded-2xl border border-red-400/30 bg-red-500/10 p-4">
+            <p className="text-sm text-red-200">{error}</p>
+            <div className="mt-4 flex flex-wrap justify-center gap-2">
+              <button
+                type="button"
+                onClick={() => setAttempt((value) => value + 1)}
+                className="rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)]"
+              >
+                Try again
+              </button>
+              <Link
+                href="/demo/instant-shop-analysis"
+                className="rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-2 text-sm"
+              >
+                Return to analysis
+              </Link>
+              <Link
+                href="/dashboard/onboarding-v2"
+                className="rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-2 text-sm"
+              >
+                Continue without analysis
+              </Link>
+            </div>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -25,7 +25,7 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
   const searchParams = useSearchParams();
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [mode, setMode] = useState<Mode>(initialMode);
-  const [identifier, setIdentifier] = useState("");
+  const [identifier, setIdentifier] = useState(() => searchParams.get("email")?.trim().toLowerCase() ?? "");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -114,7 +114,12 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         setNotice("Check your email to verify the account, then continue into shop setup.");
         return;
       }
-      router.replace("/onboarding");
+      const destination = await resolvePostAuthDestination({
+        supabase,
+        searchParams,
+        defaultDashboardHref: "/onboarding",
+      });
+      router.replace(destination);
     } finally {
       setLoading(false);
     }

--- a/features/integrations/shopBoost/preflightAnalysis.ts
+++ b/features/integrations/shopBoost/preflightAnalysis.ts
@@ -70,6 +70,7 @@ function prettyDomain(entityType: string): string {
   if (entityType === "vehicles") return "Vehicles";
   if (entityType === "parts") return "Parts";
   if (entityType === "history") return "Work orders";
+  if (entityType === "invoices") return "Invoices";
   if (entityType === "staff") return "Staff";
   return entityType;
 }

--- a/features/integrations/shopBoost/shadowShop.ts
+++ b/features/integrations/shopBoost/shadowShop.ts
@@ -19,8 +19,8 @@ import {
 
 type CsvRow = Record<string, string>;
 
-type ShadowDomainKey = "customers" | "vehicles" | "history" | "parts" | "staff";
-const SHADOW_DATASET_KEYS: ShadowDomainKey[] = ["customers", "vehicles", "history", "parts", "staff"];
+type ShadowDomainKey = "customers" | "vehicles" | "history" | "invoices" | "parts" | "staff";
+const SHADOW_DATASET_KEYS: ShadowDomainKey[] = ["customers", "vehicles", "history", "invoices", "parts", "staff"];
 
 type ShadowStagedRow = {
   id: string;
@@ -284,6 +284,7 @@ function buildItems(rows: ShadowStagedRow[], domain: ShadowDomainKey): ShadowPre
 
 function mapEntityType(key: ShadowDomainKey): string {
   if (key === "history") return "history";
+  if (key === "invoices") return "invoices";
   return key;
 }
 
@@ -325,6 +326,24 @@ function stageRowsByDomain(rows: CsvRow[], domain: ShadowDomainKey): ShadowStage
         confidence,
         reviewFlag: confidence < 75,
         blocked: !row.work_order && !row.invoice_number,
+      };
+    }
+
+    if (domain === "invoices") {
+      const confidence = confidenceFromCompleteness(row, [
+        "invoice_number",
+        "customer",
+        "total",
+        "date",
+      ]);
+      return {
+        id: `invoice-${index}`,
+        domain,
+        raw: row,
+        normalized: row,
+        confidence,
+        reviewFlag: confidence < 75,
+        blocked: !row.invoice_number && !row.invoice && !row.order_number,
       };
     }
 
@@ -686,6 +705,7 @@ export async function buildShadowShopSnapshot(args: {
     customers: [],
     vehicles: [],
     history: [],
+    invoices: [],
     parts: [],
     staff: [],
   };
@@ -694,6 +714,7 @@ export async function buildShadowShopSnapshot(args: {
     customers: { count: 0, fileName: null },
     vehicles: { count: 0, fileName: null },
     history: { count: 0, fileName: null },
+    invoices: { count: 0, fileName: null },
     parts: { count: 0, fileName: null },
     staff: { count: 0, fileName: null },
   };
@@ -716,6 +737,7 @@ export async function buildShadowShopSnapshot(args: {
     customers: stageRowsByDomain(parsedRowsByDomain.customers, "customers"),
     vehicles: stageRowsByDomain(parsedRowsByDomain.vehicles, "vehicles"),
     history: stageRowsByDomain(parsedRowsByDomain.history, "history"),
+    invoices: stageRowsByDomain(parsedRowsByDomain.invoices, "invoices"),
     parts: stageRowsByDomain(parsedRowsByDomain.parts, "parts"),
     staff: stageRowsByDomain(parsedRowsByDomain.staff, "staff"),
   };

--- a/features/integrations/shopBoost/uploadDatasets.ts
+++ b/features/integrations/shopBoost/uploadDatasets.ts
@@ -93,3 +93,19 @@ export const SHOP_BOOST_DIRECT_IMPORT_DATASETS: ShopBoostUploadDatasetKey[] = [
 ];
 
 export const SHOP_BOOST_UPLOAD_DATASET_KEYS = SHOP_BOOST_UPLOAD_DATASETS.map((d) => d.key);
+
+export const INSTANT_SHOP_ANALYSIS_DATASET_KEYS = [
+  "customers",
+  "vehicles",
+  "history",
+  "invoices",
+  "parts",
+] as const satisfies readonly ShopBoostUploadDatasetKey[];
+
+const instantAnalysisDatasetKeySet = new Set<ShopBoostUploadDatasetKey>(
+  INSTANT_SHOP_ANALYSIS_DATASET_KEYS,
+);
+
+export const INSTANT_SHOP_ANALYSIS_DATASETS = SHOP_BOOST_UPLOAD_DATASETS.filter((dataset) =>
+  instantAnalysisDatasetKeySet.has(dataset.key),
+);

--- a/features/onboarding-v2/guided/instantAnalysisHandoff.ts
+++ b/features/onboarding-v2/guided/instantAnalysisHandoff.ts
@@ -1,10 +1,136 @@
 import "server-only";
 
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import type { ShopBoostImportSummary } from "@/features/integrations/imports/runFullImport";
 import type { ShopBoostUploadDatasetKey } from "@/features/integrations/shopBoost/uploadDatasets";
 import { GUIDED_ONBOARDING_STEPS } from "@/features/onboarding-v2/guided/steps";
 import type { GuidedOnboardingStepKey } from "@/features/onboarding-v2/guided/types";
+
+
+type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+type GuidedDatabase = {
+  public: {
+    Tables: {
+      guided_onboarding_sessions: {
+        Row: {
+          id: string;
+          shop_id: string;
+          created_by: string | null;
+          status: string;
+          current_step_key: string | null;
+          existing_system: string | null;
+          started_at: string | null;
+          completed_at: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          shop_id: string;
+          created_by?: string | null;
+          status?: string;
+          current_step_key?: string | null;
+          existing_system?: string | null;
+          started_at?: string | null;
+          completed_at?: string | null;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          status?: string;
+          current_step_key?: string | null;
+          existing_system?: string | null;
+          completed_at?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
+      guided_onboarding_steps: {
+        Row: {
+          id: string;
+          session_id: string;
+          shop_id: string;
+          step_key: string;
+          destination_path: string;
+          title: string;
+          question: string;
+          description: string;
+          highlight_key: string;
+          status: string;
+          answer: Json;
+          started_at: string | null;
+          completed_at: string | null;
+          skipped_at: string | null;
+          created_at: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          session_id: string;
+          shop_id: string;
+          step_key: string;
+          destination_path: string;
+          title: string;
+          question: string;
+          description?: string;
+          highlight_key: string;
+          status?: string;
+          answer?: Json;
+          started_at?: string | null;
+          completed_at?: string | null;
+          skipped_at?: string | null;
+          created_at?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          status?: string;
+          answer?: Json;
+          started_at?: string | null;
+          completed_at?: string | null;
+          skipped_at?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
+      guided_onboarding_events: {
+        Row: {
+          id: string;
+          session_id: string;
+          shop_id: string;
+          step_key: string | null;
+          event_type: string;
+          payload: Json;
+          created_by: string | null;
+          created_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          session_id: string;
+          shop_id: string;
+          step_key?: string | null;
+          event_type: string;
+          payload?: Json;
+          created_by?: string | null;
+          created_at?: string | null;
+        };
+        Update: never;
+        Relationships: [];
+      };
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+};
 
 const DATASET_TO_GUIDED_STEP: Partial<Record<ShopBoostUploadDatasetKey, GuidedOnboardingStepKey>> = {
   customers: "customers",
@@ -72,7 +198,7 @@ export async function mapInstantAnalysisToGuidedOnboarding(args: {
   uploadedDatasets: ShopBoostUploadDatasetKey[];
   importSummary?: ShopBoostImportSummary;
 }): Promise<{ sessionId: string; redirectTo: string }> {
-  const admin = createAdminSupabase();
+  const admin = createAdminSupabase() as unknown as SupabaseClient<GuidedDatabase>;
   const now = new Date().toISOString();
 
   const { data: existingSession, error: existingSessionError } = await admin

--- a/features/onboarding-v2/guided/instantAnalysisHandoff.ts
+++ b/features/onboarding-v2/guided/instantAnalysisHandoff.ts
@@ -25,9 +25,11 @@ function emptyDomainResult(): DomainResult {
 }
 
 function domainResult(
-  summary: ShopBoostImportSummary,
+  summary: ShopBoostImportSummary | undefined,
   dataset: ShopBoostUploadDatasetKey,
 ): DomainResult {
+  if (!summary) return emptyDomainResult();
+
   const candidates =
     dataset === "history"
       ? ["history", "work_order", "work_orders"]
@@ -50,9 +52,10 @@ function domainResult(
 }
 
 function importedCount(
-  summary: ShopBoostImportSummary,
+  summary: ShopBoostImportSummary | undefined,
   dataset: ShopBoostUploadDatasetKey,
 ): number {
+  if (!summary) return 0;
   if (dataset === "customers") return summary.customersImported;
   if (dataset === "vehicles") return summary.vehiclesImported;
   if (dataset === "history") return summary.workOrdersImported;
@@ -67,7 +70,7 @@ export async function mapInstantAnalysisToGuidedOnboarding(args: {
   demoId: string;
   intakeId: string;
   uploadedDatasets: ShopBoostUploadDatasetKey[];
-  importSummary: ShopBoostImportSummary;
+  importSummary?: ShopBoostImportSummary;
 }): Promise<{ sessionId: string; redirectTo: string }> {
   const admin = createAdminSupabase();
   const now = new Date().toISOString();
@@ -205,10 +208,10 @@ export async function mapInstantAnalysisToGuidedOnboarding(args: {
       demoId: args.demoId,
       intakeId: args.intakeId,
       uploadedDatasets: mappedDatasets.map((item) => item.dataset),
-      completionState: args.importSummary.completionState,
+      completionState: args.importSummary?.completionState ?? "unknown",
       reviewPhasePending:
-        args.importSummary.rowResults.reviewCount > 0 ||
-        args.importSummary.rowResults.failedCount > 0,
+        (args.importSummary?.rowResults.reviewCount ?? 0) > 0 ||
+        (args.importSummary?.rowResults.failedCount ?? 0) > 0,
     },
     created_by: args.userId,
   });

--- a/features/onboarding-v2/guided/instantAnalysisHandoff.ts
+++ b/features/onboarding-v2/guided/instantAnalysisHandoff.ts
@@ -1,0 +1,222 @@
+import "server-only";
+
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import type { ShopBoostImportSummary } from "@/features/integrations/imports/runFullImport";
+import type { ShopBoostUploadDatasetKey } from "@/features/integrations/shopBoost/uploadDatasets";
+import { GUIDED_ONBOARDING_STEPS } from "@/features/onboarding-v2/guided/steps";
+import type { GuidedOnboardingStepKey } from "@/features/onboarding-v2/guided/types";
+
+const DATASET_TO_GUIDED_STEP: Partial<Record<ShopBoostUploadDatasetKey, GuidedOnboardingStepKey>> = {
+  customers: "customers",
+  vehicles: "vehicles",
+  history: "vehicle_history",
+  invoices: "invoices",
+  parts: "parts",
+};
+
+type DomainResult = {
+  success: number;
+  review: number;
+  failed: number;
+};
+
+function emptyDomainResult(): DomainResult {
+  return { success: 0, review: 0, failed: 0 };
+}
+
+function domainResult(
+  summary: ShopBoostImportSummary,
+  dataset: ShopBoostUploadDatasetKey,
+): DomainResult {
+  const candidates =
+    dataset === "history"
+      ? ["history", "work_order", "work_orders"]
+      : dataset === "invoices"
+        ? ["invoices", "invoice"]
+        : dataset === "customers"
+          ? ["customers", "customer"]
+          : dataset === "vehicles"
+            ? ["vehicles", "vehicle"]
+            : dataset === "parts"
+              ? ["parts", "part"]
+              : [dataset];
+
+  for (const key of candidates) {
+    const result = summary.rowResults.byDomain[key];
+    if (result) return result;
+  }
+
+  return emptyDomainResult();
+}
+
+function importedCount(
+  summary: ShopBoostImportSummary,
+  dataset: ShopBoostUploadDatasetKey,
+): number {
+  if (dataset === "customers") return summary.customersImported;
+  if (dataset === "vehicles") return summary.vehiclesImported;
+  if (dataset === "history") return summary.workOrdersImported;
+  if (dataset === "invoices") return summary.invoicesImported;
+  if (dataset === "parts") return summary.partsImported;
+  return 0;
+}
+
+export async function mapInstantAnalysisToGuidedOnboarding(args: {
+  shopId: string;
+  userId: string;
+  demoId: string;
+  intakeId: string;
+  uploadedDatasets: ShopBoostUploadDatasetKey[];
+  importSummary: ShopBoostImportSummary;
+}): Promise<{ sessionId: string; redirectTo: string }> {
+  const admin = createAdminSupabase();
+  const now = new Date().toISOString();
+
+  const { data: existingSession, error: existingSessionError } = await admin
+    .from("guided_onboarding_sessions")
+    .select("id")
+    .eq("shop_id", args.shopId)
+    .eq("status", "active")
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle<{ id: string }>();
+
+  if (existingSessionError) throw new Error(existingSessionError.message);
+
+  let sessionId = existingSession?.id ?? null;
+
+  if (!sessionId) {
+    const { data: createdSession, error: createSessionError } = await admin
+      .from("guided_onboarding_sessions")
+      .insert({
+        shop_id: args.shopId,
+        created_by: args.userId,
+        status: "active",
+        existing_system: "instant_shop_analysis",
+        current_step_key: GUIDED_ONBOARDING_STEPS[0]?.key ?? null,
+      })
+      .select("id")
+      .single<{ id: string }>();
+
+    if (createSessionError || !createdSession?.id) {
+      throw new Error(createSessionError?.message ?? "Failed to create guided onboarding session.");
+    }
+    sessionId = createdSession.id;
+  }
+
+  const { data: existingSteps, error: existingStepsError } = await admin
+    .from("guided_onboarding_steps")
+    .select("step_key")
+    .eq("shop_id", args.shopId)
+    .eq("session_id", sessionId);
+
+  if (existingStepsError) throw new Error(existingStepsError.message);
+
+  const existingStepKeys = new Set((existingSteps ?? []).map((step) => step.step_key));
+  const missingSteps = GUIDED_ONBOARDING_STEPS.filter((step) => !existingStepKeys.has(step.key));
+
+  if (missingSteps.length > 0) {
+    const { error: seedError } = await admin.from("guided_onboarding_steps").insert(
+      missingSteps.map((step) => ({
+        session_id: sessionId,
+        shop_id: args.shopId,
+        step_key: step.key,
+        destination_path: step.destinationPath,
+        title: step.title,
+        question: step.question,
+        description: step.shortDescription,
+        highlight_key: step.highlightQuery?.highlight ?? step.key,
+        status: "not_started",
+        answer: {},
+      })),
+    );
+    if (seedError) throw new Error(seedError.message);
+  }
+
+  const mappedDatasets = args.uploadedDatasets.flatMap((dataset) => {
+    const stepKey = DATASET_TO_GUIDED_STEP[dataset];
+    return stepKey ? [{ dataset, stepKey }] : [];
+  });
+
+  for (const { dataset, stepKey } of mappedDatasets) {
+    const result = domainResult(args.importSummary, dataset);
+    const { error: updateStepError } = await admin
+      .from("guided_onboarding_steps")
+      .update({
+        status: "completed",
+        answer: {
+          source: "instant_shop_analysis",
+          demoId: args.demoId,
+          intakeId: args.intakeId,
+          dataset,
+          importedCount: importedCount(args.importSummary, dataset),
+          successCount: result.success,
+          reviewCount: result.review,
+          failedCount: result.failed,
+          reviewPhasePending: result.review > 0 || result.failed > 0,
+        },
+        started_at: now,
+        completed_at: now,
+        skipped_at: null,
+        updated_at: now,
+      })
+      .eq("shop_id", args.shopId)
+      .eq("session_id", sessionId)
+      .eq("step_key", stepKey);
+
+    if (updateStepError) throw new Error(updateStepError.message);
+  }
+
+  const { data: finalSteps, error: finalStepsError } = await admin
+    .from("guided_onboarding_steps")
+    .select("step_key,status")
+    .eq("shop_id", args.shopId)
+    .eq("session_id", sessionId);
+
+  if (finalStepsError) throw new Error(finalStepsError.message);
+
+  const statusByStep = new Map((finalSteps ?? []).map((step) => [step.step_key, step.status]));
+  const nextStep =
+    GUIDED_ONBOARDING_STEPS.find((step) => {
+      const status = statusByStep.get(step.key);
+      return status !== "completed" && status !== "skipped";
+    })?.key ?? null;
+
+  const { error: updateSessionError } = await admin
+    .from("guided_onboarding_sessions")
+    .update({
+      existing_system: "instant_shop_analysis",
+      current_step_key: nextStep,
+      status: nextStep ? "active" : "completed",
+      completed_at: nextStep ? null : now,
+      updated_at: now,
+    })
+    .eq("id", sessionId)
+    .eq("shop_id", args.shopId);
+
+  if (updateSessionError) throw new Error(updateSessionError.message);
+
+  const { error: eventError } = await admin.from("guided_onboarding_events").insert({
+    session_id: sessionId,
+    shop_id: args.shopId,
+    step_key: nextStep,
+    event_type: "instant_analysis_mapped",
+    payload: {
+      demoId: args.demoId,
+      intakeId: args.intakeId,
+      uploadedDatasets: mappedDatasets.map((item) => item.dataset),
+      completionState: args.importSummary.completionState,
+      reviewPhasePending:
+        args.importSummary.rowResults.reviewCount > 0 ||
+        args.importSummary.rowResults.failedCount > 0,
+    },
+    created_by: args.userId,
+  });
+
+  if (eventError) throw new Error(eventError.message);
+
+  return {
+    sessionId,
+    redirectTo: `/dashboard/onboarding-v2/${sessionId}`,
+  };
+}

--- a/features/onboarding-v2/guided/instantAnalysisHandoff.ts
+++ b/features/onboarding-v2/guided/instantAnalysisHandoff.ts
@@ -235,13 +235,14 @@ export async function mapInstantAnalysisToGuidedOnboarding(args: {
 
   const { data: existingSteps, error: existingStepsError } = await admin
     .from("guided_onboarding_steps")
-    .select("step_key")
+    .select("step_key,status,answer")
     .eq("shop_id", args.shopId)
     .eq("session_id", sessionId);
 
   if (existingStepsError) throw new Error(existingStepsError.message);
 
-  const existingStepKeys = new Set((existingSteps ?? []).map((step) => step.step_key));
+  const existingStepByKey = new Map((existingSteps ?? []).map((step) => [step.step_key, step]));
+  const existingStepKeys = new Set(existingStepByKey.keys());
   const missingSteps = GUIDED_ONBOARDING_STEPS.filter((step) => !existingStepKeys.has(step.key));
 
   if (missingSteps.length > 0) {
@@ -268,6 +269,9 @@ export async function mapInstantAnalysisToGuidedOnboarding(args: {
   });
 
   for (const { dataset, stepKey } of mappedDatasets) {
+    const existingStep = existingStepByKey.get(stepKey);
+    if (!args.importSummary && existingStep?.status === "completed") continue;
+
     const result = domainResult(args.importSummary, dataset);
     const { error: updateStepError } = await admin
       .from("guided_onboarding_steps")

--- a/tests/instant-shop-analysis-guided-onboarding.test.ts
+++ b/tests/instant-shop-analysis-guided-onboarding.test.ts
@@ -57,6 +57,8 @@ describe("instant shop analysis guided onboarding handoff", () => {
     expect(handoff).toContain('parts: "parts"');
     expect(handoff).toContain('event_type: "instant_analysis_mapped"');
     expect(handoff).toContain("reviewPhasePending");
+    expect(handoff).toContain('select("step_key,status,answer")');
+    expect(handoff).toContain('!args.importSummary && existingStep?.status === "completed"');
   });
 
   it("binds activation to the unlocked email and provides a retry-safe handoff page", () => {

--- a/tests/instant-shop-analysis-guided-onboarding.test.ts
+++ b/tests/instant-shop-analysis-guided-onboarding.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  INSTANT_SHOP_ANALYSIS_DATASET_KEYS,
+  INSTANT_SHOP_ANALYSIS_DATASETS,
+} from "@/features/integrations/shopBoost/uploadDatasets";
+
+function read(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("instant shop analysis guided onboarding handoff", () => {
+  it("uses only the five datasets owned by guided onboarding", () => {
+    expect(INSTANT_SHOP_ANALYSIS_DATASET_KEYS).toEqual([
+      "customers",
+      "vehicles",
+      "history",
+      "invoices",
+      "parts",
+    ]);
+    expect(INSTANT_SHOP_ANALYSIS_DATASETS.map((dataset) => dataset.key)).toEqual(
+      INSTANT_SHOP_ANALYSIS_DATASET_KEYS,
+    );
+  });
+
+  it("renders only the canonical instant-analysis dataset list", () => {
+    const source = read("app/demo/instant-shop-analysis/page.tsx");
+
+    expect(source).toContain("INSTANT_SHOP_ANALYSIS_DATASETS.map");
+    expect(source).not.toContain("SHOP_BOOST_UPLOAD_DATASETS.map");
+  });
+
+  it("preserves questionnaire context and invoice analysis", () => {
+    const runRoute = read("app/api/demo/shop-boost/run/route.ts");
+    const shadowShop = read("features/integrations/shopBoost/shadowShop.ts");
+
+    expect(runRoute).toContain('formData.get("questionnaire")');
+    expect(runRoute).toContain("questionnaire,");
+    expect(shadowShop).toContain('"invoices" | "parts"');
+    expect(shadowShop).toContain('invoices: stageRowsByDomain(parsedRowsByDomain.invoices, "invoices")');
+  });
+
+  it("copies the full upload manifest and maps activation into guided onboarding", () => {
+    const activation = read("app/api/demo/shop-boost/activate/route.ts");
+    const handoff = read("features/onboarding-v2/guided/instantAnalysisHandoff.ts");
+
+    expect(activation).toContain("uploadManifest");
+    expect(activation).toContain("mapInstantAnalysisToGuidedOnboarding");
+    expect(activation).toContain("guidedSessionId");
+    expect(activation).toContain("redirectTo");
+
+    expect(handoff).toContain('customers: "customers"');
+    expect(handoff).toContain('vehicles: "vehicles"');
+    expect(handoff).toContain('history: "vehicle_history"');
+    expect(handoff).toContain('invoices: "invoices"');
+    expect(handoff).toContain('parts: "parts"');
+    expect(handoff).toContain('event_type: "instant_analysis_mapped"');
+    expect(handoff).toContain("reviewPhasePending");
+  });
+
+  it("binds activation to the unlocked email and provides a retry-safe handoff page", () => {
+    const activation = read("app/api/demo/shop-boost/activate/route.ts");
+    const handoffPage = read("app/onboarding/shop-boost/page.tsx");
+    const signIn = read("features/auth/components/SignIn.tsx");
+
+    expect(activation).toContain('.from("demo_shop_boost_leads")');
+    expect(activation).toContain('.eq("email", normalizedUserEmail)');
+    expect(activation).toContain("demoRow.shop_id !== shopId");
+    expect(handoffPage).toContain('fetch("/api/demo/shop-boost/activate"');
+    expect(handoffPage).toContain("readPersistedActivationContext");
+    expect(signIn).toContain("resolvePostAuthDestination");
+    expect(signIn).not.toContain('router.replace("/onboarding")');
+  });
+});


### PR DESCRIPTION
## What changed

- narrows Instant Shop Analysis to the five datasets used by guided onboarding: customers, vehicles, history, invoices, and parts
- persists the shop questionnaire instead of discarding it
- includes invoices in the shadow preflight analysis
- carries all five copied files through the activated intake upload manifest
- adds the missing `/onboarding/shop-boost` activation handoff expected by middleware
- creates or resumes guided onboarding after activation
- marks only uploaded data steps complete and stores import/review/failure counts for the later review phase
- redirects the owner into the personalized guided onboarding session
- preserves activation context through immediate-session signup
- binds activation to the verified account email that unlocked the report and prevents cross-shop reuse
- makes activation retries preserve completed step counts and reuse the existing guided session

## Root cause

Instant Shop Analysis, activation, authentication, and guided onboarding existed as separate flows. The activation endpoint had no UI caller, questionnaire and invoice paths were not carried through correctly, and no lifecycle code reconciled an activated intake with guided onboarding.

## User impact

A shop can now analyze the same five data domains used during onboarding, create its account, activate the staged files into its real shop, and continue guided onboarding without repeating successfully uploaded data steps.

Failed and needs-review item UI is intentionally deferred. Counts and a `reviewPhasePending` marker are persisted now so that follow-up can be added without changing this handoff contract.

## Security

- activation requires an authenticated user with a linked shop
- the authenticated email must match the email used to unlock the analysis
- an analysis already linked to another shop is rejected
- all copied storage paths are rebuilt under the authenticated shop ID
- guided session writes are explicitly scoped to the authenticated shop

## Validation

- repository-focused regression coverage added in `tests/instant-shop-analysis-guided-onboarding.test.ts`
- Vercel preview build: ready
- PR is mergeable with no review threads

Local typecheck/test execution was unavailable because the workspace checkout was removed by automated workspace maintenance. The deployment build completed successfully.