### PR TITLE
Freeze invoice branding and add curated templates

### DIFF
--- a/app/api/branding/active/route.ts
+++ b/app/api/branding/active/route.ts
@@ -44,7 +44,17 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: prefErr.message }, { status: 500 });
   }
 
-  const logo = (assets ?? []).find((asset) => asset.kind === "logo") ?? null;
+  let logo = (assets ?? []).find((asset) => asset.kind === "logo") ?? null;
+  if (profile?.logo_asset_id && logo?.id !== profile.logo_asset_id) {
+    const { data: selectedLogo } = await auth.supabase
+      .from("shop_brand_assets")
+      .select("*")
+      .eq("id", profile.logo_asset_id)
+      .eq("shop_id", auth.shopId)
+      .eq("kind", "logo")
+      .maybeSingle();
+    logo = selectedLogo ?? logo;
+  }
 
   return NextResponse.json({
     ok: true,

--- a/app/api/branding/assets/upload/route.ts
+++ b/app/api/branding/assets/upload/route.ts
@@ -4,7 +4,11 @@ import {
   requireBrandShopWriteAccess,
   safeFilePart,
 } from "@/features/branding/server/brand";
-import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import {
+  OWNER_PIN_PURPOSES,
+  requireOwnerPinVerified,
+} from "@/features/shared/lib/server/owner-pin";
+import { readRasterImageDimensions } from "@/features/branding/server/imageDimensions";
 
 type DB = Database;
 type BrandAssetKind = DB["public"]["Enums"]["brand_asset_kind"];
@@ -30,7 +34,10 @@ export async function POST(req: Request) {
   const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
     shopId: auth.shopId,
     userId: auth.userId,
-    allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+    allowedPurposes: [
+      OWNER_PIN_PURPOSES.BRANDING,
+      OWNER_PIN_PURPOSES.PRIVILEGED,
+    ],
   });
   if (!pinCheck.ok) {
     return pinCheck.response;
@@ -48,13 +55,17 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "File is required" }, { status: 400 });
   }
 
-  const ext =
-    file.name.includes(".") ? file.name.split(".").pop()?.toLowerCase() ?? "bin" : "bin";
+  const ext = file.name.includes(".")
+    ? (file.name.split(".").pop()?.toLowerCase() ?? "bin")
+    : "bin";
 
-  const filePart = safeFilePart(file.name.replace(/\.[^.]+$/, "") || `${kind}_${Date.now()}`);
+  const filePart = safeFilePart(
+    file.name.replace(/\.[^.]+$/, "") || `${kind}_${Date.now()}`,
+  );
   const path = `shops/${safeFilePart(auth.shopId)}/branding/${kind}/${Date.now()}_${filePart}.${ext}`;
 
   const bytes = Buffer.from(await file.arrayBuffer());
+  const dimensions = readRasterImageDimensions(bytes);
 
   const { error: uploadErr } = await auth.supabase.storage
     .from("branding")
@@ -67,7 +78,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: uploadErr.message }, { status: 500 });
   }
 
-  const { data: publicData } = auth.supabase.storage.from("branding").getPublicUrl(path);
+  const { data: publicData } = auth.supabase.storage
+    .from("branding")
+    .getPublicUrl(path);
 
   const insert: DB["public"]["Tables"]["shop_brand_assets"]["Insert"] = {
     shop_id: auth.shopId,
@@ -79,9 +92,13 @@ export async function POST(req: Request) {
     mime_type: file.type || null,
     file_name: file.name,
     file_size_bytes: file.size,
+    width: dimensions?.width ?? null,
+    height: dimensions?.height ?? null,
     is_active: isActive,
     created_by: auth.userId,
-    metadata: {},
+    metadata: dimensions
+      ? { aspect_ratio: dimensions.width / dimensions.height }
+      : {},
   };
 
   const { data: asset, error: insertErr } = await auth.supabase

--- a/app/api/branding/generate/route.ts
+++ b/app/api/branding/generate/route.ts
@@ -1,8 +1,17 @@
 import { NextResponse } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
-import { requireBrandShopWriteAccess, safeFilePart } from "@/features/branding/server/brand";
-import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
-import { buildLogoPrompt, getOpenAIClient } from "@/features/branding/server/logo-generation";
+import {
+  requireBrandShopWriteAccess,
+  safeFilePart,
+} from "@/features/branding/server/brand";
+import {
+  OWNER_PIN_PURPOSES,
+  requireOwnerPinVerified,
+} from "@/features/shared/lib/server/owner-pin";
+import {
+  buildLogoPrompt,
+  getOpenAIClient,
+} from "@/features/branding/server/logo-generation";
 import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
 import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
 import {
@@ -39,7 +48,10 @@ export async function POST(req: Request) {
   const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
     shopId: auth.shopId,
     userId: auth.userId,
-    allowedPurposes: [OWNER_PIN_PURPOSES.BRANDING, OWNER_PIN_PURPOSES.PRIVILEGED],
+    allowedPurposes: [
+      OWNER_PIN_PURPOSES.BRANDING,
+      OWNER_PIN_PURPOSES.PRIVILEGED,
+    ],
   });
   if (!pinCheck.ok) {
     return pinCheck.response;
@@ -60,8 +72,11 @@ export async function POST(req: Request) {
 
     if (baseAsset) {
       const meta = (baseAsset.metadata ?? {}) as Record<string, unknown>;
-      userPrompt = userPrompt || String(baseAsset.generation_prompt ?? "").trim();
-      stylePreset = stylePreset ?? (typeof meta.style_preset === "string" ? meta.style_preset : null);
+      userPrompt =
+        userPrompt || String(baseAsset.generation_prompt ?? "").trim();
+      stylePreset =
+        stylePreset ??
+        (typeof meta.style_preset === "string" ? meta.style_preset : null);
       transparentBackground =
         body.transparentBackground ?? Boolean(meta.transparent_background);
     }
@@ -81,7 +96,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Shop not found" }, { status: 404 });
   }
 
-  const shopName = String(shop.shop_name ?? shop.name ?? "ProFixIQ Shop").trim();
+  const shopName = String(
+    shop.shop_name ?? shop.name ?? "ProFixIQ Shop",
+  ).trim();
   const finalPrompt = buildLogoPrompt({
     shopName,
     prompt: userPrompt,
@@ -97,7 +114,10 @@ export async function POST(req: Request) {
     });
     if (!enforcement.allowed) {
       return NextResponse.json(
-        { error: "AI branding generation temporarily limited", code: enforcement.code },
+        {
+          error: "AI branding generation temporarily limited",
+          code: enforcement.code,
+        },
         { status: 429 },
       );
     }
@@ -117,16 +137,24 @@ export async function POST(req: Request) {
         user: auth.userId,
       }),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("AI request timed out")), policy.timeoutMs),
+        setTimeout(
+          () => reject(new Error("AI request timed out")),
+          policy.timeoutMs,
+        ),
       ),
     ]);
 
     const images = result.data ?? [];
     if (!images.length) {
-      return NextResponse.json({ error: "No logo images were returned" }, { status: 502 });
+      return NextResponse.json(
+        { error: "No logo images were returned" },
+        { status: 502 },
+      );
     }
 
