### PR TITLE
Refactor customer portal for mobile-first service updates

### DIFF
--- a/app/api/chat/start-conversation/route.ts
+++ b/app/api/chat/start-conversation/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { randomUUID } from "crypto";
-import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import { authorizeConversationCreate } from "@/features/ai/lib/chat/authorization";
 import { authorizeConversationContext } from "@/features/chat/server/conversationContext";
 
@@ -12,7 +15,8 @@ export async function POST(req: Request): Promise<NextResponse> {
     data: { user },
   } = await userClient.auth.getUser();
 
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
   const body = (await req.json().catch(() => null)) as {
     participant_ids?: string[];
@@ -36,7 +40,10 @@ export async function POST(req: Request): Promise<NextResponse> {
   });
 
   if (!createAccess.ok) {
-    return NextResponse.json({ error: createAccess.error }, { status: createAccess.status });
+    return NextResponse.json(
+      { error: createAccess.error },
+      { status: createAccess.status },
+    );
   }
 
   if (
@@ -44,7 +51,10 @@ export async function POST(req: Request): Promise<NextResponse> {
     (createAccess.actor.kind !== "staff" ||
       !["owner", "manager", "admin"].includes(createAccess.actor.role ?? ""))
   ) {
-    return NextResponse.json({ error: "Only owner/manager/admin can broadcast" }, { status: 403 });
+    return NextResponse.json(
+      { error: "Only owner/manager/admin can broadcast" },
+      { status: 403 },
+    );
   }
 
   const context = await authorizeConversationContext({
@@ -56,15 +66,89 @@ export async function POST(req: Request): Promise<NextResponse> {
   });
 
   if (!context.ok) {
-    return NextResponse.json({ error: context.error }, { status: context.status });
+    return NextResponse.json(
+      { error: context.error },
+      { status: context.status },
+    );
+  }
+
+  let recipientUserIds = createAccess.recipientUserIds;
+  let participantKindByUserId = createAccess.participantKinds;
+
+  if (
+    createAccess.actor.kind === "customer" &&
+    createAccess.customerId &&
+    context.anchors.work_order_id
+  ) {
+    const { data: workOrder, error: workOrderError } = await admin
+      .from("work_orders")
+      .select("advisor_id")
+      .eq("id", context.anchors.work_order_id)
+      .eq("shop_id", createAccess.actorShopId)
+      .eq("customer_id", createAccess.customerId)
+      .maybeSingle();
+
+    if (workOrderError) {
+      return NextResponse.json(
+        { error: workOrderError.message },
+        { status: 500 },
+      );
+    }
+
+    if (workOrder?.advisor_id) {
+      const [
+        { data: assignedAdvisor, error: advisorError },
+        { data: coverage, error: coverageError },
+      ] = await Promise.all([
+        admin
+          .from("profiles")
+          .select("id,user_id")
+          .eq("id", workOrder.advisor_id)
+          .eq("shop_id", createAccess.actorShopId)
+          .maybeSingle(),
+        admin
+          .from("profiles")
+          .select("id,user_id")
+          .eq("shop_id", createAccess.actorShopId)
+          .in("role", ["owner", "admin", "manager"])
+          .limit(25),
+      ]);
+
+      const recipientError = advisorError ?? coverageError;
+      if (recipientError) {
+        return NextResponse.json(
+          { error: recipientError.message },
+          { status: 500 },
+        );
+      }
+
+      const advisorUserId =
+        assignedAdvisor?.user_id ?? assignedAdvisor?.id ?? null;
+      if (advisorUserId) {
+        recipientUserIds = Array.from(
+          new Set([
+            advisorUserId,
+            ...(coverage ?? []).map((profile) => profile.user_id ?? profile.id),
+          ]),
+        ).filter((id) => id !== user.id);
+        participantKindByUserId = Object.fromEntries(
+          recipientUserIds.map((id) => [id, "staff" as const]),
+        );
+      }
+    }
   }
 
   const requestedId = body?.request_id?.trim();
   if (
     requestedId &&
-    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestedId)
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      requestedId,
+    )
   ) {
-    return NextResponse.json({ error: "request_id must be a UUID" }, { status: 400 });
+    return NextResponse.json(
+      { error: "request_id must be a UUID" },
+      { status: 400 },
+    );
   }
 
   const conversationId = requestedId ?? randomUUID();
@@ -75,21 +159,30 @@ export async function POST(req: Request): Promise<NextResponse> {
       .eq("id", requestedId)
       .maybeSingle();
     if (existingError) {
-      return NextResponse.json({ error: existingError.message }, { status: 500 });
+      return NextResponse.json(
+        { error: existingError.message },
+        { status: 500 },
+      );
     }
     if (existing) {
       if (existing.created_by !== user.id) {
-        return NextResponse.json({ error: "request_id is already in use" }, { status: 409 });
+        return NextResponse.json(
+          { error: "request_id is already in use" },
+          { status: 409 },
+        );
       }
-      return NextResponse.json({ id: existing.id, reused: true }, { status: 200 });
+      return NextResponse.json(
+        { id: existing.id, reused: true },
+        { status: 200 },
+      );
     }
   }
 
-  const allParticipantIds = Array.from(
-    new Set([user.id, ...createAccess.recipientUserIds]),
-  );
-  const participantKinds = allParticipantIds.map((id) =>
-    id === user.id ? createAccess.actor.kind : createAccess.participantKinds[id] ?? "staff",
+  const allParticipantIds = Array.from(new Set([user.id, ...recipientUserIds]));
+  const participantKindValues = allParticipantIds.map((id) =>
+    id === user.id
+      ? createAccess.actor.kind
+      : (participantKindByUserId[id] ?? "staff"),
   );
 
   const { data: createdId, error: createError } = await admin.rpc(
@@ -107,7 +200,7 @@ export async function POST(req: Request): Promise<NextResponse> {
       _context_id: context.anchors.context_id,
       _title: body?.title?.trim().slice(0, 160) || null,
       _participant_user_ids: allParticipantIds,
-      _participant_kinds: participantKinds,
+      _participant_kinds: participantKindValues,
     },
   );
 
@@ -115,5 +208,8 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: createError.message }, { status: 500 });
   }
 
-  return NextResponse.json({ id: createdId ?? conversationId }, { status: 201 });
+  return NextResponse.json(
+    { id: createdId ?? conversationId },
+    { status: 201 },
+  );
 }

--- a/app/portal/page.tsx
+++ b/app/portal/page.tsx
@@ -1,124 +1,261 @@
-"use client";
-
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import type { Database } from "@shared/types/types/supabase";
-import WorkOrderBoardWidget from "@shared/components/workboard/WorkOrderBoardWidget";
-import { PortalActionCard, PortalEmptyState, PortalPageHeader, PortalPrimaryButton, PortalSecondaryButton, PortalSectionCard, PortalStatCard, PortalStatusChip } from "@/features/portal/components/PortalUi";
+import {
+  CalendarDays,
+  Car,
+  ChevronRight,
+  MessageCircle,
+  Plus,
+} from "lucide-react";
+import PortalWorkOrderCard from "@/features/portal/components/PortalWorkOrderCard";
+import {
+  PortalActionCard,
+  PortalEmptyState,
+  PortalPageHeader,
+  PortalSectionCard,
+} from "@/features/portal/components/PortalUi";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { PortalAccessError } from "@/features/portal/server/portalAuth";
+import { listCustomerBookings } from "@/features/portal/server/customerBookings";
+import { listPortalWorkOrdersForCustomer } from "@/features/portal/server/portalWorkOrders";
 
-type DB = Database;
-type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
-type CustomerPortalInviteRow =
-  DB["public"]["Tables"]["customer_portal_invites"]["Row"];
-type BookingRow = DB["public"]["Tables"]["bookings"]["Row"];
-type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+export const dynamic = "force-dynamic";
 
