### PR TITLE
Fix issued-parts invoice consistency

### DIFF
--- a/app/api/billing/work-orders/route.ts
+++ b/app/api/billing/work-orders/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
-import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
+import { getIssuableInvoiceSnapshot } from "@/features/invoices/server/getIssuableInvoiceSnapshot";
 import { ROLE_GROUPS } from "@/features/shared/lib/rbac";
 
 const BILLING_STATUSES = ["completed", "ready_to_invoice", "invoiced"];
@@ -33,9 +33,10 @@ export async function GET() {
   const rows = await Promise.all(
     (data ?? []).map(async (row) => {
       try {
-        const snapshot = await getInvoiceSnapshotForWorkOrder({
+        const snapshot = await getIssuableInvoiceSnapshot({
           supabase: access.supabase,
           workOrderId: row.id,
+          shopId,
         });
 
         return {

--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -133,6 +133,7 @@ export async function reviewWorkOrder({
   kind,
 }: Args): Promise<{ ok: boolean; issues: ReviewIssue[] }> {
   const hasBillablePartsByLine = new Map<string, boolean>();
+  const hasAttachedPartsByLine = new Map<string, boolean>();
   const invoicePartIssues: ReviewIssue[] = [];
 
   const { data: allocationRows } = await supabase
@@ -149,6 +150,7 @@ export async function reviewWorkOrder({
     if (lineId && qty > 0 && (unitCost == null || unitCost > 0)) {
       hasBillablePartsByLine.set(lineId, true);
     }
+    if (lineId && qty > 0) hasAttachedPartsByLine.set(lineId, true);
   }
 
   const { data: stagedPartRows } = await supabase
@@ -170,6 +172,7 @@ export async function reviewWorkOrder({
     ) {
       hasBillablePartsByLine.set(lineId, true);
     }
+    if (lineId && quantity > 0) hasAttachedPartsByLine.set(lineId, true);
   }
 
   const { data: requestItemRows } = await supabase
@@ -193,6 +196,9 @@ export async function reviewWorkOrder({
       partRequestItemHasBillablePrice(record)
     ) {
       hasBillablePartsByLine.set(lineId, true);
+    }
+    if (lineId && partRequestItemQuantity(record) > 0) {
+      hasAttachedPartsByLine.set(lineId, true);
     }
   }
 
@@ -324,10 +330,18 @@ export async function reviewWorkOrder({
     const laborNA = record.labor_marked_na === true;
     const hasBillableParts = hasBillablePartsByLine.get(String(line.id)) === true;
     if (lineRequiresParts(record) && !hasBillableParts) {
+      const hasAttachedParts =
+        hasAttachedPartsByLine.get(String(line.id)) === true;
       issues.push({
-        kind: "missing_required_parts",
+        kind:
+          kind === "invoice_review" && hasAttachedParts
+            ? "parts_not_issued"
+            : "missing_required_parts",
         lineId: line.id,
-        message: `Required parts are missing from line: ${line.description ?? line.complaint ?? "job"}`,
+        message:
+          kind === "invoice_review" && hasAttachedParts
+            ? `Attached parts are awaiting issue to the job. Complete the parts handoff before invoicing: ${line.description ?? line.complaint ?? "job"}`
+            : `Required parts are missing from line: ${line.description ?? line.complaint ?? "job"}`,
       });
     }
 

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/features/branding/server/getActiveBrandForRender";
 import { isFrozenInvoiceDocumentConfiguration } from "@/features/invoices/lib/invoiceDocumentTheme";
 import { getActiveInvoiceVersion } from "@/features/invoices/server/financialLifecycle";
-import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
+import { getIssuableInvoiceSnapshot } from "@/features/invoices/server/getIssuableInvoiceSnapshot";
 import {
   premiumInvoiceFilename,
   renderPremiumInvoicePdf,
@@ -55,7 +55,11 @@ export async function GET(
     });
     const snapshot =
       activeVersion?.snapshot ??
-      (await getInvoiceSnapshotForWorkOrder({ supabase, workOrderId }));
+      (await getIssuableInvoiceSnapshot({
+        supabase,
+        workOrderId,
+        shopId: workOrder.shop_id,
+      }));
     const { data: invoice } = activeVersion?.invoice_id
       ? await supabase
           .from("invoices")

--- a/app/api/work-orders/[id]/invoice/route.ts
+++ b/app/api/work-orders/[id]/invoice/route.ts
@@ -6,7 +6,7 @@ export const runtime = "nodejs";
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { reviewWorkOrder } from "../_lib/reviewWorkOrder";
-import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
+import { getIssuableInvoiceSnapshot } from "@/features/invoices/server/getIssuableInvoiceSnapshot";
 import { getActiveInvoiceVersion } from "@/features/invoices/server/financialLifecycle";
 
 
@@ -95,7 +95,11 @@ export async function GET(
     });
     const snapshot =
       activeInvoiceVersion?.snapshot ??
-      (await getInvoiceSnapshotForWorkOrder({ supabase, workOrderId: woId }));
+      (await getIssuableInvoiceSnapshot({
+        supabase,
+        workOrderId: woId,
+        shopId: scopedWorkOrder.shop_id,
+      }));
     return NextResponse.json(
       { snapshot, activeInvoiceVersion },
       { headers: { "Cache-Control": "private, no-store" } },

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -873,11 +873,9 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
       : undefined;
     const qtyRaw = safeNumber(a.qty);
     const qty = qtyRaw > 0 ? qtyRaw : 1;
-    // Match FocusedJobModal's allocated-parts calculation exactly. The current
-    // work-order flow stores and displays the allocation price from unit_cost.
-    // Request/catalog values remain fallbacks for records without that value.
+    // Allocation cost is an internal valuation and must never become a customer
+    // charge. Prefer the request's customer quote, then the catalog sell price.
     const unitPrice =
-      safeNumber(a.unit_cost) ||
       (requestItem ? itemUnitPrice(requestItem) : 0) ||
       safeNumber(p?.price) ||
       safeNumber(p?.default_price);

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -616,18 +616,30 @@ export default function WorkOrdersView(): JSX.Element {
             .replaceAll(" ", "_");
 
           if (statusLower === "completed") {
-            const { error } = await supabase
-              .from("work_orders")
-              .update({
-                status: "ready_to_invoice",
-              } as DB["public"]["Tables"]["work_orders"]["Update"])
-              .eq("id", woId)
-              .eq("status", "completed");
+            const operationKey = crypto.randomUUID();
+            const readyResponse = await fetch(
+              `/api/work-orders/${woId}/mark-ready`,
+              {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  "Idempotency-Key": operationKey,
+                },
+                body: JSON.stringify({ operationKey }),
+              },
+            );
+            const readyPayload = (await readyResponse.json().catch(() => null)) as
+              | { error?: string }
+              | null;
 
-            if (error) {
+            if (!readyResponse.ok) {
               console.warn(
                 "[invoice-review] could not advance status:",
-                error.message,
+                readyPayload?.error ?? readyResponse.statusText,
+              );
+              toast.error(
+                readyPayload?.error ??
+                  "Work order could not be marked ready to invoice.",
               );
             } else {
               toast.success("Moved to Ready to invoice");
@@ -649,7 +661,7 @@ export default function WorkOrdersView(): JSX.Element {
         setReviewLoadingId(null);
       }
     },
-    [load, rows, supabase],
+    [load, rows],
   );
 
   useEffect(() => {

--- a/tests/live-invoice-flow-safety.test.ts
+++ b/tests/live-invoice-flow-safety.test.ts
@@ -8,6 +8,9 @@ const previewClient = readFileSync("features/work-orders/components/InvoicePrevi
 const sendRoute = readFileSync("app/api/invoices/send/route.ts", "utf8");
 const snapshotSource = readFileSync("features/invoices/server/getInvoiceSnapshot.ts", "utf8");
 const billingRoute = readFileSync("app/api/billing/work-orders/route.ts", "utf8");
+const invoiceRoute = readFileSync("app/api/work-orders/[id]/invoice/route.ts", "utf8");
+const invoicePdfRoute = readFileSync("app/api/work-orders/[id]/invoice-pdf/route.ts", "utf8");
+const workOrderView = readFileSync("features/work-orders/app/work-orders/view/page.tsx", "utf8");
 const manualPayment = readFileSync("features/invoices/components/RecordManualPayment.tsx", "utf8");
 
 describe("regular live invoice flow safety", () => {
@@ -29,6 +32,8 @@ describe("regular live invoice flow safety", () => {
     expect(reviewSource).toContain("work_order_parts");
     expect(reviewSource).toContain("work_order_part_allocations");
     expect(reviewSource).toContain("part_request_items");
+    expect(reviewSource).toContain('"parts_not_issued"');
+    expect(reviewSource).toContain("Complete the parts handoff before invoicing");
   });
 
   it("flags invalid or suspicious labor totals before invoice readiness passes", () => {
@@ -48,12 +53,26 @@ describe("regular live invoice flow safety", () => {
     expect(previewClient).toContain("canonicalInvoiceTotal");
   });
 
-  it("loads billing cards from the canonical server snapshot and surfaces pricing failures", () => {
+  it("uses the net-issued snapshot for billing, review, and draft PDF surfaces", () => {
     expect(billingPage).toContain('fetch("/api/billing/work-orders"');
     expect(billingPage).toContain("pricing_error");
-    expect(billingRoute).toContain("getInvoiceSnapshotForWorkOrder");
+    expect(billingRoute).toContain("getIssuableInvoiceSnapshot");
+    expect(invoiceRoute).toContain("getIssuableInvoiceSnapshot");
+    expect(invoicePdfRoute).toContain("getIssuableInvoiceSnapshot");
     expect(billingRoute).toContain("pricing_error");
     expect(billingRoute).not.toContain("catch {");
+  });
+
+  it("never turns allocation acquisition cost into a customer invoice price", () => {
+    expect(snapshotSource).toContain(
+      "Allocation cost is an internal valuation",
+    );
+    expect(snapshotSource).not.toContain("safeNumber(a.unit_cost) ||");
+  });
+
+  it("advances completed work orders through the protected mark-ready route", () => {
+    expect(workOrderView).toContain("/api/work-orders/${woId}/mark-ready");
+    expect(workOrderView).not.toContain('.update({\n                status: "ready_to_invoice"');
   });
 
   it("billing Invoice button navigates to preview instead of sending", () => {


### PR DESCRIPTION
## Root cause

The work order carried reserved/allocated parts, but none had been issued through the parts handoff. Invoice review correctly checked net-issued quantities, while the billing card, draft review, and draft PDF used staged allocation data. That produced contradictory totals and mislabeled allocated parts as missing. The staged snapshot also allowed internal allocation cost to become a customer-facing price.

## What changed

- Uses the net-issued invoice snapshot for billing cards, draft review, and draft PDFs.
- Keeps finalized invoice versions frozen and unchanged.
- Reports attached-but-unissued parts as awaiting handoff instead of missing.
- Prevents allocation acquisition cost from becoming a customer invoice price.
- Routes completed work orders through the protected mark-ready endpoint instead of a direct status update.
- Adds invoice-flow regression contracts for these boundaries.

## Impact

Before handoff, invoice surfaces show only charges actually issuable and clearly direct staff to complete parts handoff. After handoff, the issued sell-price quantities populate consistently across billing, review, PDF, and send.

## Validation

- `vitest run tests/live-invoice-flow-safety.test.ts` — 10/10 passed.
- ESLint on all changed TypeScript files — passed.
- `git diff --check` — passed.
- Full TypeScript check was attempted; it remains blocked by unrelated pre-existing missing module/type declarations (OpenAI helper aliases, PDFKit types, MobileShell, and OptimizationExecutionModal).

## Deployment note

No database migration or environment variable change is included. For the existing EL000001 data, complete the already-ready parts handoff once so reserved quantities become issued/consumed invoice quantities.