### PR TITLE
Add maintenance suggestions to work order quotes

### DIFF
--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -130,10 +130,12 @@ type CustomerVehicleSearchPick = {
 function CustomerAutocomplete({
   q,
   shopId,
+  suspended,
   onPick,
 }: {
   q: string;
   shopId: string | null;
+  suspended: boolean;
   onPick: (pick: CustomerVehicleSearchPick) => void;
 }) {
   const supabase = useMemo(() => createBrowserSupabase(), []);
@@ -145,6 +147,14 @@ function CustomerAutocomplete({
 
   useEffect(() => {
     const term = (q ?? "").trim();
+
+    if (suspended) {
+      reqCounter.current += 1;
+      setRows([]);
+      setOpen(false);
+      setBusy(false);
+      return;
+    }
 
     if (!term || !shopId || term.length < 2) {
       setRows([]);
@@ -230,7 +240,7 @@ function CustomerAutocomplete({
     }, 150);
 
     return () => window.clearTimeout(t);
-  }, [q, shopId, supabase]);
+  }, [q, shopId, supabase, suspended]);
 
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {
@@ -466,11 +476,15 @@ export default function CustomerVehicleForm({
   const [currentCustomerId, setCurrentCustomerId] = useState<string | null>(
     selectedCustomerId,
   );
+  const [customerSearchSuspended, setCustomerSearchSuspended] = useState(
+    Boolean(selectedCustomerId),
+  );
   const [duplicateMatches, setDuplicateMatches] = useState<VehicleDuplicateMatch[]>([]);
   const [duplicateWarning, setDuplicateWarning] = useState<string | null>(null);
 
   useEffect(() => {
     setCurrentCustomerId(selectedCustomerId);
+    setCustomerSearchSuspended(Boolean(selectedCustomerId));
   }, [selectedCustomerId]);
 
   const safeSetCustomer = useCallback(
@@ -564,6 +578,8 @@ export default function CustomerVehicleForm({
     c: CustomerRow,
     pickedVehicle: VehicleRow | null = null,
   ) {
+    setCustomerSearchSuspended(true);
+
     const applyCustomer = (picked: CustomerRow) => {
       const fields = hydrateCustomerFields(picked);
       safeSetCustomer("business_name", fields.business_name ?? null);
@@ -738,13 +754,15 @@ export default function CustomerVehicleForm({
                 className="input"
                 placeholder="Business name"
                 value={customer.business_name ?? ""}
-                onChange={(e) =>
-                  safeSetCustomer("business_name", e.target.value || null)
-                }
+                onChange={(e) => {
+                  setCustomerSearchSuspended(false);
+                  safeSetCustomer("business_name", e.target.value || null);
+                }}
               />
               <CustomerAutocomplete
                 q={customer.business_name ?? ""}
                 shopId={shopId}
+                suspended={customerSearchSuspended}
                 onPick={({ customer: pickedCustomer, vehicle: pickedVehicle }) => {
                   void handlePickedCustomer(pickedCustomer, pickedVehicle);
                 }}
@@ -758,11 +776,15 @@ export default function CustomerVehicleForm({
                 className="input"
                 placeholder="First name"
                 value={customer.first_name ?? ""}
-                onChange={(e) => safeSetCustomer("first_name", e.target.value || null)}
+                onChange={(e) => {
+                  setCustomerSearchSuspended(false);
+                  safeSetCustomer("first_name", e.target.value || null);
+                }}
               />
               <CustomerAutocomplete
                 q={customer.first_name ?? ""}
                 shopId={shopId}
+                suspended={customerSearchSuspended}
                 onPick={({ customer: pickedCustomer, vehicle: pickedVehicle }) => {
                   void handlePickedCustomer(pickedCustomer, pickedVehicle);
                 }}
@@ -776,11 +798,15 @@ export default function CustomerVehicleForm({
                 className="input"
                 placeholder="Last name"
                 value={customer.last_name ?? ""}
-                onChange={(e) => safeSetCustomer("last_name", e.target.value || null)}
+                onChange={(e) => {
+                  setCustomerSearchSuspended(false);
+                  safeSetCustomer("last_name", e.target.value || null);
+                }}
               />
               <CustomerAutocomplete
                 q={customer.last_name ?? ""}
                 shopId={shopId}
+                suspended={customerSearchSuspended}
                 onPick={({ customer: pickedCustomer, vehicle: pickedVehicle }) => {
                   void handlePickedCustomer(pickedCustomer, pickedVehicle);
                 }}
@@ -794,11 +820,15 @@ export default function CustomerVehicleForm({
                 className="input"
                 placeholder="Phone"
                 value={customer.phone ?? ""}
-                onChange={(e) => safeSetCustomer("phone", e.target.value || null)}
+                onChange={(e) => {
+                  setCustomerSearchSuspended(false);
+                  safeSetCustomer("phone", e.target.value || null);
+                }}
               />
               <CustomerAutocomplete
                 q={customer.phone ?? ""}
                 shopId={shopId}
+                suspended={customerSearchSuspended}
                 onPick={({ customer: pickedCustomer, vehicle: pickedVehicle }) => {
                   void handlePickedCustomer(pickedCustomer, pickedVehicle);
                 }}
@@ -813,11 +843,15 @@ export default function CustomerVehicleForm({
                 className="input"
                 placeholder="Email"
                 value={customer.email ?? ""}
-                onChange={(e) => safeSetCustomer("email", e.target.value || null)}
+                onChange={(e) => {
+                  setCustomerSearchSuspended(false);
+                  safeSetCustomer("email", e.target.value || null);
+                }}
               />
               <CustomerAutocomplete
                 q={customer.email ?? ""}
                 shopId={shopId}
+                suspended={customerSearchSuspended}
                 onPick={({ customer: pickedCustomer, vehicle: pickedVehicle }) => {
                   void handlePickedCustomer(pickedCustomer, pickedVehicle);
                 }}

--- a/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
+++ b/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
@@ -152,17 +152,15 @@ export default function CreateFlowMaintenanceSelector({
           (code) => !addedCodes.has(code.trim().toUpperCase()),
         ),
       );
+      const addedNotice =
+        `${addedCodes.size} maintenance item${addedCodes.size === 1 ? "" : "s"} added to the quote for approval.`;
       setNotice(
-        `${addedCodes.size} maintenance item${addedCodes.size === 1 ? "" : "s"} added to the quote for approval.`,
+        skipped.length > 0
+          ? `${addedNotice} Some items were skipped: ${skipped
+              .map((item) => `${item.serviceCode}: ${item.error}`)
+              .join("; ")}`
+          : addedNotice,
       );
-
-      if (skipped.length > 0) {
-        setError(
-          `Some items were skipped: ${skipped
-            .map((item) => `${item.serviceCode}: ${item.error}`)
-            .join("; ")}`,
-        );
-      }
 
       await onAdded?.();
     } catch (e) {
@@ -226,7 +224,7 @@ export default function CreateFlowMaintenanceSelector({
             Scheduled maintenance suggestions
           </h2>
           <p className="mt-1 text-[11px] text-[color:var(--theme-text-muted)]">
-            History-aware scheduled maintenance due for this vehicle. Selected items will be added after submit as pending approval items.
+            History-aware scheduled maintenance due for this vehicle. Select the items to add to this work order&apos;s quote as pending approval lines.
           </p>
           <p className="mt-1 text-[10px] uppercase tracking-wide text-[color:var(--theme-text-muted)]">
             Separate lane from menu-items catalog and inspection-template quick add

--- a/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
+++ b/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
@@ -263,7 +263,7 @@ export default function CreateFlowMaintenanceSelector({
             onClick={() => void addSelectedToQuote()}
             disabled={!workOrderId || selectedServiceCodes.length === 0 || adding}
             title={!workOrderId ? "Save & Continue before adding items to the quote." : undefined}
-            className="rounded-full border border-[color:var(--copper,#C57A4A)]/70 bg-[color:var(--copper,#C57A4A)]/12 px-3 py-1.5 text-xs font-semibold text-[color:var(--copper,#C57A4A)] hover:bg-[color:var(--copper,#C57A4A)]/18 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-full border border-[color:var(--copper)]/70 bg-[color:var(--copper)]/12 px-3 py-1.5 text-xs font-semibold text-[color:var(--copper)] hover:bg-[color:var(--copper)]/18 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {adding
               ? "Adding..."

--- a/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
+++ b/features/maintenance/components/CreateFlowMaintenanceSelector.tsx
@@ -16,12 +16,20 @@ type SuggestionsResponse = {
   suggestions?: SuggestionRow[];
 };
 
+type AddBundleResponse = {
+  ok?: boolean;
+  added?: Array<{ serviceCode: string }>;
+  skipped?: Array<{ serviceCode: string; error: string }>;
+  error?: string;
+};
+
 type Props = {
   workOrderId: string | null;
   vehicleId: string | null;
   enabled: boolean;
   selectedServiceCodes: string[];
   onChange: (codes: string[]) => void;
+  onAdded?: () => void | Promise<void>;
 };
 
 export default function CreateFlowMaintenanceSelector({
@@ -30,9 +38,12 @@ export default function CreateFlowMaintenanceSelector({
   enabled,
   selectedServiceCodes,
   onChange,
+  onAdded,
 }: Props) {
   const [loading, setLoading] = useState(false);
   const [busyCode, setBusyCode] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
   const [rows, setRows] = useState<SuggestionRow[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
@@ -94,6 +105,75 @@ export default function CreateFlowMaintenanceSelector({
   function toggleAll(nextChecked: boolean) {
     if (!rows.length) return;
     onChange(nextChecked ? rows.map((row) => row.serviceCode) : []);
+  }
+
+  async function addSelectedToQuote() {
+    if (!workOrderId || selectedServiceCodes.length === 0 || adding) return;
+
+    try {
+      setAdding(true);
+      setError(null);
+      setNotice(null);
+
+      const res = await fetch("/api/work-orders/maintenance-suggestions/add-bundle", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        cache: "no-store",
+        body: JSON.stringify({
+          workOrderId,
+          serviceCodes: selectedServiceCodes,
+        }),
+      });
+
+      const json = (await res.json().catch(() => null)) as AddBundleResponse | null;
+      if (!res.ok || !json?.ok) {
+        throw new Error(json?.error || "Failed to add maintenance items to the quote.");
+      }
+
+      const addedCodes = new Set(
+        (json.added ?? []).map((item) => item.serviceCode.trim().toUpperCase()),
+      );
+      const skipped = json.skipped ?? [];
+
+      if (addedCodes.size === 0) {
+        throw new Error(
+          skipped.map((item) => item.error).filter(Boolean).join("; ") ||
+            "No maintenance items were added.",
+        );
+      }
+
+      setRows((current) =>
+        current.filter(
+          (row) => !addedCodes.has(row.serviceCode.trim().toUpperCase()),
+        ),
+      );
+      onChange(
+        selectedServiceCodes.filter(
+          (code) => !addedCodes.has(code.trim().toUpperCase()),
+        ),
+      );
+      setNotice(
+        `${addedCodes.size} maintenance item${addedCodes.size === 1 ? "" : "s"} added to the quote for approval.`,
+      );
+
+      if (skipped.length > 0) {
+        setError(
+          `Some items were skipped: ${skipped
+            .map((item) => `${item.serviceCode}: ${item.error}`)
+            .join("; ")}`,
+        );
+      }
+
+      await onAdded?.();
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message
+          : "Failed to add maintenance items to the quote.",
+      );
+    } finally {
+      setAdding(false);
+    }
   }
 
   async function dismissCompletedPreviously(serviceCode: string) {
@@ -173,13 +253,36 @@ export default function CreateFlowMaintenanceSelector({
           <button
             type="button"
             onClick={() => toggleAll(false)}
-            disabled={!rows.length}
+            disabled={!rows.length || adding}
             className={softButtonClass}
           >
             Clear
           </button>
+          <button
+            type="button"
+            onClick={() => void addSelectedToQuote()}
+            disabled={!workOrderId || selectedServiceCodes.length === 0 || adding}
+            title={!workOrderId ? "Save & Continue before adding items to the quote." : undefined}
+            className="rounded-full border border-[color:var(--copper,#C57A4A)]/70 bg-[color:var(--copper,#C57A4A)]/12 px-3 py-1.5 text-xs font-semibold text-[color:var(--copper,#C57A4A)] hover:bg-[color:var(--copper,#C57A4A)]/18 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {adding
+              ? "Adding..."
+              : `Add to quote (${selectedServiceCodes.length})`}
+          </button>
         </div>
       </div>
+
+      {notice ? (
+        <div className="mb-3 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-200">
+          {notice}
+        </div>
+      ) : null}
+
+      {!workOrderId && selectedServiceCodes.length > 0 ? (
+        <div className="mb-3 text-xs text-[color:var(--theme-text-muted)]">
+          Save &amp; Continue first, then add the selected items to the quote.
+        </div>
+      ) : null}
 
       {!canLoad ? (
         <div className="rounded-xl border border-dashed border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-4 text-sm text-[color:var(--theme-text-secondary)]">

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -2388,6 +2388,7 @@ useEffect(() => {
               enabled={!!customerId && !!vehicleIdProp}
               selectedServiceCodes={selectedMaintenanceCodes}
               onChange={setSelectedMaintenanceCodes}
+              onAdded={fetchLines}
             />
 
             {/* Uploads */}


### PR DESCRIPTION
## What changed

- adds an **Add to quote** action to scheduled maintenance suggestions on the create work order page
- creates selected suggestions as pending-approval work order lines through the existing shop-scoped maintenance bundle API
- refreshes the work order lines and removes successfully attached suggestions from the selector
- keeps final work order submission as a safety net for any still-selected items
- closes every customer autocomplete result list immediately after an existing customer/vehicle is selected
- allows searching again as soon as the user edits a customer search field

## Root cause

The maintenance selection state was only consumed by the final form submit, so the suggestion panel had no visible action to attach selections to the quote. Customer selection populated several searchable fields, which retriggered their autocomplete effects and reopened the results after the clicked list closed.

## User impact

Advisors can select suggested maintenance and add it directly to the quote before leaving the create page. Selecting an existing customer no longer leaves customer search results covering the form.

## Validation

- inspected the existing maintenance bundle route and pending-approval line creation path
- verified selected service codes are normalized and successful additions refresh the current work order lines
- verified customer-search suppression invalidates in-flight searches and resets when the user edits a searchable field
- draft PR created so repository CI can run against the branch