### PR TITLE
Fix mobile technician inspection, photo, story, and parts workflows

### DIFF
--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -25,7 +25,8 @@ type SignInspectionArgs = {
 type Role = SignInspectionArgs["p_role"];
 
 type SignRequestBody = {
-  inspectionId: string;
+  inspectionId?: string;
+  workOrderLineId?: string;
   role: Role;
   signedName: string;
   signatureImagePath?: string | null;
@@ -33,20 +34,28 @@ type SignRequestBody = {
 };
 
 const ALLOWED_ROLES: Role[] = ["technician", "customer", "advisor"];
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null && !Array.isArray(v);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cleanUuid(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return UUID_RE.test(normalized) ? normalized : null;
 }
 
 function isSignRequestBody(value: unknown): value is SignRequestBody {
   if (!isRecord(value)) return false;
 
-  const inspectionId = value.inspectionId;
+  const inspectionId = cleanUuid(value.inspectionId);
+  const workOrderLineId = cleanUuid(value.workOrderLineId);
   const role = value.role;
   const signedName = value.signedName;
 
-  if (typeof inspectionId !== "string" || inspectionId.trim().length < 8)
-    return false;
+  if (!inspectionId && !workOrderLineId) return false;
   if (typeof signedName !== "string") return false;
   if (typeof role !== "string") return false;
 
@@ -60,77 +69,180 @@ type RpcReturn = {
   error: { message: string } | null;
 };
 
+type ResolveInspectionResult =
+  | { ok: true; inspectionId: string }
+  | { ok: false; error: string; status: number };
+
 /**
- * Call RPC WITHOUT detaching `client.rpc` (it relies on `this.rest`)
+ * Call RPC WITHOUT detaching `client.rpc` (it relies on `this.rest`).
  */
 async function callSignInspectionRpc(
   client: Supabase,
   args: SignInspectionArgs,
 ): Promise<RpcReturn> {
-  const res = (client as unknown as {
+  return (client as unknown as {
     rpc: (fn: string, args: SignInspectionArgs) => Promise<RpcReturn>;
   }).rpc("sign_inspection", args);
-
-  return res;
 }
 
 /**
- * Ensure inspection row exists BEFORE signing.
+ * Resolve the canonical, shop-scoped inspection row.
  *
- * With shop-scoped RLS policies, we MUST include shop_id on insert/upsert
- * otherwise INSERT will be denied.
+ * Mobile inspection screens start with a local UUID before the first database
+ * save. A bare `{ id, shop_id }` insert violates `inspections_anchor_chk`, so a
+ * missing mobile row is created only after its work-order line and work-order
+ * anchors have been validated. Existing desktop callers that provide only an
+ * inspection ID must already have a persisted inspection.
  */
-async function ensureInspectionExists(args: {
+async function resolveInspectionForSigning(args: {
   supabase: Supabase;
-  inspectionId: string;
+  requestedInspectionId: string | null;
+  workOrderLineId: string | null;
   shopId: string;
-}): Promise<{ ok: true } | { ok: false; error: string }> {
-  const { supabase, inspectionId, shopId } = args;
+  actorUserId: string;
+}): Promise<ResolveInspectionResult> {
+  const {
+    supabase,
+    requestedInspectionId,
+    workOrderLineId,
+    shopId,
+    actorUserId,
+  } = args;
 
-  const res = await supabase
+  if (!workOrderLineId) {
+    if (!requestedInspectionId) {
+      return {
+        ok: false,
+        error: "A persisted inspection or work-order line is required.",
+        status: 400,
+      };
+    }
+
+    const existing = await supabase
+      .from("inspections")
+      .select("id")
+      .eq("id", requestedInspectionId)
+      .eq("shop_id", shopId)
+      .maybeSingle<{ id: string }>();
+
+    if (existing.error) {
+      return { ok: false, error: existing.error.message, status: 400 };
+    }
+    if (!existing.data?.id) {
+      return {
+        ok: false,
+        error: "Save the inspection before signing it.",
+        status: 409,
+      };
+    }
+
+    return { ok: true, inspectionId: existing.data.id };
+  }
+
+  const line = await supabase
+    .from("work_order_lines")
+    .select("id, work_order_id")
+    .eq("id", workOrderLineId)
+    .eq("shop_id", shopId)
+    .maybeSingle<{ id: string; work_order_id: string | null }>();
+
+  if (line.error) {
+    return { ok: false, error: line.error.message, status: 400 };
+  }
+  if (!line.data?.id || !line.data.work_order_id) {
+    return {
+      ok: false,
+      error: "Work-order line was not found for this shop.",
+      status: 404,
+    };
+  }
+
+  const findCanonical = async () =>
+    supabase
+      .from("inspections")
+      .select("id")
+      .eq("shop_id", shopId)
+      .eq("work_order_line_id", line.data.id)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .limit(1)
+      .maybeSingle<{ id: string }>();
+
+  const existing = await findCanonical();
+  if (existing.error) {
+    return { ok: false, error: existing.error.message, status: 400 };
+  }
+  if (existing.data?.id) {
+    return { ok: true, inspectionId: existing.data.id };
+  }
+
+  const insertPayload = {
+    ...(requestedInspectionId ? { id: requestedInspectionId } : {}),
+    work_order_id: line.data.work_order_id,
+    work_order_line_id: line.data.id,
+    shop_id: shopId,
+    user_id: actorUserId,
+    summary: {},
+    is_draft: true,
+    completed: false,
+    locked: false,
+    status: "draft",
+  };
+
+  const inserted = await supabase
     .from("inspections")
-    .upsert(
-      { id: inspectionId, shop_id: shopId },
-      {
-        onConflict: "id",
-        ignoreDuplicates: true,
-      },
-    )
+    .insert(insertPayload)
     .select("id")
-    .maybeSingle();
+    .maybeSingle<{ id: string }>();
 
-  if (res.error) return { ok: false, error: res.error.message };
+  if (!inserted.error && inserted.data?.id) {
+    return { ok: true, inspectionId: inserted.data.id };
+  }
 
-  // Even if RLS blocks the SELECT return, "no error" means the upsert executed.
-  return { ok: true };
+  // A concurrent first save/sign may have inserted the canonical row. Re-read
+  // before surfacing the insert error so retries remain harmless.
+  const raced = await findCanonical();
+  if (!raced.error && raced.data?.id) {
+    return { ok: true, inspectionId: raced.data.id };
+  }
+
+  return {
+    ok: false,
+    error:
+      inserted.error?.message ||
+      raced.error?.message ||
+      "Unable to create an anchored inspection.",
+    status: 400,
+  };
 }
 
 export async function POST(req: NextRequest) {
   const supabase = createServerSupabaseRoute();
 
-  // Require authed user
   const userRes = await supabase.auth.getUser();
   const user = userRes.data.user;
   if (userRes.error || !user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let bodyUnknown: unknown;
-  try {
-    bodyUnknown = await req.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
+  const bodyUnknown = (await req.json().catch(() => null)) as unknown;
   if (!isSignRequestBody(bodyUnknown)) {
     return NextResponse.json(
-      { error: "inspectionId, role and signedName are required" },
+      {
+        error:
+          "A valid inspectionId or workOrderLineId, role, and signedName are required.",
+      },
       { status: 400 },
     );
   }
 
-  const { inspectionId, role, signedName, signatureImagePath, signatureHash } =
-    bodyUnknown;
+  const {
+    role,
+    signedName,
+    signatureImagePath,
+    signatureHash,
+  } = bodyUnknown;
+  const requestedInspectionId = cleanUuid(bodyUnknown.inspectionId);
+  const workOrderLineId = cleanUuid(bodyUnknown.workOrderLineId);
 
   let effectiveSignedName = signedName.trim();
   if (!effectiveSignedName && role === "technician") {
@@ -138,61 +250,66 @@ export async function POST(req: NextRequest) {
       .from("profiles")
       .select("full_name, first_name, last_name")
       .eq("id", user.id)
-      .maybeSingle<{ full_name?: string | null; first_name?: string | null; last_name?: string | null }>();
+      .maybeSingle<{
+        full_name?: string | null;
+        first_name?: string | null;
+        last_name?: string | null;
+      }>();
 
     if (!profileNameRes.error) {
       const full = (profileNameRes.data?.full_name ?? "").trim();
-      const joined = `${profileNameRes.data?.first_name ?? ""} ${profileNameRes.data?.last_name ?? ""}`.trim();
+      const joined = `${profileNameRes.data?.first_name ?? ""} ${
+        profileNameRes.data?.last_name ?? ""
+      }`.trim();
       effectiveSignedName = full || joined;
     }
   }
 
   if (!effectiveSignedName) {
-    return NextResponse.json({ error: "Signed name is required." }, { status: 400 });
+    return NextResponse.json(
+      { error: "Signed name is required." },
+      { status: 400 },
+    );
   }
 
-  // Fetch user's shop_id (required for RLS-scoped insert/upsert)
-  const prof = await supabase
+  const profile = await supabase
     .from("profiles")
     .select("shop_id")
     .eq("id", user.id)
-    .maybeSingle();
+    .maybeSingle<{ shop_id: string | null }>();
 
-  if (prof.error) {
+  if (profile.error) {
     return NextResponse.json(
-      { error: `Unable to read profile: ${prof.error.message}` },
+      { error: `Unable to read profile: ${profile.error.message}` },
       { status: 400 },
     );
   }
 
-  const shopId = prof.data?.shop_id ? String(prof.data.shop_id) : null;
+  const shopId = profile.data?.shop_id ?? null;
   if (!shopId) {
     return NextResponse.json(
       { error: "Your profile is missing shop_id; cannot sign inspection." },
-      { status: 400 },
+      { status: 403 },
     );
   }
 
-  // ✅ auto-create inspection row (or no-op if exists)
-  const ensured = await ensureInspectionExists({
+  const resolved = await resolveInspectionForSigning({
     supabase,
-    inspectionId,
+    requestedInspectionId,
+    workOrderLineId,
     shopId,
+    actorUserId: user.id,
   });
 
-  if (!ensured.ok) {
+  if (!resolved.ok) {
     return NextResponse.json(
-      {
-        error:
-          `Unable to auto-create inspection before signing: ${ensured.error}. ` +
-          `Check RLS policies on public.inspections and that profiles.shop_id is set.`,
-      },
-      { status: 400 },
+      { error: resolved.error },
+      { status: resolved.status },
     );
   }
 
   const rpcArgs: SignInspectionArgs = {
-    p_inspection_id: inspectionId,
+    p_inspection_id: resolved.inspectionId,
     p_role: role,
     p_signed_name: effectiveSignedName,
     p_signature_image_path: signatureImagePath ?? null,
@@ -200,10 +317,14 @@ export async function POST(req: NextRequest) {
   };
 
   const { data, error } = await callSignInspectionRpc(supabase, rpcArgs);
-
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 400 });
   }
 
-  return NextResponse.json({ success: true, data, signedName: effectiveSignedName });
+  return NextResponse.json({
+    success: true,
+    data,
+    inspectionId: resolved.inspectionId,
+    signedName: effectiveSignedName,
+  });
 }

--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -3,17 +3,8 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { Database } from "@shared/types/types/supabase";
 
-/**
- * SQL function:
- * public.sign_inspection(
- *   p_inspection_id uuid,
- *   p_role text,
- *   p_signed_name text,
- *   p_signature_image_path text default null,
- *   p_signature_hash text default null
- * )
- */
 type SignInspectionArgs = {
   p_inspection_id: string;
   p_role: "technician" | "customer" | "advisor";
@@ -23,6 +14,7 @@ type SignInspectionArgs = {
 };
 
 type Role = SignInspectionArgs["p_role"];
+type InspectionInsert = Database["public"]["Tables"]["inspections"]["Insert"];
 
 type SignRequestBody = {
   inspectionId?: string;
@@ -49,33 +41,20 @@ function cleanUuid(value: unknown): string | null {
 
 function isSignRequestBody(value: unknown): value is SignRequestBody {
   if (!isRecord(value)) return false;
-
-  const inspectionId = cleanUuid(value.inspectionId);
-  const workOrderLineId = cleanUuid(value.workOrderLineId);
-  const role = value.role;
-  const signedName = value.signedName;
-
-  if (!inspectionId && !workOrderLineId) return false;
-  if (typeof signedName !== "string") return false;
-  if (typeof role !== "string") return false;
-
-  return ALLOWED_ROLES.includes(role as Role);
+  if (!cleanUuid(value.inspectionId) && !cleanUuid(value.workOrderLineId)) {
+    return false;
+  }
+  if (typeof value.signedName !== "string") return false;
+  if (typeof value.role !== "string") return false;
+  return ALLOWED_ROLES.includes(value.role as Role);
 }
 
 type Supabase = ReturnType<typeof createServerSupabaseRoute>;
-
-type RpcReturn = {
-  data: unknown;
-  error: { message: string } | null;
-};
-
+type RpcReturn = { data: unknown; error: { message: string } | null };
 type ResolveInspectionResult =
   | { ok: true; inspectionId: string }
   | { ok: false; error: string; status: number };
 
-/**
- * Call RPC WITHOUT detaching `client.rpc` (it relies on `this.rest`).
- */
 async function callSignInspectionRpc(
   client: Supabase,
   args: SignInspectionArgs,
@@ -88,11 +67,11 @@ async function callSignInspectionRpc(
 /**
  * Resolve the canonical, shop-scoped inspection row.
  *
- * Mobile inspection screens start with a local UUID before the first database
- * save. A bare `{ id, shop_id }` insert violates `inspections_anchor_chk`, so a
- * missing mobile row is created only after its work-order line and work-order
- * anchors have been validated. Existing desktop callers that provide only an
- * inspection ID must already have a persisted inspection.
+ * Mobile inspections begin with a local UUID. Creating a bare row with only
+ * that ID and shop violates `inspections_anchor_chk`, so a missing mobile row
+ * is created only after its work-order line and work-order anchors have been
+ * validated. Existing desktop callers that provide only an inspection ID must
+ * already have a persisted row.
  */
 async function resolveInspectionForSigning(args: {
   supabase: Supabase;
@@ -135,21 +114,22 @@ async function resolveInspectionForSigning(args: {
         status: 409,
       };
     }
-
     return { ok: true, inspectionId: existing.data.id };
   }
 
-  const line = await supabase
+  const lineResult = await supabase
     .from("work_order_lines")
     .select("id, work_order_id")
     .eq("id", workOrderLineId)
     .eq("shop_id", shopId)
     .maybeSingle<{ id: string; work_order_id: string | null }>();
 
-  if (line.error) {
-    return { ok: false, error: line.error.message, status: 400 };
+  if (lineResult.error) {
+    return { ok: false, error: lineResult.error.message, status: 400 };
   }
-  if (!line.data?.id || !line.data.work_order_id) {
+
+  const line = lineResult.data;
+  if (!line?.id || !line.work_order_id) {
     return {
       ok: false,
       error: "Work-order line was not found for this shop.",
@@ -157,12 +137,14 @@ async function resolveInspectionForSigning(args: {
     };
   }
 
+  const canonicalLineId = line.id;
+  const canonicalWorkOrderId = line.work_order_id;
   const findCanonical = async () =>
     supabase
       .from("inspections")
       .select("id")
       .eq("shop_id", shopId)
-      .eq("work_order_line_id", line.data.id)
+      .eq("work_order_line_id", canonicalLineId)
       .order("updated_at", { ascending: false, nullsFirst: false })
       .limit(1)
       .maybeSingle<{ id: string }>();
@@ -175,10 +157,10 @@ async function resolveInspectionForSigning(args: {
     return { ok: true, inspectionId: existing.data.id };
   }
 
-  const insertPayload = {
+  const insertPayload: InspectionInsert = {
     ...(requestedInspectionId ? { id: requestedInspectionId } : {}),
-    work_order_id: line.data.work_order_id,
-    work_order_line_id: line.data.id,
+    work_order_id: canonicalWorkOrderId,
+    work_order_line_id: canonicalLineId,
     shop_id: shopId,
     user_id: actorUserId,
     summary: {},
@@ -217,10 +199,9 @@ async function resolveInspectionForSigning(args: {
 
 export async function POST(req: NextRequest) {
   const supabase = createServerSupabaseRoute();
-
-  const userRes = await supabase.auth.getUser();
-  const user = userRes.data.user;
-  if (userRes.error || !user) {
+  const userResult = await supabase.auth.getUser();
+  const user = userResult.data.user;
+  if (userResult.error || !user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -246,7 +227,7 @@ export async function POST(req: NextRequest) {
 
   let effectiveSignedName = signedName.trim();
   if (!effectiveSignedName && role === "technician") {
-    const profileNameRes = await supabase
+    const profileNameResult = await supabase
       .from("profiles")
       .select("full_name, first_name, last_name")
       .eq("id", user.id)
@@ -256,10 +237,10 @@ export async function POST(req: NextRequest) {
         last_name?: string | null;
       }>();
 
-    if (!profileNameRes.error) {
-      const full = (profileNameRes.data?.full_name ?? "").trim();
-      const joined = `${profileNameRes.data?.first_name ?? ""} ${
-        profileNameRes.data?.last_name ?? ""
+    if (!profileNameResult.error) {
+      const full = (profileNameResult.data?.full_name ?? "").trim();
+      const joined = `${profileNameResult.data?.first_name ?? ""} ${
+        profileNameResult.data?.last_name ?? ""
       }`.trim();
       effectiveSignedName = full || joined;
     }
@@ -272,20 +253,20 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const profile = await supabase
+  const profileResult = await supabase
     .from("profiles")
     .select("shop_id")
     .eq("id", user.id)
     .maybeSingle<{ shop_id: string | null }>();
 
-  if (profile.error) {
+  if (profileResult.error) {
     return NextResponse.json(
-      { error: `Unable to read profile: ${profile.error.message}` },
+      { error: `Unable to read profile: ${profileResult.error.message}` },
       { status: 400 },
     );
   }
 
-  const shopId = profile.data?.shop_id ?? null;
+  const shopId = profileResult.data?.shop_id ?? null;
   if (!shopId) {
     return NextResponse.json(
       { error: "Your profile is missing shop_id; cannot sign inspection." },
@@ -300,7 +281,6 @@ export async function POST(req: NextRequest) {
     shopId,
     actorUserId: user.id,
   });
-
   if (!resolved.ok) {
     return NextResponse.json(
       { error: resolved.error },
@@ -308,15 +288,13 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const rpcArgs: SignInspectionArgs = {
+  const { data, error } = await callSignInspectionRpc(supabase, {
     p_inspection_id: resolved.inspectionId,
     p_role: role,
     p_signed_name: effectiveSignedName,
     p_signature_image_path: signatureImagePath ?? null,
     p_signature_hash: signatureHash ?? null,
-  };
-
-  const { data, error } = await callSignInspectionRpc(supabase, rpcArgs);
+  });
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 400 });
   }

--- a/app/mobile/jobs/[lineId]/page.tsx
+++ b/app/mobile/jobs/[lineId]/page.tsx
@@ -196,7 +196,7 @@ export default function MobileJobPage() {
           initialCause={line.cause ?? ""}
           initialCorrection={line.correction ?? ""}
           onSaveDraft={saveStory}
-          onDraftChange={({ cause, correction }) => {
+          onDraftChange={(cause, correction) => {
             setLine((current) =>
               current ? { ...current, cause, correction } : current,
             );

--- a/app/mobile/jobs/[lineId]/page.tsx
+++ b/app/mobile/jobs/[lineId]/page.tsx
@@ -1,21 +1,209 @@
 "use client";
 
-import { useRouter, useParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import CauseCorrectionModal from "@work-orders/components/workorders/CauseCorrectionModal";
 import MobileFocusedJob from "@/features/work-orders/mobile/MobileFocusedJob";
+import { runMutationWithOfflineQueue } from "@/features/shared/lib/offline/mutations";
+import { postOfflineServerMutation } from "@/features/shared/lib/offline/server-mutations";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
+
+type StoryLine = {
+  id: string;
+  work_order_id: string | null;
+  complaint: string | null;
+  description: string | null;
+  cause: string | null;
+  correction: string | null;
+  status: string | null;
+  updated_at: string | null;
+};
+
+function operationKey(lineId: string): string {
+  const random =
+    typeof globalThis.crypto?.randomUUID === "function"
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `${lineId}:story:${random}`;
+}
 
 export default function MobileJobPage() {
   const router = useRouter();
   const params = useParams<{ lineId: string }>();
   const lineId = params.lineId;
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+
+  const [storyOpen, setStoryOpen] = useState(false);
+  const [line, setLine] = useState<StoryLine | null>(null);
+  const [loadingStory, setLoadingStory] = useState(true);
+
+  const loadStory = useCallback(async () => {
+    setLoadingStory(true);
+    try {
+      const { data, error } = await supabase
+        .from("work_order_lines")
+        .select(
+          "id, work_order_id, complaint, description, cause, correction, status, updated_at",
+        )
+        .eq("id", lineId)
+        .maybeSingle<StoryLine>();
+
+      if (error) throw error;
+      setLine(data ?? null);
+    } catch (error) {
+      // The focused job owns the primary load/error state; this supplemental
+      // editor should not replace it with a second blocking screen.
+      // eslint-disable-next-line no-console
+      console.error("[mobile job story] load failed", error);
+    } finally {
+      setLoadingStory(false);
+    }
+  }, [lineId, supabase]);
+
+  useEffect(() => {
+    void loadStory();
+  }, [loadStory]);
+
+  const checkStoryConflict = useCallback(
+    async (mode: "story" | "finish"): Promise<string | null> => {
+      if (!navigator.onLine) return null;
+
+      const { data, error } = await supabase
+        .from("work_order_lines")
+        .select("id, status")
+        .eq("id", lineId)
+        .maybeSingle<{ id: string; status: string | null }>();
+      if (error) throw error;
+      if (!data?.id) return "Job line no longer exists.";
+      if (data.status === "completed") {
+        return mode === "finish"
+          ? "Job line is already completed."
+          : "Completed job stories require advisor review.";
+      }
+      if (mode === "finish" && data.status === "declined") {
+        return "Declined job lines cannot be completed.";
+      }
+      return null;
+    },
+    [lineId, supabase],
+  );
+
+  const saveStory = useCallback(
+    async (cause: string, correction: string) => {
+      if (!line) throw new Error("Job story is still loading.");
+
+      const clientMutationId = operationKey(line.id);
+      const payload = {
+        lineId: line.id,
+        cause,
+        correction,
+        baseUpdatedAt: line.updated_at,
+      };
+      const result = await runMutationWithOfflineQueue({
+        clientMutationId,
+        actionType: "save_story_draft",
+        payload,
+        orderKey: `${line.id}:002:story`,
+        conflictCheck: () => checkStoryConflict("story"),
+        runner: async () => {
+          await postOfflineServerMutation({
+            actionType: "save_story_draft",
+            operationKey: clientMutationId,
+            payload,
+          });
+        },
+      });
+
+      if (result.conflicted) {
+        throw new Error("Story conflict detected. Reload the latest job state.");
+      }
+
+      setLine((current) =>
+        current ? { ...current, cause, correction } : current,
+      );
+
+      if (result.queued) {
+        toast.warning("Cause and correction queued for sync when back online.");
+      } else {
+        toast.success("Cause and correction saved.");
+        await loadStory();
+      }
+    },
+    [checkStoryConflict, line, loadStory],
+  );
+
+  const completeJob = useCallback(
+    async (cause: string, correction: string) => {
+      const conflict = await checkStoryConflict("finish");
+      if (conflict) throw new Error(conflict);
+
+      await runJobPunchTransition(lineId, "finish", { cause, correction });
+      setStoryOpen(false);
+      toast.success("Job completed.");
+      await loadStory();
+      router.refresh();
+      window.dispatchEvent(
+        new CustomEvent("work-order-line:completed", {
+          detail: { workOrderLineId: lineId },
+        }),
+      );
+    },
+    [checkStoryConflict, lineId, loadStory, router],
+  );
+
+  const openStory = () => {
+    if (!line) {
+      toast.error(
+        loadingStory ? "Job story is still loading." : "Job line was not found.",
+      );
+      return;
+    }
+    setStoryOpen(true);
+  };
+
+  const lineLabel =
+    line?.complaint?.trim() || line?.description?.trim() || "Job story";
 
   return (
-    <MobileFocusedJob
-      workOrderLineId={lineId}
-      onBack={() => {
-        // Prefer going back, but if there's no history, go to WO list
-        if (window.history.length > 1) router.back();
-        else router.push("/mobile/work-orders");
-      }}
-    />
+    <>
+      <MobileFocusedJob
+        workOrderLineId={lineId}
+        onChanged={loadStory}
+        onBack={() => {
+          if (window.history.length > 1) router.back();
+          else router.push("/mobile/work-orders");
+        }}
+      />
+
+      <button
+        type="button"
+        onClick={openStory}
+        aria-label="Open cause and correction editor"
+        className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] right-4 z-[120] inline-flex min-h-11 items-center justify-center rounded-full border border-[color:var(--accent-copper)] bg-[color:var(--theme-surface-panel-strong)] px-4 text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)] backdrop-blur-xl"
+      >
+        Cause / Correction
+      </button>
+
+      {storyOpen && line ? (
+        <CauseCorrectionModal
+          isOpen={storyOpen}
+          onClose={() => setStoryOpen(false)}
+          jobId={line.id}
+          lineLabel={lineLabel}
+          initialCause={line.cause ?? ""}
+          initialCorrection={line.correction ?? ""}
+          onSaveDraft={saveStory}
+          onDraftChange={({ cause, correction }) => {
+            setLine((current) =>
+              current ? { ...current, cause, correction } : current,
+            );
+          }}
+          onSubmit={completeJob}
+        />
+      ) : null}
+    </>
   );
 }

--- a/app/mobile/parts/page.tsx
+++ b/app/mobile/parts/page.tsx
@@ -1,51 +1,24 @@
-import Link from "next/link";
-
-import { getOperationsDashboardPayload } from "@/features/dashboard/server/getOperationsDashboardPayload";
+import MobilePartsWorkflow from "@/features/parts/mobile/MobilePartsWorkflow";
 
 export const dynamic = "force-dynamic";
 
-export default async function MobilePartsPage() {
-  const payload = await getOperationsDashboardPayload();
-
-  const lanes = [
-    { title: "Requests", detail: "Review new and unquoted requests.", href: "/mobile/work-orders?parts=requested" },
-    { title: "Awaiting approval", detail: "See work waiting on customer authorization.", href: "/mobile/work-orders?parts=approval" },
-    { title: "On order", detail: "Track jobs blocked by ordered parts.", href: "/mobile/work-orders?parts=ordered" },
-    { title: "Ready for technician", detail: "Return received parts to active work.", href: "/mobile/work-orders?parts=ready" },
-  ];
-
+export default function MobilePartsPage() {
   return (
     <div className="mx-auto w-full max-w-3xl space-y-4 overflow-x-hidden px-3 py-3 sm:px-4">
       <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
-        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">Parts</div>
-        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">Parts workflow</h1>
-        <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Keep requests, orders, receiving, and technician release inside the mobile shell.</p>
-      </section>
-
-      <section className="grid grid-cols-2 gap-2">
-        <div className="rounded-2xl border border-amber-500/40 bg-amber-500/10 p-3">
-          <div className="text-xs text-[color:var(--theme-text-secondary)]">Waiting parts</div>
-          <div className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{payload.topSummary.waitingParts}</div>
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">
+          Parts
         </div>
-        <Link href="/mobile/work-orders" className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3">
-          <div className="text-xs text-[color:var(--theme-text-secondary)]">Repair context</div>
-          <div className="mt-1 text-sm font-semibold text-[color:var(--accent-copper)]">Open work orders →</div>
-        </Link>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          Parts workflow
+        </h1>
+        <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+          Review requests, receive approved parts, and allocate ready inventory
+          without leaving the mobile workspace.
+        </p>
       </section>
 
-      <section className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        {lanes.map((lane) => (
-          <Link key={lane.title} href={lane.href} className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4">
-            <div className="font-semibold text-[color:var(--theme-text-primary)]">{lane.title}</div>
-            <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{lane.detail}</div>
-          </Link>
-        ))}
-      </section>
-
-      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4">
-        <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">Mobile parts rollout</h2>
-        <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">This workspace now keeps navigation mobile-native. Detailed quote, order, and receiving actions will be migrated here incrementally instead of opening desktop boards.</p>
-      </section>
+      <MobilePartsWorkflow />
     </div>
   );
 }

--- a/features/inspections/components/inspection/InspectionSignaturePanel.tsx
+++ b/features/inspections/components/inspection/InspectionSignaturePanel.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
@@ -9,6 +10,7 @@ export type SignatureRole = "technician" | "customer" | "advisor";
 
 export type InspectionSignaturePanelProps = {
   inspectionId: string | null | undefined;
+  workOrderLineId?: string | null;
   role: SignatureRole;
   defaultName?: string;
   onSigned?: () => void;
@@ -33,8 +35,10 @@ function roleLabel(role: SignatureRole): string {
 }
 
 function roleSubtext(role: SignatureRole): string {
-  if (role === "technician") return "Uses your saved signature (no re-signing every time).";
-  if (role === "advisor") return "Sign to approve/confirm this inspection snapshot.";
+  if (role === "technician")
+    return "Uses your saved signature (no re-signing every time).";
+  if (role === "advisor")
+    return "Sign to approve/confirm this inspection snapshot.";
   return "Sign to acknowledge and lock this inspection snapshot.";
 }
 
@@ -59,26 +63,42 @@ type ProfileResponse = {
   ok?: boolean;
   error?: string;
   fullName?: string | null;
+  full_name?: string | null;
   firstName?: string | null;
+  first_name?: string | null;
   lastName?: string | null;
+  last_name?: string | null;
   name?: string | null;
 };
 
 function pickNameFromProfile(json: ProfileResponse | null): string | null {
   if (!json) return null;
+  const firstName = json.firstName ?? json.first_name;
+  const lastName = json.lastName ?? json.last_name;
   const candidates = [
     json.fullName,
+    json.full_name,
     json.name,
-    [json.firstName, json.lastName].filter(Boolean).join(" "),
+    [firstName, lastName].filter(Boolean).join(" "),
   ]
-    .map((v) => (typeof v === "string" ? v.trim() : ""))
-    .filter((v) => v.length > 0);
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .filter((value) => value.length > 0);
 
   return candidates[0] ?? null;
 }
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function validUuid(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return UUID_RE.test(normalized) ? normalized : null;
+}
+
 const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
   inspectionId,
+  workOrderLineId,
   role,
   defaultName,
   onSigned,
@@ -86,38 +106,67 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
   lockNameInput,
 }) => {
   const supabase = useMemo(() => createBrowserSupabase(), []);
+  const searchParams = useSearchParams();
   const defaultLock = role === "technician";
   const [autoFilledName, setAutoFilledName] = useState<string | null>(null);
   const nameInputRef = useRef<HTMLInputElement | null>(null);
-  const shouldLockFromProps = typeof lockNameInput === "boolean" ? lockNameInput : defaultLock;
-  const nameLocked = shouldLockFromProps && role === "technician" && !!autoFilledName;
+  const shouldLockFromProps =
+    typeof lockNameInput === "boolean" ? lockNameInput : defaultLock;
+  const nameLocked =
+    shouldLockFromProps && role === "technician" && !!autoFilledName;
 
   const [name, setName] = useState(defaultName ?? "");
   const [confirm, setConfirm] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [loadingName, setLoadingName] = useState(
+    role === "technician" && !(defaultName ?? "").trim(),
+  );
 
-  // Keep name in sync if parent provides a default later
+  const resolvedWorkOrderLineId = useMemo(() => {
+    const fromProps = validUuid(workOrderLineId);
+    if (fromProps) return fromProps;
+
+    const fromUrl = validUuid(searchParams.get("workOrderLineId"));
+    if (fromUrl) return fromUrl;
+
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = window.sessionStorage.getItem("inspection:params");
+      if (!raw) return null;
+      const staged = JSON.parse(raw) as Record<string, unknown>;
+      return validUuid(staged.workOrderLineId);
+    } catch {
+      return null;
+    }
+  }, [searchParams, workOrderLineId]);
+
+  // Keep name in sync if parent provides a default later.
   useEffect(() => {
-    const n = (defaultName ?? "").trim();
-    if (!n) return;
-    // Only apply default if user hasn't typed something else
-    setName((prev) => (prev.trim().length ? prev : n));
-  }, [defaultName]);
+    const normalized = (defaultName ?? "").trim();
+    if (!normalized) return;
+    setName((previous) => (previous.trim().length ? previous : normalized));
+    if (role === "technician") {
+      setAutoFilledName((previous) => previous ?? normalized);
+      setLoadingName(false);
+    }
+  }, [defaultName, role]);
 
   async function fetchSavedTechSignature(): Promise<{
     signatureImagePath: string;
     signatureHash: string | null;
   } | null> {
     try {
-      const res = await fetch("/api/profile/signature", {
+      const response = await fetch("/api/profile/signature", {
         method: "GET",
         credentials: "include",
         headers: { "Cache-Control": "no-store" },
       });
 
-      const json = (await res.json().catch(() => null)) as SavedSigResponse | null;
+      const json = (await response
+        .json()
+        .catch(() => null)) as SavedSigResponse | null;
 
-      if (!res.ok || json?.error) {
+      if (!response.ok || json?.error) {
         throw new Error(json?.error || "Failed to load saved signature");
       }
 
@@ -128,19 +177,27 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
         signatureImagePath: path,
         signatureHash: json?.signatureHash ?? null,
       };
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : "Failed to load saved signature";
-      toast.error(msg);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to load saved signature";
+      toast.error(message);
       return null;
     }
   }
 
-  // Tech convenience: auto-fill name from profile if missing
+  // Tech convenience: auto-fill name from profile if missing.
   useEffect(() => {
-    if (role !== "technician") return;
-    if (name.trim().length > 0) return;
+    if (role !== "technician") {
+      setLoadingName(false);
+      return;
+    }
+    if (name.trim().length > 0) {
+      setLoadingName(false);
+      return;
+    }
 
     let cancelled = false;
+    setLoadingName(true);
 
     void (async () => {
       try {
@@ -156,15 +213,17 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           .maybeSingle<ProfileResponse>();
         if (error) return;
 
-        const n = pickNameFromProfile(data ?? null);
-        if (!n) return;
+        const profileName = pickNameFromProfile(data ?? null);
+        if (!profileName) return;
 
         if (!cancelled) {
-          setName(n);
-          setAutoFilledName(n);
+          setName(profileName);
+          setAutoFilledName(profileName);
         }
       } catch {
-        // ignore: name autofill is a convenience, not required
+        // Name autofill is a convenience; the technician can type a fallback.
+      } finally {
+        if (!cancelled) setLoadingName(false);
       }
     })();
 
@@ -176,8 +235,9 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
   const header = useMemo(() => `${roleLabel(role)} Signature`, [role]);
 
   const handleSign = async (): Promise<void> => {
-    if (!inspectionId) {
-      toast.error("Inspection ID missing – cannot sign yet.");
+    const normalizedInspectionId = validUuid(inspectionId);
+    if (!normalizedInspectionId && !resolvedWorkOrderLineId) {
+      toast.error("Inspection context is missing – save or reopen the inspection.");
       return;
     }
     if (!name.trim()) {
@@ -196,12 +256,13 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
       let signatureImagePath: string | null = null;
       let signatureHash: string | null = null;
 
-      // ✅ Technician: pull saved signature automatically
       if (role === "technician") {
         const saved = await fetchSavedTechSignature();
         if (!saved?.signatureImagePath) {
           if (techSettingsHref) {
-            toast.error("No saved tech signature. Please add one in Tech Settings.");
+            toast.error(
+              "No saved tech signature. Please add one in Tech Settings.",
+            );
           } else {
             toast.error("No saved tech signature. Add one in Tech Settings.");
           }
@@ -211,12 +272,13 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
         signatureHash = saved.signatureHash;
       }
 
-      const res = await fetch("/api/inspections/sign", {
+      const response = await fetch("/api/inspections/sign", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
         body: JSON.stringify({
-          inspectionId,
+          inspectionId: normalizedInspectionId,
+          workOrderLineId: resolvedWorkOrderLineId,
           role,
           signedName: name.trim(),
           signatureImagePath,
@@ -224,21 +286,28 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
         }),
       });
 
-      const json = (await res.json().catch(() => null)) as { error?: string } | null;
-      if (!res.ok || json?.error) {
+      const json = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!response.ok || json?.error) {
         throw new Error(json?.error || "Signature failed");
       }
 
       toast.success(`${roleLabel(role)} signature captured.`);
       onSigned?.();
-    } catch (e) {
+    } catch (error) {
       // eslint-disable-next-line no-console
-      console.error("sign error", e);
-      toast.error(e instanceof Error ? e.message : "Unable to save signature.");
+      console.error("sign error", error);
+      toast.error(
+        error instanceof Error ? error.message : "Unable to save signature.",
+      );
     } finally {
       setBusy(false);
     }
   };
+
+  const canResolveInspection =
+    Boolean(validUuid(inspectionId)) || Boolean(resolvedWorkOrderLineId);
 
   return (
     <div className="flex flex-col gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-4 text-xs text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-soft)]">
@@ -247,7 +316,9 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
             {header}
           </div>
-          <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-secondary)]">{roleSubtext(role)}</div>
+          <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-secondary)]">
+            {roleSubtext(role)}
+          </div>
         </div>
       </div>
 
@@ -262,7 +333,7 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           ref={nameInputRef}
           type="text"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(event) => setName(event.target.value)}
           disabled={nameLocked}
           className={[
             "mt-1 h-10 w-full rounded-lg border px-3 py-2 text-sm outline-none transition",
@@ -270,11 +341,16 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
               ? "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-secondary)]"
               : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)] focus:border-[color:var(--brand-primary)] focus:ring-2 focus:ring-[color:color-mix(in_srgb,var(--brand-primary)_24%,transparent)]",
           ].join(" ")}
-          placeholder={role === "technician" ? "Loading your name…" : "Type your full legal name"}
+          placeholder={
+            role === "technician" && loadingName
+              ? "Loading your name…"
+              : "Type your full legal name"
+          }
         />
         {role === "technician" && nameLocked ? (
           <div className="mt-1.5 text-[10px] text-[color:var(--theme-text-secondary)]">
-            Tech name is pulled from your profile (edit in your account settings if needed).
+            Tech name is pulled from your profile (edit in your account settings
+            if needed).
           </div>
         ) : null}
       </label>
@@ -283,16 +359,16 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
         <input
           type="checkbox"
           checked={confirm}
-          onChange={(e) => setConfirm(e.target.checked)}
+          onChange={(event) => setConfirm(event.target.checked)}
           className="mt-[1px] h-3.5 w-3.5 rounded border border-[color:var(--theme-border-strong)] bg-[color:var(--theme-surface-page)] text-[color:var(--brand-primary)]"
         />
         <span>{confirmText(role)}</span>
       </label>
 
-      {!inspectionId && (
+      {!canResolveInspection && (
         <p className="rounded-xl border border-amber-500/30 bg-amber-50 px-3 py-2 text-[11px] text-amber-800 dark:bg-amber-950/35 dark:text-amber-200">
-          This inspection has not been saved to the database yet. Once it has a persistent{" "}
-          <code>inspection_id</code>, this panel will allow signing.
+          This inspection has not been anchored to a work-order line yet. Save
+          or reopen it before signing.
         </p>
       )}
 
@@ -302,7 +378,11 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           {techSettingsHref ? (
             <>
               {" "}
-              Add one in <span className="font-medium text-[color:var(--theme-text-primary)]">Tech Settings</span>.
+              Add one in{" "}
+              <span className="font-medium text-[color:var(--theme-text-primary)]">
+                Tech Settings
+              </span>
+              .
             </>
           ) : null}
         </p>
@@ -312,7 +392,7 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
         <button
           type="button"
           onClick={handleSign}
-          disabled={busy || !inspectionId}
+          disabled={busy || loadingName || !canResolveInspection}
           className="inline-flex items-center rounded-lg border border-[color:var(--brand-primary)] bg-[color:var(--brand-primary)] px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {busy ? "Signing…" : "Sign"}

--- a/features/parts/mobile/MobilePartsWorkflow.tsx
+++ b/features/parts/mobile/MobilePartsWorkflow.tsx
@@ -8,13 +8,11 @@ import ReceiveDrawer, {
   type ReceiveDrawerItem,
 } from "@/features/parts/components/ReceiveDrawer";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import { Button } from "@shared/components/ui/Button";
 
 type Lane = "requests" | "approval" | "ordered" | "ready";
 
 type RequestLite = {
   id: string;
-  shop_id: string | null;
   work_order_id: string | null;
   job_id: string | null;
   status: string | null;
@@ -51,8 +49,6 @@ type LocationLite = {
 type WorkflowEntry = {
   key: string;
   requestId: string;
-  requestStatus: string;
-  requestNotes: string | null;
   workOrderId: string | null;
   workOrderLineId: string | null;
   workOrderLabel: string;
@@ -65,7 +61,6 @@ type WorkflowEntry = {
   qtyReceived: number;
   qtyAllocated: number;
   targetQty: number;
-  createdAt: string | null;
   lane: Lane | "complete";
 };
 
@@ -75,10 +70,7 @@ type AllocationDraft = {
   qty: number;
 };
 
-type ApiResult = {
-  ok?: boolean;
-  error?: string;
-};
+type ApiResult = { ok?: boolean; error?: string };
 
 const ACTIVE_REQUEST_STATUSES = ["requested", "quoted", "approved"] as const;
 const CANCELLED_ITEM_STATUSES = new Set([
@@ -87,6 +79,9 @@ const CANCELLED_ITEM_STATUSES = new Set([
   "declined",
   "rejected",
 ]);
+const actionClass =
+  "inline-flex min-h-10 items-center justify-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--accent-copper)] disabled:cursor-not-allowed disabled:opacity-50";
+const primaryActionClass = `${actionClass} border-[color:var(--accent-copper)] bg-[color:var(--accent-copper)] text-white`;
 
 function numberValue(value: unknown): number {
   const parsed = typeof value === "number" ? value : Number(value);
@@ -99,18 +94,13 @@ function clean(value: unknown): string {
 
 function resolveLane(args: {
   requestStatus: string;
-  itemStatus: string;
   targetQty: number;
   qtyReceived: number;
   qtyAllocated: number;
 }): Lane | "complete" {
-  const requestStatus = args.requestStatus.toLowerCase();
-  if (requestStatus === "requested") return "requests";
-  if (requestStatus === "quoted") return "approval";
-
-  if (args.targetQty <= 0 || args.qtyReceived < args.targetQty) {
-    return "ordered";
-  }
+  if (args.requestStatus === "requested") return "requests";
+  if (args.requestStatus === "quoted") return "approval";
+  if (args.targetQty <= 0 || args.qtyReceived < args.targetQty) return "ordered";
   if (args.qtyAllocated < args.targetQty) return "ready";
   return "complete";
 }
@@ -153,9 +143,7 @@ export default function MobilePartsWorkflow(): JSX.Element {
       const [requestResult, locationResult] = await Promise.all([
         supabase
           .from("part_requests")
-          .select(
-            "id, shop_id, work_order_id, job_id, status, notes, created_at",
-          )
+          .select("id, work_order_id, job_id, status, notes, created_at")
           .in("status", [...ACTIVE_REQUEST_STATUSES])
           .order("created_at", { ascending: false })
           .limit(300),
@@ -178,29 +166,29 @@ export default function MobilePartsWorkflow(): JSX.Element {
         ),
       );
 
-      const [itemResult, workOrderResult] = await Promise.all([
-        requestIds.length
-          ? supabase
-              .from("part_request_items")
-              .select(
-                "id, request_id, work_order_line_id, part_id, description, status, qty, qty_requested, qty_approved, qty_received, qty_consumed, created_at",
-              )
-              .in("request_id", requestIds)
-              .order("created_at", { ascending: false })
-          : Promise.resolve({ data: [], error: null }),
-        workOrderIds.length
-          ? supabase
-              .from("work_orders")
-              .select("id, custom_id")
-              .in("id", workOrderIds)
-          : Promise.resolve({ data: [], error: null }),
-      ]);
+      let items: ItemLite[] = [];
+      if (requestIds.length > 0) {
+        const itemResult = await supabase
+          .from("part_request_items")
+          .select(
+            "id, request_id, work_order_line_id, part_id, description, status, qty, qty_requested, qty_approved, qty_received, qty_consumed, created_at",
+          )
+          .in("request_id", requestIds)
+          .order("created_at", { ascending: false });
+        if (itemResult.error) throw itemResult.error;
+        items = (itemResult.data ?? []) as ItemLite[];
+      }
 
-      if (itemResult.error) throw itemResult.error;
-      if (workOrderResult.error) throw workOrderResult.error;
+      let workOrders: WorkOrderLite[] = [];
+      if (workOrderIds.length > 0) {
+        const workOrderResult = await supabase
+          .from("work_orders")
+          .select("id, custom_id")
+          .in("id", workOrderIds);
+        if (workOrderResult.error) throw workOrderResult.error;
+        workOrders = (workOrderResult.data ?? []) as WorkOrderLite[];
+      }
 
-      const items = (itemResult.data ?? []) as ItemLite[];
-      const workOrders = (workOrderResult.data ?? []) as WorkOrderLite[];
       const workOrderById = new Map(
         workOrders.map((workOrder) => [workOrder.id, workOrder]),
       );
@@ -218,39 +206,34 @@ export default function MobilePartsWorkflow(): JSX.Element {
         const workOrder = request.work_order_id
           ? workOrderById.get(request.work_order_id)
           : null;
-        const workOrderLabel = workOrder?.custom_id?.trim()
-          ? workOrder.custom_id.trim()
-          : request.work_order_id
+        const workOrderLabel =
+          clean(workOrder?.custom_id) ||
+          (request.work_order_id
             ? `WO ${request.work_order_id.slice(0, 8)}`
-            : "Unlinked request";
+            : "Unlinked request");
 
         if (requestItems.length === 0) {
-          const emptyLane = resolveLane({
-            requestStatus,
-            itemStatus: "",
-            targetQty: 0,
-            qtyReceived: 0,
-            qtyAllocated: 0,
-          });
           nextEntries.push({
             key: `request:${request.id}`,
             requestId: request.id,
-            requestStatus,
-            requestNotes: request.notes,
             workOrderId: request.work_order_id,
             workOrderLineId: request.job_id,
             workOrderLabel,
             itemId: null,
             partId: null,
-            description: request.notes?.trim() || "Parts request",
+            description: clean(request.notes) || "Parts request",
             itemStatus: "No items yet",
             qtyRequested: 0,
             qtyApproved: 0,
             qtyReceived: 0,
             qtyAllocated: 0,
             targetQty: 0,
-            createdAt: request.created_at,
-            lane: emptyLane,
+            lane: resolveLane({
+              requestStatus,
+              targetQty: 0,
+              qtyReceived: 0,
+              qtyAllocated: 0,
+            }),
           });
           continue;
         }
@@ -267,33 +250,28 @@ export default function MobilePartsWorkflow(): JSX.Element {
           const qtyReceived = Math.max(0, numberValue(item.qty_received));
           const qtyAllocated = Math.max(0, numberValue(item.qty_consumed));
           const targetQty = Math.max(qtyApproved, qtyRequested);
-          const entryLane = resolveLane({
-            requestStatus,
-            itemStatus,
-            targetQty,
-            qtyReceived,
-            qtyAllocated,
-          });
 
           nextEntries.push({
             key: item.id,
             requestId: request.id,
-            requestStatus,
-            requestNotes: request.notes,
             workOrderId: request.work_order_id,
             workOrderLineId: item.work_order_line_id ?? request.job_id,
             workOrderLabel,
             itemId: item.id,
             partId: item.part_id,
-            description: item.description?.trim() || "Requested part",
+            description: clean(item.description) || "Requested part",
             itemStatus: itemStatus || requestStatus,
             qtyRequested,
             qtyApproved,
             qtyReceived,
             qtyAllocated,
             targetQty,
-            createdAt: item.created_at ?? request.created_at,
-            lane: entryLane,
+            lane: resolveLane({
+              requestStatus,
+              targetQty,
+              qtyReceived,
+              qtyAllocated,
+            }),
           });
         }
       }
@@ -331,12 +309,10 @@ export default function MobilePartsWorkflow(): JSX.Element {
     }),
     [entries],
   );
-
   const visibleEntries = useMemo(
     () => entries.filter((entry) => entry.lane === lane),
     [entries, lane],
   );
-
   const locationOptions = useMemo(
     () =>
       locations.map((location) => ({
@@ -345,7 +321,6 @@ export default function MobilePartsWorkflow(): JSX.Element {
       })),
     [locations],
   );
-
   const defaultLocationId = useMemo(() => {
     const main = locations.find(
       (location) => clean(location.code).toUpperCase() === "MAIN",
@@ -354,28 +329,27 @@ export default function MobilePartsWorkflow(): JSX.Element {
   }, [locations]);
 
   const openAllocation = (entry: WorkflowEntry) => {
-    if (!entry.itemId) {
-      toast.error("This request does not have an actionable item yet.");
+    if (!entry.itemId || !defaultLocationId) {
+      toast.error("Select an actionable item and stock location first.");
       return;
     }
-    if (!defaultLocationId) {
-      toast.error("Create or select a stock location before allocating parts.");
-      return;
-    }
-
-    const availableToAllocate = Math.max(
+    const available = Math.max(
       0,
       Math.min(entry.qtyReceived, entry.targetQty) - entry.qtyAllocated,
     );
     setAllocation({
       entry,
       locationId: defaultLocationId,
-      qty: availableToAllocate || 1,
+      qty: available || 1,
     });
   };
 
   const submitAllocation = async () => {
     if (!allocation?.entry.itemId) return;
+    const remaining = Math.max(
+      0,
+      allocation.entry.targetQty - allocation.entry.qtyAllocated,
+    );
     if (!allocation.locationId) {
       toast.error("Select a stock location.");
       return;
@@ -384,13 +358,8 @@ export default function MobilePartsWorkflow(): JSX.Element {
       toast.error("Allocation quantity must be greater than zero.");
       return;
     }
-
-    const remaining = Math.max(
-      0,
-      allocation.entry.targetQty - allocation.entry.qtyAllocated,
-    );
     if (remaining > 0 && allocation.qty > remaining) {
-      toast.error(`Allocation exceeds the remaining quantity (${formatQty(remaining)}).`);
+      toast.error(`Allocation exceeds remaining quantity (${formatQty(remaining)}).`);
       return;
     }
 
@@ -416,7 +385,7 @@ export default function MobilePartsWorkflow(): JSX.Element {
         },
       );
       const json = (await response.json().catch(() => null)) as ApiResult | null;
-      if (!response.ok || json?.error || json?.ok === false) {
+      if (!response.ok || json?.ok === false || json?.error) {
         throw new Error(json?.error || "Unable to allocate the part.");
       }
 
@@ -463,7 +432,7 @@ export default function MobilePartsWorkflow(): JSX.Element {
             className={[
               "min-h-20 rounded-2xl border p-3 text-left transition",
               lane === laneKey
-                ? "border-[color:var(--accent-copper)] bg-[color:color-mix(in_srgb,var(--accent-copper)_10%,var(--theme-surface-panel))]"
+                ? "border-[color:var(--accent-copper)] bg-[color:var(--theme-surface-panel)]"
                 : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]",
             ].join(" ")}
           >
@@ -487,9 +456,14 @@ export default function MobilePartsWorkflow(): JSX.Element {
               {counts[lane]} active {counts[lane] === 1 ? "item" : "items"}
             </h2>
           </div>
-          <Button type="button" variant="outline" size="sm" onClick={() => void load()} disabled={loading}>
+          <button
+            type="button"
+            className={actionClass}
+            onClick={() => void load()}
+            disabled={loading}
+          >
             {loading ? "Loading…" : "Refresh"}
-          </Button>
+          </button>
         </div>
 
         {error ? (
@@ -538,65 +512,58 @@ export default function MobilePartsWorkflow(): JSX.Element {
                 </div>
 
                 <div className="mt-3 grid grid-cols-4 gap-1.5 text-center text-[10px] text-[color:var(--theme-text-secondary)]">
-                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2">
-                    <span className="block">Requested</span>
-                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
-                      {formatQty(entry.qtyRequested)}
-                    </strong>
-                  </div>
-                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2">
-                    <span className="block">Approved</span>
-                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
-                      {formatQty(entry.qtyApproved)}
-                    </strong>
-                  </div>
-                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2">
-                    <span className="block">Received</span>
-                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
-                      {formatQty(entry.qtyReceived)}
-                    </strong>
-                  </div>
-                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2">
-                    <span className="block">Allocated</span>
-                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
-                      {formatQty(entry.qtyAllocated)}
-                    </strong>
-                  </div>
+                  {[
+                    ["Requested", entry.qtyRequested],
+                    ["Approved", entry.qtyApproved],
+                    ["Received", entry.qtyReceived],
+                    ["Allocated", entry.qtyAllocated],
+                  ].map(([label, value]) => (
+                    <div
+                      key={String(label)}
+                      className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2"
+                    >
+                      <span className="block">{label}</span>
+                      <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
+                        {formatQty(Number(value))}
+                      </strong>
+                    </div>
+                  ))}
                 </div>
 
                 <div className="mt-3 flex flex-wrap gap-2">
                   {lane === "ordered" && entry.itemId ? (
-                    <Button
+                    <button
                       type="button"
-                      size="sm"
+                      className={primaryActionClass}
                       onClick={() => setReceiveEntry(entry)}
                       disabled={remainingReceive <= 0 || locations.length === 0}
                     >
                       Receive {remainingReceive > 0 ? formatQty(remainingReceive) : ""}
-                    </Button>
+                    </button>
                   ) : null}
 
                   {lane === "ready" && entry.itemId ? (
-                    <Button
+                    <button
                       type="button"
-                      size="sm"
+                      className={primaryActionClass}
                       onClick={() => openAllocation(entry)}
                       disabled={remainingAllocate <= 0 || locations.length === 0}
                     >
                       Allocate {remainingAllocate > 0 ? formatQty(remainingAllocate) : ""}
-                    </Button>
+                    </button>
                   ) : null}
 
-                  <Button asChild type="button" size="sm" variant="outline">
-                    <Link href={workbenchHref}>Open parts workbench</Link>
-                  </Button>
+                  <Link className={actionClass} href={workbenchHref}>
+                    Open parts workbench
+                  </Link>
 
                   {entry.workOrderLineId ? (
-                    <Button asChild type="button" size="sm" variant="outline">
-                      <Link href={`/mobile/jobs/${entry.workOrderLineId}`}>
-                        Open job
-                      </Link>
-                    </Button>
+                    <Link
+                      className={actionClass}
+                      href={`/mobile/jobs/${entry.workOrderLineId}`}
+                    >
+                      Open job
+                    </Link>
                   ) : null}
                 </div>
               </article>
@@ -615,7 +582,7 @@ export default function MobilePartsWorkflow(): JSX.Element {
 
       {allocation ? (
         <div
-          className="fixed inset-0 z-[700] flex items-end justify-center bg-[color:color-mix(in_srgb,var(--theme-surface-overlay)_78%,transparent)] p-3 backdrop-blur-sm sm:items-center"
+          className="fixed inset-0 z-[700] flex items-end justify-center bg-[color:var(--theme-surface-overlay)] p-3 backdrop-blur-sm sm:items-center"
           onClick={() => {
             if (!allocating) setAllocation(null);
           }}
@@ -675,21 +642,22 @@ export default function MobilePartsWorkflow(): JSX.Element {
             </label>
 
             <div className="mt-5 flex justify-end gap-2">
-              <Button
+              <button
                 type="button"
-                variant="outline"
+                className={actionClass}
                 disabled={allocating}
                 onClick={() => setAllocation(null)}
               >
                 Cancel
-              </Button>
-              <Button
+              </button>
+              <button
                 type="button"
+                className={primaryActionClass}
                 disabled={allocating}
                 onClick={() => void submitAllocation()}
               >
                 {allocating ? "Allocating…" : "Allocate to job"}
-              </Button>
+              </button>
             </div>
           </div>
         </div>

--- a/features/parts/mobile/MobilePartsWorkflow.tsx
+++ b/features/parts/mobile/MobilePartsWorkflow.tsx
@@ -1,0 +1,699 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import ReceiveDrawer, {
+  type ReceiveDrawerItem,
+} from "@/features/parts/components/ReceiveDrawer";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { Button } from "@shared/components/ui/Button";
+
+type Lane = "requests" | "approval" | "ordered" | "ready";
+
+type RequestLite = {
+  id: string;
+  shop_id: string | null;
+  work_order_id: string | null;
+  job_id: string | null;
+  status: string | null;
+  notes: string | null;
+  created_at: string | null;
+};
+
+type ItemLite = {
+  id: string;
+  request_id: string;
+  work_order_line_id: string | null;
+  part_id: string | null;
+  description: string | null;
+  status: string | null;
+  qty: number | null;
+  qty_requested: number | null;
+  qty_approved: number | null;
+  qty_received: number | null;
+  qty_consumed: number | null;
+  created_at: string | null;
+};
+
+type WorkOrderLite = {
+  id: string;
+  custom_id: string | null;
+};
+
+type LocationLite = {
+  id: string;
+  code: string | null;
+  name: string | null;
+};
+
+type WorkflowEntry = {
+  key: string;
+  requestId: string;
+  requestStatus: string;
+  requestNotes: string | null;
+  workOrderId: string | null;
+  workOrderLineId: string | null;
+  workOrderLabel: string;
+  itemId: string | null;
+  partId: string | null;
+  description: string;
+  itemStatus: string;
+  qtyRequested: number;
+  qtyApproved: number;
+  qtyReceived: number;
+  qtyAllocated: number;
+  targetQty: number;
+  createdAt: string | null;
+  lane: Lane | "complete";
+};
+
+type AllocationDraft = {
+  entry: WorkflowEntry;
+  locationId: string;
+  qty: number;
+};
+
+type ApiResult = {
+  ok?: boolean;
+  error?: string;
+};
+
+const ACTIVE_REQUEST_STATUSES = ["requested", "quoted", "approved"] as const;
+const CANCELLED_ITEM_STATUSES = new Set([
+  "cancelled",
+  "canceled",
+  "declined",
+  "rejected",
+]);
+
+function numberValue(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function clean(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function resolveLane(args: {
+  requestStatus: string;
+  itemStatus: string;
+  targetQty: number;
+  qtyReceived: number;
+  qtyAllocated: number;
+}): Lane | "complete" {
+  const requestStatus = args.requestStatus.toLowerCase();
+  if (requestStatus === "requested") return "requests";
+  if (requestStatus === "quoted") return "approval";
+
+  if (args.targetQty <= 0 || args.qtyReceived < args.targetQty) {
+    return "ordered";
+  }
+  if (args.qtyAllocated < args.targetQty) return "ready";
+  return "complete";
+}
+
+function operationKey(prefix: string, itemId: string): string {
+  const random =
+    typeof globalThis.crypto?.randomUUID === "function"
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `mobile-parts:${prefix}:${itemId}:${random}`;
+}
+
+function formatQty(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(2);
+}
+
+function laneLabel(lane: Lane): string {
+  if (lane === "requests") return "Requests";
+  if (lane === "approval") return "Awaiting approval";
+  if (lane === "ordered") return "On order / receiving";
+  return "Ready for technician";
+}
+
+export default function MobilePartsWorkflow(): JSX.Element {
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const [lane, setLane] = useState<Lane>("requests");
+  const [entries, setEntries] = useState<WorkflowEntry[]>([]);
+  const [locations, setLocations] = useState<LocationLite[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [receiveEntry, setReceiveEntry] = useState<WorkflowEntry | null>(null);
+  const [allocation, setAllocation] = useState<AllocationDraft | null>(null);
+  const [allocating, setAllocating] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [requestResult, locationResult] = await Promise.all([
+        supabase
+          .from("part_requests")
+          .select(
+            "id, shop_id, work_order_id, job_id, status, notes, created_at",
+          )
+          .in("status", [...ACTIVE_REQUEST_STATUSES])
+          .order("created_at", { ascending: false })
+          .limit(300),
+        supabase
+          .from("stock_locations")
+          .select("id, code, name")
+          .order("code", { ascending: true }),
+      ]);
+
+      if (requestResult.error) throw requestResult.error;
+      if (locationResult.error) throw locationResult.error;
+
+      const requests = (requestResult.data ?? []) as RequestLite[];
+      const requestIds = requests.map((request) => request.id);
+      const workOrderIds = Array.from(
+        new Set(
+          requests
+            .map((request) => request.work_order_id)
+            .filter((id): id is string => Boolean(id)),
+        ),
+      );
+
+      const [itemResult, workOrderResult] = await Promise.all([
+        requestIds.length
+          ? supabase
+              .from("part_request_items")
+              .select(
+                "id, request_id, work_order_line_id, part_id, description, status, qty, qty_requested, qty_approved, qty_received, qty_consumed, created_at",
+              )
+              .in("request_id", requestIds)
+              .order("created_at", { ascending: false })
+          : Promise.resolve({ data: [], error: null }),
+        workOrderIds.length
+          ? supabase
+              .from("work_orders")
+              .select("id, custom_id")
+              .in("id", workOrderIds)
+          : Promise.resolve({ data: [], error: null }),
+      ]);
+
+      if (itemResult.error) throw itemResult.error;
+      if (workOrderResult.error) throw workOrderResult.error;
+
+      const items = (itemResult.data ?? []) as ItemLite[];
+      const workOrders = (workOrderResult.data ?? []) as WorkOrderLite[];
+      const workOrderById = new Map(
+        workOrders.map((workOrder) => [workOrder.id, workOrder]),
+      );
+      const itemsByRequest = new Map<string, ItemLite[]>();
+      for (const item of items) {
+        const current = itemsByRequest.get(item.request_id) ?? [];
+        current.push(item);
+        itemsByRequest.set(item.request_id, current);
+      }
+
+      const nextEntries: WorkflowEntry[] = [];
+      for (const request of requests) {
+        const requestStatus = clean(request.status).toLowerCase();
+        const requestItems = itemsByRequest.get(request.id) ?? [];
+        const workOrder = request.work_order_id
+          ? workOrderById.get(request.work_order_id)
+          : null;
+        const workOrderLabel = workOrder?.custom_id?.trim()
+          ? workOrder.custom_id.trim()
+          : request.work_order_id
+            ? `WO ${request.work_order_id.slice(0, 8)}`
+            : "Unlinked request";
+
+        if (requestItems.length === 0) {
+          const emptyLane = resolveLane({
+            requestStatus,
+            itemStatus: "",
+            targetQty: 0,
+            qtyReceived: 0,
+            qtyAllocated: 0,
+          });
+          nextEntries.push({
+            key: `request:${request.id}`,
+            requestId: request.id,
+            requestStatus,
+            requestNotes: request.notes,
+            workOrderId: request.work_order_id,
+            workOrderLineId: request.job_id,
+            workOrderLabel,
+            itemId: null,
+            partId: null,
+            description: request.notes?.trim() || "Parts request",
+            itemStatus: "No items yet",
+            qtyRequested: 0,
+            qtyApproved: 0,
+            qtyReceived: 0,
+            qtyAllocated: 0,
+            targetQty: 0,
+            createdAt: request.created_at,
+            lane: emptyLane,
+          });
+          continue;
+        }
+
+        for (const item of requestItems) {
+          const itemStatus = clean(item.status).toLowerCase();
+          if (CANCELLED_ITEM_STATUSES.has(itemStatus)) continue;
+
+          const qtyRequested = Math.max(
+            0,
+            numberValue(item.qty_requested ?? item.qty),
+          );
+          const qtyApproved = Math.max(0, numberValue(item.qty_approved));
+          const qtyReceived = Math.max(0, numberValue(item.qty_received));
+          const qtyAllocated = Math.max(0, numberValue(item.qty_consumed));
+          const targetQty = Math.max(qtyApproved, qtyRequested);
+          const entryLane = resolveLane({
+            requestStatus,
+            itemStatus,
+            targetQty,
+            qtyReceived,
+            qtyAllocated,
+          });
+
+          nextEntries.push({
+            key: item.id,
+            requestId: request.id,
+            requestStatus,
+            requestNotes: request.notes,
+            workOrderId: request.work_order_id,
+            workOrderLineId: item.work_order_line_id ?? request.job_id,
+            workOrderLabel,
+            itemId: item.id,
+            partId: item.part_id,
+            description: item.description?.trim() || "Requested part",
+            itemStatus: itemStatus || requestStatus,
+            qtyRequested,
+            qtyApproved,
+            qtyReceived,
+            qtyAllocated,
+            targetQty,
+            createdAt: item.created_at ?? request.created_at,
+            lane: entryLane,
+          });
+        }
+      }
+
+      setEntries(nextEntries);
+      setLocations((locationResult.data ?? []) as LocationLite[]);
+    } catch (loadError) {
+      const message =
+        loadError instanceof Error
+          ? loadError.message
+          : "Unable to load the parts workflow.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const refresh = () => void load();
+    window.addEventListener("parts:received", refresh);
+    return () => window.removeEventListener("parts:received", refresh);
+  }, [load]);
+
+  const counts = useMemo(
+    () => ({
+      requests: entries.filter((entry) => entry.lane === "requests").length,
+      approval: entries.filter((entry) => entry.lane === "approval").length,
+      ordered: entries.filter((entry) => entry.lane === "ordered").length,
+      ready: entries.filter((entry) => entry.lane === "ready").length,
+    }),
+    [entries],
+  );
+
+  const visibleEntries = useMemo(
+    () => entries.filter((entry) => entry.lane === lane),
+    [entries, lane],
+  );
+
+  const locationOptions = useMemo(
+    () =>
+      locations.map((location) => ({
+        value: location.id,
+        label: [location.code, location.name].filter(Boolean).join(" — "),
+      })),
+    [locations],
+  );
+
+  const defaultLocationId = useMemo(() => {
+    const main = locations.find(
+      (location) => clean(location.code).toUpperCase() === "MAIN",
+    );
+    return main?.id ?? locations[0]?.id ?? "";
+  }, [locations]);
+
+  const openAllocation = (entry: WorkflowEntry) => {
+    if (!entry.itemId) {
+      toast.error("This request does not have an actionable item yet.");
+      return;
+    }
+    if (!defaultLocationId) {
+      toast.error("Create or select a stock location before allocating parts.");
+      return;
+    }
+
+    const availableToAllocate = Math.max(
+      0,
+      Math.min(entry.qtyReceived, entry.targetQty) - entry.qtyAllocated,
+    );
+    setAllocation({
+      entry,
+      locationId: defaultLocationId,
+      qty: availableToAllocate || 1,
+    });
+  };
+
+  const submitAllocation = async () => {
+    if (!allocation?.entry.itemId) return;
+    if (!allocation.locationId) {
+      toast.error("Select a stock location.");
+      return;
+    }
+    if (!Number.isFinite(allocation.qty) || allocation.qty <= 0) {
+      toast.error("Allocation quantity must be greater than zero.");
+      return;
+    }
+
+    const remaining = Math.max(
+      0,
+      allocation.entry.targetQty - allocation.entry.qtyAllocated,
+    );
+    if (remaining > 0 && allocation.qty > remaining) {
+      toast.error(`Allocation exceeds the remaining quantity (${formatQty(remaining)}).`);
+      return;
+    }
+
+    setAllocating(true);
+    try {
+      const key = operationKey("allocate", allocation.entry.itemId);
+      const response = await fetch(
+        `/api/parts/requests/items/${encodeURIComponent(
+          allocation.entry.itemId,
+        )}/allocate`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": key,
+          },
+          body: JSON.stringify({
+            location_id: allocation.locationId,
+            qty: allocation.qty,
+            idempotencyKey: key,
+          }),
+        },
+      );
+      const json = (await response.json().catch(() => null)) as ApiResult | null;
+      if (!response.ok || json?.error || json?.ok === false) {
+        throw new Error(json?.error || "Unable to allocate the part.");
+      }
+
+      toast.success("Part allocated to the job.");
+      setAllocation(null);
+      await load();
+    } catch (allocationError) {
+      toast.error(
+        allocationError instanceof Error
+          ? allocationError.message
+          : "Unable to allocate the part.",
+      );
+    } finally {
+      setAllocating(false);
+    }
+  };
+
+  const selectedReceiveItem: ReceiveDrawerItem | null = receiveEntry?.itemId
+    ? {
+        id: receiveEntry.itemId,
+        request_id: receiveEntry.requestId,
+        part_id: receiveEntry.partId,
+        description: receiveEntry.description,
+        status: receiveEntry.itemStatus,
+        qty_approved: receiveEntry.targetQty,
+        qty_received: receiveEntry.qtyReceived,
+        qty_remaining: Math.max(
+          0,
+          receiveEntry.targetQty - receiveEntry.qtyReceived,
+        ),
+      }
+    : null;
+
+  const lanes: Lane[] = ["requests", "approval", "ordered", "ready"];
+
+  return (
+    <div className="space-y-4">
+      <section className="grid grid-cols-2 gap-2">
+        {lanes.map((laneKey) => (
+          <button
+            key={laneKey}
+            type="button"
+            onClick={() => setLane(laneKey)}
+            className={[
+              "min-h-20 rounded-2xl border p-3 text-left transition",
+              lane === laneKey
+                ? "border-[color:var(--accent-copper)] bg-[color:color-mix(in_srgb,var(--accent-copper)_10%,var(--theme-surface-panel))]"
+                : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]",
+            ].join(" ")}
+          >
+            <span className="block text-xs text-[color:var(--theme-text-secondary)]">
+              {laneLabel(laneKey)}
+            </span>
+            <span className="mt-1 block text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+              {loading ? "…" : counts[laneKey]}
+            </span>
+          </button>
+        ))}
+      </section>
+
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">
+              {laneLabel(lane)}
+            </div>
+            <h2 className="mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]">
+              {counts[lane]} active {counts[lane] === 1 ? "item" : "items"}
+            </h2>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={() => void load()} disabled={loading}>
+            {loading ? "Loading…" : "Refresh"}
+          </Button>
+        </div>
+
+        {error ? (
+          <div className="mt-4 rounded-2xl border border-red-500/35 bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        {!loading && !error && visibleEntries.length === 0 ? (
+          <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-sm text-[color:var(--theme-text-secondary)]">
+            No parts are currently in this lane.
+          </div>
+        ) : null}
+
+        <div className="mt-4 grid gap-3">
+          {visibleEntries.map((entry) => {
+            const remainingReceive = Math.max(
+              0,
+              entry.targetQty - entry.qtyReceived,
+            );
+            const remainingAllocate = Math.max(
+              0,
+              entry.targetQty - entry.qtyAllocated,
+            );
+            const workbenchHref = entry.workOrderId
+              ? `/parts/requests/${entry.workOrderId}`
+              : "/parts/requests";
+
+            return (
+              <article
+                key={entry.key}
+                className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                      {entry.workOrderLabel}
+                    </div>
+                    <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+                      {entry.description}
+                    </h3>
+                  </div>
+                  <span className="shrink-0 rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-2.5 py-1 text-[10px] uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)]">
+                    {entry.itemStatus.replaceAll("_", " ")}
+                  </span>
+                </div>
+
+                <div className="mt-3 grid grid-cols-4 gap-1.5 text-center text-[10px] text-[color:var(--theme-text-secondary)]">
+                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2">
+                    <span className="block">Requested</span>
+                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
+                      {formatQty(entry.qtyRequested)}
+                    </strong>
+                  </div>
+                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2">
+                    <span className="block">Approved</span>
+                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
+                      {formatQty(entry.qtyApproved)}
+                    </strong>
+                  </div>
+                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2">
+                    <span className="block">Received</span>
+                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
+                      {formatQty(entry.qtyReceived)}
+                    </strong>
+                  </div>
+                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-2">
+                    <span className="block">Allocated</span>
+                    <strong className="mt-0.5 block text-sm text-[color:var(--theme-text-primary)]">
+                      {formatQty(entry.qtyAllocated)}
+                    </strong>
+                  </div>
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {lane === "ordered" && entry.itemId ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => setReceiveEntry(entry)}
+                      disabled={remainingReceive <= 0 || locations.length === 0}
+                    >
+                      Receive {remainingReceive > 0 ? formatQty(remainingReceive) : ""}
+                    </Button>
+                  ) : null}
+
+                  {lane === "ready" && entry.itemId ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => openAllocation(entry)}
+                      disabled={remainingAllocate <= 0 || locations.length === 0}
+                    >
+                      Allocate {remainingAllocate > 0 ? formatQty(remainingAllocate) : ""}
+                    </Button>
+                  ) : null}
+
+                  <Button asChild type="button" size="sm" variant="outline">
+                    <Link href={workbenchHref}>Open parts workbench</Link>
+                  </Button>
+
+                  {entry.workOrderLineId ? (
+                    <Button asChild type="button" size="sm" variant="outline">
+                      <Link href={`/mobile/jobs/${entry.workOrderLineId}`}>
+                        Open job
+                      </Link>
+                    </Button>
+                  ) : null}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <ReceiveDrawer
+        open={Boolean(receiveEntry)}
+        onClose={() => setReceiveEntry(null)}
+        item={selectedReceiveItem}
+        locations={locationOptions}
+        defaultLocationId={defaultLocationId}
+      />
+
+      {allocation ? (
+        <div
+          className="fixed inset-0 z-[700] flex items-end justify-center bg-[color:color-mix(in_srgb,var(--theme-surface-overlay)_78%,transparent)] p-3 backdrop-blur-sm sm:items-center"
+          onClick={() => {
+            if (!allocating) setAllocation(null);
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Allocate part to job"
+            className="w-full max-w-lg rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] p-5 shadow-[var(--theme-shadow-medium)]"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">
+              Ready for technician
+            </div>
+            <h3 className="mt-1 text-xl font-semibold text-[color:var(--theme-text-primary)]">
+              Allocate {allocation.entry.description}
+            </h3>
+
+            <label className="mt-4 block text-sm text-[color:var(--theme-text-secondary)]">
+              Stock location
+              <select
+                value={allocation.locationId}
+                onChange={(event) =>
+                  setAllocation((current) =>
+                    current
+                      ? { ...current, locationId: event.target.value }
+                      : current,
+                  )
+                }
+                className="mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-[color:var(--theme-text-primary)]"
+              >
+                <option value="">Select a location</option>
+                {locationOptions.map((location) => (
+                  <option key={location.value} value={location.value}>
+                    {location.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="mt-3 block text-sm text-[color:var(--theme-text-secondary)]">
+              Quantity
+              <input
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={allocation.qty}
+                onChange={(event) =>
+                  setAllocation((current) =>
+                    current
+                      ? { ...current, qty: numberValue(event.target.value) }
+                      : current,
+                  )
+                }
+                className="mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 text-[color:var(--theme-text-primary)]"
+              />
+            </label>
+
+            <div className="mt-5 flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={allocating}
+                onClick={() => setAllocation(null)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                disabled={allocating}
+                onClick={() => void submitAllocation()}
+              >
+                {allocating ? "Allocating…" : "Allocate to job"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/supabase/migrations/20260719090000_mobile_technician_stabilization.sql
+++ b/supabase/migrations/20260719090000_mobile_technician_stabilization.sql
@@ -1,0 +1,246 @@
+begin;
+
+-- pgcrypto is installed in the Supabase `extensions` schema. The offline
+-- receipt functions intentionally pin their search path, so include that
+-- schema instead of relying on the caller's session search path.
+create schema if not exists extensions;
+create extension if not exists pgcrypto with schema extensions;
+
+alter function public.apply_offline_line_mutation_atomic(
+  uuid, uuid, text, text, uuid, jsonb
+) set search_path = public, extensions;
+
+alter function public.record_offline_photo_receipt_atomic(
+  uuid, uuid, text, uuid, jsonb
+) set search_path = public, extensions;
+
+alter function public.apply_offline_shift_punch_atomic(
+  uuid, uuid, text, uuid, text, timestamptz, text
+) set search_path = public, extensions;
+
+-- Existing production databases do not consistently have a unique constraint
+-- on inspection_sessions.work_order_line_id or inspections.work_order_line_id.
+-- Serialize on the canonical work-order line and perform deterministic
+-- select/update-or-insert operations rather than relying on ON CONFLICT.
+create or replace function public.save_inspection_progress_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_actor_user_id uuid,
+  p_session jsonb,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line record;
+  v_existing jsonb;
+  v_session_id uuid;
+  v_inspection_id uuid;
+  v_inspection_locked boolean := false;
+  v_now timestamptz := coalesce(p_at, now());
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001', message = 'Authenticated actor does not match the inspection actor.';
+  end if;
+
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001', message = 'A stable operation key is required.';
+  end if;
+
+  if p_session is null or jsonb_typeof(p_session) <> 'object' then
+    raise exception using errcode = 'P0001', message = 'Inspection session payload must be a JSON object.';
+  end if;
+
+  select mok.result
+    into v_existing
+  from public.mobile_operation_keys mok
+  where mok.shop_id = p_shop_id
+    and mok.operation_name = 'save_inspection_progress'
+    and mok.operation_key = p_operation_key;
+
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select wol.id, wol.work_order_id, wol.shop_id
+    into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for update;
+
+  if not found or v_line.work_order_id is null then
+    raise exception using errcode = 'P0001', message = 'Work-order line not found for shop.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles p
+    where p.id = p_actor_user_id
+      and p.shop_id = p_shop_id
+  ) then
+    raise exception using errcode = 'P0001', message = 'Actor is not a member of this shop.';
+  end if;
+
+  -- A finalized duplicate must still protect the line from draft edits.
+  if exists (
+    select 1
+    from public.inspections i
+    where i.work_order_line_id = p_work_order_line_id
+      and i.shop_id = p_shop_id
+      and coalesce(i.locked, false) = true
+  ) then
+    raise exception using errcode = 'P0001', message = 'Inspection is finalized and locked. Reopen is required before editing.';
+  end if;
+
+  select s.id
+    into v_session_id
+  from public.inspection_sessions s
+  where s.work_order_line_id = p_work_order_line_id
+  order by s.updated_at desc nulls last, s.id desc
+  limit 1
+  for update;
+
+  if found then
+    update public.inspection_sessions
+    set work_order_id = v_line.work_order_id,
+        user_id = p_actor_user_id,
+        state = p_session,
+        updated_at = v_now
+    where id = v_session_id;
+  else
+    insert into public.inspection_sessions(
+      work_order_id,
+      work_order_line_id,
+      user_id,
+      state,
+      updated_at
+    ) values (
+      v_line.work_order_id,
+      p_work_order_line_id,
+      p_actor_user_id,
+      p_session,
+      v_now
+    )
+    returning id into v_session_id;
+  end if;
+
+  select i.id, coalesce(i.locked, false)
+    into v_inspection_id, v_inspection_locked
+  from public.inspections i
+  where i.work_order_line_id = p_work_order_line_id
+    and i.shop_id = p_shop_id
+  order by i.updated_at desc nulls last, i.id desc
+  limit 1
+  for update;
+
+  if found then
+    if v_inspection_locked then
+      raise exception using errcode = 'P0001', message = 'Inspection is finalized and locked. Reopen is required before editing.';
+    end if;
+
+    update public.inspections
+    set work_order_id = v_line.work_order_id,
+        work_order_line_id = p_work_order_line_id,
+        shop_id = p_shop_id,
+        user_id = p_actor_user_id,
+        summary = p_session,
+        is_draft = true,
+        completed = false,
+        locked = false,
+        status = 'draft',
+        updated_at = v_now
+    where id = v_inspection_id
+      and shop_id = p_shop_id
+    returning id into v_inspection_id;
+  else
+    insert into public.inspections(
+      work_order_id,
+      work_order_line_id,
+      shop_id,
+      user_id,
+      summary,
+      is_draft,
+      completed,
+      locked,
+      status,
+      updated_at
+    ) values (
+      v_line.work_order_id,
+      p_work_order_line_id,
+      p_shop_id,
+      p_actor_user_id,
+      p_session,
+      true,
+      false,
+      false,
+      'draft',
+      v_now
+    )
+    returning id into v_inspection_id;
+  end if;
+
+  if v_inspection_id is null then
+    raise exception using errcode = 'P0001', message = 'Inspection progress could not be persisted.';
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'inspection_id', v_inspection_id,
+    'inspection_session_id', v_session_id,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'saved_at', v_now,
+    'idempotent', false
+  );
+
+  insert into public.mobile_operation_keys(
+    shop_id,
+    operation_name,
+    operation_key,
+    actor_user_id,
+    work_order_id,
+    work_order_line_id,
+    result
+  ) values (
+    p_shop_id,
+    'save_inspection_progress',
+    p_operation_key,
+    p_actor_user_id,
+    v_line.work_order_id,
+    p_work_order_line_id,
+    v_result
+  );
+
+  return v_result;
+exception
+  when unique_violation then
+    select mok.result
+      into v_existing
+    from public.mobile_operation_keys mok
+    where mok.shop_id = p_shop_id
+      and mok.operation_name = 'save_inspection_progress'
+      and mok.operation_key = p_operation_key;
+
+    if found then
+      return v_existing || jsonb_build_object('idempotent', true);
+    end if;
+
+    raise;
+end;
+$$;
+
+revoke all on function public.save_inspection_progress_atomic(
+  uuid, uuid, uuid, jsonb, text, timestamptz
+) from public;
+
+grant execute on function public.save_inspection_progress_atomic(
+  uuid, uuid, uuid, jsonb, text, timestamptz
+) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+commit;

--- a/tests/mobile-technician-stabilization.test.ts
+++ b/tests/mobile-technician-stabilization.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260719090000_mobile_technician_stabilization.sql",
+  "utf8",
+);
+const signRoute = readFileSync(
+  "app/api/inspections/sign/route.ts",
+  "utf8",
+);
+const signaturePanel = readFileSync(
+  "features/inspections/components/inspection/InspectionSignaturePanel.tsx",
+  "utf8",
+);
+const mobileJobPage = readFileSync(
+  "app/mobile/jobs/[lineId]/page.tsx",
+  "utf8",
+);
+const mobilePartsPage = readFileSync(
+  "app/mobile/parts/page.tsx",
+  "utf8",
+);
+const mobilePartsWorkflow = readFileSync(
+  "features/parts/mobile/MobilePartsWorkflow.tsx",
+  "utf8",
+);
+
+describe("mobile technician stabilization", () => {
+  it("resolves pgcrypto from the Supabase extensions schema", () => {
+    expect(migration).toContain("create extension if not exists pgcrypto with schema extensions");
+    expect(migration).toContain(
+      "alter function public.record_offline_photo_receipt_atomic",
+    );
+    expect(migration.match(/set search_path = public, extensions/g)?.length).toBe(
+      3,
+    );
+  });
+
+  it("saves inspection progress without relying on missing line uniqueness", () => {
+    expect(migration).toContain(
+      "create or replace function public.save_inspection_progress_atomic",
+    );
+    expect(migration).toContain("from public.inspection_sessions s");
+    expect(migration).toContain("where id = v_session_id");
+    expect(migration).toContain("where id = v_inspection_id");
+    expect(migration).not.toContain("on conflict (work_order_line_id)");
+    expect(migration).toContain("Inspection is finalized and locked");
+  });
+
+  it("anchors a mobile inspection before signing instead of inserting a bare row", () => {
+    expect(signRoute).toContain("resolveInspectionForSigning");
+    expect(signRoute).toContain("work_order_line_id: line.data.id");
+    expect(signRoute).toContain("work_order_id: line.data.work_order_id");
+    expect(signRoute).not.toContain("Unable to auto-create inspection before signing");
+    expect(signRoute).not.toContain(".upsert(");
+    expect(signaturePanel).toContain("workOrderLineId: resolvedWorkOrderLineId");
+    expect(signaturePanel).toContain('sessionStorage.getItem("inspection:params")');
+  });
+
+  it("exposes cause and correction independently from the finish button", () => {
+    expect(mobileJobPage).toContain("Cause / Correction");
+    expect(mobileJobPage).toContain("save_story_draft");
+    expect(mobileJobPage).toContain("CauseCorrectionModal");
+  });
+
+  it("replaces the mobile parts placeholder with actionable parts commands", () => {
+    expect(mobilePartsPage).toContain("MobilePartsWorkflow");
+    expect(mobilePartsWorkflow).toContain("part_request_items");
+    expect(mobilePartsWorkflow).toContain("/receive");
+    expect(mobilePartsWorkflow).toContain("/allocate");
+    expect(mobilePartsWorkflow).toContain("Open parts workbench");
+    expect(mobilePartsPage).not.toContain("Mobile parts rollout");
+  });
+});

--- a/tests/mobile-technician-stabilization.test.ts
+++ b/tests/mobile-technician-stabilization.test.ts
@@ -28,7 +28,9 @@ const mobilePartsWorkflow = readFileSync(
 
 describe("mobile technician stabilization", () => {
   it("resolves pgcrypto from the Supabase extensions schema", () => {
-    expect(migration).toContain("create extension if not exists pgcrypto with schema extensions");
+    expect(migration).toContain(
+      "create extension if not exists pgcrypto with schema extensions",
+    );
     expect(migration).toContain(
       "alter function public.record_offline_photo_receipt_atomic",
     );
@@ -50,12 +52,18 @@ describe("mobile technician stabilization", () => {
 
   it("anchors a mobile inspection before signing instead of inserting a bare row", () => {
     expect(signRoute).toContain("resolveInspectionForSigning");
-    expect(signRoute).toContain("work_order_line_id: line.data.id");
-    expect(signRoute).toContain("work_order_id: line.data.work_order_id");
-    expect(signRoute).not.toContain("Unable to auto-create inspection before signing");
+    expect(signRoute).toContain("work_order_line_id: canonicalLineId");
+    expect(signRoute).toContain("work_order_id: canonicalWorkOrderId");
+    expect(signRoute).not.toContain(
+      "Unable to auto-create inspection before signing",
+    );
     expect(signRoute).not.toContain(".upsert(");
-    expect(signaturePanel).toContain("workOrderLineId: resolvedWorkOrderLineId");
-    expect(signaturePanel).toContain('sessionStorage.getItem("inspection:params")');
+    expect(signaturePanel).toContain(
+      "workOrderLineId: resolvedWorkOrderLineId",
+    );
+    expect(signaturePanel).toContain(
+      'sessionStorage.getItem("inspection:params")',
+    );
   });
 
   it("exposes cause and correction independently from the finish button", () => {


### PR DESCRIPTION
## Summary

Stabilizes the mobile-only technician flow without changing the working desktop work-order pages.

### Fixed
- Resolves `pgcrypto.digest(...)` from Supabase's `extensions` schema for offline photo and line mutation receipts.
- Replaces inspection progress `ON CONFLICT (work_order_line_id)` assumptions with a line-serialized, deterministic update-or-insert RPC.
- Signs the canonical shop-scoped inspection and creates a missing inspection only with validated work-order anchors, avoiding `inspections_anchor_chk` failures.
- Sends the mobile `workOrderLineId` from the signature panel and improves the technician-name loading fallback.
- Adds an independent mobile Cause / Correction action so technicians can save the story before finishing the job.
- Replaces the mobile Parts placeholder with live request lanes, inline receiving, ready-part allocation, parts workbench access, and job-context links.

## Guardrails
- Desktop work-order screens are unchanged.
- Existing RLS remains enabled; API/RPC operations retain explicit shop and actor validation.
- Existing migrations are untouched; all database changes are forward-only.
- Offline mutation/idempotency flows are preserved.

## Verification
- Vercel preview build/type validation passed for the latest head (`ed9124c`).
- Added `tests/mobile-technician-stabilization.test.ts` covering the SQL, signing anchor, independent story editor, and actionable parts workflow contracts.
- PR is mergeable with `main` and has no branch conflicts.

## Runtime smoke-test checklist after applying the migration
1. Upload a job photo and confirm the mutation receipt completes without a `digest(...)` error.
2. Save inspection progress twice and confirm the same canonical inspection/session is updated.
3. Load the technician name, confirm, and sign the inspection.
4. Open Cause / Correction before pressing Finish Job; save a partial draft, reopen it, then complete.
5. Receive an ordered part and allocate a received part from `/mobile/parts`.
