### PR TITLE
Fix mobile navigation, install flow, and shift punch-out

### DIFF
--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -2,20 +2,21 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { canonicalizeRole, getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   getMobileTilesForRole,
   type MobileRole,
 } from "@/features/mobile/config/mobile-tiles";
-
+import { buildAssistantHref } from "@/features/assistant/lib/buildAssistantHref";
+import { buildPlannerHref } from "@/features/assistant/lib/buildPlannerHref";
 import MobileShiftTracker from "@/features/mobile/components/MobileShiftTracker";
-
 
 type NavItem = {
   href: string;
   label: string;
+  subtitle?: string;
 };
 
 type Props = {
@@ -23,13 +24,48 @@ type Props = {
   onClose: () => void;
 };
 
+type InstallAvailability = {
+  available: boolean;
+  ios: boolean;
+};
+
 function isActivePath(pathname: string, href: string) {
-  const isRoot = href === "/mobile";
-  if (isRoot) return pathname === href;
-  return pathname.startsWith(href);
+  return href === "/mobile" ? pathname === href : pathname.startsWith(href);
 }
 
-function NavSection({
+function MenuLink({
+  item,
+  pathname,
+  onClose,
+}: {
+  item: NavItem;
+  pathname: string;
+  onClose: () => void;
+}) {
+  const active = isActivePath(pathname, item.href);
+  return (
+    <Link
+      href={item.href}
+      onClick={onClose}
+      className={`block rounded-xl border px-3 py-2.5 transition ${
+        active
+          ? "border-[var(--accent-copper)] bg-[color:var(--theme-surface-overlay)]"
+          : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] hover:border-[var(--accent-copper-soft)]"
+      }`}
+    >
+      <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+        {item.label}
+      </div>
+      {item.subtitle ? (
+        <div className="mt-0.5 text-[0.68rem] text-[color:var(--theme-text-muted)]">
+          {item.subtitle}
+        </div>
+      ) : null}
+    </Link>
+  );
+}
+
+function MenuSection({
   title,
   items,
   pathname,
@@ -40,52 +76,38 @@ function NavSection({
   pathname: string;
   onClose: () => void;
 }) {
+  if (items.length === 0) return null;
   return (
-    <div className="mb-3">
-      <div className="px-2 pb-2 text-[0.65rem] font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-muted)]">
+    <section className="space-y-2">
+      <h2 className="px-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">
         {title}
+      </h2>
+      <div className="space-y-1.5">
+        {items.map((item) => (
+          <MenuLink key={`${item.href}-${item.label}`} item={item} pathname={pathname} onClose={onClose} />
+        ))}
       </div>
-
-      <div className="space-y-1">
-        {items.map((item) => {
-          const active = isActivePath(pathname, item.href);
-
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              onClick={onClose}
-              className={`metal-card block rounded-xl px-3 py-2 text-sm transition ${
-                active
-                  ? "border-[var(--accent-copper)] text-[color:var(--theme-text-primary)]"
-                  : "border-[var(--metal-border-soft)] text-[color:var(--theme-text-primary)] hover:border-[var(--accent-copper-light)]"
-              }`}
-            >
-              {item.label}
-            </Link>
-          );
-        })}
-      </div>
-    </div>
+    </section>
   );
 }
 
 export function MobileBottomNav({ open, onClose }: Props) {
   const pathname = usePathname();
+  const router = useRouter();
   const supabase = useMemo(() => createBrowserSupabase(), []);
-
   const [userId, setUserId] = useState<string | null>(null);
   const [role, setRole] = useState<MobileRole | null>(null);
+  const [signingOut, setSigningOut] = useState(false);
+  const [install, setInstall] = useState<InstallAvailability>({
+    available: false,
+    ios: false,
+  });
 
-  /* ---------------------------------------------------------------------- */
-  /* Load current user – shift logic is handled inside MobileShiftTracker   */
-  /* ---------------------------------------------------------------------- */
   useEffect(() => {
     const load = async () => {
       const {
         data: { session },
       } = await supabase.auth.getSession();
-
       const id = session?.user?.id ?? null;
       setUserId(id);
       if (!id) {
@@ -98,7 +120,6 @@ export function MobileBottomNav({ open, onClose }: Props) {
         .select("role")
         .eq("id", id)
         .maybeSingle();
-
       const actor = getActorCapabilities({ role: profile?.role ?? null });
       const canonicalRole = canonicalizeRole(profile?.role ?? null);
       const allowedRole = actor.isKnownRole ? canonicalRole : null;
@@ -108,91 +129,166 @@ export function MobileBottomNav({ open, onClose }: Props) {
     void load();
   }, [supabase]);
 
-  const navItems = useMemo<NavItem[]>(() => {
+  useEffect(() => {
+    const onAvailability = (event: Event) => {
+      const custom = event as CustomEvent<InstallAvailability>;
+      setInstall(custom.detail);
+    };
+    window.addEventListener("profixiq:pwa-install-availability", onAvailability);
+    window.dispatchEvent(new Event("profixiq:pwa-install-availability-request"));
+    return () => {
+      window.removeEventListener("profixiq:pwa-install-availability", onAvailability);
+    };
+  }, [open]);
+
+  const navigationItems = useMemo<NavItem[]>(() => {
+    const home: NavItem = {
+      href: "/mobile",
+      label: "Dashboard",
+      subtitle: "Your role-specific mobile home",
+    };
     if (!role) {
-      return [
-        { href: "/mobile", label: "Home" },
-        { href: "/mobile/settings", label: "Me" },
-      ];
+      return [home, { href: "/mobile/settings", label: "My account" }];
     }
 
-    const primary = getMobileTilesForRole(role, ["home"]).slice(0, 2);
-    const dynamic = primary.map((tile) => ({
+    const dynamic = getMobileTilesForRole(role, ["all"]).map((tile) => ({
       href: tile.href,
       label: tile.title,
+      subtitle: tile.subtitle,
     }));
-
-    const items = [{ href: "/mobile", label: "Home" }, ...dynamic, { href: "/mobile/settings", label: "Me" }];
-    return items.filter((item, index) => items.findIndex((x) => x.href === item.href) === index);
+    return [home, ...dynamic].filter(
+      (item, index, items) => items.findIndex((candidate) => candidate.href === item.href) === index,
+    );
   }, [role]);
 
-  /* ---------------------------------------------------------------------- */
-  /* UI – Slide-in drawer                                                    */
-  /* ---------------------------------------------------------------------- */
+  const assistantHref = useMemo(
+    () => buildAssistantHref({ pageType: "mobile", pageTitle: "Mobile" }),
+    [],
+  );
+  const plannerHref = useMemo(
+    () =>
+      buildPlannerHref({
+        planner: "ops",
+        allowCreate: false,
+        goal: "Build next operational plan",
+      }),
+    [],
+  );
+
+  const utilityItems: NavItem[] = [
+    {
+      href: assistantHref,
+      label: "Ask Assistant",
+      subtitle: "Get help using the current shop context",
+    },
+    {
+      href: plannerHref,
+      label: "Open Planner",
+      subtitle: "Plan the next operational steps",
+    },
+    {
+      href: "/offline/sync",
+      label: "Offline & sync",
+      subtitle: "Review queued work and sync status",
+    },
+  ];
+
+  const handleSignOut = async () => {
+    if (signingOut) return;
+    setSigningOut(true);
+    try {
+      await supabase.auth.signOut();
+      onClose();
+      router.push("/sign-in");
+    } finally {
+      setSigningOut(false);
+    }
+  };
+
   return (
     <>
-      {/* Backdrop */}
-      <div
+      <button
+        type="button"
+        aria-label="Close menu"
         onClick={onClose}
-        className={`fixed inset-0 z-40 bg-[color:var(--theme-surface-inset)] backdrop-blur-sm transition-opacity ${
-          open
-            ? "opacity-100 pointer-events-auto"
-            : "opacity-0 pointer-events-none"
+        className={`fixed inset-0 z-40 bg-black/45 backdrop-blur-sm transition-opacity ${
+          open ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
         }`}
       />
 
-      {/* Side drawer */}
       <aside
-        className={`fixed inset-y-0 left-0 z-50 w-72 max-w-[80%] transform shadow-[var(--theme-shadow-medium)] transition-transform duration-200 border-r border-[var(--metal-border-soft)] ${
+        aria-hidden={!open}
+        className={`fixed inset-y-0 left-0 z-50 flex w-[min(88vw,22rem)] transform flex-col border-r border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] shadow-[var(--theme-shadow-medium)] transition-transform duration-200 ${
           open ? "translate-x-0" : "-translate-x-full"
         }`}
-        style={{ background: "var(--theme-app-bg, var(--theme-surface-page))" }}
       >
-        {/* Header */}
-        <div className="metal-bar flex items-center justify-between px-4 py-3 border-b border-[var(--metal-border-soft)]">
-          <div className="flex flex-col">
-            <span className="font-blackops text-[0.65rem] tracking-[0.24em] text-[var(--accent-copper-light)]">
+        <header className="flex items-center justify-between border-b border-[color:var(--theme-border-soft)] px-4 pb-3 pt-[calc(0.75rem+env(safe-area-inset-top,0px))]">
+          <div>
+            <div className="font-blackops text-sm tracking-[0.18em] text-[var(--accent-copper)]">
               PROFIXIQ
-            </span>
-            <span className="text-[0.7rem] text-[color:var(--theme-text-secondary)]">Mobile Bench</span>
+            </div>
+            <div className="text-xs capitalize text-[color:var(--theme-text-secondary)]">
+              {role ? `${role.replaceAll("_", " ")} menu` : "Mobile menu"}
+            </div>
           </div>
-
           <button
             type="button"
             onClick={onClose}
             aria-label="Close menu"
-            className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] hover:bg-[color:var(--theme-surface-overlay)] active:scale-95"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-lg"
           >
-            ✕
+            ×
           </button>
-        </div>
+        </header>
 
-        {/* Shift tracker – copper / glass card */}
-        <div className="px-3 pt-3 pb-2 border-b border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)]">
-          {userId ? (
-            <MobileShiftTracker userId={userId} />
-          ) : (
-            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
-              Sign in to start tracking your shift.
-            </div>
-          )}
-        </div>
+        <div className="flex-1 space-y-5 overflow-y-auto px-3 py-3">
+          {userId ? <MobileShiftTracker userId={userId} /> : null}
 
-        {/* Navigation */}
-        <nav className="flex-1 overflow-y-auto px-2 py-3">
-          <NavSection
-            title="Mobile"
-            items={navItems}
+          <MenuSection
+            title="Navigation"
+            items={navigationItems}
             pathname={pathname}
             onClose={onClose}
           />
-        </nav>
 
-        {/* Footer */}
-        <div className="border-t border-[var(--metal-border-soft)] px-4 py-2 text-[0.65rem] text-[color:var(--theme-text-muted)]">
-          <div>Tech Mode</div>
-          <div className="text-[0.6rem] text-[color:var(--theme-text-muted)]">v0.1 • Early Build</div>
+          <MenuSection
+            title="Tools"
+            items={utilityItems}
+            pathname={pathname}
+            onClose={onClose}
+          />
+
+          {install.available ? (
+            <section className="space-y-2">
+              <h2 className="px-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">
+                App
+              </h2>
+              <button
+                type="button"
+                onClick={() => window.dispatchEvent(new Event("profixiq:pwa-install-request"))}
+                className="w-full rounded-xl border border-[var(--accent-copper-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2.5 text-left"
+              >
+                <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+                  Install ProFixIQ
+                </div>
+                <div className="mt-0.5 text-[0.68rem] text-[color:var(--theme-text-muted)]">
+                  {install.ios ? "Add ProFixIQ to your Home Screen" : "Install the app on this device"}
+                </div>
+              </button>
+            </section>
+          ) : null}
         </div>
+
+        <footer className="border-t border-[color:var(--theme-border-soft)] px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom,0px))] pt-3">
+          <button
+            type="button"
+            onClick={() => void handleSignOut()}
+            disabled={signingOut}
+            className="w-full rounded-xl border border-red-500/35 bg-red-500/10 px-3 py-2.5 text-sm font-medium text-red-700 disabled:opacity-60 dark:text-red-200"
+          >
+            {signingOut ? "Signing out…" : "Sign out"}
+          </button>
+        </footer>
       </aside>
     </>
   );

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -1,135 +1,89 @@
-//components/layout/MobileShell.tsx
+// components/layout/MobileShell.tsx
 
 "use client";
 
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { MobileBottomNav } from "./MobileBottomNav";
-import AskAssistantEntry from "@/features/assistant/components/AskAssistantEntry";
-
 
 type Props = {
   children: ReactNode;
-  /** Optional custom title for the top bar */
   title?: string;
 };
 
 function getTitleFromPath(pathname: string): string {
   if (!pathname.startsWith("/mobile")) return "ProFixIQ";
-  if (pathname === "/mobile") return "Tech Home";
-
-  if (pathname.startsWith("/mobile/work-orders")) return "Work Orders";
+  if (pathname === "/mobile") return "Dashboard";
+  if (pathname.startsWith("/mobile/work-orders/create")) return "Create work order";
+  if (pathname.startsWith("/mobile/work-orders")) return "Work orders";
+  if (pathname.startsWith("/mobile/appointments")) return "Appointments";
+  if (pathname.startsWith("/mobile/inspections")) return "Inspections";
   if (pathname.startsWith("/mobile/messages")) return "Inbox";
+  if (pathname.startsWith("/mobile/tech/queue")) return "My jobs";
   if (pathname.startsWith("/mobile/settings")) return "Settings";
-
   return "ProFixIQ";
 }
 
 export function MobileShell({ children, title }: Props) {
   const pathname = usePathname();
   const router = useRouter();
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [signingOut, setSigningOut] = useState(false);
-
-  const supabase = useMemo(() => createBrowserSupabase(), []);
-
+  const [menuOpen, setMenuOpen] = useState(false);
   const resolvedTitle = title ?? getTitleFromPath(pathname);
 
   if (pathname === "/mobile/sign-in" || pathname.startsWith("/mobile/sign-in/")) {
     return children;
   }
 
-  const handleHome = () => {
-    router.push("/mobile");
-  };
-
-  const handleSignOut = async () => {
-    if (signingOut) return;
-    setSigningOut(true);
-    try {
-      await supabase.auth.signOut();
-      router.push("/sign-in");
-    } catch {
-      // swallow – worst case user still signed in
-    } finally {
-      setSigningOut(false);
-    }
-  };
-
   return (
-    <div className="flex min-h-screen flex-col app-metal-bg text-[color:var(--theme-text-primary)]">
-      {/* Top bar – dark “metal” strip with hamburger + title + home */}
-      <header className="metal-bar sticky top-0 z-40 flex items-center justify-between px-4 py-2 shadow-[var(--theme-shadow-medium)]">
-        {/* Left: menu + title */}
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={() => setSidebarOpen(true)}
-            aria-label="Open menu"
-            className="desktop-btn-secondary inline-flex h-8 w-8 items-center justify-center rounded-full border active:scale-95"
-          >
-            <span className="sr-only">Open menu</span>
-            <div className="flex flex-col gap-[3px]">
-              <span className="h-[2px] w-[14px] rounded-full bg-[color:var(--theme-surface-panel-strong)]" />
-              <span className="h-[2px] w-[14px] rounded-full bg-[color:var(--theme-surface-panel-strong)]" />
-              <span className="h-[2px] w-[14px] rounded-full bg-[color:var(--theme-surface-panel-strong)]" />
+    <div className="min-h-screen overflow-x-hidden bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
+      <header className="sticky top-0 z-40 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)]/95 pt-[env(safe-area-inset-top,0px)] shadow-sm backdrop-blur-xl">
+        <div className="flex h-14 min-w-0 items-center justify-between gap-3 px-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setMenuOpen(true)}
+              aria-label="Open navigation menu"
+              aria-expanded={menuOpen}
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] active:scale-95"
+            >
+              <span className="sr-only">Open menu</span>
+              <span className="flex flex-col gap-1">
+                <span className="h-0.5 w-4 rounded-full bg-[color:var(--theme-text-primary)]" />
+                <span className="h-0.5 w-4 rounded-full bg-[color:var(--theme-text-primary)]" />
+                <span className="h-0.5 w-4 rounded-full bg-[color:var(--theme-text-primary)]" />
+              </span>
+            </button>
+
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold">{resolvedTitle}</div>
+              <div className="truncate text-[0.62rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                ProFixIQ Mobile
+              </div>
             </div>
-          </button>
+          </div>
 
-          <span className="text-[0.75rem] font-medium text-[color:var(--theme-text-primary)]">
-            {resolvedTitle}
-          </span>
-        </div>
-
-        {/* Right: home + brand */}
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={handleHome}
-            className="desktop-btn-secondary inline-flex items-center gap-1 rounded-full border px-3 py-1 text-[0.7rem] text-[color:var(--theme-text-primary)] active:scale-95"
-          >
-            <span className="block h-[10px] w-[10px] rounded-[3px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]" />
-            <span className="uppercase tracking-[0.16em]">Home</span>
-          </button>
-
-          <div className="flex flex-col items-end leading-none">
-            <span className="font-blackops text-xs tracking-[0.22em] text-[var(--accent-copper-light)]">
+          {pathname !== "/mobile" ? (
+            <button
+              type="button"
+              onClick={() => router.push("/mobile")}
+              className="shrink-0 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs font-medium"
+            >
+              Dashboard
+            </button>
+          ) : (
+            <span className="font-blackops shrink-0 text-xs tracking-[0.18em] text-[var(--accent-copper)]">
               PROFIXIQ
             </span>
-            <span className="text-[0.65rem] text-[color:var(--theme-text-secondary)]">Tech Suite</span>
-          </div>
+          )}
         </div>
       </header>
 
-      {/* Content */}
-      <main className="relative flex-1 overflow-y-auto">
+      <main className="min-w-0 overflow-x-hidden pb-[calc(1.5rem+env(safe-area-inset-bottom,0px))]">
         {children}
       </main>
 
-      <AskAssistantEntry mobile placement="dock" />
-
-      {/* Footer – simple metal strip with sign-out */}
-      <footer className="metal-bar sticky bottom-0 z-30 flex items-center justify-between px-4 py-2 text-[0.7rem] pb-[calc(0.5rem+var(--safe-bottom))]">
-        <span className="text-[color:var(--theme-text-secondary)]">
-          ProFixIQ Mobile
-        </span>
-        <button
-          type="button"
-          onClick={handleSignOut}
-          disabled={signingOut}
-          className="inline-flex items-center gap-1 rounded-full border border-red-400/50 bg-red-500/10 px-3 py-1 text-[0.7rem] font-medium text-red-100 hover:bg-red-500/20 disabled:opacity-60"
-        >
-          {signingOut ? "Signing out…" : "Sign out"}
-        </button>
-      </footer>
-
-      {/* Slide-in side nav (formerly bottom nav) */}
-      <MobileBottomNav
-        open={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
-      />
+      <MobileBottomNav open={menuOpen} onClose={() => setMenuOpen(false)} />
     </div>
   );
 }

--- a/features/mobile/shifts/offline.ts
+++ b/features/mobile/shifts/offline.ts
@@ -159,8 +159,22 @@ export async function runMobileShiftAction(args: {
     if (scope) await saveCachedMobileShiftState({ scope, state });
     return { state, queued: false, conflicted: false };
   }
-  if (!scope) throw new Error("Offline shop scope is unavailable.");
+
   if (!args.current?.shiftId) throw new Error("No active shift is available.");
+
+  // Online actions must use the same canonical server lifecycle as desktop.
+  // Offline scope is only required when the event actually needs to be queued.
+  if (navigator.onLine) {
+    const state = await postShiftAction(args.action, key);
+    if (scope) await saveCachedMobileShiftState({ scope, state });
+    return { state, queued: false, conflicted: false };
+  }
+
+  if (!scope) {
+    throw new Error(
+      "This device is missing its shop scope. Reconnect before recording this punch.",
+    );
+  }
 
   const occurredAt = new Date().toISOString();
   let serverState: MobileShiftState | null = null;

--- a/features/shared/components/pwa/PwaRuntime.tsx
+++ b/features/shared/components/pwa/PwaRuntime.tsx
@@ -18,21 +18,32 @@ type InstallPromptEvent = Event & {
   userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
 };
 
+type InstallAvailability = {
+  available: boolean;
+  ios: boolean;
+};
+
+const INSTALL_REQUEST_EVENT = "profixiq:pwa-install-request";
+const INSTALL_AVAILABILITY_EVENT = "profixiq:pwa-install-availability";
+
 export default function PwaRuntime() {
   const pathname = usePathname() ?? "/";
   const [online, setOnline] = useState(true);
   const [summary, setSummary] = useState(() => getOfflineSyncSummary());
-  const [installPrompt, setInstallPrompt] = useState<InstallPromptEvent | null>(
-    null,
-  );
+  const [installPrompt, setInstallPrompt] = useState<InstallPromptEvent | null>(null);
   const [updateReady, setUpdateReady] = useState<ServiceWorker | null>(null);
   const [iosInstallAvailable, setIosInstallAvailable] = useState(false);
   const [showIosInstructions, setShowIosInstructions] = useState(false);
   const [activatingUpdate, setActivatingUpdate] = useState(false);
   const [syncBlocked, setSyncBlocked] = useState<string | null>(null);
-  const [viewportInsets, setViewportInsets] = useState({ bottom: 0, right: 0 });
   const updateReloading = useRef(false);
   const pending = summary.queued + summary.syncing + summary.failed;
+
+  const publishInstallAvailability = (detail: InstallAvailability) => {
+    window.dispatchEvent(
+      new CustomEvent<InstallAvailability>(INSTALL_AVAILABILITY_EVENT, { detail }),
+    );
+  };
 
   useEffect(() => {
     setOnline(navigator.onLine);
@@ -42,30 +53,10 @@ export default function PwaRuntime() {
     const standalone =
       window.matchMedia("(display-mode: standalone)").matches ||
       Boolean((navigator as Navigator & { standalone?: boolean }).standalone);
-    setIosInstallAvailable(iosDevice && !standalone);
+    const iosAvailable = iosDevice && !standalone;
+    setIosInstallAvailable(iosAvailable);
+    publishInstallAvailability({ available: iosAvailable, ios: iosAvailable });
 
-    const updateViewportInsets = () => {
-      const viewport = window.visualViewport;
-      if (!viewport) return;
-      const next = {
-        bottom: Math.max(
-          0,
-          Math.round(window.innerHeight - viewport.height - viewport.offsetTop),
-        ),
-        right: Math.max(
-          0,
-          Math.round(window.innerWidth - viewport.width - viewport.offsetLeft),
-        ),
-      };
-      setViewportInsets((current) =>
-        current.bottom === next.bottom && current.right === next.right
-          ? current
-          : next,
-      );
-    };
-    updateViewportInsets();
-    window.visualViewport?.addEventListener("resize", updateViewportInsets);
-    window.visualViewport?.addEventListener("scroll", updateViewportInsets);
     void hydrateOfflineMutationQueue();
     void navigator.storage?.persist?.().catch(() => false);
 
@@ -77,9 +68,11 @@ export default function PwaRuntime() {
         .select("shop_id")
         .eq("id", userId)
         .maybeSingle();
-      if (profile?.shop_id)
+      if (profile?.shop_id) {
         setOfflineMutationScope({ userId, shopId: profile.shop_id });
+      }
     };
+
     void supabase.auth.getSession().then(async ({ data }) => {
       const userId = data.session?.user.id;
       if (userId) await resolveScope(userId);
@@ -88,13 +81,16 @@ export default function PwaRuntime() {
     const { data: authSubscription } = supabase.auth.onAuthStateChange(
       (event, session) => {
         if (event === "SIGNED_OUT") void clearOfflineState();
-        if (session?.user.id)
+        if (session?.user.id) {
           window.setTimeout(() => void resolveScope(session.user.id), 0);
+        }
       },
     );
+
     const unsubscribe = subscribeOfflineMutations(() =>
       setSummary(getOfflineSyncSummary()),
     );
+
     const sync = () => {
       setOnline(navigator.onLine);
       if (navigator.onLine) {
@@ -109,31 +105,32 @@ export default function PwaRuntime() {
           });
       }
     };
-    window.addEventListener("online", sync);
-    window.addEventListener("offline", sync);
-    window.addEventListener("focus", sync);
-    const interval = window.setInterval(sync, 60_000);
 
     const beforeInstall = (event: Event) => {
       event.preventDefault();
       setInstallPrompt(event as InstallPromptEvent);
+      publishInstallAvailability({ available: true, ios: false });
     };
+
+    window.addEventListener("online", sync);
+    window.addEventListener("offline", sync);
+    window.addEventListener("focus", sync);
     window.addEventListener("beforeinstallprompt", beforeInstall);
+    const interval = window.setInterval(sync, 60_000);
 
     if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
-      void navigator.serviceWorker
-        .register("/sw.js", { scope: "/" })
-        .then((registration) => {
-          if (registration.waiting) setUpdateReady(registration.waiting);
-          registration.addEventListener("updatefound", () => {
-            registration.installing?.addEventListener("statechange", () => {
-              if (registration.waiting && navigator.serviceWorker.controller) {
-                setUpdateReady(registration.waiting);
-              }
-            });
+      void navigator.serviceWorker.register("/sw.js", { scope: "/" }).then((registration) => {
+        if (registration.waiting) setUpdateReady(registration.waiting);
+        registration.addEventListener("updatefound", () => {
+          registration.installing?.addEventListener("statechange", () => {
+            if (registration.waiting && navigator.serviceWorker.controller) {
+              setUpdateReady(registration.waiting);
+            }
           });
         });
+      });
     }
+
     sync();
 
     return () => {
@@ -144,17 +141,35 @@ export default function PwaRuntime() {
       window.removeEventListener("offline", sync);
       window.removeEventListener("focus", sync);
       window.removeEventListener("beforeinstallprompt", beforeInstall);
-      window.visualViewport?.removeEventListener("resize", updateViewportInsets);
-      window.visualViewport?.removeEventListener("scroll", updateViewportInsets);
     };
   }, []);
 
-  const install = async () => {
-    if (!installPrompt) return;
-    await installPrompt.prompt();
-    await installPrompt.userChoice;
-    setInstallPrompt(null);
-  };
+  useEffect(() => {
+    const install = async () => {
+      if (installPrompt) {
+        await installPrompt.prompt();
+        await installPrompt.userChoice;
+        setInstallPrompt(null);
+        publishInstallAvailability({ available: iosInstallAvailable, ios: iosInstallAvailable });
+        return;
+      }
+      if (iosInstallAvailable) setShowIosInstructions(true);
+    };
+
+    const onInstallRequest = () => void install();
+    const onAvailabilityRequest = () =>
+      publishInstallAvailability({
+        available: Boolean(installPrompt) || iosInstallAvailable,
+        ios: !installPrompt && iosInstallAvailable,
+      });
+
+    window.addEventListener(INSTALL_REQUEST_EVENT, onInstallRequest);
+    window.addEventListener("profixiq:pwa-install-availability-request", onAvailabilityRequest);
+    return () => {
+      window.removeEventListener(INSTALL_REQUEST_EVENT, onInstallRequest);
+      window.removeEventListener("profixiq:pwa-install-availability-request", onAvailabilityRequest);
+    };
+  }, [installPrompt, iosInstallAvailable]);
 
   const activateUpdate = () => {
     if (!updateReady || activatingUpdate) return;
@@ -164,118 +179,74 @@ export default function PwaRuntime() {
       updateReloading.current = true;
       window.location.reload();
     };
-    navigator.serviceWorker.addEventListener(
-      "controllerchange",
-      reloadWhenControlled,
-      {
-        once: true,
-      },
-    );
+    navigator.serviceWorker.addEventListener("controllerchange", reloadWhenControlled, {
+      once: true,
+    });
     updateReady.postMessage({ type: "SKIP_WAITING" });
     window.setTimeout(reloadWhenControlled, 8_000);
   };
 
-  if (
-    isStandalonePublicRoute(pathname) ||
-    (online &&
-      pending === 0 &&
-      !installPrompt &&
-      !iosInstallAvailable &&
-      !updateReady &&
-      !syncBlocked)
-  ) {
+  const showRuntimeStatus = !online || pending > 0 || Boolean(updateReady) || Boolean(syncBlocked);
+
+  if (isStandalonePublicRoute(pathname) || (!showRuntimeStatus && !showIosInstructions)) {
     return null;
   }
 
   return (
-    <div
-      className="fixed z-[100] flex max-w-[calc(100vw-2rem)] flex-wrap items-center justify-end gap-2 rounded-2xl border border-slate-700 bg-slate-950/95 px-3 py-2 text-xs font-semibold text-slate-100 shadow-xl backdrop-blur sm:flex-nowrap sm:rounded-full"
-      style={{
-        bottom: `calc(1rem + env(safe-area-inset-bottom, 0px) + ${viewportInsets.bottom}px)`,
-        right: `calc(1rem + env(safe-area-inset-right, 0px) + ${viewportInsets.right}px)`,
-      }}
-    >
-      <span
-        className={`h-2 w-2 rounded-full ${online ? "bg-emerald-400" : "bg-amber-400"}`}
-      />
-      <span>
-        {syncBlocked
-          ? "Sync needs attention"
-          : online
-          ? pending
-            ? `Syncing ${pending}`
-            : "Online"
-          : `Offline · ${pending} pending`}
-      </span>
-      {syncBlocked && <span className="sr-only">{syncBlocked}</span>}
-      {installPrompt && (
-        <button
-          type="button"
-          onClick={() => void install()}
-          className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
-        >
-          Install
-        </button>
+    <>
+      {showRuntimeStatus && (
+        <div className="fixed bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] right-4 z-[100] flex max-w-[calc(100vw-2rem)] items-center gap-2 rounded-full border border-slate-700 bg-slate-950/95 px-3 py-2 text-xs font-semibold text-slate-100 shadow-xl backdrop-blur">
+          <span className={`h-2 w-2 rounded-full ${online ? "bg-emerald-400" : "bg-amber-400"}`} />
+          <span>
+            {syncBlocked
+              ? "Sync needs attention"
+              : online
+                ? pending
+                  ? `Syncing ${pending}`
+                  : "Online"
+                : `Offline · ${pending} pending`}
+          </span>
+          {(pending > 0 || !online || syncBlocked) && (
+            <button
+              type="button"
+              onClick={() => window.location.assign("/offline/sync")}
+              className="rounded-full border border-slate-600 px-3 py-1"
+            >
+              Details
+            </button>
+          )}
+          {updateReady && (
+            <button
+              type="button"
+              onClick={activateUpdate}
+              disabled={activatingUpdate || pending > 0}
+              className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
+            >
+              {activatingUpdate
+                ? "Updating…"
+                : pending > 0
+                  ? "Sync first"
+                  : "Update"}
+            </button>
+          )}
+        </div>
       )}
-      {!installPrompt && iosInstallAvailable && (
-        <button
-          type="button"
-          onClick={() => setShowIosInstructions(true)}
-          className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
-        >
-          Install
-        </button>
-      )}
-      {(pending > 0 || !online || syncBlocked) && (
-        <button
-          type="button"
-          onClick={() => window.location.assign("/offline/sync")}
-          className="rounded-full border border-slate-600 px-3 py-1"
-        >
-          Details
-        </button>
-      )}
-      {updateReady && (
-        <button
-          type="button"
-          onClick={activateUpdate}
-          disabled={activatingUpdate || pending > 0}
-          className="rounded-full bg-sky-400 px-3 py-1 text-slate-950"
-        >
-          {activatingUpdate
-            ? "Updating…"
-            : pending > 0
-              ? "Sync before update"
-              : "Update"}
-        </button>
-      )}
+
       {showIosInstructions && (
         <div className="fixed inset-0 z-[110] grid place-items-center bg-slate-950/80 p-4 backdrop-blur-sm">
           <div
             role="dialog"
             aria-modal="true"
             aria-labelledby="ios-install-title"
-            className="w-full max-w-sm rounded-2xl border border-slate-700 bg-slate-900 p-5 text-left shadow-2xl"
+            className="w-full max-w-sm rounded-2xl border border-slate-700 bg-slate-900 p-5 text-left text-slate-100 shadow-2xl"
           >
             <h2 id="ios-install-title" className="text-lg font-semibold">
-              Install ProFixIQ on iPhone or iPad
+              Install ProFixIQ
             </h2>
             <ol className="mt-4 space-y-3 text-sm font-normal text-slate-300">
-              <li>
-                <span className="font-semibold text-slate-100">1.</span> Open
-                this page in Safari.
-              </li>
-              <li>
-                <span className="font-semibold text-slate-100">2.</span> Tap the
-                Share button in Safari.
-              </li>
-              <li>
-                <span className="font-semibold text-slate-100">3.</span> Choose{" "}
-                <span className="font-semibold text-slate-100">
-                  Add to Home Screen
-                </span>
-                , then tap Add.
-              </li>
+              <li>1. Open ProFixIQ in Safari.</li>
+              <li>2. Tap the Share button.</li>
+              <li>3. Choose Add to Home Screen, then tap Add.</li>
             </ol>
             <button
               type="button"
@@ -287,6 +258,6 @@ export default function PwaRuntime() {
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/tests/mobile-global-menu-and-shift-scope.test.ts
+++ b/tests/mobile-global-menu-and-shift-scope.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("mobile global navigation", () => {
+  it("keeps navigation, assistant, planner, install, and shift controls in the hamburger drawer", () => {
+    const shell = read("components/layout/MobileShell.tsx");
+    const menu = read("components/layout/MobileBottomNav.tsx");
+
+    expect(shell).toContain('aria-label="Open navigation menu"');
+    expect(shell).not.toContain("AskAssistantEntry");
+    expect(shell).not.toContain("sticky bottom-0");
+
+    expect(menu).toContain("getMobileTilesForRole(role, [\"all\"])");
+    expect(menu).toContain("Ask Assistant");
+    expect(menu).toContain("Open Planner");
+    expect(menu).toContain("Install ProFixIQ");
+    expect(menu).toContain("MobileShiftTracker");
+  });
+
+  it("moves install UI out of the global floating runtime status", () => {
+    const source = read("features/shared/components/pwa/PwaRuntime.tsx");
+
+    expect(source).toContain("profixiq:pwa-install-request");
+    expect(source).toContain("profixiq:pwa-install-availability");
+    expect(source).not.toContain(">\n              Install\n            </button>");
+  });
+});
+
+describe("mobile shift online-first behavior", () => {
+  it("calls the canonical server route while online before requiring offline scope", () => {
+    const source = read("features/mobile/shifts/offline.ts");
+    const onlineBranch = source.indexOf("if (navigator.onLine)");
+    const missingScopeBranch = source.indexOf("if (!scope)", onlineBranch);
+
+    expect(onlineBranch).toBeGreaterThan(-1);
+    expect(missingScopeBranch).toBeGreaterThan(onlineBranch);
+    expect(source.slice(onlineBranch, missingScopeBranch)).toContain(
+      "postShiftAction(args.action, key)",
+    );
+    expect(source).not.toContain('throw new Error("Offline shop scope is unavailable.")');
+  });
+});


### PR DESCRIPTION
## Summary
- replaces the mobile bottom navigation and floating utility dock with a top-left hamburger menu
- makes the drawer role-aware using the existing mobile tile configuration
- moves Assistant, Planner, offline sync, install, shift tracking, and sign-out into the global menu
- removes the persistent mobile footer and adds safe-area-aware, overflow-safe shell spacing
- moves PWA installation out of the floating runtime banner and exposes it through the global menu
- fixes mobile break, lunch, and end-shift actions so online punches use the canonical server lifecycle without requiring offline scope
- keeps offline queuing protected by user/shop scope

## Testing
- adds source-contract coverage for the role-aware menu, install integration, removal of bottom dock UI, and online-first shift actions

## Follow-up scope
This establishes the shared mobile shell and fixes the punch-out blocker. Role dashboard content can now be refined on top of one consistent navigation foundation without overlapping bottom controls.