### PR TITLE
Align billing card pricing with work order

### DIFF
--- a/features/invoices/lib/invoiceTotals.test.ts
+++ b/features/invoices/lib/invoiceTotals.test.ts
@@ -3,6 +3,23 @@ import { calculateInvoiceTotals } from "./invoiceTotals";
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 
 describe("canonical invoice totals", () => {
+  it("matches the work-order page sources for EL000001", () => {
+    const line = resolveWorkOrderLinePricing({
+      line: { labor_time: 1, price_estimate: null },
+      shopLaborRate: 140,
+      allocatedParts: [
+        { qty: 6, unit_cost: 130 },
+        { qty: 1, unit_cost: 140.4 },
+      ],
+    });
+
+    expect(line.laborHours).toBe(1);
+    expect(line.laborRate).toBe(140);
+    expect(line.laborTotal).toBe(140);
+    expect(line.partsTotal).toBeCloseTo(920.4, 2);
+    expect(line.lineTotal).toBeCloseTo(1060.4, 2);
+  });
+
   it("keeps the EL000001 labor and sell-priced parts fixture consistent", () => {
     const line = resolveWorkOrderLinePricing({
       line: { labor_time: 1, price_estimate: null },

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -336,6 +336,21 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       >
     >();
 
+  // Match the work-order page exactly for labor pricing. That page reads
+  // labor_rate in a dedicated query, so unrelated shop settings cannot turn
+  // one labor hour into one dollar on the billing card.
+  const { data: workOrderShopRate, error: workOrderShopRateError } = await supabase
+    .from("shops")
+    .select("labor_rate")
+    .eq("id", workOrder.shop_id)
+    .maybeSingle<Pick<ShopRow, "labor_rate">>();
+
+  if (workOrderShopRateError) {
+    throw new Error(
+      `Shop labor rate is unavailable: ${workOrderShopRateError.message}`,
+    );
+  }
+
   const shopResult = await supabase
     .from("shops")
     .select(
@@ -415,6 +430,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         shop_supplies_flat_amount: null,
         shop_supplies_cap_amount: null,
         ...shopCore,
+        labor_rate: workOrderShopRate?.labor_rate ?? shopCore.labor_rate,
       } as InvoiceSnapshot["shop"])
     : null;
 
@@ -755,9 +771,11 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       : undefined;
     const qtyRaw = safeNumber(a.qty);
     const qty = qtyRaw > 0 ? qtyRaw : 1;
-    // Allocations store shop cost. Customer billing must use the request/catalog
-    // sell price and must never silently expose unit_cost as the invoice price.
+    // Match FocusedJobModal's allocated-parts calculation exactly. The current
+    // work-order flow stores and displays the allocation price from unit_cost.
+    // Request/catalog values remain fallbacks for records without that value.
     const unitPrice =
+      safeNumber(a.unit_cost) ||
       (requestItem ? itemUnitPrice(requestItem) : 0) ||
       safeNumber(p?.price) ||
       safeNumber(p?.default_price);


### PR DESCRIPTION
## Root cause

The work-order page and Customer Billing still used different reads for the same completed job.

The work-order page calculates:
- labor from `work_order_lines.labor_time × shops.labor_rate`, with `labor_rate` loaded in a dedicated shop query
- parts from active `work_order_parts` plus uncovered `work_order_part_allocations`
- legacy allocation pricing from the allocation's stored `unit_cost`

Customer Billing used the shared resolver but loaded labor through a larger invoice-settings query and prioritized a separate request/catalog price chain for allocations. That allowed the card to disagree with the work-order page.

## Fix

- load `shops.labor_rate` with the same dedicated query used by the work-order ID page
- value uncovered allocations from the same stored allocation field used by FocusedJobModal
- preserve request/catalog pricing only as fallback data
- add an EL000001-shaped regression using the actual work-order sources

## Exact regression

- 1.0 labor hour × $140.00 = $140.00
- 6 × $130.00 + 1 × $140.40 = $920.40
- line subtotal = $1,060.40

## Scope

The unrelated `ai_training_source` enum insertion error is intentionally not changed in this PR.

## Database / environment

No migrations, data changes, or environment-variable changes.
