### PR TITLE
Fix realtime voice activation token failures

### DIFF
--- a/app/api/openai/realtime-token/route.ts
+++ b/app/api/openai/realtime-token/route.ts
@@ -233,6 +233,7 @@ export async function GET() {
       {
         token: extracted.token,
         expiresAt: extracted.expiresAt ?? null,
+        transcriptionModel,
       },
       {
         status: 200,

--- a/app/api/openai/realtime-token/route.ts
+++ b/app/api/openai/realtime-token/route.ts
@@ -105,8 +105,11 @@ export async function GET() {
     if (!apiKey) {
       console.error("[realtime-token] Missing OPENAI_API_KEY");
       return NextResponse.json(
-        { error: "Missing OPENAI_API_KEY" },
-        { status: 500 },
+        {
+          error: "Voice service is not configured",
+          code: "realtime_not_configured",
+        },
+        { status: 503 },
       );
     }
 
@@ -159,8 +162,11 @@ export async function GET() {
     } catch {
       console.error("[realtime-token] Invalid JSON from OpenAI", rawText);
       return NextResponse.json(
-        { error: "Invalid JSON from OpenAI" },
-        { status: 500 },
+        {
+          error: "Voice service returned an invalid response",
+          code: "realtime_invalid_response",
+        },
+        { status: 502 },
       );
     }
 
@@ -173,10 +179,11 @@ export async function GET() {
 
       return NextResponse.json(
         {
-          error: "Failed to mint realtime transcription token",
+          error: "Voice service could not start",
+          code: "realtime_session_rejected",
           upstreamStatus: response.status,
         },
-        { status: 500 },
+        { status: 502 },
       );
     }
 
@@ -188,8 +195,11 @@ export async function GET() {
         parsed,
       );
       return NextResponse.json(
-        { error: "Unexpected token response shape" },
-        { status: 500 },
+        {
+          error: "Voice service returned an invalid response",
+          code: "realtime_invalid_response",
+        },
+        { status: 502 },
       );
     }
 
@@ -224,7 +234,10 @@ export async function GET() {
         token: extracted.token,
         expiresAt: extracted.expiresAt ?? null,
       },
-      { status: 200 },
+      {
+        status: 200,
+        headers: { "Cache-Control": "no-store" },
+      },
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unhandled realtime token error";
@@ -254,9 +267,15 @@ export async function GET() {
       errorCode: "realtime_token_error",
     });
     console.error("[realtime-token] Unhandled error", err);
+    const timedOut = message === "AI request timed out";
     return NextResponse.json(
-      { error: "Unhandled realtime token error" },
-      { status: 500 },
+      {
+        error: timedOut
+          ? "Voice service took too long to respond"
+          : "Voice service could not start",
+        code: timedOut ? "realtime_upstream_timeout" : "realtime_token_error",
+      },
+      { status: timedOut ? 504 : 500 },
     );
   }
 }

--- a/features/inspections/lib/inspection/useRealtimeVoice.ts
+++ b/features/inspections/lib/inspection/useRealtimeVoice.ts
@@ -38,7 +38,10 @@ type RealtimeVoiceOptions = {
   debug?: boolean;
 };
 
