### PR TITLE
Fix runtime labor and parts pricing on invoices

### DIFF
--- a/features/invoices/lib/filterInvoicePartAllocations.test.ts
+++ b/features/invoices/lib/filterInvoicePartAllocations.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { filterInvoicePartAllocations } from "./filterInvoicePartAllocations";
+
+describe("filterInvoicePartAllocations", () => {
+  const allocation = {
+    id: "allocation-1",
+    part_id: "oil-1",
+    source_request_item_id: "request-item-1",
+  };
+  const stagedPart = {
+    id: "staged-1",
+    part_id: "oil-1",
+    source_parts_request_item_id: "request-item-1",
+  };
+
+  it("keeps an allocated part when its staged row resolved to zero quantity", () => {
+    expect(
+      filterInvoicePartAllocations({
+        allocations: [allocation],
+        stagedParts: [stagedPart],
+        displayedStagedPartIds: new Set(),
+      }),
+    ).toEqual([allocation]);
+  });
+
+  it("deduplicates an allocation only when the staged row is billable", () => {
+    expect(
+      filterInvoicePartAllocations({
+        allocations: [allocation],
+        stagedParts: [stagedPart],
+        displayedStagedPartIds: new Set([stagedPart.id]),
+      }),
+    ).toEqual([]);
+  });
+});

--- a/features/invoices/lib/filterInvoicePartAllocations.ts
+++ b/features/invoices/lib/filterInvoicePartAllocations.ts
@@ -1,0 +1,37 @@
+import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
+
+type AllocationIdentity = {
+  part_id: string;
+  source_request_item_id?: string | null;
+};
+
+type StagedPartIdentity = {
+  id: string;
+  part_id?: string | null;
+  source_parts_request_item_id?: string | null;
+};
+
+export function filterInvoicePartAllocations<
+  TAllocation extends AllocationIdentity,
+  TStagedPart extends StagedPartIdentity,
+>(args: {
+  allocations: TAllocation[];
+  stagedParts: TStagedPart[];
+  displayedStagedPartIds: Set<string>;
+}): TAllocation[] {
+  const billableStagedParts = args.stagedParts.filter((part) =>
+    args.displayedStagedPartIds.has(String(part.id)),
+  );
+  const billablePartIds = new Set(
+    billableStagedParts
+      .map((part) => part.part_id)
+      .filter((partId): partId is string =>
+        typeof partId === "string" && partId.trim().length > 0,
+      ),
+  );
+
+  return filterAllocationsNotBackedByCanonicalParts(
+    args.allocations,
+    billableStagedParts,
+  ).filter((allocation) => !billablePartIds.has(allocation.part_id));
+}

--- a/features/invoices/lib/filterInvoicePartAllocations.ts
+++ b/features/invoices/lib/filterInvoicePartAllocations.ts
@@ -1,5 +1,3 @@
-import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
-
 type AllocationIdentity = {
   part_id: string;
   source_request_item_id?: string | null;
@@ -29,9 +27,17 @@ export function filterInvoicePartAllocations<
         typeof partId === "string" && partId.trim().length > 0,
       ),
   );
+  const billableSourceItemIds = new Set(
+    billableStagedParts
+      .map((part) => part.source_parts_request_item_id)
+      .filter((itemId): itemId is string =>
+        typeof itemId === "string" && itemId.trim().length > 0,
+      ),
+  );
 
-  return filterAllocationsNotBackedByCanonicalParts(
-    args.allocations,
-    billableStagedParts,
-  ).filter((allocation) => !billablePartIds.has(allocation.part_id));
+  return args.allocations.filter((allocation) => {
+    const sourceItemId = allocation.source_request_item_id;
+    if (sourceItemId && billableSourceItemIds.has(sourceItemId)) return false;
+    return !billablePartIds.has(allocation.part_id);
+  });
 }

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -7,7 +7,7 @@ import {
   resolveShopSuppliesSettings,
 } from "@/features/work-orders/lib/shopSupplies";
 import { calculateInvoiceTotals } from "@/features/invoices/lib/invoiceTotals";
-import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
+import { filterInvoicePartAllocations } from "@/features/invoices/lib/filterInvoicePartAllocations";
 
 type DB = Database;
 
