### PR TITLE
Add duplicate dismissal and keep Parts modal actions visible

### DIFF
--- a/features/parts/components/PickOrderTaskModal.tsx
+++ b/features/parts/components/PickOrderTaskModal.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import {
   CheckCircle2,
+  CircleX,
   Loader2,
   PackageCheck,
   ShoppingCart,
@@ -130,6 +131,20 @@ export default function PickOrderTaskModal({
     [items],
   );
 
+  const duplicateItemIds = useMemo(() => {
+    const grouped = new Map<string, string[]>();
+    for (const item of items) {
+      if (!item.partId || !item.workOrderLineId) continue;
+      const key = `${item.workOrderLineId}:${item.partId}`;
+      grouped.set(key, [...(grouped.get(key) ?? []), item.id]);
+    }
+    return new Set(
+      [...grouped.values()]
+        .filter((ids) => ids.length > 1)
+        .flat(),
+    );
+  }, [items]);
+
   const allocate = useCallback(
     async (item: PickTaskItem, stock: PickStock, amount: number) => {
       const idempotencyKey = crypto.randomUUID();
@@ -186,6 +201,57 @@ export default function PickOrderTaskModal({
     [allocate, batchPicking, busyItemId, load, onChanged],
   );
 
+  const dismissDuplicate = useCallback(
+    async (item: PickTaskItem) => {
+      if (busyItemId || batchPicking) return;
+      if (
+        !window.confirm(
+          `Dismiss the duplicate request for ${item.description}?`,
+        )
+      ) {
+        return;
+      }
+
+      setBusyItemId(item.id);
+      const toastId = toast.loading(`Dismissing ${item.description}…`);
+      try {
+        const key = crypto.randomUUID();
+        const response = await fetch(
+          `/api/parts/requests/items/${encodeURIComponent(item.id)}/cancel`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Idempotency-Key": key,
+            },
+            body: JSON.stringify({ idempotencyKey: key }),
+          },
+        );
+        const payload = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        if (!response.ok) {
+          throw new Error(
+            payload?.error || `Could not dismiss ${item.description}.`,
+          );
+        }
+        toast.success("Duplicate request dismissed.", { id: toastId });
+        await load();
+        await onChanged?.();
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Could not dismiss the duplicate request.",
+          { id: toastId },
+        );
+      } finally {
+        setBusyItemId(null);
+      }
+    },
+    [batchPicking, busyItemId, load, onChanged],
+  );
+
   const pickAllAvailable = useCallback(async () => {
     if (batchPicking || busyItemId || pickable.length === 0) return;
     setBatchPicking(true);
@@ -227,8 +293,8 @@ export default function PickOrderTaskModal({
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
-      <DialogContent className="max-h-[90vh] max-w-4xl overflow-hidden p-0">
-        <DialogHeader className="relative px-5 py-4 pr-14">
+      <DialogContent className="flex max-h-[calc(100dvh-2rem)] min-h-0 max-w-4xl flex-col overflow-hidden p-0">
+        <DialogHeader className="relative shrink-0 px-5 py-4 pr-14">
           <DialogTitle className="flex items-center gap-2 text-base normal-case tracking-normal">
             <PackageCheck className="h-5 w-5 text-sky-300" />
             Pick / Order task · {workOrderLabel}
@@ -247,7 +313,7 @@ export default function PickOrderTaskModal({
           </button>
         </DialogHeader>
 
-        <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-5 py-3">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-5 py-3">
           <div className="text-xs text-[color:var(--theme-text-secondary)]">
             Pick stock first. Order only the remaining shortage. Receiving is
             reserved for actual PO quantities.
@@ -272,7 +338,7 @@ export default function PickOrderTaskModal({
           </button>
         </div>
 
-        <div className="max-h-[62vh] space-y-2 overflow-y-auto p-4 sm:p-5">
+        <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-4 sm:p-5">
           {loading ? (
             <div className="flex items-center justify-center gap-2 py-12 text-sm text-[color:var(--theme-text-secondary)]">
               <Loader2 className="h-4 w-4 animate-spin" /> Loading live stock…
@@ -289,6 +355,11 @@ export default function PickOrderTaskModal({
               const pickQty = bestStock
                 ? Math.min(item.remainingToStage, bestStock.available)
                 : 0;
+              const canDismissDuplicate =
+                duplicateItemIds.has(item.id) &&
+                item.ordered <= 0 &&
+                item.received <= 0 &&
+                item.staged <= 0;
               return (
                 <article
                   key={item.id}
@@ -319,6 +390,24 @@ export default function PickOrderTaskModal({
                     </div>
 
                     <div className="flex shrink-0 flex-wrap items-center gap-2 sm:justify-end">
+                      {canDismissDuplicate ? (
+                        <button
+                          type="button"
+                          onClick={() => void dismissDuplicate(item)}
+                          disabled={
+                            batchPicking ||
+                            (busyItemId !== null && busyItemId !== item.id)
+                          }
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-rose-400/45 bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-100 disabled:opacity-50"
+                        >
+                          {busyItemId === item.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <CircleX className="h-4 w-4" />
+                          )}
+                          Dismiss duplicate
+                        </button>
+                      ) : null}
                       {complete ? (
                         <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-100">
                           <CheckCircle2 className="h-4 w-4" /> Picked / staged
@@ -370,7 +459,7 @@ export default function PickOrderTaskModal({
           )}
         </div>
 
-        <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] px-5 py-3">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-5 py-3">
           <Link
             href={detailHref}
             className="text-xs font-semibold text-sky-200 hover:text-sky-100"

--- a/supabase/migrations/20260720034000_cancel_unmaterialized_request_items.sql
+++ b/supabase/migrations/20260720034000_cancel_unmaterialized_request_items.sql
@@ -1,0 +1,132 @@
+begin;
+
+-- Duplicate request items can exist before a canonical work_order_parts row is
+-- materialized. Cancellation previously required that row, leaving an unpicked
+-- duplicate impossible to dismiss. Preserve the normal allocation-release path
+-- when a row exists, but allow an untouched request item to be cancelled before
+-- materialization. Keep the lifecycle reconciler from restoring a cancelled
+-- item to the approved parent status.
+create or replace function public.parts_cancel_request_item(
+  p_request_item_id uuid,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item public.part_request_items%rowtype;
+  v_wop public.work_order_parts%rowtype;
+  v_alloc record;
+  v_cancel numeric := 0;
+  v_key text;
+  v_released numeric := 0;
+  v_previous_guard text :=
+    coalesce(current_setting('app.parts_lifecycle_reconciling', true), '0');
+begin
+  if nullif(trim(p_idempotency_key), '') is null then
+    raise exception 'idempotency_key is required.';
+  end if;
+
+  select * into v_item
+  from public.part_request_items
+  where id = p_request_item_id
+  for update;
+  if not found then raise exception 'Request item not found.'; end if;
+  perform public.parts_lifecycle_assert_shop_access(v_item.shop_id);
+
+  if lower(coalesce(v_item.status::text, '')) = 'cancelled' then
+    return jsonb_build_object(
+      'ok', true,
+      'idempotent', true,
+      'work_order_part_id', null,
+      'released_qty', 0,
+      'cancelled_qty', 0
+    );
+  end if;
+
+  select * into v_wop
+  from public.work_order_parts
+  where source_parts_request_item_id = p_request_item_id
+    and coalesce(is_active, true)
+  order by updated_at desc, id desc
+  limit 1
+  for update;
+
+  if found then
+    for v_alloc in
+      select *
+      from public.work_order_part_allocations
+      where work_order_part_id = v_wop.id
+      order by id
+      for update
+    loop
+      v_key := p_idempotency_key || ':release:' || v_alloc.id::text;
+      perform public.parts_release_allocation(
+        p_request_item_id,
+        v_alloc.location_id,
+        v_alloc.qty,
+        v_key
+      );
+      v_released := v_released + v_alloc.qty;
+    end loop;
+
+    v_cancel := greatest(
+      coalesce(v_wop.quantity_requested, 0)
+        - coalesce(v_wop.quantity_consumed, 0)
+        - coalesce(v_wop.quantity_returned, 0),
+      0
+    );
+
+    update public.work_order_parts
+    set quantity_cancelled = greatest(
+          coalesce(quantity_cancelled, 0), v_cancel
+        ),
+        lifecycle_status = case
+          when coalesce(quantity_consumed, 0) > 0
+            then lifecycle_status
+          else 'cancelled'
+        end,
+        updated_at = now()
+    where id = v_wop.id;
+  end if;
+
+  perform set_config('app.parts_lifecycle_reconciling', '1', true);
+  update public.part_request_items
+  set status = 'cancelled',
+      approved = false,
+      qty_approved = 0,
+      updated_at = now()
+  where id = p_request_item_id;
+  perform set_config(
+    'app.parts_lifecycle_reconciling', v_previous_guard, true
+  );
+
+  perform public.parts_publish_request_notification(
+    v_item.request_id,
+    public.parts_request_operational_stage(v_item.request_id)
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'work_order_part_id', v_wop.id,
+    'released_qty', v_released,
+    'cancelled_qty', v_cancel
+  );
+exception when others then
+  perform set_config(
+    'app.parts_lifecycle_reconciling', v_previous_guard, true
+  );
+  raise;
+end;
+$$;
+
+revoke all on function public.parts_cancel_request_item(uuid,text)
+  from public, anon;
+grant execute on function public.parts_cancel_request_item(uuid,text)
+  to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/parts/parts-line-pick-order-release.test.ts
+++ b/tests/parts/parts-line-pick-order-release.test.ts
@@ -23,6 +23,10 @@ const pickModal = readFileSync(
   "features/parts/components/PickOrderTaskModal.tsx",
   "utf8",
 );
+const dismissMigration = readFileSync(
+  "supabase/migrations/20260720034000_cancel_unmaterialized_request_items.sql",
+  "utf8",
+);
 const receiving = readFileSync("app/parts/receiving/page.tsx", "utf8");
 const notifications = readFileSync(
   "features/agent/server/syncAssistantNotifications.ts",
@@ -76,6 +80,26 @@ describe("work-order line parts release and Pick / Order flow", () => {
     expect(pickModal).toContain("Attach inventory");
     expect(pickModal).toContain("/allocate");
     expect(pickModal).toContain("Idempotency-Key");
+    expect(pickModal).toContain("Dismiss duplicate");
+    expect(pickModal).toContain("/cancel");
+  });
+
+  it("keeps the action footer visible while only the item list scrolls", () => {
+    expect(pickModal).toContain("max-h-[calc(100dvh-2rem)]");
+    expect(pickModal).toContain("min-h-0 flex-1");
+    expect(pickModal).toContain("shrink-0 flex-wrap");
+    expect(pickModal).not.toContain("max-h-[62vh]");
+  });
+
+  it("can cancel an untouched duplicate before work-order-part materialization", () => {
+    expect(dismissMigration).toContain(
+      "function public.parts_cancel_request_item",
+    );
+    expect(dismissMigration).toContain("if found then");
+    expect(dismissMigration).toContain("set status = 'cancelled'");
+    expect(dismissMigration).toContain(
+      "set_config('app.parts_lifecycle_reconciling', '1', true)",
+    );
   });
 
   it("keeps approved fulfillment out of Receiving until a PO quantity exists", () => {


### PR DESCRIPTION
## What changed

- identify duplicate request items by work-order line and inventory part
- offer **Dismiss duplicate** only for the unstarted copy with no staged, ordered, or received quantity
- route dismissal through the canonical cancellation command with a stable idempotency key
- allow cancellation before a `work_order_parts` row has been materialized
- prevent lifecycle reconciliation from immediately restoring a dismissed item
- constrain the dialog to the usable dynamic viewport and scroll only the item list
- keep the header, batch action, and Done footer visible

## Root cause

The duplicate rotor request was an independent request item with no lifecycle activity and no materialized work-order-part row. The existing cancellation function required that row, so the UI had no safe dismissal path. Separately, the dialog combined an overflow-hidden shell with a fixed `62vh` list, allowing the footer to fall below the usable browser viewport.

## Safety

Dismissal is only surfaced for a duplicate on the same work-order line when its staged, ordered, and received quantities are all zero. The database command keeps existing allocation-release behavior, is idempotent for already-cancelled rows, remains tenant-authorized, and uses the lifecycle guard so cancellation persists.

## Validation

- focused tests: 11 passed
- targeted ESLint: passed
- strict TypeScript build: passed
- `git diff --check`: passed