### PR TITLE
Complete remaining mobile role dashboards

### DIFF
--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -1,531 +1,212 @@
-// app/mobile/page.tsx
 "use client";
 
-import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import type { Database } from "@shared/types/types/supabase";
 import { resolveCurrentActor } from "@/features/shared/lib/currentActor";
-import { canonicalizeRole, getActorCapabilities } from "@/features/shared/lib/rbac";
-
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
+import type { Database } from "@shared/types/types/supabase";
 import {
   MobileTechHome,
-  type MobileTechStats,
   type MobileTechJob,
+  type MobileTechStats,
 } from "@/features/mobile/dashboard/MobileTechHome";
 import MobileAdvisorHome from "@/features/mobile/dashboard/MobileAdvisorHome";
 import MobileManagerHome from "@/features/mobile/dashboard/MobileManagerHome";
 import MobileLeadHome from "@/features/mobile/dashboard/MobileLeadHandHome";
+import MobileOperationalRoleHome from "@/features/mobile/dashboard/MobileOperationalRoleHome";
 import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
 
 type DB = Database;
-
 type Profile = DB["public"]["Tables"]["profiles"]["Row"];
 type Shop = DB["public"]["Tables"]["shops"]["Row"];
 type TechShift = DB["public"]["Tables"]["tech_shifts"]["Row"];
 type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
 
