### PR TITLE
Fix inspection autosave, realtime sync, and signatures

### DIFF
--- a/app/api/inspections/load/route.ts
+++ b/app/api/inspections/load/route.ts
@@ -29,15 +29,19 @@ export async function GET(req: NextRequest) {
         work_order_id: string | null;
         work_order_line_id: string | null;
         summary: Json | null;
-
+        locked: boolean | null;
+        finalized_at: string | null;
+        finalized_by: string | null;
       }
     | null = null;
 
   if (inspectionId) {
     const { data, error } = await supabase
       .from("inspections")
-      .select("id, work_order_id, work_order_line_id, summary")
+      .select("id, work_order_id, work_order_line_id, summary, locked, finalized_at, finalized_by")
       .eq("id", inspectionId)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .limit(1)
       .maybeSingle();
 
     if (error) {
@@ -48,8 +52,10 @@ export async function GET(req: NextRequest) {
   } else if (workOrderLineId) {
     const { data, error } = await supabase
       .from("inspections")
-      .select("id, work_order_id, work_order_line_id, summary")
+      .select("id, work_order_id, work_order_line_id, summary, locked, finalized_at, finalized_by")
       .eq("work_order_line_id", workOrderLineId)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .limit(1)
       .maybeSingle();
 
     if (error) {
@@ -70,6 +76,8 @@ export async function GET(req: NextRequest) {
       .from("inspection_sessions")
       .select("state")
       .eq("work_order_line_id", resolvedWorkOrderLineId)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .limit(1)
       .maybeSingle();
 
     if (sessionErr) {
@@ -103,8 +111,9 @@ export async function GET(req: NextRequest) {
     workOrderId: hydratedSession.workOrderId ?? null,
     workOrderLineId: hydratedSession.workOrderLineId ?? null,
     inspectionMeta: {
-      locked: false,
-      finalizedAt: null,
+      locked: Boolean(inspectionRow?.locked),
+      finalizedAt: inspectionRow?.finalized_at ?? null,
+      finalizedBy: inspectionRow?.finalized_by ?? null,
       reopenedAt: null,
       reopenedBy: null,
       reopenReason: null,

--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -297,7 +297,7 @@ export async function POST(req: NextRequest) {
     shopId,
     actorUserId: user.id,
   });
-  if (!resolved.ok) {
+  if (resolved.ok === false) {
     return NextResponse.json(
       { error: resolved.error },
       { status: resolved.status },

--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -225,39 +225,20 @@ export async function POST(req: NextRequest) {
   const requestedInspectionId = cleanUuid(bodyUnknown.inspectionId);
   const workOrderLineId = cleanUuid(bodyUnknown.workOrderLineId);
 
-  let effectiveSignedName = signedName.trim();
-  if (!effectiveSignedName && role === "technician") {
-    const profileNameResult = await supabase
-      .from("profiles")
-      .select("full_name, first_name, last_name")
-      .eq("id", user.id)
-      .maybeSingle<{
-        full_name?: string | null;
-        first_name?: string | null;
-        last_name?: string | null;
-      }>();
-
-    if (!profileNameResult.error) {
-      const full = (profileNameResult.data?.full_name ?? "").trim();
-      const joined = `${profileNameResult.data?.first_name ?? ""} ${
-        profileNameResult.data?.last_name ?? ""
-      }`.trim();
-      effectiveSignedName = full || joined;
-    }
-  }
-
-  if (!effectiveSignedName) {
-    return NextResponse.json(
-      { error: "Signed name is required." },
-      { status: 400 },
-    );
-  }
-
   const profileResult = await supabase
     .from("profiles")
-    .select("shop_id")
+    .select(
+      "shop_id, full_name, first_name, last_name, tech_signature_path, tech_signature_hash",
+    )
     .eq("id", user.id)
-    .maybeSingle<{ shop_id: string | null }>();
+    .maybeSingle<{
+      shop_id: string | null;
+      full_name: string | null;
+      first_name: string | null;
+      last_name: string | null;
+      tech_signature_path: string | null;
+      tech_signature_hash: string | null;
+    }>();
 
   if (profileResult.error) {
     return NextResponse.json(
@@ -266,11 +247,46 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const shopId = profileResult.data?.shop_id ?? null;
+  const profile = profileResult.data;
+  const shopId = profile?.shop_id ?? null;
   if (!shopId) {
     return NextResponse.json(
       { error: "Your profile is missing shop_id; cannot sign inspection." },
       { status: 403 },
+    );
+  }
+
+  const profileName =
+    (profile?.full_name ?? "").trim() ||
+    `${profile?.first_name ?? ""} ${profile?.last_name ?? ""}`.trim();
+  const effectiveSignedName =
+    role === "technician" ? profileName : signedName.trim();
+
+  if (!effectiveSignedName) {
+    return NextResponse.json(
+      {
+        error:
+          role === "technician"
+            ? "Add your full name to your profile before signing."
+            : "Signed name is required.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const effectiveSignatureImagePath =
+    role === "technician"
+      ? profile?.tech_signature_path ?? null
+      : signatureImagePath ?? null;
+  const effectiveSignatureHash =
+    role === "technician"
+      ? profile?.tech_signature_hash ?? null
+      : signatureHash ?? null;
+
+  if (role === "technician" && !effectiveSignatureImagePath) {
+    return NextResponse.json(
+      { error: "No saved technician signature. Add one in Tech Settings." },
+      { status: 409 },
     );
   }
 
@@ -292,8 +308,8 @@ export async function POST(req: NextRequest) {
     p_inspection_id: resolved.inspectionId,
     p_role: role,
     p_signed_name: effectiveSignedName,
-    p_signature_image_path: signatureImagePath ?? null,
-    p_signature_hash: signatureHash ?? null,
+    p_signature_image_path: effectiveSignatureImagePath,
+    p_signature_hash: effectiveSignatureHash,
   });
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 400 });

--- a/app/dashboard/tech/settings/page.tsx
+++ b/app/dashboard/tech/settings/page.tsx
@@ -184,7 +184,7 @@ export default function TechSettingsPage() {
 
       const blob = dataUrlToBlob(dataUrl);
       const hash = await sha256Base64(dataUrl);
-      const path = `tech-signatures/${profileId}.png`;
+      const path = `tech-signatures/${profileId}/${hash}.png`;
 
       const up = await supabase.storage.from("signatures").upload(path, blob, {
         upsert: true,

--- a/features/inspections/components/inspection/InspectionReviewPanel.tsx
+++ b/features/inspections/components/inspection/InspectionReviewPanel.tsx
@@ -7,7 +7,6 @@ import type {
   InspectionItem,
 } from "@inspections/lib/inspection/types";
 import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicleHeader";
-import { SaveInspectionButton } from "@inspections/components/inspection/SaveInspectionButton";
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
 import { Button } from "@shared/components/ui/Button";
@@ -163,10 +162,6 @@ export default function InspectionReviewPanel({
           <div className="flex flex-wrap items-center justify-end gap-2">
             {workOrderLineId && (
               <>
-                <SaveInspectionButton
-                  session={session}
-                  workOrderLineId={workOrderLineId}
-                />
                 <FinishInspectionButton
                   session={session}
                   workOrderLineId={workOrderLineId}
@@ -322,6 +317,7 @@ export default function InspectionReviewPanel({
           {/* Technician signature – no default name until it’s part of the session type */}
           <InspectionSignaturePanel
             inspectionId={session.id as string | undefined | null}
+            workOrderLineId={workOrderLineId}
             role="technician"
             onSigned={() => {
               if (!onSessionChange) return;
@@ -335,6 +331,7 @@ export default function InspectionReviewPanel({
           {/* Customer signature */}
           <InspectionSignaturePanel
             inspectionId={session.id as string | undefined | null}
+            workOrderLineId={workOrderLineId}
             role="customer"
             defaultName={customerDefaultName}
             onSigned={() => {

--- a/features/inspections/components/inspection/InspectionSignaturePanel.tsx
+++ b/features/inspections/components/inspection/InspectionSignaturePanel.tsx
@@ -36,7 +36,7 @@ function roleLabel(role: SignatureRole): string {
 
 function roleSubtext(role: SignatureRole): string {
   if (role === "technician")
-    return "Uses your saved signature (no re-signing every time).";
+    return "Uses the saved signature from your profile (no re-signing every time).";
   if (role === "advisor")
     return "Sign to approve/confirm this inspection snapshot.";
   return "Sign to acknowledge and lock this inspection snapshot.";
@@ -51,13 +51,6 @@ function confirmText(role: SignatureRole): string {
   }
   return "I confirm that I have reviewed this inspection and that the information above is accurate to the best of my knowledge.";
 }
-
-type SavedSigResponse = {
-  ok?: boolean;
-  error?: string;
-  signatureImagePath?: string | null;
-  signatureHash?: string | null;
-};
 
 type ProfileResponse = {
   ok?: boolean;
@@ -151,40 +144,6 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
     }
   }, [defaultName, role]);
 
-  async function fetchSavedTechSignature(): Promise<{
-    signatureImagePath: string;
-    signatureHash: string | null;
-  } | null> {
-    try {
-      const response = await fetch("/api/profile/signature", {
-        method: "GET",
-        credentials: "include",
-        headers: { "Cache-Control": "no-store" },
-      });
-
-      const json = (await response
-        .json()
-        .catch(() => null)) as SavedSigResponse | null;
-
-      if (!response.ok || json?.error) {
-        throw new Error(json?.error || "Failed to load saved signature");
-      }
-
-      const path = json?.signatureImagePath ?? null;
-      if (!path) return null;
-
-      return {
-        signatureImagePath: path,
-        signatureHash: json?.signatureHash ?? null,
-      };
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to load saved signature";
-      toast.error(message);
-      return null;
-    }
-  }
-
   // Tech convenience: auto-fill name from profile if missing.
   useEffect(() => {
     if (role !== "technician") {
@@ -253,25 +212,6 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
     setBusy(true);
 
     try {
-      let signatureImagePath: string | null = null;
-      let signatureHash: string | null = null;
-
-      if (role === "technician") {
-        const saved = await fetchSavedTechSignature();
-        if (!saved?.signatureImagePath) {
-          if (techSettingsHref) {
-            toast.error(
-              "No saved tech signature. Please add one in Tech Settings.",
-            );
-          } else {
-            toast.error("No saved tech signature. Add one in Tech Settings.");
-          }
-          return;
-        }
-        signatureImagePath = saved.signatureImagePath;
-        signatureHash = saved.signatureHash;
-      }
-
       const response = await fetch("/api/inspections/sign", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -281,8 +221,6 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           workOrderLineId: resolvedWorkOrderLineId,
           role,
           signedName: name.trim(),
-          signatureImagePath,
-          signatureHash,
         }),
       });
 

--- a/features/inspections/hooks/useInspectionRealtimeAutosave.tsx
+++ b/features/inspections/hooks/useInspectionRealtimeAutosave.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  replayQueuedInspectionSaves,
+  saveInspectionSession,
+} from "@inspections/lib/inspection/save";
+import type { InspectionSession } from "@inspections/lib/inspection/types";
+
+export type InspectionSyncState =
+  | "idle"
+  | "saving"
+  | "saved"
+  | "offline"
+  | "error";
+
+type UseInspectionRealtimeAutosaveArgs = {
+  session: InspectionSession | null | undefined;
+  workOrderLineId: string | null | undefined;
+  enabled?: boolean;
+  locked?: boolean;
+  debounceMs?: number;
+  onRemoteSession: (session: InspectionSession) => void;
+  onRemoteLocked?: () => void;
+};
+
+type RealtimeSessionRow = {
+  state?: unknown;
+  updated_at?: string | null;
+};
+
+type RealtimeInspectionRow = {
+  locked?: boolean | null;
+  summary?: unknown;
+  updated_at?: string | null;
+};
+
+function sessionTimestamp(session: InspectionSession | null | undefined): number {
+  const value = session?.lastUpdated;
+  const parsed = value ? new Date(value).getTime() : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function isInspectionSession(value: unknown): value is InspectionSession {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Partial<InspectionSession>;
+  return Array.isArray(candidate.sections);
+}
+
+export function useInspectionRealtimeAutosave({
+  session,
+  workOrderLineId,
+  enabled = true,
+  locked = false,
+  debounceMs = 800,
+  onRemoteSession,
+  onRemoteLocked,
+}: UseInspectionRealtimeAutosaveArgs): InspectionSyncState {
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const [state, setState] = useState<InspectionSyncState>("idle");
+  const currentSessionRef = useRef(session);
+  const onRemoteSessionRef = useRef(onRemoteSession);
+  const onRemoteLockedRef = useRef(onRemoteLocked);
+  const skipNextSerializedRef = useRef<string | null>(null);
+  const saveSequenceRef = useRef(0);
+
+  useEffect(() => {
+    currentSessionRef.current = session;
+  }, [session]);
+
+  useEffect(() => {
+    onRemoteSessionRef.current = onRemoteSession;
+  }, [onRemoteSession]);
+
+  useEffect(() => {
+    onRemoteLockedRef.current = onRemoteLocked;
+  }, [onRemoteLocked]);
+
+  useEffect(() => {
+    if (!enabled || locked || !session || !workOrderLineId) return;
+
+    const serialized = JSON.stringify(session);
+    if (skipNextSerializedRef.current === serialized) {
+      skipNextSerializedRef.current = null;
+      setState("saved");
+      return;
+    }
+
+    const sequence = ++saveSequenceRef.current;
+    setState("saving");
+
+    const timer = window.setTimeout(() => {
+      void saveInspectionSession(session, workOrderLineId)
+        .then((result) => {
+          if (sequence !== saveSequenceRef.current) return;
+          setState(result.queued || result.conflicted ? "offline" : "saved");
+        })
+        .catch((error: unknown) => {
+          if (sequence !== saveSequenceRef.current) return;
+          console.error("[inspection] autosave failed", error);
+          setState(typeof navigator !== "undefined" && !navigator.onLine ? "offline" : "error");
+        });
+    }, debounceMs);
+
+    return () => window.clearTimeout(timer);
+  }, [debounceMs, enabled, locked, session, workOrderLineId]);
+
+  useEffect(() => {
+    if (!workOrderLineId) return;
+
+    const applyRemoteSession = (value: unknown) => {
+      if (!isInspectionSession(value)) return;
+
+      const remoteAt = sessionTimestamp(value);
+      const localAt = sessionTimestamp(currentSessionRef.current);
+      if (remoteAt > 0 && localAt > remoteAt) return;
+
+      const serialized = JSON.stringify(value);
+      if (serialized === JSON.stringify(currentSessionRef.current ?? null)) return;
+
+      skipNextSerializedRef.current = serialized;
+      currentSessionRef.current = value;
+      onRemoteSessionRef.current(value);
+      setState("saved");
+    };
+
+    const channel = supabase
+      .channel(`inspection-progress:${workOrderLineId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "inspection_sessions",
+          filter: `work_order_line_id=eq.${workOrderLineId}`,
+        },
+        (payload) => {
+          const row = payload.new as RealtimeSessionRow;
+          applyRemoteSession(row?.state);
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "inspections",
+          filter: `work_order_line_id=eq.${workOrderLineId}`,
+        },
+        (payload) => {
+          const row = payload.new as RealtimeInspectionRow;
+          if (row?.locked) {
+            onRemoteLockedRef.current?.();
+            return;
+          }
+          applyRemoteSession(row?.summary);
+        },
+      )
+      .subscribe();
+
+    const handleOnline = () => {
+      void replayQueuedInspectionSaves().catch((error: unknown) => {
+        console.error("[inspection] queued autosave replay failed", error);
+      });
+    };
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      void supabase.removeChannel(channel);
+    };
+  }, [supabase, workOrderLineId]);
+
+  return state;
+}
+
+export function InspectionAutosaveStatus({
+  state,
+}: {
+  state: InspectionSyncState;
+}) {
+  const label =
+    state === "saving"
+      ? "Saving…"
+      : state === "saved"
+        ? "Saved"
+        : state === "offline"
+          ? "Saved on device · syncing"
+          : state === "error"
+            ? "Autosave needs attention"
+            : "Autosave ready";
+
+  return (
+    <span
+      aria-live="polite"
+      className={
+        state === "error"
+          ? "text-[11px] text-red-500"
+          : "text-[11px] text-[color:var(--theme-text-secondary)]"
+      }
+    >
+      {label}
+    </span>
+  );
+}

--- a/features/inspections/hooks/useInspectionSession.ts
+++ b/features/inspections/hooks/useInspectionSession.ts
@@ -158,6 +158,8 @@ export default function useInspectionSession(initialSession?: Partial<SessionWit
 
   const stamp = () => ({ lastUpdated: new Date().toISOString() });
 
+  const replaceSession = (next: SessionWithLineId) => setSession(next);
+
   const updateInspection = (updates: Partial<SessionWithLineId>) =>
     setSession((prev) => ({ ...prev, ...updates, ...stamp() }));
 
@@ -242,6 +244,7 @@ export default function useInspectionSession(initialSession?: Partial<SessionWit
 
   return {
     session,
+    replaceSession,
     updateInspection,
     updateSection,
     updateItem,

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -43,7 +43,10 @@ import TireGridHydraulic from "@inspections/lib/inspection/ui/TireGridHydraulic"
 import BatteryGrid from "@inspections/lib/inspection/ui/BatteryGrid";
 
 import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionFormContext";
-import { SaveInspectionButton } from "@inspections/components/inspection/SaveInspectionButton";
+import {
+  InspectionAutosaveStatus,
+  useInspectionRealtimeAutosave,
+} from "@inspections/hooks/useInspectionRealtimeAutosave";
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicleHeader";
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
@@ -887,6 +890,7 @@ type SmartMatchRow = {
 
   const {
     session,
+    replaceSession,
     updateInspection,
     updateItem,
     updateSection,
@@ -897,6 +901,34 @@ type SmartMatchRow = {
     addQuoteLine,
     updateQuoteLine,
   } = useInspectionSession(persistedSession ?? initialSession);
+
+  const autosaveState = useInspectionRealtimeAutosave({
+    session,
+    workOrderLineId,
+    enabled:
+      Boolean(workOrderLineId) &&
+      draftBootLoaded &&
+      serverBootLoaded &&
+      !inspectionCompletedRef.current,
+    locked: isLocked,
+    onRemoteSession: (remoteSession) => {
+      replaceSession(remoteSession);
+      localDraftUpdatedAtRef.current = inspectionDraftTimestamp(remoteSession);
+      try {
+        localStorage.setItem(draftKey, JSON.stringify(remoteSession));
+      } catch {
+        // The server copy remains authoritative if local storage is unavailable.
+      }
+    },
+    onRemoteLocked: () => {
+      setIsLocked(true);
+      try {
+        localStorage.setItem(lockKey, "1");
+      } catch {
+        // Server lock is authoritative.
+      }
+    },
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -2729,25 +2761,7 @@ type SmartMatchRow = {
 
   const actions = (
     <>
-      <SaveInspectionButton
-        session={session}
-        workOrderLineId={workOrderLineId}
-        disabled={isLocked}
-        draftKey={draftKey}
-        onRecoveryState={(state, operationKey) => {
-          setRecoveryState(state);
-          recoveryOperationKeyRef.current = operationKey;
-          queuedSessionRef.current = operationKey ? session : null;
-          skipNextQueuedEditCheckRef.current = false;
-          setRecoveryMessage(
-            state === "queued"
-              ? "Inspection is safe on this device and queued for server sync."
-              : state === "conflicted"
-                ? "Inspection is safe on this device, but sync needs review."
-                : "Inspection progress is saved on this device and the server.",
-          );
-        }}
-      />
+      <InspectionAutosaveStatus state={autosaveState} />
 
       <Button
         type="button"

--- a/features/inspections/screens/QuickAirBrakePMScreen.tsx
+++ b/features/inspections/screens/QuickAirBrakePMScreen.tsx
@@ -28,7 +28,10 @@ import type {
 import CornerGrid from "@inspections/lib/inspection/ui/CornerGrid";
 import SectionDisplay from "@inspections/lib/inspection/SectionDisplay";
 import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionFormContext";
-import { SaveInspectionButton } from "@inspections/components/inspection/SaveInspectionButton";
+import {
+  InspectionAutosaveStatus,
+  useInspectionRealtimeAutosave,
+} from "@inspections/hooks/useInspectionRealtimeAutosave";
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import { startVoiceRecognition } from "@inspections/lib/inspection/voiceControl";
 import PageShell from "@/features/shared/components/PageShell";
@@ -236,6 +239,7 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
 
   const {
     session,
+    replaceSession,
     updateInspection,
     updateItem,
     updateSection,
@@ -246,6 +250,13 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
     addQuoteLine,
     updateQuoteLine,
   } = useInspectionSession(initialSession);
+
+  const autosaveState = useInspectionRealtimeAutosave({
+    session,
+    workOrderLineId,
+    enabled: Boolean(workOrderLineId),
+    onRemoteSession: replaceSession,
+  });
 
   // ---- AI submit guarding ----
   const inFlightRef = useRef<Set<string>>(new Set());
@@ -721,7 +732,7 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
       {/* Footer */}
       <div className="mt-8 flex flex-col gap-4 border-t border-[color:var(--theme-border-soft)] pt-4 md:flex-row md:items-center md:justify-between">
         <div className="flex flex-wrap items-center gap-3">
-          <SaveInspectionButton session={session} workOrderLineId={workOrderLineId ?? ""} />
+          <InspectionAutosaveStatus state={autosaveState} />
           <FinishInspectionButton session={session} workOrderLineId={workOrderLineId ?? ""} />
           {!workOrderLineId && (
             <div className="text-xs text-red-400">

--- a/features/inspections/screens/QuickPMScreen.tsx
+++ b/features/inspections/screens/QuickPMScreen.tsx
@@ -28,7 +28,10 @@ import type {
 import CornerGrid from "@inspections/lib/inspection/ui/CornerGrid";
 import SectionDisplay from "@inspections/lib/inspection/SectionDisplay";
 import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionFormContext";
-import { SaveInspectionButton } from "@inspections/components/inspection/SaveInspectionButton";
+import {
+  InspectionAutosaveStatus,
+  useInspectionRealtimeAutosave,
+} from "@inspections/hooks/useInspectionRealtimeAutosave";
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import { startVoiceRecognition } from "@inspections/lib/inspection/voiceControl";
 import PageShell from "@/features/shared/components/PageShell";
@@ -225,6 +228,7 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
 
   const {
     session,
+    replaceSession,
     updateInspection,
     updateItem,
     updateSection,
@@ -235,6 +239,13 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
     addQuoteLine,
     updateQuoteLine,
   } = useInspectionSession(initialSession);
+
+  const autosaveState = useInspectionRealtimeAutosave({
+    session,
+    workOrderLineId,
+    enabled: Boolean(workOrderLineId),
+    onRemoteSession: replaceSession,
+  });
 
   // ---- AI submit guarding ----
   const inFlightRef = useRef<Set<string>>(new Set());
@@ -710,7 +721,7 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
       {/* Footer */}
       <div className="mt-8 flex flex-col gap-4 border-t border-[color:var(--theme-border-soft)] pt-4 md:flex-row md:items-center md:justify-between">
         <div className="flex flex-wrap items-center gap-3">
-          <SaveInspectionButton session={session} workOrderLineId={workOrderLineId ?? ""} />
+          <InspectionAutosaveStatus state={autosaveState} />
           <FinishInspectionButton session={session} workOrderLineId={workOrderLineId ?? ""} />
           {!workOrderLineId && (
             <div className="text-xs text-red-400">

--- a/features/mobile/settings/MobileSettingsScreen.tsx
+++ b/features/mobile/settings/MobileSettingsScreen.tsx
@@ -193,7 +193,7 @@ export default function MobileTechSettingsPage(): JSX.Element {
       const blob = dataUrlToBlob(dataUrl);
       const hash = await sha256Base64(dataUrl);
 
-      const path = `tech-signatures/${profileId}.png`;
+      const path = `tech-signatures/${profileId}/${hash}.png`;
 
       const up = await supabase.storage.from("signatures").upload(path, blob, {
         upsert: true,

--- a/supabase/migrations/20260721143000_inspection_autosave_realtime_signatures.sql
+++ b/supabase/migrations/20260721143000_inspection_autosave_realtime_signatures.sql
@@ -1,0 +1,388 @@
+begin;
+
+-- Reinstall the canonical draft writer as a forward migration so every
+-- environment receives the anchor-safe draft state, even when an older
+-- function definition was cached during a previous deploy.
+create or replace function public.save_inspection_progress_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_actor_user_id uuid,
+  p_session jsonb,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line record;
+  v_existing jsonb;
+  v_session_id uuid;
+  v_inspection_id uuid;
+  v_now timestamptz := coalesce(p_at, now());
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using errcode = 'P0001',
+      message = 'Authenticated actor does not match the inspection actor.';
+  end if;
+
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using errcode = 'P0001',
+      message = 'A stable operation key is required.';
+  end if;
+
+  if p_session is null or jsonb_typeof(p_session) <> 'object' then
+    raise exception using errcode = 'P0001',
+      message = 'Inspection session payload must be a JSON object.';
+  end if;
+
+  select mok.result
+    into v_existing
+  from public.mobile_operation_keys mok
+  where mok.shop_id = p_shop_id
+    and mok.operation_name = 'save_inspection_progress'
+    and mok.operation_key = p_operation_key;
+
+  if found then
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select wol.id, wol.work_order_id
+    into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for update;
+
+  if not found or v_line.work_order_id is null then
+    raise exception using errcode = 'P0001',
+      message = 'Work-order line not found for shop.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles p
+    where p.id = p_actor_user_id
+      and p.shop_id = p_shop_id
+  ) then
+    raise exception using errcode = 'P0001',
+      message = 'Actor is not a member of this shop.';
+  end if;
+
+  if exists (
+    select 1
+    from public.inspections i
+    where i.work_order_line_id = p_work_order_line_id
+      and i.shop_id = p_shop_id
+      and coalesce(i.locked, false)
+  ) then
+    raise exception using errcode = 'P0001',
+      message = 'Inspection is finalized and locked. Reopen is required before editing.';
+  end if;
+
+  select s.id
+    into v_session_id
+  from public.inspection_sessions s
+  where s.work_order_line_id = p_work_order_line_id
+  order by s.updated_at desc nulls last, s.id desc
+  limit 1
+  for update;
+
+  if found then
+    update public.inspection_sessions
+    set work_order_id = v_line.work_order_id,
+        user_id = p_actor_user_id,
+        state = p_session,
+        updated_at = v_now
+    where id = v_session_id;
+  else
+    insert into public.inspection_sessions(
+      work_order_id,
+      work_order_line_id,
+      user_id,
+      state,
+      updated_at
+    ) values (
+      v_line.work_order_id,
+      p_work_order_line_id,
+      p_actor_user_id,
+      p_session,
+      v_now
+    )
+    returning id into v_session_id;
+  end if;
+
+  select i.id
+    into v_inspection_id
+  from public.inspections i
+  where i.work_order_line_id = p_work_order_line_id
+    and i.shop_id = p_shop_id
+  order by i.updated_at desc nulls last, i.id desc
+  limit 1
+  for update;
+
+  if found then
+    update public.inspections
+    set work_order_id = v_line.work_order_id,
+        work_order_line_id = p_work_order_line_id,
+        shop_id = p_shop_id,
+        user_id = p_actor_user_id,
+        summary = p_session,
+        is_draft = true,
+        completed = false,
+        locked = false,
+        status = 'draft',
+        finalized_at = null,
+        finalized_by = null,
+        updated_at = v_now
+    where id = v_inspection_id
+      and shop_id = p_shop_id
+      and not coalesce(locked, false)
+    returning id into v_inspection_id;
+  else
+    insert into public.inspections(
+      work_order_id,
+      work_order_line_id,
+      shop_id,
+      user_id,
+      summary,
+      is_draft,
+      completed,
+      locked,
+      status,
+      updated_at
+    ) values (
+      v_line.work_order_id,
+      p_work_order_line_id,
+      p_shop_id,
+      p_actor_user_id,
+      p_session,
+      true,
+      false,
+      false,
+      'draft',
+      v_now
+    )
+    returning id into v_inspection_id;
+  end if;
+
+  if v_inspection_id is null then
+    raise exception using errcode = 'P0001',
+      message = 'Inspection progress could not be persisted.';
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'inspection_id', v_inspection_id,
+    'inspection_session_id', v_session_id,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'saved_at', v_now,
+    'idempotent', false
+  );
+
+  insert into public.mobile_operation_keys(
+    shop_id,
+    operation_name,
+    operation_key,
+    actor_user_id,
+    work_order_id,
+    work_order_line_id,
+    result
+  ) values (
+    p_shop_id,
+    'save_inspection_progress',
+    p_operation_key,
+    p_actor_user_id,
+    v_line.work_order_id,
+    p_work_order_line_id,
+    v_result
+  );
+
+  return v_result;
+exception
+  when unique_violation then
+    select mok.result
+      into v_existing
+    from public.mobile_operation_keys mok
+    where mok.shop_id = p_shop_id
+      and mok.operation_name = 'save_inspection_progress'
+      and mok.operation_key = p_operation_key;
+
+    if found then
+      return v_existing || jsonb_build_object('idempotent', true);
+    end if;
+    raise;
+end;
+$$;
+
+revoke all on function public.save_inspection_progress_atomic(
+  uuid, uuid, uuid, jsonb, text, timestamptz
+) from public;
+grant execute on function public.save_inspection_progress_atomic(
+  uuid, uuid, uuid, jsonb, text, timestamptz
+) to authenticated, service_role;
+
+-- Do not depend on an ON CONFLICT target that older production databases do
+-- not have. Serialize one inspection/role pair and update the newest existing
+-- signature, or insert the first one.
+create or replace function public.sign_inspection(
+  p_inspection_id uuid,
+  p_role text,
+  p_signed_name text,
+  p_signature_image_path text default null,
+  p_signature_hash text default null
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor uuid := auth.uid();
+  v_shop_id uuid;
+  v_signature_id uuid;
+  v_signed_name text := nullif(trim(p_signed_name), '');
+  v_signature_image_path text := nullif(trim(p_signature_image_path), '');
+  v_signature_hash text := nullif(trim(p_signature_hash), '');
+begin
+  if v_actor is null then
+    raise exception using errcode = '42501', message = 'Authentication required.';
+  end if;
+
+  if p_role not in ('technician', 'customer', 'advisor') then
+    raise exception using errcode = '22023', message = 'Unsupported signature role.';
+  end if;
+
+  select i.shop_id
+    into v_shop_id
+  from public.inspections i
+  where i.id = p_inspection_id
+  for update;
+
+  if v_shop_id is null then
+    raise exception using errcode = 'P0001', message = 'Inspection not found.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles p
+    where p.id = v_actor
+      and p.shop_id = v_shop_id
+  ) then
+    raise exception using errcode = '42501',
+      message = 'Inspection does not belong to your shop.';
+  end if;
+
+  if p_role = 'technician' then
+    select
+      coalesce(
+        nullif(trim(p.full_name), ''),
+        nullif(trim(concat_ws(' ', p.first_name, p.last_name)), '')
+      ),
+      nullif(trim(p.tech_signature_path), ''),
+      nullif(trim(p.tech_signature_hash), '')
+      into v_signed_name, v_signature_image_path, v_signature_hash
+    from public.profiles p
+    where p.id = v_actor;
+
+    if v_signed_name is null then
+      raise exception using errcode = 'P0001',
+        message = 'Add your full name to your profile before signing.';
+    end if;
+
+    if v_signature_image_path is null then
+      raise exception using errcode = 'P0001',
+        message = 'No saved technician signature. Add one in Tech Settings.';
+    end if;
+  elsif v_signed_name is null then
+    raise exception using errcode = 'P0001', message = 'Signed name is required.';
+  end if;
+
+  perform pg_advisory_xact_lock(
+    hashtextextended(p_inspection_id::text || ':' || p_role, 0)
+  );
+
+  select s.id
+    into v_signature_id
+  from public.inspection_signatures s
+  where s.inspection_id = p_inspection_id
+    and s.role = p_role
+  order by s.signed_at desc, s.id desc
+  limit 1
+  for update;
+
+  if found then
+    update public.inspection_signatures
+    set signed_by = v_actor,
+        signed_name = v_signed_name,
+        signature_image_path = v_signature_image_path,
+        signature_hash = v_signature_hash,
+        signed_at = now()
+    where id = v_signature_id;
+  else
+    insert into public.inspection_signatures(
+      inspection_id,
+      role,
+      signed_by,
+      signed_name,
+      signature_image_path,
+      signature_hash,
+      signed_at
+    ) values (
+      p_inspection_id,
+      p_role,
+      v_actor,
+      v_signed_name,
+      v_signature_image_path,
+      v_signature_hash,
+      now()
+    );
+  end if;
+
+  update public.inspections
+  set is_draft = false,
+      completed = true,
+      locked = true,
+      status = 'completed',
+      finalized_at = coalesce(finalized_at, now()),
+      finalized_by = coalesce(finalized_by, v_actor),
+      updated_at = now()
+  where id = p_inspection_id;
+end;
+$$;
+
+revoke all on function public.sign_inspection(uuid, text, text, text, text)
+  from public;
+grant execute on function public.sign_inspection(uuid, text, text, text, text)
+  to authenticated, service_role;
+
+-- Realtime is needed for another signed-in device to receive progress and lock
+-- changes without polling. Add tables only when they are not already members.
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'inspection_sessions'
+  ) then
+    alter publication supabase_realtime add table public.inspection_sessions;
+  end if;
+
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'inspections'
+  ) then
+    alter publication supabase_realtime add table public.inspections;
+  end if;
+end;
+$$;
+
+notify pgrst, 'reload schema';
+commit;

--- a/tests/inspection-autosave-realtime-signatures.test.ts
+++ b/tests/inspection-autosave-realtime-signatures.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const autosaveHook = readFileSync(
+  "features/inspections/hooks/useInspectionRealtimeAutosave.tsx",
+  "utf8",
+);
+const genericScreen = readFileSync(
+  "features/inspections/screens/GenericInspectionScreen.tsx",
+  "utf8",
+);
+const reviewPanel = readFileSync(
+  "features/inspections/components/inspection/InspectionReviewPanel.tsx",
+  "utf8",
+);
+const signaturePanel = readFileSync(
+  "features/inspections/components/inspection/InspectionSignaturePanel.tsx",
+  "utf8",
+);
+const signRoute = readFileSync("app/api/inspections/sign/route.ts", "utf8");
+const loadRoute = readFileSync("app/api/inspections/load/route.ts", "utf8");
+const migration = readFileSync(
+  "supabase/migrations/20260721143000_inspection_autosave_realtime_signatures.sql",
+  "utf8",
+);
+const desktopSettings = readFileSync(
+  "app/dashboard/tech/settings/page.tsx",
+  "utf8",
+);
+const mobileSettings = readFileSync(
+  "features/mobile/settings/MobileSettingsScreen.tsx",
+  "utf8",
+);
+
+describe("inspection autosave, realtime, and signatures", () => {
+  it("debounces every session update into the canonical server writer", () => {
+    expect(autosaveHook).toContain("saveInspectionSession(session, workOrderLineId)");
+    expect(autosaveHook).toContain("debounceMs = 800");
+    expect(genericScreen).toContain("useInspectionRealtimeAutosave");
+    expect(genericScreen).not.toContain("SaveInspectionButton");
+    expect(reviewPanel).not.toContain("SaveInspectionButton");
+  });
+
+  it("subscribes to cross-device progress and lock changes", () => {
+    expect(autosaveHook).toContain('table: "inspection_sessions"');
+    expect(autosaveHook).toContain('table: "inspections"');
+    expect(autosaveHook).toContain("onRemoteSessionRef.current(value)");
+    expect(loadRoute).toContain("Boolean(inspectionRow?.locked)");
+    expect(migration).toContain(
+      "alter publication supabase_realtime add table public.inspection_sessions",
+    );
+    expect(migration).toContain(
+      "alter publication supabase_realtime add table public.inspections",
+    );
+  });
+
+  it("keeps technician signature identity and image server-owned", () => {
+    expect(signRoute).toContain(
+      "tech_signature_path, tech_signature_hash",
+    );
+    expect(signRoute).toContain(
+      'role === "technician" ? profile?.tech_signature_path',
+    );
+    expect(signaturePanel).not.toContain("fetchSavedTechSignature");
+    expect(signaturePanel).not.toContain("signatureImagePath,");
+    expect(migration).toContain("if p_role = 'technician' then");
+    expect(migration).toContain("p.tech_signature_path");
+  });
+
+  it("does not require a missing upsert conflict target while signing", () => {
+    const signingFunction = migration.slice(
+      migration.indexOf("create or replace function public.sign_inspection"),
+    );
+    expect(signingFunction).toContain("pg_advisory_xact_lock");
+    expect(signingFunction).toContain("select s.id");
+    expect(signingFunction).not.toContain("on conflict");
+  });
+
+  it("uses content-addressed signature paths for historical integrity", () => {
+    const expected = "tech-signatures/${profileId}/${hash}.png";
+    expect(desktopSettings).toContain(expected);
+    expect(mobileSettings).toContain(expected);
+  });
+});


### PR DESCRIPTION
## What changed

- replaces manual inspection saving with debounced server autosave on generic, quick PM, and quick air-brake inspection surfaces
- keeps the existing offline queue and shows a small autosave/sync state instead of a Save Progress button
- subscribes to `inspection_sessions` and `inspections` realtime updates so another signed-in device receives progress and lock changes
- loads the canonical newest server inspection/session and returns the real database lock state
- makes technician signing server-owned: the API and RPC resolve the signed-in technician's profile name, saved signature path, and hash
- replaces the fragile signature `ON CONFLICT` assumption with a serialized update-or-insert RPC
- locks/finalizes the inspection in the database after signing, rather than only in local storage
- stores new profile signatures at immutable, content-addressed paths so updating a profile signature does not change historical inspections
- adds a forward migration for the repaired draft writer, signing RPC, and realtime publication membership
- adds contract tests covering autosave, realtime, signature ownership, and immutable signature paths

## Root cause

The inspection editor only persisted each edit to browser storage. Server persistence happened only through the manual Save Progress button, so other devices could not see live work. Signing also trusted signature fields supplied by the browser, and the database RPC used an upsert conflict target that production did not define. The post-sign lock was local-only.

## Validation

- inspected the branch diff against `main` (14 commits, 13 scoped files, no unrelated changes)
- parsed all changed TypeScript/TSX files with Prettier
- ran a TypeScript no-resolve syntax/semantic pass; corrected the one actionable discriminated-union narrowing issue
- added `tests/inspection-autosave-realtime-signatures.test.ts`
- full repository lint/type/test/build is deferred to GitHub Actions because this workspace has no checkout or project dependencies
