### PR TITLE
Fix Instant Shop Analysis staged uploads and onboarding handoff

### DIFF
--- a/app/api/demo/shop-boost/activate/route.ts
+++ b/app/api/demo/shop-boost/activate/route.ts
@@ -56,7 +56,9 @@ function pathBasename(path: string): string {
 function readPersistedImportSummary(value: unknown): ShopBoostImportSummary | null {
   const basics = isRecord(value) ? value : {};
   const migrationProgress = isRecord(basics.migrationProgress) ? basics.migrationProgress : {};
-  const summary = migrationProgress.importSummary;
+  const summary = isRecord(basics.importSummary)
+    ? basics.importSummary
+    : migrationProgress.importSummary;
   if (!isRecord(summary) || !isRecord(summary.rowResults)) return null;
   if (
     typeof summary.customersImported !== "number" ||

--- a/app/api/demo/shop-boost/claim/route.ts
+++ b/app/api/demo/shop-boost/claim/route.ts
@@ -53,6 +53,7 @@ export async function POST(
       .from("demo_shop_boost_leads")
       .select("id")
       .eq("email", emailNormalized)
+      .eq("lead_kind", "activation_claim")
       .maybeSingle();
 
     if (!existingErr && existingLead) {

--- a/app/api/demo/shop-boost/run/route.ts
+++ b/app/api/demo/shop-boost/run/route.ts
@@ -1,18 +1,31 @@
 // app/api/demo/shop-boost/run/route.ts
 import { NextRequest, NextResponse } from "next/server";
-import { randomUUID } from "crypto";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import {
   buildShadowShopSnapshot,
+  type ShadowShopCsvUpload,
   type ShadowShopSnapshot,
 } from "@/features/integrations/shopBoost/shadowShop";
 import {
-  INSTANT_SHOP_ANALYSIS_DATASET_KEYS,
-  type ShopBoostUploadDatasetKey,
-} from "@/features/integrations/shopBoost/uploadDatasets";
+  DEMO_UPLOAD_BUCKET,
+  DEMO_UPLOAD_MAX_FILE_BYTES,
+  DEMO_UPLOAD_MAX_TOTAL_BYTES,
+  type DemoStagedUploadManifestEntry,
+  validateDemoUploadFileDescriptors,
+} from "@/features/integrations/shopBoost/demoUploadContract";
+import type { ShopBoostUploadDatasetKey } from "@/features/integrations/shopBoost/uploadDatasets";
 
 type DB = Database;
+
+type DemoRunBody = {
+  demoId?: string;
+  intakeId?: string;
+  shopName?: string;
+  country?: string;
+  questionnaire?: unknown;
+  uploads?: unknown;
+};
 
 type DemoRunSuccessResponse = {
   ok: true;
@@ -28,108 +41,200 @@ type DemoRunErrorResponse = {
 
 type DemoRunResponse = DemoRunSuccessResponse | DemoRunErrorResponse;
 
-const SHOP_IMPORT_BUCKET = "shop-imports";
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
 
 function safeShopName(name: string): string {
   return name.trim().replace(/\s+/g, " ").slice(0, 80);
 }
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function asFile(v: FormDataEntryValue | null): File | null {
-  if (!v || typeof v !== "object") return null;
-  const rec = v as unknown;
-  if (!isRecord(rec)) return null;
-
-  const ab = rec.arrayBuffer;
-  const name = rec.name;
-  if (typeof ab !== "function" || typeof name !== "string") return null;
-
-  return v as File;
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  );
 }
 
-export async function POST(req: NextRequest): Promise<NextResponse<DemoRunResponse>> {
+function readUploadManifest(args: {
+  demoId: string;
+  intakeId: string;
+  uploads: unknown;
+}):
+  | { ok: true; uploads: DemoStagedUploadManifestEntry[] }
+  | { ok: false; error: string } {
+  const validated = validateDemoUploadFileDescriptors(args.uploads);
+  if (!validated.ok) return validated;
+
+  const rawUploads = Array.isArray(args.uploads) ? args.uploads : [];
+  const expectedPrefix = `demos/${args.demoId}/${args.intakeId}/`;
+  const uploads: DemoStagedUploadManifestEntry[] = [];
+
+  for (let index = 0; index < validated.files.length; index += 1) {
+    const raw = isRecord(rawUploads[index]) ? rawUploads[index] : {};
+    const path = typeof raw.path === "string" ? raw.path : "";
+    if (
+      !path.startsWith(expectedPrefix) ||
+      path.includes("..") ||
+      !path.endsWith(".csv")
+    ) {
+      return {
+        ok: false,
+        error: "The secure upload manifest is invalid or has expired. Please retry the analysis.",
+      };
+    }
+    uploads.push({ ...validated.files[index], path });
+  }
+
+  return { ok: true, uploads };
+}
+
+export async function POST(
+  req: NextRequest,
+): Promise<NextResponse<DemoRunResponse>> {
   try {
-    const formData = await req.formData();
+    const body = (await req.json().catch(() => null)) as DemoRunBody | null;
+    const demoId = body?.demoId;
+    const intakeId = body?.intakeId;
 
-    const rawShopName = formData.get("shopName");
-    const rawCountry = formData.get("country");
-
-    const shopName =
-      typeof rawShopName === "string" && rawShopName.trim().length > 0
-        ? safeShopName(rawShopName)
-        : null;
-
-    if (!shopName) {
-      return NextResponse.json({ ok: false, error: "Shop name is required." }, { status: 400 });
-    }
-
-    const countryValue =
-      typeof rawCountry === "string" && (rawCountry === "US" || rawCountry === "CA")
-        ? rawCountry
-        : "US";
-
-    const rawQuestionnaire = formData.get("questionnaire");
-    let questionnaire: Record<string, unknown> = {};
-    if (typeof rawQuestionnaire === "string" && rawQuestionnaire.trim()) {
-      try {
-        const parsed = JSON.parse(rawQuestionnaire) as unknown;
-        if (isRecord(parsed)) questionnaire = parsed;
-      } catch {
-        return NextResponse.json(
-          { ok: false, error: "Shop profile answers were invalid. Please try again." },
-          { status: 400 },
-        );
-      }
-    }
-
-    const filesByDataset: Partial<Record<ShopBoostUploadDatasetKey, File>> = {};
-    for (const key of INSTANT_SHOP_ANALYSIS_DATASET_KEYS) {
-      const file = asFile(formData.get(`${key}File`));
-      if (file) filesByDataset[key] = file;
-    }
-
-    if (Object.values(filesByDataset).length === 0) {
+    if (!isUuid(demoId) || !isUuid(intakeId)) {
       return NextResponse.json(
-        { ok: false, error: "Please upload at least one CSV so we have data to analyze." },
+        { ok: false, error: "The secure analysis intake is invalid. Please retry." },
         { status: 400 },
       );
     }
 
-    const intakeId = randomUUID();
-    const snapshot = await buildShadowShopSnapshot({
+    const shopName =
+      typeof body?.shopName === "string" && body.shopName.trim()
+        ? safeShopName(body.shopName)
+        : null;
+    if (!shopName) {
+      return NextResponse.json(
+        { ok: false, error: "Shop name is required." },
+        { status: 400 },
+      );
+    }
+
+    const countryValue =
+      body?.country === "US" || body?.country === "CA" ? body.country : "US";
+    const questionnaire = isRecord(body?.questionnaire)
+      ? body.questionnaire
+      : {};
+    const manifest = readUploadManifest({
+      demoId,
       intakeId,
-      uploadedFiles: filesByDataset,
+      uploads: body?.uploads,
     });
+    if (!manifest.ok) {
+      return NextResponse.json(manifest, { status: 400 });
+    }
 
     const supabase = createAdminSupabase();
-    const demoId = randomUUID();
+    const { data: existingDemo, error: existingError } = await supabase
+      .from("demo_shop_boosts")
+      .select("id,snapshot")
+      .eq("id", demoId)
+      .maybeSingle();
 
-    const uploadedPathEntries = await Promise.all(
-      Object.entries(filesByDataset).map(async ([dataset, file]) => {
-        const path = `demos/${demoId}/${intakeId}/${dataset}-${safeShopName(file.name || `${dataset}.csv`)}`;
-        const { error: uploadErr } = await supabase.storage
-          .from(SHOP_IMPORT_BUCKET)
-          .upload(path, file, { upsert: true, contentType: file.type || "text/csv" });
+    if (existingError) {
+      return NextResponse.json(
+        { ok: false, error: "We couldn't inspect the analysis intake. Please retry." },
+        { status: 500 },
+      );
+    }
 
-        if (uploadErr) {
-          throw new Error(`Failed to stage ${dataset} demo file: ${uploadErr.message}`);
-        }
+    if (existingDemo?.snapshot) {
+      const existingSnapshot = isRecord(existingDemo.snapshot)
+        ? existingDemo.snapshot
+        : {};
+      if (existingSnapshot.intakeId === intakeId) {
+        return NextResponse.json({
+          ok: true,
+          demoId,
+          intakeId,
+          analysis: existingSnapshot as unknown as ShadowShopSnapshot,
+        });
+      }
+      return NextResponse.json(
+        { ok: false, error: "This analysis intake is already in use. Please start again." },
+        { status: 409 },
+      );
+    }
 
-        return [dataset, path] as const;
-      }),
-    );
+    const uploadedCsvs: Partial<
+      Record<ShopBoostUploadDatasetKey, ShadowShopCsvUpload>
+    > = {};
+    const activationUploadPaths: Partial<
+      Record<ShopBoostUploadDatasetKey, string>
+    > = {};
+    let totalBytes = 0;
 
-    const activationUploadPaths = Object.fromEntries(uploadedPathEntries);
+    for (const upload of manifest.uploads) {
+      const { data: blob, error: downloadError } = await supabase.storage
+        .from(DEMO_UPLOAD_BUCKET)
+        .download(upload.path);
+
+      if (downloadError || !blob) {
+        console.error("[demo/shop-boost/run] Staged upload missing", {
+          dataset: upload.dataset,
+          path: upload.path,
+          error: downloadError?.message,
+        });
+        return NextResponse.json(
+          {
+            ok: false,
+            error: `The ${upload.dataset} upload did not finish. Please retry the analysis.`,
+          },
+          { status: 409 },
+        );
+      }
+
+      if (blob.size <= 0 || blob.size > DEMO_UPLOAD_MAX_FILE_BYTES) {
+        return NextResponse.json(
+          {
+            ok: false,
+            error: `${upload.fileName} is empty or exceeds the 20 MB analysis limit.`,
+          },
+          { status: 413 },
+        );
+      }
+
+      totalBytes += blob.size;
+      if (totalBytes > DEMO_UPLOAD_MAX_TOTAL_BYTES) {
+        return NextResponse.json(
+          {
+            ok: false,
+            error: "The staged exports exceed the 60 MB analysis limit.",
+          },
+          { status: 413 },
+        );
+      }
+
+      uploadedCsvs[upload.dataset] = {
+        fileName: upload.fileName,
+        text: await blob.text(),
+      };
+      activationUploadPaths[upload.dataset] = upload.path;
+    }
+
+    const snapshot = await buildShadowShopSnapshot({
+      intakeId,
+      uploadedCsvs,
+    });
     const snapshotWithActivation = {
       ...snapshot,
       questionnaire,
       activationUploadPaths,
+      activationUploadManifest: manifest.uploads,
     };
 
-    const { data: demoRow, error: demoErr } = await supabase
+    const { data: demoRow, error: demoError } = await supabase
       .from("demo_shop_boosts")
       .insert({
         id: demoId,
@@ -142,10 +247,13 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
       .select("id")
       .single();
 
-    if (demoErr || !demoRow?.id) {
-      console.error("Failed to insert demo_shop_boosts", demoErr);
+    if (demoError || !demoRow?.id) {
+      console.error("[demo/shop-boost/run] Failed to persist analysis", demoError);
       return NextResponse.json(
-        { ok: false, error: "We ran the analysis, but could not save the demo result." },
+        {
+          ok: false,
+          error: "We ran the analysis, but could not save the result. Please retry.",
+        },
         { status: 500 },
       );
     }
@@ -157,12 +265,19 @@ export async function POST(req: NextRequest): Promise<NextResponse<DemoRunRespon
         intakeId,
         analysis: snapshotWithActivation,
       },
-      { status: 200 },
+      {
+        status: 200,
+        headers: { "Cache-Control": "no-store" },
+      },
     );
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Unexpected error while running demo analysis.";
-    console.error("Demo run error", err);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  } catch (error) {
+    console.error("[demo/shop-boost/run] Unexpected analysis error", error);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Unexpected error while running the import analysis. Please try again.",
+      },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/demo/shop-boost/uploads/route.ts
+++ b/app/api/demo/shop-boost/uploads/route.ts
@@ -41,7 +41,7 @@ export async function POST(
       const path = `demos/${demoId}/${intakeId}/${file.dataset}-${randomUUID()}.csv`;
       const { data, error } = await admin.storage
         .from(DEMO_UPLOAD_BUCKET)
-        .createSignedUploadUrl(path, { upsert: true });
+        .createSignedUploadUrl(path);
 
       if (error || !data?.token) {
         console.error("[demo/shop-boost/uploads] Failed to sign upload", {

--- a/app/api/demo/shop-boost/uploads/route.ts
+++ b/app/api/demo/shop-boost/uploads/route.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  DEMO_UPLOAD_BUCKET,
+  type DemoSignedUploadTarget,
+  validateDemoUploadFileDescriptors,
+} from "@/features/integrations/shopBoost/demoUploadContract";
+
+type UploadPlanResponse =
+  | {
+      ok: true;
+      demoId: string;
+      intakeId: string;
+      uploads: DemoSignedUploadTarget[];
+    }
+  | { ok: false; error: string };
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  req: NextRequest,
+): Promise<NextResponse<UploadPlanResponse>> {
+  try {
+    const body = (await req.json().catch(() => null)) as {
+      files?: unknown;
+    } | null;
+    const validated = validateDemoUploadFileDescriptors(body?.files);
+
+    if (!validated.ok) {
+      return NextResponse.json(validated, { status: 400 });
+    }
+
+    const admin = createAdminSupabase();
+    const demoId = randomUUID();
+    const intakeId = randomUUID();
+    const uploads: DemoSignedUploadTarget[] = [];
+
+    for (const file of validated.files) {
+      const path = `demos/${demoId}/${intakeId}/${file.dataset}-${randomUUID()}.csv`;
+      const { data, error } = await admin.storage
+        .from(DEMO_UPLOAD_BUCKET)
+        .createSignedUploadUrl(path, { upsert: true });
+
+      if (error || !data?.token) {
+        console.error("[demo/shop-boost/uploads] Failed to sign upload", {
+          dataset: file.dataset,
+          error: error?.message,
+        });
+        return NextResponse.json(
+          {
+            ok: false,
+            error: `We couldn't prepare the ${file.dataset} upload. Please retry.`,
+          },
+          { status: 500 },
+        );
+      }
+
+      uploads.push({
+        ...file,
+        path,
+        token: data.token,
+      });
+    }
+
+    return NextResponse.json(
+      { ok: true, demoId, intakeId, uploads },
+      {
+        status: 200,
+        headers: { "Cache-Control": "no-store" },
+      },
+    );
+  } catch (error) {
+    console.error("[demo/shop-boost/uploads] Unexpected error", error);
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "We couldn't prepare secure uploads. Please try again.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/demo/instant-shop-analysis/page.tsx
+++ b/app/demo/instant-shop-analysis/page.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo, useState, type FormEvent } from "react";
 import { appendActivationContextToHref, type ActivationContext } from "@/features/integrations/shopBoost/activationContext";
 import type { ShopBoostPreflightReport } from "@/features/integrations/shopBoost/preflightAnalysis";
 import type { ShadowShopSnapshot } from "@/features/integrations/shopBoost/shadowShop";
+import { stageInstantAnalysisUploads } from "@/features/integrations/shopBoost/stageDemoUploads";
 import {
   INSTANT_SHOP_ANALYSIS_DATASETS,
   type ShopBoostUploadDatasetKey,
@@ -112,6 +113,7 @@ export default function InstantShopAnalysisPage() {
 
   const [runError, setRunError] = useState<string | null>(null);
   const [runLoading, setRunLoading] = useState(false);
+  const [runProgress, setRunProgress] = useState<string | null>(null);
 
   const [email, setEmail] = useState("");
   const [claimError, setClaimError] = useState<string | null>(null);
@@ -201,19 +203,36 @@ export default function InstantShopAnalysisPage() {
     setStep("analyzing");
 
     try {
-      const form = new FormData();
-      form.append("shopName", shopName.trim());
-      form.append("country", country);
-      form.append("questionnaire", JSON.stringify({ ...questionnaire }));
-      for (const [dataset, file] of selectedEntries) {
-        form.append(`${dataset}File`, file);
-      }
-
-      const res = await fetch("/api/demo/shop-boost/run", {
-        method: "POST",
-        body: form,
+      const staged = await stageInstantAnalysisUploads({
+        selectedFiles: selectedEntries.map(([dataset, file]) => ({
+          dataset,
+          file,
+        })),
+        onProgress: setRunProgress,
       });
 
+      setRunProgress("Building your import readiness report…");
+      const res = await fetch("/api/demo/shop-boost/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          demoId: staged.demoId,
+          intakeId: staged.intakeId,
+          shopName: shopName.trim(),
+          country,
+          questionnaire: { ...questionnaire },
+          uploads: staged.uploads,
+        }),
+      });
+
+      const responseType = res.headers.get("content-type") ?? "";
+      if (!responseType.includes("application/json")) {
+        throw new Error(
+          res.status === 413
+            ? "The selected exports are too large to analyze together."
+            : "The analysis service returned an invalid response. Please retry.",
+        );
+      }
       const json = (await res.json()) as RunResponse;
 
       if (!res.ok || !json.ok) {
@@ -246,6 +265,7 @@ export default function InstantShopAnalysisPage() {
       setStep("form");
     } finally {
       setRunLoading(false);
+      setRunProgress(null);
     }
   };
 
@@ -461,8 +481,8 @@ export default function InstantShopAnalysisPage() {
                 ))}
 
                 <p className={THEME.help}>
-                  This is a preflight preview. Full migration and materialization run only after signup,
-                  activation, and setup.
+                  Files upload securely one at a time, then the same staged exports carry into Guided
+                  Onboarding. Full materialization runs only after signup and activation.
                 </p>
               </div>
             </section>
@@ -478,12 +498,12 @@ export default function InstantShopAnalysisPage() {
                   THEME.ctaDisabled,
                 ].join(" ")}
               >
-                {isAnalyzing ? "Analyzing importability…" : "Run Instant Shop Analysis"}
+                {isAnalyzing ? "Uploading and analyzing…" : "Run Instant Shop Analysis"}
               </button>
 
               {step === "analyzing" && (
                 <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-[11px] text-[color:var(--theme-text-secondary)]">
-                  Running parser + matching heuristics to build your import readiness report…
+                  {runProgress ?? "Preparing your secure import analysis…"}
                 </span>
               )}
 

--- a/features/integrations/shopBoost/demoUploadContract.ts
+++ b/features/integrations/shopBoost/demoUploadContract.ts
@@ -1,0 +1,111 @@
+import {
+  INSTANT_SHOP_ANALYSIS_DATASET_KEYS,
+  type ShopBoostUploadDatasetKey,
+} from "@/features/integrations/shopBoost/uploadDatasets";
+
+export const DEMO_UPLOAD_BUCKET = "shop-imports";
+export const DEMO_UPLOAD_MAX_FILE_BYTES = 20 * 1024 * 1024;
+export const DEMO_UPLOAD_MAX_TOTAL_BYTES = 60 * 1024 * 1024;
+
+export type DemoUploadFileDescriptor = {
+  dataset: ShopBoostUploadDatasetKey;
+  fileName: string;
+  sizeBytes: number;
+  contentType: string;
+};
+
+export type DemoStagedUploadManifestEntry = DemoUploadFileDescriptor & {
+  path: string;
+};
+
+export type DemoSignedUploadTarget = DemoStagedUploadManifestEntry & {
+  token: string;
+};
+
+export type DemoUploadValidationResult =
+  | { ok: true; files: DemoUploadFileDescriptor[] }
+  | { ok: false; error: string };
+
+const allowedDatasetKeys = new Set<string>(INSTANT_SHOP_ANALYSIS_DATASET_KEYS);
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function isInstantAnalysisDataset(
+  value: unknown,
+): value is ShopBoostUploadDatasetKey {
+  return typeof value === "string" && allowedDatasetKeys.has(value);
+}
+
+export function normalizeDemoUploadContentType(value: unknown): string {
+  const contentType = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return contentType === "text/csv" ||
+    contentType === "application/csv" ||
+    contentType === "application/vnd.ms-excel" ||
+    contentType === "text/plain"
+    ? contentType
+    : "text/csv";
+}
+
+export function validateDemoUploadFileDescriptors(
+  value: unknown,
+): DemoUploadValidationResult {
+  if (!Array.isArray(value) || value.length === 0) {
+    return { ok: false, error: "Upload at least one CSV so we can run an import analysis." };
+  }
+
+  if (value.length > INSTANT_SHOP_ANALYSIS_DATASET_KEYS.length) {
+    return { ok: false, error: "Too many files were included in this analysis." };
+  }
+
+  const seen = new Set<ShopBoostUploadDatasetKey>();
+  const files: DemoUploadFileDescriptor[] = [];
+  let totalBytes = 0;
+
+  for (const raw of value) {
+    const entry = asRecord(raw);
+    if (!isInstantAnalysisDataset(entry.dataset)) {
+      return { ok: false, error: "One of the uploaded datasets is not supported." };
+    }
+    if (seen.has(entry.dataset)) {
+      return { ok: false, error: `Only one ${entry.dataset} CSV can be analyzed at a time.` };
+    }
+
+    const fileName = typeof entry.fileName === "string" ? entry.fileName.trim() : "";
+    if (!fileName || !fileName.toLowerCase().endsWith(".csv")) {
+      return { ok: false, error: `${entry.dataset} must be provided as a CSV file.` };
+    }
+
+    const sizeBytes = Number(entry.sizeBytes);
+    if (!Number.isSafeInteger(sizeBytes) || sizeBytes <= 0) {
+      return { ok: false, error: `${fileName} is empty or has an invalid size.` };
+    }
+    if (sizeBytes > DEMO_UPLOAD_MAX_FILE_BYTES) {
+      return {
+        ok: false,
+        error: `${fileName} is larger than the 20 MB analysis limit. Split the export and try again.`,
+      };
+    }
+
+    seen.add(entry.dataset);
+    totalBytes += sizeBytes;
+    files.push({
+      dataset: entry.dataset,
+      fileName: fileName.slice(0, 180),
+      sizeBytes,
+      contentType: normalizeDemoUploadContentType(entry.contentType),
+    });
+  }
+
+  if (totalBytes > DEMO_UPLOAD_MAX_TOTAL_BYTES) {
+    return {
+      ok: false,
+      error: "The selected exports exceed the 60 MB analysis limit. Split the largest export and retry.",
+    };
+  }
+
+  return { ok: true, files };
+}

--- a/features/integrations/shopBoost/shadowShop.ts
+++ b/features/integrations/shopBoost/shadowShop.ts
@@ -697,9 +697,15 @@ function deriveOperationalPayload(args: {
   };
 }
 
+export type ShadowShopCsvUpload = {
+  fileName: string;
+  text: string;
+};
+
 export async function buildShadowShopSnapshot(args: {
   intakeId: string;
-  uploadedFiles: Partial<Record<ShopBoostUploadDatasetKey, File>>;
+  uploadedFiles?: Partial<Record<ShopBoostUploadDatasetKey, File>>;
+  uploadedCsvs?: Partial<Record<ShopBoostUploadDatasetKey, ShadowShopCsvUpload>>;
 }): Promise<ShadowShopSnapshot> {
   const parsedRowsByDomain: Record<ShadowDomainKey, CsvRow[]> = {
     customers: [],
@@ -722,14 +728,15 @@ export async function buildShadowShopSnapshot(args: {
   for (const key of SHOP_BOOST_UPLOAD_DATASET_KEYS) {
     if (!SHADOW_DATASET_KEYS.includes(key as ShadowDomainKey)) continue;
     const shadowKey = key as ShadowDomainKey;
-    const file = args.uploadedFiles[key];
-    if (!file) continue;
-    const text = await file.text();
+    const file = args.uploadedFiles?.[key];
+    const stagedCsv = args.uploadedCsvs?.[key];
+    if (!file && !stagedCsv) continue;
+    const text = stagedCsv?.text ?? (await file!.text());
     const rows = parseCsv(text);
     parsedRowsByDomain[shadowKey] = rows;
     uploadSummary[shadowKey] = {
       count: rows.length,
-      fileName: file.name,
+      fileName: stagedCsv?.fileName ?? file?.name ?? null,
     };
   }
 

--- a/features/integrations/shopBoost/stageDemoUploads.ts
+++ b/features/integrations/shopBoost/stageDemoUploads.ts
@@ -105,6 +105,12 @@ export async function stageInstantAnalysisUploads(args: {
   return {
     demoId: plan.demoId,
     intakeId: plan.intakeId,
-    uploads: plan.uploads.map(({ token: _token, ...upload }) => upload),
+    uploads: plan.uploads.map((upload) => ({
+      dataset: upload.dataset,
+      path: upload.path,
+      fileName: upload.fileName,
+      sizeBytes: upload.sizeBytes,
+      contentType: upload.contentType,
+    })),
   };
 }

--- a/features/integrations/shopBoost/stageDemoUploads.ts
+++ b/features/integrations/shopBoost/stageDemoUploads.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  DEMO_UPLOAD_BUCKET,
+  type DemoSignedUploadTarget,
+  type DemoStagedUploadManifestEntry,
+  type DemoUploadFileDescriptor,
+} from "@/features/integrations/shopBoost/demoUploadContract";
+import type { ShopBoostUploadDatasetKey } from "@/features/integrations/shopBoost/uploadDatasets";
+
+type SelectedDemoFile = {
+  dataset: ShopBoostUploadDatasetKey;
+  file: File;
+};
+
+type UploadPlanResponse =
+  | {
+      ok: true;
+      demoId: string;
+      intakeId: string;
+      uploads: DemoSignedUploadTarget[];
+    }
+  | { ok: false; error: string };
+
+export type StagedDemoUploads = {
+  demoId: string;
+  intakeId: string;
+  uploads: DemoStagedUploadManifestEntry[];
+};
+
+async function readJsonResponse<T>(
+  response: Response,
+  fallback: string,
+): Promise<T> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) {
+    throw new Error(
+      response.status === 413
+        ? "These files are too large for a single request. ProFixIQ could not start the secure upload."
+        : fallback,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+export async function stageInstantAnalysisUploads(args: {
+  selectedFiles: SelectedDemoFile[];
+  onProgress?: (message: string) => void;
+}): Promise<StagedDemoUploads> {
+  const descriptors: DemoUploadFileDescriptor[] = args.selectedFiles.map(
+    ({ dataset, file }) => ({
+      dataset,
+      fileName: file.name,
+      sizeBytes: file.size,
+      contentType: file.type || "text/csv",
+    }),
+  );
+
+  args.onProgress?.("Preparing secure uploads…");
+  const planResponse = await fetch("/api/demo/shop-boost/uploads", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ files: descriptors }),
+  });
+  const plan = await readJsonResponse<UploadPlanResponse>(
+    planResponse,
+    "We couldn't prepare secure uploads. Please try again.",
+  );
+
+  if (!planResponse.ok || !plan.ok) {
+    throw new Error(
+      !plan.ok ? plan.error : "We couldn't prepare secure uploads. Please try again.",
+    );
+  }
+
+  const selectedByDataset = new Map(
+    args.selectedFiles.map(({ dataset, file }) => [dataset, file] as const),
+  );
+  const supabase = createBrowserSupabase();
+
+  for (let index = 0; index < plan.uploads.length; index += 1) {
+    const upload = plan.uploads[index];
+    const file = selectedByDataset.get(upload.dataset);
+    if (!file) {
+      throw new Error(`The ${upload.dataset} file selection changed. Please retry.`);
+    }
+
+    args.onProgress?.(
+      `Uploading ${index + 1} of ${plan.uploads.length}: ${file.name}`,
+    );
+    const { error } = await supabase.storage
+      .from(DEMO_UPLOAD_BUCKET)
+      .uploadToSignedUrl(upload.path, upload.token, file, {
+        cacheControl: "3600",
+        contentType: upload.contentType,
+        upsert: true,
+      });
+
+    if (error) {
+      throw new Error(`We couldn't upload ${file.name}. ${error.message}`);
+    }
+  }
+
+  return {
+    demoId: plan.demoId,
+    intakeId: plan.intakeId,
+    uploads: plan.uploads.map(({ token: _token, ...upload }) => upload),
+  };
+}

--- a/tests/instant-shop-analysis-guided-onboarding.test.ts
+++ b/tests/instant-shop-analysis-guided-onboarding.test.ts
@@ -31,14 +31,28 @@ describe("instant shop analysis guided onboarding handoff", () => {
     expect(source).not.toContain("SHOP_BOOST_UPLOAD_DATASETS.map");
   });
 
-  it("preserves questionnaire context and invoice analysis", () => {
+  it("stages files outside the analysis request and preserves questionnaire context", () => {
+    const page = read("app/demo/instant-shop-analysis/page.tsx");
+    const uploadRoute = read("app/api/demo/shop-boost/uploads/route.ts");
     const runRoute = read("app/api/demo/shop-boost/run/route.ts");
+    const uploadHelper = read(
+      "features/integrations/shopBoost/stageDemoUploads.ts",
+    );
     const shadowShop = read("features/integrations/shopBoost/shadowShop.ts");
 
-    expect(runRoute).toContain('formData.get("questionnaire")');
+    expect(page).toContain("stageInstantAnalysisUploads");
+    expect(uploadRoute).toContain("createSignedUploadUrl");
+    expect(uploadHelper).toContain("uploadToSignedUrl");
+    expect(runRoute).toContain("await req.json()");
+    expect(runRoute).toContain(".download(upload.path)");
+    expect(runRoute).toContain("uploadedCsvs");
+    expect(runRoute).not.toContain("req.formData()");
+    expect(page).not.toContain("new FormData()");
     expect(runRoute).toContain("questionnaire,");
     expect(shadowShop).toContain('"invoices" | "parts"');
-    expect(shadowShop).toContain('invoices: stageRowsByDomain(parsedRowsByDomain.invoices, "invoices")');
+    expect(shadowShop).toContain(
+      'invoices: stageRowsByDomain(parsedRowsByDomain.invoices, "invoices")',
+    );
   });
 
   it("copies the full upload manifest and maps activation into guided onboarding", () => {

--- a/tests/instant-shop-analysis-guided-onboarding.test.ts
+++ b/tests/instant-shop-analysis-guided-onboarding.test.ts
@@ -78,14 +78,17 @@ describe("instant shop analysis guided onboarding handoff", () => {
 
   it("binds activation to the unlocked email and provides a retry-safe handoff page", () => {
     const activation = read("app/api/demo/shop-boost/activate/route.ts");
+    const claim = read("app/api/demo/shop-boost/claim/route.ts");
     const handoffPage = read("app/onboarding/shop-boost/page.tsx");
     const signIn = read("features/auth/components/SignIn.tsx");
 
+    expect(claim).toContain('.eq("lead_kind", "activation_claim")');
     expect(activation).toContain('.from("demo_shop_boost_leads")');
     expect(activation).toContain('.eq("email", normalizedUserEmail)');
     expect(activation).toContain('.eq("lead_kind", "activation_claim")');
     expect(activation).toContain('role !== "owner" && role !== "admin"');
     expect(activation).toContain("readPersistedImportSummary");
+    expect(activation).toContain("isRecord(basics.importSummary)");
     expect(activation).toContain("ensureStorageCopy");
     expect(activation).toContain("demoRow.shop_id !== shopId");
     expect(handoffPage).toContain('fetch("/api/demo/shop-boost/activate"');

--- a/tests/instant-shop-analysis-staged-upload.test.ts
+++ b/tests/instant-shop-analysis-staged-upload.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEMO_UPLOAD_MAX_FILE_BYTES,
+  DEMO_UPLOAD_MAX_TOTAL_BYTES,
+  validateDemoUploadFileDescriptors,
+} from "@/features/integrations/shopBoost/demoUploadContract";
+
+describe("instant analysis staged upload contract", () => {
+  it("accepts the five guided-onboarding datasets", () => {
+    const files = ["customers", "vehicles", "history", "invoices", "parts"].map(
+      (dataset) => ({
+        dataset,
+        fileName: `${dataset}.csv`,
+        sizeBytes: 1024,
+        contentType: "text/csv",
+      }),
+    );
+
+    const result = validateDemoUploadFileDescriptors(files);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.files.map((file) => file.dataset)).toEqual([
+        "customers",
+        "vehicles",
+        "history",
+        "invoices",
+        "parts",
+      ]);
+    }
+  });
+
+  it("rejects unsupported, duplicate, oversized, and combined oversized uploads", () => {
+    expect(
+      validateDemoUploadFileDescriptors([
+        {
+          dataset: "staff",
+          fileName: "staff.csv",
+          sizeBytes: 100,
+          contentType: "text/csv",
+        },
+      ]).ok,
+    ).toBe(false);
+
+    expect(
+      validateDemoUploadFileDescriptors([
+        {
+          dataset: "customers",
+          fileName: "one.csv",
+          sizeBytes: 100,
+          contentType: "text/csv",
+        },
+        {
+          dataset: "customers",
+          fileName: "two.csv",
+          sizeBytes: 100,
+          contentType: "text/csv",
+        },
+      ]).ok,
+    ).toBe(false);
+
+    expect(
+      validateDemoUploadFileDescriptors([
+        {
+          dataset: "customers",
+          fileName: "large.csv",
+          sizeBytes: DEMO_UPLOAD_MAX_FILE_BYTES + 1,
+          contentType: "text/csv",
+        },
+      ]).ok,
+    ).toBe(false);
+
+    const combined = ["customers", "vehicles", "history", "invoices"].map(
+      (dataset) => ({
+        dataset,
+        fileName: `${dataset}.csv`,
+        sizeBytes: Math.floor(DEMO_UPLOAD_MAX_TOTAL_BYTES / 4) + 1,
+        contentType: "text/csv",
+      }),
+    );
+    expect(validateDemoUploadFileDescriptors(combined).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

- replaces the single multipart Instant Shop Analysis request with short-lived signed uploads to the existing private `shop-imports` bucket
- uploads customers, vehicles, history, invoices, and parts individually, then sends a small JSON manifest to the analysis route
- downloads and validates the staged CSVs server-side before building the existing preflight/WOW report
- preserves the exact staged object paths for post-signup activation, so Guided Onboarding imports the files without asking the shop to upload again
- adds per-file and aggregate upload limits with user-facing progress and useful errors
- makes analysis submission retry-safe when a result was saved but the browser missed the response
- prevents shared-report lead rows from blocking a legitimate activation claim
- reuses the canonical persisted activation import summary instead of rerunning a completed import

## Root cause

The landing page posted all five raw CSV files to `/api/demo/shop-boost/run` as one multipart function request. Vercel rejected realistic combined exports before the route executed with `413 FUNCTION_PAYLOAD_TOO_LARGE`, and Safari surfaced the infrastructure response as “The string did not match the expected pattern.”

## User impact

The shop now uploads each export directly and securely, sees meaningful upload/analysis progress, receives the same preflight report, and carries those exact files into the Guided Onboarding activation flow.

## Validation

- added staged-upload contract tests for the five canonical datasets, duplicate/unsupported files, and file/aggregate limits
- updated the Instant Analysis/Guided Onboarding handoff regression test to require signed uploads, storage-manifest analysis, claim scoping, and canonical summary reuse
- inspected the branch comparison against `main`: 10 scoped files, branch is based on and ahead of current `main`

No database migration is required; this uses the existing private `shop-imports` bucket.