@@ -336,7 +336,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       >
     >();
 
-  const { data: shop } = await supabase
+  const shopResult = await supabase
     .from("shops")
     .select(
       "business_name, shop_name, name, country, phone_number, email, street, city, province, postal_code, labor_rate, supplies_percent, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount, tax_rate",
@@ -365,6 +365,58 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     | "tax_rate"
       >
     >();
+
+  // Keep the core labor/tax lookup usable when a deployment has not refreshed
+  // every optional shop-supplies column yet. PostgREST rejects the entire
+  // select when even one selected column is unavailable, which previously
+  // turned a configured $140 rate into a null shop row and then a $1 fallback.
+  const shopFallbackResult = shopResult.error || !shopResult.data
+    ? await supabase
+        .from("shops")
+        .select(
+          "business_name, shop_name, name, country, phone_number, email, street, city, province, postal_code, labor_rate, supplies_percent, tax_rate",
+        )
+        .eq("id", workOrder.shop_id)
+        .maybeSingle<
+          Pick<
+            ShopRow,
+            | "business_name"
+            | "shop_name"
+            | "name"
+            | "country"
+            | "phone_number"
+            | "email"
+            | "street"
+            | "city"
+            | "province"
+            | "postal_code"
+            | "labor_rate"
+            | "supplies_percent"
+            | "tax_rate"
+          >
+        >()
+    : null;
+
+  if (shopFallbackResult?.error) {
+    throw new Error(
+      `Shop pricing configuration is unavailable: ${shopFallbackResult.error.message}`,
+    );
+  }
+
+  const shopCore = shopResult.data ?? shopFallbackResult?.data ?? null;
+  if (!shopCore) {
+    throw new Error("Shop labor and tax configuration could not be loaded.");
+  }
+  const shop = shopCore
+    ? ({
+        shop_supplies_enabled: null,
+        shop_supplies_type: null,
+        shop_supplies_percent: null,
+        shop_supplies_flat_amount: null,
+        shop_supplies_cap_amount: null,
+        ...shopCore,
+      } as InvoiceSnapshot["shop"])
+    : null;
 
   const { data: customer } = workOrder.customer_id
     ? await supabase
@@ -414,7 +466,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         >()
     : { data: null };
 
-  const { data: linesRaw } = await supabase
+  const { data: linesRaw, error: linesError } = await supabase
     .from("work_order_lines")
     .select("id, line_no, description, complaint, cause, correction, labor_time, price_estimate, intake_json")
     .eq("shop_id", workOrder.shop_id)
@@ -437,9 +489,13 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       >
     >();
 
+  if (linesError) {
+    throw new Error(`Work-order labor lines are unavailable: ${linesError.message}`);
+  }
+
   const lines = Array.isArray(linesRaw) ? linesRaw : [];
 
-  const { data: allocRaw } = await supabase
+  const { data: allocRaw, error: allocationsError } = await supabase
     .from("work_order_part_allocations")
     .select("id, shop_id, work_order_id, work_order_line_id, part_id, qty, unit_cost, source_request_item_id, created_at")
     .eq("shop_id", workOrder.shop_id)
@@ -454,8 +510,12 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       >
     >();
 
+  if (allocationsError) {
+    throw new Error(`Allocated work-order parts are unavailable: ${allocationsError.message}`);
+  }
+
   const allocs = Array.isArray(allocRaw) ? allocRaw : [];
-  const { data: stagedPartsRaw } = await supabase
+  const stagedPartsResult = await supabase
     .from("work_order_parts")
     .select("id, shop_id, work_order_line_id, part_id, quantity, unit_price, total_price, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_consumed, quantity_returned, quantity_cancelled, unit_sell_price_snapshot, lifecycle_status, source_parts_request_item_id, is_active")
     .eq("shop_id", workOrder.shop_id)
@@ -465,6 +525,43 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         Pick<WorkOrderPartRow, "id" | "shop_id" | "work_order_line_id" | "part_id" | "quantity" | "unit_price" | "total_price"> & Record<string, unknown>
       >
     >();
+
+  // The lifecycle/snapshot columns are newer than the original
+  // work_order_parts shape. Fall back to the stable pricing columns so an
+  // older deployed schema still invoices its attached parts instead of
+  // returning an empty parts array.
+  const stagedPartsFallbackResult = stagedPartsResult.error
+    ? await supabase
+        .from("work_order_parts")
+        .select(
+          "id, shop_id, work_order_line_id, part_id, quantity, unit_price, total_price",
+        )
+        .eq("shop_id", workOrder.shop_id)
+        .eq("work_order_id", workOrderId)
+        .returns<
+          Array<
+            Pick<
+              WorkOrderPartRow,
+              | "id"
+              | "shop_id"
+              | "work_order_line_id"
+              | "part_id"
+              | "quantity"
+              | "unit_price"
+              | "total_price"
+            >
+          >
+        >()
+    : null;
+
+  if (stagedPartsFallbackResult?.error) {
+    throw new Error(
+      `Attached work-order parts are unavailable: ${stagedPartsFallbackResult.error.message}`,
+    );
+  }
+
+  const stagedPartsRaw =
+    stagedPartsResult.data ?? stagedPartsFallbackResult?.data ?? [];
   const stagedParts = Array.isArray(stagedPartsRaw) ? stagedPartsRaw : [];
 
   const { data: quoteRaw } = await supabase
@@ -492,12 +589,11 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     }
   }
 
