### PR TITLE
Fix parts migration compilation and compact large-display queue

### DIFF
--- a/supabase/migrations/20260719100100_parts_request_lifecycle_automation.sql
+++ b/supabase/migrations/20260719100100_parts_request_lifecycle_automation.sql
@@ -486,15 +486,18 @@ declare
   v_now timestamptz := now();
   v_existing_count integer := 0;
 begin
-  select pr, coalesce(nullif(trim(wo.custom_id), ''), wo.id::text)
-    into v_request, v_work_order_label
-  from public.part_requests pr
-  left join public.work_orders wo on wo.id = pr.work_order_id
-  where pr.id = p_request_id;
+  select * into v_request
+  from public.part_requests
+  where id = p_request_id;
 
   if not found then
     return;
   end if;
+
+  select coalesce(nullif(trim(wo.custom_id), ''), wo.id::text)
+    into v_work_order_label
+  from public.work_orders wo
+  where wo.id = v_request.work_order_id;
 
   select count(*) into v_item_count
   from public.part_request_items

--- a/tests/parts/parts-request-lifecycle-automation.test.ts
+++ b/tests/parts/parts-request-lifecycle-automation.test.ts
@@ -88,6 +88,11 @@ describe("parts request lifecycle automation", () => {
     expect(migration).toContain(
       "revoke all on function public.parts_publish_request_notification",
     );
+    expect(migration).toContain("select * into v_request");
+    expect(migration).toContain("where wo.id = v_request.work_order_id");
+    expect(migration).not.toMatch(
+      /select\s+pr\s*,[\s\S]*?into\s+v_request\s*,\s*v_work_order_label/i,
+    );
   });
 
   it("keeps ordering and issue explicit while making handoff idempotent", () => {


### PR DESCRIPTION
## What changed

- Fixes the PL/pgSQL `%rowtype` compilation error in `parts_publish_request_notification`.
- Loads the request row and work-order label separately.
- Changes the active Parts board to four columns at the `xl` breakpoint so 1080p TVs using Windows display scaling do not fall back to two columns.
- Reduces header, summary, card, progress, and action spacing while retaining every operational field and control.
- Adds regression coverage for both the SQL loading pattern and four-column breakpoint.

## Validation

- Focused Parts lifecycle/UI test: 8/8 passed.
- Targeted ESLint passed.
- All related SQL migrations parsed successfully (72 statements).
- `git diff --check` passed.
- Full repository typecheck remains blocked by unrelated modules absent from the local sparse checkout; no errors were reported for the changed Parts page.

## Deployment

Run `20260719100100_parts_request_lifecycle_automation.sql` again from the beginning. If the SQL Editor reports an aborted transaction, run `rollback;` first in a separate query.