### PR TITLE
Fix inventory view migration compatibility

### DIFF
--- a/supabase/migrations/20260719160000_canonical_inventory_availability.sql
+++ b/supabase/migrations/20260719160000_canonical_inventory_availability.sql
@@ -81,9 +81,12 @@ on conflict (shop_id, idempotency_key)
   where idempotency_key is not null
 do nothing;
 
--- Keep the existing view contract while sourcing every quantity from the same
--- canonical tables used by parts_available() and parts_allocate_request_item().
-create or replace view public.v_part_stock
+-- Production installations have used more than one column order for this view.
+-- CREATE OR REPLACE matches by position and can misread that as a column rename,
+-- so recreate the view without CASCADE and then restore its narrow grants.
+drop view if exists public.v_part_stock;
+
+create view public.v_part_stock
 with (security_invoker = true)
 as
 with physical as (

--- a/tests/parts/canonical-inventory-availability.test.ts
+++ b/tests/parts/canonical-inventory-availability.test.ts
@@ -24,7 +24,9 @@ const snapshotHelper = readFileSync(
 
 describe("canonical inventory availability", () => {
   it("builds the picking view from the physical ledger minus active allocations", () => {
-    expect(migration).toContain("create or replace view public.v_part_stock");
+    expect(migration).toContain("drop view if exists public.v_part_stock");
+    expect(migration).not.toContain("drop view if exists public.v_part_stock cascade");
+    expect(migration).toContain("create view public.v_part_stock");
     expect(migration).toContain("with (security_invoker = true)");
     expect(migration).toContain("from public.stock_moves sm");
     expect(migration).toContain("from public.work_order_part_allocations a");


### PR DESCRIPTION
## What changed

- replace `CREATE OR REPLACE VIEW public.v_part_stock` with a non-cascading drop and recreate
- restore the security-invoker option and narrow grants after recreation
- add regression coverage preventing a return to positional view replacement

## Root cause

Production's existing `v_part_stock` column order differs from the schema dump. PostgreSQL applies `CREATE OR REPLACE VIEW` columns positionally and interpreted the third output column as an attempted rename, raising `42P16`.

## Recovery

The failed SQL ran inside `BEGIN`, so the preceding reconciliation should have rolled back with the view failure. Rerun the updated migration from the beginning.

## Validation

- PostgreSQL SQL parser: passed
- focused migration tests: 4 passed
- diff check: passed