-const formatWhen = (iso: string) => { const d = new Date(iso); if (Number.isNaN(d.getTime())) return "—"; return d.toLocaleString(undefined, { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }); };
-const formatWoRef = (wo: Pick<WorkOrderRow, "id" | "status" | "created_at" | "invoice_sent_at" | "approval_state"> | null) => wo ? `#${wo.id?.slice(0, 8) ?? "—"}` : "—";
+function dateLabel(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Date to be confirmed";
+  return date.toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
 
-export default function PortalHomePage() {
-  const supabase = useMemo(() => createBrowserSupabase(), []);
+export default async function PortalHomePage() {
+  const supabase = createServerSupabaseRSC();
 
-  const [loading, setLoading] = useState(true);
-  const [vehiclesCount, setVehiclesCount] = useState<number | null>(null);
-  const [nextBookingAt, setNextBookingAt] = useState<string | null>(null);
-  const [activeWo, setActiveWo] = useState<Pick<WorkOrderRow, "id" | "status" | "created_at" | "invoice_sent_at" | "approval_state"> | null>(null);
-  const [requiresInvite, setRequiresInvite] = useState(false);
+  try {
+    const actor = await requirePortalCustomerActor(supabase);
+    if (!actor.customer.shop_id)
+      throw new Error("Customer shop is not connected");
 
-  useEffect(() => {
-    let mounted = true;
+    const [workOrders, bookingResult, vehicleCountResult] = await Promise.all([
+      listPortalWorkOrdersForCustomer({
+        supabase,
+        customerId: actor.customer.id,
+        shopId: actor.customer.shop_id,
+      }),
+      listCustomerBookings({ supabase, customerId: actor.customer.id }),
+      supabase
+        .from("vehicles")
+        .select("id", { count: "exact", head: true })
+        .eq("shop_id", actor.customer.shop_id)
+        .eq("customer_id", actor.customer.id),
+    ]);
 
-    (async () => {
-      setLoading(true);
+    if (vehicleCountResult.error)
+      throw new Error(vehicleCountResult.error.message);
 
-      const { data: { user }, error: userErr } = await supabase.auth.getUser();
-      if (!mounted) return;
+    const active = workOrders.filter((workOrder) => !workOrder.status.complete);
+    const attention = active.filter(
+      (workOrder) => workOrder.status.actionRequired,
+    );
+    const attentionIds = new Set(attention.map((workOrder) => workOrder.id));
+    const serviceCards = active.filter(
+      (workOrder) => !attentionIds.has(workOrder.id),
+    );
+    const recent =
+      workOrders.find((workOrder) => workOrder.status.complete) ?? null;
+    const now = Date.now();
+    const nextBooking = bookingResult.ok
+      ? (bookingResult.data.find(
+          (booking) =>
+            new Date(booking.ends_at).getTime() >= now &&
+            (booking.status ?? "").toLowerCase() !== "cancelled",
+        ) ?? null)
+      : null;
+    const customerName =
+      [actor.customer.first_name, actor.customer.last_name]
+        .filter(Boolean)
+        .join(" ")
+        .trim() || "there";
 
-      if (userErr || !user) {
-        setRequiresInvite(false);
-        setVehiclesCount(null);
-        setNextBookingAt(null);
-        setActiveWo(null);
-        setLoading(false);
-        return;
-      }
-
-      const { data: cust, error: custErr } = await supabase.from("customers").select("id").eq("user_id", user.id).maybeSingle<Pick<CustomerRow, "id">>();
-      if (!mounted) return;
-
-      if (custErr || !cust?.id) {
-        setRequiresInvite(true);
-        setVehiclesCount(null);
-        setNextBookingAt(null);
-        setActiveWo(null);
-        setLoading(false);
-        return;
-      }
-
-      const normalizedUserEmail = (user.email ?? "").trim().toLowerCase();
-      const { data: inviteEvidence, error: inviteErr } = await supabase
-        .from("customer_portal_invites")
-        .select("id, customer_id, email, accepted_at, accepted_by_user_id, revoked_at")
-        .eq("customer_id", cust.id)
-        .eq("accepted_by_user_id", user.id)
-        .not("accepted_at", "is", null)
-        .is("revoked_at", null)
-        .limit(10);
-      if (!mounted) return;
-
-      const hasInviteEvidence =
-        !inviteErr &&
-        Array.isArray(inviteEvidence) &&
-        inviteEvidence.some((row) => {
-          const invite = row as Pick<
-            CustomerPortalInviteRow,
-            "id" | "customer_id" | "email" | "accepted_at" | "accepted_by_user_id" | "revoked_at"
-          >;
-          return (
-            invite.customer_id === cust.id &&
-            invite.accepted_by_user_id === user.id &&
-            Boolean(invite.accepted_at) &&
-            !invite.revoked_at &&
-            normalizedUserEmail.length > 0 &&
-            invite.email.trim().toLowerCase() === normalizedUserEmail
-          );
-        });
-
-      if (!hasInviteEvidence) {
-        setRequiresInvite(true);
-        setVehiclesCount(null);
-        setNextBookingAt(null);
-        setActiveWo(null);
-        setLoading(false);
-        return;
-      }
-
-      setRequiresInvite(false);
-
-      const { count: vCount } = await supabase.from("vehicles").select("id", { count: "exact", head: true }).eq("customer_id", cust.id);
-      const nowIso = new Date().toISOString();
-      const { data: booking } = await supabase.from("bookings").select("starts_at").eq("customer_id", cust.id).gte("starts_at", nowIso).order("starts_at", { ascending: true }).limit(1).maybeSingle<Pick<BookingRow, "starts_at">>();
-      const ACTIVE_STATUSES: Array<WorkOrderRow["status"]> = ["awaiting_approval", "queued", "planned", "in_progress"];
-      const { data: wo } = await supabase.from("work_orders").select("id, status, created_at, invoice_sent_at, approval_state").eq("customer_id", cust.id).in("status", ACTIVE_STATUSES as string[]).order("created_at", { ascending: false }).limit(1).maybeSingle<Pick<WorkOrderRow, "id" | "status" | "created_at" | "invoice_sent_at" | "approval_state">>();
-
-      if (!mounted) return;
-      setVehiclesCount(typeof vCount === "number" ? vCount : null);
-      setNextBookingAt(booking?.starts_at ?? null);
-      setActiveWo(wo ?? null);
-      setLoading(false);
-    })();
-
-    return () => { mounted = false; };
-  }, [supabase]);
-
-  if (loading) {
-    return <div className="space-y-5 text-[color:var(--theme-text-primary)]"><PortalPageHeader eyebrow="Customer portal" title="What needs your attention today?" subtitle="Loading your latest status and activity." /></div>;
-  }
-
-  if (requiresInvite) {
     return (
-      <div className="space-y-5 text-[color:var(--theme-text-primary)]">
+      <div className="mx-auto w-full max-w-5xl space-y-5 text-[color:var(--theme-text-primary)]">
+        <PortalPageHeader
+          eyebrow="Customer portal"
+          title={`Good to see you, ${customerName}`}
+          subtitle="See what’s happening with your vehicle and what you need to do next."
+          actions={
+            <Link
+              href="/portal/request/when"
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)]"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Request service
+            </Link>
+          }
+        />
+
+        {attention.length > 0 ? (
+          <section aria-labelledby="attention-heading" className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h2 id="attention-heading" className="text-sm font-semibold">
+                Needs your attention
+              </h2>
+              <span className="rounded-full bg-amber-500/15 px-2.5 py-1 text-xs font-semibold text-amber-100">
+                {attention.length}
+              </span>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+              {attention.map((workOrder) => (
+                <PortalWorkOrderCard key={workOrder.id} workOrder={workOrder} />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {serviceCards.length > 0 || attention.length === 0 ? (
+          <section aria-labelledby="active-work-heading" className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h2 id="active-work-heading" className="text-sm font-semibold">
+                {attention.length > 0
+                  ? "Other vehicles in service"
+                  : "Your vehicles in service"}
+              </h2>
+              {serviceCards.length > 0 ? (
+                <Link
+                  href="/portal/status"
+                  className="inline-flex items-center gap-1 text-xs font-semibold text-[var(--accent-copper-light)]"
+                >
+                  View all
+                  <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />
+                </Link>
+              ) : null}
+            </div>
+            {serviceCards.length > 0 ? (
+              <div className="grid gap-4 lg:grid-cols-2">
+                {serviceCards.slice(0, 4).map((workOrder) => (
+                  <PortalWorkOrderCard
+                    key={workOrder.id}
+                    workOrder={workOrder}
+                  />
+                ))}
+              </div>
+            ) : (
+              <PortalEmptyState
+                title="No vehicles are currently in service"
+                body="Request service when you are ready, or review your previous visits in service history."
+              />
+            )}
+          </section>
+        ) : null}
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <PortalSectionCard title="Upcoming appointment">
+            {nextBooking ? (
+              <Link
+                href="/portal/customer-appointments"
+                className="flex min-h-24 items-center gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4"
+              >
+                <span className="grid h-11 w-11 shrink-0 place-items-center rounded-2xl bg-sky-500/12 text-sky-100">
+                  <CalendarDays className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold">
+                    {dateLabel(nextBooking.starts_at)}
+                  </span>
+                  <span className="mt-1 block truncate text-xs text-[color:var(--theme-text-secondary)]">
+                    {nextBooking.notes?.trim() || "Service appointment"}
+                  </span>
+                </span>
+                <ChevronRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+              </Link>
+            ) : (
+              <PortalEmptyState
+                title="No upcoming appointment"
+                body="Choose a time that works for you when you request service."
+              />
+            )}
+          </PortalSectionCard>
+
+          <PortalSectionCard title="Recent service">
+            {recent ? (
+              <Link
+                href={recent.primaryAction.href}
+                className="flex min-h-24 items-center gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4"
+              >
+                <span className="grid h-11 w-11 shrink-0 place-items-center rounded-2xl bg-emerald-500/12 text-emerald-100">
+                  <Car className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-semibold">
+                    {recent.vehicleLabel}
+                  </span>
+                  <span className="mt-1 block text-xs text-[color:var(--theme-text-secondary)]">
+                    {recent.serviceSummary[0]}
+                  </span>
+                </span>
+                <ChevronRight className="h-4 w-4 shrink-0" aria-hidden="true" />
+              </Link>
+            ) : (
+              <PortalEmptyState
+                title="No completed service yet"
+                body="Completed visits will stay available here and in service history."
+              />
+            )}
+          </PortalSectionCard>
+        </div>
+
+        <section
+          aria-label="Portal shortcuts"
+          className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+        >
+          <PortalActionCard
+            href="/portal/request/when"
+            title="Request service"
+            subtitle="Start a new visit."
+            prominent
+          />
+          <PortalActionCard
+            href="/portal/messages"
+            title="Messages"
+            subtitle="Contact your advisor."
+          />
+          <PortalActionCard
+            href="/portal/vehicles"
+            title="Vehicles"
+            subtitle={`${vehicleCountResult.count ?? 0} saved`}
+          />
+          <PortalActionCard
+            href="/portal/history"
+            title="Service history"
+            subtitle="Review past visits."
+          />
+        </section>
+
+        <div className="flex items-center justify-center gap-2 pb-2 text-xs text-[color:var(--theme-text-muted)] sm:hidden">
+          <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />
+          Need help? Message the shop from any service card.
+        </div>
+      </div>
+    );
+  } catch (error) {
+    if (!(error instanceof PortalAccessError)) {
+      console.error("[portal/home] unable to load customer portal", error);
+      return (
+        <div className="mx-auto max-w-xl rounded-3xl border border-red-500/30 bg-red-500/10 p-5 text-sm text-red-100">
+          <p className="font-semibold">We couldn’t load your portal.</p>
+          <p className="mt-1">
+            Please refresh the page or contact the shop if this continues.
+          </p>
+        </div>
+      );
+    }
+    return (
+      <div className="mx-auto max-w-xl space-y-4 text-[color:var(--theme-text-primary)]">
         <PortalPageHeader
           eyebrow="Customer portal"
           title="Portal invite required"
@@ -127,25 +264,4 @@ export default function PortalHomePage() {
       </div>
     );
   }
-
-  const hasInvoice = !!activeWo && !!activeWo.invoice_sent_at && (activeWo.status === "ready_to_invoice" || activeWo.status === "invoiced");
-  const hasQuote = !!activeWo && (activeWo.status === "awaiting_approval" || activeWo.approval_state === "awaiting_customer" || activeWo.approval_state === "requested");
-
-  return <div className="space-y-5 text-[color:var(--theme-text-primary)]">
-    <PortalPageHeader eyebrow="Customer portal" title="What needs your attention today?" subtitle="Track active work, approve recommendations, and request service in one place." actions={<><PortalPrimaryButton href="/portal/request/when">Request service</PortalPrimaryButton><PortalSecondaryButton href="/portal/customer-appointments">Appointments</PortalSecondaryButton></>} />
-
-    <PortalSectionCard title="Current status" subtitle="Your latest request and next appointment.">
-      <div className="grid gap-3 sm:grid-cols-3"><PortalStatCard title="Active request" value={formatWoRef(activeWo)} sub={activeWo?.status ? `Status: ${activeWo.status}` : "No open request"} /><PortalStatCard title="Next appointment" value={nextBookingAt ? formatWhen(nextBookingAt) : "—"} /><PortalStatCard title="Vehicles" value={vehiclesCount == null ? "—" : String(vehiclesCount)} sub="Saved to your account" /></div>
-    </PortalSectionCard>
-
-    <PortalSectionCard title="Live work status" right={<Link href="/portal/status" className="text-xs text-[color:var(--theme-text-secondary)] underline">Details</Link>}>
-      <WorkOrderBoardWidget variant="portal" href="/portal/status" />
-    </PortalSectionCard>
-
-    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4"><PortalActionCard href="/portal/request/when" title="Request service" subtitle="Start a new service request now." prominent /><PortalActionCard href="/portal/messages" title="Message the shop" subtitle="Ask a question tied to your work order, appointment, or vehicle." /><PortalActionCard href="/portal/vehicles" title="Manage vehicles" subtitle="Update VIN, mileage, and details." /><PortalActionCard href="/portal/customer-appointments" title="Appointments" subtitle="View upcoming and past bookings." /></div>
-
-    <PortalSectionCard title="Recent activity" subtitle="Quote and invoice milestones are highlighted here." right={<PortalStatusChip label="Live" />}>
-      {hasInvoice && activeWo ? <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"><div><p className="text-xs uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Invoice ready</p><p className="text-sm text-[color:var(--theme-text-primary)]">Work Order {formatWoRef(activeWo)} sent {activeWo.invoice_sent_at ? formatWhen(activeWo.invoice_sent_at) : "recently"}</p></div><PortalPrimaryButton href={`/portal/invoices/${activeWo.id}`}>View invoice</PortalPrimaryButton></div> : hasQuote && activeWo ? <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"><div><p className="text-xs uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Quote ready</p><p className="text-sm text-[color:var(--theme-text-primary)]">Work Order {formatWoRef(activeWo)} is waiting for your approval.</p></div><PortalPrimaryButton href={`/portal/quotes/${activeWo.id}`}>Review quote</PortalPrimaryButton></div> : <PortalEmptyState title="No recent activity" body="After you submit a request, updates will appear here." />}
-    </PortalSectionCard>
-  </div>;
 }

--- a/app/portal/profile/page.tsx
+++ b/app/portal/profile/page.tsx
@@ -88,7 +88,9 @@ export default function PortalProfilePage() {
 
       const { data: customer, error: fetchErr } = await supabase
         .from("customers")
-        .select("first_name,last_name,phone,street,city,province,postal_code")
+        .select(
+          "id,shop_id,first_name,last_name,phone,street,city,province,postal_code",
+        )
         .eq("user_id", user.id)
         .maybeSingle<CustomerRow>();
 
@@ -109,14 +111,32 @@ export default function PortalProfilePage() {
 
       const { data: inviteRows, error: inviteErr } = await supabase
         .from("customer_portal_invites")
-        .select("id, customer_id, email")
+        .select(
+          "id,customer_id,email,accepted_at,accepted_by_user_id,revoked_at",
+        )
         .eq("customer_id", customerId)
+        .eq("accepted_by_user_id", user.id)
+        .not("accepted_at", "is", null)
+        .is("revoked_at", null)
         .limit(20);
 
-      const hasInviteEvidence = !inviteErr && Array.isArray(inviteRows) && inviteRows.some((row) => {
-        const inviteEmail = String((row as { email?: string | null }).email ?? "").trim().toLowerCase();
-        return normalizedEmail.length > 0 && inviteEmail === normalizedEmail;
-      });
+      const hasInviteEvidence =
+        !inviteErr &&
+        Array.isArray(inviteRows) &&
+        inviteRows.some((row) => {
+          const inviteEmail = String(
+            (row as { email?: string | null }).email ?? "",
+          )
+            .trim()
+            .toLowerCase();
+          return (
+            normalizedEmail.length > 0 &&
+            inviteEmail === normalizedEmail &&
+            row.accepted_by_user_id === user.id &&
+            Boolean(row.accepted_at) &&
+            !row.revoked_at
+          );
+        });
 
       if (!hasInviteEvidence) {
         setInviteRequired(true);
@@ -152,7 +172,10 @@ export default function PortalProfilePage() {
     setError(null);
     setSaved(false);
 
-    if (inviteRequired) return;
+    if (inviteRequired) {
+      setSaving(false);
+      return;
+    }
 
     const {
       data: { user },
@@ -167,21 +190,19 @@ export default function PortalProfilePage() {
 
     const toNull = (s: string) => (s.trim() === "" ? null : s.trim());
 
-    const { error: upsertErr } = await supabase
-      .from("customers")
-      .upsert(
-        {
-          user_id: user.id,
-          first_name: toNull(form.first_name),
-          last_name: toNull(form.last_name),
-          phone: toNull(form.phone),
-          street: toNull(form.street),
-          city: toNull(form.city),
-          province: toNull(form.province),
-          postal_code: toNull(form.postal_code),
-        },
-        { onConflict: "user_id" },
-      );
+    const { error: upsertErr } = await supabase.from("customers").upsert(
+      {
+        user_id: user.id,
+        first_name: toNull(form.first_name),
+        last_name: toNull(form.last_name),
+        phone: toNull(form.phone),
+        street: toNull(form.street),
+        city: toNull(form.city),
+        province: toNull(form.province),
+        postal_code: toNull(form.postal_code),
+      },
+      { onConflict: "user_id" },
+    );
 
     if (upsertErr) setError(upsertErr.message);
     else setSaved(true);
@@ -192,7 +213,11 @@ export default function PortalProfilePage() {
   if (loading) {
     return (
       <div className="mx-auto max-w-xl">
-        <div className={cardClass() + " text-sm text-[color:var(--theme-text-primary)]"}>
+        <div
+          className={
+            cardClass() + " text-sm text-[color:var(--theme-text-primary)]"
+          }
+        >
           Loading your profile…
         </div>
       </div>
@@ -200,7 +225,21 @@ export default function PortalProfilePage() {
   }
 
   if (inviteRequired) {
-    return <div className="mx-auto max-w-xl"><div className={cardClass() + " text-sm text-[color:var(--theme-text-primary)]"}><div className="font-semibold">Portal invite required</div><div className="mt-1">Open the invite link sent by the shop, or ask the shop to resend your portal invite.</div></div></div>;
+    return (
+      <div className="mx-auto max-w-xl">
+        <div
+          className={
+            cardClass() + " text-sm text-[color:var(--theme-text-primary)]"
+          }
+        >
+          <div className="font-semibold">Portal invite required</div>
+          <div className="mt-1">
+            Open the invite link sent by the shop, or ask the shop to resend
+            your portal invite.
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -210,7 +249,8 @@ export default function PortalProfilePage() {
           My profile
         </h1>
         <p className="text-xs text-[color:var(--theme-text-secondary)]">
-          Keep your contact details up to date so your shop can reach you easily.
+          Keep your contact details up to date so your shop can reach you
+          easily.
         </p>
 
         <div
@@ -240,13 +280,17 @@ export default function PortalProfilePage() {
             className={inputClass()}
             placeholder="First name"
             value={form.first_name}
-            onChange={(e) => setForm((p) => ({ ...p, first_name: e.target.value }))}
+            onChange={(e) =>
+              setForm((p) => ({ ...p, first_name: e.target.value }))
+            }
           />
           <input
             className={inputClass()}
             placeholder="Last name"
             value={form.last_name}
-            onChange={(e) => setForm((p) => ({ ...p, last_name: e.target.value }))}
+            onChange={(e) =>
+              setForm((p) => ({ ...p, last_name: e.target.value }))
+            }
           />
         </div>
 
@@ -259,8 +303,15 @@ export default function PortalProfilePage() {
           />
 
           <div className="space-y-1">
-            <input readOnly className={readOnlyClass()} placeholder="Email" value={form.email} />
-            <p className="text-[11px] text-[color:var(--theme-text-muted)]">Email is tied to your sign-in.</p>
+            <input
+              readOnly
+              className={readOnlyClass()}
+              placeholder="Email"
+              value={form.email}
+            />
+            <p className="text-[11px] text-[color:var(--theme-text-muted)]">
+              Email is tied to your sign-in.
+            </p>
           </div>
         </div>
 
@@ -283,19 +334,26 @@ export default function PortalProfilePage() {
               className={inputClass()}
               placeholder="Province/State"
               value={form.province}
-              onChange={(e) => setForm((p) => ({ ...p, province: e.target.value }))}
+              onChange={(e) =>
+                setForm((p) => ({ ...p, province: e.target.value }))
+              }
             />
             <input
               className={inputClass()}
               placeholder="Postal/ZIP code"
               value={form.postal_code}
-              onChange={(e) => setForm((p) => ({ ...p, postal_code: e.target.value }))}
+              onChange={(e) =>
+                setForm((p) => ({ ...p, postal_code: e.target.value }))
+              }
             />
           </div>
         </div>
 
         <button
-          className={subtleButtonClass() + " mt-1 border-[rgba(197,122,74,0.45)] bg-[rgba(197,122,74,0.10)] text-[color:var(--theme-text-primary)] hover:bg-[rgba(197,122,74,0.16)]"}
+          className={
+            subtleButtonClass() +
+            " mt-1 border-[rgba(197,122,74,0.45)] bg-[rgba(197,122,74,0.10)] text-[color:var(--theme-text-primary)] hover:bg-[rgba(197,122,74,0.16)]"
+          }
           onClick={onSave}
           disabled={saving}
         >

--- a/app/portal/status/page.tsx
+++ b/app/portal/status/page.tsx
@@ -1,33 +1,121 @@
+import Link from "next/link";
+import PortalWorkOrderCard from "@/features/portal/components/PortalWorkOrderCard";
+import {
+  PortalEmptyState,
+  PortalPageHeader,
+} from "@/features/portal/components/PortalUi";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
-import WorkOrderBoard from "@shared/components/workboard/WorkOrderBoard";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { PortalAccessError } from "@/features/portal/server/portalAuth";
+import { listPortalWorkOrdersForCustomer } from "@/features/portal/server/portalWorkOrders";
 
+export const dynamic = "force-dynamic";
 
 export default async function PortalStatusPage() {
   const supabase = createServerSupabaseRSC();
 
   try {
-    await requirePortalCustomerActor(supabase);
-  } catch {
+    const actor = await requirePortalCustomerActor(supabase);
+    if (!actor.customer.shop_id)
+      throw new Error("Customer shop is not connected");
+
+    const workOrders = await listPortalWorkOrdersForCustomer({
+      supabase,
+      customerId: actor.customer.id,
+      shopId: actor.customer.shop_id,
+    });
+    const active = workOrders.filter((workOrder) => !workOrder.status.complete);
+    const previous = workOrders.filter(
+      (workOrder) => workOrder.status.complete,
+    );
+
     return (
-      <main className="min-h-screen px-4 py-6 text-[color:var(--theme-text-primary)] md:px-6">
-        <div className="mx-auto max-w-[1500px]">
-          <h1 className="text-lg font-blackops uppercase tracking-[0.18em] text-[color:var(--theme-text-primary)]">Portal invite required</h1>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">Open the invite link sent by the shop, or ask the shop to resend your portal invite.</p>
+      <div className="mx-auto w-full max-w-5xl space-y-5 text-[color:var(--theme-text-primary)]">
+        <PortalPageHeader
+          eyebrow="Your service"
+          title="Your vehicles at the shop"
+          subtitle="Clear updates for your vehicles, the next step, and the person to contact."
+          actions={
+            <Link
+              href="/portal/request/when"
+              className="inline-flex min-h-11 items-center justify-center rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)]"
+            >
+              Request service
+            </Link>
+          }
+        />
+
+        {active.length === 0 ? (
+          <PortalEmptyState
+            title="No vehicles are currently in service"
+            body="Your next active service visit will appear here automatically."
+          />
+        ) : (
+          <section aria-labelledby="active-service-heading">
+            <div className="mb-3 flex items-center justify-between">
+              <h2 id="active-service-heading" className="text-sm font-semibold">
+                Active service
+              </h2>
+              <span className="text-xs text-[color:var(--theme-text-muted)]">
+                {active.length} {active.length === 1 ? "vehicle" : "vehicles"}
+              </span>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+              {active.map((workOrder) => (
+                <PortalWorkOrderCard key={workOrder.id} workOrder={workOrder} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {previous.length > 0 ? (
+          <section aria-labelledby="previous-service-heading">
+            <div className="mb-3 flex items-center justify-between">
+              <h2
+                id="previous-service-heading"
+                className="text-sm font-semibold"
+              >
+                Recently completed
+              </h2>
+              <Link
+                href="/portal/history"
+                className="text-xs text-[var(--accent-copper-light)]"
+              >
+                Full service history
+              </Link>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+              {previous.slice(0, 4).map((workOrder) => (
+                <PortalWorkOrderCard
+                  key={workOrder.id}
+                  workOrder={workOrder}
+                  compact
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    );
+  } catch (error) {
+    if (error instanceof PortalAccessError) {
+      return (
+        <div className="mx-auto max-w-xl rounded-3xl border border-amber-500/30 bg-amber-500/10 p-5 text-sm text-amber-100">
+          <p className="font-semibold">Portal invite required</p>
+          <p className="mt-1">
+            Open the invite sent by the shop, or ask the shop to resend it.
+          </p>
         </div>
-      </main>
+      );
+    }
+    console.error("[portal/status] unable to load customer work orders", error);
+    return (
+      <div className="mx-auto max-w-xl rounded-3xl border border-red-500/30 bg-red-500/10 p-5 text-sm text-red-100">
+        <p className="font-semibold">We couldn’t load your service updates.</p>
+        <p className="mt-1">
+          Please refresh the page or contact the shop if this continues.
+        </p>
+      </div>
     );
   }
-
-  return (
-    <main className="min-h-screen px-4 py-6 text-[color:var(--theme-text-primary)] md:px-6">
-      <div className="mx-auto max-w-[1500px]">
-        <WorkOrderBoard
-          variant="portal"
-          title="Live repair status"
-          subtitle="Track progress, approvals, and readiness in real time."
-        />
-      </div>
-    </main>
-  );
 }

--- a/app/portal/vehicles/page.tsx
+++ b/app/portal/vehicles/page.tsx
@@ -37,7 +37,6 @@ type VehicleForm = {
   color: string;
 };
 
-
 function cardClass() {
   return "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card backdrop-blur-xl";
 }
@@ -133,14 +132,32 @@ export default function PortalVehiclesPage() {
       if (cust) {
         const { data: inviteRows, error: inviteErr } = await supabase
           .from("customer_portal_invites")
-          .select("id, customer_id, email")
+          .select(
+            "id,customer_id,email,accepted_at,accepted_by_user_id,revoked_at",
+          )
           .eq("customer_id", cust.id)
+          .eq("accepted_by_user_id", user.id)
+          .not("accepted_at", "is", null)
+          .is("revoked_at", null)
           .limit(20);
 
-        const hasInviteEvidence = !inviteErr && Array.isArray(inviteRows) && inviteRows.some((row) => {
-          const inviteEmail = String((row as { email?: string | null }).email ?? "").trim().toLowerCase();
-          return normalizedEmail.length > 0 && inviteEmail === normalizedEmail;
-        });
+        const hasInviteEvidence =
+          !inviteErr &&
+          Array.isArray(inviteRows) &&
+          inviteRows.some((row) => {
+            const inviteEmail = String(
+              (row as { email?: string | null }).email ?? "",
+            )
+              .trim()
+              .toLowerCase();
+            return (
+              normalizedEmail.length > 0 &&
+              inviteEmail === normalizedEmail &&
+              row.accepted_by_user_id === user.id &&
+              Boolean(row.accepted_at) &&
+              !row.revoked_at
+            );
+          });
 
         if (!hasInviteEvidence) {
           setInviteRequired(true);
@@ -170,8 +187,7 @@ export default function PortalVehiclesPage() {
       setLoading(false);
     })();
 
-
-  return () => {
+    return () => {
       mounted = false;
     };
   }, [supabase]);
@@ -205,7 +221,8 @@ export default function PortalVehiclesPage() {
     }
   };
 
-  const toNull = (s: string): string | null => (s.trim() === "" ? null : s.trim());
+  const toNull = (s: string): string | null =>
+    s.trim() === "" ? null : s.trim();
 
   const toYear = (s: string): number | null => {
     const n = Number(s);
@@ -245,14 +262,20 @@ export default function PortalVehiclesPage() {
       (match) => match.match_type === "vin" && match.same_customer === false,
     );
     if (differentCustomerVin) {
-      setError("This VIN is already assigned to another customer. Contact shop/admin to move vehicle.");
+      setError(
+        "This VIN is already assigned to another customer. Contact shop/admin to move vehicle.",
+      );
       setSaving(false);
       return;
     }
 
-    const sameCustomerMatch = duplicateCheck.matches.find((match) => match.same_customer === true);
+    const sameCustomerMatch = duplicateCheck.matches.find(
+      (match) => match.same_customer === true,
+    );
     if (sameCustomerMatch) {
-      setError("Vehicle already exists. Use existing vehicle or contact shop to update it.");
+      setError(
+        "Vehicle already exists. Use existing vehicle or contact shop to update it.",
+      );
       setSaving(false);
       return;
     }
@@ -302,9 +325,16 @@ export default function PortalVehiclesPage() {
   };
 
   const onDelete = async (id: string) => {
-    if (typeof window !== "undefined" && !window.confirm("Delete this vehicle?")) return;
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm("Delete this vehicle?")
+    )
+      return;
 
-    const { error: delErr } = await supabase.from("vehicles").delete().eq("id", id);
+    const { error: delErr } = await supabase
+      .from("vehicles")
+      .delete()
+      .eq("id", id);
 
     if (delErr) {
       setError(delErr.message);
@@ -315,10 +345,13 @@ export default function PortalVehiclesPage() {
   };
 
   if (loading) {
-
-  return (
+    return (
       <div className="mx-auto max-w-3xl">
-        <div className={cardClass() + " text-sm text-[color:var(--theme-text-primary)]"}>
+        <div
+          className={
+            cardClass() + " text-sm text-[color:var(--theme-text-primary)]"
+          }
+        >
           Loading your vehicles…
         </div>
       </div>
@@ -326,7 +359,21 @@ export default function PortalVehiclesPage() {
   }
 
   if (inviteRequired) {
-    return <div className="mx-auto max-w-3xl"><div className={cardClass() + " text-sm text-[color:var(--theme-text-primary)]"}><div className="font-semibold">Portal invite required</div><div className="mt-1">Open the invite link sent by the shop, or ask the shop to resend your portal invite.</div></div></div>;
+    return (
+      <div className="mx-auto max-w-3xl">
+        <div
+          className={
+            cardClass() + " text-sm text-[color:var(--theme-text-primary)]"
+          }
+        >
+          <div className="font-semibold">Portal invite required</div>
+          <div className="mt-1">
+            Open the invite link sent by the shop, or ask the shop to resend
+            your portal invite.
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -353,7 +400,8 @@ export default function PortalVehiclesPage() {
           </h2>
           {isEdit && (
             <span className="text-xs text-[color:var(--theme-text-muted)]">
-              Editing <span className="font-mono">{editingId?.slice(0, 8)}…</span>
+              Editing{" "}
+              <span className="font-mono">{editingId?.slice(0, 8)}…</span>
             </span>
           )}
         </div>
@@ -390,7 +438,9 @@ export default function PortalVehiclesPage() {
             className={inputClass()}
             placeholder="License plate"
             value={form.license_plate}
-            onChange={(e) => setForm({ ...form, license_plate: e.target.value })}
+            onChange={(e) =>
+              setForm({ ...form, license_plate: e.target.value })
+            }
           />
           <input
             className={inputClass()}
@@ -413,8 +463,12 @@ export default function PortalVehiclesPage() {
             disabled={saving}
             className="inline-flex items-center justify-center rounded-lg border px-4 py-2 text-sm font-semibold transition disabled:opacity-60"
             style={copperButtonStyle()}
-            onMouseEnter={(e) => Object.assign(e.currentTarget.style, copperButtonHoverStyle())}
-            onMouseLeave={(e) => Object.assign(e.currentTarget.style, copperButtonStyle())}
+            onMouseEnter={(e) =>
+              Object.assign(e.currentTarget.style, copperButtonHoverStyle())
+            }
+            onMouseLeave={(e) =>
+              Object.assign(e.currentTarget.style, copperButtonStyle())
+            }
           >
             {saving ? "Saving…" : isEdit ? "Save changes" : "Add vehicle"}
           </button>
@@ -431,44 +485,63 @@ export default function PortalVehiclesPage() {
           )}
         </div>
 
-        <p className="text-xs text-[color:var(--theme-text-muted)]">Fields marked with * are required.</p>
+        <p className="text-xs text-[color:var(--theme-text-muted)]">
+          Fields marked with * are required.
+        </p>
       </section>
 
       <section className="space-y-3">
         {vehicles.length === 0 ? (
-          <div className={cardClass() + " border-dashed text-sm text-[color:var(--theme-text-secondary)]"}>
-            No vehicles yet. Add your first vehicle above so you can book appointments faster and
-            see service history.
+          <div
+            className={
+              cardClass() +
+              " border-dashed text-sm text-[color:var(--theme-text-secondary)]"
+            }
+          >
+            No vehicles yet. Add your first vehicle above so you can book
+            appointments faster and see service history.
           </div>
         ) : (
           vehicles.map((v) => {
             const title =
-              [v.year ?? "", v.make ?? "", v.model ?? ""].filter(Boolean).join(" ").trim() ||
-              "Vehicle";
+              [v.year ?? "", v.make ?? "", v.model ?? ""]
+                .filter(Boolean)
+                .join(" ")
+                .trim() || "Vehicle";
 
-                    if (inviteRequired) {
+            if (inviteRequired) {
               return (
                 <div key={v.id} className="mx-auto max-w-3xl">
-                  <div className={cardClass() + " text-sm text-[color:var(--theme-text-primary)]"}>
+                  <div
+                    className={
+                      cardClass() +
+                      " text-sm text-[color:var(--theme-text-primary)]"
+                    }
+                  >
                     <div className="font-semibold">Portal invite required</div>
                     <div className="mt-1">
-                      Open the invite link sent by the shop, or ask the shop to resend your portal invite.
+                      Open the invite link sent by the shop, or ask the shop to
+                      resend your portal invite.
                     </div>
                   </div>
                 </div>
               );
             }
 
-  return (
+            return (
               <div
                 key={v.id}
                 className="flex flex-col justify-between gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 backdrop-blur-md shadow-card sm:flex-row sm:items-center"
               >
                 <div className="min-w-0">
-                  <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">{title}</div>
+                  <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                    {title}
+                  </div>
                   <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
-                    VIN <span className="font-mono">{v.vin || "—"}</span> • Plate{" "}
-                    <span className="font-mono">{v.license_plate || "—"}</span> • Mileage{" "}
+                    VIN <span className="font-mono">{v.vin || "—"}</span> •
+                    Plate{" "}
+                    <span className="font-mono">{v.license_plate || "—"}</span>{" "}
+                    • Mileage{" "}
                     <span className="font-mono">{v.mileage || "—"}</span>
                     {v.color && (
                       <>

--- a/features/chat/components/PortalMessagesWorkspace.tsx
+++ b/features/chat/components/PortalMessagesWorkspace.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import ChatWindow from "@/features/ai/components/chat/ChatWindow";
@@ -48,25 +49,37 @@ type ContextOption = {
 
 export default function PortalMessagesWorkspace(): JSX.Element {
   const supabase = useMemo(() => createBrowserSupabase(), []);
+  const searchParams = useSearchParams();
+  const requestedWorkOrderId = searchParams.get("workOrderId")?.trim() ?? "";
+  const requestedContextKey = requestedWorkOrderId
+    ? `work_order:${requestedWorkOrderId}`
+    : "";
   const [userId, setUserId] = useState<string | null>(null);
   const [rows, setRows] = useState<ConversationPayload[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [newThread, setNewThread] = useState(false);
+  const [newThread, setNewThread] = useState(
+    searchParams.get("compose") === "1",
+  );
   const [message, setMessage] = useState("");
   const [subject, setSubject] = useState("");
   const [contextKey, setContextKey] = useState("");
   const [contextOptions, setContextOptions] = useState<ContextOption[]>([]);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(null);
-  const [newThreadDraft, setNewThreadDraft] = useState<OfflineMessageDraft | null>(null);
+  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(
+    null,
+  );
+  const [newThreadDraft, setNewThreadDraft] =
+    useState<OfflineMessageDraft | null>(null);
   const [draftReady, setDraftReady] = useState(false);
   const [draftSaved, setDraftSaved] = useState(false);
   const draftTargetId = "portal:new-conversation";
 
   const loadConversations = useCallback(async () => {
-    const response = await fetch("/api/chat/my-conversations", { credentials: "include" });
+    const response = await fetch("/api/chat/my-conversations", {
+      credentials: "include",
+    });
     if (!response.ok) throw new Error("Could not load messages");
     const payload = (await response.json()) as ConversationPayload[];
     setRows(payload);
@@ -80,32 +93,48 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     void fetch("/api/chat/context-options", { credentials: "include" })
       .then((response) => response.json())
       .then((contextPayload) => {
-        const options = (contextPayload as { options?: ContextOption[] }).options;
-        setContextOptions(Array.isArray(options) ? options : []);
+        const options = (contextPayload as { options?: ContextOption[] })
+          .options;
+        const safeOptions = Array.isArray(options) ? options : [];
+        setContextOptions(safeOptions);
+        if (
+          requestedContextKey &&
+          safeOptions.some(
+            (option) => `${option.type}:${option.id}` === requestedContextKey,
+          )
+        ) {
+          setContextKey((current) => current || requestedContextKey);
+        }
       })
       .catch(() => undefined);
     void loadConversations()
       .catch((cause: unknown) => {
         if (navigator.onLine) {
-          setError(cause instanceof Error ? cause.message : "Could not load messages");
+          setError(
+            cause instanceof Error ? cause.message : "Could not load messages",
+          );
         }
       })
       .finally(() => setLoading(false));
-  }, [loadConversations, supabase]);
+  }, [loadConversations, requestedContextKey, supabase]);
 
   useEffect(() => {
     if (!userId) return;
     let cancelled = false;
     void resolveMessagingDraftScope(userId).then(async (scope) => {
       if (!scope || cancelled) return;
-      const stored = await getOfflineMessageDraft({ scope, targetId: draftTargetId });
+      const stored = await getOfflineMessageDraft({
+        scope,
+        targetId: draftTargetId,
+      });
       if (cancelled) return;
-      const next = stored ?? createMessageDraft({ scope, targetId: draftTargetId });
+      const next =
+        stored ?? createMessageDraft({ scope, targetId: draftTargetId });
       setDraftScope(scope);
       setNewThreadDraft(next);
       setMessage(next.content);
       setSubject(next.subject ?? "");
-      setContextKey(next.contextKey ?? "");
+      setContextKey(next.contextKey || requestedContextKey);
       setDraftSaved(Boolean(stored?.content || stored?.subject));
       setDraftReady(true);
       if (navigator.onLine) void warmMessagingRouteShells();
@@ -113,13 +142,16 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     return () => {
       cancelled = true;
     };
-  }, [userId]);
+  }, [requestedContextKey, userId]);
 
   useEffect(() => {
     if (!draftReady || !draftScope || !newThreadDraft || !newThread) return;
     const timer = window.setTimeout(() => {
       if (!message.trim() && !subject.trim() && !contextKey) {
-        void removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        void removeOfflineMessageDraft({
+          scope: draftScope,
+          targetId: draftTargetId,
+        });
         setDraftSaved(false);
         return;
       }
@@ -132,7 +164,15 @@ export default function PortalMessagesWorkspace(): JSX.Element {
       }).then(() => setDraftSaved(true));
     }, 350);
     return () => window.clearTimeout(timer);
-  }, [contextKey, draftReady, draftScope, message, newThread, newThreadDraft, subject]);
+  }, [
+    contextKey,
+    draftReady,
+    draftScope,
+    message,
+    newThread,
+    newThreadDraft,
+    subject,
+  ]);
 
   const active = rows.find((row) => row.conversation.id === activeId) ?? null;
 
@@ -143,7 +183,9 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     setError(null);
 
     if (!navigator.onLine) {
-      setError("Offline — this message is saved as a draft and has not been sent.");
+      setError(
+        "Offline — this message is saved as a draft and has not been sent.",
+      );
       setSending(false);
       return;
     }
@@ -151,7 +193,8 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     const selectedContext = contextOptions.find(
       (option) => `${option.type}:${option.id}` === contextKey,
     );
-    const requestId = newThreadDraft?.conversationRequestId ?? crypto.randomUUID();
+    const requestId =
+      newThreadDraft?.conversationRequestId ?? crypto.randomUUID();
 
     try {
       const createResponse = await fetch("/api/chat/start-conversation", {
@@ -163,10 +206,14 @@ export default function PortalMessagesWorkspace(): JSX.Element {
           participant_ids: [],
           context_type: selectedContext?.type ?? null,
           context_id: selectedContext?.id ?? null,
-          title: subject.trim() || selectedContext?.label || "Message from customer",
+          title:
+            subject.trim() || selectedContext?.label || "Message from customer",
         }),
       });
-      const created = (await createResponse.json()) as { id?: string; error?: string };
+      const created = (await createResponse.json()) as {
+        id?: string;
+        error?: string;
+      };
       if (!createResponse.ok || !created.id) {
         throw new Error(created.error ?? "Could not start conversation");
       }
@@ -177,7 +224,8 @@ export default function PortalMessagesWorkspace(): JSX.Element {
         body: JSON.stringify({
           conversationId: created.id,
           content,
-          clientMessageId: newThreadDraft?.clientMessageId ?? crypto.randomUUID(),
+          clientMessageId:
+            newThreadDraft?.clientMessageId ?? crypto.randomUUID(),
         }),
       });
       if (!messageResponse.ok) {
@@ -191,13 +239,20 @@ export default function PortalMessagesWorkspace(): JSX.Element {
       setNewThread(false);
       setActiveId(created.id);
       if (draftScope) {
-        await removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
-        setNewThreadDraft(createMessageDraft({ scope: draftScope, targetId: draftTargetId }));
+        await removeOfflineMessageDraft({
+          scope: draftScope,
+          targetId: draftTargetId,
+        });
+        setNewThreadDraft(
+          createMessageDraft({ scope: draftScope, targetId: draftTargetId }),
+        );
       }
       setDraftSaved(false);
       await loadConversations();
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : "Could not send message");
+      setError(
+        cause instanceof Error ? cause.message : "Could not send message",
+      );
     } finally {
       setSending(false);
     }
@@ -214,7 +269,8 @@ export default function PortalMessagesWorkspace(): JSX.Element {
             Messages
           </h1>
           <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-            Keep questions and service updates connected to the right vehicle, appointment, or work order.
+            Contact the advisor connected to your service, with shop-team
+            coverage when they are unavailable.
           </p>
         </div>
         <button
@@ -225,7 +281,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
           }}
           className="desktop-btn-primary rounded-full border px-4 py-2 text-sm font-semibold"
         >
-          Message the shop
+          Message your advisor
         </button>
       </div>
 
@@ -235,21 +291,27 @@ export default function PortalMessagesWorkspace(): JSX.Element {
         </div>
       ) : null}
 
-      <div className="grid min-h-[620px] overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[var(--theme-shadow-medium)] md:grid-cols-[280px_1fr]">
-        <aside className="border-b border-[color:var(--theme-border-soft)] md:border-b-0 md:border-r">
+      <div className="grid min-h-[68dvh] overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[var(--theme-shadow-medium)] md:min-h-[620px] md:grid-cols-[280px_1fr]">
+        <aside
+          className={`${newThread || activeId ? "hidden md:block" : "block"} border-b border-[color:var(--theme-border-soft)] md:border-b-0 md:border-r`}
+        >
           <div className="border-b border-[color:var(--theme-border-soft)] px-4 py-3 text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
             Conversations
           </div>
           <div className="max-h-72 overflow-auto md:max-h-[570px]">
             {loading ? (
-              <p className="p-4 text-sm text-[color:var(--theme-text-secondary)]">Loading…</p>
+              <p className="p-4 text-sm text-[color:var(--theme-text-secondary)]">
+                Loading…
+              </p>
             ) : rows.length === 0 ? (
               <p className="p-4 text-sm text-[color:var(--theme-text-secondary)]">
                 No conversations yet. Message the shop when you have a question.
               </p>
             ) : (
               rows.map((row) => {
-                const staff = row.participants.find((participant) => participant.kind === "staff");
+                const staff = row.participants.find(
+                  (participant) => participant.kind === "staff",
+                );
                 return (
                   <button
                     key={row.conversation.id}
@@ -259,14 +321,22 @@ export default function PortalMessagesWorkspace(): JSX.Element {
                       setActiveId(row.conversation.id);
                     }}
                     className={`flex w-full gap-3 border-b border-[color:var(--theme-border-soft)] px-3 py-3 text-left transition hover:bg-[color:var(--theme-surface-subtle)] ${
-                      activeId === row.conversation.id ? "bg-[color:var(--theme-surface-subtle)]" : ""
+                      activeId === row.conversation.id
+                        ? "bg-[color:var(--theme-surface-subtle)]"
+                        : ""
                     }`}
                   >
-                    <UserAvatar name={staff?.full_name ?? "Shop team"} avatarUrl={staff?.avatar_url} size="sm" />
+                    <UserAvatar
+                      name={staff?.full_name ?? "Shop team"}
+                      avatarUrl={staff?.avatar_url}
+                      size="sm"
+                    />
                     <span className="min-w-0 flex-1">
                       <span className="flex items-center justify-between gap-2">
                         <span className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                          {row.conversation.title ?? row.context?.label ?? "Shop team"}
+                          {row.conversation.title ??
+                            row.context?.label ??
+                            "Shop team"}
                         </span>
                         {row.unread_count > 0 ? (
                           <span className="rounded-full bg-[var(--accent-copper-soft)] px-1.5 py-0.5 text-[10px] font-bold text-[color:var(--theme-text-on-accent)]">
@@ -290,13 +360,26 @@ export default function PortalMessagesWorkspace(): JSX.Element {
           </div>
         </aside>
 
-        <section className="flex min-h-[520px] flex-col">
+        <section
+          className={`${!newThread && !activeId ? "hidden md:flex" : "flex"} min-h-[68dvh] flex-col md:min-h-[520px]`}
+        >
           {newThread ? (
-            <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col justify-center gap-4 p-5 sm:p-8">
+            <div className="mx-auto flex w-full max-w-2xl flex-1 flex-col gap-4 p-4 sm:justify-center sm:p-8">
+              <button
+                type="button"
+                onClick={() => setNewThread(false)}
+                className="mb-1 inline-flex min-h-10 w-fit items-center rounded-full border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold md:hidden"
+              >
+                ← Conversations
+              </button>
               <div>
-                <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">New message</h2>
+                <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                  New message
+                </h2>
                 <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-                  The shop service team will receive this conversation.
+                  {requestedWorkOrderId
+                    ? "Your work order advisor receives this first. Shop management can cover if they are unavailable."
+                    : "Choose a service item so the message reaches the right shop team."}
                 </p>
               </div>
               <input
@@ -313,8 +396,12 @@ export default function PortalMessagesWorkspace(): JSX.Element {
               >
                 <option value="">General question</option>
                 {contextOptions.map((option) => (
-                  <option key={`${option.type}:${option.id}`} value={`${option.type}:${option.id}`}>
-                    {option.label}{option.secondary ? ` — ${option.secondary}` : ""}
+                  <option
+                    key={`${option.type}:${option.id}`}
+                    value={`${option.type}:${option.id}`}
+                  >
+                    {option.label}
+                    {option.secondary ? ` — ${option.secondary}` : ""}
                   </option>
                 ))}
               </select>
@@ -326,11 +413,11 @@ export default function PortalMessagesWorkspace(): JSX.Element {
                 maxLength={10_000}
                 className="resize-none rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-3 text-sm"
               />
-              <div className="flex justify-end gap-2">
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
                 <button
                   type="button"
                   onClick={() => setNewThread(false)}
-                  className="desktop-btn-secondary rounded-full border px-4 py-2 text-sm"
+                  className="desktop-btn-secondary min-h-11 rounded-full border px-4 py-2 text-sm"
                 >
                   Cancel
                 </button>
@@ -338,7 +425,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
                   type="button"
                   onClick={() => void startConversation()}
                   disabled={sending || !message.trim()}
-                  className="desktop-btn-primary rounded-full border px-4 py-2 text-sm font-semibold disabled:opacity-50"
+                  className="desktop-btn-primary min-h-11 rounded-full border px-4 py-2 text-sm font-semibold disabled:opacity-50"
                 >
                   {sending ? "Sending…" : "Send message"}
                 </button>
@@ -353,11 +440,22 @@ export default function PortalMessagesWorkspace(): JSX.Element {
             <>
               <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-4 py-3">
                 <div>
+                  <button
+                    type="button"
+                    onClick={() => setActiveId(null)}
+                    className="mb-2 inline-flex min-h-9 items-center rounded-full border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold md:hidden"
+                  >
+                    ← Conversations
+                  </button>
                   <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
                     {active.conversation.title ?? "Shop team"}
                   </h2>
                   <p className="text-xs text-[color:var(--theme-text-secondary)]">
-                    {active.participants.filter((participant) => participant.kind === "staff").map((participant) => participant.full_name).filter(Boolean).join(", ") || "Service team"}
+                    {active.participants
+                      .filter((participant) => participant.kind === "staff")
+                      .map((participant) => participant.full_name)
+                      .filter(Boolean)
+                      .join(", ") || "Service team"}
                   </p>
                 </div>
                 {active.context ? (
@@ -376,7 +474,11 @@ export default function PortalMessagesWorkspace(): JSX.Element {
                 ) : null}
               </div>
               <div className="min-h-0 flex-1 p-2">
-                <ChatWindow conversationId={active.conversation.id} userId={userId} title={active.conversation.title ?? "Shop team"} />
+                <ChatWindow
+                  conversationId={active.conversation.id}
+                  userId={userId}
+                  title={active.conversation.title ?? "Shop team"}
+                />
               </div>
             </>
           ) : (

--- a/features/portal/components/PortalShell.tsx
+++ b/features/portal/components/PortalShell.tsx
@@ -1,114 +1,145 @@
-// app/portal/PortalShell.tsx
 "use client";
 
-import React, { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import {
+  CalendarDays,
+  Car,
+  ClipboardCheck,
+  FileText,
+  History,
+  Home,
+  LogOut,
+  Menu,
+  MessageCircle,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Receipt,
+  Settings,
+  UserRound,
+  Wrench,
+  X,
+  type LucideIcon,
+} from "lucide-react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import PortalNotificationsBell from "@/features/portal/components/PortalNotificationsBell";
 import PortalAssistantEntry from "@/features/portal/components/PortalAssistantEntry";
 
-
 type NavItem = {
   href: string;
   label: string;
+  icon: LucideIcon;
 };
 
-const NAV: NavItem[] = [
-  { href: "/portal", label: "Home" },
-  { href: "/portal/messages", label: "Messages" },
-  { href: "/portal/request/when", label: "Request" },
-  { href: "/portal/approvals", label: "Approvals" },
-  { href: "/portal/customer-appointments", label: "Appointments" },
-  { href: "/portal/history", label: "History" },
-  { href: "/portal/invoices", label: "Invoices" },
-  { href: "/portal/vehicles", label: "Vehicles" },
-  { href: "/portal/profile", label: "Profile" },
-  { href: "/portal/settings", label: "Settings" },
+const PRIMARY_NAV: NavItem[] = [
+  { href: "/portal", label: "Home", icon: Home },
+  { href: "/portal/status", label: "My service", icon: Wrench },
+  { href: "/portal/messages", label: "Messages", icon: MessageCircle },
+  {
+    href: "/portal/request/when",
+    label: "Request service",
+    icon: ClipboardCheck,
+  },
+  {
+    href: "/portal/customer-appointments",
+    label: "Appointments",
+    icon: CalendarDays,
+  },
 ];
 
-function cx(...parts: Array<string | false | null | undefined>) {
+const ACCOUNT_NAV: NavItem[] = [
+  { href: "/portal/approvals", label: "Approvals", icon: FileText },
+  { href: "/portal/invoices", label: "Invoices", icon: Receipt },
+  { href: "/portal/vehicles", label: "Vehicles", icon: Car },
+  { href: "/portal/history", label: "Service history", icon: History },
+  { href: "/portal/profile", label: "My profile", icon: UserRound },
+  { href: "/portal/settings", label: "Settings", icon: Settings },
+];
+
+const NAV = [...PRIMARY_NAV, ...ACCOUNT_NAV];
+const COPPER = "#C57A4A";
+
+function cx(...parts: Array<string | false | null | undefined>): string {
   return parts.filter(Boolean).join(" ");
 }
 
-const COPPER = "#C57A4A";
-
-function isPortalAuth(pathname: string) {
+function isPortalAuth(pathname: string): boolean {
   return pathname === "/portal/auth" || pathname.startsWith("/portal/auth/");
 }
 
-function MenuIcon() {
-  return (
-    <div className="flex flex-col gap-[3px]">
-      <span className="h-[2px] w-[14px] rounded-full bg-[color:var(--theme-surface-panel-strong)]" />
-      <span className="h-[2px] w-[14px] rounded-full bg-[color:var(--theme-surface-panel-strong)]" />
-      <span className="h-[2px] w-[14px] rounded-full bg-[color:var(--theme-surface-panel-strong)]" />
-    </div>
-  );
-}
-
-function NavPill({
-  href,
-  label,
+function PortalNavLink({
+  item,
   active,
+  expanded,
   onClick,
 }: {
-  href: string;
-  label: string;
+  item: NavItem;
   active: boolean;
+  expanded: boolean;
   onClick?: () => void;
 }) {
+  const Icon = item.icon;
   return (
     <Link
-      href={href}
+      href={item.href}
       onClick={onClick}
+      title={expanded ? undefined : item.label}
+      aria-current={active ? "page" : undefined}
       className={cx(
-        "group flex items-center justify-between rounded-xl border px-4 py-3 text-sm transition",
+        "group flex min-h-11 items-center rounded-xl border text-sm font-semibold transition",
+        expanded ? "gap-3 px-3" : "justify-center px-2",
         active
-          ? "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)]"
-          : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)] hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-subtle)]",
+          ? "border-[rgba(197,122,74,0.42)] bg-[rgba(197,122,74,0.14)] text-[var(--accent-copper-light)]"
+          : "border-transparent text-[color:var(--theme-text-secondary)] hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)]",
       )}
     >
-      <span className="font-semibold">{label}</span>
-      <span
-        className={cx(
-          "h-2 w-2 rounded-full transition-opacity",
-          active ? "opacity-100" : "opacity-0 group-hover:opacity-70",
-        )}
-        style={{ backgroundColor: COPPER }}
-      />
+      <Icon className="h-[18px] w-[18px] shrink-0" aria-hidden="true" />
+      {expanded ? <span className="truncate">{item.label}</span> : null}
     </Link>
   );
 }
 
 export default function PortalShell({
   title = "Customer Portal",
-  subtitle = "Request service, approve parts, manage appointments, vehicles, and your profile",
+  subtitle = "Your service, appointments, approvals, and messages",
   children,
 }: {
   title?: string;
   subtitle?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   const pathname = usePathname();
   const router = useRouter();
-  const supabase = createBrowserSupabase();
-
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [desktopOpen, setDesktopOpen] = useState(true);
+  const [desktopExpanded, setDesktopExpanded] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
 
-  const hideNav =
-    isPortalAuth(pathname) || pathname.startsWith("/portal/shop/") || pathname.startsWith("/portal/join/");
+  const lightweightFrame =
+    isPortalAuth(pathname) ||
+    pathname.startsWith("/portal/shop/") ||
+    pathname.startsWith("/portal/join/");
+  const nestedPortal =
+    pathname.startsWith("/portal/fleet") ||
+    pathname.startsWith("/portal/property");
 
   const activeHref = useMemo(() => {
-    const exact = NAV.find((x) => x.href === pathname);
+    const exact = NAV.find((item) => item.href === pathname);
     if (exact) return exact.href;
-
-    const starts = NAV.find(
-      (x) => x.href !== "/portal" && pathname.startsWith(x.href),
+    if (pathname.startsWith("/portal/request/")) return "/portal/request/when";
+    if (
+      pathname.startsWith("/portal/work-orders/") ||
+      pathname.startsWith("/portal/quotes/")
+    ) {
+      return "/portal/status";
+    }
+    return (
+      NAV.find(
+        (item) => item.href !== "/portal" && pathname.startsWith(item.href),
+      )?.href ?? "/portal"
     );
-    return starts?.href ?? "/portal";
   }, [pathname]);
 
   const signOut = async () => {
@@ -122,42 +153,32 @@ export default function PortalShell({
     }
   };
 
-  if (isPortalAuth(pathname)) {
-    return children;
-  }
+  if (isPortalAuth(pathname)) return children;
+  if (nestedPortal) return children;
 
-  // Public shop and enrollment pages keep the lightweight portal frame.
-  if (hideNav) {
+  if (lightweightFrame) {
     return (
-      <div className="relative min-h-dvh app-metal-bg text-[color:var(--theme-text-primary)] overflow-hidden">
-        <div className="pointer-events-none absolute inset-0">
-          <div className="absolute left-1/2 top-[-22%] h-[58rem] w-[58rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(59,130,246,0.15),transparent_60%)]" />
-          <div className="absolute inset-0 bg-[var(--theme-gradient-panel)]" />
-        </div>
-
-        {/* ✅ Removed `relative` to satisfy cssConflict lint */}
-        <header className="metal-bar sticky top-0 z-40 flex items-center justify-between px-4 py-2 shadow-[var(--theme-shadow-medium)]">
-          <div className="flex flex-col leading-none">
+      <div className="relative min-h-dvh overflow-x-hidden app-metal-bg text-[color:var(--theme-text-primary)]">
+        <div className="pointer-events-none absolute inset-0 bg-[var(--theme-gradient-panel)]" />
+        <header className="metal-bar sticky top-0 z-40 flex min-h-14 items-center justify-between px-4 shadow-[var(--theme-shadow-medium)]">
+          <Link href="/portal" className="flex flex-col leading-none">
             <span
               className="font-blackops text-xs tracking-[0.22em]"
               style={{ color: COPPER }}
             >
               PROFIXIQ
             </span>
-            <span className="text-[0.65rem] text-[color:var(--theme-text-secondary)]">
+            <span className="mt-1 text-[0.65rem] text-[color:var(--theme-text-secondary)]">
               Customer Portal
             </span>
-          </div>
-
-          <button
-            type="button"
-            onClick={() => router.push("/portal")}
-            className="desktop-btn-secondary inline-flex items-center gap-1 rounded-full border px-3 py-1 text-[0.7rem] text-[color:var(--theme-text-primary)] active:scale-95"
+          </Link>
+          <Link
+            href="/portal"
+            className="inline-flex min-h-9 items-center rounded-full border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold"
           >
-            <span className="uppercase tracking-[0.16em]">Home</span>
-          </button>
+            Portal home
+          </Link>
         </header>
-
         <main className="relative min-h-[calc(100dvh-56px)] w-full">
           {children}
         </main>
@@ -166,185 +187,223 @@ export default function PortalShell({
   }
 
   return (
-    <div className="relative min-h-dvh app-metal-bg text-[color:var(--theme-text-primary)] overflow-hidden">
-      <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-1/2 top-[6%] h-[80rem] w-[80rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(59,130,246,0.12),transparent_62%)]" />
-        <div className="absolute right-[-18%] top-[28%] h-[46rem] w-[46rem] rounded-full bg-[radial-gradient(circle,rgba(56,189,248,0.06),transparent_60%)]" />
+    <div className="relative min-h-dvh overflow-x-hidden app-metal-bg text-[color:var(--theme-text-primary)]">
+      <div className="pointer-events-none fixed inset-0">
+        <div className="absolute left-1/2 top-[-20%] h-[62rem] w-[62rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(59,130,246,0.10),transparent_62%)]" />
         <div className="absolute inset-0 bg-[var(--theme-gradient-panel)]" />
       </div>
 
-      {/* ✅ Removed `relative` to satisfy cssConflict lint */}
-      <header className="metal-bar sticky top-0 z-40 flex items-center justify-between px-4 py-2 shadow-[var(--theme-shadow-medium)]">
-        <div className="flex items-center gap-3">
+      <header className="metal-bar sticky top-0 z-40 flex min-h-14 items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-3 shadow-[var(--theme-shadow-medium)] sm:px-4">
+        <div className="flex min-w-0 items-center gap-3">
           <button
             type="button"
             onClick={() => setMobileOpen(true)}
-            aria-label="Open menu"
-            className="desktop-btn-secondary inline-flex h-8 w-8 items-center justify-center rounded-full border active:scale-95 md:hidden"
+            aria-label="Open portal menu"
+            className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] active:scale-95 lg:hidden"
           >
-            <MenuIcon />
+            <Menu className="h-5 w-5" aria-hidden="true" />
           </button>
-
           <button
             type="button"
-            onClick={() => setDesktopOpen((v) => !v)}
-            aria-label="Toggle sidebar"
-            className="desktop-btn-secondary hidden h-8 w-8 items-center justify-center rounded-full border active:scale-95 md:inline-flex"
+            onClick={() => setDesktopExpanded((value) => !value)}
+            aria-label={
+              desktopExpanded ? "Collapse portal menu" : "Expand portal menu"
+            }
+            className="hidden h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] active:scale-95 lg:inline-flex"
           >
-            <MenuIcon />
+            {desktopExpanded ? (
+              <PanelLeftClose className="h-5 w-5" aria-hidden="true" />
+            ) : (
+              <PanelLeftOpen className="h-5 w-5" aria-hidden="true" />
+            )}
           </button>
-
-          <div>
-            <div className="text-[0.75rem] font-medium text-[color:var(--theme-text-primary)]">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">
               {title}
-            </div>
-            <div className="text-[0.65rem] text-[color:var(--theme-text-secondary)]">{subtitle}</div>
+            </p>
+            <p className="hidden truncate text-[11px] text-[color:var(--theme-text-secondary)] sm:block">
+              {subtitle}
+            </p>
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
           <PortalNotificationsBell />
           <PortalAssistantEntry />
-
           <Link
             href="/portal/messages"
-            className="desktop-btn-secondary inline-flex items-center rounded-full border px-3 py-1 text-[0.7rem] font-semibold transition active:scale-95"
+            className="hidden min-h-9 items-center rounded-full border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold md:inline-flex"
           >
-            <span>Messages</span>
+            Messages
           </Link>
-
           <Link
             href="/portal/request/when"
-            className="desktop-btn-primary inline-flex items-center rounded-full border px-3 py-1 text-[0.7rem] font-semibold transition active:scale-95"
+            className="hidden min-h-9 items-center rounded-full bg-[var(--accent-copper)] px-3 text-xs font-semibold text-[color:var(--theme-text-on-accent)] sm:inline-flex"
           >
-            <span>Request</span>
+            Request service
           </Link>
-
-          <Link
-            href="/portal/approvals"
-            className="desktop-btn-secondary inline-flex items-center rounded-full border px-3 py-1 text-[0.7rem] font-semibold transition active:scale-95"
-          >
-            <span>Approvals</span>
-          </Link>
-
-          <button
-            type="button"
-            onClick={() => void signOut()}
-            disabled={signingOut}
-            className="desktop-btn-secondary inline-flex items-center rounded-full border px-3 py-1 text-[0.7rem] font-semibold transition active:scale-95 disabled:opacity-60"
-            title="Sign out"
-          >
-            {signingOut ? "Signing out…" : "Sign out"}
-          </button>
         </div>
       </header>
 
-      <div className="relative mx-auto flex min-h-[calc(100dvh-56px)] w-full max-w-6xl flex-col gap-4 px-3 py-4 md:flex-row md:gap-6 md:px-6">
+      <div className="relative mx-auto flex w-full max-w-[1400px] gap-4 px-3 py-3 sm:px-4 sm:py-4 lg:gap-5 lg:px-6">
         <aside
           className={cx(
-            "desktop-panel-soft hidden overflow-hidden rounded-2xl border backdrop-blur-md shadow-card transition-all duration-300 md:flex md:flex-col",
-            desktopOpen
-              ? "w-72"
-              : "w-0 border-transparent bg-transparent shadow-none",
+            "sticky top-[72px] hidden h-[calc(100dvh-88px)] shrink-0 flex-col overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-card backdrop-blur-xl transition-[width] duration-200 lg:flex",
+            desktopExpanded ? "w-64" : "w-[72px]",
           )}
         >
-          <div
+          <Link
+            href="/portal"
             className={cx(
-              "flex h-full flex-col transition-opacity duration-200",
-              desktopOpen ? "opacity-100" : "opacity-0",
+              "flex h-16 shrink-0 items-center border-b border-[color:var(--theme-border-soft)]",
+              desktopExpanded ? "gap-3 px-4" : "justify-center px-2",
             )}
           >
-            <div className="px-5 py-5">
-              <div
-                className="font-blackops text-lg tracking-[0.16em]"
-                style={{ color: COPPER }}
+            <span
+              className="grid h-9 w-9 shrink-0 place-items-center rounded-xl border border-[rgba(197,122,74,0.35)] bg-[rgba(197,122,74,0.12)] font-blackops text-xs"
+              style={{ color: COPPER }}
+            >
+              P
+            </span>
+            {desktopExpanded ? (
+              <span className="min-w-0">
+                <span
+                  className="block font-blackops text-sm tracking-[0.16em]"
+                  style={{ color: COPPER }}
+                >
+                  PROFIXIQ
+                </span>
+                <span className="block text-[10px] text-[color:var(--theme-text-muted)]">
+                  Customer Portal
+                </span>
+              </span>
+            ) : null}
+          </Link>
+
+          <nav
+            className="min-h-0 flex-1 space-y-1 overflow-y-auto p-2"
+            aria-label="Portal navigation"
+          >
+            {PRIMARY_NAV.map((item) => (
+              <PortalNavLink
+                key={item.href}
+                item={item}
+                active={item.href === activeHref}
+                expanded={desktopExpanded}
+              />
+            ))}
+            <div className="my-2 border-t border-[color:var(--theme-border-soft)]" />
+            {ACCOUNT_NAV.map((item) => (
+              <PortalNavLink
+                key={item.href}
+                item={item}
+                active={item.href === activeHref}
+                expanded={desktopExpanded}
+              />
+            ))}
+          </nav>
+
+          <div className="border-t border-[color:var(--theme-border-soft)] p-2">
+            <button
+              type="button"
+              onClick={() => void signOut()}
+              disabled={signingOut}
+              title={desktopExpanded ? undefined : "Sign out"}
+              className={cx(
+                "flex min-h-11 w-full items-center rounded-xl border border-transparent text-sm font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-red-400/25 hover:bg-red-500/10 hover:text-red-100 disabled:opacity-60",
+                desktopExpanded ? "gap-3 px-3" : "justify-center px-2",
+              )}
+            >
+              <LogOut
+                className="h-[18px] w-[18px] shrink-0"
+                aria-hidden="true"
+              />
+              {desktopExpanded
+                ? signingOut
+                  ? "Signing out…"
+                  : "Sign out"
+                : null}
+            </button>
+          </div>
+        </aside>
+
+        <main className="min-w-0 flex-1 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+          {children}
+        </main>
+      </div>
+
+      {mobileOpen ? (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          <button
+            type="button"
+            aria-label="Close portal menu"
+            className="absolute inset-0 bg-black/65 backdrop-blur-sm"
+            onClick={() => setMobileOpen(false)}
+          />
+          <aside className="absolute inset-y-0 left-0 flex w-[88vw] max-w-[360px] flex-col border-r border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] shadow-2xl">
+            <div className="flex min-h-16 items-center justify-between border-b border-[color:var(--theme-border-soft)] px-4">
+              <div>
+                <p
+                  className="font-blackops text-base tracking-[0.16em]"
+                  style={{ color: COPPER }}
+                >
+                  PROFIXIQ
+                </p>
+                <p className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">
+                  Customer Portal
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setMobileOpen(false)}
+                aria-label="Close menu"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)]"
               >
-                PROFIXIQ
-              </div>
-              <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                Customer Portal
-              </div>
+                <X className="h-5 w-5" aria-hidden="true" />
+              </button>
             </div>
 
-            <nav className="flex-1 space-y-2 px-3 pb-4">
-              {NAV.map((item) => (
-                <NavPill
+            <nav
+              className="min-h-0 flex-1 space-y-1 overflow-y-auto p-3"
+              aria-label="Mobile portal navigation"
+            >
+              {PRIMARY_NAV.map((item) => (
+                <PortalNavLink
                   key={item.href}
-                  href={item.href}
-                  label={item.label}
+                  item={item}
                   active={item.href === activeHref}
+                  expanded
+                  onClick={() => setMobileOpen(false)}
+                />
+              ))}
+              <p className="px-3 pb-1 pt-4 text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+                Account
+              </p>
+              {ACCOUNT_NAV.map((item) => (
+                <PortalNavLink
+                  key={item.href}
+                  item={item}
+                  active={item.href === activeHref}
+                  expanded
+                  onClick={() => setMobileOpen(false)}
                 />
               ))}
             </nav>
 
-            <div className="px-5 pb-5 text-xs text-[color:var(--theme-text-muted)]">
-              Powered by ProFixIQ
+            <div className="border-t border-[color:var(--theme-border-soft)] p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+              <button
+                type="button"
+                onClick={() => void signOut()}
+                disabled={signingOut}
+                className="flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-red-400/30 bg-red-500/10 px-3 text-sm font-semibold text-red-100 disabled:opacity-60"
+              >
+                <LogOut className="h-[18px] w-[18px]" aria-hidden="true" />
+                {signingOut ? "Signing out…" : "Sign out"}
+              </button>
             </div>
-          </div>
-        </aside>
-
-        {mobileOpen && (
-          <div className="fixed inset-0 z-40 md:hidden">
-            <div
-              className="absolute inset-0 bg-[color:var(--theme-surface-overlay)]"
-              onClick={() => setMobileOpen(false)}
-            />
-            <div className="absolute left-0 top-0 h-full w-[82vw] max-w-[360px] border-r border-[color:var(--theme-border-soft)] bg-[var(--theme-surface-page)]/95 backdrop-blur-xl">
-              <div className="flex items-center justify-between border-b border-[color:var(--desktop-border)] px-5 py-5">
-                <div>
-                  <div
-                    className="font-blackops text-lg tracking-[0.16em]"
-                    style={{ color: COPPER }}
-                  >
-                    PROFIXIQ
-                  </div>
-                  <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                    Customer Portal
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  className="desktop-btn-secondary rounded-full border px-3 py-1 text-xs text-[color:var(--theme-text-primary)]"
-                  onClick={() => setMobileOpen(false)}
-                >
-                  Close
-                </button>
-              </div>
-
-              <nav className="space-y-2 px-4 py-4">
-                {NAV.map((item) => (
-                  <NavPill
-                    key={item.href}
-                    href={item.href}
-                    label={item.label}
-                    active={item.href === activeHref}
-                    onClick={() => setMobileOpen(false)}
-                  />
-                ))}
-              </nav>
-
-              <div className="mt-auto border-t border-[color:var(--theme-border-soft)] px-5 py-4">
-                <button
-                  type="button"
-                  onClick={() => void signOut()}
-                  disabled={signingOut}
-                  className="w-full inline-flex items-center justify-center gap-2 rounded-xl border border-red-400/50 bg-red-500/10 px-3 py-2 text-sm font-medium text-red-100 hover:bg-red-500/20 disabled:opacity-60"
-                >
-                  {signingOut ? "Signing out…" : "Sign out"}
-                </button>
-
-                <div className="mt-3 text-xs text-[color:var(--theme-text-muted)]">
-                  Powered by ProFixIQ
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
-        <div className="min-w-0 flex-1">
-          <div className="desktop-panel-soft min-h-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 backdrop-blur-md md:p-4">{children}</div>
+          </aside>
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }

--- a/features/portal/components/PortalWorkOrderCard.tsx
+++ b/features/portal/components/PortalWorkOrderCard.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link";
+import {
+  CalendarClock,
+  ChevronRight,
+  MessageCircle,
+  UserRound,
+} from "lucide-react";
+import type { PortalWorkOrderSummary } from "@/features/portal/server/portalWorkOrders";
+
+const STATUS_STYLE: Record<PortalWorkOrderSummary["status"]["key"], string> = {
+  appointment_confirmed: "border-sky-400/35 bg-sky-500/10 text-sky-100",
+  vehicle_received: "border-blue-400/35 bg-blue-500/10 text-blue-100",
+  inspection_underway: "border-violet-400/35 bg-violet-500/10 text-violet-100",
+  approval_needed: "border-amber-400/45 bg-amber-500/15 text-amber-100",
+  work_underway: "border-cyan-400/35 bg-cyan-500/10 text-cyan-100",
+  waiting_for_parts: "border-orange-400/40 bg-orange-500/10 text-orange-100",
+  final_checks: "border-indigo-400/35 bg-indigo-500/10 text-indigo-100",
+  ready_for_pickup: "border-emerald-400/40 bg-emerald-500/12 text-emerald-100",
+  completed:
+    "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-secondary)]",
+};
+
+function dateLabel(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function PortalWorkOrderCard({
+  workOrder,
+  compact = false,
+}: {
+  workOrder: PortalWorkOrderSummary;
+  compact?: boolean;
+}) {
+  const updated = dateLabel(workOrder.updatedAt);
+  const expected = dateLabel(workOrder.expectedCompletionAt);
+
+  return (
+    <article className="overflow-hidden rounded-3xl border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] shadow-card backdrop-blur-xl">
+      <div className={compact ? "p-4" : "p-4 sm:p-5"}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate text-lg font-semibold text-[color:var(--theme-text-primary)]">
+              {workOrder.vehicleLabel}
+            </p>
+            <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+              {workOrder.reference}
+              {workOrder.vehicleDetail ? ` • ${workOrder.vehicleDetail}` : ""}
+            </p>
+          </div>
+          <span
+            className={`max-w-[48%] shrink-0 rounded-full border px-2.5 py-1 text-center text-[10px] font-semibold uppercase leading-tight tracking-[0.1em] ${STATUS_STYLE[workOrder.status.key]}`}
+          >
+            {workOrder.status.label}
+          </span>
+        </div>
+
+        <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+            Service
+          </p>
+          <ul className="mt-2 space-y-1.5 text-sm text-[color:var(--theme-text-primary)]">
+            {workOrder.serviceSummary.map((service) => (
+              <li key={service} className="flex gap-2">
+                <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-[var(--accent-copper)]" />
+                <span>{service}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="mt-4 space-y-2 text-xs text-[color:var(--theme-text-secondary)]">
+          <p>{workOrder.status.nextStep}</p>
+          <div className="flex flex-wrap gap-x-4 gap-y-2">
+            {workOrder.advisorName ? (
+              <span className="inline-flex items-center gap-1.5">
+                <UserRound className="h-3.5 w-3.5" aria-hidden="true" />
+                Advisor: {workOrder.advisorName}
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1.5">
+                <UserRound className="h-3.5 w-3.5" aria-hidden="true" />
+                Shop service team
+              </span>
+            )}
+            {expected ? (
+              <span className="inline-flex items-center gap-1.5">
+                <CalendarClock className="h-3.5 w-3.5" aria-hidden="true" />
+                Expected {expected}
+              </span>
+            ) : updated ? (
+              <span>Updated {updated}</span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]">
+        <Link
+          href={workOrder.messageHref}
+          className="inline-flex min-h-12 items-center justify-center gap-2 border-r border-[color:var(--theme-border-soft)] px-3 py-3 text-sm font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+        >
+          <MessageCircle className="h-4 w-4" aria-hidden="true" />
+          {workOrder.advisorName ? "Message advisor" : "Message shop"}
+        </Link>
+        <Link
+          href={workOrder.primaryAction.href}
+          className="inline-flex min-h-12 items-center justify-center gap-1 px-3 py-3 text-sm font-semibold text-[var(--accent-copper-light)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+        >
+          {workOrder.primaryAction.label}
+          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/features/portal/lib/workOrderPresentation.ts
+++ b/features/portal/lib/workOrderPresentation.ts
@@ -1,0 +1,202 @@
+export type PortalWorkOrderStatusKey =
+  | "appointment_confirmed"
+  | "vehicle_received"
+  | "inspection_underway"
+  | "approval_needed"
+  | "work_underway"
+  | "waiting_for_parts"
+  | "final_checks"
+  | "ready_for_pickup"
+  | "completed";
+
+export type PortalWorkOrderStatus = {
+  key: PortalWorkOrderStatusKey;
+  label: string;
+  nextStep: string;
+  actionRequired: boolean;
+  complete: boolean;
+};
+
+type PortalWorkOrderStatusInput = {
+  status: string | null | undefined;
+  approvalState?: string | null;
+  scheduledAt?: string | null;
+  invoiceSentAt?: string | null;
+};
+
+function normalize(value: string | null | undefined): string {
+  return (value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+const CUSTOMER_APPROVAL_STATES = new Set([
+  "awaiting_approval",
+  "awaiting_customer",
+  "customer_review",
+  "pending",
+  "pending_approval",
+  "requested",
+  "sent",
+]);
+
+const WAITING_PARTS_STATES = new Set([
+  "parts_on_order",
+  "parts_waiting",
+  "pending_parts",
+  "waiting_for_parts",
+  "waiting_parts",
+]);
+
+const INSPECTION_STATES = new Set([
+  "diagnosing",
+  "inspection",
+  "inspection_in_progress",
+  "inspecting",
+]);
+
+const WORK_STATES = new Set([
+  "active",
+  "in_progress",
+  "repair_in_progress",
+  "working",
+]);
+
+const FINAL_CHECK_STATES = new Set([
+  "final_check",
+  "final_checks",
+  "quality_check",
+  "quality_control",
+]);
+
+const READY_STATES = new Set([
+  "completed",
+  "invoiced",
+  "ready_for_pickup",
+  "ready_to_invoice",
+]);
+
+const COMPLETE_STATES = new Set(["archived", "cancelled", "closed", "paid"]);
+
+export function toPortalWorkOrderStatus(
+  input: PortalWorkOrderStatusInput,
+): PortalWorkOrderStatus {
+  const status = normalize(input.status);
+  const approvalState = normalize(input.approvalState);
+
+  if (
+    status === "awaiting_approval" ||
+    CUSTOMER_APPROVAL_STATES.has(approvalState)
+  ) {
+    return {
+      key: "approval_needed",
+      label: "Your approval is needed",
+      nextStep:
+        "Review the estimate and choose how you would like the shop to proceed.",
+      actionRequired: true,
+      complete: false,
+    };
+  }
+
+  if (WAITING_PARTS_STATES.has(status)) {
+    return {
+      key: "waiting_for_parts",
+      label: "Waiting for parts",
+      nextStep:
+        "The shop is tracking the required parts and will update you when work can continue.",
+      actionRequired: false,
+      complete: false,
+    };
+  }
+
+  if (INSPECTION_STATES.has(status)) {
+    return {
+      key: "inspection_underway",
+      label: "Inspection underway",
+      nextStep:
+        "The shop is checking your vehicle and will share any recommendations with you.",
+      actionRequired: false,
+      complete: false,
+    };
+  }
+
+  if (WORK_STATES.has(status) || status === "on_hold") {
+    return {
+      key: "work_underway",
+      label: "Approved work underway",
+      nextStep:
+        "Your service team is working on the vehicle. They will contact you if anything changes.",
+      actionRequired: false,
+      complete: false,
+    };
+  }
+
+  if (FINAL_CHECK_STATES.has(status)) {
+    return {
+      key: "final_checks",
+      label: "Final checks",
+      nextStep:
+        "The work is nearly complete and the shop is completing its final review.",
+      actionRequired: false,
+      complete: false,
+    };
+  }
+
+  if (READY_STATES.has(status)) {
+    return {
+      key: "ready_for_pickup",
+      label: "Ready for pickup",
+      nextStep: input.invoiceSentAt
+        ? "Your invoice is available. Contact the shop if you need to arrange pickup."
+        : "The shop will confirm pickup details with you.",
+      actionRequired: Boolean(input.invoiceSentAt),
+      complete: false,
+    };
+  }
+
+  if (COMPLETE_STATES.has(status)) {
+    return {
+      key: "completed",
+      label: "Completed",
+      nextStep:
+        "This service visit is complete and remains available in your history.",
+      actionRequired: false,
+      complete: true,
+    };
+  }
+
+  const scheduledTime = input.scheduledAt
+    ? new Date(input.scheduledAt).getTime()
+    : Number.NaN;
+  if (Number.isFinite(scheduledTime) && scheduledTime > Date.now()) {
+    return {
+      key: "appointment_confirmed",
+      label: "Appointment confirmed",
+      nextStep:
+        "Your appointment is booked. The shop will update this card after the vehicle arrives.",
+      actionRequired: false,
+      complete: false,
+    };
+  }
+
+  if (["draft", "new", "planned", "queued", "scheduled"].includes(status)) {
+    return {
+      key: "appointment_confirmed",
+      label: "Appointment confirmed",
+      nextStep:
+        "The shop has your service request and will keep this card updated.",
+      actionRequired: false,
+      complete: false,
+    };
+  }
+
+  return {
+    key: "vehicle_received",
+    label: "Vehicle received",
+    nextStep:
+      "Your vehicle is with the shop. The next customer-visible update will appear here.",
+    actionRequired: false,
+    complete: false,
+  };
+}

--- a/features/portal/server/portalWorkOrders.ts
+++ b/features/portal/server/portalWorkOrders.ts
@@ -1,0 +1,238 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import {
+  toPortalWorkOrderStatus,
+  type PortalWorkOrderStatus,
+} from "@/features/portal/lib/workOrderPresentation";
+
+type DB = Database;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
+type ProfileRow = DB["public"]["Tables"]["profiles"]["Row"];
+type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+
+type WorkOrderSummaryRow = Pick<
+  WorkOrderRow,
+  | "id"
+  | "custom_id"
+  | "shop_id"
+  | "customer_id"
+  | "vehicle_id"
+  | "advisor_id"
+  | "status"
+  | "approval_state"
+  | "created_at"
+  | "updated_at"
+  | "scheduled_at"
+  | "expected_completion_at"
+  | "invoice_sent_at"
+  | "invoice_total"
+  | "vehicle_year"
+  | "vehicle_make"
+  | "vehicle_model"
+  | "vehicle_unit_number"
+  | "vehicle_license_plate"
+>;
+
+type VehicleSummaryRow = Pick<
+  VehicleRow,
+  "id" | "year" | "make" | "model" | "unit_number" | "license_plate"
+>;
+
+type AdvisorSummaryRow = Pick<ProfileRow, "id" | "full_name">;
+type LineSummaryRow = Pick<
+  WorkOrderLineRow,
+  "id" | "work_order_id" | "line_no" | "description" | "complaint"
+>;
+
+export type PortalWorkOrderSummary = {
+  id: string;
+  reference: string;
+  vehicleLabel: string;
+  vehicleDetail: string | null;
+  serviceSummary: string[];
+  advisorName: string | null;
+  status: PortalWorkOrderStatus;
+  updatedAt: string | null;
+  scheduledAt: string | null;
+  expectedCompletionAt: string | null;
+  invoiceSentAt: string | null;
+  invoiceTotal: number | null;
+  primaryAction: {
+    href: string;
+    label: string;
+  };
+  messageHref: string;
+};
+
+function compactText(value: string | null | undefined): string | null {
+  const text = value?.replace(/\s+/g, " ").trim() ?? "";
+  return text || null;
+}
+
+function vehiclePresentation(
+  workOrder: WorkOrderSummaryRow,
+  vehicle: VehicleSummaryRow | undefined,
+): { label: string; detail: string | null } {
+  const year = vehicle?.year ?? workOrder.vehicle_year;
+  const make = compactText(vehicle?.make ?? workOrder.vehicle_make);
+  const model = compactText(vehicle?.model ?? workOrder.vehicle_model);
+  const label = [year, make, model].filter(Boolean).join(" ") || "Your vehicle";
+  const unit = compactText(
+    vehicle?.unit_number ?? workOrder.vehicle_unit_number,
+  );
+  const plate = compactText(
+    vehicle?.license_plate ?? workOrder.vehicle_license_plate,
+  );
+  const detail = [unit ? `Unit ${unit}` : null, plate ? `Plate ${plate}` : null]
+    .filter(Boolean)
+    .join(" • ");
+  return { label, detail: detail || null };
+}
+
+function primaryAction(
+  workOrder: WorkOrderSummaryRow,
+  status: PortalWorkOrderStatus,
+): PortalWorkOrderSummary["primaryAction"] {
+  if (status.key === "approval_needed") {
+    return {
+      href: `/portal/quotes/${workOrder.id}`,
+      label: "Review estimate",
+    };
+  }
+  if (workOrder.invoice_sent_at) {
+    return {
+      href: `/portal/invoices/${workOrder.id}`,
+      label: "View invoice",
+    };
+  }
+  return {
+    href: `/portal/work-orders/view/${workOrder.id}`,
+    label: "View service",
+  };
+}
+
+export async function listPortalWorkOrdersForCustomer({
+  supabase,
+  customerId,
+  shopId,
+  limit = 50,
+}: {
+  supabase: SupabaseClient<DB>;
+  customerId: string;
+  shopId: string;
+  limit?: number;
+}): Promise<PortalWorkOrderSummary[]> {
+  const { data: workOrders, error: workOrderError } = await supabase
+    .from("work_orders")
+    .select(
+      "id,custom_id,shop_id,customer_id,vehicle_id,advisor_id,status,approval_state,created_at,updated_at,scheduled_at,expected_completion_at,invoice_sent_at,invoice_total,vehicle_year,vehicle_make,vehicle_model,vehicle_unit_number,vehicle_license_plate",
+    )
+    .eq("shop_id", shopId)
+    .eq("customer_id", customerId)
+    .order("updated_at", { ascending: false, nullsFirst: false })
+    .order("created_at", { ascending: false })
+    .limit(limit)
+    .returns<WorkOrderSummaryRow[]>();
+
+  if (workOrderError) throw new Error(workOrderError.message);
+  const rows = workOrders ?? [];
+  if (rows.length === 0) return [];
+
+  const workOrderIds = rows.map((row) => row.id);
+  const vehicleIds = Array.from(
+    new Set(
+      rows
+        .map((row) => row.vehicle_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  const advisorIds = Array.from(
+    new Set(
+      rows
+        .map((row) => row.advisor_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+
+  const [vehicleResult, advisorResult, lineResult] = await Promise.all([
+    vehicleIds.length
+      ? supabase
+          .from("vehicles")
+          .select("id,year,make,model,unit_number,license_plate")
+          .eq("shop_id", shopId)
+          .eq("customer_id", customerId)
+          .in("id", vehicleIds)
+          .returns<VehicleSummaryRow[]>()
+      : Promise.resolve({ data: [] as VehicleSummaryRow[], error: null }),
+    advisorIds.length
+      ? supabase
+          .from("profiles")
+          .select("id,full_name")
+          .eq("shop_id", shopId)
+          .in("id", advisorIds)
+          .returns<AdvisorSummaryRow[]>()
+      : Promise.resolve({ data: [] as AdvisorSummaryRow[], error: null }),
+    supabase
+      .from("work_order_lines")
+      .select("id,work_order_id,line_no,description,complaint")
+      .in("work_order_id", workOrderIds)
+      .order("line_no", { ascending: true })
+      .returns<LineSummaryRow[]>(),
+  ]);
+
+  const queryError =
+    vehicleResult.error ?? advisorResult.error ?? lineResult.error;
+  if (queryError) throw new Error(queryError.message);
+
+  const vehiclesById = new Map(
+    (vehicleResult.data ?? []).map((vehicle) => [vehicle.id, vehicle]),
+  );
+  const advisorsById = new Map(
+    (advisorResult.data ?? []).map((advisor) => [advisor.id, advisor]),
+  );
+  const linesByWorkOrder = new Map<string, string[]>();
+
+  for (const line of lineResult.data ?? []) {
+    const summary =
+      compactText(line.description) ?? compactText(line.complaint);
+    if (!summary) continue;
+    const current = linesByWorkOrder.get(line.work_order_id) ?? [];
+    if (!current.includes(summary) && current.length < 3) current.push(summary);
+    linesByWorkOrder.set(line.work_order_id, current);
+  }
+
+  return rows.map((workOrder) => {
+    const status = toPortalWorkOrderStatus({
+      status: workOrder.status,
+      approvalState: workOrder.approval_state,
+      scheduledAt: workOrder.scheduled_at,
+      invoiceSentAt: workOrder.invoice_sent_at,
+    });
+    const vehicle = vehiclePresentation(
+      workOrder,
+      workOrder.vehicle_id ? vehiclesById.get(workOrder.vehicle_id) : undefined,
+    );
+
+    return {
+      id: workOrder.id,
+      reference:
+        workOrder.custom_id?.trim() ||
+        `#${workOrder.id.slice(0, 8).toUpperCase()}`,
+      vehicleLabel: vehicle.label,
+      vehicleDetail: vehicle.detail,
+      serviceSummary: linesByWorkOrder.get(workOrder.id) ?? ["Service visit"],
+      advisorName: workOrder.advisor_id
+        ? compactText(advisorsById.get(workOrder.advisor_id)?.full_name)
+        : null,
+      status,
+      updatedAt: workOrder.updated_at ?? workOrder.created_at,
+      scheduledAt: workOrder.scheduled_at,
+      expectedCompletionAt: workOrder.expected_completion_at,
+      invoiceSentAt: workOrder.invoice_sent_at,
+      invoiceTotal: workOrder.invoice_total,
+      primaryAction: primaryAction(workOrder, status),
+      messageHref: `/portal/messages?compose=1&workOrderId=${encodeURIComponent(workOrder.id)}`,
+    };
+  });
+}

--- a/tests/customer-portal-mobile-refactor.test.ts
+++ b/tests/customer-portal-mobile-refactor.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { toPortalWorkOrderStatus } from "@/features/portal/lib/workOrderPresentation";
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("customer portal mobile refactor", () => {
+  it("translates internal work-order states into customer language", () => {
+    expect(
+      toPortalWorkOrderStatus({
+        status: "awaiting_approval",
+        approvalState: "awaiting_customer",
+      }),
+    ).toMatchObject({
+      key: "approval_needed",
+      label: "Your approval is needed",
+      actionRequired: true,
+    });
+    expect(toPortalWorkOrderStatus({ status: "waiting_parts" })).toMatchObject({
+      key: "waiting_for_parts",
+      label: "Waiting for parts",
+      actionRequired: false,
+    });
+    expect(
+      toPortalWorkOrderStatus({
+        status: "ready_to_invoice",
+        invoiceSentAt: "2026-07-21T12:00:00.000Z",
+      }),
+    ).toMatchObject({
+      key: "ready_for_pickup",
+      label: "Ready for pickup",
+      actionRequired: true,
+    });
+    expect(toPortalWorkOrderStatus({ status: "closed" })).toMatchObject({
+      key: "completed",
+      complete: true,
+    });
+  });
+
+  it("removes the internal shop board from every customer portal entry point", () => {
+    const home = read("app/portal/page.tsx");
+    const status = read("app/portal/status/page.tsx");
+
+    expect(home).not.toContain("WorkOrderBoard");
+    expect(status).not.toContain("WorkOrderBoard");
+    expect(home).toContain("listPortalWorkOrdersForCustomer");
+    expect(status).toContain("listPortalWorkOrdersForCustomer");
+    expect(status).toContain("requirePortalCustomerActor");
+  });
+
+  it("scopes portal work orders and related vehicles to the authenticated customer and shop", () => {
+    const loader = read("features/portal/server/portalWorkOrders.ts");
+
+    expect(loader).toContain('.eq("shop_id", shopId)');
+    expect(loader).toContain('.eq("customer_id", customerId)');
+    expect(loader).toContain('.in("work_order_id", workOrderIds)');
+    expect(loader).not.toContain("createAdminSupabase");
+  });
+
+  it("uses a mobile drawer and a collapsed desktop rail", () => {
+    const shell = read("features/portal/components/PortalShell.tsx");
+
+    expect(shell).toContain(
+      "const [desktopExpanded, setDesktopExpanded] = useState(false)",
+    );
+    expect(shell).toContain('aria-label="Open portal menu"');
+    expect(shell).toContain("w-[72px]");
+    expect(shell).toContain("Mobile portal navigation");
+  });
+
+  it("loads the profile identity and validates accepted invite evidence", () => {
+    const profile = read("app/portal/profile/page.tsx");
+
+    expect(profile).toContain(
+      '"id,shop_id,first_name,last_name,phone,street,city,province,postal_code"',
+    );
+    expect(profile).toContain('.eq("accepted_by_user_id", user.id)');
+    expect(profile).toContain('.not("accepted_at", "is", null)');
+    expect(profile).toContain('.is("revoked_at", null)');
+  });
+
+  it("routes work-order messages to the assigned advisor with management coverage", () => {
+    const route = read("app/api/chat/start-conversation/route.ts");
+    const workspace = read(
+      "features/chat/components/PortalMessagesWorkspace.tsx",
+    );
+
+    expect(route).toContain('.select("advisor_id")');
+    expect(route).toContain('.eq("customer_id", createAccess.customerId)');
+    expect(route).toContain('.in("role", ["owner", "admin", "manager"])');
+    expect(workspace).toContain('searchParams.get("workOrderId")');
+    expect(workspace).toContain("Message your advisor");
+  });
+});


### PR DESCRIPTION
## Root cause

The customer portal reused the internal shop work-order board. That exposed internal workflow language and actions, and its data path was not designed as a customer-only projection. The portal shell was desktop-first, messaging did not prefer the work order's assigned advisor, and the profile query omitted the customer identity it later required.

## What changed

- Replaced the shop board with mobile-first customer work-order cards on the portal home and status pages.
- Added a server-side portal work-order projection scoped by both `shop_id` and `customer_id`.
- Translated internal workflow states into customer-facing service updates and contextual actions.
- Added a hamburger drawer on mobile and a collapsed icon rail that can expand on desktop.
- Made portal messaging mobile-friendly and preselect the work order from card actions.
- Routes new work-order conversations to the assigned advisor first, with shop management coverage.
- Fixed profile and vehicle enrollment checks to require an accepted, non-revoked invite tied to the signed-in user.
- Added contract tests for scoping, status translation, navigation, profile identity, and advisor routing.

## Why this is safe

All portal work-order reads use the authenticated portal actor and are constrained by both the actor's customer ID and shop ID. Related vehicles are constrained the same way. Messaging retains the existing actor/context authorization before selecting recipients, and assigned advisor/coverage profiles remain shop-scoped. No service-role client or client-side-only tenant filter was added.

## Validation

- TypeScript: passed
- Focused ESLint: passed
- Portal/auth/chat regression suite: 37/37 passed
- Full suite: 1,003 passed; 48 existing unrelated failures
- API route boundary audit: passed
- Production bundle: compiled and type-checked; page-data collection requires the unavailable `SUPABASE_URL` in this workspace

## Database

No migration required.

## Environment variables

No new environment variables.

## Manual/deployment actions

Test the preview on a phone-sized viewport and verify one real invited customer with active, approval-needed, completed, and advisor-assigned work orders.

## Remaining risks or unverified assumptions

Live Supabase data and advisor assignments were not available locally, so the deployed preview still needs an end-to-end customer session check.