### PR TITLE
Make workforce time and admin workflows fully actionable

### DIFF
--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -129,6 +129,7 @@ export async function GET(req: NextRequest) {
 
   const trueZero = enrichedEntries.length === 0 && !refreshState.hasSourceTime;
   return NextResponse.json({
+    settings: current.settings ?? null,
     periods: periods ?? [],
     activePeriodId,
     entries: enrichedEntries,
@@ -143,4 +144,72 @@ export async function GET(req: NextRequest) {
           : null,
     },
   });
+}
+
+
+type PayrollCadence = "weekly" | "biweekly" | "semimonthly" | "monthly";
+
+type SettingsBody = {
+  cadence?: PayrollCadence;
+  week_starts_on?: number;
+  period_anchor_date?: string | null;
+};
+
+export async function PUT(req: NextRequest) {
+  const auth = await requirePayrollReviewer();
+  if (!auth.ok) return auth.response;
+  if (!["owner", "admin"].includes(String(auth.me.role ?? ""))) {
+    return NextResponse.json({ error: "Only an owner or admin can change payroll period settings." }, { status: 403 });
+  }
+
+  const body = (await req.json().catch(() => null)) as SettingsBody | null;
+  const allowedCadences: PayrollCadence[] = ["weekly", "biweekly", "semimonthly", "monthly"];
+  if (!body?.cadence || !allowedCadences.includes(body.cadence)) {
+    return NextResponse.json({ error: "Choose weekly, bi-weekly, semi-monthly, or monthly." }, { status: 400 });
+  }
+
+  const weekStartsOn = Number(body.week_starts_on);
+  if (!Number.isInteger(weekStartsOn) || weekStartsOn < 0 || weekStartsOn > 6) {
+    return NextResponse.json({ error: "Week start must be a day from Sunday through Saturday." }, { status: 400 });
+  }
+
+  const anchorDate = body.period_anchor_date?.trim() || null;
+  if (anchorDate && !/^\d{4}-\d{2}-\d{2}$/.test(anchorDate)) {
+    return NextResponse.json({ error: "Anchor date must be a valid calendar date." }, { status: 400 });
+  }
+  if (body.cadence === "biweekly" && !anchorDate) {
+    return NextResponse.json({ error: "Bi-weekly payroll requires an anchor period start date." }, { status: 400 });
+  }
+
+  const admin: AdminClient = createAdminSupabase();
+  const now = new Date().toISOString();
+  const { data: settings, error } = await (admin as any)
+    .from("shop_payroll_settings")
+    .upsert({
+      shop_id: auth.me.shop_id,
+      cadence: body.cadence,
+      week_starts_on: weekStartsOn,
+      period_anchor_date: anchorDate,
+      updated_at: now,
+    }, { onConflict: "shop_id" })
+    .select("*")
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+  await (admin as any).from("audit_logs").insert({
+    shop_id: auth.me.shop_id,
+    actor_id: auth.me.id,
+    action: "payroll.settings.updated",
+    target_table: "shop_payroll_settings",
+    target_id: settings.id,
+    metadata: {
+      cadence: body.cadence,
+      week_starts_on: weekStartsOn,
+      period_anchor_date: anchorDate,
+    },
+  });
+
+  const current = await getOrCreateCurrentPeriod(auth.me.shop_id!, auth.me.id);
+  return NextResponse.json({ ok: true, settings, currentPeriod: current.period });
 }

--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -130,6 +130,7 @@ export async function GET(req: NextRequest) {
   const trueZero = enrichedEntries.length === 0 && !refreshState.hasSourceTime;
   return NextResponse.json({
     settings: current.settings ?? null,
+    canConfigure: ["owner", "admin"].includes(String(me.role ?? "")),
     periods: periods ?? [],
     activePeriodId,
     entries: enrichedEntries,

--- a/app/api/workforce/attendance/corrections/route.ts
+++ b/app/api/workforce/attendance/corrections/route.ts
@@ -1,15 +1,24 @@
 import { NextResponse } from "next/server";
 import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { shopLocalDateTimeToUtc } from "@/features/shared/lib/utils/shopDayWindow";
 
-type CorrectionType = "create_missing_shift" | "adjust_start" | "adjust_end" | "adjust_start_and_end" | "void_shift";
+type CorrectionType =
+  | "create_missing_shift"
+  | "adjust_start"
+  | "adjust_end"
+  | "adjust_start_and_end"
+  | "void_shift"
+  | "adjust_punch";
 
 type Body = {
   correction_type?: CorrectionType;
   target_user_id?: string;
   shift_id?: string;
+  punch_id?: string;
   corrected_start_time?: string;
   corrected_end_time?: string;
+  corrected_punch_local?: string;
   reason?: string;
 };
 
@@ -44,9 +53,42 @@ export async function POST(req: Request) {
   const reason = body?.reason?.trim();
   if (!body?.correction_type) return NextResponse.json({ error: "correction_type is required" }, { status: 400 });
   if (!body.target_user_id) return NextResponse.json({ error: "target_user_id is required" }, { status: 400 });
-  if (!reason) return NextResponse.json({ error: "Correction reason is required" }, { status: 400 });
+  if (!reason || reason.length < 3) return NextResponse.json({ error: "A correction reason of at least 3 characters is required" }, { status: 400 });
   if (body.target_user_id === auth.me.id && auth.me.role !== "owner") {
-    return NextResponse.json({ error: "Only an owner can apply an audited correction to their own shift." }, { status: 403 });
+    return NextResponse.json({ error: "Only an owner can apply an audited correction to their own time." }, { status: 403 });
+  }
+
+  const admin = createAdminSupabase() as any;
+
+  if (body.correction_type === "adjust_punch") {
+    if (!body.punch_id) return NextResponse.json({ error: "punch_id is required" }, { status: 400 });
+    const local = body.corrected_punch_local?.trim();
+    const match = local ? /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}(?::\d{2})?)$/.exec(local) : null;
+    if (!match) return NextResponse.json({ error: "A valid shop-local punch date and time is required" }, { status: 400 });
+
+    const { data: shop, error: shopError } = await admin
+      .from("shops")
+      .select("timezone")
+      .eq("id", auth.me.shop_id)
+      .maybeSingle();
+    if (shopError) return NextResponse.json({ error: shopError.message }, { status: 400 });
+
+    let correctedTimestamp: string;
+    try {
+      correctedTimestamp = shopLocalDateTimeToUtc(match[1], match[2], shop?.timezone ?? "UTC");
+    } catch {
+      return NextResponse.json({ error: "Invalid punch date or time for the shop timezone" }, { status: 400 });
+    }
+
+    const { data, error } = await admin.rpc("apply_punch_correction", {
+      p_shop_id: auth.me.shop_id,
+      p_actor_profile_id: auth.me.id,
+      p_punch_id: body.punch_id,
+      p_corrected_timestamp: correctedTimestamp,
+      p_reason: reason,
+    });
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+    return NextResponse.json({ ok: true, correction: data });
   }
 
   const needsShift = body.correction_type !== "create_missing_shift";
@@ -61,7 +103,6 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "corrected_end_time is required" }, { status: 400 });
   }
 
