### PR TITLE
Build premium draft and issued invoice PDFs

### DIFF
--- a/app/api/invoice-versions/[id]/pdf/route.ts
+++ b/app/api/invoice-versions/[id]/pdf/route.ts
@@ -2,23 +2,16 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
-import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
 import type { Database } from "@shared/types/types/supabase";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
 import { getInvoiceVersionById } from "@/features/invoices/server/invoiceVersionQueries";
+import {
+  premiumInvoiceFilename,
+  renderPremiumInvoicePdf,
+} from "@/features/invoices/server/renderPremiumInvoicePdf";
 
 type DB = Database;
-
-function money(value: number | null | undefined, currency: "CAD" | "USD") {
-  return new Intl.NumberFormat(currency === "CAD" ? "en-CA" : "en-US", {
-    style: "currency",
-    currency,
-  }).format(Number(value ?? 0));
-}
-
-function text(value: unknown) {
-  return typeof value === "string" && value.trim() ? value.trim() : "—";
-}
 
 export async function GET(
   req: Request,
@@ -31,111 +24,87 @@ export async function GET(
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { id } = await context.params;
-  const admin = createClient<DB>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  );
-  const version = await getInvoiceVersionById({ supabase: admin, invoiceVersionId: id });
-  if (!version) return NextResponse.json({ error: "Invoice version not found" }, { status: 404 });
+  if (!id) return NextResponse.json({ error: "Missing invoice version id" }, { status: 400 });
 
-  const [{ data: profile }, { data: workOrder }] = await Promise.all([
-    admin
-      .from("profiles")
-      .select("shop_id")
-      .eq("id", user.id)
-      .maybeSingle<{ shop_id: string | null }>(),
-    admin
-      .from("work_orders")
-      .select("customer_id")
-      .eq("id", version.work_order_id)
-      .eq("shop_id", version.shop_id)
-      .maybeSingle<{ customer_id: string | null }>(),
-  ]);
-
-  let customerAccess = false;
-  if (workOrder?.customer_id) {
-    const { data: customer } = await admin
-      .from("customers")
-      .select("user_id")
-      .eq("id", workOrder.customer_id)
-      .maybeSingle<{ user_id: string | null }>();
-    customerAccess = customer?.user_id === user.id;
-  }
-  if (profile?.shop_id !== version.shop_id && !customerAccess) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const snapshot = version.snapshot;
-  const pdf = await PDFDocument.create();
-  const regular = await pdf.embedFont(StandardFonts.Helvetica);
-  const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
-  let page = pdf.addPage([612, 792]);
-  let y = 748;
-
-  const draw = (value: string, size = 10, isBold = false, x = 48) => {
-    if (y < 60) {
-      page = pdf.addPage([612, 792]);
-      y = 748;
-    }
-    page.drawText(value.slice(0, 95), {
-      x,
-      y,
-      size,
-      font: isBold ? bold : regular,
-      color: rgb(0.08, 0.1, 0.14),
+  try {
+    const admin = createClient<DB>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+    const version = await getInvoiceVersionById({
+      supabase: admin,
+      invoiceVersionId: id,
     });
-    y -= size + 7;
-  };
+    if (!version) {
+      return NextResponse.json({ error: "Invoice version not found" }, { status: 404 });
+    }
 
-  const shopName =
-    snapshot.shop?.business_name || snapshot.shop?.shop_name || snapshot.shop?.name || "ProFixIQ";
-  const customerName =
-    snapshot.customer?.name ||
-    [snapshot.customer?.first_name, snapshot.customer?.last_name].filter(Boolean).join(" ") ||
-    snapshot.workOrder.customer_name ||
-    "Customer";
-  const vehicle = [snapshot.vehicle?.year, snapshot.vehicle?.make, snapshot.vehicle?.model]
-    .filter((value) => value != null && String(value).trim())
-    .join(" ");
+    const [{ data: profile }, { data: workOrder }] = await Promise.all([
+      admin
+        .from("profiles")
+        .select("shop_id")
+        .eq("id", user.id)
+        .maybeSingle<{ shop_id: string | null }>(),
+      admin
+        .from("work_orders")
+        .select("customer_id")
+        .eq("id", version.work_order_id)
+        .eq("shop_id", version.shop_id)
+        .maybeSingle<{ customer_id: string | null }>(),
+    ]);
 
-  draw(shopName, 18, true);
-  draw(`Invoice version ${version.version_number}`, 13, true);
-  draw(`Status: ${version.lifecycle_status.replaceAll("_", " ")}`);
-  draw(`Issued: ${version.issued_at ? new Date(version.issued_at).toLocaleString() : "—"}`);
-  y -= 8;
-  draw(`Customer: ${customerName}`, 11, true);
-  draw(`Vehicle: ${vehicle || "—"}`);
-  draw(`VIN: ${text(snapshot.vehicle?.vin)}`);
-  y -= 10;
-  draw("Work performed", 12, true);
-  for (const line of snapshot.lines) {
-    draw(`${line.line_no ?? ""} ${line.description || line.complaint || "Service line"}`, 10, true);
-    if (line.cause) draw(`Cause: ${line.cause}`, 9, false, 60);
-    if (line.correction) draw(`Correction: ${line.correction}`, 9, false, 60);
+    let customerAccess = false;
+    if (workOrder?.customer_id) {
+      const { data: customer } = await admin
+        .from("customers")
+        .select("user_id")
+        .eq("id", workOrder.customer_id)
+        .maybeSingle<{ user_id: string | null }>();
+      customerAccess = customer?.user_id === user.id;
+    }
+    if (profile?.shop_id !== version.shop_id && !customerAccess) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const { data: invoice } = version.invoice_id
+      ? await admin
+          .from("invoices")
+          .select("invoice_number,notes")
+          .eq("id", version.invoice_id)
+          .eq("shop_id", version.shop_id)
+          .maybeSingle<{ invoice_number: string | null; notes: string | null }>()
+      : { data: null };
+    const brand = await getActiveBrandForRender(version.shop_id);
+    const pdfDocument = {
+      invoiceNumber: invoice?.invoice_number ?? version.snapshot.invoice?.invoice_number,
+      versionNumber: version.version_number,
+      status: version.lifecycle_status,
+      issuedAt: version.issued_at,
+      paidTotal: version.paid_total,
+      refundedTotal: version.refunded_total,
+      outstandingTotal: version.outstanding_total,
+      notes: invoice?.notes ?? version.snapshot.invoice?.notes,
+      draft: false,
+    };
+    const bytes = await renderPremiumInvoicePdf({
+      snapshot: version.snapshot,
+      document: pdfDocument,
+      brand,
+    });
+    const download = new URL(req.url).searchParams.get("download") === "1";
+
+    return new NextResponse(Buffer.from(bytes), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `${download ? "attachment" : "inline"}; filename="${premiumInvoiceFilename(version.snapshot, pdfDocument)}"`,
+        "Cache-Control": "private, no-store",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Invoice PDF generation failed";
+    console.error("[invoice-version-pdf] generation failed", { invoiceVersionId: id, message });
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-  y -= 8;
-  draw("Parts", 12, true);
-  for (const part of snapshot.parts) {
-    draw(`${part.name} × ${part.qty} — ${money(part.totalPrice, version.currency)}`);
-  }
-  y -= 10;
-  draw(`Labor: ${money(snapshot.laborCost, version.currency)}`, 11);
-  draw(`Parts: ${money(snapshot.partsCost, version.currency)}`, 11);
-  draw(`Shop supplies: ${money(snapshot.shopSuppliesTotal, version.currency)}`, 11);
-  draw(`Discount: -${money(snapshot.discountTotal, version.currency)}`, 11);
-  draw(`Tax: ${money(snapshot.taxTotal, version.currency)}`, 11);
-  draw(`Total: ${money(version.total, version.currency)}`, 14, true);
-  draw(`Paid: ${money(Number(version.paid_total) - Number(version.refunded_total), version.currency)}`, 11);
-  draw(`Balance: ${money(version.outstanding_total, version.currency)}`, 12, true);
-
-  const bytes = await pdf.save();
-  const download = new URL(req.url).searchParams.get("download") === "1";
-  return new Response(Buffer.from(bytes), {
-    status: 200,
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": `${download ? "attachment" : "inline"}; filename="invoice-version-${version.version_number}.pdf"`,
-      "Cache-Control": "private, no-store",
-    },
-  });
 }

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -1,859 +1,101 @@
-// app/api/work-orders/[id]/invoice-pdf/route.ts ✅ FULL FILE REPLACEMENT
-
 export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { PDFDocument, rgb, StandardFonts, type PDFImage } from "pdf-lib";
-
-import type { Database } from "@shared/types/types/supabase";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
+import { getActiveInvoiceVersion } from "@/features/invoices/server/financialLifecycle";
 import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
-
-type DB = Database;
-
-type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
-type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
-type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
-type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
-type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
-type InvoiceRow = DB["public"]["Tables"]["invoices"]["Row"];
-type InspectionRow = DB["public"]["Tables"]["inspections"]["Row"];
-
-type PdfRgb = ReturnType<typeof rgb>;
-
-function asString(v: unknown): string {
-  return typeof v === "string" ? v : v == null ? "" : String(v);
-}
-
-function safeMoney(v: unknown): number {
-  const n = typeof v === "number" ? v : Number(v);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function moneyLabel(n: number, currency: "CAD" | "USD"): string {
-  const val = Number.isFinite(n) ? n : 0;
-  return new Intl.NumberFormat(currency === "CAD" ? "en-CA" : "en-US", {
-    style: "currency",
-    currency,
-    maximumFractionDigits: 2,
-  }).format(val);
-}
-
-function wrapText(text: string, maxChars: number): string[] {
-  const t = (text ?? "").trim();
-  if (!t) return ["—"];
-  const words = t.split(/\s+/);
-  const lines: string[] = [];
-  let cur = "";
-
-  for (const w of words) {
-    if (!cur) {
-      cur = w;
-      continue;
-    }
-    if ((cur + " " + w).length <= maxChars) {
-      cur = cur + " " + w;
-    } else {
-      lines.push(cur);
-      cur = w;
-    }
-  }
-  if (cur) lines.push(cur);
-  return lines.length ? lines : ["—"];
-}
-
-function compactCsv(parts: Array<string | undefined>): string {
-  return parts
-    .map((p) => (p ?? "").trim())
-    .filter((p) => p.length > 0)
-    .join(", ");
-}
-
-function joinName(
-  first?: string | null,
-  last?: string | null,
-): string | undefined {
-  const f = (first ?? "").trim();
-  const l = (last ?? "").trim();
-  const s = [f, l].filter(Boolean).join(" ").trim();
-  return s.length ? s : undefined;
-}
-
-function pickCustomerName(
-  c?: Pick<CustomerRow, "name" | "first_name" | "last_name"> | null,
-  fallback?: string | null,
-): string | undefined {
-  const a = (c?.name ?? "").trim();
-  const b = joinName(c?.first_name ?? null, c?.last_name ?? null);
-  const f = (fallback ?? "").trim();
-  const out = a || b || f;
-  return out.length ? out : undefined;
-}
-
-function pickCustomerPhone(
-  c?: Pick<CustomerRow, "phone" | "phone_number"> | null,
-): string | undefined {
-  const p1 = (c?.phone_number ?? "").trim();
-  const p2 = (c?.phone ?? "").trim();
-  const out = p1 || p2;
-  return out.length ? out : undefined;
-}
-
-function pickShopName(
-  s?: Pick<ShopRow, "business_name" | "shop_name" | "name"> | null,
-): string | undefined {
-  const a = (s?.business_name ?? "").trim();
-  const b = (s?.shop_name ?? "").trim();
-  const c = (s?.name ?? "").trim();
-  const out = a || b || c;
-  return out.length ? out : undefined;
-}
-
-type PartDisplayRow = {
-  name: string;
-  partNumber?: string;
-  sku?: string;
-  unit?: string;
-  qty: number;
-  unitPrice: number;
-  totalPrice: number;
-  lineId?: string;
-};
-
-type DrawTextOpts = {
-  size?: number;
-  bold?: boolean;
-  x?: number;
-  color?: PdfRgb;
-};
-
-type PdfCtx = {
-  doc: PDFDocument;
-  page: ReturnType<PDFDocument["addPage"]>;
-  y: number;
-};
+import {
+  premiumInvoiceFilename,
+  renderPremiumInvoicePdf,
+} from "@/features/invoices/server/renderPremiumInvoicePdf";
 
 export async function GET(
   req: NextRequest,
-  ctx: { params: Promise<{ id: string }> },
+  context: { params: Promise<{ id: string }> },
 ) {
   const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { data: auth } = await supabase.auth.getUser();
-  if (!auth?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const params = await ctx.params;
-  const workOrderId = typeof params?.id === "string" ? params.id : "";
+  const { id: workOrderId } = await context.params;
   if (!workOrderId) {
     return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
   }
 
-  const url = new URL(req.url);
-  const forceDownload = url.searchParams.get("download") === "1";
-
-  const { data: wo, error: woErr } = await supabase
-    .from("work_orders")
-    .select("id,shop_id,customer_id,vehicle_id,customer_name,custom_id,created_at")
-    .eq("id", workOrderId)
-    .maybeSingle<
-      Pick<
-        WorkOrderRow,
-        | "id"
-        | "shop_id"
-        | "customer_id"
-        | "vehicle_id"
-        | "customer_name"
-        | "custom_id"
-        | "created_at"
-      >
-    >();
-
-  if (woErr || !wo?.id) {
-    return NextResponse.json({ error: "Work order not found" }, { status: 404 });
-  }
-  const snapshot = await getInvoiceSnapshotForWorkOrder({ supabase, workOrderId });
-
-  const { data: inv, error: invErr } = await supabase
-    .from("invoices")
-    .select("id,invoice_number,currency,subtotal,parts_cost,labor_cost,discount_total,tax_total,total,issued_at,notes,created_at")
-    .eq("work_order_id", workOrderId)
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle<
-      Pick<
-        InvoiceRow,
-        | "id"
-        | "invoice_number"
-        | "currency"
-        | "subtotal"
-        | "parts_cost"
-        | "labor_cost"
-        | "discount_total"
-        | "tax_total"
-        | "total"
-        | "issued_at"
-        | "notes"
-        | "created_at"
-      >
-    >();
-
-  if (invErr) {
-    console.warn("[invoice-pdf] invoices query failed", invErr.message);
-  }
-
-  const { data: shop } = await supabase
-    .from("shops")
-    .select("business_name,shop_name,name,phone_number,email,street,city,province,postal_code,country,labor_rate")
-    .eq("id", wo.shop_id)
-    .maybeSingle<
-      Pick<
-        ShopRow,
-        | "business_name"
-        | "shop_name"
-        | "name"
-        | "phone_number"
-        | "email"
-        | "street"
-        | "city"
-        | "province"
-        | "postal_code"
-        | "country"
-        | "labor_rate"
-      >
-    >();
-
-  const shopName = pickShopName(shop ?? null) ?? "ProFixIQ";
-  const brand = await getActiveBrandForRender(wo.shop_id);
-  const shopAddress = compactCsv([
-    (shop?.street ?? "").trim() || undefined,
-    (shop?.city ?? "").trim() || undefined,
-    (shop?.province ?? "").trim() || undefined,
-    (shop?.postal_code ?? "").trim() || undefined,
-  ]);
-  const shopContact = compactCsv([
-    (shop?.phone_number ?? "").trim() || undefined,
-    (shop?.email ?? "").trim() || undefined,
-  ]);
-
-  // Canonical totals/currency source: shared invoice snapshot to prevent drift.
-  const currency: "CAD" | "USD" = snapshot.currency;
-
-  const laborRate = safeMoney(shop?.labor_rate);
-
-  const { data: insp } = await supabase
-    .from("inspections")
-    .select("id,inspection_type,status,created_at")
-    .eq("work_order_id", workOrderId)
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle<
-      Pick<InspectionRow, "id" | "inspection_type" | "status" | "created_at">
-    >();
-
-  // Customer
-  let customer:
-    | Pick<
-        CustomerRow,
-        | "name"
-        | "first_name"
-        | "last_name"
-        | "phone"
-        | "phone_number"
-        | "email"
-        | "business_name"
-        | "street"
-        | "city"
-        | "province"
-        | "postal_code"
-      >
-    | null = null;
-
-  if (wo.customer_id) {
-    const { data: c } = await supabase
-      .from("customers")
-      .select("name,first_name,last_name,phone,phone_number,email,business_name,street,city,province,postal_code")
-      .eq("id", wo.customer_id)
-      .maybeSingle<
-        Pick<
-          CustomerRow,
-          | "name"
-          | "first_name"
-          | "last_name"
-          | "phone"
-          | "phone_number"
-          | "email"
-          | "business_name"
-          | "street"
-          | "city"
-          | "province"
-          | "postal_code"
-        >
-      >();
-    customer = c ?? null;
-  }
-
-  const customerName =
-    pickCustomerName(customer ?? null, wo.customer_name ?? null) ?? "—";
-  const customerPhone = pickCustomerPhone(customer ?? null) ?? "—";
-  const customerEmail = (customer?.email ?? "").trim() || "—";
-  const customerBusiness = (customer?.business_name ?? "").trim() || "—";
-  const customerAddress =
-    compactCsv([
-      (customer?.street ?? "").trim() || undefined,
-      (customer?.city ?? "").trim() || undefined,
-      (customer?.province ?? "").trim() || undefined,
-      (customer?.postal_code ?? "").trim() || undefined,
-    ]) || "—";
-
-  // Vehicle
-  let vehicle:
-    | Pick<
-        VehicleRow,
-        | "year"
-        | "make"
-        | "model"
-        | "vin"
-        | "license_plate"
-        | "unit_number"
-        | "mileage"
-        | "color"
-        | "engine_hours"
-      >
-    | null = null;
-
-  if (wo.vehicle_id) {
-    const { data: v } = await supabase
-      .from("vehicles")
-      .select("year,make,model,vin,license_plate,unit_number,mileage,color,engine_hours")
-      .eq("id", wo.vehicle_id)
-      .maybeSingle<
-        Pick<
-          VehicleRow,
-          | "year"
-          | "make"
-          | "model"
-          | "vin"
-          | "license_plate"
-          | "unit_number"
-          | "mileage"
-          | "color"
-          | "engine_hours"
-        >
-      >();
-    vehicle = v ?? null;
-  }
-
-  const vehicleLabel =
-    compactCsv([
-      vehicle?.year != null ? String(vehicle.year) : undefined,
-      (vehicle?.make ?? "").trim() || undefined,
-      (vehicle?.model ?? "").trim() || undefined,
-    ]) || "—";
-
-  const vin = (vehicle?.vin ?? "").trim() || "—";
-  const plate = (vehicle?.license_plate ?? "").trim() || "—";
-  const unit = (vehicle?.unit_number ?? "").trim() || "—";
-  const mileage = asString(vehicle?.mileage).trim() || "—";
-  const color = (vehicle?.color ?? "").trim() || "—";
-  const engineHours = asString(vehicle?.engine_hours).trim() || "—";
-
-  // Lines
-  const { data: lines } = await supabase
-    .from("work_order_lines")
-    .select("id,line_no,description,complaint,cause,correction,labor_time,price_estimate")
-    .eq("work_order_id", workOrderId)
-    .order("line_no", { ascending: true });
-
-  const lineRows = (Array.isArray(lines) ? lines : []) as Array<
-    Pick<
-      WorkOrderLineRow,
-      | "id"
-      | "line_no"
-      | "description"
-      | "complaint"
-      | "cause"
-      | "correction"
-      | "labor_time"
-      | "price_estimate"
-    >
-  >;
-
-  // Parts: the shared invoice snapshot applies allocation → staged work_order_parts →
-  // approved quote-line part_request_items priority and exposes the exact visible rows.
-  const allPartRows: PartDisplayRow[] = snapshot.parts.map((part) => ({
-    name: part.name,
-    partNumber: part.partNumber,
-    sku: part.sku,
-    unit: part.unit,
-    qty: part.qty,
-    unitPrice: part.unitPrice,
-    totalPrice: part.totalPrice,
-    lineId: part.lineId,
-  }));
-
-  const partsByLineId = new Map<string, PartDisplayRow[]>();
-  const unassignedParts: PartDisplayRow[] = [];
-
-  for (const p of allPartRows) {
-    if (p.lineId) {
-      const arr = partsByLineId.get(p.lineId) ?? [];
-      arr.push(p);
-      partsByLineId.set(p.lineId, arr);
-    } else {
-      unassignedParts.push(p);
+  try {
+    // The session-scoped client keeps the read inside the caller's shop RLS boundary.
+    const { data: workOrder, error: workOrderError } = await supabase
+      .from("work_orders")
+      .select("id,shop_id")
+      .eq("id", workOrderId)
+      .maybeSingle<{ id: string; shop_id: string }>();
+    if (workOrderError) throw workOrderError;
+    if (!workOrder) {
+      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
     }
-  }
 
-  // ---- Derived totals (fallback only) ----
-  const derivedPartsCost = allPartRows.reduce(
-    (sum, p) => sum + safeMoney(p.totalPrice),
-    0,
-  );
-
-  const derivedLaborHours = lineRows.reduce(
-    (sum, l) => sum + safeMoney(l.labor_time),
-    0,
-  );
-
-  const derivedLaborCost =
-    laborRate > 0 ? Math.max(0, derivedLaborHours * laborRate) : 0;
-
-  const derivedSubtotal = derivedLaborCost + derivedPartsCost;
-
-  const subtotal =
-    snapshot.subtotal != null && Number.isFinite(snapshot.subtotal)
-      ? snapshot.subtotal
-      : derivedSubtotal;
-  const laborCost =
-    snapshot.laborCost != null && Number.isFinite(snapshot.laborCost)
-      ? snapshot.laborCost
-      : derivedLaborCost;
-  const partsCost =
-    snapshot.partsCost != null && Number.isFinite(snapshot.partsCost)
-      ? snapshot.partsCost
-      : derivedPartsCost;
-  const shopSuppliesTotal =
-    snapshot.shopSuppliesTotal != null && Number.isFinite(snapshot.shopSuppliesTotal)
-      ? Math.max(0, snapshot.shopSuppliesTotal)
-      : 0;
-  const discountTotal =
-    snapshot.discountTotal != null && Number.isFinite(snapshot.discountTotal)
-      ? Math.max(0, snapshot.discountTotal)
-      : 0;
-  const taxTotal =
-    snapshot.taxTotal != null && Number.isFinite(snapshot.taxTotal)
-      ? Math.max(0, snapshot.taxTotal)
-      : 0;
-  const grandTotal =
-    snapshot.total != null && Number.isFinite(snapshot.total)
-      ? Math.max(0, snapshot.total)
-      : Math.max(0, subtotal - discountTotal + taxTotal);
-
-  // ---------------- PDF (multi-page) ----------------
-  const pdfDoc = await PDFDocument.create();
-
-  const PAGE_W = 595.28;
-  const PAGE_H = 841.89; // A4
-  const marginX = 42;
-
-  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
-  const bold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
-
-  const hexToRgb01 = (hex: string): PdfRgb => {
-    const raw = String(hex || "").trim().replace("#", "");
-    const base = raw.length >= 6 ? raw.slice(0, 6) : "C97A3D";
-    const r = Number.parseInt(base.slice(0, 2), 16);
-    const g = Number.parseInt(base.slice(2, 4), 16);
-    const b = Number.parseInt(base.slice(4, 6), 16);
-    if ([r, g, b].some((v) => Number.isNaN(v))) return rgb(0.78, 0.48, 0.28);
-    return rgb(r / 255, g / 255, b / 255);
-  };
-
-  const C_TEXT: PdfRgb = rgb(0.08, 0.08, 0.08);
-  const C_MUTED: PdfRgb = rgb(0.35, 0.35, 0.35);
-  const C_LIGHT: PdfRgb = rgb(0.7, 0.7, 0.7);
-  const C_COPPER: PdfRgb = hexToRgb01(brand.colors.primary);
-  const C_HEADER_BG: PdfRgb = hexToRgb01(brand.colors.secondary);
-  const C_WHITE: PdfRgb = rgb(1, 1, 1);
-
-  const lineH = (size: number) => size + 6;
-
-  const titleId = wo.custom_id ? asString(wo.custom_id) : `WO-${wo.id.slice(0, 8)}`;
-  const invoiceNumber = (inv?.invoice_number ?? "").trim();
-
-  const issuedAt =
-    inv?.issued_at != null
-      ? new Date(inv.issued_at).toLocaleString()
-      : inv?.created_at != null
-        ? new Date(inv.created_at).toLocaleString()
-        : wo.created_at
-          ? new Date(wo.created_at).toLocaleString()
-          : new Date().toLocaleString();
-
-  const headerH = 92;
-  const footerH = 34;
-  const rightX = 360;
-
-  let headerLogo: PDFImage | null = null;
-  if (brand.logoUrl) {
-    try {
-      const imgRes = await fetch(brand.logoUrl);
-      if (imgRes.ok) {
-        const bytes = new Uint8Array(await imgRes.arrayBuffer());
-        try {
-          headerLogo = await pdfDoc.embedPng(bytes);
-        } catch {
-          headerLogo = await pdfDoc.embedJpg(bytes);
+    const activeVersion = await getActiveInvoiceVersion({
+      supabase,
+      workOrderId,
+      shopId: workOrder.shop_id,
+    });
+    const snapshot =
+      activeVersion?.snapshot ??
+      (await getInvoiceSnapshotForWorkOrder({ supabase, workOrderId }));
+    const { data: invoice } = activeVersion?.invoice_id
+      ? await supabase
+          .from("invoices")
+          .select("invoice_number,notes")
+          .eq("id", activeVersion.invoice_id)
+          .eq("shop_id", workOrder.shop_id)
+          .maybeSingle<{ invoice_number: string | null; notes: string | null }>()
+      : { data: null };
+    const brand = await getActiveBrandForRender(workOrder.shop_id);
+    const pdfDocument = activeVersion
+      ? {
+          invoiceNumber: invoice?.invoice_number ?? snapshot.invoice?.invoice_number,
+          versionNumber: activeVersion.version_number,
+          status: activeVersion.lifecycle_status,
+          issuedAt: activeVersion.issued_at,
+          paidTotal: activeVersion.paid_total,
+          refundedTotal: activeVersion.refunded_total,
+          outstandingTotal: activeVersion.outstanding_total,
+          notes: invoice?.notes ?? snapshot.invoice?.notes,
+          draft: false,
         }
-      }
-    } catch {
-      headerLogo = null;
-    }
-  }
-
-  const drawHeader = (page: ReturnType<PDFDocument["addPage"]>) => {
-    const headerY = PAGE_H - headerH;
-
-    page.drawRectangle({ x: 0, y: headerY, width: PAGE_W, height: headerH, color: C_HEADER_BG });
-
-    const headerTop = PAGE_H - 26;
-
-    if (headerLogo) {
-      const maxW = 120;
-      const maxH = 36;
-      const scale = Math.min(maxW / headerLogo.width, maxH / headerLogo.height, 1);
-      const w = headerLogo.width * scale;
-      const h = headerLogo.height * scale;
-      page.drawImage(headerLogo, {
-        x: marginX,
-        y: headerTop - 6,
-        width: w,
-        height: h,
-      });
-    } else {
-      page.drawText(shopName, { x: marginX, y: headerTop, size: 16, font: bold, color: C_COPPER });
-    }
-
-    if (shopAddress.trim().length) {
-      page.drawText(shopAddress, { x: marginX, y: headerTop - 20, size: 9.5, font, color: C_LIGHT });
-    }
-
-    if (shopContact.trim().length) {
-      page.drawText(shopContact, { x: marginX, y: headerTop - 34, size: 9.5, font, color: rgb(0.85, 0.85, 0.85) });
-    }
-
-    page.drawText("INVOICE", { x: rightX, y: headerTop, size: 18, font: bold, color: C_WHITE });
-
-    const meta1 = invoiceNumber.length ? `Invoice #: ${invoiceNumber}` : `Work Order: ${titleId}`;
-    page.drawText(meta1, { x: rightX, y: headerTop - 20, size: 10, font, color: rgb(0.88, 0.88, 0.88) });
-
-    page.drawText(`Issued: ${issuedAt}`, { x: rightX, y: headerTop - 34, size: 10, font, color: rgb(0.7, 0.7, 0.7) });
-
-    const divY = headerY - 22;
-    page.drawRectangle({
-      x: marginX - 10,
-      y: divY,
-      width: PAGE_W - (marginX - 10) * 2,
-      height: 2,
-      color: C_COPPER,
+      : {
+          invoiceNumber: null,
+          versionNumber: null,
+          status: "draft",
+          issuedAt: null,
+          paidTotal: 0,
+          refundedTotal: 0,
+          outstandingTotal: snapshot.total,
+          notes: snapshot.invoice?.notes,
+          draft: true,
+        };
+    const bytes = await renderPremiumInvoicePdf({
+      snapshot,
+      document: pdfDocument,
+      brand,
     });
+    const download = new URL(req.url).searchParams.get("download") === "1";
 
-    return divY - 18;
-  };
-
-  const drawFooter = (page: ReturnType<PDFDocument["addPage"]>) => {
-    page.drawRectangle({ x: 0, y: 0, width: PAGE_W, height: footerH, color: C_HEADER_BG });
-
-    page.drawText(`${shopName} • Invoice`, { x: marginX, y: 14, size: 9, font, color: rgb(0.8, 0.8, 0.8) });
-    page.drawText(`Work Order: ${titleId}`, { x: rightX, y: 14, size: 9, font, color: rgb(0.65, 0.65, 0.65) });
-  };
-
-  const newPage = (): PdfCtx => {
-    const page = pdfDoc.addPage([PAGE_W, PAGE_H]);
-    const startY = drawHeader(page);
-    drawFooter(page);
-    return { doc: pdfDoc, page, y: startY };
-  };
-
-  const ensureSpace = (ctx2: PdfCtx, needed: number): PdfCtx => {
-    const bottomLimit = footerH + 26;
-    if (ctx2.y - needed >= bottomLimit) return ctx2;
-    return newPage();
-  };
-
-  const drawText = (ctx2: PdfCtx, text: string, opts?: DrawTextOpts): PdfCtx => {
-    const size = opts?.size ?? 11;
-    const x = opts?.x ?? marginX;
-    const f = opts?.bold ? bold : font;
-    const color = opts?.color ?? C_TEXT;
-
-    ctx2.page.drawText(text, { x, y: ctx2.y, size, font: f, color });
-    return { ...ctx2, y: ctx2.y - lineH(size) };
-  };
-
-  const drawRule = (ctx2: PdfCtx): PdfCtx => {
-    const y = ctx2.y - 4;
-    ctx2.page.drawRectangle({
-      x: marginX,
-      y,
-      width: PAGE_W - marginX * 2,
-      height: 1,
-      color: rgb(0.92, 0.92, 0.92),
+    return new NextResponse(Buffer.from(bytes), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `${download ? "attachment" : "inline"}; filename="${premiumInvoiceFilename(snapshot, pdfDocument)}"`,
+        "Cache-Control": "private, no-store",
+        "X-Content-Type-Options": "nosniff",
+      },
     });
-    return { ...ctx2, y: y - 12 };
-  };
-
-  let ctxPdf = newPage();
-
-  // Customer
-  ctxPdf = ensureSpace(ctxPdf, 180);
-  ctxPdf = drawText(ctxPdf, "Customer", { bold: true, size: 12, color: C_COPPER });
-  ctxPdf = drawText(ctxPdf, customerName, { size: 11 });
-  ctxPdf = drawText(ctxPdf, `Business: ${customerBusiness}`, { size: 10, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Phone: ${customerPhone}`, { size: 10, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Email: ${customerEmail}`, { size: 10, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Address: ${customerAddress}`, { size: 10, color: C_MUTED });
-
-  ctxPdf = drawText(ctxPdf, "", { size: 6 });
-
-  // Vehicle
-  ctxPdf = ensureSpace(ctxPdf, 150);
-  ctxPdf = drawText(ctxPdf, "Vehicle", { bold: true, size: 12, color: C_COPPER });
-  ctxPdf = drawText(ctxPdf, vehicleLabel, { size: 11 });
-  ctxPdf = drawText(ctxPdf, `VIN: ${vin}`, { size: 10, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Plate: ${plate}`, { size: 10, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Unit #: ${unit}`, { size: 10, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Mileage: ${mileage}`, { size: 10, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Color: ${color}`, { size: 10, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Engine Hours: ${engineHours}`, { size: 10, color: C_MUTED });
-
-  ctxPdf = drawText(ctxPdf, "", { size: 8 });
-
-  // Line Items
-  ctxPdf = ensureSpace(ctxPdf, 60);
-  ctxPdf = drawText(ctxPdf, "Line Items", { bold: true, size: 12, color: C_COPPER });
-
-  if (!lineRows.length) {
-    ctxPdf = drawText(ctxPdf, "— No line items recorded yet —", { size: 10, color: C_MUTED });
-  } else {
-    const sorted = [...lineRows].sort((a, b) => {
-      const an = typeof a.line_no === "number" ? a.line_no : Number(a.line_no);
-      const bn = typeof b.line_no === "number" ? b.line_no : Number(b.line_no);
-      const asn = Number.isFinite(an) ? an : 0;
-      const bsn = Number.isFinite(bn) ? bn : 0;
-      return asn - bsn;
-    });
-
-    for (const row of sorted) {
-      const complaint = asString(row.complaint || row.description || "—");
-      const cause = asString(row.cause || "");
-      const correction = asString(row.correction || "");
-
-      const laborHours = safeMoney(row.labor_time);
-      const laborDollars = Math.max(0, laborHours * laborRate);
-
-      const complaintLines = wrapText(complaint, 78);
-      const causeLines = cause.trim() ? wrapText(cause, 78) : [];
-      const correctionLines = correction.trim() ? wrapText(correction, 78) : [];
-
-      const lineParts = row.id ? partsByLineId.get(row.id) ?? [] : [];
-      const linePartsDollars = lineParts.reduce((sum, p) => sum + safeMoney(p.totalPrice), 0);
-      const lineTotal = laborDollars + linePartsDollars;
-
-      const approx =
-        26 +
-        (complaintLines.length + causeLines.length + correctionLines.length) * 16 +
-        (laborHours > 0 ? 32 : 0) +
-        (lineParts.length ? 24 + Math.min(lineParts.length, 8) * 16 : 0) +
-        (lineTotal > 0 ? 16 : 0);
-
-      ctxPdf = ensureSpace(ctxPdf, Math.max(110, approx));
-
-      const label =
-        row.line_no != null && asString(row.line_no).trim().length
-          ? `#${asString(row.line_no).trim()}`
-          : "•";
-
-      ctxPdf = drawText(ctxPdf, label, { bold: true, size: 10, color: C_COPPER });
-
-      ctxPdf = drawText(ctxPdf, `Complaint: ${complaintLines[0]}`, { size: 10 });
-      for (const extra of complaintLines.slice(1)) {
-        ctxPdf = drawText(ctxPdf, `          ${extra}`, { size: 10, color: C_MUTED });
-      }
-
-      for (const c of causeLines) ctxPdf = drawText(ctxPdf, `Cause: ${c}`, { size: 10, color: C_MUTED });
-      for (const c of correctionLines) ctxPdf = drawText(ctxPdf, `Correction: ${c}`, { size: 10, color: C_MUTED });
-
-      if (laborHours > 0 && laborRate > 0) {
-        ctxPdf = drawText(
-          ctxPdf,
-          `Labor: ${moneyLabel(laborDollars, currency)} (${laborHours} hr × ${moneyLabel(laborRate, currency)}/hr)`,
-          { size: 10, color: C_MUTED },
-        );
-      } else if (laborHours > 0) {
-        ctxPdf = drawText(ctxPdf, `Labor time: ${laborHours} hr`, { size: 10, color: C_MUTED });
-      }
-
-      if (lineTotal > 0) {
-        ctxPdf = drawText(ctxPdf, `Line total: ${moneyLabel(lineTotal, currency)}`, { size: 10, color: C_MUTED });
-      }
-
-      if (lineParts.length) {
-        ctxPdf = drawText(ctxPdf, "Parts for this line:", { size: 10, bold: true, color: C_MUTED });
-
-        for (const p of lineParts.slice(0, 8)) {
-          const meta = compactCsv([p.partNumber, p.sku, p.unit]);
-          const name = meta.length ? `${p.name} (${meta})` : p.name;
-
-          const qty = Number.isFinite(p.qty) ? p.qty : 0;
-          const total = moneyLabel(p.totalPrice, currency);
-          const bullet = `• ${qty} × ${name} — ${total}`;
-
-          const pieces = wrapText(bullet, 88);
-          ctxPdf = drawText(ctxPdf, pieces[0], { size: 10, color: C_MUTED });
-          for (const extra of pieces.slice(1)) {
-            ctxPdf = drawText(ctxPdf, `  ${extra}`, { size: 10, color: C_MUTED });
-          }
-        }
-
-        if (lineParts.length > 8) {
-          ctxPdf = drawText(ctxPdf, `…and ${lineParts.length - 8} more`, { size: 10, color: C_MUTED });
-        }
-      }
-
-      ctxPdf = drawRule(ctxPdf);
-    }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Invoice PDF generation failed";
+    console.error("[invoice-pdf] generation failed", { workOrderId, message });
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  // Overall Parts section
-  ctxPdf = ensureSpace(ctxPdf, 70);
-  ctxPdf = drawText(ctxPdf, "Parts", { bold: true, size: 12, color: C_COPPER });
-
-  if (!allPartRows.length) {
-    ctxPdf = drawText(ctxPdf, "— No parts on this work order —", { size: 10, color: C_MUTED });
-  } else {
-    ctxPdf = ensureSpace(ctxPdf, 40);
-    ctxPdf = drawText(ctxPdf, "Qty   Part                                Unit     Total", { size: 10, bold: true });
-
-    ctxPdf.page.drawRectangle({
-      x: marginX,
-      y: ctxPdf.y + 4,
-      width: PAGE_W - marginX * 2,
-      height: 1,
-      color: rgb(0.9, 0.9, 0.9),
-    });
-
-    const maxRows = 60;
-    const rows = allPartRows.slice(0, maxRows);
-
-    for (const p of rows) {
-      const meta = compactCsv([p.partNumber, p.sku, p.unit]);
-      const name = meta.length ? `${p.name} (${meta})` : p.name;
-      const nameLines = wrapText(name, 52);
-      const needed = 22 + nameLines.length * 16;
-
-      ctxPdf = ensureSpace(ctxPdf, needed);
-
-      const qty = Number.isFinite(p.qty) ? p.qty : 0;
-
-      ctxPdf.page.drawText(String(qty), { x: marginX, y: ctxPdf.y, size: 10, font, color: C_TEXT });
-      ctxPdf.page.drawText(nameLines[0], { x: marginX + 36, y: ctxPdf.y, size: 10, font, color: C_TEXT });
-      ctxPdf.page.drawText(moneyLabel(p.unitPrice, currency), { x: 420, y: ctxPdf.y, size: 10, font, color: C_MUTED });
-      ctxPdf.page.drawText(moneyLabel(p.totalPrice, currency), { x: 500, y: ctxPdf.y, size: 10, font, color: C_TEXT });
-
-      ctxPdf = { ...ctxPdf, y: ctxPdf.y - lineH(10) };
-
-      for (const extra of nameLines.slice(1)) {
-        ctxPdf.page.drawText(extra, { x: marginX + 36, y: ctxPdf.y, size: 10, font, color: C_MUTED });
-        ctxPdf = { ...ctxPdf, y: ctxPdf.y - lineH(10) };
-      }
-
-      ctxPdf = { ...ctxPdf, y: ctxPdf.y - 2 };
-    }
-
-    if (allPartRows.length > maxRows) {
-      ctxPdf = ensureSpace(ctxPdf, 20);
-      ctxPdf = drawText(ctxPdf, `…and ${allPartRows.length - maxRows} more parts`, { size: 10, color: C_MUTED });
-    }
-
-    if (unassignedParts.length && partsByLineId.size > 0) {
-      ctxPdf = ensureSpace(ctxPdf, 24);
-      ctxPdf = drawText(
-        ctxPdf,
-        `Note: ${unassignedParts.length} part(s) were not linked to a specific line item.`,
-        { size: 10,
-          color: C_MUTED,
-        },
-      );
-    }
-  }
-
-  // Inspection summary
-  ctxPdf = ensureSpace(ctxPdf, 90);
-  ctxPdf = drawText(ctxPdf, "Inspection", { bold: true, size: 12, color: C_COPPER });
-
-  if (!insp?.id) {
-    ctxPdf = drawText(ctxPdf, "— No inspection linked to this work order —", {
-      size: 10,
-      color: C_MUTED,
-    });
-  } else {
-    const inspType = asString(insp.inspection_type).trim() || "Inspection";
-    const inspStatus = asString(insp.status).trim() || "—";
-    const inspDate =
-      insp.created_at ? new Date(insp.created_at).toLocaleString() : "—";
-
-    ctxPdf = drawText(ctxPdf, `Type: ${inspType}`, { size: 10, color: C_MUTED });
-    ctxPdf = drawText(ctxPdf, `Status: ${inspStatus}`, { size: 10, color: C_MUTED });
-    ctxPdf = drawText(ctxPdf, `Recorded: ${inspDate}`, { size: 10, color: C_MUTED });
-    ctxPdf = drawText(ctxPdf, `Inspection ID: ${insp.id}`, { size: 9.5, color: C_LIGHT });
-  }
-
-  ctxPdf = drawText(ctxPdf, "", { size: 8 });
-
-  // Totals
-  ctxPdf = ensureSpace(ctxPdf, 150);
-  ctxPdf = drawText(ctxPdf, "Totals", { bold: true, size: 12, color: C_COPPER });
-
-  ctxPdf = drawText(ctxPdf, `Subtotal: ${moneyLabel(subtotal, currency)}`, { size: 11 });
-  ctxPdf = drawText(ctxPdf, `Labor: ${moneyLabel(laborCost, currency)}`, { size: 11, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Parts: ${moneyLabel(partsCost, currency)}`, { size: 11, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Shop supplies: ${moneyLabel(shopSuppliesTotal, currency)}`, { size: 11, color: C_MUTED });
-
-  if (discountTotal > 0) {
-    ctxPdf = drawText(ctxPdf, `Discount: -${moneyLabel(discountTotal, currency)}`, { size: 11, color: C_MUTED });
-  }
-
-  ctxPdf = drawText(ctxPdf, `Tax: ${moneyLabel(taxTotal, currency)}`, { size: 11, color: C_MUTED });
-  ctxPdf = drawText(ctxPdf, `Total: ${moneyLabel(grandTotal, currency)}`, { size: 13, bold: true });
-
-  // Notes
-  const notes = asString(inv?.notes).trim();
-  if (notes.length) {
-    ctxPdf = ensureSpace(ctxPdf, 70);
-    ctxPdf = drawText(ctxPdf, "Notes", { bold: true, size: 12, color: C_COPPER });
-
-    for (const ln of wrapText(notes, 92).slice(0, 12)) {
-      ctxPdf = ensureSpace(ctxPdf, 18);
-      ctxPdf = drawText(ctxPdf, ln, { size: 10, color: C_MUTED });
-    }
-  }
-
-  const pdfBytes = await pdfDoc.save();
-
-  const disposition = forceDownload
-    ? `attachment; filename="Invoice_${titleId}.pdf"`
-    : `inline; filename="Invoice_${titleId}.pdf"`;
-
-  return new NextResponse(Buffer.from(pdfBytes), {
-    status: 200,
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": disposition,
-      "Cache-Control": "no-store",
-    },
-  });
 }

--- a/features/invoices/server/renderPremiumInvoicePdf.test.ts
+++ b/features/invoices/server/renderPremiumInvoicePdf.test.ts
@@ -1,0 +1,176 @@
+import { PDFDocument } from "pdf-lib";
+import { writeFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import type { ActiveBrandRender } from "@/features/branding/server/getActiveBrandForRender";
+import type { InvoiceSnapshot } from "@/features/invoices/server/getInvoiceSnapshot";
+import {
+  premiumInvoiceFilename,
+  renderPremiumInvoicePdf,
+} from "./renderPremiumInvoicePdf";
+
+const brand: ActiveBrandRender = {
+  profile: null,
+  logoUrl: null,
+  colors: {
+    primary: "#C86A32",
+    secondary: "#101827",
+    accent: "#F0A45D",
+  },
+  theme: null,
+};
+
+function fixture(partCount = 2): InvoiceSnapshot {
+  const parts = Array.from({ length: partCount }, (_, index) => ({
+    id: `part-${index}`,
+    lineId: "line-1",
+    name: `Premium filter component ${index + 1}`,
+    qty: index === 0 ? 6 : 1,
+    unitPrice: index === 0 ? 132.86 : 123.24,
+    totalPrice: index === 0 ? 797.16 : 123.24,
+    partNumber: `PF-${String(index + 1).padStart(4, "0")}`,
+    source: "work_order_part" as const,
+  }));
+  const partsTotal = parts.reduce((total, part) => total + part.totalPrice, 0);
+
+  return {
+    workOrder: {
+      id: "4fc3336d-3d17-4eaa-bd20-dadd3b9a95c6",
+      shop_id: "shop-1",
+      customer_id: "customer-1",
+      vehicle_id: "vehicle-1",
+      customer_name: "Gabriel Anderson",
+      custom_id: "EL000001",
+      status: "ready_to_invoice",
+      labor_total: 140,
+      parts_total: partsTotal,
+      invoice_total: 140 + partsTotal,
+      shop_supplies_enabled_override: null,
+      shop_supplies_amount_override: null,
+      created_at: "2026-07-19T18:00:00.000Z",
+    },
+    invoice: null,
+    shop: {
+      business_name: "ProFixIQ Service Centre",
+      shop_name: null,
+      name: null,
+      country: "CA",
+      phone_number: "555-0100",
+      email: "service@example.com",
+      street: "100 Service Road",
+      city: "Calgary",
+      province: "AB",
+      postal_code: "T2P 1J9",
+      labor_rate: 140,
+      supplies_percent: null,
+      shop_supplies_enabled: false,
+      shop_supplies_type: null,
+      shop_supplies_percent: null,
+      shop_supplies_flat_amount: null,
+      shop_supplies_cap_amount: null,
+      tax_rate: 0,
+    },
+    customer: {
+      name: "Gabriel Anderson",
+      first_name: null,
+      last_name: null,
+      phone: null,
+      phone_number: "555-0110",
+      email: "gabriel@example.com",
+      business_name: null,
+      street: "200 Customer Avenue",
+      city: "Calgary",
+      province: "AB",
+      postal_code: "T2P 2K2",
+    },
+    vehicle: {
+      year: 2022,
+      make: "GMC",
+      model: "Savana",
+      vin: "1GTW7AFP0N1234567",
+      license_plate: "41-DZ-48",
+      unit_number: null,
+      mileage: "78250",
+      color: "White",
+      engine_hours: null,
+    },
+    lines: [
+      {
+        id: "line-1",
+        line_no: 1,
+        description: "Oil and filter change",
+        complaint: "Customer requested scheduled oil and filter maintenance.",
+        cause: "Engine oil reached its scheduled service interval.",
+        correction: "Replaced engine oil and filter and verified fluid level.",
+        labor_time: 1,
+        price_estimate: null,
+        intake_json: null,
+        resolvedLaborHours: 1,
+        resolvedLaborRate: 140,
+        resolvedLaborTotal: 140,
+        resolvedPartsTotal: partsTotal,
+        resolvedLineTotal: 140 + partsTotal,
+      },
+    ],
+    parts,
+    currency: "CAD",
+    laborCost: 140,
+    partsCost: partsTotal,
+    shopSuppliesTotal: 0,
+    subtotal: 140 + partsTotal,
+    discountTotal: 0,
+    taxTotal: 0,
+    taxRate: 0,
+    total: 140 + partsTotal,
+  };
+}
+
+describe("premium invoice PDF", () => {
+  it("renders a valid watermarked draft using canonical line pricing", async () => {
+    const snapshot = fixture();
+    const bytes = await renderPremiumInvoicePdf({
+      snapshot,
+      brand,
+      document: {
+        status: "draft",
+        draft: true,
+        outstandingTotal: snapshot.total,
+      },
+    });
+    const pdf = await PDFDocument.load(bytes);
+    if (process.env.INVOICE_PDF_FIXTURE_PATH) {
+      await writeFile(process.env.INVOICE_PDF_FIXTURE_PATH, bytes);
+    }
+
+    expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe("%PDF-");
+    expect(pdf.getPageCount()).toBeGreaterThanOrEqual(1);
+    expect(pdf.getTitle()).toContain("Draft invoice");
+    expect(premiumInvoiceFilename(snapshot, { status: "draft", draft: true })).toBe(
+      "Draft_Invoice_EL000001.pdf",
+    );
+  });
+
+  it("paginates every part instead of truncating the invoice", async () => {
+    const snapshot = fixture(55);
+    const bytes = await renderPremiumInvoicePdf({
+      snapshot,
+      brand,
+      document: {
+        invoiceNumber: "INV-1001",
+        versionNumber: 1,
+        status: "issued",
+        issuedAt: "2026-07-20T16:00:00.000Z",
+        paidTotal: 0,
+        refundedTotal: 0,
+        outstandingTotal: snapshot.total,
+        draft: false,
+      },
+    });
+    const pdf = await PDFDocument.load(bytes);
+    if (process.env.INVOICE_PDF_LONG_FIXTURE_PATH) {
+      await writeFile(process.env.INVOICE_PDF_LONG_FIXTURE_PATH, bytes);
+    }
+
+    expect(pdf.getPageCount()).toBeGreaterThan(1);
+    expect(pdf.getTitle()).toContain("INV-1001");
+  });
+});

--- a/features/invoices/server/renderPremiumInvoicePdf.ts
+++ b/features/invoices/server/renderPremiumInvoicePdf.ts
@@ -1,0 +1,523 @@
+import {
+  PDFDocument,
+  StandardFonts,
+  degrees,
+  rgb,
+  type PDFFont,
+  type PDFImage,
+  type PDFPage,
+  type RGB,
+} from "pdf-lib";
+import type { InvoiceSnapshot } from "@/features/invoices/server/getInvoiceSnapshot";
+import type { ActiveBrandRender } from "@/features/branding/server/getActiveBrandForRender";
+
+export type InvoicePdfDocument = {
+  invoiceNumber?: string | null;
+  versionNumber?: number | null;
+  status: string;
+  issuedAt?: string | null;
+  paidTotal?: number | null;
+  refundedTotal?: number | null;
+  outstandingTotal?: number | null;
+  notes?: string | null;
+  draft: boolean;
+};
+
+type RenderInput = {
+  snapshot: InvoiceSnapshot;
+  document: InvoicePdfDocument;
+  brand: ActiveBrandRender;
+};
+
+const PAGE_W = 612;
+const PAGE_H = 792;
+const MARGIN = 40;
+const CONTENT_W = PAGE_W - MARGIN * 2;
+const BOTTOM = 48;
+
+function finite(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function clean(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("\u2013", "-")
+    .replaceAll("\u2014", "-")
+    .replaceAll("\u2212", "-")
+    .replaceAll("\u00d7", "x")
+    .replaceAll("\u2022", "-")
+    .replaceAll("\u2026", "...")
+    .replaceAll("\u00a0", " ")
+    .replace(/[^\x20-\x7E\xA0-\xFF]/g, "?")
+    .trim();
+}
+
+function display(value: unknown, fallback = "-"): string {
+  return clean(value) || fallback;
+}
+
+function joined(values: unknown[], separator = ", "): string {
+  return values.map((value) => clean(value)).filter(Boolean).join(separator);
+}
+
+function customerName(snapshot: InvoiceSnapshot): string {
+  return (
+    clean(snapshot.customer?.name) ||
+    joined([snapshot.customer?.first_name, snapshot.customer?.last_name], " ") ||
+    clean(snapshot.workOrder.customer_name) ||
+    "Customer"
+  );
+}
+
+function shopName(snapshot: InvoiceSnapshot): string {
+  return (
+    clean(snapshot.shop?.business_name) ||
+    clean(snapshot.shop?.shop_name) ||
+    clean(snapshot.shop?.name) ||
+    "ProFixIQ"
+  );
+}
+
+function money(value: unknown, currency: "CAD" | "USD"): string {
+  return new Intl.NumberFormat(currency === "CAD" ? "en-CA" : "en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+    .format(finite(value))
+    .replaceAll("\u00a0", " ");
+}
+
+function dateLabel(value: string | null | undefined): string {
+  if (!value) return "Not issued";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not issued";
+  return new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+function hexColor(value: string | null | undefined, fallback: RGB): RGB {
+  const match = /^#?([0-9a-f]{6})$/i.exec(String(value ?? "").trim());
+  if (!match) return fallback;
+  const raw = match[1];
+  return rgb(
+    Number.parseInt(raw.slice(0, 2), 16) / 255,
+    Number.parseInt(raw.slice(2, 4), 16) / 255,
+    Number.parseInt(raw.slice(4, 6), 16) / 255,
+  );
+}
+
+function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): string[] {
+  const paragraphs = clean(text).split(/\n+/);
+  const lines: string[] = [];
+  for (const paragraph of paragraphs) {
+    const words = paragraph.split(/\s+/).filter(Boolean);
+    if (!words.length) continue;
+    let current = "";
+    for (const word of words) {
+      const candidate = current ? `${current} ${word}` : word;
+      if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+        current = candidate;
+        continue;
+      }
+      if (current) lines.push(current);
+      if (font.widthOfTextAtSize(word, size) <= maxWidth) {
+        current = word;
+        continue;
+      }
+      let fragment = "";
+      for (const character of word) {
+        const next = fragment + character;
+        if (font.widthOfTextAtSize(next, size) > maxWidth && fragment) {
+          lines.push(fragment);
+          fragment = character;
+        } else {
+          fragment = next;
+        }
+      }
+      current = fragment;
+    }
+    if (current) lines.push(current);
+  }
+  return lines.length ? lines : ["-"];
+}
+
+async function loadLogo(doc: PDFDocument, logoUrl: string | null): Promise<PDFImage | null> {
+  if (!logoUrl) return null;
+  try {
+    const response = await fetch(logoUrl);
+    if (!response.ok) return null;
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    try {
+      return await doc.embedPng(bytes);
+    } catch {
+      return await doc.embedJpg(bytes);
+    }
+  } catch {
+    return null;
+  }
+}
+
+function normalizedStatus(document: InvoicePdfDocument): string {
+  if (document.draft) return "DRAFT";
+  return clean(document.status).replaceAll("_", " ").toUpperCase() || "ISSUED";
+}
+
+function safeFileIdentifier(snapshot: InvoiceSnapshot, document: InvoicePdfDocument): string {
+  const raw = clean(document.invoiceNumber) || clean(snapshot.workOrder.custom_id) || snapshot.workOrder.id;
+  return raw.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "invoice";
+}
+
+export function premiumInvoiceFilename(
+  snapshot: InvoiceSnapshot,
+  document: InvoicePdfDocument,
+): string {
+  const prefix = document.draft ? "Draft_Invoice" : "Invoice";
+  return `${prefix}_${safeFileIdentifier(snapshot, document)}.pdf`;
+}
+
+export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8Array> {
+  const { snapshot, document, brand } = input;
+  const doc = await PDFDocument.create();
+  const regular = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+  const logo = await loadLogo(doc, brand.logoUrl);
+
+  const navy = hexColor(brand.colors.secondary, rgb(0.055, 0.09, 0.16));
+  const copper = hexColor(brand.colors.primary, rgb(0.79, 0.42, 0.2));
+  const accent = hexColor(brand.colors.accent, rgb(0.9, 0.62, 0.35));
+  const ink = rgb(0.08, 0.1, 0.14);
+  const muted = rgb(0.38, 0.42, 0.48);
+  const border = rgb(0.86, 0.88, 0.91);
+  const panel = rgb(0.965, 0.97, 0.98);
+  const white = rgb(1, 1, 1);
+  const currency = snapshot.currency;
+  const workOrderLabel = clean(snapshot.workOrder.custom_id) || `WO-${snapshot.workOrder.id.slice(0, 8)}`;
+  const invoiceLabel = clean(document.invoiceNumber) || (document.draft ? "Draft preview" : workOrderLabel);
+  const status = normalizedStatus(document);
+  let page = doc.addPage([PAGE_W, PAGE_H]);
+  const pages: PDFPage[] = [page];
+  let pageInitialized = false;
+  let y = 0;
+
+  const drawRight = (
+    value: string,
+    xRight: number,
+    atY: number,
+    size: number,
+    font: PDFFont = regular,
+    color: RGB = ink,
+  ) => {
+    const text = clean(value);
+    page.drawText(text, {
+      x: xRight - font.widthOfTextAtSize(text, size),
+      y: atY,
+      size,
+      font,
+      color,
+    });
+  };
+
+  const addPage = () => {
+    if (pageInitialized) {
+      page = doc.addPage([PAGE_W, PAGE_H]);
+      pages.push(page);
+    }
+    pageInitialized = true;
+    page.drawRectangle({ x: 0, y: PAGE_H - 112, width: PAGE_W, height: 112, color: navy });
+    page.drawRectangle({ x: 0, y: PAGE_H - 116, width: PAGE_W, height: 4, color: copper });
+
+    if (logo) {
+      const scale = Math.min(132 / logo.width, 42 / logo.height, 1);
+      page.drawImage(logo, {
+        x: MARGIN,
+        y: PAGE_H - 67,
+        width: logo.width * scale,
+        height: logo.height * scale,
+      });
+    } else {
+      page.drawText(shopName(snapshot), { x: MARGIN, y: PAGE_H - 53, size: 18, font: bold, color: white });
+    }
+
+    const shopLine = joined([
+      snapshot.shop?.phone_number,
+      snapshot.shop?.email,
+    ], "  |  ");
+    if (shopLine) page.drawText(shopLine, { x: MARGIN, y: PAGE_H - 87, size: 8.5, font: regular, color: rgb(0.8, 0.84, 0.89) });
+
+    drawRight("INVOICE", PAGE_W - MARGIN, PAGE_H - 48, 22, bold, white);
+    drawRight(invoiceLabel, PAGE_W - MARGIN, PAGE_H - 67, 10, regular, rgb(0.85, 0.88, 0.92));
+    drawRight(status, PAGE_W - MARGIN, PAGE_H - 86, 9, bold, accent);
+
+    if (document.draft) {
+      page.drawText("DRAFT", {
+        x: 135,
+        y: 330,
+        size: 82,
+        font: bold,
+        color: copper,
+        rotate: degrees(32),
+        opacity: 0.07,
+      });
+    }
+    y = PAGE_H - 140;
+  };
+
+  const ensure = (height: number): boolean => {
+    if (y - height >= BOTTOM) return false;
+    addPage();
+    return true;
+  };
+
+  const textLines = (
+    value: string,
+    x: number,
+    width: number,
+    size = 9,
+    color: RGB = ink,
+    font: PDFFont = regular,
+    gap = 4,
+  ) => {
+    const lines = wrapText(value, font, size, width);
+    for (const line of lines) {
+      ensure(size + gap);
+      page.drawText(line, { x, y, size, font, color });
+      y -= size + gap;
+    }
+  };
+
+  const sectionTitle = (value: string) => {
+    ensure(28);
+    page.drawText(clean(value).toUpperCase(), { x: MARGIN, y, size: 9, font: bold, color: copper });
+    y -= 9;
+    page.drawRectangle({ x: MARGIN, y: y - 4, width: CONTENT_W, height: 1, color: border });
+    y -= 18;
+  };
+
+  addPage();
+
+  const customerAddress = joined([
+    snapshot.customer?.street,
+    snapshot.customer?.city,
+    snapshot.customer?.province,
+    snapshot.customer?.postal_code,
+  ]);
+  const shopAddress = joined([
+    snapshot.shop?.street,
+    snapshot.shop?.city,
+    snapshot.shop?.province,
+    snapshot.shop?.postal_code,
+  ]);
+  const vehicleLabel = joined([
+    snapshot.vehicle?.year,
+    snapshot.vehicle?.make,
+    snapshot.vehicle?.model,
+  ], " ");
+  const cardTop = y;
+  const cardH = 120;
+  const gap = 14;
+  const cardW = (CONTENT_W - gap) / 2;
+  page.drawRectangle({ x: MARGIN, y: cardTop - cardH, width: cardW, height: cardH, color: panel, borderColor: border, borderWidth: 0.8 });
+  page.drawRectangle({ x: MARGIN + cardW + gap, y: cardTop - cardH, width: cardW, height: cardH, color: panel, borderColor: border, borderWidth: 0.8 });
+
+  page.drawText("BILL TO", { x: MARGIN + 14, y: cardTop - 20, size: 8, font: bold, color: copper });
+  page.drawText(customerName(snapshot), { x: MARGIN + 14, y: cardTop - 39, size: 11, font: bold, color: ink });
+  const customerDetails = [
+    clean(snapshot.customer?.business_name),
+    customerAddress,
+    joined([snapshot.customer?.phone_number || snapshot.customer?.phone, snapshot.customer?.email], "  |  "),
+  ].filter(Boolean);
+  let cardY = cardTop - 56;
+  for (const detail of customerDetails.slice(0, 3)) {
+    for (const line of wrapText(detail, regular, 8.5, cardW - 28).slice(0, 2)) {
+      page.drawText(line, { x: MARGIN + 14, y: cardY, size: 8.5, font: regular, color: muted });
+      cardY -= 12;
+    }
+  }
+
+  const rightCardX = MARGIN + cardW + gap + 14;
+  page.drawText("VEHICLE / ASSET", { x: rightCardX, y: cardTop - 20, size: 8, font: bold, color: copper });
+  page.drawText(vehicleLabel || "No vehicle recorded", { x: rightCardX, y: cardTop - 39, size: 11, font: bold, color: ink });
+  const vehicleDetails = [
+    `VIN: ${display(snapshot.vehicle?.vin)}`,
+    joined([snapshot.vehicle?.license_plate ? `Plate: ${snapshot.vehicle.license_plate}` : "", snapshot.vehicle?.unit_number ? `Unit: ${snapshot.vehicle.unit_number}` : ""], "  |  "),
+    joined([snapshot.vehicle?.mileage != null ? `Mileage: ${snapshot.vehicle.mileage}` : "", snapshot.vehicle?.engine_hours != null ? `Hours: ${snapshot.vehicle.engine_hours}` : ""], "  |  "),
+  ].filter(Boolean);
+  cardY = cardTop - 58;
+  for (const detail of vehicleDetails) {
+    page.drawText(clean(detail), { x: rightCardX, y: cardY, size: 8.5, font: regular, color: muted });
+    cardY -= 14;
+  }
+
+  y = cardTop - cardH - 22;
+  page.drawText(`Work order: ${workOrderLabel}`, { x: MARGIN, y, size: 9, font: bold, color: ink });
+  drawRight(`Issued: ${dateLabel(document.issuedAt)}`, PAGE_W - MARGIN, y, 9, regular, muted);
+  y -= 26;
+
+  sectionTitle("Services and parts");
+  const drawTableHeader = () => {
+    page.drawRectangle({ x: MARGIN, y: y - 18, width: CONTENT_W, height: 22, color: navy });
+    page.drawText("DESCRIPTION", { x: MARGIN + 10, y: y - 11, size: 8, font: bold, color: white });
+    drawRight("AMOUNT", PAGE_W - MARGIN - 10, y - 11, 8, bold, white);
+    y -= 30;
+  };
+  drawTableHeader();
+
+  const assignedPartIds = new Set<string>();
+  snapshot.lines.forEach((line, index) => {
+    if (ensure(86)) drawTableHeader();
+    const description = clean(line.description) || clean(line.complaint) || `Service ${line.line_no ?? index + 1}`;
+    const descriptionLines = wrapText(description, bold, 10, 390);
+    page.drawText(descriptionLines[0], { x: MARGIN + 10, y, size: 10, font: bold, color: ink });
+    drawRight(money(line.resolvedLineTotal, currency), PAGE_W - MARGIN - 10, y, 10, bold, ink);
+    y -= 15;
+    for (const extra of descriptionLines.slice(1)) {
+      page.drawText(extra, { x: MARGIN + 10, y, size: 9, font: regular, color: ink });
+      y -= 13;
+    }
+
+    const narratives = [
+      ["Complaint", line.complaint],
+      ["Cause", line.cause],
+      ["Correction", line.correction],
+    ] as const;
+    for (const [label, value] of narratives) {
+      const cleaned = clean(value);
+      if (!cleaned || cleaned === description) continue;
+      const narrativeLines = wrapText(`${label}: ${cleaned}`, regular, 8.5, 470);
+      for (const narrative of narrativeLines) {
+        ensure(13);
+        page.drawText(narrative, { x: MARGIN + 18, y, size: 8.5, font: regular, color: muted });
+        y -= 12;
+      }
+    }
+
+    if (line.resolvedLaborHours > 0 || line.resolvedLaborTotal > 0) {
+      ensure(16);
+      const laborLabel = `${finite(line.resolvedLaborHours)} hr labor @ ${money(line.resolvedLaborRate, currency)}/hr`;
+      page.drawText(laborLabel, { x: MARGIN + 18, y, size: 8.5, font: regular, color: muted });
+      drawRight(money(line.resolvedLaborTotal, currency), PAGE_W - MARGIN - 10, y, 8.5, regular, muted);
+      y -= 15;
+    }
+
+    const lineParts = snapshot.parts.filter((part) => part.lineId === line.id);
+    for (const part of lineParts) {
+      assignedPartIds.add(part.id);
+      if (ensure(20)) drawTableHeader();
+      const identity = joined([part.name, part.partNumber || part.sku], " - ") || "Part";
+      const label = `${finite(part.qty)} x ${identity} @ ${money(part.unitPrice, currency)}`;
+      const rows = wrapText(label, regular, 8.5, 420);
+      page.drawText(rows[0], { x: MARGIN + 18, y, size: 8.5, font: regular, color: muted });
+      drawRight(money(part.totalPrice, currency), PAGE_W - MARGIN - 10, y, 8.5, regular, muted);
+      y -= 13;
+      for (const extra of rows.slice(1)) {
+        page.drawText(extra, { x: MARGIN + 18, y, size: 8.5, font: regular, color: muted });
+        y -= 12;
+      }
+    }
+    page.drawRectangle({ x: MARGIN, y: y - 2, width: CONTENT_W, height: 0.8, color: border });
+    y -= 15;
+  });
+
+  if (snapshot.lines.length === 0 && snapshot.parts.length === 0) {
+    page.drawText("No billable service lines are recorded.", {
+      x: MARGIN + 10,
+      y,
+      size: 9,
+      font: regular,
+      color: muted,
+    });
+    y -= 24;
+  }
+
+  const unassignedParts = snapshot.parts.filter((part) => !assignedPartIds.has(part.id));
+  for (const part of unassignedParts) {
+    if (ensure(24)) drawTableHeader();
+    const identity = joined([part.name, part.partNumber || part.sku], " - ") || "Part";
+    const label = `${finite(part.qty)} x ${identity} @ ${money(part.unitPrice, currency)}`;
+    page.drawText(label, { x: MARGIN + 10, y, size: 8.5, font: regular, color: muted });
+    drawRight(money(part.totalPrice, currency), PAGE_W - MARGIN - 10, y, 8.5, regular, muted);
+    y -= 16;
+  }
+
+  const totalsW = 238;
+  const totalsX = PAGE_W - MARGIN - totalsW;
+  const totalsRows: Array<[string, number, boolean?]> = [
+    ["Labor", finite(snapshot.laborCost)],
+    ["Parts", finite(snapshot.partsCost)],
+    ["Shop supplies", finite(snapshot.shopSuppliesTotal)],
+    ["Subtotal", finite(snapshot.subtotal), true],
+  ];
+  if (finite(snapshot.discountTotal) > 0) totalsRows.push(["Discount", -finite(snapshot.discountTotal)]);
+  totalsRows.push([`Tax${finite(snapshot.taxRate) > 0 ? ` (${finite(snapshot.taxRate)}%)` : ""}`, finite(snapshot.taxTotal)]);
+  const totalsH = 62 + totalsRows.length * 19 + (document.draft ? 0 : 40);
+  ensure(totalsH + 16);
+  page.drawRectangle({ x: totalsX, y: y - totalsH, width: totalsW, height: totalsH, color: panel, borderColor: border, borderWidth: 0.8 });
+  let totalsY = y - 22;
+  for (const [label, amount, emphasized] of totalsRows) {
+    page.drawText(label, { x: totalsX + 14, y: totalsY, size: 9, font: emphasized ? bold : regular, color: emphasized ? ink : muted });
+    drawRight(money(amount, currency), totalsX + totalsW - 14, totalsY, 9, emphasized ? bold : regular, emphasized ? ink : muted);
+    totalsY -= 19;
+  }
+  page.drawRectangle({ x: totalsX + 14, y: totalsY + 7, width: totalsW - 28, height: 1, color: copper });
+  page.drawText(document.draft ? "ESTIMATED TOTAL" : "INVOICE TOTAL", { x: totalsX + 14, y: totalsY - 11, size: 10, font: bold, color: ink });
+  drawRight(money(snapshot.total, currency), totalsX + totalsW - 14, totalsY - 11, 14, bold, copper);
+  totalsY -= 34;
+
+  if (!document.draft) {
+    const paid = Math.max(0, finite(document.paidTotal) - finite(document.refundedTotal));
+    const balance = Math.max(0, finite(document.outstandingTotal));
+    page.drawText("Paid", { x: totalsX + 14, y: totalsY, size: 9, font: regular, color: muted });
+    drawRight(money(paid, currency), totalsX + totalsW - 14, totalsY, 9, regular, muted);
+    totalsY -= 18;
+    page.drawText("Balance due", { x: totalsX + 14, y: totalsY, size: 10, font: bold, color: ink });
+    drawRight(money(balance, currency), totalsX + totalsW - 14, totalsY, 10, bold, ink);
+  }
+  y -= totalsH + 22;
+
+  const notes = clean(document.notes || snapshot.invoice?.notes);
+  if (notes) {
+    sectionTitle("Notes");
+    textLines(notes, MARGIN, CONTENT_W, 9, muted, regular, 5);
+    y -= 8;
+  }
+
+  ensure(64);
+  page.drawRectangle({ x: MARGIN, y: y - 48, width: CONTENT_W, height: 48, color: navy });
+  page.drawText(document.draft ? "Draft preview - not an issued invoice" : "Thank you for your business", {
+    x: MARGIN + 14,
+    y: y - 21,
+    size: 10,
+    font: bold,
+    color: white,
+  });
+  const addressOrContact = shopAddress || joined([snapshot.shop?.phone_number, snapshot.shop?.email], " | ");
+  if (addressOrContact) {
+    page.drawText(addressOrContact, { x: MARGIN + 14, y: y - 36, size: 8, font: regular, color: rgb(0.8, 0.84, 0.89) });
+  }
+
+  pages.forEach((pdfPage, index) => {
+    pdfPage.drawRectangle({ x: 0, y: 0, width: PAGE_W, height: 34, color: navy });
+    pdfPage.drawText(`${shopName(snapshot)}  |  ${workOrderLabel}`, { x: MARGIN, y: 13, size: 7.5, font: regular, color: rgb(0.78, 0.82, 0.87) });
+    const pageLabel = `Page ${index + 1} of ${pages.length}`;
+    pdfPage.drawText(pageLabel, {
+      x: PAGE_W - MARGIN - regular.widthOfTextAtSize(pageLabel, 7.5),
+      y: 13,
+      size: 7.5,
+      font: regular,
+      color: rgb(0.78, 0.82, 0.87),
+    });
+  });
+
+  doc.setTitle(`${document.draft ? "Draft invoice" : "Invoice"} ${invoiceLabel}`);
+  doc.setAuthor(shopName(snapshot));
+  doc.setSubject(`Work order ${workOrderLabel}`);
+  doc.setCreator("ProFixIQ");
+  return doc.save();
+}

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -1268,9 +1268,11 @@ export default function InvoicePreviewPageClient({
               </div>
             </div>
 
-            <div className={reviewOk || activeInvoiceVersion ? "" : "opacity-60 pointer-events-none"}>
+            <div>
               <WorkOrderInvoiceDownloadButton
                 workOrderId={workOrderId}
+                invoiceVersionId={activeInvoiceVersion?.id}
+                draft={!activeInvoiceVersion}
                 lines={effectiveLines}
                 summary={effectiveSummary}
                 vehicleInfo={effectiveVehicleInfo}
@@ -1281,8 +1283,8 @@ export default function InvoicePreviewPageClient({
           </div>
 
           {!reviewOk && !activeInvoiceVersion ? (
-            <div className="mt-3 text-[0.75rem] text-amber-200">
-              PDF download is shown, but invoice is still blocked until required info is complete.
+            <div className="mt-3 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
+              Draft preview is available for review. Sending remains blocked until required information is complete.
             </div>
           ) : null}
         </div>

--- a/features/work-orders/components/WorkOrderInvoiceDownloadButton.tsx
+++ b/features/work-orders/components/WorkOrderInvoiceDownloadButton.tsx
@@ -1,11 +1,13 @@
 // features/work-orders/components/WorkOrderInvoiceDownloadButton.tsx
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { RepairLine } from "@ai/lib/parseRepairOutput";
 
 type Props = {
   workOrderId: string;
+  invoiceVersionId?: string | null;
+  draft?: boolean;
 
   // kept for signature parity (server route generates PDF from DB)
   lines?: RepairLine[];
@@ -26,6 +28,8 @@ type Props = {
 
 export function WorkOrderInvoiceDownloadButton({
   workOrderId,
+  invoiceVersionId,
+  draft = false,
   autoTrigger = false,
   className,
   mode = "pdf",
@@ -33,54 +37,122 @@ export function WorkOrderInvoiceDownloadButton({
   forceDownload = false,
 }: Props): JSX.Element {
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const autoTriggered = useRef(false);
 
   const urlToOpen = useMemo(() => {
     if (mode === "preview") return `/work-orders/${workOrderId}/invoice`;
 
-    const base = `/api/work-orders/${workOrderId}/invoice-pdf`;
+    const base = invoiceVersionId
+      ? `/api/invoice-versions/${invoiceVersionId}/pdf`
+      : `/api/work-orders/${workOrderId}/invoice-pdf`;
     return forceDownload ? `${base}?download=1` : base;
-  }, [mode, workOrderId, forceDownload]);
+  }, [mode, workOrderId, invoiceVersionId, forceDownload]);
 
   const open = useCallback(async (): Promise<void> => {
     if (busy) return;
     if (!workOrderId) return;
 
     setBusy(true);
-    try {
+    setError(null);
+    if (mode === "preview") {
       if (openInNewTab) {
-        window.open(urlToOpen, "_blank", "noopener,noreferrer");
+        const preview = window.open(urlToOpen, "_blank");
+        if (preview) preview.opener = null;
+      } else {
+        window.location.assign(urlToOpen);
+      }
+      setBusy(false);
+      return;
+    }
+    const popup = openInNewTab && !forceDownload
+      ? window.open("about:blank", "_blank")
+      : null;
+    if (popup) {
+      popup.opener = null;
+      popup.document.title = "Preparing invoice PDF";
+      popup.document.body.textContent = "Preparing invoice PDF...";
+    }
+    try {
+      const response = await fetch(urlToOpen, {
+        method: "GET",
+        credentials: "same-origin",
+        headers: { Accept: "application/pdf" },
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error || `Invoice PDF could not be generated (${response.status}).`);
+      }
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.toLowerCase().includes("application/pdf")) {
+        throw new Error("The invoice service returned an unexpected response.");
+      }
+
+      const blobUrl = URL.createObjectURL(await response.blob());
+      window.setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
+
+      if (forceDownload) {
+        const disposition = response.headers.get("content-disposition") ?? "";
+        const filename = /filename="?([^";]+)"?/i.exec(disposition)?.[1] ?? "invoice.pdf";
+        const link = document.createElement("a");
+        link.href = blobUrl;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
         return;
       }
-      window.location.href = urlToOpen;
+      if (popup) {
+        popup.location.replace(blobUrl);
+      } else {
+        window.location.assign(blobUrl);
+      }
+    } catch (caught: unknown) {
+      popup?.close();
+      setError(caught instanceof Error ? caught.message : "Invoice PDF could not be opened.");
     } finally {
       setBusy(false);
     }
-  }, [busy, workOrderId, openInNewTab, urlToOpen]);
+  }, [busy, workOrderId, mode, openInNewTab, forceDownload, urlToOpen]);
 
   useEffect(() => {
-    if (!autoTrigger) return;
+    if (!autoTrigger) {
+      autoTriggered.current = false;
+      return;
+    }
     if (!workOrderId) return;
+    if (autoTriggered.current) return;
+    autoTriggered.current = true;
     queueMicrotask(() => void open());
   }, [autoTrigger, workOrderId, open]);
 
   const label =
     mode === "preview"
       ? "Open invoice preview"
+      : draft
+        ? "Preview draft PDF"
       : openInNewTab
         ? "Open invoice PDF"
         : "View invoice PDF";
 
   return (
-    <button
-      type="button"
-      onClick={() => void open()}
-      disabled={!workOrderId || busy}
-      className={
-        className ??
-        "rounded-full bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-on-accent)] hover:brightness-110 disabled:opacity-60"
-      }
-    >
-      {busy ? "Opening…" : label}
-    </button>
+    <div className="flex flex-col items-end gap-1.5">
+      <button
+        type="button"
+        onClick={() => void open()}
+        disabled={!workOrderId || busy}
+        className={
+          className ??
+          "rounded-full bg-[linear-gradient(to_right,var(--accent-copper-soft),var(--accent-copper))] px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-on-accent)] hover:brightness-110 disabled:opacity-60"
+        }
+      >
+        {busy ? "Preparing PDF…" : label}
+      </button>
+      {error ? (
+        <span role="alert" className="max-w-sm text-right text-xs text-red-300">
+          {error}
+        </span>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
## Root cause

The invoice review page rendered an active-looking PDF button inside a `pointer-events-none` wrapper whenever review was blocked. The app also maintained two drifting PDF renderers: the work-order route rebuilt pricing from live rows, while the issued-version route used an immutable snapshot but a basic layout.

## What changed

- Draft PDF previews remain available while invoice sending is blocked and are visibly watermarked.
- Issued PDFs render from the immutable invoice-version snapshot, including paid and balance amounts.
- Both routes delegate to one branded premium renderer.
- Labor, parts, supplies, tax, discounts, and totals come from canonical snapshot values.
- Added customer/vehicle cards, itemized service rows, full parts pagination, repeated headers, page numbers, status treatment, and safe filenames.
- Replaced blind `window.open()` with authenticated PDF fetch, Safari-safe tab opening, loading state, content validation, and visible errors.
- Removed the previous 8-part/60-part truncation behavior.

## Validation

- Focused ESLint passed on all six changed files.
- 7 focused Vitest tests passed.
- Rendered and visually inspected the EL000001 fixture at `$140.00 + $920.40 = $1,060.40`.
- Rendered and inspected a 55-part, three-page issued invoice with repeated headers, page numbering, payment state, and no clipped or dropped rows.
- `git diff --check` passed.
- Repository-wide TypeScript still reports only pre-existing unresolved imports / missing `pdfkit` declarations outside these files; no changed-file TypeScript errors remain.

## Database / environment

No database migration or environment-variable change.