### PR TITLE
Fix public sign-in and trial shell boundaries

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,7 @@ import PwaRuntime from "@/features/shared/components/pwa/PwaRuntime";
 import type { Metadata, Viewport } from "next";
 
 import ThemedToaster from "@/features/shared/components/ThemedToaster";
+import { isStandalonePublicRoute } from "@/features/shared/lib/routes/shellBoundaries";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -57,23 +58,7 @@ export default async function RootLayout({
   const hdrs = await headers();
   const pathname = hdrs.get("x-next-pathname") ?? "";
 
-  const isPublicRoute =
-    pathname === "/" ||
-    pathname.startsWith("/launch") ||
-    pathname.startsWith("/offline") ||
-    pathname.startsWith("/signup") ||
-    pathname.startsWith("/sign-in") ||
-    pathname.startsWith("/mobile/sign-in") ||
-    pathname.startsWith("/forgot-password") ||
-    pathname.startsWith("/auth/reset") ||
-    pathname.startsWith("/auth/set-password") ||
-    pathname.startsWith("/confirm") ||
-    pathname.startsWith("/compare-plans") ||
-    pathname.startsWith("/subscribe") ||
-    pathname.startsWith("/demo") ||
-    pathname.startsWith("/portal/auth/") ||
-    pathname.startsWith("/portal/join/") ||
-    pathname.startsWith("/portal/confirm");
+  const isPublicRoute = isStandalonePublicRoute(pathname);
 
   const useAppShell = !isPublicRoute;
 

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -37,6 +37,10 @@ export function MobileShell({ children, title }: Props) {
 
   const resolvedTitle = title ?? getTitleFromPath(pathname);
 
+  if (pathname === "/mobile/sign-in" || pathname.startsWith("/mobile/sign-in/")) {
+    return children;
+  }
+
   const handleHome = () => {
     router.push("/mobile");
   };

--- a/features/portal/components/PortalShell.tsx
+++ b/features/portal/components/PortalShell.tsx
@@ -122,7 +122,11 @@ export default function PortalShell({
     }
   };
 
-  // ✅ AUTH PAGES: allow the auth page to own the full viewport/background
+  if (isPortalAuth(pathname)) {
+    return children;
+  }
+
+  // Public shop and enrollment pages keep the lightweight portal frame.
   if (hideNav) {
     return (
       <div className="relative min-h-dvh app-metal-bg text-[color:var(--theme-text-primary)] overflow-hidden">

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -18,19 +18,7 @@ import ForcePasswordChangeModal from "@/features/auth/components/ForcePasswordCh
 import AskAssistantEntry from "@/features/assistant/components/AskAssistantEntry";
 import { useActiveBrand } from "@/features/branding/hooks/useActiveBrand";
 import { isBillingAttentionStatus } from "@/features/stripe/lib/stripe/subscriptionStatus";
-
-const NON_APP_ROUTES = [
-  "/",
-  "/sign-in",
-  "/sign-up",
-  "/coming-soon",
-  "/auth",
-  "/forgot-password",
-  "/auth/reset",
-  "/auth/set-password",
-  "/mobile",
-  "/demo",
-];
+import { isOutsideDesktopAppShell } from "@/features/shared/lib/routes/shellBoundaries";
 
 const HEADER_OFFSET_DESKTOP = "pt-14";
 
@@ -124,11 +112,7 @@ export default function AppShell({
 
   const punchRef = useRef<HTMLDivElement | null>(null);
 
-  const isPortalRoute =
-    pathname === "/portal" || pathname.startsWith("/portal/");
-  const isAppRoute =
-    !isPortalRoute &&
-    !NON_APP_ROUTES.some((p) => pathname === p || pathname.startsWith(p + "/"));
+  const isAppRoute = !isOutsideDesktopAppShell(pathname);
 
   const canSeeAgentConsole =
     !!userRole &&

--- a/features/shared/components/pwa/PwaRuntime.tsx
+++ b/features/shared/components/pwa/PwaRuntime.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   clearOfflineState,
@@ -10,6 +11,7 @@ import {
   subscribeOfflineMutations,
 } from "@/features/shared/lib/offline/mutations";
 import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
+import { isStandalonePublicRoute } from "@/features/shared/lib/routes/shellBoundaries";
 
 type InstallPromptEvent = Event & {
   prompt(): Promise<void>;
@@ -17,6 +19,7 @@ type InstallPromptEvent = Event & {
 };
 
 export default function PwaRuntime() {
+  const pathname = usePathname() ?? "/";
   const [online, setOnline] = useState(true);
   const [summary, setSummary] = useState(() => getOfflineSyncSummary());
   const [installPrompt, setInstallPrompt] = useState<InstallPromptEvent | null>(
@@ -173,12 +176,13 @@ export default function PwaRuntime() {
   };
 
   if (
-    online &&
-    pending === 0 &&
-    !installPrompt &&
-    !iosInstallAvailable &&
-    !updateReady &&
-    !syncBlocked
+    isStandalonePublicRoute(pathname) ||
+    (online &&
+      pending === 0 &&
+      !installPrompt &&
+      !iosInstallAvailable &&
+      !updateReady &&
+      !syncBlocked)
   ) {
     return null;
   }

--- a/features/shared/lib/routes/shellBoundaries.test.ts
+++ b/features/shared/lib/routes/shellBoundaries.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOutsideDesktopAppShell,
+  isStandalonePublicRoute,
+} from "./shellBoundaries";
+
+describe("shell route boundaries", () => {
+  it.each([
+    "/",
+    "/sign-in",
+    "/signup",
+    "/compare-plans",
+    "/mobile/sign-in",
+    "/portal/auth/sign-in",
+    "/portal/auth/sign-in?portal=fleet",
+    "/demo/instant-shop-analysis",
+  ])("keeps %s outside authenticated application chrome", (pathname) => {
+    expect(isStandalonePublicRoute(pathname.split("?")[0])).toBe(true);
+  });
+
+  it.each(["/dashboard", "/work-orders/abc", "/parts/requests"])(
+    "keeps %s inside authenticated application chrome",
+    (pathname) => {
+      expect(isStandalonePublicRoute(pathname)).toBe(false);
+      expect(isOutsideDesktopAppShell(pathname)).toBe(false);
+    },
+  );
+
+  it.each(["/portal", "/portal/history", "/mobile", "/mobile/work-orders/abc"])(
+    "keeps %s outside the desktop shell",
+    (pathname) => {
+      expect(isOutsideDesktopAppShell(pathname)).toBe(true);
+    },
+  );
+
+  it("does not treat similarly named routes as public", () => {
+    expect(isStandalonePublicRoute("/compare-plans-private")).toBe(false);
+    expect(isStandalonePublicRoute("/sign-internal")).toBe(false);
+  });
+});

--- a/features/shared/lib/routes/shellBoundaries.ts
+++ b/features/shared/lib/routes/shellBoundaries.ts
@@ -1,0 +1,40 @@
+const STANDALONE_PUBLIC_PREFIXES = [
+  "/launch",
+  "/offline",
+  "/signup",
+  "/sign-up",
+  "/sign-in",
+  "/forgot-password",
+  "/auth/reset",
+  "/auth/set-password",
+  "/auth/callback",
+  "/confirm",
+  "/compare-plans",
+  "/subscribe",
+  "/demo",
+  "/portal/auth",
+  "/portal/join",
+  "/portal/confirm",
+] as const;
+
+function matchesRoutePrefix(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+/** Routes whose page owns the full viewport and must never inherit app chrome. */
+export function isStandalonePublicRoute(pathname: string): boolean {
+  if (pathname === "/") return true;
+  if (matchesRoutePrefix(pathname, "/mobile/sign-in")) return true;
+  return STANDALONE_PUBLIC_PREFIXES.some((prefix) =>
+    matchesRoutePrefix(pathname, prefix),
+  );
+}
+
+/** Routes rendered by a dedicated surface shell instead of the desktop dashboard shell. */
+export function isOutsideDesktopAppShell(pathname: string): boolean {
+  if (isStandalonePublicRoute(pathname)) return true;
+  if (matchesRoutePrefix(pathname, "/portal")) return true;
+  if (matchesRoutePrefix(pathname, "/mobile")) return true;
+  if (matchesRoutePrefix(pathname, "/coming-soon")) return true;
+  return pathname === "/auth" || pathname.startsWith("/auth/");
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -328,6 +328,7 @@ export async function middleware(req: NextRequest) {
 export const config = {
   matcher: [
     "/",
+    "/sign-in",
     "/compare-plans",
     "/subscribe",
     "/confirm",
@@ -338,6 +339,8 @@ export const config = {
     "/demo/:path*",
     "/portal/:path*",
     "/mobile/sign-in",
+    "/launch",
+    "/offline/:path*",
     "/onboarding/:path*",
     "/dashboard/:path*",
     "/fleet/:path*",


### PR DESCRIPTION
## Summary

- remove authenticated mobile chrome from the mobile sign-in page
- let customer and fleet authentication pages own the full viewport without duplicate portal headers
- keep pricing, trial acquisition, demo, and authentication routes outside the dashboard shell during both direct loads and client navigation
- hide PWA install/update controls on standalone public routes
- ensure middleware supplies route context for direct sign-in, launch, and offline requests
- add regression coverage for public, portal, mobile, and dashboard shell boundaries

## Root cause

Several independently maintained route lists had drifted. The mobile and portal layouts also wrapped their authentication pages even though the new authentication shell already rendered a complete page. When an authenticated user navigated client-side to `/compare-plans`, the root layout persisted and the desktop shell still classified pricing as an application route, exposing dashboard navigation around the trial page.

## Impact

Sign-in, portal authentication, and trial/pricing pages now render as isolated public surfaces. Unauthenticated protected-route requests remain controlled by middleware and continue to redirect to authentication/onboarding.

## Validation

- focused Vitest route-boundary suite: 16/16 passed
- full TypeScript check passed
- ESLint passed for all changed files
- `git diff --check` passed