-// helpers for date windows (local time)
-function startOfDayLocal(d: Date): Date {
-  const x = new Date(d);
-  x.setHours(0, 0, 0, 0);
-  return x;
+type HomePayload = {
+  advisor: { awaitingApprovals: number; waiters: number; callbacks: number };
+  manager: { activeWos: number; waiters: number; techniciansOnShift: number };
+  leadhand: { techsOnShift: number; jobsInProgress: number; jobsBlocked: number };
+};
+
+function dayWindow(now: Date) {
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(now);
+  end.setHours(23, 59, 59, 999);
+  return { start: start.toISOString(), end: end.toISOString() };
 }
 
-function endOfDayLocal(d: Date): Date {
-  const x = new Date(d);
-  x.setHours(23, 59, 59, 999);
-  return x;
-}
-
-// week starting Monday
-function startOfWeekLocal(d: Date): Date {
-  const x = startOfDayLocal(d);
-  const day = x.getDay(); // 0 (Sun) .. 6 (Sat)
-  const diffToMonday = (day + 6) % 7; // 0 if Mon, 1 if Tue, etc.
-  x.setDate(x.getDate() - diffToMonday);
-  return x;
-}
-
-function endOfWeekLocal(d: Date): Date {
-  const start = startOfWeekLocal(d);
+function weekWindow(now: Date) {
+  const start = new Date(now);
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - ((start.getDay() + 6) % 7));
   const end = new Date(start);
   end.setDate(end.getDate() + 6);
   end.setHours(23, 59, 59, 999);
-  return end;
+  return { start: start.toISOString(), end: end.toISOString() };
 }
 
-function msToHours(ms: number): number {
-  return ms <= 0 ? 0 : ms / (1000 * 60 * 60);
+function round1(value: number) {
+  return Math.round(value * 10) / 10;
 }
 
-function round1(n: number): number {
-  return Math.round(n * 10) / 10;
+function workedHours(rows: TechShift[] | null | undefined, nowMs: number) {
+  return round1(
+    (rows ?? []).reduce((total, row) => {
+      if (!row.start_time) return total;
+      const start = new Date(row.start_time).getTime();
+      const end = row.end_time ? new Date(row.end_time).getTime() : nowMs;
+      return total + Math.max(0, end - start) / 3_600_000;
+    }, 0),
+  );
 }
 
-function calcEfficiencyPct(worked: number, billed: number): number | null {
-  if (worked <= 0) return null;
-  // billed / worked, like: 10h worked, 7.6h billed → 76%
-  return (billed / worked) * 100;
+function billedHours(rows: WorkOrderLine[] | null | undefined) {
+  return round1(
+    (rows ?? []).reduce((total, row) => {
+      const value = Number(row.labor_time ?? 0);
+      return Number.isFinite(value) ? total + value : total;
+    }, 0),
+  );
 }
 
 export default function MobileHome() {
   const supabase = useMemo(() => createBrowserSupabase(), []);
-
   const [profile, setProfile] = useState<Profile | null>(null);
   const [shop, setShop] = useState<Shop | null>(null);
   const [loading, setLoading] = useState(true);
+  const [homePayload, setHomePayload] = useState<HomePayload | null>(null);
+  const [techStats, setTechStats] = useState<MobileTechStats | null>(null);
+  const [techJobs, setTechJobs] = useState<MobileTechJob[]>([]);
+  const [techLoading, setTechLoading] = useState(false);
 
-  const [stats, setStats] = useState<MobileTechStats | null>(null);
-  const [jobs, setJobs] = useState<MobileTechJob[]>([]);
-  const [statsLoading, setStatsLoading] = useState(false);
-  const [homePayload, setHomePayload] = useState<{
-    advisor: { awaitingApprovals: number; waiters: number; callbacks: number };
-    manager: { activeWos: number; waiters: number; techniciansOnShift: number };
-    leadhand: { techsOnShift: number; jobsInProgress: number; jobsBlocked: number };
-  } | null>(null);
-
-  // Load profile + shop
   useEffect(() => {
-    let alive = true;
-
-    (async () => {
+    let active = true;
+    void (async () => {
       try {
         const actor = await resolveCurrentActor(supabase);
-        if (!alive) return;
-
-        if (!actor.user) {
-          setProfile(null);
+        if (!active) return;
+        setProfile(actor.profile ?? null);
+        if (!actor.shopId) {
           setShop(null);
           return;
         }
-
-        setProfile(actor.profile ?? null);
-
-        if (actor.shopId) {
-          const { data: shopRow } = await supabase
-            .from("shops")
-            .select("*")
-            .eq("id", actor.shopId)
-            .maybeSingle();
-
-          if (!alive) return;
-          setShop(shopRow ?? null);
-        } else {
-          setShop(null);
-        }
+        const { data } = await supabase
+          .from("shops")
+          .select("*")
+          .eq("id", actor.shopId)
+          .maybeSingle();
+        if (active) setShop(data ?? null);
       } finally {
-        if (alive) setLoading(false);
+        if (active) setLoading(false);
       }
     })();
-
     return () => {
-      alive = false;
+      active = false;
     };
   }, [supabase]);
 
-  // Load tech stats + today's jobs (used by MobileTechHome)
   useEffect(() => {
-    const loadStats = async () => {
-      if (!profile?.id) return;
-      const actor = getActorCapabilities({ role: profile.role });
-      if (actor.canonicalRole !== "mechanic") return;
+    if (!profile?.id) return;
+    void (async () => {
+      const response = await fetch("/api/mobile/home-payload", { method: "GET" });
+      const body = (await response.json().catch(() => null)) as
+        | { ok?: boolean; payload?: HomePayload }
+        | null;
+      if (response.ok && body?.ok && body.payload) setHomePayload(body.payload);
+    })();
+  }, [profile?.id]);
 
-      setStatsLoading(true);
+  useEffect(() => {
+    if (!profile?.id || canonicalizeRole(profile.role) !== "mechanic") return;
+    const userId = profile.id;
+    setTechLoading(true);
+    void (async () => {
       try {
-        const uid = profile.id;
         const now = new Date();
+        const day = dayWindow(now);
+        const week = weekWindow(now);
+        const [todayShifts, weekShifts, todayDone, weekDone, activeLines, todayJobs] =
+          await Promise.all([
+            supabase.from("tech_shifts").select("*").eq("user_id", userId).eq("type", "shift").gte("start_time", day.start).lte("start_time", day.end),
+            supabase.from("tech_shifts").select("*").eq("user_id", userId).eq("type", "shift").gte("start_time", week.start).lte("start_time", week.end),
+            supabase.from("work_order_lines").select("*").or(`assigned_tech_id.eq.${userId},user_id.eq.${userId}`).eq("line_type", "job").eq("status", "completed").gte("punched_out_at", day.start).lte("punched_out_at", day.end),
+            supabase.from("work_order_lines").select("*").or(`assigned_tech_id.eq.${userId},user_id.eq.${userId}`).eq("line_type", "job").eq("status", "completed").gte("punched_out_at", week.start).lte("punched_out_at", week.end),
+            supabase.from("work_order_lines").select("*").or(`assigned_tech_id.eq.${userId},user_id.eq.${userId}`).eq("line_type", "job").in("status", ["awaiting", "assigned", "active", "on_hold"]),
+            supabase.from("work_order_lines").select("*").or(`assigned_tech_id.eq.${userId},user_id.eq.${userId}`).eq("line_type", "job").gte("created_at", day.start).lte("created_at", day.end).order("created_at", { ascending: false }).limit(6),
+          ]);
 
-        const dayStart = startOfDayLocal(now);
-        const dayEnd = endOfDayLocal(now);
-        const weekStart = startOfWeekLocal(now);
-        const weekEnd = endOfWeekLocal(now);
+        const todayWorked = workedHours(todayShifts.data as TechShift[] | null, now.getTime());
+        const weekWorked = workedHours(weekShifts.data as TechShift[] | null, now.getTime());
+        const todayBilled = billedHours(todayDone.data as WorkOrderLine[] | null);
+        const weekBilled = billedHours(weekDone.data as WorkOrderLine[] | null);
+        const active = (activeLines.data as WorkOrderLine[] | null) ?? [];
 
-        const dayStartIso = dayStart.toISOString();
-        const dayEndIso = dayEnd.toISOString();
-        const weekStartIso = weekStart.toISOString();
-        const weekEndIso = weekEnd.toISOString();
-
-        // Exclude breaks/lunch by only counting tech_shifts.type = 'shift'
-        const [
-          { data: todayShifts },
-          { data: weekShifts },
-          { data: todayCompletedLines },
-          { data: weekCompletedLines },
-          { data: activeLines },
-          { data: todayJobsRaw },
-        ] = await Promise.all([
-          supabase
-            .from("tech_shifts")
-            .select("start_time,end_time,type,user_id")
-            .eq("user_id", uid)
-            .eq("type", "shift")
-            .gte("start_time", dayStartIso)
-            .lte("start_time", dayEndIso),
-
-          supabase
-            .from("tech_shifts")
-            .select("start_time,end_time,type,user_id")
-            .eq("user_id", uid)
-            .eq("type", "shift")
-            .gte("start_time", weekStartIso)
-            .lte("start_time", weekEndIso),
-
-          // completed jobs today for billed hours + jobsCompletedToday
-          supabase
-            .from("work_order_lines")
-            .select("id,labor_time,punched_out_at,status")
-            .or(
-              `assigned_tech_id.eq.${uid},assigned_tech_id.eq.${uid},user_id.eq.${uid}`,
-            )
-            .eq("line_type", "job")
-            .eq("status", "completed")
-            .gte("punched_out_at", dayStartIso)
-            .lte("punched_out_at", dayEndIso),
-
-          // completed this week for weekly billed hours
-          supabase
-            .from("work_order_lines")
-            .select("id,labor_time,punched_out_at,status")
-            .or(
-              `assigned_tech_id.eq.${uid},assigned_tech_id.eq.${uid},user_id.eq.${uid}`,
-            )
-            .eq("line_type", "job")
-            .eq("status", "completed")
-            .gte("punched_out_at", weekStartIso)
-            .lte("punched_out_at", weekEndIso),
-
-          // active / open jobs assigned to this tech
-          supabase
-            .from("work_order_lines")
-            .select("id,status,description,job_type")
-            .or(
-              `assigned_tech_id.eq.${uid},assigned_tech_id.eq.${uid},user_id.eq.${uid}`,
-            )
-            .eq("line_type", "job")
-            .in("status", [
-              "awaiting",
-              "active",
-              "on_hold",
-            ]),
-
-          // today's jobs list for the card (simple label)
-          supabase
-            .from("work_order_lines")
-            .select("id,status,description,job_type,created_at,complaint")
-            .or(
-              `assigned_tech_id.eq.${uid},assigned_tech_id.eq.${uid},user_id.eq.${uid}`,
-            )
-            .eq("line_type", "job")
-            .gte("created_at", dayStartIso)
-            .lte("created_at", dayEndIso)
-            .order("created_at", { ascending: false }),
-        ]);
-
-        const nowMs = now.getTime();
-
-        const sumWorkedHours = (rows: TechShift[] | null | undefined) => {
-          if (!rows) return 0;
-          let total = 0;
-          for (const r of rows) {
-            if (!r.start_time) continue;
-            const s = new Date(r.start_time).getTime();
-            const e = r.end_time ? new Date(r.end_time).getTime() : nowMs;
-            if (Number.isNaN(s) || Number.isNaN(e)) continue;
-            total += Math.max(0, e - s);
-          }
-          return msToHours(total);
-        };
-
-        const sumBilledHours = (rows: WorkOrderLine[] | null | undefined) => {
-          if (!rows) return 0;
-          return rows.reduce((acc, line) => {
-            const raw = line.labor_time;
-            const n =
-              typeof raw === "number"
-                ? raw
-                : raw != null
-                  ? Number(raw)
-                  : 0;
-            if (!Number.isFinite(n)) return acc;
-            return acc + n;
-          }, 0);
-        };
-
-        const todayWorked = round1(sumWorkedHours(todayShifts as TechShift[]));
-        const weekWorked = round1(sumWorkedHours(weekShifts as TechShift[]));
-
-        const todayBilled = round1(
-          sumBilledHours(todayCompletedLines as WorkOrderLine[]),
-        );
-        const weekBilled = round1(
-          sumBilledHours(weekCompletedLines as WorkOrderLine[]),
-        );
-
-        const todayEff = calcEfficiencyPct(todayWorked, todayBilled);
-        const weekEff = calcEfficiencyPct(weekWorked, weekBilled);
-
-        const completedTodayCount = todayCompletedLines?.length ?? 0;
-
-        const active = (activeLines as WorkOrderLine[] | null) ?? [];
-        const openJobs = active.length;
-        const assignedJobs =
-          active.filter((l) => (l.status ?? "").toLowerCase() === "assigned")
-            .length || openJobs;
-
-        const jobsList: MobileTechJob[] =
-          (todayJobsRaw as WorkOrderLine[] | null)?.slice(0, 6).map((l) => {
-            const base =
-              l.description ||
-              l.complaint ||
-              (l.job_type
-                ? String(l.job_type).replace(/_/g, " ")
-                : "Job");
-            return {
-              id: String(l.id),
-              label: base,
-              status: String(l.status ?? "in_progress"),
-              href: "/mobile/tech/queue",
-            };
-          }) ?? [];
-
-        const nextStats: MobileTechStats = {
-          openJobs,
-          assignedJobs,
-          jobsCompletedToday: completedTodayCount,
+        setTechStats({
+          openJobs: active.length,
+          assignedJobs: active.filter((line) => line.status === "assigned").length || active.length,
+          jobsCompletedToday: todayDone.data?.length ?? 0,
           today: {
             workedHours: todayWorked,
             billedHours: todayBilled,
-            efficiencyPct: todayEff,
+            efficiencyPct: todayWorked > 0 ? (todayBilled / todayWorked) * 100 : null,
           },
           week: {
             workedHours: weekWorked,
             billedHours: weekBilled,
-            efficiencyPct: weekEff,
+            efficiencyPct: weekWorked > 0 ? (weekBilled / weekWorked) * 100 : null,
           },
-        };
-
-        setStats(nextStats);
-        setJobs(jobsList);
+        });
+        setTechJobs(
+          ((todayJobs.data as WorkOrderLine[] | null) ?? []).map((line) => ({
+            id: String(line.id),
+            label: line.description || line.complaint || String(line.job_type ?? "Job"),
+            status: String(line.status ?? "awaiting"),
+            href: "/mobile/tech/queue",
+          })),
+        );
       } finally {
-        setStatsLoading(false);
+        setTechLoading(false);
       }
-    };
+    })();
+  }, [profile?.id, profile?.role, supabase]);
 
-    void loadStats();
-  }, [profile, supabase]);
-
-  useEffect(() => {
-    const loadPayload = async () => {
-      const res = await fetch("/api/mobile/home-payload", { method: "GET" });
-      const json = (await res.json().catch(() => null)) as
-        | {
-            ok?: boolean;
-            payload?: {
-              advisor: { awaitingApprovals: number; waiters: number; callbacks: number };
-              manager: { activeWos: number; waiters: number; techniciansOnShift: number };
-              leadhand: { techsOnShift: number; jobsInProgress: number; jobsBlocked: number };
-            };
-          }
-        | null;
-      if (res.ok && json?.ok && json.payload) {
-        setHomePayload(json.payload);
-      }
-    };
-
-    if (!profile?.id) return;
-    void loadPayload();
-  }, [profile?.id]);
-
-  const canonicalRole = canonicalizeRole(profile?.role);
-  const role = (canonicalRole === "unknown" ? null : canonicalRole) as MobileRole | null;
-  const userName = profile?.full_name ?? null;
-  const shopName = shop?.name ?? null;
-
-  /* ------------------------------------------------------------------ */
-  /* ✅ IMPORTANT: prevent “Shop Console” flash while loading            */
-  /* ------------------------------------------------------------------ */
+  const canonical = canonicalizeRole(profile?.role);
+  const role = canonical === "unknown" ? null : (canonical as MobileRole);
+  const name = profile?.full_name || "Team member";
 
   if (loading) {
     return (
-      <main className="min-h-screen bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
-        <div className="mx-auto flex max-w-5xl flex-col items-center justify-center px-4 py-16 text-center">
-          <div className="text-[0.7rem] uppercase tracking-[0.25em] text-[color:var(--theme-text-muted)]">
-            ProFixIQ • Mobile
-          </div>
-          <div className="mt-3 h-10 w-56 animate-pulse rounded-lg bg-[color:var(--theme-surface-panel)]" />
-          <div className="mt-4 h-3 w-40 animate-pulse rounded bg-[color:var(--theme-surface-panel)]" />
-        </div>
+      <main className="min-h-screen overflow-x-hidden bg-[color:var(--theme-surface-page)] px-4 py-16 text-center text-[color:var(--theme-text-primary)]">
+        <div className="mx-auto h-10 w-56 animate-pulse rounded-lg bg-[color:var(--theme-surface-panel)]" />
       </main>
     );
   }
 
-  /* ------------------------------------------------------------------ */
-  /* Role-specific mobile home pages                                    */
-  /* ------------------------------------------------------------------ */
-
-  if (profile && canonicalRole === "mechanic") {
-    return (
-      <main className="min-h-screen bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
-        <div className="mx-auto flex max-w-5xl flex-col gap-4 px-0 pb-8 pt-2">
-          <MobileTechHome
-            techName={profile.full_name || "Tech"}
-            role={(role ?? "mechanic") as MobileRole}
-            stats={stats}
-            jobs={jobs}
-            loadingStats={statsLoading}
-          />
-        </div>
-      </main>
-    );
+  if (role === "mechanic") {
+    return <MobileTechHome techName={name} role={role} stats={techStats} jobs={techJobs} loadingStats={techLoading} />;
   }
-
-  if (profile && role === "advisor") {
-    return (
-      <main className="min-h-screen bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
-        <div className="mx-auto flex max-w-5xl flex-col gap-4 px-0 pb-8 pt-2">
-          <MobileAdvisorHome
-            advisorName={profile.full_name || "Advisor"}
-            role="advisor"
-            stats={homePayload?.advisor}
-          />
-        </div>
-      </main>
-    );
+  if (role === "advisor") {
+    return <MobileAdvisorHome advisorName={name} role={role} stats={homePayload?.advisor} />;
   }
-
-  if (profile && (role === "manager" || role === "owner" || role === "admin" || role === "foreman")) {
-    return (
-      <main className="min-h-screen bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
-        <div className="mx-auto flex max-w-5xl flex-col gap-4 px-0 pb-8 pt-2">
-          <MobileManagerHome
-            managerName={profile.full_name || "Manager"}
-            role={role}
-            stats={homePayload?.manager}
-          />
-        </div>
-      </main>
-    );
+  if (role === "lead_hand") {
+    return <MobileLeadHome leadName={name} role={role} stats={homePayload?.leadhand} />;
   }
-
-  if (profile && role === "lead_hand") {
-    return (
-      <main className="min-h-screen bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
-        <div className="mx-auto flex max-w-5xl flex-col gap-4 px-0 pb-8 pt-2">
-          <MobileLeadHome
-            leadName={profile.full_name || "Lead"}
-            role={role}
-            stats={homePayload?.leadhand}
-          />
-        </div>
-      </main>
-    );
+  if (role === "owner" || role === "admin" || role === "manager" || role === "foreman") {
+    return <MobileManagerHome managerName={name} role={role} stats={homePayload?.manager} />;
   }
-
-  /* ------------------------------------------------------------------ */
-  /* Fallback companion home (unknown roles / not authed)               */
-  /* ------------------------------------------------------------------ */
+  if (role === "parts" || role === "dispatcher" || role === "fleet_manager" || role === "driver") {
+    return <MobileOperationalRoleHome name={name} role={role} />;
+  }
 
   return (
-    <main className="min-h-screen bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
-      <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 pb-8 pt-6">
-        {/* Header */}
-        <header className="space-y-1 text-center">
-          <div className="text-[0.7rem] uppercase tracking-[0.25em] text-[color:var(--theme-text-muted)]">
-            ProFixIQ • Mobile
-          </div>
-
-          <h1 className="font-blackops text-xl uppercase tracking-[0.18em] text-orange-400">
-            Shop Console
-          </h1>
-
-          {userName ? (
-            <p className="text-[0.8rem] text-[color:var(--theme-text-secondary)]">
-              Hi <span className="font-medium text-[color:var(--theme-text-primary)]">{userName}</span>
-              {shopName ? (
-                <span className="ml-1 text-[color:var(--theme-text-secondary)]">({shopName})</span>
-              ) : null}
-              .
-            </p>
-          ) : (
-            <p className="text-[0.8rem] text-[color:var(--theme-text-secondary)]">
-              Stay on top of jobs from your phone.
-            </p>
-          )}
-        </header>
-
-        {/* App tiles */}
-        <section className="grid grid-cols-2 gap-3">
-          <Link
-            href="/mobile/work-orders"
-            className="flex h-28 flex-col justify-between rounded-2xl border border-orange-500/70 bg-gradient-to-br from-orange-500/20 via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] p-3 shadow-lg shadow-orange-500/30"
-          >
-            <div className="text-[0.7rem] uppercase tracking-[0.18em] text-orange-200/80">
-              Jobs
-            </div>
-            <div>
-              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Work Orders</div>
-              <div className="mt-1 text-[0.75rem] text-orange-100/90">
-                View &amp; update live jobs.
-              </div>
-            </div>
-          </Link>
-
-          <Link
-            href="/mobile/work-orders/create"
-            className="flex h-28 flex-col justify-between rounded-2xl border border-[color:var(--theme-border-soft)] bg-gradient-to-br from-[color:var(--theme-surface-page)] via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] p-3"
-          >
-            <div className="text-[0.7rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-              Quick
-            </div>
-            <div>
-              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                New Work Order
-              </div>
-              <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-                Capture customer &amp; vehicle.
-              </div>
-            </div>
-          </Link>
-
-          <Link
-            href="/mobile/inspections"
-            className="flex h-28 flex-col justify-between rounded-2xl border border-[color:var(--theme-border-soft)] bg-gradient-to-br from-[color:var(--theme-surface-page)] via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] p-3"
-          >
-            <div className="text-[0.7rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-              Inspections
-            </div>
-            <div>
-              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                Inspection Queue
-              </div>
-              <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-                Start &amp; review inspection forms.
-              </div>
-            </div>
-          </Link>
-
-          <Link
-            href="/mobile/messages"
-            className="flex h-28 flex-col justify-between rounded-2xl border border-[color:var(--theme-border-soft)] bg-gradient-to-br from-[color:var(--theme-surface-page)] via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] p-3"
-          >
-            <div className="text-[0.7rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-              AI
-            </div>
-            <div>
-              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                AI &amp; Messages
-              </div>
-              <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-                Chat with AI and your team.
-              </div>
-            </div>
-          </Link>
-        </section>
-
-        <footer className="mt-2 text-center text-[0.65rem] text-[color:var(--theme-text-muted)]">
-          Mobile companion • Use the desktop app for admin &amp; setup.
-        </footer>
+    <main className="min-h-screen overflow-x-hidden bg-[color:var(--theme-surface-page)] px-4 py-12 text-center text-[color:var(--theme-text-primary)]">
+      <div className="mx-auto max-w-md rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-6">
+        <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">ProFixIQ mobile</div>
+        <h1 className="mt-2 text-xl font-semibold">Mobile access is not configured</h1>
+        <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+          {shop?.name ? `${shop.name} has not assigned a supported mobile role to this account.` : "This account is not attached to a shop role."}
+        </p>
       </div>
     </main>
   );

--- a/features/mobile/dashboard/MobileOperationalRoleHome.tsx
+++ b/features/mobile/dashboard/MobileOperationalRoleHome.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import {
+  MobileActionGrid,
+  MobileAttentionList,
+  MobileDashboardHero,
+  MobileDashboardPage,
+  MobileMetricGrid,
+} from "@/features/mobile/dashboard/MobileDashboardPrimitives";
+import type { MobileRole } from "@/features/mobile/config/mobile-tiles";
+
+type Props = {
+  name: string;
+  role: Extract<MobileRole, "parts" | "dispatcher" | "fleet_manager" | "driver">;
+};
+
+type RoleConfig = {
+  eyebrow: string;
+  title: (firstName: string) => string;
+  subtitle: string;
+  action: { href: string; label: string };
+  metrics: Array<{ label: string; value: string; href: string; tone?: "default" | "positive" | "warning" }>;
+  attention: Array<{ title: string; detail: string; href: string; action: string }>;
+  actions: Array<{ title: string; detail: string; href: string }>;
+};
+
+const CONFIG: Record<Props["role"], RoleConfig> = {
+  parts: {
+    eyebrow: "Parts desk",
+    title: (name) => `Keep parts moving, ${name}`,
+    subtitle: "Quote, order, receive, and release parts without losing the work-order context.",
+    action: { href: "/parts/requests", label: "Review new requests" },
+    metrics: [
+      { label: "New requests", value: "Open", href: "/parts/requests", tone: "warning" },
+      { label: "Awaiting quote", value: "Review", href: "/parts/requests" },
+      { label: "On order", value: "Track", href: "/parts/orders" },
+      { label: "Ready for tech", value: "Release", href: "/parts/requests", tone: "positive" },
+    ],
+    attention: [
+      { title: "Requests needing a quote", detail: "Prioritize unquoted parts before they block approvals.", href: "/parts/requests", action: "Review" },
+      { title: "Orders needing follow-up", detail: "Confirm ETA changes and backorders.", href: "/parts/orders", action: "Track" },
+      { title: "Received parts not released", detail: "Notify the assigned technician and update the request.", href: "/parts/requests", action: "Release" },
+    ],
+    actions: [
+      { title: "Parts requests", detail: "Open the live request board.", href: "/parts/requests" },
+      { title: "Orders", detail: "Track ordered and partially received parts.", href: "/parts/orders" },
+      { title: "Work orders", detail: "Review the repair context.", href: "/mobile/work-orders" },
+      { title: "Team chat", detail: "Coordinate with advisors and technicians.", href: "/mobile/messages" },
+    ],
+  },
+  dispatcher: {
+    eyebrow: "Dispatch",
+    title: (name) => `Balance today’s work, ${name}`,
+    subtitle: "Keep technician assignments, bays, and incoming work aligned.",
+    action: { href: "/work-orders/board", label: "Open dispatch board" },
+    metrics: [
+      { label: "Unassigned", value: "Review", href: "/work-orders/board", tone: "warning" },
+      { label: "In progress", value: "Live", href: "/work-orders/board", tone: "positive" },
+      { label: "Blocked", value: "Resolve", href: "/work-orders/board", tone: "warning" },
+      { label: "Appointments", value: "Today", href: "/mobile/appointments" },
+    ],
+    attention: [
+      { title: "Unassigned work", detail: "Match ready jobs to available technicians.", href: "/work-orders/board", action: "Assign" },
+      { title: "Stalled jobs", detail: "Review jobs that are active without recent progress.", href: "/work-orders/board", action: "Review" },
+      { title: "Incoming appointments", detail: "Prepare the next arrivals and bay plan.", href: "/mobile/appointments", action: "Plan" },
+    ],
+    actions: [
+      { title: "Dispatch board", detail: "Balance technicians and bays.", href: "/work-orders/board" },
+      { title: "Appointments", detail: "Review today’s arrivals.", href: "/mobile/appointments" },
+      { title: "Work orders", detail: "Open active repair orders.", href: "/mobile/work-orders" },
+      { title: "Team chat", detail: "Coordinate shop-floor changes.", href: "/mobile/messages" },
+    ],
+  },
+  fleet_manager: {
+    eyebrow: "Fleet operations",
+    title: (name) => `Fleet status, ${name}`,
+    subtitle: "Monitor units, service requests, and maintenance work from one mobile view.",
+    action: { href: "/mobile/fleet", label: "Open fleet" },
+    metrics: [
+      { label: "Units", value: "Fleet", href: "/mobile/fleet" },
+      { label: "Service requests", value: "Open", href: "/mobile/fleet/service-requests", tone: "warning" },
+      { label: "In service", value: "Track", href: "/mobile/work-orders" },
+      { label: "Ready", value: "Review", href: "/mobile/fleet", tone: "positive" },
+    ],
+    attention: [
+      { title: "Open service requests", detail: "Review new driver and fleet-reported concerns.", href: "/mobile/fleet/service-requests", action: "Review" },
+      { title: "Units currently in service", detail: "Check status, approvals, and expected completion.", href: "/mobile/work-orders", action: "Track" },
+      { title: "Upcoming maintenance", detail: "Prepare units that are nearing scheduled service.", href: "/mobile/fleet", action: "Plan" },
+    ],
+    actions: [
+      { title: "Fleet overview", detail: "Review units and service state.", href: "/mobile/fleet" },
+      { title: "Service requests", detail: "Manage reported fleet issues.", href: "/mobile/fleet/service-requests" },
+      { title: "Work orders", detail: "Track units currently in the shop.", href: "/mobile/work-orders" },
+      { title: "Messages", detail: "Coordinate with drivers and the shop.", href: "/mobile/messages" },
+    ],
+  },
+  driver: {
+    eyebrow: "Driver workspace",
+    title: (name) => `Ready for the road, ${name}`,
+    subtitle: "Complete inspections and report service issues from your phone.",
+    action: { href: "/mobile/fleet/pretrip", label: "Start pre-trip inspection" },
+    metrics: [
+      { label: "Pre-trip", value: "Start", href: "/mobile/fleet/pretrip", tone: "positive" },
+      { label: "Reported issues", value: "View", href: "/mobile/fleet/service-requests" },
+      { label: "Vehicle status", value: "Check", href: "/mobile/fleet" },
+      { label: "Messages", value: "Open", href: "/mobile/messages" },
+    ],
+    attention: [
+      { title: "Complete today’s pre-trip", detail: "Record the vehicle condition before departure.", href: "/mobile/fleet/pretrip", action: "Start" },
+      { title: "Report a service issue", detail: "Send the concern and vehicle context to the fleet team.", href: "/mobile/fleet/service-requests", action: "Report" },
+    ],
+    actions: [
+      { title: "Pre-trip inspection", detail: "Complete the daily vehicle check.", href: "/mobile/fleet/pretrip" },
+      { title: "Service requests", detail: "Report or review vehicle concerns.", href: "/mobile/fleet/service-requests" },
+      { title: "Fleet", detail: "Check assigned vehicle information.", href: "/mobile/fleet" },
+      { title: "Messages", detail: "Contact dispatch or fleet management.", href: "/mobile/messages" },
+    ],
+  },
+};
+
+export default function MobileOperationalRoleHome({ name, role }: Props) {
+  const firstName = name.trim().split(/\s+/)[0] || "there";
+  const config = CONFIG[role];
+
+  return (
+    <MobileDashboardPage>
+      <MobileDashboardHero
+        eyebrow={config.eyebrow}
+        title={config.title(firstName)}
+        subtitle={config.subtitle}
+        action={config.action}
+      />
+      <MobileMetricGrid items={config.metrics} />
+      <MobileAttentionList subtitle="Highest-priority work for this role" items={config.attention} />
+      <MobileActionGrid items={config.actions} />
+    </MobileDashboardPage>
+  );
+}

--- a/tests/mobile-remaining-role-dashboards.test.ts
+++ b/tests/mobile-remaining-role-dashboards.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const mobileHome = () => readFileSync("app/mobile/page.tsx", "utf8");
+const operationalHome = () =>
+  readFileSync("features/mobile/dashboard/MobileOperationalRoleHome.tsx", "utf8");
+
+describe("remaining mobile role dashboards", () => {
+  it("routes all supported operational roles away from the generic fallback", () => {
+    const source = mobileHome();
+
+    for (const role of ["parts", "dispatcher", "fleet_manager", "driver"]) {
+      expect(source).toContain(`role === \"${role}\"`);
+    }
+    expect(source).toContain("<MobileOperationalRoleHome");
+    expect(source).toContain("overflow-x-hidden");
+  });
+
+  it("provides dedicated parts, dispatch, fleet manager, and driver experiences", () => {
+    const source = operationalHome();
+
+    expect(source).toContain("Parts desk");
+    expect(source).toContain("Review new requests");
+    expect(source).toContain("Open dispatch board");
+    expect(source).toContain("Fleet operations");
+    expect(source).toContain("Start pre-trip inspection");
+  });
+
+  it("uses shared responsive dashboard primitives and limits attention/actions", () => {
+    const source = operationalHome();
+
+    expect(source).toContain("MobileDashboardPage");
+    expect(source).toContain("MobileMetricGrid");
+    expect(source).toContain("MobileAttentionList");
+    expect(source).toContain("MobileActionGrid");
+  });
+
+  it("preserves technician statistics while removing the generic shop console", () => {
+    const source = mobileHome();
+
+    expect(source).toContain("setTechStats");
+    expect(source).toContain("workedHours");
+    expect(source).toContain("billedHours");
+    expect(source).not.toContain("Shop Console");
+  });
+});


### PR DESCRIPTION
## Summary
- adds dedicated mobile home experiences for parts, dispatcher, fleet manager, and driver roles
- routes every supported mobile role away from the generic Shop Console fallback
- gives parts a request/quote/order/receive-focused dashboard
- gives dispatch a technician assignment and bay-balancing dashboard
- gives fleet managers a unit/service-request/maintenance dashboard
- gives drivers a pre-trip and service-reporting dashboard
- preserves technician worked/billed/efficiency calculations while simplifying the mobile home route
- removes the generic production fallback and replaces it with an explicit unsupported-role state
- adds responsive overflow protection and regression tests for the remaining roles

## Context
This continues the mobile dashboard cleanup after PRs #1091 and #1092. Navigation, install, Assistant/Planner, shift punch-out, and owner/admin/manager/foreman/advisor/lead-hand layouts are already on main.

## Testing
- added `tests/mobile-remaining-role-dashboards.test.ts`
- source contracts cover role routing, responsive primitives, technician stats preservation, and removal of the generic Shop Console