-type RealtimeTokenResponse = { token?: string };
+type RealtimeTokenResponse = {
+  token?: string;
+  transcriptionModel?: string;
+};
 
 type RealtimeTokenErrorResponse = {
   error?: string;
@@ -204,6 +207,11 @@ export function useRealtimeVoice(
 
     const tokenResp = (await r.json()) as RealtimeTokenResponse;
     const token = typeof tokenResp.token === "string" ? tokenResp.token : "";
+    const sessionTranscriptionModel =
+      typeof tokenResp.transcriptionModel === "string" &&
+      tokenResp.transcriptionModel.trim()
+        ? tokenResp.transcriptionModel.trim()
+        : transcriptionModel;
     if (!token) {
       setState("error");
       const message = "Voice service returned an invalid token. Try again.";
@@ -270,7 +278,7 @@ export function useRealtimeVoice(
                 format: { type: "audio/pcm", rate: 24000 },
                 noise_reduction: { type: "near_field" },
                 transcription: {
-                  model: transcriptionModel,
+                  model: sessionTranscriptionModel,
                   language: "en",
                 },
                 // Keep these modest; if you had a known-good set before, use it.

--- a/features/inspections/lib/inspection/useRealtimeVoice.ts
+++ b/features/inspections/lib/inspection/useRealtimeVoice.ts
@@ -40,6 +40,43 @@ type RealtimeVoiceOptions = {
 
 type RealtimeTokenResponse = { token?: string };
 
+type RealtimeTokenErrorResponse = {
+  error?: string;
+  code?: string;
+};
+
+async function getRealtimeTokenError(response: Response): Promise<string> {
+  let body: RealtimeTokenErrorResponse | null = null;
+  try {
+    body = (await response.json()) as RealtimeTokenErrorResponse;
+  } catch {
+    // The status mapping below still gives the technician a useful message.
+  }
+
+  if (response.status === 401) {
+    return "Your session expired. Sign in again, then retry voice.";
+  }
+  if (response.status === 403) {
+    return "Voice is not available for this account.";
+  }
+  if (response.status === 429) {
+    return "Voice is busy. Wait a moment and try again.";
+  }
+
+  switch (body?.code) {
+    case "realtime_not_configured":
+      return "Voice is not configured for this deployment.";
+    case "realtime_upstream_timeout":
+      return "Voice took too long to connect. Try again.";
+    case "realtime_session_rejected":
+    case "realtime_invalid_response":
+    case "realtime_token_error":
+      return "Voice could not start. Try again in a moment.";
+    default:
+      return body?.error?.trim() || "Voice could not start.";
+  }
+}
+
 function base64FromArrayBuffer(buf: ArrayBuffer): string {
   let binary = "";
   const bytes = new Uint8Array(buf);
@@ -142,20 +179,36 @@ export function useRealtimeVoice(
     liveRef.current = "";
     setState("connecting");
 
-    // Get EPHEMERAL token
-    const r = await fetch("/api/openai/realtime-token", { method: "GET" });
-    if (!r.ok) {
+    // Get an ephemeral token. This happens before requesting microphone access,
+    // so token/auth failures are not misreported as microphone failures.
+    let r: Response;
+    try {
+      r = await fetch("/api/openai/realtime-token", {
+        method: "GET",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+    } catch {
+      const message = "Voice could not reach the server. Check your connection.";
       setState("error");
-      opts?.onError?.("Failed to get realtime token");
-      throw new Error("Failed to get realtime token");
+      opts?.onError?.(message);
+      throw new Error(message);
+    }
+
+    if (!r.ok) {
+      const message = await getRealtimeTokenError(r);
+      setState("error");
+      opts?.onError?.(message);
+      throw new Error(message);
     }
 
     const tokenResp = (await r.json()) as RealtimeTokenResponse;
     const token = typeof tokenResp.token === "string" ? tokenResp.token : "";
     if (!token) {
       setState("error");
-      opts?.onError?.("Missing realtime token");
-      throw new Error("Missing realtime token");
+      const message = "Voice service returned an invalid token. Try again.";
+      opts?.onError?.(message);
+      throw new Error(message);
     }
 
     // Mic

--- a/features/shared/lib/openai-realtime-models.ts
+++ b/features/shared/lib/openai-realtime-models.ts
@@ -5,9 +5,14 @@ function env(name: string): string | undefined {
   return value ? value : undefined;
 }
 
+/**
+ * Realtime transcription requires an audio transcription model. Do not fall
+ * back to the app's general text/reasoning model variables: those values can
+ * be valid elsewhere while being rejected by the Realtime API.
+ */
 export function getOpenAIRealtimeTranscriptionModel(): string {
-  return env("OPENAI_REALTIME_TRANSCRIBE_MODEL")
-    ?? env("OPENAI_FAST_MODEL")
-    ?? env("OPENAI_MODEL")
-    ?? DEFAULT_REALTIME_TRANSCRIPTION_MODEL;
+  return (
+    env("OPENAI_REALTIME_TRANSCRIBE_MODEL") ??
+    DEFAULT_REALTIME_TRANSCRIPTION_MODEL
+  );
 }


### PR DESCRIPTION
## What changed

- prevents Realtime transcription from inheriting `OPENAI_FAST_MODEL` or `OPENAI_MODEL`
- uses the dedicated `OPENAI_REALTIME_TRANSCRIBE_MODEL` only when explicitly configured, otherwise defaults to `gpt-4o-mini-transcribe`
- returns the effective transcription model with the ephemeral token so browser and server cannot configure different models
- adds stable API error codes and correct 502/503/504 status handling
- disables caching for ephemeral token responses and requests
- replaces the generic “Failed to get realtime token” message with actionable authentication, authorization, throttling, configuration, timeout, and connectivity messages

## Root cause

The realtime model resolver fell back to the application's general AI model variables. Those variables can contain a valid text or reasoning model that is not valid for a Realtime transcription session. OpenAI then rejects the client-secret request, while the browser hides the response category behind a generic toast.

The browser also independently resolved its model. Server-only environment variables are not available in the client bundle, so a configured server transcription model could be overwritten by the browser default after connecting.

## User impact

Starting inspection voice no longer depends on unrelated general AI model configuration. If token issuance still fails because of an expired login, deployment configuration, rate limit, timeout, or connectivity problem, the technician sees the correct next action instead of an undifferentiated failure.

## Validation

- compared branch against `main`: 3 changed files, no unrelated changes, branch is 5 commits ahead and 0 behind
- verified the current OpenAI Realtime client-secret endpoint and transcription-session shape against the official API reference
- local typecheck, lint, tests, and build were not available because this workspace has no repository checkout; PR CI remains required

## Database and configuration

- database migration: none
- new required environment variables: none
- optional override remains `OPENAI_REALTIME_TRANSCRIBE_MODEL`
