### PR TITLE
Fix canonical inventory availability

### DIFF
--- a/features/integrations/imports/runPartsImportPipeline.ts
+++ b/features/integrations/imports/runPartsImportPipeline.ts
@@ -2,6 +2,7 @@ import { createHash } from "crypto";
 
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { setStockOnHandSnapshot } from "@/features/parts/server/setStockOnHandSnapshot";
 
 type CsvRow = Record<string, string>;
 type ExistingPartRow = Pick<
@@ -445,6 +446,11 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
       continue;
     }
 
+    if (!staged.matched_part_id) {
+      throw new Error(`Auto-promoted parts staging row ${staged.id} has no matched part.`);
+    }
+    const matchedPartId = staged.matched_part_id;
+
     promotedRows += 1;
     const sourceHash = createHash("sha1")
       .update(`${intakeId}|${staged.raw_row_id ?? "none"}|${staged.normalized_part_number ?? ""}|${staged.normalized_sku ?? ""}`)
@@ -461,7 +467,7 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
           import_mode: "staged_auto_promote_exact_part_number",
         }),
       })
-      .eq("id", staged.matched_part_id);
+      .eq("id", matchedPartId);
 
     const { data: defaultLocation } = await supabase
       .from("stock_locations")
@@ -473,35 +479,19 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
 
     if (defaultLocation?.id) {
       inventorySeededLocations += 1;
-      const { data: existingStock } = await supabase
-        .from("part_stock")
-        .select("id,qty_on_hand")
-        .eq("part_id", staged.matched_part_id)
-        .eq("location_id", defaultLocation.id)
-        .maybeSingle();
-
       const seededQty = Number(staged.quantity_on_hand ?? 0);
-      if (existingStock?.id) {
-        await supabase
-          .from("part_stock")
-          .update({ qty_on_hand: Math.max(0, seededQty) })
-          .eq("id", existingStock.id);
-      } else {
-        await supabase.from("part_stock").insert({
-          part_id: staged.matched_part_id,
-          location_id: defaultLocation.id,
-          qty_on_hand: Math.max(0, seededQty),
-          qty_reserved: 0,
-        });
-      }
-
-      await supabase.from("stock_moves").insert({
-        shop_id: shopId,
-        part_id: staged.matched_part_id,
-        location_id: defaultLocation.id,
-        qty_delta: Math.max(0, seededQty),
-        reason: "shop_boost_snapshot_seed",
-        metadata: { intake_id: intakeId, staging_row_id: staged.id, source: "shop_boost" },
+      await setStockOnHandSnapshot({
+        client: supabase,
+        shopId,
+        partId: matchedPartId,
+        locationId: defaultLocation.id,
+        targetQty: Math.max(0, seededQty),
+        idempotencyKey: `${shopId}:inventory-snapshot:parts-import:${intakeId}:${staged.id}`,
+        metadata: {
+          intake_id: intakeId,
+          staging_row_id: staged.id,
+          source: "shop_boost_parts_pipeline",
+        },
       });
     }
 
@@ -511,7 +501,7 @@ export async function runPartsImportPipeline(args: PartsPipelineArgs): Promise<P
         intake_id: intakeId,
         raw_row_id: staged.raw_row_id,
         staging_row_id: staged.id,
-        part_id: staged.matched_part_id,
+        part_id: matchedPartId,
         source_system: sourceSystem,
         legacy_sku: staged.normalized_sku,
         legacy_part_number: staged.normalized_part_number,

--- a/features/integrations/shopBoost/reviewMaterialization.ts
+++ b/features/integrations/shopBoost/reviewMaterialization.ts
@@ -2,6 +2,7 @@ import { createHash } from "crypto";
 
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { setStockOnHandSnapshot } from "@/features/parts/server/setStockOnHandSnapshot";
 import {
   computeCompletionState,
   runPostMigrationIntegrityValidation,
@@ -648,25 +649,27 @@ async function materializePart(args: { supabase: AdminClient; item: ReviewItemRo
     .limit(1)
     .maybeSingle();
 
-  if (defaultLocation?.id) {
-    const { data: existingStock } = await supabase
-      .from("part_stock")
-      .select("id,qty_on_hand")
-      .eq("part_id", partId)
-      .eq("location_id", defaultLocation.id)
-      .maybeSingle();
-
-    if (existingStock?.id) {
-      if (Number.isFinite(quantityOnHand)) {
-        await supabase.from("part_stock").update({ qty_on_hand: Math.max(0, quantityOnHand ?? 0) }).eq("id", existingStock.id);
-      }
-    } else {
-      await supabase.from("part_stock").insert({
-        part_id: partId,
-        location_id: defaultLocation.id,
-        qty_on_hand: Math.max(0, quantityOnHand ?? 0),
-        qty_reserved: 0,
+  if (defaultLocation?.id && Number.isFinite(quantityOnHand)) {
+    try {
+      await setStockOnHandSnapshot({
+        client: supabase,
+        shopId: item.shop_id,
+        partId,
+        locationId: defaultLocation.id,
+        targetQty: Math.max(0, quantityOnHand ?? 0),
+        idempotencyKey: `${item.shop_id}:inventory-snapshot:review:${item.intake_id}:${item.id}`,
+        metadata: {
+          intake_id: item.intake_id,
+          review_item_id: item.id,
+          source: "shop_boost_review_materialization",
+        },
       });
+    } catch (error) {
+      return {
+        status: "failed_materialization",
+        materializedRecord: null,
+        error: error instanceof Error ? error.message : "Failed to set imported inventory quantity.",
+      };
     }
   }
 

--- a/features/parts/server/setStockOnHandSnapshot.ts
+++ b/features/parts/server/setStockOnHandSnapshot.ts
@@ -1,0 +1,58 @@
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
+
+type RpcResult = {
+  data: unknown;
+  error: RpcError | null;
+};
+
+type RpcInvoker = (
+  functionName: string,
+  args: Record<string, unknown>,
+) => PromiseLike<RpcResult>;
+
+type RpcClient = {
+  rpc: unknown;
+};
+
+export async function setStockOnHandSnapshot(args: {
+  client: RpcClient;
+  shopId: string;
+  partId: string;
+  locationId: string;
+  targetQty: number;
+  idempotencyKey: string;
+  metadata?: Record<string, unknown>;
+}): Promise<Record<string, unknown>> {
+  if (!Number.isFinite(args.targetQty) || args.targetQty < 0) {
+    throw new Error("Inventory snapshot quantity must be zero or greater.");
+  }
+
+  const rpc = args.client.rpc as RpcInvoker;
+  const { data, error } = await rpc.call(
+    args.client,
+    "parts_set_stock_on_hand_snapshot",
+    {
+      p_shop_id: args.shopId,
+      p_part_id: args.partId,
+      p_location_id: args.locationId,
+      p_target_qty: args.targetQty,
+      p_idempotency_key: args.idempotencyKey,
+      p_metadata: args.metadata ?? {},
+    },
+  );
+
+  if (error) {
+    throw new Error(
+      [error.message, error.details, error.hint].filter(Boolean).join(" "),
+    );
+  }
+
+  return (data && typeof data === "object" ? data : {}) as Record<
+    string,
+    unknown
+  >;
+}

--- a/supabase/migrations/20260719160000_canonical_inventory_availability.sql
+++ b/supabase/migrations/20260719160000_canonical_inventory_availability.sql
@@ -1,0 +1,294 @@
+begin;
+
+-- Inventory has two historical representations:
+--   * stock_moves is the canonical physical ledger used by allocation RPCs.
+--   * part_stock is a legacy snapshot/cache used by older imports and views.
+-- Preserve valid snapshot-only inventory only when that part/location has no
+-- physical ledger history. A higher legacy cache beside an active ledger can be
+-- stale after consumption, so it is intentionally left for manual review.
+-- Keep physical inventory writers out for this short reconciliation statement
+-- so a concurrent receipt cannot be counted immediately after the snapshot.
+lock table public.stock_moves in share row exclusive mode;
+lock table public.part_stock in share row exclusive mode;
+
+with ledger_history as (
+  select
+    sm.shop_id,
+    sm.part_id,
+    sm.location_id,
+    coalesce(sum(sm.qty_change) filter (
+      where lower(sm.reason::text) not in ('wo_allocate', 'wo_release')
+    ), 0)::numeric as qty_on_hand,
+    count(*) filter (
+      where lower(sm.reason::text) not in ('wo_allocate', 'wo_release')
+    )::integer as physical_move_count
+  from public.stock_moves sm
+  group by sm.shop_id, sm.part_id, sm.location_id
+), snapshot_gaps as (
+  select
+    p.shop_id,
+    ps.part_id,
+    ps.location_id,
+    ps.qty_on_hand::numeric as snapshot_qty,
+    coalesce(lo.qty_on_hand, 0)::numeric as ledger_qty,
+    (ps.qty_on_hand - coalesce(lo.qty_on_hand, 0))::numeric as gap_qty
+  from public.part_stock ps
+  join public.parts p
+    on p.id = ps.part_id
+  join public.stock_locations sl
+    on sl.id = ps.location_id
+   and sl.shop_id = p.shop_id
+  left join ledger_history lo
+    on lo.shop_id = p.shop_id
+   and lo.part_id = ps.part_id
+   and lo.location_id = ps.location_id
+  where ps.qty_on_hand > 0
+    and coalesce(lo.physical_move_count, 0) = 0
+)
+insert into public.stock_moves (
+  shop_id,
+  part_id,
+  location_id,
+  qty_change,
+  reason,
+  reference_kind,
+  reference_id,
+  created_by,
+  idempotency_key,
+  metadata,
+  lifecycle_quantity
+)
+select
+  sg.shop_id,
+  sg.part_id,
+  sg.location_id,
+  sg.gap_qty,
+  'adjust'::public.stock_move_reason,
+  'inventory_snapshot_backfill',
+  sg.part_id,
+  null,
+  sg.shop_id::text || ':canonical-stock-backfill:'
+    || sg.part_id::text || ':' || sg.location_id::text,
+  jsonb_build_object(
+    'operation', 'canonical_inventory_backfill',
+    'snapshot_qty', sg.snapshot_qty,
+    'ledger_qty_before', sg.ledger_qty,
+    'qty_added', sg.gap_qty
+  ),
+  sg.gap_qty
+from snapshot_gaps sg
+on conflict (shop_id, idempotency_key)
+  where idempotency_key is not null
+do nothing;
+
+-- Keep the existing view contract while sourcing every quantity from the same
+-- canonical tables used by parts_available() and parts_allocate_request_item().
+create or replace view public.v_part_stock
+with (security_invoker = true)
+as
+with physical as (
+  select
+    sm.shop_id,
+    sm.part_id,
+    sm.location_id,
+    coalesce(sum(sm.qty_change) filter (
+      where lower(sm.reason::text) not in ('wo_allocate', 'wo_release')
+    ), 0)::numeric as qty_on_hand
+  from public.stock_moves sm
+  group by sm.shop_id, sm.part_id, sm.location_id
+), allocated as (
+  select
+    a.shop_id,
+    a.part_id,
+    a.location_id,
+    coalesce(sum(a.qty), 0)::numeric as qty_reserved
+  from public.work_order_part_allocations a
+  group by a.shop_id, a.part_id, a.location_id
+), inventory_keys as (
+  select shop_id, part_id, location_id from physical
+  union
+  select shop_id, part_id, location_id from allocated
+)
+select
+  k.part_id,
+  k.location_id,
+  (coalesce(p.qty_on_hand, 0) - coalesce(a.qty_reserved, 0))::numeric
+    as qty_available,
+  coalesce(p.qty_on_hand, 0)::numeric(12,2) as qty_on_hand,
+  coalesce(a.qty_reserved, 0)::numeric(12,2) as qty_reserved
+from inventory_keys k
+left join physical p
+  on p.shop_id = k.shop_id
+ and p.part_id = k.part_id
+ and p.location_id = k.location_id
+left join allocated a
+  on a.shop_id = k.shop_id
+ and a.part_id = k.part_id
+ and a.location_id = k.location_id;
+
+revoke all on table public.v_part_stock from public, anon;
+grant select on table public.v_part_stock to authenticated, service_role;
+
+-- Importers set an absolute source-system snapshot. Convert that snapshot to a
+-- ledger delta atomically, retain a durable idempotency key, and refresh the
+-- legacy cache for callers that have not yet moved to v_part_stock.
+create or replace function public.parts_set_stock_on_hand_snapshot(
+  p_shop_id uuid,
+  p_part_id uuid,
+  p_location_id uuid,
+  p_target_qty numeric,
+  p_idempotency_key text,
+  p_metadata jsonb default '{}'::jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_part public.parts%rowtype;
+  v_location public.stock_locations%rowtype;
+  v_existing public.stock_moves%rowtype;
+  v_current_qty numeric;
+  v_delta numeric;
+  v_reserved numeric;
+  v_move_id uuid;
+begin
+  if p_target_qty is null or p_target_qty < 0 then
+    raise exception 'Inventory snapshot quantity must be zero or greater.';
+  end if;
+  if coalesce(trim(p_idempotency_key), '') = '' then
+    raise exception 'A stable idempotency key is required.';
+  end if;
+  if length(p_idempotency_key) > 300 then
+    raise exception 'Inventory snapshot idempotency key is too long.';
+  end if;
+  if position(p_shop_id::text || ':' in p_idempotency_key) <> 1 then
+    raise exception 'Inventory snapshot idempotency key must be tenant scoped.';
+  end if;
+
+  if coalesce(auth.role(), '') <> 'service_role' then
+    perform public.parts_lifecycle_assert_shop_access(p_shop_id);
+  end if;
+
+  select * into v_part
+  from public.parts
+  where id = p_part_id
+    and shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception 'Inventory part is not available for this shop.';
+  end if;
+
+  select * into v_location
+  from public.stock_locations
+  where id = p_location_id
+    and shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception 'Inventory location is not available for this shop.';
+  end if;
+
+  select * into v_existing
+  from public.stock_moves
+  where shop_id = p_shop_id
+    and idempotency_key = trim(p_idempotency_key)
+  for update;
+  if found then
+    if v_existing.part_id is distinct from p_part_id
+       or v_existing.location_id is distinct from p_location_id
+       or v_existing.reference_kind is distinct from 'inventory_snapshot' then
+      raise exception 'Inventory snapshot idempotency key belongs to another stock scope.';
+    end if;
+    if jsonb_typeof(v_existing.metadata -> 'target_qty') is distinct from 'number' then
+      raise exception 'Inventory snapshot idempotency key was reused with a different target quantity.';
+    end if;
+    if (v_existing.metadata ->> 'target_qty')::numeric is distinct from p_target_qty then
+      raise exception 'Inventory snapshot idempotency key was reused with a different target quantity.';
+    end if;
+    return coalesce(v_existing.metadata, '{}'::jsonb) || jsonb_build_object(
+      'ok', true,
+      'idempotent', true,
+      'stock_move_id', v_existing.id,
+      'part_id', p_part_id,
+      'location_id', p_location_id,
+      'target_qty', p_target_qty,
+      'on_hand_after', public.parts_on_hand(p_shop_id, p_part_id, p_location_id),
+      'available_after', public.parts_available(p_shop_id, p_part_id, p_location_id)
+    );
+  end if;
+
+  v_current_qty := public.parts_on_hand(p_shop_id, p_part_id, p_location_id);
+  v_delta := p_target_qty - v_current_qty;
+  v_reserved := public.parts_allocated(p_shop_id, p_part_id, p_location_id);
+
+  insert into public.stock_moves (
+    shop_id,
+    part_id,
+    location_id,
+    qty_change,
+    reason,
+    reference_kind,
+    reference_id,
+    created_by,
+    idempotency_key,
+    metadata,
+    lifecycle_quantity
+  ) values (
+    p_shop_id,
+    p_part_id,
+    p_location_id,
+    v_delta,
+    'adjust'::public.stock_move_reason,
+    'inventory_snapshot',
+    p_part_id,
+    auth.uid(),
+    trim(p_idempotency_key),
+    coalesce(p_metadata, '{}'::jsonb) || jsonb_build_object(
+      'operation', 'set_stock_on_hand_snapshot',
+      'target_qty', p_target_qty,
+      'on_hand_before', v_current_qty,
+      'qty_change', v_delta
+    ),
+    abs(v_delta)
+  )
+  returning id into v_move_id;
+
+  insert into public.part_stock (
+    part_id,
+    location_id,
+    qty_on_hand,
+    qty_reserved
+  ) values (
+    p_part_id,
+    p_location_id,
+    p_target_qty,
+    v_reserved
+  )
+  on conflict (part_id, location_id) do update
+  set qty_on_hand = excluded.qty_on_hand,
+      qty_reserved = excluded.qty_reserved;
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'stock_move_id', v_move_id,
+    'part_id', p_part_id,
+    'location_id', p_location_id,
+    'target_qty', p_target_qty,
+    'qty_change', v_delta,
+    'on_hand_after', p_target_qty,
+    'available_after', p_target_qty - v_reserved
+  );
+end;
+$$;
+
+revoke all on function public.parts_set_stock_on_hand_snapshot(
+  uuid, uuid, uuid, numeric, text, jsonb
+) from public, anon;
+grant execute on function public.parts_set_stock_on_hand_snapshot(
+  uuid, uuid, uuid, numeric, text, jsonb
+) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/parts/canonical-inventory-availability.test.ts
+++ b/tests/parts/canonical-inventory-availability.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260719160000_canonical_inventory_availability.sql",
+  "utf8",
+);
+const pickTaskRoute = readFileSync(
+  "app/api/parts/requests/pick-task/route.ts",
+  "utf8",
+);
+const partsImport = readFileSync(
+  "features/integrations/imports/runPartsImportPipeline.ts",
+  "utf8",
+);
+const reviewMaterialization = readFileSync(
+  "features/integrations/shopBoost/reviewMaterialization.ts",
+  "utf8",
+);
+const snapshotHelper = readFileSync(
+  "features/parts/server/setStockOnHandSnapshot.ts",
+  "utf8",
+);
+
+describe("canonical inventory availability", () => {
+  it("builds the picking view from the physical ledger minus active allocations", () => {
+    expect(migration).toContain("create or replace view public.v_part_stock");
+    expect(migration).toContain("with (security_invoker = true)");
+    expect(migration).toContain("from public.stock_moves sm");
+    expect(migration).toContain("from public.work_order_part_allocations a");
+    expect(migration).toContain(
+      "coalesce(p.qty_on_hand, 0) - coalesce(a.qty_reserved, 0)",
+    );
+    expect(pickTaskRoute).toContain('.from("v_part_stock")');
+  });
+
+  it("reconciles only snapshot-only positive stock with a replay-safe key", () => {
+    expect(migration).toContain("where ps.qty_on_hand > 0");
+    expect(migration).toContain(
+      "and coalesce(lo.physical_move_count, 0) = 0",
+    );
+    expect(migration).toContain(
+      "lock table public.stock_moves in share row exclusive mode",
+    );
+    expect(migration).toContain(":canonical-stock-backfill:");
+    expect(migration).toContain("on conflict (shop_id, idempotency_key)");
+    expect(migration).not.toMatch(
+      /snapshot_gaps[\s\S]*delete\s+from\s+public\.stock_moves/i,
+    );
+  });
+
+  it("provides a tenant-scoped idempotent snapshot command", () => {
+    expect(migration).toContain(
+      "function public.parts_set_stock_on_hand_snapshot",
+    );
+    expect(migration).toContain("parts_lifecycle_assert_shop_access");
+    expect(migration).toContain("and shop_id = p_shop_id");
+    expect(migration).toContain(
+      "Inventory snapshot idempotency key must be tenant scoped.",
+    );
+    expect(migration).toContain("auth.role(), '') <> 'service_role'");
+    expect(migration).toContain(
+      "reused with a different target quantity",
+    );
+    expect(migration).toContain("to authenticated, service_role");
+    expect(migration).toContain(
+      "revoke all on function public.parts_set_stock_on_hand_snapshot",
+    );
+  });
+
+  it("routes both import paths through the canonical snapshot command", () => {
+    for (const source of [partsImport, reviewMaterialization]) {
+      expect(source).toContain("setStockOnHandSnapshot");
+      expect(source).not.toContain('.from("part_stock")');
+    }
+    expect(partsImport).not.toContain("qty_delta");
+    expect(partsImport).not.toContain("shop_boost_snapshot_seed");
+    expect(snapshotHelper).toContain("parts_set_stock_on_hand_snapshot");
+    expect(snapshotHelper).toContain("throw new Error");
+  });
+});


### PR DESCRIPTION
## What changed

- rebuild `v_part_stock` from the canonical `stock_moves` ledger minus active allocations
- reconcile positive legacy inventory only for part/location scopes with no physical ledger history
- add a tenant-scoped, idempotent stock snapshot RPC
- route both ShopBoost inventory import paths through the canonical RPC
- surface import failures instead of silently leaving inventory tables inconsistent
- add focused regression coverage

## Root cause

The Parts Pick / Order task displayed availability from the legacy `part_stock` cache, while allocation validated `stock_moves - work_order_part_allocations`. ShopBoost imports wrote the cache and attempted an invalid ledger insert using `qty_delta` and an unsupported reason, so the UI could show stock that the allocation RPC correctly considered unavailable.

## Safety

- the reconciliation never reduces ledger inventory
- it backfills only scopes with no physical ledger movement history, avoiding restoration of already-consumed stock
- the canonical view uses security-invoker RLS and is not granted to anonymous users
- the RPC validates shop membership, part/location ownership, stable idempotency keys, and reused-key payloads
- the migration briefly locks inventory writers while reconciling to avoid concurrent receipt races

## Validation

- strict TypeScript: passed
- targeted ESLint: passed
- PostgreSQL SQL parser: passed
- focused inventory/parts tests: 18 passed
- repository-wide Vitest run: 943 passed, 56 failures in untouched existing areas

## Deployment order

Apply `20260719160000_canonical_inventory_availability.sql` to Supabase before deploying the application changes. No environment-variable changes are required.