### PR TITLE
Fix stale invoice totals on billing and review

### DIFF
--- a/features/invoices/lib/invoiceSnapshotState.ts
+++ b/features/invoices/lib/invoiceSnapshotState.ts
@@ -1,0 +1,22 @@
+const FINALIZED_INVOICE_STATUSES = new Set([
+  "issued_pending_send",
+  "issued",
+  "sent",
+  "partially_paid",
+  "paid",
+  "refunded",
+  "void",
+  "voided",
+]);
+
+export function shouldUsePersistedInvoiceTotals(args: {
+  workOrderStatus: unknown;
+  invoiceStatus: unknown;
+}): boolean {
+  const workOrderStatus = String(args.workOrderStatus ?? "").trim().toLowerCase();
+  const invoiceStatus = String(args.invoiceStatus ?? "").trim().toLowerCase();
+  return (
+    workOrderStatus === "invoiced" &&
+    FINALIZED_INVOICE_STATUSES.has(invoiceStatus)
+  );
+}

--- a/features/invoices/lib/invoiceTotals.test.ts
+++ b/features/invoices/lib/invoiceTotals.test.ts
@@ -1,8 +1,36 @@
 import { describe, expect, it } from "vitest";
 import { calculateInvoiceTotals } from "./invoiceTotals";
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+import { shouldUsePersistedInvoiceTotals } from "./invoiceSnapshotState";
 
 describe("canonical invoice totals", () => {
+  it("does not let a stale draft invoice override a ready work order", () => {
+    expect(
+      shouldUsePersistedInvoiceTotals({
+        workOrderStatus: "ready_to_invoice",
+        invoiceStatus: "draft",
+      }),
+    ).toBe(false);
+    expect(
+      shouldUsePersistedInvoiceTotals({
+        workOrderStatus: "invoiced",
+        invoiceStatus: "issued",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUsePersistedInvoiceTotals({
+        workOrderStatus: "ready_to_invoice",
+        invoiceStatus: "issued",
+      }),
+    ).toBe(false);
+    expect(
+      shouldUsePersistedInvoiceTotals({
+        workOrderStatus: "invoiced",
+        invoiceStatus: "draft",
+      }),
+    ).toBe(false);
+  });
+
   it("matches the work-order page sources for EL000001", () => {
     const line = resolveWorkOrderLinePricing({
       line: { labor_time: 1, price_estimate: null },

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -7,6 +7,7 @@ import {
   resolveShopSuppliesSettings,
 } from "@/features/work-orders/lib/shopSupplies";
 import { calculateInvoiceTotals } from "@/features/invoices/lib/invoiceTotals";
+import { shouldUsePersistedInvoiceTotals } from "@/features/invoices/lib/invoiceSnapshotState";
 import { filterInvoicePartAllocations } from "@/features/invoices/lib/filterInvoicePartAllocations";
 
 type DB = Database;
@@ -66,6 +67,7 @@ export type InvoiceSnapshot = {
     | "vehicle_id"
     | "customer_name"
     | "custom_id"
+    | "status"
     | "labor_total"
     | "parts_total"
     | "invoice_total"
@@ -283,7 +285,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const { data: workOrder, error: woErr } = await supabase
     .from("work_orders")
     .select(
-      "id, shop_id, customer_id, vehicle_id, customer_name, custom_id, labor_total, parts_total, invoice_total, shop_supplies_enabled_override, shop_supplies_amount_override, created_at",
+      "id, shop_id, customer_id, vehicle_id, customer_name, custom_id, status, labor_total, parts_total, invoice_total, shop_supplies_enabled_override, shop_supplies_amount_override, created_at",
     )
     .eq("id", workOrderId)
     .maybeSingle<
@@ -295,6 +297,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         | "vehicle_id"
         | "customer_name"
         | "custom_id"
+        | "status"
         | "labor_total"
         | "parts_total"
         | "invoice_total"
@@ -931,16 +934,33 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     );
   }
 
+  const usePersistedInvoiceTotals = shouldUsePersistedInvoiceTotals({
+    workOrderStatus: workOrder.status,
+    invoiceStatus: invoice?.status,
+  });
+
   const currency =
-    normalizeInvoiceCurrency(invoice?.currency) ??
+    (usePersistedInvoiceTotals
+      ? normalizeInvoiceCurrency(invoice?.currency)
+      : null) ??
     normalizeCurrencyFromCountry(shop?.country);
 
-  const invSubtotal = invoice ? safeNumberOrNull(invoice.subtotal) : null;
-  const invLabor = invoice ? safeNumberOrNull(invoice.labor_cost) : null;
-  const invParts = invoice ? safeNumberOrNull(invoice.parts_cost) : null;
-  const invTotal = invoice ? safeNumberOrNull(invoice.total) : null;
-  const invDiscount = safeNumber(invoice?.discount_total);
-  const invTax = safeNumber(invoice?.tax_total);
+  const invSubtotal = usePersistedInvoiceTotals
+    ? safeNumberOrNull(invoice?.subtotal)
+    : null;
+  const invLabor = usePersistedInvoiceTotals
+    ? safeNumberOrNull(invoice?.labor_cost)
+    : null;
+  const invParts = usePersistedInvoiceTotals
+    ? safeNumberOrNull(invoice?.parts_cost)
+    : null;
+  const invTotal = usePersistedInvoiceTotals
+    ? safeNumberOrNull(invoice?.total)
+    : null;
+  const invDiscount = usePersistedInvoiceTotals
+    ? safeNumber(invoice?.discount_total)
+    : 0;
+  const invTax = usePersistedInvoiceTotals ? safeNumber(invoice?.tax_total) : 0;
 
   const woLabor = positiveOrNull(workOrder.labor_total);
   const woParts = positiveOrNull(workOrder.parts_total);
@@ -989,7 +1009,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const unresolvedLaborLine = pricedLines.find(
     (line) => line.resolvedLaborHours > 0 && line.resolvedLaborTotal <= 0,
   );
-  if (!invoice && unresolvedLaborLine) {
+  if (!usePersistedInvoiceTotals && unresolvedLaborLine) {
     throw new Error(
       `Labor rate is missing for ${unresolvedLaborLine.description || `line ${unresolvedLaborLine.line_no ?? ""}`.trim()}.`,
     );
@@ -1011,10 +1031,10 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     override: resolveShopSuppliesOverride(workOrder as Parameters<typeof resolveShopSuppliesOverride>[0]),
   });
   const persistedSupplies =
-    invoice && invSubtotal != null
+    usePersistedInvoiceTotals && invSubtotal != null
       ? Math.max(0, invSubtotal - (laborCost ?? 0) - (partsCost ?? 0))
       : null;
-  const shopSuppliesTotal = invoice
+  const shopSuppliesTotal = usePersistedInvoiceTotals
     ? persistedSupplies && persistedSupplies > 0
       ? persistedSupplies
       : null
@@ -1029,15 +1049,15 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     discountTotal: invDiscount,
     taxRatePercent: configuredTaxRate,
   });
-  const subtotal = invoice
+  const subtotal = usePersistedInvoiceTotals
     ? invSubtotal ?? calculated.subtotal
     : calculated.subtotal > 0
       ? calculated.subtotal
       : null;
-  const taxTotal = invoice ? invTax : calculated.taxTotal;
+  const taxTotal = usePersistedInvoiceTotals ? invTax : calculated.taxTotal;
   const persistedTaxableBase = Math.max((subtotal ?? 0) - invDiscount, 0);
   const taxRate =
-    invoice && persistedTaxableBase > 0
+    usePersistedInvoiceTotals && persistedTaxableBase > 0
       ? (taxTotal / persistedTaxableBase) * 100
       : configuredTaxRate;
   const derivedInvoiceTotal = calculateInvoiceTotals({
@@ -1047,7 +1067,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     discountTotal: invDiscount,
     taxRatePercent: taxRate,
   }).total;
-  const total = invoice
+  const total = usePersistedInvoiceTotals
     ? invTotal ?? derivedInvoiceTotal
     : derivedInvoiceTotal > 0
       ? derivedInvoiceTotal


### PR DESCRIPTION
## Root cause

The canonical invoice snapshot found an existing draft invoice row for EL000001 and treated its persisted `$1.00 / $0.00 / $1.00` rollups as authoritative. That overrode the correctly priced itemized work-order lines (`$140.00` labor and `$920.40` parts) used by the review detail.

## What changed

- Trust persisted invoice totals only after both the work order and invoice are finalized.
- Recalculate completed and ready-to-invoice work from the canonical itemized work-order labor and parts.
- Keep issued invoice snapshots immutable.
- Add regression coverage for draft/finalized lifecycle combinations and the EL000001 pricing fixture.

## Validation

- Runtime regression: ready/draft totals are not treated as persisted; invoiced/issued totals are.
- Numerical regression: `$140.00 + $920.40 = $1,060.40` before configured supplies and tax.
- `git diff --check` passed.

## Notes

The separate parts-handoff blocker remains intact: attached parts must have a net issued inventory record before invoice issuance. This PR fixes the incorrect displayed totals without weakening that accounting control.