-  const { data: requestItemsRaw } = await supabase
+  const { data: requestItemsRaw, error: requestItemsError } = await supabase
     .from("part_request_items")
     .select("id, request_id, shop_id, work_order_id, work_order_line_id, quote_line_id, description, qty, qty_requested, qty_approved, quoted_price, unit_price, unit_cost, status, approved, part_id, vendor")
     .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
-    .not("work_order_line_id", "is", null)
     .returns<
       Array<
         Pick<
@@ -522,6 +618,10 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         >
       >
     >();
+
+  if (requestItemsError) {
+    throw new Error(`Parts pricing is unavailable: ${requestItemsError.message}`);
+  }
 
   const requestItems = Array.isArray(requestItemsRaw) ? requestItemsRaw : [];
   const requestIdsNeedingQuoteLink = Array.from(
@@ -617,7 +717,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   >();
 
   if (partIds.length > 0) {
-    const { data: partRows } = await supabase
+    const { data: partRows, error: partRowsError } = await supabase
       .from("parts")
       .select("id, name, sku, part_number, unit, price, default_price")
       .eq("shop_id", workOrder.shop_id)
@@ -636,6 +736,10 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
           >
         >
       >();
+
+    if (partRowsError) {
+      throw new Error(`Parts catalog pricing is unavailable: ${partRowsError.message}`);
+    }
 
     for (const p of Array.isArray(partRows) ? partRows : []) {
       if (isNonEmptyString(p.id)) partsMap.set(p.id, p);
@@ -763,21 +867,22 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     const lineAllocations = byLineAlloc.get(line.id) ?? [];
     const lineStaged = stagedPartsByLineForDisplay.get(line.id) ?? [];
     const rawLineStaged = byLineStaged.get(line.id) ?? [];
-    const canonicalPartIds = new Set(
-      rawLineStaged
-        .map((part) => part.part_id)
-        .filter(isNonEmptyString),
-    );
-    const unbackedAllocations = filterAllocationsNotBackedByCanonicalParts(
-      lineAllocations,
-      rawLineStaged as Array<{ source_parts_request_item_id?: string | null }>,
-    ).filter((allocation) => !canonicalPartIds.has(allocation.part_id));
+    const displayedStagedIds = new Set(lineStaged.map((part) => part.id));
+    const unbackedAllocations = filterInvoicePartAllocations({
+      allocations: lineAllocations,
+      stagedParts: rawLineStaged as Array<
+        typeof rawLineStaged[number] & {
+          source_parts_request_item_id?: string | null;
+        }
+      >,
+      displayedStagedPartIds: displayedStagedIds,
+    });
     const unbackedAllocationParts = unbackedAllocations.flatMap((allocation) => {
       const part = allocationPartById.get(String(allocation.id));
       return part ? [part] : [];
     });
 
-    if (rawLineStaged.length > 0) {
+    if (lineStaged.length > 0) {
       parts.push(...lineStaged);
       parts.push(...unbackedAllocationParts);
       continue;
@@ -797,6 +902,14 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   if (unpricedPart) {
     throw new Error(
       `Customer sell price is missing for ${unpricedPart.name || "an attached part"}.`,
+    );
+  }
+  if (
+    parts.length === 0 &&
+    (allocs.length > 0 || stagedInvoiceParts.length > 0 || fallbackRequestItems.length > 0)
+  ) {
+    throw new Error(
+      "Attached parts could not be resolved into invoice line items.",
     );
   }
 
@@ -855,7 +968,22 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     });
   }
 
-  const laborCost = invLabor ?? (resolvedLabor > 0 ? resolvedLabor : woLabor) ?? null;
+  const unresolvedLaborLine = pricedLines.find(
+    (line) => line.resolvedLaborHours > 0 && line.resolvedLaborTotal <= 0,
+  );
+  if (!invoice && unresolvedLaborLine) {
+    throw new Error(
+      `Labor rate is missing for ${unresolvedLaborLine.description || `line ${unresolvedLaborLine.line_no ?? ""}`.trim()}.`,
+    );
+  }
+
+  // Existing line items are authoritative. work_orders.labor_total has legacy
+  // rows where 1.0 represents labor hours, not $1.00, so only use that rollup
+  // when there are no itemized lines to price.
+  const laborCost =
+    invLabor ??
+    (resolvedLabor > 0 ? resolvedLabor : pricedLines.length === 0 ? woLabor : null) ??
+    null;
   const partsCost = invParts ?? (resolvedParts > 0 ? resolvedParts : woParts) ?? null;
 
   const baseSubtotal = (laborCost ?? 0) + (partsCost ?? 0);

--- a/tests/phase3-parts-atomic-routes.test.ts
+++ b/tests/phase3-parts-atomic-routes.test.ts
@@ -43,4 +43,11 @@ describe("phase 3 atomic parts routes", () => {
       "get_invoice_net_issued_parts",
     );
   });
+
+  it("keeps deployed invoice pricing compatible with stable parts columns", () => {
+    const snapshot = source("features/invoices/server/getInvoiceSnapshot.ts");
+    expect(snapshot).toContain("stagedPartsFallbackResult");
+    expect(snapshot).toContain("filterInvoicePartAllocations");
+    expect(snapshot).not.toContain('.not("work_order_line_id", "is", null)');
+  });
 });


