### PR TITLE
Add shop quote approval and smart vehicle history insights

### DIFF
--- a/app/api/work-orders/[id]/quote-history-insights/route.ts
+++ b/app/api/work-orders/[id]/quote-history-insights/route.ts
@@ -1,0 +1,247 @@
+import { NextResponse } from "next/server";
+import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { runOpenAIStructuredJson } from "@/features/shared/lib/server/openai-structured";
+import {
+  findRelevantHistoryCandidates,
+  type QuoteHistoryCandidate,
+  type QuoteHistoryMatch,
+} from "@/features/work-orders/quote-review/quoteHistoryRelevance";
+
+type DB = Database;
+type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type QuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+
+function workOrderIdFromUrl(url: string): string | null {
+  return new URL(url).pathname.split("/").filter(Boolean)[2] ?? null;
+}
+
+function numericMileage(
+  row: Pick<WorkOrder, "odometer_km" | "vehicle_mileage">,
+): number | null {
+  const value = row.odometer_km ?? row.vehicle_mileage;
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function validateSelections(
+  candidate: unknown,
+  allowed: Set<string>,
+): { selections: Array<{ quoteLineId: string; historyLineId: string }> } {
+  if (
+    !candidate ||
+    typeof candidate !== "object" ||
+    !("selections" in candidate)
+  )
+    return { selections: [] };
+  const raw = (candidate as { selections?: unknown }).selections;
+  if (!Array.isArray(raw)) return { selections: [] };
+
+  const seen = new Set<string>();
+  const selections: Array<{ quoteLineId: string; historyLineId: string }> = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const quoteLineId = String(
+      (item as { quoteLineId?: unknown }).quoteLineId ?? "",
+    ).trim();
+    const historyLineId = String(
+      (item as { historyLineId?: unknown }).historyLineId ?? "",
+    ).trim();
+    const pair = `${quoteLineId}:${historyLineId}`;
+    if (
+      !quoteLineId ||
+      !historyLineId ||
+      seen.has(quoteLineId) ||
+      !allowed.has(pair)
+    )
+      continue;
+    seen.add(quoteLineId);
+    selections.push({ quoteLineId, historyLineId });
+  }
+  return { selections };
+}
+
+export async function GET(req: Request) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  if (!access.ok) return access.response;
+
+  const workOrderId = workOrderIdFromUrl(req.url);
+  if (!workOrderId)
+    return NextResponse.json(
+      { error: "Missing work order id" },
+      { status: 400 },
+    );
+
+  const shopId = access.profile.shop_id;
+  const { data: current, error: currentError } = await access.supabase
+    .from("work_orders")
+    .select("id,shop_id,vehicle_id,odometer_km,vehicle_mileage,created_at")
+    .eq("id", workOrderId)
+    .eq("shop_id", shopId)
+    .maybeSingle<WorkOrder>();
+
+  if (currentError)
+    return NextResponse.json({ error: currentError.message }, { status: 500 });
+  if (!current)
+    return NextResponse.json(
+      { error: "Work order not found" },
+      { status: 404 },
+    );
+  if (!current.vehicle_id)
+    return NextResponse.json({ ok: true, insights: [], mode: "deterministic" });
+
+  const [
+    { data: quoteRows, error: quoteError },
+    { data: priorRows, error: priorError },
+  ] = await Promise.all([
+    access.supabase
+      .from("work_order_quote_lines")
+      .select("id,description,ai_complaint,notes")
+      .eq("shop_id", shopId)
+      .eq("work_order_id", workOrderId),
+    access.supabase
+      .from("work_orders")
+      .select(
+        "id,custom_id,odometer_km,vehicle_mileage,created_at,updated_at,status",
+      )
+      .eq("shop_id", shopId)
+      .eq("vehicle_id", current.vehicle_id)
+      .neq("id", workOrderId)
+      .in("status", ["completed", "ready_to_invoice", "invoiced"])
+      .order("updated_at", { ascending: false })
+      .limit(60),
+  ]);
+
+  if (quoteError || priorError) {
+    return NextResponse.json(
+      {
+        error:
+          quoteError?.message ?? priorError?.message ?? "History query failed",
+      },
+      { status: 500 },
+    );
+  }
+
+  const quoteLines = (quoteRows ?? []) as Pick<
+    QuoteLine,
+    "id" | "description" | "ai_complaint" | "notes"
+  >[];
+  const priorWorkOrders = (priorRows ?? []) as WorkOrder[];
+  if (quoteLines.length === 0 || priorWorkOrders.length === 0) {
+    return NextResponse.json({ ok: true, insights: [], mode: "deterministic" });
+  }
+
+  const priorIds = priorWorkOrders.map((row) => row.id);
+  const { data: lineRows, error: lineError } = await access.supabase
+    .from("work_order_lines")
+    .select(
+      "id,work_order_id,description,complaint,correction,notes,odometer_km,punched_out_at,updated_at,status,line_status",
+    )
+    .eq("shop_id", shopId)
+    .in("work_order_id", priorIds)
+    .or(
+      "status.in.(completed,ready_to_invoice,invoiced),line_status.in.(completed,ready_to_invoice,invoiced)",
+    );
+
+  if (lineError)
+    return NextResponse.json({ error: lineError.message }, { status: 500 });
+
+  const priorById = new Map(priorWorkOrders.map((row) => [row.id, row]));
+  const currentMileage = numericMileage(current);
+  const now = Date.now();
+  const candidates: QuoteHistoryCandidate[] = (
+    (lineRows ?? []) as WorkOrderLine[]
+  ).flatMap((line) => {
+    if (!line.work_order_id) return [];
+    const prior = priorById.get(line.work_order_id);
+    if (!prior) return [];
+    const completedAt =
+      line.punched_out_at ??
+      line.updated_at ??
+      prior.updated_at ??
+      prior.created_at;
+    if (!completedAt) return [];
+    const priorMileage = line.odometer_km ?? numericMileage(prior);
+    const mileageDeltaKm =
+      currentMileage != null && priorMileage != null
+        ? currentMileage - priorMileage
+        : null;
+    const description = [
+      line.description,
+      line.complaint,
+      line.correction,
+      line.notes,
+    ]
+      .filter(Boolean)
+      .join(" — ");
+    if (!description.trim()) return [];
+    return [
+      {
+        historyLineId: line.id,
+        workOrderId: prior.id,
+        workOrderNumber: prior.custom_id,
+        description,
+        completedAt,
+        mileageDeltaKm,
+        ageDays: Math.max(
+          0,
+          Math.floor((now - new Date(completedAt).getTime()) / 86_400_000),
+        ),
+      },
+    ];
+  });
+
+  const eligible = quoteLines.flatMap((line) =>
+    findRelevantHistoryCandidates({
+      quoteLineId: line.id,
+      quoteDescription: [line.description, line.ai_complaint, line.notes]
+        .filter(Boolean)
+        .join(" — "),
+      candidates,
+    }),
+  );
+  if (eligible.length === 0)
+    return NextResponse.json({ ok: true, insights: [], mode: "deterministic" });
+
+  const fallbackSelections = eligible.reduce<
+    Array<{ quoteLineId: string; historyLineId: string }>
+  >((items, match) => {
+    if (!items.some((item) => item.quoteLineId === match.quoteLineId)) {
+      items.push({
+        quoteLineId: match.quoteLineId,
+        historyLineId: match.historyLineId,
+      });
+    }
+    return items;
+  }, []);
+  const allowed = new Set(
+    eligible.map((match) => `${match.quoteLineId}:${match.historyLineId}`),
+  );
+  const ranking = await runOpenAIStructuredJson({
+    purpose: "fast",
+    feature: "quote-history-insights",
+    schemaName: "quote_history_selections",
+    system:
+      "Select at most one genuinely useful prior service record for each quote line. Never select a pair outside the supplied candidates. Prefer recent same-service work that could prevent duplication or change the advisor conversation.",
+    user: { candidates: eligible },
+    validate: (value) => validateSelections(value, allowed),
+    fallback: () => ({ selections: fallbackSelections }),
+    maxOutputTokens: 500,
+  });
+
+  const byPair = new Map(
+    eligible.map((match) => [
+      `${match.quoteLineId}:${match.historyLineId}`,
+      match,
+    ]),
+  );
+  const insights = ranking.output.selections
+    .map((selection) =>
+      byPair.get(`${selection.quoteLineId}:${selection.historyLineId}`),
+    )
+    .filter((match): match is QuoteHistoryMatch => Boolean(match));
+
+  return NextResponse.json({ ok: true, insights, mode: ranking.mode });
+}

