### PR TITLE
Fix customer portal invite activation

### DIFF
--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -26,6 +26,7 @@ export default function SetPasswordPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const supabase = useMemo(() => createBrowserSupabase(), []);
+  const isPortalActivation = searchParams.get("mode") === "portal";
 
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -35,7 +36,9 @@ export default function SetPasswordPage() {
 
   const [statusTone, setStatusTone] = useState<StatusTone>("neutral");
   const [statusMessage, setStatusMessage] = useState(
-    "Checking your reset session...",
+    isPortalActivation
+      ? "Checking your portal activation..."
+      : "Checking your reset session...",
   );
 
   useEffect(() => {
@@ -61,7 +64,9 @@ export default function SetPasswordPage() {
         setHasSession(false);
         setStatusTone("error");
         setStatusMessage(
-          "No active reset session found. Request a new password reset link and try again.",
+          isPortalActivation
+            ? "This portal activation is no longer valid. Ask your shop to resend the invitation."
+            : "No active reset session found. Request a new password reset link and try again.",
         );
         setCheckingSession(false);
         return;
@@ -78,7 +83,7 @@ export default function SetPasswordPage() {
     return () => {
       cancelled = true;
     };
-  }, [supabase]);
+  }, [isPortalActivation, supabase]);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -139,7 +144,11 @@ export default function SetPasswordPage() {
       }
 
       setStatusTone("success");
-      setStatusMessage("Password updated. Redirecting...");
+      setStatusMessage(
+        isPortalActivation
+          ? "Portal password created. Opening your portal..."
+          : "Password updated. Redirecting...",
+      );
 
       const redirect = safeInternalRedirect(
         searchParams.get("redirect"),
@@ -171,7 +180,9 @@ export default function SetPasswordPage() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-[color:var(--theme-surface-page)] px-6 py-10 text-[color:var(--theme-text-primary)]">
       <div className="w-full max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-6 shadow-2xl">
-        <h1 className="text-2xl font-semibold text-[color:var(--theme-text-primary)]">Set new password</h1>
+        <h1 className="text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+          {isPortalActivation ? "Create your portal password" : "Set new password"}
+        </h1>
         <p className={`mt-3 text-sm ${statusClass}`}>{statusMessage}</p>
 
         <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
@@ -202,7 +213,11 @@ export default function SetPasswordPage() {
             className="w-full"
             disabled={checkingSession || submitting || !hasSession}
           >
-            {submitting ? "Saving..." : "Update password"}
+            {submitting
+              ? "Saving..."
+              : isPortalActivation
+                ? "Create password"
+                : "Update password"}
           </Button>
         </form>
       </div>

--- a/app/portal/auth/activate/route.ts
+++ b/app/portal/auth/activate/route.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import { NextResponse, type NextRequest } from "next/server";
+import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+type PortalOtpType = "invite" | "magiclink" | "signup";
+
+function asPortalOtpType(value: string | null): PortalOtpType | null {
+  return value === "invite" || value === "magiclink" || value === "signup"
+    ? value
+    : null;
+}
+
+function activationFailureUrl(req: NextRequest): URL {
+  const url = new URL("/portal/auth/sign-in", req.url);
+  url.searchParams.set("portal", "customer");
+  url.searchParams.set("activation", "invalid");
+  return url;
+}
+
+export async function GET(req: NextRequest) {
+  const tokenHash = req.nextUrl.searchParams.get("token_hash")?.trim() ?? "";
+  const type = asPortalOtpType(req.nextUrl.searchParams.get("type"));
+  const inviteId = req.nextUrl.searchParams.get("invite")?.trim() ?? "";
+  const next = safeInternalRedirect(
+    req.nextUrl.searchParams.get("next"),
+    "/auth/set-password?mode=portal&redirect=%2Fportal",
+    ["/auth/set-password", "/portal"],
+  );
+
+  if (!tokenHash || !type || !inviteId) {
+    return NextResponse.redirect(activationFailureUrl(req));
+  }
+
+  const supabase = createServerSupabaseRoute();
+  const { error } = await supabase.auth.verifyOtp({
+    token_hash: tokenHash,
+    type,
+  });
+
+  if (error) {
+    return NextResponse.redirect(activationFailureUrl(req));
+  }
+
+  const confirmUrl = new URL("/portal/auth/confirm", req.url);
+  confirmUrl.searchParams.set("invite", inviteId);
+  confirmUrl.searchParams.set("next", next);
+  return NextResponse.redirect(confirmUrl);
+}

--- a/app/portal/auth/confirm/page.tsx
+++ b/app/portal/auth/confirm/page.tsx
@@ -39,7 +39,9 @@ export default function PortalConfirmPage() {
         } = await supabase.auth.getSession();
         if (cancelled) return;
         if (!session?.user) {
-          router.replace("/portal/auth/sign-in");
+          router.replace(
+            "/portal/auth/sign-in?portal=customer&activation=invalid",
+          );
           return;
         }
         if (!inviteId) {

--- a/app/portal/auth/sign-in/PortalSignInForm.tsx
+++ b/app/portal/auth/sign-in/PortalSignInForm.tsx
@@ -27,6 +27,11 @@ export default function PortalSignInForm() {
   useEffect(() => {
     const requested = searchParams.get("portal");
     if (requested === "fleet" || requested === "customer") setPortalType(requested);
+    if (searchParams.get("activation") === "invalid") {
+      setError(
+        "This activation link is invalid or has expired. Ask your shop to resend your customer portal invitation.",
+      );
+    }
   }, [searchParams]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -183,9 +188,9 @@ export default function PortalSignInForm() {
           <>Fleet access is invitation-only. Contact your shop or fleet administrator if you need an invitation.</>
         ) : (
           <>
-            Need access? Open the invitation from your shop or{" "}
+            Portal access is created from your shop invitation. There is no separate account sign-up. If you need access, ask your shop to resend the invitation or{" "}
             <Link href="/portal/auth/sign-up" className="font-semibold text-[var(--accent-copper)] hover:underline">
-              learn how to enroll
+              view activation help
             </Link>
             .
           </>

--- a/app/portal/auth/sign-up/PortalSignUpForm.tsx
+++ b/app/portal/auth/sign-up/PortalSignUpForm.tsx
@@ -17,8 +17,8 @@ const steps = [
   },
   {
     icon: MailCheck,
-    title: "Create your password",
-    body: "Open the one-time email, set a password, and continue into your portal.",
+    title: "Activate from the email",
+    body: "The secure email creates and links your portal access. You do not need to register separately.",
   },
 ];
 
@@ -34,10 +34,10 @@ export default function PortalSignUpForm() {
         Customer portal
       </div>
       <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em] text-[color:var(--theme-text-primary)]">
-        Activate portal access
+        Portal activation help
       </h1>
       <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-        Customer accounts are created from a shop invitation or a verified shop QR code. This keeps your records private and correctly linked.
+        Customer accounts must be created from a shop invitation or a verified shop QR code. If your link expired or was already used, ask the shop to resend it.
       </p>
 
       <div className="mt-6 space-y-3">
@@ -54,9 +54,13 @@ export default function PortalSignUpForm() {
         ))}
       </div>
 
+      <div className="mt-6 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-4 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+        Creating a general ProFixIQ account will not connect your customer or vehicle records. Always start from the activation email sent by your shop.
+      </div>
+
       <div className="mt-6 grid gap-2 sm:grid-cols-2">
         <Link href="/portal/auth/sign-in" className="rounded-xl bg-[var(--accent-copper)] px-4 py-3 text-center text-sm font-bold text-[color:var(--theme-text-on-accent)]">
-          I already activated
+          Sign in if activated
         </Link>
         <Link href="/" className="rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-3 text-center text-sm font-semibold text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]">
           Back to ProFixIQ

--- a/features/portal/server/customerPortalInvites.ts
+++ b/features/portal/server/customerPortalInvites.ts
@@ -80,18 +80,29 @@ export async function issueCustomerPortalInvite(input: {
     inviteId = createdInvite.id;
   }
 
-  const afterAccept = "/auth/set-password?redirect=%2Fportal";
-  const redirectTo = `${siteUrl()}/portal/auth/confirm?${new URLSearchParams({
-    invite: inviteId,
-    next: afterAccept,
+  const portalDestination = input.workOrderId
+    ? `/portal/work-orders/view/${input.workOrderId}`
+    : "/portal";
+  const afterAccept = `/auth/set-password?${new URLSearchParams({
+    mode: "portal",
+    redirect: portalDestination,
   }).toString()}`;
   const { data: linkData, error: linkError } = await supabaseAdmin.auth.admin.generateLink({
     type: "magiclink",
     email,
-    options: { redirectTo },
   });
-  const portalLink = linkData?.properties?.action_link;
-  if (linkError || !portalLink) throw new Error("Portal activation link could not be created.");
+  const tokenHash = linkData?.properties?.hashed_token?.trim();
+  const verificationType = linkData?.properties?.verification_type;
+  if (linkError || !tokenHash || verificationType !== "magiclink") {
+    throw new Error("Portal activation link could not be created.");
+  }
+
+  const portalLink = `${siteUrl()}/portal/auth/activate?${new URLSearchParams({
+    token_hash: tokenHash,
+    type: verificationType,
+    invite: inviteId,
+    next: afterAccept,
+  }).toString()}`;
 
   const [{ data: shop }, brand] = await Promise.all([
     supabaseAdmin
@@ -115,5 +126,5 @@ export async function issueCustomerPortalInvite(input: {
     portalType: "customer",
   });
 
-  return { inviteId, redirectTo };
+  return { inviteId, portalLink };
 }

--- a/tests/phase7-portal-invite-booking-contract.test.ts
+++ b/tests/phase7-portal-invite-booking-contract.test.ts
@@ -9,6 +9,7 @@ const bookingSql = read(
   "supabase/migrations/20260715080100_phase7_atomic_portal_booking_lifecycle.sql",
 );
 const confirmPage = read("app/portal/auth/confirm/page.tsx");
+const activationRoute = read("app/portal/auth/activate/route.ts");
 const inviteRoute = read("app/api/portal/invites/accept/route.ts");
 const setupRoute = read("app/api/portal/qr/setup/route.ts");
 const canonicalInviteService = read(
@@ -31,6 +32,12 @@ describe("Phase 7 portal identity and booking lifecycle", () => {
     expect(setupRoute).toContain("issueCustomerPortalInvite");
     expect(canonicalInviteService).toContain("new URLSearchParams({");
     expect(canonicalInviteService).toContain("invite: inviteId");
+    expect(canonicalInviteService).toContain("properties?.hashed_token");
+    expect(canonicalInviteService).toContain('mode: "portal"');
+    expect(canonicalInviteService).not.toContain("properties?.action_link");
+    expect(activationRoute).toContain("supabase.auth.verifyOtp");
+    expect(activationRoute).toContain("token_hash: tokenHash");
+    expect(activationRoute).toContain('new URL("/portal/auth/confirm"');
     expect(confirmPage).toContain("/api/portal/invites/accept");
     expect(confirmPage).not.toContain('.from("customers")');
     expect(confirmPage).not.toContain('.from("customer_portal_invites")');


### PR DESCRIPTION
## Summary

Fixes customer portal activation links sent from work-order creation and QR enrollment.

### Root cause

The custom SendGrid email used Supabase's generated action link and the client confirmation page expected either a PKCE code or an already-established browser session. On affected browsers, including iOS email handoffs, the callback reached ProFixIQ without a usable session and redirected the customer to portal sign-in. The portal "sign-up" page did not create or link an account, so a separately created account could not pass the portal access checks.

### What changed

- build the branded email link from Supabase's one-time `hashed_token`
- add a server route that verifies the token and establishes the Supabase cookie before confirmation
- preserve the existing atomic invite acceptance and customer/email ownership checks
- send work-order invitations back to the invited work order after password creation
- give first-time customers portal-specific password setup language
- replace the misleading separate sign-up language with activation/recovery guidance
- show an actionable expired or invalid invitation message
- extend the portal lifecycle contract test for server-side token verification

### Validation

- `tsc --noEmit` — passed
- focused ESLint on all changed files — passed
- `vitest run tests/phase7-portal-invite-booking-contract.test.ts` — 3 tests passed
- `node scripts/audit-api-routes.mjs` — passed; 366 routes analyzed
- full `vitest run` — 995 passed, 48 failed, 2 skipped; failures are in existing unrelated navigation, workforce, financial, parts, mobile, and OpenAI contracts
- `next build` — could not complete in this workspace because the local dependency runtime exited with `fatal library error, lookup self`

### Deployment

- Database migration: none
- Environment variables: none
- Manual provider configuration: none
