### PR TITLE
Standardize dashboards for large displays

### DIFF
--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -487,7 +487,7 @@ export default function PartsDashboardPage(): JSX.Element {
   ];
 
   return (
-    <main className="mx-auto w-full max-w-[1640px] space-y-4 p-4 text-[color:var(--theme-text-primary)] md:p-6">
+    <main className="mx-auto w-full max-w-[1800px] space-y-4 p-3 text-[color:var(--theme-text-primary)] sm:p-4 lg:p-5">
       <header className="flex flex-col gap-4 px-1 py-1 md:flex-row md:items-end md:justify-between">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Parts Overview</h1>

--- a/app/work-orders/board/page.tsx
+++ b/app/work-orders/board/page.tsx
@@ -19,7 +19,7 @@ export default async function WorkOrderBoardPage({
   const initialStage = parseWorkOrderBoardStageFilter(rawStage);
   return (
     <main className="min-h-screen px-4 py-5 text-[color:var(--theme-text-primary)] md:px-6">
-      <div className="mx-auto max-w-[1680px] space-y-4">
+      <div className="mx-auto w-full max-w-[1800px] space-y-4">
         <OperationalViewSwitcher role={identity.role} />
         <WorkOrderBoard
           variant="shop"

--- a/features/dashboard/app/dashboard/admin/AdminDashboardClient.tsx
+++ b/features/dashboard/app/dashboard/admin/AdminDashboardClient.tsx
@@ -15,7 +15,7 @@ export default function AdminDashboardClient() {
   ];
 
   return (
-    <div className="min-h-screen p-6 text-[color:var(--theme-text-primary)]">
+    <div className="mx-auto min-h-screen w-full max-w-[1800px] px-3 py-4 text-[color:var(--theme-text-primary)] sm:px-5 lg:px-6">
       <header className="mb-6 flex items-end justify-between">
         <div>
           <h1 className="text-3xl font-bold text-orange-400">Admin Dashboard</h1>
@@ -29,7 +29,7 @@ export default function AdminDashboardClient() {
         <AdminQuickPanel />
       </div>
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
         {tiles.map((t) => (
           <Link key={t.href} href={t.href} className="block">
             <div className="p-4 bg-surface rounded shadow-card transition hover:-translate-y-0.5 hover:shadow-lg">

--- a/features/dashboard/app/dashboard/admin/AdminSurface.tsx
+++ b/features/dashboard/app/dashboard/admin/AdminSurface.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 const shellFrame =
-  "mx-auto w-full max-w-7xl space-y-5 px-4 pb-8 pt-6 text-[color:var(--theme-text-primary)] sm:px-6 lg:px-8";
+  "mx-auto w-full max-w-[1800px] space-y-4 px-3 pb-6 pt-4 text-[color:var(--theme-text-primary)] sm:px-5 lg:px-6";
 
 const panelFrame =
   "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(255,255,255,0.015))] shadow-[var(--theme-shadow-medium)] backdrop-blur-md";

--- a/features/dashboard/app/dashboard/admin/BillingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/BillingClient.tsx
@@ -439,7 +439,7 @@ export default function BillingClient() {
       "
       style={{ ["--copper" as never]: COPPER }}
     >
-      <div className="mx-auto max-w-6xl">
+      <div className="mx-auto w-full max-w-[1800px]">
         {/* Header */}
         <div className={cx(card, "px-5 py-4")}>
           <div className="text-xs uppercase tracking-[0.25em] text-[color:var(--theme-text-secondary)]">

--- a/features/dashboard/app/dashboard/advisor/page.tsx
+++ b/features/dashboard/app/dashboard/advisor/page.tsx
@@ -59,10 +59,10 @@ function Tile({ href, title, subtitle, cta }: TileProps) {
 
 export default function AdvisorDashboardPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-[color:var(--theme-surface-page)] via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] px-3 py-8 text-foreground">
-      <div className="mx-auto max-w-6xl">
+    <div className="min-h-screen bg-gradient-to-b from-[color:var(--theme-surface-page)] via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] px-3 py-4 text-foreground sm:px-5 lg:px-6">
+      <div className="mx-auto w-full max-w-[1800px]">
         {/* Page header */}
-        <header className="mb-8 space-y-2">
+        <header className="mb-5 space-y-2">
           <div className="inline-flex items-center rounded-full border border-[color:var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--theme-text-secondary)]">
             Advisor Console
           </div>
@@ -86,7 +86,7 @@ export default function AdvisorDashboardPage() {
             </h2>
             <span className="h-px flex-1 bg-gradient-to-r from-[var(--accent-copper-soft)]/70 via-[color:var(--theme-surface-panel)] to-transparent" />
           </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <Tile
               href="/work-orders/create"
               title="Create Work Order"
@@ -129,7 +129,7 @@ export default function AdvisorDashboardPage() {
             </h2>
             <span className="h-px flex-1 bg-gradient-to-r from-[var(--accent-copper-soft)]/70 via-[color:var(--theme-surface-panel)] to-transparent" />
           </div>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
             <Tile
               href="/inspections/templates"
               title="Templates"

--- a/features/dashboard/app/dashboard/owner/reports/page.tsx
+++ b/features/dashboard/app/dashboard/owner/reports/page.tsx
@@ -309,7 +309,7 @@ export default function ReportsPage() {
       title="Owner Reports"
       description="Performance dashboards + Shop Health (AI snapshot) in one place."
     >
-      <div className="mx-auto max-w-6xl space-y-6 text-foreground">
+      <div className="mx-auto w-full max-w-[1800px] space-y-4 text-foreground">
         {/* Header + tabs */}
         <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-4 backdrop-blur">
           <div className="flex flex-wrap items-start justify-between gap-3">

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -1395,7 +1395,7 @@ export default function OwnerSettingsPage() {
   if (loading) {
     return (
       <div
-        className="mx-auto max-w-[1600px] animate-pulse space-y-5 p-4 sm:p-5 lg:p-6"
+        className="mx-auto max-w-[1800px] animate-pulse space-y-5 p-4 sm:p-5 lg:p-6"
         aria-label="Loading shop settings"
       >
         <div className="h-28 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]" />
@@ -1564,7 +1564,7 @@ export default function OwnerSettingsPage() {
               : [];
 
   return (
-    <div className="mx-auto flex max-w-[1600px] flex-col gap-5 p-4 text-foreground sm:p-5 lg:p-6">
+    <div className="mx-auto flex max-w-[1800px] flex-col gap-5 p-4 text-foreground sm:p-5 lg:p-6">
       <OwnerSettingsHeader
         shopName={shopName}
         roleLabel={ownerRole === "admin" ? "Admin" : "Owner"}

--- a/features/dashboard/app/dashboard/tech/page.tsx
+++ b/features/dashboard/app/dashboard/tech/page.tsx
@@ -2,7 +2,7 @@
 
 export default function TechDashboard() {
   return (
-    <div className="p-6 text-[color:var(--theme-text-primary)] font-blackops">
+    <div className="mx-auto w-full max-w-[1800px] px-3 py-4 text-[color:var(--theme-text-primary)] font-blackops sm:px-5 lg:px-6">
       <h1 className="text-2xl text-orange-500">Technician Dashboard</h1>
       <p className="mt-4">
         Welcome, tech! View your jobs and punch in/out here.

--- a/features/dashboard/components/DashboardModuleSystem.tsx
+++ b/features/dashboard/components/DashboardModuleSystem.tsx
@@ -66,7 +66,7 @@ export function DashboardMetric({ label, value, tone = "default" }: { label: str
 }
 
 export function DashboardMetricRow({ children, columns = 3 }: { children: ReactNode; columns?: 2 | 3 | 4 }) {
-  return <div className={cn("grid gap-2.5", columns === 2 ? "grid-cols-2" : columns === 4 ? "grid-cols-2 lg:grid-cols-4" : "grid-cols-3")}>{children}</div>;
+  return <div className={cn("grid gap-2.5", columns === 2 ? "grid-cols-2" : columns === 4 ? "grid-cols-2 xl:grid-cols-4" : "grid-cols-3")}>{children}</div>;
 }
 
 export function DashboardSignalList({ items }: { items: Array<{ label: string; value?: string; tone?: "default" | "accent"; }>; }) {

--- a/features/dashboard/lib/dashboard-responsive-layout.ts
+++ b/features/dashboard/lib/dashboard-responsive-layout.ts
@@ -41,7 +41,10 @@ export const DASHBOARD_WIDGET_RESPONSIVE_META: Record<DashboardWidgetId, Dashboa
 export function getDashboardViewport(width: number): DashboardViewport {
   if (width < 640) return "mobile";
   if (width < 1200) return "tablet";
-  if (width < 1536) return "laptop";
+  // Large wall displays are commonly rendered at 125–150% OS scaling. Treat
+  // the resulting 1280px+ CSS viewport as desktop so dashboards retain their
+  // dense control-room layout instead of falling back to laptop density.
+  if (width < 1280) return "laptop";
   return "desktop";
 }
 

--- a/features/dashboard/widgets/modules/StatsOverviewWidgetModule.tsx
+++ b/features/dashboard/widgets/modules/StatsOverviewWidgetModule.tsx
@@ -53,7 +53,7 @@ function StatsOverviewWidget({ context }: { context: DashboardRenderContext }) {
   const tech = isTechRole(context.role);
 
   return (
-    <div className="grid gap-2.5 md:grid-cols-2 2xl:grid-cols-4">
+    <div className="grid gap-2.5 md:grid-cols-2 xl:grid-cols-4">
       <MetricCard
         label="Appointments"
         value={context.counts.appointments}

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -514,7 +514,9 @@ export default function AppShell({
 
           <main className="flex w-full min-w-0 flex-1 flex-col overflow-x-hidden px-3 pb-14 pt-16 md:px-4 md:pb-6 md:pt-16 lg:px-6 lg:pt-[4.25rem] xl:px-8 2xl:px-10">
             <TabsBridge tabsSubdued={chatOpen}>
-              <div className="relative z-0 min-w-0">{children}</div>
+              <div className="relative z-0 mx-auto w-full max-w-[1800px] min-w-0">
+                {children}
+              </div>
             </TabsBridge>
           </main>
 

--- a/features/shared/components/RoleHubTiles/RoleHubTiles.tsx
+++ b/features/shared/components/RoleHubTiles/RoleHubTiles.tsx
@@ -104,7 +104,7 @@ export default function RoleHubTiles({
   const { open, setOpen } = useSectionOpenState(sections);
 
   return (
-    <div className="mx-auto max-w-6xl px-4 py-8 space-y-4">
+    <div className="mx-auto w-full max-w-[1800px] space-y-4 px-3 py-4 sm:px-5 lg:px-6">
       <div>
         <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
         {description ? <p className="text-sm text-muted-foreground mt-1">{description}</p> : null}
@@ -125,7 +125,7 @@ export default function RoleHubTiles({
             </button>
 
             {isOpen && (
-              <div className="grid gap-3 px-4 pb-4 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid gap-3 px-4 pb-4 sm:grid-cols-2 xl:grid-cols-4">
                 {tiles.map((t) => (
                   <Link
                     key={t.href}

--- a/features/shared/components/nav/NavFromTiles.tsx
+++ b/features/shared/components/nav/NavFromTiles.tsx
@@ -76,11 +76,11 @@ export default function NavFromTiles({
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="mx-auto w-full max-w-[1800px] px-3 py-4 sm:px-5 lg:px-6">
         <h1 className="mb-2 text-3xl font-blackops tracking-[0.08em] text-[var(--accent-copper-light)]">
           {heading}
         </h1>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}

--- a/tests/dashboard-large-screen-layout.test.ts
+++ b/tests/dashboard-large-screen-layout.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("large-screen dashboard layout", () => {
+  it("uses one wide application frame for dashboard and operational surfaces", () => {
+    for (const path of [
+      "features/shared/components/AppShell.tsx",
+      "features/shared/components/RoleHubTiles/RoleHubTiles.tsx",
+      "features/dashboard/app/dashboard/advisor/page.tsx",
+      "features/dashboard/app/dashboard/admin/AdminSurface.tsx",
+      "features/dashboard/app/dashboard/admin/AdminDashboardClient.tsx",
+      "features/dashboard/app/dashboard/admin/BillingClient.tsx",
+      "features/dashboard/app/dashboard/owner/reports/page.tsx",
+      "features/dashboard/app/dashboard/owner/settings/page.tsx",
+      "app/parts/page.tsx",
+      "app/work-orders/board/page.tsx",
+    ]) {
+      expect(read(path), path).toContain("max-w-[1800px]");
+    }
+  });
+
+  it("treats scaled 1080p TV viewports as desktop dashboard density", () => {
+    const responsive = read(
+      "features/dashboard/lib/dashboard-responsive-layout.ts",
+    );
+    expect(responsive).toContain('if (width < 1280) return "laptop"');
+    expect(responsive).not.toContain('if (width < 1536) return "laptop"');
+  });
+
+  it("moves four-up dashboard grids to the xl breakpoint", () => {
+    const roleTiles = read(
+      "features/shared/components/RoleHubTiles/RoleHubTiles.tsx",
+    );
+    const advisor = read(
+      "features/dashboard/app/dashboard/advisor/page.tsx",
+    );
+    const moduleSystem = read(
+      "features/dashboard/components/DashboardModuleSystem.tsx",
+    );
+    const stats = read(
+      "features/dashboard/widgets/modules/StatsOverviewWidgetModule.tsx",
+    );
+
+    expect(roleTiles).toContain("sm:grid-cols-2 xl:grid-cols-4");
+    expect(advisor).toContain("sm:grid-cols-2 xl:grid-cols-4");
+    expect(moduleSystem).toContain("grid-cols-2 xl:grid-cols-4");
+    expect(stats).toContain("md:grid-cols-2 xl:grid-cols-4");
+  });
+});


### PR DESCRIPTION
## What changed

- Standardizes dashboard and operational board content on a shared 1800px large-screen frame.
- Treats 1280px+ CSS viewports as desktop density so 1080p TVs using 125–150% OS scaling do not fall back to laptop layouts.
- Moves four-up role navigation, advisor, metric, and summary grids to the `xl` breakpoint.
- Expands Admin, Billing, Reports, Owner Settings, Parts Dashboard, and Work Order Board surfaces consistently.
- Keeps forms, imports, user settings, and dialogs intentionally narrow for readability.

## Validation

- 11 focused large-screen and Parts workflow tests passed.
- ESLint passed for all 16 changed files.
- `git diff --check` passed.

## Vercel production finding

The prior merge commit `0a76503` has no GitHub deployment status and no workflow run. The repository already enables deployments for `main` in `vercel.json`, so Production was never triggered by the Vercel project integration. Verify Vercel Project Settings → Git has Production Branch set to `main` and automatic production deployments enabled before merging this PR.