### PR TITLE
Bill approval-attached work order parts

### DIFF
--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -148,7 +148,7 @@ export async function POST(req: Request) {
       return NextResponse.json(
         {
           error:
-            "Invoice totals changed because one or more attached parts have not been issued to the work order. Complete the parts handoff, then review the invoice again.",
+            "Invoice totals changed because approved parts were not materialized on the work order. Reopen the approved line and repair its attached parts before invoicing.",
           draftParts,
           issuableParts,
           draftTotal,

--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -5,16 +5,6 @@ import { seedWorkOrderIntelligenceFromReview } from "@/features/ai/server/workOr
 import { isReviewableQuoteLine } from "@/features/work-orders/lib/quotes/reviewableQuoteLines";
 
 type DB = Database;
-type PartsRpcClient = {
-  rpc: (
-    name: string,
-    args: Record<string, unknown>,
-  ) => PromiseLike<{
-    data: unknown;
-    error: { message: string; details?: string | null; hint?: string | null } | null;
-  }>;
-};
-
 export type ReviewIssue = { kind: string; lineId?: string; message: string };
 export type ReviewKind = "ai_review" | "invoice_review";
 
@@ -133,7 +123,7 @@ export async function reviewWorkOrder({
   kind,
 }: Args): Promise<{ ok: boolean; issues: ReviewIssue[] }> {
   const hasBillablePartsByLine = new Map<string, boolean>();
-  const hasAttachedPartsByLine = new Map<string, boolean>();
+  const hasCanonicalPartsByLine = new Map<string, boolean>();
   const invoicePartIssues: ReviewIssue[] = [];
 
   const { data: allocationRows } = await supabase
@@ -150,29 +140,55 @@ export async function reviewWorkOrder({
     if (lineId && qty > 0 && (unitCost == null || unitCost > 0)) {
       hasBillablePartsByLine.set(lineId, true);
     }
-    if (lineId && qty > 0) hasAttachedPartsByLine.set(lineId, true);
   }
 
   const { data: stagedPartRows } = await supabase
     .from("work_order_parts")
-    .select("work_order_line_id, quantity, unit_price, total_price")
+    .select(
+      "work_order_line_id, quantity, quantity_requested, quantity_returned, quantity_cancelled, unit_price, unit_sell_price_snapshot, total_price, is_active",
+    )
     .eq("work_order_id", workOrderId)
     .eq("shop_id", shopId);
   for (const row of stagedPartRows ?? []) {
     const record = row as Record<string, unknown>;
     const lineId = typeof row.work_order_line_id === "string" ? row.work_order_line_id : "";
-    const quantity = numericValue(record.quantity) ?? 0;
-    const unitPrice = numericValue(record.unit_price);
+    const requested =
+      numericValue(record.quantity_requested) ??
+      numericValue(record.quantity) ??
+      0;
+    const quantity = Math.max(
+      0,
+      requested -
+        (numericValue(record.quantity_returned) ?? 0) -
+        (numericValue(record.quantity_cancelled) ?? 0),
+    );
+    const unitPrice =
+      numericValue(record.unit_sell_price_snapshot) ??
+      numericValue(record.unit_price);
     const totalPrice = numericValue(record.total_price);
     if (
       lineId &&
+      record.is_active !== false &&
       quantity > 0 &&
       ((unitPrice != null && unitPrice > 0) ||
         (totalPrice != null && totalPrice > 0))
     ) {
       hasBillablePartsByLine.set(lineId, true);
     }
-    if (lineId && quantity > 0) hasAttachedPartsByLine.set(lineId, true);
+    if (lineId && record.is_active !== false && quantity > 0) {
+      hasCanonicalPartsByLine.set(lineId, true);
+      if (
+        kind === "invoice_review" &&
+        !((unitPrice != null && unitPrice > 0) ||
+          (totalPrice != null && totalPrice > 0))
+      ) {
+        invoicePartIssues.push({
+          kind: "missing_part_sell_price",
+          lineId,
+          message: "An attached part is missing its customer sell price.",
+        });
+      }
+    }
   }
 
   const { data: requestItemRows } = await supabase
@@ -197,40 +213,12 @@ export async function reviewWorkOrder({
     ) {
       hasBillablePartsByLine.set(lineId, true);
     }
-    if (lineId && partRequestItemQuantity(record) > 0) {
-      hasAttachedPartsByLine.set(lineId, true);
-    }
   }
 
   if (kind === "invoice_review") {
-    const { data: netIssuedParts, error: netIssuedPartsError } = await (
-      supabase as unknown as PartsRpcClient
-    ).rpc(
-      "get_invoice_net_issued_parts",
-      {
-        p_shop_id: shopId,
-        p_work_order_id: workOrderId,
-      },
-    );
-    if (netIssuedPartsError) throw netIssuedPartsError;
-
     hasBillablePartsByLine.clear();
-    for (const raw of Array.isArray(netIssuedParts) ? netIssuedParts : []) {
-      if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
-      const part = raw as Record<string, unknown>;
-      const lineId = typeof part.lineId === "string" ? part.lineId : "";
-      const quantity = numericValue(part.qty) ?? 0;
-      const unitPrice = numericValue(part.unitPrice) ?? 0;
-      if (!lineId || quantity <= 0) continue;
-      if (unitPrice > 0) {
-        hasBillablePartsByLine.set(lineId, true);
-      } else {
-        invoicePartIssues.push({
-          kind: "missing_part_sell_price",
-          lineId,
-          message: `Issued part has no customer sell price: ${String(part.name ?? "Part")}`,
-        });
-      }
+    for (const lineId of hasCanonicalPartsByLine.keys()) {
+      hasBillablePartsByLine.set(lineId, true);
     }
   }
 
@@ -330,18 +318,10 @@ export async function reviewWorkOrder({
     const laborNA = record.labor_marked_na === true;
     const hasBillableParts = hasBillablePartsByLine.get(String(line.id)) === true;
     if (lineRequiresParts(record) && !hasBillableParts) {
-      const hasAttachedParts =
-        hasAttachedPartsByLine.get(String(line.id)) === true;
       issues.push({
-        kind:
-          kind === "invoice_review" && hasAttachedParts
-            ? "parts_not_issued"
-            : "missing_required_parts",
+        kind: "missing_required_parts",
         lineId: line.id,
-        message:
-          kind === "invoice_review" && hasAttachedParts
-            ? `Attached parts are awaiting issue to the job. Complete the parts handoff before invoicing: ${line.description ?? line.complaint ?? "job"}`
-            : `Required parts are missing from line: ${line.description ?? line.complaint ?? "job"}`,
+        message: `Required approved parts are not attached to line: ${line.description ?? line.complaint ?? "job"}`,
       });
     }
 

--- a/app/api/work-orders/[id]/mark-ready/route.ts
+++ b/app/api/work-orders/[id]/mark-ready/route.ts
@@ -101,7 +101,7 @@ export async function POST(req: Request) {
         {
           ok: false,
           error:
-            "Attached parts must be issued to the work order before it can be marked ready to invoice.",
+            "Approved parts must be attached to the work order before it can be marked ready to invoice.",
         },
         { status: 409 },
       );

--- a/features/invoices/lib/approvedInvoiceParts.ts
+++ b/features/invoices/lib/approvedInvoiceParts.ts
@@ -1,0 +1,30 @@
+type QuantityInput = {
+  quantityRequested: unknown;
+  quantity: unknown;
+  quantityReturned: unknown;
+  quantityCancelled: unknown;
+};
+
+function finite(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function resolveApprovedPartInvoiceQuantity(
+  input: QuantityInput,
+): number {
+  const requested = finite(input.quantityRequested);
+  const attached = requested > 0 ? requested : finite(input.quantity);
+  return Math.max(
+    0,
+    attached -
+      Math.max(0, finite(input.quantityReturned)) -
+      Math.max(0, finite(input.quantityCancelled)),
+  );
+}
+
+export function selectApprovedAttachedInvoiceParts<
+  T extends { source?: string },
+>(parts: readonly T[]): T[] {
+  return parts.filter((part) => part.source === "work_order_part");
+}

--- a/features/invoices/server/getInvoiceSnapshot.ts
+++ b/features/invoices/server/getInvoiceSnapshot.ts
@@ -7,6 +7,7 @@ import {
   resolveShopSuppliesSettings,
 } from "@/features/work-orders/lib/shopSupplies";
 import { calculateInvoiceTotals } from "@/features/invoices/lib/invoiceTotals";
+import { resolveApprovedPartInvoiceQuantity } from "@/features/invoices/lib/approvedInvoiceParts";
 import { shouldUsePersistedInvoiceTotals } from "@/features/invoices/lib/invoiceSnapshotState";
 import { filterInvoicePartAllocations } from "@/features/invoices/lib/filterInvoicePartAllocations";
 import type { InvoiceDocumentConfiguration } from "@/features/invoices/lib/invoiceDocumentTheme";
@@ -904,18 +905,14 @@ export async function getInvoiceSnapshotForWorkOrder(args: {
         : undefined;
       const partRecord = part as Record<string, unknown>;
       if (partRecord.is_active === false) return [];
-      const consumed = safeNumber(partRecord.quantity_consumed);
-      const returned = safeNumber(partRecord.quantity_returned);
-      const cancelled = safeNumber(partRecord.quantity_cancelled);
-      const requested = safeNumber(partRecord.quantity_requested);
-      const qty =
-        consumed > 0
-          ? Math.max(0, consumed - returned)
-          : Math.max(
-              0,
-              (requested > 0 ? requested : safeNumber(part.quantity)) -
-                cancelled,
-            );
+      // Approval freezes the customer-facing quantity on work_order_parts.
+      // Consumption is an inventory event and must not change invoice quantity.
+      const qty = resolveApprovedPartInvoiceQuantity({
+        quantityRequested: partRecord.quantity_requested,
+        quantity: part.quantity,
+        quantityReturned: partRecord.quantity_returned,
+        quantityCancelled: partRecord.quantity_cancelled,
+      });
       if (qty <= 0) return [];
       const totalRaw = safeNumber(part.total_price);
       const unitPrice =

--- a/features/invoices/server/getIssuableInvoiceSnapshot.ts
+++ b/features/invoices/server/getIssuableInvoiceSnapshot.ts
@@ -6,67 +6,13 @@ import {
   type InvoiceSnapshotPart,
 } from "@/features/invoices/server/getInvoiceSnapshot";
 import { calculateInvoiceTotals, roundMoney } from "@/features/invoices/lib/invoiceTotals";
+import { selectApprovedAttachedInvoiceParts } from "@/features/invoices/lib/approvedInvoiceParts";
 
 type DB = Database;
-type RpcError = { message: string; details?: string | null; hint?: string | null };
-type RpcClient = {
-  rpc: (
-    name: string,
-    args: Record<string, unknown>,
-  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
-};
-
-type NetIssuedPart = InvoiceSnapshotPart & {
-  manufacturer?: string;
-  supplier?: string;
-  unitCost?: number;
-};
 
 function finite(value: unknown): number {
   const parsed = typeof value === "number" ? value : Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function optionalText(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function normalizeParts(value: unknown): NetIssuedPart[] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((entry): NetIssuedPart[] => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
-    const row = entry as Record<string, unknown>;
-    const id = optionalText(row.id) ?? "";
-    const name = optionalText(row.name) ?? "";
-    const qty = finite(row.qty);
-    const unitPrice = finite(row.unitPrice);
-    if (!id || !name || qty <= 0 || unitPrice < 0) return [];
-
-    const lineId = optionalText(row.lineId);
-    const sku = optionalText(row.sku);
-    const partNumber = optionalText(row.partNumber);
-    const vendor = optionalText(row.vendor);
-    const manufacturer = optionalText(row.manufacturer);
-    const supplier = optionalText(row.supplier);
-
-    return [
-      {
-        id,
-        name,
-        qty,
-        unitPrice,
-        totalPrice: roundMoney(finite(row.totalPrice) || qty * unitPrice),
-        unitCost: finite(row.unitCost),
-        source: "work_order_part",
-        ...(lineId ? { lineId } : {}),
-        ...(sku ? { sku } : {}),
-        ...(partNumber ? { partNumber } : {}),
-        ...(vendor ? { vendor } : {}),
-        ...(manufacturer ? { manufacturer } : {}),
-        ...(supplier ? { supplier } : {}),
-      },
-    ];
-  });
 }
 
 export async function getIssuableInvoiceSnapshot(input: {
@@ -79,16 +25,14 @@ export async function getIssuableInvoiceSnapshot(input: {
     workOrderId: input.workOrderId,
   });
 
-  const rpc = input.supabase as unknown as RpcClient;
-  const { data, error } = await rpc.rpc("get_invoice_net_issued_parts", {
-    p_shop_id: input.shopId,
-    p_work_order_id: input.workOrderId,
-  });
-  if (error) {
-    throw new Error([error.message, error.details, error.hint].filter(Boolean).join(" — "));
-  }
-
-  const parts = normalizeParts(data);
+  // Customer approval materializes durable work_order_parts with frozen sell
+  // prices. Inventory reservation, picking, and issue are operational stock
+  // events; they must not add, remove, or reprice an approved customer charge.
+  // Allocation/request fallbacks remain useful while building a draft, but an
+  // invoice may only use the canonical parts attached to the work-order line.
+  const parts: InvoiceSnapshotPart[] = selectApprovedAttachedInvoiceParts(
+    base.parts,
+  );
   const partsCost = roundMoney(
     parts.reduce((sum, part) => sum + finite(part.totalPrice), 0),
   );

--- a/tests/approved-invoice-parts.test.ts
+++ b/tests/approved-invoice-parts.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveApprovedPartInvoiceQuantity,
+  selectApprovedAttachedInvoiceParts,
+} from "../features/invoices/lib/approvedInvoiceParts";
+
+describe("approved invoice parts", () => {
+  it("keeps the approved attached quantity independent of inventory consumption", () => {
+    expect(
+      resolveApprovedPartInvoiceQuantity({
+        quantityRequested: 6,
+        quantity: 6,
+        quantityReturned: 0,
+        quantityCancelled: 0,
+      }),
+    ).toBe(6);
+  });
+
+  it("reduces the customer quantity only for returns or cancellations", () => {
+    expect(
+      resolveApprovedPartInvoiceQuantity({
+        quantityRequested: 6,
+        quantity: 6,
+        quantityReturned: 1,
+        quantityCancelled: 2,
+      }),
+    ).toBe(3);
+  });
+
+  it("excludes request and allocation fallbacks from final invoice parts", () => {
+    const attached = { id: "attached", source: "work_order_part" };
+    expect(
+      selectApprovedAttachedInvoiceParts([
+        attached,
+        { id: "allocation", source: "work_order_part_allocation" },
+        { id: "request", source: "quote_line_part_request" },
+      ]),
+    ).toEqual([attached]);
+  });
+
+  it("keeps the EL000001 approval snapshots as the customer parts total", () => {
+    const parts = selectApprovedAttachedInvoiceParts([
+      {
+        source: "work_order_part",
+        quantity: 6,
+        unitPrice: 229.39,
+        totalPrice: 1_376.34,
+      },
+      {
+        source: "work_order_part",
+        quantity: 1,
+        unitPrice: 260.47,
+        totalPrice: 260.47,
+      },
+    ]);
+
+    expect(parts.reduce((sum, part) => sum + part.totalPrice, 0)).toBeCloseTo(
+      1_636.81,
+      2,
+    );
+  });
+});

--- a/tests/live-invoice-flow-safety.test.ts
+++ b/tests/live-invoice-flow-safety.test.ts
@@ -32,8 +32,8 @@ describe("regular live invoice flow safety", () => {
     expect(reviewSource).toContain("work_order_parts");
     expect(reviewSource).toContain("work_order_part_allocations");
     expect(reviewSource).toContain("part_request_items");
-    expect(reviewSource).toContain('"parts_not_issued"');
-    expect(reviewSource).toContain("Complete the parts handoff before invoicing");
+    expect(reviewSource).toContain("hasCanonicalPartsByLine");
+    expect(reviewSource).toContain("Required approved parts are not attached");
   });
 
   it("flags invalid or suspicious labor totals before invoice readiness passes", () => {
@@ -53,7 +53,7 @@ describe("regular live invoice flow safety", () => {
     expect(previewClient).toContain("canonicalInvoiceTotal");
   });
 
-  it("uses the net-issued snapshot for billing, review, and draft PDF surfaces", () => {
+  it("uses the canonical approved-parts snapshot for billing, review, and draft PDF surfaces", () => {
     expect(billingPage).toContain('fetch("/api/billing/work-orders"');
     expect(billingPage).toContain("pricing_error");
     expect(billingRoute).toContain("getIssuableInvoiceSnapshot");
@@ -86,7 +86,7 @@ describe("regular live invoice flow safety", () => {
     expect(previewClient).toContain('fetch("/api/invoices/send"');
     expect(sendRoute).toContain("getIssuableInvoiceSnapshot");
     expect(sendRoute).toContain("draftParts");
-    expect(sendRoute).toContain("Complete the parts handoff");
+    expect(sendRoute).toContain("approved parts were not materialized");
   });
 
   it("keeps post-issue accounting and manual POS actions reachable", () => {

--- a/tests/phase3-parts-atomic-routes.test.ts
+++ b/tests/phase3-parts-atomic-routes.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 function source(path: string) {
-  return readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+  return readFileSync(resolve(process.cwd(), path), "utf8");
 }
 
 describe("phase 3 atomic parts routes", () => {
@@ -35,13 +36,15 @@ describe("phase 3 atomic parts routes", () => {
     expect(route).not.toContain('from("work_order_part_allocations")');
   });
 
-  it("uses canonical issued quantity for invoice creation", () => {
+  it("uses canonical approval-attached parts for invoice creation", () => {
     expect(source("app/api/invoices/send/route.ts")).toContain(
       "getIssuableInvoiceSnapshot",
     );
-    expect(source("features/invoices/server/getIssuableInvoiceSnapshot.ts")).toContain(
-      "get_invoice_net_issued_parts",
+    const issuableSnapshot = source(
+      "features/invoices/server/getIssuableInvoiceSnapshot.ts",
     );
+    expect(issuableSnapshot).toContain("selectApprovedAttachedInvoiceParts");
+    expect(issuableSnapshot).not.toContain("get_invoice_net_issued_parts");
   });
 
   it("keeps deployed invoice pricing compatible with stable parts columns", () => {

--- a/tests/phase3-parts-sql-contract.test.ts
+++ b/tests/phase3-parts-sql-contract.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 function source(path: string) {
-  return readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+  return readFileSync(resolve(process.cwd(), path), "utf8");
 }
 
 describe("phase 3 parts SQL contract", () => {


### PR DESCRIPTION
## Root cause

Customer approval already materializes durable `work_order_parts` with quantity and sell-price snapshots. The merged invoice repair then treated inventory consumption from `get_invoice_net_issued_parts` as the customer billing source, so an operational parts handoff could add or remove charges at invoice time.

## What changed

- Makes approval-attached `work_order_parts` the only canonical final-invoice parts source.
- Keeps approved quantity stable regardless of reservation, picking, handoff, or consumption.
- Reduces invoice quantity only for recorded returns or cancellations.
- Removes the issued-parts RPC dependency from invoice review and issuance.
- Changes review/readiness errors to report failed approval materialization instead of requesting a handoff.
- Preserves the existing sell-price snapshot and excludes allocation/request fallbacks from final invoices.
- Adds the EL000001 sell-price fixture and lifecycle regression coverage.

## Impact

Parts attach when the repair line is approved and remain attached through completion and invoicing. Inventory operations remain independent stock controls; invoicing is read-only and does not require a Parts Requests handoff.

For EL000001, the approved sell-price snapshots resolve to:
- 6 × $229.39 = $1,376.34
- 1 × $260.47 = $260.47
- Parts total = $1,636.81

## Validation

- 12 focused invoice/parts test files: 84/84 tests passed.
- Changed-file ESLint: passed.
- `git diff --check`: passed.
- Full TypeScript check was attempted and remains blocked by unrelated pre-existing missing module/type declarations on `main` (OpenAI helper aliases, PDFKit types, MobileShell, and OptimizationExecutionModal).

## Database and deployment

No migration, data mutation, generated type, or environment-variable change is included. The existing approval materialization triggers remain the attachment boundary.