### PR TITLE
Add premium free-form technician voice workflows

### DIFF
--- a/app/api/ai/interpret/route.ts
+++ b/app/api/ai/interpret/route.ts
@@ -320,6 +320,11 @@ Rules:
 - Use synonyms: pass=ok, okay=ok, failed=fail, not applicable=na, recommend=recommend, rec=recommend.
 - Keep values concise and units normalized when possible.
 - When you set a FAIL or RECOMMEND status, include a short note if the transcript includes a reason (leak/loose/cracked/worn/etc).
+- The technician may inspect the vehicle in ANY order. Never assume a guided sequence or force the current UI item.
+- A transcript may contain multiple unrelated findings or measurements. Return one command per distinct item, preserving the technician's spoken order.
+- Use the named corner, axle, side, component, or section to resolve each command independently.
+- Do not merge distinct inspection items into one command.
+- Never invent a status, measurement, part, quantity, labor time, test, or repair that the technician did not say.
 
 IMPORTANT:
 - Prefer "oneshot_item" when a single utterance includes status + reason + parts and/or labor.

--- a/app/api/work-orders/documentation/rewrite/route.ts
+++ b/app/api/work-orders/documentation/rewrite/route.ts
@@ -1,0 +1,215 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import {
+  getOpenAIModelForPurpose,
+  openAITemperatureParam,
+} from "@/features/shared/lib/server/openai-models";
+import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
+import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
+import {
+  enforceAIOperationalPolicy,
+  estimateAICostUsd,
+  registerAIUsageEvent,
+} from "@/features/shared/lib/server/ai-ops-guard";
+
+export const runtime = "nodejs";
+
+const FEATURE = "work_order_documentation_rewrite" as const;
+const ENDPOINT = "/api/work-orders/documentation/rewrite";
+
+const requestSchema = z.object({
+  jobId: z.string().uuid(),
+  transcript: z.string().trim().min(3).max(12000),
+  existingCause: z.string().max(12000).optional().default(""),
+  existingCorrection: z.string().max(12000).optional().default(""),
+});
+
+const responseSchema = z.object({
+  cause: z.string().trim().min(1).max(12000),
+  correction: z.string().trim().min(1).max(12000),
+});
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  const startedAt = Date.now();
+  const policy = getAIPolicy(FEATURE);
+  const model = getOpenAIModelForPurpose(policy.modelPurpose);
+  const access = await requireShopScopedApiAccess();
+
+  if (!access.ok) return access.response;
+
+  const parsedBody = requestSchema.safeParse(
+    await req.json().catch(() => null),
+  );
+  if (!parsedBody.success) {
+    return errorResponse("A valid job and dictated story are required.", 400);
+  }
+
+  const admin = await createAdminSupabase();
+  const { data: line, error: lineError } = await admin
+    .from("work_order_lines")
+    .select("id, work_order_id, complaint, description, cause, correction")
+    .eq("id", parsedBody.data.jobId)
+    .maybeSingle();
+
+  if (lineError) {
+    console.error("[documentation-rewrite] line lookup failed", lineError);
+    return errorResponse("Unable to load this job.", 500);
+  }
+  if (!line?.work_order_id) {
+    return errorResponse("Job not found.", 404);
+  }
+
+  const { data: workOrder, error: workOrderError } = await admin
+    .from("work_orders")
+    .select("id, shop_id")
+    .eq("id", line.work_order_id)
+    .maybeSingle();
+
+  if (
+    workOrderError ||
+    !workOrder ||
+    workOrder.shop_id !== access.profile.shop_id
+  ) {
+    return errorResponse("Job not found.", 404);
+  }
+
+  const enforcement = enforceAIOperationalPolicy({
+    feature: FEATURE,
+    endpoint: ENDPOINT,
+    shopId: access.profile.shop_id,
+  });
+  if (!enforcement.allowed) {
+    return NextResponse.json(
+      {
+        error: "AI documentation rewrite is temporarily limited.",
+        code: enforcement.code,
+      },
+      { status: 429 },
+    );
+  }
+
+  try {
+    const openai = getOpenAIClient();
+    const completion = await Promise.race([
+      openai.chat.completions.create({
+        model,
+        ...openAITemperatureParam(model, 0.1),
+        response_format: { type: "json_object" },
+        max_completion_tokens: policy.maxTokens,
+        messages: [
+          {
+            role: "system",
+            content: [
+              "You rewrite automotive technician dictation into a professional cause and correction story.",
+              "Return only a JSON object with string fields cause and correction.",
+              "Preserve every measurement, test result, part, procedure, qualifier, and uncertainty exactly as supplied.",
+              "Never invent a diagnosis, test, measurement, part, repair, verification step, or result.",
+              "Cause explains the verified condition or source of the concern.",
+              "Correction explains only what the technician actually performed or verified.",
+              "Use concise professional shop language and correct obvious transcription errors.",
+              "If the dictation does not establish a confirmed cause or correction, state that clearly instead of guessing.",
+            ].join(" "),
+          },
+          {
+            role: "user",
+            content: JSON.stringify({
+              complaint: line.complaint ?? line.description ?? null,
+              currentDraft: {
+                cause: parsedBody.data.existingCause || line.cause || null,
+                correction:
+                  parsedBody.data.existingCorrection || line.correction || null,
+              },
+              technicianDictation: parsedBody.data.transcript,
+            }),
+          },
+        ],
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("AI documentation rewrite timed out")),
+          policy.timeoutMs,
+        ),
+      ),
+    ]);
+
+    const raw = completion.choices[0]?.message?.content ?? "{}";
+    const parsed = responseSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success) {
+      throw new Error("AI returned an invalid documentation rewrite");
+    }
+
+    const usage = completion.usage;
+    const totalTokens = usage?.total_tokens ?? null;
+    const estimatedCost = estimateAICostUsd(FEATURE, totalTokens);
+
+    recordAITelemetry({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shop_id: access.profile.shop_id,
+      user_id: access.profile.id,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: usage?.prompt_tokens ?? null,
+      completion_tokens: usage?.completion_tokens ?? null,
+      total_tokens: totalTokens,
+      estimated_cost_usd: estimatedCost,
+      status: "success",
+      error_code: null,
+      error_message: null,
+    });
+    registerAIUsageEvent({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shopId: access.profile.shop_id,
+      model,
+      totalTokens,
+      estimatedCostUsd: estimatedCost,
+      status: "success",
+      errorCode: null,
+    });
+
+    return NextResponse.json(parsed.data);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Documentation rewrite failed";
+
+    recordAITelemetry({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shop_id: access.profile.shop_id,
+      user_id: access.profile.id,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      estimated_cost_usd: 0,
+      status: "error",
+      error_code: "documentation_rewrite_failed",
+      error_message: message,
+    });
+    registerAIUsageEvent({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shopId: access.profile.shop_id,
+      model,
+      totalTokens: null,
+      estimatedCostUsd: 0,
+      status: "error",
+      errorCode: "documentation_rewrite_failed",
+    });
+
+    console.error("[documentation-rewrite]", error);
+    return errorResponse(
+      "Could not rewrite the job story. Your original dictation is unchanged.",
+      502,
+    );
+  }
+}

