### PR TITLE
Add Instant Analysis cleanup to guided onboarding

### DIFF
--- a/app/api/shop-boost/review-items/[id]/route.ts
+++ b/app/api/shop-boost/review-items/[id]/route.ts
@@ -1,25 +1,14 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { resolveAndMaterializeReviewItem } from "@/features/integrations/shopBoost/reviewMaterialization";
 
 type RouteContext = { params: Promise<{ id: string }> };
 
 export async function PATCH(req: Request, context: RouteContext) {
   const { id } = await context.params;
-  const supabaseUser = createServerSupabaseRoute();
-  const {
-    data: { user },
-  } = await supabaseUser.auth.getUser();
-
-  if (!user?.id) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
-
-  const { data: profile } = await supabaseUser
-    .from("profiles")
-    .select("shop_id")
-    .eq("id", user.id)
-    .maybeSingle<{ shop_id: string | null }>();
-
-  if (!profile?.shop_id) return NextResponse.json({ ok: false, error: "No shop linked." }, { status: 400 });
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.profile.shop_id!;
 
   const body = (await req.json().catch(() => ({}))) as {
     resolution_action?: "linked_to_existing" | "created_new" | "ignored";
@@ -37,8 +26,8 @@ export async function PATCH(req: Request, context: RouteContext) {
 
   const result = await resolveAndMaterializeReviewItem({
     reviewItemId: id,
-    shopId: profile.shop_id,
-    userId: user.id,
+    shopId,
+    userId: access.profile.id,
     resolutionAction: body.resolution_action ?? "ignored",
     confirmHighRiskAction: body.confirm_high_risk_action === true,
     ignoreReasonCode: body.ignore_reason_code,

--- a/app/api/shop-boost/review-items/apply-safe/route.ts
+++ b/app/api/shop-boost/review-items/apply-safe/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { applyHighConfidenceRecommendations } from "@/features/integrations/shopBoost/reviewMaterialization";
+
+export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+
+  const body = (await req.json().catch(() => ({}))) as { intakeId?: string };
+  const intakeId = typeof body.intakeId === "string" ? body.intakeId.trim() : "";
+  if (!intakeId) {
+    return NextResponse.json({ ok: false, error: "intakeId is required." }, { status: 400 });
+  }
+
+  const results = await applyHighConfidenceRecommendations({
+    shopId: access.profile.shop_id!,
+    userId: access.profile.id,
+    intakeId,
+    threshold: 0.85,
+  });
+
+  const succeeded = results.filter((result) => result.ok).length;
+  const failed = results.length - succeeded;
+
+  return NextResponse.json({
+    ok: failed === 0,
+    attempted: results.length,
+    succeeded,
+    failed,
+    results,
+  });
+}

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -102,7 +102,7 @@ function deriveRecommendationExplanation(recommendation: RecommendationDto): str
 export async function GET(req: Request) {
   const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
   if (!access.ok) return access.response;
-  const shopId = access.shopId!;
+  const shopId = access.profile.shop_id!;
 
   const url = new URL(req.url);
   const domain = url.searchParams.get("domain");

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { buildCanonicalIntakeTruth } from "@/features/integrations/shopBoost/canonicalTruth";
 import { confidenceLabelFromScore, deriveReviewRecommendation, type RecommendedAction, type ReviewRecommendation } from "@/features/integrations/shopBoost/reviewGuidance";
 
@@ -100,20 +100,9 @@ function deriveRecommendationExplanation(recommendation: RecommendationDto): str
 }
 
 export async function GET(req: Request) {
-  const supabaseUser = createServerSupabaseRoute();
-  const {
-    data: { user },
-  } = await supabaseUser.auth.getUser();
-
-  if (!user?.id) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
-
-  const { data: profile } = await supabaseUser
-    .from("profiles")
-    .select("shop_id")
-    .eq("id", user.id)
-    .maybeSingle<{ shop_id: string | null }>();
-
-  if (!profile?.shop_id) return NextResponse.json({ ok: false, error: "No shop linked." }, { status: 400 });
+  const access = await requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] });
+  if (!access.ok) return access.response;
+  const shopId = access.shopId!;
 
   const url = new URL(req.url);
   const domain = url.searchParams.get("domain");
@@ -129,7 +118,7 @@ export async function GET(req: Request) {
           await admin
             .from("shop_boost_intakes")
             .select("id")
-            .eq("shop_id", profile.shop_id)
+            .eq("shop_id", shopId)
             .order("created_at", { ascending: false })
             .limit(1)
             .maybeSingle<{ id: string }>()
@@ -174,7 +163,7 @@ export async function GET(req: Request) {
   let query = admin
     .from("shop_boost_review_items")
     .select("id,intake_id,domain,issue_type,summary,raw_payload,normalized_payload,target_domain,blocking_reason,dependency_refs,downstream_impact_count,cluster_key,cluster_confidence,suggested_matches,status,resolution_action,ignore_reason_code,ignore_note,ignored_at,resolved_at,materialized_at,materialization_error,materialized_record,created_at,recommended_action,recommendation_reason,recommendation_confidence,candidate_targets,recommendation_seen_at,recommendation_followed")
-    .eq("shop_id", profile.shop_id)
+    .eq("shop_id", shopId)
     .eq("intake_id", resolvedIntakeId)
     .order("created_at", { ascending: false })
     .limit(250);
@@ -223,7 +212,7 @@ export async function GET(req: Request) {
 
   const canonicalTruth = await buildCanonicalIntakeTruth({
     admin: admin as any,
-    shopId: profile.shop_id,
+    shopId: shopId,
     intakeId: resolvedIntakeId,
   });
 
@@ -234,7 +223,7 @@ export async function GET(req: Request) {
   const { data: intake } = await admin
     .from("shop_boost_intakes")
     .select("intake_basics")
-    .eq("shop_id", profile.shop_id)
+    .eq("shop_id", shopId)
     .eq("id", resolvedIntakeId)
     .maybeSingle();
   const migration = asRecord(asRecord(intake?.intake_basics).migrationProgress);

--- a/app/api/shop-boost/review-items/route.ts
+++ b/app/api/shop-boost/review-items/route.ts
@@ -169,7 +169,11 @@ export async function GET(req: Request) {
     .limit(250);
 
   if (domain) query = query.eq("domain", domain);
-  if (status) query = query.eq("status", status);
+  if (status === "unresolved") {
+    query = query.in("status", ["pending", "failed_materialization"]);
+  } else if (status) {
+    query = query.eq("status", status);
+  }
 
   const { data, error } = await query;
   if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });

--- a/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
+++ b/features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx
@@ -5,6 +5,7 @@ import { buildGuidedDestination, GUIDED_ONBOARDING_STEPS, getGuidedOnboardingSte
 import type { GuidedOnboardingSessionDetail, GuidedOnboardingStepRow } from "@/features/onboarding-v2/guided/types";
 import { OnboardingHighlightFrame } from "./OnboardingHighlightFrame";
 import ShopSettingsSetupModal from "./ShopSettingsSetupModal";
+import InstantAnalysisReviewPanel from "./InstantAnalysisReviewPanel";
 
 type Props = {
   initialSessionId?: string;
@@ -185,6 +186,8 @@ export default function GuidedOnboardingWorkspace({ initialSessionId }: Props) {
       {error ? <div className="rounded-2xl border border-red-400/30 bg-red-950/30 px-4 py-3 text-sm text-red-100">{error}</div> : null}
       {loadingCopy ? <div className="rounded-2xl border border-orange-300/25 bg-orange-400/10 px-4 py-3 text-sm text-orange-100">{loadingCopy}</div> : null}
       {loadState === "loading" ? <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 text-sm text-[color:var(--theme-text-secondary)]">Loading guided setup…</div> : null}
+
+      {detail ? <InstantAnalysisReviewPanel steps={detail.steps} /> : null}
 
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_360px]">
         <section className="space-y-5">

--- a/features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx
+++ b/features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx
@@ -146,7 +146,7 @@ export default function InstantAnalysisReviewPanel({ steps }: Props) {
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams({ intakeId, status: "" });
+      const params = new URLSearchParams({ intakeId, status: "unresolved" });
       const response = await fetch(`/api/shop-boost/review-items?${params.toString()}`, {
         cache: "no-store",
       });

--- a/features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx
+++ b/features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx
@@ -1,0 +1,494 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { GuidedOnboardingStepRow } from "@/features/onboarding-v2/guided/types";
+
+type ResolutionAction = "linked_to_existing" | "created_new" | "ignored";
+type RecommendedAction = "link_existing" | "create_new" | "merge_candidate" | "ignore";
+type ReviewStatus = "pending" | "failed_materialization" | "materialized" | "ignored" | "resolved";
+
+type ReviewItem = {
+  id: string;
+  intake_id: string;
+  domain: string;
+  issue_type: string;
+  summary: string;
+  status: ReviewStatus | string;
+  blocking_reason: string | null;
+  materialization_error: string | null;
+  raw_payload: Record<string, unknown> | null;
+  normalized_payload: Record<string, unknown> | null;
+  review_explanation: string;
+  recommendation_explanation: string;
+  recommendation: {
+    recommendedAction: RecommendedAction;
+    recommendationReason: string;
+    recommendationConfidence: number;
+    confidenceLabel: "HIGH" | "MEDIUM" | "LOW";
+    candidateTargets: Array<{ id: string; label: string; score: number }>;
+  };
+};
+
+type ReviewResponse = {
+  ok: true;
+  intakeId: string;
+  items: ReviewItem[];
+  summary: {
+    unresolved_total: number;
+    blockers_total: number;
+    status_counts: Record<string, number>;
+  };
+  guidance: {
+    state: string;
+    operational_blockers_count: number;
+    non_blocking_issues_count: number;
+  };
+};
+
+type Props = {
+  steps: GuidedOnboardingStepRow[];
+};
+
+const DOMAIN_FILTERS = [
+  { key: "all", label: "All" },
+  { key: "customers", label: "Customers" },
+  { key: "vehicles", label: "Vehicles" },
+  { key: "history", label: "History" },
+  { key: "invoices", label: "Invoices" },
+  { key: "parts", label: "Parts" },
+] as const;
+
+const IGNORE_REASONS = [
+  { value: "duplicate", label: "Duplicate" },
+  { value: "obsolete", label: "Old or obsolete data" },
+  { value: "invalid", label: "Invalid row" },
+  { value: "test_data", label: "Test data" },
+  { value: "intentionally_skipped", label: "Intentionally skipped" },
+  { value: "unsupported_format", label: "Unsupported format" },
+  { value: "other", label: "Other" },
+] as const;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function canonicalDomain(domain: string) {
+  const normalized = domain.trim().toLowerCase();
+  if (normalized === "customer" || normalized === "customers") return "customers";
+  if (normalized === "vehicle" || normalized === "vehicles") return "vehicles";
+  if (normalized === "history" || normalized === "work_order" || normalized === "work_orders") return "history";
+  if (normalized === "invoice" || normalized === "invoices") return "invoices";
+  if (normalized === "part" || normalized === "parts") return "parts";
+  return null;
+}
+
+function domainLabel(domain: string) {
+  const canonical = canonicalDomain(domain);
+  return DOMAIN_FILTERS.find((item) => item.key === canonical)?.label ?? domain;
+}
+
+function resolutionForRecommendation(action: RecommendedAction): ResolutionAction {
+  if (action === "link_existing" || action === "merge_candidate") return "linked_to_existing";
+  if (action === "ignore") return "ignored";
+  return "created_new";
+}
+
+function recommendedActionLabel(action: RecommendedAction, failed: boolean) {
+  const prefix = failed ? "Retry: " : "";
+  if (action === "link_existing") return `${prefix}Link existing record`;
+  if (action === "merge_candidate") return `${prefix}Confirm duplicate link`;
+  if (action === "ignore") return `${prefix}Ignore invalid row`;
+  return `${prefix}Create missing record`;
+}
+
+function isHighRisk(item: ReviewItem) {
+  return (
+    item.recommendation.recommendedAction === "merge_candidate" ||
+    item.issue_type === "conflict" ||
+    item.issue_type === "duplicate_candidate"
+  );
+}
+
+function findInstantAnalysisIntake(steps: GuidedOnboardingStepRow[]) {
+  for (const step of steps) {
+    const answer = asRecord(step.answer);
+    if (answer.source !== "instant_shop_analysis") continue;
+    const intakeId = typeof answer.intakeId === "string" ? answer.intakeId.trim() : "";
+    if (intakeId) return intakeId;
+  }
+  return null;
+}
+
+async function readJsonError(response: Response, fallback: string) {
+  const body = (await response.json().catch(() => null)) as { error?: string } | null;
+  return body?.error ?? fallback;
+}
+
+export default function InstantAnalysisReviewPanel({ steps }: Props) {
+  const intakeId = useMemo(() => findInstantAnalysisIntake(steps), [steps]);
+  const [payload, setPayload] = useState<ReviewResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [busyItemId, setBusyItemId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<(typeof DOMAIN_FILTERS)[number]["key"]>("all");
+  const [confirmHighRiskId, setConfirmHighRiskId] = useState<string | null>(null);
+  const [ignoreItemId, setIgnoreItemId] = useState<string | null>(null);
+  const [ignoreReason, setIgnoreReason] = useState<(typeof IGNORE_REASONS)[number]["value"]>("intentionally_skipped");
+
+  const loadReview = useCallback(async () => {
+    if (!intakeId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ intakeId, status: "" });
+      const response = await fetch(`/api/shop-boost/review-items?${params.toString()}`, {
+        cache: "no-store",
+      });
+      if (!response.ok) throw new Error(await readJsonError(response, "Unable to load data cleanup"));
+      setPayload((await response.json()) as ReviewResponse);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Unable to load data cleanup");
+    } finally {
+      setLoading(false);
+    }
+  }, [intakeId]);
+
+  useEffect(() => {
+    void loadReview();
+  }, [loadReview]);
+
+  const unresolvedItems = useMemo(
+    () =>
+      (payload?.items ?? []).filter(
+        (item) =>
+          (item.status === "pending" || item.status === "failed_materialization") &&
+          canonicalDomain(item.domain),
+      ),
+    [payload],
+  );
+
+  const visibleItems = useMemo(
+    () =>
+      filter === "all"
+        ? unresolvedItems
+        : unresolvedItems.filter((item) => canonicalDomain(item.domain) === filter),
+    [filter, unresolvedItems],
+  );
+
+  const countsByDomain = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of unresolvedItems) {
+      const domain = canonicalDomain(item.domain);
+      if (domain) counts.set(domain, (counts.get(domain) ?? 0) + 1);
+    }
+    return counts;
+  }, [unresolvedItems]);
+
+  const resolveItem = useCallback(
+    async (
+      item: ReviewItem,
+      resolutionAction: ResolutionAction,
+      options?: { confirmHighRisk?: boolean; ignoreReason?: string },
+    ) => {
+      setBusyItemId(item.id);
+      setError(null);
+      try {
+        const response = await fetch(`/api/shop-boost/review-items/${item.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            resolution_action: resolutionAction,
+            confirm_high_risk_action: options?.confirmHighRisk === true,
+            ...(resolutionAction === "ignored"
+              ? {
+                  ignore_reason_code: options?.ignoreReason ?? "intentionally_skipped",
+                  ignore_note: "Reviewed during guided onboarding data cleanup.",
+                }
+              : {}),
+          }),
+        });
+        if (!response.ok) throw new Error(await readJsonError(response, "Unable to apply this fix"));
+        setConfirmHighRiskId(null);
+        setIgnoreItemId(null);
+        await loadReview();
+      } catch (actionError) {
+        setError(actionError instanceof Error ? actionError.message : "Unable to apply this fix");
+      } finally {
+        setBusyItemId(null);
+      }
+    },
+    [loadReview],
+  );
+
+  if (!intakeId) return null;
+
+  if (loading && !payload) {
+    return (
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5">
+        <p className="text-sm text-[color:var(--theme-text-secondary)]">Checking imported data for items that need your review…</p>
+      </section>
+    );
+  }
+
+  if (!loading && payload && unresolvedItems.length === 0) {
+    return (
+      <section className="rounded-3xl border border-emerald-400/30 bg-emerald-500/10 p-5 shadow-[var(--theme-shadow-medium)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-300">Data cleanup complete</p>
+        <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-[color:var(--theme-text-primary)]">Your imported shop data is ready</h2>
+            <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+              Every flagged customer, vehicle, history, invoice, and part row has been handled.
+            </p>
+          </div>
+          <span className="w-fit rounded-full border border-emerald-400/30 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-200">
+            0 items remaining
+          </span>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="overflow-hidden rounded-3xl border border-amber-400/30 bg-[color:var(--theme-surface-inset)] shadow-[var(--theme-shadow-medium)]">
+      <div className="border-b border-[color:var(--theme-border-soft)] bg-amber-500/10 p-5 sm:p-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-300">Imported data cleanup</p>
+            <h2 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+              A few rows need a quick decision
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+              ProFixIQ imported everything it could safely verify. Review only the exceptions below; each card explains what happened and recommends the safest fix.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 py-3">
+              <p className="text-2xl font-semibold text-[color:var(--theme-text-primary)]">{unresolvedItems.length}</p>
+              <p className="text-xs text-[color:var(--theme-text-secondary)]">Need review</p>
+            </div>
+            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 py-3">
+              <p className="text-2xl font-semibold text-red-300">
+                {unresolvedItems.filter((item) => item.status === "failed_materialization").length}
+              </p>
+              <p className="text-xs text-[color:var(--theme-text-secondary)]">Retry needed</p>
+            </div>
+            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 py-3">
+              <p className="text-2xl font-semibold text-amber-300">{payload?.summary.blockers_total ?? 0}</p>
+              <p className="text-xs text-[color:var(--theme-text-secondary)]">Blocking launch</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-5 sm:p-6">
+        {error ? (
+          <div className="mb-4 rounded-2xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          {DOMAIN_FILTERS.map((domain) => {
+            const count = domain.key === "all" ? unresolvedItems.length : countsByDomain.get(domain.key) ?? 0;
+            if (domain.key !== "all" && count === 0) return null;
+            const selected = filter === domain.key;
+            return (
+              <button
+                key={domain.key}
+                type="button"
+                onClick={() => setFilter(domain.key)}
+                className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                  selected
+                    ? "border-amber-300/60 bg-amber-400/15 text-amber-200"
+                    : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-secondary)]"
+                }`}
+              >
+                {domain.label} · {count}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-5 space-y-4">
+          {visibleItems.map((item) => {
+            const failed = item.status === "failed_materialization";
+            const highRisk = isHighRisk(item);
+            const recommendationAction = resolutionForRecommendation(item.recommendation.recommendedAction);
+            const confirmingHighRisk = confirmHighRiskId === item.id;
+            const ignoring = ignoreItemId === item.id;
+            const busy = busyItemId === item.id;
+
+            return (
+              <article
+                key={item.id}
+                className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4 sm:p-5"
+              >
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-1 text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                        {domainLabel(item.domain)}
+                      </span>
+                      <span className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
+                        failed
+                          ? "border-red-400/30 bg-red-500/10 text-red-200"
+                          : "border-amber-400/30 bg-amber-500/10 text-amber-200"
+                      }`}>
+                        {failed ? "Fix failed — retry available" : "Needs review"}
+                      </span>
+                      {item.blocking_reason ? (
+                        <span className="rounded-full border border-red-400/30 bg-red-500/10 px-2.5 py-1 text-xs font-semibold text-red-200">
+                          Blocks launch
+                        </span>
+                      ) : null}
+                    </div>
+                    <h3 className="mt-3 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                      {item.summary || `${domainLabel(item.domain)} row needs review`}
+                    </h3>
+                    <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+                      {failed && item.materialization_error
+                        ? item.materialization_error
+                        : item.review_explanation}
+                    </p>
+                  </div>
+                  <div className="shrink-0 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 lg:w-72">
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                        ProFixIQ recommends
+                      </p>
+                      <span className="text-xs font-semibold text-emerald-300">
+                        {Math.round(item.recommendation.recommendationConfidence * 100)}%
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                      {recommendedActionLabel(item.recommendation.recommendedAction, failed)}
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                      {item.recommendation_explanation}
+                    </p>
+                  </div>
+                </div>
+
+                <details className="mt-4 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]">
+                  <summary className="cursor-pointer px-4 py-3 text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                    See source and normalized data
+                  </summary>
+                  <div className="grid gap-3 border-t border-[color:var(--theme-border-soft)] p-3 lg:grid-cols-2">
+                    <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-[color:var(--theme-surface-page)] p-3 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
+                      {JSON.stringify(item.raw_payload ?? {}, null, 2)}
+                    </pre>
+                    <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-[color:var(--theme-surface-page)] p-3 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
+                      {JSON.stringify(item.normalized_payload ?? {}, null, 2)}
+                    </pre>
+                  </div>
+                </details>
+
+                {confirmingHighRisk ? (
+                  <div className="mt-4 rounded-2xl border border-red-400/30 bg-red-500/10 p-4">
+                    <p className="text-sm font-semibold text-red-200">Confirm this duplicate or conflict decision</p>
+                    <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                      This may connect imported history to an existing record. Confirm only after checking the suggested match and source data.
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void resolveItem(item, recommendationAction, { confirmHighRisk: true })}
+                        className="rounded-xl bg-red-500 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+                      >
+                        {busy ? "Applying…" : "Confirm and apply"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => setConfirmHighRiskId(null)}
+                        className="rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-2 text-sm text-[color:var(--theme-text-primary)]"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+
+                {ignoring ? (
+                  <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
+                    <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]" htmlFor={`ignore-${item.id}`}>
+                      Why should this row be ignored?
+                    </label>
+                    <div className="mt-2 flex flex-col gap-2 sm:flex-row">
+                      <select
+                        id={`ignore-${item.id}`}
+                        value={ignoreReason}
+                        onChange={(event) => setIgnoreReason(event.target.value as typeof ignoreReason)}
+                        className="min-w-0 flex-1 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)]"
+                      >
+                        {IGNORE_REASONS.map((reason) => (
+                          <option key={reason.value} value={reason.value}>{reason.label}</option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void resolveItem(item, "ignored", { ignoreReason })}
+                        className="rounded-xl bg-[color:var(--theme-text-primary)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-surface-page)] disabled:opacity-50"
+                      >
+                        {busy ? "Saving…" : "Ignore this row"}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => setIgnoreItemId(null)}
+                        className="rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-2 text-sm text-[color:var(--theme-text-primary)]"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+
+                {!confirmingHighRisk && !ignoring ? (
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => {
+                        if (highRisk) {
+                          setConfirmHighRiskId(item.id);
+                          return;
+                        }
+                        if (recommendationAction === "ignored") {
+                          setIgnoreItemId(item.id);
+                          return;
+                        }
+                        void resolveItem(item, recommendationAction);
+                      }}
+                      className="rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)] disabled:opacity-50"
+                    >
+                      {busy ? "Applying…" : recommendedActionLabel(item.recommendation.recommendedAction, failed)}
+                    </button>
+                    {recommendationAction !== "ignored" ? (
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => {
+                          setIgnoreReason("intentionally_skipped");
+                          setIgnoreItemId(item.id);
+                        }}
+                        className="rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-secondary)] disabled:opacity-50"
+                      >
+                        Ignore instead
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx
+++ b/features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx
@@ -134,6 +134,7 @@ export default function InstantAnalysisReviewPanel({ steps }: Props) {
   const [payload, setPayload] = useState<ReviewResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [busyItemId, setBusyItemId] = useState<string | null>(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState<(typeof DOMAIN_FILTERS)[number]["key"]>("all");
   const [confirmHighRiskId, setConfirmHighRiskId] = useState<string | null>(null);
@@ -180,6 +181,18 @@ export default function InstantAnalysisReviewPanel({ steps }: Props) {
     [filter, unresolvedItems],
   );
 
+  const safeItems = useMemo(
+    () =>
+      unresolvedItems.filter(
+        (item) =>
+          item.status === "pending" &&
+          item.recommendation.recommendationConfidence >= 0.85 &&
+          item.recommendation.recommendedAction !== "merge_candidate" &&
+          !isHighRisk(item),
+      ),
+    [unresolvedItems],
+  );
+
   const countsByDomain = useMemo(() => {
     const counts = new Map<string, number>();
     for (const item of unresolvedItems) {
@@ -224,6 +237,33 @@ export default function InstantAnalysisReviewPanel({ steps }: Props) {
     },
     [loadReview],
   );
+
+  const applySafeFixes = useCallback(async () => {
+    if (!intakeId || safeItems.length === 0) return;
+    setBulkBusy(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/shop-boost/review-items/apply-safe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ intakeId }),
+      });
+      const result = (await response.json().catch(() => null)) as
+        | { ok?: boolean; attempted?: number; succeeded?: number; failed?: number; error?: string }
+        | null;
+      if (!response.ok) throw new Error(result?.error ?? "Unable to apply safe fixes");
+      await loadReview();
+      if ((result?.failed ?? 0) > 0) {
+        setError(
+          `ProFixIQ fixed ${result?.succeeded ?? 0} items. ${result?.failed ?? 0} still need individual review.`,
+        );
+      }
+    } catch (bulkError) {
+      setError(bulkError instanceof Error ? bulkError.message : "Unable to apply safe fixes");
+    } finally {
+      setBulkBusy(false);
+    }
+  }, [intakeId, loadReview, safeItems.length]);
 
   if (!intakeId) return null;
 
@@ -290,6 +330,27 @@ export default function InstantAnalysisReviewPanel({ steps }: Props) {
         {error ? (
           <div className="mb-4 rounded-2xl border border-red-400/30 bg-red-500/10 px-4 py-3 text-sm text-red-200">
             {error}
+          </div>
+        ) : null}
+
+        {safeItems.length > 1 ? (
+          <div className="mb-5 flex flex-col gap-3 rounded-2xl border border-emerald-400/30 bg-emerald-500/10 p-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-emerald-200">
+                {safeItems.length} high-confidence fixes are ready
+              </p>
+              <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                Apply the safe recommendations together. Duplicate merges and lower-confidence decisions always stay manual.
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={bulkBusy || Boolean(busyItemId)}
+              onClick={() => void applySafeFixes()}
+              className="shrink-0 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50"
+            >
+              {bulkBusy ? "Applying safe fixes…" : `Fix ${safeItems.length} safe items`}
+            </button>
           </div>
         ) : null}
 

--- a/features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx
+++ b/features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx
@@ -105,9 +105,12 @@ function recommendedActionLabel(action: RecommendedAction, failed: boolean) {
 
 function isHighRisk(item: ReviewItem) {
   return (
-    item.recommendation.recommendedAction === "merge_candidate" ||
-    item.issue_type === "conflict" ||
-    item.issue_type === "duplicate_candidate"
+    resolutionForRecommendation(item.recommendation.recommendedAction) === "linked_to_existing" &&
+    (
+      item.recommendation.recommendedAction === "merge_candidate" ||
+      item.issue_type === "conflict" ||
+      item.issue_type === "duplicate_candidate"
+    )
   );
 }
 

--- a/tests/instant-analysis-review-checkpoint.test.ts
+++ b/tests/instant-analysis-review-checkpoint.test.ts
@@ -53,7 +53,7 @@ describe("instant analysis guided onboarding review checkpoint", () => {
     const panel = read("features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx");
     const safeRoute = read("app/api/shop-boost/review-items/apply-safe/route.ts");
 
-    expect(panel).toContain("Fix \${safeItems.length} safe items");
+    expect(panel).toContain('Fix ${safeItems.length} safe items');
     expect(panel).toContain("Duplicate merges and lower-confidence decisions always stay manual");
     expect(safeRoute).toContain("applyHighConfidenceRecommendations");
     expect(safeRoute).toContain("threshold: 0.85");

--- a/tests/instant-analysis-review-checkpoint.test.ts
+++ b/tests/instant-analysis-review-checkpoint.test.ts
@@ -31,10 +31,12 @@ describe("instant analysis guided onboarding review checkpoint", () => {
   it("loads pending and failed materializations for the activated intake", () => {
     const panel = read("features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx");
 
-    expect(panel).toContain('new URLSearchParams({ intakeId, status: "" })');
+    expect(panel).toContain('new URLSearchParams({ intakeId, status: "unresolved" })');
     expect(panel).toContain('item.status === "pending" || item.status === "failed_materialization"');
     expect(panel).toContain("Retry needed");
     expect(panel).toContain("Blocking launch");
+    const listRoute = read("app/api/shop-boost/review-items/route.ts");
+    expect(listRoute).toContain('query.in("status", ["pending", "failed_materialization"])');
   });
 
   it("supports recommended fixes, explicit risky confirmation, and reasoned ignores", () => {

--- a/tests/instant-analysis-review-checkpoint.test.ts
+++ b/tests/instant-analysis-review-checkpoint.test.ts
@@ -47,6 +47,17 @@ describe("instant analysis guided onboarding review checkpoint", () => {
     expect(panel).toContain("ignore_reason_code");
   });
 
+  it("keeps cleanup under ten minutes with explicit safe bulk fixes", () => {
+    const panel = read("features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx");
+    const safeRoute = read("app/api/shop-boost/review-items/apply-safe/route.ts");
+
+    expect(panel).toContain("Fix \${safeItems.length} safe items");
+    expect(panel).toContain("Duplicate merges and lower-confidence decisions always stay manual");
+    expect(safeRoute).toContain("applyHighConfidenceRecommendations");
+    expect(safeRoute).toContain("threshold: 0.85");
+    expect(safeRoute).toContain('allowRoles: ["owner", "admin"]');
+  });
+
   it("restricts review reads and writes to owners and admins", () => {
     const listRoute = read("app/api/shop-boost/review-items/route.ts");
     const itemRoute = read("app/api/shop-boost/review-items/[id]/route.ts");

--- a/tests/instant-analysis-review-checkpoint.test.ts
+++ b/tests/instant-analysis-review-checkpoint.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function read(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("instant analysis guided onboarding review checkpoint", () => {
+  it("renders review inside guided onboarding only for instant-analysis sessions", () => {
+    const workspace = read("features/onboarding-v2/components/GuidedOnboardingWorkspace.tsx");
+    const panel = read("features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx");
+
+    expect(workspace).toContain('import InstantAnalysisReviewPanel from "./InstantAnalysisReviewPanel"');
+    expect(workspace).toContain("<InstantAnalysisReviewPanel steps={detail.steps} />");
+    expect(panel).toContain('answer.source !== "instant_shop_analysis"');
+    expect(panel).toContain("answer.intakeId");
+  });
+
+  it("keeps cleanup scoped to the five guided onboarding data domains", () => {
+    const panel = read("features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx");
+
+    expect(panel).toContain('{ key: "customers", label: "Customers" }');
+    expect(panel).toContain('{ key: "vehicles", label: "Vehicles" }');
+    expect(panel).toContain('{ key: "history", label: "History" }');
+    expect(panel).toContain('{ key: "invoices", label: "Invoices" }');
+    expect(panel).toContain('{ key: "parts", label: "Parts" }');
+    expect(panel).not.toContain('{ key: "staff"');
+  });
+
+  it("loads pending and failed materializations for the activated intake", () => {
+    const panel = read("features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx");
+
+    expect(panel).toContain('new URLSearchParams({ intakeId, status: "" })');
+    expect(panel).toContain('item.status === "pending" || item.status === "failed_materialization"');
+    expect(panel).toContain("Retry needed");
+    expect(panel).toContain("Blocking launch");
+  });
+
+  it("supports recommended fixes, explicit risky confirmation, and reasoned ignores", () => {
+    const panel = read("features/onboarding-v2/components/InstantAnalysisReviewPanel.tsx");
+
+    expect(panel).toContain('resolution_action: resolutionAction');
+    expect(panel).toContain('confirm_high_risk_action: options?.confirmHighRisk === true');
+    expect(panel).toContain("Confirm and apply");
+    expect(panel).toContain("Why should this row be ignored?");
+    expect(panel).toContain("ignore_reason_code");
+  });
+
+  it("restricts review reads and writes to owners and admins", () => {
+    const listRoute = read("app/api/shop-boost/review-items/route.ts");
+    const itemRoute = read("app/api/shop-boost/review-items/[id]/route.ts");
+
+    expect(listRoute).toContain('requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] })');
+    expect(itemRoute).toContain('requireShopScopedApiAccess({ allowRoles: ["owner", "admin"] })');
+    expect(listRoute).toContain(".eq(\"shop_id\", shopId)");
+    expect(itemRoute).toContain("shopId,");
+  });
+});


### PR DESCRIPTION
## What changed

- adds an **Imported data cleanup** checkpoint directly inside Guided Setup for Instant Shop Analysis sessions
- loads only unresolved `pending` and `failed_materialization` rows for the activated intake
- keeps the review scope restricted to customers, vehicles, history, invoices, and parts
- groups exceptions by dataset and distinguishes needs-review, retry-needed, and launch-blocking items
- shows ProFixIQ’s recommendation, confidence, explanation, source data, and normalized data
- supports recommended create/link/ignore actions using the existing materialization engine
- requires explicit confirmation for duplicate/conflict link actions
- requires an ignore reason and preserves the existing audit trail
- adds an explicit **Fix safe items** action for recommendations at or above 85% confidence
- never bulk-applies duplicate merges or lower-confidence decisions
- shows a positive cleanup-complete state when no unresolved rows remain
- restricts review reads, writes, and safe bulk actions to owners/admins with shop-scoped access

## Why this fits the onboarding flow

The review checkpoint is derived from the `instant_shop_analysis` guided-step answers created by PR #1082. It uses that activation’s `intakeId`, so it cannot drift to a different import. Completed import steps remain completed; cleanup is presented above the next guided step instead of forcing the user to repeat onboarding.

## Safety and tenancy

- every endpoint uses `requireShopScopedApiAccess`
- only owner/admin roles can read or resolve review items
- every query and materialization remains scoped to the authenticated shop
- risky link/merge decisions require explicit confirmation
- high-confidence bulk cleanup excludes merge candidates and low-confidence rows
- existing dependency replay, integrity recomputation, and audit logging are reused

## Validation

Added focused regression coverage in:

`tests/instant-analysis-review-checkpoint.test.ts`

Coverage verifies:

- Instant Analysis session detection
- the five-dataset allowlist
- unresolved-only loading
- pending and failed review states
- recommended actions and retry behavior
- explicit high-risk confirmation
- reasoned ignores
- safe bulk-fix threshold and exclusions
- owner/admin route guards

- Vercel preview build: **Ready**
- PR is mergeable
- Review threads: none

No database migration or new environment variables are required.
