### PR TITLE
Fix active work status and inspection parts flow

### DIFF
--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -228,14 +228,12 @@ export async function POST(req: NextRequest) {
   const profileResult = await supabase
     .from("profiles")
     .select(
-      "shop_id, full_name, first_name, last_name, tech_signature_path, tech_signature_hash",
+      "shop_id, full_name, tech_signature_path, tech_signature_hash",
     )
     .eq("id", user.id)
     .maybeSingle<{
       shop_id: string | null;
       full_name: string | null;
-      first_name: string | null;
-      last_name: string | null;
       tech_signature_path: string | null;
       tech_signature_hash: string | null;
     }>();
@@ -256,9 +254,13 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const profileName =
-    (profile?.full_name ?? "").trim() ||
-    `${profile?.first_name ?? ""} ${profile?.last_name ?? ""}`.trim();
+  const authMetadataName =
+    typeof user.user_metadata?.full_name === "string"
+      ? user.user_metadata.full_name.trim()
+      : typeof user.user_metadata?.name === "string"
+        ? user.user_metadata.name.trim()
+        : "";
+  const profileName = (profile?.full_name ?? "").trim() || authMetadataName;
   const effectiveSignedName =
     role === "technician" ? profileName : signedName.trim();
 

--- a/features/inspections/lib/inspection/SectionDisplay.tsx
+++ b/features/inspections/lib/inspection/SectionDisplay.tsx
@@ -59,6 +59,12 @@ interface SectionDisplayProps {
     hours: number | null,
   ) => void;
 
+  onUpdateNoPartsRequired?: (
+    sectionIndex: number,
+    itemIndex: number,
+    noPartsRequired: boolean,
+  ) => void;
+
   /** Optional external collapse control (used by sticky header). */
   isCollapsed?: boolean;
   onToggleCollapse?: (sectionIndex: number) => void;
@@ -92,6 +98,7 @@ type ItemExtended = InspectionSection["items"][number] & {
   // parts + labor
   parts?: PartRow[];
   laborHours?: number | null;
+  noPartsRequired?: boolean;
 };
 
 function isGridSection(title: string): boolean {
@@ -181,6 +188,7 @@ export default function SectionDisplay(props: SectionDisplayProps) {
     onDismissSmartMatch,
     onUpdateParts,
     onUpdateLaborHours,
+    onUpdateNoPartsRequired,
     isCollapsed,
     onToggleCollapse,
   } = props;
@@ -227,7 +235,8 @@ export default function SectionDisplay(props: SectionDisplayProps) {
 
   const canEditPartsLabor =
     typeof onUpdateParts === "function" ||
-    typeof onUpdateLaborHours === "function";
+    typeof onUpdateLaborHours === "function" ||
+    typeof onUpdateNoPartsRequired === "function";
 
   // ✅ per-item UI state: collapse + edit
   const [partsOpenByKey, setPartsOpenByKey] = useState<Record<string, boolean>>(
@@ -554,9 +563,34 @@ export default function SectionDisplay(props: SectionDisplayProps) {
 
                         const currentParts = getParts(item);
                         const currentLabor = getLaborHours(item);
+                        const noPartsRequired = item.noPartsRequired === true;
 
                         const handlePartsChange = (parts: PartRow[]) => {
                           onUpdateParts?.(sectionIndex, itemIndex, parts);
+                          if (
+                            parts.some(
+                              (part) =>
+                                part.description.trim().length > 0 || part.qty > 0,
+                            )
+                          ) {
+                            onUpdateNoPartsRequired?.(
+                              sectionIndex,
+                              itemIndex,
+                              false,
+                            );
+                          }
+                        };
+
+                        const handleNoPartsRequiredChange = (checked: boolean) => {
+                          if (checked) {
+                            clearQtyDraftPrefix(`${k}:part:`);
+                            onUpdateParts?.(sectionIndex, itemIndex, []);
+                          }
+                          onUpdateNoPartsRequired?.(
+                            sectionIndex,
+                            itemIndex,
+                            checked,
+                          );
                         };
 
                         const handleLaborChange = (hours: number | null) => {
@@ -653,6 +687,26 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                                 )}
                               </div>
                             </div>
+
+                            <label className="mb-2 flex min-h-10 cursor-pointer items-center gap-2 rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-2 text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
+                              <input
+                                type="checkbox"
+                                checked={noPartsRequired}
+                                disabled={lockInputs}
+                                onChange={(event) =>
+                                  handleNoPartsRequiredChange(
+                                    event.currentTarget.checked,
+                                  )
+                                }
+                                className="h-4 w-4 rounded border-[color:var(--theme-border-soft)] accent-[var(--brand-primary,#C1663B)]"
+                              />
+                              <span>
+                                No parts required
+                                <span className="ml-2 font-normal text-[color:var(--theme-text-muted)]">
+                                  Blank parts also skip Parts workflow.
+                                </span>
+                              </span>
+                            </label>
 
                             {partsOpen && (
                               <>
@@ -763,12 +817,12 @@ export default function SectionDisplay(props: SectionDisplayProps) {
 
                                   <button
                                     type="button"
-                                    disabled={lockInputs}
+                                    disabled={lockInputs || noPartsRequired}
                                     onClick={addEmptyPart}
                                     className={[
                                       "mt-1 inline-flex items-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)]",
                                       "hover:border-accent/80 hover:text-accent",
-                                      lockInputs
+                                      lockInputs || noPartsRequired
                                         ? "opacity-50 cursor-not-allowed hover:border-[color:var(--theme-border-soft)] hover:text-[color:var(--theme-text-primary)]"
                                         : "",
                                     ].join(" ")}

--- a/features/inspections/lib/inspection/addWorkOrderLine.ts
+++ b/features/inspections/lib/inspection/addWorkOrderLine.ts
@@ -74,6 +74,7 @@ export async function addWorkOrderLineFromSuggestion(args: {
     notes: part.notes ?? null,
   }));
 
+  const hasParts = parts.length > 0;
   const partsTotal = parts.reduce(
     (sum, part) => sum + (typeof part.cost === "number" ? part.cost * part.qty : 0),
     0,
@@ -96,7 +97,7 @@ export async function addWorkOrderLineFromSuggestion(args: {
           description: args.description,
           source: args.source ?? "inspection",
           sourceSectionTitle: args.section ?? null,
-          status: "pending_parts",
+          status: hasParts ? "pending_parts" : "advisor_pending",
           stage: "advisor_pending",
           complaint: derivedComplaint || null,
           notes: derivedComplaint || null,
@@ -118,6 +119,8 @@ export async function addWorkOrderLineFromSuggestion(args: {
           metadata: {
             helper: "addWorkOrderLineFromSuggestion",
             helper_behavior: "creates_work_order_quote_lines_not_work_order_lines",
+            parts_required: hasParts,
+            no_parts_required: !hasParts,
           },
         },
       ],

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -2122,6 +2122,7 @@ type SmartMatchRow = {
     const itExt = it as unknown as {
       parts?: { description: string; qty: number }[];
       laborHours?: number | null;
+      noPartsRequired?: boolean;
       name?: string | null;
 
       // ✅ estimate state (persisted on the item)
@@ -2142,6 +2143,7 @@ type SmartMatchRow = {
 
     const manualLaborHours =
       typeof itExt.laborHours === "number" ? itExt.laborHours : null;
+    const noPartsRequired = itExt.noPartsRequired === true;
 
     inFlightRef.current.add(key);
 
@@ -2255,6 +2257,7 @@ type SmartMatchRow = {
           .filter((p) => p.description.length > 0 && p.qty > 0);
 
         let createdJobId: string | null = null;
+        let createdQuoteLineId: string | null = existingQuoteId;
 
         if (existingLineId) {
           const updateRes = await fetch(
@@ -2318,7 +2321,12 @@ type SmartMatchRow = {
             complaint,
             suggestion: {
               ...suggestion,
-              parts: mergedParts,
+              parts: noPartsRequired
+                ? []
+                : cleanParts.map((part) => ({
+                    name: part.description,
+                    qty: part.qty,
+                  })),
               laborHours: laborTime,
               notes: complaint ?? undefined,
             },
@@ -2327,8 +2335,11 @@ type SmartMatchRow = {
           });
 
           const createdId = (created as unknown as { id?: unknown })?.id;
-          createdJobId =
-            (createdId ? String(createdId) : null) || workOrderLineId || null;
+          createdQuoteLineId = createdId ? String(createdId) : null;
+
+          if (!createdQuoteLineId) {
+            throw new Error("Quote line created without an id");
+          }
 
           updateInspection({
             voiceMeta: {
@@ -2337,54 +2348,22 @@ type SmartMatchRow = {
             } satisfies VoiceMeta,
           });
 
-          if (cleanParts.length > 0) {
-            try {
-              const res = await fetch("/api/parts/requests/create", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  workOrderId,
-                  jobId: createdJobId,
-                  notes: String(it.notes ?? "") || null,
-                  items: cleanParts,
-                }),
-              });
-
-              if (!res.ok) {
-                const body = (await res.json().catch(() => null)) as unknown;
-                // eslint-disable-next-line no-console
-                console.error("Parts request error", body);
-                toast.error("Line added, but parts request failed", {
-                  id: toastId,
-                });
-                return;
-              }
-
-              toast.success("Line + parts request created from inspection", {
-                id: toastId,
-              });
-            } catch (err: unknown) {
-              // eslint-disable-next-line no-console
-              console.error("Parts request failed", err);
-              toast.error("Line added, but couldn't reach parts request service", {
-                id: toastId,
-              });
-              return;
-            }
-          } else {
-            toast.success("Added to work order (no parts requested)", {
-              id: toastId,
-            });
-          }
+          toast.success(
+            cleanParts.length > 0 && !noPartsRequired
+              ? "Added to Quote Review with parts request"
+              : "Added to Quote Review — no parts required",
+            { id: toastId },
+          );
         }
 
-        if (createdJobId) {
+        if (createdJobId || createdQuoteLineId) {
           updateItem(secIdx, itemIdx, {
             estimateSubmitted: true,
             estimateSubmittedAt: itExt.estimateSubmittedAt ?? nowIso,
             estimateLastUpdatedAt: nowIso,
             estimateWorkOrderLineId: createdJobId,
-            estimateQuoteLineId: quoteId,
+            estimateQuoteLineId: createdQuoteLineId ?? quoteId,
+            noPartsRequired: noPartsRequired || cleanParts.length === 0,
           } as ItemPatch);
         }
       } else {
@@ -3299,6 +3278,17 @@ type SmartMatchRow = {
                                 laborHours: hours,
                               } as ItemPatch);
                             }}
+                            onUpdateNoPartsRequired={(
+                              secIdx: number,
+                              itemIdx: number,
+                              value: boolean,
+                            ) => {
+                              if (guardLocked()) return;
+                              updateItem(secIdx, itemIdx, {
+                                noPartsRequired: value,
+                                ...(value ? { parts: [] } : {}),
+                              } as ItemPatch);
+                            }}
                             requireNoteForAI
                             onSubmitAI={(secIdx: number, itemIdx: number) => {
                               void submitAIForItem(secIdx, itemIdx);
@@ -3408,7 +3398,7 @@ type SmartMatchRow = {
         <div className="mx-auto flex max-w-[1240px] flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="grid grid-cols-2 gap-2 [&>*]:w-full [&>*:last-child:nth-child(odd)]:col-span-2 sm:flex sm:flex-wrap sm:items-center sm:[&>*]:w-auto">{actions}</div>
           <div className="order-first text-[10px] font-medium text-[color:var(--theme-text-secondary)] sm:order-none">
-            Draft auto-saves locally
+            Saved to shop • syncs across devices
           </div>
         </div>
       </div>

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -2212,14 +2212,15 @@ type SmartMatchRow = {
         return;
       }
 
-      const mergedParts: Array<{ name: string; qty: number; cost?: number }> = [
-        ...((suggestion.parts ?? []) as Array<{
-          name: string;
-          qty: number;
-          cost?: number;
-        }>),
-        ...manualParts.map((p) => ({ name: p.description, qty: p.qty })),
-      ];
+      const mergedParts: Array<{ name: string; qty: number; cost?: number }> =
+        noPartsRequired
+          ? []
+          : manualParts
+              .map((part) => ({
+                name: String(part.description ?? "").trim(),
+                qty: Number(part.qty ?? 0),
+              }))
+              .filter((part) => part.name.length > 0 && part.qty > 0);
 
       const laborTime =
         manualLaborHours != null && !Number.isNaN(manualLaborHours)
@@ -2328,6 +2329,7 @@ type SmartMatchRow = {
                     qty: part.qty,
                   })),
               laborHours: laborTime,
+              price: Math.max(0, laborRate * laborTime),
               notes: complaint ?? undefined,
             },
             source: "inspection",

--- a/features/shared/hooks/useWorkOrderBoard.ts
+++ b/features/shared/hooks/useWorkOrderBoard.ts
@@ -52,7 +52,35 @@ export function useWorkOrderBoard(
       return;
     }
 
-    setRows((data ?? []) as WorkOrderBoardRow[]);
+    const boardRows = (data ?? []) as WorkOrderBoardRow[];
+
+    if (variant !== "shop" || boardRows.length === 0) {
+      setRows(boardRows);
+      setLoading(false);
+      return;
+    }
+
+    const workOrderIds = boardRows.map((row) => row.work_order_id);
+    const { data: activeSegments } = await supabase
+      .from("work_order_line_labor_segments")
+      .select("work_order_id")
+      .in("work_order_id", workOrderIds)
+      .is("ended_at", null);
+
+    const activeWorkOrderIds = new Set(
+      (activeSegments ?? [])
+        .map((segment) => segment.work_order_id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    );
+
+    setRows(
+      boardRows.map((row) =>
+        activeWorkOrderIds.has(row.work_order_id) &&
+        row.overall_stage !== "completed"
+          ? { ...row, overall_stage: "in_progress" }
+          : row,
+      ),
+    );
     setLoading(false);
   }, [opts?.fleetId, opts?.limit, supabase, variant]);
 
@@ -69,6 +97,15 @@ export function useWorkOrderBoard(
       .on(
         "postgres_changes",
         { event: "*", schema: "public", table: "work_order_lines" },
+        () => fetchRows(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "work_order_line_labor_segments",
+        },
         () => fetchRows(),
       )
       .on(

--- a/tests/inspection-active-work-parts-regressions.test.ts
+++ b/tests/inspection-active-work-parts-regressions.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const signRoute = readFileSync("app/api/inspections/sign/route.ts", "utf8");
+const boardHook = readFileSync(
+  "features/shared/hooks/useWorkOrderBoard.ts",
+  "utf8",
+);
+const sectionDisplay = readFileSync(
+  "features/inspections/lib/inspection/SectionDisplay.tsx",
+  "utf8",
+);
+const genericScreen = readFileSync(
+  "features/inspections/screens/GenericInspectionScreen.tsx",
+  "utf8",
+);
+const quoteHelper = readFileSync(
+  "features/inspections/lib/inspection/addWorkOrderLine.ts",
+  "utf8",
+);
+
+describe("active work and inspection parts regressions", () => {
+  it("reads only real profile columns while signing", () => {
+    expect(signRoute).toContain(
+      "shop_id, full_name, tech_signature_path, tech_signature_hash",
+    );
+    expect(signRoute).not.toContain("first_name");
+    expect(signRoute).not.toContain("last_name");
+    expect(signRoute).toContain("user.user_metadata?.full_name");
+  });
+
+  it("treats an active labor segment as authoritative in-progress work", () => {
+    expect(boardHook).toContain('"work_order_line_labor_segments"');
+    expect(boardHook).toContain('.is("ended_at", null)');
+    expect(boardHook).toContain('overall_stage: "in_progress"');
+    expect(boardHook).toContain('table: "work_order_line_labor_segments"');
+  });
+
+  it("offers an explicit no-parts-required inspection choice", () => {
+    expect(sectionDisplay).toContain("No parts required");
+    expect(sectionDisplay).toContain("Blank parts also skip Parts workflow.");
+    expect(sectionDisplay).toContain("onUpdateNoPartsRequired");
+    expect(genericScreen).toContain("noPartsRequired: value");
+  });
+
+  it("starts Parts only from technician-entered valid parts", () => {
+    expect(genericScreen).toContain(
+      "parts: noPartsRequired\n                ? []\n                : cleanParts.map",
+    );
+    expect(quoteHelper).toContain(
+      'status: hasParts ? "pending_parts" : "advisor_pending"',
+    );
+    expect(quoteHelper).toContain("no_parts_required: !hasParts");
+    expect(
+      genericScreen.match(/\/api\/parts\/requests\/create/g) ?? [],
+    ).toHaveLength(1);
+  });
+
+  it("stores the canonical quote-line identity for new findings", () => {
+    expect(genericScreen).toContain(
+      "createdQuoteLineId = createdId ? String(createdId) : null",
+    );
+    expect(genericScreen).toContain(
+      "estimateQuoteLineId: createdQuoteLineId ?? quoteId",
+    );
+    expect(genericScreen).toContain(
+      "Saved to shop • syncs across devices",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- fixes technician inspection signing by removing the invalid `profiles.first_name` / `last_name` query and retaining server-owned identity/signature resolution
- treats an open labor segment as authoritative in-progress work on the shop Work Order Board and refreshes the board live when punches change
- adds a clear **No parts required** control to failed/recommended inspection findings
- makes blank parts equivalent to no parts required: the quote goes to advisor review without entering Parts
- sends only manually entered, valid parts into the canonical parts request flow; AI-suggested parts no longer silently create requests
- removes the duplicate parts-request call for new inspection quote lines
- stores the actual canonical quote-line ID on the inspection finding instead of treating it as a work-order line ID
- updates the inspection footer to describe server/device synchronization accurately
- adds focused regression coverage for all three reported failures

## Root causes

1. The merged signing route selected profile columns that do not exist in production.
2. The board view stage did not account for the canonical active labor segment, so EL000005 could be punched in while still shown under Awaiting.
3. The inspection helper always labeled new findings `pending_parts` and passed AI-suggested parts to the canonical quote creator, even when the technician left Parts blank. New findings then also made a second parts-request call.

## Validation

- compared the complete branch against current `main`: 6 scoped files, 7 commits, no unrelated changes
- performed source-level checks of the changed TypeScript/TSX and the new Vitest regression contract
- full repository typecheck/test/build is deferred to CI because this workspace has no repository checkout or dependencies

## Deployment note

No new migration is included. The previously merged autosave migration `supabase/migrations/20260721143000_inspection_autosave_realtime_signatures.sql` must be applied in Supabase. Until it is applied, server autosave will continue to report that it needs attention.