--- a/features/inspections/components/inspection/VoiceControlsPanel.tsx
+++ b/features/inspections/components/inspection/VoiceControlsPanel.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import ModalShell from "@/features/shared/components/ModalShell";
+import { Button } from "@shared/components/ui/Button";
+
+type VoiceControlsPanelProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  voiceState: "idle" | "connecting" | "listening" | "error";
+  isHeld: boolean;
+};
+
+const COMMAND_GROUPS = [
+  {
+    title: "Findings",
+    description: "Work in any order. Name the item or area you are checking.",
+    examples: [
+      "Left front tire pressure 34 psi, tread 6 millimetres.",
+      "Right rear shock leaking, fail.",
+      "Front brake pads 8 millimetres, pass.",
+      "All exterior lights pass.",
+    ],
+  },
+  {
+    title: "Parts and labour",
+    description: "Add estimate details in the same sentence as the finding.",
+    examples: [
+      "Recommend right front wheel bearing, one bearing, 1.4 hours.",
+      "Fail rear brake pads, add one pad set and 1.2 hours.",
+      "Add two front tires to the left front tire finding.",
+    ],
+  },
+  {
+    title: "Corrections",
+    description: "Correct the most recent finding naturally.",
+    examples: [
+      "Change that to recommend.",
+      "Add note: worn on the outer edge.",
+      "Correction: the measurement was 5 millimetres.",
+    ],
+  },
+  {
+    title: "Voice session",
+    description: "The session stays free-form until you hold or stop it.",
+    examples: [
+      "Buster hold.",
+      "Buster resume.",
+      "Buster stop listening.",
+    ],
+  },
+] as const;
+
+function stateLabel(
+  voiceState: VoiceControlsPanelProps["voiceState"],
+  isHeld: boolean,
+): string {
+  if (isHeld) return "On hold";
+  if (voiceState === "listening") return "Free-form listening";
+  if (voiceState === "connecting") return "Connecting";
+  if (voiceState === "error") return "Needs attention";
+  return "Not listening";
+}
+
+export default function VoiceControlsPanel({
+  isOpen,
+  onClose,
+  voiceState,
+  isHeld,
+}: VoiceControlsPanelProps): JSX.Element {
+  const active = voiceState === "listening" || voiceState === "connecting";
+
+  return (
+    <ModalShell
+      isOpen={isOpen}
+      onClose={onClose}
+      title="VOICE CONTROLS"
+      size="md"
+      hideFooter
+    >
+      <div
+        className="max-h-[76vh] space-y-4 overflow-y-auto pr-1"
+        style={{ WebkitOverflowScrolling: "touch" }}
+      >
+        <div className="overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]">
+          <div className="border-b border-[color:var(--theme-border-soft)] bg-[linear-gradient(135deg,color-mix(in_srgb,var(--brand-primary)_22%,transparent),transparent)] px-4 py-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper-light)]">
+                  Buster free-form voice
+                </div>
+                <h2 className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                  Inspect your way
+                </h2>
+              </div>
+              <span
+                className={[
+                  "shrink-0 rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.14em]",
+                  active && !isHeld
+                    ? "border-emerald-400/35 bg-emerald-500/10 text-emerald-200"
+                    : isHeld
+                      ? "border-amber-400/35 bg-amber-500/10 text-amber-200"
+                      : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] text-[color:var(--theme-text-secondary)]",
+                ].join(" ")}
+              >
+                {stateLabel(voiceState, isHeld)}
+              </span>
+            </div>
+            <p className="mt-2 text-sm leading-5 text-[color:var(--theme-text-secondary)]">
+              Start listening once, then call out findings in any order. Buster
+              matches each phrase to the inspection item you name. It never
+              forces a sequence or advances you through a checklist.
+            </p>
+          </div>
+
+          <div className="grid gap-3 p-3 sm:grid-cols-2">
+            {COMMAND_GROUPS.map((group) => (
+              <section
+                key={group.title}
+                className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-3"
+              >
+                <h3 className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)]">
+                  {group.title}
+                </h3>
+                <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                  {group.description}
+                </p>
+                <div className="mt-3 space-y-2">
+                  {group.examples.map((example) => (
+                    <div
+                      key={example}
+                      className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs leading-5 text-[color:var(--theme-text-primary)]"
+                    >
+                      “{example}”
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-sky-400/25 bg-sky-500/10 px-3 py-3 text-xs leading-5 text-sky-100">
+          <span className="font-semibold">Best results:</span> identify the
+          corner, component or section when shop conversation could be
+          ambiguous. You can combine several measurements and findings in one
+          sentence.
+        </div>
+
+        <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+          Audio is processed only while voice capture is active. The visible
+          status on the inspection screen always shows whether Buster is
+          listening, held or stopped.
+        </div>
+
+        <div className="flex justify-end">
+          <Button type="button" variant="copper" size="sm" onClick={onClose}>
+            Back to inspection
+          </Button>
+        </div>
+      </div>
+    </ModalShell>
+  );
+}

--- a/features/inspections/lib/inspection/useRealtimeVoice.ts
+++ b/features/inspections/lib/inspection/useRealtimeVoice.ts
@@ -389,5 +389,40 @@ export function useRealtimeVoice(
     setState("idle");
   }
 
+  useEffect(() => {
+    return () => {
+      stoppedRef.current = true;
+
+      try {
+        workletRef.current?.disconnect();
+      } catch {}
+      workletRef.current = null;
+
+      try {
+        zeroGainRef.current?.disconnect();
+      } catch {}
+      zeroGainRef.current = null;
+
+      const socket = wsRef.current;
+      wsRef.current = null;
+      try {
+        socket?.close();
+      } catch {}
+
+      try {
+        mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+      } catch {}
+      mediaStreamRef.current = null;
+
+      const audioContext = audioCtxRef.current;
+      audioCtxRef.current = null;
+      try {
+        void audioContext?.close();
+      } catch {}
+
+      liveRef.current = "";
+    };
+  }, []);
+
   return { start, stop };
 }

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -1762,6 +1762,12 @@ type SmartMatchRow = {
       const correctionNote = correctionSpeech.match(
         /^(?:add|append)\s+(?:a\s+)?note\s*(?::|that)?\s*(.+)$/,
       )?.[1];
+      const correctionValueMatch = correctionSpeech.match(
+        /\b(?:change|correct|correction|actually).*(?:measurement|reading|value)?\s*(?:was|is|to)?\s*(\d+(?:\.\d+)?)\b/,
+      );
+      const correctionValue = correctionValueMatch
+        ? Number(correctionValueMatch[1])
+        : null;
 
       if (
         correctionTarget &&
@@ -1783,6 +1789,19 @@ type SmartMatchRow = {
             sectionIndex: correctionTarget.sectionIndex,
             itemIndex: correctionTarget.itemIndex,
             note: correctionNote,
+          } as unknown as ParsedCommand,
+        ];
+      } else if (
+        correctionTarget &&
+        correctionValue != null &&
+        Number.isFinite(correctionValue)
+      ) {
+        commands = [
+          {
+            command: "update_value",
+            sectionIndex: correctionTarget.sectionIndex,
+            itemIndex: correctionTarget.itemIndex,
+            value: correctionValue,
           } as unknown as ParsedCommand,
         ];
       } else {

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -825,6 +825,10 @@ type SmartMatchRow = {
   const [voiceControlsOpen, setVoiceControlsOpen] = useState(false);
   const [voiceHeld, setVoiceHeld] = useState(false);
   const voiceHeldRef = useRef(false);
+  const lastVoiceTargetRef = useRef<{
+    sectionIndex: number;
+    itemIndex: number;
+  } | null>(null);
 
   const [voiceState, setVoiceState] = useState<
     "idle" | "connecting" | "listening" | "error"
@@ -1743,7 +1747,47 @@ type SmartMatchRow = {
     const applied: VoiceCommandApplyResult[] = [];
 
     try {
-      commands = await interpretCommand(mainText, ctx);
+      const correctionTarget = lastVoiceTargetRef.current;
+      const correctionSpeech = normalizeSpeech(mainText);
+      const correctionStatus =
+        /\b(ok|okay|pass|good)\b/.test(correctionSpeech)
+          ? "ok"
+          : /\b(fail|failed|bad)\b/.test(correctionSpeech)
+            ? "fail"
+            : /\b(recommend|recommended|rec)\b/.test(correctionSpeech)
+              ? "recommend"
+              : /\b(not applicable|n a|na)\b/.test(correctionSpeech)
+                ? "na"
+                : null;
+      const correctionNote = correctionSpeech.match(
+        /^(?:add|append)\s+(?:a\s+)?note\s*(?::|that)?\s*(.+)$/,
+      )?.[1];
+
+      if (
+        correctionTarget &&
+        correctionStatus &&
+        /\b(change|correct|actually|make)\b/.test(correctionSpeech)
+      ) {
+        commands = [
+          {
+            command: "update_status",
+            sectionIndex: correctionTarget.sectionIndex,
+            itemIndex: correctionTarget.itemIndex,
+            status: correctionStatus,
+          } as unknown as ParsedCommand,
+        ];
+      } else if (correctionTarget && correctionNote) {
+        commands = [
+          {
+            command: "add_note",
+            sectionIndex: correctionTarget.sectionIndex,
+            itemIndex: correctionTarget.itemIndex,
+            note: correctionNote,
+          } as unknown as ParsedCommand,
+        ];
+      } else {
+        commands = await interpretCommand(mainText, ctx);
+      }
 
       // ✅ FALLBACK: if AI returns nothing, try local parsing
       if (!commands.length) {
@@ -1798,6 +1842,7 @@ type SmartMatchRow = {
 
           if (r?.appliedTarget) {
             lastAppliedTarget = r.appliedTarget;
+            lastVoiceTargetRef.current = r.appliedTarget;
 
             const okResult: VoiceCommandApplyResult = {
               command: commandLabel(command),

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -18,6 +18,7 @@ import { requestQuoteSuggestion } from "@inspections/lib/inspection/aiQuote";
 import { addWorkOrderLineFromSuggestion } from "@inspections/lib/inspection/addWorkOrderLine";
 import { useRealtimeVoice } from "@inspections/lib/inspection/useRealtimeVoice";
 import { buildVoiceBrainFeedback } from "@inspections/lib/inspection/voice/voiceBrain";
+import VoiceControlsPanel from "@inspections/components/inspection/VoiceControlsPanel";
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
 import type {
@@ -821,10 +822,9 @@ type SmartMatchRow = {
   >({});
   const smartMatchTimers = useRef<Record<string, number>>({});
 
-  const [wakeActive, setWakeActive] = useState(false);
-  // ✅ Use ref for logic to avoid React state race between transcripts
-  const wakeActiveRef = useRef<boolean>(false);
-  const wakeTimeoutRef = useRef<number | null>(null);
+  const [voiceControlsOpen, setVoiceControlsOpen] = useState(false);
+  const [voiceHeld, setVoiceHeld] = useState(false);
+  const voiceHeldRef = useRef(false);
 
   const [voiceState, setVoiceState] = useState<
     "idle" | "connecting" | "listening" | "error"
@@ -1832,13 +1832,20 @@ type SmartMatchRow = {
         }
       }
 
+      const successfulUpdates = applied.filter((result) => result.ok).length;
       const feedback =
-        primaryFeedback ??
-        buildVoiceBrainFeedback({
-          rawSpeech: text,
-          parsed: commands,
-          applied,
-        });
+        successfulUpdates > 1
+          ? {
+              spoken: `${successfulUpdates} inspection updates recorded.`,
+              toast: `${successfulUpdates} inspection updates recorded`,
+              followUp: { kind: "none" as const },
+            }
+          : primaryFeedback ??
+            buildVoiceBrainFeedback({
+              rawSpeech: text,
+              parsed: commands,
+              applied,
+            });
 
       if (feedback.toast) {
         toast.success(feedback.toast);
@@ -1886,104 +1893,66 @@ type SmartMatchRow = {
     }
   };
 
-  function maybeHandleWakeWord(raw: string): string | null {
+  function maybeHandleVoicePhrase(raw: string): string | null {
     const normalized = raw
       .toLowerCase()
-      .replace(/[^\w\s]/g, " ")
+      .replace(/[^\w\s.]/g, " ")
       .replace(/\s+/g, " ")
       .trim();
 
-    // Include common STT variations
-    const WAKE_PREFIXES = ["hey profix", "hey pro fix", "hey buster"] as const;
+    if (!normalized) return null;
 
-    const matchPrefixFrom = (
-      input: string,
-    ): { prefix: string; remainder: string } | null => {
-      for (const prefix of WAKE_PREFIXES) {
-        if (input === prefix) return { prefix, remainder: "" };
-        if (input.startsWith(prefix + " ")) {
-          return { prefix, remainder: input.slice(prefix.length).trimStart() };
-        }
+    const WAKE_PREFIXES = ["hey profix", "hey pro fix", "hey buster", "buster"] as const;
+    let command = normalized;
+
+    for (const prefix of WAKE_PREFIXES) {
+      if (command === prefix) return null;
+      if (command.startsWith(prefix + " ")) {
+        command = command.slice(prefix.length).trimStart();
+        break;
       }
+    }
+
+    const resumeCommand =
+      /^(resume|resume listening|start listening|continue listening)$/.test(command);
+    const holdCommand =
+      /^(hold|hold listening|pause listening|ignore conversation)$/.test(command);
+    const stopCommand =
+      /^(stop|stop listening|end voice|end voice session)$/.test(command);
+
+    if (resumeCommand) {
+      voiceHeldRef.current = false;
+      setVoiceHeld(false);
+      toast.success("Free-form voice resumed.");
+      speakLocal("Listening.");
       return null;
-    };
-
-    const setWake = (on: boolean) => {
-      wakeActiveRef.current = on; // logic gate
-      setWakeActive(on); // UI badge
-    };
-
-    const bumpTimeout = () => {
-      if (wakeTimeoutRef.current) window.clearTimeout(wakeTimeoutRef.current);
-      wakeTimeoutRef.current = window.setTimeout(() => setWake(false), 8000);
-    };
-
-    const beep = () => {
-      try {
-        type WebkitAudioWindow = Window & {
-          webkitAudioContext?: typeof AudioContext;
-        };
-        const AudioCtxCtor =
-          window.AudioContext ||
-          (window as WebkitAudioWindow).webkitAudioContext;
-
-        if (!AudioCtxCtor) return;
-
-        const ctx = new AudioCtxCtor();
-        const o = ctx.createOscillator();
-        const g = ctx.createGain();
-        o.type = "sine";
-        o.frequency.value = 880;
-        g.gain.value = 0.05;
-        o.connect(g);
-        g.connect(ctx.destination);
-        o.start();
-        window.setTimeout(() => {
-          o.stop();
-          void ctx.close();
-        }, 120);
-      } catch {
-        // ignore
-      }
-    };
-
-    const awake = wakeActiveRef.current;
-
-    if (!awake) {
-      const match = matchPrefixFrom(normalized);
-      if (!match) return null;
-
-      setWake(true);
-      bumpTimeout();
-
-      toast.success("READY", { duration: 1200 });
-      beep();
-
-      // Wake-only? arm but do NOT forward empty transcript
-      if (!match.remainder) return null;
-
-      return match.remainder;
     }
 
-    // already awake: extend timeout and strip prefix if repeated
-    bumpTimeout();
+    if (voiceHeldRef.current) return null;
 
-    const repeated = matchPrefixFrom(normalized);
-    if (repeated) {
-      // Wake-only while already awake => keep armed, no command to process
-      if (!repeated.remainder) return null;
-      return repeated.remainder;
+    if (holdCommand) {
+      voiceHeldRef.current = true;
+      setVoiceHeld(true);
+      toast.success("Voice is on hold. Say Buster resume to continue.");
+      speakLocal("Voice on hold.");
+      return null;
     }
 
-    // No repeated wake word; treat full phrase as the command
-    return normalized;
+    if (stopCommand) {
+      window.setTimeout(() => stopListening(), 0);
+      toast.success("Voice session stopped.");
+      speakLocal("Voice stopped.");
+      return null;
+    }
+
+    return command;
   }
 
   const voice = useRealtimeVoice(
     async (text: string) => {
       await handleTranscript(text);
     },
-    (raw: string) => maybeHandleWakeWord(raw),
+    (raw: string) => maybeHandleVoicePhrase(raw),
     {
       onStateChange: setVoiceState,
       onPulse: triggerVoicePulse,
@@ -2000,6 +1969,8 @@ type SmartMatchRow = {
     if (guardLocked()) return;
 
     try {
+      voiceHeldRef.current = false;
+      setVoiceHeld(false);
       await voice.start();
     } catch (e: unknown) {
       // eslint-disable-next-line no-console
@@ -2017,13 +1988,8 @@ type SmartMatchRow = {
       voice.stop();
     } catch {}
 
-    wakeActiveRef.current = false;
-    setWakeActive(false);
-
-    if (wakeTimeoutRef.current) {
-      window.clearTimeout(wakeTimeoutRef.current);
-      wakeTimeoutRef.current = null;
-    }
+    voiceHeldRef.current = false;
+    setVoiceHeld(false);
   };
 
   const inFlightRef = useRef<Set<string>>(new Set());
@@ -2830,8 +2796,10 @@ type SmartMatchRow = {
               </div>
               <div className="min-w-0">
                 <div className="text-sm font-semibold sm:text-base">
-                  {voiceState === "listening"
-                    ? "Listening for the next finding…"
+                  {voiceHeld
+                    ? "Voice is on hold"
+                    : voiceState === "listening"
+                    ? "Free-form voice is listening…"
                     : voiceState === "connecting"
                       ? "Connecting voice capture…"
                       : voiceState === "error"
@@ -2844,13 +2812,41 @@ type SmartMatchRow = {
                   {[4, 8, 6, 11, 7, 13, 9, 5, 10, 6, 12, 8, 4, 9, 5, 7].map((height, index) => (
                     <span key={`${height}-${index}`} className={cn("w-0.5 rounded-full bg-orange-300/80", !isListening && "opacity-25")} style={{ height }} />
                   ))}
-                  {wakeActive ? <span className="ml-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-orange-200">Ready</span> : null}
+                  {voiceHeld ? (
+                    <span className="ml-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-200">
+                      Say “Buster resume”
+                    </span>
+                  ) : isListening ? (
+                    <span className="ml-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-orange-200">
+                      Any order · wake phrase optional
+                    </span>
+                  ) : null}
                 </div>
               </div>
             </div>
 
             <div className="flex shrink-0 flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="border-white/20 bg-white/5 text-[11px] font-semibold text-white hover:bg-white/10"
+                onClick={() => setVoiceControlsOpen(true)}
+              >
+                Voice controls
+              </Button>
               {!isLocked && <StartListeningButton isListening={isListening} onStart={startListening} />}
+              {!isLocked && isListening && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="border-white/20 bg-white/5 text-[11px] font-semibold text-white hover:bg-white/10"
+                  onClick={stopListening}
+                >
+                  Stop
+                </Button>
+              )}
               {!isLocked && (isListening || isPaused) && (
                 <PauseResumeButton
                   isPaused={isPaused}
@@ -3338,6 +3334,13 @@ type SmartMatchRow = {
           </div>
         </div>
       </div>
+
+      <VoiceControlsPanel
+        isOpen={voiceControlsOpen}
+        onClose={() => setVoiceControlsOpen(false)}
+        voiceState={voiceState}
+        isHeld={voiceHeld}
+      />
 
       {showMissingLineWarning && (
         <div className={cn("inset-x-0 z-50 px-3", isEmbed ? "sticky bottom-[76px]" : "fixed bottom-[52px]")}>

--- a/features/shared/lib/server/ai-ops-guard.ts
+++ b/features/shared/lib/server/ai-ops-guard.ts
@@ -86,6 +86,16 @@ const FEATURE_POLICY: Record<AIFeature, AIOpsPolicy> = {
     anomalyHighCostUsd: envNum("AI_ANOMALY_COST_REALTIME_TOKEN", 0.05),
     anomalyHardDenialThreshold: envNum("AI_ANOMALY_DENIAL_REALTIME_TOKEN", 8),
   },
+  work_order_documentation_rewrite: {
+    budgetSoftUsd: envNum("AI_BUDGET_SOFT_USD_DOCUMENTATION", 30),
+    budgetHardUsd: envNum("AI_BUDGET_HARD_USD_DOCUMENTATION", 50),
+    rateLimitMax: envNum("AI_RATE_LIMIT_DOCUMENTATION_MAX", 40),
+    rateLimitWindowMs: envNum("AI_RATE_LIMIT_DOCUMENTATION_WINDOW_MS", 5 * 60 * 1000),
+    anomalySpikeThreshold: envNum("AI_ANOMALY_SPIKE_DOCUMENTATION", 25),
+    anomalyFailureThreshold: envNum("AI_ANOMALY_FAIL_DOCUMENTATION", 6),
+    anomalyHighCostUsd: envNum("AI_ANOMALY_COST_DOCUMENTATION", 0.15),
+    anomalyHardDenialThreshold: envNum("AI_ANOMALY_DENIAL_DOCUMENTATION", 4),
+  },
   branding_generate_logo: {
     budgetSoftUsd: envNum("AI_BUDGET_SOFT_USD_BRANDING", 80),
     budgetHardUsd: envNum("AI_BUDGET_HARD_USD_BRANDING", 120),

--- a/features/shared/lib/server/ai-policy.ts
+++ b/features/shared/lib/server/ai-policy.ts
@@ -14,6 +14,7 @@ export type AIFeature =
   | "work_orders_suggest_lines"
   | "ai_summarize_stats"
   | "openai_realtime_token"
+  | "work_order_documentation_rewrite"
   | "branding_generate_logo";
 
 const AI_POLICIES: Record<AIFeature, AIPolicy> = {
@@ -36,6 +37,13 @@ const AI_POLICIES: Record<AIFeature, AIPolicy> = {
     modelPurpose: "fast",
     timeoutMs: 10000,
     maxTokens: 0,
+    fallbackMode: "hard_fail",
+  },
+  work_order_documentation_rewrite: {
+    feature: "work_order_documentation_rewrite",
+    modelPurpose: "extraction",
+    timeoutMs: 15000,
+    maxTokens: 700,
     fallbackMode: "hard_fail",
   },
   branding_generate_logo: {

--- a/features/shared/voice/VoiceDictationButton.tsx
+++ b/features/shared/voice/VoiceDictationButton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { Mic, Square } from "lucide-react";
+import { Button } from "@shared/components/ui/Button";
+import {
+  useRealtimeVoice,
+  type VoiceState,
+} from "@inspections/lib/inspection/useRealtimeVoice";
+
+type VoiceDictationButtonProps = {
+  onTranscript: (text: string) => void;
+  disabled?: boolean;
+  idleLabel?: string;
+  listeningLabel?: string;
+  className?: string;
+};
+
+export default function VoiceDictationButton({
+  onTranscript,
+  disabled = false,
+  idleLabel = "Dictate",
+  listeningLabel = "Stop dictation",
+  className,
+}: VoiceDictationButtonProps): JSX.Element {
+  const [state, setState] = useState<VoiceState>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const voice = useRealtimeVoice(
+    (text) => onTranscript(text.trim()),
+    (text) => text.trim() || null,
+    {
+      onStateChange: setState,
+      onError: setError,
+    },
+  );
+
+  const active = state === "connecting" || state === "listening";
+
+  const toggle = async (): Promise<void> => {
+    setError(null);
+    if (active) {
+      voice.stop();
+      return;
+    }
+
+    try {
+      await voice.start();
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "Voice dictation unavailable.",
+      );
+    }
+  };
+
+  return (
+    <div className={className}>
+      <Button
+        type="button"
+        variant={active ? "outline" : "copper"}
+        size="sm"
+        disabled={disabled}
+        onClick={() => void toggle()}
+        aria-pressed={active}
+        className="gap-2"
+      >
+        {active ? (
+          <Square className="h-3.5 w-3.5" aria-hidden />
+        ) : (
+          <Mic className="h-3.5 w-3.5" aria-hidden />
+        )}
+        {state === "connecting"
+          ? "Connecting…"
+          : active
+            ? listeningLabel
+            : idleLabel}
+      </Button>
+      {error ? (
+        <div className="mt-1 text-[11px] text-red-300" role="alert">
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/features/work-orders/components/workorders/CauseCorrectionModal.tsx
+++ b/features/work-orders/components/workorders/CauseCorrectionModal.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import ModalShell from "@/features/shared/components/ModalShell";
+import VoiceDictationButton from "@/features/shared/voice/VoiceDictationButton";
 
 interface CauseCorrectionModalProps {
   isOpen: boolean;
@@ -41,6 +42,12 @@ export default function CauseCorrectionModal({
   const [savingDraft, setSavingDraft] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [ok, setOk] = useState<string | null>(null);
+  const [dictatedStory, setDictatedStory] = useState("");
+  const [rewriting, setRewriting] = useState(false);
+  const [rewritePreview, setRewritePreview] = useState<{
+    cause: string;
+    correction: string;
+  } | null>(null);
 
   const causeRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -50,6 +57,9 @@ export default function CauseCorrectionModal({
       setCorrection(initialCorrection);
       setError(null);
       setOk(null);
+      setDictatedStory("");
+      setRewritePreview(null);
+      setRewriting(false);
       setTimeout(() => causeRef.current?.focus(), 50);
     }
   }, [isOpen, initialCause, initialCorrection]);
@@ -104,7 +114,61 @@ export default function CauseCorrectionModal({
     }
   };
 
-  const busy = submitting || savingDraft;
+  const handleRewrite = async (): Promise<void> => {
+    const transcript = dictatedStory.trim();
+    if (!transcript || rewriting) return;
+
+    setRewriting(true);
+    setError(null);
+    setOk(null);
+    try {
+      const response = await fetch("/api/work-orders/documentation/rewrite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jobId,
+          transcript,
+          existingCause: cause,
+          existingCorrection: correction,
+        }),
+      });
+      const body = (await response.json().catch(() => null)) as
+        | { cause?: string; correction?: string; error?: string }
+        | null;
+
+      if (
+        !response.ok ||
+        typeof body?.cause !== "string" ||
+        typeof body?.correction !== "string"
+      ) {
+        throw new Error(body?.error || "Could not rewrite the job story.");
+      }
+
+      setRewritePreview({
+        cause: body.cause,
+        correction: body.correction,
+      });
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Could not rewrite the job story.",
+      );
+    } finally {
+      setRewriting(false);
+    }
+  };
+
+  const applyRewrite = (): void => {
+    if (!rewritePreview) return;
+    setCause(rewritePreview.cause);
+    setCorrection(rewritePreview.correction);
+    onDraftChange?.(rewritePreview.cause, rewritePreview.correction);
+    setRewritePreview(null);
+    setOk("AI rewrite applied to the editable draft.");
+  };
+
+  const busy = submitting || savingDraft || rewriting;
 
   const headerLabel =
     (lineLabel ?? "").trim().length > 0 ? lineLabel.trim() : jobId;
@@ -130,6 +194,93 @@ export default function CauseCorrectionModal({
             complete, searchable, and useful later.
           </div>
         </div>
+
+        <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] px-4 py-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper-light)]">
+                Voice story
+              </div>
+              <p className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                Describe what you verified and what you did. The original
+                dictation stays visible until you choose to apply the rewrite.
+              </p>
+            </div>
+            <VoiceDictationButton
+              disabled={busy}
+              idleLabel="Dictate story"
+              listeningLabel="Stop"
+              onTranscript={(transcript) => {
+                if (!transcript) return;
+                setDictatedStory((current) => {
+                  const existing = current.trim();
+                  return existing ? `${existing} ${transcript}` : transcript;
+                });
+                setRewritePreview(null);
+              }}
+            />
+          </div>
+
+          <textarea
+            rows={4}
+            value={dictatedStory}
+            onChange={(event) => {
+              setDictatedStory(event.target.value);
+              setRewritePreview(null);
+            }}
+            className="mt-3 w-full rounded-lg border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] outline-none transition focus:border-[var(--accent-copper-soft)] focus:ring-2 focus:ring-[var(--accent-copper-soft)]/60"
+            placeholder="Raw technician dictation appears here…"
+          />
+
+          <div className="mt-2 flex justify-end">
+            <button
+              type="button"
+              disabled={rewriting || dictatedStory.trim().length < 3}
+              onClick={() => void handleRewrite()}
+              className="rounded-full border border-[var(--accent-copper-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] text-[var(--accent-copper-light)] transition hover:bg-[color:var(--theme-surface-subtle)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {rewriting ? "Rewriting…" : "Rewrite cause & correction"}
+            </button>
+          </div>
+
+          {rewritePreview ? (
+            <div className="mt-3 space-y-3 rounded-xl border border-emerald-400/25 bg-emerald-500/5 p-3">
+              <div>
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-emerald-200">
+                  Proposed cause
+                </div>
+                <p className="mt-1 text-sm leading-5 text-[color:var(--theme-text-primary)]">
+                  {rewritePreview.cause}
+                </p>
+              </div>
+              <div>
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-emerald-200">
+                  Proposed correction
+                </div>
+                <p className="mt-1 text-sm leading-5 text-[color:var(--theme-text-primary)]">
+                  {rewritePreview.correction}
+                </p>
+              </div>
+              <div className="flex flex-wrap justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setRewritePreview(null)}
+                  className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs text-[color:var(--theme-text-secondary)]"
+                >
+                  Keep current draft
+                </button>
+                <button
+                  type="button"
+                  onClick={applyRewrite}
+                  className="rounded-full bg-emerald-500 px-4 py-1.5 text-xs font-semibold text-emerald-950"
+                >
+                  Apply rewrite
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+
         <div className="flex items-center justify-between text-[0.7rem] text-[color:var(--theme-text-secondary)]">
           <div className="flex min-w-0 flex-col gap-0.5">
             <span className="font-semibold uppercase tracking-[0.18em]">

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/features/work-orders/lib/display/workOrderParts";
 
 import VehicleHistoryModal from "@/features/work-orders/components/workorders/VehicleHistoryModal";
+import VoiceDictationButton from "@/features/shared/voice/VoiceDictationButton";
 import {
   clearTechnicianJobEditorDraftFields,
   findProjectedTechnicianJob,
@@ -1373,9 +1374,29 @@ export default function MobileFocusedJob(props: {
 
                 {/* tech notes */}
                 <div className={`${panel} px-4 py-4`}>
-                  <label className="mb-1 block text-sm font-medium text-[color:var(--theme-text-primary)]">
-                    Tech Notes
-                  </label>
+                  <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
+                    <div>
+                      <label className="block text-sm font-medium text-[color:var(--theme-text-primary)]">
+                        Tech Notes
+                      </label>
+                      <p className="mt-0.5 text-[11px] text-[color:var(--theme-text-secondary)]">
+                        Dictation appends to the draft and stays editable.
+                      </p>
+                    </div>
+                    <VoiceDictationButton
+                      disabled={savingNotes || mode === "view"}
+                      idleLabel="Dictate note"
+                      listeningLabel="Stop"
+                      onTranscript={(transcript) => {
+                        if (!transcript) return;
+                        setTechNotes((current) => {
+                          const existing = current.trim();
+                          return existing ? `${existing} ${transcript}` : transcript;
+                        });
+                        setNotesDirty(true);
+                      }}
+                    />
+                  </div>
                   <textarea
                     rows={4}
                     value={techNotes}


### PR DESCRIPTION
## What changed

- replaces the short wake-window inspection interaction with a technician-led free-form voice session
- keeps inspection order entirely technician-controlled; voice resolves named items across the full inspection
- adds a premium Voice Controls panel with supported commands and examples
- supports multi-item findings in one utterance with concise batch confirmation
- adds voice hold, resume, stop, status correction, note append, and measurement correction
- releases realtime microphone, WebSocket, and audio resources when the screen unmounts
- adds OpenAI realtime dictation to technician work-order notes
- adds voice dictation plus review-before-apply AI cause/correction rewriting
- adds shop-scoped authorization, structured-output validation, rate/budget guards, and canonical AI telemetry for documentation rewrites

## Why

The prior implementation was capable but command-shaped: it required a wake phrase, opened only an eight-second command window, and centered the current UI item. Technicians inspect vehicles in different orders, so the voice experience must accept findings in any order without prescribing a workflow.

## User impact

Technicians can start listening once and call out inspection findings naturally while moving around the vehicle. The controls panel remains available when they need examples. Work-order notes can be dictated, and cause/correction can be professionally rewritten without replacing the technician's original draft until they explicitly apply the proposal.

## Safety and integrity

- no database writes were added to the rewrite endpoint; it returns an editable preview only
- work-order line access is validated through the canonical authenticated shop scope before AI processing
- model output is schema validated
- the prompt prohibits invented tests, measurements, parts, procedures, or results
- existing inspection/work-order persistence and offline mutation paths remain canonical

## Validation

Local validation could not be run from this environment because no repository checkout or GitHub CLI is available. Please rely on PR CI for:
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm audit:api-routes`

## Database and configuration

- Database migration: none
- New required environment variables: none
- Manual provider configuration: none
