### PR TITLE
Automate approved parts pick and order flow

### DIFF
--- a/app/api/parts/requests/pick-task/route.ts
+++ b/app/api/parts/requests/pick-task/route.ts
@@ -1,0 +1,210 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.trim(),
+    )
+  );
+}
+
+function n(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export async function GET(req: Request) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ["owner", "admin", "manager", "parts"],
+  });
+  if (!access.ok) return access.response;
+
+  const workOrderId = new URL(req.url).searchParams.get("workOrderId");
+  if (!isUuid(workOrderId)) {
+    return NextResponse.json(
+      { ok: false, error: "A valid workOrderId is required." },
+      { status: 400 },
+    );
+  }
+
+  const { data: workOrder, error: workOrderError } = await access.supabase
+    .from("work_orders")
+    .select("id, custom_id")
+    .eq("id", workOrderId)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+  if (workOrderError) {
+    return NextResponse.json(
+      { ok: false, error: workOrderError.message },
+      { status: 500 },
+    );
+  }
+  if (!workOrder) {
+    return NextResponse.json(
+      { ok: false, error: "Work order not found for this shop." },
+      { status: 404 },
+    );
+  }
+
+  const { data: requests, error: requestError } = await access.supabase
+    .from("part_requests")
+    .select("id, job_id, status")
+    .eq("shop_id", access.profile.shop_id)
+    .eq("work_order_id", workOrderId)
+    .in("status", [
+      "approved",
+      "partially_ordered",
+      "partially_consumed",
+      "partially_returned",
+    ]);
+  if (requestError) {
+    return NextResponse.json(
+      { ok: false, error: requestError.message },
+      { status: 500 },
+    );
+  }
+
+  const requestIds = (requests ?? []).map((request) => request.id);
+  if (requestIds.length === 0) {
+    return NextResponse.json({
+      ok: true,
+      workOrder,
+      items: [],
+      summary: { itemCount: 0, pickableCount: 0, orderedCount: 0 },
+    });
+  }
+
+  const { data: items, error: itemError } = await access.supabase
+    .from("part_request_items")
+    .select(
+      "id,request_id,work_order_line_id,part_id,description,requested_part_number,qty,qty_requested,qty_approved,qty_ordered,qty_received,qty_reserved,qty_consumed,qty_returned,po_id,status",
+    )
+    .eq("shop_id", access.profile.shop_id)
+    .in("request_id", requestIds)
+    .neq("status", "cancelled")
+    .order("created_at", { ascending: true });
+  if (itemError) {
+    return NextResponse.json(
+      { ok: false, error: itemError.message },
+      { status: 500 },
+    );
+  }
+
+  const partIds = [
+    ...new Set(
+      (items ?? [])
+        .map((item) => item.part_id)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ];
+  const [stockResult, locationResult] = await Promise.all([
+    partIds.length
+      ? access.supabase
+          .from("v_part_stock")
+          .select("part_id,location_id,qty_available,qty_on_hand,qty_reserved")
+          .in("part_id", partIds)
+      : Promise.resolve({ data: [], error: null }),
+    access.supabase
+      .from("stock_locations")
+      .select("id, code, name")
+      .eq("shop_id", access.profile.shop_id),
+  ]);
+  if (stockResult.error) {
+    return NextResponse.json(
+      { ok: false, error: stockResult.error.message },
+      { status: 500 },
+    );
+  }
+  if (locationResult.error) {
+    return NextResponse.json(
+      { ok: false, error: locationResult.error.message },
+      { status: 500 },
+    );
+  }
+
+  const locations = new Map(
+    (locationResult.data ?? []).map((location) => [
+      location.id,
+      {
+        id: location.id,
+        label:
+          [location.code, location.name].filter(Boolean).join(" — ") ||
+          "Stock location",
+      },
+    ]),
+  );
+  const stockByPart = new Map<
+    string,
+    Array<{
+      locationId: string;
+      locationLabel: string;
+      available: number;
+      onHand: number;
+      reserved: number;
+    }>
+  >();
+  for (const row of stockResult.data ?? []) {
+    if (!row.part_id || !row.location_id) continue;
+    const location = locations.get(row.location_id);
+    const next = {
+      locationId: row.location_id,
+      locationLabel: location?.label ?? "Stock location",
+      available: Math.max(0, n(row.qty_available)),
+      onHand: Math.max(0, n(row.qty_on_hand)),
+      reserved: Math.max(0, n(row.qty_reserved)),
+    };
+    stockByPart.set(row.part_id, [
+      ...(stockByPart.get(row.part_id) ?? []),
+      next,
+    ]);
+  }
+
+  const taskItems = (items ?? []).map((item) => {
+    const required = Math.max(
+      n(item.qty_approved),
+      n(item.qty_requested),
+      n(item.qty),
+      0,
+    );
+    const handedOff = Math.max(n(item.qty_consumed) - n(item.qty_returned), 0);
+    const staged = n(item.qty_reserved) + handedOff;
+    const remainingToStage = Math.max(required - staged, 0);
+    const stock = (
+      item.part_id ? (stockByPart.get(item.part_id) ?? []) : []
+    ).sort((a, b) => b.available - a.available);
+    return {
+      id: item.id,
+      requestId: item.request_id,
+      workOrderLineId: item.work_order_line_id,
+      partId: item.part_id,
+      description: item.description,
+      partNumber: item.requested_part_number,
+      status: item.status,
+      poId: item.po_id,
+      required,
+      ordered: n(item.qty_ordered),
+      received: n(item.qty_received),
+      staged,
+      remainingToStage,
+      stock,
+    };
+  });
+
+  return NextResponse.json({
+    ok: true,
+    workOrder,
+    items: taskItems,
+    summary: {
+      itemCount: taskItems.length,
+      pickableCount: taskItems.filter(
+        (item) =>
+          item.remainingToStage > 0 &&
+          item.stock.some((stock) => stock.available > 0),
+      ).length,
+      orderedCount: taskItems.filter((item) => item.ordered > item.received)
+        .length,
+    },
+  });
+}

