### PR TITLE
Preserve resolved invoice parts

### DIFF
--- a/features/invoices/lib/approvedInvoiceParts.ts
+++ b/features/invoices/lib/approvedInvoiceParts.ts
@@ -22,9 +22,3 @@ export function resolveApprovedPartInvoiceQuantity(
       Math.max(0, finite(input.quantityCancelled)),
   );
 }
-
-export function selectApprovedAttachedInvoiceParts<
-  T extends { source?: string },
->(parts: readonly T[]): T[] {
-  return parts.filter((part) => part.source === "work_order_part");
-}

--- a/features/invoices/server/getIssuableInvoiceSnapshot.ts
+++ b/features/invoices/server/getIssuableInvoiceSnapshot.ts
@@ -3,10 +3,8 @@ import type { Database } from "@shared/types/types/supabase";
 import {
   getInvoiceSnapshotForWorkOrder,
   type InvoiceSnapshot,
-  type InvoiceSnapshotPart,
 } from "@/features/invoices/server/getInvoiceSnapshot";
 import { calculateInvoiceTotals, roundMoney } from "@/features/invoices/lib/invoiceTotals";
-import { selectApprovedAttachedInvoiceParts } from "@/features/invoices/lib/approvedInvoiceParts";
 
 type DB = Database;
 
@@ -25,14 +23,13 @@ export async function getIssuableInvoiceSnapshot(input: {
     workOrderId: input.workOrderId,
   });
 
-  // Customer approval materializes durable work_order_parts with frozen sell
-  // prices. Inventory reservation, picking, and issue are operational stock
-  // events; they must not add, remove, or reprice an approved customer charge.
-  // Allocation/request fallbacks remain useful while building a draft, but an
-  // invoice may only use the canonical parts attached to the work-order line.
-  const parts: InvoiceSnapshotPart[] = selectApprovedAttachedInvoiceParts(
-    base.parts,
-  );
+  // getInvoiceSnapshotForWorkOrder has already resolved each completed line's
+  // attached parts through the deployed-schema-compatible precedence chain:
+  // work_order_parts, backed allocations, then linked request items. Do not
+  // filter that canonical result by its diagnostic source label; legacy rows
+  // can legitimately resolve through a fallback while remaining attached to
+  // the same approved work-order line.
+  const parts = [...base.parts];
   const partsCost = roundMoney(
     parts.reduce((sum, part) => sum + finite(part.totalPrice), 0),
   );

--- a/tests/approved-invoice-parts.test.ts
+++ b/tests/approved-invoice-parts.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  resolveApprovedPartInvoiceQuantity,
-  selectApprovedAttachedInvoiceParts,
-} from "../features/invoices/lib/approvedInvoiceParts";
+import { resolveApprovedPartInvoiceQuantity } from "../features/invoices/lib/approvedInvoiceParts";
 
 describe("approved invoice parts", () => {
   it("keeps the approved attached quantity independent of inventory consumption", () => {
@@ -27,19 +24,8 @@ describe("approved invoice parts", () => {
     ).toBe(3);
   });
 
-  it("excludes request and allocation fallbacks from final invoice parts", () => {
-    const attached = { id: "attached", source: "work_order_part" };
-    expect(
-      selectApprovedAttachedInvoiceParts([
-        attached,
-        { id: "allocation", source: "work_order_part_allocation" },
-        { id: "request", source: "quote_line_part_request" },
-      ]),
-    ).toEqual([attached]);
-  });
-
   it("keeps the EL000001 approval snapshots as the customer parts total", () => {
-    const parts = selectApprovedAttachedInvoiceParts([
+    const parts = [
       {
         source: "work_order_part",
         quantity: 6,
@@ -52,7 +38,7 @@ describe("approved invoice parts", () => {
         unitPrice: 260.47,
         totalPrice: 260.47,
       },
-    ]);
+    ];
 
     expect(parts.reduce((sum, part) => sum + part.totalPrice, 0)).toBeCloseTo(
       1_636.81,

--- a/tests/phase3-parts-atomic-routes.test.ts
+++ b/tests/phase3-parts-atomic-routes.test.ts
@@ -43,7 +43,10 @@ describe("phase 3 atomic parts routes", () => {
     const issuableSnapshot = source(
       "features/invoices/server/getIssuableInvoiceSnapshot.ts",
     );
-    expect(issuableSnapshot).toContain("selectApprovedAttachedInvoiceParts");
+    expect(issuableSnapshot).toContain("const parts = [...base.parts]");
+    expect(issuableSnapshot).not.toContain(
+      'part.source === "work_order_part"',
+    );
     expect(issuableSnapshot).not.toContain("get_invoice_net_issued_parts");
   });
 


### PR DESCRIPTION
## Root cause

PR #1123 added a second filter that retained only resolved parts whose diagnostic source label was exactly `work_order_part`. EL000001 is a legacy/deployed-schema-compatible record whose attached parts resolve through the allocation fallback, so that filter converted a valid resolved parts list into an empty array.

## What changed

- Removes the second source-label filter from the issuable invoice snapshot.
- Preserves the complete parts array already resolved by `getInvoiceSnapshotForWorkOrder`.
- Keeps the upstream precedence, approval quantity, sell-price, return, cancellation, and duplicate-allocation protections unchanged.
- Adds a regression assertion that issuance must not filter on `part.source`.

## Impact

Billing, invoice review, draft PDF, and invoice send now consume the same resolved parts. EL000001's parts will no longer disappear merely because its legacy attachment resolved through `work_order_part_allocation` rather than the newer source label.

## Validation

- 12 focused invoice and parts lifecycle test files: 84/84 tests passed.
- Changed-file ESLint: passed.
- `git diff --check`: passed.

## Database and deployment

No migration, data mutation, generated type, or environment-variable change.