### PR TITLE
Fix activation, persistence, parts, and quote review findings

### DIFF
--- a/app/api/demo/shop-boost/activate/route.ts
+++ b/app/api/demo/shop-boost/activate/route.ts
@@ -3,7 +3,10 @@ import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { buildShopBoostProfile } from "@/features/integrations/ai/shopBoost";
-import { runShopBoostImport } from "@/features/integrations/imports/runFullImport";
+import {
+  runShopBoostImport,
+  type ShopBoostImportSummary,
+} from "@/features/integrations/imports/runFullImport";
 import { updateIntakeProgress } from "@/features/integrations/shopBoost/status";
 import {
   INSTANT_SHOP_ANALYSIS_DATASET_KEYS,
@@ -50,6 +53,53 @@ function pathBasename(path: string): string {
   return chunks[chunks.length - 1] ?? "upload.csv";
 }
 
+function readPersistedImportSummary(value: unknown): ShopBoostImportSummary | null {
+  const basics = isRecord(value) ? value : {};
+  const migrationProgress = isRecord(basics.migrationProgress) ? basics.migrationProgress : {};
+  const summary = migrationProgress.importSummary;
+  if (!isRecord(summary) || !isRecord(summary.rowResults)) return null;
+  if (
+    typeof summary.customersImported !== "number" ||
+    typeof summary.vehiclesImported !== "number" ||
+    typeof summary.workOrdersImported !== "number" ||
+    typeof summary.invoicesImported !== "number" ||
+    typeof summary.partsImported !== "number" ||
+    typeof summary.completionState !== "string"
+  ) {
+    return null;
+  }
+  return summary as unknown as ShopBoostImportSummary;
+}
+
+async function ensureStorageCopy(args: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  sourcePath: string;
+  targetPath: string;
+}): Promise<void> {
+  const chunks = args.targetPath.split("/").filter(Boolean);
+  const fileName = chunks.pop();
+  const directory = chunks.join("/");
+  if (!fileName) throw new Error("Invalid activation storage target.");
+
+  const targetExists = async () => {
+    const { data, error } = await args.admin.storage
+      .from("shop-imports")
+      .list(directory, { limit: 100, search: fileName });
+    if (error) throw new Error(error.message);
+    return (data ?? []).some((entry) => entry.name === fileName);
+  };
+
+  if (await targetExists()) return;
+
+  const { error: copyError } = await args.admin.storage
+    .from("shop-imports")
+    .copy(args.sourcePath, args.targetPath);
+
+  if (!copyError) return;
+  if (await targetExists()) return;
+  throw new Error(copyError.message);
+}
+
 export async function POST(req: NextRequest) {
   const supabaseUser = createServerSupabaseRoute();
   const {
@@ -71,12 +121,20 @@ export async function POST(req: NextRequest) {
 
   const { data: profile } = await supabaseUser
     .from("profiles")
-    .select("shop_id")
+    .select("shop_id,role")
     .eq("id", user.id)
-    .maybeSingle<{ shop_id: string | null }>();
+    .maybeSingle<{ shop_id: string | null; role: string | null }>();
 
   if (!profile?.shop_id) {
     return NextResponse.json({ ok: false, error: "No shop linked." }, { status: 400 });
+  }
+
+  const role = profile.role?.trim().toLowerCase();
+  if (role !== "owner" && role !== "admin") {
+    return NextResponse.json(
+      { ok: false, error: "Only a shop owner or administrator can activate an analysis." },
+      { status: 403 },
+    );
   }
 
   const shopId = profile.shop_id;
@@ -112,6 +170,7 @@ export async function POST(req: NextRequest) {
     .select("id")
     .eq("demo_id", demoId)
     .eq("email", normalizedUserEmail)
+    .eq("lead_kind", "activation_claim")
     .maybeSingle();
 
   if (claimedLeadError || !claimedLead?.id) {
@@ -140,18 +199,30 @@ export async function POST(req: NextRequest) {
 
   const existing = await admin
     .from("shop_boost_intakes")
-    .select("id,status")
+    .select("id,status,intake_basics")
     .eq("shop_id", shopId)
     .eq("id", intakeId)
-    .maybeSingle();
+    .maybeSingle<{ id: string; status: string | null; intake_basics: unknown }>();
 
-  if (existing.data?.id) {
+  if (existing.error) {
+    return NextResponse.json(
+      { ok: false, error: `Failed to inspect activation state: ${existing.error.message}` },
+      { status: 500 },
+    );
+  }
+
+  const persistedImportSummary = readPersistedImportSummary(existing.data?.intake_basics);
+  const terminalStatus =
+    existing.data?.status === "completed" || existing.data?.status === "completed_with_errors";
+
+  if (existing.data?.id && terminalStatus && persistedImportSummary) {
     const guided = await mapInstantAnalysisToGuidedOnboarding({
       shopId,
       userId: user.id,
       demoId,
       intakeId,
       uploadedDatasets,
+      importSummary: persistedImportSummary,
     });
     return NextResponse.json({
       ok: true,
@@ -163,57 +234,66 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const copiedPaths: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
-  for (const [datasetKey, sourcePath] of Object.entries(sourcePaths) as Array<[ShopBoostUploadDatasetKey, string]>) {
-    const targetPath = `shops/${shopId}/${intakeId}/${datasetKey}-${pathBasename(sourcePath)}`;
-    const { error: copyErr } = await admin.storage.from("shop-imports").copy(sourcePath, targetPath);
-    if (copyErr) {
-      return NextResponse.json(
-        { ok: false, error: `Failed to prepare ${datasetKey} for activation import.` },
-        { status: 500 },
-      );
+  if (!existing.data?.id) {
+    const copiedPaths: Partial<Record<ShopBoostUploadDatasetKey, string>> = {};
+    for (const [datasetKey, sourcePath] of Object.entries(sourcePaths) as Array<[ShopBoostUploadDatasetKey, string]>) {
+      const targetPath = `shops/${shopId}/${intakeId}/${datasetKey}-${pathBasename(sourcePath)}`;
+      try {
+        await ensureStorageCopy({ admin, sourcePath, targetPath });
+      } catch (copyError) {
+        console.error("[demo/shop-boost/activate] Failed to prepare activation file", {
+          datasetKey,
+          sourcePath,
+          targetPath,
+          error: copyError instanceof Error ? copyError.message : copyError,
+        });
+        return NextResponse.json(
+          { ok: false, error: `Failed to prepare ${datasetKey} for activation import.` },
+          { status: 500 },
+        );
+      }
+      copiedPaths[datasetKey] = targetPath;
     }
-    copiedPaths[datasetKey] = targetPath;
-  }
 
-  const uploadManifest = Object.fromEntries(
-    uploadedDatasets.map((dataset) => [
-      dataset,
-      {
+    const uploadManifest = Object.fromEntries(
+      uploadedDatasets.map((dataset) => [
         dataset,
-        path: copiedPaths[dataset],
-        fileName: copiedPaths[dataset] ? pathBasename(copiedPaths[dataset]!) : null,
-        contentType: "text/csv",
-        sizeBytes: null,
-        target: dataset,
-        importMode: dataset === "invoices" ? "staging" : "direct",
+        {
+          dataset,
+          path: copiedPaths[dataset],
+          fileName: copiedPaths[dataset] ? pathBasename(copiedPaths[dataset]!) : null,
+          contentType: "text/csv",
+          sizeBytes: null,
+          target: dataset,
+          importMode: dataset === "invoices" ? "staging" : "direct",
+        },
+      ]),
+    );
+
+    const intakeInsert: DB["public"]["Tables"]["shop_boost_intakes"]["Insert"] = {
+      id: intakeId,
+      shop_id: shopId,
+      questionnaire:
+        questionnaire as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["questionnaire"],
+      customers_file_path: copiedPaths.customers ?? null,
+      vehicles_file_path: copiedPaths.vehicles ?? null,
+      parts_file_path: copiedPaths.parts ?? null,
+      history_file_path: copiedPaths.history ?? null,
+      staff_file_path: copiedPaths.staff ?? null,
+      intake_basics: {
+        source: "demo_preview_activation",
+        demoId,
+        activatedByUserId: user.id,
+        activatedAt: new Date().toISOString(),
+        uploadManifest,
       },
-    ]),
-  );
+      status: "pending",
+    };
 
-  const intakeInsert: DB["public"]["Tables"]["shop_boost_intakes"]["Insert"] = {
-    id: intakeId,
-    shop_id: shopId,
-    questionnaire:
-      questionnaire as DB["public"]["Tables"]["shop_boost_intakes"]["Insert"]["questionnaire"],
-    customers_file_path: copiedPaths.customers ?? null,
-    vehicles_file_path: copiedPaths.vehicles ?? null,
-    parts_file_path: copiedPaths.parts ?? null,
-    history_file_path: copiedPaths.history ?? null,
-    staff_file_path: copiedPaths.staff ?? null,
-    intake_basics: {
-      source: "demo_preview_activation",
-      demoId,
-      activatedByUserId: user.id,
-      activatedAt: new Date().toISOString(),
-      uploadManifest,
-    },
-    status: "pending",
-  };
-
-  const { error: insertErr } = await admin.from("shop_boost_intakes").insert(intakeInsert);
-  if (insertErr) {
-    return NextResponse.json({ ok: false, error: `Failed to start intake: ${insertErr.message}` }, { status: 500 });
+    const { error: insertErr } = await admin.from("shop_boost_intakes").insert(intakeInsert);
+    if (insertErr) {
+      return NextResponse.json({ ok: false, error: `Failed to start intake: ${insertErr.message}` }, { status: 500 });
+    }
   }
 
   await updateIntakeProgress({
@@ -255,6 +335,7 @@ export async function POST(req: NextRequest) {
     patch: {
       completedAt: new Date().toISOString(),
       failedAt: null,
+      importSummary,
       resultSummary: {
         customersImported: importSummary.customersImported,
         vehiclesImported: importSummary.vehiclesImported,

--- a/app/api/demo/shop-boost/activate/route.ts
+++ b/app/api/demo/shop-boost/activate/route.ts
@@ -216,6 +216,11 @@ export async function POST(req: NextRequest) {
     existing.data?.status === "completed" || existing.data?.status === "completed_with_errors";
 
   if (existing.data?.id && terminalStatus && persistedImportSummary) {
+    await admin
+      .from("demo_shop_boosts")
+      .update({ shop_id: shopId, intake_id: intakeId })
+      .eq("id", demoId);
+
     const guided = await mapInstantAnalysisToGuidedOnboarding({
       shopId,
       userId: user.id,

--- a/app/api/demo/shop-boost/claim/route.ts
+++ b/app/api/demo/shop-boost/claim/route.ts
@@ -102,7 +102,8 @@ export async function POST(
         demo_id: demoId,
         email: emailNormalized,
         summary,
-      } as DB["public"]["Tables"]["demo_shop_boost_leads"]["Insert"]);
+        lead_kind: "activation_claim",
+      } as DB["public"]["Tables"]["demo_shop_boost_leads"]["Insert"] & { lead_kind: "activation_claim" });
 
     if (leadErr) {
       console.error("[demo/shop-boost/claim] Failed to insert demo lead", leadErr);

--- a/app/api/demo/shop-boost/share/route.ts
+++ b/app/api/demo/shop-boost/share/route.ts
@@ -63,10 +63,10 @@ export async function POST(req: NextRequest) {
 
     const { data: existingLead } = await supabase
       .from("demo_shop_boost_leads")
-      .select("id, share_count, emails_sent")
+      .select("id, share_count, emails_sent, lead_kind")
       .eq("demo_id", demoId)
       .eq("email", recipientEmail)
-      .maybeSingle<{ id: string; share_count: number | null; emails_sent: number | null }>();
+      .maybeSingle<{ id: string; share_count: number | null; emails_sent: number | null; lead_kind: string | null }>();
 
     if (existingLead?.id) {
       await supabase
@@ -76,6 +76,7 @@ export async function POST(req: NextRequest) {
           emails_sent: (existingLead.emails_sent ?? 0) + 1,
           last_viewed_at: new Date().toISOString(),
           engagement_score: Math.min(100, ((existingLead.emails_sent ?? 0) + 1) * 8),
+          lead_kind: existingLead.lead_kind === "activation_claim" ? "activation_claim" : "share_recipient",
         } as Record<string, unknown>)
         .eq("id", existingLead.id);
     } else {
@@ -86,6 +87,7 @@ export async function POST(req: NextRequest) {
         share_count: 1,
         emails_sent: 1,
         engagement_score: 8,
+        lead_kind: "share_recipient",
       } as Record<string, unknown>);
     }
 

--- a/app/api/work-orders/[id]/quote-history-insights/route.ts
+++ b/app/api/work-orders/[id]/quote-history-insights/route.ts
@@ -141,6 +141,7 @@ export async function GET(req: Request) {
     )
     .eq("shop_id", shopId)
     .in("work_order_id", priorIds)
+    .is("voided_at", null)
     .or(
       "status.in.(completed,ready_to_invoice,invoiced),line_status.in.(completed,ready_to_invoice,invoiced)",
     );

--- a/app/api/work-orders/quotes/[id]/decline/route.ts
+++ b/app/api/work-orders/quotes/[id]/decline/route.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { applyWorkOrderQuoteLineDecision } from "@/features/work-orders/server/workOrderQuoteLineApproval";
 
 export const runtime = "nodejs";
 
@@ -42,7 +43,7 @@ export async function POST(req: NextRequest) {
 
     const { data: q, error: qErr } = await supabase
       .from("work_order_quote_lines")
-      .select("id,shop_id")
+      .select("id,shop_id,work_order_id")
       .eq("id", id)
       .single();
 
@@ -54,16 +55,37 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const { error: updErr } = await supabase
-      .from("work_order_quote_lines")
-      .update({ status: "declined", declined_at: new Date().toISOString(), updated_at: new Date().toISOString() })
-      .eq("id", id);
+    const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+    const result = await applyWorkOrderQuoteLineDecision({
+      supabase,
+      quoteLineIds: [q.id],
+      workOrderId: q.work_order_id,
+      shopId: q.shop_id,
+      customerId: null,
+      actorUserId: user.id,
+      decision: "decline",
+      decisionSource: "shop",
+      contactMethod: "other",
+      decisionNote:
+        typeof body.note === "string" ? body.note.trim().slice(0, 1000) : null,
+      operationKey:
+        typeof body.operationKey === "string"
+          ? body.operationKey.trim().slice(0, 160)
+          : undefined,
+    });
 
-    if (updErr) {
-      return NextResponse.json({ error: updErr.message }, { status: 500 });
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.error ?? "Failed to decline quote" },
+        { status: 400 },
+      );
     }
 
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({
+      ok: true,
+      approvalState: result.approvalState,
+      idempotent: result.idempotent === true,
+    });
   } catch {
     return NextResponse.json({ error: "Failed to decline quote" }, { status: 500 });
   }

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -54,10 +54,16 @@ export default function AuthCallbackPage() {
         const mode = sp.get("mode")?.trim();
         const sessionId = sp.get("session_id")?.trim();
         const flow = sp.get("flow")?.trim();
+        const demoId = sp.get("demoId")?.trim();
+        const intakeId = sp.get("intakeId")?.trim();
+        const activationContext = sp.get("activationContext")?.trim();
         if (redirect) passthrough.set("redirect", redirect);
         if (mode) passthrough.set("mode", mode);
         if (sessionId) passthrough.set("session_id", sessionId);
         if (flow) passthrough.set("flow", flow);
+        if (demoId) passthrough.set("demoId", demoId);
+        if (intakeId) passthrough.set("intakeId", intakeId);
+        if (activationContext) passthrough.set("activationContext", activationContext);
         const signInHref = `/sign-in${passthrough.toString() ? `?${passthrough.toString()}` : ""}`;
 
         router.replace(signInHref);

--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -67,14 +67,37 @@ function panelClass(extra = "") {
   return `rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] ${extra}`;
 }
 
-function targetQty(
-  item: Pick<RequestItemRow, "qty" | "qty_approved" | "qty_requested">,
+function approvedReceivingQty(
+  item: Pick<RequestItemRow, "qty_approved">,
 ) {
-  return Math.max(
-    Number(item.qty_approved ?? 0),
-    Number(item.qty_requested ?? 0),
-    Number(item.qty ?? 0),
-  );
+  return Math.max(0, Number(item.qty_approved ?? 0));
+}
+
+function approvedRequestFlow(
+  items: Array<
+    Pick<RequestItemRow, "qty_approved" | "qty_received" | "qty_consumed">
+  >,
+): "awaitingApproval" | "orderReceive" | "readyTech" | "complete" {
+  if (items.length === 0 || items.some((item) => approvedReceivingQty(item) <= 0)) {
+    return "awaitingApproval";
+  }
+  if (
+    items.every(
+      (item) => Number(item.qty_consumed ?? 0) >= approvedReceivingQty(item),
+    )
+  ) {
+    return "complete";
+  }
+  if (
+    items.every(
+      (item) =>
+        Number(item.qty_received ?? 0) >= approvedReceivingQty(item) &&
+        Number(item.qty_consumed ?? 0) < approvedReceivingQty(item),
+    )
+  ) {
+    return "readyTech";
+  }
+  return "orderReceive";
 }
 
 function sourceLabel(kind: string | null, reason: string | null) {
@@ -167,7 +190,6 @@ export default function PartsDashboardPage(): JSX.Element {
       const [
         partsRes,
         movesRes,
-        requestsRes,
         openPoRes,
         stagingRes,
         candidateRes,
@@ -184,10 +206,6 @@ export default function PartsDashboardPage(): JSX.Element {
           )
           .gte("created_at", d30Ago.toISOString())
           .order("created_at", { ascending: true }),
-        supabase
-          .from("part_requests")
-          .select("id,status,work_order_id")
-          .in("status", ["requested", "quoted", "approved", "fulfilled"]),
         supabase
           .from("purchase_orders")
           .select("id", { count: "exact", head: true })
@@ -270,19 +288,25 @@ export default function PartsDashboardPage(): JSX.Element {
         setPartNameById(names);
       }
 
-      const requests = (requestsRes.data ?? []) as Array<
+      const requests: Array<
         Pick<RequestRow, "id" | "status" | "work_order_id">
-      >;
+      > = [];
+      const pageSize = 500;
+      for (let offset = 0; ; offset += pageSize) {
+        const page = await supabase
+          .from("part_requests")
+          .select("id,status,work_order_id")
+          .in("status", ["requested", "quoted", "approved", "fulfilled"])
+          .order("id", { ascending: true })
+          .range(offset, offset + pageSize - 1);
+        if (page.error) throw page.error;
+        const rows = (page.data ?? []) as typeof requests;
+        requests.push(...rows);
+        if (rows.length < pageSize) break;
+      }
+
       const requestIds = requests.map((request) => request.id);
-      const itemsRes = requestIds.length
-        ? await supabase
-            .from("part_request_items")
-            .select(
-              "request_id,status,qty,qty_requested,qty_approved,qty_received,qty_consumed",
-            )
-            .in("request_id", requestIds)
-        : { data: [], error: null };
-      const items = (itemsRes.data ?? []) as Array<
+      const items: Array<
         Pick<
           RequestItemRow,
           | "request_id"
@@ -293,7 +317,24 @@ export default function PartsDashboardPage(): JSX.Element {
           | "qty_received"
           | "qty_consumed"
         >
-      >;
+      > = [];
+      for (let chunkStart = 0; chunkStart < requestIds.length; chunkStart += 200) {
+        const requestIdChunk = requestIds.slice(chunkStart, chunkStart + 200);
+        for (let offset = 0; ; offset += pageSize) {
+          const page = await supabase
+            .from("part_request_items")
+            .select(
+              "request_id,status,qty,qty_requested,qty_approved,qty_received,qty_consumed",
+            )
+            .in("request_id", requestIdChunk)
+            .order("id", { ascending: true })
+            .range(offset, offset + pageSize - 1);
+          if (page.error) throw page.error;
+          const rows = (page.data ?? []) as typeof items;
+          items.push(...rows);
+          if (rows.length < pageSize) break;
+        }
+      }
       const itemsByRequest = new Map<string, typeof items>();
       for (const item of items) {
         const current = itemsByRequest.get(item.request_id) ?? [];
@@ -319,11 +360,12 @@ export default function PartsDashboardPage(): JSX.Element {
       setOpenPoCount(openPoRes.count ?? 0);
       setReceiveQueueCount(
         items.filter((item) => {
-          const target = targetQty(item);
+          const target = approvedReceivingQty(item);
           return (
             activeIds.has(item.request_id) &&
             target > 0 &&
-            Number(item.qty_received ?? 0) < target
+            Number(item.qty_received ?? 0) < target &&
+            Number(item.qty_consumed ?? 0) < target
           );
         }).length,
       );
@@ -349,18 +391,7 @@ export default function PartsDashboardPage(): JSX.Element {
           continue;
         }
         const requestItems = itemsByRequest.get(request.id) ?? [];
-        const isReady =
-          requestItems.length > 0 &&
-          requestItems.every((item) => {
-            const target = targetQty(item);
-            return (
-              target > 0 &&
-              Number(item.qty_received ?? 0) >= target &&
-              Number(item.qty_consumed ?? 0) < target
-            );
-          });
-        if (isReady) nextFlow.readyTech += 1;
-        else nextFlow.orderReceive += 1;
+        nextFlow[approvedRequestFlow(requestItems)] += 1;
       }
       setFlow(nextFlow);
       setLoading(false);

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -45,9 +45,15 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     const redirect = safeInternalRedirect(searchParams.get("redirect"), "");
     const sessionId = searchParams.get("session_id")?.trim();
     const flow = searchParams.get("flow")?.trim();
+    const demoId = searchParams.get("demoId")?.trim();
+    const intakeId = searchParams.get("intakeId")?.trim();
+    const activationContext = searchParams.get("activationContext")?.trim();
     if (redirect) params.set("redirect", redirect);
     if (sessionId) params.set("session_id", sessionId);
     if (flow) params.set("flow", flow);
+    if (demoId) params.set("demoId", demoId);
+    if (intakeId) params.set("intakeId", intakeId);
+    if (activationContext) params.set("activationContext", activationContext);
     return `${origin}/auth/callback${params.size ? `?${params.toString()}` : ""}`;
   }, [origin, searchParams]);
 

--- a/features/onboarding-v2/guided/instantAnalysisHandoff.ts
+++ b/features/onboarding-v2/guided/instantAnalysisHandoff.ts
@@ -151,7 +151,7 @@ function emptyDomainResult(): DomainResult {
 }
 
 function domainResult(
-  summary: ShopBoostImportSummary | undefined,
+  summary: ShopBoostImportSummary,
   dataset: ShopBoostUploadDatasetKey,
 ): DomainResult {
   if (!summary) return emptyDomainResult();
@@ -178,7 +178,7 @@ function domainResult(
 }
 
 function importedCount(
-  summary: ShopBoostImportSummary | undefined,
+  summary: ShopBoostImportSummary,
   dataset: ShopBoostUploadDatasetKey,
 ): number {
   if (!summary) return 0;
@@ -196,7 +196,7 @@ export async function mapInstantAnalysisToGuidedOnboarding(args: {
   demoId: string;
   intakeId: string;
   uploadedDatasets: ShopBoostUploadDatasetKey[];
-  importSummary?: ShopBoostImportSummary;
+  importSummary: ShopBoostImportSummary;
 }): Promise<{ sessionId: string; redirectTo: string }> {
   const admin = createAdminSupabase() as unknown as SupabaseClient<GuidedDatabase>;
   const now = new Date().toISOString();
@@ -269,9 +269,6 @@ export async function mapInstantAnalysisToGuidedOnboarding(args: {
   });
 
   for (const { dataset, stepKey } of mappedDatasets) {
-    const existingStep = existingStepByKey.get(stepKey);
-    if (!args.importSummary && existingStep?.status === "completed") continue;
-
     const result = domainResult(args.importSummary, dataset);
     const { error: updateStepError } = await admin
       .from("guided_onboarding_steps")

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -895,6 +895,24 @@ useEffect(() => {
     drivetrain: strOrNull(v.drivetrain ?? null),
   });
 
+  const buildImplicitCustomerPatch = (
+    patch: Omit<ReturnType<typeof buildCustomerInsert>, "shop_id">,
+  ) =>
+    Object.fromEntries(
+      Object.entries(patch).filter(([, value]) => value !== null && value !== undefined && value !== ""),
+    ) as Partial<CustomerRow>;
+
+  const buildImplicitVehiclePatch = (
+    v: VehicleWithExtra,
+    customerIdIn: string,
+  ): Partial<VehicleRow> =>
+    Object.fromEntries(
+      Object.entries(buildVehiclePatch(v, customerIdIn)).filter(
+        ([key, value]) =>
+          key === "customer_id" || (value !== null && value !== undefined && value !== ""),
+      ),
+    ) as Partial<VehicleRow>;
+
   const hydrateCustomerFromRow = useCallback(
     (row: CustomerRowWithBusiness): CustomerWithBusiness =>
       normalizeCustomerForIntake({
@@ -1164,7 +1182,7 @@ useEffect(() => {
 
         const { data: patched, error: patchErr } = await supabase
           .from("customers")
-          .update(customerPatch)
+          .update(buildImplicitCustomerPatch(customerPatch))
           .eq("id", row.id)
           .eq("shop_id", shopId)
           .select("*")
@@ -1190,7 +1208,7 @@ useEffect(() => {
 
         const { data: patched, error: patchErr } = await supabase
           .from("customers")
-          .update(customerPatch)
+          .update(buildImplicitCustomerPatch(customerPatch))
           .eq("id", row.id)
           .eq("shop_id", shopId)
           .select("*")
@@ -1251,7 +1269,7 @@ useEffect(() => {
       }
       const { data: existing, error: existingErr } = await supabase
         .from("vehicles")
-        .update(buildVehiclePatch(vehicle, cust.id))
+        .update(buildImplicitVehiclePatch(vehicle, cust.id))
         .eq("id", sameCustomerMatch.id)
         .eq("shop_id", shopId)
         .eq("customer_id", cust.id)
@@ -1318,9 +1336,9 @@ useEffect(() => {
       if (findErr) throw findErr;
 
       if (maybe?.length) {
-        // ✅ patch update the matched vehicle so edits persist
+        // Identifier-based reuse must preserve fields the advisor did not enter.
         const id = (maybe[0] as VehicleRow).id;
-        const patch = buildVehiclePatch(vehicle, cust.id);
+        const patch = buildImplicitVehiclePatch(vehicle, cust.id);
 
         const { data: updated, error: updErr } = await supabase
           .from("vehicles")
@@ -1392,6 +1410,8 @@ useEffect(() => {
       const shopId = await getOrLinkShopId(user.id);
       if (!shopId) throw new Error("Your profile isn’t linked to a shop yet.");
 
+      const hadExplicitCustomerId = Boolean(customerId);
+      const hadExplicitVehicleId = Boolean(vehicleId);
       const cust = await ensureCustomer(shopId);
       const veh = await ensureVehicleRow(cust, shopId);
       const persistedCustomer = hydrateCustomerFromRow(cust);
@@ -1399,12 +1419,20 @@ useEffect(() => {
 
       assertWritePersisted(
         "customer",
-        buildCustomerInsert(customer, shopId),
+        hadExplicitCustomerId
+          ? buildCustomerInsert(customer, shopId)
+          : buildImplicitCustomerPatch(
+              (({ shop_id: _shopId, ...patch }) => patch)(
+                buildCustomerInsert(customer, shopId),
+              ),
+            ),
         cust as unknown as Record<string, unknown>,
       );
       assertWritePersisted(
         "vehicle",
-        buildVehiclePatch(vehicle, cust.id) as Record<string, unknown>,
+        (hadExplicitVehicleId
+          ? buildVehiclePatch(vehicle, cust.id)
+          : buildImplicitVehiclePatch(vehicle, cust.id)) as Record<string, unknown>,
         veh as unknown as Record<string, unknown>,
       );
 

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -299,11 +299,23 @@ function badgeClass(tone: ReturnType<typeof workflowDisplay>["tone"]): string {
   }
 }
 
+function isSentForDecision(line: EditableQuoteLine): boolean {
+  const status = safeTrim(line.status).toLowerCase();
+  const stage = safeTrim(line.stage).toLowerCase();
+  return (
+    Boolean(line.sent_to_customer_at) ||
+    status === "sent" ||
+    status === "customer_pending" ||
+    stage === "sent" ||
+    stage === "customer_pending"
+  );
+}
+
 function canSendLine(line: EditableQuoteLine): boolean {
   const status = safeTrim(line.status).toLowerCase();
   const stage = safeTrim(line.stage).toLowerCase();
   if (NON_SENDABLE_STATUSES.has(status)) return false;
-  if (status === "sent" || Boolean(line.sent_to_customer_at)) return false;
+  if (isSentForDecision(line)) return false;
   return SEND_READY_STATUSES.has(status) || SEND_READY_STAGES.has(stage);
 }
 
@@ -1004,7 +1016,7 @@ export default function QuoteReviewView(props: {
                             </button>
                             {!line.sent_to_customer_at && canSendLine(line) ? <span className="rounded-xl border border-emerald-300/35 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-100">Will send</span> : null}
                             {!finalDecision ? <>
-                              <button type="button" disabled={!canSendLine(line) && safeTrim(line.status).toLowerCase() !== "sent"} onClick={() => openDecisionDialog(line, "approve")} className="rounded-xl border border-emerald-300/40 bg-emerald-500/15 px-3 py-2 text-xs font-semibold text-emerald-100 disabled:opacity-45">Approve</button>
+                              <button type="button" disabled={!canSendLine(line) && !isSentForDecision(line)} onClick={() => openDecisionDialog(line, "approve")} className="rounded-xl border border-emerald-300/40 bg-emerald-500/15 px-3 py-2 text-xs font-semibold text-emerald-100 disabled:opacity-45">Approve</button>
                               <button type="button" onClick={() => openDecisionDialog(line, "defer")} className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">Defer</button>
                               <button type="button" onClick={() => openDecisionDialog(line, "decline")} className="rounded-xl border border-red-400/45 bg-red-500/10 px-3 py-2 text-xs font-semibold text-red-100">Decline</button>
                             </> : null}

--- a/features/work-orders/quote-review/quoteHistoryRelevance.ts
+++ b/features/work-orders/quote-review/quoteHistoryRelevance.ts
@@ -105,13 +105,18 @@ function normalize(value: string): string {
     .trim();
 }
 
+function containsPhrase(value: string, phrase: string): boolean {
+  const normalizedValue = ` ${normalize(value)} `;
+  const normalizedPhrase = normalize(phrase);
+  return Boolean(normalizedPhrase) && normalizedValue.includes(` ${normalizedPhrase} `);
+}
+
 function ruleFor(value: string): ServiceRule | null {
-  const normalized = normalize(value);
   return (
     RULES.find(
       (rule) =>
-        rule.terms.some((term) => normalized.includes(term)) &&
-        !(rule.excludes ?? []).some((term) => normalized.includes(term)),
+        rule.terms.some((term) => containsPhrase(value, term)) &&
+        !(rule.excludes ?? []).some((term) => containsPhrase(value, term)),
     ) ?? null
   );
 }
@@ -129,11 +134,12 @@ export function findRelevantHistoryCandidates(input: {
       (candidate) =>
         ruleFor(candidate.description)?.family === quoteRule.family,
     )
-    .filter((candidate) =>
-      candidate.mileageDeltaKm == null
-        ? candidate.ageDays <= quoteRule.maxDays
-        : candidate.mileageDeltaKm >= 0 &&
-          candidate.mileageDeltaKm <= quoteRule.maxKm,
+    .filter(
+      (candidate) =>
+        candidate.ageDays <= quoteRule.maxDays &&
+        (candidate.mileageDeltaKm == null ||
+          (candidate.mileageDeltaKm >= 0 &&
+            candidate.mileageDeltaKm <= quoteRule.maxKm)),
     )
     .sort((a, b) => {
       const aScore = a.mileageDeltaKm ?? a.ageDays * 40;

--- a/features/work-orders/quote-review/quoteHistoryRelevance.ts
+++ b/features/work-orders/quote-review/quoteHistoryRelevance.ts
@@ -105,10 +105,22 @@ function normalize(value: string): string {
     .trim();
 }
 
+function tokenMatches(candidate: string, expected: string): boolean {
+  if (candidate === expected || candidate === `${expected}s`) return true;
+  return expected.endsWith("y") && candidate === `${expected.slice(0, -1)}ies`;
+}
+
 function containsPhrase(value: string, phrase: string): boolean {
-  const normalizedValue = ` ${normalize(value)} `;
-  const normalizedPhrase = normalize(phrase);
-  return Boolean(normalizedPhrase) && normalizedValue.includes(` ${normalizedPhrase} `);
+  const valueTokens = normalize(value).split(" ").filter(Boolean);
+  const phraseTokens = normalize(phrase).split(" ").filter(Boolean);
+  if (phraseTokens.length === 0 || phraseTokens.length > valueTokens.length) {
+    return false;
+  }
+  return valueTokens.some((_, start) =>
+    phraseTokens.every((token, offset) =>
+      tokenMatches(valueTokens[start + offset] ?? "", token),
+    ),
+  );
 }
 
 function ruleFor(value: string): ServiceRule | null {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "profixiq",
   "version": "1.0.0",
   "private": true,
-  "packageManager": "pnpm@10.34.5",
   "main": "postcss.config.js",
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "profixiq",
   "version": "1.0.0",
   "private": true,
+  "packageManager": "pnpm@10.34.5",
   "main": "postcss.config.js",
   "scripts": {
     "dev": "next dev",

--- a/supabase/migrations/20260717010000_demo_shop_boost_lead_kind.sql
+++ b/supabase/migrations/20260717010000_demo_shop_boost_lead_kind.sql
@@ -1,0 +1,28 @@
+begin;
+
+alter table public.demo_shop_boost_leads
+  add column if not exists lead_kind text;
+
+update public.demo_shop_boost_leads
+set lead_kind = case
+  when summary ilike 'Shared by %' then 'share_recipient'
+  else 'activation_claim'
+end
+where lead_kind is null;
+
+alter table public.demo_shop_boost_leads
+  alter column lead_kind set default 'activation_claim',
+  alter column lead_kind set not null;
+
+alter table public.demo_shop_boost_leads
+  drop constraint if exists demo_shop_boost_leads_lead_kind_check;
+
+alter table public.demo_shop_boost_leads
+  add constraint demo_shop_boost_leads_lead_kind_check
+  check (lead_kind in ('activation_claim', 'share_recipient'));
+
+create index if not exists demo_shop_boost_leads_activation_claim_idx
+  on public.demo_shop_boost_leads (demo_id, lower(email))
+  where lead_kind = 'activation_claim';
+
+commit;

--- a/supabase/migrations/20260717011000_quote_decision_integrity_fixes.sql
+++ b/supabase/migrations/20260717011000_quote_decision_integrity_fixes.sql
@@ -1,0 +1,154 @@
+begin;
+
+alter table public.work_order_quote_lines
+  drop constraint if exists work_order_quote_lines_stage_check;
+
+alter table public.work_order_quote_lines
+  add constraint work_order_quote_lines_stage_check
+  check (
+    stage is null
+    or stage::text = any (
+      array[
+        'advisor_pending'::text,
+        'customer_pending'::text,
+        'customer_approved'::text,
+        'customer_declined'::text,
+        'customer_deferred'::text,
+        'sent'::text,
+        'ready_to_send'::text
+      ]
+    )
+  );
+
+create or replace function public.apply_shop_quote_decision_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_quote_line_ids uuid[],
+  p_decision text,
+  p_actor_user_id uuid,
+  p_contact_method text,
+  p_note text,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_decision text := lower(trim(coalesce(p_decision, '')));
+  v_contact text := lower(trim(coalesce(p_contact_method, '')));
+  v_now timestamptz := coalesce(p_at, now());
+  v_existing jsonb;
+  v_result jsonb;
+  v_line_id uuid;
+begin
+  if auth.uid() is null or auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Shop quote decision actor mismatch.';
+  end if;
+  if v_decision not in ('approve', 'decline', 'defer') then
+    raise exception using errcode = 'P0001', message = 'Unsupported quote decision.';
+  end if;
+  if v_contact not in ('phone', 'in_person', 'email', 'other') then
+    raise exception using errcode = 'P0001', message = 'Unsupported quote decision contact method.';
+  end if;
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+  select result into v_existing
+  from public.quote_lifecycle_operation_keys
+  where shop_id = p_shop_id
+    and operation_name = 'shop_quote_decision'
+    and operation_key = p_operation_key;
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+  if not exists (
+    select 1 from public.profiles p
+    where p.id = p_actor_user_id
+      and p.shop_id = p_shop_id
+      and lower(coalesce(p.role::text, '')) in ('owner', 'admin', 'manager', 'advisor', 'service', 'foreman')
+  ) then
+    raise exception using errcode = 'P0001', message = 'Shop quote decision actor is not authorized.';
+  end if;
+  if exists (
+    select 1 from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id
+      and q.work_order_id = p_work_order_id
+      and q.id = any(coalesce(p_quote_line_ids, array[]::uuid[]))
+      and (
+        q.work_order_line_id is not null
+        or q.approved_at is not null
+        or lower(coalesce(q.stage::text, '')) = 'customer_approved'
+        or lower(coalesce(q.status::text, '')) in ('approved', 'customer_approved', 'converted')
+      )
+      and v_decision <> 'approve'
+  ) then
+    raise exception using errcode = 'P0001', message = 'Approved work cannot be reversed from quote review.';
+  end if;
+
+  v_result := public.apply_customer_quote_decision_atomic(
+    p_shop_id,
+    p_work_order_id,
+    p_quote_line_ids,
+    v_decision,
+    false,
+    null,
+    p_actor_user_id,
+    p_operation_key || ':canonical',
+    v_now
+  );
+
+  update public.work_order_quote_lines
+  set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_strip_nulls(jsonb_build_object(
+        'decision_origin', 'shop_recorded',
+        'shop_decision', v_decision,
+        'shop_decision_at', v_now,
+        'shop_decision_actor_user_id', p_actor_user_id,
+        'shop_decision_contact_method', v_contact,
+        'shop_decision_note', left(nullif(trim(coalesce(p_note, '')), ''), 1000)
+      )),
+      updated_at = v_now
+  where shop_id = p_shop_id
+    and work_order_id = p_work_order_id
+    and id = any(coalesce(p_quote_line_ids, array[]::uuid[]));
+
+  if v_decision = 'approve' then
+    for v_line_id in
+      select q.work_order_line_id
+      from public.work_order_quote_lines q
+      where q.shop_id = p_shop_id
+        and q.work_order_id = p_work_order_id
+        and q.id = any(coalesce(p_quote_line_ids, array[]::uuid[]))
+        and q.work_order_line_id is not null
+    loop
+      update public.work_order_lines
+      set intake_json = coalesce(intake_json, '{}'::jsonb) || jsonb_strip_nulls(jsonb_build_object(
+            'decision_origin', 'shop_recorded',
+            'shop_decision_at', v_now,
+            'shop_decision_actor_user_id', p_actor_user_id,
+            'shop_decision_contact_method', v_contact,
+            'shop_decision_note', left(nullif(trim(coalesce(p_note, '')), ''), 1000)
+          )),
+          updated_at = v_now
+      where id = v_line_id and shop_id = p_shop_id and work_order_id = p_work_order_id;
+    end loop;
+  end if;
+
+  v_result := v_result || jsonb_build_object('decision_origin', 'shop_recorded');
+  insert into public.quote_lifecycle_operation_keys(
+    shop_id, operation_name, operation_key, actor_user_id, work_order_id, result
+  ) values (
+    p_shop_id, 'shop_quote_decision', p_operation_key,
+    p_actor_user_id, p_work_order_id, v_result
+  );
+  return v_result;
+end;
+$$;
+
+revoke all on function public.apply_shop_quote_decision_atomic(uuid,uuid,uuid[],text,uuid,text,text,text,timestamptz) from public, anon;
+grant execute on function public.apply_shop_quote_decision_atomic(uuid,uuid,uuid[],text,uuid,text,text,text,timestamptz) to authenticated;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/create-work-order-customer-vehicle-save.test.ts
+++ b/tests/create-work-order-customer-vehicle-save.test.ts
@@ -12,6 +12,7 @@ describe("create work order customer and vehicle persistence", () => {
     expect(page).toContain("const { shop_id: _shopId, ...customerPatch } = customerWrite");
     expect(page).not.toContain("const needsPatch =");
     expect(page).toContain(".update(customerPatch)");
+    expect(page).toContain(".update(buildImplicitCustomerPatch(customerPatch))");
     expect(page).toContain(".insert(customerWrite)");
   });
 
@@ -43,8 +44,10 @@ describe("create work order customer and vehicle persistence", () => {
     }
   });
 
-  it("applies current form values when an existing duplicate is reused", () => {
-    expect(page).toContain(".update(buildVehiclePatch(vehicle, cust.id))");
+  it("preserves blank fields when an implicit duplicate is reused", () => {
+    expect(page).toContain(".update(buildImplicitVehiclePatch(vehicle, cust.id))");
+    expect(page).toContain("buildImplicitCustomerPatch(customerPatch)");
+    expect(page).toContain('key === "customer_id"');
     expect(page).toContain('.eq("customer_id", cust.id)');
   });
 

--- a/tests/instant-shop-analysis-guided-onboarding.test.ts
+++ b/tests/instant-shop-analysis-guided-onboarding.test.ts
@@ -58,7 +58,8 @@ describe("instant shop analysis guided onboarding handoff", () => {
     expect(handoff).toContain('event_type: "instant_analysis_mapped"');
     expect(handoff).toContain("reviewPhasePending");
     expect(handoff).toContain('select("step_key,status,answer")');
-    expect(handoff).toContain('!args.importSummary && existingStep?.status === "completed"');
+    expect(handoff).toContain("importSummary: ShopBoostImportSummary");
+    expect(handoff).not.toContain("importSummary?: ShopBoostImportSummary");
   });
 
   it("binds activation to the unlocked email and provides a retry-safe handoff page", () => {
@@ -68,10 +69,16 @@ describe("instant shop analysis guided onboarding handoff", () => {
 
     expect(activation).toContain('.from("demo_shop_boost_leads")');
     expect(activation).toContain('.eq("email", normalizedUserEmail)');
+    expect(activation).toContain('.eq("lead_kind", "activation_claim")');
+    expect(activation).toContain('role !== "owner" && role !== "admin"');
+    expect(activation).toContain("readPersistedImportSummary");
+    expect(activation).toContain("ensureStorageCopy");
     expect(activation).toContain("demoRow.shop_id !== shopId");
     expect(handoffPage).toContain('fetch("/api/demo/shop-boost/activate"');
     expect(handoffPage).toContain("readPersistedActivationContext");
     expect(signIn).toContain("resolvePostAuthDestination");
+    expect(signIn).toContain('searchParams.get("activationContext")');
+    expect(signIn).toContain('params.set("activationContext", activationContext)');
     expect(signIn).not.toContain('router.replace("/onboarding")');
   });
 });

--- a/tests/parts-dashboard-redesign.test.ts
+++ b/tests/parts-dashboard-redesign.test.ts
@@ -22,6 +22,14 @@ describe("Parts dashboard redesign", () => {
     );
   });
 
+  it("uses approved receiving quantities, consumed completion, and paged totals", () => {
+    expect(source).toContain("function approvedReceivingQty");
+    expect(source).toContain("function approvedRequestFlow");
+    expect(source).toContain('return "complete"');
+    expect(source).toContain(".range(offset, offset + pageSize - 1)");
+    expect(source).not.toContain("function targetQty");
+  });
+
   it("keeps the dashboard on canonical parts routes", () => {
     expect(source).toContain('href="/parts/requests"');
     expect(source).toContain('href="/parts/receiving"');

--- a/tests/quote-history-insights-route.test.ts
+++ b/tests/quote-history-insights-route.test.ts
@@ -17,6 +17,7 @@ describe("quote history insights route", () => {
       route.match(/\.eq\("shop_id", shopId\)/g)?.length ?? 0,
     ).toBeGreaterThanOrEqual(4);
     expect(route).toContain('.neq("id", workOrderId)');
+    expect(route).toContain('.is("voided_at", null)');
   });
 
   it("gates candidates deterministically and validates AI-selected pairs", () => {

--- a/tests/quote-history-relevance.test.ts
+++ b/tests/quote-history-relevance.test.ts
@@ -53,6 +53,36 @@ describe("quote history relevance", () => {
     expect(matches).toEqual([]);
   });
 
+  it("does not classify ignition coil service as engine oil", () => {
+    const matches = findRelevantHistoryCandidates({
+      quoteLineId: "quote-1",
+      quoteDescription: "Ignition coil service",
+      candidates: [
+        candidate({
+          description: "Engine oil service",
+          mileageDeltaKm: 2_000,
+          ageDays: 30,
+        }),
+      ],
+    });
+    expect(matches).toEqual([]);
+  });
+
+  it("applies the age limit even when mileage is available", () => {
+    const matches = findRelevantHistoryCandidates({
+      quoteLineId: "quote-1",
+      quoteDescription: "Engine oil change",
+      candidates: [
+        candidate({
+          description: "Engine oil service",
+          mileageDeltaKm: 2_000,
+          ageDays: 800,
+        }),
+      ],
+    });
+    expect(matches).toEqual([]);
+  });
+
   it("uses time limits when mileage is unavailable", () => {
     const matches = findRelevantHistoryCandidates({
       quoteLineId: "quote-1",

--- a/tests/shop-quote-decision-contract.test.ts
+++ b/tests/shop-quote-decision-contract.test.ts
@@ -58,5 +58,4 @@ describe("shop quote decision contract", () => {
     expect(legacyDecline).toContain('decisionSource: "shop"');
     expect(legacyDecline).not.toContain('.update({ status: "declined"');
   });
-  });
 });

--- a/tests/shop-quote-decision-contract.test.ts
+++ b/tests/shop-quote-decision-contract.test.ts
@@ -14,8 +14,12 @@ const helper = fs.readFileSync(
 const migration = fs.readFileSync(
   path.join(
     root,
-    "supabase/migrations/20260717003000_shop_recorded_quote_decisions.sql",
+    "supabase/migrations/20260717011000_quote_decision_integrity_fixes.sql",
   ),
+  "utf8",
+);
+const legacyDecline = fs.readFileSync(
+  path.join(root, "app/api/work-orders/quotes/[id]/decline/route.ts"),
   "utf8",
 );
 
@@ -44,5 +48,15 @@ describe("shop quote decision contract", () => {
     expect(migration).toContain(
       "Approved work cannot be reversed from quote review",
     );
+    expect(migration).toContain("q.approved_at is not null");
+    expect(migration).toContain("q.stage::text, '')) = 'customer_approved'");
+  });
+
+  it("supports deferred stages and delegates legacy decline", () => {
+    expect(migration).toContain("'customer_deferred'::text");
+    expect(legacyDecline).toContain("applyWorkOrderQuoteLineDecision");
+    expect(legacyDecline).toContain('decisionSource: "shop"');
+    expect(legacyDecline).not.toContain('.update({ status: "declined"');
+  });
   });
 });


### PR DESCRIPTION
## What changed

This PR addresses all 17 Codex review findings across Instant Shop Analysis, guided onboarding handoff, work-order customer/vehicle persistence, the parts dashboard, and quote decisions/history.

### Instant Shop Analysis
- separates activation claims from read-only share recipients
- requires owner/admin authorization before service-role activation writes
- resumes incomplete intakes instead of treating row existence as completion
- persists the full import summary and requires it for guided onboarding handoff
- makes deterministic storage copies retry-safe
- preserves activation context through email verification and callback fallback

### Customer and vehicle persistence
- keeps full patches for explicitly selected records
- uses sparse, non-destructive patches for implicit email/phone/VIN/plate matches
- validates only fields that were intended to change in implicit reuse

### Parts operations
- pages all request and request-item rows before deriving totals
- uses approved quantities for receiving
- classifies consumed requests as complete instead of returning them to receiving
- centralizes approved-request lifecycle classification

### Quote lifecycle and history
- adds the canonical deferred stage to the database constraint
- blocks decline/defer when any canonical approval marker is present
- delegates the legacy decline route to the canonical atomic mutation
- recognizes timestamp/stage-sent lines for shop decisions
- excludes voided work from history insights
- matches service phrases on token boundaries with plural handling
- applies both age and mileage relevance limits

## Root cause

Several flows collapsed distinct states into one signal: generic lead vs activation owner, intake row vs completed import, blank field vs intentional clear, requested quantity vs approved receiving quantity, and individual quote status markers vs the canonical lifecycle. This PR makes those boundaries explicit.

## Validation

- 26 targeted Vitest tests passed across 6 suites.
- All changed TypeScript/TSX runtime files parsed successfully with esbuild.
- Full repository typecheck, lint, and test suite are delegated to CI because the execution workspace did not contain a complete checkout.

## Database

Adds:
- `20260717010000_demo_shop_boost_lead_kind.sql`
- `20260717011000_quote_decision_integrity_fixes.sql`

The migrations must be applied before deploying the corresponding application routes/UI.
