### PR TITLE
Fix Quote Review parts sync contract test

### DIFF
--- a/features/parts/server/syncQuoteLinePartsStatus.test.ts
+++ b/features/parts/server/syncQuoteLinePartsStatus.test.ts
@@ -1,20 +1,77 @@
-import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { syncQuoteLinePartsStatus } from "./syncQuoteLinePartsStatus";
 
 describe("syncQuoteLinePartsStatus contract", () => {
-  const source = readFileSync("features/parts/server/syncQuoteLinePartsStatus.ts", "utf8");
+  it("delegates to the canonical RPC with shop and quote-line scope", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: { ok: true }, error: null });
 
-  it("keeps quote-line part item hydration scoped by shop, work order, and quote line", () => {
-    expect(source).toMatch(/from\("part_request_items"\)[\s\S]*\.eq\("shop_id", shopId\)[\s\S]*\.eq\("work_order_id", line\.work_order_id\)[\s\S]*\.eq\("quote_line_id", quoteLineId\)/);
+    await syncQuoteLinePartsStatus(
+      { rpc } as unknown as Parameters<typeof syncQuoteLinePartsStatus>[0],
+      { shopId: " shop-1 ", quoteLineId: " ql-1 " },
+    );
+
+    expect(rpc).toHaveBeenCalledWith("sync_quote_line_pricing_from_parts", {
+      p_shop_id: "shop-1",
+      p_quote_line_id: "ql-1",
+    });
   });
 
-  it("persists displayable parts_quote items without requiring inventory selection", () => {
-    expect(source).toContain("required_count");
-    expect(source).toContain("quoted_count");
-    expect(source).toContain("pending_count");
-    expect(source).toContain("description: item.description");
-    expect(source).toContain("qty,");
-    expect(source).toContain("part_id: item.part_id");
-    expect(source).toContain("vendor: item.vendor");
+  it("maps the canonical RPC result for Quote Review consumers", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        ok: true,
+        quoteLineId: "ql-1",
+        shopId: "shop-1",
+        requestId: "pr-1",
+        itemCount: 2,
+        quotedCount: 1,
+        pendingCount: 1,
+        partsTotal: 45.5,
+        laborRate: 140,
+        laborTotal: 210,
+        status: "pending_parts",
+        stage: "advisor_pending",
+      },
+      error: null,
+    });
+
+    await expect(
+      syncQuoteLinePartsStatus(
+        { rpc } as unknown as Parameters<typeof syncQuoteLinePartsStatus>[0],
+        { shopId: "shop-1", quoteLineId: "ql-1" },
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      quoteLineId: "ql-1",
+      shopId: "shop-1",
+      requestId: "pr-1",
+      itemCount: 2,
+      quotedCount: 1,
+      pendingCount: 1,
+      partsTotal: 45.5,
+      laborRate: 140,
+      laborTotal: 210,
+      status: "pending_parts",
+      stage: "advisor_pending",
+      skipped: undefined,
+      error: undefined,
+    });
+  });
+
+  it("returns a scoped validation error before calling the RPC", async () => {
+    const rpc = vi.fn();
+
+    await expect(
+      syncQuoteLinePartsStatus(
+        { rpc } as unknown as Parameters<typeof syncQuoteLinePartsStatus>[0],
+        { shopId: "", quoteLineId: "ql-1" },
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      quoteLineId: "ql-1",
+      shopId: "",
+      error: "shopId and quoteLineId are required",
+    });
+    expect(rpc).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Summary
- Replace stale source-inspection assertions in `syncQuoteLinePartsStatus.test.ts` with behavior-level wrapper tests.
- Verify the wrapper delegates to the canonical `sync_quote_line_pricing_from_parts` RPC with `p_shop_id` and `p_quote_line_id`.
- Verify canonical RPC result normalization for Quote Review consumers and validation before RPC calls.

### Root cause
The current test expected inline `part_request_items` querying and `parts_quote` metadata writes inside `features/parts/server/syncQuoteLinePartsStatus.ts`, but that behavior now lives in the canonical database RPC defined by `supabase/migrations/20260714024500_quote_review_canonical_pricing_sync.sql`. The stale source-inspection test failed against the current architecture.

### Validation
Not run in this workspace: no local `EdwardLakin/ProFixIQ` checkout is available and `git` is not installed on PATH in the provided environment.

### Database
No migration required.

### Environment variables
None required.

### Manual actions
None.