--- a/app/api/work-orders/quotes/[id]/authorize/route.ts
+++ b/app/api/work-orders/quotes/[id]/authorize/route.ts
@@ -4,9 +4,24 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { applyWorkOrderQuoteLineDecision } from "@/features/work-orders/server/workOrderQuoteLineApproval";
+import type {
+  QuoteApprovalDecision,
+  QuoteDecisionContactMethod,
+} from "@/features/work-orders/server/workOrderQuoteLineApproval";
 
 export const runtime = "nodejs";
 
+const DECISIONS = new Set<QuoteApprovalDecision>([
+  "approve",
+  "decline",
+  "defer",
+]);
+const CONTACT_METHODS = new Set<QuoteDecisionContactMethod>([
+  "phone",
+  "in_person",
+  "email",
+  "other",
+]);
 
 export async function POST(req: NextRequest) {
   const supabase = createServerSupabaseRoute();
@@ -49,6 +64,37 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const body = (await req.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const decisionValue = String(body.decision ?? "approve")
+      .trim()
+      .toLowerCase();
+    const contactValue = String(body.contactMethod ?? "other")
+      .trim()
+      .toLowerCase();
+    if (!DECISIONS.has(decisionValue as QuoteApprovalDecision)) {
+      return NextResponse.json(
+        { error: "Unsupported quote decision" },
+        { status: 400 },
+      );
+    }
+    if (!CONTACT_METHODS.has(contactValue as QuoteDecisionContactMethod)) {
+      return NextResponse.json(
+        { error: "Unsupported contact method" },
+        { status: 400 },
+      );
+    }
+    const decision = decisionValue as QuoteApprovalDecision;
+    const contactMethod = contactValue as QuoteDecisionContactMethod;
+    const note =
+      typeof body.note === "string" ? body.note.trim().slice(0, 1000) : null;
+    const operationKey =
+      typeof body.operationKey === "string"
+        ? body.operationKey.trim().slice(0, 160)
+        : undefined;
+
     const { data: q, error: qErr } = await supabase
       .from("work_order_quote_lines")
       .select("id, shop_id, work_order_id, work_order_line_id")
@@ -79,7 +125,11 @@ export async function POST(req: NextRequest) {
       shopId: q.shop_id,
       customerId: null,
       actorUserId: user.id,
-      decision: "approve",
+      decision,
+      decisionSource: "shop",
+      contactMethod,
+      decisionNote: note,
+      operationKey,
     });
 
     if (!result.ok) {
@@ -95,6 +145,7 @@ export async function POST(req: NextRequest) {
         result.workOrderLineIds[0] ?? q.work_order_line_id ?? null,
       workOrderLineIds: result.workOrderLineIds,
       approvalState: result.approvalState,
+      decision,
       partRelink: result.partRelink,
     });
   } catch {

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -41,6 +41,9 @@ type QuoteLine = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 type QuoteLineUpdate = DB["public"]["Tables"]["work_order_quote_lines"]["Update"];
 type PartsByQuoteLine = Record<string, ResolvedQuotePart[]>;
 type RequestByQuoteLine = Record<string, PartRequest[]>;
+type QuoteDecision = "approve" | "decline" | "defer";
+type ContactMethod = "phone" | "in_person" | "email" | "other";
+type HistoryInsight = { quoteLineId: string; historyLineId: string; workOrderId: string; workOrderNumber: string | null; description: string; completedAt: string; mileageDeltaKm: number | null; ageDays: number; reason: string };
 
 type EditableQuoteLine = QuoteLine & {
   _dirty?: boolean;
@@ -95,6 +98,18 @@ function fmt(value: number | null | undefined): string {
 
 function statusLabel(value: string | null | undefined): string {
   return safeTrim(value).replaceAll("_", " ") || "—";
+}
+
+function isFinalDecision(line: EditableQuoteLine): boolean {
+  const status = safeTrim(line.status).toLowerCase();
+  return Boolean(line.work_order_line_id) || ["approved", "converted", "declined", "deferred"].includes(status);
+}
+
+function historyDistanceLabel(insight: HistoryInsight): string {
+  if (insight.mileageDeltaKm != null) return `${Math.round(insight.mileageDeltaKm).toLocaleString()} km ago`;
+  if (insight.ageDays < 45) return `${insight.ageDays} days ago`;
+  if (insight.ageDays < 730) return `${Math.max(1, Math.round(insight.ageDays / 30))} months ago`;
+  return `${Math.max(1, Math.round(insight.ageDays / 365))} years ago`;
 }
 
 function isValidEmail(value: string): boolean {
@@ -346,6 +361,13 @@ export default function QuoteReviewView(props: {
   const [requestsByQuoteLine, setRequestsByQuoteLine] = useState<RequestByQuoteLine>({});
   const [workLines, setWorkLines] = useState<WorkOrderLine[]>([]);
   const [openDetails, setOpenDetails] = useState<Record<string, boolean>>({});
+  const [openParts, setOpenParts] = useState<Record<string, boolean>>({});
+  const [historyInsights, setHistoryInsights] = useState<Record<string, HistoryInsight>>({});
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [decisionDialog, setDecisionDialog] = useState<{ line: EditableQuoteLine; decision: QuoteDecision } | null>(null);
+  const [decisionContact, setDecisionContact] = useState<ContactMethod>("phone");
+  const [decisionNote, setDecisionNote] = useState("");
+  const [decisionSaving, setDecisionSaving] = useState(false);
   const [saving, setSaving] = useState(false);
   const [sending, setSending] = useState(false);
   const [savingCustomerEmail, setSavingCustomerEmail] = useState(false);
@@ -358,6 +380,19 @@ export default function QuoteReviewView(props: {
   const [savingSuppliesOverride, setSavingSuppliesOverride] = useState(false);
 
   const laborRate = useMemo(() => asNumber((shop as unknown as { labor_rate?: unknown } | null)?.labor_rate) ?? 120, [shop]);
+
+  const loadHistoryInsights = useCallback(async () => {
+    if (!woId) return;
+    setHistoryLoading(true);
+    try {
+      const response = await fetch(`/api/work-orders/${woId}/quote-history-insights`, { cache: "no-store" });
+      const payload = (await response.json().catch(() => null)) as { insights?: HistoryInsight[] } | null;
+      if (!response.ok) return;
+      setHistoryInsights(Object.fromEntries((payload?.insights ?? []).map((insight) => [insight.quoteLineId, insight])));
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, [woId]);
 
   const reload = useCallback(async () => {
     if (!woId) return;
@@ -492,7 +527,8 @@ export default function QuoteReviewView(props: {
     setLoading(false);
     loadedOnceRef.current = true;
     setLoadedOnce(true);
-  }, [supabase, woId]);
+    void loadHistoryInsights();
+  }, [loadHistoryInsights, supabase, woId]);
 
   useEffect(() => {
     loadedOnceRef.current = false;
@@ -613,26 +649,36 @@ export default function QuoteReviewView(props: {
     }
   }
 
-  async function updateQuoteLineState(line: EditableQuoteLine, status: string, stage?: string | null) {
-    if (!wo?.shop_id) return;
-    const patch: QuoteLineUpdate = {
-      status,
-      stage: stage ?? line.stage,
-      declined_at: status === "declined" ? new Date().toISOString() : line.declined_at,
-      updated_at: new Date().toISOString(),
-    };
-    const { error } = await supabase
-      .from("work_order_quote_lines")
-      .update(patch)
-      .eq("id", line.id)
-      .eq("shop_id", wo.shop_id)
-      .eq("work_order_id", woId);
-    if (error) {
-      toast.error(error.message);
-      return;
+  function openDecisionDialog(line: EditableQuoteLine, decision: QuoteDecision) {
+    setDecisionContact("phone");
+    setDecisionNote("");
+    setDecisionDialog({ line, decision });
+  }
+
+  async function confirmShopDecision() {
+    if (!decisionDialog || decisionSaving) return;
+    setDecisionSaving(true);
+    try {
+      if (quoteLines.some((line) => line._dirty)) {
+        const saved = await saveAllDirty();
+        if (!saved) return;
+      }
+      const response = await fetch(`/api/work-orders/quotes/${decisionDialog.line.id}/authorize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision: decisionDialog.decision, contactMethod: decisionContact, note: decisionNote, operationKey: crypto.randomUUID() }),
+      });
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (!response.ok) throw new Error(payload?.error ?? "Could not record the shop decision.");
+      const pastTense = decisionDialog.decision === "approve" ? "approved" : decisionDialog.decision === "decline" ? "declined" : "deferred";
+      toast.success(`Quote line ${pastTense} by the shop.`);
+      setDecisionDialog(null);
+      await reload();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not record the shop decision.");
+    } finally {
+      setDecisionSaving(false);
     }
-    toast.success(`Quote line marked ${statusLabel(status)}.`);
-    await reload();
   }
 
   async function saveSuppliesOverride() {
@@ -838,6 +884,8 @@ export default function QuoteReviewView(props: {
                     const partsTotal = quoteLinePartsTotal(line);
                     const total = quoteLineTotal(line, laborRate);
                     const sources = sourceSummary(line);
+                    const historyInsight = historyInsights[line.id];
+                    const finalDecision = isFinalDecision(line);
 
                     return (
                       <div key={line.id} className={`${padX} py-4`}>
@@ -870,16 +918,28 @@ export default function QuoteReviewView(props: {
                             <div>Labor rate: <span className="text-[color:var(--theme-text-primary)]">{fmt(lineLaborRate)}/hr</span></div>
                           </div>
 
+                          {historyInsight ? (
+                            <div className="mt-3 rounded-xl border border-sky-300/30 bg-sky-400/10 p-3 text-xs">
+                              <div className="flex flex-wrap items-start justify-between gap-2">
+                                <div>
+                                  <div className="font-semibold uppercase tracking-[0.16em] text-sky-100">Relevant vehicle history</div>
+                                  <div className="mt-1 text-[color:var(--theme-text-primary)]">Completed {historyDistanceLabel(historyInsight)}{historyInsight.workOrderNumber ? ` on WO ${historyInsight.workOrderNumber}` : " on a prior work order"}.</div>
+                                  <div className="mt-1 text-[color:var(--theme-text-secondary)]">{historyInsight.description}</div>
+                                </div>
+                                <a href={`/work-orders/${historyInsight.workOrderId}`} className="rounded-lg border border-sky-300/35 px-2.5 py-1.5 font-semibold text-sky-100 hover:bg-sky-400/10">View prior WO</a>
+                              </div>
+                            </div>
+                          ) : historyLoading ? <div className="mt-3 text-xs text-[color:var(--theme-text-muted)]">Checking relevant vehicle history…</div> : null}
+
                           <div className="mt-3 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
                             <div className="flex flex-wrap items-center justify-between gap-2">
                               <div className="font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">Required parts</div>
-                              {partsSummary ? (
-                                <div className="text-[color:var(--theme-text-secondary)]">
-                                  Sync: <span className="text-[color:var(--theme-text-primary)]">{partsSummary.pendingCount > 0 ? "pending" : "quoted"} • {partsSummary.quotedCount}/{partsSummary.requiredCount} quoted • {fmt(partsSummary.partsTotal)}</span>
-                                </div>
-                              ) : null}
+                              <div className="flex flex-wrap items-center gap-2">
+                                {partsSummary ? <div className="text-[color:var(--theme-text-secondary)]">Sync: <span className="text-[color:var(--theme-text-primary)]">{partsSummary.pendingCount > 0 ? "pending" : "quoted"} • {partsSummary.quotedCount}/{partsSummary.requiredCount} quoted • {fmt(partsSummary.partsTotal)}</span></div> : null}
+                                {(partsByQuoteLine[line.id] ?? []).length > 0 ? <button type="button" onClick={() => setOpenParts((prev) => ({ ...prev, [line.id]: !prev[line.id] }))} className="rounded-lg border border-[color:var(--desktop-border)] px-2.5 py-1.5 font-semibold text-[color:var(--theme-text-primary)]">{openParts[line.id] ? "Hide parts" : `View ${(partsByQuoteLine[line.id] ?? []).length} parts`}</button> : null}
+                              </div>
                             </div>
-                            {(partsByQuoteLine[line.id] ?? []).length > 0 ? (
+                            {(partsByQuoteLine[line.id] ?? []).length > 0 && openParts[line.id] ? (
                               <div className="mt-2 space-y-2">
                                 {(partsByQuoteLine[line.id] ?? []).map((part) => {
                                   const request = part.requestId ? (requestsByQuoteLine[line.id] ?? []).find((candidate) => candidate.id === part.requestId) ?? null : null;
@@ -936,26 +996,21 @@ export default function QuoteReviewView(props: {
                           ) : null}
 
                           <div className="mt-3 flex flex-wrap gap-2">
-                            <button type="button" onClick={() => setOpenDetails((prev) => ({ ...prev, [line.id]: !prev[line.id] }))} className="desktop-btn-secondary rounded-xl px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">
+                            <button type="button" disabled={finalDecision} onClick={() => setOpenDetails((prev) => ({ ...prev, [line.id]: !prev[line.id] }))} className="desktop-btn-secondary rounded-xl px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-45">
                               {openDetails[line.id] ? "Hide editor" : "Edit quote line"}
                             </button>
-                            <button type="button" onClick={() => markRecommendedReady(line)} className="desktop-btn-secondary rounded-xl px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">
+                            <button type="button" disabled={finalDecision} onClick={() => markRecommendedReady(line)} className="desktop-btn-secondary rounded-xl px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-45">
                               Recompute ready state
                             </button>
                             {!line.sent_to_customer_at && canSendLine(line) ? <span className="rounded-xl border border-emerald-300/35 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-100">Will send</span> : null}
-                            {safeTrim(line.status).toLowerCase() !== "declined" ? (
-                              <button type="button" onClick={() => void updateQuoteLineState(line, "declined", line.stage)} className="rounded-xl border border-red-400/45 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-100">
-                                Decline
-                              </button>
-                            ) : null}
-                            {safeTrim(line.status).toLowerCase() !== "deferred" ? (
-                              <button type="button" onClick={() => void updateQuoteLineState(line, "deferred", line.stage)} className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">
-                                Defer
-                              </button>
-                            ) : null}
+                            {!finalDecision ? <>
+                              <button type="button" disabled={!canSendLine(line) && safeTrim(line.status).toLowerCase() !== "sent"} onClick={() => openDecisionDialog(line, "approve")} className="rounded-xl border border-emerald-300/40 bg-emerald-500/15 px-3 py-2 text-xs font-semibold text-emerald-100 disabled:opacity-45">Approve</button>
+                              <button type="button" onClick={() => openDecisionDialog(line, "defer")} className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">Defer</button>
+                              <button type="button" onClick={() => openDecisionDialog(line, "decline")} className="rounded-xl border border-red-400/45 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-100">Decline</button>
+                            </> : null}
                           </div>
 
-                          {openDetails[line.id] ? (
+                          {openDetails[line.id] && !finalDecision ? (
                             <div className="desktop-panel-soft mt-3 p-4">
                               <div className={embedded ? "grid gap-3" : "grid gap-3 md:grid-cols-2"}>
                                 <label className="text-xs text-[color:var(--theme-text-secondary)]">
@@ -996,10 +1051,6 @@ export default function QuoteReviewView(props: {
                                     <option value="pending_parts">pending parts</option>
                                     <option value="quoted">ready / quoted</option>
                                     <option value="sent">sent</option>
-                                    <option value="approved">approved</option>
-                                    <option value="declined">declined</option>
-                                    <option value="deferred">deferred</option>
-                                    <option value="converted">converted</option>
                                   </select>
                                 </label>
                                 <label className="text-xs text-[color:var(--theme-text-secondary)]">
@@ -1103,7 +1154,7 @@ export default function QuoteReviewView(props: {
                   {sending ? "Sending…" : "Send ready quote lines"}
                 </button>
                 <div className="mt-3 text-xs text-[color:var(--theme-text-muted)]">Portal link will be: <span className="text-[color:var(--theme-text-secondary)]">/portal/quotes/{woId}</span></div>
-                <div className="mt-2 text-xs text-[color:var(--theme-text-muted)]">Phase 5C still needs customer portal rendering, approval, and materialization of approved quote lines into punchable work_order_lines.</div>
+                <div className="mt-2 text-xs text-[color:var(--theme-text-muted)]">Customer portal decisions and shop-recorded phone decisions use the same canonical approval lifecycle.</div>
               </div>
             </div>
 
@@ -1118,6 +1169,30 @@ export default function QuoteReviewView(props: {
         </div>
 
         {!embedded && <div className="mt-6 text-xs text-[color:var(--theme-text-muted)]">Work Order ID: {wo.id} • Status: {statusLabel(wo.status)}</div>}
+
+        {decisionDialog ? (
+          <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/65 p-4" role="dialog" aria-modal="true" aria-labelledby="shop-decision-title">
+            <div className="w-full max-w-lg rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--theme-surface-overlay)] p-5 shadow-2xl">
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Classic shop approval</div>
+              <h2 id="shop-decision-title" className="mt-2 text-lg font-semibold text-[color:var(--theme-text-primary)]">Record {statusLabel(decisionDialog.decision)} — {safeTrim(decisionDialog.line.description) || "quote line"}</h2>
+              <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">Use this after confirming the customer&apos;s decision outside the portal. The advisor, contact method, time, and note are retained with the quote.</p>
+              <label className="mt-4 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                Customer contact method
+                <select value={decisionContact} onChange={(event) => setDecisionContact(event.target.value as ContactMethod)} className={inputCls}>
+                  <option value="phone">Phone call</option><option value="in_person">In person</option><option value="email">Email</option><option value="other">Other</option>
+                </select>
+              </label>
+              <label className="mt-3 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                Advisor note (optional)
+                <textarea value={decisionNote} onChange={(event) => setDecisionNote(event.target.value.slice(0, 1000))} rows={3} placeholder="Example: Approved by phone with Jamie at 2:15 PM." className={inputCls} />
+              </label>
+              <div className="mt-5 flex flex-wrap justify-end gap-2">
+                <button type="button" disabled={decisionSaving} onClick={() => setDecisionDialog(null)} className="desktop-btn-secondary rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-50">Cancel</button>
+                <button type="button" disabled={decisionSaving} onClick={() => void confirmShopDecision()} className={decisionDialog.decision === "decline" ? "rounded-xl border border-red-400/45 bg-red-500/15 px-4 py-2 text-sm font-semibold text-red-100 disabled:opacity-50" : "desktop-btn-primary rounded-xl px-4 py-2 text-sm font-semibold disabled:opacity-50"}>{decisionSaving ? "Recording…" : `Confirm ${statusLabel(decisionDialog.decision)}`}</button>
+              </div>
+            </div>
+          </div>
+        ) : null}
 
         <AddJobModal
           isOpen={addJobOpen}

--- a/features/work-orders/quote-review/quoteHistoryRelevance.ts
+++ b/features/work-orders/quote-review/quoteHistoryRelevance.ts
@@ -1,0 +1,153 @@
+export type QuoteHistoryCandidate = {
+  historyLineId: string;
+  workOrderId: string;
+  workOrderNumber: string | null;
+  description: string;
+  completedAt: string;
+  mileageDeltaKm: number | null;
+  ageDays: number;
+};
+
+export type QuoteHistoryMatch = QuoteHistoryCandidate & {
+  quoteLineId: string;
+  serviceFamily: string;
+  reason: string;
+};
+
+type ServiceRule = {
+  family: string;
+  terms: string[];
+  excludes?: string[];
+  maxKm: number;
+  maxDays: number;
+};
+
+const RULES: ServiceRule[] = [
+  {
+    family: "brake fluid",
+    terms: ["brake fluid", "brake flush", "hydraulic flush"],
+    maxKm: 50_000,
+    maxDays: 1460,
+  },
+  {
+    family: "brake friction",
+    terms: ["brake pad", "brake shoe", "brake rotor", "brake drum"],
+    excludes: ["fluid", "flush"],
+    maxKm: 40_000,
+    maxDays: 1095,
+  },
+  {
+    family: "engine oil",
+    terms: ["oil change", "engine oil", "oil service"],
+    maxKm: 16_000,
+    maxDays: 550,
+  },
+  {
+    family: "transmission service",
+    terms: ["transmission fluid", "transmission service", "trans fluid"],
+    maxKm: 80_000,
+    maxDays: 1825,
+  },
+  {
+    family: "coolant service",
+    terms: ["coolant flush", "coolant service", "antifreeze"],
+    maxKm: 80_000,
+    maxDays: 1825,
+  },
+  {
+    family: "spark plugs",
+    terms: ["spark plug", "ignition tune"],
+    maxKm: 120_000,
+    maxDays: 2555,
+  },
+  {
+    family: "battery",
+    terms: ["battery replacement", "replace battery", "battery install"],
+    maxKm: 60_000,
+    maxDays: 1460,
+  },
+  {
+    family: "tires",
+    terms: ["tire replacement", "replace tire", "new tires"],
+    maxKm: 60_000,
+    maxDays: 1460,
+  },
+  {
+    family: "alignment",
+    terms: ["wheel alignment", "alignment"],
+    maxKm: 30_000,
+    maxDays: 730,
+  },
+  {
+    family: "filters",
+    terms: ["air filter", "cabin filter", "fuel filter"],
+    maxKm: 40_000,
+    maxDays: 730,
+  },
+  {
+    family: "suspension",
+    terms: ["shock", "strut", "control arm", "ball joint"],
+    maxKm: 80_000,
+    maxDays: 1825,
+  },
+  {
+    family: "abs",
+    terms: ["abs sensor", "wheel speed sensor", "abs wiring"],
+    maxKm: 50_000,
+    maxDays: 1460,
+  },
+];
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function ruleFor(value: string): ServiceRule | null {
+  const normalized = normalize(value);
+  return (
+    RULES.find(
+      (rule) =>
+        rule.terms.some((term) => normalized.includes(term)) &&
+        !(rule.excludes ?? []).some((term) => normalized.includes(term)),
+    ) ?? null
+  );
+}
+
+export function findRelevantHistoryCandidates(input: {
+  quoteLineId: string;
+  quoteDescription: string;
+  candidates: QuoteHistoryCandidate[];
+}): QuoteHistoryMatch[] {
+  const quoteRule = ruleFor(input.quoteDescription);
+  if (!quoteRule) return [];
+
+  return input.candidates
+    .filter(
+      (candidate) =>
+        ruleFor(candidate.description)?.family === quoteRule.family,
+    )
+    .filter((candidate) =>
+      candidate.mileageDeltaKm == null
+        ? candidate.ageDays <= quoteRule.maxDays
+        : candidate.mileageDeltaKm >= 0 &&
+          candidate.mileageDeltaKm <= quoteRule.maxKm,
+    )
+    .sort((a, b) => {
+      const aScore = a.mileageDeltaKm ?? a.ageDays * 40;
+      const bScore = b.mileageDeltaKm ?? b.ageDays * 40;
+      return aScore - bScore;
+    })
+    .slice(0, 4)
+    .map((candidate) => ({
+      ...candidate,
+      quoteLineId: input.quoteLineId,
+      serviceFamily: quoteRule.family,
+      reason:
+        candidate.mileageDeltaKm == null
+          ? `Same service family completed ${candidate.ageDays} days ago.`
+          : `Same service family completed ${Math.round(candidate.mileageDeltaKm).toLocaleString()} km ago.`,
+    }));
+}

--- a/features/work-orders/server/workOrderQuoteLineApproval.ts
+++ b/features/work-orders/server/workOrderQuoteLineApproval.ts
@@ -11,6 +11,12 @@ import {
 type DB = Database;
 
 export type QuoteApprovalDecision = "approve" | "decline" | "defer";
+export type QuoteDecisionSource = "customer" | "shop";
+export type QuoteDecisionContactMethod =
+  | "phone"
+  | "in_person"
+  | "email"
+  | "other";
 
 export type QuoteLineLearningResult = {
   quoteLineId: string;
@@ -32,7 +38,11 @@ export type RelinkQuoteLinePartsResult = {
   }>;
 };
 
-type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
 type RpcClient = {
   rpc: (
     name: string,
@@ -93,6 +103,9 @@ export async function applyWorkOrderQuoteLineDecision(params: {
   customerId: string | null;
   actorUserId: string;
   decision: QuoteApprovalDecision;
+  decisionSource?: QuoteDecisionSource;
+  contactMethod?: QuoteDecisionContactMethod;
+  decisionNote?: string | null;
   declineRemaining?: boolean;
   operationKey?: string;
 }): Promise<{
@@ -105,7 +118,9 @@ export async function applyWorkOrderQuoteLineDecision(params: {
   idempotent?: boolean;
   error?: string;
 }> {
-  const quoteLineIds = [...new Set(params.quoteLineIds.map((id) => id.trim()).filter(Boolean))];
+  const quoteLineIds = [
+    ...new Set(params.quoteLineIds.map((id) => id.trim()).filter(Boolean)),
+  ];
   if (quoteLineIds.length === 0) {
     return {
       ok: false,
@@ -132,17 +147,31 @@ export async function applyWorkOrderQuoteLineDecision(params: {
     });
 
   const rpc = params.supabase as unknown as RpcClient;
-  const { data, error } = await rpc.rpc("apply_customer_quote_decision_atomic", {
-    p_shop_id: params.shopId,
-    p_work_order_id: params.workOrderId,
-    p_quote_line_ids: quoteLineIds,
-    p_decision: params.decision,
-    p_decline_remaining: declineRemaining,
-    p_customer_id: params.customerId,
-    p_actor_user_id: params.actorUserId,
-    p_operation_key: `${params.shopId}:quote-decision:${rawOperationKey}`,
-    p_at: new Date().toISOString(),
-  });
+  const isShopDecision = params.decisionSource === "shop";
+  const rpcResult = isShopDecision
+    ? await rpc.rpc("apply_shop_quote_decision_atomic", {
+        p_shop_id: params.shopId,
+        p_work_order_id: params.workOrderId,
+        p_quote_line_ids: quoteLineIds,
+        p_decision: params.decision,
+        p_actor_user_id: params.actorUserId,
+        p_contact_method: params.contactMethod ?? "other",
+        p_note: params.decisionNote?.trim() || null,
+        p_operation_key: `${params.shopId}:shop-quote-decision:${rawOperationKey}`,
+        p_at: new Date().toISOString(),
+      })
+    : await rpc.rpc("apply_customer_quote_decision_atomic", {
+        p_shop_id: params.shopId,
+        p_work_order_id: params.workOrderId,
+        p_quote_line_ids: quoteLineIds,
+        p_decision: params.decision,
+        p_decline_remaining: declineRemaining,
+        p_customer_id: params.customerId,
+        p_actor_user_id: params.actorUserId,
+        p_operation_key: `${params.shopId}:quote-decision:${rawOperationKey}`,
+        p_at: new Date().toISOString(),
+      });
+  const { data, error } = rpcResult;
 
   if (error) {
     return {
@@ -158,7 +187,9 @@ export async function applyWorkOrderQuoteLineDecision(params: {
 
   const result = data && typeof data === "object" ? (data as RpcResult) : {};
   const workOrderLineIds = Array.isArray(result.work_order_line_ids)
-    ? result.work_order_line_ids.filter((id): id is string => typeof id === "string")
+    ? result.work_order_line_ids.filter(
+        (id): id is string => typeof id === "string",
+      )
     : [];
   const committedQuoteLineIds = Array.isArray(result.quote_line_ids)
     ? result.quote_line_ids.filter((id): id is string => typeof id === "string")

--- a/supabase/migrations/20260717003000_shop_recorded_quote_decisions.sql
+++ b/supabase/migrations/20260717003000_shop_recorded_quote_decisions.sql
@@ -1,0 +1,128 @@
+begin;
+
+create or replace function public.apply_shop_quote_decision_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_quote_line_ids uuid[],
+  p_decision text,
+  p_actor_user_id uuid,
+  p_contact_method text,
+  p_note text,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_decision text := lower(trim(coalesce(p_decision, '')));
+  v_contact text := lower(trim(coalesce(p_contact_method, '')));
+  v_now timestamptz := coalesce(p_at, now());
+  v_existing jsonb;
+  v_result jsonb;
+  v_line_id uuid;
+begin
+  if auth.uid() is null or auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Shop quote decision actor mismatch.';
+  end if;
+  if v_decision not in ('approve', 'decline', 'defer') then
+    raise exception using errcode = 'P0001', message = 'Unsupported quote decision.';
+  end if;
+  if v_contact not in ('phone', 'in_person', 'email', 'other') then
+    raise exception using errcode = 'P0001', message = 'Unsupported quote decision contact method.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+  select result into v_existing
+  from public.quote_lifecycle_operation_keys
+  where shop_id = p_shop_id
+    and operation_name = 'shop_quote_decision'
+    and operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+  if not exists (
+    select 1 from public.profiles p
+    where p.id = p_actor_user_id
+      and p.shop_id = p_shop_id
+      and lower(coalesce(p.role::text, '')) in ('owner', 'admin', 'manager', 'advisor', 'service', 'foreman')
+  ) then
+    raise exception using errcode = 'P0001', message = 'Shop quote decision actor is not authorized.';
+  end if;
+  if exists (
+    select 1 from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id
+      and q.work_order_id = p_work_order_id
+      and q.id = any(coalesce(p_quote_line_ids, array[]::uuid[]))
+      and (q.work_order_line_id is not null or lower(coalesce(q.status::text, '')) in ('approved', 'converted'))
+      and v_decision <> 'approve'
+  ) then
+    raise exception using errcode = 'P0001', message = 'Approved work cannot be reversed from quote review.';
+  end if;
+
+  v_result := public.apply_customer_quote_decision_atomic(
+    p_shop_id,
+    p_work_order_id,
+    p_quote_line_ids,
+    v_decision,
+    false,
+    null,
+    p_actor_user_id,
+    p_operation_key || ':canonical',
+    v_now
+  );
+
+  update public.work_order_quote_lines
+  set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_strip_nulls(jsonb_build_object(
+        'decision_origin', 'shop_recorded',
+        'shop_decision', v_decision,
+        'shop_decision_at', v_now,
+        'shop_decision_actor_user_id', p_actor_user_id,
+        'shop_decision_contact_method', v_contact,
+        'shop_decision_note', left(nullif(trim(coalesce(p_note, '')), ''), 1000)
+      )),
+      updated_at = v_now
+  where shop_id = p_shop_id
+    and work_order_id = p_work_order_id
+    and id = any(coalesce(p_quote_line_ids, array[]::uuid[]));
+
+  if v_decision = 'approve' then
+    for v_line_id in
+      select q.work_order_line_id
+      from public.work_order_quote_lines q
+      where q.shop_id = p_shop_id
+        and q.work_order_id = p_work_order_id
+        and q.id = any(coalesce(p_quote_line_ids, array[]::uuid[]))
+        and q.work_order_line_id is not null
+    loop
+      update public.work_order_lines
+      set intake_json = coalesce(intake_json, '{}'::jsonb) || jsonb_strip_nulls(jsonb_build_object(
+            'decision_origin', 'shop_recorded',
+            'shop_decision_at', v_now,
+            'shop_decision_actor_user_id', p_actor_user_id,
+            'shop_decision_contact_method', v_contact,
+            'shop_decision_note', left(nullif(trim(coalesce(p_note, '')), ''), 1000)
+          )),
+          updated_at = v_now
+      where id = v_line_id and shop_id = p_shop_id and work_order_id = p_work_order_id;
+    end loop;
+  end if;
+
+  v_result := v_result || jsonb_build_object('decision_origin', 'shop_recorded');
+  insert into public.quote_lifecycle_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id, work_order_id, result
+  ) values (
+    p_shop_id, 'shop_quote_decision', p_operation_key,
+    p_actor_user_id, p_work_order_id, v_result
+  );
+  return v_result;
+end;
+$$;
+
+revoke all on function public.apply_shop_quote_decision_atomic(uuid,uuid,uuid[],text,uuid,text,text,text,timestamptz) from public, anon;
+grant execute on function public.apply_shop_quote_decision_atomic(uuid,uuid,uuid[],text,uuid,text,text,text,timestamptz) to authenticated;
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/quote-history-insights-route.test.ts
+++ b/tests/quote-history-insights-route.test.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const route = fs.readFileSync(
+  path.join(
+    process.cwd(),
+    "app/api/work-orders/[id]/quote-history-insights/route.ts",
+  ),
+  "utf8",
+);
+
+describe("quote history insights route", () => {
+  it("requires quote authorization and scopes every history source to the actor shop", () => {
+    expect(route).toContain('requiredCapability: "canAuthorizeQuotes"');
+    expect(
+      route.match(/\.eq\("shop_id", shopId\)/g)?.length ?? 0,
+    ).toBeGreaterThanOrEqual(4);
+    expect(route).toContain('.neq("id", workOrderId)');
+  });
+
+  it("gates candidates deterministically and validates AI-selected pairs", () => {
+    expect(route).toContain("findRelevantHistoryCandidates");
+    expect(route).toContain("!allowed.has(pair)");
+    expect(route).toContain("fallbackSelections");
+  });
+});

--- a/tests/quote-history-relevance.test.ts
+++ b/tests/quote-history-relevance.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  findRelevantHistoryCandidates,
+  type QuoteHistoryCandidate,
+} from "@/features/work-orders/quote-review/quoteHistoryRelevance";
+
+function candidate(
+  overrides: Partial<QuoteHistoryCandidate>,
+): QuoteHistoryCandidate {
+  return {
+    historyLineId: "history-1",
+    workOrderId: "wo-old",
+    workOrderNumber: "EL000001",
+    description: "Brake fluid flush",
+    completedAt: "2026-01-01T00:00:00.000Z",
+    mileageDeltaKm: 10_000,
+    ageDays: 180,
+    ...overrides,
+  };
+}
+
+describe("quote history relevance", () => {
+  it("surfaces a recent brake fluid service", () => {
+    const matches = findRelevantHistoryCandidates({
+      quoteLineId: "quote-1",
+      quoteDescription: "Brake fluid level/condition — recommend brake flush",
+      candidates: [candidate({})],
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.serviceFamily).toBe("brake fluid");
+  });
+
+  it("does not confuse brake friction work with brake fluid service", () => {
+    const matches = findRelevantHistoryCandidates({
+      quoteLineId: "quote-1",
+      quoteDescription: "Brake fluid flush",
+      candidates: [candidate({ description: "Rear brake pads and rotors" })],
+    });
+    expect(matches).toEqual([]);
+  });
+
+  it("ignores brake friction work outside its mileage window", () => {
+    const matches = findRelevantHistoryCandidates({
+      quoteLineId: "quote-1",
+      quoteDescription: "Rear brake pads worn",
+      candidates: [
+        candidate({
+          description: "Rear brake pads replaced",
+          mileageDeltaKm: 80_000,
+        }),
+      ],
+    });
+    expect(matches).toEqual([]);
+  });
+
+  it("uses time limits when mileage is unavailable", () => {
+    const matches = findRelevantHistoryCandidates({
+      quoteLineId: "quote-1",
+      quoteDescription: "Engine oil change",
+      candidates: [
+        candidate({
+          description: "Engine oil service",
+          mileageDeltaKm: null,
+          ageDays: 800,
+        }),
+      ],
+    });
+    expect(matches).toEqual([]);
+  });
+});

--- a/tests/shop-quote-decision-contract.test.ts
+++ b/tests/shop-quote-decision-contract.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const route = fs.readFileSync(
+  path.join(root, "app/api/work-orders/quotes/[id]/authorize/route.ts"),
+  "utf8",
+);
+const helper = fs.readFileSync(
+  path.join(root, "features/work-orders/server/workOrderQuoteLineApproval.ts"),
+  "utf8",
+);
+const migration = fs.readFileSync(
+  path.join(
+    root,
+    "supabase/migrations/20260717003000_shop_recorded_quote_decisions.sql",
+  ),
+  "utf8",
+);
+
+describe("shop quote decision contract", () => {
+  it("accepts all three advisor decisions and records the shop source", () => {
+    expect(route).toContain('"approve"');
+    expect(route).toContain('"decline"');
+    expect(route).toContain('"defer"');
+    expect(route).toContain('decisionSource: "shop"');
+    expect(helper).toContain('"apply_shop_quote_decision_atomic"');
+  });
+
+  it("keeps materialization in the canonical atomic decision function", () => {
+    expect(migration).toContain("public.apply_customer_quote_decision_atomic");
+    expect(migration).toContain("decision_origin', 'shop_recorded'");
+    expect(migration).toContain("operation_name = 'shop_quote_decision'");
+    expect(migration).toContain("p_operation_key || ':canonical'");
+  });
+
+  it("enforces actor, tenant, role, and non-reversal checks in SQL", () => {
+    expect(migration).toContain("auth.uid() <> p_actor_user_id");
+    expect(migration).toContain("p.shop_id = p_shop_id");
+    expect(migration).toContain(
+      "'owner', 'admin', 'manager', 'advisor', 'service', 'foreman'",
+    );
+    expect(migration).toContain(
+      "Approved work cannot be reversed from quote review",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- adds shop-side Approve, Defer, and Decline actions to Quote Review
- records phone/in-person/email/other contact context and an optional advisor note
- delegates shop decisions to the canonical atomic quote materialization workflow
- prevents reversing approved or converted work from Quote Review
- adds tenant-scoped, line-level vehicle history insights
- gates history by service family, mileage, and time before AI ranks eligible records
- validates AI selections against deterministic candidate pairs and falls back without AI
- collapses parts details to tighten the quote review layout

## Root cause

Quote Review could directly change decline/defer status, but it had no audited shop-side approval flow. Canonical approval and materialization were only exposed through customer-facing approval paths. Vehicle service history was also not evaluated in the context of individual quote lines.

## User impact

Advisors can record classic phone-call decisions without leaving Quote Review. Relevant recent work is shown inline, while unrelated or stale history such as brake work performed far outside the configured mileage window is suppressed.

## Validation

- `pnpm typecheck` — passed
- targeted ESLint for all changed TypeScript/TSX files — passed
- 15 focused Vitest tests — passed
- `pnpm audit:api-routes` — passed, 358 routes analyzed
- `git diff --check` — passed
- `pnpm build` — not fully verified because the restricted runner could not fetch Google Fonts

## Deployment

Apply `supabase/migrations/20260717003000_shop_recorded_quote_decisions.sql` before deploying the application code. No new environment variables are required.