### PR TITLE
Refine mobile dashboards by role

### DIFF
--- a/features/mobile/dashboard/MobileAdvisorHome.tsx
+++ b/features/mobile/dashboard/MobileAdvisorHome.tsx
@@ -1,14 +1,17 @@
-// features/mobile/dashboard/MobileAdvisorHome.tsx
 "use client";
 
-import Link from "next/link";
 import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
+import {
+  MobileActionGrid,
+  MobileAttentionList,
+  MobileDashboardHero,
+  MobileDashboardPage,
+  MobileMetricGrid,
+} from "@/features/mobile/dashboard/MobileDashboardPrimitives";
 
 type AdvisorStats = {
   awaitingApprovals: number;
-  /** active work orders count (was 'waiters') */
   waiters: number;
-  /** today's appointment count (was 'callbacks') */
   callbacks: number;
 };
 
@@ -18,132 +21,35 @@ type Props = {
   stats?: AdvisorStats;
 };
 
-export default function MobileAdvisorHome({
-  advisorName,
-  role: _role,
-  stats,
-}: Props) {
-  const firstName = advisorName?.split(" ")[0] ?? advisorName ?? "Advisor";
+export default function MobileAdvisorHome({ advisorName, stats }: Props) {
+  const firstName = advisorName?.split(" ")[0] || "Advisor";
+  const { awaitingApprovals, waiters: activeWos, callbacks: todaysAppts } = stats ?? {
+    awaitingApprovals: 0,
+    waiters: 0,
+    callbacks: 0,
+  };
 
-  const { awaitingApprovals, waiters: activeWos, callbacks: todaysAppts } =
-    stats ?? {
-      awaitingApprovals: 0,
-      waiters: 0,
-      callbacks: 0,
-    };
-
-  return (
-    <div className="space-y-6 px-4 py-4">
-      {/* Hero */}
-      <section className="metal-panel metal-panel--hero rounded-2xl border border-[var(--metal-border-soft)] px-4 py-4 text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)]">
-        <div className="space-y-4">
-          <div className="text-center">
-            <h1 className="text-xl font-semibold leading-tight">
-              <span className="text-[color:var(--theme-text-primary)]">Welcome back, </span>
-              <span className="text-[var(--accent-copper)]">{firstName}</span>{" "}
-              <span className="align-middle">📋</span>
-            </h1>
-            <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-              Bench-side view of approvals, active work orders and today&apos;s
-              appointments.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-3 gap-3 text-xs">
-            <SummaryChip
-              label="Awaiting approval"
-              value={awaitingApprovals}
-              accent
-            />
-            <SummaryChip label="Active WOs" value={activeWos} />
-            <SummaryChip label="Appts today" value={todaysAppts} />
-          </div>
-        </div>
-      </section>
-
-      {/* Work focus cards – view, create, appointments, messages */}
-      <section className="space-y-3">
-        <FocusCard
-          title="Work order view"
-          body="Open the mobile work order board to manage jobs and assign techs."
-          href="/mobile/work-orders"
-          cta="Open work orders"
-        />
-        <FocusCard
-          title="Create work order"
-          body="Start a new work order from the counter or phone."
-          href="/mobile/work-orders/create"
-          cta="New work order"
-        />
-        <FocusCard
-          title="Today’s appointments"
-          body="See today’s bookings and add drop-offs on the fly."
-          href="/mobile/appointments"
-          cta="Open appointments"
-        />
-        <FocusCard
-          title="Messages & chat"
-          body="Stay in sync with techs, parts and management."
-          href="/mobile/messages"
-          cta="Open messages"
-        />
-      </section>
-    </div>
-  );
-}
-
-function SummaryChip({
-  label,
-  value,
-  accent = false,
-}: {
-  label: string;
-  value: number;
-  accent?: boolean;
-}) {
-  const base =
-    "metal-card rounded-2xl px-3 py-3 shadow-[var(--theme-shadow-medium)] text-center";
-  const variant = accent
-    ? "border border-[var(--accent-copper-soft)] text-[var(--accent-copper-soft)] shadow-[var(--theme-shadow-medium)]"
-    : "border border-[var(--metal-border-soft)] text-[color:var(--theme-text-primary)]";
+  const attention = [
+    ...(awaitingApprovals > 0 ? [{ title: "approvals waiting", detail: "Quotes need customer or shop approval.", href: "/mobile/work-orders", action: "Review", count: awaitingApprovals }] : []),
+    ...(activeWos > 0 ? [{ title: "active work orders", detail: "Keep customers updated and work moving.", href: "/mobile/work-orders", action: "Open", count: activeWos }] : []),
+  ];
 
   return (
-    <div className={`${base} ${variant}`}>
-      <div className="text-[0.6rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-        {label}
-      </div>
-      <div className="mt-1 text-lg font-semibold">{value}</div>
-    </div>
-  );
-}
-
-function FocusCard({
-  title,
-  body,
-  href,
-  cta,
-}: {
-  title: string;
-  body: string;
-  href: string;
-  cta: string;
-}) {
-  return (
-    <Link
-      href={href}
-      className="metal-card block rounded-2xl border border-[var(--metal-border-soft)] px-4 py-3 text-sm text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper-soft)]"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <div className="text-[0.65rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-            {title}
-          </div>
-          <div className="mt-1 text-xs text-[color:var(--theme-text-primary)]">{body}</div>
-        </div>
-        <span className="text-[0.7rem] text-[var(--accent-copper-soft)]">
-          {cta} →
-        </span>
-      </div>
-    </Link>
+    <MobileDashboardPage>
+      <MobileDashboardHero eyebrow="Advisor workspace" title={`Good day, ${firstName}`} subtitle="Customer communication, approvals and today’s arrivals in one place." action={{ href: "/mobile/work-orders/create", label: "+ Create work order" }} />
+      <MobileMetricGrid items={[
+        { label: "Awaiting approval", value: awaitingApprovals, href: "/mobile/work-orders", tone: awaitingApprovals > 0 ? "warning" : "default" },
+        { label: "Active work orders", value: activeWos, href: "/mobile/work-orders" },
+        { label: "Appointments today", value: todaysAppts, href: "/mobile/appointments", tone: "positive" },
+        { label: "Customers waiting", value: activeWos, href: "/mobile/work-orders" },
+      ]} />
+      <MobileAttentionList subtitle="The highest-priority customer-facing work." items={attention} />
+      <MobileActionGrid items={[
+        { title: "Appointments", detail: "Review arrivals and add bookings.", href: "/mobile/appointments" },
+        { title: "Work orders", detail: "Open the live work-order queue.", href: "/mobile/work-orders" },
+        { title: "Inspections", detail: "Review inspection progress.", href: "/mobile/inspections" },
+        { title: "Team chat", detail: "Coordinate with the shop.", href: "/mobile/messages" },
+      ]} />
+    </MobileDashboardPage>
   );
 }

--- a/features/mobile/dashboard/MobileDashboardPrimitives.tsx
+++ b/features/mobile/dashboard/MobileDashboardPrimitives.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export function MobileDashboardPage({ children }: { children: ReactNode }) {
+  return <div className="mx-auto w-full max-w-3xl space-y-4 overflow-x-hidden px-3 py-3 sm:px-4">{children}</div>;
+}
+
+export function MobileDashboardHero({ eyebrow, title, subtitle, action }: { eyebrow: string; title: string; subtitle: string; action?: { href: string; label: string } }) {
+  return (
+    <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+      <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">{eyebrow}</div>
+      <h1 className="mt-2 text-2xl font-semibold leading-tight text-[color:var(--theme-text-primary)]">{title}</h1>
+      <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{subtitle}</p>
+      {action ? <Link href={action.href} className="mt-4 flex min-h-12 w-full items-center justify-center rounded-2xl bg-[color:var(--accent-copper)] px-4 text-sm font-semibold text-white shadow-sm">{action.label}</Link> : null}
+    </section>
+  );
+}
+
+export function MobileMetricGrid({ items }: { items: Array<{ label: string; value: number | string; href?: string; tone?: "default" | "positive" | "warning" }> }) {
+  return (
+    <section className="grid min-w-0 grid-cols-2 gap-2">
+      {items.map((item) => {
+        const className = `min-w-0 rounded-2xl border p-3 ${item.tone === "warning" ? "border-amber-500/40 bg-amber-500/10" : item.tone === "positive" ? "border-emerald-500/35 bg-emerald-500/10" : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]"}`;
+        const body = <><div className="truncate text-xs text-[color:var(--theme-text-secondary)]">{item.label}</div><div className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{item.value}</div></>;
+        return item.href ? <Link key={item.label} href={item.href} className={className}>{body}</Link> : <div key={item.label} className={className}>{body}</div>;
+      })}
+    </section>
+  );
+}
+
+export function MobileAttentionList({ title = "Needs attention", subtitle, items }: { title?: string; subtitle?: string; items: Array<{ title: string; detail: string; href: string; action: string; count?: number }> }) {
+  return (
+    <section className="overflow-hidden rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
+      <div className="p-4"><h2 className="text-xl font-semibold text-[color:var(--theme-text-primary)]">{title}</h2>{subtitle ? <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{subtitle}</p> : null}</div>
+      <div className="divide-y divide-[color:var(--theme-border-soft)]">
+        {items.length ? items.slice(0, 3).map((item) => <Link key={`${item.title}-${item.href}`} href={item.href} className="block p-4 active:bg-[color:var(--theme-surface-overlay)]"><div className="flex min-w-0 items-start justify-between gap-3"><div className="min-w-0"><div className="font-semibold text-[color:var(--theme-text-primary)]">{item.count ? `${item.count} ` : ""}{item.title}</div><div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{item.detail}</div></div><span className="shrink-0 text-sm font-medium text-[color:var(--accent-copper)]">{item.action} →</span></div></Link>) : <div className="p-4 text-sm text-[color:var(--theme-text-secondary)]">Nothing urgent right now.</div>}
+      </div>
+    </section>
+  );
+}
+
+export function MobileActionGrid({ items }: { items: Array<{ title: string; detail: string; href: string }> }) {
+  return <section className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">{items.slice(0, 4).map((item) => <Link key={item.href} href={item.href} className="min-w-0 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4"><div className="font-semibold text-[color:var(--theme-text-primary)]">{item.title}</div><div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{item.detail}</div></Link>)}</section>;
+}

--- a/features/mobile/dashboard/MobileLeadHandHome.tsx
+++ b/features/mobile/dashboard/MobileLeadHandHome.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-
-import Link from "next/link";
 import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
-import { MobileRoleHub } from "@/features/mobile/components/MobileRoleHub";
+import {
+  MobileActionGrid,
+  MobileAttentionList,
+  MobileDashboardHero,
+  MobileDashboardPage,
+  MobileMetricGrid,
+} from "@/features/mobile/dashboard/MobileDashboardPrimitives";
 
 type LeadHandStats = {
   techsOnShift: number;
@@ -17,139 +21,35 @@ type Props = {
   stats?: LeadHandStats;
 };
 
-export default function MobileLeadHandHome({ leadName, role, stats }: Props) {
-  const firstName = leadName?.split(" ")[0] ?? leadName ?? "Lead";
+export default function MobileLeadHandHome({ leadName, stats }: Props) {
+  const firstName = leadName?.split(" ")[0] || "Lead";
+  const { techsOnShift, jobsInProgress, jobsBlocked } = stats ?? {
+    techsOnShift: 0,
+    jobsInProgress: 0,
+    jobsBlocked: 0,
+  };
 
-  const { techsOnShift, jobsInProgress, jobsBlocked } =
-    stats ?? {
-      techsOnShift: 0,
-      jobsInProgress: 0,
-      jobsBlocked: 0,
-    };
-
-  return (
-    <div className="space-y-6 px-4 py-4">
-      {/* Hero */}
-      <section className="metal-panel metal-panel--hero rounded-2xl border border-[var(--metal-border-soft)] px-4 py-4 text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)]">
-        <div className="space-y-4">
-          <div className="text-center">
-            <h1 className="text-xl font-semibold leading-tight">
-              <span className="text-[color:var(--theme-text-primary)]">Shop floor, </span>
-              <span className="text-[var(--accent-copper)]">{firstName}</span>{" "}
-              <span className="align-middle">🧰</span>
-            </h1>
-            <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-              Quick view of tech coverage, in-progress work and blockers.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-3 gap-3 text-xs">
-            <StatChip label="Techs on shift" value={techsOnShift} accent />
-            <StatChip label="In progress" value={jobsInProgress} />
-            <StatChip label="Blocked" value={jobsBlocked} warn />
-          </div>
-        </div>
-      </section>
-
-      {/* Core flows – mirrored with manager */}
-      <section className="space-y-3">
-        <ActionCard
-          title="Work order queue"
-          body="Review jobs in the queue and balance workload."
-          href="/mobile/work-orders"
-          cta="Open work orders"
-        />
-        <ActionCard
-          title="Create work order"
-          body="Spin up a new job when vehicles land."
-          href="/mobile/work-orders/create"
-          cta="New work order"
-        />
-        <ActionCard
-          title="Appointments"
-          body="Check today’s appointments and what’s arriving next."
-          href="/mobile/appointments"
-          cta="Open appointments"
-        />
-        <ActionCard
-          title="Messages & chat"
-          body="Coordinate with advisors, techs and parts."
-          href="/mobile/messages"
-          cta="Open messages"
-        />
-      </section>
-
-      {/* Shortcuts from config – same scopes as manager */}
-      <MobileRoleHub
-        role={role}
-        scopes={["work_orders", "appointments", "all"]}
-        title="Lead-hand shortcuts"
-        subtitle="Hands-on tools for keeping the floor moving."
-      />
-    </div>
-  );
-}
-
-function StatChip({
-  label,
-  value,
-  accent,
-  warn,
-}: {
-  label: string;
-  value: number;
-  accent?: boolean;
-  warn?: boolean;
-}) {
-  const base =
-    "metal-card rounded-2xl px-3 py-3 shadow-[var(--theme-shadow-medium)] text-center border";
-
-  let color = "border-[var(--metal-border-soft)] text-[color:var(--theme-text-primary)]";
-  if (accent) {
-    color =
-      "border-emerald-400/70 text-emerald-100 shadow-[0_0_18px_rgba(16,185,129,0.55)]";
-  } else if (warn && value > 0) {
-    color =
-      "border-red-500/80 text-red-100 shadow-[0_0_18px_rgba(239,68,68,0.55)]";
-  }
+  const attention = [
+    ...(jobsBlocked > 0 ? [{ title: "blocked jobs", detail: "Review holds, parts and technician constraints.", href: "/mobile/work-orders", action: "Resolve", count: jobsBlocked }] : []),
+    ...(techsOnShift > jobsInProgress ? [{ title: "technicians may need work", detail: "Balance assignments across the active team.", href: "/work-orders/board", action: "Dispatch", count: techsOnShift - jobsInProgress }] : []),
+  ];
 
   return (
-    <div className={`${base} ${color}`}>
-      <div className="text-[0.6rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-        {label}
-      </div>
-      <div className="mt-1 text-lg font-semibold">{value}</div>
-    </div>
-  );
-}
-
-function ActionCard({
-  title,
-  body,
-  href,
-  cta,
-}: {
-  title: string;
-  body: string;
-  href: string;
-  cta: string;
-}) {
-  return (
-    <Link
-      href={href}
-      className="metal-card block rounded-2xl border border-[var(--metal-border-soft)] px-4 py-3 text-sm text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper-soft)]"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <div className="text-[0.65rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-            {title}
-          </div>
-          <div className="mt-1 text-xs text-[color:var(--theme-text-primary)]">{body}</div>
-        </div>
-        <span className="text-[0.7rem] text-[var(--accent-copper-soft)]">
-          {cta} →
-        </span>
-      </div>
-    </Link>
+    <MobileDashboardPage>
+      <MobileDashboardHero eyebrow="Lead-hand workspace" title={`Shop floor, ${firstName}`} subtitle="Technician capacity, active work and blockers without dashboard clutter." action={{ href: "/work-orders/board", label: "Open dispatch" }} />
+      <MobileMetricGrid items={[
+        { label: "Technicians on shift", value: techsOnShift, href: "/dashboard/workforce/attendance", tone: techsOnShift > 0 ? "positive" : "warning" },
+        { label: "Jobs in progress", value: jobsInProgress, href: "/mobile/work-orders" },
+        { label: "Blocked jobs", value: jobsBlocked, href: "/mobile/work-orders", tone: jobsBlocked > 0 ? "warning" : "default" },
+        { label: "Available capacity", value: Math.max(0, techsOnShift - jobsInProgress), href: "/work-orders/board" },
+      ]} />
+      <MobileAttentionList subtitle="Floor conditions that need intervention." items={attention} />
+      <MobileActionGrid items={[
+        { title: "Dispatch board", detail: "Balance jobs and technicians.", href: "/work-orders/board" },
+        { title: "Work orders", detail: "Review active and blocked jobs.", href: "/mobile/work-orders" },
+        { title: "Inspections", detail: "Open inspection progress.", href: "/mobile/inspections" },
+        { title: "Team chat", detail: "Coordinate with advisors and parts.", href: "/mobile/messages" },
+      ]} />
+    </MobileDashboardPage>
   );
 }

--- a/features/mobile/dashboard/MobileManagerHome.tsx
+++ b/features/mobile/dashboard/MobileManagerHome.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-
-import Link from "next/link";
 import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
-import { MobileRoleHub } from "@/features/mobile/components/MobileRoleHub";
+import {
+  MobileActionGrid,
+  MobileAttentionList,
+  MobileDashboardHero,
+  MobileDashboardPage,
+  MobileMetricGrid,
+} from "@/features/mobile/dashboard/MobileDashboardPrimitives";
 
 type ManagerStats = {
   activeWos: number;
   waiters: number;
   techniciansOnShift: number;
-  /** Optional: today’s billed total as a string (e.g. "$3,420") */
   todayBilled?: string | null;
 };
 
@@ -19,155 +22,46 @@ type Props = {
   stats?: ManagerStats;
 };
 
+const ROLE_COPY: Partial<Record<MobileRole, { eyebrow: string; subtitle: string; primary: string }>> = {
+  owner: { eyebrow: "Owner overview", subtitle: "Shop health, staffing and operational exceptions.", primary: "Review shop priorities" },
+  admin: { eyebrow: "Admin workspace", subtitle: "Attendance, workload and issues requiring action.", primary: "Review attendance" },
+  manager: { eyebrow: "Manager workspace", subtitle: "Work flow, customer waiters and technician coverage.", primary: "Open dispatch" },
+  foreman: { eyebrow: "Foreman workspace", subtitle: "Technician loading, blockers and work in motion.", primary: "Open dispatch" },
+};
+
 export default function MobileManagerHome({ managerName, role, stats }: Props) {
-  const firstName = managerName?.split(" ")[0] ?? managerName ?? "Manager";
+  const firstName = managerName?.split(" ")[0] || "Manager";
+  const { activeWos, waiters, techniciansOnShift, todayBilled } = stats ?? {
+    activeWos: 0,
+    waiters: 0,
+    techniciansOnShift: 0,
+    todayBilled: null,
+  };
+  const copy = ROLE_COPY[role] ?? ROLE_COPY.manager!;
+  const primaryHref = role === "admin" ? "/dashboard/workforce/attendance" : "/work-orders/board";
 
-  const { activeWos, waiters, techniciansOnShift, todayBilled } =
-    stats ?? {
-      activeWos: 0,
-      waiters: 0,
-      techniciansOnShift: 0,
-      todayBilled: null,
-    };
-
-  return (
-    <div className="space-y-6 px-4 py-4">
-      {/* Hero */}
-      <section className="metal-panel metal-panel--hero rounded-2xl border border-[var(--metal-border-soft)] px-4 py-4 text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)]">
-        <div className="space-y-4">
-          <div className="text-center">
-            <h1 className="text-xl font-semibold leading-tight">
-              <span className="text-[color:var(--theme-text-primary)]">Shop overview, </span>
-              <span className="text-[var(--accent-copper)]">{firstName}</span>{" "}
-              <span className="align-middle">📊</span>
-            </h1>
-            <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-              High-level view of workload, waiters and technician coverage.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-3 gap-3 text-xs">
-            <ManagerStatChip label="Active WOs" value={activeWos} />
-            <ManagerStatChip
-              label="Waiters"
-              value={waiters}
-              warn={waiters > 0}
-            />
-            <ManagerStatChip
-              label="Techs on shift"
-              value={techniciansOnShift}
-              accent={techniciansOnShift > 0}
-            />
-          </div>
-
-          <div className="mt-1 text-center text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-            Today billed:{" "}
-            <span className="font-semibold text-[var(--accent-copper-soft)]">
-              {todayBilled ?? "—"}
-            </span>
-          </div>
-        </div>
-      </section>
-
-      {/* Core flows – queue, create, appointments, messages (mirrors lead-hand) */}
-      <section className="space-y-3">
-        <FlowCard
-          title="Work order queue"
-          body="See jobs in flight and where capacity is tight."
-          href="/mobile/work-orders"
-          cta="Open work orders"
-        />
-        <FlowCard
-          title="Create work order"
-          body="Start a new job from the counter or bay."
-          href="/mobile/work-orders/create"
-          cta="New work order"
-        />
-        <FlowCard
-          title="Appointments"
-          body="Look at today’s bookings and add new appointments."
-          href="/mobile/appointments"
-          cta="Open appointments"
-        />
-        <FlowCard
-          title="Messages & chat"
-          body="Stay in sync with advisors, techs and parts."
-          href="/mobile/messages"
-          cta="Open messages"
-        />
-      </section>
-
-      {/* Shortcuts from config (aligned with WO + appointments) */}
-      <MobileRoleHub
-        role={role}
-        scopes={["work_orders", "appointments", "all"]}
-        title="Manager shortcuts"
-        subtitle="Quick links that mirror your desktop views."
-      />
-    </div>
-  );
-}
-
-function ManagerStatChip({
-  label,
-  value,
-  accent,
-  warn,
-}: {
-  label: string;
-  value: number;
-  accent?: boolean;
-  warn?: boolean;
-}) {
-  const base =
-    "metal-card rounded-2xl px-3 py-3 shadow-[var(--theme-shadow-medium)] text-center border";
-
-  let color = "border-[var(--metal-border-soft)] text-[color:var(--theme-text-primary)]";
-  if (accent) {
-    color =
-      "border-emerald-400/70 text-emerald-100 shadow-[0_0_18px_rgba(16,185,129,0.55)]";
-  } else if (warn && value > 0) {
-    color =
-      "border-red-500/80 text-red-100 shadow-[0_0_18px_rgba(239,68,68,0.55)]";
-  }
+  const attention = [
+    ...(waiters > 0 ? [{ title: "customers waiting", detail: "Front-counter work needs immediate follow-up.", href: "/mobile/work-orders", action: "Review", count: waiters }] : []),
+    ...(techniciansOnShift === 0 ? [{ title: "No technicians clocked in", detail: "Confirm attendance before assigning work.", href: "/dashboard/workforce/attendance", action: "Attendance" }] : []),
+    ...(activeWos > 0 ? [{ title: "active work orders", detail: "Review flow and identify blocked work.", href: "/mobile/work-orders", action: "Open", count: activeWos }] : []),
+  ];
 
   return (
-    <div className={`${base} ${color}`}>
-      <div className="text-[0.6rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-        {label}
-      </div>
-      <div className="mt-1 text-lg font-semibold">{value}</div>
-    </div>
-  );
-}
-
-function FlowCard({
-  title,
-  body,
-  href,
-  cta,
-}: {
-  title: string;
-  body: string;
-  href: string;
-  cta: string;
-}) {
-  return (
-    <Link
-      href={href}
-      className="metal-card block rounded-2xl border border-[var(--metal-border-soft)] px-4 py-3 text-sm text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper-soft)]"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <div className="text-[0.65rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-            {title}
-          </div>
-          <div className="mt-1 text-xs text-[color:var(--theme-text-primary)]">{body}</div>
-        </div>
-        <span className="text-[0.7rem] text-[var(--accent-copper-soft)]">
-          {cta} →
-        </span>
-      </div>
-    </Link>
+    <MobileDashboardPage>
+      <MobileDashboardHero eyebrow={copy.eyebrow} title={`Shop overview, ${firstName}`} subtitle={copy.subtitle} action={{ href: primaryHref, label: copy.primary }} />
+      <MobileMetricGrid items={[
+        { label: "Active work orders", value: activeWos, href: "/mobile/work-orders" },
+        { label: "Customers waiting", value: waiters, href: "/mobile/work-orders", tone: waiters > 0 ? "warning" : "default" },
+        { label: "Technicians on shift", value: techniciansOnShift, href: "/dashboard/workforce/attendance", tone: techniciansOnShift > 0 ? "positive" : "warning" },
+        { label: "Today billed", value: todayBilled ?? "—", href: "/mobile/reports" },
+      ]} />
+      <MobileAttentionList subtitle="Only the items most likely to slow the shop down." items={attention} />
+      <MobileActionGrid items={[
+        { title: "Work order board", detail: "Review live work and status flow.", href: "/work-orders/board" },
+        { title: "Attendance", detail: "See who is clocked in and active.", href: "/dashboard/workforce/attendance" },
+        { title: "Appointments", detail: "Review today’s arrivals.", href: "/mobile/appointments" },
+        { title: "Reports", detail: "Open revenue and efficiency views.", href: "/mobile/reports" },
+      ]} />
+    </MobileDashboardPage>
   );
 }

--- a/tests/mobile-role-dashboard-layout.test.ts
+++ b/tests/mobile-role-dashboard-layout.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("mobile role dashboard layout", () => {
+  it("uses a shared overflow-safe dashboard shell", () => {
+    const source = read("features/mobile/dashboard/MobileDashboardPrimitives.tsx");
+    expect(source).toContain("overflow-x-hidden");
+    expect(source).toContain("grid-cols-2");
+    expect(source).toContain("items.slice(0, 3)");
+    expect(source).toContain("items.slice(0, 4)");
+  });
+
+  it("keeps owner, admin, manager and foreman copy role-aware", () => {
+    const source = read("features/mobile/dashboard/MobileManagerHome.tsx");
+    for (const role of ["owner", "admin", "manager", "foreman"]) {
+      expect(source).toContain(`${role}:`);
+    }
+    expect(source).toContain("/dashboard/workforce/attendance");
+    expect(source).toContain("/work-orders/board");
+  });
+
+  it("gives advisor and lead hand dashboards one primary action and compact metrics", () => {
+    const advisor = read("features/mobile/dashboard/MobileAdvisorHome.tsx");
+    const lead = read("features/mobile/dashboard/MobileLeadHandHome.tsx");
+    expect(advisor).toContain("+ Create work order");
+    expect(lead).toContain("Open dispatch");
+    expect(advisor).toContain("MobileMetricGrid");
+    expect(lead).toContain("MobileMetricGrid");
+  });
+});


### PR DESCRIPTION
## Summary
- adds shared responsive mobile dashboard primitives with overflow-safe containers
- rebuilds the advisor dashboard around approvals, active work orders, appointments, and customer-facing priorities
- rebuilds the manager dashboard with role-specific copy and primary actions for owner, admin, manager, and foreman
- rebuilds the lead-hand dashboard around technician capacity, active work, blockers, and dispatch
- limits home-screen attention items and shortcuts to keep the mobile experience focused
- adds source-contract tests for responsive layout and role-aware dashboard behavior

## Notes
This continues the mobile cleanup after PR #1091. The global hamburger menu, assistant/planner/install consolidation, and punch-out fix are already on main; this PR focuses on the dashboard content layer.

## Testing
- added `tests/mobile-role-dashboard-layout.test.ts`
- source contracts cover horizontal overflow protection, compact metric grids, priority limits, role copy, and primary actions