-    const createdAssets: Array<DB["public"]["Tables"]["shop_brand_assets"]["Row"]> = [];
+    const createdAssets: Array<
+      DB["public"]["Tables"]["shop_brand_assets"]["Row"]
+    > = [];
 
     for (let i = 0; i < images.length; i += 1) {
       const item = images[i];
@@ -166,6 +194,8 @@ export async function POST(req: Request) {
           mime_type: "image/png",
           file_name: filename,
           file_size_bytes: bytes.length,
+          width: 1024,
+          height: 1024,
           is_active: false,
           created_by: auth.userId,
           metadata: {
@@ -175,6 +205,8 @@ export async function POST(req: Request) {
             model: "gpt-image-1.5",
             final_prompt: finalPrompt,
             based_on_asset_id: body.basedOnAssetId ?? null,
+            normalized_safe_area_percent: 8,
+            recommended_logo_zoom: 1.25,
           },
         })
         .select("*")
@@ -197,12 +229,19 @@ export async function POST(req: Request) {
       user_id: auth.userId,
       model,
       latency_ms: Date.now() - startedAt,
-      prompt_tokens: (result.usage as { input_tokens?: number } | undefined)?.input_tokens ?? null,
-      completion_tokens: (result.usage as { output_tokens?: number } | undefined)?.output_tokens ?? null,
-      total_tokens: (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+      prompt_tokens:
+        (result.usage as { input_tokens?: number } | undefined)?.input_tokens ??
+        null,
+      completion_tokens:
+        (result.usage as { output_tokens?: number } | undefined)
+          ?.output_tokens ?? null,
+      total_tokens:
+        (result.usage as { total_tokens?: number } | undefined)?.total_tokens ??
+        null,
       estimated_cost_usd: estimateAICostUsd(
         "branding_generate_logo",
-        (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+        (result.usage as { total_tokens?: number } | undefined)?.total_tokens ??
+          null,
       ),
       status: "success",
       error_code: null,
@@ -213,10 +252,13 @@ export async function POST(req: Request) {
       endpoint: "/api/branding/generate",
       shopId: auth.shopId,
       model,
-      totalTokens: (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+      totalTokens:
+        (result.usage as { total_tokens?: number } | undefined)?.total_tokens ??
+        null,
       estimatedCostUsd: estimateAICostUsd(
         "branding_generate_logo",
-        (result.usage as { total_tokens?: number } | undefined)?.total_tokens ?? null,
+        (result.usage as { total_tokens?: number } | undefined)?.total_tokens ??
+          null,
       ),
       status: "success",
       errorCode: null,
@@ -228,7 +270,8 @@ export async function POST(req: Request) {
       usage: result.usage ?? null,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Logo generation failed";
+    const message =
+      error instanceof Error ? error.message : "Logo generation failed";
     recordAITelemetry({
       feature: "branding_generate_logo",
       endpoint: "/api/branding/generate",

--- a/app/api/branding/invoice-design/route.ts
+++ b/app/api/branding/invoice-design/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import type { Json } from "@shared/types/types/supabase";
+import {
+  requireBrandShopReadAccess,
+  requireBrandShopWriteAccess,
+} from "@/features/branding/server/brand";
+import {
+  OWNER_PIN_PURPOSES,
+  requireOwnerPinVerified,
+} from "@/features/shared/lib/server/owner-pin";
+import {
+  INVOICE_PALETTES,
+  INVOICE_TEMPLATES,
+  normalizeInvoiceDocumentSettings,
+} from "@/features/invoices/lib/invoiceDocumentTheme";
+
+type Payload = {
+  shopId?: string;
+  settings?: unknown;
+};
+
+function metadataObject(
+  value: Json | null | undefined,
+): Record<string, Json | undefined> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, Json | undefined>)
+    : {};
+}
+
+export async function GET(req: Request) {
+  const requestedShopId = new URL(req.url).searchParams.get("shopId");
+  const auth = await requireBrandShopReadAccess(requestedShopId);
+  if (!auth.ok)
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const { data, error } = await auth.supabase
+    .from("shop_brand_profiles")
+    .select("metadata")
+    .eq("shop_id", auth.shopId)
+    .maybeSingle<{ metadata: Json | null }>();
+  if (error)
+    return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const metadata = metadataObject(data?.metadata);
+  return NextResponse.json({
+    ok: true,
+    settings: normalizeInvoiceDocumentSettings(metadata.invoice_document),
+    templates: INVOICE_TEMPLATES,
+    palettes: INVOICE_PALETTES,
+  });
+}
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => ({}))) as Payload;
+  const auth = await requireBrandShopWriteAccess(body.shopId);
+  if (!auth.ok)
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const pinCheck = await requireOwnerPinVerified(req, auth.supabase as never, {
+    shopId: auth.shopId,
+    userId: auth.userId,
+    allowedPurposes: [
+      OWNER_PIN_PURPOSES.SETTINGS,
+      OWNER_PIN_PURPOSES.BRANDING,
+      OWNER_PIN_PURPOSES.PRIVILEGED,
+    ],
+  });
+  if (!pinCheck.ok) return pinCheck.response;
+
+  const settings = normalizeInvoiceDocumentSettings(body.settings);
+  const { data: current, error: readError } = await auth.supabase
+    .from("shop_brand_profiles")
+    .select("metadata")
+    .eq("shop_id", auth.shopId)
+    .maybeSingle<{ metadata: Json | null }>();
+  if (readError)
+    return NextResponse.json({ error: readError.message }, { status: 500 });
+
+  const metadata = metadataObject(current?.metadata);
+  const { error } = await auth.supabase.from("shop_brand_profiles").upsert(
+    {
+      shop_id: auth.shopId,
+      metadata: { ...metadata, invoice_document: settings } as Json,
+      updated_by: auth.userId,
+    },
+    { onConflict: "shop_id" },
+  );
+  if (error)
+    return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true, settings });
+}

--- a/app/api/branding/invoice-preview/route.ts
+++ b/app/api/branding/invoice-preview/route.ts
@@ -1,0 +1,137 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { requireBrandShopReadAccess } from "@/features/branding/server/brand";
+import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
+import type { InvoiceSnapshot } from "@/features/invoices/server/getInvoiceSnapshot";
+import { renderPremiumInvoicePdf } from "@/features/invoices/server/renderPremiumInvoicePdf";
+
+export async function GET() {
+  const auth = await requireBrandShopReadAccess(null);
+  if (!auth.ok)
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const { data: shop, error } = await auth.supabase
+    .from("shops")
+    .select(
+      "business_name,shop_name,name,country,phone_number,email,street,city,province,postal_code,labor_rate,supplies_percent,shop_supplies_enabled,shop_supplies_type,shop_supplies_percent,shop_supplies_flat_amount,shop_supplies_cap_amount,tax_rate,logo_url,invoice_terms,invoice_footer",
+    )
+    .eq("id", auth.shopId)
+    .single();
+  if (error || !shop)
+    return NextResponse.json(
+      { error: error?.message ?? "Shop not found" },
+      { status: 404 },
+    );
+
+  const brand = await getActiveBrandForRender(auth.shopId);
+  const snapshot: InvoiceSnapshot = {
+    workOrder: {
+      id: "00000000-0000-0000-0000-000000000001",
+      shop_id: auth.shopId,
+      customer_id: null,
+      vehicle_id: null,
+      customer_name: "Sample Customer",
+      custom_id: "WO-PREVIEW",
+      status: "ready_to_invoice",
+      labor_total: 210,
+      parts_total: 184.5,
+      invoice_total: 414.23,
+      shop_supplies_enabled_override: null,
+      shop_supplies_amount_override: null,
+      created_at: new Date().toISOString(),
+    },
+    invoice: null,
+    shop,
+    customer: {
+      name: "Jordan Taylor",
+      first_name: "Jordan",
+      last_name: "Taylor",
+      phone: null,
+      phone_number: "(555) 014-2020",
+      email: "jordan@example.com",
+      business_name: null,
+      street: "125 Customer Way",
+      city: shop.city,
+      province: shop.province,
+      postal_code: shop.postal_code,
+    },
+    vehicle: {
+      year: 2023,
+      make: "Ford",
+      model: "F-150",
+      vin: "1FTFW1E80PFA12345",
+      license_plate: "SHOP-01",
+      unit_number: "TRK-12",
+      mileage: "48210",
+      color: "Blue",
+      engine_hours: null,
+    },
+    lines: [
+      {
+        id: "preview-line",
+        line_no: 1,
+        description: "Scheduled maintenance service",
+        complaint: "Customer requested scheduled maintenance.",
+        cause: "Service interval reached.",
+        correction:
+          "Completed inspection, oil service, and filter replacement.",
+        labor_time: 1.5,
+        price_estimate: null,
+        intake_json: null,
+        resolvedLaborHours: 1.5,
+        resolvedLaborRate: 140,
+        resolvedLaborTotal: 210,
+        resolvedPartsTotal: 184.5,
+        resolvedLineTotal: 394.5,
+      },
+    ],
+    parts: [
+      {
+        id: "preview-part-1",
+        lineId: "preview-line",
+        name: "Premium oil filter",
+        qty: 1,
+        unitPrice: 42.5,
+        totalPrice: 42.5,
+        partNumber: "OF-2023",
+      },
+      {
+        id: "preview-part-2",
+        lineId: "preview-line",
+        name: "Synthetic engine oil",
+        qty: 6,
+        unitPrice: 23.67,
+        totalPrice: 142.02,
+        partNumber: "5W30",
+      },
+    ],
+    currency: String(shop.country).toUpperCase() === "CA" ? "CAD" : "USD",
+    laborCost: 210,
+    partsCost: 184.52,
+    shopSuppliesTotal: 0,
+    subtotal: 394.52,
+    discountTotal: 0,
+    taxTotal: 19.73,
+    taxRate: 5,
+    total: 414.25,
+  };
+
+  const bytes = await renderPremiumInvoicePdf({
+    snapshot,
+    brand,
+    document: {
+      status: "draft",
+      draft: true,
+      outstandingTotal: snapshot.total,
+    },
+  });
+  return new NextResponse(Buffer.from(bytes), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": "inline; filename=Invoice_Design_Preview.pdf",
+      "Cache-Control": "private, no-store",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/app/api/invoice-versions/[id]/pdf/route.ts
+++ b/app/api/invoice-versions/[id]/pdf/route.ts
@@ -4,7 +4,11 @@ import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
+import {
+  activeBrandFromFrozenDocument,
+  getActiveBrandForRender,
+} from "@/features/branding/server/getActiveBrandForRender";
+import { isFrozenInvoiceDocumentConfiguration } from "@/features/invoices/lib/invoiceDocumentTheme";
 import { getInvoiceVersionById } from "@/features/invoices/server/invoiceVersionQueries";
 import {
   premiumInvoiceFilename,
@@ -21,10 +25,15 @@ export async function GET(
   const {
     data: { user },
   } = await sessionClient.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { id } = await context.params;
-  if (!id) return NextResponse.json({ error: "Missing invoice version id" }, { status: 400 });
+  if (!id)
+    return NextResponse.json(
+      { error: "Missing invoice version id" },
+      { status: 400 },
+    );
 
   try {
     const admin = createClient<DB>(
@@ -36,7 +45,10 @@ export async function GET(
       invoiceVersionId: id,
     });
     if (!version) {
-      return NextResponse.json({ error: "Invoice version not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Invoice version not found" },
+        { status: 404 },
+      );
     }
 
     const [{ data: profile }, { data: workOrder }] = await Promise.all([
@@ -72,11 +84,22 @@ export async function GET(
           .select("invoice_number,notes")
           .eq("id", version.invoice_id)
           .eq("shop_id", version.shop_id)
-          .maybeSingle<{ invoice_number: string | null; notes: string | null }>()
+          .maybeSingle<{
+            invoice_number: string | null;
+            notes: string | null;
+          }>()
       : { data: null };
-    const brand = await getActiveBrandForRender(version.shop_id);
+    // New invoice versions carry an immutable renderer configuration. The
+    // active-brand fallback is only for historical versions created before
+    // document freezing was introduced.
+    const brand = isFrozenInvoiceDocumentConfiguration(
+      version.snapshot.documentConfiguration,
+    )
+      ? activeBrandFromFrozenDocument(version.snapshot.documentConfiguration)
+      : await getActiveBrandForRender(version.shop_id);
     const pdfDocument = {
-      invoiceNumber: invoice?.invoice_number ?? version.snapshot.invoice?.invoice_number,
+      invoiceNumber:
+        invoice?.invoice_number ?? version.snapshot.invoice?.invoice_number,
       versionNumber: version.version_number,
       status: version.lifecycle_status,
       issuedAt: version.issued_at,
@@ -103,8 +126,12 @@ export async function GET(
       },
     });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : "Invoice PDF generation failed";
-    console.error("[invoice-version-pdf] generation failed", { invoiceVersionId: id, message });
+    const message =
+      error instanceof Error ? error.message : "Invoice PDF generation failed";
+    console.error("[invoice-version-pdf] generation failed", {
+      invoiceVersionId: id,
+      message,
+    });
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { runPostSendPersistence, sendInvoiceReadyEmail } from "@/features/email/server";
+import {
+  runPostSendPersistence,
+  sendInvoiceReadyEmail,
+} from "@/features/email/server";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
 import { getIssuableInvoiceSnapshot } from "@/features/invoices/server/getIssuableInvoiceSnapshot";
 import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
@@ -29,7 +32,9 @@ type Body = {
 };
 
 function joinedName(first?: string | null, last?: string | null) {
-  return [first?.trim(), last?.trim()].filter(Boolean).join(" ").trim() || undefined;
+  return (
+    [first?.trim(), last?.trim()].filter(Boolean).join(" ").trim() || undefined
+  );
 }
 
 function resolvedShopName(
@@ -70,7 +75,10 @@ export async function POST(req: Request) {
     const body = (await req.json().catch(() => null)) as Body | null;
     const workOrderId = body?.workOrderId?.trim() ?? "";
     if (!workOrderId) {
-      return NextResponse.json({ error: "Missing work order ID" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Missing work order ID" },
+        { status: 400 },
+      );
     }
 
     const { data: workOrder } = await admin
@@ -79,14 +87,26 @@ export async function POST(req: Request) {
       .eq("id", workOrderId)
       .eq("shop_id", access.profile.shop_id)
       .maybeSingle<
-        Pick<WorkOrderRow, "id" | "shop_id" | "customer_id" | "customer_name" | "status">
+        Pick<
+          WorkOrderRow,
+          "id" | "shop_id" | "customer_id" | "customer_name" | "status"
+        >
       >();
-    if (!workOrder) return NextResponse.json({ error: "Invalid work order" }, { status: 404 });
+    if (!workOrder)
+      return NextResponse.json(
+        { error: "Invalid work order" },
+        { status: 404 },
+      );
 
-    const status = String(workOrder.status ?? "").trim().toLowerCase().replaceAll(" ", "_");
+    const status = String(workOrder.status ?? "")
+      .trim()
+      .toLowerCase()
+      .replaceAll(" ", "_");
     if (!["completed", "ready_to_invoice", "invoiced"].includes(status)) {
       return NextResponse.json(
-        { error: `Work order status ${workOrder.status ?? "unknown"} is not ready for invoicing` },
+        {
+          error: `Work order status ${workOrder.status ?? "unknown"} is not ready for invoicing`,
+        },
         { status: 409 },
       );
     }
@@ -139,7 +159,10 @@ export async function POST(req: Request) {
     }
     const total = Number(snapshot.total ?? 0);
     if (!Number.isFinite(total) || total <= 0) {
-      return NextResponse.json({ error: "Cannot issue a zero-total invoice." }, { status: 400 });
+      return NextResponse.json(
+        { error: "Cannot issue a zero-total invoice." },
+        { status: 400 },
+      );
     }
 
     const [{ data: shop }, { data: customer }] = await Promise.all([
@@ -154,14 +177,23 @@ export async function POST(req: Request) {
             .select("id,user_id,name,first_name,last_name,email")
             .eq("id", workOrder.customer_id)
             .maybeSingle<
-              Pick<CustomerRow, "id" | "user_id" | "name" | "first_name" | "last_name" | "email">
+              Pick<
+                CustomerRow,
+                "id" | "user_id" | "name" | "first_name" | "last_name" | "email"
+              >
             >()
         : Promise.resolve({ data: null, error: null }),
     ]);
 
-    const email = body?.customerEmail?.trim().toLowerCase() || customer?.email?.trim().toLowerCase() || "";
+    const email =
+      body?.customerEmail?.trim().toLowerCase() ||
+      customer?.email?.trim().toLowerCase() ||
+      "";
     if (!email) {
-      return NextResponse.json({ error: "Missing customer email." }, { status: 400 });
+      return NextResponse.json(
+        { error: "Missing customer email." },
+        { status: 400 },
+      );
     }
 
     const now = new Date().toISOString();
@@ -204,19 +236,30 @@ export async function POST(req: Request) {
         .insert(payload)
         .select("id")
         .single<{ id: string }>();
-      if (error || !data?.id) throw new Error(error?.message ?? "Failed to create invoice");
+      if (error || !data?.id)
+        throw new Error(error?.message ?? "Failed to create invoice");
       invoiceId = data.id;
     }
     if (!invoiceId) throw new Error("Invoice persistence did not return an id");
 
+    // Resolve document branding once, at issuance. The complete renderer
+    // configuration is stored in the immutable version snapshot so historical
+    // invoices never change when the shop updates its logo or template later.
+    const brand = await getActiveBrandForRender(workOrder.shop_id);
+    const issuedSnapshot = {
+      ...snapshot,
+      documentConfiguration: brand.document,
+    };
     const version = await finalizeInvoiceVersion({
       supabase: admin,
       shopId: workOrder.shop_id,
       workOrderId,
       invoiceId,
-      snapshot,
+      snapshot: issuedSnapshot,
       actorUserId: access.profile.id,
-      operationKey: req.headers.get("idempotency-key")?.trim() || `invoice-send:${workOrderId}`,
+      operationKey:
+        req.headers.get("idempotency-key")?.trim() ||
+        `invoice-send:${workOrderId}`,
     });
 
     const base = SITE_URL.trim().replace(/\/+$/, "");
@@ -229,16 +272,14 @@ export async function POST(req: Request) {
       joinedName(customer?.first_name, customer?.last_name) ||
       workOrder.customer_name?.trim() ||
       undefined;
-    const brand = await getActiveBrandForRender(workOrder.shop_id);
-
     await sendInvoiceReadyEmail({
       shopId: workOrder.shop_id,
       to: email,
       portalUrl,
       workOrderId,
       invoiceTotal: version.total,
-      laborTotal: snapshot.laborCost ?? 0,
-      partsTotal: snapshot.partsCost ?? 0,
+      laborTotal: issuedSnapshot.laborCost ?? 0,
+      partsTotal: issuedSnapshot.partsCost ?? 0,
       customerName: customerLabel,
       shopName: shopLabel,
       brandLogoUrl: brand?.logoUrl ?? null,
@@ -299,14 +340,16 @@ export async function POST(req: Request) {
             {
               step: "portal_invoice_notification_insert",
               run: async () => {
-                const { error } = await admin.from("portal_notifications").insert({
-                  user_id: customer.user_id,
-                  customer_id: customer.id,
-                  work_order_id: workOrderId,
-                  kind: "invoice_ready",
-                  title: "Invoice ready",
-                  body: `Your invoice for Work Order ${workOrderId} at ${shopLabel} is ready to view.`,
-                });
+                const { error } = await admin
+                  .from("portal_notifications")
+                  .insert({
+                    user_id: customer.user_id,
+                    customer_id: customer.id,
+                    work_order_id: workOrderId,
+                    kind: "invoice_ready",
+                    title: "Invoice ready",
+                    body: `Your invoice for Work Order ${workOrderId} at ${shopLabel} is ready to view.`,
+                  });
                 if (error) throw new Error(error.message);
               },
             },
@@ -323,7 +366,8 @@ export async function POST(req: Request) {
       warnings: warnings.length ? warnings : undefined,
     });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : "Unknown error sending invoice";
+    const message =
+      error instanceof Error ? error.message : "Unknown error sending invoice";
     console.error("[invoices/send] failed:", message);
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -2,7 +2,11 @@ export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
+import {
+  activeBrandFromFrozenDocument,
+  getActiveBrandForRender,
+} from "@/features/branding/server/getActiveBrandForRender";
+import { isFrozenInvoiceDocumentConfiguration } from "@/features/invoices/lib/invoiceDocumentTheme";
 import { getActiveInvoiceVersion } from "@/features/invoices/server/financialLifecycle";
 import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
 import {
@@ -18,11 +22,15 @@ export async function GET(
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { id: workOrderId } = await context.params;
   if (!workOrderId) {
-    return NextResponse.json({ error: "Missing work order id" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Missing work order id" },
+      { status: 400 },
+    );
   }
 
   try {
@@ -34,7 +42,10 @@ export async function GET(
       .maybeSingle<{ id: string; shop_id: string }>();
     if (workOrderError) throw workOrderError;
     if (!workOrder) {
-      return NextResponse.json({ error: "Work order not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Work order not found" },
+        { status: 404 },
+      );
     }
 
     const activeVersion = await getActiveInvoiceVersion({
@@ -51,12 +62,20 @@ export async function GET(
           .select("invoice_number,notes")
           .eq("id", activeVersion.invoice_id)
           .eq("shop_id", workOrder.shop_id)
-          .maybeSingle<{ invoice_number: string | null; notes: string | null }>()
+          .maybeSingle<{
+            invoice_number: string | null;
+            notes: string | null;
+          }>()
       : { data: null };
-    const brand = await getActiveBrandForRender(workOrder.shop_id);
+    const brand =
+      activeVersion &&
+      isFrozenInvoiceDocumentConfiguration(snapshot.documentConfiguration)
+        ? activeBrandFromFrozenDocument(snapshot.documentConfiguration)
+        : await getActiveBrandForRender(workOrder.shop_id);
     const pdfDocument = activeVersion
       ? {
-          invoiceNumber: invoice?.invoice_number ?? snapshot.invoice?.invoice_number,
+          invoiceNumber:
+            invoice?.invoice_number ?? snapshot.invoice?.invoice_number,
           versionNumber: activeVersion.version_number,
           status: activeVersion.lifecycle_status,
           issuedAt: activeVersion.issued_at,
@@ -94,7 +113,8 @@ export async function GET(
       },
     });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : "Invoice PDF generation failed";
+    const message =
+      error instanceof Error ? error.message : "Invoice PDF generation failed";
     console.error("[invoice-pdf] generation failed", { workOrderId, message });
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/features/branding/server/getActiveBrandForRender.ts
+++ b/features/branding/server/getActiveBrandForRender.ts
@@ -1,5 +1,9 @@
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import {
+  resolveInvoiceDocumentConfiguration,
+  type InvoiceDocumentConfiguration,
+} from "@/features/invoices/lib/invoiceDocumentTheme";
 
 type DB = Database;
 
@@ -12,6 +16,7 @@ export type ActiveBrandRender = {
     accent: string;
   };
   theme: Record<string, unknown> | null;
+  document: InvoiceDocumentConfiguration;
 };
 
 export async function getActiveBrandForRender(
@@ -28,29 +33,68 @@ export async function getActiveBrandForRender(
     .eq("shop_id", shopId)
     .maybeSingle();
 
-  const { data: assets } = await supabase
-    .from("shop_brand_assets")
-    .select("*")
-    .eq("shop_id", shopId)
-    .eq("is_active", true);
+  const [{ data: assets }, { data: shop }] = await Promise.all([
+    supabase
+      .from("shop_brand_assets")
+      .select("*")
+      .eq("shop_id", shopId)
+      .eq("is_active", true),
+    supabase
+      .from("shops")
+      .select("logo_url,invoice_terms,invoice_footer")
+      .eq("id", shopId)
+      .maybeSingle<{
+        logo_url: string | null;
+        invoice_terms: string | null;
+        invoice_footer: string | null;
+      }>(),
+  ]);
 
-  const logo = (assets ?? []).find((a) => a.kind === "logo") ?? null;
+  let logo = (assets ?? []).find((a) => a.kind === "logo") ?? null;
+  if (profile?.logo_asset_id && logo?.id !== profile.logo_asset_id) {
+    const { data: selectedLogo } = await supabase
+      .from("shop_brand_assets")
+      .select("*")
+      .eq("id", profile.logo_asset_id)
+      .eq("shop_id", shopId)
+      .eq("kind", "logo")
+      .maybeSingle();
+    logo = selectedLogo ?? logo;
+  }
   const metadata =
     profile && typeof profile.metadata === "object" && profile.metadata
       ? (profile.metadata as Record<string, unknown>)
       : null;
 
+  const documentSettings = metadata?.invoice_document;
+  const logoUrl = logo?.file_url ?? shop?.logo_url ?? null;
+  const document = resolveInvoiceDocumentConfiguration({
+    settings: documentSettings,
+    logoUrl,
+    terms: shop?.invoice_terms,
+    footer: shop?.invoice_footer,
+  });
+
   return {
     profile: profile ?? null,
-    logoUrl: logo?.file_url ?? null,
-    colors: {
-      primary: profile?.primary_color ?? "#C97A3D",
-      secondary: profile?.secondary_color ?? "#0F172A",
-      accent: profile?.accent_color ?? "#E2A164",
-    },
+    logoUrl,
+    colors: document.colors,
     theme:
       metadata && typeof metadata.theme === "object"
         ? (metadata.theme as Record<string, unknown>)
         : null,
+    document,
+  };
+}
+
+export function activeBrandFromFrozenDocument(
+  document: InvoiceDocumentConfiguration,
+): ActiveBrandRender {
+  return {
+    profile: null,
+    logoUrl: document.logoUrl,
+    colors: document.colors,
+    theme: null,
+    document,
   };
 }

--- a/features/branding/server/imageDimensions.test.ts
+++ b/features/branding/server/imageDimensions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { readRasterImageDimensions } from "./imageDimensions";
+
+describe("readRasterImageDimensions", () => {
+  it("reads dimensions from a PNG header", () => {
+    const bytes = new Uint8Array(24);
+    bytes.set([0x89, 0x50, 0x4e, 0x47], 0);
+    const view = new DataView(bytes.buffer);
+    view.setUint32(16, 1024);
+    view.setUint32(20, 512);
+    expect(readRasterImageDimensions(bytes)).toEqual({
+      width: 1024,
+      height: 512,
+    });
+  });
+
+  it("rejects unknown image data", () => {
+    expect(readRasterImageDimensions(new Uint8Array([1, 2, 3]))).toBeNull();
+  });
+});

--- a/features/branding/server/imageDimensions.ts
+++ b/features/branding/server/imageDimensions.ts
@@ -1,0 +1,48 @@
+export type ImageDimensions = { width: number; height: number };
+
+/** Reads PNG/JPEG dimensions without decoding the full image or invoking native binaries. */
+export function readRasterImageDimensions(
+  bytes: Uint8Array,
+): ImageDimensions | null {
+  if (
+    bytes.length >= 24 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const width = view.getUint32(16);
+    const height = view.getUint32(20);
+    return width > 0 && height > 0 ? { width, height } : null;
+  }
+
+  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    let offset = 2;
+    while (offset + 9 < bytes.length) {
+      if (bytes[offset] !== 0xff) {
+        offset += 1;
+        continue;
+      }
+      const marker = bytes[offset + 1];
+      if (marker === 0xd8 || marker === 0xd9) {
+        offset += 2;
+        continue;
+      }
+      const length = (bytes[offset + 2] << 8) | bytes[offset + 3];
+      if (length < 2 || offset + length + 2 > bytes.length) break;
+      if (
+        [
+          0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd,
+          0xce, 0xcf,
+        ].includes(marker)
+      ) {
+        const height = (bytes[offset + 5] << 8) | bytes[offset + 6];
+        const width = (bytes[offset + 7] << 8) | bytes[offset + 8];
+        return width > 0 && height > 0 ? { width, height } : null;
+      }
+      offset += length + 2;
+    }
+  }
+  return null;
+}

--- a/features/branding/server/logo-generation.ts
+++ b/features/branding/server/logo-generation.ts
@@ -38,7 +38,8 @@ export function getOpenAIClient() {
 
 export function buildLogoPrompt(input: BuildLogoPromptInput): string {
   const preset = (input.stylePreset?.trim() || "industrial-dark") as LogoPreset;
-  const presetGuidance = PRESET_GUIDANCE[preset] ?? PRESET_GUIDANCE["industrial-dark"];
+  const presetGuidance =
+    PRESET_GUIDANCE[preset] ?? PRESET_GUIDANCE["industrial-dark"];
   const shopName = input.shopName?.trim() || "ProFixIQ Shop";
   const userPrompt = input.prompt.trim();
 
@@ -51,6 +52,8 @@ export function buildLogoPrompt(input: BuildLogoPromptInput): string {
     "- centered composition",
     "- strong silhouette",
     "- legible at small sizes",
+    "- visible artwork fills 80 to 90 percent of the canvas",
+    "- keep only 5 to 8 percent transparent safety padding; never place a small emblem in a large empty canvas",
     "- no mockup walls, paper, business cards, shirts, buildings, or 3D scene staging",
     "- no photorealistic environment",
     "- avoid clutter and tiny unreadable text",
@@ -59,6 +62,6 @@ export function buildLogoPrompt(input: BuildLogoPromptInput): string {
     input.transparentBackground
       ? "- use a transparent background with no backdrop card or scene"
       : "- use a very clean simple background and keep focus on the logo only",
-    "Deliver a polished production-ready logo image."
+    "Deliver a polished production-ready logo image.",
   ].join("\n");
 }

--- a/features/dashboard/app/dashboard/owner/settings/page.tsx
+++ b/features/dashboard/app/dashboard/owner/settings/page.tsx
@@ -34,6 +34,7 @@ import {
   OwnerSettingsStat,
 } from "@/features/dashboard/components/owner-settings/OwnerSettingsPanels";
 import BrandStudioSummaryCard from "@/features/branding/components/BrandStudioSummaryCard";
+import InvoiceDesignSettings from "@/features/dashboard/components/owner-settings/InvoiceDesignSettings";
 import QuickBooksConnectCard from "@/features/integrations/quickbooks/components/QuickBooksConnectCard";
 import ProfileIdentityCard from "@/features/users/components/ProfileIdentityCard";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
@@ -47,12 +48,6 @@ import {
 } from "@/features/stripe/lib/stripe/plan-normalization";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { applyThemePreference } from "@/features/shared/lib/theme";
-
-type FileInputChangeEvent = {
-  target: {
-    files: FileList | null;
-  };
-};
 
 type HourRow = {
   weekday: number;
@@ -295,7 +290,7 @@ export default function OwnerSettingsPage() {
   const [postalCode, setPostalCode] = useState("");
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
-  const [logoUrl, setLogoUrl] = useState("");
+  const [invoicePreviewRevision, setInvoicePreviewRevision] = useState(0);
 
   // Money / defaults
   const [laborRate, setLaborRate] = useState("");
@@ -695,7 +690,6 @@ export default function OwnerSettingsPage() {
       setPostalCode((shop.postal_code as string | null) || "");
       setPhone((shop.phone_number as string | null) || "");
       setEmail((shop.email as string | null) || "");
-      setLogoUrl((shop.logo_url as string | null) || "");
 
       const c = (shop.country as string | null) || "US";
       setCountry(c === "CA" ? "CA" : "US");
@@ -934,7 +928,6 @@ export default function OwnerSettingsPage() {
         postal_code: postalCode,
         phone_number: phone,
         email,
-        logo_url: logoUrl,
 
         labor_rate: laborRate ? parseFloat(laborRate) : null,
         supplies_percent:
@@ -980,27 +973,8 @@ export default function OwnerSettingsPage() {
     }
 
     setCoreDirty(false);
+    setInvoicePreviewRevision((value) => value + 1);
     toast.success("Core shop settings saved.");
-  };
-
-  const handleLogoUpload = async (e: FileInputChangeEvent) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    const filePath = `logos/${crypto.randomUUID()}-${file.name}`;
-    const { error } = await supabase.storage
-      .from("logos")
-      .upload(filePath, file, { upsert: true });
-
-    if (error) {
-      toast.error(error.message);
-      return;
-    }
-
-    const { data } = supabase.storage.from("logos").getPublicUrl(filePath);
-    setLogoUrl(data.publicUrl);
-    setCoreDirty(true);
-    toast.success("Logo uploaded.");
   };
 
   const savePricingValidDays = async () => {
@@ -1259,17 +1233,15 @@ export default function OwnerSettingsPage() {
         }),
       });
 
-      const j = await res
-        .json()
-        .catch(
-          () =>
-            ({}) as {
-              ok?: boolean;
-              error?: string;
-              details?: string;
-              url?: string;
-            },
-        );
+      const j = await res.json().catch(
+        () =>
+          ({}) as {
+            ok?: boolean;
+            error?: string;
+            details?: string;
+            url?: string;
+          },
+      );
 
       if (res.ok && j?.ok && j?.url) {
         window.location.href = j.url;
@@ -1844,7 +1816,6 @@ export default function OwnerSettingsPage() {
               postalCode={postalCode}
               phone={phone}
               email={email}
-              logoUrl={logoUrl}
               provinceLabel={provinceLabel}
               postalLabel={postalLabel}
               selectClass={selectClass}
@@ -1885,13 +1856,9 @@ export default function OwnerSettingsPage() {
                 setEmail(value);
                 setCoreDirty(true);
               }}
-              onLogoUrlChange={(value) => {
-                setLogoUrl(value);
-                setCoreDirty(true);
-              }}
-              onLogoUpload={handleLogoUpload}
             />
           ) : null}
+          {activeSection === "business" ? <BrandStudioSummaryCard /> : null}
           {activeSection === "operations" ? (
             <OwnerSettingsOperationsSection
               isUnlocked={isUnlocked}
@@ -1970,8 +1937,6 @@ export default function OwnerSettingsPage() {
           {activeSection === "automation" ? (
             <OwnerAiAutomationSection isUnlocked={isUnlocked} />
           ) : null}
-          {activeSection === "integrations" ? <BrandStudioSummaryCard /> : null}
-
           {activeSection === "integrations" ? (
             <OwnerSettingsPanel
               id="quickbooks-integration"
@@ -2034,6 +1999,13 @@ export default function OwnerSettingsPage() {
                 </span>
               </label>
             </OwnerSettingsPanel>
+          ) : null}
+          {activeSection === "communications" ? (
+            <InvoiceDesignSettings
+              shopId={shopId}
+              isUnlocked={isUnlocked}
+              onSaved={() => setInvoicePreviewRevision((value) => value + 1)}
+            />
           ) : null}
 
           {activeSection === "scheduling" ? (
@@ -2117,16 +2089,7 @@ export default function OwnerSettingsPage() {
             orgId={orgId}
             orgName={orgName}
             locations={locations}
-            shopName={shopName}
-            address={address}
-            city={city}
-            province={province}
-            postalCode={postalCode}
-            phone={phone}
-            email={email}
-            logoUrl={logoUrl}
-            invoiceTerms={invoiceTerms}
-            invoiceFooter={invoiceFooter}
+            invoicePreviewRevision={invoicePreviewRevision}
             emailLogs={emailLogs}
             emailLogsLoading={emailLogsLoading}
             onOpenStripeConnect={openStripeConnect}

--- a/features/dashboard/components/owner-settings/InvoiceDesignSettings.tsx
+++ b/features/dashboard/components/owner-settings/InvoiceDesignSettings.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@shared/components/ui/Button";
+import {
+  DEFAULT_INVOICE_DOCUMENT_SETTINGS,
+  INVOICE_PALETTES,
+  INVOICE_TEMPLATES,
+  type InvoiceDocumentSettings,
+} from "@/features/invoices/lib/invoiceDocumentTheme";
+import { OwnerSettingsPanel } from "./OwnerSettingsPanels";
+
+type Props = {
+  shopId: string | null;
+  isUnlocked: boolean;
+  onSaved?: () => void;
+};
+
+const selectClass =
+  "w-full rounded-md border border-border bg-[color:var(--theme-surface-page)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none disabled:opacity-50";
+
+export default function InvoiceDesignSettings({
+  shopId,
+  isUnlocked,
+  onSaved,
+}: Props) {
+  const [settings, setSettings] = useState<InvoiceDocumentSettings>(
+    DEFAULT_INVOICE_DOCUMENT_SETTINGS,
+  );
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    void fetch("/api/branding/invoice-design", { cache: "no-store" })
+      .then(async (response) => {
+        const body = await response.json().catch(() => null);
+        if (!response.ok)
+          throw new Error(body?.error || "Failed to load invoice design");
+        if (active && body?.settings)
+          setSettings(body.settings as InvoiceDocumentSettings);
+      })
+      .catch((error: unknown) =>
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Failed to load invoice design",
+        ),
+      )
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const update = <K extends keyof InvoiceDocumentSettings>(
+    key: K,
+    value: InvoiceDocumentSettings[K],
+  ) => {
+    setSettings((current) => ({ ...current, [key]: value }));
+    setDirty(true);
+  };
+
+  async function save() {
+    if (!shopId || !isUnlocked) return;
+    setSaving(true);
+    try {
+      const response = await fetch("/api/branding/invoice-design", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shopId, settings }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok)
+        throw new Error(body?.error || "Failed to save invoice design");
+      if (body?.settings) setSettings(body.settings as InvoiceDocumentSettings);
+      setDirty(false);
+      onSaved?.();
+      toast.success("Invoice design saved.");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to save invoice design",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <OwnerSettingsPanel
+      id="invoice-document-design"
+      tone="secondary"
+      title="Invoice design"
+      description="Choose one of 30 professionally constrained template and palette combinations."
+      action={
+        <Button
+          size="sm"
+          onClick={() => void save()}
+          disabled={!isUnlocked || loading || saving || !dirty}
+        >
+          {saving ? "Saving..." : dirty ? "Save design" : "Design saved"}
+        </Button>
+      }
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <label className="space-y-1.5 text-sm">
+          <span className="text-xs text-[color:var(--theme-text-secondary)]">
+            Layout
+          </span>
+          <select
+            className={selectClass}
+            value={settings.templateId}
+            disabled={!isUnlocked || loading}
+            onChange={(event) =>
+              update(
+                "templateId",
+                event.target.value as InvoiceDocumentSettings["templateId"],
+              )
+            }
+          >
+            {INVOICE_TEMPLATES.map((template) => (
+              <option key={template.id} value={template.id}>
+                {template.name}
+              </option>
+            ))}
+          </select>
+          <p className="text-[11px] text-[color:var(--theme-text-muted)]">
+            {
+              INVOICE_TEMPLATES.find(
+                (template) => template.id === settings.templateId,
+              )?.description
+            }
+          </p>
+        </label>
+        <label className="space-y-1.5 text-sm">
+          <span className="text-xs text-[color:var(--theme-text-secondary)]">
+            Color palette
+          </span>
+          <select
+            className={selectClass}
+            value={settings.paletteId}
+            disabled={!isUnlocked || loading}
+            onChange={(event) =>
+              update(
+                "paletteId",
+                event.target.value as InvoiceDocumentSettings["paletteId"],
+              )
+            }
+          >
+            {INVOICE_PALETTES.map((palette) => (
+              <option key={palette.id} value={palette.id}>
+                {palette.name}
+              </option>
+            ))}
+          </select>
+          <div className="flex gap-1.5 pt-1">
+            {Object.values(
+              INVOICE_PALETTES.find(
+                (palette) => palette.id === settings.paletteId,
+              )?.colors ?? {},
+            ).map((color) => (
+              <span
+                key={color}
+                className="h-5 w-10 rounded border border-[color:var(--theme-border-soft)]"
+                style={{ backgroundColor: color }}
+              />
+            ))}
+          </div>
+        </label>
+        <label className="space-y-1.5 text-sm">
+          <span className="text-xs text-[color:var(--theme-text-secondary)]">
+            Logo size
+          </span>
+          <select
+            className={selectClass}
+            value={settings.logoSize}
+            disabled={!isUnlocked || loading}
+            onChange={(event) =>
+              update(
+                "logoSize",
+                event.target.value as InvoiceDocumentSettings["logoSize"],
+              )
+            }
+          >
+            <option value="small">Small</option>
+            <option value="medium">Medium</option>
+            <option value="large">Large</option>
+          </select>
+        </label>
+        <label className="space-y-1.5 text-sm">
+          <span className="text-xs text-[color:var(--theme-text-secondary)]">
+            Logo alignment
+          </span>
+          <select
+            className={selectClass}
+            value={settings.logoAlignment}
+            disabled={!isUnlocked || loading}
+            onChange={(event) =>
+              update(
+                "logoAlignment",
+                event.target.value as InvoiceDocumentSettings["logoAlignment"],
+              )
+            }
+          >
+            <option value="left">Left</option>
+            <option value="center">Centered</option>
+          </select>
+        </label>
+        <label className="space-y-1.5 text-sm md:col-span-2">
+          <span className="flex justify-between text-xs text-[color:var(--theme-text-secondary)]">
+            <span>Logo scale</span>
+            <span>{Math.round(settings.logoZoom * 100)}%</span>
+          </span>
+          <input
+            className="w-full accent-[color:var(--accent-copper)]"
+            type="range"
+            min="75"
+            max="200"
+            step="5"
+            value={Math.round(settings.logoZoom * 100)}
+            disabled={!isUnlocked || loading}
+            onChange={(event) =>
+              update("logoZoom", Number(event.target.value) / 100)
+            }
+          />
+          <p className="text-[11px] text-[color:var(--theme-text-muted)]">
+            Increase this for square logos with transparent padding.
+          </p>
+        </label>
+        <label className="space-y-1.5 text-sm">
+          <span className="text-xs text-[color:var(--theme-text-secondary)]">
+            Line detail
+          </span>
+          <select
+            className={selectClass}
+            value={settings.detailDensity}
+            disabled={!isUnlocked || loading}
+            onChange={(event) =>
+              update(
+                "detailDensity",
+                event.target.value as InvoiceDocumentSettings["detailDensity"],
+              )
+            }
+          >
+            <option value="compact">Compact</option>
+            <option value="standard">Standard</option>
+            <option value="detailed">Detailed</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-3 rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)]">
+          <input
+            type="checkbox"
+            checked={settings.showNarratives}
+            disabled={!isUnlocked || loading}
+            onChange={(event) => update("showNarratives", event.target.checked)}
+          />
+          Show complaint, cause, and correction
+        </label>
+      </div>
+    </OwnerSettingsPanel>
+  );
+}

--- a/features/dashboard/components/owner-settings/OwnerSettingsBusinessSection.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsBusinessSection.tsx
@@ -1,15 +1,7 @@
 "use client";
 
-import Image from "next/image";
 import { Input } from "@shared/components/ui/input";
-import { Button } from "@shared/components/ui/Button";
 import { OwnerSettingsPanel } from "@/features/dashboard/components/owner-settings/OwnerSettingsPanels";
-
-type FileInputChangeEvent = {
-  target: {
-    files: FileList | null;
-  };
-};
 
 type CountryCode = "US" | "CA";
 
@@ -36,7 +28,6 @@ type Props = {
   postalCode: string;
   phone: string;
   email: string;
-  logoUrl: string;
   provinceLabel: string;
   postalLabel: string;
   selectClass: string;
@@ -50,8 +41,6 @@ type Props = {
   onPostalCodeChange: (value: string) => void;
   onPhoneChange: (value: string) => void;
   onEmailChange: (value: string) => void;
-  onLogoUrlChange: (value: string) => void;
-  onLogoUpload: (e: FileInputChangeEvent) => void;
 };
 
 export default function OwnerSettingsBusinessSection({
@@ -65,7 +54,6 @@ export default function OwnerSettingsBusinessSection({
   postalCode,
   phone,
   email,
-  logoUrl,
   provinceLabel,
   postalLabel,
   selectClass,
@@ -79,8 +67,6 @@ export default function OwnerSettingsBusinessSection({
   onPostalCodeChange,
   onPhoneChange,
   onEmailChange,
-  onLogoUrlChange,
-  onLogoUpload,
 }: Props) {
   return (
     <OwnerSettingsPanel
@@ -191,44 +177,6 @@ export default function OwnerSettingsBusinessSection({
             />
           </label>
         </div>
-
-        <div className="grid gap-2 md:grid-cols-2">
-          <label className="block space-y-1.5">
-            <span className={labelClass}>Logo URL</span>
-            <Input
-              value={logoUrl}
-              onChange={(e) => onLogoUrlChange(e.target.value)}
-              placeholder="https://…"
-              disabled={!isUnlocked}
-            />
-          </label>
-          <label className="block space-y-1.5">
-            <span className={labelClass}>Upload logo</span>
-            <Input
-              type="file"
-              accept="image/*"
-              onChange={
-                onLogoUpload as unknown as React.ChangeEventHandler<HTMLInputElement>
-              }
-              disabled={!isUnlocked}
-            />
-          </label>
-        </div>
-
-        <Button variant="secondary" className="mt-1" disabled>
-          AI logo maker · Coming soon
-        </Button>
-
-        {logoUrl ? (
-          <Image
-            src={logoUrl}
-            alt="Logo"
-            width={128}
-            height={80}
-            unoptimized
-            className="mt-2 h-20 w-32 rounded bg-[color:var(--theme-surface-panel-strong)] p-1 object-contain"
-          />
-        ) : null}
       </div>
     </OwnerSettingsPanel>
   );

--- a/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
+++ b/features/dashboard/components/owner-settings/OwnerSettingsSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Image from "next/image";
 import { Button } from "@shared/components/ui/Button";
+import { useState } from "react";
 import ShopPublicProfileSection from "@/features/shops/components/ShopPublicProfileSection";
 import {
   OwnerSettingsPanel,
@@ -77,16 +77,7 @@ type Props = {
   orgId: string | null;
   orgName: string;
   locations: ShopLocationRow[];
-  shopName: string;
-  address: string;
-  city: string;
-  province: string;
-  postalCode: string;
-  phone: string;
-  email: string;
-  logoUrl: string;
-  invoiceTerms: string;
-  invoiceFooter: string;
+  invoicePreviewRevision?: number;
   emailLogs: EmailLogRow[];
   emailLogsLoading: boolean;
   onOpenStripeConnect: () => void;
@@ -138,16 +129,7 @@ export default function OwnerSettingsSidebar({
   orgId,
   orgName,
   locations,
-  shopName,
-  address,
-  city,
-  province,
-  postalCode,
-  phone,
-  email,
-  logoUrl,
-  invoiceTerms,
-  invoiceFooter,
+  invoicePreviewRevision = 0,
   emailLogs,
   emailLogsLoading,
   onOpenStripeConnect,
@@ -182,6 +164,8 @@ export default function OwnerSettingsSidebar({
   const manageSubscriptionLoading = hasManagedSubscription
     ? portalLoading
     : checkoutLoading;
+  const [localPreviewRevision, setLocalPreviewRevision] = useState(0);
+  const previewRevision = invoicePreviewRevision + localPreviewRevision;
 
   return (
     <div className={sticky ? "space-y-5 xl:sticky xl:top-20" : "space-y-5"}>
@@ -415,36 +399,36 @@ export default function OwnerSettingsSidebar({
       ) : null}
 
       {show("preview") ? (
-        <OwnerSettingsPanel tone="passive" title="Invoice preview">
-          <div className="space-y-2 rounded-xl bg-[color:var(--theme-surface-panel-strong)] p-3 text-xs text-[color:var(--theme-text-on-accent)] shadow">
-            {logoUrl ? (
-              <Image
-                src={logoUrl}
-                alt="Logo"
-                width={160}
-                height={48}
-                unoptimized
-                className="h-12 object-contain"
-              />
-            ) : null}
-            <div className="font-semibold">{shopName || "Your shop name"}</div>
-            <div>
-              {address}
-              {address ? "," : ""} {city} {province} {postalCode}
-            </div>
-            <div>
-              {phone} {phone && email ? "•" : ""} {email}
-            </div>
-            <hr className="my-2" />
-            <div className="font-semibold text-[color:var(--theme-text-on-accent)]">
-              Invoice terms
-            </div>
-            <p>{invoiceTerms || "—"}</p>
-            <div className="font-semibold text-[color:var(--theme-text-on-accent)]">
-              Footer
-            </div>
-            <p>{invoiceFooter || "—"}</p>
+        <OwnerSettingsPanel
+          tone="passive"
+          title="Invoice preview"
+          description="Rendered by the same PDF engine used for customer invoices."
+          action={
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => setLocalPreviewRevision((value) => value + 1)}
+            >
+              Refresh
+            </Button>
+          }
+        >
+          <div className="overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)] bg-white shadow">
+            <iframe
+              key={previewRevision}
+              src={`/api/branding/invoice-preview?revision=${previewRevision}`}
+              title="Invoice PDF preview"
+              className="h-[520px] w-full"
+            />
           </div>
+          <a
+            className="mt-3 inline-flex text-xs font-medium text-[color:var(--accent-copper-light)] underline"
+            href={`/api/branding/invoice-preview?revision=${previewRevision}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open full PDF preview
+          </a>
         </OwnerSettingsPanel>
       ) : null}
 

--- a/features/invoices/lib/invoiceDocumentTheme.test.ts
+++ b/features/invoices/lib/invoiceDocumentTheme.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  INVOICE_PALETTES,
+  INVOICE_TEMPLATES,
+  isFrozenInvoiceDocumentConfiguration,
+  normalizeInvoiceDocumentSettings,
+  resolveInvoiceDocumentConfiguration,
+} from "./invoiceDocumentTheme";
+
+describe("invoice document theme", () => {
+  it("offers exactly thirty curated layout and palette combinations", () => {
+    expect(INVOICE_TEMPLATES).toHaveLength(6);
+    expect(INVOICE_PALETTES).toHaveLength(5);
+    expect(INVOICE_TEMPLATES.length * INVOICE_PALETTES.length).toBe(30);
+  });
+
+  it("normalizes untrusted settings and clamps logo zoom", () => {
+    expect(
+      normalizeInvoiceDocumentSettings({
+        templateId: "not-real",
+        paletteId: "blue-slate",
+        logoZoom: 99,
+        showNarratives: false,
+      }),
+    ).toMatchObject({
+      templateId: "oem-clean",
+      paletteId: "blue-slate",
+      logoZoom: 2,
+      showNarratives: false,
+    });
+  });
+
+  it("resolves a self-contained configuration suitable for invoice versioning", () => {
+    const configuration = resolveInvoiceDocumentConfiguration({
+      settings: {
+        templateId: "heavy-duty",
+        paletteId: "green-graphite",
+        logoZoom: 1.5,
+      },
+      logoUrl: "https://example.com/logo.png",
+      terms: "Due on receipt",
+      footer: "Thank you",
+    });
+    expect(configuration.colors.primary).toBe("#23856D");
+    expect(configuration.terms).toBe("Due on receipt");
+    expect(isFrozenInvoiceDocumentConfiguration(configuration)).toBe(true);
+  });
+});

--- a/features/invoices/lib/invoiceDocumentTheme.ts
+++ b/features/invoices/lib/invoiceDocumentTheme.ts
@@ -1,0 +1,227 @@
+export const INVOICE_TEMPLATE_IDS = [
+  "oem-clean",
+  "modern-service",
+  "heavy-duty",
+  "performance",
+  "fleet-professional",
+  "minimal-premium",
+] as const;
+
+export type InvoiceTemplateId = (typeof INVOICE_TEMPLATE_IDS)[number];
+
+export const INVOICE_PALETTE_IDS = [
+  "copper-navy",
+  "blue-slate",
+  "red-charcoal",
+  "green-graphite",
+  "monochrome",
+] as const;
+
+export type InvoicePaletteId = (typeof INVOICE_PALETTE_IDS)[number];
+export type InvoiceLogoSize = "small" | "medium" | "large";
+export type InvoiceLogoAlignment = "left" | "center";
+export type InvoiceDetailDensity = "compact" | "standard" | "detailed";
+
+export type InvoiceDocumentSettings = {
+  version: 1;
+  templateId: InvoiceTemplateId;
+  paletteId: InvoicePaletteId;
+  logoSize: InvoiceLogoSize;
+  logoAlignment: InvoiceLogoAlignment;
+  logoZoom: number;
+  detailDensity: InvoiceDetailDensity;
+  showNarratives: boolean;
+};
+
+export type InvoiceDocumentConfiguration = InvoiceDocumentSettings & {
+  logoUrl: string | null;
+  colors: {
+    primary: string;
+    secondary: string;
+    accent: string;
+  };
+  terms: string | null;
+  footer: string | null;
+};
+
+export const INVOICE_TEMPLATES: ReadonlyArray<{
+  id: InvoiceTemplateId;
+  name: string;
+  description: string;
+  headerStyle: "solid" | "split" | "minimal";
+  panelStyle: "filled" | "outlined" | "minimal";
+}> = [
+  {
+    id: "oem-clean",
+    name: "OEM Clean",
+    description: "Balanced, familiar service-department layout.",
+    headerStyle: "solid",
+    panelStyle: "filled",
+  },
+  {
+    id: "modern-service",
+    name: "Modern Service",
+    description: "Airy layout with a crisp split header.",
+    headerStyle: "split",
+    panelStyle: "filled",
+  },
+  {
+    id: "heavy-duty",
+    name: "Heavy Duty",
+    description: "High-contrast structure for commercial repair.",
+    headerStyle: "solid",
+    panelStyle: "outlined",
+  },
+  {
+    id: "performance",
+    name: "Performance",
+    description: "Bold accent treatment with compact details.",
+    headerStyle: "split",
+    panelStyle: "outlined",
+  },
+  {
+    id: "fleet-professional",
+    name: "Fleet Professional",
+    description: "Dense, scan-friendly commercial invoice.",
+    headerStyle: "solid",
+    panelStyle: "minimal",
+  },
+  {
+    id: "minimal-premium",
+    name: "Minimal Premium",
+    description: "Quiet typography and restrained color.",
+    headerStyle: "minimal",
+    panelStyle: "minimal",
+  },
+];
+
+export const INVOICE_PALETTES: ReadonlyArray<{
+  id: InvoicePaletteId;
+  name: string;
+  colors: InvoiceDocumentConfiguration["colors"];
+}> = [
+  {
+    id: "copper-navy",
+    name: "Copper & Navy",
+    colors: { primary: "#C86A32", secondary: "#101827", accent: "#F0A45D" },
+  },
+  {
+    id: "blue-slate",
+    name: "Blue & Slate",
+    colors: { primary: "#2563EB", secondary: "#172033", accent: "#60A5FA" },
+  },
+  {
+    id: "red-charcoal",
+    name: "Red & Charcoal",
+    colors: { primary: "#C83E3E", secondary: "#202124", accent: "#EF7A72" },
+  },
+  {
+    id: "green-graphite",
+    name: "Green & Graphite",
+    colors: { primary: "#23856D", secondary: "#1B2525", accent: "#62BFA6" },
+  },
+  {
+    id: "monochrome",
+    name: "Monochrome",
+    colors: { primary: "#3F4752", secondary: "#111418", accent: "#8E99A6" },
+  },
+];
+
+export const DEFAULT_INVOICE_DOCUMENT_SETTINGS: InvoiceDocumentSettings = {
+  version: 1,
+  templateId: "oem-clean",
+  paletteId: "copper-navy",
+  logoSize: "medium",
+  logoAlignment: "left",
+  logoZoom: 1.25,
+  detailDensity: "standard",
+  showNarratives: true,
+};
+
+function member<T extends readonly string[]>(
+  values: T,
+  value: unknown,
+): value is T[number] {
+  return (
+    typeof value === "string" && (values as readonly string[]).includes(value)
+  );
+}
+
+export function normalizeInvoiceDocumentSettings(
+  value: unknown,
+): InvoiceDocumentSettings {
+  const input =
+    value && typeof value === "object"
+      ? (value as Record<string, unknown>)
+      : {};
+  const zoom = Number(input.logoZoom);
+  return {
+    version: 1,
+    templateId: member(INVOICE_TEMPLATE_IDS, input.templateId)
+      ? input.templateId
+      : DEFAULT_INVOICE_DOCUMENT_SETTINGS.templateId,
+    paletteId: member(INVOICE_PALETTE_IDS, input.paletteId)
+      ? input.paletteId
+      : DEFAULT_INVOICE_DOCUMENT_SETTINGS.paletteId,
+    logoSize: member(["small", "medium", "large"] as const, input.logoSize)
+      ? input.logoSize
+      : DEFAULT_INVOICE_DOCUMENT_SETTINGS.logoSize,
+    logoAlignment: member(["left", "center"] as const, input.logoAlignment)
+      ? input.logoAlignment
+      : DEFAULT_INVOICE_DOCUMENT_SETTINGS.logoAlignment,
+    logoZoom: Number.isFinite(zoom)
+      ? Math.min(2, Math.max(0.75, zoom))
+      : DEFAULT_INVOICE_DOCUMENT_SETTINGS.logoZoom,
+    detailDensity: member(
+      ["compact", "standard", "detailed"] as const,
+      input.detailDensity,
+    )
+      ? input.detailDensity
+      : DEFAULT_INVOICE_DOCUMENT_SETTINGS.detailDensity,
+    showNarratives:
+      typeof input.showNarratives === "boolean"
+        ? input.showNarratives
+        : DEFAULT_INVOICE_DOCUMENT_SETTINGS.showNarratives,
+  };
+}
+
+export function paletteFor(id: InvoicePaletteId) {
+  return (
+    INVOICE_PALETTES.find((palette) => palette.id === id) ?? INVOICE_PALETTES[0]
+  );
+}
+
+export function templateFor(id: InvoiceTemplateId) {
+  return (
+    INVOICE_TEMPLATES.find((template) => template.id === id) ??
+    INVOICE_TEMPLATES[0]
+  );
+}
+
+export function resolveInvoiceDocumentConfiguration(args: {
+  settings?: unknown;
+  logoUrl?: string | null;
+  terms?: string | null;
+  footer?: string | null;
+}): InvoiceDocumentConfiguration {
+  const settings = normalizeInvoiceDocumentSettings(args.settings);
+  return {
+    ...settings,
+    logoUrl: args.logoUrl?.trim() || null,
+    colors: paletteFor(settings.paletteId).colors,
+    terms: args.terms?.trim() || null,
+    footer: args.footer?.trim() || null,
+  };
+}
+
+export function isFrozenInvoiceDocumentConfiguration(
+  value: unknown,
+): value is InvoiceDocumentConfiguration {
+  if (!value || typeof value !== "object") return false;
+  const input = value as Partial<InvoiceDocumentConfiguration>;
+  return (
+    input.version === 1 &&
+    typeof input.colors?.primary === "string" &&
+    "logoUrl" in input
+  );
+}

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -9,6 +9,7 @@ import {
 import { calculateInvoiceTotals } from "@/features/invoices/lib/invoiceTotals";
 import { shouldUsePersistedInvoiceTotals } from "@/features/invoices/lib/invoiceSnapshotState";
 import { filterInvoicePartAllocations } from "@/features/invoices/lib/filterInvoicePartAllocations";
+import type { InvoiceDocumentConfiguration } from "@/features/invoices/lib/invoiceDocumentTheme";
 
 type DB = Database;
 
@@ -18,9 +19,11 @@ type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
 type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
 type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
-type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
+type AllocationRow =
+  DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
-type WorkOrderQuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type WorkOrderQuoteLineRow =
+  DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"];
 type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
 type PartRequestRow = DB["public"]["Tables"]["part_requests"]["Row"];
@@ -36,7 +39,10 @@ export type InvoiceSnapshotPart = {
   partNumber?: string;
   unit?: string;
   vendor?: string;
-  source?: "work_order_part_allocation" | "work_order_part" | "quote_line_part_request";
+  source?:
+    | "work_order_part_allocation"
+    | "work_order_part"
+    | "quote_line_part_request";
 };
 
 export type InvoiceSnapshotLine = Pick<
@@ -91,27 +97,30 @@ export type InvoiceSnapshot = {
     | "created_at"
     | "notes"
   > | null;
-  shop: Pick<
-    ShopRow,
-    | "business_name"
-    | "shop_name"
-    | "name"
-    | "country"
-    | "phone_number"
-    | "email"
-    | "street"
-    | "city"
-    | "province"
-    | "postal_code"
-    | "labor_rate"
-    | "supplies_percent"
-    | "shop_supplies_enabled"
-    | "shop_supplies_type"
-    | "shop_supplies_percent"
-    | "shop_supplies_flat_amount"
-    | "shop_supplies_cap_amount"
-    | "tax_rate"
-  > | null;
+  shop:
+    | (Pick<
+        ShopRow,
+        | "business_name"
+        | "shop_name"
+        | "name"
+        | "country"
+        | "phone_number"
+        | "email"
+        | "street"
+        | "city"
+        | "province"
+        | "postal_code"
+        | "labor_rate"
+        | "supplies_percent"
+        | "shop_supplies_enabled"
+        | "shop_supplies_type"
+        | "shop_supplies_percent"
+        | "shop_supplies_flat_amount"
+        | "shop_supplies_cap_amount"
+        | "tax_rate"
+      > &
+        Partial<Pick<ShopRow, "logo_url" | "invoice_terms" | "invoice_footer">>)
+    | null;
   customer: Pick<
     CustomerRow,
     | "name"
@@ -149,6 +158,8 @@ export type InvoiceSnapshot = {
   taxTotal: number | null;
   taxRate?: number | null;
   total: number | null;
+  /** Immutable resolved renderer configuration. Present on issued invoice versions. */
+  documentConfiguration?: InvoiceDocumentConfiguration;
 };
 
 function safeNumberOrNull(v: unknown): number | null {
@@ -168,14 +179,18 @@ function positiveOrNull(v: unknown): number | null {
 }
 
 function normalizeInvoiceCurrency(v: unknown): "CAD" | "USD" | null {
-  const c = String(v ?? "").trim().toUpperCase();
+  const c = String(v ?? "")
+    .trim()
+    .toUpperCase();
   if (c === "CAD") return "CAD";
   if (c === "USD") return "USD";
   return null;
 }
 
 function normalizeCurrencyFromCountry(country: unknown): "CAD" | "USD" {
-  const c = String(country ?? "").trim().toUpperCase();
+  const c = String(country ?? "")
+    .trim()
+    .toUpperCase();
   return c === "CA" ? "CAD" : "USD";
 }
 
@@ -216,7 +231,9 @@ function itemUnitPrice(
   );
 }
 
-function itemQuantity(item: Pick<PartRequestItemRow, "qty" | "qty_requested" | "qty_approved">): number {
+function itemQuantity(
+  item: Pick<PartRequestItemRow, "qty" | "qty_requested" | "qty_approved">,
+): number {
   const qty = safeNumber(item.qty);
   const requested = safeNumber(item.qty_requested);
   const approved = safeNumber(item.qty_approved);
@@ -225,11 +242,16 @@ function itemQuantity(item: Pick<PartRequestItemRow, "qty" | "qty_requested" | "
 }
 
 function quoteLineIsInvoiceFallbackEligible(
-  quote: Pick<WorkOrderQuoteLineRow, "status" | "work_order_line_id"> | undefined,
+  quote:
+    | Pick<WorkOrderQuoteLineRow, "status" | "work_order_line_id">
+    | undefined,
   lineId: string,
 ): boolean {
-  if (!quote?.work_order_line_id || quote.work_order_line_id !== lineId) return false;
-  const status = String(quote.status ?? "").trim().toLowerCase();
+  if (!quote?.work_order_line_id || quote.work_order_line_id !== lineId)
+    return false;
+  const status = String(quote.status ?? "")
+    .trim()
+    .toLowerCase();
   return !NON_BILLABLE_QUOTE_LINE_STATUSES.has(status);
 }
 
@@ -252,14 +274,19 @@ function partRequestItemIsInvoiceFallbackEligible(
     workOrderId: string;
     workOrderLineId: string;
     requestQuoteLineIdByRequestId: Map<string, string>;
-    quoteLineById: Map<string, Pick<WorkOrderQuoteLineRow, "status" | "work_order_line_id">>;
+    quoteLineById: Map<
+      string,
+      Pick<WorkOrderQuoteLineRow, "status" | "work_order_line_id">
+    >;
   },
 ): boolean {
   if (item.shop_id !== args.shopId) return false;
   if (item.work_order_id !== args.workOrderId) return false;
   if (item.work_order_line_id !== args.workOrderLineId) return false;
 
-  const status = String(item.status ?? "").trim().toLowerCase();
+  const status = String(item.status ?? "")
+    .trim()
+    .toLowerCase();
   const statusIsBillable = BILLABLE_PART_REQUEST_ITEM_STATUSES.has(status);
   if (!statusIsBillable && item.approved !== true) return false;
   if (itemQuantity(item) <= 0) return false;
@@ -342,11 +369,12 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   // Match the work-order page exactly for labor pricing. That page reads
   // labor_rate in a dedicated query, so unrelated shop settings cannot turn
   // one labor hour into one dollar on the billing card.
-  const { data: workOrderShopRate, error: workOrderShopRateError } = await supabase
-    .from("shops")
-    .select("labor_rate")
-    .eq("id", workOrder.shop_id)
-    .maybeSingle<Pick<ShopRow, "labor_rate">>();
+  const { data: workOrderShopRate, error: workOrderShopRateError } =
+    await supabase
+      .from("shops")
+      .select("labor_rate")
+      .eq("id", workOrder.shop_id)
+      .maybeSingle<Pick<ShopRow, "labor_rate">>();
 
   if (workOrderShopRateError) {
     throw new Error(
@@ -357,7 +385,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const shopResult = await supabase
     .from("shops")
     .select(
-      "business_name, shop_name, name, country, phone_number, email, street, city, province, postal_code, labor_rate, supplies_percent, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount, tax_rate",
+      "business_name, shop_name, name, country, phone_number, email, street, city, province, postal_code, labor_rate, supplies_percent, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount, tax_rate, logo_url, invoice_terms, invoice_footer",
     )
     .eq("id", workOrder.shop_id)
     .maybeSingle<
@@ -374,13 +402,16 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         | "province"
         | "postal_code"
         | "labor_rate"
-    | "supplies_percent"
-    | "shop_supplies_enabled"
-    | "shop_supplies_type"
-    | "shop_supplies_percent"
-    | "shop_supplies_flat_amount"
-    | "shop_supplies_cap_amount"
-    | "tax_rate"
+        | "supplies_percent"
+        | "shop_supplies_enabled"
+        | "shop_supplies_type"
+        | "shop_supplies_percent"
+        | "shop_supplies_flat_amount"
+        | "shop_supplies_cap_amount"
+        | "tax_rate"
+        | "logo_url"
+        | "invoice_terms"
+        | "invoice_footer"
       >
     >();
 
@@ -388,32 +419,36 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   // every optional shop-supplies column yet. PostgREST rejects the entire
   // select when even one selected column is unavailable, which previously
   // turned a configured $140 rate into a null shop row and then a $1 fallback.
-  const shopFallbackResult = shopResult.error || !shopResult.data
-    ? await supabase
-        .from("shops")
-        .select(
-          "business_name, shop_name, name, country, phone_number, email, street, city, province, postal_code, labor_rate, supplies_percent, tax_rate",
-        )
-        .eq("id", workOrder.shop_id)
-        .maybeSingle<
-          Pick<
-            ShopRow,
-            | "business_name"
-            | "shop_name"
-            | "name"
-            | "country"
-            | "phone_number"
-            | "email"
-            | "street"
-            | "city"
-            | "province"
-            | "postal_code"
-            | "labor_rate"
-            | "supplies_percent"
-            | "tax_rate"
-          >
-        >()
-    : null;
+  const shopFallbackResult =
+    shopResult.error || !shopResult.data
+      ? await supabase
+          .from("shops")
+          .select(
+            "business_name, shop_name, name, country, phone_number, email, street, city, province, postal_code, labor_rate, supplies_percent, tax_rate, logo_url, invoice_terms, invoice_footer",
+          )
+          .eq("id", workOrder.shop_id)
+          .maybeSingle<
+            Pick<
+              ShopRow,
+              | "business_name"
+              | "shop_name"
+              | "name"
+              | "country"
+              | "phone_number"
+              | "email"
+              | "street"
+              | "city"
+              | "province"
+              | "postal_code"
+              | "labor_rate"
+              | "supplies_percent"
+              | "tax_rate"
+              | "logo_url"
+              | "invoice_terms"
+              | "invoice_footer"
+            >
+          >()
+      : null;
 
   if (shopFallbackResult?.error) {
     throw new Error(
@@ -487,7 +522,9 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
 
   const { data: linesRaw, error: linesError } = await supabase
     .from("work_order_lines")
-    .select("id, line_no, description, complaint, cause, correction, labor_time, price_estimate, intake_json")
+    .select(
+      "id, line_no, description, complaint, cause, correction, labor_time, price_estimate, intake_json",
+    )
     .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .order("line_no", { ascending: true })
@@ -509,14 +546,18 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     >();
 
   if (linesError) {
-    throw new Error(`Work-order labor lines are unavailable: ${linesError.message}`);
+    throw new Error(
+      `Work-order labor lines are unavailable: ${linesError.message}`,
+    );
   }
 
   const lines = Array.isArray(linesRaw) ? linesRaw : [];
 
   const { data: allocRaw, error: allocationsError } = await supabase
     .from("work_order_part_allocations")
-    .select("id, shop_id, work_order_id, work_order_line_id, part_id, qty, unit_cost, source_request_item_id, created_at")
+    .select(
+      "id, shop_id, work_order_id, work_order_line_id, part_id, qty, unit_cost, source_request_item_id, created_at",
+    )
     .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .order("created_at", { ascending: true })
@@ -524,24 +565,46 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       Array<
         Pick<
           AllocationRow,
-          "id" | "shop_id" | "work_order_id" | "work_order_line_id" | "part_id" | "qty" | "unit_cost" | "source_request_item_id" | "created_at"
+          | "id"
+          | "shop_id"
+          | "work_order_id"
+          | "work_order_line_id"
+          | "part_id"
+          | "qty"
+          | "unit_cost"
+          | "source_request_item_id"
+          | "created_at"
         >
       >
     >();
 
   if (allocationsError) {
-    throw new Error(`Allocated work-order parts are unavailable: ${allocationsError.message}`);
+    throw new Error(
+      `Allocated work-order parts are unavailable: ${allocationsError.message}`,
+    );
   }
 
   const allocs = Array.isArray(allocRaw) ? allocRaw : [];
   const stagedPartsResult = await supabase
     .from("work_order_parts")
-    .select("id, shop_id, work_order_line_id, part_id, quantity, unit_price, total_price, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_consumed, quantity_returned, quantity_cancelled, unit_sell_price_snapshot, lifecycle_status, source_parts_request_item_id, is_active")
+    .select(
+      "id, shop_id, work_order_line_id, part_id, quantity, unit_price, total_price, description_snapshot, manufacturer_snapshot, part_number_snapshot, quantity_requested, quantity_consumed, quantity_returned, quantity_cancelled, unit_sell_price_snapshot, lifecycle_status, source_parts_request_item_id, is_active",
+    )
     .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .returns<
       Array<
-        Pick<WorkOrderPartRow, "id" | "shop_id" | "work_order_line_id" | "part_id" | "quantity" | "unit_price" | "total_price"> & Record<string, unknown>
+        Pick<
+          WorkOrderPartRow,
+          | "id"
+          | "shop_id"
+          | "work_order_line_id"
+          | "part_id"
+          | "quantity"
+          | "unit_price"
+          | "total_price"
+        > &
+          Record<string, unknown>
       >
     >();
 
@@ -585,10 +648,27 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
 
   const { data: quoteRaw } = await supabase
     .from("work_order_quote_lines")
-    .select("id, work_order_line_id, status, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, grand_total")
+    .select(
+      "id, work_order_line_id, status, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, grand_total",
+    )
     .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
-    .returns<Array<Pick<WorkOrderQuoteLineRow, "id" | "work_order_line_id" | "status" | "labor_hours" | "est_labor_hours" | "labor_total" | "parts_total" | "subtotal" | "grand_total">>>();
+    .returns<
+      Array<
+        Pick<
+          WorkOrderQuoteLineRow,
+          | "id"
+          | "work_order_line_id"
+          | "status"
+          | "labor_hours"
+          | "est_labor_hours"
+          | "labor_total"
+          | "parts_total"
+          | "subtotal"
+          | "grand_total"
+        >
+      >
+    >();
   const activeQuotes = (Array.isArray(quoteRaw) ? quoteRaw : []).filter((q) => {
     const s = String(q.status ?? "").toLowerCase();
     return s !== "converted" && !NON_BILLABLE_QUOTE_LINE_STATUSES.has(s);
@@ -610,7 +690,9 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
 
   const { data: requestItemsRaw, error: requestItemsError } = await supabase
     .from("part_request_items")
-    .select("id, request_id, shop_id, work_order_id, work_order_line_id, quote_line_id, description, qty, qty_requested, qty_approved, quoted_price, unit_price, unit_cost, status, approved, part_id, vendor")
+    .select(
+      "id, request_id, shop_id, work_order_id, work_order_line_id, quote_line_id, description, qty, qty_requested, qty_approved, quoted_price, unit_price, unit_cost, status, approved, part_id, vendor",
+    )
     .eq("shop_id", workOrder.shop_id)
     .eq("work_order_id", workOrderId)
     .returns<
@@ -639,7 +721,9 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     >();
 
   if (requestItemsError) {
-    throw new Error(`Parts pricing is unavailable: ${requestItemsError.message}`);
+    throw new Error(
+      `Parts pricing is unavailable: ${requestItemsError.message}`,
+    );
   }
 
   const requestItems = Array.isArray(requestItemsRaw) ? requestItemsRaw : [];
@@ -661,7 +745,12 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       .eq("work_order_id", workOrderId)
       .in("id", requestIdsNeedingQuoteLink)
       .returns<
-        Array<Pick<PartRequestRow, "id" | "shop_id" | "work_order_id" | "quote_line_id">>
+        Array<
+          Pick<
+            PartRequestRow,
+            "id" | "shop_id" | "work_order_id" | "quote_line_id"
+          >
+        >
       >();
 
     for (const request of Array.isArray(requestRows) ? requestRows : []) {
@@ -671,7 +760,10 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         isNonEmptyString(request.id) &&
         isNonEmptyString(request.quote_line_id)
       ) {
-        requestQuoteLineIdByRequestId.set(request.id, request.quote_line_id.trim());
+        requestQuoteLineIdByRequestId.set(
+          request.id,
+          request.quote_line_id.trim(),
+        );
       }
     }
   }
@@ -694,7 +786,9 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   }
 
   const fallbackRequestItems = requestItems.filter((item) => {
-    const lineId = isNonEmptyString(item.work_order_line_id) ? item.work_order_line_id.trim() : "";
+    const lineId = isNonEmptyString(item.work_order_line_id)
+      ? item.work_order_line_id.trim()
+      : "";
     if (!lineId) return false;
 
     return partRequestItemIsInvoiceFallbackEligible(item, {
@@ -706,7 +800,10 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     });
   });
 
-  const byLineFallbackRequestItems = new Map<string, typeof fallbackRequestItems>();
+  const byLineFallbackRequestItems = new Map<
+    string,
+    typeof fallbackRequestItems
+  >();
   for (const item of fallbackRequestItems) {
     if (!item.work_order_line_id) continue;
     byLineFallbackRequestItems.set(item.work_order_line_id, [
@@ -757,7 +854,9 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       >();
 
     if (partRowsError) {
-      throw new Error(`Parts catalog pricing is unavailable: ${partRowsError.message}`);
+      throw new Error(
+        `Parts catalog pricing is unavailable: ${partRowsError.message}`,
+      );
     }
 
     for (const p of Array.isArray(partRows) ? partRows : []) {
@@ -800,70 +899,90 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     });
   }
 
-  const stagedInvoiceParts: InvoiceSnapshotPart[] = stagedParts.flatMap((part) => {
-    const p = isNonEmptyString(part.part_id) ? partsMap.get(part.part_id) : undefined;
-    const partRecord = part as Record<string, unknown>;
-    if (partRecord.is_active === false) return [];
-    const consumed = safeNumber(partRecord.quantity_consumed);
-    const returned = safeNumber(partRecord.quantity_returned);
-    const cancelled = safeNumber(partRecord.quantity_cancelled);
-    const requested = safeNumber(partRecord.quantity_requested);
-    const qty =
-      consumed > 0
-        ? Math.max(0, consumed - returned)
-        : Math.max(0, (requested > 0 ? requested : safeNumber(part.quantity)) - cancelled);
-    if (qty <= 0) return [];
-    const totalRaw = safeNumber(part.total_price);
-    const unitPrice =
-      safeNumber(partRecord.unit_sell_price_snapshot) ||
-      safeNumber(part.unit_price) ||
-      safeNumber(p?.price) ||
-      safeNumber(p?.default_price);
-    const totalPrice = unitPrice > 0 ? Math.max(0, qty * unitPrice) : totalRaw;
-    const lineId = isNonEmptyString(part.work_order_line_id)
-      ? part.work_order_line_id.trim()
-      : undefined;
+  const stagedInvoiceParts: InvoiceSnapshotPart[] = stagedParts.flatMap(
+    (part) => {
+      const p = isNonEmptyString(part.part_id)
+        ? partsMap.get(part.part_id)
+        : undefined;
+      const partRecord = part as Record<string, unknown>;
+      if (partRecord.is_active === false) return [];
+      const consumed = safeNumber(partRecord.quantity_consumed);
+      const returned = safeNumber(partRecord.quantity_returned);
+      const cancelled = safeNumber(partRecord.quantity_cancelled);
+      const requested = safeNumber(partRecord.quantity_requested);
+      const qty =
+        consumed > 0
+          ? Math.max(0, consumed - returned)
+          : Math.max(
+              0,
+              (requested > 0 ? requested : safeNumber(part.quantity)) -
+                cancelled,
+            );
+      if (qty <= 0) return [];
+      const totalRaw = safeNumber(part.total_price);
+      const unitPrice =
+        safeNumber(partRecord.unit_sell_price_snapshot) ||
+        safeNumber(part.unit_price) ||
+        safeNumber(p?.price) ||
+        safeNumber(p?.default_price);
+      const totalPrice =
+        unitPrice > 0 ? Math.max(0, qty * unitPrice) : totalRaw;
+      const lineId = isNonEmptyString(part.work_order_line_id)
+        ? part.work_order_line_id.trim()
+        : undefined;
 
-    return [{
-      id: String(part.id),
-      lineId,
-      name: (String(partRecord.description_snapshot ?? "").trim() || (p?.name ?? "Part")).trim() || "Part",
-      qty,
-      unitPrice,
-      totalPrice,
-      sku: (p?.sku ?? "").trim() || undefined,
-      partNumber: (String(partRecord.part_number_snapshot ?? "").trim() || (p?.part_number ?? "")).trim() || undefined,
-      unit: (p?.unit ?? "").trim() || undefined,
-      source: "work_order_part",
-    }];
-  });
+      return [
+        {
+          id: String(part.id),
+          lineId,
+          name:
+            (
+              String(partRecord.description_snapshot ?? "").trim() ||
+              (p?.name ?? "Part")
+            ).trim() || "Part",
+          qty,
+          unitPrice,
+          totalPrice,
+          sku: (p?.sku ?? "").trim() || undefined,
+          partNumber:
+            (
+              String(partRecord.part_number_snapshot ?? "").trim() ||
+              (p?.part_number ?? "")
+            ).trim() || undefined,
+          unit: (p?.unit ?? "").trim() || undefined,
+          source: "work_order_part",
+        },
+      ];
+    },
+  );
 
-  const requestItemInvoiceParts: InvoiceSnapshotPart[] = fallbackRequestItems.map((item) => {
-    const p = isNonEmptyString(item.part_id) ? partsMap.get(item.part_id) : undefined;
-    const qty = itemQuantity(item);
-    const unitPrice = itemUnitPrice(item);
-    const lineId = isNonEmptyString(item.work_order_line_id)
-      ? item.work_order_line_id.trim()
-      : undefined;
-    const name =
-      (item.description ?? "").trim() ||
-      (p?.name ?? "").trim() ||
-      "Part";
+  const requestItemInvoiceParts: InvoiceSnapshotPart[] =
+    fallbackRequestItems.map((item) => {
+      const p = isNonEmptyString(item.part_id)
+        ? partsMap.get(item.part_id)
+        : undefined;
+      const qty = itemQuantity(item);
+      const unitPrice = itemUnitPrice(item);
+      const lineId = isNonEmptyString(item.work_order_line_id)
+        ? item.work_order_line_id.trim()
+        : undefined;
+      const name =
+        (item.description ?? "").trim() || (p?.name ?? "").trim() || "Part";
 
-    return {
-      id: String(item.id),
-      lineId,
-      name,
-      qty,
-      unitPrice,
-      totalPrice: Math.max(0, qty * unitPrice),
-      sku: (p?.sku ?? "").trim() || undefined,
-      partNumber: (p?.part_number ?? "").trim() || undefined,
-      unit: (p?.unit ?? "").trim() || undefined,
-      vendor: (item.vendor ?? "").trim() || undefined,
-      source: "quote_line_part_request",
-    };
-  });
+      return {
+        id: String(item.id),
+        lineId,
+        name,
+        qty,
+        unitPrice,
+        totalPrice: Math.max(0, qty * unitPrice),
+        sku: (p?.sku ?? "").trim() || undefined,
+        partNumber: (p?.part_number ?? "").trim() || undefined,
+        unit: (p?.unit ?? "").trim() || undefined,
+        vendor: (item.vendor ?? "").trim() || undefined,
+        source: "quote_line_part_request",
+      };
+    });
 
   const stagedPartsByLineForDisplay = new Map<string, InvoiceSnapshotPart[]>();
   for (const part of stagedInvoiceParts) {
@@ -874,7 +993,10 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     ]);
   }
 
-  const fallbackPartsByLineForDisplay = new Map<string, InvoiceSnapshotPart[]>();
+  const fallbackPartsByLineForDisplay = new Map<
+    string,
+    InvoiceSnapshotPart[]
+  >();
   for (const part of requestItemInvoiceParts) {
     if (!part.lineId) continue;
     fallbackPartsByLineForDisplay.set(part.lineId, [
@@ -892,16 +1014,18 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     const unbackedAllocations = filterInvoicePartAllocations({
       allocations: lineAllocations,
       stagedParts: rawLineStaged as Array<
-        typeof rawLineStaged[number] & {
+        (typeof rawLineStaged)[number] & {
           source_parts_request_item_id?: string | null;
         }
       >,
       displayedStagedPartIds: displayedStagedIds,
     });
-    const unbackedAllocationParts = unbackedAllocations.flatMap((allocation) => {
-      const part = allocationPartById.get(String(allocation.id));
-      return part ? [part] : [];
-    });
+    const unbackedAllocationParts = unbackedAllocations.flatMap(
+      (allocation) => {
+        const part = allocationPartById.get(String(allocation.id));
+        return part ? [part] : [];
+      },
+    );
 
     if (lineStaged.length > 0) {
       parts.push(...lineStaged);
@@ -927,7 +1051,9 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   }
   if (
     parts.length === 0 &&
-    (allocs.length > 0 || stagedInvoiceParts.length > 0 || fallbackRequestItems.length > 0)
+    (allocs.length > 0 ||
+      stagedInvoiceParts.length > 0 ||
+      fallbackRequestItems.length > 0)
   ) {
     throw new Error(
       "Attached parts could not be resolved into invoice line items.",
@@ -942,8 +1068,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const currency =
     (usePersistedInvoiceTotals
       ? normalizeInvoiceCurrency(invoice?.currency)
-      : null) ??
-    normalizeCurrencyFromCountry(shop?.country);
+      : null) ?? normalizeCurrencyFromCountry(shop?.country);
 
   const invSubtotal = usePersistedInvoiceTotals
     ? safeNumberOrNull(invoice?.subtotal)
@@ -966,7 +1091,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   const woParts = positiveOrNull(workOrder.parts_total);
   const woInvoiceTotal = positiveOrNull(workOrder.invoice_total);
 
-  const byLineQuote = new Map<string, typeof activeQuotes[number]>();
+  const byLineQuote = new Map<string, (typeof activeQuotes)[number]>();
   for (const q of activeQuotes) {
     if (!q.work_order_line_id) continue;
     byLineQuote.set(q.work_order_line_id, q);
@@ -1020,15 +1145,24 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
   // when there are no itemized lines to price.
   const laborCost =
     invLabor ??
-    (resolvedLabor > 0 ? resolvedLabor : pricedLines.length === 0 ? woLabor : null) ??
+    (resolvedLabor > 0
+      ? resolvedLabor
+      : pricedLines.length === 0
+        ? woLabor
+        : null) ??
     null;
-  const partsCost = invParts ?? (resolvedParts > 0 ? resolvedParts : woParts) ?? null;
+  const partsCost =
+    invParts ?? (resolvedParts > 0 ? resolvedParts : woParts) ?? null;
 
   const baseSubtotal = (laborCost ?? 0) + (partsCost ?? 0);
   const shopSupplies = calculateShopSupplies({
     baseAmount: baseSubtotal,
-    settings: resolveShopSuppliesSettings(shop as Parameters<typeof resolveShopSuppliesSettings>[0]),
-    override: resolveShopSuppliesOverride(workOrder as Parameters<typeof resolveShopSuppliesOverride>[0]),
+    settings: resolveShopSuppliesSettings(
+      shop as Parameters<typeof resolveShopSuppliesSettings>[0],
+    ),
+    override: resolveShopSuppliesOverride(
+      workOrder as Parameters<typeof resolveShopSuppliesOverride>[0],
+    ),
   });
   const persistedSupplies =
     usePersistedInvoiceTotals && invSubtotal != null
@@ -1050,7 +1184,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     taxRatePercent: configuredTaxRate,
   });
   const subtotal = usePersistedInvoiceTotals
-    ? invSubtotal ?? calculated.subtotal
+    ? (invSubtotal ?? calculated.subtotal)
     : calculated.subtotal > 0
       ? calculated.subtotal
       : null;
@@ -1068,7 +1202,7 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
     taxRatePercent: taxRate,
   }).total;
   const total = usePersistedInvoiceTotals
-    ? invTotal ?? derivedInvoiceTotal
+    ? (invTotal ?? derivedInvoiceTotal)
     : derivedInvoiceTotal > 0
       ? derivedInvoiceTotal
       : woInvoiceTotal;

--- a/features/invoices/server/renderPremiumInvoicePdf.test.ts
+++ b/features/invoices/server/renderPremiumInvoicePdf.test.ts
@@ -7,6 +7,11 @@ import {
   premiumInvoiceFilename,
   renderPremiumInvoicePdf,
 } from "./renderPremiumInvoicePdf";
+import {
+  INVOICE_PALETTES,
+  INVOICE_TEMPLATES,
+  resolveInvoiceDocumentConfiguration,
+} from "@/features/invoices/lib/invoiceDocumentTheme";
 
 const brand: ActiveBrandRender = {
   profile: null,
@@ -17,6 +22,10 @@ const brand: ActiveBrandRender = {
     accent: "#F0A45D",
   },
   theme: null,
+  document: resolveInvoiceDocumentConfiguration({
+    terms: "Payment due on receipt.",
+    footer: "Thank you for trusting our shop.",
+  }),
 };
 
 function fixture(partCount = 2): InvoiceSnapshot {
@@ -144,9 +153,9 @@ describe("premium invoice PDF", () => {
     expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe("%PDF-");
     expect(pdf.getPageCount()).toBeGreaterThanOrEqual(1);
     expect(pdf.getTitle()).toContain("Draft invoice");
-    expect(premiumInvoiceFilename(snapshot, { status: "draft", draft: true })).toBe(
-      "Draft_Invoice_EL000001.pdf",
-    );
+    expect(
+      premiumInvoiceFilename(snapshot, { status: "draft", draft: true }),
+    ).toBe("Draft_Invoice_EL000001.pdf");
   });
 
   it("paginates every part instead of truncating the invoice", async () => {
@@ -172,5 +181,31 @@ describe("premium invoice PDF", () => {
 
     expect(pdf.getPageCount()).toBeGreaterThan(1);
     expect(pdf.getTitle()).toContain("INV-1001");
+  });
+
+  it("renders every curated template and palette combination", async () => {
+    const snapshot = fixture();
+    for (const template of INVOICE_TEMPLATES) {
+      for (const palette of INVOICE_PALETTES) {
+        const themedBrand: ActiveBrandRender = {
+          ...brand,
+          colors: palette.colors,
+          document: resolveInvoiceDocumentConfiguration({
+            settings: { templateId: template.id, paletteId: palette.id },
+          }),
+        };
+        const bytes = await renderPremiumInvoicePdf({
+          snapshot,
+          brand: themedBrand,
+          document: {
+            status: "draft",
+            draft: true,
+            outstandingTotal: snapshot.total,
+          },
+        });
+        const pdf = await PDFDocument.load(bytes);
+        expect(pdf.getPageCount()).toBeGreaterThanOrEqual(1);
+      }
+    }
   });
 });

--- a/features/invoices/server/renderPremiumInvoicePdf.ts
+++ b/features/invoices/server/renderPremiumInvoicePdf.ts
@@ -10,6 +10,7 @@ import {
 } from "pdf-lib";
 import type { InvoiceSnapshot } from "@/features/invoices/server/getInvoiceSnapshot";
 import type { ActiveBrandRender } from "@/features/branding/server/getActiveBrandForRender";
+import { templateFor } from "@/features/invoices/lib/invoiceDocumentTheme";
 
 export type InvoicePdfDocument = {
   invoiceNumber?: string | null;
@@ -33,7 +34,7 @@ const PAGE_W = 612;
 const PAGE_H = 792;
 const MARGIN = 40;
 const CONTENT_W = PAGE_W - MARGIN * 2;
-const BOTTOM = 48;
+const BOTTOM = 38;
 
 function finite(value: unknown): number {
   const parsed = typeof value === "number" ? value : Number(value);
@@ -58,13 +59,19 @@ function display(value: unknown, fallback = "-"): string {
 }
 
 function joined(values: unknown[], separator = ", "): string {
-  return values.map((value) => clean(value)).filter(Boolean).join(separator);
+  return values
+    .map((value) => clean(value))
+    .filter(Boolean)
+    .join(separator);
 }
 
 function customerName(snapshot: InvoiceSnapshot): string {
   return (
     clean(snapshot.customer?.name) ||
-    joined([snapshot.customer?.first_name, snapshot.customer?.last_name], " ") ||
+    joined(
+      [snapshot.customer?.first_name, snapshot.customer?.last_name],
+      " ",
+    ) ||
     clean(snapshot.workOrder.customer_name) ||
     "Customer"
   );
@@ -113,7 +120,12 @@ function hexColor(value: string | null | undefined, fallback: RGB): RGB {
   );
 }
 
-function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): string[] {
+function wrapText(
+  text: string,
+  font: PDFFont,
+  size: number,
+  maxWidth: number,
+): string[] {
   const paragraphs = clean(text).split(/\n+/);
   const lines: string[] = [];
   for (const paragraph of paragraphs) {
@@ -148,7 +160,10 @@ function wrapText(text: string, font: PDFFont, size: number, maxWidth: number): 
   return lines.length ? lines : ["-"];
 }
 
-async function loadLogo(doc: PDFDocument, logoUrl: string | null): Promise<PDFImage | null> {
+async function loadLogo(
+  doc: PDFDocument,
+  logoUrl: string | null,
+): Promise<PDFImage | null> {
   if (!logoUrl) return null;
   try {
     const response = await fetch(logoUrl);
@@ -169,9 +184,17 @@ function normalizedStatus(document: InvoicePdfDocument): string {
   return clean(document.status).replaceAll("_", " ").toUpperCase() || "ISSUED";
 }
 
-function safeFileIdentifier(snapshot: InvoiceSnapshot, document: InvoicePdfDocument): string {
-  const raw = clean(document.invoiceNumber) || clean(snapshot.workOrder.custom_id) || snapshot.workOrder.id;
-  return raw.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "invoice";
+function safeFileIdentifier(
+  snapshot: InvoiceSnapshot,
+  document: InvoicePdfDocument,
+): string {
+  const raw =
+    clean(document.invoiceNumber) ||
+    clean(snapshot.workOrder.custom_id) ||
+    snapshot.workOrder.id;
+  return (
+    raw.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "invoice"
+  );
 }
 
 export function premiumInvoiceFilename(
@@ -182,12 +205,16 @@ export function premiumInvoiceFilename(
   return `${prefix}_${safeFileIdentifier(snapshot, document)}.pdf`;
 }
 
-export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8Array> {
+export async function renderPremiumInvoicePdf(
+  input: RenderInput,
+): Promise<Uint8Array> {
   const { snapshot, document, brand } = input;
   const doc = await PDFDocument.create();
   const regular = await doc.embedFont(StandardFonts.Helvetica);
   const bold = await doc.embedFont(StandardFonts.HelveticaBold);
   const logo = await loadLogo(doc, brand.logoUrl);
+  const documentTheme = brand.document;
+  const template = templateFor(documentTheme.templateId);
 
   const navy = hexColor(brand.colors.secondary, rgb(0.055, 0.09, 0.16));
   const copper = hexColor(brand.colors.primary, rgb(0.79, 0.42, 0.2));
@@ -197,9 +224,23 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
   const border = rgb(0.86, 0.88, 0.91);
   const panel = rgb(0.965, 0.97, 0.98);
   const white = rgb(1, 1, 1);
+  const headerHeight =
+    template.headerStyle === "minimal"
+      ? 88
+      : template.headerStyle === "split"
+        ? 102
+        : 108;
+  const headerBackground = template.headerStyle === "minimal" ? white : navy;
+  const headerInk = template.headerStyle === "minimal" ? navy : white;
+  const headerMuted =
+    template.headerStyle === "minimal" ? muted : rgb(0.8, 0.84, 0.89);
   const currency = snapshot.currency;
-  const workOrderLabel = clean(snapshot.workOrder.custom_id) || `WO-${snapshot.workOrder.id.slice(0, 8)}`;
-  const invoiceLabel = clean(document.invoiceNumber) || (document.draft ? "Draft preview" : workOrderLabel);
+  const workOrderLabel =
+    clean(snapshot.workOrder.custom_id) ||
+    `WO-${snapshot.workOrder.id.slice(0, 8)}`;
+  const invoiceLabel =
+    clean(document.invoiceNumber) ||
+    (document.draft ? "Draft preview" : workOrderLabel);
   const status = normalizedStatus(document);
   let page = doc.addPage([PAGE_W, PAGE_H]);
   const pages: PDFPage[] = [page];
@@ -230,30 +271,101 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
       pages.push(page);
     }
     pageInitialized = true;
-    page.drawRectangle({ x: 0, y: PAGE_H - 112, width: PAGE_W, height: 112, color: navy });
-    page.drawRectangle({ x: 0, y: PAGE_H - 116, width: PAGE_W, height: 4, color: copper });
+    page.drawRectangle({
+      x: 0,
+      y: PAGE_H - headerHeight,
+      width: PAGE_W,
+      height: headerHeight,
+      color: headerBackground,
+    });
+    if (template.headerStyle === "split") {
+      page.drawRectangle({
+        x: PAGE_W * 0.62,
+        y: PAGE_H - headerHeight,
+        width: PAGE_W * 0.38,
+        height: headerHeight,
+        color: navy,
+      });
+    }
+    page.drawRectangle({
+      x: 0,
+      y: PAGE_H - headerHeight - 4,
+      width: PAGE_W,
+      height: 4,
+      color: copper,
+    });
 
     if (logo) {
-      const scale = Math.min(132 / logo.width, 42 / logo.height, 1);
+      const maxHeight =
+        documentTheme.logoSize === "small"
+          ? 38
+          : documentTheme.logoSize === "large"
+            ? 62
+            : 50;
+      const maxWidth =
+        documentTheme.logoSize === "small"
+          ? 116
+          : documentTheme.logoSize === "large"
+            ? 178
+            : 148;
+      const scale =
+        Math.min(maxWidth / logo.width, maxHeight / logo.height) *
+        documentTheme.logoZoom;
+      const width = logo.width * scale;
+      const height = logo.height * scale;
+      const logoAreaWidth =
+        template.headerStyle === "split" ? PAGE_W * 0.54 : PAGE_W * 0.58;
+      const logoX =
+        documentTheme.logoAlignment === "center"
+          ? MARGIN + (logoAreaWidth - MARGIN - width) / 2
+          : MARGIN;
       page.drawImage(logo, {
-        x: MARGIN,
-        y: PAGE_H - 67,
-        width: logo.width * scale,
-        height: logo.height * scale,
+        x: logoX,
+        y: PAGE_H - 18 - height,
+        width,
+        height,
       });
     } else {
-      page.drawText(shopName(snapshot), { x: MARGIN, y: PAGE_H - 53, size: 18, font: bold, color: white });
+      page.drawText(shopName(snapshot), {
+        x: MARGIN,
+        y: PAGE_H - 48,
+        size: 18,
+        font: bold,
+        color: headerInk,
+      });
     }
 
-    const shopLine = joined([
-      snapshot.shop?.phone_number,
-      snapshot.shop?.email,
-    ], "  |  ");
-    if (shopLine) page.drawText(shopLine, { x: MARGIN, y: PAGE_H - 87, size: 8.5, font: regular, color: rgb(0.8, 0.84, 0.89) });
+    const shopLine = joined(
+      [snapshot.shop?.phone_number, snapshot.shop?.email],
+      "  |  ",
+    );
+    if (shopLine)
+      page.drawText(shopLine, {
+        x: MARGIN,
+        y: PAGE_H - headerHeight + 18,
+        size: 8.5,
+        font: regular,
+        color: headerMuted,
+      });
 
-    drawRight("INVOICE", PAGE_W - MARGIN, PAGE_H - 48, 22, bold, white);
-    drawRight(invoiceLabel, PAGE_W - MARGIN, PAGE_H - 67, 10, regular, rgb(0.85, 0.88, 0.92));
-    drawRight(status, PAGE_W - MARGIN, PAGE_H - 86, 9, bold, accent);
+    const rightHeaderInk = template.headerStyle === "minimal" ? navy : white;
+    drawRight(
+      "INVOICE",
+      PAGE_W - MARGIN,
+      PAGE_H - 42,
+      22,
+      bold,
+      rightHeaderInk,
+    );
+    drawRight(
+      invoiceLabel,
+      PAGE_W - MARGIN,
+      PAGE_H - 61,
+      10,
+      regular,
+      template.headerStyle === "minimal" ? muted : rgb(0.85, 0.88, 0.92),
+    );
+    drawRight(status, PAGE_W - MARGIN, PAGE_H - 80, 9, bold, accent);
 
     if (document.draft) {
       page.drawText("DRAFT", {
@@ -266,7 +378,7 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
         opacity: 0.07,
       });
     }
-    y = PAGE_H - 140;
+    y = PAGE_H - headerHeight - 28;
   };
 
   const ensure = (height: number): boolean => {
@@ -294,9 +406,21 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
 
   const sectionTitle = (value: string) => {
     ensure(28);
-    page.drawText(clean(value).toUpperCase(), { x: MARGIN, y, size: 9, font: bold, color: copper });
+    page.drawText(clean(value).toUpperCase(), {
+      x: MARGIN,
+      y,
+      size: 9,
+      font: bold,
+      color: copper,
+    });
     y -= 9;
-    page.drawRectangle({ x: MARGIN, y: y - 4, width: CONTENT_W, height: 1, color: border });
+    page.drawRectangle({
+      x: MARGIN,
+      y: y - 4,
+      width: CONTENT_W,
+      height: 1,
+      color: border,
+    });
     y -= 18;
   };
 
@@ -314,56 +438,160 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
     snapshot.shop?.province,
     snapshot.shop?.postal_code,
   ]);
-  const vehicleLabel = joined([
-    snapshot.vehicle?.year,
-    snapshot.vehicle?.make,
-    snapshot.vehicle?.model,
-  ], " ");
+  const vehicleLabel = joined(
+    [snapshot.vehicle?.year, snapshot.vehicle?.make, snapshot.vehicle?.model],
+    " ",
+  );
   const cardTop = y;
-  const cardH = 120;
+  const cardH = 110;
   const gap = 14;
   const cardW = (CONTENT_W - gap) / 2;
-  page.drawRectangle({ x: MARGIN, y: cardTop - cardH, width: cardW, height: cardH, color: panel, borderColor: border, borderWidth: 0.8 });
-  page.drawRectangle({ x: MARGIN + cardW + gap, y: cardTop - cardH, width: cardW, height: cardH, color: panel, borderColor: border, borderWidth: 0.8 });
+  const cardColor = template.panelStyle === "filled" ? panel : white;
+  const cardBorderWidth = template.panelStyle === "minimal" ? 0 : 0.8;
+  page.drawRectangle({
+    x: MARGIN,
+    y: cardTop - cardH,
+    width: cardW,
+    height: cardH,
+    color: cardColor,
+    borderColor: border,
+    borderWidth: cardBorderWidth,
+  });
+  page.drawRectangle({
+    x: MARGIN + cardW + gap,
+    y: cardTop - cardH,
+    width: cardW,
+    height: cardH,
+    color: cardColor,
+    borderColor: border,
+    borderWidth: cardBorderWidth,
+  });
 
-  page.drawText("BILL TO", { x: MARGIN + 14, y: cardTop - 20, size: 8, font: bold, color: copper });
-  page.drawText(customerName(snapshot), { x: MARGIN + 14, y: cardTop - 39, size: 11, font: bold, color: ink });
+  page.drawText("BILL TO", {
+    x: MARGIN + 14,
+    y: cardTop - 20,
+    size: 8,
+    font: bold,
+    color: copper,
+  });
+  page.drawText(customerName(snapshot), {
+    x: MARGIN + 14,
+    y: cardTop - 39,
+    size: 11,
+    font: bold,
+    color: ink,
+  });
   const customerDetails = [
     clean(snapshot.customer?.business_name),
     customerAddress,
-    joined([snapshot.customer?.phone_number || snapshot.customer?.phone, snapshot.customer?.email], "  |  "),
+    joined(
+      [
+        snapshot.customer?.phone_number || snapshot.customer?.phone,
+        snapshot.customer?.email,
+      ],
+      "  |  ",
+    ),
   ].filter(Boolean);
   let cardY = cardTop - 56;
   for (const detail of customerDetails.slice(0, 3)) {
     for (const line of wrapText(detail, regular, 8.5, cardW - 28).slice(0, 2)) {
-      page.drawText(line, { x: MARGIN + 14, y: cardY, size: 8.5, font: regular, color: muted });
+      page.drawText(line, {
+        x: MARGIN + 14,
+        y: cardY,
+        size: 8.5,
+        font: regular,
+        color: muted,
+      });
       cardY -= 12;
     }
   }
 
   const rightCardX = MARGIN + cardW + gap + 14;
-  page.drawText("VEHICLE / ASSET", { x: rightCardX, y: cardTop - 20, size: 8, font: bold, color: copper });
-  page.drawText(vehicleLabel || "No vehicle recorded", { x: rightCardX, y: cardTop - 39, size: 11, font: bold, color: ink });
+  page.drawText("VEHICLE / ASSET", {
+    x: rightCardX,
+    y: cardTop - 20,
+    size: 8,
+    font: bold,
+    color: copper,
+  });
+  page.drawText(vehicleLabel || "No vehicle recorded", {
+    x: rightCardX,
+    y: cardTop - 39,
+    size: 11,
+    font: bold,
+    color: ink,
+  });
   const vehicleDetails = [
     `VIN: ${display(snapshot.vehicle?.vin)}`,
-    joined([snapshot.vehicle?.license_plate ? `Plate: ${snapshot.vehicle.license_plate}` : "", snapshot.vehicle?.unit_number ? `Unit: ${snapshot.vehicle.unit_number}` : ""], "  |  "),
-    joined([snapshot.vehicle?.mileage != null ? `Mileage: ${snapshot.vehicle.mileage}` : "", snapshot.vehicle?.engine_hours != null ? `Hours: ${snapshot.vehicle.engine_hours}` : ""], "  |  "),
+    joined(
+      [
+        snapshot.vehicle?.license_plate
+          ? `Plate: ${snapshot.vehicle.license_plate}`
+          : "",
+        snapshot.vehicle?.unit_number
+          ? `Unit: ${snapshot.vehicle.unit_number}`
+          : "",
+      ],
+      "  |  ",
+    ),
+    joined(
+      [
+        snapshot.vehicle?.mileage != null
+          ? `Mileage: ${snapshot.vehicle.mileage}`
+          : "",
+        snapshot.vehicle?.engine_hours != null
+          ? `Hours: ${snapshot.vehicle.engine_hours}`
+          : "",
+      ],
+      "  |  ",
+    ),
   ].filter(Boolean);
   cardY = cardTop - 58;
   for (const detail of vehicleDetails) {
-    page.drawText(clean(detail), { x: rightCardX, y: cardY, size: 8.5, font: regular, color: muted });
+    page.drawText(clean(detail), {
+      x: rightCardX,
+      y: cardY,
+      size: 8.5,
+      font: regular,
+      color: muted,
+    });
     cardY -= 14;
   }
 
   y = cardTop - cardH - 22;
-  page.drawText(`Work order: ${workOrderLabel}`, { x: MARGIN, y, size: 9, font: bold, color: ink });
-  drawRight(`Issued: ${dateLabel(document.issuedAt)}`, PAGE_W - MARGIN, y, 9, regular, muted);
+  page.drawText(`Work order: ${workOrderLabel}`, {
+    x: MARGIN,
+    y,
+    size: 9,
+    font: bold,
+    color: ink,
+  });
+  drawRight(
+    `Issued: ${dateLabel(document.issuedAt)}`,
+    PAGE_W - MARGIN,
+    y,
+    9,
+    regular,
+    muted,
+  );
   y -= 26;
 
   sectionTitle("Services and parts");
   const drawTableHeader = () => {
-    page.drawRectangle({ x: MARGIN, y: y - 18, width: CONTENT_W, height: 22, color: navy });
-    page.drawText("DESCRIPTION", { x: MARGIN + 10, y: y - 11, size: 8, font: bold, color: white });
+    page.drawRectangle({
+      x: MARGIN,
+      y: y - 18,
+      width: CONTENT_W,
+      height: 22,
+      color: navy,
+    });
+    page.drawText("DESCRIPTION", {
+      x: MARGIN + 10,
+      y: y - 11,
+      size: 8,
+      font: bold,
+      color: white,
+    });
     drawRight("AMOUNT", PAGE_W - MARGIN - 10, y - 11, 8, bold, white);
     y -= 30;
   };
@@ -372,28 +600,64 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
   const assignedPartIds = new Set<string>();
   snapshot.lines.forEach((line, index) => {
     if (ensure(86)) drawTableHeader();
-    const description = clean(line.description) || clean(line.complaint) || `Service ${line.line_no ?? index + 1}`;
+    const description =
+      clean(line.description) ||
+      clean(line.complaint) ||
+      `Service ${line.line_no ?? index + 1}`;
     const descriptionLines = wrapText(description, bold, 10, 390);
-    page.drawText(descriptionLines[0], { x: MARGIN + 10, y, size: 10, font: bold, color: ink });
-    drawRight(money(line.resolvedLineTotal, currency), PAGE_W - MARGIN - 10, y, 10, bold, ink);
+    page.drawText(descriptionLines[0], {
+      x: MARGIN + 10,
+      y,
+      size: 10,
+      font: bold,
+      color: ink,
+    });
+    drawRight(
+      money(line.resolvedLineTotal, currency),
+      PAGE_W - MARGIN - 10,
+      y,
+      10,
+      bold,
+      ink,
+    );
     y -= 15;
     for (const extra of descriptionLines.slice(1)) {
-      page.drawText(extra, { x: MARGIN + 10, y, size: 9, font: regular, color: ink });
+      page.drawText(extra, {
+        x: MARGIN + 10,
+        y,
+        size: 9,
+        font: regular,
+        color: ink,
+      });
       y -= 13;
     }
 
-    const narratives = [
-      ["Complaint", line.complaint],
-      ["Cause", line.cause],
-      ["Correction", line.correction],
-    ] as const;
+    const narratives =
+      documentTheme.showNarratives && documentTheme.detailDensity !== "compact"
+        ? ([
+            ["Complaint", line.complaint],
+            ["Cause", line.cause],
+            ["Correction", line.correction],
+          ] as const)
+        : [];
     for (const [label, value] of narratives) {
       const cleaned = clean(value);
       if (!cleaned || cleaned === description) continue;
-      const narrativeLines = wrapText(`${label}: ${cleaned}`, regular, 8.5, 470);
+      const narrativeLines = wrapText(
+        `${label}: ${cleaned}`,
+        regular,
+        8.5,
+        470,
+      );
       for (const narrative of narrativeLines) {
         ensure(13);
-        page.drawText(narrative, { x: MARGIN + 18, y, size: 8.5, font: regular, color: muted });
+        page.drawText(narrative, {
+          x: MARGIN + 18,
+          y,
+          size: 8.5,
+          font: regular,
+          color: muted,
+        });
         y -= 12;
       }
     }
@@ -401,8 +665,21 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
     if (line.resolvedLaborHours > 0 || line.resolvedLaborTotal > 0) {
       ensure(16);
       const laborLabel = `${finite(line.resolvedLaborHours)} hr labor @ ${money(line.resolvedLaborRate, currency)}/hr`;
-      page.drawText(laborLabel, { x: MARGIN + 18, y, size: 8.5, font: regular, color: muted });
-      drawRight(money(line.resolvedLaborTotal, currency), PAGE_W - MARGIN - 10, y, 8.5, regular, muted);
+      page.drawText(laborLabel, {
+        x: MARGIN + 18,
+        y,
+        size: 8.5,
+        font: regular,
+        color: muted,
+      });
+      drawRight(
+        money(line.resolvedLaborTotal, currency),
+        PAGE_W - MARGIN - 10,
+        y,
+        8.5,
+        regular,
+        muted,
+      );
       y -= 15;
     }
 
@@ -410,18 +687,44 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
     for (const part of lineParts) {
       assignedPartIds.add(part.id);
       if (ensure(20)) drawTableHeader();
-      const identity = joined([part.name, part.partNumber || part.sku], " - ") || "Part";
+      const identity =
+        joined([part.name, part.partNumber || part.sku], " - ") || "Part";
       const label = `${finite(part.qty)} x ${identity} @ ${money(part.unitPrice, currency)}`;
       const rows = wrapText(label, regular, 8.5, 420);
-      page.drawText(rows[0], { x: MARGIN + 18, y, size: 8.5, font: regular, color: muted });
-      drawRight(money(part.totalPrice, currency), PAGE_W - MARGIN - 10, y, 8.5, regular, muted);
+      page.drawText(rows[0], {
+        x: MARGIN + 18,
+        y,
+        size: 8.5,
+        font: regular,
+        color: muted,
+      });
+      drawRight(
+        money(part.totalPrice, currency),
+        PAGE_W - MARGIN - 10,
+        y,
+        8.5,
+        regular,
+        muted,
+      );
       y -= 13;
       for (const extra of rows.slice(1)) {
-        page.drawText(extra, { x: MARGIN + 18, y, size: 8.5, font: regular, color: muted });
+        page.drawText(extra, {
+          x: MARGIN + 18,
+          y,
+          size: 8.5,
+          font: regular,
+          color: muted,
+        });
         y -= 12;
       }
     }
-    page.drawRectangle({ x: MARGIN, y: y - 2, width: CONTENT_W, height: 0.8, color: border });
+    page.drawRectangle({
+      x: MARGIN,
+      y: y - 2,
+      width: CONTENT_W,
+      height: 0.8,
+      color: border,
+    });
     y -= 15;
   });
 
@@ -436,13 +739,29 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
     y -= 24;
   }
 
-  const unassignedParts = snapshot.parts.filter((part) => !assignedPartIds.has(part.id));
+  const unassignedParts = snapshot.parts.filter(
+    (part) => !assignedPartIds.has(part.id),
+  );
   for (const part of unassignedParts) {
     if (ensure(24)) drawTableHeader();
-    const identity = joined([part.name, part.partNumber || part.sku], " - ") || "Part";
+    const identity =
+      joined([part.name, part.partNumber || part.sku], " - ") || "Part";
     const label = `${finite(part.qty)} x ${identity} @ ${money(part.unitPrice, currency)}`;
-    page.drawText(label, { x: MARGIN + 10, y, size: 8.5, font: regular, color: muted });
-    drawRight(money(part.totalPrice, currency), PAGE_W - MARGIN - 10, y, 8.5, regular, muted);
+    page.drawText(label, {
+      x: MARGIN + 10,
+      y,
+      size: 8.5,
+      font: regular,
+      color: muted,
+    });
+    drawRight(
+      money(part.totalPrice, currency),
+      PAGE_W - MARGIN - 10,
+      y,
+      8.5,
+      regular,
+      muted,
+    );
     y -= 16;
   }
 
@@ -454,30 +773,103 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
     ["Shop supplies", finite(snapshot.shopSuppliesTotal)],
     ["Subtotal", finite(snapshot.subtotal), true],
   ];
-  if (finite(snapshot.discountTotal) > 0) totalsRows.push(["Discount", -finite(snapshot.discountTotal)]);
-  totalsRows.push([`Tax${finite(snapshot.taxRate) > 0 ? ` (${finite(snapshot.taxRate)}%)` : ""}`, finite(snapshot.taxTotal)]);
+  if (finite(snapshot.discountTotal) > 0)
+    totalsRows.push(["Discount", -finite(snapshot.discountTotal)]);
+  totalsRows.push([
+    `Tax${finite(snapshot.taxRate) > 0 ? ` (${finite(snapshot.taxRate)}%)` : ""}`,
+    finite(snapshot.taxTotal),
+  ]);
   const totalsH = 62 + totalsRows.length * 19 + (document.draft ? 0 : 40);
   ensure(totalsH + 16);
-  page.drawRectangle({ x: totalsX, y: y - totalsH, width: totalsW, height: totalsH, color: panel, borderColor: border, borderWidth: 0.8 });
+  page.drawRectangle({
+    x: totalsX,
+    y: y - totalsH,
+    width: totalsW,
+    height: totalsH,
+    color: panel,
+    borderColor: border,
+    borderWidth: 0.8,
+  });
   let totalsY = y - 22;
   for (const [label, amount, emphasized] of totalsRows) {
-    page.drawText(label, { x: totalsX + 14, y: totalsY, size: 9, font: emphasized ? bold : regular, color: emphasized ? ink : muted });
-    drawRight(money(amount, currency), totalsX + totalsW - 14, totalsY, 9, emphasized ? bold : regular, emphasized ? ink : muted);
+    page.drawText(label, {
+      x: totalsX + 14,
+      y: totalsY,
+      size: 9,
+      font: emphasized ? bold : regular,
+      color: emphasized ? ink : muted,
+    });
+    drawRight(
+      money(amount, currency),
+      totalsX + totalsW - 14,
+      totalsY,
+      9,
+      emphasized ? bold : regular,
+      emphasized ? ink : muted,
+    );
     totalsY -= 19;
   }
-  page.drawRectangle({ x: totalsX + 14, y: totalsY + 7, width: totalsW - 28, height: 1, color: copper });
-  page.drawText(document.draft ? "ESTIMATED TOTAL" : "INVOICE TOTAL", { x: totalsX + 14, y: totalsY - 11, size: 10, font: bold, color: ink });
-  drawRight(money(snapshot.total, currency), totalsX + totalsW - 14, totalsY - 11, 14, bold, copper);
+  page.drawRectangle({
+    x: totalsX + 14,
+    y: totalsY + 7,
+    width: totalsW - 28,
+    height: 1,
+    color: copper,
+  });
+  page.drawText(document.draft ? "ESTIMATED TOTAL" : "INVOICE TOTAL", {
+    x: totalsX + 14,
+    y: totalsY - 11,
+    size: 10,
+    font: bold,
+    color: ink,
+  });
+  drawRight(
+    money(snapshot.total, currency),
+    totalsX + totalsW - 14,
+    totalsY - 11,
+    14,
+    bold,
+    copper,
+  );
   totalsY -= 34;
 
   if (!document.draft) {
-    const paid = Math.max(0, finite(document.paidTotal) - finite(document.refundedTotal));
+    const paid = Math.max(
+      0,
+      finite(document.paidTotal) - finite(document.refundedTotal),
+    );
     const balance = Math.max(0, finite(document.outstandingTotal));
-    page.drawText("Paid", { x: totalsX + 14, y: totalsY, size: 9, font: regular, color: muted });
-    drawRight(money(paid, currency), totalsX + totalsW - 14, totalsY, 9, regular, muted);
+    page.drawText("Paid", {
+      x: totalsX + 14,
+      y: totalsY,
+      size: 9,
+      font: regular,
+      color: muted,
+    });
+    drawRight(
+      money(paid, currency),
+      totalsX + totalsW - 14,
+      totalsY,
+      9,
+      regular,
+      muted,
+    );
     totalsY -= 18;
-    page.drawText("Balance due", { x: totalsX + 14, y: totalsY, size: 10, font: bold, color: ink });
-    drawRight(money(balance, currency), totalsX + totalsW - 14, totalsY, 10, bold, ink);
+    page.drawText("Balance due", {
+      x: totalsX + 14,
+      y: totalsY,
+      size: 10,
+      font: bold,
+      color: ink,
+    });
+    drawRight(
+      money(balance, currency),
+      totalsX + totalsW - 14,
+      totalsY,
+      10,
+      bold,
+      ink,
+    );
   }
   y -= totalsH + 22;
 
@@ -488,23 +880,66 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
     y -= 8;
   }
 
-  ensure(64);
-  page.drawRectangle({ x: MARGIN, y: y - 48, width: CONTENT_W, height: 48, color: navy });
-  page.drawText(document.draft ? "Draft preview - not an issued invoice" : "Thank you for your business", {
-    x: MARGIN + 14,
-    y: y - 21,
-    size: 10,
-    font: bold,
-    color: white,
+  const terms = clean(documentTheme.terms);
+  if (terms) {
+    sectionTitle("Payment terms");
+    textLines(terms, MARGIN, CONTENT_W, 9, muted, regular, 5);
+    y -= 8;
+  }
+
+  const footerMessage = document.draft
+    ? "Draft preview - not an issued invoice"
+    : clean(documentTheme.footer) || "Thank you for your business";
+  const footerLines = wrapText(footerMessage, bold, 9.5, CONTENT_W - 28).slice(
+    0,
+    2,
+  );
+  const footerBoxHeight = footerLines.length > 1 ? 58 : 48;
+  ensure(footerBoxHeight);
+  page.drawRectangle({
+    x: MARGIN,
+    y: y - footerBoxHeight,
+    width: CONTENT_W,
+    height: footerBoxHeight,
+    color: navy,
   });
-  const addressOrContact = shopAddress || joined([snapshot.shop?.phone_number, snapshot.shop?.email], " | ");
+  footerLines.forEach((line, index) => {
+    page.drawText(line, {
+      x: MARGIN + 14,
+      y: y - 20 - index * 12,
+      size: 9.5,
+      font: bold,
+      color: white,
+    });
+  });
+  const addressOrContact =
+    shopAddress ||
+    joined([snapshot.shop?.phone_number, snapshot.shop?.email], " | ");
   if (addressOrContact) {
-    page.drawText(addressOrContact, { x: MARGIN + 14, y: y - 36, size: 8, font: regular, color: rgb(0.8, 0.84, 0.89) });
+    page.drawText(addressOrContact, {
+      x: MARGIN + 14,
+      y: y - footerBoxHeight + 10,
+      size: 8,
+      font: regular,
+      color: rgb(0.8, 0.84, 0.89),
+    });
   }
 
   pages.forEach((pdfPage, index) => {
-    pdfPage.drawRectangle({ x: 0, y: 0, width: PAGE_W, height: 34, color: navy });
-    pdfPage.drawText(`${shopName(snapshot)}  |  ${workOrderLabel}`, { x: MARGIN, y: 13, size: 7.5, font: regular, color: rgb(0.78, 0.82, 0.87) });
+    pdfPage.drawRectangle({
+      x: 0,
+      y: 0,
+      width: PAGE_W,
+      height: 34,
+      color: navy,
+    });
+    pdfPage.drawText(`${shopName(snapshot)}  |  ${workOrderLabel}`, {
+      x: MARGIN,
+      y: 13,
+      size: 7.5,
+      font: regular,
+      color: rgb(0.78, 0.82, 0.87),
+    });
     const pageLabel = `Page ${index + 1} of ${pages.length}`;
     pdfPage.drawText(pageLabel, {
       x: PAGE_W - MARGIN - regular.widthOfTextAtSize(pageLabel, 7.5),
@@ -515,7 +950,9 @@ export async function renderPremiumInvoicePdf(input: RenderInput): Promise<Uint8
     });
   });
 
-  doc.setTitle(`${document.draft ? "Draft invoice" : "Invoice"} ${invoiceLabel}`);
+  doc.setTitle(
+    `${document.draft ? "Draft invoice" : "Invoice"} ${invoiceLabel}`,
+  );
   doc.setAuthor(shopName(snapshot));
   doc.setSubject(`Work order ${workOrderLabel}`);
   doc.setCreator("ProFixIQ");

--- a/tests/owner-settings-experience.test.ts
+++ b/tests/owner-settings-experience.test.ts
@@ -55,13 +55,13 @@ describe("owner settings experience", () => {
       "City",
       "Phone number",
       "Public email",
-      "Logo URL",
     ]) {
       expect(business).toContain(label);
     }
 
-    expect(business).toContain("AI logo maker · Coming soon");
-    expect(business).toContain("disabled");
+    expect(business).not.toContain("Logo URL");
+    expect(business).not.toContain("AI logo maker");
+    expect(page).toContain("BrandStudioSummaryCard");
   });
 
   it("makes scheduling changes and blackout dates clear", () => {


### PR DESCRIPTION
## What changed

- centralizes invoice document configuration and freezes branding, colors, terms, footer, and layout when an invoice is issued
- replaces the mocked Owner Settings preview with the production PDF renderer
- makes Brand Studio the canonical logo source and removes the legacy logo URL/upload and coming-soon controls
- adds logo size, alignment, and zoom controls plus uploaded-image dimension detection and better generation framing
- adds six layouts and five palettes for 30 curated invoice combinations
- connects draft PDFs, issued PDFs, invoice versions, and invoice email delivery to the same resolved document configuration

## Root cause

Invoice settings, Brand Studio assets, the Owner Settings preview, and issued PDF rendering followed separate data paths. That allowed previews to diverge from actual invoices and allowed branding to change after issuance.

## Impact

Owners can configure a controlled premium invoice design, preview the exact renderer, and rely on newly issued invoice versions retaining the branding and terms used at issuance.

## Validation

- TypeScript `tsc --noEmit`
- targeted ESLint across changed files
- 14 focused Vitest tests
- rendered all 30 template/palette combinations
- rendered and visually inspected a Letter-size PDF
- API route-boundary audit across 366 routes
- `git diff --check`

## Notes

- no database migration or environment-variable changes
- settings use existing `shop_brand_profiles.metadata.invoice_document`
- issued configuration is stored in the existing invoice-version snapshot JSON
- legacy issued invoices without frozen document configuration retain the current-brand fallback