### PR TITLE
Remove AI and inferred-parts invoice gates

### DIFF
--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -37,68 +37,6 @@ function numericValue(value: unknown): number | null {
   return null;
 }
 
-function hasMeaningfulJson(value: unknown): boolean {
-  if (value == null) return false;
-  if (Array.isArray(value)) return value.length > 0;
-  if (typeof value === "object") {
-    return Object.keys(value as Record<string, unknown>).length > 0;
-  }
-  if (typeof value === "string") return value.trim().length > 0;
-  return Boolean(value);
-}
-
-function isInfoLine(line: Record<string, unknown>): boolean {
-  const lineType = String(line.line_type ?? "").trim().toLowerCase();
-  const jobType = String(line.job_type ?? "").trim().toLowerCase();
-  return lineType === "info" || lineType === "note" || jobType === "info";
-}
-
-function lineRequiresParts(line: Record<string, unknown>): boolean {
-  if (line.no_parts_required === true || isInfoLine(line)) return false;
-  const jobType = String(line.job_type ?? "").trim().toLowerCase();
-  const lineType = String(line.line_type ?? "").trim().toLowerCase();
-  if (
-    jobType === "inspection" ||
-    jobType === "diagnosis" ||
-    lineType === "inspection" ||
-    lineType === "diagnostic"
-  ) {
-    return (
-      line.parts_required === true ||
-      hasMeaningfulJson(line.parts_required) ||
-      hasMeaningfulJson(line.parts_needed)
-    );
-  }
-  if (line.parts_required === true) return true;
-  if (hasMeaningfulJson(line.parts_required)) return true;
-  if (hasMeaningfulJson(line.parts_needed)) return true;
-  if (typeof line.parts === "string" && line.parts.trim()) return true;
-  if (line.parts_verification_required === true) return true;
-
-  const text = [
-    line.description,
-    line.complaint,
-    line.cause,
-    line.correction,
-    line.notes,
-    line.job_type,
-    line.service_code,
-  ]
-    .map((value) => String(value ?? "").toLowerCase())
-    .join(" ");
-
-  if (
-    /\b(oil|filter|air filter|cabin filter|fuel filter|brake|pads?|rotors?|battery|tire|spark plug|belt|hose|coolant|transmission fluid|differential fluid|wiper)\b/.test(
-      text,
-    )
-  ) {
-    return true;
-  }
-
-  const status = String(line.status ?? "").trim().toLowerCase();
-  return status === "pending_parts" || status === "awaiting_parts";
-}
-
 function partRequestItemHasBillablePrice(row: Record<string, unknown>): boolean {
   const price =
     numericValue(row.quoted_price) ??
@@ -142,20 +80,18 @@ export async function reviewWorkOrder({
     }
   }
 
-  const { data: stagedPartRows } = await supabase
+  const { data: stagedPartRows, error: stagedPartsError } = await supabase
     .from("work_order_parts")
     .select(
-      "work_order_line_id, quantity, quantity_requested, quantity_returned, quantity_cancelled, unit_price, unit_sell_price_snapshot, total_price, is_active",
+      "work_order_line_id, quantity_requested, quantity_returned, quantity_cancelled, unit_price, unit_sell_price_snapshot, total_price, is_active",
     )
     .eq("work_order_id", workOrderId)
     .eq("shop_id", shopId);
+  if (stagedPartsError) throw stagedPartsError;
   for (const row of stagedPartRows ?? []) {
     const record = row as Record<string, unknown>;
     const lineId = typeof row.work_order_line_id === "string" ? row.work_order_line_id : "";
-    const requested =
-      numericValue(record.quantity_requested) ??
-      numericValue(record.quantity) ??
-      0;
+    const requested = numericValue(record.quantity_requested) ?? 0;
     const quantity = Math.max(
       0,
       requested -
@@ -317,14 +253,6 @@ export async function reviewWorkOrder({
     const noCharge = record.no_charge === true;
     const laborNA = record.labor_marked_na === true;
     const hasBillableParts = hasBillablePartsByLine.get(String(line.id)) === true;
-    if (lineRequiresParts(record) && !hasBillableParts) {
-      issues.push({
-        kind: "missing_required_parts",
-        lineId: line.id,
-        message: `Required approved parts are not attached to line: ${line.description ?? line.complaint ?? "job"}`,
-      });
-    }
-
     const laborHours = numericValue(line.labor_time) ?? 0;
     const lineLaborRate = numericValue(record.labor_rate);
     const effectiveLaborRate =

--- a/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
+++ b/app/api/work-orders/[id]/_lib/reviewWorkOrder.ts
@@ -37,6 +37,12 @@ function numericValue(value: unknown): number | null {
   return null;
 }
 
+function isInfoLine(line: Record<string, unknown>): boolean {
+  const lineType = String(line.line_type ?? "").trim().toLowerCase();
+  const jobType = String(line.job_type ?? "").trim().toLowerCase();
+  return lineType === "info" || lineType === "note" || jobType === "info";
+}
+
 function partRequestItemHasBillablePrice(row: Record<string, unknown>): boolean {
   const price =
     numericValue(row.quoted_price) ??

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -12,7 +12,6 @@ import type { RepairLine } from "@ai/lib/parseRepairOutput";
 import CustomerPaymentButton from "@/features/stripe/components/CustomerPaymentButton";
 import { WorkOrderInvoiceDownloadButton } from "@work-orders/components/WorkOrderInvoiceDownloadButton";
 import SyncInvoiceToQuickBooksButton from "@/features/integrations/quickbooks/components/SyncInvoiceToQuickBooksButton";
-import WorkOrderCloseoutGatePreview from "@/features/work-orders/components/WorkOrderCloseoutGatePreview";
 import RecordManualPayment from "@/features/invoices/components/RecordManualPayment";
 
 type DB = Database;
@@ -1138,7 +1137,6 @@ export default function InvoicePreviewPageClient({
           </section>
         ) : null}
 
-        <WorkOrderCloseoutGatePreview workOrderId={workOrderId} />
         {snapshotWarning ? (
           <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[0.75rem] text-amber-100">
             {snapshotWarning}

--- a/tests/live-invoice-flow-safety.test.ts
+++ b/tests/live-invoice-flow-safety.test.ts
@@ -26,14 +26,19 @@ describe("regular live invoice flow safety", () => {
     }).laborTotal).toBe(125);
   });
 
-  it("blocks AI/invoice review when parts are required but no billable parts are attached", () => {
-    expect(reviewSource).toContain("function lineRequiresParts");
-    expect(reviewSource).toContain("missing_required_parts");
+  it("keeps AI advisory and never infers an invoice blocker from repair text", () => {
+    expect(previewClient).not.toContain("WorkOrderCloseoutGatePreview");
+    expect(reviewSource).not.toContain("function lineRequiresParts");
+    expect(reviewSource).not.toContain("missing_required_parts");
+    expect(reviewSource).not.toContain("Required approved parts are not attached");
+  });
+
+  it("loads attached work-order parts from the durable approved quantity", () => {
     expect(reviewSource).toContain("work_order_parts");
-    expect(reviewSource).toContain("work_order_part_allocations");
-    expect(reviewSource).toContain("part_request_items");
+    expect(reviewSource).toContain("quantity_requested");
+    expect(reviewSource).toContain("stagedPartsError");
     expect(reviewSource).toContain("hasCanonicalPartsByLine");
-    expect(reviewSource).toContain("Required approved parts are not attached");
+    expect(reviewSource).not.toContain("record.quantity)");
   });
 
   it("flags invalid or suspicious labor totals before invoice readiness passes", () => {


### PR DESCRIPTION
## What changed

- Removes the AI closeout-gate preview from the invoice page.
- Removes the repair-description keyword heuristic that inferred required parts and blocked invoice issuance.
- Reads attached parts from the durable `work_order_parts.quantity_requested` value.
- Fails explicitly when the attached-parts query errors instead of silently treating the work order as having no parts.
- Adds focused regression coverage proving AI preview output and inferred repair text cannot block invoicing.

## Root cause

The invoice validator mixed deterministic billing validation with a text heuristic that treated words such as oil, filter, brake, and battery as proof that a line required parts. Its `work_order_parts` query also requested a legacy quantity fallback and ignored query errors. This allowed a valid invoice snapshot to show attached parts while the validator independently concluded that none were attached.

The AI closeout panel was preview-only, but placing it directly above the real invoice blocker made it appear—and behave conceptually—like part of invoice authorization.

## User impact

AI recommendations no longer appear in or influence invoice closeout. Invoicing still requires completed lines, valid customer/contact information, valid labor pricing, and sell prices for parts that are actually attached.

## Validation

- Reviewed the branch comparison against current `main`.
- Added source-contract regression coverage in `tests/live-invoice-flow-safety.test.ts`.
- Confirmed the diff is limited to the invoice validator, invoice preview surface, and focused test.
- Local pnpm execution was unavailable because the workspace checkout had been cleared; CI should run repository checks on this draft PR.

## Database and configuration

- No migration.
- No environment variables.
- No external configuration.