--- a/app/api/work-orders/[id]/lines/[lineId]/parts-request/route.ts
+++ b/app/api/work-orders/[id]/lines/[lineId]/parts-request/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
+
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.trim(),
+    )
+  );
+}
+
+export async function POST(
+  req: Request,
+  context: { params: Promise<{ id: string; lineId: string }> },
+) {
+  const { id: workOrderId, lineId } = await context.params;
+  if (!isUuid(workOrderId) || !isUuid(lineId)) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid work order or repair line." },
+      { status: 400 },
+    );
+  }
+
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canManageWorkOrders",
+  });
+  if (!access.ok) return access.response;
+
+  const body = (await req.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const rawKey =
+    req.headers.get("Idempotency-Key")?.trim() ||
+    (typeof body?.idempotencyKey === "string"
+      ? body.idempotencyKey.trim()
+      : "");
+  if (!rawKey || rawKey.length > 160) {
+    return NextResponse.json(
+      { ok: false, error: "A valid idempotency key is required." },
+      { status: 400 },
+    );
+  }
+
+  const { data: line, error: lineError } = await access.supabase
+    .from("work_order_lines")
+    .select("id")
+    .eq("id", lineId)
+    .eq("work_order_id", workOrderId)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+  if (lineError) {
+    return NextResponse.json(
+      { ok: false, error: lineError.message },
+      { status: 500 },
+    );
+  }
+  if (!line) {
+    return NextResponse.json(
+      { ok: false, error: "Repair line not found for this shop." },
+      { status: 404 },
+    );
+  }
+
+  const operationKey = `${access.profile.shop_id}:line-request:${lineId}:${rawKey}`;
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc(
+    "parts_request_work_order_line_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_work_order_id: workOrderId,
+      p_work_order_line_id: lineId,
+      p_operation_key: operationKey,
+      p_actor_user_id: access.profile.id,
+    },
+  );
+
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    const status = error.message.includes("NO_LINE_PARTS") ? 400 : 409;
+    return NextResponse.json({ ok: false, error: message }, { status });
+  }
+
+  return NextResponse.json({ ok: true, result: data });
+}

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -37,6 +37,7 @@ type InboxItem = {
   description: string;
   status: string;
   qty_approved: number;
+  qty_ordered: number;
   qty_received: number;
   qty_remaining: number;
   qty_allocated: number;
@@ -104,11 +105,20 @@ export default function ReceivingInboxPage(): JSX.Element {
     const [{ data: priRows, error: priErr }, { count: rawCount }] = await Promise.all([
       supabase
         .from("part_request_items")
-        .select("id, created_at, request_id, part_id, description, status, qty_approved, qty_received, qty_consumed, po_id")
+        .select("id, created_at, request_id, part_id, description, status, qty_approved, qty_ordered, qty_received, qty_consumed, po_id")
         .eq("shop_id", sid)
+        .not("po_id", "is", null)
+        .gt("qty_ordered", 0)
+        .in("status", ["partially_ordered", "ordered", "partially_received"])
         .order("created_at", { ascending: true })
         .range(from, to),
-      supabase.from("part_request_items").select("id", { count: "exact", head: true }).eq("shop_id", sid),
+      supabase
+        .from("part_request_items")
+        .select("id", { count: "exact", head: true })
+        .eq("shop_id", sid)
+        .not("po_id", "is", null)
+        .gt("qty_ordered", 0)
+        .in("status", ["partially_ordered", "ordered", "partially_received"]),
     ]);
 
     if (priErr) {
@@ -121,6 +131,7 @@ export default function ReceivingInboxPage(): JSX.Element {
       .map((r) => {
         const row = r as PartRequestItemRow;
         const approved = n(row.qty_approved);
+        const ordered = n(row.qty_ordered);
         const received = n(row.qty_received);
         return {
           id: String(row.id),
@@ -130,14 +141,15 @@ export default function ReceivingInboxPage(): JSX.Element {
           description: String(row.description ?? ""),
           status: String(row.status ?? ""),
           qty_approved: approved,
+          qty_ordered: ordered,
           qty_received: received,
-          qty_remaining: Math.max(0, approved - received),
+          qty_remaining: Math.max(0, ordered - received),
           qty_allocated: n(row.qty_consumed),
           po_id: row.po_id ?? null,
           work_order_id: null,
         };
       })
-      .filter((x) => x.qty_approved > 0 && x.qty_remaining > 0);
+      .filter((x) => x.po_id !== null && x.qty_ordered > 0 && x.qty_remaining > 0);
 
     setItems(normalized);
     setLastUpdated(new Date());
@@ -268,7 +280,7 @@ export default function ReceivingInboxPage(): JSX.Element {
                 const partSummary = p ? toPartDisplaySummary(p) : null;
                 const trust = it.part_id ? trustByPartId[it.part_id] : undefined;
                 const itemState = toItemFlowDisplay({ rawStatus: it.status, qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
-                const recvState = toReceiveProgressDisplay({ qtyApproved: it.qty_approved, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
+                const recvState = toReceiveProgressDisplay({ qtyApproved: it.qty_ordered, qtyReceived: it.qty_received, qtyAllocated: it.qty_allocated });
                 return (
                   <tr key={it.id} className="border-t border-[color:var(--desktop-border)] align-top">
                     <td className="p-3.5">
@@ -283,7 +295,7 @@ export default function ReceivingInboxPage(): JSX.Element {
                       <span className="desktop-link-chip">{receiveProgressLabel(recvState)}</span>
                       {trust ? <span className={`ml-2 inline-flex rounded-full border px-2 py-1 text-xs ${trustBadgeTone(trust.level)}`}>{trustLevelLabel(trust.level)}</span> : null}
                     </td>
-                    <td className="p-3.5 tabular-nums text-[color:var(--theme-text-primary)]">{it.qty_received} / {it.qty_approved} <span className="text-[color:var(--theme-text-muted)]">({it.qty_remaining} rem)</span></td>
+                    <td className="p-3.5 tabular-nums text-[color:var(--theme-text-primary)]">{it.qty_received} / {it.qty_ordered} ordered <span className="text-[color:var(--theme-text-muted)]">({it.qty_remaining} rem)</span></td>
                     <td className="p-3.5"><button onClick={() => {setDrawerItem({ ...it, part_name: partSummary?.name ?? null, sku: partSummary?.sku ?? null, trust_level: trust?.level, trust_reasons: trust?.reasons ?? [] }); setDrawerOpen(true);}} className="rounded-lg border border-sky-500/35 px-3 py-1 text-sky-200">Receive</button></td>
                   </tr>
                 );

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import PickOrderTaskModal from "@/features/parts/components/PickOrderTaskModal";
 import {
   earliestPartsRequestStage,
   isPartsRequestItemHandedOff,
@@ -368,10 +369,12 @@ function QueueCard({
   bucket,
   handingOff,
   onHandoff,
+  onOpenPickOrder,
 }: {
   bucket: WoBucket;
   handingOff: boolean;
   onHandoff: (bucket: WoBucket) => Promise<void>;
+  onOpenPickOrder: (bucket: WoBucket) => void;
 }) {
   const meta = bucket.stage === "completed" ? null : STAGE_META[bucket.stage];
   const href = requestHref(bucket);
@@ -462,6 +465,14 @@ function QueueCard({
           <Wrench className="h-4 w-4" />
           {handingOff ? "Completing handoff…" : "Complete handoff"}
         </button>
+      ) : bucket.stage === "order_receive" ? (
+        <button
+          type="button"
+          onClick={() => onOpenPickOrder(bucket)}
+          className={`mt-3 inline-flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-semibold transition ${meta?.button}`}
+        >
+          <ShoppingCart className="h-4 w-4" /> Open Pick / Order task
+        </button>
       ) : (
         <Link
           href={href}
@@ -529,6 +540,7 @@ export default function PartsRequestsPage(): JSX.Element {
   const [handingOffWorkOrder, setHandingOffWorkOrder] = useState<string | null>(
     null,
   );
+  const [pickOrderBucket, setPickOrderBucket] = useState<WoBucket | null>(null);
 
   const reload = useCallback(async () => {
     const sequence = ++reloadSequence.current;
@@ -692,6 +704,26 @@ export default function PartsRequestsPage(): JSX.Element {
     () => buildBuckets(completedModels, workOrders),
     [completedModels, workOrders],
   );
+
+  useEffect(() => {
+    if (loading || tab !== "active" || pickOrderBucket) return;
+    const next = activeBuckets.find(
+      (bucket) => bucket.stage === "order_receive",
+    );
+    if (!next) return;
+    const fingerprint = next.models
+      .map((model) => model.request.id)
+      .sort()
+      .join(":");
+    const storageKey = `parts-pick-order-seen:${fingerprint}`;
+    try {
+      if (window.sessionStorage.getItem(storageKey)) return;
+      window.sessionStorage.setItem(storageKey, "1");
+    } catch {
+      // Storage can be unavailable in locked-down browser contexts.
+    }
+    setPickOrderBucket(next);
+  }, [activeBuckets, loading, pickOrderBucket, tab]);
 
   const visibleBuckets = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -918,6 +950,7 @@ export default function PartsRequestsPage(): JSX.Element {
                         bucket={bucket}
                         handingOff={handingOffWorkOrder === bucket.workOrderId}
                         onHandoff={completeHandoff}
+                        onOpenPickOrder={setPickOrderBucket}
                       />
                     ))
                   ) : (
@@ -938,6 +971,7 @@ export default function PartsRequestsPage(): JSX.Element {
               bucket={bucket}
               handingOff={false}
               onHandoff={completeHandoff}
+              onOpenPickOrder={setPickOrderBucket}
             />
           ))}
         </div>
@@ -949,6 +983,18 @@ export default function PartsRequestsPage(): JSX.Element {
           </p>
         </div>
       )}
+
+      <PickOrderTaskModal
+        open={pickOrderBucket !== null}
+        workOrderId={pickOrderBucket?.workOrderId ?? null}
+        workOrderLabel={
+          pickOrderBucket ? workOrderLabel(pickOrderBucket) : "Work order"
+        }
+        customerName={pickOrderBucket?.customerName}
+        vehicleLabel={pickOrderBucket?.vehicleLabel}
+        onClose={() => setPickOrderBucket(null)}
+        onChanged={reload}
+      />
     </main>
   );
 }

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -71,7 +71,10 @@ type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"] & {
   parts?: { name: string | null; sku?: string | null; part_number?: string | null; manufacturer?: string | null } | null;
 };
 type LineTechRow = DB["public"]["Tables"]["work_order_line_technicians"]["Row"];
-type PartRequestRow = Pick<DB["public"]["Tables"]["part_requests"]["Row"], "id" | "quote_line_id" | "status">;
+type PartRequestRow = Pick<
+  DB["public"]["Tables"]["part_requests"]["Row"],
+  "id" | "quote_line_id" | "job_id" | "status"
+>;
 
 type WorkOrderLineWithInspectionMeta = WorkOrderLine & {
   // real DB column
@@ -120,6 +123,25 @@ function splitCustomId(raw: string): { prefix: string; n: number | null } {
 function isCompletedLineStatus(status: string | null | undefined): boolean {
   const normalized = String(status ?? "").trim().toLowerCase();
   return normalized === "completed" || normalized === "ready_to_invoice" || normalized === "invoiced";
+}
+
+function partsRequestActionLabel(requests: PartRequestRow[]): string {
+  if (requests.length === 0) return "Request all parts";
+  const statuses = new Set(
+    requests.map((request) => String(request.status ?? "requested").toLowerCase()),
+  );
+  if (statuses.has("fulfilled")) return "Parts handed off";
+  if (
+    statuses.has("approved") ||
+    statuses.has("partially_ordered") ||
+    statuses.has("partially_consumed") ||
+    statuses.has("partially_returned")
+  ) {
+    return "Open Pick / Order";
+  }
+  if (statuses.has("quoted")) return "Awaiting approval";
+  if (statuses.has("rejected") || statuses.has("cancelled")) return "View parts history";
+  return "Parts requested";
 }
 
 /** Normalize “where is the inspection template id stored for this line?” */
@@ -212,6 +234,8 @@ export default function WorkOrderIdClient(): JSX.Element {
   const [allocsByLine, setAllocsByLine] = useState<Record<string, AllocationRow[]>>({});
   const [stagedPartsByLine, setStagedPartsByLine] = useState<Record<string, WorkOrderPartRow[]>>({});
   const [partRequestsByQuoteLine, setPartRequestsByQuoteLine] = useState<Record<string, PartRequestRow[]>>({});
+  const [partRequestsByLine, setPartRequestsByLine] = useState<Record<string, PartRequestRow[]>>({});
+  const [requestingPartsLineId, setRequestingPartsLineId] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [loadedOnce, setLoadedOnce] = useState<boolean>(false);
   const [viewError, setViewError] = useState<string | null>(null);
@@ -673,10 +697,9 @@ export default function WorkOrderIdClient(): JSX.Element {
 
             supabase
               .from("part_requests")
-              .select("id, quote_line_id, status")
+              .select("id, quote_line_id, job_id, status")
               .eq("work_order_id", woRow.id)
-              .eq("shop_id", woRow.shop_id)
-              .not("quote_line_id", "is", null),
+              .eq("shop_id", woRow.shop_id),
           ]);
 
           const byLine: Record<string, AllocationRow[]> = {};
@@ -710,17 +733,26 @@ export default function WorkOrderIdClient(): JSX.Element {
           setLineTechsByLine(techMap);
 
           const requestsByQuote: Record<string, PartRequestRow[]> = {};
+          const requestsByLine: Record<string, PartRequestRow[]> = {};
           (partRequestsQuery.data as PartRequestRow[] | null)?.forEach((request) => {
             const quoteLineId = request.quote_line_id;
-            if (!quoteLineId) return;
-            if (!requestsByQuote[quoteLineId]) requestsByQuote[quoteLineId] = [];
-            requestsByQuote[quoteLineId].push(request);
+            if (quoteLineId) {
+              if (!requestsByQuote[quoteLineId]) requestsByQuote[quoteLineId] = [];
+              requestsByQuote[quoteLineId].push(request);
+            }
+            const lineId = request.job_id;
+            if (lineId) {
+              if (!requestsByLine[lineId]) requestsByLine[lineId] = [];
+              requestsByLine[lineId].push(request);
+            }
           });
           setPartRequestsByQuoteLine(requestsByQuote);
+          setPartRequestsByLine(requestsByLine);
         } else {
           setAllocsByLine({});
           setStagedPartsByLine({});
           setPartRequestsByQuoteLine({});
+          setPartRequestsByLine({});
           setLineTechsByLine({});
         }
 
@@ -1099,6 +1131,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   const currentActor = getActorCapabilities({ role: currentUserRole });
   const canAssign = currentActor.canAssignWork;
   const canApprove = currentActor.canAuthorizeQuotes;
+  const canRequestParts = currentActor.canManageWorkOrders;
 
   const canDeleteLine = currentUserRole ? LINE_DELETE_ROLES.has(currentUserRole) : false;
 
@@ -1405,6 +1438,58 @@ export default function WorkOrderIdClient(): JSX.Element {
     window.addEventListener(evtName, handler as EventListener);
     return () => window.removeEventListener(evtName, handler as EventListener);
   }, [partsLineId, fetchAll]);
+
+  const requestAllPartsForLine = useCallback(
+    async (lineId: string, existingRequests: PartRequestRow[]) => {
+      if (!wo?.id || requestingPartsLineId) return;
+      if (existingRequests.length > 0) {
+        router.push(`/parts/requests/${encodeURIComponent(wo.custom_id || wo.id)}`);
+        return;
+      }
+
+      setRequestingPartsLineId(lineId);
+      const toastId = toast.loading("Requesting every part on this line…");
+      try {
+        const idempotencyKey = crypto.randomUUID();
+        const response = await fetch(
+          `/api/work-orders/${encodeURIComponent(wo.id)}/lines/${encodeURIComponent(lineId)}/parts-request`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Idempotency-Key": idempotencyKey,
+            },
+            body: JSON.stringify({ idempotencyKey }),
+          },
+        );
+        const payload = (await response.json().catch(() => null)) as {
+          error?: string;
+          result?: { stage?: string };
+        } | null;
+        if (!response.ok) {
+          throw new Error(payload?.error || "Unable to request line parts.");
+        }
+
+        const released = payload?.result?.stage === "order_receive";
+        toast.success(
+          released
+            ? "Approved parts were released to the Pick / Order queue."
+            : "Every part on this line was requested.",
+          { id: toastId },
+        );
+        window.dispatchEvent(new Event("parts-request:submitted"));
+        await fetchAll();
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Unable to request line parts.",
+          { id: toastId },
+        );
+      } finally {
+        setRequestingPartsLineId(null);
+      }
+    },
+    [fetchAll, requestingPartsLineId, router, wo],
+  );
 
   /* -------------------------- UI -------------------------- */
   if (!routeId) return <div className="p-6 text-red-500">Missing work order id.</div>;
@@ -1928,6 +2013,9 @@ export default function WorkOrderIdClient(): JSX.Element {
                           .filter((name): name is string => Boolean(name))
                       : [];
                     const isSelectedForPanel = panelLineId === ln.id;
+                    const linePartRequests = partRequestsByLine[ln.id] ?? [];
+                    const hasRequestableParts =
+                      canRequestParts && (stagedPartsByLine[ln.id] ?? []).length > 0;
 
                     return (
                       <JobCard
@@ -1995,6 +2083,13 @@ export default function WorkOrderIdClient(): JSX.Element {
                             : undefined
                         }
                         onAddPart={() => setPartsLineId(ln.id)}
+                        onRequestParts={
+                          hasRequestableParts
+                            ? () => void requestAllPartsForLine(ln.id, linePartRequests)
+                            : undefined
+                        }
+                        requestPartsLabel={partsRequestActionLabel(linePartRequests)}
+                        requestPartsBusy={requestingPartsLineId === ln.id}
                         pricing={pricingByLine[ln.id] ?? null}
                         reviewOk={reviewOk}
                         reviewIssues={reviewIssuesByLine[ln.id] ?? []}

--- a/features/agent/server/syncAssistantNotifications.ts
+++ b/features/agent/server/syncAssistantNotifications.ts
@@ -156,6 +156,11 @@ export async function syncAssistantNotifications(params: {
   const scopeKey = userScoped ? `user:${userId}` : "shop";
   const canonicalRole = canonicalizeRole(role);
   const canSeePartsWorkflow = ["owner", "admin", "manager", "parts"].includes(canonicalRole);
+  const visibleSources = canSeePartsWorkflow
+    ? [source, "parts_workflow"]
+    : userScoped
+      ? [source, "parts_tech_workflow"]
+      : [source];
 
   let computed = await getOpsNotifications(shopId);
 
@@ -286,7 +291,7 @@ export async function syncAssistantNotifications(params: {
     .from("assistant_notifications")
     .select("*")
     .eq("shop_id", shopId)
-    .in("source", canSeePartsWorkflow ? [source, "parts_workflow"] : [source])
+    .in("source", visibleSources)
     .in("status", ["active", "acknowledged", "open"])
     .order("last_seen_at", { ascending: false });
 

--- a/features/parts/components/PickOrderTaskModal.tsx
+++ b/features/parts/components/PickOrderTaskModal.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import Link from "next/link";
+import {
+  CheckCircle2,
+  Loader2,
+  PackageCheck,
+  ShoppingCart,
+  Warehouse,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@shared/components/ui/dialog";
+
+type PickStock = {
+  locationId: string;
+  locationLabel: string;
+  available: number;
+  onHand: number;
+  reserved: number;
+};
+
+type PickTaskItem = {
+  id: string;
+  requestId: string;
+  workOrderLineId: string | null;
+  partId: string | null;
+  description: string;
+  partNumber: string | null;
+  status: string;
+  poId: string | null;
+  required: number;
+  ordered: number;
+  received: number;
+  staged: number;
+  remainingToStage: number;
+  stock: PickStock[];
+};
+
+type PickTaskResponse = {
+  ok: boolean;
+  error?: string;
+  workOrder?: { id: string; custom_id: string | null };
+  items?: PickTaskItem[];
+  summary?: {
+    itemCount: number;
+    pickableCount: number;
+    orderedCount: number;
+  };
+};
+
+type Props = {
+  open: boolean;
+  workOrderId: string | null;
+  workOrderLabel: string;
+  customerName?: string | null;
+  vehicleLabel?: string | null;
+  onClose: () => void;
+  onChanged?: () => Promise<void> | void;
+};
+
+function qty(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(2);
+}
+
+export default function PickOrderTaskModal({
+  open,
+  workOrderId,
+  workOrderLabel,
+  customerName,
+  vehicleLabel,
+  onClose,
+  onChanged,
+}: Props): JSX.Element {
+  const [items, setItems] = useState<PickTaskItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyItemId, setBusyItemId] = useState<string | null>(null);
+  const [batchPicking, setBatchPicking] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!open || !workOrderId) return;
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `/api/parts/requests/pick-task?workOrderId=${encodeURIComponent(workOrderId)}`,
+        { cache: "no-store" },
+      );
+      const payload = (await response
+        .json()
+        .catch(() => null)) as PickTaskResponse | null;
+      if (!response.ok || !payload?.ok) {
+        throw new Error(
+          payload?.error || "Unable to load the Pick / Order task.",
+        );
+      }
+      setItems(payload.items ?? []);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Unable to load the Pick / Order task.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [open, workOrderId]);
+
+  useEffect(() => {
+    if (open) void load();
+  }, [load, open]);
+
+  const detailHref = `/parts/requests/${encodeURIComponent(
+    workOrderLabel || workOrderId || "",
+  )}`;
+
+  const pickable = useMemo(
+    () =>
+      items.filter(
+        (item) =>
+          item.remainingToStage > 0 &&
+          item.stock.some((stock) => stock.available > 0),
+      ),
+    [items],
+  );
+
+  const allocate = useCallback(
+    async (item: PickTaskItem, stock: PickStock, amount: number) => {
+      const idempotencyKey = crypto.randomUUID();
+      const response = await fetch(
+        `/api/parts/requests/items/${encodeURIComponent(item.id)}/allocate`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotencyKey,
+          },
+          body: JSON.stringify({
+            locationId: stock.locationId,
+            qty: amount,
+            idempotencyKey,
+          }),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!response.ok) {
+        throw new Error(
+          payload?.error || `Could not pick ${item.description}.`,
+        );
+      }
+    },
+    [],
+  );
+
+  const pickOne = useCallback(
+    async (item: PickTaskItem, stock: PickStock) => {
+      if (busyItemId || batchPicking) return;
+      const amount = Math.min(item.remainingToStage, stock.available);
+      if (amount <= 0) return;
+      setBusyItemId(item.id);
+      const toastId = toast.loading(`Picking ${item.description}…`);
+      try {
+        await allocate(item, stock, amount);
+        toast.success(`${qty(amount)} picked from ${stock.locationLabel}.`, {
+          id: toastId,
+        });
+        await load();
+        await onChanged?.();
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Could not pick this part.",
+          { id: toastId },
+        );
+      } finally {
+        setBusyItemId(null);
+      }
+    },
+    [allocate, batchPicking, busyItemId, load, onChanged],
+  );
+
+  const pickAllAvailable = useCallback(async () => {
+    if (batchPicking || busyItemId || pickable.length === 0) return;
+    setBatchPicking(true);
+    const toastId = toast.loading("Picking all available stock…");
+    let pickedCount = 0;
+    try {
+      for (const item of pickable) {
+        let remaining = item.remainingToStage;
+        for (const stock of item.stock) {
+          if (remaining <= 0) break;
+          const amount = Math.min(remaining, stock.available);
+          if (amount <= 0) continue;
+          await allocate(item, stock, amount);
+          remaining -= amount;
+          pickedCount += 1;
+        }
+      }
+      toast.success(
+        pickedCount > 0
+          ? "Available stock was picked and staged."
+          : "No available stock could be picked.",
+        { id: toastId },
+      );
+      await load();
+      await onChanged?.();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Could not finish the batch pick.",
+        { id: toastId },
+      );
+      await load();
+      await onChanged?.();
+    } finally {
+      setBatchPicking(false);
+    }
+  }, [allocate, batchPicking, busyItemId, load, onChanged, pickable]);
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-h-[90vh] max-w-4xl overflow-hidden p-0">
+        <DialogHeader className="relative px-5 py-4 pr-14">
+          <DialogTitle className="flex items-center gap-2 text-base normal-case tracking-normal">
+            <PackageCheck className="h-5 w-5 text-sky-300" />
+            Pick / Order task · {workOrderLabel}
+          </DialogTitle>
+          <DialogDescription>
+            {[customerName, vehicleLabel].filter(Boolean).join(" · ") ||
+              "Approved parts fulfillment"}
+          </DialogDescription>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close Pick / Order task"
+            className="absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </DialogHeader>
+
+        <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-5 py-3">
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">
+            Pick stock first. Order only the remaining shortage. Receiving is
+            reserved for actual PO quantities.
+          </div>
+          <button
+            type="button"
+            onClick={() => void pickAllAvailable()}
+            disabled={
+              loading ||
+              batchPicking ||
+              busyItemId !== null ||
+              pickable.length === 0
+            }
+            className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-emerald-400/45 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-100 disabled:opacity-50"
+          >
+            {batchPicking ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Warehouse className="h-4 w-4" />
+            )}
+            Pick all available
+          </button>
+        </div>
+
+        <div className="max-h-[62vh] space-y-2 overflow-y-auto p-4 sm:p-5">
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-12 text-sm text-[color:var(--theme-text-secondary)]">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading live stock…
+            </div>
+          ) : items.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-secondary)]">
+              No approved parts are waiting for this work order.
+            </div>
+          ) : (
+            items.map((item) => {
+              const bestStock = item.stock.find((stock) => stock.available > 0);
+              const waitingReceipt = item.ordered > item.received;
+              const complete = item.remainingToStage <= 0;
+              const pickQty = bestStock
+                ? Math.min(item.remainingToStage, bestStock.available)
+                : 0;
+              return (
+                <article
+                  key={item.id}
+                  className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-3.5"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="font-semibold text-[color:var(--theme-text-primary)]">
+                        {item.description}
+                      </div>
+                      <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                        {item.partNumber ? `${item.partNumber} · ` : ""}
+                        Required {qty(item.required)} · Staged{" "}
+                        {qty(item.staged)}
+                        {item.ordered > 0
+                          ? ` · Ordered ${qty(item.ordered)}`
+                          : ""}
+                        {item.received > 0
+                          ? ` · Received ${qty(item.received)}`
+                          : ""}
+                      </div>
+                      {bestStock ? (
+                        <div className="mt-2 text-xs text-emerald-200">
+                          {qty(bestStock.available)} available at{" "}
+                          {bestStock.locationLabel}
+                        </div>
+                      ) : null}
+                    </div>
+
+                    <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+                      {complete ? (
+                        <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-100">
+                          <CheckCircle2 className="h-4 w-4" /> Picked / staged
+                        </span>
+                      ) : !item.partId ? (
+                        <Link
+                          href={detailHref}
+                          className="rounded-lg border border-amber-400/45 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-100"
+                        >
+                          Attach inventory
+                        </Link>
+                      ) : bestStock ? (
+                        <button
+                          type="button"
+                          onClick={() => void pickOne(item, bestStock)}
+                          disabled={
+                            batchPicking ||
+                            (busyItemId !== null && busyItemId !== item.id)
+                          }
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-400/45 bg-emerald-500/10 px-3 py-2 text-xs font-semibold text-emerald-100 disabled:opacity-50"
+                        >
+                          {busyItemId === item.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Warehouse className="h-4 w-4" />
+                          )}
+                          Pick {qty(pickQty)}
+                        </button>
+                      ) : waitingReceipt ? (
+                        <Link
+                          href="/parts/receiving"
+                          className="rounded-lg border border-sky-400/45 bg-sky-500/10 px-3 py-2 text-xs font-semibold text-sky-100"
+                        >
+                          Ordered · receive
+                        </Link>
+                      ) : (
+                        <Link
+                          href={detailHref}
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-amber-400/45 bg-amber-500/10 px-3 py-2 text-xs font-semibold text-amber-100"
+                        >
+                          <ShoppingCart className="h-4 w-4" /> Order shortage
+                        </Link>
+                      )}
+                    </div>
+                  </div>
+                </article>
+              );
+            })
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] px-5 py-3">
+          <Link
+            href={detailHref}
+            className="text-xs font-semibold text-sky-200 hover:text-sky-100"
+          >
+            Open full request workbench →
+          </Link>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-[color:var(--theme-border-soft)] px-4 py-2 text-xs font-semibold"
+          >
+            Done
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, type JSX, type MouseEvent } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { ChevronDown, ChevronUp, CircleAlert, CircleCheck, Wrench } from "lucide-react";
+import { ChevronDown, ChevronUp, CircleAlert, CircleCheck, PackagePlus, Wrench } from "lucide-react";
 
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
@@ -52,6 +52,9 @@ type JobCardProps = {
   onPriorityChange?: (priority: JobLinePriority) => void;
   onOpenInspection?: () => void;
   onAddPart?: () => void;
+  onRequestParts?: () => void;
+  requestPartsLabel?: string;
+  requestPartsBusy?: boolean;
   onDelete?: () => void;
   pricing?: PricingSummary | null;
   reviewIssues?: ReviewIssue[];
@@ -308,6 +311,9 @@ export function JobCard({
   onPriorityChange,
   onOpenInspection,
   onAddPart,
+  onRequestParts,
+  requestPartsLabel = "Request all parts",
+  requestPartsBusy = false,
   onDelete,
   pricing,
   reviewIssues,
@@ -376,6 +382,16 @@ export function JobCard({
   const handleDeleteActionClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onDelete?.();
+  };
+
+  const handleAddPartClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onAddPart?.();
+  };
+
+  const handleRequestPartsClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onRequestParts?.();
   };
 
   return (
@@ -468,8 +484,22 @@ export function JobCard({
                 ) : null}
 
                 {onAddPart ? (
-                  <Button type="button" variant="secondary" size="sm" onClick={onAddPart}>
+                  <Button type="button" variant="secondary" size="sm" onClick={handleAddPartClick}>
                     Add Part
+                  </Button>
+                ) : null}
+
+                {onRequestParts ? (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleRequestPartsClick}
+                    disabled={requestPartsBusy}
+                    className="border-sky-400/45 bg-sky-500/10 text-sky-100 hover:bg-sky-500/20"
+                  >
+                    <PackagePlus className="mr-1 h-4 w-4" />
+                    {requestPartsBusy ? "Requesting…" : requestPartsLabel}
                   </Button>
                 ) : null}
 

--- a/supabase/migrations/20260719143000_parts_line_pick_order_release.sql
+++ b/supabase/migrations/20260719143000_parts_line_pick_order_release.sql
@@ -1,0 +1,771 @@
+begin;
+
+-- A work-order part is the quoted/approved commercial row. Keep an explicit
+-- reverse pointer on the request item so the same line part can be requested
+-- repeatedly without creating duplicate operational items.
+alter table public.part_request_items
+  add column if not exists source_work_order_part_id uuid
+    references public.work_order_parts(id) on delete set null;
+
+create index if not exists idx_part_request_items_source_work_order_part
+  on public.part_request_items (shop_id, source_work_order_part_id)
+  where source_work_order_part_id is not null;
+
+update public.part_request_items pri
+set source_work_order_part_id = wop.id,
+    updated_at = now()
+from public.work_order_parts wop
+where wop.source_parts_request_item_id = pri.id
+  and pri.source_work_order_part_id is null;
+
+-- Materialize every active part on one repair line into one reusable request.
+-- The repair line is locked first, making concurrent clicks and approval
+-- triggers serialize. A fresh operation key may safely sync newly-added parts.
+create or replace function public.parts_request_work_order_line_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_work_order_line_id uuid,
+  p_operation_key text,
+  p_actor_user_id uuid default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_request public.part_requests%rowtype;
+  v_operation public.parts_operation_keys;
+  v_work_order_part record;
+  v_request_item_id uuid;
+  v_part_count integer := 0;
+  v_created_count integer := 0;
+  v_updated_count integer := 0;
+  v_result jsonb;
+  v_previous_lifecycle_guard text :=
+    coalesce(current_setting('app.parts_lifecycle_reconciling', true), '0');
+  v_auto_release boolean :=
+    current_setting('app.parts_line_auto_releasing', true) = '1';
+begin
+  if coalesce(trim(p_operation_key), '') = '' then
+    raise exception 'A stable operation key is required.';
+  end if;
+  if length(p_operation_key) > 300 then
+    raise exception 'Parts line request operation key is too long.';
+  end if;
+  if position(p_shop_id::text || ':' in p_operation_key) <> 1 then
+    raise exception 'Parts line request operation key must be scoped to its shop.';
+  end if;
+
+  if not v_auto_release then
+    perform public.parts_lifecycle_assert_shop_access(p_shop_id);
+    if auth.role() <> 'service_role' and not exists (
+      select 1
+      from public.profiles p
+      where p.id = auth.uid()
+        and p.shop_id = p_shop_id
+        and lower(coalesce(p.role::text, '')) in (
+          'owner', 'admin', 'manager', 'advisor', 'service', 'parts',
+          'mechanic', 'tech', 'technician', 'lead_hand', 'foreman'
+        )
+    ) then
+      raise exception 'Parts line request actor is not authorized for this shop.';
+    end if;
+    if p_actor_user_id is not null and auth.role() <> 'service_role'
+       and p_actor_user_id is distinct from auth.uid() then
+      raise exception 'Parts line request actor mismatch.';
+    end if;
+  end if;
+
+  select * into v_line
+  from public.work_order_lines
+  where id = p_work_order_line_id
+    and shop_id = p_shop_id
+    and work_order_id = p_work_order_id
+  for update;
+  if not found then
+    raise exception 'Work-order line not found for this work order and shop.';
+  end if;
+
+  perform public.parts_assert_work_order_mutable(p_shop_id, p_work_order_id);
+
+  v_operation := public.parts_begin_operation(
+    p_shop_id,
+    p_operation_key,
+    'request_work_order_line_parts',
+    'work_order_line',
+    p_work_order_line_id,
+    p_actor_user_id
+  );
+  if v_operation.completed_at is not null then
+    return coalesce(v_operation.result, '{}'::jsonb)
+      || jsonb_build_object('idempotent', true);
+  end if;
+
+  select count(*) into v_part_count
+  from public.work_order_parts wop
+  where wop.shop_id = p_shop_id
+    and wop.work_order_id = p_work_order_id
+    and wop.work_order_line_id = p_work_order_line_id
+    and coalesce(wop.is_active, true)
+    and greatest(
+      coalesce(wop.quantity_requested, 0),
+      coalesce(wop.quantity, 0),
+      0
+    ) > 0;
+  if v_part_count = 0 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NO_LINE_PARTS',
+      detail = 'Add at least one quoted part to this repair line before requesting Parts fulfillment.';
+  end if;
+
+  -- Reuse a request already anchored to the line, including a quote-origin
+  -- request whose canonical line was materialized at approval.
+  select pr.* into v_request
+  from public.part_requests pr
+  where pr.shop_id = p_shop_id
+    and pr.work_order_id = p_work_order_id
+    and pr.job_id = p_work_order_line_id
+    and lower(coalesce(pr.status::text, 'requested')) not in (
+      'fulfilled', 'returned', 'rejected', 'cancelled', 'deferred'
+    )
+  order by pr.created_at, pr.id
+  limit 1
+  for update;
+
+  if not found then
+    select pr.* into v_request
+    from public.work_order_parts wop
+    join public.part_request_items pri
+      on pri.id = wop.source_parts_request_item_id
+    join public.part_requests pr on pr.id = pri.request_id
+    where wop.shop_id = p_shop_id
+      and wop.work_order_id = p_work_order_id
+      and wop.work_order_line_id = p_work_order_line_id
+      and pr.shop_id = p_shop_id
+      and lower(coalesce(pr.status::text, 'requested')) not in (
+        'fulfilled', 'returned', 'rejected', 'cancelled', 'deferred'
+      )
+    order by pr.created_at, pr.id
+    limit 1
+    for update of pr;
+  end if;
+
+  perform set_config('app.parts_lifecycle_reconciling', '1', true);
+
+  if v_request.id is null then
+    insert into public.part_requests (
+      shop_id, work_order_id, job_id, requested_by, notes, status
+    ) values (
+      p_shop_id, p_work_order_id, p_work_order_line_id,
+      coalesce(p_actor_user_id, auth.uid()),
+      'All parts requested from work-order line',
+      'requested'::public.part_request_status
+    ) returning * into v_request;
+  elsif v_request.job_id is null then
+    update public.part_requests
+    set job_id = p_work_order_line_id
+    where id = v_request.id
+    returning * into v_request;
+  end if;
+
+  for v_work_order_part in
+    select
+      wop.*,
+      p.name as inventory_name,
+      p.part_number as inventory_part_number,
+      p.manufacturer as inventory_manufacturer,
+      p.price as inventory_price,
+      p.cost as inventory_cost
+    from public.work_order_parts wop
+    left join public.parts p
+      on p.id = wop.part_id and p.shop_id = p_shop_id
+    where wop.shop_id = p_shop_id
+      and wop.work_order_id = p_work_order_id
+      and wop.work_order_line_id = p_work_order_line_id
+      and coalesce(wop.is_active, true)
+      and greatest(
+        coalesce(wop.quantity_requested, 0),
+        coalesce(wop.quantity, 0),
+        0
+      ) > 0
+    order by wop.id
+    for update of wop
+  loop
+    v_request_item_id := null;
+
+    if v_work_order_part.source_parts_request_item_id is not null then
+      select pri.id into v_request_item_id
+      from public.part_request_items pri
+      where pri.id = v_work_order_part.source_parts_request_item_id
+        and pri.shop_id = p_shop_id
+        and pri.request_id = v_request.id;
+    end if;
+
+    if v_request_item_id is null then
+      select pri.id into v_request_item_id
+      from public.part_request_items pri
+      where pri.shop_id = p_shop_id
+        and pri.request_id = v_request.id
+        and pri.source_work_order_part_id = v_work_order_part.id
+      order by pri.created_at, pri.id
+      limit 1
+      for update;
+    end if;
+
+    if v_request_item_id is null then
+      insert into public.part_request_items (
+        request_id, shop_id, work_order_id, work_order_line_id,
+        source_work_order_part_id, part_id, description,
+        requested_part_number, requested_manufacturer,
+        qty, qty_requested, qty_approved, quoted_price, unit_price,
+        unit_cost, status, approved
+      ) values (
+        v_request.id, p_shop_id, p_work_order_id, p_work_order_line_id,
+        v_work_order_part.id, v_work_order_part.part_id,
+        coalesce(
+          nullif(trim(v_work_order_part.description_snapshot), ''),
+          nullif(trim(v_work_order_part.inventory_name), ''),
+          'Part'
+        ),
+        coalesce(
+          nullif(trim(v_work_order_part.part_number_snapshot), ''),
+          nullif(trim(v_work_order_part.inventory_part_number), '')
+        ),
+        coalesce(
+          nullif(trim(v_work_order_part.manufacturer_snapshot), ''),
+          nullif(trim(v_work_order_part.inventory_manufacturer), '')
+        ),
+        greatest(
+          coalesce(v_work_order_part.quantity_requested, 0),
+          coalesce(v_work_order_part.quantity, 0),
+          0
+        ),
+        greatest(
+          coalesce(v_work_order_part.quantity_requested, 0),
+          coalesce(v_work_order_part.quantity, 0),
+          0
+        ),
+        0,
+        coalesce(
+          v_work_order_part.unit_sell_price_snapshot,
+          v_work_order_part.unit_price,
+          v_work_order_part.inventory_price
+        ),
+        coalesce(
+          v_work_order_part.unit_sell_price_snapshot,
+          v_work_order_part.unit_price,
+          v_work_order_part.inventory_price
+        ),
+        coalesce(
+          v_work_order_part.unit_cost_snapshot,
+          v_work_order_part.inventory_cost
+        ),
+        'requested'::public.part_request_item_status,
+        false
+      ) returning id into v_request_item_id;
+      v_created_count := v_created_count + 1;
+    else
+      update public.part_request_items pri
+      set source_work_order_part_id = coalesce(
+            pri.source_work_order_part_id, v_work_order_part.id
+          ),
+          part_id = coalesce(pri.part_id, v_work_order_part.part_id),
+          description = coalesce(
+            nullif(trim(v_work_order_part.description_snapshot), ''),
+            nullif(trim(pri.description), ''),
+            nullif(trim(v_work_order_part.inventory_name), ''),
+            'Part'
+          ),
+          qty = greatest(
+            coalesce(v_work_order_part.quantity_requested, 0),
+            coalesce(v_work_order_part.quantity, 0),
+            coalesce(pri.qty, 0),
+            0
+          ),
+          qty_requested = greatest(
+            coalesce(v_work_order_part.quantity_requested, 0),
+            coalesce(v_work_order_part.quantity, 0),
+            coalesce(pri.qty_requested, 0),
+            0
+          ),
+          quoted_price = coalesce(
+            pri.quoted_price,
+            v_work_order_part.unit_sell_price_snapshot,
+            v_work_order_part.unit_price,
+            v_work_order_part.inventory_price
+          ),
+          unit_price = coalesce(
+            pri.unit_price,
+            v_work_order_part.unit_sell_price_snapshot,
+            v_work_order_part.unit_price,
+            v_work_order_part.inventory_price
+          ),
+          updated_at = now()
+      where pri.id = v_request_item_id
+        and coalesce(pri.qty_ordered, 0) = 0
+        and coalesce(pri.qty_received, 0) = 0
+        and coalesce(pri.qty_reserved, 0) = 0
+        and coalesce(pri.qty_consumed, 0) = 0
+        and coalesce(pri.qty_returned, 0) = 0
+        and pri.po_id is null;
+      if found then
+        v_updated_count := v_updated_count + 1;
+      end if;
+    end if;
+  end loop;
+
+  perform set_config(
+    'app.parts_lifecycle_reconciling', v_previous_lifecycle_guard, true
+  );
+  perform public.parts_reconcile_request_lifecycle(v_request.id);
+  select * into v_request
+  from public.part_requests
+  where id = v_request.id
+  for update;
+
+  -- The pre-approval guard intentionally blocks a work-order part from being
+  -- operationally linked until the line/request is approved.
+  if public.parts_request_is_operationally_released(v_request.id) then
+    update public.work_order_parts wop
+    set source_parts_request_id = v_request.id,
+        source_parts_request_item_id = pri.id,
+        updated_at = now()
+    from public.part_request_items pri
+    where pri.request_id = v_request.id
+      and pri.source_work_order_part_id = wop.id
+      and wop.shop_id = p_shop_id
+      and wop.work_order_id = p_work_order_id
+      and wop.work_order_line_id = p_work_order_line_id
+      and (
+        wop.source_parts_request_id is distinct from v_request.id
+        or wop.source_parts_request_item_id is distinct from pri.id
+      );
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'requestId', v_request.id,
+    'requestStatus', v_request.status,
+    'stage', public.parts_request_operational_stage(v_request.id),
+    'partCount', v_part_count,
+    'createdItemCount', v_created_count,
+    'updatedItemCount', v_updated_count
+  );
+  return public.parts_complete_operation(v_operation.id, v_result);
+exception when others then
+  perform set_config(
+    'app.parts_lifecycle_reconciling', v_previous_lifecycle_guard, true
+  );
+  raise;
+end;
+$$;
+
+revoke all on function public.parts_request_work_order_line_atomic(
+  uuid, uuid, uuid, text, uuid
+) from public, anon;
+grant execute on function public.parts_request_work_order_line_atomic(
+  uuid, uuid, uuid, text, uuid
+) to authenticated, service_role;
+
+-- Approval is the release boundary. Existing requests reconcile first; this
+-- trigger then creates/synchronizes a request if the line only had quote parts.
+create or replace function public.trg_parts_auto_release_approved_line()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_previous_guard text :=
+    coalesce(current_setting('app.parts_line_auto_releasing', true), '0');
+  v_approved boolean;
+begin
+  v_approved := (
+    lower(coalesce(new.approval_state::text, '')) = 'approved'
+    or lower(coalesce(new.line_status::text, '')) = 'authorized'
+  );
+  if not v_approved or new.shop_id is null or new.work_order_id is null then
+    return new;
+  end if;
+  if not exists (
+    select 1
+    from public.work_order_parts wop
+    where wop.shop_id = new.shop_id
+      and wop.work_order_id = new.work_order_id
+      and wop.work_order_line_id = new.id
+      and coalesce(wop.is_active, true)
+      and greatest(
+        coalesce(wop.quantity_requested, 0),
+        coalesce(wop.quantity, 0),
+        0
+      ) > 0
+  ) then
+    return new;
+  end if;
+
+  perform set_config('app.parts_line_auto_releasing', '1', true);
+  perform public.parts_request_work_order_line_atomic(
+    new.shop_id,
+    new.work_order_id,
+    new.id,
+    new.shop_id::text || ':line-auto-release:approval:' || new.id::text,
+    auth.uid()
+  );
+  perform set_config('app.parts_line_auto_releasing', v_previous_guard, true);
+  return new;
+exception when others then
+  perform set_config('app.parts_line_auto_releasing', v_previous_guard, true);
+  raise;
+end;
+$$;
+
+drop trigger if exists trg_parts_auto_release_approved_line
+  on public.work_order_lines;
+create trigger trg_parts_auto_release_approved_line
+after insert or update of approval_state, line_status
+on public.work_order_lines
+for each row
+execute function public.trg_parts_auto_release_approved_line();
+
+-- Parts added to an already-approved menu/repair line should enter the same
+-- Pick/Order queue without another user-to-user request.
+create or replace function public.trg_parts_auto_release_approved_line_part()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_previous_guard text :=
+    coalesce(current_setting('app.parts_line_auto_releasing', true), '0');
+  v_signature text;
+begin
+  if new.shop_id is null or new.work_order_id is null
+     or new.work_order_line_id is null or not coalesce(new.is_active, true) then
+    return new;
+  end if;
+
+  select * into v_line
+  from public.work_order_lines
+  where id = new.work_order_line_id
+    and shop_id = new.shop_id
+    and work_order_id = new.work_order_id;
+  if not found or not (
+    lower(coalesce(v_line.approval_state::text, '')) = 'approved'
+    or lower(coalesce(v_line.line_status::text, '')) = 'authorized'
+  ) then
+    return new;
+  end if;
+
+  v_signature := md5(concat_ws('|',
+    new.id::text,
+    coalesce(new.part_id::text, ''),
+    coalesce(new.quantity::text, ''),
+    coalesce(new.quantity_requested::text, ''),
+    coalesce(new.unit_price::text, ''),
+    coalesce(new.unit_sell_price_snapshot::text, ''),
+    coalesce(new.is_active::text, '')
+  ));
+
+  perform set_config('app.parts_line_auto_releasing', '1', true);
+  perform public.parts_request_work_order_line_atomic(
+    new.shop_id,
+    new.work_order_id,
+    new.work_order_line_id,
+    new.shop_id::text || ':line-auto-release:part:'
+      || new.id::text || ':' || v_signature,
+    auth.uid()
+  );
+  perform set_config('app.parts_line_auto_releasing', v_previous_guard, true);
+  return new;
+exception when others then
+  perform set_config('app.parts_line_auto_releasing', v_previous_guard, true);
+  raise;
+end;
+$$;
+
+drop trigger if exists trg_parts_auto_release_approved_line_part
+  on public.work_order_parts;
+create trigger trg_parts_auto_release_approved_line_part
+after insert or update of part_id, quantity, quantity_requested, unit_price,
+  unit_sell_price_snapshot, is_active, work_order_line_id
+on public.work_order_parts
+for each row
+execute function public.trg_parts_auto_release_approved_line_part();
+
+-- Keep technician notices user-scoped. Parts still receives its existing
+-- shop-scoped parts_workflow notice; the assigned technician gets a separate
+-- notification only after every approved quantity is staged.
+create or replace function public.parts_sync_work_order_line_fulfillment_status(
+  p_request_id uuid,
+  p_stage text
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_request public.part_requests%rowtype;
+  v_line_id uuid;
+begin
+  select * into v_request
+  from public.part_requests
+  where id = p_request_id;
+  if not found then return; end if;
+
+  v_line_id := v_request.job_id;
+  if v_line_id is null then
+    select pri.work_order_line_id into v_line_id
+    from public.part_request_items pri
+    where pri.request_id = p_request_id
+      and pri.work_order_line_id is not null
+    order by pri.created_at, pri.id
+    limit 1;
+  end if;
+  if v_line_id is null then return; end if;
+
+  if p_stage = 'order_receive' then
+    update public.work_order_lines
+    set status = 'waiting_parts',
+        updated_at = now()
+    where id = v_line_id
+      and shop_id = v_request.shop_id
+      and work_order_id = v_request.work_order_id
+      and lower(coalesce(status::text, '')) in (
+        'awaiting', 'pending', 'approved', 'queued', 'ready',
+        'waiting_parts'
+      );
+  elsif p_stage = 'ready_for_tech' then
+    update public.work_order_lines
+    set status = 'approved',
+        updated_at = now()
+    where id = v_line_id
+      and shop_id = v_request.shop_id
+      and work_order_id = v_request.work_order_id
+      and lower(coalesce(status::text, '')) = 'waiting_parts';
+  end if;
+end;
+$$;
+
+revoke all on function public.parts_sync_work_order_line_fulfillment_status(
+  uuid, text
+) from public, anon, authenticated;
+
+create or replace function public.parts_sync_technician_ready_notification(
+  p_request_id uuid
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_request public.part_requests%rowtype;
+  v_stage text;
+  v_work_order_label text;
+  v_line_id uuid;
+  v_technician_id uuid;
+  v_now timestamptz := now();
+  v_fingerprint text;
+begin
+  select * into v_request
+  from public.part_requests
+  where id = p_request_id;
+  if not found then
+    return;
+  end if;
+
+  v_stage := public.parts_request_operational_stage(p_request_id);
+  perform public.parts_sync_work_order_line_fulfillment_status(
+    p_request_id, v_stage
+  );
+  update public.assistant_notifications
+  set status = 'resolved',
+      resolved_at = coalesce(resolved_at, v_now),
+      updated_at = v_now
+  where shop_id = v_request.shop_id
+    and source = 'parts_tech_workflow'
+    and entity_type = 'part_request'
+    and entity_id = p_request_id
+    and lower(coalesce(status, 'active')) in (
+      'active', 'open', 'acknowledged'
+    );
+
+  if v_stage <> 'ready_for_tech' then
+    return;
+  end if;
+
+  select coalesce(nullif(trim(wo.custom_id), ''), wo.id::text)
+  into v_work_order_label
+  from public.work_orders wo
+  where wo.id = v_request.work_order_id;
+
+  v_line_id := v_request.job_id;
+  if v_line_id is null then
+    select pri.work_order_line_id into v_line_id
+    from public.part_request_items pri
+    where pri.request_id = p_request_id
+      and pri.work_order_line_id is not null
+    order by pri.created_at, pri.id
+    limit 1;
+  end if;
+
+  for v_technician_id in
+    select technician_id
+    from (
+      select wol.assigned_tech_id as technician_id
+      from public.work_order_lines wol
+      where wol.id = v_line_id
+        and wol.shop_id = v_request.shop_id
+      union
+      select wolt.technician_id
+      from public.work_order_line_technicians wolt
+      where wolt.work_order_line_id = v_line_id
+    ) assigned
+    where technician_id is not null
+  loop
+    v_fingerprint := 'parts-tech-ready::' || p_request_id::text
+      || '::' || v_technician_id::text;
+    insert into public.assistant_notifications (
+      shop_id, user_id, role, source, fingerprint, code, level,
+      title, message, href, entity_type, entity_id, status, metadata,
+      first_seen_at, last_seen_at, resolved_at, updated_at
+    ) values (
+      v_request.shop_id,
+      v_technician_id,
+      'mechanic',
+      'parts_tech_workflow',
+      v_fingerprint,
+      'parts_ready_for_technician',
+      'info',
+      'Parts ready for your job',
+      format('%s has every approved part staged and ready.',
+        coalesce(v_work_order_label, 'Work order')),
+      '/work-orders/' || v_request.work_order_id::text
+        || case when v_line_id is null then ''
+          else '?line=' || v_line_id::text end,
+      'part_request',
+      p_request_id,
+      'active',
+      jsonb_build_object(
+        'requestId', p_request_id,
+        'workOrderId', v_request.work_order_id,
+        'workOrderLineId', v_line_id,
+        'stage', v_stage
+      ),
+      v_now, v_now, null, v_now
+    )
+    on conflict (shop_id, fingerprint)
+    do update set
+      user_id = excluded.user_id,
+      role = excluded.role,
+      code = excluded.code,
+      level = excluded.level,
+      title = excluded.title,
+      message = excluded.message,
+      href = excluded.href,
+      status = 'active',
+      metadata = excluded.metadata,
+      last_seen_at = excluded.last_seen_at,
+      resolved_at = null,
+      updated_at = excluded.updated_at;
+  end loop;
+end;
+$$;
+
+revoke all on function public.parts_sync_technician_ready_notification(uuid)
+  from public, anon, authenticated;
+
+create or replace function public.trg_parts_sync_technician_ready_from_item()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  perform public.parts_sync_technician_ready_notification(
+    case when tg_op = 'DELETE' then old.request_id else new.request_id end
+  );
+  if tg_op = 'DELETE' then return old; end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_zz_parts_sync_technician_ready_from_item
+  on public.part_request_items;
+create trigger trg_zz_parts_sync_technician_ready_from_item
+after insert or update of qty_approved, qty_reserved, qty_consumed,
+  qty_returned, status or delete
+on public.part_request_items
+for each row
+execute function public.trg_parts_sync_technician_ready_from_item();
+
+create or replace function public.trg_parts_sync_technician_ready_from_request()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  perform public.parts_sync_technician_ready_notification(new.id);
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_zz_parts_sync_technician_ready_from_request
+  on public.part_requests;
+create trigger trg_zz_parts_sync_technician_ready_from_request
+after insert or update of status, job_id, handoff_completed_at
+on public.part_requests
+for each row
+execute function public.trg_parts_sync_technician_ready_from_request();
+
+-- Reconcile already-approved active lines without duplicating existing work.
+do $$
+declare
+  v_line record;
+  v_previous_guard text :=
+    coalesce(current_setting('app.parts_line_auto_releasing', true), '0');
+begin
+  perform set_config('app.parts_line_auto_releasing', '1', true);
+  for v_line in
+    select wol.id, wol.shop_id, wol.work_order_id
+    from public.work_order_lines wol
+    where (
+      lower(coalesce(wol.approval_state::text, '')) = 'approved'
+      or lower(coalesce(wol.line_status::text, '')) = 'authorized'
+    )
+      and not public.work_order_is_financially_locked(
+        wol.shop_id, wol.work_order_id
+      )
+      and exists (
+        select 1
+        from public.work_order_parts wop
+        where wop.shop_id = wol.shop_id
+          and wop.work_order_id = wol.work_order_id
+          and wop.work_order_line_id = wol.id
+          and coalesce(wop.is_active, true)
+      )
+    order by wol.id
+  loop
+    perform public.parts_request_work_order_line_atomic(
+      v_line.shop_id,
+      v_line.work_order_id,
+      v_line.id,
+      v_line.shop_id::text || ':line-auto-release:backfill:'
+        || v_line.id::text,
+      null
+    );
+  end loop;
+  perform set_config('app.parts_line_auto_releasing', v_previous_guard, true);
+exception when others then
+  perform set_config('app.parts_line_auto_releasing', v_previous_guard, true);
+  raise;
+end $$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/parts/parts-line-pick-order-release.test.ts
+++ b/tests/parts/parts-line-pick-order-release.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260719143000_parts_line_pick_order_release.sql",
+  "utf8",
+);
+const lineRoute = readFileSync(
+  "app/api/work-orders/[id]/lines/[lineId]/parts-request/route.ts",
+  "utf8",
+);
+const pickTaskRoute = readFileSync(
+  "app/api/parts/requests/pick-task/route.ts",
+  "utf8",
+);
+const workOrder = readFileSync("app/work-orders/[id]/Client.tsx", "utf8");
+const jobCard = readFileSync(
+  "features/work-orders/components/JobCard.tsx",
+  "utf8",
+);
+const queue = readFileSync("app/parts/requests/page.tsx", "utf8");
+const pickModal = readFileSync(
+  "features/parts/components/PickOrderTaskModal.tsx",
+  "utf8",
+);
+const receiving = readFileSync("app/parts/receiving/page.tsx", "utf8");
+const notifications = readFileSync(
+  "features/agent/server/syncAssistantNotifications.ts",
+  "utf8",
+);
+
+describe("work-order line parts release and Pick / Order flow", () => {
+  it("materializes all line parts through one idempotent tenant-scoped command", () => {
+    expect(migration).toContain(
+      "function public.parts_request_work_order_line_atomic",
+    );
+    expect(migration).toContain("source_work_order_part_id");
+    expect(migration).toContain("for update;");
+    expect(migration).toContain("request_work_order_line_parts");
+    expect(migration).toContain("NO_LINE_PARTS");
+    expect(migration).toContain("parts_begin_operation");
+    expect(migration).toContain("parts_reconcile_request_lifecycle");
+    expect(migration).toContain("parts_request_is_operationally_released");
+  });
+
+  it("automatically releases approved lines and parts added after approval", () => {
+    expect(migration).toContain("trg_parts_auto_release_approved_line");
+    expect(migration).toContain("trg_parts_auto_release_approved_line_part");
+    expect(migration).toContain("line-auto-release:approval:");
+    expect(migration).toContain("line-auto-release:part:");
+    expect(migration).toContain("approval_state::text");
+    expect(migration).toContain("line_status::text");
+  });
+
+  it("exposes a one-click line action without allowing cross-shop requests", () => {
+    expect(jobCard).toContain("Request all parts");
+    expect(jobCard).toContain("onRequestParts");
+    expect(workOrder).toContain("requestAllPartsForLine");
+    expect(workOrder).toContain("partsRequestActionLabel");
+    expect(workOrder).toContain("Idempotency-Key");
+    expect(lineRoute).toContain("requireShopScopedApiAccess");
+    expect(lineRoute).toContain('.eq("shop_id", access.profile.shop_id)');
+    expect(lineRoute).toContain("parts_request_work_order_line_atomic");
+  });
+
+  it("opens an actionable Pick / Order task and uses atomic allocation", () => {
+    expect(queue).toContain("PickOrderTaskModal");
+    expect(queue).toContain("parts-pick-order-seen:");
+    expect(queue).toContain("Open Pick / Order task");
+    expect(pickTaskRoute).toContain(
+      'allowRoles: ["owner", "admin", "manager", "parts"]',
+    );
+    expect(pickTaskRoute).toContain('.from("v_part_stock")');
+    expect(pickModal).toContain("Pick all available");
+    expect(pickModal).toContain("Order shortage");
+    expect(pickModal).toContain("Attach inventory");
+    expect(pickModal).toContain("/allocate");
+    expect(pickModal).toContain("Idempotency-Key");
+  });
+
+  it("keeps approved fulfillment out of Receiving until a PO quantity exists", () => {
+    expect(receiving).toContain('.not("po_id", "is", null)');
+    expect(receiving).toContain('.gt("qty_ordered", 0)');
+    expect(receiving).toContain("ordered - received");
+    expect(receiving).toContain("x.po_id !== null");
+    expect(receiving).toContain("it.qty_received} / {it.qty_ordered} ordered");
+  });
+
+  it("updates the repair line and sends Parts Ready only to assigned technicians", () => {
+    expect(migration).toContain(
+      "function public.parts_sync_work_order_line_fulfillment_status",
+    );
+    expect(migration).toContain("set status = 'waiting_parts'");
+    expect(migration).toContain("p_stage = 'ready_for_tech'");
+    expect(migration).toContain("parts_tech_workflow");
+    expect(migration).toContain("parts_ready_for_technician");
+    expect(migration).toContain("wol.assigned_tech_id");
+    expect(migration).toContain("work_order_line_technicians");
+    expect(notifications).toContain('"parts_tech_workflow"');
+  });
+});


### PR DESCRIPTION
## Summary

- add a one-click **Request all parts** action to each work-order repair line
- automatically release approved line parts into a dedicated Pick / Order task
- let Parts pick individual items or all available stock with existing atomic allocation APIs
- keep Receiving limited to actual PO quantities and notify assigned technicians when all approved parts are staged
- add tenant-scoped, idempotent database automation and regression coverage

## Parts flow

1. Quote or add parts on the work-order line.
2. Request the line once, or let approval auto-release it.
3. Parts receives an Order & Receive task and an on-screen Pick / Order modal.
4. Parts picks available stock, attaches missing inventory identities, or orders the shortage.
5. Only ordered PO quantities enter Receiving.
6. When all approved quantities are staged, the assigned technician receives a user-scoped notification.
7. Explicit handoff completes and archives the request through the existing lifecycle.

## Validation

- `tsc --noEmit --pretty false`
- `vitest run tests/parts/parts-line-pick-order-release.test.ts tests/parts/parts-request-lifecycle-automation.test.ts tests/parts/parts-request-ordering-path.test.ts` (21 passed)
- targeted ESLint (0 errors; 2 existing Receiving hook warnings)
- PostgreSQL/libpg_query parse of `20260719143000_parts_line_pick_order_release.sql` (26 statements accepted)
- `git diff --check`

## Database

Apply `supabase/migrations/20260719143000_parts_line_pick_order_release.sql` after the existing 20260719100100/20260719100200 parts lifecycle migrations.