### PR TITLE
Keep mobile dashboard actions inside the mobile shell

### DIFF
--- a/app/mobile/dispatch/page.tsx
+++ b/app/mobile/dispatch/page.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+
+import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+
+export const dynamic = "force-dynamic";
+
+export default async function MobileDispatchPage() {
+  const payload = await getOperationsDashboardPayload();
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 overflow-x-hidden px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">Dispatch</div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">Live shop floor</h1>
+        <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Review active work, blockers, and technician capacity without leaving mobile.</p>
+      </section>
+
+      <section className="grid grid-cols-2 gap-2">
+        {[
+          ["Active jobs", payload.topSummary.activeJobs, "/mobile/work-orders"],
+          ["Blocked", payload.topSummary.blockedJobs, "/mobile/work-orders?view=blocked"],
+          ["Techs clocked in", payload.topSummary.techniciansClockedIn, "/mobile/workforce/attendance"],
+          ["Waiting parts", payload.topSummary.waitingParts, "/mobile/parts"],
+        ].map(([label, value, href]) => (
+          <Link key={String(label)} href={String(href)} className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3">
+            <div className="text-xs text-[color:var(--theme-text-secondary)]">{label}</div>
+            <div className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{value}</div>
+          </Link>
+        ))}
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
+        <div className="border-b border-[color:var(--theme-border-soft)] p-4">
+          <h2 className="text-xl font-semibold text-[color:var(--theme-text-primary)]">Work in motion</h2>
+        </div>
+        {payload.liveWork.length > 0 ? (
+          <div className="divide-y divide-[color:var(--theme-border-soft)]">
+            {payload.liveWork.slice(0, 12).map((item) => (
+              <Link key={item.id} href={`/mobile/work-orders/${item.id}`} className="block p-4 active:bg-[color:var(--theme-surface-overlay)]">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-semibold text-[color:var(--theme-text-primary)]">{item.label}</div>
+                    <div className="mt-1 text-sm capitalize text-[color:var(--theme-text-secondary)]">{item.stage.replaceAll("_", " ")}</div>
+                  </div>
+                  <span className="shrink-0 text-xs font-medium text-[color:var(--accent-copper)]">Open →</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <div className="p-4 text-sm text-[color:var(--theme-text-secondary)]">No active work is available.</div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/mobile/parts/page.tsx
+++ b/app/mobile/parts/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+
+import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+
+export const dynamic = "force-dynamic";
+
+export default async function MobilePartsPage() {
+  const payload = await getOperationsDashboardPayload();
+
+  const lanes = [
+    { title: "Requests", detail: "Review new and unquoted requests.", href: "/mobile/work-orders?parts=requested" },
+    { title: "Awaiting approval", detail: "See work waiting on customer authorization.", href: "/mobile/work-orders?parts=approval" },
+    { title: "On order", detail: "Track jobs blocked by ordered parts.", href: "/mobile/work-orders?parts=ordered" },
+    { title: "Ready for technician", detail: "Return received parts to active work.", href: "/mobile/work-orders?parts=ready" },
+  ];
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 overflow-x-hidden px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">Parts</div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">Parts workflow</h1>
+        <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Keep requests, orders, receiving, and technician release inside the mobile shell.</p>
+      </section>
+
+      <section className="grid grid-cols-2 gap-2">
+        <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 p-3">
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">Waiting parts</div>
+          <div className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{payload.topSummary.waitingParts}</div>
+        </div>
+        <Link href="/mobile/work-orders" className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3">
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">Repair context</div>
+          <div className="mt-1 text-sm font-semibold text-[color:var(--accent-copper)]">Open work orders →</div>
+        </Link>
+      </section>
+
+      <section className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {lanes.map((lane) => (
+          <Link key={lane.title} href={lane.href} className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4">
+            <div className="font-semibold text-[color:var(--theme-text-primary)]">{lane.title}</div>
+            <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{lane.detail}</div>
+          </Link>
+        ))}
+      </section>
+
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4">
+        <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">Mobile parts rollout</h2>
+        <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">This workspace now keeps navigation mobile-native. Detailed quote, order, and receiving actions will be migrated here incrementally instead of opening desktop boards.</p>
+      </section>
+    </div>
+  );
+}

--- a/app/mobile/workforce/attendance/page.tsx
+++ b/app/mobile/workforce/attendance/page.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+
+import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+
+export const dynamic = "force-dynamic";
+
+export default async function MobileAttendancePage() {
+  const payload = await getOperationsDashboardPayload();
+  const technicians = payload.technicianActivity;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 overflow-x-hidden px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">
+          Workforce
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          Attendance & activity
+        </h1>
+        <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+          See who is clocked in, what they are working on, and where capacity is available.
+        </p>
+      </section>
+
+      <section className="grid grid-cols-2 gap-2">
+        <div className="rounded-2xl border border-emerald-500/35 bg-emerald-500/10 p-3">
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">Clocked in</div>
+          <div className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+            {payload.topSummary.techniciansClockedIn}
+          </div>
+        </div>
+        <Link href="/mobile/dispatch" className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3">
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">Dispatch</div>
+          <div className="mt-1 text-sm font-semibold text-[color:var(--accent-copper)]">Review capacity →</div>
+        </Link>
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
+        <div className="border-b border-[color:var(--theme-border-soft)] p-4">
+          <h2 className="text-xl font-semibold text-[color:var(--theme-text-primary)]">Technicians on shift</h2>
+        </div>
+        {technicians.length > 0 ? (
+          <div className="divide-y divide-[color:var(--theme-border-soft)]">
+            {technicians.map((tech) => (
+              <div key={tech.id} className="p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-semibold text-[color:var(--theme-text-primary)]">{tech.name}</div>
+                    <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+                      {tech.activeLines > 0 ? `${tech.activeLines} active job${tech.activeLines === 1 ? "" : "s"}` : "Available for work"}
+                    </div>
+                  </div>
+                  <div className="shrink-0 text-right text-xs text-[color:var(--theme-text-secondary)]">
+                    <div>{tech.stage}</div>
+                    <div className="mt-1">{tech.elapsed}</div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="p-4 text-sm text-[color:var(--theme-text-secondary)]">No technicians are currently clocked in.</div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/features/mobile/config/mobile-tiles.ts
+++ b/features/mobile/config/mobile-tiles.ts
@@ -22,9 +22,8 @@ export type MobileScope =
   | "jobs"
   | "inspect"
   | "messages"
-  | "planner" // keep in case something else still references it
+  | "planner"
   | "settings"
-  // align mobile dashboards with desktop views
   | "work_orders"
   | "appointments"
   | "inspections"
@@ -41,25 +40,39 @@ export type MobileTile = {
 
 export const MOBILE_TILES: MobileTile[] = [
   {
-    href: "/dashboard",
+    href: "/mobile",
     title: "Shop Overview",
     subtitle: "Today at a glance",
     roles: ["owner", "admin", "manager", "advisor", "mechanic", "lead_hand", "foreman", "parts", "dispatcher", "fleet_manager", "driver"],
     scopes: ["dashboard", "home", "all"],
   },
   {
-    href: "/work-orders/board",
+    href: "/mobile/work-orders",
     title: "Work Order Board",
     subtitle: "Live work flow",
     roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
     scopes: ["dashboard", "home", "jobs", "work_orders", "all"],
   },
   {
-    href: "/dashboard/workforce/attendance",
+    href: "/mobile/workforce/attendance",
     title: "Attendance & Activity",
     subtitle: "Live staff and job time",
     roles: ["owner", "admin", "manager"],
     scopes: ["dashboard", "home", "work_orders", "all"],
+  },
+  {
+    href: "/mobile/dispatch",
+    title: "Dispatch",
+    subtitle: "Technicians, bays and blockers",
+    roles: ["manager", "lead_hand", "foreman", "dispatcher"],
+    scopes: ["dashboard", "home", "jobs", "work_orders", "all"],
+  },
+  {
+    href: "/mobile/parts",
+    title: "Parts",
+    subtitle: "Requests, orders and receiving",
+    roles: ["parts", "owner", "admin", "manager"],
+    scopes: ["dashboard", "home", "jobs", "work_orders", "all"],
   },
   {
     href: "/mobile/tech/queue",
@@ -69,20 +82,12 @@ export const MOBILE_TILES: MobileTile[] = [
     scopes: ["home", "jobs", "work_orders", "all"],
   },
   {
-    href: "/mobile/work-orders",
-    title: "Work Orders",
-    subtitle: "Shop work order board",
-    roles: ["manager", "lead_hand", "foreman", "advisor", "owner", "admin"],
-    scopes: ["home", "jobs", "work_orders", "all"],
-  },
-  {
     href: "/mobile/inspections",
     title: "Inspections",
     subtitle: "Run checklists on vehicles",
     roles: ["mechanic", "advisor", "manager", "lead_hand", "foreman"],
     scopes: ["home", "inspect", "inspections", "work_orders", "all"],
   },
-  // 🔁 Planner → Appointments (mobile day planner)
   {
     href: "/mobile/appointments",
     title: "Appointments",
@@ -104,8 +109,6 @@ export const MOBILE_TILES: MobileTile[] = [
     roles: ["mechanic", "advisor", "manager", "lead_hand", "owner", "admin", "parts"],
     scopes: ["home", "settings", "all"],
   },
-
-  // 🔶 Mobile owner/manager reports
   {
     href: "/mobile/reports",
     title: "Reports",
@@ -113,8 +116,6 @@ export const MOBILE_TILES: MobileTile[] = [
     roles: ["owner", "admin", "manager"],
     scopes: ["home", "work_orders", "all"],
   },
-
-  // 🔧 Mobile technicians / leaderboard
   {
     href: "/mobile/technicians",
     title: "Technicians",
@@ -122,8 +123,6 @@ export const MOBILE_TILES: MobileTile[] = [
     roles: ["owner", "admin", "manager"],
     scopes: ["home", "jobs", "work_orders", "all"],
   },
-
-  // 🚚 Fleet – management / dispatch view
   {
     href: "/mobile/fleet",
     title: "Fleet",
@@ -131,8 +130,6 @@ export const MOBILE_TILES: MobileTile[] = [
     roles: ["owner", "admin", "manager", "fleet_manager", "dispatcher"],
     scopes: ["home", "fleet", "all"],
   },
-
-  // 📝 Driver daily pre-trip (mobile)
   {
     href: "/mobile/fleet/pretrip",
     title: "Pre-trip",
@@ -140,8 +137,6 @@ export const MOBILE_TILES: MobileTile[] = [
     roles: ["driver"],
     scopes: ["home", "fleet", "inspect", "all"],
   },
-
-  // 👨‍🔧 Mobile tech self performance
   {
     href: "/mobile/tech/performance",
     title: "My Performance",
@@ -149,8 +144,6 @@ export const MOBILE_TILES: MobileTile[] = [
     roles: ["mechanic"],
     scopes: ["home", "jobs", "all"],
   },
-
-  // 🚨 Fleet service requests (mobile)
   {
     href: "/mobile/fleet/service-requests",
     title: "Service Requests",

--- a/features/mobile/dashboard/MobileManagerHome.tsx
+++ b/features/mobile/dashboard/MobileManagerHome.tsx
@@ -38,11 +38,15 @@ export default function MobileManagerHome({ managerName, role, stats }: Props) {
     todayBilled: null,
   };
   const copy = ROLE_COPY[role] ?? ROLE_COPY.manager!;
-  const primaryHref = role === "admin" ? "/dashboard/workforce/attendance" : "/work-orders/board";
+  const primaryHref = role === "admin"
+    ? "/mobile/workforce/attendance"
+    : role === "manager" || role === "foreman"
+      ? "/mobile/dispatch"
+      : "/mobile/work-orders";
 
   const attention = [
     ...(waiters > 0 ? [{ title: "customers waiting", detail: "Front-counter work needs immediate follow-up.", href: "/mobile/work-orders", action: "Review", count: waiters }] : []),
-    ...(techniciansOnShift === 0 ? [{ title: "No technicians clocked in", detail: "Confirm attendance before assigning work.", href: "/dashboard/workforce/attendance", action: "Attendance" }] : []),
+    ...(techniciansOnShift === 0 ? [{ title: "No technicians clocked in", detail: "Confirm attendance before assigning work.", href: "/mobile/workforce/attendance", action: "Attendance" }] : []),
     ...(activeWos > 0 ? [{ title: "active work orders", detail: "Review flow and identify blocked work.", href: "/mobile/work-orders", action: "Open", count: activeWos }] : []),
   ];
 
@@ -52,13 +56,13 @@ export default function MobileManagerHome({ managerName, role, stats }: Props) {
       <MobileMetricGrid items={[
         { label: "Active work orders", value: activeWos, href: "/mobile/work-orders" },
         { label: "Customers waiting", value: waiters, href: "/mobile/work-orders", tone: waiters > 0 ? "warning" : "default" },
-        { label: "Technicians on shift", value: techniciansOnShift, href: "/dashboard/workforce/attendance", tone: techniciansOnShift > 0 ? "positive" : "warning" },
+        { label: "Technicians on shift", value: techniciansOnShift, href: "/mobile/workforce/attendance", tone: techniciansOnShift > 0 ? "positive" : "warning" },
         { label: "Today billed", value: todayBilled ?? "—", href: "/mobile/reports" },
       ]} />
       <MobileAttentionList subtitle="Only the items most likely to slow the shop down." items={attention} />
       <MobileActionGrid items={[
-        { title: "Work order board", detail: "Review live work and status flow.", href: "/work-orders/board" },
-        { title: "Attendance", detail: "See who is clocked in and active.", href: "/dashboard/workforce/attendance" },
+        { title: "Work order board", detail: "Review live work and status flow.", href: "/mobile/work-orders" },
+        { title: "Attendance", detail: "See who is clocked in and active.", href: "/mobile/workforce/attendance" },
         { title: "Appointments", detail: "Review today’s arrivals.", href: "/mobile/appointments" },
         { title: "Reports", detail: "Open revenue and efficiency views.", href: "/mobile/reports" },
       ]} />

--- a/features/mobile/dashboard/MobileOperationalRoleHome.tsx
+++ b/features/mobile/dashboard/MobileOperationalRoleHome.tsx
@@ -29,21 +29,21 @@ const CONFIG: Record<Props["role"], RoleConfig> = {
     eyebrow: "Parts desk",
     title: (name) => `Keep parts moving, ${name}`,
     subtitle: "Quote, order, receive, and release parts without losing the work-order context.",
-    action: { href: "/parts/requests", label: "Review new requests" },
+    action: { href: "/mobile/parts", label: "Review new requests" },
     metrics: [
-      { label: "New requests", value: "Open", href: "/parts/requests", tone: "warning" },
-      { label: "Awaiting quote", value: "Review", href: "/parts/requests" },
-      { label: "On order", value: "Track", href: "/parts/orders" },
-      { label: "Ready for tech", value: "Release", href: "/parts/requests", tone: "positive" },
+      { label: "New requests", value: "Open", href: "/mobile/parts?view=requests", tone: "warning" },
+      { label: "Awaiting quote", value: "Review", href: "/mobile/parts?view=quotes" },
+      { label: "On order", value: "Track", href: "/mobile/parts?view=orders" },
+      { label: "Ready for tech", value: "Release", href: "/mobile/parts?view=ready", tone: "positive" },
     ],
     attention: [
-      { title: "Requests needing a quote", detail: "Prioritize unquoted parts before they block approvals.", href: "/parts/requests", action: "Review" },
-      { title: "Orders needing follow-up", detail: "Confirm ETA changes and backorders.", href: "/parts/orders", action: "Track" },
-      { title: "Received parts not released", detail: "Notify the assigned technician and update the request.", href: "/parts/requests", action: "Release" },
+      { title: "Requests needing a quote", detail: "Prioritize unquoted parts before they block approvals.", href: "/mobile/parts?view=quotes", action: "Review" },
+      { title: "Orders needing follow-up", detail: "Confirm ETA changes and backorders.", href: "/mobile/parts?view=orders", action: "Track" },
+      { title: "Received parts not released", detail: "Notify the assigned technician and update the request.", href: "/mobile/parts?view=ready", action: "Release" },
     ],
     actions: [
-      { title: "Parts requests", detail: "Open the live request board.", href: "/parts/requests" },
-      { title: "Orders", detail: "Track ordered and partially received parts.", href: "/parts/orders" },
+      { title: "Parts requests", detail: "Open the mobile request workspace.", href: "/mobile/parts?view=requests" },
+      { title: "Orders", detail: "Track ordered and partially received parts.", href: "/mobile/parts?view=orders" },
       { title: "Work orders", detail: "Review the repair context.", href: "/mobile/work-orders" },
       { title: "Team chat", detail: "Coordinate with advisors and technicians.", href: "/mobile/messages" },
     ],
@@ -52,20 +52,20 @@ const CONFIG: Record<Props["role"], RoleConfig> = {
     eyebrow: "Dispatch",
     title: (name) => `Balance today’s work, ${name}`,
     subtitle: "Keep technician assignments, bays, and incoming work aligned.",
-    action: { href: "/work-orders/board", label: "Open dispatch board" },
+    action: { href: "/mobile/dispatch", label: "Open dispatch board" },
     metrics: [
-      { label: "Unassigned", value: "Review", href: "/work-orders/board", tone: "warning" },
-      { label: "In progress", value: "Live", href: "/work-orders/board", tone: "positive" },
-      { label: "Blocked", value: "Resolve", href: "/work-orders/board", tone: "warning" },
+      { label: "Unassigned", value: "Review", href: "/mobile/dispatch?view=unassigned", tone: "warning" },
+      { label: "In progress", value: "Live", href: "/mobile/dispatch?view=active", tone: "positive" },
+      { label: "Blocked", value: "Resolve", href: "/mobile/dispatch?view=blocked", tone: "warning" },
       { label: "Appointments", value: "Today", href: "/mobile/appointments" },
     ],
     attention: [
-      { title: "Unassigned work", detail: "Match ready jobs to available technicians.", href: "/work-orders/board", action: "Assign" },
-      { title: "Stalled jobs", detail: "Review jobs that are active without recent progress.", href: "/work-orders/board", action: "Review" },
+      { title: "Unassigned work", detail: "Match ready jobs to available technicians.", href: "/mobile/dispatch?view=unassigned", action: "Assign" },
+      { title: "Stalled jobs", detail: "Review jobs that are active without recent progress.", href: "/mobile/dispatch?view=blocked", action: "Review" },
       { title: "Incoming appointments", detail: "Prepare the next arrivals and bay plan.", href: "/mobile/appointments", action: "Plan" },
     ],
     actions: [
-      { title: "Dispatch board", detail: "Balance technicians and bays.", href: "/work-orders/board" },
+      { title: "Dispatch board", detail: "Balance technicians and bays.", href: "/mobile/dispatch" },
       { title: "Appointments", detail: "Review today’s arrivals.", href: "/mobile/appointments" },
       { title: "Work orders", detail: "Open active repair orders.", href: "/mobile/work-orders" },
       { title: "Team chat", detail: "Coordinate shop-floor changes.", href: "/mobile/messages" },
@@ -124,12 +124,7 @@ export default function MobileOperationalRoleHome({ name, role }: Props) {
 
   return (
     <MobileDashboardPage>
-      <MobileDashboardHero
-        eyebrow={config.eyebrow}
-        title={config.title(firstName)}
-        subtitle={config.subtitle}
-        action={config.action}
-      />
+      <MobileDashboardHero eyebrow={config.eyebrow} title={config.title(firstName)} subtitle={config.subtitle} action={config.action} />
       <MobileMetricGrid items={config.metrics} />
       <MobileAttentionList subtitle="Highest-priority work for this role" items={config.attention} />
       <MobileActionGrid items={config.actions} />

--- a/tests/mobile-native-route-audit.test.ts
+++ b/tests/mobile-native-route-audit.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("mobile-native navigation", () => {
+  it("keeps role dashboard actions inside the mobile shell", () => {
+    for (const path of [
+      "features/mobile/dashboard/MobileManagerHome.tsx",
+      "features/mobile/dashboard/MobileOperationalRoleHome.tsx",
+      "features/mobile/config/mobile-tiles.ts",
+    ]) {
+      const source = read(path);
+      expect(source).not.toContain('href: "/work-orders/board"');
+      expect(source).not.toContain('href: "/dashboard/workforce/attendance"');
+      expect(source).not.toContain('href: "/parts/requests"');
+      expect(source).not.toContain('href: "/parts/orders"');
+    }
+  });
+
+  it("provides mobile-native destinations for high-frequency operations", () => {
+    expect(read("app/mobile/workforce/attendance/page.tsx")).toContain("Attendance & activity");
+    expect(read("app/mobile/dispatch/page.tsx")).toContain("Live shop floor");
+    expect(read("app/mobile/parts/page.tsx")).toContain("Parts workflow");
+  });
+
+  it("uses the existing shop-scoped operations payload", () => {
+    for (const path of [
+      "app/mobile/workforce/attendance/page.tsx",
+      "app/mobile/dispatch/page.tsx",
+      "app/mobile/parts/page.tsx",
+    ]) {
+      expect(read(path)).toContain("getOperationsDashboardPayload");
+      expect(read(path)).toContain('export const dynamic = "force-dynamic"');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- audits role-aware mobile dashboard and hamburger-menu destinations
- removes direct mobile links to desktop work-order, attendance, and parts routes
- adds mobile-native attendance, dispatch, and parts workspaces
- routes owner/admin/manager/foreman actions to `/mobile/work-orders`, `/mobile/workforce/attendance`, and `/mobile/dispatch`
- routes parts and dispatcher dashboards to `/mobile/parts` and `/mobile/dispatch`
- keeps the new pages shop-scoped by reusing the existing server-side operations dashboard payload
- adds regression coverage preventing desktop route leakage from mobile navigation

## Notes
This is the first mobile-native destination pass after PRs #1091-#1093. It fixes the exact owner-dashboard behavior shown in testing: mobile actions no longer open the desktop work-order board or desktop attendance page.

The new parts workspace establishes a mobile-native shell and status lanes; deeper quote/order/receiving mutations can be migrated into that route in the next parts-specific slice.

## Testing
- added `tests/mobile-native-route-audit.test.ts`
- verifies high-frequency role actions remain under `/mobile`
- verifies attendance, dispatch, and parts mobile pages use the shop-scoped operations payload