### PR TITLE
Keep every role and route inside the mobile application

### DIFF
--- a/app/api/auth/sign-in/route.ts
+++ b/app/api/auth/sign-in/route.ts
@@ -2,10 +2,14 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities } from "@/features/shared/lib/rbac";
-import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+
 import { enforceAuthRateLimit } from "@/features/auth/server/authRateLimit";
+import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import {
   buildShopUserAuthEmail,
   getAuthIdentifierStrategy,
@@ -46,7 +50,10 @@ export async function POST(req: Request) {
       : "shop";
 
   if (!identifier || !password) {
-    return NextResponse.json({ ok: false, error: GENERIC_ERROR }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: GENERIC_ERROR },
+      { status: 400 },
+    );
   }
 
   const rateLimit = enforceAuthRateLimit(req, `sign-in:${surface}`, identifier, {
@@ -56,21 +63,33 @@ export async function POST(req: Request) {
   if (!rateLimit.allowed) {
     return NextResponse.json(
       { ok: false, error: "Too many attempts. Wait a moment and try again." },
-      { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
+      },
     );
   }
 
   const supabase = createServerSupabaseRoute();
   const authEmail = await resolveAuthEmail(identifier);
-  const { data, error } = await supabase.auth.signInWithPassword({ email: authEmail, password });
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: authEmail,
+    password,
+  });
 
   if (error || !data.user) {
-    return NextResponse.json({ ok: false, error: GENERIC_ERROR }, { status: 401 });
+    return NextResponse.json(
+      { ok: false, error: GENERIC_ERROR },
+      { status: 401 },
+    );
   }
 
   const deny = async () => {
     await supabase.auth.signOut();
-    return NextResponse.json({ ok: false, error: GENERIC_ERROR }, { status: 403 });
+    return NextResponse.json(
+      { ok: false, error: GENERIC_ERROR },
+      { status: 403 },
+    );
   };
 
   if (
@@ -104,7 +123,9 @@ export async function POST(req: Request) {
   }
 
   if (surface === "fleet") {
-    const actor = await resolveFleetActorContext(supabase, { userId: data.user.id });
+    const actor = await resolveFleetActorContext(supabase, {
+      userId: data.user.id,
+    });
     if (!actor.capabilities.canAccessPortalFleetWrappers) return deny();
     return NextResponse.json({ ok: true, destination: "/portal/fleet" });
   }
@@ -120,14 +141,14 @@ export async function POST(req: Request) {
   if (surface === "mobile") {
     const capabilities = getActorCapabilities({ role: profile.role });
     const canUseMobile =
-      capabilities.canRunInspections ||
-      capabilities.canManageWorkOrders ||
-      capabilities.canPerformAssignedWork;
+      capabilities.isKnownRole && capabilities.canonicalRole !== "customer";
     if (!canUseMobile) return deny();
   }
 
   const destination = profile.must_change_password
-    ? "/auth/set-password"
+    ? surface === "mobile"
+      ? "/auth/set-password?redirect=%2Fmobile"
+      : "/auth/set-password"
     : surface === "mobile"
       ? "/mobile"
       : profile.completed_onboarding || profile.shop_id

--- a/app/api/fleet/service-requests/route.ts
+++ b/app/api/fleet/service-requests/route.ts
@@ -1,12 +1,13 @@
 // app/api/fleet/service-requests/route.ts
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
+
 import {
   resolveFleetActorContext,
   resolveFleetActorScope,
 } from "@/features/fleet/lib/resolveFleetActorContext";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 
@@ -28,19 +29,20 @@ export type PortalServiceRequest = {
 };
 
 type Body = {
-  fleetId?: string | null; // optional for future fleet switching
+  fleetId?: string | null;
 };
 
 export async function POST(req: NextRequest) {
   try {
     const supabase = createServerSupabaseRoute();
-
     const body = (await req.json().catch(() => ({}))) as Body;
 
     const actor = await resolveFleetActorContext(supabase, {
       requestedFleetId: body.fleetId ?? null,
     });
-    if (!actor.userId || !actor.capabilities.canSeeFleetWideUnits) {
+    const canReadRequests =
+      actor.capabilities.canSeeFleetWideUnits || actor.isFleetActor;
+    if (!actor.userId || !canReadRequests) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -55,7 +57,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // RLS + membership policies enforce access
+    // RLS and fleet membership remain the final authorization boundary.
     const { data: requests, error: requestError } = await supabase
       .from("fleet_service_requests")
       .select(
@@ -86,9 +88,7 @@ export async function POST(req: NextRequest) {
       | "scheduled_for_date"
     >[];
 
-    const vehicleIds = Array.from(new Set(typed.map((r) => r.vehicle_id)));
-
-    // Optional enrichment (requires vehicles SELECT RLS for fleet members)
+    const vehicleIds = Array.from(new Set(typed.map((request) => request.vehicle_id)));
     const vehiclesMap = new Map<
       string,
       { unitLabel: string | null; plate: string | null }
@@ -104,42 +104,42 @@ export async function POST(req: NextRequest) {
         // eslint-disable-next-line no-console
         console.error("[fleet/service-requests] vehicles error:", vehiclesError);
       } else {
-        const vrows = (vehicleRows ?? []) as Pick<
+        const rows = (vehicleRows ?? []) as Pick<
           VehicleRow,
           "id" | "unit_number" | "license_plate" | "vin"
         >[];
 
-        for (const v of vrows) {
+        for (const vehicle of rows) {
           const primaryLabel =
-            (v.unit_number && v.unit_number.trim().length > 0
-              ? v.unit_number
-              : v.license_plate || v.vin) ?? null;
+            (vehicle.unit_number && vehicle.unit_number.trim().length > 0
+              ? vehicle.unit_number
+              : vehicle.license_plate || vehicle.vin) ?? null;
 
-          vehiclesMap.set(v.id, {
+          vehiclesMap.set(vehicle.id, {
             unitLabel: primaryLabel,
-            plate: v.license_plate ?? null,
+            plate: vehicle.license_plate ?? null,
           });
         }
       }
     }
 
-    const payload: PortalServiceRequest[] = typed.map((r) => {
-      const vehicle = vehiclesMap.get(r.vehicle_id) ?? {
+    const payload: PortalServiceRequest[] = typed.map((request) => {
+      const vehicle = vehiclesMap.get(request.vehicle_id) ?? {
         unitLabel: null,
         plate: null,
       };
 
       return {
-        id: r.id,
-        vehicleId: r.vehicle_id,
+        id: request.id,
+        vehicleId: request.vehicle_id,
         unitLabel: vehicle.unitLabel,
         plate: vehicle.plate,
-        title: r.title,
-        summary: r.summary,
-        severity: r.severity,
-        status: r.status,
-        createdAt: r.created_at,
-        scheduledForDate: r.scheduled_for_date,
+        title: request.title,
+        summary: request.summary,
+        severity: request.severity,
+        status: request.status,
+        createdAt: request.created_at,
+        scheduledForDate: request.scheduled_for_date,
       };
     });
 

--- a/app/launch/page.tsx
+++ b/app/launch/page.tsx
@@ -1,41 +1,54 @@
 "use client";
 
 import { useEffect } from "react";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+
 import { resolveInstalledLaunchPath } from "@/features/shared/lib/pwa/launch";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 export default function LaunchPage() {
   useEffect(() => {
     let active = true;
+
     const launch = async () => {
+      const compactViewport = window.matchMedia("(max-width: 900px)").matches;
+
       if (!navigator.onLine) {
-        window.location.replace("/offline");
+        window.location.replace(compactViewport ? "/mobile/offline" : "/offline");
         return;
       }
+
       const supabase = createBrowserSupabase();
       const { data: sessionData } = await supabase.auth.getSession();
       const userId = sessionData.session?.user.id;
       if (!active) return;
+
       if (!userId) {
-        window.location.replace("/sign-in?next=/launch");
+        window.location.replace(
+          compactViewport
+            ? "/mobile/sign-in?redirect=%2Flaunch"
+            : "/sign-in?next=/launch",
+        );
         return;
       }
+
       const { data: profile } = await supabase
         .from("profiles")
         .select("role")
         .eq("id", userId)
         .maybeSingle();
       if (!active) return;
-      const compactViewport = window.matchMedia("(max-width: 900px)").matches;
+
       window.location.replace(
         resolveInstalledLaunchPath(profile?.role, compactViewport),
       );
     };
+
     void launch();
     return () => {
       active = false;
     };
   }, []);
+
   return (
     <main className="grid min-h-screen place-items-center bg-slate-950 text-slate-100">
       <p className="text-sm uppercase tracking-[0.2em]">Opening ProFixIQ…</p>

--- a/app/mobile/assistant/page.tsx
+++ b/app/mobile/assistant/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useMemo, useState } from "react";
+
+import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
+import { useAssistant } from "@/features/assistant/hooks/useAssistant";
+import type { AssistantContext } from "@/features/assistant/types/assistant";
+import { Button } from "@shared/components/ui/Button";
+
+function optionalParam(params: URLSearchParams, key: string): string | undefined {
+  const value = params.get(key)?.trim();
+  return value || undefined;
+}
+
+export default function MobileAssistantPage() {
+  const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
+  const [question, setQuestion] = useState("");
+
+  const context = useMemo<AssistantContext>(() => {
+    const params = new URLSearchParams(searchKey);
+    return {
+      workOrderId: optionalParam(params, "workOrderId"),
+      vehicleId: optionalParam(params, "vehicleId"),
+      customerId: optionalParam(params, "customerId"),
+      bookingId: optionalParam(params, "bookingId"),
+      pageType: optionalParam(params, "pageType") ?? "mobile",
+      pageTitle: optionalParam(params, "pageTitle") ?? "Mobile",
+    };
+  }, [searchKey]);
+
+  const contextKey = useMemo(
+    () =>
+      [
+        context.pageType,
+        context.workOrderId,
+        context.vehicleId,
+        context.customerId,
+        context.bookingId,
+      ]
+        .filter(Boolean)
+        .join(":"),
+    [context],
+  );
+  const { ask, loading, data, messages, clearConversation } =
+    useAssistant(contextKey);
+
+  const submit = async () => {
+    const value = question.trim();
+    if (!value || loading) return;
+    await ask(value, context);
+    setQuestion("");
+  };
+
+  const contextLabel = [
+    context.workOrderId ? "Work order" : null,
+    context.vehicleId ? "Vehicle" : null,
+    context.customerId ? "Customer" : null,
+    context.bookingId ? "Appointment" : null,
+  ]
+    .filter(Boolean)
+    .join(" • ");
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Shop assistant
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          Ask a question
+        </h1>
+        <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+          This is a deliberate question-and-answer tool. It does not change work
+          orders, appointments, parts, or shop records automatically.
+        </p>
+        {contextLabel ? (
+          <div className="mt-3 inline-flex rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]">
+            Context: {contextLabel}
+          </div>
+        ) : null}
+      </section>
+
+      {messages.length > 0 ? (
+        <section className="max-h-64 space-y-2 overflow-y-auto rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3">
+          {messages.slice(-8).map((message, index) => (
+            <div
+              key={`${message.role}-${index}-${message.content.slice(0, 20)}`}
+              className={`rounded-2xl px-3 py-2 text-sm leading-5 ${
+                message.role === "user"
+                  ? "ml-6 bg-[color:var(--accent-copper)] text-white"
+                  : "mr-6 border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)]"
+              }`}
+            >
+              {message.content}
+            </div>
+          ))}
+        </section>
+      ) : null}
+
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <label
+          htmlFor="mobile-assistant-question"
+          className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]"
+        >
+          Question
+        </label>
+        <textarea
+          id="mobile-assistant-question"
+          value={question}
+          onChange={(event) => setQuestion(event.target.value)}
+          placeholder="Ask about shop status, a customer, a work order, parts, appointments, or fleet operations."
+          className="mt-2 min-h-32 w-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)] focus:ring-2 focus:ring-[var(--accent-copper-soft)]/30"
+        />
+        <div className="mt-3 flex items-center justify-between gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={loading || messages.length === 0}
+            onClick={() => {
+              clearConversation();
+              setQuestion("");
+            }}
+          >
+            Clear
+          </Button>
+          <Button
+            type="button"
+            variant="copper"
+            size="sm"
+            disabled={loading || !question.trim()}
+            isLoading={loading}
+            onClick={() => void submit()}
+          >
+            Ask Assistant
+          </Button>
+        </div>
+      </section>
+
+      <AssistantResponseCard data={data} />
+    </div>
+  );
+}

--- a/app/mobile/customers/[id]/page.tsx
+++ b/app/mobile/customers/[id]/page.tsx
@@ -1,12 +1,12 @@
-// app/mobile/customers/[id]/page.tsx (FULL FILE REPLACEMENT)
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
+import { useParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
-import { format } from "date-fns";
 
 type DB = Database;
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
@@ -15,22 +15,22 @@ type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
 
 type ParamsShape = Record<string, string | string[]>;
 
-function paramToString(v: string | string[] | undefined): string | null {
-  if (!v) return null;
-  return Array.isArray(v) ? v[0] ?? null : v;
+function paramToString(value: string | string[] | undefined): string | null {
+  if (!value) return null;
+  return Array.isArray(value) ? value[0] ?? null : value;
 }
 
 const STATUS_BADGE: Record<string, string> = {
   awaiting:
-    "bg-sky-500/10 border border-sky-500/60 text-[0.65rem] uppercase tracking-[0.16em] text-sky-100 rounded-full px-2 py-0.5",
+    "rounded-full border border-sky-500/60 bg-sky-500/10 px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.16em] text-sky-100",
   in_progress:
-    "bg-orange-500/10 border border-orange-500/60 text-[0.65rem] uppercase tracking-[0.16em] text-orange-100 rounded-full px-2 py-0.5",
+    "rounded-full border border-orange-500/60 bg-orange-500/10 px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.16em] text-orange-100",
   on_hold:
-    "bg-yellow-500/10 border border-yellow-500/60 text-[0.65rem] uppercase tracking-[0.16em] text-yellow-100 rounded-full px-2 py-0.5",
+    "rounded-full border border-yellow-500/60 bg-yellow-500/10 px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.16em] text-yellow-100",
   completed:
-    "bg-emerald-500/10 border border-emerald-500/60 text-[0.65rem] uppercase tracking-[0.16em] text-emerald-100 rounded-full px-2 py-0.5",
+    "rounded-full border border-emerald-500/60 bg-emerald-500/10 px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.16em] text-emerald-100",
   invoiced:
-    "bg-purple-500/10 border border-purple-500/60 text-[0.65rem] uppercase tracking-[0.16em] text-purple-100 rounded-full px-2 py-0.5",
+    "rounded-full border border-purple-500/60 bg-purple-500/10 px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.16em] text-purple-100",
 };
 
 function statusChipClass(status: string | null | undefined): string {
@@ -40,137 +40,160 @@ function statusChipClass(status: string | null | undefined): string {
 
 export default function MobileCustomerProfilePage() {
   const params = useParams();
-  const router = useRouter();
   const customerId = useMemo(() => {
     const raw = (params as ParamsShape)?.id;
     return paramToString(raw);
   }, [params]);
-
   const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [customer, setCustomer] = useState<Customer | null>(null);
   const [vehicles, setVehicles] = useState<Vehicle[]>([]);
   const [workOrders, setWorkOrders] = useState<WorkOrder[]>([]);
   const [loading, setLoading] = useState(true);
-  const [err, setErr] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!customerId) return;
+    let active = true;
 
-    (async () => {
+    void (async () => {
       setLoading(true);
-      setErr(null);
+      setError(null);
       try {
-        const [cRes, vRes, woRes] = await Promise.all([
-          supabase
-            .from("customers")
-            .select("*")
-            .eq("id", customerId)
-            .maybeSingle(),
-          supabase
-            .from("vehicles")
-            .select("*")
-            .eq("customer_id", customerId)
-            .order("created_at", { ascending: true }),
-          supabase
-            .from("work_orders")
-            .select("*")
-            .eq("customer_id", customerId)
-            .order("created_at", { ascending: false }),
-        ]);
+        const [customerResult, vehiclesResult, workOrdersResult] =
+          await Promise.all([
+            supabase
+              .from("customers")
+              .select("*")
+              .eq("id", customerId)
+              .maybeSingle(),
+            supabase
+              .from("vehicles")
+              .select("*")
+              .eq("customer_id", customerId)
+              .order("created_at", { ascending: true }),
+            supabase
+              .from("work_orders")
+              .select("*")
+              .eq("customer_id", customerId)
+              .order("created_at", { ascending: false }),
+          ]);
 
-        if (cRes.error) throw cRes.error;
-        setCustomer(cRes.data ?? null);
+        if (customerResult.error) throw customerResult.error;
+        if (vehiclesResult.error) throw vehiclesResult.error;
+        if (workOrdersResult.error) throw workOrdersResult.error;
+        if (!active) return;
 
-        if (vRes.error) throw vRes.error;
-        const directVehicles = vRes.data ?? [];
-        const directVehicleIds = directVehicles.map((v) => v.id).filter(Boolean);
+        const customerRecord = customerResult.data ?? null;
+        const directVehicles = (vehiclesResult.data ?? []) as Vehicle[];
+        const directVehicleIds = directVehicles
+          .map((vehicle) => vehicle.id)
+          .filter(Boolean);
 
-        if (woRes.error) throw woRes.error;
-        const fallbackWosRes = directVehicleIds.length
+        const vehicleWorkOrdersResult = directVehicleIds.length
           ? await supabase
               .from("work_orders")
               .select("*")
               .in("vehicle_id", directVehicleIds)
               .order("created_at", { ascending: false })
           : { data: [], error: null };
+        if (vehicleWorkOrdersResult.error) throw vehicleWorkOrdersResult.error;
 
-        if (fallbackWosRes.error) throw fallbackWosRes.error;
-
-        const customerRecord = cRes.data;
-        const fallbackWosByNameCandidates = [
+        const fallbackNames = [
           customerRecord?.business_name,
           customerRecord?.name,
           [customerRecord?.first_name ?? "", customerRecord?.last_name ?? ""]
             .filter(Boolean)
             .join(" ")
             .trim(),
-        ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+        ].filter(
+          (value): value is string =>
+            typeof value === "string" && value.trim().length > 0,
+        );
 
-        let fallbackWosByName: WorkOrder[] = [];
-        if ((woRes.data?.length ?? 0) === 0 && (fallbackWosRes.data?.length ?? 0) === 0) {
-          for (const candidate of fallbackWosByNameCandidates) {
-            let byNameQuery = supabase
+        let nameWorkOrders: WorkOrder[] = [];
+        if (
+          (workOrdersResult.data?.length ?? 0) === 0 &&
+          (vehicleWorkOrdersResult.data?.length ?? 0) === 0
+        ) {
+          for (const candidate of fallbackNames) {
+            let query = supabase
               .from("work_orders")
               .select("*")
               .ilike("customer_name", candidate);
-            if (customerRecord?.shop_id) byNameQuery = byNameQuery.eq("shop_id", customerRecord.shop_id);
-            const byNameRes = await byNameQuery
+            if (customerRecord?.shop_id) {
+              query = query.eq("shop_id", customerRecord.shop_id);
+            }
+            const result = await query
               .order("created_at", { ascending: false })
               .limit(25);
-            if (byNameRes.error) throw byNameRes.error;
-            if ((byNameRes.data?.length ?? 0) > 0) {
-              fallbackWosByName = byNameRes.data as WorkOrder[];
+            if (result.error) throw result.error;
+            if ((result.data?.length ?? 0) > 0) {
+              nameWorkOrders = result.data as WorkOrder[];
               break;
             }
           }
         }
 
-        const allWorkOrders = [...(woRes.data ?? []), ...(fallbackWosRes.data ?? []), ...fallbackWosByName];
         const workOrdersById = new Map<string, WorkOrder>();
-        for (const wo of allWorkOrders) {
-          if (!wo?.id) continue;
-          workOrdersById.set(wo.id, wo);
+        for (const workOrder of [
+          ...((workOrdersResult.data ?? []) as WorkOrder[]),
+          ...((vehicleWorkOrdersResult.data ?? []) as WorkOrder[]),
+          ...nameWorkOrders,
+        ]) {
+          if (workOrder.id) workOrdersById.set(workOrder.id, workOrder);
         }
-        const mergedWorkOrders = Array.from(workOrdersById.values()).sort(
-          (a, b) => new Date(String(b.created_at ?? "")).getTime() - new Date(String(a.created_at ?? "")).getTime(),
+        const mergedWorkOrders = [...workOrdersById.values()].sort(
+          (left, right) =>
+            new Date(right.created_at ?? 0).getTime() -
+            new Date(left.created_at ?? 0).getTime(),
         );
 
         const fallbackVehicleIds = Array.from(
           new Set(
             mergedWorkOrders
-              .map((wo) => wo.vehicle_id)
-              .filter((id): id is string => typeof id === "string" && id.length > 0),
+              .map((workOrder) => workOrder.vehicle_id)
+              .filter((id): id is string => Boolean(id)),
           ),
         ).filter((id) => !directVehicleIds.includes(id));
 
-        const fallbackVehiclesRes = fallbackVehicleIds.length
-          ? await supabase.from("vehicles").select("*").in("id", fallbackVehicleIds)
+        const fallbackVehiclesResult = fallbackVehicleIds.length
+          ? await supabase
+              .from("vehicles")
+              .select("*")
+              .in("id", fallbackVehicleIds)
           : { data: [], error: null };
+        if (fallbackVehiclesResult.error) throw fallbackVehiclesResult.error;
+        if (!active) return;
 
-        if (fallbackVehiclesRes.error) throw fallbackVehiclesRes.error;
-
-        setVehicles([...(directVehicles as Vehicle[]), ...((fallbackVehiclesRes.data ?? []) as Vehicle[])]);
+        setCustomer(customerRecord);
+        setVehicles([
+          ...directVehicles,
+          ...((fallbackVehiclesResult.data ?? []) as Vehicle[]),
+        ]);
         setWorkOrders(mergedWorkOrders);
-      } catch (e) {
-        const msg =
-          e instanceof Error ? e.message : "Failed to load customer profile.";
-        setErr(msg);
+      } catch (caught) {
+        if (!active) return;
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : "Failed to load customer profile.",
+        );
         setCustomer(null);
         setVehicles([]);
         setWorkOrders([]);
       } finally {
-        setLoading(false);
+        if (active) setLoading(false);
       }
     })();
+
+    return () => {
+      active = false;
+    };
   }, [customerId, supabase]);
 
   if (!customerId) {
-    return (
-        <div className="px-4 py-4 text-sm text-red-400">
-          Missing customer id.
-        </div>
-    );
+    return <div className="px-4 py-4 text-sm text-red-400">Missing customer id.</div>;
   }
 
   const displayName = customer
@@ -182,224 +205,221 @@ export default function MobileCustomerProfilePage() {
     : "Customer";
 
   return (
-      <div className="mx-auto w-full max-w-5xl px-4 py-4 space-y-4 text-foreground">
-        {/* Top bar */}
-        <div className="flex items-center justify-between gap-2">
-          <button
-            type="button"
-            onClick={() => router.back()}
-            className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-1 text-xs text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-panel)]"
-          >
-            ← Back
-          </button>
+    <div className="mx-auto w-full max-w-5xl space-y-4 px-4 py-4 text-foreground">
+      <div className="flex items-center justify-between gap-2">
+        <Link
+          href="/mobile/work-orders"
+          className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-1 text-xs text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-panel)]"
+        >
+          ← Work orders
+        </Link>
+        <Link
+          href={`/mobile/work-orders/create?customerId=${encodeURIComponent(customerId)}`}
+          className="rounded-full border border-[var(--accent-copper-soft)]/70 bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-[0.7rem] font-semibold text-[color:var(--theme-text-primary)]"
+        >
+          + Work order
+        </Link>
+      </div>
 
-          <Link
-            href={`/customers/${customerId}`}
-            className="rounded-full border border-orange-500/70 bg-orange-500 px-3 py-1 text-[0.7rem] font-semibold text-[color:var(--theme-text-on-accent)] hover:bg-orange-400"
-          >
-            Open full view
-          </Link>
+      <div className="space-y-1">
+        <h1 className="text-lg font-blackops uppercase tracking-[0.18em] text-[color:var(--theme-text-primary)]">
+          Customer
+        </h1>
+        <p className="text-xs text-[color:var(--theme-text-secondary)]">
+          {displayName}
+        </p>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-red-500/60 bg-red-950/40 px-3 py-2 text-xs text-red-200">
+          {error}
         </div>
+      ) : null}
 
-        {/* Heading */}
-        <div className="space-y-1">
-          <h1 className="text-lg font-blackops uppercase tracking-[0.18em] text-[color:var(--theme-text-primary)]">
-            Customer
-          </h1>
-          <p className="text-xs text-[color:var(--theme-text-secondary)]">{displayName}</p>
+      {loading ? (
+        <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-4 text-sm text-[color:var(--theme-text-secondary)]">
+          Loading customer…
         </div>
-
-        {err && (
-          <div className="rounded-md border border-red-500/60 bg-red-950/40 px-3 py-2 text-xs text-red-200">
-            {err}
-          </div>
-        )}
-
-        {loading ? (
-          <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-4 text-sm text-[color:var(--theme-text-secondary)]">
-            Loading customer…
-          </div>
-        ) : !customer ? (
-          <div className="rounded-lg border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-6 text-sm text-[color:var(--theme-text-secondary)]">
-            Customer not found.
-          </div>
-        ) : (
-          <>
-            {/* Customer details */}
-            <section className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm">
-              <div className="mb-1 text-[0.7rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
-                Contact
+      ) : !customer ? (
+        <div className="rounded-lg border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-6 text-sm text-[color:var(--theme-text-secondary)]">
+          Customer not found.
+        </div>
+      ) : (
+        <>
+          <section className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm">
+            <div className="mb-1 text-[0.7rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+              Contact
+            </div>
+            <div className="space-y-1 text-xs text-[color:var(--theme-text-primary)]">
+              <div>
+                <span className="text-[color:var(--theme-text-muted)]">Name:</span>{" "}
+                {displayName}
               </div>
-              <div className="space-y-1 text-xs text-[color:var(--theme-text-primary)]">
-                <div>
-                  <span className="text-[color:var(--theme-text-muted)]">Name:</span> {displayName}
-                </div>
-                <div>
-                  <span className="text-[color:var(--theme-text-muted)]">Email:</span>{" "}
-                  {customer.email ?? "—"}
-                </div>
-                <div>
-                  <span className="text-[color:var(--theme-text-muted)]">Phone:</span>{" "}
-                  {customer.phone ?? "—"}
-                </div>
+              <div>
+                <span className="text-[color:var(--theme-text-muted)]">Email:</span>{" "}
+                {customer.email ?? "—"}
               </div>
+              <div>
+                <span className="text-[color:var(--theme-text-muted)]">Phone:</span>{" "}
+                {customer.phone ?? "—"}
+              </div>
+            </div>
 
-              <div className="mt-3 mb-1 text-[0.7rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
-                Address
+            <div className="mb-1 mt-3 text-[0.7rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+              Address
+            </div>
+            <div className="space-y-1 text-xs text-[color:var(--theme-text-primary)]">
+              <div>{customer.address || "—"}</div>
+              <div>
+                {[
+                  customer.city || "",
+                  customer.province || "",
+                  customer.postal_code || "",
+                ]
+                  .filter(Boolean)
+                  .join(", ") || "—"}
               </div>
-              <div className="space-y-1 text-xs text-[color:var(--theme-text-primary)]">
-                <div>{customer.address || "—"}</div>
-                <div>
-                  {[
-                    customer.city || "",
-                    customer.province || "",
-                    customer.postal_code || "",
+            </div>
+          </section>
+
+          <section className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm">
+            <div className="mb-1 flex items-center justify-between">
+              <div className="text-[0.7rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                Vehicles
+              </div>
+              {vehicles.length > 0 ? (
+                <div className="text-[0.7rem] text-[color:var(--theme-text-muted)]">
+                  {vehicles.length} total
+                </div>
+              ) : null}
+            </div>
+
+            {vehicles.length === 0 ? (
+              <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                No vehicles yet.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {vehicles.map((vehicle) => {
+                  const title = [
+                    vehicle.year ? String(vehicle.year) : "",
+                    vehicle.make ?? "",
+                    vehicle.model ?? "",
                   ]
                     .filter(Boolean)
-                    .join(", ") || "—"}
-                </div>
-              </div>
-            </section>
+                    .join(" ");
 
-            {/* Vehicles */}
-            <section className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm">
-              <div className="mb-1 flex items-center justify-between">
-                <div className="text-[0.7rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
-                  Vehicles
-                </div>
-                {vehicles.length > 0 && (
-                  <div className="text-[0.7rem] text-[color:var(--theme-text-muted)]">
-                    {vehicles.length} total
-                  </div>
-                )}
-              </div>
-
-              {vehicles.length === 0 ? (
-                <p className="text-xs text-[color:var(--theme-text-secondary)]">No vehicles yet.</p>
-              ) : (
-                <div className="space-y-2">
-                  {vehicles.map((v) => {
-                    const title = [
-                      v.year ? String(v.year) : "",
-                      v.make ?? "",
-                      v.model ?? "",
-                    ]
-                      .filter(Boolean)
-                      .join(" ");
-
-                    return (
-                      <div
-                        key={v.id}
-                        className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-xs text-[color:var(--theme-text-primary)]"
-                      >
-                        <div className="flex items-center justify-between gap-2">
-                          <div className="font-medium text-[color:var(--theme-text-primary)]">
-                            {title || "Vehicle"}
-                          </div>
-                          {v.license_plate && (
-                            <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-0.5 text-[0.65rem] text-[color:var(--theme-text-primary)]">
-                              {v.license_plate}
-                            </span>
-                          )}
-                        </div>
-
-                        <div className="mt-2 grid grid-cols-2 gap-1 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
-                          <div>
-                            <span className="text-[color:var(--theme-text-muted)]">VIN:</span>{" "}
-                            {v.vin || "—"}
-                          </div>
-                          <div>
-                            <span className="text-[color:var(--theme-text-muted)]">Mileage:</span>{" "}
-                            {v.mileage || "—"}
-                          </div>
-                          <div>
-                            <span className="text-[color:var(--theme-text-muted)]">Unit #:</span>{" "}
-                            {v.unit_number || "—"}
-                          </div>
-                          <div>
-                            <span className="text-[color:var(--theme-text-muted)]">Color:</span>{" "}
-                            {v.color || "—"}
-                          </div>
-                          <div>
-                            <span className="text-[color:var(--theme-text-muted)]">Engine hrs:</span>{" "}
-                            {v.engine_hours != null
-                              ? String(v.engine_hours)
-                              : "—"}
-                          </div>
-                          <div>
-                            <span className="text-[color:var(--theme-text-muted)]">Engine:</span>{" "}
-                            {v.engine || "—"}
-                          </div>
-                          <div>
-                            <span className="text-[color:var(--theme-text-muted)]">Trans:</span>{" "}
-                            {v.transmission || "—"}
-                          </div>
-                          <div>
-                            <span className="text-[color:var(--theme-text-muted)]">Fuel:</span>{" "}
-                            {v.fuel_type || "—"}
-                          </div>
-                          <div className="col-span-2">
-                            <span className="text-[color:var(--theme-text-muted)]">Drivetrain:</span>{" "}
-                            {v.drivetrain || "—"}
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </section>
-
-            {/* Work order history */}
-            <section className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm">
-              <div className="mb-1 flex items-center justify-between">
-                <div className="text-[0.7rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
-                  Work Orders
-                </div>
-                {workOrders.length > 0 && (
-                  <div className="text-[0.7rem] text-[color:var(--theme-text-muted)]">
-                    {workOrders.length} total
-                  </div>
-                )}
-              </div>
-
-              {workOrders.length === 0 ? (
-                <p className="text-xs text-[color:var(--theme-text-secondary)]">
-                  No work orders yet for this customer.
-                </p>
-              ) : (
-                <div className="space-y-2">
-                  {workOrders.map((wo) => (
-                    <button
-                      key={wo.id}
-                      type="button"
-                      onClick={() => router.push(`/mobile/work-orders/${wo.id}`)}
-                      className="w-full rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-left text-xs text-[color:var(--theme-text-primary)] hover:border-orange-500/80"
+                  return (
+                    <div
+                      key={vehicle.id}
+                      className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-xs text-[color:var(--theme-text-primary)]"
                     >
                       <div className="flex items-center justify-between gap-2">
-                        <div className="min-w-0">
-                          <div className="font-medium text-[color:var(--theme-text-primary)] truncate">
-                            {wo.custom_id
-                              ? `WO ${wo.custom_id}`
-                              : `WO #${wo.id.slice(0, 8)}`}
-                          </div>
-                          <div className="text-[0.7rem] text-[color:var(--theme-text-secondary)]">
-                            {wo.created_at
-                              ? format(new Date(wo.created_at), "PP p")
-                              : "—"}
-                          </div>
+                        <div className="font-medium text-[color:var(--theme-text-primary)]">
+                          {title || "Vehicle"}
                         </div>
-                        <span className={statusChipClass(wo.status ?? null)}>
-                          {(wo.status ?? "awaiting").replaceAll("_", " ")}
-                        </span>
+                        {vehicle.license_plate ? (
+                          <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-0.5 text-[0.65rem] text-[color:var(--theme-text-primary)]">
+                            {vehicle.license_plate}
+                          </span>
+                        ) : null}
                       </div>
-                    </button>
-                  ))}
+
+                      <div className="mt-2 grid grid-cols-2 gap-1 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
+                        <div>
+                          <span className="text-[color:var(--theme-text-muted)]">VIN:</span>{" "}
+                          {vehicle.vin || "—"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--theme-text-muted)]">Mileage:</span>{" "}
+                          {vehicle.mileage || "—"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--theme-text-muted)]">Unit #:</span>{" "}
+                          {vehicle.unit_number || "—"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--theme-text-muted)]">Color:</span>{" "}
+                          {vehicle.color || "—"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--theme-text-muted)]">Engine hrs:</span>{" "}
+                          {vehicle.engine_hours != null
+                            ? String(vehicle.engine_hours)
+                            : "—"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--theme-text-muted)]">Engine:</span>{" "}
+                          {vehicle.engine || "—"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--theme-text-muted)]">Trans:</span>{" "}
+                          {vehicle.transmission || "—"}
+                        </div>
+                        <div>
+                          <span className="text-[color:var(--theme-text-muted)]">Fuel:</span>{" "}
+                          {vehicle.fuel_type || "—"}
+                        </div>
+                        <div className="col-span-2">
+                          <span className="text-[color:var(--theme-text-muted)]">Drivetrain:</span>{" "}
+                          {vehicle.drivetrain || "—"}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          <section className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm">
+            <div className="mb-1 flex items-center justify-between">
+              <div className="text-[0.7rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                Work Orders
+              </div>
+              {workOrders.length > 0 ? (
+                <div className="text-[0.7rem] text-[color:var(--theme-text-muted)]">
+                  {workOrders.length} total
                 </div>
-              )}
-            </section>
-          </>
-        )}
-      </div>
+              ) : null}
+            </div>
+
+            {workOrders.length === 0 ? (
+              <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                No work orders yet for this customer.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {workOrders.map((workOrder) => (
+                  <Link
+                    key={workOrder.id}
+                    href={`/mobile/work-orders/${workOrder.id}`}
+                    className="block w-full rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-left text-xs text-[color:var(--theme-text-primary)] hover:border-orange-500/80"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="truncate font-medium text-[color:var(--theme-text-primary)]">
+                          {workOrder.custom_id
+                            ? `WO ${workOrder.custom_id}`
+                            : `WO #${workOrder.id.slice(0, 8)}`}
+                        </div>
+                        <div className="text-[0.7rem] text-[color:var(--theme-text-secondary)]">
+                          {workOrder.created_at
+                            ? format(new Date(workOrder.created_at), "PP p")
+                            : "—"}
+                        </div>
+                      </div>
+                      <span className={statusChipClass(workOrder.status ?? null)}>
+                        {(workOrder.status ?? "awaiting").replaceAll("_", " ")}
+                      </span>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
   );
 }

--- a/app/mobile/fleet/page.tsx
+++ b/app/mobile/fleet/page.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  fetchMobileFleetUnits,
+  type MobileFleetUnit,
+} from "@/features/mobile/fleet/client";
+
+function statusLabel(status: MobileFleetUnit["status"]): string {
+  if (status === "oos") return "Out of service";
+  if (status === "limited") return "Limited";
+  return "In service";
+}
+
+function statusClass(status: MobileFleetUnit["status"]): string {
+  if (status === "oos") {
+    return "border-red-400/45 bg-red-500/10 text-red-100";
+  }
+  if (status === "limited") {
+    return "border-amber-400/45 bg-amber-500/10 text-amber-100";
+  }
+  return "border-emerald-400/40 bg-emerald-500/10 text-emerald-100";
+}
+
+export default function MobileFleetPage() {
+  const searchParams = useSearchParams();
+  const selectedUnitId = searchParams.get("unit");
+  const [units, setUnits] = useState<MobileFleetUnit[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setUnits(await fetchMobileFleetUnits());
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "Fleet units could not be loaded.",
+      );
+      setUnits([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const counts = useMemo(
+    () => ({
+      total: units.length,
+      limited: units.filter((unit) => unit.status === "limited").length,
+      oos: units.filter((unit) => unit.status === "oos").length,
+    }),
+    [units],
+  );
+
+  const sortedUnits = useMemo(
+    () =>
+      [...units].sort((left, right) => {
+        if (left.id === selectedUnitId) return -1;
+        if (right.id === selectedUnitId) return 1;
+        const rank = { oos: 0, limited: 1, in_service: 2 } as const;
+        const statusDifference = rank[left.status] - rank[right.status];
+        if (statusDifference !== 0) return statusDifference;
+        return left.label.localeCompare(right.label);
+      }),
+    [selectedUnitId, units],
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Fleet mobile
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          Fleet units
+        </h1>
+        <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+          Review unit availability, open pre-trips, and check service requests
+          without leaving the mobile app.
+        </p>
+        <div className="mt-4 grid grid-cols-3 gap-2">
+          <Metric label="Units" value={counts.total} />
+          <Metric label="Limited" value={counts.limited} warning />
+          <Metric label="Out of service" value={counts.oos} danger />
+        </div>
+      </section>
+
+      <section className="grid grid-cols-2 gap-2">
+        <Link
+          href="/mobile/fleet/pretrip"
+          className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4 active:scale-[0.99]"
+        >
+          <div className="font-semibold text-[color:var(--theme-text-primary)]">
+            Pre-trip
+          </div>
+          <div className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+            Select a unit and complete the walk-around.
+          </div>
+        </Link>
+        <Link
+          href="/mobile/fleet/service-requests"
+          className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4 active:scale-[0.99]"
+        >
+          <div className="font-semibold text-[color:var(--theme-text-primary)]">
+            Service requests
+          </div>
+          <div className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+            Review reported issues and scheduled follow-up.
+          </div>
+        </Link>
+      </section>
+
+      {error ? (
+        <section className="rounded-2xl border border-red-500/40 bg-red-950/30 p-4 text-sm text-red-100">
+          <div className="font-semibold">Fleet could not be loaded</div>
+          <p className="mt-1 text-xs">{error}</p>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="mt-3 min-h-10 rounded-xl border border-red-300/30 px-4 text-xs font-semibold"
+          >
+            Try again
+          </button>
+        </section>
+      ) : null}
+
+      <section className="space-y-2">
+        <div className="flex items-center justify-between px-1">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+            Units
+          </h2>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="text-xs font-semibold text-[var(--accent-copper)] disabled:opacity-50"
+          >
+            Refresh
+          </button>
+        </div>
+
+        {loading ? (
+          [0, 1, 2].map((item) => (
+            <div
+              key={item}
+              className="h-28 animate-pulse rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]"
+            />
+          ))
+        ) : sortedUnits.length === 0 ? (
+          <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+            No fleet units are available for this account.
+          </div>
+        ) : (
+          sortedUnits.map((unit) => (
+            <article
+              key={unit.id}
+              className={`rounded-2xl border bg-[color:var(--theme-surface-panel)] p-4 ${
+                unit.id === selectedUnitId
+                  ? "border-[var(--accent-copper-soft)]/70"
+                  : "border-[color:var(--theme-border-soft)]"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-base font-semibold text-[color:var(--theme-text-primary)]">
+                    {unit.label}
+                  </div>
+                  <div className="mt-1 truncate text-xs text-[color:var(--theme-text-secondary)]">
+                    {[unit.fleetName, unit.plate, unit.vin]
+                      .filter(Boolean)
+                      .join(" • ") || "Unit details unavailable"}
+                  </div>
+                  {unit.nextInspectionDate ? (
+                    <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                      Next inspection: {unit.nextInspectionDate}
+                    </div>
+                  ) : null}
+                </div>
+                <span
+                  className={`shrink-0 rounded-full border px-2.5 py-1 text-[0.65rem] font-semibold ${statusClass(unit.status)}`}
+                >
+                  {statusLabel(unit.status)}
+                </span>
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <Link
+                  href={`/mobile/fleet/pretrip/${unit.id}`}
+                  className="flex min-h-10 items-center justify-center rounded-xl bg-[color:var(--accent-copper)] px-3 text-xs font-semibold text-white"
+                >
+                  Start pre-trip
+                </Link>
+                <Link
+                  href={`/mobile/fleet/service-requests?vehicleId=${encodeURIComponent(unit.id)}`}
+                  className="flex min-h-10 items-center justify-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)]"
+                >
+                  View requests
+                </Link>
+              </div>
+            </article>
+          ))
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  warning = false,
+  danger = false,
+}: {
+  label: string;
+  value: number;
+  warning?: boolean;
+  danger?: boolean;
+}) {
+  const tone = danger && value > 0
+    ? "text-red-200"
+    : warning && value > 0
+      ? "text-amber-200"
+      : "text-[color:var(--theme-text-primary)]";
+  return (
+    <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-2 text-center">
+      <div className={`text-lg font-semibold ${tone}`}>{value}</div>
+      <div className="mt-0.5 text-[0.56rem] uppercase tracking-[0.1em] text-[color:var(--theme-text-muted)]">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/app/mobile/fleet/pretrip/[unitId]/page.tsx
+++ b/app/mobile/fleet/pretrip/[unitId]/page.tsx
@@ -1,11 +1,11 @@
-// app/mobile/fleet/pretrip/[unitId]/page.tsx
 "use client";
 
+import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import PretripForm from "@/features/fleet/components/PretripForm";
 
+import PretripForm from "@/features/fleet/components/PretripForm";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 export default function MobileFleetPretripPage() {
   const params = useParams<{ unitId: string }>();
@@ -13,7 +13,7 @@ export default function MobileFleetPretripPage() {
   const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const unitId = params?.unitId ? String(params.unitId) : null;
-  const driverHint = search.get("driver"); // optional query param for name prefill
+  const driverHint = search.get("driver");
 
   if (!unitId) {
     return (
@@ -25,7 +25,15 @@ export default function MobileFleetPretripPage() {
 
   return (
     <main className="mx-auto flex min-h-[calc(100vh-3rem)] max-w-xl flex-col bg-[color:var(--theme-surface-page)] px-3 py-4 text-[color:var(--theme-text-primary)]">
-      {/* Header strip */}
+      <div className="mb-3">
+        <Link
+          href="/mobile/fleet/pretrip"
+          className="inline-flex min-h-10 items-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)]"
+        >
+          ← Select unit
+        </Link>
+      </div>
+
       <header className="mb-4 rounded-2xl border border-[color:var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-4 py-3 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
         <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--theme-text-muted)]">
           Daily Pre-trip
@@ -38,14 +46,14 @@ export default function MobileFleetPretripPage() {
             >
               Unit {unitId}
             </div>
-            {driverHint && (
+            {driverHint ? (
               <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
                 Logged in as{" "}
                 <span className="font-semibold text-[color:var(--theme-text-primary)]">
                   {driverHint}
                 </span>
               </p>
-            )}
+            ) : null}
           </div>
 
           <span className="inline-flex items-center rounded-full border border-[color:var(--accent-copper-soft,#7E4023)] bg-[color:var(--theme-surface-overlay)] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--accent-copper-light,#E39A6E)] shadow-[var(--theme-shadow-medium)]">
@@ -58,9 +66,12 @@ export default function MobileFleetPretripPage() {
         </p>
       </header>
 
-      {/* Pre-trip form body */}
       <div className="rounded-2xl border border-[color:var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] p-3 shadow-[var(--theme-shadow-medium)] backdrop-blur-xl">
-        <PretripForm unitId={unitId} driverHint={driverHint} supabase={supabase} />
+        <PretripForm
+          unitId={unitId}
+          driverHint={driverHint}
+          supabase={supabase}
+        />
       </div>
     </main>
   );

--- a/app/mobile/fleet/pretrip/page.tsx
+++ b/app/mobile/fleet/pretrip/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  fetchMobileFleetUnits,
+  type MobileFleetUnit,
+} from "@/features/mobile/fleet/client";
+
+export default function MobilePretripIndexPage() {
+  const [units, setUnits] = useState<MobileFleetUnit[]>([]);
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setUnits(await fetchMobileFleetUnits());
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : "Fleet units could not be loaded.",
+      );
+      setUnits([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const visibleUnits = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    return units
+      .filter((unit) => {
+        if (!normalized) return true;
+        return [unit.label, unit.fleetName, unit.plate, unit.vin]
+          .filter(Boolean)
+          .some((value) => String(value).toLowerCase().includes(normalized));
+      })
+      .sort((left, right) => left.label.localeCompare(right.label));
+  }, [query, units]);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Daily inspection
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          Start a pre-trip
+        </h1>
+        <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+          Select the unit you are inspecting. The walk-around opens in the mobile
+          form and defects remain tied to that unit.
+        </p>
+      </section>
+
+      <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3">
+        <label
+          htmlFor="mobile-pretrip-unit-search"
+          className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]"
+        >
+          Find unit
+        </label>
+        <input
+          id="mobile-pretrip-unit-search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Unit, plate, VIN, or fleet"
+          className="mt-2 min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)]"
+        />
+      </section>
+
+      {error ? (
+        <section className="rounded-2xl border border-red-500/40 bg-red-950/30 p-4 text-sm text-red-100">
+          <div className="font-semibold">Units could not be loaded</div>
+          <p className="mt-1 text-xs">{error}</p>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="mt-3 min-h-10 rounded-xl border border-red-300/30 px-4 text-xs font-semibold"
+          >
+            Try again
+          </button>
+        </section>
+      ) : null}
+
+      <section className="space-y-2">
+        {loading ? (
+          [0, 1, 2].map((item) => (
+            <div
+              key={item}
+              className="h-24 animate-pulse rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]"
+            />
+          ))
+        ) : visibleUnits.length === 0 ? (
+          <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+            {units.length === 0
+              ? "No units are available for this account."
+              : "No units match that search."}
+          </div>
+        ) : (
+          visibleUnits.map((unit) => (
+            <Link
+              key={unit.id}
+              href={`/mobile/fleet/pretrip/${unit.id}`}
+              className="block rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 active:scale-[0.99]"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate text-base font-semibold text-[color:var(--theme-text-primary)]">
+                    {unit.label}
+                  </div>
+                  <div className="mt-1 truncate text-xs text-[color:var(--theme-text-secondary)]">
+                    {[unit.fleetName, unit.plate, unit.vin]
+                      .filter(Boolean)
+                      .join(" • ") || "Unit details unavailable"}
+                  </div>
+                </div>
+                <span className="shrink-0 text-sm font-semibold text-[var(--accent-copper)]">
+                  Inspect →
+                </span>
+              </div>
+            </Link>
+          ))
+        )}
+      </section>
+
+      <Link
+        href="/mobile/fleet"
+        className="flex min-h-11 items-center justify-center rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 text-sm font-semibold text-[color:var(--theme-text-primary)]"
+      >
+        Back to fleet
+      </Link>
+    </div>
+  );
+}

--- a/app/mobile/fleet/service-requests/page.tsx
+++ b/app/mobile/fleet/service-requests/page.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  fetchMobileFleetServiceRequests,
+  type MobileFleetServiceRequest,
+} from "@/features/mobile/fleet/client";
+
+type RequestFilter = "active" | "scheduled" | "closed" | "all";
+
+function normalizedStatus(request: MobileFleetServiceRequest): string {
+  return String(request.status ?? "open").toLowerCase().replaceAll(" ", "_");
+}
+
+function isClosed(request: MobileFleetServiceRequest): boolean {
+  return ["closed", "completed", "resolved", "cancelled"].includes(
+    normalizedStatus(request),
+  );
+}
+
+function matchesFilter(
+  request: MobileFleetServiceRequest,
+  filter: RequestFilter,
+): boolean {
+  const status = normalizedStatus(request);
+  if (filter === "all") return true;
+  if (filter === "closed") return isClosed(request);
+  if (filter === "scheduled") return status === "scheduled";
+  return !isClosed(request) && status !== "scheduled";
+}
+
+function severityClass(severity: string | null): string {
+  const value = String(severity ?? "").toLowerCase();
+  if (value === "safety" || value === "compliance" || value === "critical") {
+    return "border-red-400/45 bg-red-500/10 text-red-100";
+  }
+  if (value === "high" || value === "urgent") {
+    return "border-amber-400/45 bg-amber-500/10 text-amber-100";
+  }
+  return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-secondary)]";
+}
+
+export default function MobileFleetServiceRequestsPage() {
+  const searchParams = useSearchParams();
+  const selectedVehicleId = searchParams.get("vehicleId");
+  const [requests, setRequests] = useState<MobileFleetServiceRequest[]>([]);
+  const [filter, setFilter] = useState<RequestFilter>("active");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setRequests(await fetchMobileFleetServiceRequests());
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Service requests could not be loaded.",
+      );
+      setRequests([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const visibleRequests = useMemo(
+    () =>
+      requests
+        .filter(
+          (request) =>
+            (!selectedVehicleId || request.vehicleId === selectedVehicleId) &&
+            matchesFilter(request, filter),
+        )
+        .sort(
+          (left, right) =>
+            new Date(right.createdAt).getTime() -
+            new Date(left.createdAt).getTime(),
+        ),
+    [filter, requests, selectedVehicleId],
+  );
+
+  const counts = useMemo(
+    () => ({
+      active: requests.filter((request) => matchesFilter(request, "active")).length,
+      scheduled: requests.filter((request) =>
+        matchesFilter(request, "scheduled"),
+      ).length,
+      closed: requests.filter((request) => matchesFilter(request, "closed")).length,
+    }),
+    [requests],
+  );
+
+  const filters: Array<{ value: RequestFilter; label: string; count: number }> = [
+    { value: "active", label: "Active", count: counts.active },
+    { value: "scheduled", label: "Scheduled", count: counts.scheduled },
+    { value: "closed", label: "Closed", count: counts.closed },
+    { value: "all", label: "All", count: requests.length },
+  ];
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Fleet maintenance
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          Service requests
+        </h1>
+        <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+          Review reported unit issues and scheduled follow-up. New driver defects
+          are captured through the mobile pre-trip form.
+        </p>
+        {selectedVehicleId ? (
+          <div className="mt-3 flex items-center justify-between gap-3 rounded-xl border border-[var(--accent-copper-soft)]/40 bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-xs">
+            <span className="truncate text-[color:var(--theme-text-secondary)]">
+              Filtered to one unit
+            </span>
+            <Link
+              href="/mobile/fleet/service-requests"
+              className="shrink-0 font-semibold text-[var(--accent-copper)]"
+            >
+              Clear
+            </Link>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="flex gap-2 overflow-x-auto pb-1" aria-label="Request filters">
+        {filters.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            aria-pressed={filter === item.value}
+            onClick={() => setFilter(item.value)}
+            className={`shrink-0 rounded-full border px-3 py-2 text-xs font-semibold ${
+              filter === item.value
+                ? "border-[color:var(--accent-copper)] bg-[color:var(--accent-copper)] text-white"
+                : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]"
+            }`}
+          >
+            {item.label} {item.count}
+          </button>
+        ))}
+      </section>
+
+      {error ? (
+        <section className="rounded-2xl border border-red-500/40 bg-red-950/30 p-4 text-sm text-red-100">
+          <div className="font-semibold">Requests could not be loaded</div>
+          <p className="mt-1 text-xs">{error}</p>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="mt-3 min-h-10 rounded-xl border border-red-300/30 px-4 text-xs font-semibold"
+          >
+            Try again
+          </button>
+        </section>
+      ) : null}
+
+      <section className="space-y-2">
+        {loading ? (
+          [0, 1, 2].map((item) => (
+            <div
+              key={item}
+              className="h-32 animate-pulse rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]"
+            />
+          ))
+        ) : visibleRequests.length === 0 ? (
+          <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+            No service requests match this view.
+          </div>
+        ) : (
+          visibleRequests.map((request) => (
+            <article
+              key={request.id}
+              className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[0.65rem] uppercase tracking-[0.15em] text-[color:var(--theme-text-secondary)]">
+                    {[request.unitLabel, request.plate]
+                      .filter(Boolean)
+                      .join(" • ") || "Fleet unit"}
+                  </div>
+                  <div className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+                    {request.title}
+                  </div>
+                </div>
+                <span
+                  className={`shrink-0 rounded-full border px-2.5 py-1 text-[0.62rem] font-semibold uppercase tracking-[0.1em] ${severityClass(request.severity)}`}
+                >
+                  {request.severity || "normal"}
+                </span>
+              </div>
+
+              {request.summary ? (
+                <p className="mt-2 text-sm leading-5 text-[color:var(--theme-text-secondary)]">
+                  {request.summary}
+                </p>
+              ) : null}
+
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-[color:var(--theme-text-muted)]">
+                <span className="capitalize">
+                  Status: {normalizedStatus(request).replaceAll("_", " ")}
+                </span>
+                <span>{new Date(request.createdAt).toLocaleDateString()}</span>
+              </div>
+              {request.scheduledForDate ? (
+                <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  Scheduled for {request.scheduledForDate}
+                </div>
+              ) : null}
+
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <Link
+                  href={`/mobile/fleet?unit=${encodeURIComponent(request.vehicleId)}`}
+                  className="flex min-h-10 items-center justify-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)]"
+                >
+                  View unit
+                </Link>
+                <Link
+                  href={`/mobile/fleet/pretrip/${request.vehicleId}`}
+                  className="flex min-h-10 items-center justify-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)]"
+                >
+                  Open pre-trip
+                </Link>
+              </div>
+            </article>
+          ))
+        )}
+      </section>
+
+      <Link
+        href="/mobile/fleet"
+        className="flex min-h-11 items-center justify-center rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 text-sm font-semibold text-[color:var(--theme-text-primary)]"
+      >
+        Back to fleet
+      </Link>
+    </div>
+  );
+}

--- a/app/mobile/inspections/[id]/page.tsx
+++ b/app/mobile/inspections/[id]/page.tsx
@@ -1,57 +1,42 @@
-// app/mobile/inspections/[id]/page.tsx
 "use client";
 
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import { useParams, useSearchParams, useRouter } from "next/navigation";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { toast } from "sonner";
 
 import GenericInspectionScreen from "@/features/inspections/screens/GenericInspectionScreen";
-
-/* ------------------------------------------------------------------ */
-/* Types                                                              */
-/* ------------------------------------------------------------------ */
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 type SectionItem = { item: string; unit?: string | null };
 type Section = { title: string; items: SectionItem[] };
 
-/* ------------------------------------------------------------------ */
-/* Regex helpers to detect existing “corner grid” sections             */
-/* ------------------------------------------------------------------ */
-
-// LF/RF/LR/RR ...
 const HYD_ITEM_RE = /^(LF|RF|LR|RR)\s+/i;
-
-// Steer/Drive/Tag/Trailer <N> Left|Right ...
 const AIR_ITEM_RE =
   /^(Steer\s*\d*|Drive\s*\d+|Tag|Trailer\s*\d+)\s+(Left|Right)\s+/i;
 
 function looksLikeCornerTitle(title: string | undefined | null): boolean {
   if (!title) return false;
-  const t = title.toLowerCase();
+  const value = title.toLowerCase();
   return (
-    t.includes("corner grid") ||
-    t.includes("tires & brakes") ||
-    t.includes("tires and brakes") ||
-    t.includes("air brake") ||
-    t.includes("hydraulic brake")
+    value.includes("corner grid") ||
+    value.includes("tires & brakes") ||
+    value.includes("tires and brakes") ||
+    value.includes("air brake") ||
+    value.includes("hydraulic brake")
   );
 }
 
 function stripExistingCornerGrids(sections: Section[]): Section[] {
-  return (sections ?? []).filter((s) => {
-    if (looksLikeCornerTitle(s.title)) return false;
-
-    const items = s.items ?? [];
-    const looksHyd = items.some((it) => HYD_ITEM_RE.test(it.item || ""));
-    const looksAir = items.some((it) => AIR_ITEM_RE.test(it.item || ""));
-    return !(looksHyd || looksAir);
+  return (sections ?? []).filter((section) => {
+    if (looksLikeCornerTitle(section.title)) return false;
+    const items = section.items ?? [];
+    const looksHydraulic = items.some((item) =>
+      HYD_ITEM_RE.test(item.item || ""),
+    );
+    const looksAir = items.some((item) => AIR_ITEM_RE.test(item.item || ""));
+    return !(looksHydraulic || looksAir);
   });
 }
-
-/* ------------------------------------------------------------------ */
-/* Canonical corner grid builders                                     */
-/* ------------------------------------------------------------------ */
 
 function buildHydraulicCornerSection(): Section {
   const metrics: Array<{ label: string; unit: string | null }> = [
@@ -63,11 +48,13 @@ function buildHydraulicCornerSection(): Section {
     { label: "Rotor Thickness", unit: "mm" },
     { label: "Wheel Torque", unit: "ft·lb" },
   ];
-  const corners = ["LF", "RF", "LR", "RR"];
   const items: SectionItem[] = [];
-  for (const c of corners) {
-    for (const m of metrics) {
-      items.push({ item: `${c} ${m.label}`, unit: m.unit });
+  for (const corner of ["LF", "RF", "LR", "RR"]) {
+    for (const metric of metrics) {
+      items.push({
+        item: `${corner} ${metric.label}`,
+        unit: metric.unit,
+      });
     }
   }
   return { title: "Corner Grid (Hydraulic)", items };
@@ -86,7 +73,6 @@ function buildAirCornerSection(): Section {
     { item: "Steer 1 Left Push Rod Travel", unit: "in" },
     { item: "Steer 1 Right Push Rod Travel", unit: "in" },
   ];
-
   const drive: SectionItem[] = [
     { item: "Drive 1 Left Tire Pressure", unit: "psi" },
     { item: "Drive 1 Right Tire Pressure", unit: "psi" },
@@ -101,73 +87,50 @@ function buildAirCornerSection(): Section {
     { item: "Drive 1 Left Push Rod Travel", unit: "in" },
     { item: "Drive 1 Right Push Rod Travel", unit: "in" },
   ];
-
   return { title: "Corner Grid (Air)", items: [...steer, ...drive] };
 }
-
-/* ------------------------------------------------------------------ */
-/* Deterministic grid selection                                       */
-/* ------------------------------------------------------------------ */
 
 function prepareSectionsWithCornerGrid(
   sections: Section[],
   vehicleType: string | null | undefined,
   gridParam: string | null,
 ): Section[] {
-  const s = Array.isArray(sections) ? sections : [];
-
-  // If template already has a corner grid title, don’t inject anything.
-  const hasCornerByTitle = s.some((sec) => looksLikeCornerTitle(sec.title));
-  if (hasCornerByTitle) return s;
-
-  const withoutGrids = stripExistingCornerGrids(s);
-  const gridMode = (gridParam || "").toLowerCase(); // air | hyd | none | ""
-
-  if (gridMode === "none") return withoutGrids;
-
-  let injectAir: boolean;
-  if (gridMode === "air" || gridMode === "hyd") {
-    injectAir = gridMode === "air";
-  } else {
-    const vt = (vehicleType || "").toLowerCase();
-    injectAir =
-      vt.includes("truck") ||
-      vt.includes("bus") ||
-      vt.includes("coach") ||
-      vt.includes("trailer") ||
-      vt.includes("heavy") ||
-      vt.includes("medium-heavy") ||
-      vt.includes("air");
+  const source = Array.isArray(sections) ? sections : [];
+  if (source.some((section) => looksLikeCornerTitle(section.title))) {
+    return source;
   }
 
-  const injected = injectAir
-    ? buildAirCornerSection()
-    : buildHydraulicCornerSection();
+  const withoutGrids = stripExistingCornerGrids(source);
+  const gridMode = (gridParam || "").toLowerCase();
+  if (gridMode === "none") return withoutGrids;
 
-  return [injected, ...withoutGrids];
+  const injectAir =
+    gridMode === "air" ||
+    (gridMode !== "hyd" &&
+      ["truck", "bus", "coach", "trailer", "heavy", "medium-heavy", "air"].some(
+        (token) => (vehicleType || "").toLowerCase().includes(token),
+      ));
+
+  return [
+    injectAir ? buildAirCornerSection() : buildHydraulicCornerSection(),
+    ...withoutGrids,
+  ];
 }
-
-/* ------------------------------------------------------------------ */
-/* Mobile runner page                                                 */
-/* ------------------------------------------------------------------ */
 
 export default function MobileInspectionRunnerPage() {
   const router = useRouter();
   const params = useParams<{ id: string }>();
   const search = useSearchParams();
-  const searchKey = search.toString(); // ✅ stable snapshot for deps
-
+  const searchKey = search.toString();
   const supabase = useMemo(() => createBrowserSupabase(), []);
-
   const lineId = params?.id ? String(params.id) : null;
 
-  // pull values from the stable snapshot
   const { workOrderId, templateId, gridOverride } = useMemo(() => {
-    const sp = new URLSearchParams(searchKey);
+    const values = new URLSearchParams(searchKey);
     return {
-      workOrderId: sp.get("workOrderId"),
-      templateId: sp.get("templateId"),
-      gridOverride: sp.get("grid"), // air | hyd | none | null
+      workOrderId: values.get("workOrderId"),
+      templateId: values.get("templateId"),
+      gridOverride: values.get("grid"),
     };
   }, [searchKey]);
 
@@ -176,75 +139,67 @@ export default function MobileInspectionRunnerPage() {
 
   useEffect(() => {
     let cancelled = false;
-
     if (!lineId || !templateId) {
       setError("Missing inspection line or template.");
       setLoading(false);
       return;
     }
 
-    (async () => {
+    void (async () => {
       try {
-        const { data, error: qErr } = await supabase
+        const { data, error: queryError } = await supabase
           .from("inspection_templates")
           .select("template_name, sections, vehicle_type")
           .eq("id", templateId)
           .maybeSingle();
-
         if (cancelled) return;
-
-        if (qErr || !data) {
-          console.error(qErr);
+        if (queryError || !data) {
+          // eslint-disable-next-line no-console
+          console.error(queryError);
           setError("Template not found.");
           toast.error("Template not found.");
           return;
         }
 
-        const rawSections = (data.sections ?? []) as Section[];
-        const title = data.template_name ?? "Inspection";
-        const vehicleType = String(data.vehicle_type ?? "");
-
         const sections = prepareSectionsWithCornerGrid(
-          rawSections,
-          vehicleType,
+          (data.sections ?? []) as Section[],
+          String(data.vehicle_type ?? ""),
           gridOverride,
         );
-
-        // rebuild params from searchKey (stable)
-        const sp = new URLSearchParams(searchKey);
-        const paramsObj: Record<string, string> = {};
-        sp.forEach((v, k) => {
-          paramsObj[k] = v;
+        const runtimeParams: Record<string, string> = {};
+        new URLSearchParams(searchKey).forEach((value, key) => {
+          runtimeParams[key] = value;
         });
+        runtimeParams.mode = "run";
+        runtimeParams.view = "mobile";
+        runtimeParams.workOrderLineId = lineId;
+        runtimeParams.lineId = lineId;
+        if (workOrderId) runtimeParams.workOrderId = workOrderId;
+        runtimeParams.templateId = templateId;
+        runtimeParams.template = "generic";
 
-        // ✅ Force runtime identity (desktop-aligned)
-        paramsObj.mode = "run";
-        paramsObj.view = "mobile";
-
-        // ✅ Canonical identifiers used by runtime/persistence
-        paramsObj.workOrderLineId = lineId;
-        paramsObj.lineId = lineId; // compat for older readers
-        if (workOrderId) paramsObj.workOrderId = workOrderId;
-        paramsObj.templateId = templateId;
-        paramsObj.template = "generic";
-
-        if (typeof window !== "undefined") {
-          // ✅ Runtime keys ONLY (desktop-aligned)
-          sessionStorage.setItem("inspection:sections", JSON.stringify(sections));
-          sessionStorage.setItem("inspection:title", title);
-          sessionStorage.setItem("inspection:vehicleType", vehicleType);
-          sessionStorage.setItem("inspection:template", "generic");
-          sessionStorage.setItem("inspection:params", JSON.stringify(paramsObj));
-
-          // ❌ Kill legacy keys so builder UI can't “win”
-          sessionStorage.removeItem("customInspection:sections");
-          sessionStorage.removeItem("customInspection:title");
-          sessionStorage.removeItem("customInspection:includeOil");
-          sessionStorage.removeItem("customInspection:includeBatteryGrid");
-          sessionStorage.removeItem("customInspection:gridMode");
-        }
-      } catch (e) {
-        console.error(e);
+        sessionStorage.setItem("inspection:sections", JSON.stringify(sections));
+        sessionStorage.setItem(
+          "inspection:title",
+          data.template_name ?? "Inspection",
+        );
+        sessionStorage.setItem(
+          "inspection:vehicleType",
+          String(data.vehicle_type ?? ""),
+        );
+        sessionStorage.setItem("inspection:template", "generic");
+        sessionStorage.setItem(
+          "inspection:params",
+          JSON.stringify(runtimeParams),
+        );
+        sessionStorage.removeItem("customInspection:sections");
+        sessionStorage.removeItem("customInspection:title");
+        sessionStorage.removeItem("customInspection:includeOil");
+        sessionStorage.removeItem("customInspection:includeBatteryGrid");
+        sessionStorage.removeItem("customInspection:gridMode");
+      } catch (caught) {
+        // eslint-disable-next-line no-console
+        console.error(caught);
         if (cancelled) return;
         setError("Failed to prepare inspection.");
         toast.error("Failed to prepare inspection.");
@@ -256,7 +211,7 @@ export default function MobileInspectionRunnerPage() {
     return () => {
       cancelled = true;
     };
-  }, [lineId, templateId, workOrderId, gridOverride, searchKey, supabase]);
+  }, [gridOverride, lineId, searchKey, supabase, templateId, workOrderId]);
 
   if (!lineId) {
     return (
@@ -282,17 +237,22 @@ export default function MobileInspectionRunnerPage() {
     );
   }
 
+  const backHref = workOrderId
+    ? `/mobile/work-orders/${workOrderId}?focus=${encodeURIComponent(lineId)}`
+    : "/mobile/inspections";
+
   return (
     <div className="app-shell flex min-h-screen flex-col text-foreground">
-      {/* Mobile header (keeps theme, page not modal) */}
       <header className="metal-bar sticky top-0 z-40 flex items-center justify-between gap-2 px-3 py-2">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push(backHref)}
           className="inline-flex items-center gap-1 rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-overlay)]"
         >
           <span>←</span>
-          <span className="uppercase tracking-[0.16em]">Back</span>
+          <span className="uppercase tracking-[0.16em]">
+            {workOrderId ? "Job" : "Inspections"}
+          </span>
         </button>
 
         <div className="flex-1 truncate px-2 text-center text-[11px] font-medium text-[color:var(--theme-text-primary)]">
@@ -301,7 +261,6 @@ export default function MobileInspectionRunnerPage() {
             {lineId.slice(0, 8)}
           </span>
         </div>
-
         <div className="w-14" />
       </header>
 

--- a/app/mobile/inspections/maintenance-50-air/page.tsx
+++ b/app/mobile/inspections/maintenance-50-air/page.tsx
@@ -1,17 +1,15 @@
-// app/mobile/inspections/maintenance-50-air/page.tsx
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
 
 export default function MobileMaintenance50AirRunnerPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const query = searchParams.toString();
+  const extra = query ? `&${query}` : "";
 
-  const qs = searchParams.toString();
-  const extra = qs ? `&${qs}` : "";
-
-  // Desktop route, reused in mobile view + embed mode
+  // The inspection runtime is embedded with its mobile controls enabled. The
+  // technician never navigates to the desktop inspection route directly.
   const src = `/inspections/maintenance-50-air?view=mobile&embed=1${extra}`;
 
   return (
@@ -19,10 +17,10 @@ export default function MobileMaintenance50AirRunnerPage() {
       <header className="flex items-center justify-between gap-2 border-b border-[color:var(--theme-border-soft)] px-3 py-2">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push("/mobile/inspections")}
           className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-1 text-xs text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-panel)]"
         >
-          ← Back
+          ← Inspections
         </button>
 
         <div className="flex-1 px-2 text-center">
@@ -31,12 +29,7 @@ export default function MobileMaintenance50AirRunnerPage() {
           </h1>
         </div>
 
-        <Link
-          href={`/inspections/maintenance-50-air${qs ? `?${qs}` : ""}`}
-          className="rounded-full border border-[color:var(--accent-copper-soft)] bg-[color:var(--accent-copper-soft)] px-3 py-1 text-[0.7rem] font-semibold text-[color:var(--theme-text-on-accent)] hover:bg-[color:var(--accent-copper-light)]"
-        >
-          Desktop
-        </Link>
+        <div className="w-20" aria-hidden="true" />
       </header>
 
       <main className="flex-1 overflow-hidden">

--- a/app/mobile/inspections/maintenance-50/page.tsx
+++ b/app/mobile/inspections/maintenance-50/page.tsx
@@ -1,17 +1,15 @@
-// app/mobile/inspections/maintenance-50/page.tsx
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
 
 export default function MobileMaintenance50RunnerPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const query = searchParams.toString();
+  const extra = query ? `&${query}` : "";
 
-  const qs = searchParams.toString();
-  const extra = qs ? `&${qs}` : "";
-
-  // Desktop route, reused in mobile view + embed mode
+  // The inspection runtime is embedded with its mobile controls enabled. The
+  // technician never navigates to the desktop inspection route directly.
   const src = `/inspections/maintenance-50?view=mobile&embed=1${extra}`;
 
   return (
@@ -19,10 +17,10 @@ export default function MobileMaintenance50RunnerPage() {
       <header className="flex items-center justify-between gap-2 border-b border-[color:var(--theme-border-soft)] px-3 py-2">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => router.push("/mobile/inspections")}
           className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-1 text-xs text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-panel)]"
         >
-          ← Back
+          ← Inspections
         </button>
 
         <div className="flex-1 px-2 text-center">
@@ -31,12 +29,7 @@ export default function MobileMaintenance50RunnerPage() {
           </h1>
         </div>
 
-        <Link
-          href={`/inspections/maintenance-50${qs ? `?${qs}` : ""}`}
-          className="rounded-full border border-[color:var(--accent-copper-soft)] bg-[color:var(--accent-copper-soft)] px-3 py-1 text-[0.7rem] font-semibold text-[color:var(--theme-text-on-accent)] hover:bg-[color:var(--accent-copper-light)]"
-        >
-          Desktop
-        </Link>
+        <div className="w-20" aria-hidden="true" />
       </header>
 
       <main className="flex-1 overflow-hidden">

--- a/app/mobile/inspections/page.tsx
+++ b/app/mobile/inspections/page.tsx
@@ -1,13 +1,11 @@
-// app/mobile/inspections/page.tsx
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { format } from "date-fns";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-
-/** Only the columns we actually care about for mobile */
 type InspectionRow = {
   id: string;
   custom_id: string | null;
@@ -24,7 +22,8 @@ const STATUS_CLASS: Record<string, string> = {
   open: "border-sky-500/70 bg-sky-500/10 text-sky-100",
   in_progress: "border-orange-500/70 bg-orange-500/10 text-orange-100",
   completed: "border-emerald-500/70 bg-emerald-500/10 text-emerald-100",
-  archived: "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] text-[color:var(--theme-text-primary)]",
+  archived:
+    "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] text-[color:var(--theme-text-primary)]",
 };
 
 function statusChip(status: string | null | undefined): string {
@@ -35,18 +34,17 @@ function statusChip(status: string | null | undefined): string {
 
 export default function MobileInspectionsListPage() {
   const supabase = useMemo(() => createBrowserSupabase(), []);
-
   const [rows, setRows] = useState<InspectionRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [err, setErr] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    (async () => {
+    let active = true;
+    void (async () => {
       setLoading(true);
-      setErr(null);
-
+      setError(null);
       try {
-        const { data, error } = await supabase
+        const { data, error: queryError } = await supabase
           .from("inspection_sessions")
           .select(
             "id, custom_id, status, created_at, customer_name, vehicle_label",
@@ -54,54 +52,78 @@ export default function MobileInspectionsListPage() {
           .order("created_at", { ascending: false })
           .limit(50);
 
-        if (error) throw error;
+        if (queryError) throw queryError;
+        if (!active) return;
 
-        const mapped: InspectionRow[] = (data ?? []).map((r) => ({
-          id: r.id,
-          custom_id: r.custom_id ?? null,
-          status: r.status ?? null,
-          created_at: r.created_at ?? null,
-          customer_name: r.customer_name ?? null,
-          vehicle_label: r.vehicle_label ?? null,
-        }));
-
-        setRows(mapped);
-      } catch (e) {
-        const msg =
-          e instanceof Error ? e.message : "Failed to load inspections.";
-        setErr(msg);
+        setRows(
+          (data ?? []).map((row) => ({
+            id: row.id,
+            custom_id: row.custom_id ?? null,
+            status: row.status ?? null,
+            created_at: row.created_at ?? null,
+            customer_name: row.customer_name ?? null,
+            vehicle_label: row.vehicle_label ?? null,
+          })),
+        );
+      } catch (caught) {
+        if (!active) return;
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : "Failed to load inspections.",
+        );
         setRows([]);
       } finally {
-        setLoading(false);
+        if (active) setLoading(false);
       }
     })();
+
+    return () => {
+      active = false;
+    };
   }, [supabase]);
 
   return (
     <div className="min-h-screen space-y-4 bg-[color:var(--theme-surface-page)] px-4 py-4 text-foreground">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-2">
-        <div>
-          <h1 className="font-blackops text-lg uppercase tracking-[0.18em] text-[color:var(--theme-text-primary)]">
-            Inspections
-          </h1>
-          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Quick mobile view of recent inspections for this shop.
-          </p>
+      <header>
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Vehicle checks
         </div>
+        <h1 className="mt-2 font-blackops text-lg uppercase tracking-[0.18em] text-[color:var(--theme-text-primary)]">
+          Inspections
+        </h1>
+        <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+          Open a recent inspection or return to a work order to start the correct
+          checklist for that job.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-2 gap-2">
         <Link
-          href="/inspections"
-          className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 py-1 text-[0.7rem] text-[color:var(--theme-text-primary)] hover:border-orange-400 hover:bg-[color:var(--theme-surface-panel-strong)]"
+          href="/mobile/tech/queue"
+          className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3 text-sm font-semibold text-[color:var(--theme-text-primary)]"
         >
-          Desktop view
+          My jobs
+          <div className="mt-1 text-xs font-normal text-[color:var(--theme-text-secondary)]">
+            Open the assigned line first
+          </div>
+        </Link>
+        <Link
+          href="/mobile/work-orders"
+          className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3 text-sm font-semibold text-[color:var(--theme-text-primary)]"
+        >
+          Work orders
+          <div className="mt-1 text-xs font-normal text-[color:var(--theme-text-secondary)]">
+            Find another vehicle or job
+          </div>
         </Link>
       </div>
 
-      {err && (
+      {error ? (
         <div className="rounded-md border border-red-500/60 bg-red-950/40 px-3 py-2 text-xs text-red-200">
-          {err}
+          {error}
         </div>
-      )}
+      ) : null}
 
       {loading ? (
         <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-4 text-sm text-[color:var(--theme-text-secondary)]">
@@ -113,38 +135,35 @@ export default function MobileInspectionsListPage() {
         </div>
       ) : (
         <div className="space-y-2">
-          {rows.map((r) => {
-            const href = `/mobile/inspections/${r.id}`;
-            const created =
-              r.created_at != null
-                ? format(new Date(r.created_at), "PP p")
-                : "—";
+          {rows.map((row) => {
+            const created = row.created_at
+              ? format(new Date(row.created_at), "PP p")
+              : "—";
 
             return (
               <Link
-                key={r.id}
-                href={href}
-                className="block rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)] shadow-sm shadow-[var(--theme-shadow-medium)] hover:border-orange-500/70 hover:bg-[color:var(--theme-surface-panel)]"
+                key={row.id}
+                href={`/mobile/inspections/${row.id}`}
+                className="block rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)] shadow-sm shadow-[var(--theme-shadow-medium)] active:scale-[0.99]"
               >
                 <div className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-1.5">
                       <span className="font-semibold text-[color:var(--theme-text-primary)]">
-                        {r.custom_id ?? `Inspect ${r.id.slice(0, 6)}`}
+                        {row.custom_id ?? `Inspect ${row.id.slice(0, 6)}`}
                       </span>
-
-                      <span className={statusChip(r.status ?? "open")}>
-                        {(r.status ?? "open").replaceAll("_", " ")}
+                      <span className={statusChip(row.status)}>
+                        {(row.status ?? "open").replaceAll("_", " ")}
                       </span>
                     </div>
-
                     <div className="mt-1 truncate text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-                      {r.customer_name ?? "No customer"}{" "}
-                      <span className="mx-1 text-[color:var(--theme-text-muted)]">•</span>
-                      {r.vehicle_label ?? "No vehicle"}
+                      {row.customer_name ?? "No customer"}
+                      <span className="mx-1 text-[color:var(--theme-text-muted)]">
+                        •
+                      </span>
+                      {row.vehicle_label ?? "No vehicle"}
                     </div>
                   </div>
-
                   <span className="ml-2 shrink-0 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
                     {created}
                   </span>

--- a/app/mobile/jobs/[lineId]/page.tsx
+++ b/app/mobile/jobs/[lineId]/page.tsx
@@ -174,10 +174,7 @@ export default function MobileJobPage() {
       <MobileFocusedJob
         workOrderLineId={lineId}
         onChanged={loadStory}
-        onBack={() => {
-          if (window.history.length > 1) router.back();
-          else router.push("/mobile/tech/queue");
-        }}
+        onBack={() => router.push("/mobile/tech/queue")}
       />
 
       <div className="fixed inset-x-0 bottom-0 z-[120] border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)]/95 px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pt-2 shadow-[0_-12px_30px_rgba(0,0,0,0.22)] backdrop-blur-xl">

--- a/app/mobile/messages/[chatId]/page.tsx
+++ b/app/mobile/messages/[chatId]/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
+import Link from "next/link";
+import { useParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+
+import ChatWindow from "@/features/ai/components/chat/ChatWindow";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
-import ChatWindow from "@/features/ai/components/chat/ChatWindow";
 
 type DB = Database;
-
 type ConversationRow = DB["public"]["Tables"]["conversations"]["Row"];
 type Participant = { id: string; full_name: string | null };
 
@@ -20,73 +21,74 @@ type ConversationPayload = {
 
 export default function MobileChatThreadPage() {
   const params = useParams<{ chatId: string }>();
-  const router = useRouter();
   const conversationId = params.chatId;
-
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [userId, setUserId] = useState<string | null>(null);
-  const [title, setTitle] = useState<string>("Conversation");
+  const [title, setTitle] = useState("Conversation");
 
-  // who am I + build a nice title
   useEffect(() => {
-    (async () => {
+    let active = true;
+    void (async () => {
       const {
         data: { user },
       } = await supabase.auth.getUser();
-      const uid = user?.id ?? null;
-      setUserId(uid);
+      const currentUserId = user?.id ?? null;
+      if (!active) return;
+      setUserId(currentUserId);
 
       try {
-        const res = await fetch("/api/chat/my-conversations", {
-          method: "GET",
+        const response = await fetch("/api/chat/my-conversations", {
           credentials: "include",
+          cache: "no-store",
         });
-        if (!res.ok) return;
-
-        const data = (await res.json()) as ConversationPayload[];
+        if (!response.ok) return;
+        const data = (await response.json()) as ConversationPayload[];
         const found = data.find(
           (item) => item.conversation.id === conversationId,
         );
-        if (!found) return;
+        if (!found || !active) return;
 
         const others =
-          uid == null
+          currentUserId == null
             ? found.participants
-            : found.participants.filter((p) => p.id !== uid);
-
-        const label =
+            : found.participants.filter(
+                (participant) => participant.id !== currentUserId,
+              );
+        setTitle(
           others[0]?.full_name ??
-          found.conversation.context_type ??
-          found.conversation.title ??
-          `Conversation ${conversationId.slice(0, 6)}`;
-
-        setTitle(label);
+            found.conversation.context_type ??
+            found.conversation.title ??
+            `Conversation ${conversationId.slice(0, 6)}`,
+        );
       } catch {
-        // keep default title
+        // Keep the generic title when the conversation list is unavailable.
       }
     })();
-  }, [supabase, conversationId]);
+
+    return () => {
+      active = false;
+    };
+  }, [conversationId, supabase]);
 
   return (
     <div className="flex min-h-screen flex-col bg-background px-4 py-3 text-foreground">
-      {/* Top bar */}
       <div className="metal-bar mb-3 flex items-center justify-between gap-2 border-b border-[var(--metal-border-soft)] pb-2">
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="inline-flex items-center rounded-full border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-1 text-xs text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)] hover:bg-[color:var(--theme-surface-overlay)]"
+        <Link
+          href="/mobile/messages"
+          className="inline-flex items-center rounded-full border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-1 text-xs text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)]"
         >
-          ← Back
-        </button>
+          ← Messages
+        </Link>
         <div className="min-w-0 text-right">
           <h1 className="truncate text-sm font-blackops uppercase tracking-[0.18em] text-[var(--accent-copper-light)]">
             {title}
           </h1>
-          <p className="mt-0.5 text-[0.65rem] text-[color:var(--theme-text-muted)]">Chat</p>
+          <p className="mt-0.5 text-[0.65rem] text-[color:var(--theme-text-muted)]">
+            Chat
+          </p>
         </div>
       </div>
 
-      {/* Chat window */}
       {!userId ? (
         <div className="metal-card mt-4 rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
           Loading…

--- a/app/mobile/not-found.tsx
+++ b/app/mobile/not-found.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function MobileNotFound() {
+  return (
+    <div className="mx-auto flex min-h-[60vh] w-full max-w-xl items-center px-4 py-10">
+      <section className="w-full rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5 text-center shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          ProFixIQ mobile
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          Mobile page not found
+        </h1>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+          This destination is not available on the current mobile build. Return to
+          your role-specific mobile home instead of leaving the mobile app.
+        </p>
+        <Link
+          href="/mobile"
+          className="mt-5 flex min-h-12 items-center justify-center rounded-2xl bg-[color:var(--accent-copper)] px-4 text-sm font-semibold text-white"
+        >
+          Return to mobile home
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/app/mobile/offline/page.tsx
+++ b/app/mobile/offline/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  clearSyncedOfflineMutations,
+  getOfflineMutationScope,
+  getOfflineSyncSummary,
+  hydrateOfflineMutationQueue,
+  listOfflineMutations,
+  subscribeOfflineMutations,
+  type PendingMutation,
+} from "@/features/shared/lib/offline/mutations";
+import { replayAndReconcileOfflineMutations } from "@/features/shared/lib/offline/replay";
+
+function mutationLabel(actionType: string): string {
+  const labels: Record<string, string> = {
+    "inspection:save-session": "Inspection progress",
+    "inspection:upload-photo": "Inspection photo",
+    "shift:punch-event": "Shift punch",
+    update_work_order_line_notes: "Job notes",
+    upload_job_photo: "Job photo",
+    save_story_draft: "Cause and correction",
+    "job:punch-transition": "Job status",
+    "parts-request:create-draft": "Parts request",
+  };
+  return labels[actionType] ?? actionType.replaceAll("_", " ");
+}
+
+function statusClass(status: PendingMutation["status"]): string {
+  if (status === "synced") return "text-emerald-200";
+  if (status === "syncing") return "text-sky-200";
+  if (status === "failed" || status === "conflicted") return "text-red-200";
+  return "text-amber-200";
+}
+
+export default function MobileOfflinePage() {
+  const [items, setItems] = useState<PendingMutation[]>([]);
+  const [summary, setSummary] = useState(() => getOfflineSyncSummary());
+  const [online, setOnline] = useState(
+    () => typeof navigator !== "undefined" && navigator.onLine,
+  );
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    await hydrateOfflineMutationQueue();
+    const scope = getOfflineMutationScope();
+    setItems(listOfflineMutations(scope));
+    setSummary(getOfflineSyncSummary());
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const unsubscribe = subscribeOfflineMutations(() => void refresh());
+    const updateConnection = () => setOnline(navigator.onLine);
+    window.addEventListener("online", updateConnection);
+    window.addEventListener("offline", updateConnection);
+    return () => {
+      unsubscribe();
+      window.removeEventListener("online", updateConnection);
+      window.removeEventListener("offline", updateConnection);
+    };
+  }, [refresh]);
+
+  const syncNow = async () => {
+    if (!online || busy) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const result = await replayAndReconcileOfflineMutations();
+      setMessage(
+        `Synced ${result.replayed}. ${result.failed} failed and ${result.conflicted} need review.`,
+      );
+      await refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Sync could not finish.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const clearCompleted = async () => {
+    if (busy) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      await clearSyncedOfflineMutations();
+      setMessage("Completed sync history cleared.");
+      await refresh();
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : "Completed history could not be cleared.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const pending = items.filter((item) => item.status !== "synced");
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+              Device work
+            </div>
+            <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+              Offline &amp; sync
+            </h1>
+            <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+              Review work saved for the active user and shop on this device.
+            </p>
+          </div>
+          <span
+            className={`shrink-0 rounded-full border px-3 py-1 text-xs font-semibold ${
+              online
+                ? "border-emerald-400/40 bg-emerald-500/10 text-emerald-100"
+                : "border-amber-400/40 bg-amber-500/10 text-amber-100"
+            }`}
+          >
+            {online ? "Connected" : "Offline"}
+          </span>
+        </div>
+
+        <div className="mt-4 grid grid-cols-4 gap-2 text-center">
+          <Metric label="Queued" value={summary.queued} />
+          <Metric label="Syncing" value={summary.syncing} />
+          <Metric label="Failed" value={summary.failed} warning />
+          <Metric label="Conflicts" value={summary.conflicted} warning />
+        </div>
+
+        <button
+          type="button"
+          disabled={!online || busy || pending.length === 0}
+          onClick={() => void syncNow()}
+          className="mt-4 min-h-12 w-full rounded-2xl bg-[color:var(--accent-copper)] px-4 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-45"
+        >
+          {busy ? "Working…" : "Sync now"}
+        </button>
+        {message ? (
+          <p className="mt-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs text-[color:var(--theme-text-secondary)]">
+            {message}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="overflow-hidden rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
+        <div className="flex items-center justify-between gap-3 p-4">
+          <div>
+            <h2 className="font-semibold text-[color:var(--theme-text-primary)]">
+              Device queue
+            </h2>
+            <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+              {pending.length} update{pending.length === 1 ? "" : "s"} require attention.
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={busy || items.every((item) => item.status !== "synced")}
+            onClick={() => void clearCompleted()}
+            className="text-xs font-semibold text-[var(--accent-copper)] disabled:opacity-40"
+          >
+            Clear completed
+          </button>
+        </div>
+
+        <div className="divide-y divide-[color:var(--theme-border-soft)]">
+          {items.length === 0 ? (
+            <div className="p-4 text-sm text-[color:var(--theme-text-secondary)]">
+              Nothing is queued on this device.
+            </div>
+          ) : (
+            items.slice(0, 50).map((item) => (
+              <div key={item.clientMutationId} className="p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                      {mutationLabel(item.actionType)}
+                    </div>
+                    <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                      {new Date(item.createdAt).toLocaleString()}
+                    </div>
+                    {item.lastError ? (
+                      <div className="mt-1 text-xs text-red-200">{item.lastError}</div>
+                    ) : null}
+                    {item.conflictReason ? (
+                      <div className="mt-1 text-xs text-amber-200">
+                        {item.conflictReason}
+                      </div>
+                    ) : null}
+                  </div>
+                  <span
+                    className={`shrink-0 text-xs font-semibold capitalize ${statusClass(item.status)}`}
+                  >
+                    {item.status}
+                  </span>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      <Link
+        href="/mobile"
+        className="flex min-h-11 items-center justify-center rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 text-sm font-semibold text-[color:var(--theme-text-primary)]"
+      >
+        Return to mobile home
+      </Link>
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  warning = false,
+}: {
+  label: string;
+  value: number;
+  warning?: boolean;
+}) {
+  return (
+    <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-2">
+      <div
+        className={`text-lg font-semibold ${
+          warning && value > 0
+            ? "text-red-200"
+            : "text-[color:var(--theme-text-primary)]"
+        }`}
+      >
+        {value}
+      </div>
+      <div className="mt-0.5 truncate text-[0.56rem] uppercase tracking-[0.1em] text-[color:var(--theme-text-muted)]">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/app/mobile/page.tsx
+++ b/app/mobile/page.tsx
@@ -231,7 +231,10 @@ export default function MobileHome() {
   }, [profile?.id, profile?.role, supabase]);
 
   const canonical = canonicalizeRole(profile?.role);
-  const role = canonical === "unknown" ? null : (canonical as MobileRole);
+  const role =
+    canonical === "unknown" || canonical === "customer"
+      ? null
+      : (canonical as MobileRole);
   const name = profile?.full_name || "Team member";
 
   if (loading) {
@@ -253,7 +256,7 @@ export default function MobileHome() {
       />
     );
   }
-  if (role === "advisor") {
+  if (role === "advisor" || role === "service") {
     return (
       <MobileAdvisorHome
         advisorName={name}

--- a/app/mobile/planner/page.tsx
+++ b/app/mobile/planner/page.tsx
@@ -1,5 +1,116 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useMemo } from "react";
+
+const WORKSPACES = [
+  {
+    title: "Dispatch",
+    detail: "Balance technicians, bays, active jobs, and blockers.",
+    href: "/mobile/dispatch",
+  },
+  {
+    title: "Work orders",
+    detail: "Review live work and open the correct mobile work order.",
+    href: "/mobile/work-orders",
+  },
+  {
+    title: "Appointments",
+    detail: "Review arrivals and manage the day from mobile.",
+    href: "/mobile/appointments",
+  },
+  {
+    title: "Parts",
+    detail: "Open requests, receiving, and ready parts.",
+    href: "/mobile/parts",
+  },
+  {
+    title: "Attendance",
+    detail: "See staff on shift and current activity.",
+    href: "/mobile/workforce/attendance",
+  },
+  {
+    title: "Fleet",
+    detail: "Review units, pre-trips, and service requests.",
+    href: "/mobile/fleet",
+  },
+] as const;
 
 export default function MobilePlannerPage() {
-  redirect("/mobile");
+  const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
+
+  const context = useMemo(() => {
+    const params = new URLSearchParams(searchKey);
+    return {
+      goal: params.get("goal")?.trim() || null,
+      workOrderId: params.get("workOrderId")?.trim() || null,
+      bookingId: params.get("bookingId")?.trim() || null,
+      vehicleId: params.get("vehicleId")?.trim() || null,
+    };
+  }, [searchKey]);
+
+  const contextualHref = context.workOrderId
+    ? `/mobile/work-orders/${context.workOrderId}`
+    : context.bookingId
+      ? "/mobile/appointments"
+      : context.vehicleId
+        ? `/mobile/fleet?unit=${encodeURIComponent(context.vehicleId)}`
+        : null;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Operations planner
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          Choose the workspace you need
+        </h1>
+        <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+          Planning remains manual and role-controlled. This page keeps the useful
+          operational destinations together without leaving the mobile app.
+        </p>
+      </section>
+
+      {context.goal || contextualHref ? (
+        <section className="rounded-3xl border border-[var(--accent-copper-soft)]/40 bg-[color:var(--theme-surface-panel)] p-4">
+          <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            Current context
+          </div>
+          {context.goal ? (
+            <p className="mt-2 text-sm text-[color:var(--theme-text-primary)]">
+              {context.goal}
+            </p>
+          ) : null}
+          {contextualHref ? (
+            <Link
+              href={contextualHref}
+              className="mt-3 flex min-h-11 items-center justify-center rounded-xl bg-[color:var(--accent-copper)] px-4 text-sm font-semibold text-white"
+            >
+              Open related mobile record
+            </Link>
+          ) : null}
+        </section>
+      ) : null}
+
+      <section className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {WORKSPACES.map((workspace) => (
+          <Link
+            key={workspace.href}
+            href={workspace.href}
+            className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4 active:scale-[0.99]"
+          >
+            <div className="font-semibold text-[color:var(--theme-text-primary)]">
+              {workspace.title}
+            </div>
+            <div className="mt-1 text-sm leading-5 text-[color:var(--theme-text-secondary)]">
+              {workspace.detail}
+            </div>
+          </Link>
+        ))}
+      </section>
+    </div>
+  );
 }

--- a/app/mobile/sign-in/page.tsx
+++ b/app/mobile/sign-in/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Eye, EyeOff, Loader2, Smartphone, WifiOff } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Eye, EyeOff, Loader2, Smartphone, WifiOff } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
 import AuthShell from "@/features/auth/components/AuthShell";
 import AuthStatus from "@/features/auth/components/AuthStatus";
 import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
@@ -40,7 +41,11 @@ export default function MobileSignInPage() {
     setLoading(true);
     setError("");
     try {
-      const result = await signInWithIdentifier({ identifier, password, surface: "mobile" });
+      const result = await signInWithIdentifier({
+        identifier,
+        password,
+        surface: "mobile",
+      });
       if (!result.ok) {
         setError(result.error);
         return;
@@ -83,7 +88,10 @@ export default function MobileSignInPage() {
 
       <form className="mt-5 space-y-4" onSubmit={handleSubmit}>
         <div>
-          <label htmlFor="mobile-identifier" className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+          <label
+            htmlFor="mobile-identifier"
+            className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+          >
             Email or shop username
           </label>
           <input
@@ -99,10 +107,16 @@ export default function MobileSignInPage() {
 
         <div>
           <div className="mb-1.5 flex items-center justify-between">
-            <label htmlFor="mobile-password" className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+            <label
+              htmlFor="mobile-password"
+              className="text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+            >
               Password
             </label>
-            <Link href="/forgot-password?redirect=%2Fmobile" className="text-xs font-semibold text-[var(--accent-copper)] hover:underline">
+            <Link
+              href="/forgot-password?redirect=%2Fmobile"
+              className="text-xs font-semibold text-[var(--accent-copper)] hover:underline"
+            >
               Forgot password?
             </Link>
           </div>
@@ -123,7 +137,11 @@ export default function MobileSignInPage() {
               aria-label={showPassword ? "Hide password" : "Show password"}
               className="absolute inset-y-0 right-0 grid w-12 place-items-center text-[color:var(--theme-text-muted)]"
             >
-              {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+              {showPassword ? (
+                <EyeOff className="h-5 w-5" />
+              ) : (
+                <Eye className="h-5 w-5" />
+              )}
             </button>
           </div>
         </div>
@@ -139,16 +157,17 @@ export default function MobileSignInPage() {
       </form>
 
       <div className="mt-5 flex items-start gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
-        <WifiOff className="mt-0.5 h-4 w-4 shrink-0 text-[var(--accent-copper)]" aria-hidden />
-        Once signed in, supported inspection work can continue through brief connection drops.
+        <WifiOff
+          className="mt-0.5 h-4 w-4 shrink-0 text-[var(--accent-copper)]"
+          aria-hidden
+        />
+        Once signed in, supported inspection work can continue through brief
+        connection drops.
       </div>
 
-      <div className="mt-5 text-center text-xs text-[color:var(--theme-text-muted)]">
-        Need the full dashboard?{" "}
-        <Link href="/sign-in" className="font-semibold text-[var(--accent-copper)] hover:underline">
-          Shop sign in
-        </Link>
-      </div>
+      <p className="mt-5 text-center text-xs leading-5 text-[color:var(--theme-text-muted)]">
+        Signing in here always returns you to the role-specific mobile workspace.
+      </p>
     </AuthShell>
   );
 }

--- a/app/mobile/work-orders/[id]/vehicle/page.tsx
+++ b/app/mobile/work-orders/[id]/vehicle/page.tsx
@@ -1,48 +1,47 @@
-// app/mobile/work-orders/[id]/vehicle/page.tsx (FULL FILE REPLACEMENT)
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import { useParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
-import type { Database } from "@shared/types/types/supabase";
-
 import MobileCustomerVehicleForm from "@/features/work-orders/mobile/MobileCustomerVehicleForm";
 import type {
   MobileCustomer,
   MobileVehicle,
 } from "@/features/work-orders/mobile/types";
+import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
 
-function toYearValue(v: unknown): string | number | null {
-  if (v === null || v === undefined) return null;
-  if (typeof v === "number") return v;
-  if (typeof v === "string") {
-    const s = v.trim();
-    if (!s) return null;
-    const n = Number(s);
-    return Number.isFinite(n) ? n : s;
+function toYearValue(value: unknown): string | number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!normalized) return null;
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : normalized;
   }
   return null;
 }
 
-function toStrOrNull(v: unknown): string | null {
-  const s = typeof v === "string" ? v.trim() : "";
-  return s.length ? s : null;
+function toStringOrNull(value: unknown): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized.length ? normalized : null;
 }
 
-function toNumOrNull(v: unknown): number | null {
-  if (v === null || v === undefined) return null;
-  if (typeof v === "number" && Number.isFinite(v)) return v;
-  if (typeof v === "string") {
-    const s = v.trim();
-    if (!s) return null;
-    const n = Number(s);
-    return Number.isFinite(n) ? n : null;
+function toNumberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    if (!normalized) return null;
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : null;
   }
   return null;
 }
@@ -50,9 +49,7 @@ function toNumOrNull(v: unknown): number | null {
 export default function MobileWorkOrderVehiclePage() {
   const params = useParams<{ id: string }>();
   const workOrderId = params?.id;
-
-  const [wo, setWo] = useState<WorkOrderRow | null>(null);
-
+  const [workOrder, setWorkOrder] = useState<WorkOrderRow | null>(null);
   const [customer, setCustomer] = useState<MobileCustomer>({
     id: null,
     first_name: null,
@@ -65,7 +62,6 @@ export default function MobileWorkOrderVehiclePage() {
     province: null,
     postal_code: null,
   });
-
   const [vehicle, setVehicle] = useState<MobileVehicle>({
     id: null,
     vin: null,
@@ -78,119 +74,122 @@ export default function MobileWorkOrderVehiclePage() {
     unit_number: null,
     engine_hours: null,
   });
-
-  const [loading, setLoading] = useState<boolean>(true);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     if (!workOrderId) return;
-
     setLoading(true);
     setError(null);
 
     try {
-      // 1) Load the work order (just the fields we care about)
-      const { data: woRow, error: woErr } = await supabase
+      const { data: workOrderRow, error: workOrderError } = await supabase
         .from("work_orders")
         .select("id, custom_id, customer_id, vehicle_id, shop_id")
         .eq("id", workOrderId)
         .maybeSingle();
-
-      if (woErr) throw woErr;
-
-      if (!woRow) {
+      if (workOrderError) throw workOrderError;
+      if (!workOrderRow) {
         setError("Work order not found.");
-        setLoading(false);
         return;
       }
 
-      setWo(woRow as WorkOrderRow);
+      setWorkOrder(workOrderRow as WorkOrderRow);
 
-      // 2) Load customer, if linked
-      if (woRow.customer_id) {
-        const { data: cust, error: custErr } = await supabase
+      if (workOrderRow.customer_id) {
+        const { data: customerRow, error: customerError } = await supabase
           .from("customers")
           .select(
             "id, business_name, first_name, last_name, phone, phone_number, email, address, city, province, postal_code",
           )
-          .eq("id", woRow.customer_id)
+          .eq("id", workOrderRow.customer_id)
           .maybeSingle();
+        if (customerError) throw customerError;
 
-        if (custErr) throw custErr;
-
-        if (cust) {
-          const c = cust as CustomerRow;
+        if (customerRow) {
+          const typed = customerRow as CustomerRow;
           setCustomer({
-            id: c.id,
-            business_name: (c as unknown as { business_name?: string | null })
-              .business_name ?? null,
-            first_name: (c.first_name as string | null) ?? null,
-            last_name: (c.last_name as string | null) ?? null,
-            // prefer phone, fall back to phone_number
+            id: typed.id,
+            business_name:
+              (typed as CustomerRow & { business_name?: string | null })
+                .business_name ?? null,
+            first_name: typed.first_name ?? null,
+            last_name: typed.last_name ?? null,
             phone:
-              (c.phone as string | null) ??
-              ((c as unknown as { phone_number?: string | null }).phone_number ??
-                null),
-            email: (c.email as string | null) ?? null,
-            address: (c as unknown as { address?: string | null }).address ?? null,
-            city: (c as unknown as { city?: string | null }).city ?? null,
-            province: (c as unknown as { province?: string | null }).province ?? null,
-            postal_code:
-              (c as unknown as { postal_code?: string | null }).postal_code ??
+              typed.phone ??
+              (typed as CustomerRow & { phone_number?: string | null })
+                .phone_number ??
               null,
+            email: typed.email ?? null,
+            address:
+              (typed as CustomerRow & { address?: string | null }).address ??
+              null,
+            city:
+              (typed as CustomerRow & { city?: string | null }).city ?? null,
+            province:
+              (typed as CustomerRow & { province?: string | null }).province ??
+              null,
+            postal_code:
+              (typed as CustomerRow & { postal_code?: string | null })
+                .postal_code ?? null,
           });
         }
       }
 
-      // 3) Load vehicle, if linked
-      if (woRow.vehicle_id) {
-        const { data: veh, error: vehErr } = await supabase
+      if (workOrderRow.vehicle_id) {
+        const { data: vehicleRow, error: vehicleError } = await supabase
           .from("vehicles")
           .select(
             "id, vin, year, make, model, license_plate, mileage, color, unit_number, engine_hours, engine, transmission, fuel_type, drivetrain",
           )
-          .eq("id", woRow.vehicle_id)
+          .eq("id", workOrderRow.vehicle_id)
           .maybeSingle();
+        if (vehicleError) throw vehicleError;
 
-        if (vehErr) throw vehErr;
-
-        if (veh) {
-          const v = veh as VehicleRow;
-
+        if (vehicleRow) {
+          const typed = vehicleRow as VehicleRow;
           setVehicle({
-            id: v.id,
-            vin: (v as unknown as { vin?: string | null }).vin ?? null,
-            year: toYearValue((v as unknown as { year?: unknown }).year),
-            make: (v.make as string | null) ?? null,
-            model: (v.model as string | null) ?? null,
-            license_plate: (v.license_plate as string | null) ?? null,
-            mileage: toStrOrNull((v as unknown as { mileage?: unknown }).mileage),
-            color: (v as unknown as { color?: string | null }).color ?? null,
+            id: typed.id,
+            vin: (typed as VehicleRow & { vin?: string | null }).vin ?? null,
+            year: toYearValue(
+              (typed as VehicleRow & { year?: unknown }).year,
+            ),
+            make: typed.make ?? null,
+            model: typed.model ?? null,
+            license_plate: typed.license_plate ?? null,
+            mileage: toStringOrNull(
+              (typed as VehicleRow & { mileage?: unknown }).mileage,
+            ),
+            color:
+              (typed as VehicleRow & { color?: string | null }).color ?? null,
             unit_number:
-              (v as unknown as { unit_number?: string | null }).unit_number ??
-              null,
-            engine_hours:
-              toNumOrNull((v as unknown as { engine_hours?: unknown }).engine_hours) ??
-              null,
-            // these are optional in MobileVehicle type, but if your DB has them, keep them too
-            engine: (v as unknown as { engine?: string | null }).engine ?? null,
+              (typed as VehicleRow & { unit_number?: string | null })
+                .unit_number ?? null,
+            engine_hours: toNumberOrNull(
+              (typed as VehicleRow & { engine_hours?: unknown }).engine_hours,
+            ),
+            engine:
+              (typed as VehicleRow & { engine?: string | null }).engine ?? null,
             transmission:
-              (v as unknown as { transmission?: string | null }).transmission ??
-              null,
+              (typed as VehicleRow & { transmission?: string | null })
+                .transmission ?? null,
             fuel_type:
-              (v as unknown as { fuel_type?: string | null }).fuel_type ?? null,
+              (typed as VehicleRow & { fuel_type?: string | null })
+                .fuel_type ?? null,
             drivetrain:
-              (v as unknown as { drivetrain?: string | null }).drivetrain ?? null,
+              (typed as VehicleRow & { drivetrain?: string | null })
+                .drivetrain ?? null,
           });
         }
       }
-    } catch (e) {
-      console.error("[MobileWorkOrderVehiclePage] fetch error:", e);
-      const msg =
-        e instanceof Error
-          ? e.message
-          : "Failed to load customer/vehicle info.";
-      setError(msg);
+    } catch (caught) {
+      // eslint-disable-next-line no-console
+      console.error("[MobileWorkOrderVehiclePage] fetch error:", caught);
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Failed to load customer and vehicle information.",
+      );
     } finally {
       setLoading(false);
     }
@@ -208,29 +207,41 @@ export default function MobileWorkOrderVehiclePage() {
     );
   }
 
-  if (loading) {
-    return (
-      <div className="p-4 text-sm text-[color:var(--theme-text-primary)]">
-        Loading customer &amp; vehicle…
-      </div>
-    );
-  }
-
-  if (error) {
-    return <div className="p-4 text-sm text-red-300">{error}</div>;
-  }
-
   return (
     <div className="min-h-screen bg-[var(--theme-surface-page)] px-3 py-4 text-[color:var(--theme-text-primary)]">
-      <div className="mx-auto max-w-xl">
-        <MobileCustomerVehicleForm
-          wo={wo}
-          customer={customer}
-          vehicle={vehicle}
-          onCustomerChange={setCustomer}
-          onVehicleChange={setVehicle}
-          supabase={supabase}
-        />
+      <div className="mx-auto max-w-xl space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <Link
+            href={`/mobile/work-orders/${workOrderId}`}
+            className="inline-flex min-h-10 items-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)]"
+          >
+            ← Work order
+          </Link>
+          <div className="truncate text-right text-xs text-[color:var(--theme-text-secondary)]">
+            {workOrder?.custom_id
+              ? `WO ${workOrder.custom_id}`
+              : `WO ${workOrderId.slice(0, 8)}`}
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+            Loading customer &amp; vehicle…
+          </div>
+        ) : error ? (
+          <div className="rounded-2xl border border-red-500/40 bg-red-950/30 p-4 text-sm text-red-200">
+            {error}
+          </div>
+        ) : (
+          <MobileCustomerVehicleForm
+            wo={workOrder}
+            customer={customer}
+            vehicle={vehicle}
+            onCustomerChange={setCustomer}
+            onVehicleChange={setVehicle}
+            supabase={supabase}
+          />
+        )}
       </div>
     </div>
   );

--- a/app/mobile/work-orders/view/page.tsx
+++ b/app/mobile/work-orders/view/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { format } from "date-fns";
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import type { Database } from "@shared/types/types/supabase";
-import AssignTechModal from "@/features/work-orders/components/workorders/extras/AssignTechModal";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import AssignTechModal from "@/features/work-orders/components/workorders/extras/AssignTechModal";
+import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -16,14 +16,16 @@ type Customer = DB["public"]["Tables"]["customers"]["Row"];
 type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
 type Profile = DB["public"]["Tables"]["profiles"]["Row"];
 
-type Row = WorkOrder & {
-  customers: Pick<Customer, "first_name" | "last_name" | "phone" | "email"> | null;
-  vehicles: Pick<Vehicle, "year" | "make" | "model" | "license_plate"> | null;
+type WorkOrderListRow = WorkOrder & {
+  customers: Pick<
+    Customer,
+    "first_name" | "last_name" | "phone" | "email"
+  > | null;
+  vehicles: Pick<
+    Vehicle,
+    "year" | "make" | "model" | "license_plate"
+  > | null;
 };
-
-/* ------------------------------------------------------------------ */
-/* Status badges                                                      */
-/* ------------------------------------------------------------------ */
 
 type StatusKey =
   | "awaiting_approval"
@@ -37,31 +39,6 @@ type StatusKey =
   | "ready_to_invoice"
   | "invoiced";
 
-const BADGE_BASE =
-  "inline-flex items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-[0.12em]";
-
-const STATUS_BADGE: Record<StatusKey, string> = {
-  awaiting_approval: "bg-blue-500/10 border-blue-400/60 text-blue-100",
-  awaiting: "bg-sky-500/10 border-sky-400/60 text-sky-100",
-  queued: "bg-indigo-500/10 border-indigo-400/60 text-indigo-100",
-  in_progress:
-    "bg-[var(--accent-copper)]/15 border-[var(--accent-copper-light)]/70 text-[var(--accent-copper-light)]",
-  on_hold: "bg-amber-500/10 border-amber-400/70 text-amber-100",
-  planned: "bg-purple-500/10 border-purple-400/70 text-purple-100",
-  new: "bg-[color:var(--theme-surface-panel)] border-[color:var(--theme-border-soft)] text-[color:var(--theme-text-primary)]",
-  completed: "bg-green-500/10 border-green-400/70 text-green-100",
-  ready_to_invoice:
-    "bg-emerald-500/10 border-emerald-400/70 text-emerald-100",
-  invoiced: "bg-teal-500/10 border-teal-400/70 text-teal-100",
-};
-
-const statusChip = (s: string | null | undefined) => {
-  const key = (s ?? "awaiting").toLowerCase().replaceAll(" ", "_") as StatusKey;
-  const cls = STATUS_BADGE[key] ?? STATUS_BADGE.awaiting;
-  return `${BADGE_BASE} ${cls}`;
-};
-
-/** “Normal flow” = tech/active; hides AA, completed, billing states */
 const NORMAL_FLOW_STATUSES: StatusKey[] = [
   "awaiting",
   "queued",
@@ -71,209 +48,209 @@ const NORMAL_FLOW_STATUSES: StatusKey[] = [
   "new",
 ];
 
-/* ------------------------------------------------------------------ */
-/* Input styles                                                        */
-/* ------------------------------------------------------------------ */
+const BADGE_BASE =
+  "inline-flex items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-[0.12em]";
 
-const INPUT_DARK =
-  "w-full rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-xs text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] " +
-  "shadow-[var(--theme-shadow-medium)] backdrop-blur focus:border-[var(--accent-copper)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-copper)]";
+const STATUS_BADGE: Record<StatusKey, string> = {
+  awaiting_approval: "border-blue-400/60 bg-blue-500/10 text-blue-100",
+  awaiting: "border-sky-400/60 bg-sky-500/10 text-sky-100",
+  queued: "border-indigo-400/60 bg-indigo-500/10 text-indigo-100",
+  in_progress:
+    "border-[var(--accent-copper-light)]/70 bg-[var(--accent-copper)]/15 text-[var(--accent-copper-light)]",
+  on_hold: "border-amber-400/70 bg-amber-500/10 text-amber-100",
+  planned: "border-purple-400/70 bg-purple-500/10 text-purple-100",
+  new: "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] text-[color:var(--theme-text-primary)]",
+  completed: "border-green-400/70 bg-green-500/10 text-green-100",
+  ready_to_invoice:
+    "border-emerald-400/70 bg-emerald-500/10 text-emerald-100",
+  invoiced: "border-teal-400/70 bg-teal-500/10 text-teal-100",
+};
 
-const SELECT_DARK =
-  "w-full rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-xs text-[color:var(--theme-text-primary)] " +
-  "shadow-[var(--theme-shadow-medium)] backdrop-blur focus:border-[var(--accent-copper)] focus:outline-none focus:ring-1 focus:ring-[var(--accent-copper)]";
+function statusChip(status: string | null | undefined): string {
+  const key = (status ?? "awaiting")
+    .toLowerCase()
+    .replaceAll(" ", "_") as StatusKey;
+  return `${BADGE_BASE} ${STATUS_BADGE[key] ?? STATUS_BADGE.awaiting}`;
+}
 
-const BUTTON_MUTED =
-  "rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1.5 text-xs text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)] " +
-  "transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/15 hover:text-[color:var(--theme-text-primary)] active:opacity-80";
+function customerName(row: WorkOrderListRow): string {
+  return row.customers
+    ? [row.customers.first_name ?? "", row.customers.last_name ?? ""]
+        .filter(Boolean)
+        .join(" ")
+    : "";
+}
 
-/* ------------------------------------------------------------------ */
-/* Page                                                                */
-/* ------------------------------------------------------------------ */
+function vehicleLabel(row: WorkOrderListRow): string {
+  if (!row.vehicles) return "";
+  return [row.vehicles.year, row.vehicles.make, row.vehicles.model]
+    .map((value) => String(value ?? "").trim())
+    .filter(Boolean)
+    .join(" ");
+}
+
+const inputClass =
+  "w-full rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper)] focus:ring-1 focus:ring-[var(--accent-copper)]";
 
 export default function MobileWorkOrdersViewPage() {
   const supabase = useMemo(() => createBrowserSupabase(), []);
-
-  const [rows, setRows] = useState<Row[]>([]);
+  const [rows, setRows] = useState<WorkOrderListRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [q, setQ] = useState("");
-  const [status, setStatus] = useState<string>("");
-  const [err, setErr] = useState<string | null>(null);
-
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const [currentRole, setCurrentRole] = useState<string | null>(null);
-
-  // mechanics for AssignTechModal
+  const [shopId, setShopId] = useState<string | null>(null);
   const [mechanics, setMechanics] = useState<
     Array<Pick<Profile, "id" | "full_name" | "role">>
   >([]);
-
-  // primary line per WO (for assigning via modal)
-  const [primaryLineByWo, setPrimaryLineByWo] = useState<Record<string, string>>(
-    {},
-  );
-
-  // assign-tech modal state
+  const [primaryLineByWorkOrder, setPrimaryLineByWorkOrder] = useState<
+    Record<string, string>
+  >({});
   const [assignModalOpen, setAssignModalOpen] = useState(false);
-  const [assignModalLineId, setAssignModalLineId] = useState<string | null>(
-    null,
-  );
+  const [assignModalLineId, setAssignModalLineId] = useState<string | null>(null);
 
-  // load role + mechanics once
   useEffect(() => {
-    (async () => {
+    let active = true;
+    void (async () => {
       const {
         data: { user },
       } = await supabase.auth.getUser();
+      if (!user?.id || !active) return;
 
-      if (user?.id) {
-        const { data: prof } = await supabase
-          .from("profiles")
-          .select("role")
-          .eq("id", user.id)
-          .maybeSingle();
-        setCurrentRole(prof?.role ?? null);
-      }
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("role, shop_id")
+        .eq("id", user.id)
+        .maybeSingle<{ role: string | null; shop_id: string | null }>();
+      if (!active) return;
+      setCurrentRole(profile?.role ?? null);
+      setShopId(profile?.shop_id ?? null);
 
       try {
-        const res = await fetch("/api/assignables");
-        const json = await res.json();
-        if (res.ok && Array.isArray(json.data)) {
-          setMechanics(json.data);
+        const response = await fetch("/api/assignables", { cache: "no-store" });
+        const body = (await response.json().catch(() => null)) as
+          | { data?: Array<Pick<Profile, "id" | "full_name" | "role">> }
+          | null;
+        if (active && response.ok && Array.isArray(body?.data)) {
+          setMechanics(body.data);
         }
       } catch {
-        // silent – modal can still fall back to its own fetch
+        // AssignTechModal can still load its own list if this preload fails.
       }
     })();
+
+    return () => {
+      active = false;
+    };
   }, [supabase]);
 
   const canAssign = getActorCapabilities({ role: currentRole }).canAssignWork;
 
   const load = useCallback(async () => {
     setLoading(true);
-    setErr(null);
+    setError(null);
+    try {
+      let workOrderQuery = supabase
+        .from("work_orders")
+        .select(
+          `
+          *,
+          customers:customers(first_name,last_name,phone,email),
+          vehicles:vehicles(year,make,model,license_plate)
+        `,
+        )
+        .order("created_at", { ascending: false })
+        .limit(75);
 
-    // 1) fetch work orders
-    let woQuery = supabase
-      .from("work_orders")
-      .select(
-        `
-        *,
-        customers:customers(first_name,last_name,phone,email),
-        vehicles:vehicles(year,make,model,license_plate)
-      `,
-      )
-      .order("created_at", { ascending: false })
-      .limit(50);
+      if (shopId) workOrderQuery = workOrderQuery.eq("shop_id", shopId);
+      workOrderQuery = status
+        ? workOrderQuery.eq("status", status)
+        : workOrderQuery.in(
+            "status",
+            NORMAL_FLOW_STATUSES as unknown as string[],
+          );
 
-    if (status === "") {
-      woQuery = woQuery.in(
-        "status",
-        NORMAL_FLOW_STATUSES as unknown as string[],
-      );
-    } else {
-      woQuery = woQuery.eq("status", status);
-    }
+      const { data, error: queryError } = await workOrderQuery;
+      if (queryError) throw queryError;
 
-    const { data, error } = await woQuery;
+      const workOrders = (data ?? []) as unknown as WorkOrderListRow[];
+      setRows(workOrders);
 
-    if (error) {
-      setErr(error.message);
-      setRows([]);
-      setPrimaryLineByWo({});
-      setLoading(false);
-      return;
-    }
+      const workOrderIds = workOrders.map((workOrder) => workOrder.id);
+      if (workOrderIds.length === 0) {
+        setPrimaryLineByWorkOrder({});
+        return;
+      }
 
-    const workOrders = (data ?? []) as Row[];
-
-    // 2) client-side text search
-    const qlc = q.trim().toLowerCase();
-    const filtered =
-      qlc.length === 0
-        ? workOrders
-        : workOrders.filter((r) => {
-            const name = [r.customers?.first_name ?? "", r.customers?.last_name ?? ""]
-              .filter(Boolean)
-              .join(" ")
-              .toLowerCase();
-            const plate = r.vehicles?.license_plate?.toLowerCase() ?? "";
-            const ymm = [
-              r.vehicles?.year ?? "",
-              r.vehicles?.make ?? "",
-              r.vehicles?.model ?? "",
-            ]
-              .join(" ")
-              .toLowerCase();
-            const cid = (r.custom_id ?? "").toLowerCase();
-            return (
-              r.id.toLowerCase().includes(qlc) ||
-              cid.includes(qlc) ||
-              name.includes(qlc) ||
-              plate.includes(qlc) ||
-              ymm.includes(qlc)
-            );
-          });
-
-    setRows(filtered);
-
-    // 3) get a primary line id for each work order (first line)
-    const ids = filtered.map((r) => r.id);
-    if (ids.length > 0) {
-      const { data: lines, error: lineErr } = await supabase
+      let lineQuery = supabase
         .from("work_order_lines")
         .select("id, work_order_id, created_at")
-        .in("work_order_id", ids)
+        .in("work_order_id", workOrderIds)
         .eq("line_type", "job")
         .order("created_at", { ascending: true });
+      if (shopId) lineQuery = lineQuery.eq("shop_id", shopId);
 
-      if (!lineErr && lines) {
-        const map: Record<string, string> = {};
-        lines.forEach((ln) => {
-          const woId = ln.work_order_id as string;
-          if (!map[woId]) {
-            map[woId] = ln.id as string;
-          }
-        });
-        setPrimaryLineByWo(map);
-      } else {
-        setPrimaryLineByWo({});
+      const { data: lines, error: lineError } = await lineQuery;
+      if (lineError) throw lineError;
+
+      const nextPrimaryLines: Record<string, string> = {};
+      for (const line of lines ?? []) {
+        if (line.work_order_id && !nextPrimaryLines[line.work_order_id]) {
+          nextPrimaryLines[line.work_order_id] = line.id;
+        }
       }
-    } else {
-      setPrimaryLineByWo({});
+      setPrimaryLineByWorkOrder(nextPrimaryLines);
+    } catch (caught) {
+      setRows([]);
+      setPrimaryLineByWorkOrder({});
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Work orders could not be loaded.",
+      );
+    } finally {
+      setLoading(false);
     }
-
-    setLoading(false);
-  }, [q, status, supabase]);
+  }, [shopId, status, supabase]);
 
   useEffect(() => {
     void load();
   }, [load]);
 
-  const total = rows.length;
-  const activeCount = useMemo(
-    () =>
-      rows.filter((r) =>
-        NORMAL_FLOW_STATUSES.includes(
-          (r.status ?? "awaiting").toLowerCase().replaceAll(
-            " ",
-            "_",
-          ) as StatusKey,
-        ),
-      ).length,
-    [rows],
-  );
-  const awaitingApprovalCount = useMemo(
-    () =>
-      rows.filter(
-        (r) => (r.status ?? "").toLowerCase() === "awaiting_approval",
-      ).length,
-    [rows],
-  );
+  const visibleRows = useMemo(() => {
+    const value = query.trim().toLowerCase();
+    if (!value) return rows;
+    return rows.filter((row) => {
+      const haystack = [
+        row.id,
+        row.custom_id,
+        customerName(row),
+        vehicleLabel(row),
+        row.vehicles?.license_plate,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(value);
+    });
+  }, [query, rows]);
 
-  const openAssignModalForWo = (woId: string) => {
-    const lineId = primaryLineByWo[woId];
+  const activeCount = rows.filter((row) =>
+    NORMAL_FLOW_STATUSES.includes(
+      (row.status ?? "awaiting")
+        .toLowerCase()
+        .replaceAll(" ", "_") as StatusKey,
+    ),
+  ).length;
+  const awaitingApprovalCount = rows.filter(
+    (row) => (row.status ?? "").toLowerCase() === "awaiting_approval",
+  ).length;
+
+  const openAssignModal = (workOrderId: string) => {
+    const lineId = primaryLineByWorkOrder[workOrderId];
     if (!lineId) {
-      toast.error("No job lines on this work order yet.");
+      toast.error("No job lines are available on this work order yet.");
       return;
     }
     setAssignModalLineId(lineId);
@@ -283,59 +260,45 @@ export default function MobileWorkOrdersViewPage() {
   return (
     <main className="min-h-screen bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
       <div className="mx-auto flex max-w-5xl flex-col gap-4 px-4 pb-8 pt-4">
-        {/* Header */}
         <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-gradient-to-br from-[color:var(--theme-surface-page)] via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] px-4 py-4 shadow-card">
-          <h1 className="font-blackops text-lg uppercase tracking-[0.2em] text-[var(--accent-copper-light)]">
-            Work orders
-          </h1>
-          <p className="mt-1 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-            Advisor view of active jobs and their tech assignments.
-          </p>
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h1 className="font-blackops text-lg uppercase tracking-[0.2em] text-[var(--accent-copper-light)]">
+                Work orders
+              </h1>
+              <p className="mt-1 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
+                Advisor view of active jobs and technician assignments.
+              </p>
+            </div>
+            <Link
+              href="/mobile/work-orders/create"
+              className="shrink-0 rounded-full bg-[color:var(--accent-copper)] px-3 py-2 text-xs font-semibold text-white"
+            >
+              + Create
+            </Link>
+          </div>
 
-          <div className="mt-3 flex gap-4 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
-            <div>
-              <div className="uppercase tracking-[0.13em] text-[color:var(--theme-text-muted)]">
-                Total
-              </div>
-              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">{total}</div>
-            </div>
-            <div>
-              <div className="uppercase tracking-[0.13em] text-[color:var(--theme-text-muted)]">
-                Active
-              </div>
-              <div className="text-sm font-semibold text-sky-200">
-                {activeCount}
-              </div>
-            </div>
-            <div>
-              <div className="uppercase tracking-[0.13em] text-[color:var(--theme-text-muted)]">
-                Awaiting approval
-              </div>
-              <div className="text-sm font-semibold text-blue-200">
-                {awaitingApprovalCount}
-              </div>
-            </div>
+          <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+            <Metric label="Total" value={rows.length} />
+            <Metric label="Active" value={activeCount} />
+            <Metric label="Approval" value={awaitingApprovalCount} />
           </div>
         </section>
 
-        {/* Filters */}
         <section className="space-y-2 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs shadow-[var(--theme-shadow-medium)] backdrop-blur-md">
-          <div>
-            <input
-              value={q}
-              onChange={(e) => setQ(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && void load()}
-              placeholder="Search id, customer, plate, YMM…"
-              className={INPUT_DARK}
-            />
-          </div>
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search ID, customer, plate, year, make, or model"
+            className={inputClass}
+          />
           <div className="flex gap-2">
             <select
               value={status}
-              onChange={(e) => setStatus(e.target.value)}
-              className={SELECT_DARK}
+              onChange={(event) => setStatus(event.target.value)}
+              className={inputClass}
             >
-              <option value="">Active (normal flow)</option>
+              <option value="">Active flow</option>
               <option value="awaiting_approval">Awaiting approval</option>
               <option value="awaiting">Awaiting</option>
               <option value="queued">Queued</option>
@@ -347,104 +310,85 @@ export default function MobileWorkOrdersViewPage() {
               <option value="ready_to_invoice">Ready to invoice</option>
               <option value="invoiced">Invoiced</option>
             </select>
-            <button type="button" onClick={() => void load()} className={BUTTON_MUTED}>
+            <button
+              type="button"
+              onClick={() => void load()}
+              disabled={loading}
+              className="shrink-0 rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-4 py-2 text-xs font-semibold disabled:opacity-50"
+            >
               Refresh
             </button>
           </div>
         </section>
 
-        {err && (
+        {error ? (
           <div className="rounded-xl border border-red-500/50 bg-red-950/60 px-3 py-2 text-xs text-red-100">
-            {err}
+            {error}
           </div>
-        )}
+        ) : null}
 
-        {/* List */}
         {loading ? (
           <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)] shadow-[var(--theme-shadow-medium)]">
             Loading work orders…
           </div>
-        ) : rows.length === 0 ? (
+        ) : visibleRows.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6 text-sm text-[color:var(--theme-text-secondary)] shadow-[var(--theme-shadow-medium)]">
-            No work orders match your current filters.
+            No work orders match the current view.
           </div>
         ) : (
           <section className="space-y-2">
-            {rows.map((r) => {
-              const href = `/work-orders/${r.custom_id ?? r.id}?mode=view`;
-
-              const customerName = r.customers
-                ? [r.customers.first_name ?? "", r.customers.last_name ?? ""]
-                    .filter(Boolean)
-                    .join(" ")
-                : "";
-
-              const vehicleLabel = r.vehicles
-                ? `${r.vehicles.year ?? ""} ${r.vehicles.make ?? ""} ${
-                    r.vehicles.model ?? ""
-                  }`.trim()
-                : "";
-
-              const plate = r.vehicles?.license_plate ?? "";
+            {visibleRows.map((row) => {
+              const href = `/mobile/work-orders/${row.id}?mode=view`;
+              const name = customerName(row);
+              const vehicle = vehicleLabel(row);
+              const plate = row.vehicles?.license_plate ?? "";
 
               return (
                 <article
-                  key={r.id}
+                  key={row.id}
                   className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-gradient-to-br from-[color:var(--theme-surface-page)] via-[color:var(--theme-surface-panel)] to-[color:var(--theme-surface-page)] px-3 py-3 text-sm shadow-[var(--theme-shadow-medium)]"
                 >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0">
+                  <div className="flex items-start justify-between gap-3">
+                    <Link href={href} className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-1.5">
-                        <Link
-                          href={href}
-                          className="text-sm font-semibold text-[color:var(--theme-text-primary)] underline decoration-neutral-600/50 underline-offset-2 hover:decoration-[var(--accent-copper-light)]"
-                        >
-                          {r.custom_id ? r.custom_id : `#${r.id.slice(0, 8)}`}
-                        </Link>
-                        {r.custom_id && (
-                          <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-1.5 py-0.5 text-[0.6rem] font-mono text-[color:var(--theme-text-secondary)]">
-                            #{r.id.slice(0, 6)}
-                          </span>
-                        )}
-                        <span className={statusChip(r.status)}>
-                          {(r.status ?? "awaiting").replaceAll("_", " ")}
+                        <span className="font-semibold text-[color:var(--theme-text-primary)]">
+                          {row.custom_id ?? `#${row.id.slice(0, 8)}`}
+                        </span>
+                        <span className={statusChip(row.status)}>
+                          {(row.status ?? "awaiting").replaceAll("_", " ")}
                         </span>
                       </div>
-
                       <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-                        {customerName || "No customer"}{" "}
-                        <span className="mx-1 text-[color:var(--theme-text-muted)]">•</span>
-                        {vehicleLabel || "No vehicle"}
-                        {plate ? (
-                          <span className="ml-1 text-[color:var(--theme-text-secondary)]">
-                            ({plate})
-                          </span>
-                        ) : null}
+                        {name || "No customer"}
+                        <span className="mx-1 text-[color:var(--theme-text-muted)]">
+                          •
+                        </span>
+                        {vehicle || "No vehicle"}
+                        {plate ? ` (${plate})` : ""}
                       </div>
-
                       <div className="mt-1 text-[0.7rem] text-[color:var(--theme-text-muted)]">
-                        {r.created_at
-                          ? format(new Date(r.created_at), "PP p")
+                        {row.created_at
+                          ? format(new Date(row.created_at), "PP p")
                           : "—"}
                       </div>
-                    </div>
+                    </Link>
 
-                    <div className="flex flex-col items-end gap-1">
+                    <div className="flex shrink-0 flex-col gap-1.5">
                       <Link
                         href={href}
-                        className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2.5 py-1 text-[0.7rem] text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper-light)] hover:bg-[var(--accent-copper)]/20"
+                        className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1.5 text-center text-[0.7rem] font-semibold text-[color:var(--theme-text-primary)]"
                       >
                         Open
                       </Link>
-                      {canAssign && (
+                      {canAssign ? (
                         <button
                           type="button"
-                          onClick={() => openAssignModalForWo(r.id)}
-                          className="rounded-full border border-sky-500/60 bg-sky-500/10 px-2.5 py-1 text-[0.7rem] text-sky-100 transition hover:bg-sky-500/25"
+                          onClick={() => openAssignModal(row.id)}
+                          className="rounded-full border border-sky-500/60 bg-sky-500/10 px-3 py-1.5 text-[0.7rem] font-semibold text-sky-100"
                         >
                           Assign tech
                         </button>
-                      )}
+                      ) : null}
                     </div>
                   </div>
                 </article>
@@ -453,9 +397,8 @@ export default function MobileWorkOrdersViewPage() {
           </section>
         )}
 
-        {/* Assign-tech modal – uses first job line on the WO */}
         <AssignTechModal
-          isOpen={assignModalOpen && !!assignModalLineId}
+          isOpen={assignModalOpen && Boolean(assignModalLineId)}
           onClose={() => {
             setAssignModalOpen(false);
             setAssignModalLineId(null);
@@ -463,11 +406,23 @@ export default function MobileWorkOrdersViewPage() {
           workOrderLineId={assignModalLineId ?? ""}
           mechanics={mechanics}
           onAssigned={async () => {
-            // after assigning, refresh the list
             await load();
           }}
         />
       </div>
     </main>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-2">
+      <div className="text-lg font-semibold text-[color:var(--theme-text-primary)]">
+        {value}
+      </div>
+      <div className="mt-0.5 text-[0.58rem] uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
+        {label}
+      </div>
+    </div>
   );
 }

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -4,8 +4,6 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
-import { buildAssistantHref } from "@/features/assistant/lib/buildAssistantHref";
-import { buildPlannerHref } from "@/features/assistant/lib/buildPlannerHref";
 import MobileShiftTracker from "@/features/mobile/components/MobileShiftTracker";
 import {
   getMobileTilesForRole,
@@ -184,23 +182,9 @@ export function MobileBottomNav({ open, onClose }: Props) {
     );
   }, [role]);
 
-  const assistantHref = useMemo(
-    () => buildAssistantHref({ pageType: "mobile", pageTitle: "Mobile" }),
-    [],
-  );
-  const plannerHref = useMemo(
-    () =>
-      buildPlannerHref({
-        planner: "ops",
-        allowCreate: false,
-        goal: "Build next operational plan",
-      }),
-    [],
-  );
-
   const utilityItems = useMemo<NavItem[]>(() => {
     const syncItem: NavItem = {
-      href: "/offline/sync",
+      href: "/mobile/offline",
       label: "Offline & sync",
       subtitle: "Review queued work and sync status",
     };
@@ -209,18 +193,18 @@ export function MobileBottomNav({ open, onClose }: Props) {
 
     return [
       {
-        href: assistantHref,
+        href: "/mobile/assistant",
         label: "Ask Assistant",
-        subtitle: "Get help using the current shop context",
+        subtitle: "Ask a deliberate question using shop context",
       },
       {
-        href: plannerHref,
-        label: "Open Planner",
-        subtitle: "Plan operational work",
+        href: "/mobile/planner",
+        label: "Operations planner",
+        subtitle: "Open mobile operational workspaces",
       },
       syncItem,
     ];
-  }, [assistantHref, plannerHref, role]);
+  }, [role]);
 
   const handleSignOut = async () => {
     if (signingOut) return;
@@ -228,7 +212,8 @@ export function MobileBottomNav({ open, onClose }: Props) {
     try {
       await supabase.auth.signOut();
       onClose();
-      router.push("/sign-in");
+      router.replace("/mobile/sign-in");
+      router.refresh();
     } finally {
       setSigningOut(false);
     }
@@ -288,7 +273,7 @@ export function MobileBottomNav({ open, onClose }: Props) {
                 Ask ProFixIQ from a job
               </div>
               <p className="mt-1 text-[0.7rem] leading-4 text-[color:var(--theme-text-muted)]">
-                Open a job and tap AI Assist so your vehicle and job context are
+                Open a job and tap AI Assist so the vehicle and job context are
                 included with the question.
               </p>
             </section>

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -2,8 +2,9 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { resolveMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
 import { MobileBottomNav } from "./MobileBottomNav";
 
 type Props = {
@@ -27,8 +28,20 @@ function getTitleFromPath(pathname: string): string {
   if (pathname.startsWith("/mobile/tech/performance")) {
     return "My performance";
   }
+  if (pathname.startsWith("/mobile/workforce/attendance")) {
+    return "Attendance";
+  }
+  if (pathname.startsWith("/mobile/fleet/service-requests")) {
+    return "Service requests";
+  }
+  if (pathname.startsWith("/mobile/fleet/pretrip")) return "Pre-trip";
+  if (pathname.startsWith("/mobile/fleet")) return "Fleet";
+  if (pathname.startsWith("/mobile/assistant")) return "Assistant";
+  if (pathname.startsWith("/mobile/planner")) return "Planner";
+  if (pathname.startsWith("/mobile/offline")) return "Offline & sync";
   if (pathname.startsWith("/mobile/settings")) return "Settings";
   if (pathname.startsWith("/mobile/reports")) return "Reports";
+  if (pathname.startsWith("/mobile/technicians")) return "Technicians";
   if (pathname.startsWith("/mobile/dispatch")) return "Dispatch";
   return "ProFixIQ";
 }
@@ -41,11 +54,46 @@ function isImmersiveRoute(pathname: string): boolean {
   return /^\/mobile\/inspections\/[^/]+$/.test(pathname);
 }
 
+function shouldIgnoreAnchor(anchor: HTMLAnchorElement, event: MouseEvent): boolean {
+  if (event.defaultPrevented || event.button !== 0) return true;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return true;
+  if (anchor.hasAttribute("download")) return true;
+  if (anchor.dataset.mobileRouteBypass === "true") return true;
+
+  const target = anchor.getAttribute("target");
+  return Boolean(target && target !== "_self");
+}
+
 export function MobileShell({ children, title }: Props) {
   const pathname = usePathname();
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const resolvedTitle = title ?? getTitleFromPath(pathname);
+
+  useEffect(() => {
+    const keepNavigationMobile = (event: MouseEvent) => {
+      const element = event.target instanceof Element ? event.target : null;
+      const anchor = element?.closest("a[href]") as HTMLAnchorElement | null;
+      if (!anchor || shouldIgnoreAnchor(anchor, event)) return;
+      if (anchor.origin !== window.location.origin) return;
+
+      const currentHref = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      const requestedHref = `${anchor.pathname}${anchor.search}${anchor.hash}`;
+      const mobileHref = resolveMobileHref(requestedHref);
+      if (!mobileHref || mobileHref === requestedHref || mobileHref === currentHref) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      router.push(mobileHref);
+    };
+
+    // Listen at document level so links rendered by portals and shared modals
+    // cannot accidentally escape from the mobile application shell.
+    document.addEventListener("click", keepNavigationMobile, true);
+    return () => document.removeEventListener("click", keepNavigationMobile, true);
+  }, [router]);
 
   if (pathname === "/mobile/sign-in" || pathname.startsWith("/mobile/sign-in/")) {
     return children;

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -80,13 +80,14 @@ export function MobileShell({ children, title }: Props) {
       const currentHref = `${window.location.pathname}${window.location.search}${window.location.hash}`;
       const requestedHref = `${anchor.pathname}${anchor.search}${anchor.hash}`;
       const mobileHref = resolveMobileHref(requestedHref);
-      if (!mobileHref || mobileHref === requestedHref || mobileHref === currentHref) {
-        return;
-      }
+      if (!mobileHref || mobileHref === requestedHref) return;
 
+      // Always cancel a desktop-surface link once it has a mobile equivalent.
+      // When the equivalent is the current page, cancelling is still required;
+      // otherwise the browser would continue to the desktop route.
       event.preventDefault();
       event.stopPropagation();
-      router.push(mobileHref);
+      if (mobileHref !== currentHref) router.push(mobileHref);
     };
 
     // Listen at document level so links rendered by portals and shared modals

--- a/features/assistant/components/AskAssistantEntry.tsx
+++ b/features/assistant/components/AskAssistantEntry.tsx
@@ -1,15 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
+import { useMemo, useState } from "react";
 
-import type { AssistantContext } from "../types/assistant";
-import { buildAssistantHref } from "../lib/buildAssistantHref";
-import { buildPlannerHref } from "../lib/buildPlannerHref";
-import { useAssistant } from "../hooks/useAssistant";
-import AssistantResponseCard from "./AssistantResponseCard";
-
+import { resolveMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
 import { Button } from "@shared/components/ui/Button";
 import {
   Dialog,
@@ -18,6 +13,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@shared/components/ui/dialog";
+import { useAssistant } from "../hooks/useAssistant";
+import { buildAssistantHref } from "../lib/buildAssistantHref";
+import { buildPlannerHref } from "../lib/buildPlannerHref";
+import type { AssistantContext } from "../types/assistant";
+import AssistantResponseCard from "./AssistantResponseCard";
 
 type Props = {
   mobile?: boolean;
@@ -26,7 +26,6 @@ type Props = {
 
 function deriveContextFromPath(pathname: string): AssistantContext {
   const context: AssistantContext = {};
-
   const workOrderMatch =
     pathname.match(/^\/work-orders\/([^/]+)$/i) ??
     pathname.match(/^\/work-orders\/([^/]+)\/quote-review$/i) ??
@@ -44,7 +43,6 @@ function deriveContextFromPath(pathname: string): AssistantContext {
   const customerMatch =
     pathname.match(/^\/customers\/([^/]+)$/i) ??
     pathname.match(/^\/mobile\/customers\/([^/]+)$/i);
-
   if (customerMatch?.[1]) {
     context.customerId = customerMatch[1];
     context.pageType = "customer";
@@ -55,7 +53,6 @@ function deriveContextFromPath(pathname: string): AssistantContext {
   const bookingMatch =
     pathname.match(/^\/portal\/bookings\/([^/]+)$/i) ??
     pathname.match(/^\/dashboard\/appointments\/([^/]+)$/i);
-
   if (bookingMatch?.[1]) {
     context.bookingId = bookingMatch[1];
     context.pageType = "booking";
@@ -66,7 +63,6 @@ function deriveContextFromPath(pathname: string): AssistantContext {
   const vehicleMatch =
     pathname.match(/^\/fleet\/assets\/([^/]+)$/i) ??
     pathname.match(/^\/portal\/fleet\/units\/([^/]+)$/i);
-
   if (vehicleMatch?.[1]) {
     context.vehicleId = vehicleMatch[1];
     context.pageType = "vehicle";
@@ -83,7 +79,6 @@ function deriveContextFromPath(pathname: string): AssistantContext {
   if (pathname.startsWith("/mobile")) {
     context.pageType = "mobile";
     context.pageTitle = "Mobile";
-    return context;
   }
 
   return context;
@@ -109,9 +104,7 @@ function getPlannerLabel(context: AssistantContext): string {
     case "work_order":
       return "Plan next steps";
     case "customer":
-      return "Open in Planner";
     case "vehicle":
-      return "Open in Planner";
     case "booking":
       return "Open in Planner";
     default:
@@ -155,23 +148,29 @@ export default function AskAssistantEntry({
 }: Props) {
   const pathname = usePathname();
   const context = useMemo(() => deriveContextFromPath(pathname), [pathname]);
+  const mobileSurface = mobile || pathname.startsWith("/mobile");
 
-  const assistantHref = useMemo(() => buildAssistantHref(context), [context]);
-  const plannerHref = useMemo(
-    () =>
-      buildPlannerHref({
-        planner: "ops",
-        allowCreate: false,
-        goal: getPlannerGoal(context),
-        workOrderId: context.workOrderId,
-        bookingId: context.bookingId,
-      }),
-    [context],
-  );
+  const assistantHref = useMemo(() => {
+    const built = buildAssistantHref(context);
+    return mobileSurface
+      ? resolveMobileHref(built) ?? "/mobile/assistant"
+      : built;
+  }, [context, mobileSurface]);
+  const plannerHref = useMemo(() => {
+    const built = buildPlannerHref({
+      planner: "ops",
+      allowCreate: false,
+      goal: getPlannerGoal(context),
+      workOrderId: context.workOrderId,
+      bookingId: context.bookingId,
+    });
+    return mobileSurface
+      ? resolveMobileHref(built) ?? "/mobile/planner"
+      : built;
+  }, [context, mobileSurface]);
 
   const assistantLabel = useMemo(() => getAssistantLabel(context), [context]);
   const plannerLabel = useMemo(() => getPlannerLabel(context), [context]);
-
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const contextKey = [
@@ -180,12 +179,13 @@ export default function AskAssistantEntry({
     context.customerId,
     context.vehicleId,
     context.bookingId,
-  ].filter(Boolean).join(":");
-  const { ask, loading, data, messages, clearConversation } = useAssistant(contextKey);
-  const transcriptMessages = messages.at(-1)?.role === "assistant"
-    ? messages.slice(0, -1)
-    : messages;
-
+  ]
+    .filter(Boolean)
+    .join(":");
+  const { ask, loading, data, messages, clearConversation } =
+    useAssistant(contextKey);
+  const transcriptMessages =
+    messages.at(-1)?.role === "assistant" ? messages.slice(0, -1) : messages;
   const effectiveQuery = query.trim() || getDefaultPrompt(context);
 
   if (placement === "header") {
@@ -195,9 +195,9 @@ export default function AskAssistantEntry({
           type="button"
           title={assistantLabel}
           onClick={() => setOpen(true)}
-          className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-2.5 text-xs font-medium text-[color:var(--theme-text-primary)] shadow-sm backdrop-blur-md transition hover:border-[color:var(--accent-copper-soft,#fdba74)]/60 hover:bg-[color:var(--theme-surface-panel)] hover:text-[color:var(--theme-text-primary)]"
+          className="inline-flex h-8 items-center justify-center rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-2.5 text-xs font-medium text-[color:var(--theme-text-primary)] shadow-sm backdrop-blur-md transition hover:border-[color:var(--accent-copper-soft,#fdba74)]/60 hover:bg-[color:var(--theme-surface-panel)]"
         >
-          <span>Assistant</span>
+          Assistant
         </button>
 
         <Dialog open={open} onOpenChange={setOpen}>
@@ -205,7 +205,10 @@ export default function AskAssistantEntry({
             <DialogHeader>
               <DialogTitle
                 className="text-[color:var(--accent-copper,#c1663b)]"
-                style={{ fontFamily: "Black Ops One, var(--font-blackops), system-ui" }}
+                style={{
+                  fontFamily:
+                    "Black Ops One, var(--font-blackops), system-ui",
+                }}
               >
                 AI Assistant
               </DialogTitle>
@@ -220,9 +223,11 @@ export default function AskAssistantEntry({
                   {transcriptMessages.slice(-8).map((message, index) => (
                     <div
                       key={`${message.role}-${index}-${message.content.slice(0, 24)}`}
-                      className={message.role === "user"
-                        ? "ml-8 rounded-xl bg-[color:var(--theme-surface-overlay)] p-3 text-sm text-[color:var(--theme-text-primary)]"
-                        : "mr-8 whitespace-pre-line rounded-xl border border-[color:var(--theme-border-soft)] p-3 text-sm text-[color:var(--theme-text-secondary)]"}
+                      className={
+                        message.role === "user"
+                          ? "ml-8 rounded-xl bg-[color:var(--theme-surface-overlay)] p-3 text-sm text-[color:var(--theme-text-primary)]"
+                          : "mr-8 whitespace-pre-line rounded-xl border border-[color:var(--theme-border-soft)] p-3 text-sm text-[color:var(--theme-text-secondary)]"
+                      }
                     >
                       {message.content}
                     </div>
@@ -232,16 +237,19 @@ export default function AskAssistantEntry({
 
               <textarea
                 value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder={getDefaultPrompt(context) || "Ask anything about your shop..."}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={
+                  getDefaultPrompt(context) || "Ask anything about your shop..."
+                }
                 className="min-h-[140px] w-full rounded-2xl border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] p-3 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-[color:var(--accent-copper-soft,#fdba74)]"
               />
 
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="text-xs text-[color:var(--theme-text-muted)]">
-                  {context.pageTitle ? `Context: ${context.pageTitle}` : "General shop context"}
+                  {context.pageTitle
+                    ? `Context: ${context.pageTitle}`
+                    : "General shop context"}
                 </div>
-
                 <div className="flex gap-2">
                   <Button
                     type="button"
@@ -254,7 +262,6 @@ export default function AskAssistantEntry({
                   >
                     Clear
                   </Button>
-
                   <Button
                     type="button"
                     onClick={() => ask(effectiveQuery, context)}
@@ -274,40 +281,43 @@ export default function AskAssistantEntry({
     );
   }
 
+  const utilityLinks = (
+    <>
+      <Link
+        href={assistantHref}
+        className="mobile-tech-btn-utility inline-flex items-center rounded-full px-3 py-2 text-[0.72rem] leading-none"
+      >
+        {assistantLabel}
+      </Link>
+      <Link
+        href={plannerHref}
+        className="mobile-tech-btn-ghost inline-flex items-center rounded-full px-3 py-2 text-[0.7rem] leading-none"
+      >
+        {plannerLabel}
+      </Link>
+    </>
+  );
+
   if (placement === "dock") {
     return (
-      <div className="flex flex-wrap gap-2" role="navigation" aria-label="Utility actions">
-        <Link
-          href={assistantHref}
-          className="mobile-tech-btn-utility inline-flex items-center rounded-full px-3 py-2 text-[0.72rem] leading-none"
-        >
-          {assistantLabel}
-        </Link>
-        <Link
-          href={plannerHref}
-          className="mobile-tech-btn-ghost inline-flex items-center rounded-full px-3 py-2 text-[0.7rem] leading-none"
-        >
-          {plannerLabel}
-        </Link>
+      <div
+        className="flex flex-wrap gap-2"
+        role="navigation"
+        aria-label="Utility actions"
+      >
+        {utilityLinks}
       </div>
     );
   }
 
   if (mobile) {
     return (
-      <div className="mobile-tech-utility-dock" role="navigation" aria-label="Utility actions">
-        <Link
-          href={assistantHref}
-          className="mobile-tech-btn-utility inline-flex items-center rounded-full px-3 py-2 text-[0.72rem] leading-none"
-        >
-          {assistantLabel}
-        </Link>
-        <Link
-          href={plannerHref}
-          className="mobile-tech-btn-ghost inline-flex items-center rounded-full px-3 py-2 text-[0.7rem] leading-none"
-        >
-          {plannerLabel}
-        </Link>
+      <div
+        className="mobile-tech-utility-dock"
+        role="navigation"
+        aria-label="Utility actions"
+      >
+        {utilityLinks}
       </div>
     );
   }

--- a/features/mobile/config/mobile-tiles.ts
+++ b/features/mobile/config/mobile-tiles.ts
@@ -38,12 +38,26 @@ export type MobileTile = {
   scopes: MobileScope[];
 };
 
+const ALL_MOBILE_ROLES: MobileRole[] = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "mechanic",
+  "lead_hand",
+  "foreman",
+  "parts",
+  "dispatcher",
+  "fleet_manager",
+  "driver",
+];
+
 export const MOBILE_TILES: MobileTile[] = [
   {
     href: "/mobile",
     title: "Shop Overview",
     subtitle: "Today at a glance",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "lead_hand", "foreman", "parts", "dispatcher", "fleet_manager", "driver"],
+    roles: ALL_MOBILE_ROLES,
     scopes: ["dashboard", "home", "all"],
   },
   {
@@ -99,14 +113,14 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/messages",
     title: "Team Chat",
     subtitle: "Stay in sync",
-    roles: ["mechanic", "advisor", "manager", "lead_hand", "foreman", "owner", "admin", "parts"],
+    roles: ALL_MOBILE_ROLES,
     scopes: ["home", "messages", "all"],
   },
   {
     href: "/mobile/settings",
     title: "Settings",
     subtitle: "Account & mobile options",
-    roles: ["mechanic", "advisor", "manager", "lead_hand", "owner", "admin", "parts"],
+    roles: ALL_MOBILE_ROLES,
     scopes: ["home", "settings", "all"],
   },
   {
@@ -148,7 +162,17 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/fleet/service-requests",
     title: "Service Requests",
     subtitle: "Fleet issues & follow-up",
-    roles: ["owner", "admin", "manager", "lead_hand", "mechanic", "parts", "fleet_manager", "dispatcher"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "lead_hand",
+      "mechanic",
+      "parts",
+      "fleet_manager",
+      "dispatcher",
+      "driver",
+    ],
     scopes: ["home", "work_orders", "inspections", "fleet", "all"],
   },
 ];

--- a/features/mobile/config/mobile-tiles.ts
+++ b/features/mobile/config/mobile-tiles.ts
@@ -7,6 +7,7 @@ export type MobileRole = Extract<
   | "admin"
   | "manager"
   | "advisor"
+  | "service"
   | "mechanic"
   | "lead_hand"
   | "foreman"
@@ -43,6 +44,7 @@ const ALL_MOBILE_ROLES: MobileRole[] = [
   "admin",
   "manager",
   "advisor",
+  "service",
   "mechanic",
   "lead_hand",
   "foreman",
@@ -64,7 +66,15 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/work-orders",
     title: "Work Order Board",
     subtitle: "Live work flow",
-    roles: ["owner", "admin", "manager", "advisor", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+      "lead_hand",
+      "foreman",
+    ],
     scopes: ["dashboard", "home", "jobs", "work_orders", "all"],
   },
   {
@@ -99,14 +109,29 @@ export const MOBILE_TILES: MobileTile[] = [
     href: "/mobile/inspections",
     title: "Inspections",
     subtitle: "Run checklists on vehicles",
-    roles: ["mechanic", "advisor", "manager", "lead_hand", "foreman"],
+    roles: [
+      "mechanic",
+      "advisor",
+      "service",
+      "manager",
+      "lead_hand",
+      "foreman",
+    ],
     scopes: ["home", "inspect", "inspections", "work_orders", "all"],
   },
   {
     href: "/mobile/appointments",
     title: "Appointments",
     subtitle: "Today’s schedule",
-    roles: ["advisor", "manager", "lead_hand", "foreman", "owner", "admin"],
+    roles: [
+      "advisor",
+      "service",
+      "manager",
+      "lead_hand",
+      "foreman",
+      "owner",
+      "admin",
+    ],
     scopes: ["home", "appointments", "work_orders", "all"],
   },
   {

--- a/features/mobile/dashboard/MobileDashboardPrimitives.tsx
+++ b/features/mobile/dashboard/MobileDashboardPrimitives.tsx
@@ -3,44 +3,180 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
+import { requireMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
+
 export function MobileDashboardPage({ children }: { children: ReactNode }) {
-  return <div className="mx-auto w-full max-w-3xl space-y-4 overflow-x-hidden px-3 py-3 sm:px-4">{children}</div>;
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-4 overflow-x-hidden px-3 py-3 sm:px-4">
+      {children}
+    </div>
+  );
 }
 
-export function MobileDashboardHero({ eyebrow, title, subtitle, action }: { eyebrow: string; title: string; subtitle: string; action?: { href: string; label: string } }) {
+export function MobileDashboardHero({
+  eyebrow,
+  title,
+  subtitle,
+  action,
+}: {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  action?: { href: string; label: string };
+}) {
   return (
     <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
-      <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">{eyebrow}</div>
-      <h1 className="mt-2 text-2xl font-semibold leading-tight text-[color:var(--theme-text-primary)]">{title}</h1>
-      <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{subtitle}</p>
-      {action ? <Link href={action.href} className="mt-4 flex min-h-12 w-full items-center justify-center rounded-2xl bg-[color:var(--accent-copper)] px-4 text-sm font-semibold text-white shadow-sm">{action.label}</Link> : null}
+      <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--accent-copper)]">
+        {eyebrow}
+      </div>
+      <h1 className="mt-2 text-2xl font-semibold leading-tight text-[color:var(--theme-text-primary)]">
+        {title}
+      </h1>
+      <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+        {subtitle}
+      </p>
+      {action ? (
+        <Link
+          href={requireMobileHref(action.href)}
+          className="mt-4 flex min-h-12 w-full items-center justify-center rounded-2xl bg-[color:var(--accent-copper)] px-4 text-sm font-semibold text-white shadow-sm"
+        >
+          {action.label}
+        </Link>
+      ) : null}
     </section>
   );
 }
 
-export function MobileMetricGrid({ items }: { items: Array<{ label: string; value: number | string; href?: string; tone?: "default" | "positive" | "warning" }> }) {
+export function MobileMetricGrid({
+  items,
+}: {
+  items: Array<{
+    label: string;
+    value: number | string;
+    href?: string;
+    tone?: "default" | "positive" | "warning";
+  }>;
+}) {
   return (
     <section className="grid min-w-0 grid-cols-2 gap-2">
       {items.map((item) => {
-        const className = `min-w-0 rounded-2xl border p-3 ${item.tone === "warning" ? "border-amber-500/40 bg-amber-500/10" : item.tone === "positive" ? "border-emerald-500/35 bg-emerald-500/10" : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]"}`;
-        const body = <><div className="truncate text-xs text-[color:var(--theme-text-secondary)]">{item.label}</div><div className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{item.value}</div></>;
-        return item.href ? <Link key={item.label} href={item.href} className={className}>{body}</Link> : <div key={item.label} className={className}>{body}</div>;
+        const className = `min-w-0 rounded-2xl border p-3 ${
+          item.tone === "warning"
+            ? "border-amber-500/40 bg-amber-500/10"
+            : item.tone === "positive"
+              ? "border-emerald-500/35 bg-emerald-500/10"
+              : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]"
+        }`;
+        const body = (
+          <>
+            <div className="truncate text-xs text-[color:var(--theme-text-secondary)]">
+              {item.label}
+            </div>
+            <div className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+              {item.value}
+            </div>
+          </>
+        );
+        return item.href ? (
+          <Link
+            key={item.label}
+            href={requireMobileHref(item.href)}
+            className={className}
+          >
+            {body}
+          </Link>
+        ) : (
+          <div key={item.label} className={className}>
+            {body}
+          </div>
+        );
       })}
     </section>
   );
 }
 
-export function MobileAttentionList({ title = "Needs attention", subtitle, items }: { title?: string; subtitle?: string; items: Array<{ title: string; detail: string; href: string; action: string; count?: number }> }) {
+export function MobileAttentionList({
+  title = "Needs attention",
+  subtitle,
+  items,
+}: {
+  title?: string;
+  subtitle?: string;
+  items: Array<{
+    title: string;
+    detail: string;
+    href: string;
+    action: string;
+    count?: number;
+  }>;
+}) {
   return (
     <section className="overflow-hidden rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)]">
-      <div className="p-4"><h2 className="text-xl font-semibold text-[color:var(--theme-text-primary)]">{title}</h2>{subtitle ? <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{subtitle}</p> : null}</div>
+      <div className="p-4">
+        <h2 className="text-xl font-semibold text-[color:var(--theme-text-primary)]">
+          {title}
+        </h2>
+        {subtitle ? (
+          <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+            {subtitle}
+          </p>
+        ) : null}
+      </div>
       <div className="divide-y divide-[color:var(--theme-border-soft)]">
-        {items.length ? items.slice(0, 3).map((item) => <Link key={`${item.title}-${item.href}`} href={item.href} className="block p-4 active:bg-[color:var(--theme-surface-overlay)]"><div className="flex min-w-0 items-start justify-between gap-3"><div className="min-w-0"><div className="font-semibold text-[color:var(--theme-text-primary)]">{item.count ? `${item.count} ` : ""}{item.title}</div><div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{item.detail}</div></div><span className="shrink-0 text-sm font-medium text-[color:var(--accent-copper)]">{item.action} →</span></div></Link>) : <div className="p-4 text-sm text-[color:var(--theme-text-secondary)]">Nothing urgent right now.</div>}
+        {items.length ? (
+          items.slice(0, 3).map((item) => (
+            <Link
+              key={`${item.title}-${item.href}`}
+              href={requireMobileHref(item.href)}
+              className="block p-4 active:bg-[color:var(--theme-surface-overlay)]"
+            >
+              <div className="flex min-w-0 items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="font-semibold text-[color:var(--theme-text-primary)]">
+                    {item.count ? `${item.count} ` : ""}
+                    {item.title}
+                  </div>
+                  <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+                    {item.detail}
+                  </div>
+                </div>
+                <span className="shrink-0 text-sm font-medium text-[color:var(--accent-copper)]">
+                  {item.action} →
+                </span>
+              </div>
+            </Link>
+          ))
+        ) : (
+          <div className="p-4 text-sm text-[color:var(--theme-text-secondary)]">
+            Nothing urgent right now.
+          </div>
+        )}
       </div>
     </section>
   );
 }
 
-export function MobileActionGrid({ items }: { items: Array<{ title: string; detail: string; href: string }> }) {
-  return <section className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">{items.slice(0, 4).map((item) => <Link key={item.href} href={item.href} className="min-w-0 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4"><div className="font-semibold text-[color:var(--theme-text-primary)]">{item.title}</div><div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{item.detail}</div></Link>)}</section>;
+export function MobileActionGrid({
+  items,
+}: {
+  items: Array<{ title: string; detail: string; href: string }>;
+}) {
+  return (
+    <section className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
+      {items.slice(0, 4).map((item) => (
+        <Link
+          key={`${item.href}-${item.title}`}
+          href={requireMobileHref(item.href)}
+          className="min-w-0 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4"
+        >
+          <div className="font-semibold text-[color:var(--theme-text-primary)]">
+            {item.title}
+          </div>
+          <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+            {item.detail}
+          </div>
+        </Link>
+      ))}
+    </section>
+  );
 }

--- a/features/mobile/dashboard/MobileLeadHandHome.tsx
+++ b/features/mobile/dashboard/MobileLeadHandHome.tsx
@@ -29,27 +29,94 @@ export default function MobileLeadHandHome({ leadName, stats }: Props) {
     jobsBlocked: 0,
   };
 
+  const availableCapacity = Math.max(0, techsOnShift - jobsInProgress);
   const attention = [
-    ...(jobsBlocked > 0 ? [{ title: "blocked jobs", detail: "Review holds, parts and technician constraints.", href: "/mobile/work-orders", action: "Resolve", count: jobsBlocked }] : []),
-    ...(techsOnShift > jobsInProgress ? [{ title: "technicians may need work", detail: "Balance assignments across the active team.", href: "/work-orders/board", action: "Dispatch", count: techsOnShift - jobsInProgress }] : []),
+    ...(jobsBlocked > 0
+      ? [
+          {
+            title: "blocked jobs",
+            detail: "Review holds, parts, and technician constraints.",
+            href: "/mobile/dispatch?view=blocked",
+            action: "Resolve",
+            count: jobsBlocked,
+          },
+        ]
+      : []),
+    ...(availableCapacity > 0
+      ? [
+          {
+            title: "technicians may need work",
+            detail: "Balance assignments across the active team.",
+            href: "/mobile/dispatch?view=unassigned",
+            action: "Dispatch",
+            count: availableCapacity,
+          },
+        ]
+      : []),
   ];
 
   return (
     <MobileDashboardPage>
-      <MobileDashboardHero eyebrow="Lead-hand workspace" title={`Shop floor, ${firstName}`} subtitle="Technician capacity, active work and blockers without dashboard clutter." action={{ href: "/work-orders/board", label: "Open dispatch" }} />
-      <MobileMetricGrid items={[
-        { label: "Technicians on shift", value: techsOnShift, href: "/dashboard/workforce/attendance", tone: techsOnShift > 0 ? "positive" : "warning" },
-        { label: "Jobs in progress", value: jobsInProgress, href: "/mobile/work-orders" },
-        { label: "Blocked jobs", value: jobsBlocked, href: "/mobile/work-orders", tone: jobsBlocked > 0 ? "warning" : "default" },
-        { label: "Available capacity", value: Math.max(0, techsOnShift - jobsInProgress), href: "/work-orders/board" },
-      ]} />
-      <MobileAttentionList subtitle="Floor conditions that need intervention." items={attention} />
-      <MobileActionGrid items={[
-        { title: "Dispatch board", detail: "Balance jobs and technicians.", href: "/work-orders/board" },
-        { title: "Work orders", detail: "Review active and blocked jobs.", href: "/mobile/work-orders" },
-        { title: "Inspections", detail: "Open inspection progress.", href: "/mobile/inspections" },
-        { title: "Team chat", detail: "Coordinate with advisors and parts.", href: "/mobile/messages" },
-      ]} />
+      <MobileDashboardHero
+        eyebrow="Lead-hand workspace"
+        title={`Shop floor, ${firstName}`}
+        subtitle="Technician capacity, active work, and blockers without dashboard clutter."
+        action={{ href: "/mobile/dispatch", label: "Open dispatch" }}
+      />
+      <MobileMetricGrid
+        items={[
+          {
+            label: "Technicians on shift",
+            value: techsOnShift,
+            href: "/mobile/workforce/attendance",
+            tone: techsOnShift > 0 ? "positive" : "warning",
+          },
+          {
+            label: "Jobs in progress",
+            value: jobsInProgress,
+            href: "/mobile/work-orders?view=active",
+          },
+          {
+            label: "Blocked jobs",
+            value: jobsBlocked,
+            href: "/mobile/dispatch?view=blocked",
+            tone: jobsBlocked > 0 ? "warning" : "default",
+          },
+          {
+            label: "Available capacity",
+            value: availableCapacity,
+            href: "/mobile/dispatch?view=unassigned",
+          },
+        ]}
+      />
+      <MobileAttentionList
+        subtitle="Floor conditions that need intervention."
+        items={attention}
+      />
+      <MobileActionGrid
+        items={[
+          {
+            title: "Dispatch board",
+            detail: "Balance jobs and technicians.",
+            href: "/mobile/dispatch",
+          },
+          {
+            title: "Work orders",
+            detail: "Review active and blocked jobs.",
+            href: "/mobile/work-orders",
+          },
+          {
+            title: "Inspections",
+            detail: "Open inspection progress.",
+            href: "/mobile/inspections",
+          },
+          {
+            title: "Team chat",
+            detail: "Coordinate with advisors and parts.",
+            href: "/mobile/messages",
+          },
+        ]}
+      />
     </MobileDashboardPage>
   );
 }

--- a/features/mobile/fleet/client.ts
+++ b/features/mobile/fleet/client.ts
@@ -1,0 +1,59 @@
+export type MobileFleetUnit = {
+  id: string;
+  label: string;
+  fleetName?: string | null;
+  plate?: string | null;
+  vin?: string | null;
+  status: "in_service" | "limited" | "oos";
+  nextInspectionDate?: string | null;
+  location?: string | null;
+};
+
+export type MobileFleetServiceRequest = {
+  id: string;
+  vehicleId: string;
+  unitLabel: string | null;
+  plate: string | null;
+  title: string;
+  summary: string;
+  severity: string | null;
+  status: string | null;
+  createdAt: string;
+  scheduledForDate: string | null;
+};
+
+async function readJson<T>(response: Response): Promise<T> {
+  const body = (await response.json().catch(() => null)) as
+    | (T & { error?: string })
+    | null;
+  if (!response.ok || !body) {
+    throw new Error(body?.error || "The mobile fleet request failed.");
+  }
+  return body;
+}
+
+export async function fetchMobileFleetUnits(): Promise<MobileFleetUnit[]> {
+  const response = await fetch("/api/fleet/units", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+    cache: "no-store",
+  });
+  const body = await readJson<{ units?: MobileFleetUnit[] }>(response);
+  return body.units ?? [];
+}
+
+export async function fetchMobileFleetServiceRequests(): Promise<
+  MobileFleetServiceRequest[]
+> {
+  const response = await fetch("/api/fleet/service-requests", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+    cache: "no-store",
+  });
+  const body = await readJson<{
+    requests?: MobileFleetServiceRequest[];
+  }>(response);
+  return body.requests ?? [];
+}

--- a/features/mobile/messages/new/page.client.tsx
+++ b/features/mobile/messages/new/page.client.tsx
@@ -1,15 +1,15 @@
-// app/mobile/messages/new/page.client.tsx
 "use client";
 
-import { useEffect, useMemo, useState, useCallback } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
 const ROLE_OPTIONS = [
   { value: "all", label: "All roles" },
-  { value: "tech", label: "Tech" },
+  { value: "mechanic", label: "Technician" },
   { value: "advisor", label: "Advisor" },
   { value: "parts", label: "Parts" },
   { value: "foreman", label: "Foreman" },
@@ -23,206 +23,199 @@ type UserRow = {
   email?: string | null;
 };
 
+type UsersResponse =
+  | UserRow[]
+  | { users?: UserRow[]; data?: UserRow[]; error?: string };
+
+function normalizeUsers(input: UsersResponse | null): UserRow[] {
+  if (Array.isArray(input)) return input;
+  if (Array.isArray(input?.users)) return input.users;
+  if (Array.isArray(input?.data)) return input.data;
+  return [];
+}
+
 export default function MobileNewMessagePage() {
   const router = useRouter();
   const supabase = useMemo(() => createBrowserSupabase(), []);
-
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
-
   const [users, setUsers] = useState<UserRow[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
-
   const [search, setSearch] = useState("");
-  const [role, setRole] = useState<"all" | string>("all");
+  const [role, setRole] = useState("all");
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
 
-  // Load current user
   useEffect(() => {
-    (async () => {
+    let active = true;
+    void (async () => {
       const {
         data: { user },
       } = await supabase.auth.getUser();
-      if (user) {
-        setCurrentUserId(user.id);
-      }
+      if (active) setCurrentUserId(user?.id ?? null);
     })();
+    return () => {
+      active = false;
+    };
   }, [supabase]);
 
-  // Load users (same pattern as desktop modal)
   useEffect(() => {
-    (async () => {
+    let active = true;
+    void (async () => {
       setLoadingUsers(true);
       setApiError(null);
-
-      let gotUsers = false;
       try {
-        const res = await fetch("/api/chat/users", {
-          method: "GET",
+        const response = await fetch("/api/chat/users", {
           credentials: "include",
+          cache: "no-store",
         });
-        const json = await res.json().catch(() => ({} as any));
-
-        if (res.ok) {
-          const list: UserRow[] = Array.isArray(json)
-            ? json
-            : Array.isArray(json.users)
-            ? json.users
-            : Array.isArray(json.data)
-            ? json.data
-            : [];
-          setUsers(list ?? []);
-          gotUsers = true;
-        } else if (res.status !== 401) {
-          setApiError(json?.error || `HTTP ${res.status}`);
+        const body = (await response.json().catch(() => null)) as
+          | UsersResponse
+          | null;
+        if (response.ok) {
+          if (active) setUsers(normalizeUsers(body));
+          return;
         }
-      } catch (err) {
-        console.warn("[MobileNewMessage] /api/chat/users failed:", err);
-      }
-
-      if (!gotUsers) {
-        try {
-          const { data: profiles, error } = await supabase
-            .from("profiles")
-            .select("id, user_id, full_name, role, email")
-            .order("full_name", { ascending: true })
-            .limit(200);
-
-          if (error) {
-            setApiError("Could not load users.");
-            setUsers([]);
-          } else {
-            setUsers(
-              (profiles ?? []).map((p) => ({
-                id: p.user_id ?? p.id,
-                full_name: p.full_name,
-                role: p.role,
-                email: p.email,
-              })),
-            );
-          }
-        } catch {
-          setApiError("Could not load users.");
-          setUsers([]);
+        if (response.status !== 401) {
+          throw new Error(
+            !Array.isArray(body) && body?.error
+              ? body.error
+              : `Could not load users (${response.status}).`,
+          );
         }
-      }
 
-      setLoadingUsers(false);
+        const { data: profiles, error } = await supabase
+          .from("profiles")
+          .select("id, user_id, full_name, role, email")
+          .order("full_name", { ascending: true })
+          .limit(200);
+        if (error) throw error;
+        if (active) {
+          setUsers(
+            (profiles ?? []).map((profile) => ({
+              id: profile.user_id ?? profile.id,
+              full_name: profile.full_name,
+              role: profile.role,
+              email: profile.email,
+            })),
+          );
+        }
+      } catch (caught) {
+        if (!active) return;
+        setUsers([]);
+        setApiError(
+          caught instanceof Error ? caught.message : "Could not load users.",
+        );
+      } finally {
+        if (active) setLoadingUsers(false);
+      }
     })();
+    return () => {
+      active = false;
+    };
   }, [supabase]);
 
-  // Filtered users
   const filteredUsers = useMemo(() => {
-    const t = search.trim().toLowerCase();
-    return users.filter((u) => {
-      if (role !== "all" && (u.role ?? "") !== role) return false;
-      if (!t) return true;
-      return (
-        (u.full_name ?? "").toLowerCase().includes(t) ||
-        (u.role ?? "").toLowerCase().includes(t) ||
-        (u.email ?? "").toLowerCase().includes(t)
-      );
+    const term = search.trim().toLowerCase();
+    return users.filter((user) => {
+      if (role !== "all" && (user.role ?? "") !== role) return false;
+      if (!term) return true;
+      return [user.full_name, user.role, user.email]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(term));
     });
-  }, [users, search, role]);
+  }, [role, search, users]);
 
   const toggleSelected = (id: string) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    setSelectedIds((current) =>
+      current.includes(id)
+        ? current.filter((value) => value !== id)
+        : [...current, id],
     );
   };
 
   const handleSend = useCallback(async () => {
     const text = message.trim();
-    if (!text) return;
-    if (sending) return;
-
+    if (!text || sending) return;
     if (!currentUserId) {
       toast.error("No authenticated user.");
       return;
     }
-
     if (selectedIds.length === 0) {
       toast.error("Select at least one recipient.");
       return;
     }
 
     setSending(true);
-
     try {
-      // 1) Create conversation via canonical lifecycle API
-      const conversationRes = await fetch("/api/chat/start-conversation", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ participant_ids: selectedIds }),
-      });
-
-      const conversationJson = await conversationRes.json().catch(() => ({} as { id?: string; error?: string }));
-      if (!conversationRes.ok || !conversationJson.id) {
-        throw new Error(conversationJson?.error || "Could not start conversation.");
+      const conversationResponse = await fetch(
+        "/api/chat/start-conversation",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ participant_ids: selectedIds }),
+        },
+      );
+      const conversationBody = (await conversationResponse
+        .json()
+        .catch(() => null)) as { id?: string; error?: string } | null;
+      if (!conversationResponse.ok || !conversationBody?.id) {
+        throw new Error(
+          conversationBody?.error || "Could not start conversation.",
+        );
       }
 
-      const conversationId = conversationJson.id;
-
-      // 2) Insert first message via existing API route
-      const msgRes = await fetch("/api/chat/send-message", {
+      const messageResponse = await fetch("/api/chat/send-message", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          conversationId,
+          conversationId: conversationBody.id,
           senderId: currentUserId,
           content: text,
         }),
       });
-
-      if (!msgRes.ok) {
-        console.error(
-          "[MobileNewMessage] send-message failed:",
-          await msgRes.text(),
-        );
-        toast.error("Message failed to send.");
-        setSending(false);
-        return;
+      if (!messageResponse.ok) {
+        const body = (await messageResponse.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error || "Message failed to send.");
       }
 
-      // 3) Jump into the live conversation thread
-      router.replace(`/mobile/messages/${conversationId}`);
-    } catch (e) {
-      console.error("[MobileNewMessage] startConversation failed:", e);
-      toast.error("Could not start conversation.");
+      router.replace(`/mobile/messages/${conversationBody.id}`);
+    } catch (caught) {
+      toast.error(
+        caught instanceof Error
+          ? caught.message
+          : "Could not start conversation.",
+      );
       setSending(false);
     }
-  }, [message, sending, currentUserId, selectedIds, router]);
+  }, [currentUserId, message, router, selectedIds, sending]);
 
   return (
     <div className="min-h-screen bg-background px-4 py-4 text-foreground">
       <div className="mx-auto max-w-2xl space-y-4">
-        {/* Header */}
         <div className="flex items-center justify-between gap-2">
-          <button
-            type="button"
-            onClick={() => router.back()}
-            className="rounded-full border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-1 text-[0.7rem] text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-overlay)]"
+          <Link
+            href="/mobile/messages"
+            className="rounded-full border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-1 text-[0.7rem] text-[color:var(--theme-text-secondary)]"
           >
-            ← Back
-          </button>
+            ← Messages
+          </Link>
           <h1 className="font-blackops text-lg uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)]">
             New chat
           </h1>
-          <div className="w-[60px]" />{/* spacer */}
+          <div className="w-[78px]" aria-hidden="true" />
         </div>
 
-        {apiError && (
+        {apiError ? (
           <div className="rounded-md border border-red-500/60 bg-red-950/40 px-3 py-2 text-xs text-red-200">
             {apiError}
           </div>
-        )}
+        ) : null}
 
-        {/* Recipient + role selectors */}
-        <div className="metal-card rounded-xl border border-[var(--metal-border-soft)] bg-[var(--metal-surface)] px-3 py-3 space-y-3">
-          {/* Selected pills */}
+        <section className="metal-card space-y-3 rounded-xl border border-[var(--metal-border-soft)] bg-[var(--metal-surface)] px-3 py-3">
           <div className="space-y-1">
             <div className="text-[0.7rem] font-medium text-[color:var(--theme-text-secondary)]">
               Recipients
@@ -234,16 +227,17 @@ export default function MobileNewMessagePage() {
                 </span>
               ) : (
                 users
-                  .filter((u) => selectedIds.includes(u.id))
-                  .map((u) => (
+                  .filter((user) => selectedIds.includes(user.id))
+                  .map((user) => (
                     <span
-                      key={u.id}
-                      className="inline-flex items-center gap-1 rounded-full bg-[color:var(--theme-surface-overlay)] px-2 py-1 text-[0.7rem] text-[color:var(--theme-text-primary)] border border-[var(--metal-border-soft)]"
+                      key={user.id}
+                      className="inline-flex items-center gap-1 rounded-full border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-2 py-1 text-[0.7rem] text-[color:var(--theme-text-primary)]"
                     >
-                      {u.full_name ?? "(no name)"}
+                      {user.full_name ?? "No name"}
                       <button
                         type="button"
-                        onClick={() => toggleSelected(u.id)}
+                        onClick={() => toggleSelected(user.id)}
+                        aria-label={`Remove ${user.full_name ?? "recipient"}`}
                         className="ml-1 text-[0.75rem] text-[color:var(--theme-text-muted)] hover:text-red-400"
                       >
                         ✕
@@ -254,29 +248,27 @@ export default function MobileNewMessagePage() {
             </div>
           </div>
 
-          {/* Role filter + search */}
           <div className="flex gap-2">
             <select
               value={role}
-              onChange={(e) => setRole(e.target.value)}
-              className="h-9 rounded border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-2 text-[0.75rem] text-[color:var(--theme-text-primary)] focus:border-[var(--accent-copper-soft)] focus:outline-none"
+              onChange={(event) => setRole(event.target.value)}
+              className="h-10 rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-2 text-[0.75rem] text-[color:var(--theme-text-primary)] outline-none focus:border-[var(--accent-copper-soft)]"
             >
-              {ROLE_OPTIONS.map((r) => (
-                <option key={r.value} value={r.value}>
-                  {r.label}
+              {ROLE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
                 </option>
               ))}
             </select>
             <input
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search name, role, email…"
-              className="flex-1 h-9 rounded border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-2 text-[0.75rem] text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)] focus:outline-none"
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search name, role, or email"
+              className="h-10 min-w-0 flex-1 rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 text-[0.75rem] text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)]"
             />
           </div>
 
-          {/* User list */}
-          <div className="mt-2 max-h-64 overflow-y-auto rounded border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)]">
+          <div className="max-h-64 overflow-y-auto rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)]">
             {loadingUsers ? (
               <div className="px-3 py-3 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
                 Loading users…
@@ -287,13 +279,13 @@ export default function MobileNewMessagePage() {
               </div>
             ) : (
               <ul className="divide-y divide-[color:var(--theme-border-soft)]">
-                {filteredUsers.map((u) => {
-                  const checked = selectedIds.includes(u.id);
+                {filteredUsers.map((user) => {
+                  const checked = selectedIds.includes(user.id);
                   return (
-                    <li key={u.id}>
+                    <li key={user.id}>
                       <button
                         type="button"
-                        onClick={() => toggleSelected(u.id)}
+                        onClick={() => toggleSelected(user.id)}
                         className={`flex w-full items-center gap-2 px-3 py-2 text-left text-[0.75rem] ${
                           checked
                             ? "bg-[var(--accent-copper-soft)]/10"
@@ -311,11 +303,11 @@ export default function MobileNewMessagePage() {
                         </div>
                         <div className="min-w-0">
                           <div className="truncate text-[color:var(--theme-text-primary)]">
-                            {u.full_name ?? "(no name)"}
+                            {user.full_name ?? "No name"}
                           </div>
                           <div className="truncate text-[0.65rem] text-[color:var(--theme-text-secondary)]">
-                            {u.role ?? "—"}
-                            {u.email ? ` • ${u.email}` : ""}
+                            {user.role ?? "—"}
+                            {user.email ? ` • ${user.email}` : ""}
                           </div>
                         </div>
                       </button>
@@ -325,37 +317,28 @@ export default function MobileNewMessagePage() {
               </ul>
             )}
           </div>
-        </div>
+        </section>
 
-        {/* First message composer */}
-        <div className="metal-card rounded-xl border border-[var(--metal-border-soft)] bg-[var(--metal-surface)] px-3 py-3 space-y-3">
+        <section className="metal-card space-y-3 rounded-xl border border-[var(--metal-border-soft)] bg-[var(--metal-surface)] px-3 py-3">
           <div className="text-[0.7rem] font-medium text-[color:var(--theme-text-secondary)]">
             First message
           </div>
           <textarea
             rows={4}
             value={message}
-            onChange={(e) => setMessage(e.target.value)}
+            onChange={(event) => setMessage(event.target.value)}
             placeholder="Type your message…"
-            className="w-full resize-none rounded border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)] focus:outline-none"
+            className="w-full resize-none rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)]"
           />
           <button
             type="button"
             onClick={() => void handleSend()}
-            disabled={
-              sending || !message.trim() || selectedIds.length === 0
-            }
-            className="
-              w-full rounded-full border border-[var(--accent-copper-soft)]
-              bg-[color:var(--theme-surface-overlay)] px-4 py-2 text-sm font-semibold
-              text-[var(--accent-copper-soft)]
-              shadow-[var(--theme-shadow-medium)]
-              hover:bg-[color:var(--theme-surface-overlay)] disabled:opacity-50
-            "
+            disabled={sending || !message.trim() || selectedIds.length === 0}
+            className="min-h-11 w-full rounded-xl bg-[color:var(--accent-copper)] px-4 text-sm font-semibold text-white disabled:opacity-45"
           >
-            {sending ? "Starting…" : "Start chat"}
+            {sending ? "Sending…" : "Start conversation"}
           </button>
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/features/mobile/navigation/mobile-route-continuity.ts
+++ b/features/mobile/navigation/mobile-route-continuity.ts
@@ -1,0 +1,199 @@
+const MOBILE_ORIGIN = "https://mobile.profixiq.local";
+
+const NON_NAVIGATION_PROTOCOLS = [
+  "mailto:",
+  "tel:",
+  "sms:",
+  "javascript:",
+] as const;
+
+function withSuffix(pathname: string, search: string, hash: string): string {
+  return `${pathname}${search}${hash}`;
+}
+
+function firstPathSegmentAfter(pathname: string, prefix: string): string | null {
+  const remainder = pathname.slice(prefix.length).replace(/^\/+/, "");
+  const segment = remainder.split("/")[0]?.trim();
+  return segment || null;
+}
+
+function mapWorkOrderPath(pathname: string): string {
+  if (pathname === "/work-orders" || pathname === "/work-orders/") {
+    return "/mobile/work-orders";
+  }
+  if (pathname.startsWith("/work-orders/board")) return "/mobile/dispatch";
+  if (
+    pathname.startsWith("/work-orders/create") ||
+    pathname.startsWith("/work-orders/new")
+  ) {
+    return "/mobile/work-orders/create";
+  }
+
+  const viewId = firstPathSegmentAfter(pathname, "/work-orders/view");
+  if (viewId) return `/mobile/work-orders/${viewId}`;
+
+  const workOrderId = firstPathSegmentAfter(pathname, "/work-orders");
+  return workOrderId
+    ? `/mobile/work-orders/${workOrderId}`
+    : "/mobile/work-orders";
+}
+
+function mapInspectionPath(pathname: string): string {
+  if (pathname.startsWith("/inspections/maintenance-50-air")) {
+    return "/mobile/inspections/maintenance-50-air";
+  }
+  if (pathname.startsWith("/inspections/maintenance-50")) {
+    return "/mobile/inspections/maintenance-50";
+  }
+
+  const inspectionId = firstPathSegmentAfter(pathname, "/inspections");
+  const nonRecordRoutes = new Set([
+    "run",
+    "fill",
+    "templates",
+    "builder",
+    "maintenance",
+  ]);
+
+  return inspectionId && !nonRecordRoutes.has(inspectionId)
+    ? `/mobile/inspections/${inspectionId}`
+    : "/mobile/inspections";
+}
+
+function mapMessagePath(pathname: string): string {
+  const suffix = pathname.slice("/messages".length);
+  return `/mobile/messages${suffix}`;
+}
+
+function mapCustomerPath(pathname: string): string {
+  const customerId = firstPathSegmentAfter(pathname, "/customers");
+  return customerId ? `/mobile/customers/${customerId}` : "/mobile/work-orders";
+}
+
+function mapFleetPath(pathname: string): string {
+  if (pathname.startsWith("/fleet/service-requests")) {
+    return "/mobile/fleet/service-requests";
+  }
+  if (pathname.startsWith("/fleet/pretrip")) {
+    const unitId = firstPathSegmentAfter(pathname, "/fleet/pretrip");
+    return unitId
+      ? `/mobile/fleet/pretrip/${unitId}`
+      : "/mobile/fleet/pretrip";
+  }
+  if (pathname.startsWith("/fleet/assets")) {
+    const unitId = firstPathSegmentAfter(pathname, "/fleet/assets");
+    return unitId
+      ? `/mobile/fleet?unit=${encodeURIComponent(unitId)}`
+      : "/mobile/fleet";
+  }
+  return "/mobile/fleet";
+}
+
+function mapDashboardPath(pathname: string): string {
+  if (pathname.startsWith("/dashboard/workforce")) {
+    return "/mobile/workforce/attendance";
+  }
+  if (
+    pathname.startsWith("/dashboard/admin/people") ||
+    pathname.startsWith("/dashboard/admin/employees") ||
+    pathname.startsWith("/dashboard/technicians")
+  ) {
+    return "/mobile/technicians";
+  }
+  if (pathname.startsWith("/dashboard/appointments")) {
+    return "/mobile/appointments";
+  }
+  if (pathname.startsWith("/dashboard/reports")) {
+    return "/mobile/reports";
+  }
+  return "/mobile";
+}
+
+/**
+ * Resolves a known ProFixIQ application route to its mobile-native counterpart.
+ * External URLs, hashes, API routes, portal routes, and shared auth routes return
+ * null so the caller can leave them alone.
+ */
+export function resolveMobileHref(rawHref: string | null | undefined): string | null {
+  const href = String(rawHref ?? "").trim();
+  if (!href || href === "#") return null;
+  if (
+    NON_NAVIGATION_PROTOCOLS.some((protocol) =>
+      href.toLowerCase().startsWith(protocol),
+    )
+  ) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(href, MOBILE_ORIGIN);
+  } catch {
+    return null;
+  }
+
+  if (parsed.origin !== MOBILE_ORIGIN) return null;
+
+  const { pathname, search, hash } = parsed;
+  if (pathname.startsWith("/mobile")) {
+    return withSuffix(pathname, search, hash);
+  }
+
+  let mobilePath: string | null = null;
+
+  if (pathname === "/" || pathname.startsWith("/dashboard")) {
+    mobilePath = pathname === "/" ? "/mobile" : mapDashboardPath(pathname);
+  } else if (pathname.startsWith("/work-orders")) {
+    mobilePath = mapWorkOrderPath(pathname);
+  } else if (pathname.startsWith("/tech/queue")) {
+    mobilePath = "/mobile/tech/queue";
+  } else if (pathname.startsWith("/tech/performance")) {
+    mobilePath = "/mobile/tech/performance";
+  } else if (pathname.startsWith("/appointments")) {
+    mobilePath = "/mobile/appointments";
+  } else if (pathname.startsWith("/inspections")) {
+    mobilePath = mapInspectionPath(pathname);
+  } else if (pathname.startsWith("/parts")) {
+    mobilePath = "/mobile/parts";
+  } else if (pathname.startsWith("/messages")) {
+    mobilePath = mapMessagePath(pathname);
+  } else if (pathname.startsWith("/customers")) {
+    mobilePath = mapCustomerPath(pathname);
+  } else if (pathname.startsWith("/fleet")) {
+    mobilePath = mapFleetPath(pathname);
+  } else if (pathname.startsWith("/offline")) {
+    mobilePath = "/mobile/offline";
+  } else if (
+    pathname.startsWith("/assistant") ||
+    pathname.startsWith("/ai/assistant")
+  ) {
+    mobilePath = "/mobile/assistant";
+  } else if (pathname.startsWith("/agent/planner")) {
+    mobilePath = "/mobile/planner";
+  } else if (pathname.startsWith("/settings")) {
+    mobilePath = "/mobile/settings";
+  } else if (pathname.startsWith("/reports")) {
+    mobilePath = "/mobile/reports";
+  } else if (pathname.startsWith("/technicians")) {
+    mobilePath = "/mobile/technicians";
+  } else if (pathname === "/sign-in") {
+    mobilePath = "/mobile/sign-in";
+  }
+
+  if (!mobilePath) return null;
+
+  // Some mobile mappings already include their own query string.
+  if (mobilePath.includes("?")) {
+    const [mappedPath, mappedQuery] = mobilePath.split("?", 2);
+    const merged = new URLSearchParams(mappedQuery);
+    parsed.searchParams.forEach((value, key) => merged.set(key, value));
+    const query = merged.toString();
+    return `${mappedPath}${query ? `?${query}` : ""}${hash}`;
+  }
+
+  return withSuffix(mobilePath, search, hash);
+}
+
+export function requireMobileHref(rawHref: string): string {
+  return resolveMobileHref(rawHref) ?? "/mobile";
+}

--- a/features/shared/components/ui/PreviousPageButton.tsx
+++ b/features/shared/components/ui/PreviousPageButton.tsx
@@ -1,9 +1,10 @@
-// @shared/components/ui/PreviousPageButton.tsx
 "use client";
 
-import * as React from "react";
-import { useRouter } from "next/navigation";
 import { ChevronLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+import * as React from "react";
+
+import { resolveMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
 import { cn } from "@shared/lib/utils";
 
 type PreviousPageButtonProps = {
@@ -24,24 +25,29 @@ export default function PreviousPageButton({
   const router = useRouter();
 
   const handleClick = React.useCallback(() => {
+    if (typeof window === "undefined") return;
+    const mobileSurface = window.location.pathname.startsWith("/mobile");
+
     if (to) {
-      router.push(to);
+      router.push(
+        mobileSurface ? resolveMobileHref(to) ?? "/mobile" : to,
+      );
       return;
     }
 
-    if (typeof window !== "undefined") {
-      if (window.history.length > 1) {
-        router.back();
-        return;
-      }
-
-      const pathname = window.location.pathname || "";
-      const fallback = pathname.startsWith("/mobile")
-        ? "/mobile/work-orders"
-        : "/work-orders";
-
-      router.push(fallback);
+    // A mobile Back button must never depend on browser history because a PWA,
+    // notification, old desktop tab, or copied URL can put a desktop route
+    // immediately behind the current page.
+    if (mobileSurface) {
+      router.push("/mobile/work-orders");
+      return;
     }
+
+    if (window.history.length > 1) {
+      router.back();
+      return;
+    }
+    router.push("/work-orders");
   }, [router, to]);
 
   return (

--- a/features/shared/lib/pwa/launch.ts
+++ b/features/shared/lib/pwa/launch.ts
@@ -5,10 +5,19 @@ export function resolveInstalledLaunchPath(
   compactViewport: boolean,
 ): string {
   const canonicalRole = canonicalizeRole(role);
+
   if (canonicalRole === "customer") return "/portal";
+
+  if (compactViewport) {
+    if (canonicalRole === "driver") return "/mobile/fleet/pretrip";
+    if (["fleet_manager", "dispatcher"].includes(canonicalRole)) {
+      return "/mobile/fleet";
+    }
+    return "/mobile";
+  }
+
   if (["fleet_manager", "dispatcher", "driver"].includes(canonicalRole)) {
     return "/fleet";
   }
-  if (compactViewport) return "/mobile";
   return "/dashboard";
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,7 @@ import { createServerClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import { resolveMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   hasSupabasePublicEnv,
@@ -18,6 +19,14 @@ function isAssetPath(p: string) {
     p.endsWith(".svg") ||
     /\.(png|jpg|jpeg|gif|webp|ico|css|js|map)$/i.test(p)
   );
+}
+
+function isMobileDeviceRequest(req: NextRequest): boolean {
+  const clientHint = req.headers.get("sec-ch-ua-mobile");
+  if (clientHint === "?1") return true;
+
+  const userAgent = req.headers.get("user-agent") ?? "";
+  return /android|iphone|ipad|ipod|mobile|windows phone/i.test(userAgent);
 }
 
 function safeRedirectPath(v: string | null): string | null {
@@ -87,6 +96,7 @@ async function resolvePortalAccessServer(
 
 export async function middleware(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
+  const mobileDeviceRequest = isMobileDeviceRequest(req);
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-next-pathname", pathname);
 
@@ -203,7 +213,9 @@ export async function middleware(req: NextRequest) {
         ? "/onboarding"
         : needsShopBoostIntake
           ? "/onboarding/shop-boost"
-          : "/dashboard",
+          : mobileDeviceRequest
+            ? "/mobile"
+            : "/dashboard",
       req.url,
     );
     return NextResponse.redirect(target, { headers: res.headers });
@@ -227,17 +239,14 @@ export async function middleware(req: NextRequest) {
         return NextResponse.redirect(target, { headers: res.headers });
       }
 
-      const to =
-        redirectParam ??
-        (isMobileSignIn
-          ? completed
+      const defaultAuthenticatedPath = !completed
+        ? "/onboarding"
+        : needsShopBoostIntake
+          ? "/onboarding/shop-boost"
+          : isMobileSignIn || mobileDeviceRequest
             ? "/mobile"
-            : "/onboarding"
-          : !completed
-            ? "/onboarding"
-            : needsShopBoostIntake
-              ? "/onboarding/shop-boost"
-              : "/dashboard");
+            : "/dashboard";
+      const to = redirectParam ?? defaultAuthenticatedPath;
       const target = new URL(to, req.url);
       return NextResponse.redirect(target, { headers: res.headers });
     }
@@ -287,6 +296,21 @@ export async function middleware(req: NextRequest) {
       req.url,
     );
     return NextResponse.redirect(target, { headers: res.headers });
+  }
+
+  if (
+    mobileDeviceRequest &&
+    completed &&
+    !needsShopBoostIntake &&
+    !isPortal &&
+    !pathname.startsWith("/mobile")
+  ) {
+    const requestedHref = `${pathname}${search}`;
+    const mobileHref = resolveMobileHref(requestedHref);
+    if (mobileHref && mobileHref !== requestedHref) {
+      const target = new URL(mobileHref, req.url);
+      return NextResponse.redirect(target, { headers: res.headers });
+    }
   }
 
   if (pathname.startsWith("/mobile") && !canUseMobile) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -41,7 +41,6 @@ function isShopBoostOrchestratedRole(role: string | null | undefined): boolean {
 
 function createMiddlewareSupabase(req: NextRequest, res: NextResponse) {
   const { supabaseUrl, supabaseAnonKey } = readSupabasePublicEnv("middleware");
-
   return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
       getAll() {
@@ -71,7 +70,6 @@ async function resolvePortalAccessServer(
       .eq("user_id", userId)
       .limit(1)
       .maybeSingle();
-
     customer = Boolean(cust?.id);
   } catch {
     // ignore
@@ -137,7 +135,6 @@ export async function middleware(req: NextRequest) {
   }
 
   const supabase = createMiddlewareSupabase(req, res);
-
   const {
     data: { user },
     error: userError,
@@ -156,6 +153,7 @@ export async function middleware(req: NextRequest) {
   let canUseMobile = false;
   const isPortalOnlyAccount =
     user?.app_metadata?.profixiq_portal_only === true;
+
   if (user && !isPortal) {
     try {
       const { data: profile } = await supabase
@@ -168,9 +166,7 @@ export async function middleware(req: NextRequest) {
       completed = !!profile?.completed_onboarding || !!profile?.shop_id;
       const capabilities = getActorCapabilities({ role: profile?.role });
       canUseMobile =
-        capabilities.canRunInspections ||
-        capabilities.canManageWorkOrders ||
-        capabilities.canPerformAssignedWork;
+        capabilities.isKnownRole && capabilities.canonicalRole !== "customer";
 
       if (
         profile?.completed_onboarding &&
@@ -184,7 +180,6 @@ export async function middleware(req: NextRequest) {
           .order("created_at", { ascending: false })
           .limit(1)
           .maybeSingle();
-
         needsShopBoostIntake = !intake?.id;
       }
     } catch {
@@ -218,7 +213,6 @@ export async function middleware(req: NextRequest) {
     const redirectParam = safeRedirectPath(
       req.nextUrl.searchParams.get("redirect"),
     );
-
     const isMainSignIn =
       pathname.startsWith("/sign-in") || pathname.startsWith("/signup");
     const isMobileSignIn = pathname.startsWith("/mobile/sign-in");
@@ -232,20 +226,18 @@ export async function middleware(req: NextRequest) {
         );
         return NextResponse.redirect(target, { headers: res.headers });
       }
+
       const to =
         redirectParam ??
         (isMobileSignIn
-          ? completed && canUseMobile
+          ? completed
             ? "/mobile"
-            : completed
-              ? "/dashboard"
-              : "/onboarding"
+            : "/onboarding"
           : !completed
             ? "/onboarding"
             : needsShopBoostIntake
               ? "/onboarding/shop-boost"
               : "/dashboard");
-
       const target = new URL(to, req.url);
       return NextResponse.redirect(target, { headers: res.headers });
     }
@@ -258,11 +250,14 @@ export async function middleware(req: NextRequest) {
     ) {
       const access = await resolvePortalAccessServer(supabase, user.id);
       const requestedFleet = redirectParam?.startsWith("/portal/fleet") ?? false;
-
-      let to = redirectParam ?? (access.fleet && !access.customer ? "/portal/fleet" : "/portal");
+      let to =
+        redirectParam ??
+        (access.fleet && !access.customer ? "/portal/fleet" : "/portal");
 
       if (requestedFleet && !access.fleet) to = "/portal";
-      if (!requestedFleet && !access.customer && access.fleet) to = "/portal/fleet";
+      if (!requestedFleet && !access.customer && access.fleet) {
+        to = "/portal/fleet";
+      }
 
       const target = new URL(to, req.url);
       return NextResponse.redirect(target, { headers: res.headers });
@@ -282,7 +277,6 @@ export async function middleware(req: NextRequest) {
     const loginPath = isMobileRoute ? "/mobile/sign-in" : "/sign-in";
     const login = new URL(loginPath, req.url);
     login.searchParams.set("redirect", pathname + search);
-
     return NextResponse.redirect(login, { headers: res.headers });
   }
 
@@ -296,13 +290,22 @@ export async function middleware(req: NextRequest) {
   }
 
   if (pathname.startsWith("/mobile") && !canUseMobile) {
-    const target = new URL(completed ? "/dashboard" : "/onboarding", req.url);
-    return NextResponse.redirect(target, { headers: res.headers });
+    if (!completed) {
+      const target = new URL("/onboarding", req.url);
+      return NextResponse.redirect(target, { headers: res.headers });
+    }
+
+    // Keep completed but unsupported/legacy roles inside the mobile surface.
+    // `/mobile` renders the role-not-configured state without exposing desktop.
+    if (pathname !== "/mobile") {
+      const target = new URL("/mobile", req.url);
+      return NextResponse.redirect(target, { headers: res.headers });
+    }
+    return res;
   }
 
   if (isPortal) {
     const access = await resolvePortalAccessServer(supabase, user.id);
-
     const isFleetPortalPath =
       pathname === "/portal/fleet" || pathname.startsWith("/portal/fleet/");
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,8 @@ const withSerwist = withSerwistInit({
   additionalPrecacheEntries: [
     { url: "/offline", revision: null },
     { url: "/offline/sync", revision: null },
+    { url: "/mobile", revision: null },
+    { url: "/mobile/offline", revision: null },
     { url: "/mobile/tech/queue", revision: null },
   ],
 });

--- a/tests/auth-portal-hardening.test.ts
+++ b/tests/auth-portal-hardening.test.ts
@@ -87,4 +87,25 @@ describe("authentication and portal hardening", () => {
     expect(signup).toContain('initialMode="sign-up"');
     expect(shell).toContain("ThemeToggle");
   });
+
+  it("allows every known non-customer shop role to stay on mobile", () => {
+    const signInRoute = read("app/api/auth/sign-in/route.ts");
+    const middleware = read("middleware.ts");
+    const mobileHome = read("app/mobile/page.tsx");
+    const tiles = read("features/mobile/config/mobile-tiles.ts");
+
+    for (const source of [signInRoute, middleware]) {
+      expect(source).toContain("capabilities.isKnownRole");
+      expect(source).toContain('capabilities.canonicalRole !== "customer"');
+    }
+    expect(signInRoute).toContain(
+      '"/auth/set-password?redirect=%2Fmobile"',
+    );
+    expect(middleware).toContain('pathname !== "/mobile"');
+    expect(middleware).not.toContain('completed ? "/dashboard" : "/onboarding"');
+    expect(mobileHome).toContain(
+      'role === "advisor" || role === "service"',
+    );
+    expect(tiles).toContain('| "service"');
+  });
 });

--- a/tests/mobile-native-route-audit.test.ts
+++ b/tests/mobile-native-route-audit.test.ts
@@ -1,27 +1,73 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const read = (path: string) => readFileSync(path, "utf8");
 
+const ROLE_DASHBOARDS = [
+  "features/mobile/dashboard/MobileManagerHome.tsx",
+  "features/mobile/dashboard/MobileAdvisorHome.tsx",
+  "features/mobile/dashboard/MobileLeadHandHome.tsx",
+  "features/mobile/dashboard/MobileOperationalRoleHome.tsx",
+  "features/mobile/dashboard/MobileTechHome.tsx",
+  "features/mobile/config/mobile-tiles.ts",
+  "components/layout/MobileBottomNav.tsx",
+];
+
+const FORBIDDEN_DESTINATIONS = [
+  'href: "/work-orders/board"',
+  'href: "/dashboard/workforce/attendance"',
+  'href: "/parts/requests"',
+  'href: "/parts/orders"',
+  'href: "/sign-in"',
+  'href: "/offline/sync"',
+  'href: "/assistant"',
+  'href: "/agent/planner"',
+];
+
 describe("mobile-native navigation", () => {
-  it("keeps role dashboard actions inside the mobile shell", () => {
-    for (const path of [
-      "features/mobile/dashboard/MobileManagerHome.tsx",
-      "features/mobile/dashboard/MobileOperationalRoleHome.tsx",
-      "features/mobile/config/mobile-tiles.ts",
-    ]) {
+  it("keeps every role dashboard and mobile menu inside the mobile shell", () => {
+    for (const path of ROLE_DASHBOARDS) {
       const source = read(path);
-      expect(source).not.toContain('href: "/work-orders/board"');
-      expect(source).not.toContain('href: "/dashboard/workforce/attendance"');
-      expect(source).not.toContain('href: "/parts/requests"');
-      expect(source).not.toContain('href: "/parts/orders"');
+      for (const destination of FORBIDDEN_DESTINATIONS) {
+        expect(source, `${path} contains ${destination}`).not.toContain(
+          destination,
+        );
+      }
+    }
+  });
+
+  it("provides mobile-native destinations for every configured static tile", () => {
+    const source = read("features/mobile/config/mobile-tiles.ts");
+    const hrefs = [...source.matchAll(/href:\s*"(\/mobile[^"]*)"/g)].map(
+      (match) => match[1],
+    );
+
+    expect(hrefs.length).toBeGreaterThan(10);
+    for (const href of new Set(hrefs)) {
+      const pathname = href.split(/[?#]/)[0];
+      const routePath =
+        pathname === "/mobile"
+          ? "app/mobile/page.tsx"
+          : `app${pathname}/page.tsx`;
+      expect(existsSync(routePath), `missing mobile route for ${href}`).toBe(true);
     }
   });
 
   it("provides mobile-native destinations for high-frequency operations", () => {
-    expect(read("app/mobile/workforce/attendance/page.tsx")).toContain("Attendance & activity");
+    expect(read("app/mobile/workforce/attendance/page.tsx")).toContain(
+      "Attendance & activity",
+    );
     expect(read("app/mobile/dispatch/page.tsx")).toContain("Live shop floor");
     expect(read("app/mobile/parts/page.tsx")).toContain("Parts workflow");
+    expect(read("app/mobile/fleet/page.tsx")).toContain("Fleet units");
+    expect(read("app/mobile/fleet/pretrip/page.tsx")).toContain(
+      "Start a pre-trip",
+    );
+    expect(read("app/mobile/fleet/service-requests/page.tsx")).toContain(
+      "Service requests",
+    );
+    expect(read("app/mobile/offline/page.tsx")).toContain("Offline &amp; sync");
+    expect(read("app/mobile/assistant/page.tsx")).toContain("Ask a question");
   });
 
   it("uses the existing shop-scoped operations payload", () => {
@@ -32,6 +78,18 @@ describe("mobile-native navigation", () => {
     ]) {
       expect(read(path)).toContain("getOperationsDashboardPayload");
       expect(read(path)).toContain('export const dynamic = "force-dynamic"');
+    }
+  });
+
+  it("keeps mobile inspection entry points from exposing desktop links", () => {
+    for (const path of [
+      "app/mobile/inspections/page.tsx",
+      "app/mobile/inspections/maintenance-50/page.tsx",
+      "app/mobile/inspections/maintenance-50-air/page.tsx",
+    ]) {
+      const source = read(path);
+      expect(source).not.toContain(">Desktop<");
+      expect(source).not.toContain("Desktop view");
     }
   });
 });

--- a/tests/mobile-role-dashboard-layout.test.ts
+++ b/tests/mobile-role-dashboard-layout.test.ts
@@ -26,9 +26,14 @@ describe("mobile role dashboard layout", () => {
     expect(source).not.toContain("/work-orders/board");
   });
 
-  it("gives advisor and lead hand dashboards one primary action and compact metrics", () => {
+  it("gives advisor, service and lead hand roles compact mobile dashboards", () => {
+    const home = read("app/mobile/page.tsx");
+    const tiles = read("features/mobile/config/mobile-tiles.ts");
     const advisor = read("features/mobile/dashboard/MobileAdvisorHome.tsx");
     const lead = read("features/mobile/dashboard/MobileLeadHandHome.tsx");
+
+    expect(home).toContain('role === "advisor" || role === "service"');
+    expect(tiles).toContain('| "service"');
     expect(advisor).toContain("+ Create work order");
     expect(lead).toContain("Open dispatch");
     expect(advisor).toContain("MobileMetricGrid");

--- a/tests/mobile-role-dashboard-layout.test.ts
+++ b/tests/mobile-role-dashboard-layout.test.ts
@@ -4,21 +4,26 @@ import { describe, expect, it } from "vitest";
 const read = (path: string) => readFileSync(path, "utf8");
 
 describe("mobile role dashboard layout", () => {
-  it("uses a shared overflow-safe dashboard shell", () => {
-    const source = read("features/mobile/dashboard/MobileDashboardPrimitives.tsx");
+  it("uses a shared overflow-safe dashboard shell and mobile href normalizer", () => {
+    const source = read(
+      "features/mobile/dashboard/MobileDashboardPrimitives.tsx",
+    );
     expect(source).toContain("overflow-x-hidden");
     expect(source).toContain("grid-cols-2");
     expect(source).toContain("items.slice(0, 3)");
     expect(source).toContain("items.slice(0, 4)");
+    expect(source).toContain("requireMobileHref");
   });
 
-  it("keeps owner, admin, manager and foreman copy role-aware", () => {
+  it("keeps owner, admin, manager and foreman copy role-aware and mobile-native", () => {
     const source = read("features/mobile/dashboard/MobileManagerHome.tsx");
     for (const role of ["owner", "admin", "manager", "foreman"]) {
       expect(source).toContain(`${role}:`);
     }
-    expect(source).toContain("/dashboard/workforce/attendance");
-    expect(source).toContain("/work-orders/board");
+    expect(source).toContain("/mobile/workforce/attendance");
+    expect(source).toContain("/mobile/dispatch");
+    expect(source).not.toContain("/dashboard/workforce/attendance");
+    expect(source).not.toContain("/work-orders/board");
   });
 
   it("gives advisor and lead hand dashboards one primary action and compact metrics", () => {
@@ -28,5 +33,23 @@ describe("mobile role dashboard layout", () => {
     expect(lead).toContain("Open dispatch");
     expect(advisor).toContain("MobileMetricGrid");
     expect(lead).toContain("MobileMetricGrid");
+    expect(lead).toContain("/mobile/dispatch");
+    expect(lead).toContain("/mobile/workforce/attendance");
+  });
+
+  it("keeps operational role dashboard destinations mobile-native", () => {
+    const source = read(
+      "features/mobile/dashboard/MobileOperationalRoleHome.tsx",
+    );
+    for (const href of [
+      "/mobile/parts",
+      "/mobile/dispatch",
+      "/mobile/fleet",
+      "/mobile/fleet/pretrip",
+      "/mobile/fleet/service-requests",
+      "/mobile/messages",
+    ]) {
+      expect(source).toContain(href);
+    }
   });
 });

--- a/tests/mobile-route-continuity.test.ts
+++ b/tests/mobile-route-continuity.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  requireMobileHref,
+  resolveMobileHref,
+} from "../features/mobile/navigation/mobile-route-continuity";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("mobile route continuity", () => {
+  it.each([
+    ["/dashboard", "/mobile"],
+    ["/dashboard/workforce/attendance", "/mobile/workforce/attendance"],
+    ["/work-orders/board", "/mobile/dispatch"],
+    ["/work-orders/create", "/mobile/work-orders/create"],
+    ["/work-orders/abc/quote-review", "/mobile/work-orders/abc"],
+    ["/tech/queue", "/mobile/tech/queue"],
+    ["/appointments?day=2026-07-19", "/mobile/appointments?day=2026-07-19"],
+    [
+      "/inspections/maintenance-50-air?workOrderId=wo",
+      "/mobile/inspections/maintenance-50-air?workOrderId=wo",
+    ],
+    ["/parts/requests/123", "/mobile/parts"],
+    ["/messages/chat-1", "/mobile/messages/chat-1"],
+    ["/customers/customer-1", "/mobile/customers/customer-1"],
+    ["/fleet/pretrip/unit-1", "/mobile/fleet/pretrip/unit-1"],
+    ["/fleet/service-requests", "/mobile/fleet/service-requests"],
+    ["/offline/sync", "/mobile/offline"],
+    ["/assistant?workOrderId=wo", "/mobile/assistant?workOrderId=wo"],
+    ["/agent/planner?goal=dispatch", "/mobile/planner?goal=dispatch"],
+    ["/sign-in", "/mobile/sign-in"],
+  ])("maps %s to %s", (source, expected) => {
+    expect(resolveMobileHref(source)).toBe(expected);
+  });
+
+  it("preserves mobile, external, portal and shared auth destinations", () => {
+    expect(resolveMobileHref("/mobile/work-orders?view=active")).toBe(
+      "/mobile/work-orders?view=active",
+    );
+    expect(resolveMobileHref("https://example.com/work-orders")).toBeNull();
+    expect(resolveMobileHref("mailto:service@example.com")).toBeNull();
+    expect(resolveMobileHref("/portal/fleet")).toBeNull();
+    expect(resolveMobileHref("/forgot-password?redirect=%2Fmobile")).toBeNull();
+    expect(requireMobileHref("/unknown-internal-route")).toBe("/mobile");
+  });
+
+  it("installs a document-level guard for links rendered by shared components", () => {
+    const shell = read("components/layout/MobileShell.tsx");
+    expect(shell).toContain("resolveMobileHref");
+    expect(shell).toContain('document.addEventListener("click"');
+    expect(shell).toContain("anchor.origin !== window.location.origin");
+    expect(shell).toContain("router.push(mobileHref)");
+  });
+
+  it("keeps authentication and mobile utilities inside mobile routes", () => {
+    const menu = read("components/layout/MobileBottomNav.tsx");
+    const signIn = read("app/mobile/sign-in/page.tsx");
+    expect(menu).toContain('href: "/mobile/assistant"');
+    expect(menu).toContain('href: "/mobile/planner"');
+    expect(menu).toContain('href: "/mobile/offline"');
+    expect(menu).toContain('router.replace("/mobile/sign-in")');
+    expect(signIn).not.toContain('href="/sign-in"');
+  });
+
+  it("allows scoped drivers and fleet managers to read mobile service requests", () => {
+    const route = read("app/api/fleet/service-requests/route.ts");
+    expect(route).toContain(
+      "actor.capabilities.canSeeFleetWideUnits || actor.isFleetActor",
+    );
+    expect(route).toContain("RLS and fleet membership remain");
+  });
+});

--- a/tests/mobile-route-continuity.test.ts
+++ b/tests/mobile-route-continuity.test.ts
@@ -59,7 +59,8 @@ describe("mobile route continuity", () => {
     expect(middleware).toContain('req.headers.get("sec-ch-ua-mobile")');
     expect(middleware).toContain("resolveMobileHref(requestedHref)");
     expect(middleware).toContain("mobileDeviceRequest &&");
-    expect(middleware).toContain('mobileDeviceRequest\n            ? "/mobile"');
+    expect(middleware).toContain("defaultAuthenticatedPath");
+    expect(middleware).toContain('? "/mobile"');
   });
 
   it("keeps authentication and mobile utilities inside mobile routes", () => {

--- a/tests/mobile-route-continuity.test.ts
+++ b/tests/mobile-route-continuity.test.ts
@@ -50,6 +50,7 @@ describe("mobile route continuity", () => {
     expect(shell).toContain("resolveMobileHref");
     expect(shell).toContain('document.addEventListener("click"');
     expect(shell).toContain("anchor.origin !== window.location.origin");
+    expect(shell).toContain("event.preventDefault()");
     expect(shell).toContain("router.push(mobileHref)");
   });
 
@@ -61,6 +62,27 @@ describe("mobile route continuity", () => {
     expect(menu).toContain('href: "/mobile/offline"');
     expect(menu).toContain('router.replace("/mobile/sign-in")');
     expect(signIn).not.toContain('href="/sign-in"');
+  });
+
+  it("uses deterministic mobile back routes instead of browser history", () => {
+    const job = read("app/mobile/jobs/[lineId]/page.tsx");
+    const inspection = read("app/mobile/inspections/[id]/page.tsx");
+    const chat = read("app/mobile/messages/[chatId]/page.tsx");
+    const newMessage = read("features/mobile/messages/new/page.client.tsx");
+    const vehicle = read("app/mobile/work-orders/[id]/vehicle/page.tsx");
+    const previous = read("features/shared/components/ui/PreviousPageButton.tsx");
+
+    expect(job).toContain('router.push("/mobile/tech/queue")');
+    expect(job).not.toContain("router.back()");
+    expect(inspection).toContain("const backHref = workOrderId");
+    expect(inspection).not.toContain("router.back()");
+    expect(chat).toContain('href="/mobile/messages"');
+    expect(chat).not.toContain("router.back()");
+    expect(newMessage).toContain('href="/mobile/messages"');
+    expect(vehicle).toContain(
+      'href={`/mobile/work-orders/${workOrderId}`}',
+    );
+    expect(previous).toContain('router.push("/mobile/work-orders")');
   });
 
   it("allows scoped drivers and fleet managers to read mobile service requests", () => {

--- a/tests/mobile-route-continuity.test.ts
+++ b/tests/mobile-route-continuity.test.ts
@@ -45,13 +45,21 @@ describe("mobile route continuity", () => {
     expect(requireMobileHref("/unknown-internal-route")).toBe("/mobile");
   });
 
-  it("installs a document-level guard for links rendered by shared components", () => {
+  it("installs client and server guards for desktop links opened on mobile", () => {
     const shell = read("components/layout/MobileShell.tsx");
+    const middleware = read("middleware.ts");
+
     expect(shell).toContain("resolveMobileHref");
     expect(shell).toContain('document.addEventListener("click"');
     expect(shell).toContain("anchor.origin !== window.location.origin");
     expect(shell).toContain("event.preventDefault()");
     expect(shell).toContain("router.push(mobileHref)");
+
+    expect(middleware).toContain("isMobileDeviceRequest");
+    expect(middleware).toContain('req.headers.get("sec-ch-ua-mobile")');
+    expect(middleware).toContain("resolveMobileHref(requestedHref)");
+    expect(middleware).toContain("mobileDeviceRequest &&");
+    expect(middleware).toContain('mobileDeviceRequest\n            ? "/mobile"');
   });
 
   it("keeps authentication and mobile utilities inside mobile routes", () => {
@@ -70,6 +78,7 @@ describe("mobile route continuity", () => {
     const chat = read("app/mobile/messages/[chatId]/page.tsx");
     const newMessage = read("features/mobile/messages/new/page.client.tsx");
     const vehicle = read("app/mobile/work-orders/[id]/vehicle/page.tsx");
+    const pretrip = read("app/mobile/fleet/pretrip/[unitId]/page.tsx");
     const previous = read("features/shared/components/ui/PreviousPageButton.tsx");
 
     expect(job).toContain('router.push("/mobile/tech/queue")');
@@ -82,6 +91,7 @@ describe("mobile route continuity", () => {
     expect(vehicle).toContain(
       'href={`/mobile/work-orders/${workOrderId}`}',
     );
+    expect(pretrip).toContain('href="/mobile/fleet/pretrip"');
     expect(previous).toContain('router.push("/mobile/work-orders")');
   });
 

--- a/tests/pwa-sync-center.test.ts
+++ b/tests/pwa-sync-center.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+
 import { resolveInstalledLaunchPath } from "@/features/shared/lib/pwa/launch";
 
 const read = (path: string) => readFileSync(path, "utf8");
@@ -8,16 +9,33 @@ describe("PWA install and sync center", () => {
   it("launches installed sessions into the correct role and viewport experience", () => {
     expect(resolveInstalledLaunchPath("customer", false)).toBe("/portal");
     expect(resolveInstalledLaunchPath("fleet_manager", false)).toBe("/fleet");
+    expect(resolveInstalledLaunchPath("fleet_manager", true)).toBe(
+      "/mobile/fleet",
+    );
+    expect(resolveInstalledLaunchPath("dispatcher", true)).toBe(
+      "/mobile/fleet",
+    );
+    expect(resolveInstalledLaunchPath("driver", true)).toBe(
+      "/mobile/fleet/pretrip",
+    );
     expect(resolveInstalledLaunchPath("technician", true)).toBe("/mobile");
     expect(resolveInstalledLaunchPath("service_advisor", false)).toBe(
       "/dashboard",
     );
   });
 
-  it("precaches the offline fallback and sync center", () => {
+  it("keeps compact launch recovery inside mobile routes", () => {
+    const source = read("app/launch/page.tsx");
+    expect(source).toContain('compactViewport ? "/mobile/offline" : "/offline"');
+    expect(source).toContain('"/mobile/sign-in?redirect=%2Flaunch"');
+  });
+
+  it("precaches desktop and mobile offline route shells", () => {
     const source = read("next.config.ts");
     expect(source).toContain('{ url: "/offline", revision: null }');
     expect(source).toContain('{ url: "/offline/sync", revision: null }');
+    expect(source).toContain('{ url: "/mobile", revision: null }');
+    expect(source).toContain('{ url: "/mobile/offline", revision: null }');
   });
 
   it("waits for service worker control before reloading an update", () => {


### PR DESCRIPTION
## Summary

Continues the mobile refactor across every supported role and closes the routing gaps that could send a phone or tablet user into the full desktop application.

The core contract is now:

> Once a shop user enters the mobile surface, every supported internal destination resolves to a mobile page for that operation. Mobile navigation does not fall through to `/dashboard` or a desktop feature route.

## Route continuity

- Adds one canonical desktop-to-mobile route resolver covering:
  - dashboard and role home
  - dispatch and attendance
  - work-order lists, creation, detail, and advisor views
  - technician queue and performance
  - appointments
  - inspections and Maintenance 50 runners
  - parts
  - messages and customer records
  - fleet, pre-trip, and service requests
  - reports, technicians, and settings
  - assistant, planner, and offline sync
  - authentication
- Installs a document-level capture guard in `MobileShell` so links rendered by shared components, dialogs, and portal-mounted modals cannot escape the mobile application.
- Adds middleware-level mobile-device routing so copied links, bookmarks, notifications, and old desktop URLs resolve to the corresponding `/mobile/...` route before rendering.
- Preserves external URLs, customer/fleet portal routes, API routes, enrollment routes, and shared password-recovery routes.
- Adds a mobile-native not-found page instead of sending users to a desktop-oriented fallback.

## All supported mobile roles

Reviewed and aligned the mobile home, tiles, menu, authentication, and launch behavior for:

- Owner
- Admin
- Manager
- Advisor
- Legacy Service / Service Advisor
- Technician / Mechanic
- Lead hand
- Foreman
- Parts
- Dispatcher
- Fleet manager
- Driver

Role handling now routes to:

- Technician home for mechanics
- Advisor home for advisor and legacy service roles
- Lead-hand home for lead hands
- Management home for owner, admin, manager, and foreman
- Operational role home for parts, dispatcher, fleet manager, and driver

Unknown or customer-only roles receive a mobile configuration state rather than being redirected to the main dashboard.

## Role dashboard and menu fixes

- Normalizes every shared dashboard hero, metric, attention item, and action-grid link through the mobile route resolver.
- Fixes lead-hand dispatch and attendance links that still targeted desktop routes.
- Expands role tile coverage so all supported roles retain mobile messages and settings access.
- Keeps technician AI access job-scoped.
- Gives non-technician roles mobile-native Assistant and Operations Planner pages.
- Keeps sign-out and subsequent sign-in on `/mobile/sign-in`.
- Mobile sign-in now accepts every known non-customer shop role instead of only the earlier restricted role subset.
- Required password changes retain a `/mobile` return destination.

## Newly completed mobile-native routes

- `/mobile/fleet`
- `/mobile/fleet/pretrip`
- `/mobile/fleet/service-requests`
- `/mobile/offline`
- `/mobile/assistant`
- a real `/mobile/planner` operations page instead of redirecting back to Home
- `/mobile/not-found`

Fleet routes use the existing fleet/shop-scoped APIs and RLS. Service-request reads now support correctly scoped fleet actors, including drivers, while fleet membership and RLS remain the final authorization boundary.

## Detail-page continuity

- Removes explicit Desktop links from mobile inspection pages.
- Gives hydraulic and air-brake Maintenance 50 runners a deterministic mobile Inspections back action.
- Makes inspection back navigation return to the originating mobile work order when context exists.
- Makes focused jobs return to `/mobile/tech/queue` instead of relying on browser history.
- Makes message threads and new-message flows return to `/mobile/messages`.
- Removes the desktop customer-profile escape and keeps work-order history links mobile-native.
- Adds mobile back actions to work-order customer/vehicle detail and fleet pre-trip pages.
- Updates the shared Previous Page button so mobile pages never use history that may contain a desktop route.
- Updates shared Assistant/Planner entry links to emit mobile destinations when rendered on a mobile surface.

## Installed app and offline behavior

- Compact PWA launch now routes:
  - drivers to `/mobile/fleet/pretrip`
  - fleet managers and dispatchers to `/mobile/fleet`
  - other supported shop roles to `/mobile`
  - customer accounts to the customer portal
- Compact offline launch goes to `/mobile/offline`.
- Compact unauthenticated launch goes to `/mobile/sign-in`.
- Precaches the mobile home and mobile offline route shells in addition to the existing offline assets.

## Guardrails

- Desktop layouts and desktop role destinations remain available on desktop viewports.
- Customer and fleet portal separation remains intact.
- Existing authentication, RLS, tenant scoping, offline queue, job punch, inspection, work-order, and parts behavior is reused.
- No automation was added.
- No database migration is required.

## Verification

- Vercel preview build and TypeScript validation passed for head `be9aaab`.
- PR is mergeable with `main` and has no branch conflicts.
- Expanded mobile route, role-dashboard, authentication, and PWA tests.
- Added unit coverage for the canonical route resolver.
- Added route-existence checks for every configured static mobile tile.
- Added source contracts for deterministic mobile back navigation and middleware mobile-device redirects.

## Live-device smoke test before merge

1. Sign in as each supported role and confirm `/mobile` renders the correct role home.
2. Open every dashboard tile and menu item; confirm the URL remains under `/mobile`.
3. Open copied desktop work-order, dispatch, inspection, parts, customer, fleet, and message links on iPhone and Android; confirm middleware sends them to the matching mobile page.
4. Test focused-job, inspection, customer, message, vehicle, and pre-trip Back actions from a clean PWA launch and from a desktop-originating history stack.
5. Confirm mobile sign-out returns to `/mobile/sign-in`, including forced-password-change accounts.
6. Verify fleet manager, dispatcher, and driver unit/service-request scopes with real memberships.
7. Verify offline launch, route-shell availability, queue replay, and conflict review from the installed PWA.
8. Check safe-area and keyboard behavior on iPhone and Android.