### PR TITLE
Clarify invoice ready state and blockers

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -370,9 +370,13 @@ export default function BillingPage(): JSX.Element {
     );
   }, [historicalInvoices.length, supabase]);
 
-  const handleAiReview = useCallback(async (id: string) => {
+  const handleAiReview = useCallback(async (row: Row) => {
+    const normalizedStatus = String(row.status ?? "")
+      .toLowerCase()
+      .replaceAll(" ", "_");
+
     try {
-      const res = await fetch(`/api/work-orders/${id}/ai-review`, {
+      const res = await fetch(`/api/work-orders/${row.id}/ai-review`, {
         method: "POST",
       });
 
@@ -390,7 +394,13 @@ export default function BillingPage(): JSX.Element {
         return;
       }
 
-      toast.success("AI review passed. You can mark ready to invoice.");
+      if (normalizedStatus === "ready_to_invoice") {
+        toast.success("Review passed. This work order is already ready to invoice.");
+      } else if (normalizedStatus === "invoiced") {
+        toast.success("Review passed. This invoice has already been issued.");
+      } else {
+        toast.success("Review passed. The work order can be marked ready to invoice.");
+      }
     } catch (e) {
       const msg = e instanceof Error ? e.message : "AI review failed.";
       toast.error(msg);
@@ -752,25 +762,30 @@ export default function BillingPage(): JSX.Element {
 
                     <button
                       type="button"
-                      onClick={() => void handleAiReview(r.id)}
+                      onClick={() => void handleAiReview(r)}
                       className="rounded-full border border-sky-500/60 bg-sky-500/10 px-3 py-1.5 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
                       title="Run AI checklist"
                     >
                       AI Review
                     </button>
 
-                    <button
-                      type="button"
-                      onClick={() => void handleMarkReady(r.id)}
-                      disabled={
-                        r.status === "invoiced" ||
-                        r.status === "ready_to_invoice"
-                      }
-                      className="rounded-full border border-sky-400/60 bg-sky-500/10 px-3 py-1.5 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:opacity-50"
-                      title="Mark ready to invoice"
-                    >
-                      Mark Ready
-                    </button>
+                    {statusLower === "ready_to_invoice" ? (
+                      <span
+                        className="inline-flex items-center rounded-full border border-emerald-400/60 bg-emerald-500/10 px-3 py-1.5 text-sm font-semibold text-emerald-100"
+                        title="This work order is already ready to invoice"
+                      >
+                        Ready ✓
+                      </span>
+                    ) : statusLower !== "invoiced" ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleMarkReady(r.id)}
+                        className="rounded-full border border-sky-400/60 bg-sky-500/10 px-3 py-1.5 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                        title="Mark ready to invoice"
+                      >
+                        Mark Ready
+                      </button>
+                    ) : null}
 
                     <button
                       type="button"

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -766,6 +766,11 @@ export default function InvoicePreviewPageClient({
     return map;
   }, [reviewIssues]);
 
+  const generalReviewIssues = useMemo(
+    () => reviewIssues.filter((issue) => !issue.lineId),
+    [reviewIssues],
+  );
+
   const canTakeStripePayment = Boolean(shopId && stripeAccountId);
   const invoiceCurrency =
     activeInvoiceVersion?.currency ??
@@ -1144,29 +1149,31 @@ export default function InvoicePreviewPageClient({
         {!activeInvoiceVersion && !reviewOk ? (
           <div className="rounded-xl border border-amber-500/30 bg-[color:var(--theme-surface-inset)] px-3 py-2">
             <div className="text-[0.7rem] uppercase tracking-[0.18em] text-amber-200">
-              Invoice blocked
+              Invoice needs attention
             </div>
             <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-              Fix the items below, then refresh this page.
+              Complete the required items below before sending the invoice.
             </div>
 
             {reviewError ? (
               <div className="mt-2 text-[0.75rem] text-red-200">{reviewError}</div>
             ) : null}
 
-            <ul className="mt-2 space-y-1 text-[0.8rem] text-[color:var(--theme-text-primary)]">
-              {(reviewIssues ?? []).slice(0, 12).map((i, idx) => (
-                <li key={`${i.kind}-${idx}`} className="flex gap-2">
-                  <span className="text-amber-300">•</span>
-                  <span>{i.message}</span>
-                </li>
-              ))}
-            </ul>
+            {generalReviewIssues.length > 0 ? (
+              <ul className="mt-2 space-y-1 text-[0.8rem] text-[color:var(--theme-text-primary)]">
+                {generalReviewIssues.slice(0, 12).map((issue, index) => (
+                  <li key={`${issue.kind}-${index}`} className="flex gap-2">
+                    <span className="text-amber-300">•</span>
+                    <span>{issue.message}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
 
             {issuesByLineId.size > 0 ? (
               <div className="mt-3 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2">
                 <div className="text-[0.7rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-                  Line issues
+                  Required line updates
                 </div>
                 <ul className="mt-2 space-y-2 text-[0.8rem] text-[color:var(--theme-text-primary)]">
                   {(effectiveLines ?? [])

--- a/tests/live-invoice-flow-safety.test.ts
+++ b/tests/live-invoice-flow-safety.test.ts
@@ -89,6 +89,28 @@ describe("regular live invoice flow safety", () => {
     expect(sendRoute).toContain("approved parts were not materialized");
   });
 
+  it("shows completed readiness as state instead of a disabled action", () => {
+    expect(billingPage).toContain("Ready ✓");
+    expect(billingPage).toContain(
+      "Review passed. This work order is already ready to invoice.",
+    );
+    expect(billingPage).toContain("statusLower === \"ready_to_invoice\"");
+    expect(billingPage).not.toContain(
+      'disabled={\n                        r.status === "invoiced" ||',
+    );
+  });
+
+  it("renders each invoice blocker only once", () => {
+    expect(previewClient).toContain("generalReviewIssues");
+    expect(previewClient).toContain(
+      "reviewIssues.filter((issue) => !issue.lineId)",
+    );
+    expect(previewClient).toContain("Required line updates");
+    expect(previewClient).not.toContain(
+      "(reviewIssues ?? []).slice(0, 12)",
+    );
+  });
+
   it("keeps post-issue accounting and manual POS actions reachable", () => {
     expect(billingPage).toContain("Open Invoice");
     expect(previewClient).toContain("SyncInvoiceToQuickBooksButton");


### PR DESCRIPTION
## What changed

- Replaces the disabled **Mark Ready** button with a clear **Ready ✓** state once a work order is already `ready_to_invoice`.
- Makes AI Review success messaging reflect whether the work order still needs to be marked ready, is already ready, or is already invoiced.
- Removes duplicate invoice blocker rendering by separating global issues from line-specific issues.
- Renames the blocker panel and line section with clearer operational wording.
- Adds focused regression coverage for both UI behaviors.

## Root cause

The billing card always rendered the Mark Ready action and only disabled it after the transition had already completed. AI Review used one generic success message regardless of work-order status. The invoice blocker panel also rendered line-scoped issues in both the general list and the grouped line list.

## User impact

Ready work orders now show their completed state and direct the user toward **Invoice**. Required invoice corrections remain visible once, grouped under the affected line.

## Validation

- Remote diff reviewed against current `main`.
- Focused source-contract regression coverage added in `tests/live-invoice-flow-safety.test.ts`.
- Local pnpm checks were not available because the workspace checkout had been removed; CI should run the repository checks on this draft PR.

## Database and configuration

- No migration.
- No environment variables.
- No manual provider configuration.