### PR TITLE
Harden inspection autosave and profile-backed signing

### DIFF
--- a/app/api/inspections/finalize/pdf/route.ts
+++ b/app/api/inspections/finalize/pdf/route.ts
@@ -3,8 +3,10 @@ import "server-only";
 
 export const runtime = "nodejs";
 
+import { createHash } from "node:crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
 import type { Database, Json } from "@shared/types/types/supabase";
 import { generateInspectionPDF } from "@/features/inspections/lib/inspection/pdf";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
@@ -12,10 +14,44 @@ import type { InspectionSession } from "@/features/inspections/lib/inspection/ty
 
 type DB = Database;
 
-type Body = { workOrderLineId?: string };
+type Body = {
+  workOrderLineId?: string;
+  expectedSyncRevision?: number;
+};
+
+type FinalizeInspectionArgs = {
+  p_inspection_id: string;
+  p_work_order_line_id: string;
+  p_actor_user_id: string;
+  p_expected_sync_revision: number;
+  p_pdf_storage_path: string;
+  p_pdf_sha256: string;
+  p_pdf_url: string | null;
+};
+
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
+type FinalizeRpcClient = {
+  rpc: (
+    name: "finalize_inspection_pdf_atomic",
+    args: FinalizeInspectionArgs,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
 
 function isRecord(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null;
+}
+
+function isStorageAlreadyExistsError(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  const status = Number(error.statusCode ?? error.status);
+  const message = [error.message, error.error]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+  return status === 409 || /already exists|duplicate/i.test(message);
 }
 
 function asString(x: unknown): string | null {
@@ -36,8 +72,22 @@ export async function POST(req: NextRequest) {
   }
 
   const workOrderLineId = asString((raw as Body).workOrderLineId);
+  const expectedSyncRevision = (raw as Body).expectedSyncRevision;
   if (!workOrderLineId) {
-    return NextResponse.json({ error: "Missing workOrderLineId" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Missing workOrderLineId" },
+      { status: 400 },
+    );
+  }
+  if (
+    typeof expectedSyncRevision !== "number" ||
+    !Number.isSafeInteger(expectedSyncRevision) ||
+    expectedSyncRevision < 1
+  ) {
+    return NextResponse.json(
+      { error: "Missing or invalid expectedSyncRevision" },
+      { status: 400 },
+    );
   }
 
   // 2) Auth
@@ -64,110 +114,148 @@ export async function POST(req: NextRequest) {
   if (lineErr) {
     // eslint-disable-next-line no-console
     console.error("[inspections/finalize/pdf] line lookup failed", lineErr);
-    return NextResponse.json({ error: "Failed to look up work order line" }, { status: 500 });
+    return NextResponse.json(
+      { error: "Failed to look up work order line" },
+      { status: 500 },
+    );
   }
 
   const workOrderId = asString(line?.work_order_id);
   const shopId = asString(line?.work_orders?.shop_id);
 
   if (!workOrderId) {
-    return NextResponse.json({ error: "Work order line missing work_order_id" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Work order line missing work_order_id" },
+      { status: 400 },
+    );
   }
   if (!shopId) {
-    return NextResponse.json({ error: "Work order line missing shop_id" }, { status: 400 });
-  }
-
-  // ✅ Ensure Storage policy can evaluate current_shop_id()
-  // If your policy uses current_shop_id(), this MUST be set server-side.
-  const { error: ctxErr } = await supabase.rpc("set_current_shop_id", { p_shop_id: shopId });
-  if (ctxErr) {
-    // eslint-disable-next-line no-console
-    console.error("[inspections/finalize/pdf] set_current_shop_id failed", ctxErr);
     return NextResponse.json(
-      { error: ctxErr.message || "Failed to set shop context" },
-      { status: 500 },
+      { error: "Work order line missing shop_id" },
+      { status: 400 },
     );
   }
 
-  const nowIso = new Date().toISOString();
+  const { data: profile, error: profileErr } = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null }>();
 
-  // 4) Load inspection summary + ensure canonical inspections row exists
-  //    - First try inspections.summary
-  //    - Fallback to inspection_sessions.state
-  //    - If inspections row doesn't exist, UPSERT it (draft first, then finalize below)
+  if (profileErr || profile?.shop_id !== shopId) {
+    return NextResponse.json(
+      { error: profileErr?.message ?? "Forbidden" },
+      { status: 403 },
+    );
+  }
 
+  // Storage requests run in a separate transaction, so a transaction-local
+  // shop GUC cannot authorize them. Scope is verified above; the admin client
+  // is used only for this exact tenant-derived object path.
+  const storageSupabase = createAdminClient();
+
+  // 4) Autosave creates the canonical draft. Finalization reads the newest
+  // deterministic row and never relies on a production uniqueness constraint.
   const { data: insp, error: inspErr } = await supabase
     .from("inspections")
-    .select("id, work_order_id, work_order_line_id, summary, pdf_storage_path")
+    .select(
+      "id, work_order_id, work_order_line_id, summary, pdf_storage_path, updated_at, locked, completed, is_draft",
+    )
     .eq("work_order_line_id", workOrderLineId)
+    .eq("shop_id", shopId)
+    .order("updated_at", { ascending: false, nullsFirst: false })
+    .order("id", { ascending: false })
+    .limit(1)
     .maybeSingle<
       Pick<
         DB["public"]["Tables"]["inspections"]["Row"],
-        "id" | "work_order_id" | "work_order_line_id" | "summary" | "pdf_storage_path"
+        | "id"
+        | "work_order_id"
+        | "work_order_line_id"
+        | "summary"
+        | "pdf_storage_path"
+        | "updated_at"
+        | "locked"
+        | "completed"
+        | "is_draft"
       >
     >();
 
   if (inspErr) {
     // eslint-disable-next-line no-console
-    console.error("[inspections/finalize/pdf] inspections lookup failed", inspErr);
-    return NextResponse.json({ error: "Failed to load inspection" }, { status: 500 });
+    console.error(
+      "[inspections/finalize/pdf] inspections lookup failed",
+      inspErr,
+    );
+    return NextResponse.json(
+      { error: "Failed to load inspection" },
+      { status: 500 },
+    );
   }
 
-  let summary = (insp?.summary ?? null) as unknown as InspectionSession | null;
+  if (!insp?.id) {
+    return NextResponse.json(
+      { error: "Inspection has not finished autosaving yet. Try again." },
+      { status: 409 },
+    );
+  }
+  if (insp.locked || insp.completed || insp.is_draft === false) {
+    return NextResponse.json(
+      { error: "Inspection is already finalized and locked." },
+      { status: 409 },
+    );
+  }
+
+  let summary = (insp.summary ?? null) as unknown as InspectionSession | null;
 
   if (!summary) {
     const { data: sess, error: sessErr } = await supabase
       .from("inspection_sessions")
       .select("state")
       .eq("work_order_line_id", workOrderLineId)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .order("id", { ascending: false })
+      .limit(1)
       .maybeSingle<{ state: Json | null }>();
 
     if (sessErr) {
       // eslint-disable-next-line no-console
-      console.error("[inspections/finalize/pdf] session lookup failed", sessErr);
-      return NextResponse.json({ error: "Inspection session missing" }, { status: 404 });
+      console.error(
+        "[inspections/finalize/pdf] session lookup failed",
+        sessErr,
+      );
+      return NextResponse.json(
+        { error: "Inspection session missing" },
+        { status: 404 },
+      );
     }
 
     summary = (sess?.state ?? null) as unknown as InspectionSession | null;
   }
 
   if (!summary || typeof summary !== "object") {
-    return NextResponse.json({ error: "Inspection summary missing/invalid" }, { status: 400 });
-  }
-
-  // ✅ Ensure inspections row exists (UPSERT by work_order_line_id)
-  // This makes finalize idempotent and guarantees invoice/email can attach.
-  const { data: ensured, error: ensureErr } = await supabase
-    .from("inspections")
-    .upsert(
-      {
-        work_order_id: workOrderId,
-        work_order_line_id: workOrderLineId,
-        shop_id: shopId,
-        user_id: user.id,
-        summary: summary as unknown as Json,
-        // keep it draft until PDF upload succeeds
-        is_draft: true,
-        completed: false,
-        locked: false,
-        status: "draft",
-        updated_at: nowIso,
-      } satisfies DB["public"]["Tables"]["inspections"]["Insert"],
-      { onConflict: "work_order_line_id" },
-    )
-    .select("id, pdf_storage_path")
-    .single<{ id: string; pdf_storage_path: string | null }>();
-
-  if (ensureErr || !ensured?.id) {
-    // eslint-disable-next-line no-console
-    console.error("[inspections/finalize/pdf] inspections upsert failed", ensureErr);
     return NextResponse.json(
-      { error: ensureErr?.message ?? "Failed to create inspection record" },
-      { status: 500 },
+      { error: "Inspection summary missing/invalid" },
+      { status: 400 },
     );
   }
 
-  const inspectionId = ensured.id;
+  const summaryRevision =
+    typeof summary.syncRevision === "number" &&
+    Number.isFinite(summary.syncRevision)
+      ? Math.max(0, Math.trunc(summary.syncRevision))
+      : 0;
+  if (summaryRevision !== expectedSyncRevision) {
+    return NextResponse.json(
+      {
+        error:
+          "Inspection changed on another device. Review the latest version and finalize again.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const inspectionId = insp.id;
   const brand = await getActiveBrandForRender(shopId);
 
   // 5) Generate PDF
@@ -176,6 +264,8 @@ export async function POST(req: NextRequest) {
     shopName: null,
     colors: brand.colors,
   });
+  const pdfBuffer = Buffer.from(pdfBytes);
+  const pdfHash = createHash("sha256").update(pdfBuffer).digest("hex");
 
   // 6) Upload to storage (Policy-based: path includes shop id)
   const bucket = "inspection_pdfs";
@@ -184,13 +274,13 @@ export async function POST(req: NextRequest) {
   const inspPart = safeFilePart(String(inspectionId));
   const linePart = safeFilePart(workOrderLineId);
 
-  const path = `shops/${shopPart}/work_orders/${woPart}/inspections/${inspPart}/line_${linePart}.pdf`;
+  const path = `shops/${shopPart}/work_orders/${woPart}/inspections/${inspPart}/line_${linePart}_r${summaryRevision}_${pdfHash}.pdf`;
 
-  const { error: uploadErr } = await supabase.storage
+  const { error: uploadErr } = await storageSupabase.storage
     .from(bucket)
-    .upload(path, Buffer.from(pdfBytes), { contentType: "application/pdf", upsert: true });
+    .upload(path, pdfBuffer, { contentType: "application/pdf", upsert: false });
 
-  if (uploadErr) {
+  if (uploadErr && !isStorageAlreadyExistsError(uploadErr)) {
     // eslint-disable-next-line no-console
     console.error("[inspections/finalize/pdf] upload failed", {
       message: uploadErr.message,
@@ -216,39 +306,53 @@ export async function POST(req: NextRequest) {
   }
 
   // Optional: signed URL for quick-open in UI
-  const { data: signed, error: signedErr } = await supabase.storage
+  const { data: signed, error: signedErr } = await storageSupabase.storage
     .from(bucket)
     .createSignedUrl(path, 60 * 60 * 24 * 30);
 
   if (signedErr) {
     // eslint-disable-next-line no-console
-    console.warn("[inspections/finalize/pdf] createSignedUrl failed", signedErr);
+    console.warn(
+      "[inspections/finalize/pdf] createSignedUrl failed",
+      signedErr,
+    );
   }
 
-  const nowIso2 = new Date().toISOString();
+  // 7) Publish the immutable object only if the persisted summary revision is
+  // still the one used to generate it. The RPC locks and rechecks the row.
+  const finalizeRpc = storageSupabase as unknown as FinalizeRpcClient;
+  const { error: finalizeErr } = await finalizeRpc.rpc(
+    "finalize_inspection_pdf_atomic",
+    {
+      p_inspection_id: inspectionId,
+      p_work_order_line_id: workOrderLineId,
+      p_actor_user_id: user.id,
+      p_expected_sync_revision: expectedSyncRevision,
+      p_pdf_storage_path: path,
+      p_pdf_sha256: pdfHash,
+      p_pdf_url: signed?.signedUrl ?? null,
+    },
+  );
 
-  // 7) Update inspections record (mark complete + store PDF path/url)
-  const { error: updErr } = await supabase
-    .from("inspections")
-    .update(
-      {
-        pdf_storage_path: path,
-        pdf_url: signed?.signedUrl ?? null,
-        locked: true,
-        completed: true,
-        is_draft: false,
-        finalized_at: nowIso2,
-        finalized_by: user.id,
-        updated_at: nowIso2,
-        status: "completed",
-      } satisfies DB["public"]["Tables"]["inspections"]["Update"],
-    )
-    .eq("id", inspectionId);
-
-  if (updErr) {
+  if (finalizeErr) {
     // eslint-disable-next-line no-console
-    console.error("[inspections/finalize/pdf] inspections update failed", updErr);
-    return NextResponse.json({ error: updErr.message }, { status: 500 });
+    console.error(
+      "[inspections/finalize/pdf] atomic finalization failed",
+      finalizeErr,
+    );
+    const message = [finalizeErr.message, finalizeErr.details, finalizeErr.hint]
+      .filter(Boolean)
+      .join(" — ");
+    const lower = message.toLowerCase();
+    const status =
+      lower.includes("changed on another device") ||
+      lower.includes("saved inspection revision") ||
+      lower.includes("already finalized") ||
+      lower.includes("locked") ||
+      lower.includes("not found")
+        ? 409
+        : 400;
+    return NextResponse.json({ error: message }, { status });
   }
 
   return NextResponse.json({

--- a/app/api/inspections/load/route.ts
+++ b/app/api/inspections/load/route.ts
@@ -3,6 +3,22 @@ import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server
 import type { Json } from "@shared/types/types/supabase";
 import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
 
+type InspectionRow = {
+  id: string;
+  work_order_id: string | null;
+  work_order_line_id: string | null;
+  summary: Json | null;
+  locked: boolean | null;
+  completed: boolean | null;
+  is_draft: boolean | null;
+  status: string | null;
+  finalized_at: string | null;
+  finalized_by: string | null;
+  reopened_at: string | null;
+  reopened_by: string | null;
+  reopen_reason: string | null;
+  updated_at: string | null;
+};
 
 function asString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0
@@ -12,9 +28,10 @@ function asString(value: unknown): string | null {
 
 export async function GET(req: NextRequest) {
   const supabase = createServerSupabaseRoute();
-
   const inspectionId = asString(req.nextUrl.searchParams.get("inspectionId"));
-  const workOrderLineId = asString(req.nextUrl.searchParams.get("workOrderLineId"));
+  const workOrderLineId = asString(
+    req.nextUrl.searchParams.get("workOrderLineId"),
+  );
 
   if (!inspectionId && !workOrderLineId) {
     return NextResponse.json(
@@ -23,45 +40,85 @@ export async function GET(req: NextRequest) {
     );
   }
 
-  let inspectionRow:
-    | {
-        id: string;
-        work_order_id: string | null;
-        work_order_line_id: string | null;
-        summary: Json | null;
-        locked: boolean | null;
-        finalized_at: string | null;
-        finalized_by: string | null;
-      }
-    | null = null;
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+  if (userError || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-  if (inspectionId) {
-    const { data, error } = await supabase
-      .from("inspections")
-      .select("id, work_order_id, work_order_line_id, summary, locked, finalized_at, finalized_by")
-      .eq("id", inspectionId)
-      .order("updated_at", { ascending: false, nullsFirst: false })
-      .limit(1)
-      .maybeSingle();
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("shop_id")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null }>();
 
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
+  const shopId = profile?.shop_id ?? null;
+  if (profileError || !shopId) {
+    return NextResponse.json(
+      { error: "Unable to resolve actor shop." },
+      { status: 403 },
+    );
+  }
+
+  if (workOrderLineId) {
+    const { data: line, error: lineError } = await supabase
+      .from("work_order_lines")
+      .select("id")
+      .eq("id", workOrderLineId)
+      .eq("shop_id", shopId)
+      .maybeSingle<{ id: string }>();
+
+    if (lineError) {
+      return NextResponse.json({ error: lineError.message }, { status: 500 });
     }
+    if (!line) {
+      return NextResponse.json(
+        { error: "Work-order line was not found for this shop." },
+        { status: 404 },
+      );
+    }
+  }
 
-    inspectionRow = data;
-  } else if (workOrderLineId) {
+  const selectColumns =
+    "id, work_order_id, work_order_line_id, summary, locked, completed, is_draft, status, finalized_at, finalized_by, reopened_at, reopened_by, reopen_reason, updated_at";
+
+  let inspectionRow: InspectionRow | null = null;
+
+  // A work-order line is the canonical identity across devices. Device-local
+  // inspection UUIDs are only a fallback for legacy standalone inspections.
+  if (workOrderLineId) {
     const { data, error } = await supabase
       .from("inspections")
-      .select("id, work_order_id, work_order_line_id, summary, locked, finalized_at, finalized_by")
+      .select(selectColumns)
+      .eq("shop_id", shopId)
       .eq("work_order_line_id", workOrderLineId)
       .order("updated_at", { ascending: false, nullsFirst: false })
+      .order("id", { ascending: false })
       .limit(1)
-      .maybeSingle();
+      .maybeSingle<InspectionRow>();
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+    inspectionRow = data;
+  }
 
+  // When a line is supplied it remains authoritative. Falling back to an
+  // unrelated same-shop UUID can hydrate one job with another job's snapshot.
+  if (!inspectionRow && inspectionId && !workOrderLineId) {
+    const { data, error } = await supabase
+      .from("inspections")
+      .select(selectColumns)
+      .eq("shop_id", shopId)
+      .eq("id", inspectionId)
+      .limit(1)
+      .maybeSingle<InspectionRow>();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
     inspectionRow = data;
   }
 
@@ -72,16 +129,20 @@ export async function GET(req: NextRequest) {
     (inspectionRow?.summary as unknown as InspectionSession | null) ?? null;
 
   if (!session && resolvedWorkOrderLineId) {
-    const { data: sessionRow, error: sessionErr } = await supabase
+    const { data: sessionRow, error: sessionError } = await supabase
       .from("inspection_sessions")
       .select("state")
       .eq("work_order_line_id", resolvedWorkOrderLineId)
       .order("updated_at", { ascending: false, nullsFirst: false })
+      .order("id", { ascending: false })
       .limit(1)
-      .maybeSingle();
+      .maybeSingle<{ state: Json | null }>();
 
-    if (sessionErr) {
-      return NextResponse.json({ error: sessionErr.message }, { status: 500 });
+    if (sessionError) {
+      return NextResponse.json(
+        { error: sessionError.message },
+        { status: 500 },
+      );
     }
 
     session =
@@ -89,20 +150,30 @@ export async function GET(req: NextRequest) {
   }
 
   if (!session) {
-    return NextResponse.json({ session: null }, { status: 200 });
+    return NextResponse.json({
+      session: null,
+      inspectionMeta: inspectionRow
+        ? {
+            locked: Boolean(inspectionRow.locked),
+            completed: Boolean(inspectionRow.completed),
+            isDraft: Boolean(inspectionRow.is_draft),
+            status: inspectionRow.status,
+            finalizedAt: inspectionRow.finalized_at,
+            finalizedBy: inspectionRow.finalized_by,
+            reopenedAt: inspectionRow.reopened_at,
+            reopenedBy: inspectionRow.reopened_by,
+            reopenReason: inspectionRow.reopen_reason,
+            updatedAt: inspectionRow.updated_at,
+          }
+        : null,
+    });
   }
 
-  const hydratedSession = {
+  const hydratedSession: InspectionSession = {
     ...session,
     id: inspectionRow?.id ?? session.id ?? inspectionId ?? "",
-    workOrderId:
-      inspectionRow?.work_order_id ??
-      (session as InspectionSession & { workOrderId?: string | null }).workOrderId ??
-      null,
-    workOrderLineId:
-      resolvedWorkOrderLineId ??
-      ((session as InspectionSession & { workOrderLineId?: string | null })
-        .workOrderLineId ?? null),
+    workOrderId: inspectionRow?.work_order_id ?? session.workOrderId ?? null,
+    workOrderLineId: resolvedWorkOrderLineId ?? session.workOrderLineId ?? null,
   };
 
   return NextResponse.json({
@@ -112,11 +183,15 @@ export async function GET(req: NextRequest) {
     workOrderLineId: hydratedSession.workOrderLineId ?? null,
     inspectionMeta: {
       locked: Boolean(inspectionRow?.locked),
+      completed: Boolean(inspectionRow?.completed),
+      isDraft: Boolean(inspectionRow?.is_draft),
+      status: inspectionRow?.status ?? null,
       finalizedAt: inspectionRow?.finalized_at ?? null,
       finalizedBy: inspectionRow?.finalized_by ?? null,
-      reopenedAt: null,
-      reopenedBy: null,
-      reopenReason: null,
+      reopenedAt: inspectionRow?.reopened_at ?? null,
+      reopenedBy: inspectionRow?.reopened_by ?? null,
+      reopenReason: inspectionRow?.reopen_reason ?? null,
+      updatedAt: inspectionRow?.updated_at ?? null,
     },
   });
 }

--- a/app/api/inspections/reopen/route.ts
+++ b/app/api/inspections/reopen/route.ts
@@ -1,79 +1,83 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 
-const REOPEN_ALLOWED_ROLES = new Set(["admin", "advisor", "owner", "manager"]);
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-function asString(v: unknown): string | null {
-  return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
 }
+
+type ReopenResult = {
+  ok?: boolean;
+  already_open?: boolean;
+  inspection_id?: string;
+  reopened_at?: string;
+  signing_cycle?: number;
+};
+
+type ReopenRpcClient = {
+  rpc: (
+    name: "reopen_inspection",
+    args: { p_inspection_id: string; p_reason: string },
+  ) => Promise<{
+    data: ReopenResult | null;
+    error: { message: string } | null;
+  }>;
+};
 
 export async function POST(req: NextRequest) {
   const supabase = createServerSupabaseRoute();
-
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabase.auth.getUser();
-
-  if (userErr || !user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const userResult = await supabase.auth.getUser();
+  if (userResult.error || !userResult.data.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
   const body = (await req.json().catch(() => null)) as {
     inspectionId?: unknown;
     reason?: unknown;
   } | null;
-
   const inspectionId = asString(body?.inspectionId);
   const reason = asString(body?.reason);
 
-  if (!inspectionId) return NextResponse.json({ error: "inspectionId is required" }, { status: 400 });
-  if (!reason) return NextResponse.json({ error: "Reopen reason is required" }, { status: 400 });
-
-  const { data: me, error: meErr } = await supabase
-    .from("profiles")
-    .select("id, shop_id, role")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (meErr || !me?.shop_id) {
-    return NextResponse.json({ error: meErr?.message ?? "Missing profile/shop scope" }, { status: 400 });
+  if (!inspectionId || !UUID_RE.test(inspectionId)) {
+    return NextResponse.json(
+      { error: "A valid inspectionId is required." },
+      { status: 400 },
+    );
+  }
+  if (!reason) {
+    return NextResponse.json(
+      { error: "Reopen reason is required." },
+      { status: 400 },
+    );
   }
 
-  if (!REOPEN_ALLOWED_ROLES.has(String(me.role ?? "").toLowerCase())) {
-    return NextResponse.json({ error: "Forbidden: only admin/advisor/owner/manager can reopen inspections." }, { status: 403 });
+  const { data, error } = await (supabase as unknown as ReopenRpcClient).rpc(
+    "reopen_inspection",
+    {
+      p_inspection_id: inspectionId,
+      p_reason: reason,
+    },
+  );
+
+  if (error) {
+    const lower = error.message.toLowerCase();
+    const status = lower.includes("only an admin")
+      ? 403
+      : lower.includes("does not belong")
+        ? 403
+        : lower.includes("not found")
+          ? 404
+          : 409;
+    return NextResponse.json({ error: error.message }, { status });
   }
 
-  const { data: inspection, error: inspectionErr } = await supabase
-    .from("inspections")
-    .select("id, shop_id, locked")
-    .eq("id", inspectionId)
-    .maybeSingle();
-
-  if (inspectionErr) return NextResponse.json({ error: inspectionErr.message }, { status: 500 });
-  if (!inspection) return NextResponse.json({ error: "Inspection not found" }, { status: 404 });
-  if (inspection.shop_id !== me.shop_id) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-
-  if (!inspection.locked) {
-    return NextResponse.json({ ok: true, alreadyOpen: true });
-  }
-
-  const nowIso = new Date().toISOString();
-  const reopenPatch: Record<string, unknown> = {
-    locked: false,
-    status: "in_progress",
-    is_draft: true,
-    completed: false,
-    reopened_at: nowIso,
-    reopened_by: user.id,
-    reopen_reason: reason,
-    updated_at: nowIso,
-  };
-
-  const { error: updateErr } = await supabase
-    .from("inspections")
-    .update(reopenPatch)
-    .eq("id", inspectionId);
-
-  if (updateErr) return NextResponse.json({ error: updateErr.message }, { status: 500 });
-
-  return NextResponse.json({ ok: true, reopenedAt: nowIso });
+  return NextResponse.json({
+    ok: true,
+    alreadyOpen: Boolean(data?.already_open),
+    inspectionId: data?.inspection_id ?? inspectionId,
+    reopenedAt: data?.reopened_at ?? null,
+    signingCycle: data?.signing_cycle ?? 0,
+  });
 }

--- a/app/api/inspections/save/route.ts
+++ b/app/api/inspections/save/route.ts
@@ -85,9 +85,17 @@ export async function POST(req: NextRequest) {
       .filter(Boolean)
       .join(" — ");
     const lower = message.toLowerCase();
-    const status = lower.includes("locked") || lower.includes("not found") ? 409 : 400;
+    const status =
+      lower.includes("locked") ||
+      lower.includes("finalized") ||
+      lower.includes("not found") ||
+      lower.includes("newer server version") ||
+      lower.includes("conflict")
+        ? 409
+        : 400;
     return NextResponse.json({ error: message }, { status });
   }
 
   return NextResponse.json(data ?? { ok: true });
 }
+

--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -3,18 +3,17 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
+
+type Role = "technician" | "customer" | "advisor";
 
 type SignInspectionArgs = {
   p_inspection_id: string;
-  p_role: "technician" | "customer" | "advisor";
+  p_role: Role;
   p_signed_name: string;
   p_signature_image_path: string | null;
   p_signature_hash: string | null;
+  p_expected_sync_revision: number;
 };
-
-type Role = SignInspectionArgs["p_role"];
-type InspectionInsert = Database["public"]["Tables"]["inspections"]["Insert"];
 
 type SignRequestBody = {
   inspectionId?: string;
@@ -23,9 +22,37 @@ type SignRequestBody = {
   signedName: string;
   signatureImagePath?: string | null;
   signatureHash?: string | null;
+  expectedSyncRevision: number;
+};
+
+type ProfileRow = {
+  shop_id: string | null;
+  role: string | null;
+  full_name: string | null;
+  tech_signature_path: string | null;
+  tech_signature_hash: string | null;
 };
 
 const ALLOWED_ROLES: Role[] = ["technician", "customer", "advisor"];
+const ADVISOR_PROFILE_ROLES = new Set([
+  "advisor",
+  "service_advisor",
+  "service advisor",
+  "owner",
+  "admin",
+  "manager",
+]);
+const TECHNICIAN_PROFILE_ROLES = new Set([
+  "technician",
+  "tech",
+  "mechanic",
+  "owner",
+  "admin",
+  "manager",
+  "foreman",
+  "lead_hand",
+  "lead hand",
+]);
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -39,6 +66,14 @@ function cleanUuid(value: unknown): string | null {
   return UUID_RE.test(normalized) ? normalized : null;
 }
 
+function cleanText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function profileName(profile: ProfileRow): string | null {
+  return cleanText(profile.full_name);
+}
+
 function isSignRequestBody(value: unknown): value is SignRequestBody {
   if (!isRecord(value)) return false;
   if (!cleanUuid(value.inspectionId) && !cleanUuid(value.workOrderLineId)) {
@@ -46,6 +81,12 @@ function isSignRequestBody(value: unknown): value is SignRequestBody {
   }
   if (typeof value.signedName !== "string") return false;
   if (typeof value.role !== "string") return false;
+  if (
+    !Number.isSafeInteger(value.expectedSyncRevision) ||
+    Number(value.expectedSyncRevision) < 1
+  ) {
+    return false;
+  }
   return ALLOWED_ROLES.includes(value.role as Role);
 }
 
@@ -59,142 +100,93 @@ async function callSignInspectionRpc(
   client: Supabase,
   args: SignInspectionArgs,
 ): Promise<RpcReturn> {
-  return (client as unknown as {
-    rpc: (fn: string, args: SignInspectionArgs) => Promise<RpcReturn>;
-  }).rpc("sign_inspection", args);
+  return (
+    client as unknown as {
+      rpc: (fn: string, args: SignInspectionArgs) => Promise<RpcReturn>;
+    }
+  ).rpc("sign_inspection", args);
 }
 
-/**
- * Resolve the canonical, shop-scoped inspection row.
- *
- * Mobile inspections begin with a local UUID. Creating a bare row with only
- * that ID and shop violates `inspections_anchor_chk`, so a missing mobile row
- * is created only after its work-order line and work-order anchors have been
- * validated. Existing desktop callers that provide only an inspection ID must
- * already have a persisted row.
- */
 async function resolveInspectionForSigning(args: {
   supabase: Supabase;
   requestedInspectionId: string | null;
   workOrderLineId: string | null;
   shopId: string;
-  actorUserId: string;
 }): Promise<ResolveInspectionResult> {
-  const {
-    supabase,
-    requestedInspectionId,
-    workOrderLineId,
-    shopId,
-    actorUserId,
-  } = args;
+  const { supabase, requestedInspectionId, workOrderLineId, shopId } = args;
 
-  if (!workOrderLineId) {
-    if (!requestedInspectionId) {
-      return {
-        ok: false,
-        error: "A persisted inspection or work-order line is required.",
-        status: 400,
-      };
-    }
-
-    const existing = await supabase
-      .from("inspections")
+  if (workOrderLineId) {
+    const lineResult = await supabase
+      .from("work_order_lines")
       .select("id")
-      .eq("id", requestedInspectionId)
+      .eq("id", workOrderLineId)
       .eq("shop_id", shopId)
       .maybeSingle<{ id: string }>();
 
-    if (existing.error) {
-      return { ok: false, error: existing.error.message, status: 400 };
+    if (lineResult.error) {
+      return { ok: false, error: lineResult.error.message, status: 400 };
     }
-    if (!existing.data?.id) {
+    if (!lineResult.data?.id) {
       return {
         ok: false,
-        error: "Save the inspection before signing it.",
-        status: 409,
+        error: "Work-order line was not found for this shop.",
+        status: 404,
       };
     }
-    return { ok: true, inspectionId: existing.data.id };
-  }
 
-  const lineResult = await supabase
-    .from("work_order_lines")
-    .select("id, work_order_id")
-    .eq("id", workOrderLineId)
-    .eq("shop_id", shopId)
-    .maybeSingle<{ id: string; work_order_id: string | null }>();
-
-  if (lineResult.error) {
-    return { ok: false, error: lineResult.error.message, status: 400 };
-  }
-
-  const line = lineResult.data;
-  if (!line?.id || !line.work_order_id) {
-    return {
-      ok: false,
-      error: "Work-order line was not found for this shop.",
-      status: 404,
-    };
-  }
-
-  const canonicalLineId = line.id;
-  const canonicalWorkOrderId = line.work_order_id;
-  const findCanonical = async () =>
-    supabase
+    const canonical = await supabase
       .from("inspections")
       .select("id")
       .eq("shop_id", shopId)
-      .eq("work_order_line_id", canonicalLineId)
+      .eq("work_order_line_id", lineResult.data.id)
       .order("updated_at", { ascending: false, nullsFirst: false })
+      .order("id", { ascending: false })
       .limit(1)
       .maybeSingle<{ id: string }>();
 
-  const existing = await findCanonical();
+    if (canonical.error) {
+      return { ok: false, error: canonical.error.message, status: 400 };
+    }
+    if (canonical.data?.id) {
+      return { ok: true, inspectionId: canonical.data.id };
+    }
+
+    return {
+      ok: false,
+      error:
+        "Inspection has not finished autosaving. Wait a moment and sign again.",
+      status: 409,
+    };
+  }
+
+  if (!requestedInspectionId) {
+    return {
+      ok: false,
+      error: "A saved inspection is required before signing.",
+      status: 400,
+    };
+  }
+
+  const existing = await supabase
+    .from("inspections")
+    .select("id")
+    .eq("id", requestedInspectionId)
+    .eq("shop_id", shopId)
+    .limit(1)
+    .maybeSingle<{ id: string }>();
+
   if (existing.error) {
     return { ok: false, error: existing.error.message, status: 400 };
   }
-  if (existing.data?.id) {
-    return { ok: true, inspectionId: existing.data.id };
+  if (!existing.data?.id) {
+    return {
+      ok: false,
+      error:
+        "Inspection has not finished autosaving. Wait a moment and sign again.",
+      status: 409,
+    };
   }
-
-  const insertPayload: InspectionInsert = {
-    ...(requestedInspectionId ? { id: requestedInspectionId } : {}),
-    work_order_id: canonicalWorkOrderId,
-    work_order_line_id: canonicalLineId,
-    shop_id: shopId,
-    user_id: actorUserId,
-    summary: {},
-    is_draft: true,
-    completed: false,
-    locked: false,
-    status: "draft",
-  };
-
-  const inserted = await supabase
-    .from("inspections")
-    .insert(insertPayload)
-    .select("id")
-    .maybeSingle<{ id: string }>();
-
-  if (!inserted.error && inserted.data?.id) {
-    return { ok: true, inspectionId: inserted.data.id };
-  }
-
-  // A concurrent first save/sign may have inserted the canonical row. Re-read
-  // before surfacing the insert error so retries remain harmless.
-  const raced = await findCanonical();
-  if (!raced.error && raced.data?.id) {
-    return { ok: true, inspectionId: raced.data.id };
-  }
-
-  return {
-    ok: false,
-    error:
-      inserted.error?.message ||
-      raced.error?.message ||
-      "Unable to create an anchored inspection.",
-    status: 400,
-  };
+  return { ok: true, inspectionId: existing.data.id };
 }
 
 export async function POST(req: NextRequest) {
@@ -210,44 +202,30 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(
       {
         error:
-          "A valid inspectionId or workOrderLineId, role, and signedName are required.",
+          "A saved inspection revision, valid inspection context, role, and signedName are required.",
       },
       { status: 400 },
     );
   }
 
-  const {
-    role,
-    signedName,
-    signatureImagePath,
-    signatureHash,
-  } = bodyUnknown;
   const requestedInspectionId = cleanUuid(bodyUnknown.inspectionId);
   const workOrderLineId = cleanUuid(bodyUnknown.workOrderLineId);
 
-  const profileResult = await supabase
+  const { data: profile, error: profileError } = await supabase
     .from("profiles")
     .select(
-      "shop_id, full_name, tech_signature_path, tech_signature_hash",
+      "shop_id, full_name, tech_signature_path, tech_signature_hash, role",
     )
     .eq("id", user.id)
-    .maybeSingle<{
-      shop_id: string | null;
-      full_name: string | null;
-      tech_signature_path: string | null;
-      tech_signature_hash: string | null;
-    }>();
+    .maybeSingle<ProfileRow>();
 
-  if (profileResult.error) {
+  if (profileError) {
     return NextResponse.json(
-      { error: `Unable to read profile: ${profileResult.error.message}` },
+      { error: `Unable to read profile: ${profileError.message}` },
       { status: 400 },
     );
   }
-
-  const profile = profileResult.data;
-  const shopId = profile?.shop_id ?? null;
-  if (!shopId) {
+  if (!profile?.shop_id) {
     return NextResponse.json(
       { error: "Your profile is missing shop_id; cannot sign inspection." },
       { status: 403 },
@@ -256,39 +234,72 @@ export async function POST(req: NextRequest) {
 
   const authMetadataName =
     typeof user.user_metadata?.full_name === "string"
-      ? user.user_metadata.full_name.trim()
+      ? cleanText(user.user_metadata.full_name)
       : typeof user.user_metadata?.name === "string"
-        ? user.user_metadata.name.trim()
-        : "";
-  const profileName = (profile?.full_name ?? "").trim() || authMetadataName;
-  const effectiveSignedName =
-    role === "technician" ? profileName : signedName.trim();
+        ? cleanText(user.user_metadata.name)
+        : null;
+
+  let effectiveSignedName = cleanText(bodyUnknown.signedName);
+  let effectiveSignaturePath = cleanText(bodyUnknown.signatureImagePath);
+  let effectiveSignatureHash = cleanText(bodyUnknown.signatureHash);
+
+  if (bodyUnknown.role === "technician") {
+    if (
+      !TECHNICIAN_PROFILE_ROLES.has(
+        String(profile.role ?? "")
+          .trim()
+          .toLowerCase(),
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Your profile cannot sign as a technician." },
+        { status: 403 },
+      );
+    }
+
+    // Technician identity and evidence are always server-owned; client-sent
+    // signature fields cannot replace the saved profile signature.
+    effectiveSignedName = profileName(profile) ?? authMetadataName;
+    effectiveSignaturePath = cleanText(profile.tech_signature_path);
+    effectiveSignatureHash = cleanText(profile.tech_signature_hash);
+
+    if (!effectiveSignedName) {
+      return NextResponse.json(
+        { error: "Add your full name to your profile before signing." },
+        { status: 409 },
+      );
+    }
+    if (!effectiveSignaturePath || !effectiveSignatureHash) {
+      return NextResponse.json(
+        {
+          error:
+            "No valid saved technician signature exists. Add one in Tech Settings.",
+        },
+        { status: 409 },
+      );
+    }
+  }
+
+  if (bodyUnknown.role === "advisor") {
+    if (
+      !ADVISOR_PROFILE_ROLES.has(
+        String(profile.role ?? "")
+          .trim()
+          .toLowerCase(),
+      )
+    ) {
+      return NextResponse.json(
+        { error: "Your profile cannot sign as a service advisor." },
+        { status: 403 },
+      );
+    }
+    effectiveSignedName = profileName(profile) ?? authMetadataName;
+  }
 
   if (!effectiveSignedName) {
     return NextResponse.json(
-      {
-        error:
-          role === "technician"
-            ? "Add your full name to your profile before signing."
-            : "Signed name is required.",
-      },
+      { error: "Signed name is required." },
       { status: 400 },
-    );
-  }
-
-  const effectiveSignatureImagePath =
-    role === "technician"
-      ? profile?.tech_signature_path ?? null
-      : signatureImagePath ?? null;
-  const effectiveSignatureHash =
-    role === "technician"
-      ? profile?.tech_signature_hash ?? null
-      : signatureHash ?? null;
-
-  if (role === "technician" && !effectiveSignatureImagePath) {
-    return NextResponse.json(
-      { error: "No saved technician signature. Add one in Tech Settings." },
-      { status: 409 },
     );
   }
 
@@ -296,8 +307,7 @@ export async function POST(req: NextRequest) {
     supabase,
     requestedInspectionId,
     workOrderLineId,
-    shopId,
-    actorUserId: user.id,
+    shopId: profile.shop_id,
   });
   if (resolved.ok === false) {
     return NextResponse.json(
@@ -308,13 +318,28 @@ export async function POST(req: NextRequest) {
 
   const { data, error } = await callSignInspectionRpc(supabase, {
     p_inspection_id: resolved.inspectionId,
-    p_role: role,
+    p_role: bodyUnknown.role,
     p_signed_name: effectiveSignedName,
-    p_signature_image_path: effectiveSignatureImagePath,
+    p_signature_image_path: effectiveSignaturePath,
     p_signature_hash: effectiveSignatureHash,
+    p_expected_sync_revision: bodyUnknown.expectedSyncRevision,
   });
+
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    const lower = error.message.toLowerCase();
+    const status =
+      lower.includes("not found") ||
+      lower.includes("no saved") ||
+      lower.includes("no valid saved") ||
+      lower.includes("does not belong") ||
+      lower.includes("changed on another device") ||
+      lower.includes("finalized") ||
+      lower.includes("locked") ||
+      lower.includes("already signed") ||
+      lower.includes("saved inspection revision")
+        ? 409
+        : 400;
+    return NextResponse.json({ error: error.message }, { status });
   }
 
   return NextResponse.json({
@@ -324,3 +349,4 @@ export async function POST(req: NextRequest) {
     signedName: effectiveSignedName,
   });
 }
+

--- a/app/dashboard/tech/settings/page.tsx
+++ b/app/dashboard/tech/settings/page.tsx
@@ -187,11 +187,16 @@ export default function TechSettingsPage() {
       const path = `tech-signatures/${profileId}/${hash}.png`;
 
       const up = await supabase.storage.from("signatures").upload(path, blob, {
-        upsert: true,
+        upsert: false,
         contentType: "image/png",
       });
 
-      if (up.error) throw up.error;
+      if (
+        up.error &&
+        !/already exists|resource exists|duplicate/i.test(up.error.message)
+      ) {
+        throw up.error;
+      }
 
       const { error: updErr } = await supabase
         .from("profiles")
@@ -383,3 +388,5 @@ export default function TechSettingsPage() {
     </div>
   );
 }
+
+

--- a/features/inspections/components/inspection/FinishInspectionButton.tsx
+++ b/features/inspections/components/inspection/FinishInspectionButton.tsx
@@ -13,6 +13,7 @@ type Props = {
   session: InspectionSession;
   workOrderLineId?: string | null;
   disabled?: boolean;
+  beforeNavigate?: () => Promise<unknown>;
 };
 
 type ItemLike = {
@@ -51,14 +52,30 @@ function countFindings(session: InspectionSession): number {
   return count;
 }
 
-export default function FinishInspectionButton({ session, workOrderLineId, disabled = false }: Props) {
+export default function FinishInspectionButton({
+  session,
+  workOrderLineId,
+  disabled = false,
+  beforeNavigate,
+}: Props) {
   const router = useRouter();
 
   const findingsCount = useMemo(() => countFindings(session), [session]);
 
-  const handleFinish = (): void => {
+  const handleFinish = async (): Promise<void> => {
     if (!workOrderLineId) {
       toast.error("Missing work order line id — can’t finish.");
+      return;
+    }
+
+    try {
+      await beforeNavigate?.();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Wait for the inspection to finish saving.",
+      );
       return;
     }
 
@@ -87,7 +104,7 @@ export default function FinishInspectionButton({ session, workOrderLineId, disab
 
   return (
     <Button
-      onClick={handleFinish}
+      onClick={() => void handleFinish()}
       type="button"
       size="sm"
       disabled={disabled}
@@ -103,3 +120,4 @@ export default function FinishInspectionButton({ session, workOrderLineId, disab
     </Button>
   );
 }
+

--- a/features/inspections/components/inspection/InspectionReviewPanel.tsx
+++ b/features/inspections/components/inspection/InspectionReviewPanel.tsx
@@ -1,13 +1,14 @@
 // features/inspections/components/inspection/InspectionReviewPanel.tsx
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type {
   InspectionSession,
   InspectionItem,
 } from "@inspections/lib/inspection/types";
 import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicleHeader";
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
+import { useInspectionAutosave } from "@inspections/hooks/useInspectionAutosave";
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
 import { Button } from "@shared/components/ui/Button";
 
@@ -59,11 +60,35 @@ function flattenItems(session: InspectionSession): Array<{
 }
 
 export default function InspectionReviewPanel({
-  session,
+  session: sessionProp,
   workOrderLineId,
   onSessionChange,
 }: Props) {
+  const [session, setSession] = useState(sessionProp);
   const [downloading, setDownloading] = useState(false);
+
+  useEffect(() => {
+    setSession(sessionProp);
+  }, [sessionProp]);
+  const [isLocked, setIsLocked] = useState(false);
+  const {
+    flush: flushAutosave,
+    flushToServer: flushAutosaveToServer,
+    label: autosaveLabel,
+    lastError: autosaveError,
+  } = useInspectionAutosave({
+    session,
+    inspectionId: session.id,
+    workOrderLineId,
+    enabled: Boolean(workOrderLineId),
+    locked: isLocked,
+    draftKey: `inspection-${session.id ?? workOrderLineId ?? "review"}`,
+    onRemoteSession: (remote) => {
+      setSession(remote);
+      onSessionChange?.(remote);
+    },
+    onRemoteMeta: (meta) => setIsLocked(meta.locked),
+  });
 
   const stats = useMemo(() => calcStats(session), [session]);
   const flatItems = useMemo(() => flattenItems(session), [session]);
@@ -113,6 +138,7 @@ export default function InspectionReviewPanel({
     setDownloading(true);
 
     try {
+      await flushAutosave();
       const filenameBase =
         session.templateName?.replace(/[^\w\-]+/g, "_") || "inspection";
       const filename = `${filenameBase}.pdf`;
@@ -165,7 +191,15 @@ export default function InspectionReviewPanel({
                 <FinishInspectionButton
                   session={session}
                   workOrderLineId={workOrderLineId}
+                  disabled={isLocked}
+                  beforeNavigate={() => flushAutosaveToServer()}
                 />
+                <div className="text-[11px] text-[color:var(--theme-text-secondary)]">
+                  {autosaveLabel}
+                  {autosaveError && (
+                    <span className="ml-2 text-red-400">{autosaveError}</span>
+                  )}
+                </div>
               </>
             )}
             <Button
@@ -319,12 +353,15 @@ export default function InspectionReviewPanel({
             inspectionId={session.id as string | undefined | null}
             workOrderLineId={workOrderLineId}
             role="technician"
+            techSettingsHref="/dashboard/tech/settings"
+            beforeSign={() => flushAutosaveToServer()}
             onSigned={() => {
-              if (!onSessionChange) return;
-              onSessionChange({
+              const next = {
                 ...session,
                 signedByTech: true,
-              } as InspectionSession);
+              } as InspectionSession;
+              setSession(next);
+              onSessionChange?.(next);
             }}
           />
 
@@ -333,13 +370,15 @@ export default function InspectionReviewPanel({
             inspectionId={session.id as string | undefined | null}
             workOrderLineId={workOrderLineId}
             role="customer"
+            beforeSign={() => flushAutosaveToServer()}
             defaultName={customerDefaultName}
             onSigned={() => {
-              if (!onSessionChange) return;
-              onSessionChange({
+              const next = {
                 ...session,
                 signedByCustomer: true,
-              } as InspectionSession);
+              } as InspectionSession;
+              setSession(next);
+              onSessionChange?.(next);
             }}
           />
         </div>
@@ -347,3 +386,4 @@ export default function InspectionReviewPanel({
     </div>
   );
 }
+

--- a/features/inspections/components/inspection/InspectionSignaturePanel.tsx
+++ b/features/inspections/components/inspection/InspectionSignaturePanel.tsx
@@ -14,6 +14,9 @@ export type InspectionSignaturePanelProps = {
   role: SignatureRole;
   defaultName?: string;
   onSigned?: () => void;
+  beforeSign: () => Promise<
+    { syncRevision?: number | null } | null | void
+  >;
 
   /**
    * Optional: where to send a tech to save their signature (one-time setup).
@@ -39,7 +42,7 @@ function roleSubtext(role: SignatureRole): string {
     return "Uses the saved signature from your profile (no re-signing every time).";
   if (role === "advisor")
     return "Sign to approve/confirm this inspection snapshot.";
-  return "Sign to acknowledge and lock this inspection snapshot.";
+  return "A staff user records the customer's typed acknowledgement; no drawn customer signature is captured.";
 }
 
 function confirmText(role: SignatureRole): string {
@@ -57,23 +60,12 @@ type ProfileResponse = {
   error?: string;
   fullName?: string | null;
   full_name?: string | null;
-  firstName?: string | null;
-  first_name?: string | null;
-  lastName?: string | null;
-  last_name?: string | null;
   name?: string | null;
 };
 
 function pickNameFromProfile(json: ProfileResponse | null): string | null {
   if (!json) return null;
-  const firstName = json.firstName ?? json.first_name;
-  const lastName = json.lastName ?? json.last_name;
-  const candidates = [
-    json.fullName,
-    json.full_name,
-    json.name,
-    [firstName, lastName].filter(Boolean).join(" "),
-  ]
+  const candidates = [json.fullName, json.full_name, json.name]
     .map((value) => (typeof value === "string" ? value.trim() : ""))
     .filter((value) => value.length > 0);
 
@@ -95,6 +87,7 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
   role,
   defaultName,
   onSigned,
+  beforeSign,
   techSettingsHref,
   lockNameInput,
 }) => {
@@ -167,17 +160,24 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
 
         const { data, error } = await supabase
           .from("profiles")
-          .select("full_name, first_name, last_name")
+          .select("full_name")
           .eq("id", user.id)
           .maybeSingle<ProfileResponse>();
         if (error) return;
 
-        const profileName = pickNameFromProfile(data ?? null);
-        if (!profileName) return;
+        const authMetadataName =
+          typeof user.user_metadata?.full_name === "string"
+            ? user.user_metadata.full_name.trim()
+            : typeof user.user_metadata?.name === "string"
+              ? user.user_metadata.name.trim()
+              : "";
+        const resolvedName =
+          pickNameFromProfile(data ?? null) || authMetadataName || null;
+        if (!resolvedName) return;
 
         if (!cancelled) {
-          setName(profileName);
-          setAutoFilledName(profileName);
+          setName(resolvedName);
+          setAutoFilledName(resolvedName);
         }
       } catch {
         // Name autofill is a convenience; the technician can type a fallback.
@@ -212,6 +212,23 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
     setBusy(true);
 
     try {
+      // Signing must always cover the latest server snapshot. The API then
+      // resolves the technician name and saved signature from the authenticated
+      // profile instead of trusting browser-supplied evidence.
+      const prepared = await beforeSign();
+      const expectedSyncRevision =
+        prepared &&
+        typeof prepared.syncRevision === "number" &&
+        Number.isSafeInteger(prepared.syncRevision) &&
+        prepared.syncRevision > 0
+          ? prepared.syncRevision
+          : null;
+      if (expectedSyncRevision == null) {
+        throw new Error(
+          "Inspection did not finish saving to the server. Wait for autosave and sign again.",
+        );
+      }
+
       const response = await fetch("/api/inspections/sign", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -221,6 +238,7 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           workOrderLineId: resolvedWorkOrderLineId,
           role,
           signedName: name.trim(),
+          expectedSyncRevision,
         }),
       });
 
@@ -312,14 +330,16 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
 
       {role === "technician" ? (
         <p className="text-[11px] text-[color:var(--theme-text-secondary)]">
-          If signing fails, it usually means no saved signature exists yet.
+          Your saved profile signature is applied automatically when you sign.
           {techSettingsHref ? (
             <>
               {" "}
-              Add one in{" "}
-              <span className="font-medium text-[color:var(--theme-text-primary)]">
-                Tech Settings
-              </span>
+              <a
+                href={techSettingsHref}
+                className="font-medium text-[color:var(--theme-text-primary)] underline underline-offset-2"
+              >
+                Manage signature
+              </a>
               .
             </>
           ) : null}
@@ -333,7 +353,13 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
           disabled={busy || loadingName || !canResolveInspection}
           className="inline-flex items-center rounded-lg border border-[color:var(--brand-primary)] bg-[color:var(--brand-primary)] px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-sm transition hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {busy ? "Signing…" : "Sign"}
+          {busy
+            ? role === "customer"
+              ? "Recording…"
+              : "Signing…"
+            : role === "customer"
+              ? "Record acknowledgement"
+              : "Sign"}
         </button>
       </div>
     </div>
@@ -341,3 +367,4 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
 };
 
 export default InspectionSignaturePanel;
+

--- a/features/inspections/hooks/useInspectionAutosave.ts
+++ b/features/inspections/hooks/useInspectionAutosave.ts
@@ -1,0 +1,849 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { saveInspectionSession } from "@inspections/lib/inspection/save";
+import type { InspectionSession } from "@inspections/lib/inspection/types";
+import {
+  saveInspectionOfflineDraft,
+  type InspectionDraftRecoveryState,
+} from "@inspections/lib/inspection/offlineDrafts";
+
+export type InspectionSyncState =
+  | "hydrating"
+  | "idle"
+  | "saving"
+  | "saved"
+  | "queued"
+  | "conflicted"
+  | "error";
+
+export type InspectionRemoteMeta = {
+  locked: boolean;
+  finalizedAt: string | null;
+  updatedAt: string | null;
+};
+
+type UseInspectionAutosaveArgs = {
+  session: InspectionSession | null;
+  inspectionId?: string | null;
+  workOrderLineId?: string | null;
+  enabled?: boolean;
+  locked?: boolean;
+  draftKey?: string;
+  debounceMs?: number;
+  recoveryOperationKey?: string;
+  onRemoteSession: (session: InspectionSession) => void;
+  onRemoteMeta?: (meta: InspectionRemoteMeta) => void;
+  onRecoveryState?: (
+    state: InspectionDraftRecoveryState,
+    operationKey?: string,
+  ) => void;
+};
+
+type LoadResponse = {
+  session?: InspectionSession | null;
+  inspectionMeta?: {
+    locked?: boolean | null;
+    finalizedAt?: string | null;
+    updatedAt?: string | null;
+  } | null;
+};
+
+type RealtimeInspectionRow = {
+  summary?: unknown;
+  locked?: boolean | null;
+  finalized_at?: string | null;
+  updated_at?: string | null;
+  work_order_line_id?: string | null;
+};
+
+type PersistResult = {
+  session: InspectionSession;
+  durable: boolean;
+  queued: boolean;
+  conflicted: boolean;
+};
+
+function timestamp(value: unknown): number {
+  if (typeof value !== "string" || !value.trim()) return 0;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function revision(session: InspectionSession | null): number {
+  const value = session?.syncRevision;
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : 0;
+}
+
+function fingerprint(session: InspectionSession | null): string {
+  if (!session) return "";
+  return [
+    session.id ?? "",
+    revision(session),
+    session.lastUpdated ?? "",
+  ].join(":");
+}
+
+function hasDurableSession(value: unknown): value is InspectionSession {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<InspectionSession>;
+  return Array.isArray(candidate.sections) && candidate.sections.length > 0;
+}
+
+function sessionMatchesWorkOrderLine(
+  session: InspectionSession | null,
+  workOrderLineId?: string | null,
+): boolean {
+  const embeddedLineId = session?.workOrderLineId?.trim() ?? "";
+  const activeLineId = workOrderLineId?.trim() ?? "";
+  return !embeddedLineId || !activeLineId || embeddedLineId === activeLineId;
+}
+
+function hasMeaningfulLocalChanges(session: InspectionSession): boolean {
+  if (session.transcript?.trim()) return true;
+  if ((session.quote?.length ?? 0) > 0) return true;
+
+  return (session.sections ?? []).some((section) =>
+    (section.items ?? []).some((item) => {
+      const value = item as unknown as {
+        status?: unknown;
+        notes?: unknown;
+        value?: unknown;
+        photoUrls?: unknown;
+      };
+      const status = String(value.status ?? "").trim().toLowerCase();
+      const hasStatus =
+        status.length > 0 &&
+        !["pending", "not_started", "not started"].includes(status);
+      const hasNotes =
+        typeof value.notes === "string" && value.notes.trim().length > 0;
+      const hasValue =
+        value.value !== null &&
+        value.value !== undefined &&
+        String(value.value).trim().length > 0;
+      const hasPhotos =
+        Array.isArray(value.photoUrls) && value.photoUrls.length > 0;
+      return hasStatus || hasNotes || hasValue || hasPhotos;
+    }),
+  );
+}
+
+function remoteShouldReplace(
+  remote: InspectionSession,
+  local: InspectionSession | null,
+  lastPersistedFingerprint: string,
+): boolean {
+  if (!local) return true;
+
+  const remoteRevision = revision(remote);
+  const localRevision = revision(local);
+  const localFingerprint = fingerprint(local);
+  const localIsDirty = lastPersistedFingerprint
+    ? Boolean(localFingerprint) &&
+      localFingerprint !== lastPersistedFingerprint
+    : hasMeaningfulLocalChanges(local);
+
+  // Never erase an unsaved edit (including a field the user intentionally
+  // cleared). The following save will surface a revision conflict if another
+  // device advanced while this client was dirty.
+  if (localIsDirty) return false;
+  if (remoteRevision > localRevision) return true;
+  if (remoteRevision < localRevision) return false;
+  return timestamp(remote.lastUpdated) >= timestamp(local.lastUpdated);
+}
+
+function errorStatus(error: unknown): number | null {
+  if (!error || typeof error !== "object") return null;
+  const value = (error as { status?: unknown }).status;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function inspectionSyncLabel(
+  state: InspectionSyncState,
+  locked = false,
+): string {
+  if (locked) return "Signed and locked · synced on all devices";
+  if (state === "hydrating") return "Checking saved inspection…";
+  if (state === "saving") return "Saving to all devices…";
+  if (state === "saved") return "Saved to shop • syncs across devices";
+  if (state === "queued") return "Saved on this device · sync queued";
+  if (state === "conflicted") return "Newer server changes need review";
+  if (state === "error") return "Autosave needs attention";
+  return "Autosave ready";
+}
+
+export function useInspectionAutosave({
+  session,
+  inspectionId,
+  workOrderLineId,
+  enabled = true,
+  locked = false,
+  draftKey,
+  debounceMs = 700,
+  recoveryOperationKey,
+  onRemoteSession,
+  onRemoteMeta,
+  onRecoveryState,
+}: UseInspectionAutosaveArgs) {
+  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const identityKey =
+    workOrderLineId?.trim() || inspectionId?.trim() || "";
+  const [state, setState] = useState<InspectionSyncState>("hydrating");
+  const [hydrated, setHydrated] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  const latestSessionRef = useRef<InspectionSession | null>(session);
+  const identityRef = useRef(identityKey);
+  const lastServerFingerprintRef = useRef("");
+  const lastServerRevisionRef = useRef(0);
+  const lastServerUpdatedAtRef = useRef(0);
+  const lastQueuedFingerprintRef = useRef("");
+  const lastRemoteMetaAtRef = useRef(0);
+  const pendingOperationKeyRef = useRef<string | undefined>(undefined);
+  const pendingOperationFingerprintRef = useRef("");
+  const saveQueueRef = useRef<Promise<InspectionSession | null>>(
+    Promise.resolve(null),
+  );
+  const hydrationPromiseRef = useRef<Promise<void>>(Promise.resolve());
+  const onRemoteSessionRef = useRef(onRemoteSession);
+  const onRemoteMetaRef = useRef(onRemoteMeta);
+  const onRecoveryStateRef = useRef(onRecoveryState);
+
+  onRemoteSessionRef.current = onRemoteSession;
+  onRemoteMetaRef.current = onRemoteMeta;
+  onRecoveryStateRef.current = onRecoveryState;
+
+  if (identityRef.current !== identityKey) {
+    identityRef.current = identityKey;
+    lastServerFingerprintRef.current = "";
+    lastServerRevisionRef.current = 0;
+    lastServerUpdatedAtRef.current = 0;
+    lastQueuedFingerprintRef.current = "";
+    lastRemoteMetaAtRef.current = 0;
+    pendingOperationKeyRef.current = undefined;
+    pendingOperationFingerprintRef.current = "";
+    saveQueueRef.current = Promise.resolve(null);
+    hydrationPromiseRef.current = Promise.resolve();
+  }
+  latestSessionRef.current = session;
+
+  useEffect(() => {
+    setLastError(null);
+    setState("hydrating");
+    setHydrated(false);
+  }, [identityKey]);
+
+  useEffect(() => {
+    const recoveredKey = recoveryOperationKey?.trim();
+    if (recoveredKey && !pendingOperationKeyRef.current) {
+      pendingOperationKeyRef.current = recoveredKey;
+      pendingOperationFingerprintRef.current = fingerprint(
+        latestSessionRef.current,
+      );
+    }
+  }, [recoveryOperationKey]);
+
+  const applyRemoteMeta = useCallback(
+    (meta: Partial<InspectionRemoteMeta>): boolean => {
+      if (identityRef.current !== identityKey) return false;
+
+      const nextUpdatedAt = timestamp(meta.updatedAt);
+      if (
+        (nextUpdatedAt === 0 && lastRemoteMetaAtRef.current > 0) ||
+        (nextUpdatedAt > 0 &&
+          nextUpdatedAt < lastRemoteMetaAtRef.current)
+      ) {
+        return false;
+      }
+      if (nextUpdatedAt > 0) {
+        lastRemoteMetaAtRef.current = nextUpdatedAt;
+      }
+      onRemoteMetaRef.current?.({
+        locked: Boolean(meta.locked),
+        finalizedAt: meta.finalizedAt ?? null,
+        updatedAt: meta.updatedAt ?? null,
+      });
+      return true;
+    },
+    [identityKey],
+  );
+
+  const applyRemote = useCallback(
+    (
+      remote: InspectionSession,
+      meta?: Partial<InspectionRemoteMeta> | null,
+      force = false,
+    ) => {
+      if (identityRef.current !== identityKey) return false;
+
+      const previousServerFingerprint =
+        lastServerFingerprintRef.current;
+      // Route/query identity can change one render before the owning screen has
+      // restored the matching draft. Never let that previous line's session
+      // arbitrate against the canonical session for the new line.
+      const current = sessionMatchesWorkOrderLine(
+        latestSessionRef.current,
+        workOrderLineId,
+      )
+        ? latestSessionRef.current
+        : null;
+      const metaAccepted = meta ? applyRemoteMeta(meta) : true;
+      const remoteFingerprint = fingerprint(remote);
+      const remoteRevision = revision(remote);
+      const remoteUpdatedAt = timestamp(
+        remote.serverUpdatedAt ?? meta?.updatedAt ?? remote.lastUpdated,
+      );
+      const shouldReplace =
+        force ||
+        (metaAccepted && Boolean(meta?.locked)) ||
+        remoteShouldReplace(
+          remote,
+          current,
+          previousServerFingerprint,
+        );
+
+      if (
+        remoteRevision > lastServerRevisionRef.current ||
+        (remoteRevision === lastServerRevisionRef.current &&
+          remoteUpdatedAt >= lastServerUpdatedAtRef.current)
+      ) {
+        lastServerRevisionRef.current = remoteRevision;
+        lastServerUpdatedAtRef.current = remoteUpdatedAt;
+        lastServerFingerprintRef.current = remoteFingerprint;
+      }
+
+      if (
+        pendingOperationFingerprintRef.current &&
+        pendingOperationFingerprintRef.current === remoteFingerprint
+      ) {
+        pendingOperationKeyRef.current = undefined;
+        pendingOperationFingerprintRef.current = "";
+      }
+
+      if (!shouldReplace) return false;
+
+      lastServerFingerprintRef.current = remoteFingerprint;
+      lastServerRevisionRef.current = remoteRevision;
+      lastServerUpdatedAtRef.current = remoteUpdatedAt;
+      lastQueuedFingerprintRef.current = "";
+      latestSessionRef.current = remote;
+      pendingOperationKeyRef.current = undefined;
+      pendingOperationFingerprintRef.current = "";
+      setLastError(null);
+      setState("saved");
+      onRemoteSessionRef.current(remote);
+      return true;
+    },
+    [applyRemoteMeta, identityKey, workOrderLineId],
+  );
+
+  const pullLatest = useCallback(async () => {
+    if (!enabled || (!inspectionId && !workOrderLineId)) return;
+
+    const params = new URLSearchParams();
+    if (inspectionId) params.set("inspectionId", inspectionId);
+    if (workOrderLineId) params.set("workOrderLineId", workOrderLineId);
+
+    const response = await fetch(
+      `/api/inspections/load?${params.toString()}`,
+      {
+        method: "GET",
+        credentials: "include",
+        cache: "no-store",
+      },
+    );
+
+    if (!response.ok) {
+      const json = (await response.json().catch(() => null)) as
+        | { error?: string }
+        | null;
+      throw new Error(json?.error ?? "Unable to load saved inspection.");
+    }
+
+    if (identityRef.current !== identityKey) return;
+
+    const json = (await response.json().catch(() => null)) as LoadResponse | null;
+    const meta: InspectionRemoteMeta = {
+      locked: Boolean(json?.inspectionMeta?.locked),
+      finalizedAt: json?.inspectionMeta?.finalizedAt ?? null,
+      updatedAt: json?.inspectionMeta?.updatedAt ?? null,
+    };
+    const remote = json?.session;
+    if (hasDurableSession(remote)) {
+      applyRemote(remote, meta);
+    } else {
+      applyRemoteMeta(meta);
+    }
+  }, [
+    applyRemote,
+    applyRemoteMeta,
+    enabled,
+    identityKey,
+    inspectionId,
+    workOrderLineId,
+  ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setHydrated(false);
+    setState("hydrating");
+
+    if (!enabled) {
+      hydrationPromiseRef.current = Promise.resolve();
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const promise = (async () => {
+      try {
+        await pullLatest();
+        if (!cancelled) {
+          setLastError(null);
+          setState((current) => (current === "saved" ? current : "idle"));
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setLastError(
+            error instanceof Error
+              ? error.message
+              : "Unable to load saved inspection.",
+          );
+          // Local/offline recovery remains usable and will queue the next save.
+          setState(typeof navigator !== "undefined" && !navigator.onLine
+            ? "queued"
+            : "error");
+        }
+      } finally {
+        if (!cancelled) setHydrated(true);
+      }
+    })();
+
+    hydrationPromiseRef.current = promise;
+    return () => {
+      cancelled = true;
+    };
+  }, [pullLatest]);
+
+  useEffect(() => {
+    if (!enabled || !workOrderLineId) return;
+
+    const channel = supabase
+      .channel(`inspection-live:${workOrderLineId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "inspections",
+          filter: `work_order_line_id=eq.${workOrderLineId}`,
+        },
+        (payload) => {
+          if (payload.eventType === "DELETE") return;
+          const row = (payload.new ?? {}) as RealtimeInspectionRow;
+          const meta: InspectionRemoteMeta = {
+            locked: Boolean(row.locked),
+            finalizedAt: row.finalized_at ?? null,
+            updatedAt: row.updated_at ?? null,
+          };
+          if (hasDurableSession(row.summary)) {
+            applyRemote(row.summary, meta);
+          } else {
+            applyRemoteMeta(meta);
+          }
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [
+    applyRemote,
+    applyRemoteMeta,
+    enabled,
+    supabase,
+    workOrderLineId,
+  ]);
+
+  const persistSnapshot = useCallback(
+    async (
+      snapshot: InspectionSession,
+      requireServer = false,
+    ): Promise<PersistResult> => {
+      if (identityRef.current !== identityKey) {
+        return {
+          session: snapshot,
+          durable: false,
+          queued: false,
+          conflicted: true,
+        };
+      }
+      if (!workOrderLineId) {
+        throw new Error("Inspection is not attached to a work-order line.");
+      }
+
+      if (!sessionMatchesWorkOrderLine(snapshot, workOrderLineId)) {
+        const message =
+          "Inspection draft belongs to a different work-order line.";
+        setLastError(message);
+        setState("conflicted");
+        return {
+          session: snapshot,
+          durable: false,
+          queued: false,
+          conflicted: true,
+        };
+      }
+
+      const nextFingerprint = fingerprint(snapshot);
+      if (
+        nextFingerprint &&
+        nextFingerprint === lastServerFingerprintRef.current
+      ) {
+        return {
+          session: snapshot,
+          durable: true,
+          queued: false,
+          conflicted: false,
+        };
+      }
+
+      if (locked) {
+        throw new Error("Signed inspection is locked.");
+      }
+
+      const offline =
+        typeof navigator !== "undefined" && !navigator.onLine;
+      if (
+        !requireServer &&
+        offline &&
+        nextFingerprint &&
+        nextFingerprint === lastQueuedFingerprintRef.current
+      ) {
+        return {
+          session: snapshot,
+          durable: false,
+          queued: true,
+          conflicted: false,
+        };
+      }
+
+      if (requireServer && offline) {
+        setState("queued");
+        const message =
+          "Connect to the internet and wait for autosave before signing or finalizing.";
+        setLastError(message);
+        throw new Error(message);
+      }
+
+      const previousOperationKey = pendingOperationKeyRef.current;
+      const canReuseOperationKey =
+        Boolean(previousOperationKey) &&
+        pendingOperationFingerprintRef.current === nextFingerprint;
+      const operationKey =
+        (canReuseOperationKey ? previousOperationKey : undefined) ??
+        (typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `${workOrderLineId}:${Date.now()}`);
+      pendingOperationKeyRef.current = operationKey;
+      pendingOperationFingerprintRef.current = nextFingerprint;
+      setState("saving");
+      setLastError(null);
+
+      try {
+        const result = await saveInspectionSession(
+          snapshot,
+          workOrderLineId,
+          {
+            operationKey,
+            requireServer,
+            supersedesOperationKey: canReuseOperationKey
+              ? undefined
+              : previousOperationKey,
+          },
+        );
+
+        if (identityRef.current !== identityKey) {
+          return {
+            session: snapshot,
+            durable: false,
+            queued: false,
+            conflicted: true,
+          };
+        }
+
+        const recoveryState: InspectionDraftRecoveryState = result.conflicted
+          ? "conflicted"
+          : result.queued
+            ? "queued"
+            : "editing";
+
+        if (result.queued || result.conflicted) {
+          pendingOperationKeyRef.current = result.operationKey;
+          pendingOperationFingerprintRef.current = nextFingerprint;
+        } else {
+          pendingOperationKeyRef.current = undefined;
+          pendingOperationFingerprintRef.current = "";
+        }
+
+        let persistedSnapshot = snapshot;
+        if (!result.queued && !result.conflicted) {
+          const acknowledgedSnapshot: InspectionSession = {
+            ...snapshot,
+            id: result.inspectionId ?? snapshot.id,
+            syncRevision: result.syncRevision ?? snapshot.syncRevision,
+            serverUpdatedAt:
+              result.savedAt ?? snapshot.serverUpdatedAt ?? null,
+          };
+          const current = latestSessionRef.current;
+          const acknowledgementRevision = revision(acknowledgedSnapshot);
+
+          if (!current || fingerprint(current) === nextFingerprint) {
+            persistedSnapshot = acknowledgedSnapshot;
+            latestSessionRef.current = acknowledgedSnapshot;
+            onRemoteSessionRef.current(acknowledgedSnapshot);
+          } else if (acknowledgementRevision >= revision(current)) {
+            // Preserve edits made while the request was in flight, but advance
+            // their concurrency token so the follow-up save is accepted.
+            persistedSnapshot = {
+              ...current,
+              id: acknowledgedSnapshot.id,
+              syncRevision: acknowledgedSnapshot.syncRevision,
+              serverUpdatedAt: acknowledgedSnapshot.serverUpdatedAt,
+            };
+            latestSessionRef.current = persistedSnapshot;
+            onRemoteSessionRef.current(persistedSnapshot);
+          } else {
+            // Realtime already delivered a newer server revision.
+            persistedSnapshot = current;
+          }
+
+          if (acknowledgementRevision >= lastServerRevisionRef.current) {
+            lastServerRevisionRef.current = acknowledgementRevision;
+            lastServerUpdatedAtRef.current = timestamp(
+              acknowledgedSnapshot.serverUpdatedAt,
+            );
+            // Record only the snapshot the server acknowledged. A newer local
+            // edit must remain dirty and receive its own operation key.
+            lastServerFingerprintRef.current =
+              fingerprint(acknowledgedSnapshot);
+          }
+          lastQueuedFingerprintRef.current = "";
+        } else {
+          lastQueuedFingerprintRef.current = nextFingerprint;
+        }
+
+        if (draftKey) {
+          await saveInspectionOfflineDraft({
+            draftKey,
+            session: persistedSnapshot,
+            state: recoveryState,
+            operationKey: pendingOperationKeyRef.current,
+          });
+        }
+        if (identityRef.current !== identityKey) {
+          return {
+            session: snapshot,
+            durable: false,
+            queued: false,
+            conflicted: true,
+          };
+        }
+        onRecoveryStateRef.current?.(
+          recoveryState,
+          pendingOperationKeyRef.current,
+        );
+
+        if (result.conflicted) setState("conflicted");
+        else if (result.queued) setState("queued");
+        else setState("saved");
+
+        return {
+          session: persistedSnapshot,
+          durable: !result.queued && !result.conflicted,
+          queued: result.queued,
+          conflicted: result.conflicted,
+        };
+      } catch (error) {
+        if (identityRef.current !== identityKey) throw error;
+        const message =
+          error instanceof Error ? error.message : "Inspection autosave failed.";
+        const conflicted = errorStatus(error) === 409;
+        pendingOperationKeyRef.current = operationKey;
+        pendingOperationFingerprintRef.current = nextFingerprint;
+        if (conflicted) {
+          lastQueuedFingerprintRef.current = nextFingerprint;
+          if (draftKey) {
+            await saveInspectionOfflineDraft({
+              draftKey,
+              session: snapshot,
+              state: "conflicted",
+              operationKey,
+            });
+          }
+          onRecoveryStateRef.current?.("conflicted", operationKey);
+        }
+        setLastError(message);
+        setState(conflicted ? "conflicted" : "error");
+        throw error;
+      }
+    },
+    [draftKey, identityKey, locked, workOrderLineId],
+  );
+
+  const queueFlush = useCallback(
+    async (
+      override: InspectionSession | null | undefined,
+      requireServer: boolean,
+    ): Promise<InspectionSession | null> => {
+      await hydrationPromiseRef.current;
+      const task = saveQueueRef.current
+        .catch(() => null)
+        .then(async () => {
+          if (identityRef.current !== identityKey) return null;
+          let snapshot = override ?? latestSessionRef.current;
+          if (!snapshot || !enabled) return null;
+
+          // A signing/finalization flush is a barrier, not a single request.
+          // If the user edits while one snapshot is in flight, persist the
+          // patched latest snapshot too before returning its server revision.
+          const maxBarrierPasses = requireServer ? 8 : 1;
+          for (let pass = 0; pass < maxBarrierPasses; pass += 1) {
+            const result = await persistSnapshot(snapshot, requireServer);
+            if (identityRef.current !== identityKey) return null;
+            if (requireServer && !result.durable) {
+              const message = result.conflicted
+                ? "A newer inspection was saved on another device. Review it before signing."
+                : "Inspection changes are queued but not yet saved to the server.";
+              setLastError(message);
+              throw new Error(message);
+            }
+
+            const latest = latestSessionRef.current ?? result.session;
+            if (
+              !requireServer ||
+              fingerprint(latest) === lastServerFingerprintRef.current
+            ) {
+              return latest;
+            }
+            snapshot = latest;
+          }
+
+          const message =
+            "Inspection kept changing while it was saving. Pause edits and sign again.";
+          setLastError(message);
+          setState("error");
+          throw new Error(message);
+        });
+      saveQueueRef.current = task;
+      return task;
+    },
+    [enabled, identityKey, persistSnapshot],
+  );
+
+  const flush = useCallback(
+    (override?: InspectionSession | null) =>
+      queueFlush(override, false),
+    [queueFlush],
+  );
+
+  const flushToServer = useCallback(
+    (override?: InspectionSession | null) =>
+      queueFlush(override, true),
+    [queueFlush],
+  );
+
+  useEffect(() => {
+    if (
+      !enabled ||
+      !hydrated ||
+      locked ||
+      !workOrderLineId ||
+      !session
+    ) {
+      return;
+    }
+
+    const nextFingerprint = fingerprint(session);
+    const offline =
+      typeof navigator !== "undefined" && !navigator.onLine;
+    if (
+      nextFingerprint &&
+      (nextFingerprint === lastServerFingerprintRef.current ||
+        (offline && nextFingerprint === lastQueuedFingerprintRef.current))
+    ) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      void flush().catch(() => {
+        // Status and retry UI are handled by the hook.
+      });
+    }, debounceMs);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    debounceMs,
+    enabled,
+    flush,
+    hydrated,
+    locked,
+    session,
+    workOrderLineId,
+  ]);
+
+  useEffect(() => {
+    if (!enabled || !hydrated) return;
+
+    const flushLatest = () => {
+      if (!locked) {
+        void flush().catch(() => {
+          // The durable local draft remains the unload fallback.
+        });
+      }
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") flushLatest();
+    };
+    const onOnline = () => {
+      flushLatest();
+    };
+    const onFocus = () => {
+      void pullLatest().catch(() => {
+        // Realtime remains primary; focus refresh is a fallback.
+      });
+    };
+
+    window.addEventListener("pagehide", flushLatest);
+    window.addEventListener("online", onOnline);
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      window.removeEventListener("pagehide", flushLatest);
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [enabled, flush, hydrated, locked, pullLatest]);
+
+  return {
+    state,
+    hydrated,
+    lastError,
+    flush,
+    flushToServer,
+    refresh: pullLatest,
+    label: inspectionSyncLabel(state, locked),
+  };
+}

--- a/features/inspections/hooks/useInspectionSession.ts
+++ b/features/inspections/hooks/useInspectionSession.ts
@@ -158,8 +158,6 @@ export default function useInspectionSession(initialSession?: Partial<SessionWit
 
   const stamp = () => ({ lastUpdated: new Date().toISOString() });
 
-  const replaceSession = (next: SessionWithLineId) => setSession(next);
-
   const updateInspection = (updates: Partial<SessionWithLineId>) =>
     setSession((prev) => ({ ...prev, ...updates, ...stamp() }));
 
@@ -225,6 +223,16 @@ export default function useInspectionSession(initialSession?: Partial<SessionWit
       ...stamp(),
     }));
   };
+
+  // Hydration must preserve the persisted timestamp, progress position,
+  // transcript, completion state, and sync revision. startSession is only for a
+  // genuinely new inspection.
+  const replaceSession = (sessionData: Partial<SessionWithLineId>) =>
+    setSession((prev) => ({
+      ...prev,
+      ...sessionData,
+      sections: sessionData.sections ?? prev.sections,
+    }));
 
   const pauseSession = () =>
     updateInspection({ isPaused: true, status: "paused" });

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -358,7 +358,7 @@ export default function InspectionFindingsPage(): JSX.Element {
     setDraftUi((prev) => {
       const nextUi: DraftUiState = { ...prev };
 
-      for (const row of submissionFindings) {
+      for (const row of findings) {
         const key = findingKey(row.sectionIndex, row.itemIndex);
         nextUi[key] ??= {
           laborHoursText: laborHoursToText(row.item.laborHours),

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -26,6 +26,7 @@ import { requestQuoteSuggestion } from "@inspections/lib/inspection/aiQuote";
 import { cn } from "@shared/lib/utils";
 import { getPendingInspectionPhotoCount } from "@inspections/lib/inspection/inspectionPhotoStaging";
 import { removeInspectionOfflineDraft } from "@inspections/lib/inspection/offlineDrafts";
+import { useInspectionAutosave } from "@inspections/hooks/useInspectionAutosave";
 
 type FindingRow = {
   sectionIndex: number;
@@ -187,6 +188,13 @@ function laborHoursToText(value: number | null | undefined): string {
   return String(value);
 }
 
+function sessionSyncRevision(session: InspectionSession | null): number {
+  const value = session?.syncRevision;
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : 0;
+}
+
 function updateQuoteLineInSession(
   session: InspectionSession,
   id: string,
@@ -222,6 +230,14 @@ export default function InspectionFindingsPage(): JSX.Element {
 
   const [session, setSession] = useState<InspectionSession | null>(null);
   const [busy, setBusy] = useState(false);
+  const busyRef = useRef(false);
+  const latestSessionRef = useRef<InspectionSession | null>(session);
+  latestSessionRef.current = session;
+  const activeDraftKeyRef = useRef(draftKey);
+  activeDraftKeyRef.current = draftKey;
+  const [isLocked, setIsLocked] = useState(false);
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
   const [draftUi, setDraftUi] = useState<DraftUiState>({});
   const [uploadingKey, setUploadingKey] = useState<string | null>(null);
   const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
@@ -245,111 +261,37 @@ export default function InspectionFindingsPage(): JSX.Element {
       : "") ||
     "";
 
+  const {
+    flush: flushAutosave,
+    flushToServer: flushAutosaveToServer,
+    label: autosaveLabel,
+    lastError: autosaveError,
+  } = useInspectionAutosave({
+    session,
+    inspectionId: resolvedInspectionId,
+    workOrderLineId: resolvedWorkOrderLineId,
+    enabled: Boolean(resolvedInspectionId || resolvedWorkOrderLineId),
+    locked: isLocked,
+    draftKey,
+    onRemoteSession: (remote) => {
+      latestSessionRef.current = remote;
+      setSession(remote);
+      writeDraftSession(draftKey, remote);
+    },
+    onRemoteMeta: (meta) => {
+      isLockedRef.current = meta.locked;
+      setIsLocked(meta.locked);
+    },
+  });
+
   const syncFromDraft = useCallback(async () => {
+    if (isLockedRef.current || busyRef.current) return;
     const loaded = readDraftSession(draftKey);
-
-    const loadedWorkOrderId =
-      loaded && typeof loaded.workOrderId === "string"
-        ? loaded.workOrderId.trim()
-        : "";
-
-    const loadedWorkOrderLineId =
-      loaded &&
-      typeof (loaded as InspectionSession & { workOrderLineId?: string | null })
-        .workOrderLineId === "string"
-        ? String(
-            (loaded as InspectionSession & { workOrderLineId?: string | null })
-              .workOrderLineId ?? "",
-          ).trim()
-        : "";
-
     if (loaded) {
+      latestSessionRef.current = loaded;
       setSession(loaded);
     }
-
-    const needsBackfill =
-      !loaded || !loadedWorkOrderId || !loadedWorkOrderLineId;
-
-    if (!needsBackfill) {
-      return;
-    }
-
-    if (!inspectionId && !workOrderLineId && !resolvedWorkOrderLineId) {
-      return;
-    }
-
-    try {
-      const params = new URLSearchParams();
-      if (inspectionId) params.set("inspectionId", inspectionId);
-      if (resolvedWorkOrderLineId) {
-        params.set("workOrderLineId", resolvedWorkOrderLineId);
-      }
-
-      const res = await fetch(`/api/inspections/load?${params.toString()}`, {
-        method: "GET",
-        credentials: "include",
-        cache: "no-store",
-      });
-
-      const data = (await res.json().catch(() => null)) as
-        | { session?: InspectionSession | null }
-        | null;
-
-      const serverSession = data?.session ?? null;
-      if (serverSession) {
-        const mergedSession = {
-          ...(loaded ?? {}),
-          ...serverSession,
-          workOrderId:
-            (typeof serverSession.workOrderId === "string" &&
-            serverSession.workOrderId.trim().length > 0
-              ? serverSession.workOrderId.trim()
-              : "") ||
-            loadedWorkOrderId ||
-            workOrderId ||
-            resolvedWorkOrderId ||
-            null,
-          workOrderLineId:
-            ((typeof (
-              serverSession as InspectionSession & {
-                workOrderLineId?: string | null;
-              }
-            ).workOrderLineId === "string" &&
-            String(
-              (
-                serverSession as InspectionSession & {
-                  workOrderLineId?: string | null;
-                }
-              ).workOrderLineId ?? "",
-            ).trim().length > 0
-              ? String(
-                  (
-                    serverSession as InspectionSession & {
-                      workOrderLineId?: string | null;
-                    }
-                  ).workOrderLineId ?? "",
-                ).trim()
-              : "") ||
-              loadedWorkOrderLineId ||
-              workOrderLineId ||
-              resolvedWorkOrderLineId ||
-              null),
-        } as InspectionSession;
-
-        writeDraftSession(draftKey, mergedSession);
-        setSession(mergedSession);
-      }
-    } catch (err) {
-      console.error("[inspection-findings] failed to load saved session", err);
-    }
-  }, [
-    draftKey,
-    inspectionId,
-    workOrderId,
-    workOrderLineId,
-    resolvedWorkOrderId,
-    resolvedWorkOrderLineId,
-  ]);
+  }, [draftKey]);
 
   useEffect(() => {
     void syncFromDraft();
@@ -416,7 +358,7 @@ export default function InspectionFindingsPage(): JSX.Element {
     setDraftUi((prev) => {
       const nextUi: DraftUiState = { ...prev };
 
-      for (const row of findings) {
+      for (const row of submissionFindings) {
         const key = findingKey(row.sectionIndex, row.itemIndex);
         nextUi[key] ??= {
           laborHoursText: laborHoursToText(row.item.laborHours),
@@ -433,11 +375,13 @@ export default function InspectionFindingsPage(): JSX.Element {
     itemIndex: number,
     patch: Partial<InspectionItem>,
   ): void => {
+    if (isLockedRef.current || busyRef.current) return;
     setSession((prev) => {
-      if (!prev) return prev;
+      if (isLockedRef.current || busyRef.current || !prev) return prev;
 
       const next: InspectionSession = {
         ...prev,
+        lastUpdated: new Date().toISOString(),
         sections: prev.sections.map((sec, sIdx) => {
           if (sIdx !== sectionIndex) return sec;
           return {
@@ -450,6 +394,7 @@ export default function InspectionFindingsPage(): JSX.Element {
       };
 
       writeDraftSession(draftKey, next);
+      latestSessionRef.current = next;
 
       if (typeof window !== "undefined") {
         window.dispatchEvent(
@@ -468,15 +413,20 @@ export default function InspectionFindingsPage(): JSX.Element {
     itemIndex: number,
     patch: Partial<{ laborHoursText: string; partsText: string }>,
   ): void => {
+    if (isLockedRef.current || busyRef.current) return;
     const key = findingKey(sectionIndex, itemIndex);
-    setDraftUi((prev) => ({
-      ...prev,
+    setDraftUi((prev) =>
+      isLockedRef.current || busyRef.current
+        ? prev
+        : ({
+            ...prev,
       [key]: {
         laborHoursText: prev[key]?.laborHoursText ?? "",
         partsText: prev[key]?.partsText ?? "",
-        ...patch,
-      },
-    }));
+            ...patch,
+          },
+        }),
+    );
   };
 
   const markReviewed = (row: FindingRow): void => {
@@ -491,6 +441,14 @@ export default function InspectionFindingsPage(): JSX.Element {
     row: FindingRow,
     file: File,
   ): Promise<void> => {
+    if (busyRef.current) {
+      toast.error("Wait for the current findings submission to finish.");
+      return;
+    }
+    if (isLockedRef.current) {
+      toast.error("This signed inspection is locked.");
+      return;
+    }
     if (!resolvedInspectionId) {
       toast.error("Missing inspection id.");
       return;
@@ -525,6 +483,13 @@ export default function InspectionFindingsPage(): JSX.Element {
         throw new Error(json?.error || "Failed to upload photo");
       }
 
+      if (isLockedRef.current) {
+        toast.error(
+          "This inspection was signed while the photo was uploading; it was not attached.",
+        );
+        return;
+      }
+
       const nextUrl = json?.url ?? null;
       const current = row.item.photoUrls ?? [];
       const nextPhotoUrls = nextUrl ? [...current, nextUrl] : current;
@@ -547,75 +512,107 @@ export default function InspectionFindingsPage(): JSX.Element {
   };
 
   const handleSubmitReviewed = async (): Promise<void> => {
-    if (!session) return;
+    if (!session || isLockedRef.current || busyRef.current) return;
+    busyRef.current = true;
+    setBusy(true);
+    const submissionDraftKey = draftKey;
+    let submissionRevision = sessionSyncRevision(session);
+    let submissionInspectionId = String(session.id ?? resolvedInspectionId);
 
-    let pendingPhotoCount: number;
-    try {
-      pendingPhotoCount = await getPendingInspectionPhotoCount(draftKey);
-    } catch {
-      toast.error(
-        "Unable to verify staged inspection photos. Open Sync Center and try again.",
-      );
-      return;
-    }
-    if (pendingPhotoCount > 0) {
-      toast.error(
-        `${pendingPhotoCount} inspection photo${pendingPhotoCount === 1 ? " is" : "s are"} still waiting to sync. Upload or remove them before submitting.`,
-      );
-      return;
-    }
-
-    if (!resolvedWorkOrderId) {
-      toast.error("Missing work order id.");
-      return;
-    }
-
-    if (!resolvedWorkOrderLineId) {
-      toast.error("Missing work order line id.");
-      return;
-    }
-
-    const pending = collectFindings(session).filter(
-      (row) => row.item.findingReviewed !== true,
-    );
-
-    if (pending.length > 0) {
-      toast.error("Review every finding before submitting.");
-      return;
-    }
-
-    const actionable = findings.filter((row) => {
-      const item = row.item as InspectionItem & {
-        estimateSubmitted?: boolean;
-        estimateQuoteLineId?: string | null;
-      };
-
-      const status = String(item.status ?? "").toLowerCase();
-      if (status !== "fail" && status !== "recommend") return false;
-
-      const note = String(item.notes ?? "").trim();
-      if (!note) return false;
-
+    const assertSubmissionCurrent = (): void => {
+      if (isLockedRef.current) {
+        throw new Error(
+          "This inspection was signed on another device while findings were being prepared.",
+        );
+      }
+      if (activeDraftKeyRef.current !== submissionDraftKey) {
+        throw new Error("The active inspection changed before submission finished.");
+      }
+      const latest = latestSessionRef.current;
       if (
-        item.estimateSubmitted === true &&
-        typeof item.estimateQuoteLineId === "string" &&
-        item.estimateQuoteLineId.trim().length > 0
+        latest &&
+        submissionInspectionId &&
+        latest.id &&
+        latest.id !== submissionInspectionId
       ) {
-        return true;
+        throw new Error("The active inspection changed before submission finished.");
+      }
+      if (latest && sessionSyncRevision(latest) > submissionRevision) {
+        throw new Error(
+          "This inspection changed on another device. Review the latest changes and submit again.",
+        );
+      }
+    };
+
+    try {
+      let pendingPhotoCount: number;
+      try {
+        pendingPhotoCount = await getPendingInspectionPhotoCount(draftKey);
+      } catch {
+        toast.error(
+          "Unable to verify staged inspection photos. Open Sync Center and try again.",
+        );
+        return;
+      }
+      assertSubmissionCurrent();
+      if (pendingPhotoCount > 0) {
+        toast.error(
+          `${pendingPhotoCount} inspection photo${pendingPhotoCount === 1 ? " is" : "s are"} still waiting to sync. Upload or remove them before submitting.`,
+        );
+        return;
       }
 
-      return true;
-    });
+      if (!resolvedWorkOrderId) {
+        toast.error("Missing work order id.");
+        return;
+      }
 
-    if (actionable.length === 0) {
-      toast.error("No reviewed findings are ready to submit.");
-      return;
-    }
+      if (!resolvedWorkOrderLineId) {
+        toast.error("Missing work order line id.");
+        return;
+      }
 
-    setBusy(true);
+      const durableSession = await flushAutosaveToServer(session);
+      if (!durableSession) {
+        throw new Error("Inspection did not finish saving to the server.");
+      }
+      latestSessionRef.current = durableSession;
+      submissionRevision = sessionSyncRevision(durableSession);
+      submissionInspectionId = String(
+        durableSession.id ?? submissionInspectionId,
+      );
+      assertSubmissionCurrent();
 
-    try {
-      let nextSession: InspectionSession = { ...session };
+      const submissionFindings = collectFindings(durableSession);
+      const pending = submissionFindings.filter(
+        (row) => row.item.findingReviewed !== true,
+      );
+
+      if (pending.length > 0) {
+        toast.error("Review every finding before submitting.");
+        return;
+      }
+
+      const actionable = submissionFindings.filter((row) => {
+        const item = row.item as InspectionItem & {
+          estimateSubmitted?: boolean;
+          estimateQuoteLineId?: string | null;
+        };
+        const status = String(item.status ?? "").toLowerCase();
+        const note = String(item.notes ?? "").trim();
+        return (
+          (status === "fail" || status === "recommend") && note.length > 0
+        );
+      });
+
+      // A clean inspection has no quote findings, but still needs a durable
+      // finalization path. Only block when findings exist but are incomplete.
+      if (submissionFindings.length > 0 && actionable.length === 0) {
+        toast.error("No reviewed findings are ready to submit.");
+        return;
+      }
+
+      let nextSession: InspectionSession = { ...durableSession };
       const nowIso = new Date().toISOString();
       const quotePayloadItems: Array<{
         id: string;
@@ -687,6 +684,7 @@ export default function InspectionFindingsPage(): JSX.Element {
             pricingValidUntil?: string | null;
             confidence?: number | null;
           } | null;
+          noPartsRequired?: boolean;
         };
 
         const manualParts = Array.isArray(itemExt.parts) ? itemExt.parts : [];
@@ -772,9 +770,13 @@ export default function InspectionFindingsPage(): JSX.Element {
           status,
           vehicle: nextSession.vehicle ?? undefined,
         });
+        assertSubmissionCurrent();
 
+        const noPartsRequired = itemExt.noPartsRequired === true;
         const verifiedParts: Array<{ name: string; qty: number }> =
-          manualParts.length > 0
+          noPartsRequired
+            ? []
+            : manualParts.length > 0
             ? manualParts.map((part) => ({
                 name: part.description,
                 qty: part.qty,
@@ -851,6 +853,7 @@ export default function InspectionFindingsPage(): JSX.Element {
             inspection_status: status,
             technician_notes: note,
             manual_parts: manualParts,
+            no_parts_required: noPartsRequired,
             source_value: itemExt.value ?? null,
             ai_enrichment_state: suggestion ? "available" : "unavailable",
             menu_match: acceptedMatch
@@ -872,6 +875,7 @@ export default function InspectionFindingsPage(): JSX.Element {
       }
 
       if (quotePayloadItems.length > 0) {
+        assertSubmissionCurrent();
         const quoteRes = await fetch("/api/work-orders/quotes/add", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -896,6 +900,7 @@ export default function InspectionFindingsPage(): JSX.Element {
               }>;
             }
           | null;
+        assertSubmissionCurrent();
 
         if (!quoteRes.ok) {
           throw new Error(quoteJson?.error || "Failed to send findings to quote review");
@@ -929,8 +934,22 @@ export default function InspectionFindingsPage(): JSX.Element {
         };
       }
 
+      assertSubmissionCurrent();
+      nextSession = { ...nextSession, lastUpdated: nowIso };
+      latestSessionRef.current = nextSession;
       setSession(nextSession);
       writeDraftSession(draftKey, nextSession);
+      const persistedSession = await flushAutosaveToServer(nextSession);
+      if (!persistedSession) {
+        throw new Error("Inspection did not finish saving to the server.");
+      }
+      nextSession = persistedSession;
+      latestSessionRef.current = persistedSession;
+      submissionRevision = sessionSyncRevision(persistedSession);
+      submissionInspectionId = String(
+        persistedSession.id ?? submissionInspectionId,
+      );
+      assertSubmissionCurrent();
 
       if (typeof window !== "undefined") {
         window.dispatchEvent(
@@ -942,12 +961,14 @@ export default function InspectionFindingsPage(): JSX.Element {
 
       const payload = summarizeFromSections(nextSession);
 
-      let bestEffortWarning: string | null = null;
-
+      assertSubmissionCurrent();
       const pdfRes = await fetch(`/api/inspections/finalize/pdf`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ workOrderLineId: resolvedWorkOrderLineId }),
+        body: JSON.stringify({
+          workOrderLineId: resolvedWorkOrderLineId,
+          expectedSyncRevision: nextSession.syncRevision ?? 0,
+        }),
       });
 
       const pdfJson = (await pdfRes.json().catch(() => null)) as
@@ -955,9 +976,10 @@ export default function InspectionFindingsPage(): JSX.Element {
         | null;
 
       if (!pdfRes.ok || !pdfJson?.ok) {
-        bestEffortWarning =
-          bestEffortWarning ??
-          (pdfJson?.error || "Findings submitted, but PDF finalize failed.");
+        throw new Error(
+          pdfJson?.error ||
+            "Inspection could not be finalized. Your draft is still saved.",
+        );
       }
 
       await removeInspectionOfflineDraft({
@@ -983,17 +1005,14 @@ export default function InspectionFindingsPage(): JSX.Element {
       );
 
       window.dispatchEvent(new CustomEvent("inspection:close"));
-      if (bestEffortWarning) {
-        toast.warning(bestEffortWarning);
-      } else {
-        toast.success("Findings sent to quote review.");
-      }
+      toast.success("Findings sent to quote review.");
       router.push(`/quote-review/${resolvedWorkOrderId}`);
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Unable to submit findings";
       toast.error(message);
     } finally {
+      busyRef.current = false;
       setBusy(false);
     }
   };
@@ -1017,6 +1036,11 @@ export default function InspectionFindingsPage(): JSX.Element {
       description="Review failed and recommended findings before sending them to advisor quote review."
     >
       <div className="mx-auto max-w-5xl space-y-4">
+        {isLocked && (
+          <div className="rounded-xl border border-amber-500/60 bg-amber-500/10 p-3 text-sm text-amber-100">
+            This inspection is signed and locked. Reopen it before changing findings.
+          </div>
+        )}
         <DecisionEventFeed events={decisionEvents} compact maxVisible={5} />
         {findings.length === 0 ? (
           <div className={cn(PANEL_VARIANTS.passive, "p-4 text-sm text-[color:var(--theme-text-secondary)]")}>
@@ -1074,6 +1098,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                       <textarea
                         className="min-h-[110px] w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-primary)] outline-none"
                         value={String(row.item.notes ?? "")}
+                        disabled={isLocked || busy}
                         onChange={(e) =>
                           updateFinding(row.sectionIndex, row.itemIndex, {
                             notes: e.target.value,
@@ -1093,6 +1118,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                           }}
                           type="file"
                           accept="image/*"
+                          disabled={isLocked || busy}
                           className="hidden"
                           onChange={(e) => {
                             const file = e.target.files?.[0];
@@ -1105,7 +1131,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                           type="button"
                           className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 hover:bg-[color:var(--theme-surface-subtle)] disabled:opacity-60"
                           onClick={() => fileInputRefs.current[key]?.click()}
-                          disabled={isUploading}
+                          disabled={isUploading || isLocked || busy}
                         >
                           {isUploading ? "Uploading photo..." : "Add photo evidence"}
                         </button>
@@ -1137,6 +1163,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                         inputMode="decimal"
                         className="w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-primary)] outline-none"
                         value={laborHoursText}
+                        disabled={isLocked || busy}
                         onChange={(e) => {
                           const raw = e.target.value;
                           if (/^\d*\.?\d*$/.test(raw)) {
@@ -1185,6 +1212,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                       <textarea
                         className="min-h-[110px] w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-primary)] outline-none"
                         value={partsText}
+                        disabled={isLocked || busy}
                         onChange={(e) => {
                           updateUiDraft(row.sectionIndex, row.itemIndex, {
                             partsText: e.target.value,
@@ -1204,6 +1232,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                   <button
                     type="button"
                     className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-emerald-200 hover:bg-emerald-500/20"
+                    disabled={isLocked || busy}
                     onClick={() => markReviewed(row)}
                   >
                     {reviewed ? "Reviewed" : "Mark reviewed"}
@@ -1212,6 +1241,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                   <button
                     type="button"
                     className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 hover:bg-[color:var(--theme-surface-subtle)]"
+                    disabled={isLocked || busy}
                     onClick={() =>
                       updateFinding(row.sectionIndex, row.itemIndex, {
                         photoRequested: true,
@@ -1224,6 +1254,7 @@ export default function InspectionFindingsPage(): JSX.Element {
                   <button
                     type="button"
                     className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 hover:bg-[color:var(--theme-surface-subtle)]"
+                    disabled={isLocked || busy}
                     onClick={() =>
                       updateFinding(row.sectionIndex, row.itemIndex, {
                         photoReviewed: true,
@@ -1243,7 +1274,8 @@ export default function InspectionFindingsPage(): JSX.Element {
 
         <div className={cn(PANEL_VARIANTS.secondary, "flex flex-wrap items-center justify-between gap-3 p-4")}>
           <div className="text-sm text-[color:var(--theme-text-secondary)]">
-            Reviewed findings:{" "}
+            <div>
+              Reviewed findings:{" "}
             <span className="font-semibold text-[color:var(--theme-text-primary)]">
               {
                 findings.filter((row) => row.item.findingReviewed === true)
@@ -1252,13 +1284,41 @@ export default function InspectionFindingsPage(): JSX.Element {
             </span>
             {" / "}
             <span className="font-semibold text-[color:var(--theme-text-primary)]">{findings.length}</span>
+            </div>
+            <div className="mt-1 text-xs">
+              {autosaveLabel}
+              {autosaveError && (
+                <span className="ml-2 text-red-400">{autosaveError}</span>
+              )}
+            </div>
           </div>
 
           <div className="flex gap-2">
-            <Button type="button" variant="outline" onClick={() => router.back()}>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={busy}
+              onClick={async () => {
+                try {
+                  await flushAutosave();
+                  router.back();
+                } catch (error) {
+                  toast.error(
+                    error instanceof Error
+                      ? error.message
+                      : "Wait for the inspection to finish saving.",
+                  );
+                }
+              }}
+            >
               Back
             </Button>
-            <Button type="button" onClick={handleSubmitReviewed} isLoading={busy}>
+            <Button
+              type="button"
+              onClick={handleSubmitReviewed}
+              isLoading={busy}
+              disabled={isLocked || busy}
+            >
               {busy ? "Sending…" : "Send to Quote Review"}
             </Button>
           </div>

--- a/features/inspections/lib/inspection/offlineDrafts.ts
+++ b/features/inspections/lib/inspection/offlineDrafts.ts
@@ -7,6 +7,7 @@ import {
   saveOfflineSnapshot,
 } from "@/features/shared/lib/offline/database";
 import {
+  dismissOfflineMutation,
   hydrateOfflineMutationQueue,
   listOfflineMutations,
   resolveOfflineMutationScope,
@@ -72,6 +73,7 @@ export async function saveInspectionOfflineDraft(args: {
 export async function getInspectionOfflineDraft(args: {
   draftKey: string;
   sessionHint: Partial<InspectionSession>;
+  newerSessionHint?: Partial<InspectionSession> | null;
 }): Promise<InspectionOfflineDraft | null> {
   const scope = await scopeFor(args.sessionHint);
   if (!scope) return null;
@@ -88,7 +90,7 @@ export async function getInspectionOfflineDraft(args: {
     const queued = listOfflineMutations(scope).find(
       (mutation) => mutation.clientMutationId === draft.operationKey,
     );
-    if (!queued || queued.status === "synced") {
+    if (!queued) {
       const reconciled = {
         ...draft,
         state: "editing" as const,
@@ -97,11 +99,40 @@ export async function getInspectionOfflineDraft(args: {
       await saveInspectionOfflineDraft(reconciled);
       return reconciled;
     }
+    if (queued.status === "synced") {
+      // Keep the key until the autosave client retrieves the server's
+      // idempotent acknowledgement and its canonical sync revision.
+      const awaitingAcknowledgement = {
+        ...draft,
+        state: "queued" as const,
+      };
+      await saveInspectionOfflineDraft(awaitingAcknowledgement);
+      return awaitingAcknowledgement;
+    }
     const queuedSession =
       (queued.payload && typeof queued.payload === "object"
         ? (queued.payload as { session?: Partial<InspectionSession> }).session
         : null) ?? null;
-    if (sessionTimestamp(draft.session) > sessionTimestamp(queuedSession)) {
+    const newestLocalTimestamp = Math.max(
+      sessionTimestamp(draft.session),
+      sessionTimestamp(args.newerSessionHint ?? null),
+    );
+    if (newestLocalTimestamp > sessionTimestamp(queuedSession)) {
+      try {
+        await dismissOfflineMutation(draft.operationKey);
+      } catch {
+        return { ...draft, state: "conflicted" };
+      }
+      const supersededMutation = listOfflineMutations(scope).find(
+        (mutation) =>
+          mutation.clientMutationId === draft.operationKey &&
+          mutation.status !== "synced",
+      );
+      if (supersededMutation) {
+        // A syncing mutation cannot be removed safely. Keep its lineage visible
+        // instead of reusing the key for a different payload.
+        return { ...draft, state: "conflicted" };
+      }
       const reconciled = {
         ...draft,
         state: "editing" as const,

--- a/features/inspections/lib/inspection/save.ts
+++ b/features/inspections/lib/inspection/save.ts
@@ -2,7 +2,10 @@
 "use client";
 
 import type { InspectionSession } from "@inspections/lib/inspection/types";
-import { runMutationWithOfflineQueue } from "@/features/shared/lib/offline/mutations";
+import {
+  dismissOfflineMutation,
+  runMutationWithOfflineQueue,
+} from "@/features/shared/lib/offline/mutations";
 import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
 
 const ACTION_SAVE_INSPECTION = "inspection:save-session";
@@ -13,7 +16,21 @@ type InspectionSavePayload = {
   operationKey: string;
 };
 
-async function postInspectionSave(payload: InspectionSavePayload) {
+type SaveInspectionOptions = {
+  operationKey?: string;
+  requireServer?: boolean;
+  supersedesOperationKey?: string;
+};
+
+type InspectionSaveResponse = {
+  inspection_id?: string;
+  sync_revision?: number;
+  saved_at?: string;
+};
+
+async function postInspectionSave(
+  payload: InspectionSavePayload,
+): Promise<InspectionSaveResponse> {
   const res = await fetch("/api/inspections/save", {
     method: "POST",
     headers: {
@@ -21,22 +38,24 @@ async function postInspectionSave(payload: InspectionSavePayload) {
       "Idempotency-Key": payload.operationKey,
     },
     credentials: "include",
+    keepalive: true,
     body: JSON.stringify({
       ...payload,
       idempotencyKey: payload.operationKey,
     }),
   });
 
+  const json = (await res.json().catch(() => null)) as
+    | (InspectionSaveResponse & { error?: string })
+    | null;
   if (!res.ok) {
-    const json = (await res.json().catch(() => null)) as {
-      error?: string;
-    } | null;
     const error = new Error(json?.error || "Save failed") as Error & {
       status?: number;
     };
     error.status = res.status;
     throw error;
   }
+  return json ?? {};
 }
 
 export async function replayQueuedInspectionSaves(): Promise<void> {
@@ -46,32 +65,76 @@ export async function replayQueuedInspectionSaves(): Promise<void> {
 export async function saveInspectionSession(
   session: InspectionSession,
   workOrderLineId: string,
-): Promise<{ queued: boolean; conflicted: boolean; operationKey: string }> {
+  options: SaveInspectionOptions = {},
+): Promise<{
+  queued: boolean;
+  conflicted: boolean;
+  operationKey: string;
+  inspectionId?: string;
+  syncRevision?: number;
+  savedAt?: string;
+}> {
   if (!workOrderLineId) {
     throw new Error("Missing workOrderLineId");
   }
 
   const operationKey =
-    typeof crypto !== "undefined" && "randomUUID" in crypto
+    options.operationKey?.trim() ||
+    (typeof crypto !== "undefined" && "randomUUID" in crypto
       ? crypto.randomUUID()
-      : `${workOrderLineId}:${Date.now()}`;
+      : `${workOrderLineId}:${Date.now()}`);
   const payload: InspectionSavePayload = {
     workOrderLineId,
     session,
     operationKey,
   };
 
+  const supersededKey = options.supersedesOperationKey?.trim();
+  if (supersededKey && supersededKey !== operationKey) {
+    // A distinct key prevents an in-flight replay from acknowledging a newer
+    // payload. Queued (not syncing) snapshots are safely coalesced away.
+    await dismissOfflineMutation(supersededKey);
+  }
+
+  const serverResponse: { current: InspectionSaveResponse | null } = {
+    current: null,
+  };
   const result = await runMutationWithOfflineQueue({
     clientMutationId: operationKey,
     actionType: ACTION_SAVE_INSPECTION,
     payload,
-    orderKey: `${workOrderLineId}:inspection-progress:${operationKey}`,
-    runner: () => postInspectionSave(payload),
+    orderKey: `${workOrderLineId}:inspection-progress`,
+    queueOnOffline: options.requireServer !== true,
+    runner: async () => {
+      serverResponse.current = await postInspectionSave(payload);
+    },
   });
+
+  // A recovered operation may already be marked synced in IndexedDB even
+  // though the page that originally sent it never captured the server's new
+  // revision. Re-read that idempotent result online before treating the local
+  // snapshot as durable; otherwise its next edit would reuse a stale revision
+  // and conflict with the very save that just succeeded.
+  if (!result.queued && !result.conflicted && !serverResponse.current) {
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      return {
+        queued: true,
+        conflicted: false,
+        operationKey,
+      };
+    }
+    serverResponse.current = await postInspectionSave(payload);
+  }
 
   if (typeof navigator !== "undefined" && navigator.onLine) {
     await replayQueuedInspectionSaves();
   }
 
-  return { ...result, operationKey };
+  return {
+    ...result,
+    operationKey,
+    inspectionId: serverResponse.current?.inspection_id,
+    syncRevision: serverResponse.current?.sync_revision,
+    savedAt: serverResponse.current?.saved_at,
+  };
 }

--- a/features/inspections/lib/inspection/types.ts
+++ b/features/inspections/lib/inspection/types.ts
@@ -329,6 +329,7 @@ export interface InspectionSession {
   customerId?: string | null;
   vehicleId?: string | null;
   workOrderId?: string | null;
+  workOrderLineId?: string | null;
   templateId?: string | null;
   templateName?: string | null;
   templateitem?: string | null;
@@ -345,8 +346,11 @@ export interface InspectionSession {
   completed: boolean;
   isPaused: boolean;
   lastUpdated?: string;
+  syncRevision?: number;
+  serverUpdatedAt?: string | null;
   customer?: SessionCustomer | null;
   vehicle?: SessionVehicle | null;
   sections: InspectionCategory[];
   quote?: Array<QuoteLine | QuoteLineItem>;
 }
+

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -11,6 +11,7 @@ import PauseResumeButton from "@inspections/lib/inspection/PauseResume";
 import StartListeningButton from "@inspections/lib/inspection/StartListeningButton";
 import ProgressTracker from "@inspections/lib/inspection/ProgressTracker";
 import useInspectionSession from "@inspections/hooks/useInspectionSession";
+import { useInspectionAutosave } from "@inspections/hooks/useInspectionAutosave";
 
 import { handleTranscriptFn } from "@inspections/lib/inspection/handleTranscript";
 import { interpretCommand } from "@inspections/components/inspection/interpretCommand";
@@ -43,10 +44,6 @@ import TireGridHydraulic from "@inspections/lib/inspection/ui/TireGridHydraulic"
 import BatteryGrid from "@inspections/lib/inspection/ui/BatteryGrid";
 
 import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionFormContext";
-import {
-  InspectionAutosaveStatus,
-  useInspectionRealtimeAutosave,
-} from "@inspections/hooks/useInspectionRealtimeAutosave";
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicleHeader";
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
@@ -808,6 +805,24 @@ type SmartMatchRow = {
 
   const [isPaused, setIsPaused] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
+  const applyLockedState = (
+    nextLocked: boolean,
+    persistEvidence = true,
+  ): void => {
+    // Update the ref synchronously so in-flight async handlers are blocked even
+    // before React commits the state update from a Realtime event.
+    isLockedRef.current = nextLocked;
+    setIsLocked(nextLocked);
+    if (!persistEvidence) return;
+    try {
+      if (nextLocked) localStorage.setItem(lockKey, "1");
+      else localStorage.removeItem(lockKey);
+    } catch {
+      // Server metadata remains authoritative when storage is unavailable.
+    }
+  };
 
   const [newItemLabels, setNewItemLabels] = useState<Record<number, string>>(
     {},
@@ -842,7 +857,6 @@ type SmartMatchRow = {
 
   const [voicePulse, setVoicePulse] = useState(false);
   const pulseTimerRef = useRef<number | null>(null);
-  const [serverBootLoaded, setServerBootLoaded] = useState(false);
   const [draftBootLoaded, setDraftBootLoaded] = useState(false);
   const [recoveryState, setRecoveryState] =
     useState<InspectionDraftRecoveryState>("editing");
@@ -852,7 +866,6 @@ type SmartMatchRow = {
   const skipNextQueuedEditCheckRef = useRef(false);
   const inspectionCompletedRef = useRef(false);
   const localDraftUpdatedAtRef = useRef(0);
-  const serverStartedRef = useRef<string | null>(null);
 
   const triggerVoicePulse = (): void => {
     setVoicePulse(true);
@@ -890,43 +903,102 @@ type SmartMatchRow = {
 
   const {
     session,
+    updateInspection: updateSessionInspection,
+    updateItem: updateSessionItem,
+    updateSection: updateSessionSection,
+    startSession: startInspectionSession,
     replaceSession,
-    updateInspection,
-    updateItem,
-    updateSection,
-    startSession,
-    finishSession,
-    resumeSession,
-    pauseSession,
-    addQuoteLine,
-    updateQuoteLine,
+    finishSession: finishInspectionSession,
+    resumeSession: resumeInspectionSession,
+    pauseSession: pauseInspectionSession,
+    addQuoteLine: addSessionQuoteLine,
+    updateQuoteLine: updateSessionQuoteLine,
   } = useInspectionSession(persistedSession ?? initialSession);
 
-  const autosaveState = useInspectionRealtimeAutosave({
+  // Realtime finalization can arrive while this screen is open. Keep every
+  // mutation entry point read-only as soon as the canonical row is locked.
+  const updateInspection = (
+    ...args: Parameters<typeof updateSessionInspection>
+  ) => {
+    if (!isLockedRef.current) updateSessionInspection(...args);
+  };
+  const updateItem = (...args: Parameters<typeof updateSessionItem>) => {
+    if (!isLockedRef.current) updateSessionItem(...args);
+  };
+  const updateSection = (...args: Parameters<typeof updateSessionSection>) => {
+    if (!isLockedRef.current) updateSessionSection(...args);
+  };
+  const addQuoteLine = (...args: Parameters<typeof addSessionQuoteLine>) => {
+    if (!isLockedRef.current) addSessionQuoteLine(...args);
+  };
+  const updateQuoteLine = (
+    ...args: Parameters<typeof updateSessionQuoteLine>
+  ) => {
+    if (!isLockedRef.current) updateSessionQuoteLine(...args);
+  };
+  const startSession = (
+    ...args: Parameters<typeof startInspectionSession>
+  ) => {
+    if (!isLockedRef.current) startInspectionSession(...args);
+  };
+  const resumeSession = (
+    ...args: Parameters<typeof resumeInspectionSession>
+  ) => {
+    if (!isLockedRef.current) resumeInspectionSession(...args);
+  };
+  const pauseSession = (
+    ...args: Parameters<typeof pauseInspectionSession>
+  ) => {
+    if (!isLockedRef.current) pauseInspectionSession(...args);
+  };
+  const finishSession = (
+    ...args: Parameters<typeof finishInspectionSession>
+  ) => {
+    if (!isLockedRef.current) finishInspectionSession(...args);
+  };
+
+  const {
+    hydrated: serverBootLoaded,
+    flush: flushAutosave,
+    flushToServer: flushAutosaveToServer,
+    label: autosaveLabel,
+    lastError: autosaveError,
+  } = useInspectionAutosave({
     session,
+    inspectionId,
     workOrderLineId,
-    enabled:
-      Boolean(workOrderLineId) &&
-      draftBootLoaded &&
-      serverBootLoaded &&
-      !inspectionCompletedRef.current,
+    enabled: draftBootLoaded && !inspectionCompletedRef.current,
     locked: isLocked,
-    onRemoteSession: (remoteSession) => {
-      replaceSession(remoteSession);
-      localDraftUpdatedAtRef.current = inspectionDraftTimestamp(remoteSession);
+    draftKey,
+    recoveryOperationKey: recoveryOperationKeyRef.current,
+    onRemoteSession: (remote) => {
+      replaceSession(remote);
+      localDraftUpdatedAtRef.current = inspectionDraftTimestamp(remote);
       try {
-        localStorage.setItem(draftKey, JSON.stringify(remoteSession));
+        localStorage.setItem(draftKey, JSON.stringify(remote));
       } catch {
-        // The server copy remains authoritative if local storage is unavailable.
+        // IndexedDB and the server remain authoritative.
       }
     },
-    onRemoteLocked: () => {
-      setIsLocked(true);
-      try {
-        localStorage.setItem(lockKey, "1");
-      } catch {
-        // Server lock is authoritative.
-      }
+    onRemoteMeta: (meta) => {
+      // An unversioned `locked: false` response means the canonical row has not
+      // been observed yet; it must not erase durable evidence of an offline
+      // signed inspection. Versioned server metadata remains authoritative.
+      if (meta.updatedAt === null && !meta.locked) return;
+      applyLockedState(meta.locked, meta.updatedAt !== null);
+    },
+    onRecoveryState: (state, operationKey) => {
+      setRecoveryState(state);
+      recoveryOperationKeyRef.current = operationKey;
+      queuedSessionRef.current = operationKey ? session : null;
+      skipNextQueuedEditCheckRef.current = false;
+      setRecoveryMessage(
+        state === "queued"
+          ? "Inspection is safe on this device and queued for server sync."
+          : state === "conflicted"
+            ? "Inspection is safe on this device, but sync needs review."
+            : "Inspection progress is saved and available on all devices.",
+      );
     },
   });
 
@@ -938,6 +1010,7 @@ type SmartMatchRow = {
         const recovered = await getInspectionOfflineDraft({
           draftKey,
           sessionHint: persistedSession ?? initialSession,
+          newerSessionHint: persistedSession,
         });
         if (cancelled) return;
         if (recovered) {
@@ -946,7 +1019,7 @@ type SmartMatchRow = {
           const preferred =
             recoveredAt >= legacyAt ? recovered.session : persistedSession;
           if (preferred) {
-            startSession(preferred);
+            replaceSession(preferred);
             localDraftUpdatedAtRef.current = inspectionDraftTimestamp(preferred);
           }
           setRecoveryState(recovered.state);
@@ -1122,6 +1195,8 @@ type SmartMatchRow = {
   };
 
   const dismissSmartMatch = async (sectionIndex: number, itemIndex: number) => {
+    if (guardLocked()) return;
+
     const key = itemKey(sectionIndex, itemIndex);
     const sec = session.sections?.[sectionIndex];
     const item = sec?.items?.[itemIndex];
@@ -1163,6 +1238,8 @@ type SmartMatchRow = {
     sectionIndex: number,
     itemIndex: number,
   ): Promise<void> => {
+    if (guardLocked()) return;
+
     const key = itemKey(sectionIndex, itemIndex);
     const match = smartMatchByKey[key];
     const sec = session?.sections?.[sectionIndex];
@@ -1242,6 +1319,8 @@ type SmartMatchRow = {
           | { ok?: boolean; error?: string; workOrderQuoteLineId?: string | null; quoteLineId?: string | null }
           | null;
 
+        if (guardLocked()) return;
+
         if (!res.ok || !json?.ok) {
           throw new Error(json?.error || "Failed to add matched repair");
         }
@@ -1287,6 +1366,8 @@ type SmartMatchRow = {
           jobType: "repair",
         });
 
+        if (guardLocked()) return;
+
         const createdId = (created as { id?: unknown } | null)?.id;
         createdWorkOrderLineId =
           typeof createdId === "string" && createdId ? createdId : null;
@@ -1324,6 +1405,7 @@ type SmartMatchRow = {
         } satisfies VoiceMeta,
       });
 
+      if (guardLocked()) return;
       await fetch("/api/inspections/smart-match/history", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1338,7 +1420,7 @@ type SmartMatchRow = {
         }),
       });
 
-
+      if (guardLocked()) return;
       await fetch("/api/inspections/smart-match/feedback", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1352,6 +1434,8 @@ type SmartMatchRow = {
           vehicle: asVehicleForSmartMatch(vehicle),
         }),
       });
+
+      if (guardLocked()) return;
 
       const autoAcceptReady =
         match.autoAcceptReady === true ||
@@ -1390,12 +1474,14 @@ type SmartMatchRow = {
     if (typeof window === "undefined") return;
     try {
       const raw = localStorage.getItem(lockKey);
-      setIsLocked(raw === "1");
+      applyLockedState(raw === "1");
     } catch {}
+    // Lock hydration is keyed only to the draft identity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lockKey]);
 
   const guardLocked = (): boolean => {
-    if (!isLocked) return false;
+    if (!isLockedRef.current) return false;
     toast.error("This inspection is signed and locked. Editing is disabled.");
     return true;
   };
@@ -1420,88 +1506,13 @@ type SmartMatchRow = {
           null,
       };
 
-      startSession(hydratedSession);
+      replaceSession(hydratedSession);
     } else {
       startSession(initialSession);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [persistedSession, initialSession, workOrderId, workOrderLineId]);
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const loadSavedInspection = async () => {
-      if (!draftBootLoaded) return;
-      if (!inspectionId && !workOrderLineId) {
-        setServerBootLoaded(true);
-        return;
-      }
-
-      try {
-        const params = new URLSearchParams();
-        if (inspectionId) params.set("inspectionId", inspectionId);
-        if (workOrderLineId) params.set("workOrderLineId", workOrderLineId);
-
-        const res = await fetch(`/api/inspections/load?${params.toString()}`, {
-          method: "GET",
-          credentials: "include",
-          cache: "no-store",
-        });
-
-        const data = (await res.json().catch(() => null)) as
-          | {
-              session?: InspectionSession | null;
-              inspectionMeta?: { locked?: boolean | null };
-            }
-          | null;
-
-        if (cancelled) return;
-
-        const loaded = data?.session ?? null;
-
-        if (
-          loaded &&
-          Array.isArray(loaded.sections) &&
-          loaded.sections.length > 0
-        ) {
-          const serverUpdatedAt = inspectionDraftTimestamp(loaded);
-          if (serverUpdatedAt >= localDraftUpdatedAtRef.current) {
-            startSession(loaded);
-            localDraftUpdatedAtRef.current = serverUpdatedAt;
-
-            try {
-              localStorage.setItem(draftKey, JSON.stringify(loaded));
-            } catch {
-              // noop
-            }
-
-            serverStartedRef.current = String(
-              loaded.id ?? inspectionId ?? workOrderLineId ?? "loaded",
-            );
-          } else {
-            setRecoveryMessage(
-              "Recovered a newer device draft; the older server copy was not applied.",
-            );
-          }
-        }
-        setIsLocked(Boolean(data?.inspectionMeta?.locked));
-      } catch (err) {
-        console.error("[inspection] failed to load saved inspection", err);
-      } finally {
-        if (!cancelled) {
-          setServerBootLoaded(true);
-        }
-      }
-    };
-
-    void loadSavedInspection();
-
-    return () => {
-      cancelled = true;
-    };
-    // startSession is intentionally omitted; this fetch should run once per identity.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inspectionId, workOrderLineId, draftKey, draftBootLoaded]);
 
   useEffect(() => {
     if (session && (session.sections?.length ?? 0) === 0) {
@@ -1533,7 +1544,7 @@ type SmartMatchRow = {
         queuedSessionRef.current = null;
         setRecoveryState("editing");
         setRecoveryMessage(
-          "Newer edits are safe on this device. Save Progress again to queue them for server sync.",
+          "Newer edits are safe on this device and will sync automatically.",
         );
       }
     }
@@ -1840,6 +1851,8 @@ type SmartMatchRow = {
         commands = await interpretCommand(mainText, ctx);
       }
 
+      if (guardLocked()) return;
+
       // ✅ FALLBACK: if AI returns nothing, try local parsing
       if (!commands.length) {
         const fallback = localFallbackCommands(mainText);
@@ -1874,6 +1887,8 @@ type SmartMatchRow = {
         | null = null;
 
       for (const command of commands) {
+        if (guardLocked()) return;
+
         // lightweight detection from parsed shape
         try {
           const result = await handleTranscriptFn({
@@ -1885,6 +1900,8 @@ type SmartMatchRow = {
             finishSession,
             rawSpeech: mainText,
           });
+
+          if (guardLocked()) return;
 
           // ✅ capture resolver-selected target (preferred)
           const r = result as unknown as {
@@ -2068,6 +2085,9 @@ type SmartMatchRow = {
       voiceHeldRef.current = false;
       setVoiceHeld(false);
       await voice.start();
+      if (guardLocked()) {
+        voice.stop();
+      }
     } catch (e: unknown) {
       // eslint-disable-next-line no-console
       console.error(e);
@@ -2098,10 +2118,7 @@ type SmartMatchRow = {
   ): Promise<void> => {
     if (!session) return;
 
-    if (isLocked) {
-      toast.error("Inspection is locked; AI suggestions are disabled.");
-      return;
-    }
+    if (guardLocked()) return;
 
     const key = `${secIdx}:${itemIdx}`;
     if (inFlightRef.current.has(key)) return;
@@ -2206,6 +2223,10 @@ type SmartMatchRow = {
         vehicle: session.vehicle ?? undefined,
       });
 
+      // Finalization can arrive over Realtime while AI or network work is in
+      // flight. Do not continue into local or work-order mutations afterward.
+      if (guardLocked()) return;
+
       if (!suggestion) {
         updateQuoteLine(quoteId, { aiState: "error" });
         toast.error("No AI suggestion available", { id: toastId });
@@ -2250,17 +2271,20 @@ type SmartMatchRow = {
       });
 
       if (workOrderId) {
-        const cleanParts = manualParts
-          .map((p) => ({
-            description: String(p.description ?? "").trim(),
-            qty: Number(p.qty ?? 0),
-          }))
-          .filter((p) => p.description.length > 0 && p.qty > 0);
+        const cleanParts = noPartsRequired
+          ? []
+          : manualParts
+              .map((p) => ({
+                description: String(p.description ?? "").trim(),
+                qty: Number(p.qty ?? 0),
+              }))
+              .filter((p) => p.description.length > 0 && p.qty > 0);
 
         let createdJobId: string | null = null;
         let createdQuoteLineId: string | null = existingQuoteId;
 
         if (existingLineId) {
+          if (guardLocked()) return;
           const updateRes = await fetch(
             "/api/work-orders/lines/update-from-inspection",
             {
@@ -2277,6 +2301,8 @@ type SmartMatchRow = {
             },
           );
 
+          if (guardLocked()) return;
+
           if (!updateRes.ok) {
             const body = (await updateRes.json().catch(() => null)) as unknown;
             // eslint-disable-next-line no-console
@@ -2288,6 +2314,7 @@ type SmartMatchRow = {
           createdJobId = existingLineId;
 
           if (cleanParts.length > 0) {
+            if (guardLocked()) return;
             const res = await fetch("/api/parts/requests/create", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -2298,6 +2325,8 @@ type SmartMatchRow = {
                 items: cleanParts,
               }),
             });
+
+            if (guardLocked()) return;
 
             if (!res.ok) {
               const body = (await res.json().catch(() => null)) as unknown;
@@ -2314,6 +2343,7 @@ type SmartMatchRow = {
         } else {
           const complaint = String(it.notes ?? "").trim() || null;
 
+          if (guardLocked()) return;
           const created = await addWorkOrderLineFromSuggestion({
             workOrderId,
             description: desc,
@@ -2335,6 +2365,8 @@ type SmartMatchRow = {
             source: "inspection",
             jobType: "repair",
           });
+
+          if (guardLocked()) return;
 
           const createdId = (created as unknown as { id?: unknown })?.id;
           createdQuoteLineId = createdId ? String(createdId) : null;
@@ -2660,15 +2692,13 @@ type SmartMatchRow = {
   };
 
   const handleSigned = (): void => {
-    setIsLocked(true);
-    try {
-      localStorage.setItem(lockKey, "1");
-    } catch {}
+    applyLockedState(true);
     toast.success("Inspection snapshot locked by signature.");
   };
 
   const handleReopenLockedInspection = async (): Promise<void> => {
-    if (!inspectionId) {
+    const canonicalInspectionId = session?.id ?? inspectionId;
+    if (!canonicalInspectionId) {
       toast.error("Inspection id missing; cannot reopen.");
       return;
     }
@@ -2684,15 +2714,15 @@ type SmartMatchRow = {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ inspectionId, reason: reason.trim() }),
+        body: JSON.stringify({
+          inspectionId: canonicalInspectionId,
+          reason: reason.trim(),
+        }),
       });
       const json = (await res.json().catch(() => null)) as { error?: string } | null;
       if (!res.ok || json?.error) throw new Error(json?.error ?? "Failed to reopen inspection");
 
-      setIsLocked(false);
-      try {
-        localStorage.removeItem(lockKey);
-      } catch {}
+      applyLockedState(false);
       toast.success("Inspection reopened. Editing is enabled.");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to reopen inspection.");
@@ -2742,14 +2772,23 @@ type SmartMatchRow = {
 
   const actions = (
     <>
-      <InspectionAutosaveStatus state={autosaveState} />
-
       <Button
         type="button"
         variant="outline"
         size="sm"
         className="font-medium border-[color:var(--theme-border-soft)] text-[11px] tracking-[0.16em] uppercase text-[color:var(--theme-text-primary)]"
-        onClick={() => router.push(findingsHref)}
+        onClick={async () => {
+          try {
+            await flushAutosave();
+            router.push(findingsHref);
+          } catch (error) {
+            toast.error(
+              error instanceof Error
+                ? error.message
+                : "Wait for the inspection to finish saving.",
+            );
+          }
+        }}
         disabled={isLocked}
       >
         Open findings list
@@ -2760,6 +2799,7 @@ type SmartMatchRow = {
           session={session}
           workOrderLineId={workOrderLineId}
           disabled={isLocked}
+          beforeNavigate={() => flushAutosaveToServer()}
         />
       )}
 
@@ -3369,6 +3409,7 @@ type SmartMatchRow = {
         <div className="mt-2">
           <InspectionSignaturePanel
             inspectionId={inspectionId}
+            workOrderLineId={workOrderLineId}
             role="technician"
             defaultName={(() => {
               const techName =
@@ -3378,7 +3419,8 @@ type SmartMatchRow = {
                   : "";
               return techName.trim().length ? techName.trim() : undefined;
             })()}
-            techSettingsHref="/settings/tech"
+            techSettingsHref="/dashboard/tech/settings"
+            beforeSign={() => flushAutosaveToServer()}
             onSigned={handleSigned}
           />
         </div>
@@ -3400,7 +3442,10 @@ type SmartMatchRow = {
         <div className="mx-auto flex max-w-[1240px] flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="grid grid-cols-2 gap-2 [&>*]:w-full [&>*:last-child:nth-child(odd)]:col-span-2 sm:flex sm:flex-wrap sm:items-center sm:[&>*]:w-auto">{actions}</div>
           <div className="order-first text-[10px] font-medium text-[color:var(--theme-text-secondary)] sm:order-none">
-            Saved to shop • syncs across devices
+            <span>{autosaveLabel}</span>
+            {autosaveError && (
+              <span className="ml-2 text-red-300">{autosaveError}</span>
+            )}
           </div>
         </div>
       </div>
@@ -3415,7 +3460,7 @@ type SmartMatchRow = {
       {showMissingLineWarning && (
         <div className={cn("inset-x-0 z-50 px-3", isEmbed ? "sticky bottom-[76px]" : "fixed bottom-[52px]")}>
           <div className="mx-auto max-w-[1100px] rounded-xl border border-red-500/40 bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-xs text-red-200 shadow-[var(--theme-shadow-medium)]">
-            Missing <code>workOrderLineId</code> — save/finish will be blocked.
+            Missing <code>workOrderLineId</code> — autosave/finish will be blocked.
           </div>
         </div>
       )}

--- a/features/inspections/screens/QuickAirBrakePMScreen.tsx
+++ b/features/inspections/screens/QuickAirBrakePMScreen.tsx
@@ -309,13 +309,6 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
       updateSessionQuoteLine(...args);
     }
   };
-  const startSession = (
-    ...args: Parameters<typeof startInspectionSession>
-  ) => {
-    if (draftReadyRef.current && !isLockedRef.current) {
-      startInspectionSession(...args);
-    }
-  };
   const resumeSession = (
     ...args: Parameters<typeof resumeInspectionSession>
   ) => {

--- a/features/inspections/screens/QuickAirBrakePMScreen.tsx
+++ b/features/inspections/screens/QuickAirBrakePMScreen.tsx
@@ -10,6 +10,8 @@ import PauseResumeButton from "@inspections/lib/inspection/PauseResume";
 import StartListeningButton from "@inspections/lib/inspection/StartListeningButton";
 import ProgressTracker from "@inspections/lib/inspection/ProgressTracker";
 import useInspectionSession from "@inspections/hooks/useInspectionSession";
+import { useInspectionAutosave } from "@inspections/hooks/useInspectionAutosave";
+import { getInspectionOfflineDraft } from "@inspections/lib/inspection/offlineDrafts";
 
 import { handleTranscriptFn } from "@inspections/lib/inspection/handleTranscript";
 import { interpretCommand } from "@inspections/components/inspection/interpretCommand";
@@ -28,10 +30,6 @@ import type {
 import CornerGrid from "@inspections/lib/inspection/ui/CornerGrid";
 import SectionDisplay from "@inspections/lib/inspection/SectionDisplay";
 import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionFormContext";
-import {
-  InspectionAutosaveStatus,
-  useInspectionRealtimeAutosave,
-} from "@inspections/hooks/useInspectionRealtimeAutosave";
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import { startVoiceRecognition } from "@inspections/lib/inspection/voiceControl";
 import PageShell from "@/features/shared/components/PageShell";
@@ -214,11 +212,38 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [searchParams],
   );
+  const draftKey = `inspection-${workOrderLineId ?? inspectionId}`;
 
   const [unit, setUnit] = useState<"metric" | "imperial">("metric");
+  const [draftBootLoaded, setDraftBootLoaded] = useState(false);
+  const [loadedDraftKey, setLoadedDraftKey] = useState<string | null>(null);
+  const [recoveryOperationKey, setRecoveryOperationKey] = useState<
+    string | undefined
+  >(undefined);
+  const [isLocked, setIsLocked] = useState(false);
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
   const [isListening, setIsListening] = useState<boolean>(false);
   const [isPaused, setIsPaused] = useState<boolean>(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const draftReady = draftBootLoaded && loadedDraftKey === draftKey;
+  const draftReadyRef = useRef(false);
+
+  const stopRecognition = (): void => {
+    try {
+      recognitionRef.current?.stop();
+    } catch {}
+    recognitionRef.current = null;
+    setIsListening(false);
+  };
+
+  const applyLockedState = (nextLocked: boolean): void => {
+    // Realtime can lock the row while a voice callback is still running. Update
+    // the ref first so every mutation wrapper sees the lock immediately.
+    isLockedRef.current = nextLocked;
+    setIsLocked(nextLocked);
+    if (nextLocked) stopRecognition();
+  };
 
   const templateName: string =
     props.template || get("template") || "Maintenance 50 (Air)";
@@ -226,6 +251,8 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
   const initialSession = useMemo<Partial<InspectionSession>>(
     () => ({
       id: inspectionId,
+      workOrderId,
+      workOrderLineId,
       templateitem: templateName,
       status: "not_started" as InspectionStatus,
       isPaused: false,
@@ -234,29 +261,103 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
       quote: [],
       sections: [],
     }),
-    [inspectionId, templateName],
+    [inspectionId, templateName, workOrderId, workOrderLineId],
   );
 
   const {
     session,
+    updateInspection: updateSessionInspection,
+    updateItem: updateSessionItem,
+    updateSection: updateSessionSection,
+    startSession: startInspectionSession,
     replaceSession,
-    updateInspection,
-    updateItem,
-    updateSection,
-    startSession,
-    finishSession,
-    resumeSession,
-    pauseSession,
-    addQuoteLine,
-    updateQuoteLine,
+    finishSession: finishInspectionSession,
+    resumeSession: resumeInspectionSession,
+    pauseSession: pauseInspectionSession,
+    addQuoteLine: addSessionQuoteLine,
+    updateQuoteLine: updateSessionQuoteLine,
   } = useInspectionSession(initialSession);
 
-  const autosaveState = useInspectionRealtimeAutosave({
+  // Realtime finalization can arrive while this screen is open. Keep every
+  // mutation entry point read-only as soon as the canonical row is locked.
+  const updateInspection = (
+    ...args: Parameters<typeof updateSessionInspection>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      updateSessionInspection(...args);
+    }
+  };
+  const updateItem = (...args: Parameters<typeof updateSessionItem>) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      updateSessionItem(...args);
+    }
+  };
+  const updateSection = (...args: Parameters<typeof updateSessionSection>) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      updateSessionSection(...args);
+    }
+  };
+  const addQuoteLine = (...args: Parameters<typeof addSessionQuoteLine>) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      addSessionQuoteLine(...args);
+    }
+  };
+  const updateQuoteLine = (
+    ...args: Parameters<typeof updateSessionQuoteLine>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      updateSessionQuoteLine(...args);
+    }
+  };
+  const startSession = (
+    ...args: Parameters<typeof startInspectionSession>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      startInspectionSession(...args);
+    }
+  };
+  const resumeSession = (
+    ...args: Parameters<typeof resumeInspectionSession>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      resumeInspectionSession(...args);
+    }
+  };
+  const pauseSession = (
+    ...args: Parameters<typeof pauseInspectionSession>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      pauseInspectionSession(...args);
+    }
+  };
+  const finishSession = (
+    ...args: Parameters<typeof finishInspectionSession>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      finishInspectionSession(...args);
+    }
+  };
+
+  const {
+    hydrated: serverBootLoaded,
+    flushToServer: flushAutosaveToServer,
+    label: autosaveLabel,
+    lastError: autosaveError,
+  } = useInspectionAutosave({
     session,
+    inspectionId,
     workOrderLineId,
-    enabled: Boolean(workOrderLineId),
+    enabled: draftReady,
+    locked: isLocked,
+    draftKey,
+    recoveryOperationKey,
     onRemoteSession: replaceSession,
+    onRemoteMeta: (meta) => applyLockedState(meta.locked),
+    onRecoveryState: (_state, operationKey) =>
+      setRecoveryOperationKey(operationKey),
   });
+  const inspectionReady = draftReady && serverBootLoaded;
+  draftReadyRef.current = inspectionReady;
 
   // ---- AI submit guarding ----
   const inFlightRef = useRef<Set<string>>(new Set());
@@ -267,7 +368,7 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
     secIdx: number,
     itemIdx: number,
   ): Promise<void> => {
-    if (!session) return;
+    if (!draftReadyRef.current || !session || isLockedRef.current) return;
     const key = `${secIdx}:${itemIdx}`;
     if (inFlightRef.current.has(key)) return;
 
@@ -312,6 +413,11 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
         status,
       });
 
+      if (isLockedRef.current) {
+        toast.error("Inspection was signed while AI was running.", { id: tId });
+        return;
+      }
+
       if (!suggestion) {
         updateQuoteLine(id, { aiState: "error" });
         toast.error("No AI suggestion available", { id: tId });
@@ -335,6 +441,13 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
         },
         aiState: "done",
       });
+
+      if (isLockedRef.current) {
+        toast.error("Inspection was signed before work-order changes were sent.", {
+          id: tId,
+        });
+        return;
+      }
 
       if (workOrderId) {
         await addWorkOrderLineFromSuggestion({
@@ -361,37 +474,77 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
 
   // ---- boot/restore ----
   useEffect(() => {
-    const key = `inspection-${inspectionId}`;
-    const saved =
-      typeof window !== "undefined" ? localStorage.getItem(key) : null;
-    if (saved) {
+    let cancelled = false;
+    setDraftBootLoaded(false);
+    setLoadedDraftKey(null);
+    setRecoveryOperationKey(undefined);
+    applyLockedState(false);
+    stopRecognition();
+
+    void (async () => {
+      let browserSession: InspectionSession | null = null;
       try {
-        const parsed = JSON.parse(saved) as InspectionSession;
-        updateInspection(parsed);
+        const saved = localStorage.getItem(draftKey);
+        browserSession = saved
+          ? (JSON.parse(saved) as InspectionSession)
+          : null;
       } catch {
-        startSession(initialSession);
+        browserSession = null;
       }
-    } else {
-      startSession(initialSession);
-    }
+
+      const durableDraft = await getInspectionOfflineDraft({
+        draftKey,
+        sessionHint: browserSession ?? initialSession,
+        newerSessionHint: browserSession,
+      }).catch(() => null);
+
+      const durableSession = durableDraft?.session ?? null;
+      const durableAt = Date.parse(durableSession?.lastUpdated ?? "") || 0;
+      const browserAt = Date.parse(browserSession?.lastUpdated ?? "") || 0;
+      const restored =
+        durableAt >= browserAt ? durableSession : browserSession;
+      const restoredLineId = restored?.workOrderLineId?.trim() ?? "";
+      const activeLineId = workOrderLineId?.trim() ?? "";
+      const restoredMatchesIdentity =
+        !restoredLineId || !activeLineId || restoredLineId === activeLineId;
+
+      if (cancelled) return;
+      if (restoredMatchesIdentity) {
+        setRecoveryOperationKey(durableDraft?.operationKey);
+      } else {
+        setRecoveryOperationKey(undefined);
+      }
+      if (restored && restoredMatchesIdentity) replaceSession(restored);
+      else startInspectionSession(initialSession);
+      setLoadedDraftKey(draftKey);
+      setDraftBootLoaded(true);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // draftKey is the canonical line identity for offline recovery.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [draftKey]);
 
-  // persist
+  // Keep the lightweight browser copy under the same line-stable identity.
   useEffect(() => {
-    if (session) {
-      const key = `inspection-${inspectionId}`;
-      localStorage.setItem(key, JSON.stringify(session));
+    if (draftReady && session) {
+      localStorage.setItem(draftKey, JSON.stringify(session));
     }
-  }, [session, inspectionId]);
+  }, [draftKey, draftReady, session]);
 
-  // persist on unload
   useEffect(() => {
-    const key = `inspection-${inspectionId}`;
     const persistNow = () => {
+      if (!draftReady) return;
       try {
-        localStorage.setItem(key, JSON.stringify(session ?? initialSession));
-      } catch {}
+        localStorage.setItem(
+          draftKey,
+          JSON.stringify(session ?? initialSession),
+        );
+      } catch {
+        // The durable IndexedDB draft remains authoritative.
+      }
     };
     const onVisibility = () => {
       if (document.visibilityState === "hidden") persistNow();
@@ -404,11 +557,11 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
       window.removeEventListener("pagehide", persistNow);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [session, inspectionId, initialSession]);
+  }, [draftKey, draftReady, initialSession, session]);
 
   // build sections once
   useEffect(() => {
-    if (!session) return;
+    if (!draftReady || !session) return;
     if ((session.sections?.length ?? 0) > 0) return;
     const next: InspectionSection[] = [
       buildHydraulicMeasurementsSection(),
@@ -420,7 +573,7 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
     updateInspection({
       sections: applyUnitsHydraulic(next, unit) as typeof session.sections,
     });
-  }, [session, updateInspection, unit]);
+  }, [draftReady, session, updateInspection, unit]);
 
   // re-apply units
   useEffect(() => {
@@ -436,6 +589,7 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
 
   // transcript → commands
   const handleTranscript = async (text: string): Promise<void> => {
+    if (!draftReadyRef.current || isLockedRef.current) return;
     const commands: ParsedCommand[] = await interpretCommand(text);
     const sess: InspectionSession | undefined = session ?? undefined;
     if (!sess) return;
@@ -453,6 +607,7 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
 
   // ✅ MUST be Promise-returning for StartListeningButton typing
   const startListening = async (): Promise<void> => {
+    if (!draftReadyRef.current || isLockedRef.current) return;
     if (recognitionRef.current) {
       try {
         recognitionRef.current.stop();
@@ -732,11 +887,30 @@ export default function Maintenance50AirScreen(props: ScreenProps): JSX.Element 
       {/* Footer */}
       <div className="mt-8 flex flex-col gap-4 border-t border-[color:var(--theme-border-soft)] pt-4 md:flex-row md:items-center md:justify-between">
         <div className="flex flex-wrap items-center gap-3">
-          <InspectionAutosaveStatus state={autosaveState} />
-          <FinishInspectionButton session={session} workOrderLineId={workOrderLineId ?? ""} />
+          <FinishInspectionButton
+            session={session}
+            workOrderLineId={workOrderLineId ?? ""}
+            disabled={isLocked || !inspectionReady}
+            beforeNavigate={async () => {
+              if (!draftReadyRef.current) {
+                throw new Error("Wait for this inspection to finish loading.");
+              }
+              const saved = await flushAutosaveToServer();
+              if (!saved) {
+                throw new Error("Inspection changed before autosave completed.");
+              }
+              return saved;
+            }}
+          />
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">
+            {autosaveLabel}
+            {autosaveError && (
+              <span className="ml-2 text-red-400">{autosaveError}</span>
+            )}
+          </div>
           {!workOrderLineId && (
             <div className="text-xs text-red-400">
-              Missing <code>workOrderLineId</code> — save/finish will be blocked.
+              Missing <code>workOrderLineId</code> — autosave/finish will be blocked.
             </div>
           )}
         </div>

--- a/features/inspections/screens/QuickPMScreen.tsx
+++ b/features/inspections/screens/QuickPMScreen.tsx
@@ -10,6 +10,8 @@ import PauseResumeButton from "@inspections/lib/inspection/PauseResume";
 import StartListeningButton from "@inspections/lib/inspection/StartListeningButton";
 import ProgressTracker from "@inspections/lib/inspection/ProgressTracker";
 import useInspectionSession from "@inspections/hooks/useInspectionSession";
+import { useInspectionAutosave } from "@inspections/hooks/useInspectionAutosave";
+import { getInspectionOfflineDraft } from "@inspections/lib/inspection/offlineDrafts";
 
 import { handleTranscriptFn } from "@inspections/lib/inspection/handleTranscript";
 import { interpretCommand } from "@inspections/components/inspection/interpretCommand";
@@ -28,10 +30,6 @@ import type {
 import CornerGrid from "@inspections/lib/inspection/ui/CornerGrid";
 import SectionDisplay from "@inspections/lib/inspection/SectionDisplay";
 import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionFormContext";
-import {
-  InspectionAutosaveStatus,
-  useInspectionRealtimeAutosave,
-} from "@inspections/hooks/useInspectionRealtimeAutosave";
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import { startVoiceRecognition } from "@inspections/lib/inspection/voiceControl";
 import PageShell from "@/features/shared/components/PageShell";
@@ -203,11 +201,38 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [searchParams],
   );
+  const draftKey = `inspection-${workOrderLineId ?? inspectionId}`;
 
   const [unit, setUnit] = useState<"metric" | "imperial">("metric");
+  const [draftBootLoaded, setDraftBootLoaded] = useState(false);
+  const [loadedDraftKey, setLoadedDraftKey] = useState<string | null>(null);
+  const [recoveryOperationKey, setRecoveryOperationKey] = useState<
+    string | undefined
+  >(undefined);
+  const [isLocked, setIsLocked] = useState(false);
+  const isLockedRef = useRef(isLocked);
+  isLockedRef.current = isLocked;
   const [isListening, setIsListening] = useState<boolean>(false);
   const [isPaused, setIsPaused] = useState<boolean>(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const draftReady = draftBootLoaded && loadedDraftKey === draftKey;
+  const draftReadyRef = useRef(false);
+
+  const stopRecognition = (): void => {
+    try {
+      recognitionRef.current?.stop();
+    } catch {}
+    recognitionRef.current = null;
+    setIsListening(false);
+  };
+
+  const applyLockedState = (nextLocked: boolean): void => {
+    // Realtime can lock the row while a voice callback is still running. Update
+    // the ref first so every mutation wrapper sees the lock immediately.
+    isLockedRef.current = nextLocked;
+    setIsLocked(nextLocked);
+    if (nextLocked) stopRecognition();
+  };
 
   const templateName: string =
     props.template || get("template") || "Maintenance 50";
@@ -215,6 +240,8 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
   const initialSession = useMemo<Partial<InspectionSession>>(
     () => ({
       id: inspectionId,
+      workOrderId,
+      workOrderLineId,
       templateitem: templateName,
       status: "not_started" as InspectionStatus,
       isPaused: false,
@@ -223,29 +250,103 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
       quote: [],
       sections: [],
     }),
-    [inspectionId, templateName],
+    [inspectionId, templateName, workOrderId, workOrderLineId],
   );
 
   const {
     session,
+    updateInspection: updateSessionInspection,
+    updateItem: updateSessionItem,
+    updateSection: updateSessionSection,
+    startSession: startInspectionSession,
     replaceSession,
-    updateInspection,
-    updateItem,
-    updateSection,
-    startSession,
-    finishSession,
-    resumeSession,
-    pauseSession,
-    addQuoteLine,
-    updateQuoteLine,
+    finishSession: finishInspectionSession,
+    resumeSession: resumeInspectionSession,
+    pauseSession: pauseInspectionSession,
+    addQuoteLine: addSessionQuoteLine,
+    updateQuoteLine: updateSessionQuoteLine,
   } = useInspectionSession(initialSession);
 
-  const autosaveState = useInspectionRealtimeAutosave({
+  // Realtime finalization can arrive while this screen is open. Keep every
+  // mutation entry point read-only as soon as the canonical row is locked.
+  const updateInspection = (
+    ...args: Parameters<typeof updateSessionInspection>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      updateSessionInspection(...args);
+    }
+  };
+  const updateItem = (...args: Parameters<typeof updateSessionItem>) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      updateSessionItem(...args);
+    }
+  };
+  const updateSection = (...args: Parameters<typeof updateSessionSection>) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      updateSessionSection(...args);
+    }
+  };
+  const addQuoteLine = (...args: Parameters<typeof addSessionQuoteLine>) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      addSessionQuoteLine(...args);
+    }
+  };
+  const updateQuoteLine = (
+    ...args: Parameters<typeof updateSessionQuoteLine>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      updateSessionQuoteLine(...args);
+    }
+  };
+  const startSession = (
+    ...args: Parameters<typeof startInspectionSession>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      startInspectionSession(...args);
+    }
+  };
+  const resumeSession = (
+    ...args: Parameters<typeof resumeInspectionSession>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      resumeInspectionSession(...args);
+    }
+  };
+  const pauseSession = (
+    ...args: Parameters<typeof pauseInspectionSession>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      pauseInspectionSession(...args);
+    }
+  };
+  const finishSession = (
+    ...args: Parameters<typeof finishInspectionSession>
+  ) => {
+    if (draftReadyRef.current && !isLockedRef.current) {
+      finishInspectionSession(...args);
+    }
+  };
+
+  const {
+    hydrated: serverBootLoaded,
+    flushToServer: flushAutosaveToServer,
+    label: autosaveLabel,
+    lastError: autosaveError,
+  } = useInspectionAutosave({
     session,
+    inspectionId,
     workOrderLineId,
-    enabled: Boolean(workOrderLineId),
+    enabled: draftReady,
+    locked: isLocked,
+    draftKey,
+    recoveryOperationKey,
     onRemoteSession: replaceSession,
+    onRemoteMeta: (meta) => applyLockedState(meta.locked),
+    onRecoveryState: (_state, operationKey) =>
+      setRecoveryOperationKey(operationKey),
   });
+  const inspectionReady = draftReady && serverBootLoaded;
+  draftReadyRef.current = inspectionReady;
 
   // ---- AI submit guarding ----
   const inFlightRef = useRef<Set<string>>(new Set());
@@ -256,7 +357,7 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
     secIdx: number,
     itemIdx: number,
   ): Promise<void> => {
-    if (!session) return;
+    if (!draftReadyRef.current || !session || isLockedRef.current) return;
     const key = `${secIdx}:${itemIdx}`;
     if (inFlightRef.current.has(key)) return;
 
@@ -301,6 +402,11 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
         status,
       });
 
+      if (isLockedRef.current) {
+        toast.error("Inspection was signed while AI was running.", { id: tId });
+        return;
+      }
+
       if (!suggestion) {
         updateQuoteLine(id, { aiState: "error" });
         toast.error("No AI suggestion available", { id: tId });
@@ -324,6 +430,13 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
         },
         aiState: "done",
       });
+
+      if (isLockedRef.current) {
+        toast.error("Inspection was signed before work-order changes were sent.", {
+          id: tId,
+        });
+        return;
+      }
 
       if (workOrderId) {
         await addWorkOrderLineFromSuggestion({
@@ -350,37 +463,77 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
 
   // ---- boot/restore ----
   useEffect(() => {
-    const key = `inspection-${inspectionId}`;
-    const saved =
-      typeof window !== "undefined" ? localStorage.getItem(key) : null;
-    if (saved) {
+    let cancelled = false;
+    setDraftBootLoaded(false);
+    setLoadedDraftKey(null);
+    setRecoveryOperationKey(undefined);
+    applyLockedState(false);
+    stopRecognition();
+
+    void (async () => {
+      let browserSession: InspectionSession | null = null;
       try {
-        const parsed = JSON.parse(saved) as InspectionSession;
-        updateInspection(parsed);
+        const saved = localStorage.getItem(draftKey);
+        browserSession = saved
+          ? (JSON.parse(saved) as InspectionSession)
+          : null;
       } catch {
-        startSession(initialSession);
+        browserSession = null;
       }
-    } else {
-      startSession(initialSession);
-    }
+
+      const durableDraft = await getInspectionOfflineDraft({
+        draftKey,
+        sessionHint: browserSession ?? initialSession,
+        newerSessionHint: browserSession,
+      }).catch(() => null);
+
+      const durableSession = durableDraft?.session ?? null;
+      const durableAt = Date.parse(durableSession?.lastUpdated ?? "") || 0;
+      const browserAt = Date.parse(browserSession?.lastUpdated ?? "") || 0;
+      const restored =
+        durableAt >= browserAt ? durableSession : browserSession;
+      const restoredLineId = restored?.workOrderLineId?.trim() ?? "";
+      const activeLineId = workOrderLineId?.trim() ?? "";
+      const restoredMatchesIdentity =
+        !restoredLineId || !activeLineId || restoredLineId === activeLineId;
+
+      if (cancelled) return;
+      if (restoredMatchesIdentity) {
+        setRecoveryOperationKey(durableDraft?.operationKey);
+      } else {
+        setRecoveryOperationKey(undefined);
+      }
+      if (restored && restoredMatchesIdentity) replaceSession(restored);
+      else startInspectionSession(initialSession);
+      setLoadedDraftKey(draftKey);
+      setDraftBootLoaded(true);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // draftKey is the canonical line identity for offline recovery.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [draftKey]);
 
-  // persist
+  // Keep the lightweight browser copy under the same line-stable identity.
   useEffect(() => {
-    if (session) {
-      const key = `inspection-${inspectionId}`;
-      localStorage.setItem(key, JSON.stringify(session));
+    if (draftReady && session) {
+      localStorage.setItem(draftKey, JSON.stringify(session));
     }
-  }, [session, inspectionId]);
+  }, [draftKey, draftReady, session]);
 
-  // persist on unload
   useEffect(() => {
-    const key = `inspection-${inspectionId}`;
     const persistNow = () => {
+      if (!draftReady) return;
       try {
-        localStorage.setItem(key, JSON.stringify(session ?? initialSession));
-      } catch {}
+        localStorage.setItem(
+          draftKey,
+          JSON.stringify(session ?? initialSession),
+        );
+      } catch {
+        // The durable IndexedDB draft remains authoritative.
+      }
     };
     const onVisibility = () => {
       if (document.visibilityState === "hidden") persistNow();
@@ -393,11 +546,11 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
       window.removeEventListener("pagehide", persistNow);
       document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [session, inspectionId, initialSession]);
+  }, [draftKey, draftReady, initialSession, session]);
 
   // build sections once
   useEffect(() => {
-    if (!session) return;
+    if (!draftReady || !session) return;
     if ((session.sections?.length ?? 0) > 0) return;
     const next: InspectionSection[] = [
       buildHydraulicMeasurementsSection(),
@@ -409,7 +562,7 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
     updateInspection({
       sections: applyUnitsHydraulic(next, unit) as typeof session.sections,
     });
-  }, [session, updateInspection, unit]);
+  }, [draftReady, session, updateInspection, unit]);
 
   // re-apply units when toggle changes
   useEffect(() => {
@@ -425,6 +578,7 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
 
   // transcript → commands
   const handleTranscript = async (text: string): Promise<void> => {
+    if (!draftReadyRef.current || isLockedRef.current) return;
     const commands: ParsedCommand[] = await interpretCommand(text);
     const sess: InspectionSession | undefined = session ?? undefined;
     if (!sess) return;
@@ -442,6 +596,7 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
 
   // ✅ MUST be Promise-returning for StartListeningButton typing
   const startListening = async (): Promise<void> => {
+    if (!draftReadyRef.current || isLockedRef.current) return;
     if (recognitionRef.current) {
       try {
         recognitionRef.current.stop();
@@ -721,11 +876,30 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
       {/* Footer */}
       <div className="mt-8 flex flex-col gap-4 border-t border-[color:var(--theme-border-soft)] pt-4 md:flex-row md:items-center md:justify-between">
         <div className="flex flex-wrap items-center gap-3">
-          <InspectionAutosaveStatus state={autosaveState} />
-          <FinishInspectionButton session={session} workOrderLineId={workOrderLineId ?? ""} />
+          <FinishInspectionButton
+            session={session}
+            workOrderLineId={workOrderLineId ?? ""}
+            disabled={isLocked || !inspectionReady}
+            beforeNavigate={async () => {
+              if (!draftReadyRef.current) {
+                throw new Error("Wait for this inspection to finish loading.");
+              }
+              const saved = await flushAutosaveToServer();
+              if (!saved) {
+                throw new Error("Inspection changed before autosave completed.");
+              }
+              return saved;
+            }}
+          />
+          <div className="text-xs text-[color:var(--theme-text-secondary)]">
+            {autosaveLabel}
+            {autosaveError && (
+              <span className="ml-2 text-red-400">{autosaveError}</span>
+            )}
+          </div>
           {!workOrderLineId && (
             <div className="text-xs text-red-400">
-              Missing <code>workOrderLineId</code> — save/finish will be blocked.
+              Missing <code>workOrderLineId</code> — autosave/finish will be blocked.
             </div>
           )}
         </div>

--- a/features/inspections/screens/QuickPMScreen.tsx
+++ b/features/inspections/screens/QuickPMScreen.tsx
@@ -298,13 +298,6 @@ export default function Maintenance50Screen(props: ScreenProps): JSX.Element {
       updateSessionQuoteLine(...args);
     }
   };
-  const startSession = (
-    ...args: Parameters<typeof startInspectionSession>
-  ) => {
-    if (draftReadyRef.current && !isLockedRef.current) {
-      startInspectionSession(...args);
-    }
-  };
   const resumeSession = (
     ...args: Parameters<typeof resumeInspectionSession>
   ) => {

--- a/features/mobile/settings/MobileSettingsScreen.tsx
+++ b/features/mobile/settings/MobileSettingsScreen.tsx
@@ -5,7 +5,7 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
@@ -44,7 +44,7 @@ async function sha256Base64(dataUrl: string): Promise<string> {
 }
 
 export default function MobileTechSettingsPage(): JSX.Element {
-  const supabase = createBrowserSupabase();
+  const supabase = useMemo(() => createBrowserSupabase(), []);
 
   // profile fields (from profiles table)
   const [loading, setLoading] = useState(true);
@@ -196,11 +196,16 @@ export default function MobileTechSettingsPage(): JSX.Element {
       const path = `tech-signatures/${profileId}/${hash}.png`;
 
       const up = await supabase.storage.from("signatures").upload(path, blob, {
-        upsert: true,
+        upsert: false,
         contentType: "image/png",
       });
 
-      if (up.error) throw up.error;
+      if (
+        up.error &&
+        !/already exists|resource exists|duplicate/i.test(up.error.message)
+      ) {
+        throw up.error;
+      }
 
       const update: Database["public"]["Tables"]["profiles"]["Update"] = {
         tech_signature_path: path,
@@ -600,3 +605,4 @@ function CheckboxRow({
     </label>
   );
 }
+

--- a/features/shared/signaturePad/controller.tsx
+++ b/features/shared/signaturePad/controller.tsx
@@ -6,6 +6,21 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 const SIGNATURE_INK_COLOR = "#0f172a";
 const SIGNATURE_CANVAS_COLOR = "#ffffff";
 
+function canvasHasVisibleInk(canvas: HTMLCanvasElement): boolean {
+  const context = canvas.getContext("2d", { willReadFrequently: true });
+  if (!context || canvas.width < 1 || canvas.height < 1) return false;
+
+  const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
+  for (let index = 0; index < pixels.length; index += 4) {
+    const alpha = pixels[index + 3];
+    const isNotWhite =
+      pixels[index] < 245 || pixels[index + 1] < 245 || pixels[index + 2] < 245;
+    if (alpha > 0 && isNotWhite) return true;
+  }
+
+  return false;
+}
+
 type SigCanvasInstance = {
   clear: () => void;
   isEmpty: () => boolean;
@@ -15,7 +30,9 @@ type SigCanvasInstance = {
 
 export type OpenOptions = { shopName?: string };
 
-export function openSignaturePad(opts: OpenOptions = {}): Promise<string | null> {
+export function openSignaturePad(
+  opts: OpenOptions = {},
+): Promise<string | null> {
   return new Promise((resolve) => {
     const detail = { shopName: opts.shopName ?? "", resolve };
     window.dispatchEvent(new CustomEvent("signaturepad:open", { detail }));
@@ -29,7 +46,8 @@ export default function SignaturePad() {
 function SignaturePadHost() {
   const [open, setOpen] = useState(false);
   const [shopName, setShopName] = useState<string>("");
-  const [SigCanvasComp, setSigCanvasComp] = useState<React.ComponentType<any> | null>(null);
+  const [SigCanvasComp, setSigCanvasComp] =
+    useState<React.ComponentType<any> | null>(null);
 
   const resolverRef = useRef<((v: string | null) => void) | null>(null);
   const sigRef = useRef<SigCanvasInstance | null>(null);
@@ -65,28 +83,41 @@ function SignaturePadHost() {
       // clear any previous ink and size up next paint
       requestAnimationFrame(() => {
         sigRef.current?.clear?.();
-        const el = containerRef.current;
-        const w = Math.max(320, Math.floor(el?.clientWidth || 0)) || 480;
-        const h = Math.floor(w * 0.44);
+        const measuredWidth = Math.floor(
+          containerRef.current?.clientWidth || 0,
+        );
+        const w = measuredWidth > 0 ? measuredWidth : 480;
+        const h = Math.max(120, Math.floor(w * 0.44));
         setSize({ w, h });
       });
     };
     window.addEventListener("signaturepad:open", handler as EventListener);
-    return () => window.removeEventListener("signaturepad:open", handler as EventListener);
+    return () =>
+      window.removeEventListener("signaturepad:open", handler as EventListener);
   }, []);
 
   // Responsive sizing
   useLayoutEffect(() => {
-    if (!containerRef.current) return;
+    if (!open || !containerRef.current) return;
     const el = containerRef.current;
-    const ro = new ResizeObserver(() => {
-      const w = Math.max(320, Math.floor(el.clientWidth)) || 480;
-      const h = Math.floor(w * 0.44);
-      setSize({ w, h });
-    });
+
+    const syncSize = () => {
+      const measuredWidth = Math.floor(el.clientWidth);
+      if (measuredWidth < 1) return;
+      const next = {
+        w: measuredWidth,
+        h: Math.max(120, Math.floor(measuredWidth * 0.44)),
+      };
+      setSize((current) =>
+        current.w === next.w && current.h === next.h ? current : next,
+      );
+    };
+
+    syncSize();
+    const ro = new ResizeObserver(syncSize);
     ro.observe(el);
     return () => ro.disconnect();
-  }, []);
+  }, [open]);
 
   // Retina crispness
   useEffect(() => {
@@ -98,25 +129,28 @@ function SignaturePadHost() {
     const W = Math.floor(size.w * ratio);
     const H = Math.floor(size.h * ratio);
     if (canvas.width !== W || canvas.height !== H) {
+      // Resizing clears the bitmap. Reset SignaturePad's internal ink state too
+      // so an orientation change can never save a blank image as a signature.
+      sigRef.current?.clear?.();
       canvas.width = W;
       canvas.height = H;
       canvas.style.width = `${size.w}px`;
       canvas.style.height = `${size.h}px`;
       ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
     }
-  }, [size]);
+  }, [SigCanvasComp, open, size]);
 
   // Prevent page scroll while signing (iOS)
   useEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    if (!open || !el) return;
     const preventScroll = (e: TouchEvent) => {
       const t = e.target as HTMLElement | null;
       if (t?.tagName?.toLowerCase() === "canvas") e.preventDefault();
     };
     el.addEventListener("touchmove", preventScroll, { passive: false });
     return () => el.removeEventListener("touchmove", preventScroll);
-  }, []);
+  }, [open]);
 
   const closeWith = (v: string | null) => {
     resolverRef.current?.(v);
@@ -124,7 +158,10 @@ function SignaturePadHost() {
     setOpen(false);
   };
 
-  const hasInk = () => !!sigRef.current && typeof sigRef.current.isEmpty === "function" && !sigRef.current.isEmpty();
+  const hasInk = () =>
+    !!sigRef.current &&
+    typeof sigRef.current.isEmpty === "function" &&
+    !sigRef.current.isEmpty();
 
   const handleClear = () => sigRef.current?.clear?.();
 
@@ -161,6 +198,9 @@ function SignaturePadHost() {
       if (canvas.width === 0 || canvas.height === 0) {
         throw new Error("Signature area not ready. Please try again.");
       }
+      if (!canvasHasVisibleInk(canvas)) {
+        throw new Error("Please draw a signature before saving.");
+      }
 
       const base64 = canvas.toDataURL("image/png");
       if (!base64 || base64.length < 50) {
@@ -188,7 +228,9 @@ function SignaturePadHost() {
       >
         <h2
           className="mb-1 text-center text-lg font-semibold text-[color:var(--theme-text-primary)]"
-          style={{ fontFamily: "'Black Ops One', Roboto, ui-sans-serif, system-ui" }}
+          style={{
+            fontFamily: "'Black Ops One', Roboto, ui-sans-serif, system-ui",
+          }}
         >
           {shopName ? `${shopName} — Customer Approval` : "Customer Approval"}
         </h2>
@@ -207,8 +249,14 @@ function SignaturePadHost() {
               canvasProps={{
                 width: size.w,
                 height: size.h,
-                className: "w-full rounded-md border border-[color:var(--theme-border-soft)]",
-                style: { backgroundColor: SIGNATURE_CANVAS_COLOR },
+                className:
+                  "w-full rounded-md border border-[color:var(--theme-border-soft)]",
+                style: {
+                  backgroundColor: SIGNATURE_CANVAS_COLOR,
+                  touchAction: "none",
+                  userSelect: "none",
+                  WebkitUserSelect: "none",
+                },
                 role: "img",
                 "aria-label": "Signature input area",
               }}
@@ -241,7 +289,10 @@ function SignaturePadHost() {
               onClick={() => closeWith(null)}
               disabled={saving}
               className="rounded px-4 py-2 text-[color:var(--theme-text-primary)] disabled:opacity-50"
-              style={{ backgroundColor: "#ef4444", fontFamily: "'Black Ops One', Roboto, ui-sans-serif, system-ui" }}
+              style={{
+                backgroundColor: "#ef4444",
+                fontFamily: "'Black Ops One', Roboto, ui-sans-serif, system-ui",
+              }}
             >
               Cancel
             </button>
@@ -252,8 +303,12 @@ function SignaturePadHost() {
                 e.stopPropagation();
                 handleSave();
               }}
-              className="rounded px-4 py-2 text-[color:var(--theme-text-primary)]"
-              style={{ backgroundColor: "var(--theme-surface-panel)", fontFamily: "'Black Ops One', Roboto, ui-sans-serif, system-ui" }}
+              disabled={saving}
+              className="rounded px-4 py-2 text-[color:var(--theme-text-primary)] disabled:opacity-50"
+              style={{
+                backgroundColor: "var(--theme-surface-panel)",
+                fontFamily: "'Black Ops One', Roboto, ui-sans-serif, system-ui",
+              }}
             >
               {saving ? "Saving…" : "Save"}
             </button>

--- a/supabase/migrations/20260721160000_inspection_live_autosave_signature_hardening.sql
+++ b/supabase/migrations/20260721160000_inspection_live_autosave_signature_hardening.sql
@@ -1,0 +1,1280 @@
+begin;
+
+-- Track the inspection signing contract in migrations. Existing production
+-- databases already have this table; fresh environments must get the same shape.
+create table if not exists public.inspection_signatures (
+  id uuid primary key default gen_random_uuid(),
+  inspection_id uuid not null references public.inspections(id) on delete restrict,
+  role text not null,
+  signed_by uuid references auth.users(id) on delete set null,
+  signed_name text,
+  signature_image_path text,
+  signature_hash text,
+  signing_cycle bigint not null default 0,
+  signed_sync_revision bigint,
+  signed_summary_hash text,
+  signed_summary jsonb,
+  signed_at timestamptz not null default now(),
+  ip_address text,
+  user_agent text
+);
+
+alter table public.inspection_signatures
+  add column if not exists signing_cycle bigint not null default 0,
+  add column if not exists signed_sync_revision bigint,
+  add column if not exists signed_summary_hash text,
+  add column if not exists signed_summary jsonb;
+
+alter table public.inspections
+  add column if not exists signing_cycle bigint not null default 0,
+  add column if not exists reopened_at timestamptz,
+  add column if not exists reopened_by uuid references auth.users(id)
+    on delete set null,
+  add column if not exists reopen_reason text;
+
+-- A rerun performs its controlled repairs inside this transaction, then
+-- reinstalls both guards before commit.
+drop trigger if exists prevent_inspection_signature_evidence_mutation
+  on public.inspection_signatures;
+drop trigger if exists prevent_finalized_inspection_mutation
+  on public.inspections;
+
+-- Historical installs used ON DELETE CASCADE, which allowed deleting the
+-- inspection to erase its signature evidence. Replace any inspection foreign
+-- key on this table with an explicit restrictive constraint.
+do $$
+declare
+  v_constraint record;
+begin
+  for v_constraint in
+    select c.conname
+    from pg_constraint c
+    where c.conrelid = 'public.inspection_signatures'::regclass
+      and c.confrelid = 'public.inspections'::regclass
+      and c.contype = 'f'
+  loop
+    execute format(
+      'alter table public.inspection_signatures drop constraint %I',
+      v_constraint.conname
+    );
+  end loop;
+end;
+$$;
+
+alter table public.inspection_signatures
+  add constraint inspection_signatures_inspection_id_fkey
+  foreign key (inspection_id)
+  references public.inspections(id)
+  on delete restrict
+  not valid;
+
+alter table public.inspection_signatures
+  validate constraint inspection_signatures_inspection_id_fkey;
+
+create index if not exists inspection_signatures_inspection_role_latest_idx
+  on public.inspection_signatures (inspection_id, role, signed_at desc, id desc);
+
+alter table public.inspection_signatures enable row level security;
+
+drop policy if exists inspection_signatures_shop_select
+  on public.inspection_signatures;
+create policy inspection_signatures_shop_select
+  on public.inspection_signatures
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.inspections i
+      join public.profiles p
+        on p.id = auth.uid()
+       and p.shop_id = i.shop_id
+      where i.id = inspection_signatures.inspection_id
+    )
+  );
+
+-- `profiles.self.update` intentionally supports ordinary account settings, but
+-- role and tenant membership must never be self-assignable. Keep service-role
+-- and administrative writes intact while defaulting authenticated updates to
+-- an explicit set of self-service columns.
+revoke update on table public.profiles from authenticated;
+grant update (
+  avatar_url,
+  business_name,
+  city,
+  completed_onboarding,
+  email,
+  full_name,
+  last_active_at,
+  must_change_password,
+  phone,
+  postal_code,
+  province,
+  shop_name,
+  street,
+  tech_signature_hash,
+  tech_signature_path,
+  tech_signature_updated_at,
+  updated_at,
+  username
+) on table public.profiles to authenticated;
+
+create or replace function public.prevent_profile_authorization_self_write()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $profile_authorization_guard$
+declare
+  v_actor_user_id uuid := auth.uid();
+begin
+  -- Service-role and trusted database administration have no end-user JWT and
+  -- remain able to provision or move memberships.
+  if v_actor_user_id is null then
+    return new;
+  end if;
+
+  if tg_op = 'INSERT' then
+    if new.id = v_actor_user_id and (
+      new.role is not null
+      or new.shop_id is not null
+      or new.organization_id is not null
+      or new.agent_role is not null
+      or (
+        new.user_id is not null
+        and new.user_id is distinct from v_actor_user_id
+      )
+    ) then
+      raise exception using
+        errcode = '42501',
+        message = 'Profile role and shop membership are server-managed.';
+    end if;
+    return new;
+  end if;
+
+  if old.id = v_actor_user_id and (
+    new.id is distinct from old.id
+    or new.user_id is distinct from old.user_id
+    or new.role is distinct from old.role
+    or new.shop_id is distinct from old.shop_id
+    or new.organization_id is distinct from old.organization_id
+    or new.agent_role is distinct from old.agent_role
+    or new.plan is distinct from old.plan
+    or new.created_by is distinct from old.created_by
+  ) then
+    raise exception using
+      errcode = '42501',
+      message = 'Profile role and shop membership are server-managed.';
+  end if;
+
+  return new;
+end;
+$profile_authorization_guard$;
+
+drop trigger if exists prevent_profile_authorization_self_write
+  on public.profiles;
+create trigger prevent_profile_authorization_self_write
+before insert or update on public.profiles
+for each row
+execute function public.prevent_profile_authorization_self_write();
+
+-- Drop the drifted production expression before repairing rows it may reject.
+-- The replacement is added in this same transaction before commit.
+alter table public.inspections
+  drop constraint if exists inspections_draft_not_finalized_chk;
+
+-- Normalize drifted lifecycle rows, then install the explicit invariant used by
+-- save/reopen/sign.
+update public.inspections
+set is_draft = false
+where coalesce(is_draft, false)
+  and (
+    coalesce(completed, false)
+    or coalesce(locked, false)
+    or lower(coalesce(status, '')) in ('completed', 'finalized', 'signed')
+  );
+
+update public.inspections
+set finalized_at = null,
+    finalized_by = null,
+    status = case
+      when lower(coalesce(status, '')) in ('completed', 'finalized', 'signed')
+        then 'draft'
+      else coalesce(status, 'draft')
+    end
+where coalesce(is_draft, false)
+  and not coalesce(completed, false)
+  and not coalesce(locked, false)
+  and (finalized_at is not null or finalized_by is not null);
+
+alter table public.inspections
+  add constraint inspections_draft_not_finalized_chk
+  check (
+    not coalesce(is_draft, false)
+    or (
+      not coalesce(completed, false)
+      and not coalesce(locked, false)
+      and finalized_at is null
+      and finalized_by is null
+      and lower(coalesce(status, 'draft')) not in (
+        'completed',
+        'finalized',
+        'signed'
+      )
+    )
+  ) not valid;
+
+-- Repair drifted installs where the idempotency table exists without its
+-- original uniqueness contract. Keep the newest result for duplicate keys.
+with ranked_operation_keys as (
+  select
+    id,
+    row_number() over (
+      partition by shop_id, operation_name, operation_key
+      order by created_at desc, id desc
+    ) as row_number
+  from public.mobile_operation_keys
+)
+delete from public.mobile_operation_keys mok
+using ranked_operation_keys ranked
+where mok.id = ranked.id
+  and ranked.row_number > 1;
+
+create unique index if not exists
+  mobile_operation_keys_shop_operation_key_uidx
+on public.mobile_operation_keys (shop_id, operation_name, operation_key);
+
+-- Persist one canonical server snapshot without relying on work-order-line
+-- uniqueness, which is not consistent in existing production data.
+create or replace function public.save_inspection_progress_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_actor_user_id uuid,
+  p_session jsonb,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line record;
+  v_existing_result jsonb;
+  v_existing_summary jsonb := '{}'::jsonb;
+  v_canonical_session jsonb;
+  v_session_id uuid;
+  v_inspection_id uuid;
+  -- `p_at` remains in the public signature for forward compatibility, but a
+  -- caller-controlled timestamp cannot be used as a concurrency token.
+  v_now timestamptz := clock_timestamp();
+  v_result jsonb;
+  v_server_revision bigint := 0;
+  v_client_revision bigint := 0;
+  v_next_revision bigint;
+  v_server_updated_at timestamptz;
+  v_client_updated_at timestamptz;
+  v_inspection_exists boolean := false;
+  v_inspection_locked boolean := false;
+  v_inspection_completed boolean := false;
+  v_inspection_is_draft boolean := true;
+  v_inspection_status text := 'draft';
+  v_inspection_finalized_at timestamptz;
+  v_inspection_finalized_by uuid;
+  v_session_fingerprint text := md5(p_session::text);
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Authenticated actor does not match the inspection actor.';
+  end if;
+
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'A stable operation key is required.';
+  end if;
+
+  if p_session is null or jsonb_typeof(p_session) <> 'object' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection session payload must be a JSON object.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles p
+    where p.id = p_actor_user_id
+      and p.shop_id = p_shop_id
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Actor is not a member of this shop.';
+  end if;
+
+  select wol.id, wol.work_order_id, wol.shop_id
+    into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for update;
+
+  if not found or v_line.work_order_id is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Work-order line not found for shop.';
+  end if;
+
+  -- Authorization and line scope are checked before idempotency lookup because
+  -- this SECURITY DEFINER function is callable directly by authenticated users.
+  -- Locking the line first also makes simultaneous retries with the same key
+  -- observe the committed idempotency result instead of a false revision clash.
+  select mok.result
+    into v_existing_result
+  from public.mobile_operation_keys mok
+  where mok.shop_id = p_shop_id
+    and mok.operation_name = 'save_inspection_progress'
+    and mok.operation_key = p_operation_key;
+
+  if found then
+    if coalesce(v_existing_result->>'session_fingerprint', '') is distinct from
+       v_session_fingerprint then
+      raise exception using
+        errcode = 'P0001',
+        message = 'Inspection operation key was reused for a different snapshot.';
+    end if;
+    return v_existing_result || jsonb_build_object('idempotent', true);
+  end if;
+
+  -- Lock only the deterministic canonical row. Historical duplicates may
+  -- contain old finalized evidence and must not block an active canonical draft.
+  select
+    i.id,
+    coalesce(i.summary, '{}'::jsonb),
+    coalesce(i.locked, false),
+    coalesce(i.completed, false),
+    coalesce(i.is_draft, true),
+    coalesce(i.status, 'draft'),
+    i.finalized_at,
+    i.finalized_by,
+    i.updated_at
+  into
+    v_inspection_id,
+    v_existing_summary,
+    v_inspection_locked,
+    v_inspection_completed,
+    v_inspection_is_draft,
+    v_inspection_status,
+    v_inspection_finalized_at,
+    v_inspection_finalized_by,
+    v_server_updated_at
+  from public.inspections i
+  where i.work_order_line_id = p_work_order_line_id
+    and i.shop_id = p_shop_id
+  order by i.updated_at desc nulls last, i.id desc
+  limit 1
+  for update;
+
+  if found then
+    v_inspection_exists := true;
+    if (
+      v_inspection_locked
+      or v_inspection_completed
+      or not v_inspection_is_draft
+      or v_inspection_finalized_at is not null
+      or v_inspection_finalized_by is not null
+      or lower(v_inspection_status) in ('completed', 'finalized', 'signed')
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'Inspection is finalized and locked. Reopen is required before editing.';
+    end if;
+
+    if coalesce(v_existing_summary->>'syncRevision', '') ~ '^[0-9]+$' then
+      v_server_revision := (v_existing_summary->>'syncRevision')::bigint;
+    end if;
+  else
+    insert into public.inspections (
+      work_order_id,
+      work_order_line_id,
+      shop_id,
+      user_id,
+      summary,
+      is_draft,
+      completed,
+      locked,
+      status,
+      finalized_at,
+      finalized_by,
+      updated_at
+    ) values (
+      v_line.work_order_id,
+      p_work_order_line_id,
+      p_shop_id,
+      p_actor_user_id,
+      p_session,
+      true,
+      false,
+      false,
+      'draft',
+      null,
+      null,
+      v_now
+    )
+    returning id into v_inspection_id;
+  end if;
+
+  if coalesce(p_session->>'syncRevision', '') ~ '^[0-9]+$' then
+    v_client_revision := (p_session->>'syncRevision')::bigint;
+  end if;
+
+  if v_inspection_exists and v_client_revision <> v_server_revision then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection save conflicts with a newer server version.';
+  end if;
+
+  v_next_revision := v_server_revision + 1;
+  v_canonical_session :=
+    p_session || jsonb_build_object(
+      'id', v_inspection_id,
+      'workOrderId', v_line.work_order_id,
+      'workOrderLineId', p_work_order_line_id,
+      'syncRevision', v_next_revision,
+      'serverUpdatedAt', v_now
+    );
+
+  update public.inspections
+  set work_order_id = v_line.work_order_id,
+      work_order_line_id = p_work_order_line_id,
+      shop_id = p_shop_id,
+      user_id = p_actor_user_id,
+      summary = v_canonical_session,
+      is_draft = true,
+      completed = false,
+      locked = false,
+      status = 'draft',
+      finalized_at = null,
+      finalized_by = null,
+      updated_at = v_now
+  where id = v_inspection_id
+    and shop_id = p_shop_id
+    and not coalesce(locked, false)
+    and not coalesce(completed, false)
+    and coalesce(is_draft, true)
+    and lower(coalesce(status, 'draft')) not in (
+      'completed',
+      'finalized',
+      'signed'
+    );
+
+  if not found then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection was finalized while autosave was in progress.';
+  end if;
+
+  select s.id
+    into v_session_id
+  from public.inspection_sessions s
+  where s.work_order_line_id = p_work_order_line_id
+  order by s.updated_at desc nulls last, s.id desc
+  limit 1
+  for update;
+
+  if found then
+    update public.inspection_sessions
+    set work_order_id = v_line.work_order_id,
+        user_id = p_actor_user_id,
+        state = v_canonical_session,
+        updated_at = v_now
+    where id = v_session_id;
+  else
+    insert into public.inspection_sessions (
+      work_order_id,
+      work_order_line_id,
+      user_id,
+      state,
+      updated_at
+    ) values (
+      v_line.work_order_id,
+      p_work_order_line_id,
+      p_actor_user_id,
+      v_canonical_session,
+      v_now
+    )
+    returning id into v_session_id;
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'inspection_id', v_inspection_id,
+    'inspection_session_id', v_session_id,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'sync_revision', v_next_revision,
+    'saved_at', v_now,
+    'session_fingerprint', v_session_fingerprint,
+    'idempotent', false
+  );
+
+  insert into public.mobile_operation_keys (
+    shop_id,
+    operation_name,
+    operation_key,
+    actor_user_id,
+    work_order_id,
+    work_order_line_id,
+    result
+  ) values (
+    p_shop_id,
+    'save_inspection_progress',
+    p_operation_key,
+    p_actor_user_id,
+    v_line.work_order_id,
+    p_work_order_line_id,
+    v_result
+  );
+
+  return v_result;
+exception
+  when unique_violation then
+    select mok.result
+      into v_existing_result
+    from public.mobile_operation_keys mok
+    where mok.shop_id = p_shop_id
+      and mok.operation_name = 'save_inspection_progress'
+      and mok.operation_key = p_operation_key;
+
+    if found then
+      if coalesce(v_existing_result->>'session_fingerprint', '') is distinct from
+         v_session_fingerprint then
+        raise exception using
+          errcode = 'P0001',
+          message = 'Inspection operation key was reused for a different snapshot.';
+      end if;
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+
+    raise;
+end;
+$$;
+
+revoke all on function public.save_inspection_progress_atomic(
+  uuid, uuid, uuid, jsonb, text, timestamptz
+) from public;
+grant execute on function public.save_inspection_progress_atomic(
+  uuid, uuid, uuid, jsonb, text, timestamptz
+) to authenticated, service_role;
+
+-- Finalization is a compare-and-swap on the persisted summary revision. PDF
+-- generation and immutable upload happen before this call; only the transaction
+-- that still owns the expected revision is allowed to publish that object path.
+create or replace function public.finalize_inspection_pdf_atomic(
+  p_inspection_id uuid,
+  p_work_order_line_id uuid,
+  p_actor_user_id uuid,
+  p_expected_sync_revision bigint,
+  p_pdf_storage_path text,
+  p_pdf_sha256 text,
+  p_pdf_url text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_authenticated_user_id uuid := auth.uid();
+  v_actor_shop_id uuid;
+  v_work_order_id uuid;
+  v_summary jsonb;
+  v_revision bigint := 0;
+  v_locked boolean := false;
+  v_completed boolean := false;
+  v_is_draft boolean := true;
+  v_status text := 'draft';
+  v_finalized_at timestamptz;
+  v_finalized_by uuid;
+  v_pdf_sha256 text := lower(coalesce(nullif(trim(p_pdf_sha256), ''), ''));
+  v_expected_path text;
+  v_now timestamptz := clock_timestamp();
+begin
+  if v_authenticated_user_id is not null
+     and v_authenticated_user_id is distinct from p_actor_user_id then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Authenticated actor does not match the finalization actor.';
+  end if;
+
+  if p_expected_sync_revision is null or p_expected_sync_revision < 1 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'A saved inspection revision is required before finalizing.';
+  end if;
+
+  select p.shop_id
+    into v_actor_shop_id
+  from public.profiles p
+  where p.id = p_actor_user_id;
+
+  if not found or v_actor_shop_id is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Finalization actor is not assigned to a shop.';
+  end if;
+
+  select
+    i.work_order_id,
+    i.summary,
+    coalesce(i.locked, false),
+    coalesce(i.completed, false),
+    coalesce(i.is_draft, true),
+    coalesce(i.status, 'draft'),
+    i.finalized_at,
+    i.finalized_by
+  into
+    v_work_order_id,
+    v_summary,
+    v_locked,
+    v_completed,
+    v_is_draft,
+    v_status,
+    v_finalized_at,
+    v_finalized_by
+  from public.inspections i
+  where i.id = p_inspection_id
+    and i.work_order_line_id = p_work_order_line_id
+    and i.shop_id = v_actor_shop_id
+  for update;
+
+  if not found or v_work_order_id is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection was not found for this shop and work-order line.';
+  end if;
+
+  -- Preserve the legacy fallback used by the route, while normalizing the
+  -- winning snapshot back onto the canonical inspection row at finalization.
+  if v_summary is null then
+    select s.state
+      into v_summary
+    from public.inspection_sessions s
+    where s.work_order_line_id = p_work_order_line_id
+    order by s.updated_at desc nulls last, s.id desc
+    limit 1
+    for update;
+  end if;
+
+  if v_summary is null or jsonb_typeof(v_summary) <> 'object' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection summary is missing or invalid.';
+  end if;
+
+  if coalesce(v_summary->>'syncRevision', '') ~ '^[0-9]+$' then
+    v_revision := (v_summary->>'syncRevision')::bigint;
+  end if;
+
+  if p_expected_sync_revision <> v_revision then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection changed on another device before finalization.';
+  end if;
+
+  if (
+    v_locked
+    or v_completed
+    or not v_is_draft
+    or v_finalized_at is not null
+    or v_finalized_by is not null
+    or lower(v_status) in ('completed', 'finalized', 'signed')
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection is already finalized and locked.';
+  end if;
+
+  if v_pdf_sha256 !~ '^[0-9a-f]{64}$' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'A valid finalized PDF content hash is required.';
+  end if;
+
+  v_expected_path :=
+    'shops/' || v_actor_shop_id::text ||
+    '/work_orders/' || v_work_order_id::text ||
+    '/inspections/' || p_inspection_id::text ||
+    '/line_' || p_work_order_line_id::text ||
+    '_r' || v_revision::text ||
+    '_' || v_pdf_sha256 || '.pdf';
+
+  if nullif(trim(p_pdf_storage_path), '') is distinct from v_expected_path then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Finalized PDF path does not match the inspection snapshot.';
+  end if;
+
+  update public.inspections
+  set summary = v_summary,
+      pdf_storage_path = v_expected_path,
+      pdf_url = nullif(trim(p_pdf_url), ''),
+      locked = true,
+      completed = true,
+      is_draft = false,
+      status = 'completed',
+      finalized_at = v_now,
+      finalized_by = p_actor_user_id,
+      updated_at = v_now
+  where id = p_inspection_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'inspection_id', p_inspection_id,
+    'work_order_id', v_work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'sync_revision', v_revision,
+    'pdf_storage_path', v_expected_path,
+    'finalized_at', v_now
+  );
+end;
+$$;
+
+revoke all on function public.finalize_inspection_pdf_atomic(
+  uuid, uuid, uuid, bigint, text, text, text
+) from public, authenticated;
+grant execute on function public.finalize_inspection_pdf_atomic(
+  uuid, uuid, uuid, bigint, text, text, text
+) to service_role;
+
+-- Reopen is a server-clock, row-locked lifecycle transition. Incrementing a
+-- durable cycle separates idempotency from timestamp ordering and guarantees
+-- that evidence from an earlier finalized snapshot never suppresses signing
+-- after reopen.
+drop function if exists public.reopen_inspection(uuid, text);
+create or replace function public.reopen_inspection(
+  p_inspection_id uuid,
+  p_reason text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor_user_id uuid := auth.uid();
+  v_actor_shop_id uuid;
+  v_actor_role text;
+  v_inspection_shop_id uuid;
+  v_locked boolean := false;
+  v_completed boolean := false;
+  v_is_draft boolean := true;
+  v_status text := 'draft';
+  v_finalized_at timestamptz;
+  v_finalized_by uuid;
+  v_signing_cycle bigint := 0;
+  v_next_cycle bigint;
+  v_now timestamptz := clock_timestamp();
+  v_reason text := nullif(trim(p_reason), '');
+begin
+  if v_actor_user_id is null then
+    raise exception using errcode = 'P0001', message = 'Authentication is required.';
+  end if;
+  if v_reason is null then
+    raise exception using errcode = 'P0001', message = 'Reopen reason is required.';
+  end if;
+
+  select p.shop_id, lower(trim(coalesce(p.role::text, '')))
+    into v_actor_shop_id, v_actor_role
+  from public.profiles p
+  where p.id = v_actor_user_id;
+
+  if not found or v_actor_shop_id is null then
+    raise exception using errcode = 'P0001', message = 'Missing profile or shop membership.';
+  end if;
+  if v_actor_role not in ('admin', 'advisor', 'owner', 'manager') then
+    raise exception using
+      errcode = '42501',
+      message = 'Only an admin, advisor, owner, or manager can reopen inspections.';
+  end if;
+
+  select
+    i.shop_id,
+    coalesce(i.locked, false),
+    coalesce(i.completed, false),
+    coalesce(i.is_draft, true),
+    coalesce(i.status, 'draft'),
+    i.finalized_at,
+    i.finalized_by,
+    coalesce(i.signing_cycle, 0)
+  into
+    v_inspection_shop_id,
+    v_locked,
+    v_completed,
+    v_is_draft,
+    v_status,
+    v_finalized_at,
+    v_finalized_by,
+    v_signing_cycle
+  from public.inspections i
+  where i.id = p_inspection_id
+  for update;
+
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Inspection was not found.';
+  end if;
+  if v_inspection_shop_id is distinct from v_actor_shop_id then
+    raise exception using errcode = '42501', message = 'Inspection does not belong to your shop.';
+  end if;
+
+  if not v_locked
+     and not v_completed
+     and v_is_draft
+     and v_finalized_at is null
+     and v_finalized_by is null
+     and lower(v_status) not in ('completed', 'finalized', 'signed') then
+    return jsonb_build_object(
+      'ok', true,
+      'already_open', true,
+      'inspection_id', p_inspection_id,
+      'signing_cycle', v_signing_cycle
+    );
+  end if;
+
+  v_next_cycle := v_signing_cycle + 1;
+  perform set_config('profixiq.inspection_reopen', 'on', true);
+
+  update public.inspections
+  set locked = false,
+      completed = false,
+      is_draft = true,
+      status = 'in_progress',
+      finalized_at = null,
+      finalized_by = null,
+      reopened_at = v_now,
+      reopened_by = v_actor_user_id,
+      reopen_reason = v_reason,
+      signing_cycle = v_next_cycle,
+      updated_at = v_now
+  where id = p_inspection_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'already_open', false,
+    'inspection_id', p_inspection_id,
+    'reopened_at', v_now,
+    'signing_cycle', v_next_cycle
+  );
+end;
+$$;
+
+revoke all on function public.reopen_inspection(uuid, text) from public;
+grant execute on function public.reopen_inspection(uuid, text) to authenticated;
+
+-- Replace the drifted signing RPC without assuming or deleting duplicate
+-- historical signature rows. The inspection row serializes concurrent signing.
+drop function if exists public.sign_inspection(uuid, text, text, text, text);
+drop function if exists public.sign_inspection(
+  uuid, text, text, text, text, bigint
+);
+drop function if exists public.sign_inspection(
+  uuid, text, text, bigint, text, text
+);
+
+create or replace function public.sign_inspection(
+  p_inspection_id uuid,
+  p_role text,
+  p_signed_name text,
+  p_expected_sync_revision bigint,
+  p_signature_image_path text default null,
+  p_signature_hash text default null
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor_user_id uuid := auth.uid();
+  v_inspection_shop_id uuid;
+  v_inspection_locked boolean := false;
+  v_inspection_completed boolean := false;
+  v_inspection_is_draft boolean := true;
+  v_inspection_finalized_at timestamptz;
+  v_signing_cycle bigint := 0;
+  v_inspection_summary jsonb := '{}'::jsonb;
+  v_inspection_revision bigint := 0;
+  v_signature_id uuid;
+  v_signature_actor uuid;
+  v_signature_name text;
+  v_now timestamptz := clock_timestamp();
+  v_effective_name text := nullif(trim(p_signed_name), '');
+  v_effective_path text := nullif(trim(p_signature_image_path), '');
+  v_effective_hash text := nullif(trim(p_signature_hash), '');
+  v_profile record;
+begin
+  if v_actor_user_id is null then
+    raise exception using errcode = 'P0001', message = 'Authentication is required.';
+  end if;
+
+  if p_role is null or p_role not in ('technician', 'customer', 'advisor') then
+    raise exception using errcode = 'P0001', message = 'Unsupported inspection signature role.';
+  end if;
+
+  if p_expected_sync_revision is null or p_expected_sync_revision < 1 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'A saved inspection revision is required before signing.';
+  end if;
+
+  select
+    i.shop_id,
+    coalesce(i.locked, false),
+    coalesce(i.completed, false),
+    coalesce(i.is_draft, true),
+    i.finalized_at,
+    coalesce(i.signing_cycle, 0),
+    coalesce(i.summary, '{}'::jsonb)
+  into
+    v_inspection_shop_id,
+    v_inspection_locked,
+    v_inspection_completed,
+    v_inspection_is_draft,
+    v_inspection_finalized_at,
+    v_signing_cycle,
+    v_inspection_summary
+  from public.inspections i
+  where i.id = p_inspection_id
+  for update;
+
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Inspection was not found.';
+  end if;
+
+  if coalesce(v_inspection_summary->>'syncRevision', '') ~ '^[0-9]+$' then
+    v_inspection_revision :=
+      (v_inspection_summary->>'syncRevision')::bigint;
+  end if;
+
+  if p_expected_sync_revision <> v_inspection_revision then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection changed on another device before signing. Review the latest version and sign again.';
+  end if;
+
+  select
+    p.shop_id,
+    p.role,
+    p.full_name,
+    p.tech_signature_path,
+    p.tech_signature_hash
+  into v_profile
+  from public.profiles p
+  where p.id = v_actor_user_id;
+
+  if not found or v_profile.shop_id is distinct from v_inspection_shop_id then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection does not belong to the authenticated user shop.';
+  end if;
+
+  if p_role = 'advisor' then
+    if lower(coalesce(v_profile.role::text, '')) not in (
+      'advisor',
+      'service_advisor',
+      'service advisor',
+      'owner',
+      'admin',
+      'manager'
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'Authenticated user cannot sign as service advisor.';
+    end if;
+
+    v_effective_name := coalesce(
+      nullif(trim(v_profile.full_name), ''),
+      nullif(trim(auth.jwt() -> 'user_metadata' ->> 'full_name'), ''),
+      nullif(trim(auth.jwt() -> 'user_metadata' ->> 'name'), '')
+    );
+  end if;
+
+  if p_role = 'technician' then
+    if lower(coalesce(v_profile.role::text, '')) not in (
+      'technician',
+      'tech',
+      'mechanic',
+      'owner',
+      'admin',
+      'manager',
+      'foreman',
+      'lead_hand',
+      'lead hand'
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'Authenticated user cannot sign as technician.';
+    end if;
+
+    v_effective_name := coalesce(
+      nullif(trim(v_profile.full_name), ''),
+      nullif(trim(auth.jwt() -> 'user_metadata' ->> 'full_name'), ''),
+      nullif(trim(auth.jwt() -> 'user_metadata' ->> 'name'), '')
+    );
+    v_effective_path := nullif(trim(v_profile.tech_signature_path), '');
+    v_effective_hash := nullif(trim(v_profile.tech_signature_hash), '');
+
+    if v_effective_path is null
+       or v_effective_hash is null
+       or v_effective_hash !~ '^[0-9a-fA-F]{64}$'
+       or not (
+         v_effective_path =
+           'tech-signatures/' || v_actor_user_id::text || '.png'
+         or v_effective_path =
+           'tech-signatures/' || v_actor_user_id::text || '/' ||
+           lower(v_effective_hash) || '.png'
+       )
+       or not exists (
+         select 1
+         from storage.objects o
+         where o.bucket_id = 'signatures'
+           and o.name = v_effective_path
+       ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'No valid saved technician signature exists in this profile.';
+    end if;
+  end if;
+
+  if v_effective_name is null then
+    raise exception using errcode = 'P0001', message = 'Signed name is required.';
+  end if;
+
+  -- Only this exact atomic reopen generation and server revision can satisfy
+  -- an idempotent retry. Older evidence remains queryable but cannot suppress
+  -- a new signing cycle.
+  select s.id, s.signed_by, s.signed_name
+    into v_signature_id, v_signature_actor, v_signature_name
+  from public.inspection_signatures s
+  where s.inspection_id = p_inspection_id
+    and s.role = p_role
+    and s.signing_cycle = v_signing_cycle
+    and s.signed_sync_revision = v_inspection_revision
+  order by s.signed_at desc nulls last, s.id desc
+  limit 1
+  for update;
+
+  if found then
+    if (
+      v_inspection_locked
+      or v_inspection_completed
+      or not v_inspection_is_draft
+      or v_inspection_finalized_at is not null
+    ) and v_signature_actor = v_actor_user_id
+      and (
+        p_role in ('technician', 'advisor')
+        or v_signature_name is not distinct from v_effective_name
+      ) then
+      return;
+    end if;
+
+    raise exception using
+      errcode = 'P0001',
+      message = 'This inspection revision is already signed for that role.';
+  end if;
+
+  insert into public.inspection_signatures (
+    inspection_id,
+    role,
+    signed_by,
+    signed_name,
+    signature_image_path,
+    signature_hash,
+    signing_cycle,
+    signed_sync_revision,
+    signed_summary_hash,
+    signed_summary,
+    signed_at
+  ) values (
+    p_inspection_id,
+    p_role,
+    v_actor_user_id,
+    v_effective_name,
+    v_effective_path,
+    v_effective_hash,
+    v_signing_cycle,
+    v_inspection_revision,
+    encode(
+      extensions.digest(
+        convert_to(v_inspection_summary::text, 'UTF8'),
+        'sha256'
+      ),
+      'hex'
+    ),
+    v_inspection_summary,
+    v_now
+  );
+
+  -- The first role finalizes the snapshot. Additional roles can append their
+  -- own immutable evidence without rewriting the already-finalized row.
+  if not v_inspection_locked
+     and not v_inspection_completed
+     and v_inspection_is_draft
+     and v_inspection_finalized_at is null then
+    perform set_config('profixiq.inspection_sign', 'on', true);
+    update public.inspections
+    set locked = true,
+        completed = true,
+        is_draft = false,
+        status = 'completed',
+        finalized_at = v_now,
+        finalized_by = v_actor_user_id,
+        updated_at = v_now
+    where id = p_inspection_id;
+  end if;
+end;
+$$;
+
+revoke all on function public.sign_inspection(
+  uuid, text, text, bigint, text, text
+) from public;
+grant execute on function public.sign_inspection(
+  uuid, text, text, bigint, text, text
+) to authenticated, service_role;
+
+-- Signature rows are append-only evidence. RLS already denies ordinary
+-- mutation; this trigger also stops indirect cascades and privileged accidental
+-- rewrites. Deliberate database-owner maintenance requires disabling the
+-- trigger explicitly and therefore remains auditable.
+create or replace function public.prevent_inspection_signature_evidence_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $signature_evidence_guard$
+begin
+  raise exception using
+    errcode = 'P0001',
+    message = 'Inspection signature evidence is immutable.';
+end;
+$signature_evidence_guard$;
+
+drop trigger if exists prevent_inspection_signature_evidence_mutation
+  on public.inspection_signatures;
+create trigger prevent_inspection_signature_evidence_mutation
+before update or delete on public.inspection_signatures
+for each row
+execute function public.prevent_inspection_signature_evidence_mutation();
+
+-- Once finalized or signed, an inspection can only change through the signing
+-- transition itself or the row-locked reopen RPC above. This closes the broad
+-- legacy shop UPDATE/DELETE policies without disrupting edits to open drafts.
+create or replace function public.prevent_finalized_inspection_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $inspection_evidence_guard$
+declare
+  v_has_signature boolean := false;
+  v_internal_transition boolean :=
+    current_setting('profixiq.inspection_sign', true) = 'on'
+    or current_setting('profixiq.inspection_reopen', true) = 'on';
+begin
+  if v_internal_transition then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+
+  select exists (
+    select 1
+    from public.inspection_signatures s
+    where s.inspection_id = old.id
+  ) into v_has_signature;
+
+  if coalesce(old.locked, false)
+     or coalesce(old.completed, false)
+     or not coalesce(old.is_draft, true)
+     or old.finalized_at is not null
+     or old.finalized_by is not null
+     or lower(coalesce(old.status, 'draft')) in ('completed', 'finalized', 'signed')
+     or v_has_signature then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Finalized inspection evidence is immutable; use the authorized reopen operation.';
+  end if;
+
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$inspection_evidence_guard$;
+
+drop trigger if exists prevent_finalized_inspection_mutation
+  on public.inspections;
+create trigger prevent_finalized_inspection_mutation
+before update or delete on public.inspections
+for each row
+execute function public.prevent_finalized_inspection_mutation();
+
+-- Saved technician signatures are immutable evidence. Updating a signature
+-- creates a new content-addressed object and only moves the profile pointer.
+create or replace function public.prevent_technician_signature_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, storage
+as $signature_guard$
+begin
+  if old.bucket_id = 'signatures'
+     and old.name like 'tech-signatures/%' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Saved technician signature evidence is immutable.';
+  end if;
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$signature_guard$;
+
+drop trigger if exists prevent_technician_signature_mutation
+  on storage.objects;
+create trigger prevent_technician_signature_mutation
+before update or delete on storage.objects
+for each row
+execute function public.prevent_technician_signature_mutation();
+
+-- Realtime drives open inspections on every signed-in device. Guard publication
+-- membership so this migration is safe to rerun.
+do $$
+declare
+  v_table_name text;
+begin
+  if exists (
+    select 1 from pg_publication where pubname = 'supabase_realtime'
+  ) then
+    foreach v_table_name in array array[
+      'inspections',
+      'inspection_sessions',
+      'inspection_signatures'
+    ]
+    loop
+      if not exists (
+        select 1
+        from pg_publication_tables
+        where pubname = 'supabase_realtime'
+          and schemaname = 'public'
+          and tablename = v_table_name
+      ) then
+        execute format(
+          'alter publication supabase_realtime add table public.%I',
+          v_table_name
+        );
+      end if;
+    end loop;
+  end if;
+end;
+$$;
+
+alter table public.inspections replica identity full;
+alter table public.inspection_sessions replica identity full;
+alter table public.inspection_signatures replica identity full;
+
+notify pgrst, 'reload schema';
+commit;

--- a/tests/inspection-active-work-parts-regressions.test.ts
+++ b/tests/inspection-active-work-parts-regressions.test.ts
@@ -2,6 +2,10 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const signRoute = readFileSync("app/api/inspections/sign/route.ts", "utf8");
+const autosaveHook = readFileSync(
+  "features/inspections/hooks/useInspectionAutosave.ts",
+  "utf8",
+);
 const boardHook = readFileSync(
   "features/shared/hooks/useWorkOrderBoard.ts",
   "utf8",
@@ -63,8 +67,9 @@ describe("active work and inspection parts regressions", () => {
     expect(genericScreen).toContain(
       "estimateQuoteLineId: createdQuoteLineId ?? quoteId",
     );
-    expect(genericScreen).toContain(
+    expect(autosaveHook).toContain(
       "Saved to shop • syncs across devices",
     );
   });
 });
+

--- a/tests/inspection-autosave-realtime-signatures.test.ts
+++ b/tests/inspection-autosave-realtime-signatures.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const autosaveHook = readFileSync(
-  "features/inspections/hooks/useInspectionRealtimeAutosave.tsx",
+  "features/inspections/hooks/useInspectionAutosave.ts",
   "utf8",
 );
 const genericScreen = readFileSync(
@@ -20,7 +20,7 @@ const signaturePanel = readFileSync(
 const signRoute = readFileSync("app/api/inspections/sign/route.ts", "utf8");
 const loadRoute = readFileSync("app/api/inspections/load/route.ts", "utf8");
 const migration = readFileSync(
-  "supabase/migrations/20260721143000_inspection_autosave_realtime_signatures.sql",
+  "supabase/migrations/20260721160000_inspection_live_autosave_signature_hardening.sql",
   "utf8",
 );
 const desktopSettings = readFileSync(
@@ -34,51 +34,51 @@ const mobileSettings = readFileSync(
 
 describe("inspection autosave, realtime, and signatures", () => {
   it("debounces every session update into the canonical server writer", () => {
-    expect(autosaveHook).toContain("saveInspectionSession(session, workOrderLineId)");
-    expect(autosaveHook).toContain("debounceMs = 800");
-    expect(genericScreen).toContain("useInspectionRealtimeAutosave");
+    expect(autosaveHook).toContain("saveInspectionSession(");
+    expect(autosaveHook).toContain("debounceMs = 700");
+    expect(autosaveHook).toContain("maxBarrierPasses");
+    expect(genericScreen).toContain("useInspectionAutosave");
     expect(genericScreen).not.toContain("SaveInspectionButton");
     expect(reviewPanel).not.toContain("SaveInspectionButton");
   });
 
   it("subscribes to cross-device progress and lock changes", () => {
-    expect(autosaveHook).toContain('table: "inspection_sessions"');
+    expect(autosaveHook).toContain('"postgres_changes"');
     expect(autosaveHook).toContain('table: "inspections"');
-    expect(autosaveHook).toContain("onRemoteSessionRef.current(value)");
-    expect(loadRoute).toContain("Boolean(inspectionRow?.locked)");
-    expect(migration).toContain(
-      "alter publication supabase_realtime add table public.inspection_sessions",
-    );
-    expect(migration).toContain(
-      "alter publication supabase_realtime add table public.inspections",
-    );
+    expect(autosaveHook).toContain("onRemoteSessionRef.current(remote)");
+    expect(loadRoute).toContain("locked: Boolean(inspectionRow?.locked)");
+    expect(migration).toContain("'inspection_sessions'");
+    expect(migration).toContain("'inspections'");
+    expect(migration).toContain("replica identity full");
   });
 
   it("keeps technician signature identity and image server-owned", () => {
-    expect(signRoute).toContain(
-      "tech_signature_path, tech_signature_hash",
-    );
-    expect(signRoute).toContain(
-      'role === "technician" ? profile?.tech_signature_path',
-    );
+    expect(signRoute).toContain("tech_signature_path");
+    expect(signRoute).toContain("tech_signature_hash");
+    expect(signRoute).toContain("expectedSyncRevision");
     expect(signaturePanel).not.toContain("fetchSavedTechSignature");
-    expect(signaturePanel).not.toContain("signatureImagePath,");
+    expect(signaturePanel).not.toContain("signatureImagePath");
     expect(migration).toContain("if p_role = 'technician' then");
-    expect(migration).toContain("p.tech_signature_path");
+    expect(migration).toContain("v_profile.tech_signature_path");
   });
 
   it("does not require a missing upsert conflict target while signing", () => {
     const signingFunction = migration.slice(
       migration.indexOf("create or replace function public.sign_inspection"),
     );
-    expect(signingFunction).toContain("pg_advisory_xact_lock");
+    expect(signingFunction).toContain("for update");
     expect(signingFunction).toContain("select s.id");
+    expect(signingFunction).toContain("insert into public.inspection_signatures");
     expect(signingFunction).not.toContain("on conflict");
   });
 
-  it("uses content-addressed signature paths for historical integrity", () => {
+  it("uses immutable content-addressed signature paths", () => {
     const expected = "tech-signatures/${profileId}/${hash}.png";
     expect(desktopSettings).toContain(expected);
     expect(mobileSettings).toContain(expected);
+    expect(desktopSettings).toContain("upsert: false");
+    expect(mobileSettings).toContain("upsert: false");
+    expect(migration).toContain("prevent_technician_signature_mutation");
   });
 });
+

--- a/tests/inspection-identity-lock-guards.test.ts
+++ b/tests/inspection-identity-lock-guards.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const autosave = read("features/inspections/hooks/useInspectionAutosave.ts");
+const generic = read(
+  "features/inspections/screens/GenericInspectionScreen.tsx",
+);
+const quickScreens = [
+  read("features/inspections/screens/QuickPMScreen.tsx"),
+  read("features/inspections/screens/QuickAirBrakePMScreen.tsx"),
+];
+
+describe("inspection identity and lock guards", () => {
+  it("never persists or arbitrates a session from another work-order line", () => {
+    expect(autosave).toContain("function sessionMatchesWorkOrderLine(");
+    expect(autosave).toContain(
+      "sessionMatchesWorkOrderLine(\n        latestSessionRef.current,",
+    );
+    expect(autosave).toContain(
+      "if (!sessionMatchesWorkOrderLine(snapshot, workOrderLineId))",
+    );
+    expect(autosave).toContain(
+      "Inspection draft belongs to a different work-order line.",
+    );
+  });
+
+  it("does not publish a provisional unlock while changing identities", () => {
+    const resetStart = autosave.indexOf(
+      'useEffect(() => {\n    setLastError(null);',
+    );
+    const resetEnd = autosave.indexOf(
+      "useEffect(() => {\n    const recoveredKey",
+      resetStart,
+    );
+    expect(resetStart).toBeGreaterThan(-1);
+    expect(resetEnd).toBeGreaterThan(resetStart);
+    expect(autosave.slice(resetStart, resetEnd)).not.toContain(
+      "onRemoteMetaRef.current",
+    );
+  });
+
+  it("keeps local lock evidence until versioned server metadata arrives", () => {
+    expect(generic).toContain("if (!persistEvidence) return;");
+    expect(generic).toContain(
+      "if (meta.updatedAt === null && !meta.locked) return;",
+    );
+    expect(generic).toContain(
+      "applyLockedState(meta.locked, meta.updatedAt !== null);",
+    );
+  });
+
+  it("boots each quick screen under its exact draft identity", () => {
+    for (const screen of quickScreens) {
+      expect(screen).toContain(
+        "const [loadedDraftKey, setLoadedDraftKey] = useState<string | null>(null);",
+      );
+      expect(screen).toContain(
+        "const draftReady = draftBootLoaded && loadedDraftKey === draftKey;",
+      );
+      expect(screen).toContain("enabled: draftReady,");
+      expect(screen).toContain("hydrated: serverBootLoaded,");
+      expect(screen).toContain(
+        "const inspectionReady = draftReady && serverBootLoaded;",
+      );
+      expect(screen).toContain("setDraftBootLoaded(false);");
+      expect(screen).toContain("setLoadedDraftKey(null);");
+      expect(screen).toContain("setLoadedDraftKey(draftKey);");
+      expect(screen).toContain("if (!draftReady) return;");
+      expect(screen).toContain("disabled={isLocked || !inspectionReady}");
+      expect(screen).toContain("recoveryOperationKey,");
+      expect(screen).toContain("durableDraft?.operationKey");
+    }
+  });
+
+  it("applies realtime locks synchronously and stops voice mutations", () => {
+    for (const screen of quickScreens) {
+      const applyStart = screen.indexOf(
+        "const applyLockedState = (nextLocked: boolean): void => {",
+      );
+      const refUpdate = screen.indexOf(
+        "isLockedRef.current = nextLocked;",
+        applyStart,
+      );
+      const stateUpdate = screen.indexOf("setIsLocked(nextLocked);", applyStart);
+      expect(applyStart).toBeGreaterThan(-1);
+      expect(refUpdate).toBeGreaterThan(applyStart);
+      expect(stateUpdate).toBeGreaterThan(refUpdate);
+      expect(screen).toContain("if (nextLocked) stopRecognition();");
+      expect(screen).toContain(
+        "if (draftReadyRef.current && !isLockedRef.current)",
+      );
+      expect(screen).toContain(
+        "onRemoteMeta: (meta) => applyLockedState(meta.locked),",
+      );
+    }
+  });
+});

--- a/tests/inspection-live-autosave-signature.test.ts
+++ b/tests/inspection-live-autosave-signature.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const migration = read(
+  "supabase/migrations/20260721160000_inspection_live_autosave_signature_hardening.sql",
+);
+const autosave = read("features/inspections/hooks/useInspectionAutosave.ts");
+const loadRoute = read("app/api/inspections/load/route.ts");
+const signRoute = read("app/api/inspections/sign/route.ts");
+const signaturePanel = read(
+  "features/inspections/components/inspection/InspectionSignaturePanel.tsx",
+);
+const finalizeRoute = read("app/api/inspections/finalize/pdf/route.ts");
+const findings = read("features/inspections/lib/inspection/findings/page.tsx");
+const desktopSettings = read("app/dashboard/tech/settings/page.tsx");
+const mobileSettings = read(
+  "features/mobile/settings/MobileSettingsScreen.tsx",
+);
+const screens = [
+  read("features/inspections/screens/GenericInspectionScreen.tsx"),
+  read("features/inspections/screens/QuickPMScreen.tsx"),
+  read("features/inspections/screens/QuickAirBrakePMScreen.tsx"),
+  read("features/inspections/components/inspection/InspectionReviewPanel.tsx"),
+];
+
+describe("inspection live autosave and saved signatures", () => {
+  it("repairs draft lifecycle fields and saves without line uniqueness", () => {
+    expect(migration).toContain("Normalize drifted lifecycle rows");
+    expect(migration).toContain("finalized_at = null");
+    expect(migration).toContain("finalized_by = null");
+    expect(migration).toContain(
+      "create or replace function public.save_inspection_progress_atomic",
+    );
+    expect(migration).toContain("'syncRevision', v_next_revision");
+    expect(migration).toContain(
+      "Inspection save conflicts with a newer server version.",
+    );
+    expect(migration).not.toContain("on conflict (work_order_line_id)");
+  });
+
+  it("hydrates the canonical line and streams server changes to open devices", () => {
+    const lineLookup = loadRoute.indexOf(
+      '.eq("work_order_line_id", workOrderLineId)',
+    );
+    const idLookup = loadRoute.indexOf('.eq("id", inspectionId)');
+    expect(lineLookup).toBeGreaterThan(-1);
+    expect(idLookup).toBeGreaterThan(lineLookup);
+    expect(loadRoute).toContain("locked: Boolean(inspectionRow?.locked)");
+    expect(autosave).toContain('"postgres_changes"');
+    expect(autosave).toContain('table: "inspections"');
+    expect(autosave).toContain("remoteShouldReplace");
+    expect(migration).toContain(
+      "alter publication supabase_realtime add table",
+    );
+    expect(migration).toContain(
+      "alter table public.inspections replica identity full",
+    );
+  });
+
+  it("autosaves every active inspection surface and removes manual save controls", () => {
+    for (const screen of screens) {
+      expect(screen).toContain("useInspectionAutosave");
+      expect(screen).not.toContain("<SaveInspectionButton");
+      expect(screen).not.toContain("import { SaveInspectionButton }");
+    }
+    expect(screens[0]).toContain("beforeSign={() => flushAutosaveToServer()}");
+    expect(screens[0]).toContain(
+      "beforeNavigate={() => flushAutosaveToServer()}",
+    );
+    expect(findings).toContain("await flushAutosaveToServer(nextSession)");
+    expect(autosave).toContain("flushToServer");
+    expect(autosave).toContain("A signing/finalization flush is a barrier");
+    expect(autosave).toContain("maxBarrierPasses");
+    expect(autosave).toContain("requireServer");
+    expect(autosave).toContain("pendingOperationFingerprintRef");
+    expect(migration).toContain("'session_fingerprint'");
+    expect(findings).toContain("lastUpdated: new Date().toISOString()");
+  });
+
+  it("uses authenticated profile signature evidence without an invalid conflict target", () => {
+    expect(signRoute).toContain("tech_signature_path");
+    expect(signRoute).toContain("tech_signature_hash");
+    expect(signRoute).toContain("profileName(profile)");
+    expect(signaturePanel).toContain("const prepared = await beforeSign()");
+    expect(signaturePanel).toContain("expectedSyncRevision");
+    expect(signaturePanel).not.toContain("/api/profile/signature");
+    expect(signaturePanel).not.toContain("signatureImagePath");
+    expect(migration).toContain(
+      "create or replace function public.sign_inspection",
+    );
+    expect(migration).toContain("from public.inspection_signatures s");
+    expect(migration).not.toContain("update public.inspection_signatures");
+    expect(migration).not.toContain("on conflict (inspection_id, role)");
+  });
+
+  it("keeps signature files immutable and finalizes the autosaved row deterministically", () => {
+    expect(desktopSettings).toContain(
+      "tech-signatures/${profileId}/${hash}.png",
+    );
+    expect(mobileSettings).toContain(
+      "tech-signatures/${profileId}/${hash}.png",
+    );
+    expect(finalizeRoute).toContain(
+      "Inspection has not finished autosaving yet",
+    );
+    expect(finalizeRoute).toContain(
+      '.order("updated_at", { ascending: false, nullsFirst: false })',
+    );
+    expect(desktopSettings).toContain("upsert: false");
+    expect(mobileSettings).toContain("upsert: false");
+    expect(migration).toContain("prevent_technician_signature_mutation");
+    expect(migration).toContain("signed_sync_revision");
+    expect(migration).toContain("signed_summary");
+    expect(migration).toContain("extensions.digest");
+    expect(migration).toContain(
+      "create or replace function public.finalize_inspection_pdf_atomic",
+    );
+    expect(finalizeRoute).toContain('createHash("sha256")');
+    expect(finalizeRoute).toContain("upsert: false");
+    expect(finalizeRoute).toContain('"finalize_inspection_pdf_atomic"');
+    expect(finalizeRoute).toContain("expectedSyncRevision");
+    expect(finalizeRoute).not.toContain('.eq("updated_at", insp.updated_at)');
+    expect(finalizeRoute).not.toContain(".upsert(");
+    expect(finalizeRoute).not.toContain("onConflict");
+  });
+});

--- a/tests/inspection-offline-recovery.test.ts
+++ b/tests/inspection-offline-recovery.test.ts
@@ -4,11 +4,15 @@ import { describe, expect, it } from "vitest";
 const read = (path: string) => readFileSync(path, "utf8");
 const drafts = read("features/inspections/lib/inspection/offlineDrafts.ts");
 const screen = read("features/inspections/screens/GenericInspectionScreen.tsx");
-const saveButton = read(
-  "features/inspections/components/inspection/SaveInspectionButton.tsx",
+const autosave = read(
+  "features/inspections/hooks/useInspectionAutosave.ts",
 );
 const save = read("features/inspections/lib/inspection/save.ts");
 const findings = read("features/inspections/lib/inspection/findings/page.tsx");
+const quickScreens = [
+  read("features/inspections/screens/QuickPMScreen.tsx"),
+  read("features/inspections/screens/QuickAirBrakePMScreen.tsx"),
+];
 
 describe("technician inspection offline recovery", () => {
   it("stores expiring drafts under the authenticated user and shop scope", () => {
@@ -28,19 +32,16 @@ describe("technician inspection offline recovery", () => {
     expect(drafts).toContain('state: "editing" as const');
   });
 
-  it("recovers before server boot and refuses to replace a newer device draft", () => {
+  it("recovers before server hydration and preserves meaningful newer device edits", () => {
     expect(screen).toContain("getInspectionOfflineDraft");
-    expect(screen).toContain("if (!draftBootLoaded) return");
-    expect(screen).toContain(
-      "serverUpdatedAt >= localDraftUpdatedAtRef.current",
-    );
-    expect(screen).toContain("the older server copy was not applied");
+    expect(screen).toContain("replaceSession(preferred)");
+    expect(screen).toContain("recoveryOperationKey:");
     expect(screen).toContain("!draftBootLoaded ||");
     expect(screen).toContain("!serverBootLoaded ||");
     expect(screen).toContain("const localDraftUpdatedAtRef = useRef(0)");
-    expect(screen).toContain(
-      "inspectionCompletedRef.current || !serverBootLoaded",
-    );
+    expect(autosave).toContain("remoteShouldReplace");
+    expect(autosave).toContain("hasMeaningfulLocalChanges");
+    expect(autosave).toContain("recoveryOperationKey?.trim()");
   });
 
   it("detaches newer edits from an older queued save", () => {
@@ -49,10 +50,46 @@ describe("technician inspection offline recovery", () => {
     expect(screen).toContain('draftState = "editing"');
     expect(screen).toContain("operationKey = undefined");
     expect(screen).toContain("state: draftState");
-    expect(drafts).toContain(
-      "sessionTimestamp(draft.session) > sessionTimestamp(queuedSession)",
-    );
+    expect(drafts).toContain("newestLocalTimestamp");
+    expect(drafts).toContain("await dismissOfflineMutation(draft.operationKey)");
+    expect(drafts).toContain("supersededMutation");
     expect(drafts).toContain('state: "editing" as const');
+    expect(screen).toContain("newerSessionHint: persistedSession");
+    for (const quick of quickScreens) {
+      expect(quick).toContain("recoveryOperationKey,");
+      expect(quick).toContain("setRecoveryOperationKey(operationKey)");
+      expect(quick).toContain("newerSessionHint: browserSession");
+      expect(quick).toContain("restoredMatchesIdentity");
+      expect(quick).toContain("durableDraft?.operationKey");
+    }
+  });
+
+  it("recovers a synced operation acknowledgement before issuing a newer revision", () => {
+    expect(drafts).toContain('if (queued.status === "synced")');
+    expect(drafts).toContain("awaitingAcknowledgement");
+    expect(save).toContain(
+      "!result.queued && !result.conflicted && !serverResponse.current",
+    );
+    expect(save).toContain("serverResponse.current = await postInspectionSave(payload)");
+    expect(save).toContain("queued: true");
+  });
+
+  it("blocks findings edits while submission is in flight and preserves explicit no-parts decisions", () => {
+    expect(findings).toContain("busyRef.current = true");
+    expect(findings).toContain("assertSubmissionCurrent()");
+    expect(findings).toContain("latestSessionRef.current");
+    expect(findings).toContain("activeDraftKeyRef.current");
+    expect(findings).toContain("const noPartsRequired =");
+    expect(findings).toContain("no_parts_required: noPartsRequired");
+    expect(findings).toContain("submissionFindings.length > 0");
+    const finalizeResponseStart = findings.indexOf("const pdfJson =");
+    const finalizeResponseCheck = findings.indexOf(
+      "if (!pdfRes.ok || !pdfJson?.ok)",
+      finalizeResponseStart,
+    );
+    expect(
+      findings.slice(finalizeResponseStart, finalizeResponseCheck),
+    ).not.toContain("assertSubmissionCurrent()");
   });
 
   it("clears durable and legacy drafts from the mounted findings flow", () => {
@@ -63,7 +100,9 @@ describe("technician inspection offline recovery", () => {
     expect(findings.indexOf("await removeInspectionOfflineDraft")).toBeLessThan(
       findings.indexOf('new CustomEvent("inspection:completed"'),
     );
-    expect(saveButton).toContain("? result.operationKey");
-    expect(save).toContain("return { ...result, operationKey }");
+    expect(screen).not.toContain("<SaveInspectionButton");
+    expect(autosave).toContain("saveInspectionOfflineDraft");
+    expect(save).toContain("operationKey,");
+    expect(save).toContain("syncRevision: serverResponse.current?.sync_revision");
   });
 });

--- a/tests/inspection-release-blockers.test.ts
+++ b/tests/inspection-release-blockers.test.ts
@@ -1,0 +1,151 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const migration = read(
+  "supabase/migrations/20260721160000_inspection_live_autosave_signature_hardening.sql",
+);
+const loadRoute = read("app/api/inspections/load/route.ts");
+const finalizeRoute = read("app/api/inspections/finalize/pdf/route.ts");
+const reopenRoute = read("app/api/inspections/reopen/route.ts");
+
+describe("inspection release-blocker hardening", () => {
+  it("authorizes save retries before reading SECURITY DEFINER idempotency data", () => {
+    const saveFunction = migration.slice(
+      migration.indexOf(
+        "create or replace function public.save_inspection_progress_atomic",
+      ),
+      migration.indexOf(
+        "create or replace function public.finalize_inspection_pdf_atomic",
+      ),
+    );
+    const membershipCheck = saveFunction.indexOf(
+      "Actor is not a member of this shop.",
+    );
+    const lineCheck = saveFunction.indexOf(
+      "Work-order line not found for shop.",
+    );
+    const idempotencyRead = saveFunction.indexOf("select mok.result");
+
+    expect(membershipCheck).toBeGreaterThan(-1);
+    expect(lineCheck).toBeGreaterThan(membershipCheck);
+    expect(idempotencyRead).toBeGreaterThan(lineCheck);
+    expect(saveFunction).toContain("v_now timestamptz := clock_timestamp()");
+    expect(saveFunction).not.toContain(
+      "v_now timestamptz := coalesce(p_at, now())",
+    );
+  });
+
+  it("publishes finalization through a locked revision compare-and-swap", () => {
+    const finalizeFunction = migration.slice(
+      migration.indexOf(
+        "create or replace function public.finalize_inspection_pdf_atomic",
+      ),
+      migration.indexOf("create or replace function public.sign_inspection"),
+    );
+
+    expect(finalizeFunction).toContain("p_expected_sync_revision bigint");
+    expect(finalizeFunction).toContain("for update");
+    expect(finalizeFunction).toContain(
+      "p_expected_sync_revision <> v_revision",
+    );
+    expect(finalizeFunction).toContain(
+      "order by s.updated_at desc nulls last, s.id desc",
+    );
+    expect(finalizeFunction).toContain(
+      "Finalized PDF path does not match the inspection snapshot.",
+    );
+    expect(finalizeFunction).toContain(") to service_role;");
+    expect(finalizeFunction).not.toContain(") to authenticated, service_role;");
+    expect(finalizeRoute).toContain('"finalize_inspection_pdf_atomic"');
+    expect(finalizeRoute).toContain(
+      "storageSupabase as unknown as FinalizeRpcClient",
+    );
+    expect(finalizeRoute).toContain(
+      "p_expected_sync_revision: expectedSyncRevision",
+    );
+    expect(finalizeRoute).not.toContain('.eq("updated_at", insp.updated_at)');
+  });
+
+  it("keeps finalized PDF objects immutable and content addressed", () => {
+    expect(finalizeRoute).toContain('createHash("sha256")');
+    expect(finalizeRoute).toContain("_${pdfHash}.pdf");
+    expect(finalizeRoute).toContain("upsert: false");
+    expect(finalizeRoute).not.toContain("upsert: true");
+  });
+
+  it("uses the same deterministic null ordering for canonical finalize reads", () => {
+    expect(
+      finalizeRoute.match(
+        /\.order\("updated_at", \{ ascending: false, nullsFirst: false \}\)/g,
+      ),
+    ).toHaveLength(2);
+    expect(finalizeRoute).toContain('.order("id", { ascending: false })');
+  });
+
+  it("never falls back to a device UUID when a canonical line was supplied", () => {
+    expect(loadRoute).toContain(
+      "if (!inspectionRow && inspectionId && !workOrderLineId)",
+    );
+    expect(loadRoute).not.toContain("if (!inspectionRow && inspectionId) {");
+  });
+
+  it("keeps role and tenant membership server-managed", () => {
+    expect(migration).toContain("prevent_profile_authorization_self_write");
+    expect(migration).toContain(
+      "revoke update on table public.profiles from authenticated",
+    );
+    expect(migration).toContain(
+      "Profile role and shop membership are server-managed.",
+    );
+    expect(migration).toContain("new.role is distinct from old.role");
+    expect(migration).toContain("new.shop_id is distinct from old.shop_id");
+  });
+
+  it("makes signature evidence append-only and prevents parent cascades", () => {
+    expect(migration).toContain("on delete restrict");
+    expect(migration).toContain(
+      "prevent_inspection_signature_evidence_mutation",
+    );
+    expect(migration).toContain("prevent_finalized_inspection_mutation");
+    expect(migration).toContain("Finalized inspection evidence is immutable");
+  });
+
+  it("requires a real immutable storage object for technician signing", () => {
+    const signingFunction = migration.slice(
+      migration.indexOf("create or replace function public.sign_inspection"),
+      migration.indexOf(
+        "create or replace function public.prevent_inspection_signature_evidence_mutation",
+      ),
+    );
+    expect(signingFunction).toContain("from storage.objects o");
+    expect(signingFunction).toContain("o.bucket_id = 'signatures'");
+    expect(signingFunction).toContain("o.name = v_effective_path");
+  });
+
+  it("reopens atomically with a database-clock signing generation", () => {
+    const reopenFunction = migration.slice(
+      migration.indexOf("create or replace function public.reopen_inspection"),
+      migration.indexOf("create or replace function public.sign_inspection"),
+    );
+    const signingFunction = migration.slice(
+      migration.indexOf("create or replace function public.sign_inspection"),
+    );
+
+    expect(reopenFunction).toContain("for update");
+    expect(reopenFunction).toContain("clock_timestamp()");
+    expect(reopenFunction).toContain("v_next_cycle := v_signing_cycle + 1");
+    expect(reopenFunction).toContain("signing_cycle = v_next_cycle");
+    expect(signingFunction).toContain("s.signing_cycle = v_signing_cycle");
+    expect(signingFunction).toContain(
+      "s.signed_sync_revision = v_inspection_revision",
+    );
+    expect(signingFunction).not.toContain(
+      "s.signed_at >= v_inspection_reopened_at",
+    );
+    expect(reopenRoute).toContain('"reopen_inspection",');
+    expect(reopenRoute).not.toContain('.from("inspections")');
+    expect(reopenRoute).not.toContain("new Date().toISOString()");
+  });
+});

--- a/tests/mobile-technician-stabilization.test.ts
+++ b/tests/mobile-technician-stabilization.test.ts
@@ -5,6 +5,10 @@ const migration = readFileSync(
   "supabase/migrations/20260719090000_mobile_technician_stabilization.sql",
   "utf8",
 );
+const liveInspectionMigration = readFileSync(
+  "supabase/migrations/20260721160000_inspection_live_autosave_signature_hardening.sql",
+  "utf8",
+);
 const signRoute = readFileSync(
   "app/api/inspections/sign/route.ts",
   "utf8",
@@ -23,6 +27,10 @@ const mobilePartsPage = readFileSync(
 );
 const mobilePartsWorkflow = readFileSync(
   "features/parts/mobile/MobilePartsWorkflow.tsx",
+  "utf8",
+);
+const receiveDrawer = readFileSync(
+  "features/parts/components/ReceiveDrawer.tsx",
   "utf8",
 );
 
@@ -50,24 +58,30 @@ describe("mobile technician stabilization", () => {
     expect(migration).toContain("Inspection is finalized and locked");
   });
 
-  it("anchors a mobile inspection before signing instead of inserting a bare row", () => {
+  it("requires autosave and resolves technician evidence on the server before signing", () => {
     expect(signRoute).toContain("resolveInspectionForSigning");
-    expect(signRoute).toContain("work_order_line_id: canonicalLineId");
-    expect(signRoute).toContain("work_order_id: canonicalWorkOrderId");
-    expect(signRoute).not.toContain(
-      "Unable to auto-create inspection before signing",
-    );
+    expect(signRoute).toContain("Inspection has not finished autosaving");
+    expect(signRoute).toContain("tech_signature_path");
+    expect(signRoute).toContain("profileName(profile)");
     expect(signRoute).not.toContain(".upsert(");
     expect(signaturePanel).toContain(
       "workOrderLineId: resolvedWorkOrderLineId",
     );
     expect(signaturePanel).toContain(
-      'sessionStorage.getItem("inspection:params")',
+      "const prepared = await beforeSign()",
+    );
+    expect(signaturePanel).not.toContain("signatureImagePath");
+    expect(signaturePanel).not.toContain("/api/profile/signature");
+    expect(liveInspectionMigration).toContain(
+      "create or replace function public.sign_inspection",
+    );
+    expect(liveInspectionMigration).not.toContain(
+      "update public.inspection_signatures",
     );
   });
 
   it("exposes cause and correction independently from the finish button", () => {
-    expect(mobileJobPage).toContain("Cause / Correction");
+    expect(mobileJobPage).toContain("Cause & Correction");
     expect(mobileJobPage).toContain("save_story_draft");
     expect(mobileJobPage).toContain("CauseCorrectionModal");
   });
@@ -75,9 +89,10 @@ describe("mobile technician stabilization", () => {
   it("replaces the mobile parts placeholder with actionable parts commands", () => {
     expect(mobilePartsPage).toContain("MobilePartsWorkflow");
     expect(mobilePartsWorkflow).toContain("part_request_items");
-    expect(mobilePartsWorkflow).toContain("/receive");
+    expect(receiveDrawer).toContain("/receive");
     expect(mobilePartsWorkflow).toContain("/allocate");
     expect(mobilePartsWorkflow).toContain("Open parts workbench");
     expect(mobilePartsPage).not.toContain("Mobile parts rollout");
   });
 });
+

--- a/tests/phase6-inspection-progress-route.test.ts
+++ b/tests/phase6-inspection-progress-route.test.ts
@@ -17,6 +17,10 @@ describe("Phase 6 inspection progress route", () => {
     expect(route).toContain("A stable Idempotency-Key is required.");
     expect(client).toContain('"Idempotency-Key": payload.operationKey');
     expect(client).toContain("clientMutationId: operationKey");
+    expect(client).toContain("operationKey?: string");
+    expect(client).toContain(
+      'orderKey: `${workOrderLineId}:inspection-progress`',
+    );
   });
 
   it("uses only the canonical atomic RPC for critical writes", () => {
@@ -32,7 +36,13 @@ describe("Phase 6 inspection progress route", () => {
     expect(replay).toContain("operationKey,");
   });
 
-  it("preserves HTTP status for permanent-error classification", () => {
+  it("preserves HTTP status and server revision acknowledgements", () => {
     expect(client).toContain("error.status = res.status");
+    expect(client).toContain(
+      "syncRevision: serverResponse.current?.sync_revision",
+    );
+    expect(route).toContain('lower.includes("newer server version")');
+    expect(route).toContain("? 409");
   });
 });
+

--- a/tests/signature-pad-touch-safety.test.ts
+++ b/tests/signature-pad-touch-safety.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const controller = readFileSync(
+  "features/shared/signaturePad/controller.tsx",
+  "utf8",
+);
+
+describe("shared signature pad touch and blank-capture safety", () => {
+  it("attaches responsive and non-passive touch handling when the modal opens", () => {
+    expect(controller).toContain("if (!open || !containerRef.current) return;");
+    expect(controller).toContain(
+      'addEventListener("touchmove", preventScroll, { passive: false })',
+    );
+    expect(controller).toContain("}, [open]);");
+    expect(controller).toContain('touchAction: "none"');
+  });
+
+  it("uses the actual narrow-screen width instead of forcing canvas overflow", () => {
+    expect(controller).toContain(
+      "const w = measuredWidth > 0 ? measuredWidth : 480;",
+    );
+    expect(controller).not.toContain("Math.max(320");
+  });
+
+  it("rejects an exported canvas that contains no visible signature ink", () => {
+    expect(controller).toContain("function canvasHasVisibleInk");
+    expect(controller).toContain(
+      "getImageData(0, 0, canvas.width, canvas.height)",
+    );
+    expect(controller).toContain("if (!canvasHasVisibleInk(canvas))");
+    expect(
+      controller.indexOf("if (!canvasHasVisibleInk(canvas))"),
+    ).toBeLessThan(controller.indexOf('canvas.toDataURL("image/png")'));
+  });
+
+  it("resets SignaturePad state whenever a resize clears the bitmap", () => {
+    const resizeBlock = controller.slice(
+      controller.indexOf("if (canvas.width !== W || canvas.height !== H)"),
+      controller.indexOf("// Prevent page scroll while signing"),
+    );
+    expect(resizeBlock.indexOf("sigRef.current?.clear?.()")).toBeGreaterThan(
+      -1,
+    );
+    expect(resizeBlock.indexOf("sigRef.current?.clear?.()")).toBeLessThan(
+      resizeBlock.indexOf("canvas.width = W"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- replace local-only/manual inspection saving with canonical server autosave, revision checks, offline replay recovery, and Supabase Realtime updates across signed-in devices
- remove manual Save controls from active inspection surfaces
- apply the authenticated technician's saved profile signature on Sign, validate the stored signature object, and keep signed evidence immutable
- fix the shared signature pad on iOS/narrow screens and reject blank captures
- make finalization and reopen atomic, revision-safe lifecycle transitions
- preserve current active-work and explicit no-parts behavior while preventing stale findings/quote submission races

## Root causes fixed

- drifted draft rows could retain finalized lifecycle fields and violate `inspections_draft_not_finalized_chk`
- the operation-key table could lack the uniqueness contract assumed by the signing/save conflict path
- drafts were primarily local, so another signed-in device could not reliably hydrate or follow changes
- signing trusted incomplete profile/storage state and reopen/finalize used non-atomic application-side transitions

## Validation

- 49 focused regression tests across 9 test files
- TypeScript/TSX parse validation for all changed source and test files
- PostgreSQL 17 parser validation: 55 statements
- branch is synchronized with current `main` and changes 30 scoped files

## Deployment note

Apply `20260721160000_inspection_live_autosave_signature_hardening.sql` before deploying the application changes. The migration is forward-only and is intended to follow the inspection migration already merged into `main`.