### PR TITLE
Fix instant shop analysis accuracy and onboarding handoff

### DIFF
--- a/app/api/demo/shop-boost/run/route.ts
+++ b/app/api/demo/shop-boost/run/route.ts
@@ -226,6 +226,7 @@ export async function POST(
     const snapshot = await buildShadowShopSnapshot({
       intakeId,
       uploadedCsvs,
+      questionnaire,
     });
     const snapshotWithActivation = {
       ...snapshot,

--- a/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
+++ b/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
@@ -378,129 +378,201 @@ function Dashboard({
   onGate: (action: GateActionContext) => void;
 }) {
   const { snapshot } = context;
+  const readiness = snapshot.importReadiness ?? {
+    detectedRecords: snapshot.preflightReport.totals.detectedRecords,
+    readyRecords: snapshot.preflightReport.totals.likelyAutoImportCount,
+    reviewRecords: snapshot.preflightReport.totals.likelyReviewNeededCount,
+    blockedRecords: snapshot.preflightReport.totals.likelyBlockerCount,
+    historyRows:
+      snapshot.operationalNarrative.historyRowsDetected ??
+      snapshot.operationalNarrative.jobsIdentified,
+    uniqueHistoryJobs: snapshot.operationalNarrative.jobsIdentified,
+    readyHistoryJobs: snapshot.operationalNarrative.workReadyCount,
+    reviewHistoryJobs: snapshot.operationalNarrative.reviewNeededCount,
+    blockedHistoryJobs: snapshot.operationalNarrative.estimatedOperationalBlockers,
+    linkageAccuracy: snapshot.projectionConfidence.factors.matchingAccuracy,
+    domainCoverage: snapshot.projectionConfidence.factors.domainCoverage,
+  };
+  const evidenceLevel = snapshot.roi.evidence_level ?? "insufficient";
+  const lowImpact = snapshot.roi.estimated_monthly_impact_low ?? 0;
+  const highImpact =
+    snapshot.roi.estimated_monthly_impact_high ?? snapshot.roi.estimated_monthly_impact;
+  const hasExplicitWorkflowSignals =
+    snapshot.urgencySignals.stalledJobs > 0 ||
+    snapshot.urgencySignals.customersWaiting > 0;
+  const domainRows = [
+    ["Customers", snapshot.uploadSummary.customers.count],
+    ["Vehicles", snapshot.uploadSummary.vehicles.count],
+    ["History", snapshot.uploadSummary.history.count],
+    ["Invoices", snapshot.uploadSummary.invoices.count],
+    ["Parts", snapshot.uploadSummary.parts.count],
+  ] as const;
 
   return (
     <section className="space-y-4">
       <div className="rounded-xl border border-[rgba(214,176,150,0.35)] bg-[rgba(145,90,60,0.14)] p-4">
-        <p className="text-[11px] uppercase tracking-[0.15em] text-[rgba(240,205,178,0.95)]">{decisionSummary.heading}</p>
-        <p className="mt-2 text-sm text-[color:var(--theme-text-primary)]">{decisionSummary.summary}</p>
-        <div className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
-          <p className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-[color:var(--theme-text-primary)]">Monthly value at risk: <span className="font-semibold text-[color:var(--theme-text-primary)]">{formatUsd(decisionSummary.monthlyValueAtRisk)}</span></p>
-          <p className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-[color:var(--theme-text-primary)]">Recoverable value: <span className="font-semibold text-emerald-300">{formatUsd(decisionSummary.recoverableValue)}</span></p>
+        <p className="text-[11px] uppercase tracking-[0.15em] text-[rgba(240,205,178,0.95)]">
+          {decisionSummary.heading}
+        </p>
+        <p className="mt-2 text-base font-semibold text-[color:var(--theme-text-primary)]">
+          {decisionSummary.summary}
+        </p>
+        <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+          {decisionSummary.readinessSummary}
+        </p>
+      </div>
+
+      <div>
+        <div className="mb-2 flex flex-wrap items-end justify-between gap-2">
+          <div>
+            <h3 className="text-sm font-semibold">Your import snapshot</h3>
+            <p className="text-xs text-[color:var(--theme-text-secondary)]">
+              History lines are grouped into unique repair orders before readiness is scored.
+            </p>
+          </div>
+          <p className="text-xs text-[color:var(--theme-text-muted)]">
+            {readiness.detectedRecords.toLocaleString()} total rows scanned
+          </p>
         </div>
-        <div className="mt-2 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
-          <p>{decisionSummary.readinessSummary}</p>
-          <p className="mt-1 text-[color:var(--theme-text-secondary)]">{decisionSummary.blockerSummary}</p>
-        </div>
-      </div>
-      <div className="rounded-xl border border-cyan-500/25 bg-cyan-500/10 p-3 text-xs text-cyan-100">Operational preview: ProFixIQ inferred workflow states from your CSVs and preflight trust logic.</div>
-
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <Metric label="Trust score" value={`${snapshot.dashboard.trustScore}%`} />
-        <Metric label="Jobs identified" value={String(snapshot.operationalNarrative.jobsIdentified)} />
-        <Metric label="Ready to flow" value={String(snapshot.operationalNarrative.workReadyCount)} />
-        <Metric label="Needs review" value={String(snapshot.operationalNarrative.reviewNeededCount)} />
-      </div>
-
-      <div className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 p-3 text-sm">
-        <p className="font-semibold text-[color:var(--theme-text-primary)]">Your shop impact with ProFixIQ</p>
-        <div className="mt-2 grid gap-2 text-xs text-emerald-100 sm:grid-cols-2">
-          <p>+{formatUsd(snapshot.roi.estimated_monthly_impact)}/month recovered revenue</p>
-          <p>+{snapshot.roi.approval_speed_gain}% faster approvals</p>
-          <p>-{snapshot.roi.labor_recovery_hours} hrs wasted labor</p>
-          <p>+{snapshot.roi.parts_leakage_reduction}% parts accuracy</p>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+          <Metric label="History rows" value={readiness.historyRows.toLocaleString()} />
+          <Metric label="Repair orders" value={readiness.uniqueHistoryJobs.toLocaleString()} />
+          <Metric label="Ready to import" value={readiness.readyHistoryJobs.toLocaleString()} />
+          <Metric label="Needs review" value={readiness.reviewHistoryJobs.toLocaleString()} />
+          <Metric label="Blocked" value={readiness.blockedHistoryJobs.toLocaleString()} />
         </div>
       </div>
 
-      <div className="rounded-xl border border-amber-500/25 bg-amber-500/10 p-3 text-xs text-amber-100">
-        <p className="font-semibold">Urgency signals</p>
-        <ul className="mt-2 list-disc space-y-1 pl-5">
-          <li>{snapshot.urgencySignals.stalledJobs} jobs currently stalled.</li>
-          <li>{formatUsd(snapshot.urgencySignals.revenueAtRiskNow)} at risk right now.</li>
-          <li>{snapshot.urgencySignals.customersWaiting} customers waiting on next-step communication.</li>
-        </ul>
-      </div>
-
-      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-primary)]">
-        <p className="font-semibold text-[color:var(--theme-text-primary)]">Operational consequences from current state</p>
-        <div className="mt-2 space-y-2">
-          {consequenceItems.slice(0, 5).map((item) => (
-            <div key={item.key} className={`rounded-md border px-3 py-2 ${item.severity === "critical" ? "border-rose-500/35 bg-rose-500/10" : item.severity === "warning" ? "border-amber-500/35 bg-amber-500/10" : "border-emerald-500/35 bg-emerald-500/10"}`}>
-              <p className="font-semibold text-[color:var(--theme-text-primary)]">{item.title}</p>
-              <p className="mt-0.5 text-[color:var(--theme-text-secondary)]">{item.detail}</p>
+      <div className="grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="font-semibold">Five-dataset activation map</p>
+              <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                These are the same domains used by guided onboarding.
+              </p>
             </div>
-          ))}
+            <p className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-1 text-xs text-[color:var(--theme-text-secondary)]">
+              {readiness.domainCoverage}% coverage
+            </p>
+          </div>
+          <div className="mt-3 divide-y divide-[color:var(--theme-border-soft)] text-sm">
+            {domainRows.map(([label, count]) => (
+              <div key={label} className="flex items-center justify-between py-2">
+                <span>{label}</span>
+                <span className={count > 0 ? "text-emerald-300" : "text-amber-300"}>
+                  {count > 0 ? `${count.toLocaleString()} rows staged` : "Not provided"}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-3 grid gap-2 text-xs sm:grid-cols-3">
+            <div className="rounded-lg border border-[color:var(--theme-border-soft)] p-3">
+              <p className="font-semibold">1. Activate</p>
+              <p className="mt-1 text-[color:var(--theme-text-secondary)]">Reuse these staged files—no second upload.</p>
+            </div>
+            <div className="rounded-lg border border-[color:var(--theme-border-soft)] p-3">
+              <p className="font-semibold">2. Materialize</p>
+              <p className="mt-1 text-[color:var(--theme-text-secondary)]">Write safe rows through the guided import pipeline.</p>
+            </div>
+            <div className="rounded-lg border border-[color:var(--theme-border-soft)] p-3">
+              <p className="font-semibold">3. Review</p>
+              <p className="mt-1 text-[color:var(--theme-text-secondary)]">Hold ambiguous or failed items for guided review.</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-cyan-500/25 bg-cyan-500/10 p-4">
+          <p className="font-semibold text-cyan-50">{decisionSummary.confidence.title}</p>
+          <p className="mt-1 text-xs text-cyan-50/80">{decisionSummary.confidence.explanation}</p>
+          <div className="mt-4 grid grid-cols-3 gap-2 text-center">
+            <div className="rounded-lg border border-cyan-300/20 bg-black/10 p-2">
+              <p className="text-xl font-semibold">{snapshot.dashboard.trustScore}%</p>
+              <p className="text-[10px] uppercase tracking-wide text-cyan-50/70">Import trust</p>
+            </div>
+            <div className="rounded-lg border border-cyan-300/20 bg-black/10 p-2">
+              <p className="text-xl font-semibold">{readiness.linkageAccuracy}%</p>
+              <p className="text-[10px] uppercase tracking-wide text-cyan-50/70">Link quality</p>
+            </div>
+            <div className="rounded-lg border border-cyan-300/20 bg-black/10 p-2">
+              <p className="text-xl font-semibold">{readiness.domainCoverage}%</p>
+              <p className="text-[10px] uppercase tracking-wide text-cyan-50/70">Data coverage</p>
+            </div>
+          </div>
+          <p className="mt-3 text-xs text-cyan-50/75">
+            {snapshot.operationalSignals.goLiveMomentumLabel}
+          </p>
         </div>
       </div>
 
-      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-primary)]">
-        <p className="font-semibold text-[color:var(--theme-text-primary)]">Operational narrative</p>
-        <ul className="mt-2 space-y-1 text-xs text-[color:var(--theme-text-secondary)]">
-          <li>{snapshot.operationalNarrative.jobsIdentified} jobs were identified from your uploaded history.</li>
-          <li>{snapshot.operationalNarrative.approvalsLikelyNeeded} jobs look ready for approval routing.</li>
-          <li>{snapshot.operationalNarrative.partsInventoryConflicts} parts signals need inventory reconciliation.</li>
-          <li>{snapshot.operationalNarrative.unresolvedCustomerVehicleLinks} records need customer/vehicle link review before full history cleanup.</li>
-        </ul>
-      </div>
-
-      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-primary)]">
-        <p className="font-semibold text-[color:var(--theme-text-primary)]">Why this is happening (based on your data)</p>
-        <ul className="mt-2 list-disc space-y-1 pl-5 text-[color:var(--theme-text-secondary)]">
+      <div className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="font-semibold text-[color:var(--theme-text-primary)]">
+              {evidenceLevel === "observed"
+                ? "Evidence-backed recovery opportunity"
+                : evidenceLevel === "modeled"
+                  ? "Modeled capacity opportunity"
+                  : "Build your measurable baseline"}
+            </p>
+            <p className="mt-1 max-w-2xl text-xs text-emerald-50/80">
+              {evidenceLevel === "observed"
+                ? "This range uses explicit workflow statuses found in the uploaded files."
+                : evidenceLevel === "modeled"
+                  ? "This is a planning range based on reported monthly repair-order volume—not a claim about current losses."
+                  : "The files establish import readiness, but do not contain enough operating evidence for a credible savings claim yet."}
+            </p>
+          </div>
+          {highImpact > 0 ? (
+            <p className="text-2xl font-semibold text-emerald-200">
+              {formatUsd(lowImpact)}–{formatUsd(highImpact)}
+              <span className="ml-1 text-xs font-normal">/ month</span>
+            </p>
+          ) : null}
+        </div>
+        <ul className="mt-3 list-disc space-y-1 pl-5 text-xs text-emerald-50/80">
           {snapshot.roi.assumptions.map((assumption) => (
             <li key={assumption}>{assumption}</li>
           ))}
         </ul>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-2">
-        <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
-          <p className="font-semibold text-[color:var(--theme-text-primary)]">Before vs after</p>
-          <p className="mt-2">Approval rate: {snapshot.impactComparison.before.approval_rate}% → {snapshot.impactComparison.after.approval_rate}%</p>
-          <p>Avg job completion time: {snapshot.impactComparison.before.avg_job_completion_time}d → {snapshot.impactComparison.after.avg_job_completion_time}d</p>
-          <p>Parts sync rate: {snapshot.impactComparison.before.parts_sync_rate}% → {snapshot.impactComparison.after.parts_sync_rate}%</p>
-        </div>
-        <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
-          <p className="font-semibold text-[color:var(--theme-text-primary)]">{decisionSummary.confidence.title}</p>
-          <p className="mt-1">{decisionSummary.confidence.explanation}</p>
-          <p className="mt-1">Confidence score: <span className="font-semibold text-cyan-200">{snapshot.projectionConfidence.score}%</span></p>
-          <p className="mt-1">Data completeness: {snapshot.projectionConfidence.factors.dataCompleteness}%</p>
-          <p>Matching accuracy: {snapshot.projectionConfidence.factors.matchingAccuracy}%</p>
-          <p>Domain coverage: {snapshot.projectionConfidence.factors.domainCoverage}%</p>
-          <p className="mt-1 text-[color:var(--theme-text-secondary)]">Increases confidence: {decisionSummary.confidence.increasesConfidence}</p>
-          <p className="text-[color:var(--theme-text-muted)]">Lowers confidence: {decisionSummary.confidence.lowersConfidence}</p>
-        </div>
-      </div>
-
-      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
-        <p className="font-semibold text-[color:var(--theme-text-primary)]">Plan alignment</p>
-        <p className="mt-1">Starter unlocks {snapshot.planAlignment.starterImpactUnlockPct}% of this impact. Pro unlocks {snapshot.planAlignment.proImpactUnlockPct}% with workflow automation + approvals + parts sync.</p>
-      </div>
-
-      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
-        <p className="font-semibold text-[color:var(--theme-text-primary)]">What we prepared for you</p>
-        <ul className="mt-2 list-disc space-y-1 pl-5">
-          {snapshot.migrationStory.highlights.map((highlight) => (
-            <li key={highlight}>{highlight}</li>
-          ))}
-        </ul>
-      </div>
-
-      <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/10 p-3 text-xs text-emerald-100">
-        <p className="font-semibold">Go-live confidence</p>
-        <p className="mt-1">{snapshot.operationalSignals.goLiveMomentumLabel}</p>
-        <p className="mt-1 text-emerald-50/80">{snapshot.activationConfidence.confidenceCopy}</p>
-      </div>
-
-      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-primary)]">
-        <p className="font-semibold text-[color:var(--theme-text-primary)]">Stakeholder framing</p>
-        <div className="mt-2 space-y-2">
-          {stakeholderTakeaways.map((takeaway) => (
-            <div key={takeaway.role} className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2">
-              <p className="font-semibold text-[color:var(--theme-text-primary)]">{takeaway.label}</p>
-              <p className="mt-1 text-[color:var(--theme-text-secondary)]">{takeaway.message}</p>
+      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
+        <p className="font-semibold">What needs attention before go-live</p>
+        <div className="mt-3 grid gap-2 md:grid-cols-3">
+          {consequenceItems.slice(0, 3).map((item) => (
+            <div
+              key={item.key}
+              className={`rounded-lg border p-3 text-xs ${
+                item.severity === "critical"
+                  ? "border-rose-500/35 bg-rose-500/10"
+                  : item.severity === "warning"
+                    ? "border-amber-500/35 bg-amber-500/10"
+                    : "border-emerald-500/35 bg-emerald-500/10"
+              }`}
+            >
+              <p className="font-semibold">{item.title}</p>
+              <p className="mt-1 text-[color:var(--theme-text-secondary)]">{item.detail}</p>
             </div>
           ))}
         </div>
+      </div>
+
+      {hasExplicitWorkflowSignals ? (
+        <div className="rounded-xl border border-amber-500/25 bg-amber-500/10 p-4 text-xs text-amber-50">
+          <p className="font-semibold">Explicit workflow signals in the export</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-amber-50/80">
+            {snapshot.urgencySignals.explainer.map((signal) => (
+              <li key={signal}>{signal}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/10 p-4 text-xs text-emerald-50">
+        <p className="font-semibold">The handoff is prepared</p>
+        <p className="mt-1 text-emerald-50/80">{snapshot.activationConfidence.confidenceCopy}</p>
+        <p className="mt-2 text-emerald-50/80">{stakeholderTakeaways[0]?.message}</p>
       </div>
 
       <div className="flex flex-wrap gap-2">

--- a/features/integrations/shopBoost/analysisAccuracy.ts
+++ b/features/integrations/shopBoost/analysisAccuracy.ts
@@ -1,0 +1,281 @@
+export type InstantAnalysisRow = Record<string, string>;
+
+export type InstantHistoryOutcome = "ready" | "review" | "blocked";
+export type InstantHistoryOperationalStatus =
+  | "awaiting_approval"
+  | "blocked"
+  | "ready_to_invoice"
+  | null;
+
+export type InstantHistoryJobAssessment = {
+  key: string;
+  roNumber: string;
+  customer: string;
+  vehicle: string;
+  concern: string;
+  hasParts: boolean;
+  hasLabor: boolean;
+  confidence: number;
+  outcome: InstantHistoryOutcome;
+  missingCustomerLink: boolean;
+  missingVehicleLink: boolean;
+  operationalStatus: InstantHistoryOperationalStatus;
+};
+
+export type InstantHistoryAssessment = {
+  rowCount: number;
+  uniqueJobCount: number;
+  readyJobCount: number;
+  reviewJobCount: number;
+  blockedJobCount: number;
+  unresolvedLinkCount: number;
+  linkageAccuracy: number;
+  explicitStalledCount: number;
+  explicitAwaitingApprovalCount: number;
+  jobs: InstantHistoryJobAssessment[];
+};
+
+const JOB_ID_ALIASES = [
+  "work_order",
+  "work_order_number",
+  "workorder",
+  "workorder_number",
+  "repair_order",
+  "repair_order_number",
+  "ro",
+  "ro_number",
+  "invoice",
+  "invoice_number",
+  "order_number",
+  "job_number",
+];
+
+const CUSTOMER_ALIASES = [
+  "customer",
+  "customer_name",
+  "customer_id",
+  "customer_number",
+  "customer_email",
+  "customer_phone",
+  "client",
+  "client_name",
+  "account_number",
+];
+
+const VEHICLE_ALIASES = [
+  "vehicle",
+  "vehicle_id",
+  "vehicle_description",
+  "vin",
+  "vehicle_vin",
+  "license_plate",
+  "plate",
+  "unit",
+  "unit_number",
+  "fleet_unit",
+];
+
+const CONCERN_ALIASES = [
+  "description",
+  "concern",
+  "service",
+  "job",
+  "operation",
+  "correction",
+  "work_performed",
+];
+
+const STATUS_ALIASES = [
+  "status",
+  "work_order_status",
+  "ro_status",
+  "job_status",
+  "invoice_status",
+  "approval_status",
+];
+
+const PART_ALIASES = [
+  "part_number",
+  "part",
+  "parts",
+  "sku",
+  "parts_total",
+  "part_description",
+];
+
+const LABOR_ALIASES = [
+  "labor",
+  "labor_hours",
+  "hours",
+  "technician",
+  "tech",
+  "labor_total",
+];
+
+function normalizedKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function normalizedValue(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function pickAlias(row: InstantAnalysisRow, aliases: string[]): string {
+  for (const [key, value] of Object.entries(row)) {
+    if (!aliases.includes(normalizedKey(key))) continue;
+    const candidate = normalizedValue(value);
+    if (candidate) return candidate;
+  }
+  return "";
+}
+
+function normalizeStatus(value: string): InstantHistoryOperationalStatus {
+  const status = normalizedKey(value);
+  if (
+    status === "awaiting_approval" ||
+    status === "approval_pending" ||
+    status === "pending_approval" ||
+    status === "waiting_for_approval"
+  ) {
+    return "awaiting_approval";
+  }
+  if (
+    status === "blocked" ||
+    status === "stalled" ||
+    status === "on_hold" ||
+    status === "hold"
+  ) {
+    return "blocked";
+  }
+  if (
+    status === "ready_to_invoice" ||
+    status === "completed" ||
+    status === "complete" ||
+    status === "invoiced"
+  ) {
+    return "ready_to_invoice";
+  }
+  return null;
+}
+
+export function assessInstantAnalysisHistory(
+  rows: InstantAnalysisRow[],
+): InstantHistoryAssessment {
+  const groups = new Map<
+    string,
+    {
+      key: string;
+      stableIdentifier: boolean;
+      roNumber: string;
+      customer: string;
+      vehicle: string;
+      concern: string;
+      hasParts: boolean;
+      hasLabor: boolean;
+      operationalStatus: InstantHistoryOperationalStatus;
+    }
+  >();
+
+  rows.forEach((row, index) => {
+    const roNumber = pickAlias(row, JOB_ID_ALIASES);
+    const key = roNumber
+      ? `job:${normalizedKey(roNumber)}`
+      : `unidentified-row:${index}`;
+    const current = groups.get(key) ?? {
+      key,
+      stableIdentifier: Boolean(roNumber),
+      roNumber: roNumber || `Unidentified history row ${index + 1}`,
+      customer: "",
+      vehicle: "",
+      concern: "",
+      hasParts: false,
+      hasLabor: false,
+      operationalStatus: null,
+    };
+
+    current.customer ||= pickAlias(row, CUSTOMER_ALIASES);
+    current.vehicle ||= pickAlias(row, VEHICLE_ALIASES);
+    current.concern ||= pickAlias(row, CONCERN_ALIASES);
+    current.hasParts ||= Boolean(pickAlias(row, PART_ALIASES));
+    current.hasLabor ||= Boolean(pickAlias(row, LABOR_ALIASES));
+    current.operationalStatus ||=
+      normalizeStatus(pickAlias(row, STATUS_ALIASES));
+    groups.set(key, current);
+  });
+
+  const jobs: InstantHistoryJobAssessment[] = Array.from(groups.values()).map(
+    (group) => {
+      const missingCustomerLink = !group.customer;
+      const missingVehicleLink = !group.vehicle;
+      const confidence =
+        30 +
+        (group.stableIdentifier ? 30 : 0) +
+        (missingCustomerLink ? 0 : 20) +
+        (missingVehicleLink ? 0 : 20);
+      const outcome: InstantHistoryOutcome = !group.stableIdentifier
+        ? "blocked"
+        : missingCustomerLink || missingVehicleLink
+          ? "review"
+          : "ready";
+
+      return {
+        key: group.key,
+        roNumber: group.roNumber,
+        customer: group.customer || "Customer link needs review",
+        vehicle: group.vehicle || "Vehicle link needs review",
+        concern: group.concern || "Historical service record",
+        hasParts: group.hasParts,
+        hasLabor: group.hasLabor,
+        confidence,
+        outcome,
+        missingCustomerLink,
+        missingVehicleLink,
+        operationalStatus: group.operationalStatus,
+      };
+    },
+  );
+
+  const readyJobCount = jobs.filter((job) => job.outcome === "ready").length;
+  const reviewJobCount = jobs.filter((job) => job.outcome === "review").length;
+  const blockedJobCount = jobs.filter((job) => job.outcome === "blocked").length;
+  const unresolvedLinkCount = jobs.filter(
+    (job) => job.missingCustomerLink || job.missingVehicleLink,
+  ).length;
+  const availableLinks = jobs.reduce(
+    (count, job) =>
+      count +
+      (job.missingCustomerLink ? 0 : 1) +
+      (job.missingVehicleLink ? 0 : 1),
+    0,
+  );
+  const linkageAccuracy =
+    jobs.length > 0 ? Math.round((availableLinks / (jobs.length * 2)) * 100) : 100;
+
+  return {
+    rowCount: rows.length,
+    uniqueJobCount: jobs.length,
+    readyJobCount,
+    reviewJobCount,
+    blockedJobCount,
+    unresolvedLinkCount,
+    linkageAccuracy,
+    explicitStalledCount: jobs.filter(
+      (job) => job.operationalStatus === "blocked",
+    ).length,
+    explicitAwaitingApprovalCount: jobs.filter(
+      (job) => job.operationalStatus === "awaiting_approval",
+    ).length,
+    jobs,
+  };
+}
+
+export function calculateInstantAnalysisDomainCoverage(
+  counts: Record<"customers" | "vehicles" | "history" | "invoices" | "parts", number>,
+): number {
+  const populated = Object.values(counts).filter((count) => count > 0).length;
+  return Math.round((populated / 5) * 100);
+}

--- a/features/integrations/shopBoost/conversionPolish.ts
+++ b/features/integrations/shopBoost/conversionPolish.ts
@@ -45,57 +45,82 @@ export type ObjectionHandlingContent = {
 };
 
 export function formatUsd(value: number): string {
-  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function importReadiness(snapshot: ShadowShopSnapshot) {
+  return snapshot.importReadiness ?? {
+    detectedRecords: snapshot.preflightReport.totals.detectedRecords,
+    readyRecords: snapshot.preflightReport.totals.likelyAutoImportCount,
+    reviewRecords: snapshot.preflightReport.totals.likelyReviewNeededCount,
+    blockedRecords: snapshot.preflightReport.totals.likelyBlockerCount,
+    historyRows: snapshot.operationalNarrative.historyRowsDetected ?? snapshot.operationalNarrative.jobsIdentified,
+    uniqueHistoryJobs: snapshot.operationalNarrative.jobsIdentified,
+    readyHistoryJobs: snapshot.operationalNarrative.workReadyCount,
+    reviewHistoryJobs: snapshot.operationalNarrative.reviewNeededCount,
+    blockedHistoryJobs: snapshot.operationalNarrative.estimatedOperationalBlockers,
+    linkageAccuracy: snapshot.projectionConfidence.factors.matchingAccuracy,
+    domainCoverage: snapshot.projectionConfidence.factors.domainCoverage,
+  };
 }
 
 export function buildConfidencePresentation(snapshot: ShadowShopSnapshot): ConfidencePresentation {
   const score = snapshot.projectionConfidence.score;
-  const reviewNeeded = snapshot.operationalNarrative.reviewNeededCount;
-  const blockers = snapshot.dashboard.blockerCount;
+  const readiness = importReadiness(snapshot);
 
-  if (score >= 80 && blockers === 0) {
+  if (score >= 80 && readiness.blockedHistoryJobs === 0 && readiness.reviewHistoryJobs === 0) {
     return {
       band: "HIGH",
-      title: "High confidence",
-      explanation: "Based on strong record coverage, low blockers, and stable matching across your uploaded domains.",
-      increasesConfidence: "More complete history, customer/vehicle links, and clean identifiers increase confidence.",
-      lowersConfidence: "Confidence drops if blocker volume rises or if key identifiers are missing.",
+      title: "High import confidence",
+      explanation: "The uploaded domains have stable identifiers and customer/vehicle links for controlled import.",
+      increasesConfidence: "Complete identifiers and linked repair orders increase confidence.",
+      lowersConfidence: "Missing identifiers and ambiguous customer/vehicle links reduce confidence.",
     };
   }
 
-  if (score >= 60) {
+  if (score >= 60 && readiness.blockedHistoryJobs === 0) {
     return {
       band: "MODERATE",
-      title: "Moderate confidence",
-      explanation: "Directional estimate with meaningful signal, but some records still need review before live operational use.",
-      increasesConfidence: "Resolving flagged rows and validating parts/customer links will tighten this estimate.",
-      lowersConfidence: "Unreviewed record clusters and unresolved blockers keep uncertainty elevated.",
+      title: "Moderate import confidence",
+      explanation: "Most data can proceed, with ambiguous repair orders held for guided review.",
+      increasesConfidence: "Confirming flagged customer and vehicle links will raise confidence.",
+      lowersConfidence: `${readiness.reviewHistoryJobs} repair order${readiness.reviewHistoryJobs === 1 ? "" : "s"} still need link review.`,
     };
   }
 
   return {
     band: "EARLY_ESTIMATE",
-    title: "Early estimate",
-    explanation: "Value is directional while coverage and matching quality are still limited in this preview dataset.",
-    increasesConfidence: "Adding missing exports and completing guided review will improve confidence.",
-    lowersConfidence: `High review load (${reviewNeeded}) and blocker count (${blockers}) keep this estimate early-stage.`,
+    title: "Import review required",
+    explanation: "Some repair orders lack the identifiers or links required for safe materialization.",
+    increasesConfidence: "Resolving the guided review queue will improve import confidence.",
+    lowersConfidence: `${readiness.blockedHistoryJobs} blocked and ${readiness.reviewHistoryJobs} review repair orders remain.`,
   };
 }
 
 export function buildConsequenceItems(snapshot: ShadowShopSnapshot): ConsequenceItem[] {
   const items: ConsequenceItem[] = [];
-  const reviewNeeded = snapshot.operationalNarrative.reviewNeededCount;
-  const blockerCount = snapshot.dashboard.blockerCount;
+  const readiness = importReadiness(snapshot);
   const partsConflicts = snapshot.operationalNarrative.partsInventoryConflicts;
-  const linkGaps = snapshot.operationalNarrative.unresolvedCustomerVehicleLinks;
-  const stalledJobs = snapshot.urgencySignals.stalledJobs;
 
-  if (reviewNeeded > 0) {
+  if (readiness.reviewHistoryJobs > 0) {
     items.push({
       key: "review-needed",
       severity: "warning",
-      title: `${reviewNeeded} records need guided review`,
-      detail: "Some records require review before they are safe to use in live approvals, invoicing, and service history.",
+      title: `${readiness.reviewHistoryJobs} repair order${readiness.reviewHistoryJobs === 1 ? "" : "s"} need guided review`,
+      detail: "These repair orders will be held until their customer and vehicle links are confirmed.",
+    });
+  }
+
+  if (readiness.blockedHistoryJobs > 0) {
+    items.push({
+      key: "blockers",
+      severity: "critical",
+      title: `${readiness.blockedHistoryJobs} repair order${readiness.blockedHistoryJobs === 1 ? "" : "s"} lack a stable identifier`,
+      detail: "A repair-order or invoice identifier is required before those rows can be materialized.",
     });
   }
 
@@ -103,35 +128,8 @@ export function buildConsequenceItems(snapshot: ShadowShopSnapshot): Consequence
     items.push({
       key: "parts-conflicts",
       severity: "warning",
-      title: `${partsConflicts} parts/inventory conflicts detected`,
-      detail: "Inventory counts may not reflect live stock until part mappings and quantities are reviewed.",
-    });
-  }
-
-  if (linkGaps > 0) {
-    items.push({
-      key: "link-gaps",
-      severity: "warning",
-      title: `${linkGaps} customer/vehicle linkage gaps`,
-      detail: "Service history may not attach cleanly to the right customer or vehicle until linkage review is complete.",
-    });
-  }
-
-  if (snapshot.workflowJobs.some((job) => job.status === "blocked")) {
-    items.push({
-      key: "work-order-linkage",
-      severity: "warning",
-      title: "Work-order lineage has unresolved gaps",
-      detail: "Past jobs may not fully support quoting, approvals, and historical lookup until unresolved links are reviewed.",
-    });
-  }
-
-  if (blockerCount > 0) {
-    items.push({
-      key: "blockers",
-      severity: "critical",
-      title: `${blockerCount} blockers currently prevent trusted go-live`,
-      detail: "Your shop is not yet ready for trusted go-live until blocker items are resolved in guided migration review.",
+      title: `${partsConflicts} parts row${partsConflicts === 1 ? "" : "s"} need mapping review`,
+      detail: "Those rows will be held from live inventory until their identifiers are confirmed.",
     });
   }
 
@@ -139,17 +137,17 @@ export function buildConsequenceItems(snapshot: ShadowShopSnapshot): Consequence
     items.push({
       key: "clean",
       severity: "info",
-      title: "No blocker patterns detected in this pass",
-      detail: "Most records look ready for guided activation with targeted review on edge cases only.",
+      title: "No import blockers detected",
+      detail: "The detected repair orders have stable identifiers and customer/vehicle links for controlled activation.",
     });
   }
 
-  if (stalledJobs > 0) {
+  if (snapshot.urgencySignals.stalledJobs > 0) {
     items.push({
       key: "stalled",
       severity: "warning",
-      title: `${stalledJobs} jobs are stalled today`,
-      detail: "Stalled jobs continue delaying approvals and customer communication until workflow bottlenecks are addressed.",
+      title: `${snapshot.urgencySignals.stalledJobs} explicitly stalled repair order${snapshot.urgencySignals.stalledJobs === 1 ? "" : "s"}`,
+      detail: "This count comes from status fields in the uploaded export, not an inferred workflow state.",
     });
   }
 
@@ -157,83 +155,116 @@ export function buildConsequenceItems(snapshot: ShadowShopSnapshot): Consequence
 }
 
 function buildTopDrivers(snapshot: ShadowShopSnapshot): string[] {
+  const readiness = importReadiness(snapshot);
   return [
-    `${snapshot.urgencySignals.stalledJobs} stalled jobs causing handoff friction`,
-    `${snapshot.operationalNarrative.unresolvedCustomerVehicleLinks} customer/vehicle link gaps`,
-    `${snapshot.operationalNarrative.partsInventoryConflicts} parts reconciliation issues`,
-  ].filter((entry) => !entry.startsWith("0 "));
+    readiness.reviewHistoryJobs > 0
+      ? `${readiness.reviewHistoryJobs} repair orders need customer/vehicle link review`
+      : "",
+    readiness.blockedHistoryJobs > 0
+      ? `${readiness.blockedHistoryJobs} repair orders need stable identifiers`
+      : "",
+    snapshot.operationalNarrative.partsInventoryConflicts > 0
+      ? `${snapshot.operationalNarrative.partsInventoryConflicts} parts rows need mapping review`
+      : "",
+  ].filter(Boolean);
 }
 
 export function buildDecisionSummary(context: ShadowPreviewContext): DecisionSummary {
   const { snapshot, shopName } = context;
   const confidence = buildConfidencePresentation(snapshot);
+  const readiness = importReadiness(snapshot);
+  const evidenceLevel = snapshot.roi.evidence_level ?? "insufficient";
+  const low = snapshot.roi.estimated_monthly_impact_low ?? 0;
+  const high = snapshot.roi.estimated_monthly_impact_high ?? snapshot.roi.estimated_monthly_impact;
   const recoverableValue = Math.max(0, snapshot.roi.estimated_monthly_impact);
-  const monthlyValueAtRisk = Math.max(snapshot.urgencySignals.revenueAtRiskNow, Math.round(recoverableValue * 0.6));
-  const blockers = snapshot.dashboard.blockerCount;
+  const monthlyValueAtRisk =
+    evidenceLevel === "observed" ? Math.max(0, snapshot.urgencySignals.revenueAtRiskNow) : 0;
+  const monthlyRos = Number(snapshot.questionnaire?.avgMonthlyRos ?? 0);
 
-  const readinessSummary = blockers > 0
-    ? "Activation is possible, but blocker resolution is required before trusted go-live."
-    : snapshot.dashboard.reviewQueueCount > 0
-      ? "Activation can proceed with guided review before full live confidence."
-      : "Dataset appears ready for controlled activation and guided import.";
+  const summary =
+    evidenceLevel === "observed"
+      ? `The uploaded status fields for ${shopName} show active workflow friction. The evidence-backed recovery scenario is ${formatUsd(low)}–${formatUsd(high)}/month.`
+      : evidenceLevel === "modeled"
+        ? `At the reported ${Math.round(monthlyRos)} repair orders/month, ProFixIQ models ${formatUsd(low)}–${formatUsd(high)}/month in recoverable capacity. This is a planning estimate, not measured current loss.`
+        : `${shopName}'s files show import readiness and review needs, but not enough operational evidence to claim a credible savings amount yet.`;
+
+  const readinessSummary =
+    readiness.blockedHistoryJobs > 0
+      ? "Activation can begin, but blocked repair orders must be resolved before full materialization."
+      : readiness.reviewHistoryJobs > 0
+        ? "Activation can proceed; ambiguous repair orders will enter guided review."
+        : "The detected repair orders are ready for controlled activation.";
 
   return {
     heading: "What your data says right now",
-    summary: `Your data suggests ${shopName} is currently losing approximately ${formatUsd(monthlyValueAtRisk)}/month from workflow friction, delayed approvals, and unresolved migration gaps.`,
+    summary,
     monthlyValueAtRisk,
     recoverableValue,
     topDrivers: buildTopDrivers(snapshot).slice(0, 3),
     readinessSummary,
-    blockerSummary: blockers > 0
-      ? `${blockers} blocker${blockers === 1 ? "" : "s"} must be resolved during guided migration review.`
-      : "No hard blockers detected in this preview pass.",
+    blockerSummary:
+      readiness.blockedHistoryJobs > 0
+        ? `${readiness.blockedHistoryJobs} repair-order blocker${readiness.blockedHistoryJobs === 1 ? "" : "s"} will be surfaced in guided review.`
+        : "No repair-order identifier blockers were detected.",
     confidence,
-    primaryActionLabel: blockers > 0 ? "Review and activate your migration" : "Start fixing these issues",
-    primaryActionHelper: blockers > 0
-      ? "Activation starts a real import with held-review controls for unsafe rows."
-      : `Estimated recoverable value after activation: ${formatUsd(recoverableValue)}/month.`,
-    secondaryActionLabel: "Share this findings report",
+    primaryActionLabel:
+      readiness.blockedHistoryJobs > 0 || readiness.reviewHistoryJobs > 0
+        ? "Activate and review your import"
+        : "Turn this analysis into a live system",
+    primaryActionHelper:
+      "Activation carries these five staged datasets and their review decisions into guided onboarding.",
+    secondaryActionLabel: "Share this analysis",
   };
 }
 
 export function buildStakeholderTakeaways(snapshot: ShadowShopSnapshot): StakeholderTakeaway[] {
+  const readiness = importReadiness(snapshot);
+  const range =
+    (snapshot.roi.estimated_monthly_impact_high ?? 0) > 0
+      ? ` The planning range is ${formatUsd(snapshot.roi.estimated_monthly_impact_low ?? 0)}–${formatUsd(snapshot.roi.estimated_monthly_impact_high ?? 0)}/month.`
+      : "";
+
   return [
     {
       role: "owner",
-      label: "Recommended next step for the owner",
-      message: `Activate guided migration to recover up to ${formatUsd(snapshot.roi.estimated_monthly_impact)}/month while maintaining review control before go-live.`,
+      label: "Owner next step",
+      message: `Activate the controlled import; ProFixIQ will carry the files into setup and hold ambiguous rows for review.${range}`,
     },
     {
       role: "manager",
-      label: "Manager takeaway",
-      message: `${snapshot.operationalNarrative.reviewNeededCount} records need review and ${snapshot.urgencySignals.stalledJobs} jobs are stalled, so queue cleanup should be prioritized during activation.`,
+      label: "Import manager takeaway",
+      message: `${readiness.readyHistoryJobs} repair orders are ready, ${readiness.reviewHistoryJobs} need review, and ${readiness.blockedHistoryJobs} are blocked.`,
     },
     {
       role: "advisor",
-      label: "Advisor/service-writer impact",
-      message: `${snapshot.operationalNarrative.unresolvedCustomerVehicleLinks} linkage gaps may affect quoting and history confidence until guided review is completed.`,
+      label: "Advisor impact",
+      message:
+        readiness.reviewHistoryJobs > 0
+          ? `${readiness.reviewHistoryJobs} repair orders need customer/vehicle confirmation before their history is trusted.`
+          : "Detected repair orders have the customer and vehicle links needed for history lookup.",
     },
   ];
 }
 
 export function buildObjectionHandlingContent(snapshot: ShadowShopSnapshot): ObjectionHandlingContent {
-  const blockerCount = snapshot.dashboard.blockerCount;
-  const reviewQueue = snapshot.dashboard.reviewQueueCount;
+  const readiness = importReadiness(snapshot);
+  const reviewQueue = readiness.reviewHistoryJobs + readiness.blockedHistoryJobs;
 
   return {
     title: "How activation stays safe",
     bullets: [
-      "Preview data is read-only and has not created a live shop workspace yet.",
-      "Activation starts a real import process, not a blind overwrite.",
-      "Flagged and ambiguous rows are held for guided review instead of silently written live.",
-      "You stay in control of go-live timing while review queues are cleared.",
-      blockerCount > 0
-        ? `${blockerCount} blocker${blockerCount === 1 ? " is" : "s are"} currently tracked and surfaced explicitly before trusted go-live.`
-        : "No blocker pattern is currently forcing hard stop conditions.",
+      "The preview is read-only and has not created live operational records.",
+      "Activation uses the same customers, vehicles, history, invoices, and parts flow as guided onboarding.",
+      "Ambiguous rows are held for review instead of silently written live.",
+      "The staged files and analysis context carry into setup, so the shop does not upload them again.",
+      readiness.blockedHistoryJobs > 0
+        ? `${readiness.blockedHistoryJobs} blocked repair order${readiness.blockedHistoryJobs === 1 ? "" : "s"} will remain held until resolved.`
+        : "No repair-order identifier blocker is forcing a hard stop.",
     ],
-    whyReviewExists: reviewQueue > 0
-      ? `Why some items need review: ${reviewQueue} records have missing identifiers or ambiguous matches that require confirmation before safe operational use.`
-      : "Why some items need review: edge cases are queued when matching confidence is below trusted thresholds.",
+    whyReviewExists:
+      reviewQueue > 0
+        ? `Why review exists: ${reviewQueue} repair orders have missing identifiers or ambiguous customer/vehicle links.`
+        : "Why review exists: only future ambiguous matches will be routed to the review queue.",
   };
 }
 
@@ -245,10 +276,15 @@ export function buildActivationCTAState(args: {
   confidence: number;
 }): { label: string; subtext: string; helper: string; urgencyTone: "low" | "medium" | "high" } {
   const monthlyImpact = Math.max(0, args.monthlyImpact);
+  const impactSubtext =
+    monthlyImpact > 0
+      ? `Modeled monthly capacity: ${formatUsd(monthlyImpact)}`
+      : "Establish a measurable baseline during activation";
+
   if (args.readiness === "READY") {
     return {
       label: "Turn this analysis into a live system",
-      subtext: `Estimated recoverable value: ${formatUsd(monthlyImpact)}/month`,
+      subtext: impactSubtext,
       helper: "Nothing has been written yet. Activation starts a controlled import.",
       urgencyTone: "low",
     };
@@ -256,9 +292,9 @@ export function buildActivationCTAState(args: {
 
   if (args.readiness === "REVIEW_REQUIRED") {
     return {
-      label: "Start fixing these issues",
-      subtext: `${args.reviewQueue} records are queued for guided review before go-live.`,
-      helper: `Estimated recoverable value: ${formatUsd(monthlyImpact)}/month. You review flagged records before live use.`,
+      label: "Activate and review your import",
+      subtext: `${args.reviewQueue} items are queued for guided review.`,
+      helper: "Safe rows can proceed while ambiguous rows remain held.",
       urgencyTone: "medium",
     };
   }
@@ -266,7 +302,7 @@ export function buildActivationCTAState(args: {
   return {
     label: "Review and activate your migration",
     subtext: `${args.blockers} blocker${args.blockers === 1 ? "" : "s"} must be resolved before trusted go-live.`,
-    helper: "Activation begins real import and holds unsafe rows for review instead of blind writes.",
+    helper: "Activation begins the real import and holds unsafe rows for review.",
     urgencyTone: "high",
   };
 }

--- a/features/integrations/shopBoost/roiEngine.ts
+++ b/features/integrations/shopBoost/roiEngine.ts
@@ -7,15 +7,29 @@ import type {
 } from "@/features/integrations/shopBoost/shadowShop";
 import type { ShopBoostPreflightReport } from "@/features/integrations/shopBoost/preflightAnalysis";
 
+export type ShopBoostROIEvidenceLevel = "observed" | "modeled" | "insufficient";
+
 export type ShopBoostROI = {
   revenue_opportunity: number;
   approval_speed_gain: number;
   labor_recovery_hours: number;
   parts_leakage_reduction: number;
   estimated_monthly_impact: number;
+  estimated_monthly_impact_low: number;
+  estimated_monthly_impact_high: number;
+  evidence_level: ShopBoostROIEvidenceLevel;
   confidence: number;
   assumptions: string[];
 };
+
+function numericQuestionnaireValue(
+  questionnaire: Record<string, unknown> | undefined,
+  key: string,
+): number {
+  const value = questionnaire?.[key];
+  const parsed = typeof value === "number" ? value : Number(String(value ?? "").trim());
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
 
 export function buildShopBoostROI(args: {
   snapshotLike: {
@@ -27,50 +41,80 @@ export function buildShopBoostROI(args: {
     operationalNarrative: ShadowOperationalNarrative;
   };
   domainSummaries: Array<{ domain: string; total: number; reviewRequired: number; failed: number }>;
+  questionnaire?: Record<string, unknown>;
 }): ShopBoostROI {
   const { snapshotLike } = args;
+  const monthlyRepairOrders = numericQuestionnaireValue(args.questionnaire, "avgMonthlyRos");
+  const awaitingApproval = snapshotLike.operationalNarrative.approvalsLikelyNeeded;
+  const explicitlyStalled = snapshotLike.operationalNarrative.blockedCount;
+  const observedJobSignals = awaitingApproval + explicitlyStalled;
+  const hasObservedWorkflowEvidence = observedJobSignals > 0;
 
-  const stalledJobs = snapshotLike.workflowJobs.filter((job) => job.status === "blocked" || job.status === "awaiting_approval").length;
-  const approvalBacklog = snapshotLike.approvalFlow.waitingCustomerApproval;
-  const incompleteWorkOrders = snapshotLike.operationalNarrative.reviewNeededCount + snapshotLike.operationalNarrative.blockedCount;
-  const duplicateSignals = Math.max(0, Math.round((100 - snapshotLike.migrationStory.autoMatchedCustomersPct) * 0.08));
-  const missingPartsLinkage = snapshotLike.partsSignals.filter((signal) => signal.status !== "likely_stocked").length;
+  const observedRevenueOpportunity = Math.round(
+    awaitingApproval * 160 * 0.2 + explicitlyStalled * 210 * 0.25,
+  );
+  const modeledLaborHours =
+    monthlyRepairOrders > 0 ? Math.round((monthlyRepairOrders * 3.5 / 60) * 10) / 10 : 0;
+  const modeledCapacityValue = Math.round(modeledLaborHours * 90);
+  const estimatedMonthlyImpact = observedRevenueOpportunity + modeledCapacityValue;
 
-  const approvalRecovery = Math.round(approvalBacklog * 160 * 0.2);
-  const stalledRecovery = Math.round(stalledJobs * 210 * 0.25);
-  const dataHygieneRecovery = Math.round((incompleteWorkOrders + duplicateSignals) * 95 * 0.14);
+  const evidenceLevel: ShopBoostROIEvidenceLevel = hasObservedWorkflowEvidence
+    ? "observed"
+    : monthlyRepairOrders > 0
+      ? "modeled"
+      : "insufficient";
+  const lowEstimate = estimatedMonthlyImpact > 0
+    ? Math.round(estimatedMonthlyImpact * 0.6)
+    : 0;
+  const highEstimate = estimatedMonthlyImpact > 0
+    ? Math.round(estimatedMonthlyImpact * 1.2)
+    : 0;
+  const approvalSpeedGain = awaitingApproval > 0
+    ? Math.min(30, Math.max(1, Math.round((awaitingApproval / Math.max(snapshotLike.operationalNarrative.jobsIdentified, 1)) * 100 * 0.35)))
+    : 0;
 
-  const revenueOpportunity = Math.max(0, approvalRecovery + stalledRecovery + dataHygieneRecovery);
-  const approvalSpeedGain = Math.max(8, Math.min(34, Math.round((approvalBacklog / Math.max(snapshotLike.workflowJobs.length, 1)) * 100 * 0.45 + 8)));
-  const laborRecoveryHours = Math.max(2, Math.round((incompleteWorkOrders * 0.55 + duplicateSignals * 0.35) * 10) / 10);
-  const partsLeakageReduction = Math.max(5, Math.min(28, Math.round((missingPartsLinkage / Math.max(snapshotLike.partsSignals.length, 1)) * 100 * 0.4 + 5)));
-
-  const monthlyImpact = Math.round(revenueOpportunity + laborRecoveryHours * 90 + missingPartsLinkage * 45);
   const domainCoverage = args.domainSummaries.filter((domain) => domain.total > 0).length;
   const confidence = Math.max(
-    45,
+    20,
     Math.min(
-      96,
+      92,
       Math.round(
-        snapshotLike.preflightReport.confidence.score * 0.5 +
-          snapshotLike.migrationStory.autoMatchedCustomersPct * 0.25 +
+        snapshotLike.preflightReport.confidence.score * 0.55 +
+          snapshotLike.migrationStory.autoMatchedCustomersPct * 0.2 +
           (domainCoverage / Math.max(args.domainSummaries.length, 1)) * 100 * 0.25,
       ),
     ),
   );
 
+  const assumptions: string[] = [];
+  if (monthlyRepairOrders > 0) {
+    assumptions.push(
+      `Capacity scenario uses the shop-reported ${Math.round(monthlyRepairOrders)} repair orders/month and 3.5 minutes of avoidable admin time per repair order.`,
+      "Recovered capacity is valued at $90/hour; this is a planning assumption, not measured current loss.",
+    );
+  }
+  if (hasObservedWorkflowEvidence) {
+    assumptions.push(
+      `The uploaded status fields explicitly identify ${awaitingApproval} awaiting-approval and ${explicitlyStalled} stalled repair orders.`,
+      "Observed workflow recovery uses conservative lower-end recovery rates.",
+    );
+  }
+  if (assumptions.length === 0) {
+    assumptions.push(
+      "The files do not contain enough explicit operating-status or monthly-volume evidence to calculate a credible savings range yet.",
+    );
+  }
+
   return {
-    revenue_opportunity: revenueOpportunity,
+    revenue_opportunity: observedRevenueOpportunity,
     approval_speed_gain: approvalSpeedGain,
-    labor_recovery_hours: laborRecoveryHours,
-    parts_leakage_reduction: partsLeakageReduction,
-    estimated_monthly_impact: monthlyImpact,
+    labor_recovery_hours: modeledLaborHours,
+    parts_leakage_reduction: 0,
+    estimated_monthly_impact: estimatedMonthlyImpact,
+    estimated_monthly_impact_low: lowEstimate,
+    estimated_monthly_impact_high: highEstimate,
+    evidence_level: evidenceLevel,
     confidence,
-    assumptions: [
-      `Based on your data, ${approvalBacklog} jobs are currently waiting for approval and typically lose 15-25% if delayed.`,
-      `We detected ${missingPartsLinkage} parts linkage issues that commonly increase write-offs and rebill time.`,
-      `Stalled and incomplete jobs (${stalledJobs + incompleteWorkOrders}) were valued conservatively using lower-end shop recovery patterns.`,
-      "Ranges are directional and use conservative estimates from typical independent/fleet shop workflow patterns.",
-    ],
+    assumptions,
   };
 }

--- a/features/integrations/shopBoost/shadowShop.ts
+++ b/features/integrations/shopBoost/shadowShop.ts
@@ -418,47 +418,86 @@ function collectRecurringServicePatterns(historyRows: ShadowStagedRow[]): number
   return Array.from(patternCounts.values()).filter((count) => count >= 2).length;
 }
 
-function inferWorkflowJobs(historyRows: ShadowStagedRow[]): ShadowWorkflowJob[] {
-  return historyRows.slice(0, 12).map((row, index) => {
-    const confidence = row.confidence;
-    const hasParts = Boolean(
-      row.normalized.part_number || row.normalized.part || row.normalized.parts || row.normalized.sku,
-    );
-    const hasLabor = Boolean(
-      row.normalized.labor || row.normalized.labor_hours || row.normalized.hours || row.normalized.technician,
-    );
+function reconcilePreflightReport(
+  report: ShopBoostPreflightReport,
+  history: InstantHistoryAssessment,
+): ShopBoostPreflightReport {
+  const relationshipReview = history.reviewJobCount;
+  const relationshipBlockers = history.blockedJobCount;
+  const reviewCount = Math.max(report.totals.likelyReviewNeededCount, relationshipReview);
+  const blockerCount = Math.max(report.totals.likelyBlockerCount, relationshipBlockers);
+  const detected = report.totals.detectedRecords;
+  const autoCount = Math.max(0, detected - reviewCount - blockerCount);
+  const coverage = detected > 0 ? Math.round((autoCount / detected) * 100) : 0;
+  let score = Math.round(report.confidence.score * 0.55 + history.linkageAccuracy * 0.45);
+  if (blockerCount > 0) score = Math.min(score, 69);
+  else if (reviewCount > 0) score = Math.min(score, 89);
+  score = Math.max(1, Math.min(99, score));
 
-    const needsReview = row.reviewFlag;
-    const blocked = row.blocked;
-    const status: ShadowWorkflowJob["status"] = blocked
-      ? "blocked"
-      : confidence >= 87
-      ? "ready_to_invoice"
-      : confidence >= 78
-      ? "awaiting_approval"
-      : needsReview
-      ? "in_inspection"
-      : "queued";
+  const readiness: ShopBoostPreflightReport["confidence"]["readiness"] =
+    blockerCount > 0
+      ? "NOT_READY"
+      : reviewCount > 0
+        ? "COMPLETED_WITH_REVIEW"
+        : "READY_FOR_GO_LIVE";
+  const integrityStatus: ShopBoostPreflightReport["confidence"]["integrityStatus"] =
+    blockerCount > 0 ? "not_ready" : reviewCount > 0 ? "ready_with_warnings" : "ready";
 
-    const approvalState: ShadowWorkflowJob["approvalState"] =
-      status === "awaiting_approval" ? "ready" : blocked ? "blocked" : "not_required";
+  return {
+    ...report,
+    totals: {
+      detectedRecords: detected,
+      estimatedAutoImportCoverage: coverage,
+      likelyAutoImportCount: autoCount,
+      likelyReviewNeededCount: reviewCount,
+      likelyBlockerCount: blockerCount,
+    },
+    confidence: {
+      score,
+      label: score >= 80 ? "high" : score >= 55 ? "medium" : "low",
+      readiness,
+      integrityStatus,
+    },
+    reviewNotes: [
+      ...report.reviewNotes,
+      `History relationship check grouped ${history.rowCount} rows into ${history.uniqueJobCount} repair orders; ${relationshipReview} need link review and ${relationshipBlockers} lack a stable repair-order identifier.`,
+    ],
+  };
+}
 
-    const invoiceState: ShadowWorkflowJob["invoiceState"] = status === "ready_to_invoice" ? "ready" : "pending";
+function inferWorkflowJobs(history: InstantHistoryAssessment): ShadowWorkflowJob[] {
+  return history.jobs.slice(0, 12).map((job) => {
+    const status: ShadowWorkflowJob["status"] =
+      job.operationalStatus === "awaiting_approval"
+        ? "awaiting_approval"
+        : job.operationalStatus === "blocked" || job.outcome === "blocked"
+          ? "blocked"
+          : job.operationalStatus === "ready_to_invoice"
+            ? "ready_to_invoice"
+            : job.outcome === "review"
+              ? "in_inspection"
+              : "queued";
+    const needsReview = job.outcome !== "ready";
 
     return {
-      id: row.id,
-      roNumber: pick(row.normalized, ["work_order", "ro", "invoice_number", "order_number"], `RO-${index + 1}`),
-      customer: pick(row.normalized, ["customer", "customer_name", "name"], "Customer match pending"),
-      vehicle: pick(row.normalized, ["vehicle", "vin", "license_plate", "unit_number"], "Vehicle match pending"),
-      concernSummary: pick(row.normalized, ["description", "concern", "service", "job"], "General service workflow"),
+      id: job.key,
+      roNumber: job.roNumber,
+      customer: job.customer,
+      vehicle: job.vehicle,
+      concernSummary: job.concern,
       status,
-      hasParts,
-      hasLabor,
-      approvalState,
+      hasParts: job.hasParts,
+      hasLabor: job.hasLabor,
+      approvalState:
+        status === "awaiting_approval"
+          ? "ready"
+          : status === "blocked"
+            ? "blocked"
+            : "not_required",
       inspectionState: needsReview ? "needs_review" : "ready",
       quoteState: needsReview ? "needs_review" : "draft_ready",
-      invoiceState,
-      confidence,
+      invoiceState: status === "ready_to_invoice" ? "ready" : "pending",
+      confidence: job.confidence,
     };
   });
 }
@@ -470,40 +509,42 @@ function inferPartsSignals(partsRows: ShadowStagedRow[], workflowJobs: ShadowWor
     const status: ShadowPartSignal["status"] = row.blocked
       ? "review_needed"
       : row.reviewFlag
-      ? "likely_missing"
-      : "likely_stocked";
-
-    const confidenceNote =
-      status === "likely_stocked"
-        ? "Part mapping has stable identifiers"
-        : status === "likely_missing"
-        ? "Part is referenced but inventory certainty is limited"
-        : "Part identifiers need reconciliation before import";
+        ? "likely_missing"
+        : "likely_stocked";
 
     return {
       id: row.id,
       label,
       status,
-      confidenceNote,
+      confidenceNote:
+        status === "likely_stocked"
+          ? "Part mapping has stable identifiers"
+          : status === "likely_missing"
+            ? "Part mapping needs confirmation before live inventory use"
+            : "Part identifiers need reconciliation before import",
       referencedByJobs,
     };
   });
 
   if (fromCatalog.length > 0) return fromCatalog;
-
-  const fallback = workflowJobs.filter((job) => job.hasParts).slice(0, 6);
-  return fallback.map((job, index) => ({
-    id: `job-part-${index}`,
-    label: `${job.roNumber} parts cluster`,
-    status: "review_needed",
-    confidenceNote: "No parts catalog uploaded. Parts references will be reviewed during activation.",
-    referencedByJobs: 1,
-  }));
+  return workflowJobs
+    .filter((job) => job.hasParts)
+    .slice(0, 6)
+    .map((job, index) => ({
+      id: `job-part-${index}`,
+      label: `${job.roNumber} parts cluster`,
+      status: "review_needed",
+      confidenceNote: "No parts catalog uploaded. Parts references will be reviewed during activation.",
+      referencedByJobs: 1,
+    }));
 }
 
 function deriveOperationalPayload(args: {
   rowsByDomain: Record<ShadowDomainKey, ShadowStagedRow[]>;
   preflightReport: ShopBoostPreflightReport;
+  historyAssessment: InstantHistoryAssessment;
+  domainCoverage: number;
+  questionnaire?: Record<string, unknown>;
 }): Pick<
   ShadowShopSnapshot,
   | "operationalNarrative"
@@ -523,53 +564,48 @@ function deriveOperationalPayload(args: {
   const vehiclesRows = args.rowsByDomain.vehicles;
   const customersRows = args.rowsByDomain.customers;
   const partsRows = args.rowsByDomain.parts;
+  const history = args.historyAssessment;
 
-  const workflowJobs = inferWorkflowJobs(historyRows);
+  const workflowJobs = inferWorkflowJobs(history);
   const recurringPatterns = collectRecurringServicePatterns(historyRows);
-  const unresolvedLinks = historyRows.filter(
-    (row) =>
-      !pick(row.normalized, ["customer", "customer_name"], "") ||
-      !pick(row.normalized, ["vehicle", "vin", "license_plate"], ""),
-  ).length;
-
+  const unresolvedLinks = history.unresolvedLinkCount;
   const partsSignals = inferPartsSignals(partsRows, workflowJobs);
-  const partsConflicts = partsSignals.filter((signal) => signal.status !== "likely_stocked").length;
-
-  const approvalsLikelyNeeded = workflowJobs.filter((job) => job.status === "awaiting_approval").length;
-  const jobsReady = workflowJobs.filter((job) => job.status === "ready_to_invoice").length;
-  const jobsBlocked = workflowJobs.filter((job) => job.status === "blocked").length;
-  const jobsReview = workflowJobs.filter((job) => job.inspectionState === "needs_review").length;
+  const partsConflicts = partsRows.filter((row) => row.blocked || row.reviewFlag).length;
+  const approvalsLikelyNeeded = history.explicitAwaitingApprovalCount;
+  const jobsReady = history.readyJobCount;
+  const jobsBlocked = history.blockedJobCount;
+  const jobsReview = history.reviewJobCount + history.blockedJobCount;
 
   const approvalFlow: ShadowApprovalFlowPreview = {
-    inspectionReady: workflowJobs.filter((job) => job.inspectionState === "ready").length,
-    recommendationDrafted: workflowJobs.filter((job) => job.quoteState === "draft_ready").length,
+    inspectionReady: history.readyJobCount,
+    recommendationDrafted: history.readyJobCount,
     waitingCustomerApproval: approvalsLikelyNeeded,
-    invoiceReady: workflowJobs.filter((job) => job.invoiceState === "ready").length,
+    invoiceReady: history.jobs.filter((job) => job.operationalStatus === "ready_to_invoice").length,
   };
 
   const operationalNarrative: ShadowOperationalNarrative = {
-    jobsIdentified: historyRows.length,
+    historyRowsDetected: history.rowCount,
+    jobsIdentified: history.uniqueJobCount,
     approvalsLikelyNeeded,
     partsInventoryConflicts: partsConflicts,
     unresolvedCustomerVehicleLinks: unresolvedLinks,
-    suggestedInspections: Math.max(2, Math.min(historyRows.length, Math.round(historyRows.length * 0.28))),
-    suggestedMenuOpportunities: Math.max(recurringPatterns, Math.round(historyRows.length * 0.2)),
-    estimatedOperationalBlockers: args.preflightReport.totals.likelyBlockerCount,
+    suggestedInspections: Math.min(history.uniqueJobCount, Math.max(0, recurringPatterns)),
+    suggestedMenuOpportunities: recurringPatterns,
+    estimatedOperationalBlockers: jobsBlocked,
     workReadyCount: jobsReady,
-    blockedCount: jobsBlocked,
+    blockedCount: history.explicitStalledCount,
     reviewNeededCount: jobsReview,
   };
 
   const goLiveMomentumLabel =
-    args.preflightReport.confidence.readiness === "READY_FOR_GO_LIVE" ||
-    args.preflightReport.confidence.readiness === "COMPLETED_CLEAN"
-      ? "Most of your data looks go-live ready after activation."
-      : args.preflightReport.totals.likelyBlockerCount > 0
-      ? "You are close to go-live once flagged blockers are reviewed."
-      : "You are close to go-live with a short review queue.";
+    jobsBlocked > 0
+      ? `${jobsBlocked} repair order${jobsBlocked === 1 ? "" : "s"} need an identifier before import can complete.`
+      : jobsReview > 0
+        ? `${jobsReview} repair order${jobsReview === 1 ? "" : "s"} will be held for guided review; the rest can continue through activation.`
+        : "The detected repair orders are ready for controlled activation.";
 
   const operationalSignals: ShadowDashboardSignals = {
-    jobsInProgress: workflowJobs.filter((job) => job.status === "in_inspection" || job.status === "awaiting_approval").length,
+    jobsInProgress: approvalsLikelyNeeded,
     jobsBlockedByDataQuality: jobsBlocked,
     jobsReadyForCustomerCommunication: approvalsLikelyNeeded,
     goLiveMomentumLabel,
@@ -580,22 +616,36 @@ function deriveOperationalPayload(args: {
       ? Math.max(
           0,
           Math.min(
-            99,
-            Math.round(((customersRows.length - customersRows.filter((row) => row.reviewFlag).length) / customersRows.length) * 100),
+            100,
+            Math.round(
+              ((customersRows.length - customersRows.filter((row) => row.reviewFlag || row.blocked).length) /
+                customersRows.length) *
+                100,
+            ),
           ),
         )
       : 0;
 
+  const migrationStory: ShadowMigrationStory = {
+    autoMatchedCustomersPct,
+    linkedVehicleProfiles: Math.max(
+      0,
+      vehiclesRows.length - vehiclesRows.filter((row) => row.blocked || row.reviewFlag).length,
+    ),
+    preparedWorkflowJobs: history.readyJobCount,
+    recordsNeedingReview: jobsReview,
+    recurringPatternsDetected: recurringPatterns,
+    highlights: [
+      `${history.rowCount} history rows were grouped into ${history.uniqueJobCount} unique repair orders.`,
+      `${history.readyJobCount} repair orders have the identifiers and customer/vehicle links needed for import.`,
+      `${jobsReview} repair orders will enter the same guided review path used by onboarding.`,
+      `${partsRows.length} parts rows and ${args.rowsByDomain.invoices.length} invoice rows are staged for activation.`,
+    ],
+  };
+
   const impactComparison = buildShopBoostImpactComparison({
     preflightReport: args.preflightReport,
-    migrationStory: {
-      autoMatchedCustomersPct,
-      linkedVehicleProfiles: vehiclesRows.length - vehiclesRows.filter((row) => row.blocked).length,
-      preparedWorkflowJobs: workflowJobs.length,
-      recordsNeedingReview: args.preflightReport.totals.likelyReviewNeededCount,
-      recurringPatternsDetected: recurringPatterns,
-      highlights: [],
-    },
+    migrationStory,
     workflowJobs,
     approvalFlow,
     partsSignals,
@@ -610,14 +660,7 @@ function deriveOperationalPayload(args: {
   const roi = buildShopBoostROI({
     snapshotLike: {
       preflightReport: args.preflightReport,
-      migrationStory: {
-        autoMatchedCustomersPct,
-        linkedVehicleProfiles: vehiclesRows.length - vehiclesRows.filter((row) => row.blocked).length,
-        preparedWorkflowJobs: workflowJobs.length,
-        recordsNeedingReview: args.preflightReport.totals.likelyReviewNeededCount,
-        recurringPatternsDetected: recurringPatterns,
-        highlights: [],
-      },
+      migrationStory,
       workflowJobs,
       approvalFlow,
       partsSignals,
@@ -629,49 +672,43 @@ function deriveOperationalPayload(args: {
       reviewRequired: domain.likelyNeedsReview,
       failed: domain.potentialBlockers,
     })),
+    questionnaire: args.questionnaire,
   });
 
-  const stalledJobs = workflowJobs.filter((job) => job.status === "blocked" || job.status === "awaiting_approval").length;
-  const customersWaiting = workflowJobs.filter((job) => job.status === "awaiting_approval").length;
+  const stalledJobs = history.explicitStalledCount;
+  const customersWaiting = history.explicitAwaitingApprovalCount;
   const urgencySignals: ShadowUrgencySignals = {
     stalledJobs,
     customersWaiting,
-    revenueAtRiskNow: Math.round(roi.revenue_opportunity * 0.75),
+    revenueAtRiskNow:
+      roi.evidence_level === "observed" ? Math.round(roi.revenue_opportunity * 0.75) : 0,
     explainer: [
-      `Based on your data, ${customersWaiting} jobs are waiting for approval routing right now.`,
-      `We detected ${partsConflicts} parts linkage issues, which creates downstream estimate and invoice delays.`,
-      `${stalledJobs} jobs are currently stalled by blockers or approval lag, putting near-term revenue at risk.`,
+      customersWaiting > 0
+        ? `The CSV status fields explicitly mark ${customersWaiting} repair orders as awaiting approval.`
+        : "No uploaded status field explicitly marks a repair order as awaiting approval.",
+      stalledJobs > 0
+        ? `The CSV status fields explicitly mark ${stalledJobs} repair orders as stalled or blocked.`
+        : "No uploaded status field explicitly marks a repair order as stalled.",
+      partsConflicts > 0
+        ? `${partsConflicts} parts rows need identifier or mapping review before inventory use.`
+        : "No parts identifier conflicts were detected in this preflight pass.",
     ],
   };
 
-  const migrationStory: ShadowMigrationStory = {
-    autoMatchedCustomersPct,
-    linkedVehicleProfiles: vehiclesRows.length - vehiclesRows.filter((row) => row.blocked).length,
-    preparedWorkflowJobs: workflowJobs.length,
-    recordsNeedingReview: args.preflightReport.totals.likelyReviewNeededCount,
-    recurringPatternsDetected: recurringPatterns,
-    highlights: [
-      `${autoMatchedCustomersPct}% of customers look auto-matchable from uploaded identifiers.`,
-      `Prepared ${workflowJobs.length} workflow-ready jobs from your uploaded history.`,
-      `${args.preflightReport.totals.likelyReviewNeededCount} records are flagged for guided review before full cutover.`,
-      `${Math.max(recurringPatterns, 1)} recurring service patterns can seed menu and inspection setup.`,
-    ],
-  };
-
-  const domainCoverageScore = Math.round(
-    (([customersRows, vehiclesRows, historyRows, partsRows].filter((rows) => rows.length > 0).length + (args.rowsByDomain.staff.length > 0 ? 1 : 0)) / 5) *
-      100,
-  );
-  const anomalyPenalty = Math.min(35, Math.round((jobsBlocked + partsConflicts + unresolvedLinks) * 1.8));
+  const anomalyRate =
+    history.uniqueJobCount > 0
+      ? (history.reviewJobCount + history.blockedJobCount) / history.uniqueJobCount
+      : 0;
+  const anomalyPenalty = Math.min(40, Math.round(anomalyRate * 40));
   const projectionScore = Math.max(
-    35,
+    1,
     Math.min(
-      98,
+      99,
       Math.round(
-        autoMatchedCustomersPct * 0.35 +
-          Math.max(0, 100 - args.preflightReport.totals.likelyReviewNeededCount * 1.4) * 0.25 +
-          domainCoverageScore * 0.25 +
-          Math.max(0, 100 - anomalyPenalty) * 0.15,
+        args.preflightReport.confidence.score * 0.45 +
+          history.linkageAccuracy * 0.35 +
+          args.domainCoverage * 0.2 -
+          anomalyPenalty * 0.25,
       ),
     ),
   );
@@ -680,9 +717,9 @@ function deriveOperationalPayload(args: {
     score: projectionScore,
     label: projectionScore >= 78 ? "HIGH" : projectionScore >= 58 ? "MEDIUM" : "LOW",
     factors: {
-      dataCompleteness: Math.max(0, Math.round(100 - args.preflightReport.totals.likelyReviewNeededCount * 1.3)),
-      matchingAccuracy: autoMatchedCustomersPct,
-      domainCoverage: domainCoverageScore,
+      dataCompleteness: args.preflightReport.totals.estimatedAutoImportCoverage,
+      matchingAccuracy: history.linkageAccuracy,
+      domainCoverage: args.domainCoverage,
       anomalyPenalty,
     },
   };
@@ -690,7 +727,10 @@ function deriveOperationalPayload(args: {
   const planAlignment: ShadowPlanAlignment = {
     starterImpactUnlockPct: 42,
     proImpactUnlockPct: 100,
-    summary: `Starter unlocks core import + baseline cleanup. Pro unlocks approvals, workflow automation, and parts sync to capture up to ${Math.round((roi.estimated_monthly_impact * 12) / 1000)}k/year impact potential.`,
+    summary:
+      roi.estimated_monthly_impact > 0
+        ? `Starter supports the controlled import. Pro adds approvals, workflow automation, and parts operations for the modeled ${roi.estimated_monthly_impact_low}-${roi.estimated_monthly_impact_high} monthly capacity range.`
+        : "Starter supports the controlled import. Pro adds approvals, workflow automation, and parts operations after activation establishes a measurable baseline.",
   };
 
   const activationConfidence: ShadowActivationConfidence = {
@@ -700,7 +740,7 @@ function deriveOperationalPayload(args: {
     noWritesBeforeActivation: true,
     contextCarriesForward: true,
     confidenceCopy:
-      "This preview is generated from your uploaded files using the same preflight logic used for migration readiness. Activating starts your real import and carries this context into setup.",
+      "This preview uses the same five datasets and review-first handoff as guided onboarding. Activation carries the staged files and review context into the real import.",
   };
 
   return {

--- a/features/integrations/shopBoost/shadowShop.ts
+++ b/features/integrations/shopBoost/shadowShop.ts
@@ -16,6 +16,11 @@ import {
   buildShopBoostROI,
   type ShopBoostROI,
 } from "@/features/integrations/shopBoost/roiEngine";
+import {
+  assessInstantAnalysisHistory,
+  calculateInstantAnalysisDomainCoverage,
+  type InstantHistoryAssessment,
+} from "@/features/integrations/shopBoost/analysisAccuracy";
 
 type CsvRow = Record<string, string>;
 
@@ -49,6 +54,7 @@ export type ShadowSetupIssue = {
 };
 
 export type ShadowOperationalNarrative = {
+  historyRowsDetected: number;
   jobsIdentified: number;
   approvalsLikelyNeeded: number;
   partsInventoryConflicts: number;
@@ -141,11 +147,27 @@ export type ShadowPlanAlignment = {
   summary: string;
 };
 
+export type ShadowImportReadiness = {
+  detectedRecords: number;
+  readyRecords: number;
+  reviewRecords: number;
+  blockedRecords: number;
+  historyRows: number;
+  uniqueHistoryJobs: number;
+  readyHistoryJobs: number;
+  reviewHistoryJobs: number;
+  blockedHistoryJobs: number;
+  linkageAccuracy: number;
+  domainCoverage: number;
+};
+
 export type ShadowShopSnapshot = {
   intakeId: string;
   generatedAt: string;
+  questionnaire?: Record<string, unknown>;
   uploadSummary: Record<ShadowDomainKey, { count: number; fileName: string | null }>;
   preflightReport: ShopBoostPreflightReport;
+  importReadiness: ShadowImportReadiness;
   dashboard: {
     estimatedImportedRecords: number;
     reviewQueueCount: number;

--- a/features/integrations/shopBoost/shadowShop.ts
+++ b/features/integrations/shopBoost/shadowShop.ts
@@ -768,6 +768,7 @@ export async function buildShadowShopSnapshot(args: {
   intakeId: string;
   uploadedFiles?: Partial<Record<ShopBoostUploadDatasetKey, File>>;
   uploadedCsvs?: Partial<Record<ShopBoostUploadDatasetKey, ShadowShopCsvUpload>>;
+  questionnaire?: Record<string, unknown>;
 }): Promise<ShadowShopSnapshot> {
   const parsedRowsByDomain: Record<ShadowDomainKey, CsvRow[]> = {
     customers: [],
@@ -822,7 +823,15 @@ export async function buildShadowShopSnapshot(args: {
   const menuSuggestionCount = collectRecurringServicePatterns(stagedRowsByDomain.history);
   const inspectionSuggestionCount = Math.max(0, Math.round(stagedRowsByDomain.history.length * 0.28));
 
-  const preflightReport = buildShopBoostPreflightReport({
+  const historyAssessment = assessInstantAnalysisHistory(parsedRowsByDomain.history);
+  const domainCoverage = calculateInstantAnalysisDomainCoverage({
+    customers: parsedRowsByDomain.customers.length,
+    vehicles: parsedRowsByDomain.vehicles.length,
+    history: parsedRowsByDomain.history.length,
+    invoices: parsedRowsByDomain.invoices.length,
+    parts: parsedRowsByDomain.parts.length,
+  });
+  const rawPreflightReport = buildShopBoostPreflightReport({
     rows: preflightRows,
     hasHistoryData: stagedRowsByDomain.history.length > 0,
     hasVehicleData: stagedRowsByDomain.vehicles.length > 0,
@@ -830,6 +839,7 @@ export async function buildShadowShopSnapshot(args: {
     menuSuggestionCount,
     inspectionSuggestionCount,
   });
+  const preflightReport = reconcilePreflightReport(rawPreflightReport, historyAssessment);
 
   const setupIssues: ShadowSetupIssue[] = [
     ...preflightReport.blockers.map((blocker, index) => ({
@@ -849,13 +859,30 @@ export async function buildShadowShopSnapshot(args: {
   const operationalPayload = deriveOperationalPayload({
     rowsByDomain: stagedRowsByDomain,
     preflightReport,
+    historyAssessment,
+    domainCoverage,
+    questionnaire: args.questionnaire,
   });
 
   return {
     intakeId: args.intakeId,
     generatedAt: new Date().toISOString(),
+    questionnaire: args.questionnaire ?? {},
     uploadSummary,
     preflightReport,
+    importReadiness: {
+      detectedRecords: preflightReport.totals.detectedRecords,
+      readyRecords: preflightReport.totals.likelyAutoImportCount,
+      reviewRecords: preflightReport.totals.likelyReviewNeededCount,
+      blockedRecords: preflightReport.totals.likelyBlockerCount,
+      historyRows: historyAssessment.rowCount,
+      uniqueHistoryJobs: historyAssessment.uniqueJobCount,
+      readyHistoryJobs: historyAssessment.readyJobCount,
+      reviewHistoryJobs: historyAssessment.reviewJobCount,
+      blockedHistoryJobs: historyAssessment.blockedJobCount,
+      linkageAccuracy: historyAssessment.linkageAccuracy,
+      domainCoverage,
+    },
     dashboard: {
       estimatedImportedRecords: preflightReport.totals.likelyAutoImportCount,
       reviewQueueCount: preflightReport.totals.likelyReviewNeededCount,

--- a/tests/instant-shop-analysis-accuracy.test.ts
+++ b/tests/instant-shop-analysis-accuracy.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  assessInstantAnalysisHistory,
+  calculateInstantAnalysisDomainCoverage,
+} from "@/features/integrations/shopBoost/analysisAccuracy";
+
+describe("instant shop analysis accuracy", () => {
+  it("groups repair-history lines into repair orders before reporting job counts", () => {
+    const rows = Array.from({ length: 7_343 }, (_, index) => ({
+      ro_number: `RO-${index % 12}`,
+      customer_name: `Customer ${index % 12}`,
+      vin: `VIN-${index % 12}`,
+      description: "Historical line item",
+    }));
+
+    const assessment = assessInstantAnalysisHistory(rows);
+
+    expect(assessment.rowCount).toBe(7_343);
+    expect(assessment.uniqueJobCount).toBe(12);
+    expect(assessment.readyJobCount).toBe(12);
+    expect(assessment.reviewJobCount).toBe(0);
+    expect(assessment.blockedJobCount).toBe(0);
+    expect(assessment.linkageAccuracy).toBe(100);
+  });
+
+  it("counts linkage review once per repair order instead of once per line", () => {
+    const rows = Array.from({ length: 300 }, (_, index) => ({
+      repair_order: `RO-${index % 3}`,
+      customer_id: `C-${index % 3}`,
+      vehicle_vin: index % 3 === 1 ? "" : `VIN-${index % 3}`,
+    }));
+
+    const assessment = assessInstantAnalysisHistory(rows);
+
+    expect(assessment.uniqueJobCount).toBe(3);
+    expect(assessment.readyJobCount).toBe(2);
+    expect(assessment.reviewJobCount).toBe(1);
+    expect(assessment.unresolvedLinkCount).toBe(1);
+    expect(assessment.linkageAccuracy).toBe(83);
+  });
+
+  it("only reports live workflow signals when the export explicitly supplies statuses", () => {
+    const assessment = assessInstantAnalysisHistory([
+      { ro: "100", customer: "A", vehicle: "VIN-A" },
+      { ro: "101", customer: "B", vehicle: "VIN-B", status: "waiting for approval" },
+      { ro: "102", customer: "C", vehicle: "VIN-C", work_order_status: "on hold" },
+    ]);
+
+    expect(assessment.explicitAwaitingApprovalCount).toBe(1);
+    expect(assessment.explicitStalledCount).toBe(1);
+  });
+
+  it("scores coverage against the five datasets used by guided onboarding", () => {
+    expect(
+      calculateInstantAnalysisDomainCoverage({
+        customers: 1,
+        vehicles: 1,
+        history: 1,
+        invoices: 1,
+        parts: 1,
+      }),
+    ).toBe(100);
+
+    expect(
+      calculateInstantAnalysisDomainCoverage({
+        customers: 1,
+        vehicles: 1,
+        history: 1,
+        invoices: 0,
+        parts: 1,
+      }),
+    ).toBe(80);
+  });
+});


### PR DESCRIPTION
## What changed

- groups repair-history line items into unique repair orders before calculating ready, review, and blocked counts
- scores customer/vehicle linkage once per repair order instead of once per history line
- calculates domain coverage from the exact five guided-onboarding datasets: customers, vehicles, history, invoices, and parts
- removes invented approval, parts, stalled-job, and current-loss claims when the uploaded files do not explicitly support them
- labels financial impact as observed, modeled, or insufficient and shows a range with visible assumptions
- redesigns the analysis dashboard around a single import snapshot and five-dataset activation map
- carries the questionnaire into snapshot generation so reported repair-order volume can support a clearly labeled capacity model
- keeps backward-compatible fallbacks for previously saved analysis snapshots

## Root cause

The preview mixed row-level preflight confidence with a 12-row workflow sample. That made a 7,343-line history file appear to contain 7,343 jobs while only 12 were evaluated, and it generated operational and ROI claims from confidence thresholds instead of explicit source evidence. Invoice coverage was also omitted while staff data—outside this onboarding scope—was counted.

## User impact

Shops now get a credible “wow” moment: they can see exactly what ProFixIQ found, what can import automatically, what will be held for guided review, and how the same staged data carries into activation without uploading again.

## Validation

- regression coverage for 7,343 history rows grouped into 12 repair orders
- linkage-review aggregation coverage
- explicit-status-only workflow signal coverage
- five-domain coverage checks
- Vercel preview build: passed