-  const admin = createAdminSupabase() as any;
   const { data, error } = await admin.rpc("apply_shift_correction", {
     p_shop_id: auth.me.shop_id,
     p_actor_profile_id: auth.me.id,

--- a/features/dashboard/app/dashboard/admin/AdminLandingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/AdminLandingClient.tsx
@@ -153,20 +153,20 @@ export default function AdminLandingClient() {
       />
 
       <AdminPanel>
-        <AdminPanelTitle title="Immediate Attention" description="Live snapshot from governance, workforce, and payroll-time datasets." />
+        <AdminPanelTitle title="Immediate Attention" description="Every live status opens the page where the work can be completed." />
         {error ? <p className="px-4 py-3 text-xs text-red-300">Failed to load summary: {error}</p> : null}
         {!summary ? (
           <AdminEmptyState title="Loading governance summary" body="Collecting counts from canonical admin surfaces." />
         ) : (
           <AdminStatGrid>
-            <AdminStatCard label="People" value={summary.userCount} hint="Canonical shop-scoped person records." />
-            <AdminStatCard label="Workforce profiles" value={summary.employeeCount} hint="People with assigned workforce posture." />
-            <AdminStatCard label="Shops" value={summary.shopCount} hint="Tenant records in oversight scope." />
-            <AdminStatCard label="Audit (24h)" value={summary.audit24hCount} hint="Privileged events in last day." />
-            <AdminStatCard label="Open payroll periods" value={summary.openPayrollPeriods} hint="Open or draft periods needing reviewer attention." />
-            <AdminStatCard label="Payroll blocking exceptions" value={summary.payrollBlockingExceptions} hint="Must be cleared before approval lock." />
-            <AdminStatCard label="Payroll warnings" value={summary.payrollWarningExceptions} hint="Non-blocking anomalies to review." />
-            <AdminStatCard label="Workforce missing profile setup" value={summary.profileSetupMissingWorkforce} hint="Workforce readiness follow-up." />
+            <Link href="/dashboard/workforce/people"><AdminStatCard label="People" value={summary.userCount} hint="Open employee records and access controls →" /></Link>
+            <Link href="/dashboard/workforce/people"><AdminStatCard label="Workforce profiles" value={summary.employeeCount} hint="Review payroll readiness and profile gaps →" /></Link>
+            <Link href="/dashboard/admin/shops"><AdminStatCard label="Shops" value={summary.shopCount} hint={`${summary.incompleteShopCount} need profile follow-up →`} /></Link>
+            <Link href="/dashboard/admin/audit"><AdminStatCard label="Audit (24h)" value={summary.audit24hCount} hint="Inspect privileged events →" /></Link>
+            <Link href="/dashboard/workforce/payroll-review"><AdminStatCard label="Open payroll periods" value={summary.openPayrollPeriods} hint="Open payroll review →" /></Link>
+            <Link href="/dashboard/workforce/payroll-review?severity=blocking"><AdminStatCard label="Payroll blocking exceptions" value={summary.payrollBlockingExceptions} hint="Open required corrections →" /></Link>
+            <Link href="/dashboard/workforce/payroll-review?severity=warning"><AdminStatCard label="Payroll warnings" value={summary.payrollWarningExceptions} hint="Review advisory exceptions →" /></Link>
+            <Link href="/dashboard/workforce/people"><AdminStatCard label="Workforce missing profile setup" value={summary.profileSetupMissingWorkforce} hint="Complete employee setup →" /></Link>
           </AdminStatGrid>
         )}
       </AdminPanel>

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -371,7 +371,7 @@ export default function PayrollTimeClient() {
               <option value="monthly">Monthly</option>
             </select>
           </label>
-          {(settingsForm.cadence === "weekly" || settingsForm.cadence === "biweekly") ? (
+          {settingsForm.cadence === "weekly" ? (
             <label className="grid gap-1 text-xs text-[color:var(--theme-text-secondary)]">
               Week starts
               <select

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -224,11 +224,11 @@ export default function PayrollTimeClient() {
     void loadExportHistory(activePeriodId);
   }, [activePeriodId]);
 
-  async function runAction(path: string, actionName: string, payload: Record<string, unknown>) {
+  async function runAction(path: string, actionName: string, payload: Record<string, unknown>, method: "POST" | "PUT" = "POST") {
     setBusyAction(actionName);
     setError(null);
     const res = await fetch(path, {
-      method: "POST",
+      method,
       headers: { "content-type": "application/json" },
       body: JSON.stringify(payload),
     });
@@ -243,7 +243,7 @@ export default function PayrollTimeClient() {
   }
 
   async function handleSavePeriodSettings() {
-    const result = await runAction("/api/payroll-time/periods", "settings", settingsForm);
+    const result = await runAction("/api/payroll-time/periods", "settings", settingsForm, "PUT");
     if (result) await load(result?.currentPeriod?.id ?? null);
   }
 

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -24,6 +24,12 @@ type Period = {
   exported_at: string | null;
 };
 
+type PayrollSettings = {
+  cadence: "weekly" | "biweekly" | "semimonthly" | "monthly";
+  week_starts_on: number;
+  period_anchor_date: string | null;
+};
+
 type Entry = {
   id: string;
   user_id: string;
@@ -88,6 +94,13 @@ function fmtFileSize(bytes: number | null | undefined) {
 export default function PayrollTimeClient() {
 
   const [periods, setPeriods] = useState<Period[]>([]);
+  const [payrollSettings, setPayrollSettings] = useState<PayrollSettings | null>(null);
+  const [canConfigurePeriods, setCanConfigurePeriods] = useState(false);
+  const [settingsForm, setSettingsForm] = useState<PayrollSettings>({
+    cadence: "biweekly",
+    week_starts_on: 1,
+    period_anchor_date: new Date().toISOString().slice(0, 10),
+  });
   const [activePeriodId, setActivePeriodId] = useState<string | null>(null);
   const [entries, setEntries] = useState<Entry[]>([]);
   const [exceptions, setExceptions] = useState<Exception[]>([]);
@@ -180,6 +193,16 @@ export default function PayrollTimeClient() {
       return;
     }
 
+    const nextSettings = (body?.settings ?? null) as PayrollSettings | null;
+    setPayrollSettings(nextSettings);
+    setCanConfigurePeriods(Boolean(body?.canConfigure));
+    if (nextSettings) {
+      setSettingsForm({
+        cadence: nextSettings.cadence,
+        week_starts_on: Number(nextSettings.week_starts_on ?? 1),
+        period_anchor_date: nextSettings.period_anchor_date ?? new Date().toISOString().slice(0, 10),
+      });
+    }
     setPeriods((body?.periods ?? []) as Period[]);
     setActivePeriodId((body?.activePeriodId as string | null) ?? null);
     setEntries((body?.entries ?? []) as Entry[]);
@@ -217,6 +240,11 @@ export default function PayrollTimeClient() {
     }
     setBusyAction(null);
     return body;
+  }
+
+  async function handleSavePeriodSettings() {
+    const result = await runAction("/api/payroll-time/periods", "settings", settingsForm);
+    if (result) await load(result?.currentPeriod?.id ?? null);
   }
 
   async function handleRebuild() {
@@ -321,6 +349,66 @@ export default function PayrollTimeClient() {
           {summary.blocking === 0 && summary.warnings === 0 ? <p>Payroll totals are ready for review.</p> : null}
           <p className="text-xs text-[color:var(--theme-text-muted)]">Overtime, long shifts, missing lunch, and job-time ratio flags are advisory. Valid recorded attendance remains visible and payable for owner/admin decisions.</p>
         </div>
+      </AdminPanel>
+
+      <AdminPanel>
+        <AdminPanelTitle
+          title="Pay period settings"
+          description="Choose how payroll periods are generated. Approved and exported periods remain locked historical snapshots."
+        />
+        <AdminToolbar>
+          <label className="grid gap-1 text-xs text-[color:var(--theme-text-secondary)]">
+            Frequency
+            <select
+              className="min-w-52 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)]"
+              value={settingsForm.cadence}
+              disabled={!canConfigurePeriods || busyAction !== null}
+              onChange={(event) => setSettingsForm((current) => ({ ...current, cadence: event.target.value as PayrollSettings["cadence"] }))}
+            >
+              <option value="weekly">Weekly</option>
+              <option value="biweekly">Bi-weekly</option>
+              <option value="semimonthly">Semi-monthly (1–15 / 16–end)</option>
+              <option value="monthly">Monthly</option>
+            </select>
+          </label>
+          {(settingsForm.cadence === "weekly" || settingsForm.cadence === "biweekly") ? (
+            <label className="grid gap-1 text-xs text-[color:var(--theme-text-secondary)]">
+              Week starts
+              <select
+                className="min-w-44 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)]"
+                value={settingsForm.week_starts_on}
+                disabled={!canConfigurePeriods || busyAction !== null}
+                onChange={(event) => setSettingsForm((current) => ({ ...current, week_starts_on: Number(event.target.value) }))}
+              >
+                {["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].map((day, index) => <option key={day} value={index}>{day}</option>)}
+              </select>
+            </label>
+          ) : null}
+          {settingsForm.cadence === "biweekly" ? (
+            <label className="grid gap-1 text-xs text-[color:var(--theme-text-secondary)]">
+              Anchor period starts
+              <input
+                type="date"
+                className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)]"
+                value={settingsForm.period_anchor_date ?? ""}
+                disabled={!canConfigurePeriods || busyAction !== null}
+                onChange={(event) => setSettingsForm((current) => ({ ...current, period_anchor_date: event.target.value }))}
+              />
+            </label>
+          ) : null}
+          <button
+            className="self-end rounded-lg border border-orange-400/40 bg-orange-500/10 px-3 py-2 text-xs uppercase tracking-[0.12em] text-orange-200 disabled:opacity-50"
+            disabled={!canConfigurePeriods || busyAction !== null}
+            onClick={() => void handleSavePeriodSettings()}
+          >
+            {busyAction === "settings" ? "Saving…" : "Save period settings"}
+          </button>
+        </AdminToolbar>
+        <p className="px-4 pb-4 text-xs text-[color:var(--theme-text-muted)]">
+          {canConfigurePeriods
+            ? `Current rule: ${payrollSettings?.cadence ?? "not configured"}. Changing it creates/selects the current matching period without rewriting approved history.`
+            : "Only an owner or admin can change the pay-period rule."}
+        </p>
       </AdminPanel>
 
       <AdminPanel>

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -224,7 +224,7 @@ export default function PayrollTimeClient() {
     void loadExportHistory(activePeriodId);
   }, [activePeriodId]);
 
-  async function runAction(path: string, actionName: string, payload: Record<string, unknown>, method: "POST" | "PUT" = "POST") {
+  async function runAction(path: string, actionName: string, payload: unknown, method: "POST" | "PUT" = "POST") {
     setBusyAction(actionName);
     setError(null);
     const res = await fetch(path, {

--- a/features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx
@@ -62,6 +62,22 @@ export function formatDateTime(value: string | null | undefined, timezone?: stri
   }).format(d);
 }
 
+function toShopLocalInput(value: string | null | undefined, timezone?: string | null): string {
+  const date = safeDate(value);
+  if (!date) return "";
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone || undefined,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(date);
+  const byType = new Map(parts.map((part) => [part.type, part.value]));
+  return `${byType.get("year")}-${byType.get("month")}-${byType.get("day")}T${byType.get("hour")}:${byType.get("minute")}`;
+}
+
 export function getEmployeeDisplayName(shift: Pick<ShiftRow, "employeeName" | "employeeEmail" | "employee">): string {
   const employeeName = shift.employeeName?.trim() || shift.employee?.name?.trim();
   if (employeeName) return employeeName;
@@ -128,6 +144,16 @@ export function AttendanceOverviewClient({ from, to, timezone, role, selectedDat
   const [data, setData] = useState<AttendanceResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [punchEdit, setPunchEdit] = useState<{
+    punchId: string;
+    shiftId: string;
+    userId: string;
+    eventType: string;
+    localTime: string;
+  } | null>(null);
+  const [correctionReason, setCorrectionReason] = useState("");
+  const [correctionError, setCorrectionError] = useState<string | null>(null);
+  const [savingPunch, setSavingPunch] = useState(false);
 
   const fetchAttendance = useCallback(async () => {
     setLoading(true);
@@ -228,6 +254,35 @@ export function AttendanceOverviewClient({ from, to, timezone, role, selectedDat
     };
   }, [data?.billableMinutes, punches, shifts, timezone]);
 
+
+  async function savePunchCorrection() {
+    if (!punchEdit) return;
+    setSavingPunch(true);
+    setCorrectionError(null);
+    try {
+      const response = await fetch("/api/workforce/attendance/corrections", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          correction_type: "adjust_punch",
+          target_user_id: punchEdit.userId,
+          shift_id: punchEdit.shiftId,
+          punch_id: punchEdit.punchId,
+          corrected_punch_local: punchEdit.localTime,
+          reason: correctionReason,
+        }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok) throw new Error(body?.error ?? "Unable to save punch correction.");
+      setPunchEdit(null);
+      setCorrectionReason("");
+      await fetchAttendance();
+    } catch (error) {
+      setCorrectionError(error instanceof Error ? error.message : "Unable to save punch correction.");
+    } finally {
+      setSavingPunch(false);
+    }
+  }
 
   return (
     <div className="space-y-5">
@@ -337,13 +392,73 @@ export function AttendanceOverviewClient({ from, to, timezone, role, selectedDat
                       <div><p className="text-[10px] uppercase text-[color:var(--theme-text-muted)]">Punches</p><p className="font-medium">{events.length}</p></div>
                       <div><p className="text-[10px] uppercase text-[color:var(--theme-text-muted)]">Status</p><p className="font-medium capitalize">{shift.status ?? "unknown"}</p></div>
                     </div>
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      {events.length === 0 ? <span className="text-xs text-amber-300">No punch events recorded</span> : events.map((event) => (
-                        <span key={String(event.id)} className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-xs text-[color:var(--theme-text-secondary)]">
-                          {displayEventType(normalizeEventType(event))} · {safeDate(event.timestamp)?.toLocaleTimeString([], { hour: "numeric", minute: "2-digit", timeZone: timezone || undefined }) ?? "Unknown"}
-                        </span>
-                      ))}
+                    <div className="mt-3 overflow-hidden rounded-lg border border-[color:var(--theme-border-soft)]">
+                      {events.length === 0 ? <p className="p-3 text-xs text-amber-300">No punch events recorded</p> : events.map((event) => {
+                        const punchId = typeof event.id === "string" ? event.id : "";
+                        const eventType = normalizeEventType(event);
+                        return (
+                          <div key={punchId || `${eventType}-${event.timestamp}`} className="grid gap-2 border-b border-[color:var(--theme-border-soft)] p-3 last:border-b-0 sm:grid-cols-[minmax(120px,1fr)_minmax(170px,1.4fr)_auto] sm:items-center">
+                            <div>
+                              <p className="text-xs font-semibold text-[color:var(--theme-text-primary)]">{displayEventType(eventType)}</p>
+                              {event.note ? <p className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">{event.note}</p> : null}
+                            </div>
+                            <p className="text-xs text-[color:var(--theme-text-secondary)]">{formatDateTime(event.timestamp, timezone)}</p>
+                            <button
+                              type="button"
+                              disabled={!punchId || !shiftId || !shift.user_id}
+                              onClick={() => {
+                                if (!punchId || !shiftId || !shift.user_id) return;
+                                setPunchEdit({
+                                  punchId,
+                                  shiftId,
+                                  userId: shift.user_id,
+                                  eventType,
+                                  localTime: toShopLocalInput(event.timestamp, timezone),
+                                });
+                                setCorrectionReason("");
+                                setCorrectionError(null);
+                              }}
+                              className="rounded-lg border border-orange-400/40 px-2.5 py-1.5 text-xs font-medium text-orange-300 disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              Edit
+                            </button>
+                          </div>
+                        );
+                      })}
                     </div>
+                    {punchEdit?.shiftId === shiftId ? (
+                      <div className="mt-3 rounded-lg border border-orange-400/30 bg-orange-500/5 p-3">
+                        <p className="text-xs font-semibold text-orange-200">Edit {displayEventType(punchEdit.eventType)} punch</p>
+                        <p className="mt-1 text-[11px] text-[color:var(--theme-text-muted)]">The saved time uses the shop timezone and creates an audit record. Approved/exported periods cannot be changed.</p>
+                        <div className="mt-3 grid gap-3 sm:grid-cols-[minmax(190px,1fr)_minmax(220px,2fr)_auto] sm:items-end">
+                          <label className="grid gap-1 text-xs text-[color:var(--theme-text-secondary)]">
+                            Punch time
+                            <input
+                              type="datetime-local"
+                              value={punchEdit.localTime}
+                              onChange={(event) => setPunchEdit((current) => current ? { ...current, localTime: event.target.value } : current)}
+                              className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)]"
+                            />
+                          </label>
+                          <label className="grid gap-1 text-xs text-[color:var(--theme-text-secondary)]">
+                            Reason
+                            <input
+                              value={correctionReason}
+                              onChange={(event) => setCorrectionReason(event.target.value)}
+                              placeholder="Required for audit history"
+                              className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)]"
+                            />
+                          </label>
+                          <div className="flex gap-2">
+                            <button type="button" disabled={savingPunch || correctionReason.trim().length < 3 || !punchEdit.localTime} onClick={() => void savePunchCorrection()} className="rounded-lg bg-orange-500 px-3 py-2 text-xs font-semibold text-white disabled:opacity-40">
+                              {savingPunch ? "Saving…" : "Save"}
+                            </button>
+                            <button type="button" disabled={savingPunch} onClick={() => setPunchEdit(null)} className="rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs">Cancel</button>
+                          </div>
+                        </div>
+                        {correctionError ? <p className="mt-2 text-xs text-red-300">{correctionError}</p> : null}
+                      </div>
+                    ) : null}
                     <div className="mt-3 flex gap-3 text-xs">
                       {shift.user_id ? <Link href={`/dashboard/workforce/payroll-review?person_id=${shift.user_id}`} className="font-medium text-orange-300">Payroll detail</Link> : null}
                       {shift.user_id ? <Link href={`/dashboard/admin/people/${shift.user_id}#payroll-posture`} className="font-medium text-orange-300">Employee record</Link> : null}

--- a/features/payroll-time/lib/payPeriodBounds.ts
+++ b/features/payroll-time/lib/payPeriodBounds.ts
@@ -1,0 +1,59 @@
+export type PayrollCadence = "weekly" | "biweekly" | "semimonthly" | "monthly";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function atUtcDay(value: Date | string): Date {
+  const date = value instanceof Date ? value : new Date(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(date.getTime())) throw new Error("Invalid payroll date");
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function addUtcDays(value: Date, days: number): Date {
+  return new Date(value.getTime() + days * DAY_MS);
+}
+
+export function calculatePayPeriodBounds(params: {
+  shopDate: Date;
+  cadence: PayrollCadence;
+  weekStartsOn: number;
+  anchorDate?: string | null;
+}): { start: Date; end: Date } {
+  const today = atUtcDay(params.shopDate);
+  const weekStartsOn = Number.isInteger(params.weekStartsOn) && params.weekStartsOn >= 0 && params.weekStartsOn <= 6
+    ? params.weekStartsOn
+    : 1;
+  const dayOffset = (today.getUTCDay() - weekStartsOn + 7) % 7;
+  const weekStart = addUtcDays(today, -dayOffset);
+
+  if (params.cadence === "weekly") {
+    return { start: weekStart, end: addUtcDays(weekStart, 6) };
+  }
+
+  if (params.cadence === "biweekly") {
+    const anchor = atUtcDay(params.anchorDate || "2024-01-01");
+    const daysSinceAnchor = Math.floor((today.getTime() - anchor.getTime()) / DAY_MS);
+    const cycle = Math.floor(daysSinceAnchor / 14);
+    const start = addUtcDays(anchor, cycle * 14);
+    return { start, end: addUtcDays(start, 13) };
+  }
+
+  const year = today.getUTCFullYear();
+  const month = today.getUTCMonth();
+  if (params.cadence === "semimonthly") {
+    if (today.getUTCDate() <= 15) {
+      return {
+        start: new Date(Date.UTC(year, month, 1)),
+        end: new Date(Date.UTC(year, month, 15)),
+      };
+    }
+    return {
+      start: new Date(Date.UTC(year, month, 16)),
+      end: new Date(Date.UTC(year, month + 1, 0)),
+    };
+  }
+
+  return {
+    start: new Date(Date.UTC(year, month, 1)),
+    end: new Date(Date.UTC(year, month + 1, 0)),
+  };
+}

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -244,11 +244,28 @@ export async function getOrCreateCurrentPeriod(shopId: string, actorId: string) 
   let periodEnd = currentWeekEnd;
 
   if (cadence === "biweekly") {
-    const epoch = Date.UTC(2024, 0, 1);
-    const weeksSinceEpoch = Math.floor((currentWeekStart.getTime() - epoch) / (7 * 24 * 60 * 60 * 1000));
-    const isEven = weeksSinceEpoch % 2 === 0;
-    periodStart = isEven ? currentWeekStart : addDays(currentWeekStart, -7);
+    const configuredAnchor = payrollSettings?.period_anchor_date
+      ? startOfUtcDay(`${payrollSettings.period_anchor_date}T00:00:00.000Z`)
+      : startOfUtcDay("2024-01-01T00:00:00.000Z");
+    const daysSinceAnchor = Math.floor((todayUtc.getTime() - configuredAnchor.getTime()) / (24 * 60 * 60 * 1000));
+    const cycle = Math.floor(daysSinceAnchor / 14);
+    periodStart = addDays(configuredAnchor, cycle * 14);
     periodEnd = addDays(periodStart, 13);
+  } else if (cadence === "semimonthly") {
+    const year = todayUtc.getUTCFullYear();
+    const month = todayUtc.getUTCMonth();
+    if (todayUtc.getUTCDate() <= 15) {
+      periodStart = new Date(Date.UTC(year, month, 1));
+      periodEnd = new Date(Date.UTC(year, month, 15));
+    } else {
+      periodStart = new Date(Date.UTC(year, month, 16));
+      periodEnd = new Date(Date.UTC(year, month + 1, 0));
+    }
+  } else if (cadence === "monthly") {
+    const year = todayUtc.getUTCFullYear();
+    const month = todayUtc.getUTCMonth();
+    periodStart = new Date(Date.UTC(year, month, 1));
+    periodEnd = new Date(Date.UTC(year, month + 1, 0));
   }
 
   const periodStartIso = toIsoDate(periodStart);
@@ -369,14 +386,14 @@ export async function rebuildPeriod(params: { shopId: string; actorId: string; p
       .select("id, user_id, type, status, start_time, end_time, excluded_from_payroll")
       .eq("shop_id", shopId)
       .neq("excluded_from_payroll", true)
-      .gte("start_time", rangeStart)
-      .lt("start_time", rangeEnd),
+      .lt("start_time", rangeEnd)
+      .or(`end_time.is.null,end_time.gt.${rangeStart}`),
     admin
       .from("work_order_line_labor_segments")
       .select("id, technician_id, started_at, ended_at")
       .eq("shop_id", shopId)
-      .gte("started_at", rangeStart)
-      .lt("started_at", rangeEnd),
+      .lt("started_at", rangeEnd)
+      .or(`ended_at.is.null,ended_at.gt.${rangeStart}`),
   ]);
 
   if (shiftsErr) throw new Error(shiftsErr.message);

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -1,6 +1,7 @@
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { createHash } from "crypto";
 import { getShopDayRange } from "@/features/shared/lib/utils/shopDayWindow";
+import { calculatePayPeriodBounds, type PayrollCadence } from "@/features/payroll-time/lib/payPeriodBounds";
 
 export type PayrollPeriodStatus = "draft" | "open" | "approved" | "exported";
 
@@ -231,42 +232,15 @@ export async function getOrCreateCurrentPeriod(shopId: string, actorId: string) 
     payrollSettings = inserted.data;
   }
 
-  const cadence = payrollSettings?.cadence ?? "biweekly";
+  const cadence = (payrollSettings?.cadence ?? "biweekly") as PayrollCadence;
   const weekStartsOn = Number(payrollSettings?.week_starts_on ?? 1);
-
   const todayUtc = startOfUtcDay(`${toShopDate(today.toISOString(), timezone)}T00:00:00.000Z`);
-  const day = todayUtc.getUTCDay();
-  const diffToWeekStart = (day - weekStartsOn + 7) % 7;
-  const currentWeekStart = addDays(todayUtc, -diffToWeekStart);
-  const currentWeekEnd = addDays(currentWeekStart, 6);
-
-  let periodStart = currentWeekStart;
-  let periodEnd = currentWeekEnd;
-
-  if (cadence === "biweekly") {
-    const configuredAnchor = payrollSettings?.period_anchor_date
-      ? startOfUtcDay(`${payrollSettings.period_anchor_date}T00:00:00.000Z`)
-      : startOfUtcDay("2024-01-01T00:00:00.000Z");
-    const daysSinceAnchor = Math.floor((todayUtc.getTime() - configuredAnchor.getTime()) / (24 * 60 * 60 * 1000));
-    const cycle = Math.floor(daysSinceAnchor / 14);
-    periodStart = addDays(configuredAnchor, cycle * 14);
-    periodEnd = addDays(periodStart, 13);
-  } else if (cadence === "semimonthly") {
-    const year = todayUtc.getUTCFullYear();
-    const month = todayUtc.getUTCMonth();
-    if (todayUtc.getUTCDate() <= 15) {
-      periodStart = new Date(Date.UTC(year, month, 1));
-      periodEnd = new Date(Date.UTC(year, month, 15));
-    } else {
-      periodStart = new Date(Date.UTC(year, month, 16));
-      periodEnd = new Date(Date.UTC(year, month + 1, 0));
-    }
-  } else if (cadence === "monthly") {
-    const year = todayUtc.getUTCFullYear();
-    const month = todayUtc.getUTCMonth();
-    periodStart = new Date(Date.UTC(year, month, 1));
-    periodEnd = new Date(Date.UTC(year, month + 1, 0));
-  }
+  const { start: periodStart, end: periodEnd } = calculatePayPeriodBounds({
+    shopDate: todayUtc,
+    cadence,
+    weekStartsOn,
+    anchorDate: payrollSettings?.period_anchor_date ?? null,
+  });
 
   const periodStartIso = toIsoDate(periodStart);
   const periodEndIso = toIsoDate(periodEnd);

--- a/supabase/migrations/20260717020000_workforce_admin_actionability.sql
+++ b/supabase/migrations/20260717020000_workforce_admin_actionability.sql
@@ -1,0 +1,192 @@
+-- Workforce admin actionability: configurable payroll periods and audited punch edits.
+
+alter table public.shop_payroll_settings
+  add column if not exists period_anchor_date date;
+
+alter table public.shop_payroll_settings
+  drop constraint if exists shop_payroll_settings_cadence_check;
+
+alter table public.shop_payroll_settings
+  add constraint shop_payroll_settings_cadence_check
+  check (cadence in ('weekly', 'biweekly', 'semimonthly', 'monthly')) not valid;
+
+alter table public.shop_payroll_settings
+  validate constraint shop_payroll_settings_cadence_check;
+
+create table if not exists public.punch_corrections (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  punch_id uuid not null references public.punch_events(id) on delete restrict,
+  shift_id uuid not null references public.tech_shifts(id) on delete restrict,
+  target_user_id uuid not null references public.profiles(id) on delete restrict,
+  actor_profile_id uuid not null references public.profiles(id) on delete restrict,
+  reason text not null check (length(trim(reason)) > 0),
+  original_timestamp timestamptz not null,
+  corrected_timestamp timestamptz not null,
+  event_type text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_punch_corrections_shop_created
+  on public.punch_corrections(shop_id, created_at desc);
+create index if not exists idx_punch_corrections_punch
+  on public.punch_corrections(punch_id, created_at desc);
+
+alter table public.punch_corrections enable row level security;
+
+do $$
+begin
+  create policy punch_corrections_shop_read on public.punch_corrections
+    for select to authenticated
+    using (shop_id = public.current_shop_id());
+exception when duplicate_object then null;
+end $$;
+
+create or replace function public.apply_punch_correction(
+  p_shop_id uuid,
+  p_actor_profile_id uuid,
+  p_punch_id uuid,
+  p_corrected_timestamp timestamptz,
+  p_reason text
+)
+returns public.punch_corrections
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor public.profiles%rowtype;
+  v_punch public.punch_events%rowtype;
+  v_shift public.tech_shifts%rowtype;
+  v_shop public.shops%rowtype;
+  v_period public.payroll_pay_periods%rowtype;
+  v_result public.punch_corrections%rowtype;
+  v_new_start timestamptz;
+  v_new_end timestamptz;
+  v_work_date date;
+begin
+  if p_corrected_timestamp is null then
+    raise exception 'Corrected punch time is required';
+  end if;
+  if p_reason is null or length(trim(p_reason)) < 3 then
+    raise exception 'A correction reason of at least 3 characters is required';
+  end if;
+
+  select * into v_actor
+  from public.profiles
+  where id = p_actor_profile_id and shop_id = p_shop_id;
+  if not found or coalesce(v_actor.role, '') not in ('owner', 'admin', 'manager') then
+    raise exception 'Forbidden';
+  end if;
+
+  select pe.* into v_punch
+  from public.punch_events pe
+  join public.tech_shifts ts on ts.id = pe.shift_id
+  where pe.id = p_punch_id and ts.shop_id = p_shop_id
+  for update of pe;
+  if not found then raise exception 'Punch not found in this shop'; end if;
+
+  select * into v_shift
+  from public.tech_shifts
+  where id = v_punch.shift_id and shop_id = p_shop_id
+  for update;
+  if not found then raise exception 'Shift not found in this shop'; end if;
+
+  if v_punch.user_id <> v_shift.user_id then
+    raise exception 'Punch user does not match shift user';
+  end if;
+  if v_actor.id = v_shift.user_id and coalesce(v_actor.role, '') <> 'owner' then
+    raise exception 'Only an owner can correct their own punch';
+  end if;
+
+  select * into v_shop from public.shops where id = p_shop_id;
+  v_work_date := (p_corrected_timestamp at time zone coalesce(v_shop.timezone, 'UTC'))::date;
+
+  select * into v_period
+  from public.payroll_pay_periods
+  where shop_id = p_shop_id
+    and (
+      v_work_date between period_start and period_end
+      or (v_punch.timestamp at time zone coalesce(v_shop.timezone, 'UTC'))::date between period_start and period_end
+    )
+  order by period_start desc
+  limit 1;
+
+  if found and v_period.status in ('approved', 'exported') then
+    raise exception 'Approved/exported payroll periods are locked';
+  end if;
+
+  v_new_start := case when v_punch.event_type = 'start_shift' then p_corrected_timestamp else v_shift.start_time end;
+  v_new_end := case when v_punch.event_type = 'end_shift' then p_corrected_timestamp else v_shift.end_time end;
+
+  if v_new_start is null then raise exception 'Shift start is required'; end if;
+  if v_new_end is not null and v_new_end <= v_new_start then
+    raise exception 'Punch correction would make the shift interval invalid';
+  end if;
+  if v_punch.event_type not in ('start_shift', 'end_shift')
+     and (p_corrected_timestamp < v_shift.start_time or (v_shift.end_time is not null and p_corrected_timestamp > v_shift.end_time)) then
+    raise exception 'Break and lunch punches must stay inside the shift';
+  end if;
+
+  if v_punch.event_type in ('start_shift', 'end_shift') and exists (
+    select 1
+    from public.tech_shifts other
+    where other.shop_id = p_shop_id
+      and other.user_id = v_shift.user_id
+      and other.id <> v_shift.id
+      and coalesce(other.excluded_from_payroll, false) = false
+      and tstzrange(other.start_time, coalesce(other.end_time, 'infinity'::timestamptz), '[)')
+          && tstzrange(v_new_start, coalesce(v_new_end, 'infinity'::timestamptz), '[)')
+  ) then
+    raise exception 'Punch correction would overlap another shift';
+  end if;
+
+  update public.punch_events
+  set timestamp = p_corrected_timestamp,
+      note = concat_ws(E'\n', nullif(note, ''), 'Admin correction: ' || trim(p_reason))
+  where id = v_punch.id;
+
+  if v_punch.event_type = 'start_shift' then
+    update public.tech_shifts set start_time = p_corrected_timestamp where id = v_shift.id;
+  elsif v_punch.event_type = 'end_shift' then
+    update public.tech_shifts
+    set end_time = p_corrected_timestamp, status = 'completed'
+    where id = v_shift.id;
+  end if;
+
+  insert into public.punch_corrections (
+    shop_id, punch_id, shift_id, target_user_id, actor_profile_id,
+    reason, original_timestamp, corrected_timestamp, event_type
+  ) values (
+    p_shop_id, v_punch.id, v_shift.id, v_shift.user_id, v_actor.id,
+    trim(p_reason), v_punch.timestamp, p_corrected_timestamp, v_punch.event_type
+  )
+  returning * into v_result;
+
+  if found then
+    update public.payroll_pay_periods
+    set notes = concat_ws(E'\n', notes, 'Punch correction applied; rebuild required.'),
+        updated_at = now()
+    where id = v_period.id;
+  end if;
+
+  insert into public.audit_logs (
+    shop_id, actor_id, action, target_table, target_id, metadata
+  ) values (
+    p_shop_id, v_actor.id, 'workforce.punch.corrected', 'punch_events', v_punch.id,
+    jsonb_build_object(
+      'shift_id', v_shift.id,
+      'target_user_id', v_shift.user_id,
+      'event_type', v_punch.event_type,
+      'original_timestamp', v_punch.timestamp,
+      'corrected_timestamp', p_corrected_timestamp,
+      'reason', trim(p_reason)
+    )
+  );
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.apply_punch_correction(uuid, uuid, uuid, timestamptz, text) from public;
+grant execute on function public.apply_punch_correction(uuid, uuid, uuid, timestamptz, text) to service_role;

--- a/tests/workforce-admin-actionability.test.ts
+++ b/tests/workforce-admin-actionability.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { calculatePayPeriodBounds } from "../features/payroll-time/lib/payPeriodBounds";
+
+function isoDate(value: Date) {
+  return value.toISOString().slice(0, 10);
+}
+
+const attendanceUi = readFileSync("features/dashboard/app/dashboard/workforce/AttendanceOverviewClient.tsx", "utf8");
+const correctionRoute = readFileSync("app/api/workforce/attendance/corrections/route.ts", "utf8");
+const payrollUi = readFileSync("features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx", "utf8");
+const adminUi = readFileSync("features/dashboard/app/dashboard/admin/AdminLandingClient.tsx", "utf8");
+const migration = readFileSync("supabase/migrations/20260717020000_workforce_admin_actionability.sql", "utf8");
+
+describe("workforce admin actionability", () => {
+  it("calculates weekly periods from the configured week start", () => {
+    const period = calculatePayPeriodBounds({
+      shopDate: new Date("2026-07-17T00:00:00.000Z"),
+      cadence: "weekly",
+      weekStartsOn: 1,
+    });
+    expect(isoDate(period.start)).toBe("2026-07-13");
+    expect(isoDate(period.end)).toBe("2026-07-19");
+  });
+
+  it("calculates bi-weekly periods from the shop anchor", () => {
+    const period = calculatePayPeriodBounds({
+      shopDate: new Date("2026-07-17T00:00:00.000Z"),
+      cadence: "biweekly",
+      weekStartsOn: 1,
+      anchorDate: "2026-07-06",
+    });
+    expect(isoDate(period.start)).toBe("2026-07-06");
+    expect(isoDate(period.end)).toBe("2026-07-19");
+  });
+
+  it("calculates both semi-monthly windows", () => {
+    const first = calculatePayPeriodBounds({
+      shopDate: new Date("2026-07-12T00:00:00.000Z"),
+      cadence: "semimonthly",
+      weekStartsOn: 1,
+    });
+    const second = calculatePayPeriodBounds({
+      shopDate: new Date("2026-07-27T00:00:00.000Z"),
+      cadence: "semimonthly",
+      weekStartsOn: 1,
+    });
+    expect([isoDate(first.start), isoDate(first.end)]).toEqual(["2026-07-01", "2026-07-15"]);
+    expect([isoDate(second.start), isoDate(second.end)]).toEqual(["2026-07-16", "2026-07-31"]);
+  });
+
+  it("handles monthly leap-year boundaries", () => {
+    const period = calculatePayPeriodBounds({
+      shopDate: new Date("2028-02-12T00:00:00.000Z"),
+      cadence: "monthly",
+      weekStartsOn: 1,
+    });
+    expect([isoDate(period.start), isoDate(period.end)]).toEqual(["2028-02-01", "2028-02-29"]);
+  });
+
+  it("connects punch rows to audited shop-timezone corrections", () => {
+    expect(attendanceUi).toContain('type="datetime-local"');
+    expect(attendanceUi).toContain('correction_type: "adjust_punch"');
+    expect(correctionRoute).toContain("shopLocalDateTimeToUtc");
+    expect(correctionRoute).toContain('admin.rpc("apply_punch_correction"');
+    expect(migration).toContain("Approved/exported payroll periods are locked");
+    expect(migration).toContain("workforce.punch.corrected");
+  });
+
+  it("exposes every payroll cadence and actionable admin drill-downs", () => {
+    for (const cadence of ["weekly", "biweekly", "semimonthly", "monthly"]) {
+      expect(payrollUi).toContain(`value="${cadence}"`);
+    }
+    expect(adminUi).toContain('/dashboard/workforce/payroll-review?severity=blocking');
+    expect(adminUi).toContain('/dashboard/workforce/payroll-review?severity=warning');
+    expect(adminUi).toContain('/dashboard/admin/audit');
+  });
+});


### PR DESCRIPTION
## What changed

- replaces punch chips with a complete per-shift punch ledger
- lets owners/admins/managers edit punch times directly from the daily timecard
- converts edited wall time with the shop timezone, including DST
- records every punch correction in a durable audit table and the admin audit log
- updates canonical shift boundaries when clock-in or clock-out punches change
- blocks edits to approved/exported payroll periods and rejects invalid/overlapping shifts
- adds payroll settings for weekly, bi-weekly, semi-monthly, and monthly periods
- adds configurable week start and bi-weekly anchor date
- implements actual semi-monthly and monthly boundary calculation, including month length/leap years
- preserves approved/exported pay periods as immutable history when settings change
- turns admin dashboard status cards into direct work-queue links
- restores overlap queries for payroll shifts and job segments so long/open work is not dropped

## Root causes

The punch list was presentation-only and linked users to a separate shift correction page. Payroll cadence existed only as a database field: there was no settings endpoint/UI, monthly was not allowed, and semi-monthly was never calculated. Admin summary cards showed counts but provided no action target.

## Database

Run after merge:

1. `20260717020000_workforce_admin_actionability.sql`

This migration adds the monthly cadence, a bi-weekly anchor date, audited punch corrections, and the atomic correction RPC.

## Validation

- added deterministic weekly, bi-weekly, semi-monthly, monthly, leap-year, punch audit, locked-period, and admin drill-down tests
- retained tenant/shop checks in both the API authorization layer and correction RPC
- Vercel preview build completed successfully
- Supabase preview migration tasks are paused by the repository integration; the migration was reviewed statically but not applied to a preview database

## Deployment notes

- Environment variables: none required
- Manual action: apply the migration after merge before using punch edits or monthly payroll settings