### PR DESCRIPTION
## Root cause

The first invoice-integrity repair selected newer optional columns together with core pricing fields. In a deployment where one lifecycle/snapshot column is unavailable, PostgREST rejects the complete select. The code then treated the missing result as an empty row:

- the configured shop labor rate disappeared
- the legacy work-order value `labor_total = 1` was displayed as `$1.00`
- staged parts could disappear
- zero-quantity staged rows suppressed otherwise valid part allocations
- allocation-linked request items without their own work-order-line id were excluded from sell-price resolution

## Fix

- retry shop pricing with the stable labor/tax field set
- retry work-order parts using the stable deployed table shape
- load request items referenced by allocations even when their line id is null
- only deduplicate an allocation when its staged counterpart actually produced a billable invoice part
- never interpret a legacy labor-hours rollup as dollars when itemized lines exist
- show a pricing error instead of a false zero when required pricing data cannot be loaded

## Regression coverage

Adds focused tests proving:

1. an allocation remains billable when its staged row resolves to zero quantity
2. an allocation is deduplicated when the staged row is genuinely billable

The existing invoice fixture continues to require 1.0 hour × $140.00 = $140.00 and $920.40 of parts.

## Validation

- TypeScript syntax checks passed for all three changed files
- `git diff --check` passed
- full repository TypeScript typecheck passed
- Vercel application build passed
- no lint diagnostics were reported in the changed files
- the Phase 3 job remains red only because its repository-wide lint command finds unrelated existing errors
- no database data, migrations, or environment variables changed

## Manual QA

After deployment, refresh Customer Billing and confirm EL000001 shows:

- Labor: $140.00
- Parts: $920.40
- Pre-supplies/pre-tax subtotal: $1,060.40
