### PR TITLE
Build durable shop-wide assistant conversations

### DIFF
--- a/app/api/shop-assistant/chat/route.ts
+++ b/app/api/shop-assistant/chat/route.ts
@@ -1,0 +1,277 @@
+import { NextResponse } from "next/server";
+
+import { answerAssistant } from "@/features/agent/assistant/server/answerAssistant";
+import type {
+  AssistantAnswer,
+  AssistantConversationMessage,
+  AssistantResolvedContext,
+} from "@/features/agent/assistant/types";
+import {
+  requireShopAssistantActor,
+  shopAssistantErrorMessage,
+  shopAssistantErrorStatus,
+} from "@/features/shop-assistant/server/requireShopAssistantActor";
+import {
+  findAssistantReply,
+  getOrCreateShopAssistantThread,
+  insertAssistantMessage,
+  insertUserMessageIdempotent,
+  loadShopAssistantMessages,
+  mergeThreadContext,
+  threadContextFromPage,
+  updateShopAssistantThreadContext,
+} from "@/features/shop-assistant/server/threadStore";
+import type {
+  ShopAssistantChatRequest,
+  ShopAssistantChatResponse,
+  ShopAssistantMessage,
+  ShopAssistantThreadContext,
+} from "@/features/shop-assistant/types";
+
+function isTechnicianDiagnosticRequest(question: string): boolean {
+  return /\b(?:[PBCU][0-9A-F]{4}|diagnos(?:e|is|tic)|pinout|expected voltage|misfire|no[- ]start|wiring test)\b/i.test(
+    question,
+  );
+}
+
+function technicianRedirectAnswer(): AssistantAnswer {
+  return {
+    intent: "unknown",
+    summary:
+      "Open the work order and use its Technician AI for diagnostic guidance. The shop-wide assistant is reserved for operations, customers, scheduling, parts, billing, reporting, and workforce coordination.",
+    bullets: [],
+    links: [],
+    entities: [],
+    actions: [],
+  };
+}
+
+function uniqueLines(values: string[]): string[] {
+  const seen = new Set<string>();
+  const output: string[] = [];
+
+  for (const value of values) {
+    const clean = value.trim();
+    const key = clean.toLowerCase();
+    if (!clean || seen.has(key)) continue;
+    seen.add(key);
+    output.push(clean);
+  }
+
+  return output;
+}
+
+function answerContent(answer: AssistantAnswer): string {
+  return uniqueLines([answer.summary, ...answer.bullets]).join("\n");
+}
+
+function conversationMessages(
+  messages: ShopAssistantMessage[],
+): AssistantConversationMessage[] {
+  return messages
+    .filter(
+      (message) =>
+        (message.role === "user" || message.role === "assistant") &&
+        message.content.trim(),
+    )
+    .slice(-20)
+    .map((message) => ({
+      role: message.role === "user" ? "user" : "assistant",
+      content: message.content.trim().slice(0, 4000),
+    }));
+}
+
+function contextFromResolved(
+  resolved?: AssistantResolvedContext,
+): ShopAssistantThreadContext {
+  return {
+    activeWorkOrderId: resolved?.workOrderId,
+    activeCustomerId: resolved?.customerId,
+    activeVehicleId: resolved?.vehicleId,
+    activeBookingId: resolved?.bookingId,
+  };
+}
+
+function responseFromExisting(params: {
+  thread: Awaited<ReturnType<typeof getOrCreateShopAssistantThread>>;
+  messages: ShopAssistantMessage[];
+  reply: ShopAssistantMessage;
+}): ShopAssistantChatResponse {
+  return {
+    ok: true,
+    thread: params.thread,
+    messages: params.messages,
+    turn: {
+      kind: "answer",
+      message: params.reply,
+    },
+  };
+}
+
+export async function POST(request: Request) {
+  let actor: Awaited<ReturnType<typeof requireShopAssistantActor>> | null = null;
+  let threadId: string | null = null;
+  let requestClientMessageId: string | null = null;
+
+  try {
+    actor = await requireShopAssistantActor();
+    const body = (await request.json().catch(() => null)) as
+      | ShopAssistantChatRequest
+      | null;
+    const question = body?.question?.trim() ?? "";
+    const clientMessageId = body?.clientMessageId?.trim() ?? "";
+
+    if (!question) {
+      return NextResponse.json<ShopAssistantChatResponse>(
+        { ok: false, error: "Question is required", retryable: false },
+        { status: 400 },
+      );
+    }
+    if (question.length > 8000) {
+      return NextResponse.json<ShopAssistantChatResponse>(
+        { ok: false, error: "Question is too long", retryable: false },
+        { status: 400 },
+      );
+    }
+    if (clientMessageId.length < 8 || clientMessageId.length > 200) {
+      return NextResponse.json<ShopAssistantChatResponse>(
+        {
+          ok: false,
+          error: "A valid client message id is required",
+          retryable: false,
+        },
+        { status: 400 },
+      );
+    }
+
+    requestClientMessageId = clientMessageId;
+    let thread = await getOrCreateShopAssistantThread(
+      actor,
+      body?.threadId,
+      body?.context,
+    );
+    threadId = thread.id;
+
+    const requestedContext = threadContextFromPage(body?.context);
+    if (Object.values(requestedContext).some(Boolean)) {
+      thread = await updateShopAssistantThreadContext({
+        actor,
+        thread,
+        context: requestedContext,
+      });
+    }
+
+    const userWrite = await insertUserMessageIdempotent({
+      actor,
+      threadId: thread.id,
+      content: question,
+      clientMessageId,
+      payload: {
+        pageType: body?.context?.pageType,
+        pageTitle: body?.context?.pageTitle,
+      },
+    });
+
+    if (!userWrite.created) {
+      const existingReply = await findAssistantReply(
+        actor,
+        thread.id,
+        clientMessageId,
+      );
+      if (!existingReply) {
+        return NextResponse.json<ShopAssistantChatResponse>(
+          {
+            ok: false,
+            error: "This request is already being processed",
+            retryable: true,
+          },
+          { status: 409 },
+        );
+      }
+
+      const messages = await loadShopAssistantMessages(actor, thread.id);
+      return NextResponse.json(
+        responseFromExisting({ thread, messages, reply: existingReply }),
+      );
+    }
+
+    const storedMessages = await loadShopAssistantMessages(actor, thread.id);
+    const answer = isTechnicianDiagnosticRequest(question)
+      ? technicianRedirectAnswer()
+      : await answerAssistant({
+          shopId: actor.shopId,
+          userId: actor.userId,
+          role: actor.role,
+          request: {
+            question,
+            context: body?.context,
+            session: {
+              workOrderId: thread.context.activeWorkOrderId,
+              vehicleId: thread.context.activeVehicleId,
+              customerId: thread.context.activeCustomerId,
+              bookingId: thread.context.activeBookingId,
+            },
+            messages: conversationMessages(storedMessages),
+          },
+        });
+
+    const reply = await insertAssistantMessage({
+      actor,
+      threadId: thread.id,
+      content: answerContent(answer),
+      payload: {
+        requestClientMessageId: clientMessageId,
+        answer,
+      },
+    });
+
+    const nextContext = mergeThreadContext(
+      contextFromResolved(answer.resolvedContext),
+      { lastIntent: answer.intent },
+    );
+    const shouldSetTitle = thread.title === "Shop Assistant";
+    thread = await updateShopAssistantThreadContext({
+      actor,
+      thread,
+      context: nextContext,
+      title: shouldSetTitle ? question.slice(0, 80) : undefined,
+    });
+
+    const messages = await loadShopAssistantMessages(actor, thread.id);
+    return NextResponse.json<ShopAssistantChatResponse>({
+      ok: true,
+      thread,
+      messages,
+      turn: {
+        kind: "answer",
+        message: reply,
+      },
+    });
+  } catch (error: unknown) {
+    if (actor && threadId && requestClientMessageId) {
+      try {
+        await insertAssistantMessage({
+          actor,
+          threadId,
+          kind: "error",
+          content: shopAssistantErrorMessage(error),
+          payload: {
+            requestClientMessageId,
+            retryable: true,
+          },
+        });
+      } catch {
+        // Preserve the original failure when persistence also fails.
+      }
+    }
+
+    return NextResponse.json<ShopAssistantChatResponse>(
+      {
+        ok: false,
+        error: shopAssistantErrorMessage(error),
+        retryable: shopAssistantErrorStatus(error) >= 500,
+      },
+      { status: shopAssistantErrorStatus(error) },
+    );
+  }
+}

--- a/app/api/shop-assistant/state/route.ts
+++ b/app/api/shop-assistant/state/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import {
+  requireShopAssistantActor,
+  shopAssistantErrorMessage,
+  shopAssistantErrorStatus,
+} from "@/features/shop-assistant/server/requireShopAssistantActor";
+import { buildShopState } from "@/features/shop-assistant/server/state/buildShopState";
+import type { ShopAssistantStateResponse } from "@/features/shop-assistant/server/state/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const actor = await requireShopAssistantActor();
+    const state = await buildShopState(actor);
+
+    return NextResponse.json<ShopAssistantStateResponse>(
+      { ok: true, state },
+      {
+        headers: {
+          "cache-control": "private, no-store, max-age=0",
+        },
+      },
+    );
+  } catch (error: unknown) {
+    return NextResponse.json<ShopAssistantStateResponse>(
+      { ok: false, error: shopAssistantErrorMessage(error) },
+      { status: shopAssistantErrorStatus(error) },
+    );
+  }
+}

--- a/app/api/shop-assistant/threads/[threadId]/messages/route.ts
+++ b/app/api/shop-assistant/threads/[threadId]/messages/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+import type { ShopAssistantMessagesResponse } from "@/features/shop-assistant/types";
+import {
+  requireShopAssistantActor,
+  shopAssistantErrorMessage,
+  shopAssistantErrorStatus,
+} from "@/features/shop-assistant/server/requireShopAssistantActor";
+import {
+  getShopAssistantThread,
+  loadShopAssistantMessages,
+} from "@/features/shop-assistant/server/threadStore";
+
+type RouteContext = {
+  params: Promise<{ threadId: string }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const actor = await requireShopAssistantActor();
+    const { threadId } = await context.params;
+    const thread = await getShopAssistantThread(actor, threadId);
+    const messages = await loadShopAssistantMessages(actor, thread.id);
+
+    return NextResponse.json<ShopAssistantMessagesResponse>({
+      ok: true,
+      thread,
+      messages,
+    });
+  } catch (error: unknown) {
+    return NextResponse.json<ShopAssistantMessagesResponse>(
+      { ok: false, error: shopAssistantErrorMessage(error) },
+      { status: shopAssistantErrorStatus(error) },
+    );
+  }
+}

--- a/app/api/shop-assistant/threads/route.ts
+++ b/app/api/shop-assistant/threads/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+
+import type {
+  ShopAssistantContext,
+  ShopAssistantThreadListResponse,
+} from "@/features/shop-assistant/types";
+import {
+  requireShopAssistantActor,
+  shopAssistantErrorMessage,
+  shopAssistantErrorStatus,
+} from "@/features/shop-assistant/server/requireShopAssistantActor";
+import {
+  createShopAssistantThread,
+  listShopAssistantThreads,
+} from "@/features/shop-assistant/server/threadStore";
+
+export async function GET() {
+  try {
+    const actor = await requireShopAssistantActor();
+    const threads = await listShopAssistantThreads(actor);
+
+    return NextResponse.json<ShopAssistantThreadListResponse>({
+      ok: true,
+      threads,
+      activeThreadId: threads[0]?.id ?? null,
+      role: actor.canonicalRole,
+    });
+  } catch (error: unknown) {
+    return NextResponse.json<ShopAssistantThreadListResponse>(
+      { ok: false, error: shopAssistantErrorMessage(error) },
+      { status: shopAssistantErrorStatus(error) },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const actor = await requireShopAssistantActor();
+    const body = (await request.json().catch(() => ({}))) as {
+      context?: ShopAssistantContext;
+    };
+    const thread = await createShopAssistantThread(actor, body.context);
+
+    return NextResponse.json(
+      {
+        ok: true as const,
+        thread,
+        messages: [],
+      },
+      { status: 201 },
+    );
+  } catch (error: unknown) {
+    return NextResponse.json(
+      { ok: false as const, error: shopAssistantErrorMessage(error) },
+      { status: shopAssistantErrorStatus(error) },
+    );
+  }
+}

--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -8,15 +8,16 @@ import { useSearchParams } from "next/navigation";
 import PageShell from "@/features/shared/components/PageShell";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 import ShopAssistantConversation from "@/features/shop-assistant/components/ShopAssistantConversation";
+import ShopAssistantDashboard from "@/features/shop-assistant/components/ShopAssistantDashboard";
 import { useShopAssistant } from "@/features/shop-assistant/hooks/useShopAssistant";
 import type { ShopAssistantContext } from "@/features/shop-assistant/types";
 import { Button } from "@shared/components/ui/Button";
 
 const EXAMPLE_PROMPTS = [
   "Which work orders are waiting on approvals right now?",
-  "Summarize open inspections with safety concerns from this week.",
+  "Summarize the jobs delayed by parts.",
   "What changed today across bookings, invoices, and technician activity?",
-  "Show repeat issues for this vehicle and what we recommended last time.",
+  "Which queued jobs should be assigned next?",
 ];
 
 function optionalParam(params: URLSearchParams, key: string): string | undefined {
@@ -68,20 +69,6 @@ export default function AssistantPage() {
     clearConversation,
   } = useShopAssistant(contextKey);
 
-  const contextChips = useMemo(
-    () => [
-      { label: "Shop-wide", active: true },
-      {
-        label: "Current page",
-        active: Boolean(context.pageType || context.pageTitle),
-      },
-      { label: "Current customer", active: Boolean(context.customerId) },
-      { label: "Current vehicle", active: Boolean(context.vehicleId) },
-      { label: "Current work order", active: Boolean(context.workOrderId) },
-    ],
-    [context],
-  );
-
   const submit = async () => {
     const value = query.trim();
     if (!value || sending) return;
@@ -92,79 +79,72 @@ export default function AssistantPage() {
   return (
     <PageShell
       title="Shop Assistant"
-      description="Your durable, shop-wide operations conversation across work orders, customers, scheduling, parts, billing, and workforce."
+      description="Live shop intelligence, proactive alerts, and a durable operations conversation."
     >
-      <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
-        <div className="desktop-panel-soft p-4">
-          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-            Assistant scope
+      <div className="space-y-4">
+        <ShopAssistantDashboard
+          onPrompt={setQuery}
+          refreshToken={messages.at(-1)?.id}
+        />
+
+        <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
+          <div className="desktop-panel-soft p-4">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+              Shop conversation
+            </div>
+            <p className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
+              Ask questions or request operational actions across the shop. Diagnostic
+              guidance remains inside each work order&apos;s Technician AI.
+            </p>
           </div>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {contextChips.map((chip) => (
-              <span
-                key={chip.label}
-                className={`desktop-pill px-3 py-1 text-xs ${
-                  chip.active
-                    ? "border-[color:var(--brand-accent,#E39A6E)]/55 bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_16%,transparent)] text-[color:var(--brand-accent,#E39A6E)]"
-                    : "text-[color:var(--theme-text-secondary)]"
-                }`}
+
+          <ShopAssistantConversation
+            messages={messages}
+            loading={loading}
+            error={error}
+            canRetry={canRetry}
+            onRetry={() => void retry()}
+            className="max-h-[34rem]"
+          />
+
+          <textarea
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Ask about shop operations or request an action…"
+            className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-[color:var(--theme-text-primary)]"
+          />
+
+          <div className="flex flex-wrap gap-2">
+            {EXAMPLE_PROMPTS.map((example) => (
+              <button
+                key={example}
+                type="button"
+                className="desktop-pill px-3 py-1 text-xs text-[color:var(--theme-text-secondary)] hover:border-[color:var(--brand-accent,#E39A6E)]/50 hover:text-[color:var(--brand-accent,#E39A6E)]"
+                onClick={() => setQuery(example)}
               >
-                {chip.label}
-              </span>
+                {example}
+              </button>
             ))}
           </div>
-          <p className="mt-3 text-xs text-[color:var(--theme-text-secondary)]">
-            Conversations persist across reloads. Diagnostic guidance remains inside
-            each work order&apos;s Technician AI.
-          </p>
-        </div>
 
-        <ShopAssistantConversation
-          messages={messages}
-          loading={loading}
-          error={error}
-          canRetry={canRetry}
-          onRetry={() => void retry()}
-          className="max-h-[34rem]"
-        />
-
-        <textarea
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Ask about shop operations or request an action…"
-          className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-[color:var(--theme-text-primary)]"
-        />
-
-        <div className="flex flex-wrap gap-2">
-          {EXAMPLE_PROMPTS.map((example) => (
-            <button
-              key={example}
+          <div className="flex items-center justify-between gap-3">
+            <Button
               type="button"
-              className="desktop-pill px-3 py-1 text-xs text-[color:var(--theme-text-secondary)] hover:border-[color:var(--brand-accent,#E39A6E)]/50 hover:text-[color:var(--brand-accent,#E39A6E)]"
-              onClick={() => setQuery(example)}
+              variant="ghost"
+              disabled={loading || sending}
+              onClick={() => void clearConversation(context)}
             >
-              {example}
-            </button>
-          ))}
-        </div>
-
-        <div className="flex items-center justify-between gap-3">
-          <Button
-            type="button"
-            variant="ghost"
-            disabled={loading || sending}
-            onClick={() => void clearConversation(context)}
-          >
-            New conversation
-          </Button>
-          <Button
-            type="button"
-            onClick={() => void submit()}
-            isLoading={sending}
-            disabled={loading || sending || !query.trim()}
-          >
-            Send
-          </Button>
+              New conversation
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void submit()}
+              isLoading={sending}
+              disabled={loading || sending || !query.trim()}
+            >
+              Send
+            </Button>
+          </div>
         </div>
       </div>
     </PageShell>

--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -4,13 +4,13 @@
 
 import { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import PageShell from "@/features/shared/components/PageShell";
-import { Button } from "@shared/components/ui/Button";
-import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
-import { useAssistant } from "@/features/assistant/hooks/useAssistant";
-import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
-import type { AssistantContext } from "@/features/assistant/types/assistant";
+import PageShell from "@/features/shared/components/PageShell";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
+import ShopAssistantConversation from "@/features/shop-assistant/components/ShopAssistantConversation";
+import { useShopAssistant } from "@/features/shop-assistant/hooks/useShopAssistant";
+import type { ShopAssistantContext } from "@/features/shop-assistant/types";
+import { Button } from "@shared/components/ui/Button";
 
 const EXAMPLE_PROMPTS = [
   "Which work orders are waiting on approvals right now?",
@@ -19,33 +19,62 @@ const EXAMPLE_PROMPTS = [
   "Show repeat issues for this vehicle and what we recommended last time.",
 ];
 
+function optionalParam(params: URLSearchParams, key: string): string | undefined {
+  const value = params.get(key)?.trim();
+  return value || undefined;
+}
+
 export default function AssistantPage() {
   const [query, setQuery] = useState("");
-  const { ask, loading, data } = useAssistant();
   const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
 
-  const context = useMemo<AssistantContext>(() => {
-    const workOrderId = searchParams.get("workOrderId") ?? undefined;
-    const vehicleId = searchParams.get("vehicleId") ?? undefined;
-    const customerId = searchParams.get("customerId") ?? undefined;
-    const bookingId = searchParams.get("bookingId") ?? undefined;
-    const pageType = searchParams.get("pageType") ?? undefined;
-    const pageTitle = searchParams.get("pageTitle") ?? undefined;
-
+  const context = useMemo<ShopAssistantContext>(() => {
+    const params = new URLSearchParams(searchKey);
     return {
-      workOrderId,
-      vehicleId,
-      customerId,
-      bookingId,
-      pageType,
-      pageTitle,
+      workOrderId: optionalParam(params, "workOrderId"),
+      vehicleId: optionalParam(params, "vehicleId"),
+      customerId: optionalParam(params, "customerId"),
+      bookingId: optionalParam(params, "bookingId"),
+      invoiceId: optionalParam(params, "invoiceId"),
+      pageType: optionalParam(params, "pageType") ?? "desktop",
+      pageTitle: optionalParam(params, "pageTitle") ?? "Shop Assistant",
     };
-  }, [searchParams]);
+  }, [searchKey]);
+
+  const contextKey = useMemo(
+    () =>
+      [
+        context.pageType,
+        context.workOrderId,
+        context.vehicleId,
+        context.customerId,
+        context.bookingId,
+        context.invoiceId,
+      ]
+        .filter(Boolean)
+        .join(":"),
+    [context],
+  );
+
+  const {
+    messages,
+    loading,
+    sending,
+    error,
+    canRetry,
+    send,
+    retry,
+    clearConversation,
+  } = useShopAssistant(contextKey);
 
   const contextChips = useMemo(
     () => [
       { label: "Shop-wide", active: true },
-      { label: "Current page", active: Boolean(context.pageType || context.pageTitle) },
+      {
+        label: "Current page",
+        active: Boolean(context.pageType || context.pageTitle),
+      },
       { label: "Current customer", active: Boolean(context.customerId) },
       { label: "Current vehicle", active: Boolean(context.vehicleId) },
       { label: "Current work order", active: Boolean(context.workOrderId) },
@@ -53,10 +82,17 @@ export default function AssistantPage() {
     [context],
   );
 
+  const submit = async () => {
+    const value = query.trim();
+    if (!value || sending) return;
+    setQuery("");
+    await send(value, context);
+  };
+
   return (
     <PageShell
       title="Shop Assistant"
-      description="Your universal shop intelligence surface for questions, explanations, and cross-record history."
+      description="Your durable, shop-wide operations conversation across work orders, customers, scheduling, parts, billing, and workforce."
     >
       <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
         <div className="desktop-panel-soft p-4">
@@ -78,16 +114,24 @@ export default function AssistantPage() {
             ))}
           </div>
           <p className="mt-3 text-xs text-[color:var(--theme-text-secondary)]">
-            Ask across work orders, customers, vehicles, inspections, approvals,
-            bookings, invoices, fleet, parts, and staff/shop activity. Current-page
-            context is applied when available.
+            Conversations persist across reloads. Diagnostic guidance remains inside
+            each work order&apos;s Technician AI.
           </p>
         </div>
 
+        <ShopAssistantConversation
+          messages={messages}
+          loading={loading}
+          error={error}
+          canRetry={canRetry}
+          onRetry={() => void retry()}
+          className="max-h-[34rem]"
+        />
+
         <textarea
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Ask a shop question, request an explanation, or compare records..."
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Ask about shop operations or request an action…"
           className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-[color:var(--theme-text-primary)]"
         />
 
@@ -104,17 +148,24 @@ export default function AssistantPage() {
           ))}
         </div>
 
-        <div className="mt-4 flex justify-center">
+        <div className="flex items-center justify-between gap-3">
           <Button
-            onClick={() => ask(query, context)}
-            isLoading={loading}
-            disabled={!query.trim()}
+            type="button"
+            variant="ghost"
+            disabled={loading || sending}
+            onClick={() => void clearConversation(context)}
           >
-            Ask Assistant
+            New conversation
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void submit()}
+            isLoading={sending}
+            disabled={loading || sending || !query.trim()}
+          >
+            Send
           </Button>
         </div>
-
-        <AssistantResponseCard data={data} />
       </div>
     </PageShell>
   );

--- a/app/mobile/assistant/page.tsx
+++ b/app/mobile/assistant/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
 import ShopAssistantConversation from "@/features/shop-assistant/components/ShopAssistantConversation";
+import ShopAssistantDashboard from "@/features/shop-assistant/components/ShopAssistantDashboard";
 import { useShopAssistant } from "@/features/shop-assistant/hooks/useShopAssistant";
 import type { ShopAssistantContext } from "@/features/shop-assistant/types";
 import { Button } from "@shared/components/ui/Button";
@@ -64,34 +65,12 @@ export default function MobileAssistantPage() {
     await send(value, context);
   };
 
-  const contextLabel = [
-    context.workOrderId ? "Work order" : null,
-    context.vehicleId ? "Vehicle" : null,
-    context.customerId ? "Customer" : null,
-    context.bookingId ? "Appointment" : null,
-  ]
-    .filter(Boolean)
-    .join(" • ");
-
   return (
     <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
-      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
-        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
-          Shop assistant
-        </div>
-        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
-          Run the shop from one conversation
-        </h1>
-        <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-          Ask across work orders, customers, scheduling, parts, billing, and shop
-          operations. This conversation is restored when you return.
-        </p>
-        {contextLabel ? (
-          <div className="mt-3 inline-flex rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Context: {contextLabel}
-          </div>
-        ) : null}
-      </section>
+      <ShopAssistantDashboard
+        onPrompt={setQuestion}
+        refreshToken={messages.at(-1)?.id}
+      />
 
       <ShopAssistantConversation
         messages={messages}
@@ -107,7 +86,7 @@ export default function MobileAssistantPage() {
           htmlFor="mobile-assistant-question"
           className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]"
         >
-          Message
+          Shop conversation
         </label>
         <textarea
           id="mobile-assistant-question"

--- a/app/mobile/assistant/page.tsx
+++ b/app/mobile/assistant/page.tsx
@@ -3,9 +3,9 @@
 import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
-import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
-import { useAssistant } from "@/features/assistant/hooks/useAssistant";
-import type { AssistantContext } from "@/features/assistant/types/assistant";
+import ShopAssistantConversation from "@/features/shop-assistant/components/ShopAssistantConversation";
+import { useShopAssistant } from "@/features/shop-assistant/hooks/useShopAssistant";
+import type { ShopAssistantContext } from "@/features/shop-assistant/types";
 import { Button } from "@shared/components/ui/Button";
 
 function optionalParam(params: URLSearchParams, key: string): string | undefined {
@@ -18,13 +18,14 @@ export default function MobileAssistantPage() {
   const searchKey = searchParams.toString();
   const [question, setQuestion] = useState("");
 
-  const context = useMemo<AssistantContext>(() => {
+  const context = useMemo<ShopAssistantContext>(() => {
     const params = new URLSearchParams(searchKey);
     return {
       workOrderId: optionalParam(params, "workOrderId"),
       vehicleId: optionalParam(params, "vehicleId"),
       customerId: optionalParam(params, "customerId"),
       bookingId: optionalParam(params, "bookingId"),
+      invoiceId: optionalParam(params, "invoiceId"),
       pageType: optionalParam(params, "pageType") ?? "mobile",
       pageTitle: optionalParam(params, "pageTitle") ?? "Mobile",
     };
@@ -38,19 +39,29 @@ export default function MobileAssistantPage() {
         context.vehicleId,
         context.customerId,
         context.bookingId,
+        context.invoiceId,
       ]
         .filter(Boolean)
         .join(":"),
     [context],
   );
-  const { ask, loading, data, messages, clearConversation } =
-    useAssistant(contextKey);
+
+  const {
+    messages,
+    loading,
+    sending,
+    error,
+    canRetry,
+    send,
+    retry,
+    clearConversation,
+  } = useShopAssistant(contextKey);
 
   const submit = async () => {
     const value = question.trim();
-    if (!value || loading) return;
-    await ask(value, context);
+    if (!value || sending) return;
     setQuestion("");
+    await send(value, context);
   };
 
   const contextLabel = [
@@ -69,11 +80,11 @@ export default function MobileAssistantPage() {
           Shop assistant
         </div>
         <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
-          Ask a question
+          Run the shop from one conversation
         </h1>
         <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-          This is a deliberate question-and-answer tool. It does not change work
-          orders, appointments, parts, or shop records automatically.
+          Ask across work orders, customers, scheduling, parts, billing, and shop
+          operations. This conversation is restored when you return.
         </p>
         {contextLabel ? (
           <div className="mt-3 inline-flex rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]">
@@ -82,35 +93,27 @@ export default function MobileAssistantPage() {
         ) : null}
       </section>
 
-      {messages.length > 0 ? (
-        <section className="max-h-64 space-y-2 overflow-y-auto rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3">
-          {messages.slice(-8).map((message, index) => (
-            <div
-              key={`${message.role}-${index}-${message.content.slice(0, 20)}`}
-              className={`rounded-2xl px-3 py-2 text-sm leading-5 ${
-                message.role === "user"
-                  ? "ml-6 bg-[color:var(--accent-copper)] text-white"
-                  : "mr-6 border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)]"
-              }`}
-            >
-              {message.content}
-            </div>
-          ))}
-        </section>
-      ) : null}
+      <ShopAssistantConversation
+        messages={messages}
+        loading={loading}
+        error={error}
+        canRetry={canRetry}
+        onRetry={() => void retry()}
+        className="max-h-[28rem]"
+      />
 
       <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
         <label
           htmlFor="mobile-assistant-question"
           className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]"
         >
-          Question
+          Message
         </label>
         <textarea
           id="mobile-assistant-question"
           value={question}
           onChange={(event) => setQuestion(event.target.value)}
-          placeholder="Ask about shop status, a customer, a work order, parts, appointments, or fleet operations."
+          placeholder="Ask about shop status or request an operational action."
           className="mt-2 min-h-32 w-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)] focus:ring-2 focus:ring-[var(--accent-copper-soft)]/30"
         />
         <div className="mt-3 flex items-center justify-between gap-2">
@@ -118,28 +121,26 @@ export default function MobileAssistantPage() {
             type="button"
             variant="ghost"
             size="sm"
-            disabled={loading || messages.length === 0}
+            disabled={loading || sending}
             onClick={() => {
-              clearConversation();
+              void clearConversation(context);
               setQuestion("");
             }}
           >
-            Clear
+            New
           </Button>
           <Button
             type="button"
             variant="copper"
             size="sm"
-            disabled={loading || !question.trim()}
-            isLoading={loading}
+            disabled={loading || sending || !question.trim()}
+            isLoading={sending}
             onClick={() => void submit()}
           >
-            Ask Assistant
+            Send
           </Button>
         </div>
       </section>
-
-      <AssistantResponseCard data={data} />
     </div>
   );
 }

--- a/features/shop-assistant/components/ShopAlertList.tsx
+++ b/features/shop-assistant/components/ShopAlertList.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+
+import type { ShopAssistantAlert } from "@/features/shop-assistant/server/state/types";
+
+type Props = {
+  alerts: ShopAssistantAlert[];
+};
+
+function levelClasses(level: ShopAssistantAlert["level"]): string {
+  if (level === "critical") {
+    return "border-red-400/35 bg-red-500/10";
+  }
+  if (level === "warning") {
+    return "border-amber-400/35 bg-amber-500/10";
+  }
+  return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]";
+}
+
+export default function ShopAlertList({ alerts }: Props) {
+  if (alerts.length === 0) {
+    return (
+      <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+        No proactive shop alerts are active right now.
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="Proactive shop alerts" className="space-y-2">
+      {alerts.slice(0, 8).map((alert) => {
+        const content = (
+          <>
+            <div className="flex items-start justify-between gap-3">
+              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                {alert.title}
+              </div>
+              <span className="rounded-full border border-current/20 px-2 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.1em] text-[color:var(--theme-text-secondary)]">
+                {alert.level}
+              </span>
+            </div>
+            <div className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+              {alert.message}
+            </div>
+          </>
+        );
+
+        const className = `block rounded-2xl border p-3 transition ${levelClasses(
+          alert.level,
+        )} ${alert.href ? "hover:border-[color:var(--brand-accent,#E39A6E)]/55" : ""}`;
+
+        return alert.href ? (
+          <Link key={alert.id} href={alert.href} className={className}>
+            {content}
+          </Link>
+        ) : (
+          <div key={alert.id} className={className}>
+            {content}
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/features/shop-assistant/components/ShopAssistantConversation.tsx
+++ b/features/shop-assistant/components/ShopAssistantConversation.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { Button } from "@shared/components/ui/Button";
+import type { ShopAssistantMessage } from "@/features/shop-assistant/types";
+
+type Props = {
+  messages: ShopAssistantMessage[];
+  loading?: boolean;
+  error?: string | null;
+  canRetry?: boolean;
+  onRetry?: () => void;
+  className?: string;
+};
+
+function messageLabel(message: ShopAssistantMessage): string {
+  if (message.kind === "confirmation") return "Confirmation required";
+  if (message.kind === "action_result") return "Action result";
+  if (message.kind === "error") return "Assistant error";
+  if (message.role === "user") return "You";
+  return "Shop Assistant";
+}
+
+export default function ShopAssistantConversation({
+  messages,
+  loading = false,
+  error,
+  canRetry = false,
+  onRetry,
+  className = "",
+}: Props) {
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ block: "nearest" });
+  }, [messages, loading, error]);
+
+  if (messages.length === 0 && !loading && !error) return null;
+
+  return (
+    <section
+      aria-label="Shop assistant conversation"
+      aria-live="polite"
+      className={`space-y-3 overflow-y-auto rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3 ${className}`}
+    >
+      {messages.map((message) => {
+        const isUser = message.role === "user";
+        const isError = message.kind === "error";
+
+        return (
+          <article
+            key={message.id}
+            data-message-id={message.id}
+            data-client-message-id={message.clientMessageId ?? undefined}
+            className={`rounded-2xl border px-3 py-2 text-sm leading-5 ${
+              isUser
+                ? "ml-6 border-transparent bg-[color:var(--accent-copper)] text-white"
+                : isError
+                  ? "mr-6 border-red-400/30 bg-red-500/10 text-[color:var(--theme-text-primary)]"
+                  : "mr-6 border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)]"
+            } ${message.optimistic ? "opacity-75" : ""}`}
+          >
+            <div
+              className={`mb-1 text-[0.65rem] font-semibold uppercase tracking-[0.12em] ${
+                isUser ? "text-white/75" : "text-[color:var(--theme-text-secondary)]"
+              }`}
+            >
+              {messageLabel(message)}
+            </div>
+            <div className="whitespace-pre-wrap break-words">{message.content}</div>
+          </article>
+        );
+      })}
+
+      {loading ? (
+        <div className="mr-6 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-sm text-[color:var(--theme-text-secondary)]">
+          Restoring conversation…
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="rounded-2xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-[color:var(--theme-text-primary)]">
+          <div>{error}</div>
+          {canRetry && onRetry ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="mt-2"
+              onClick={onRetry}
+            >
+              Retry
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+      <div ref={endRef} />
+    </section>
+  );
+}

--- a/features/shop-assistant/components/ShopAssistantDashboard.tsx
+++ b/features/shop-assistant/components/ShopAssistantDashboard.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import ShopAlertList from "@/features/shop-assistant/components/ShopAlertList";
+import ShopStateMetricGrid from "@/features/shop-assistant/components/ShopStateMetricGrid";
+import ShopSuggestionList from "@/features/shop-assistant/components/ShopSuggestionList";
+import { useShopAssistantState } from "@/features/shop-assistant/hooks/useShopAssistantState";
+
+type Props = {
+  onPrompt: (prompt: string) => void;
+  refreshToken?: string | number;
+};
+
+function roleLabel(role: string): string {
+  return role.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export default function ShopAssistantDashboard({
+  onPrompt,
+  refreshToken,
+}: Props) {
+  const { state, loading, error, refresh } =
+    useShopAssistantState(refreshToken);
+
+  if (loading && !state) {
+    return (
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+        Loading the live shop picture…
+      </section>
+    );
+  }
+
+  if (!state) {
+    return (
+      <section className="rounded-3xl border border-red-400/30 bg-red-500/10 p-4 text-sm text-[color:var(--theme-text-primary)]">
+        <div>{error ?? "The live shop picture is unavailable."}</div>
+        <button
+          type="button"
+          className="mt-3 rounded-full border border-current/30 px-3 py-1 text-xs font-semibold"
+          onClick={() => void refresh()}
+        >
+          Try again
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+            {roleLabel(state.role)} view • live shop state
+          </div>
+          <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+            {state.headline}
+          </h1>
+          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+            Updated {new Date(state.generatedAt).toLocaleTimeString([], {
+              hour: "numeric",
+              minute: "2-digit",
+            })}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]"
+          onClick={() => void refresh()}
+        >
+          Refresh
+        </button>
+      </header>
+
+      <ShopStateMetricGrid metrics={state.metrics} />
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <div>
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            Needs attention
+          </h2>
+          <ShopAlertList alerts={state.alerts} />
+        </div>
+        <div>
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            Suggested next moves
+          </h2>
+          <ShopSuggestionList
+            suggestions={state.suggestions}
+            onSelect={onPrompt}
+          />
+        </div>
+      </div>
+
+      {error ? (
+        <div className="text-xs text-amber-300">
+          The latest background refresh failed; showing the most recent shop state.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/features/shop-assistant/components/ShopStateMetricGrid.tsx
+++ b/features/shop-assistant/components/ShopStateMetricGrid.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { ShopAssistantMetrics } from "@/features/shop-assistant/server/state/types";
+
+type Props = {
+  metrics: ShopAssistantMetrics;
+};
+
+const METRICS: Array<{
+  key: keyof ShopAssistantMetrics;
+  label: string;
+  suffix?: string;
+}> = [
+  { key: "openWorkOrders", label: "Open work orders" },
+  { key: "stalledWorkOrders", label: "Stalled" },
+  { key: "overdueApprovals", label: "Overdue approvals" },
+  { key: "delayedParts", label: "Delayed parts" },
+  { key: "idleTechnicians", label: "Available techs" },
+  { key: "readyToInvoice", label: "Ready to invoice" },
+  { key: "todaysBookings", label: "Today’s bookings" },
+  { key: "shopUtilizationPct", label: "Utilization", suffix: "%" },
+];
+
+export default function ShopStateMetricGrid({ metrics }: Props) {
+  return (
+    <section aria-label="Live shop metrics" className="grid grid-cols-2 gap-2 md:grid-cols-4">
+      {METRICS.map((metric) => (
+        <div
+          key={metric.key}
+          className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3"
+        >
+          <div className="text-2xl font-semibold tabular-nums text-[color:var(--theme-text-primary)]">
+            {metrics[metric.key]}
+            {metric.suffix ?? ""}
+          </div>
+          <div className="mt-1 text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)]">
+            {metric.label}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/features/shop-assistant/components/ShopSuggestionList.tsx
+++ b/features/shop-assistant/components/ShopSuggestionList.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+
+import type { ShopAssistantSuggestion } from "@/features/shop-assistant/server/state/types";
+
+type Props = {
+  suggestions: ShopAssistantSuggestion[];
+  onSelect: (prompt: string) => void;
+};
+
+export default function ShopSuggestionList({ suggestions, onSelect }: Props) {
+  return (
+    <section aria-label="Suggested shop actions" className="grid gap-2 md:grid-cols-2">
+      {suggestions.map((suggestion) => (
+        <div
+          key={suggestion.id}
+          className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3"
+        >
+          <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            {suggestion.title}
+          </div>
+          <div className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+            {suggestion.description}
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              className="rounded-full border border-[color:var(--brand-accent,#E39A6E)]/45 bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)] px-3 py-1 text-xs font-semibold text-[color:var(--brand-accent,#E39A6E)]"
+              onClick={() => onSelect(suggestion.prompt)}
+            >
+              Ask assistant
+            </button>
+            {suggestion.href ? (
+              <Link
+                href={suggestion.href}
+                className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]"
+              >
+                Open
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/features/shop-assistant/hooks/useShopAssistant.ts
+++ b/features/shop-assistant/hooks/useShopAssistant.ts
@@ -1,0 +1,250 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import type {
+  ShopAssistantChatRequest,
+  ShopAssistantChatResponse,
+  ShopAssistantContext,
+  ShopAssistantMessage,
+  ShopAssistantMessagesResponse,
+  ShopAssistantThread,
+  ShopAssistantThreadListResponse,
+} from "@/features/shop-assistant/types";
+
+type RetryRequest = ShopAssistantChatRequest;
+
+function newClientMessageId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `shop-assistant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function mergeMessages(
+  current: ShopAssistantMessage[],
+  incoming: ShopAssistantMessage[],
+): ShopAssistantMessage[] {
+  const byId = new Map<string, ShopAssistantMessage>();
+  const serverClientIds = new Set(
+    incoming
+      .map((message) => message.clientMessageId)
+      .filter((value): value is string => Boolean(value)),
+  );
+
+  for (const message of current) {
+    if (
+      message.optimistic &&
+      message.clientMessageId &&
+      serverClientIds.has(message.clientMessageId)
+    ) {
+      continue;
+    }
+    byId.set(message.id, message);
+  }
+
+  for (const message of incoming) byId.set(message.id, message);
+
+  return [...byId.values()].sort((left, right) => {
+    const timeDelta =
+      new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
+    if (timeDelta !== 0) return timeDelta;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  return (await response.json().catch(() => ({}))) as T;
+}
+
+export function useShopAssistant(resetKey?: string) {
+  const [thread, setThread] = useState<ShopAssistantThread | null>(null);
+  const [messages, setMessages] = useState<ShopAssistantMessage[]>([]);
+  const [role, setRole] = useState<CanonicalRole | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [retryRequest, setRetryRequest] = useState<RetryRequest | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const sendingRef = useRef(false);
+
+  const loadMessages = useCallback(async (threadId: string) => {
+    const response = await fetch(
+      `/api/shop-assistant/threads/${encodeURIComponent(threadId)}/messages`,
+      { cache: "no-store" },
+    );
+    const payload = await readJson<ShopAssistantMessagesResponse>(response);
+    if (!response.ok || !payload.ok) {
+      throw new Error(payload.ok ? "Failed to load conversation" : payload.error);
+    }
+
+    setThread(payload.thread);
+    setMessages((current) => mergeMessages(current, payload.messages));
+  }, []);
+
+  const restore = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/shop-assistant/threads", {
+        cache: "no-store",
+      });
+      const payload = await readJson<ShopAssistantThreadListResponse>(response);
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.ok ? "Failed to load assistant" : payload.error);
+      }
+
+      setRole(payload.role);
+      const active = payload.threads.find(
+        (candidate) => candidate.id === payload.activeThreadId,
+      );
+
+      if (active) {
+        setThread(active);
+        await loadMessages(active.id);
+      } else {
+        setThread(null);
+        setMessages([]);
+      }
+    } catch (restoreError: unknown) {
+      setError(
+        restoreError instanceof Error
+          ? restoreError.message
+          : "Failed to load shop assistant",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [loadMessages]);
+
+  useEffect(() => {
+    void restore();
+    return () => abortRef.current?.abort();
+  }, [resetKey, restore]);
+
+  const createConversation = useCallback(
+    async (context?: ShopAssistantContext) => {
+      const response = await fetch("/api/shop-assistant/threads", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ context }),
+      });
+      const payload = await readJson<ShopAssistantMessagesResponse>(response);
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.ok ? "Failed to create conversation" : payload.error);
+      }
+
+      setThread(payload.thread);
+      setMessages(payload.messages);
+      setRetryRequest(null);
+      setError(null);
+      return payload.thread;
+    },
+    [],
+  );
+
+  const sendRequest = useCallback(
+    async (requestPayload: RetryRequest) => {
+      if (sendingRef.current) return;
+      sendingRef.current = true;
+      setSending(true);
+      setError(null);
+
+      const optimisticMessage: ShopAssistantMessage = {
+        id: `optimistic:${requestPayload.clientMessageId}`,
+        threadId: requestPayload.threadId ?? "pending",
+        role: "user",
+        kind: "text",
+        content: requestPayload.question,
+        payload: {},
+        clientMessageId: requestPayload.clientMessageId,
+        createdAt: new Date().toISOString(),
+        optimistic: true,
+      };
+      setMessages((current) => mergeMessages(current, [optimisticMessage]));
+
+      const controller = new AbortController();
+      abortRef.current?.abort();
+      abortRef.current = controller;
+
+      try {
+        const response = await fetch("/api/shop-assistant/chat", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(requestPayload),
+          signal: controller.signal,
+        });
+        const payload = await readJson<ShopAssistantChatResponse>(response);
+        if (!response.ok || !payload.ok) {
+          throw new Error(payload.ok ? "Shop assistant request failed" : payload.error);
+        }
+
+        setThread(payload.thread);
+        setMessages((current) => mergeMessages(current, payload.messages));
+        setRetryRequest(null);
+      } catch (sendError: unknown) {
+        if (controller.signal.aborted) return;
+        setRetryRequest(requestPayload);
+        setError(
+          sendError instanceof Error
+            ? sendError.message
+            : "Shop assistant request failed",
+        );
+      } finally {
+        if (abortRef.current === controller) abortRef.current = null;
+        sendingRef.current = false;
+        setSending(false);
+      }
+    },
+    [],
+  );
+
+  const send = useCallback(
+    async (question: string, context?: ShopAssistantContext) => {
+      const clean = question.trim();
+      if (!clean || sendingRef.current) return;
+
+      let activeThread = thread;
+      if (!activeThread) activeThread = await createConversation(context);
+
+      await sendRequest({
+        question: clean,
+        context,
+        threadId: activeThread.id,
+        clientMessageId: newClientMessageId(),
+      });
+    },
+    [createConversation, sendRequest, thread],
+  );
+
+  const retry = useCallback(async () => {
+    if (!retryRequest || sendingRef.current) return;
+    await sendRequest(retryRequest);
+  }, [retryRequest, sendRequest]);
+
+  const clearConversation = useCallback(
+    async (context?: ShopAssistantContext) => {
+      abortRef.current?.abort();
+      await createConversation(context);
+    },
+    [createConversation],
+  );
+
+  const cancel = useCallback(() => abortRef.current?.abort(), []);
+
+  return {
+    thread,
+    messages,
+    role,
+    loading,
+    sending,
+    error,
+    canRetry: Boolean(retryRequest),
+    send,
+    retry,
+    cancel,
+    clearConversation,
+    refresh: restore,
+  };
+}

--- a/features/shop-assistant/hooks/useShopAssistantState.ts
+++ b/features/shop-assistant/hooks/useShopAssistantState.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+  ShopAssistantState,
+  ShopAssistantStateResponse,
+} from "@/features/shop-assistant/server/state/types";
+
+const REFRESH_INTERVAL_MS = 45_000;
+
+export function useShopAssistantState(refreshToken?: string | number) {
+  const [state, setState] = useState<ShopAssistantState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef<AbortController | null>(null);
+
+  const refresh = useCallback(async () => {
+    requestRef.current?.abort();
+    const controller = new AbortController();
+    requestRef.current = controller;
+
+    try {
+      setError(null);
+      const response = await fetch("/api/shop-assistant/state", {
+        cache: "no-store",
+        signal: controller.signal,
+      });
+      const payload = (await response.json().catch(() => ({}))) as
+        | ShopAssistantStateResponse
+        | { ok?: false; error?: string };
+
+      if (!response.ok || payload.ok !== true) {
+        throw new Error(
+          payload.ok === false && payload.error
+            ? payload.error
+            : "Failed to load live shop state",
+        );
+      }
+
+      setState(payload.state);
+    } catch (refreshError: unknown) {
+      if (controller.signal.aborted) return;
+      setError(
+        refreshError instanceof Error
+          ? refreshError.message
+          : "Failed to load live shop state",
+      );
+    } finally {
+      if (requestRef.current === controller) requestRef.current = null;
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+
+    const interval = window.setInterval(() => {
+      if (document.visibilityState === "visible") void refresh();
+    }, REFRESH_INTERVAL_MS);
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      requestRef.current?.abort();
+    };
+  }, [refresh, refreshToken]);
+
+  return { state, loading, error, refresh };
+}

--- a/features/shop-assistant/server/requireShopAssistantActor.ts
+++ b/features/shop-assistant/server/requireShopAssistantActor.ts
@@ -1,0 +1,89 @@
+import "server-only";
+
+import type { ActorCapabilities, CanonicalRole } from "@/features/shared/lib/rbac";
+import {
+  canonicalizeRole,
+  getActorCapabilities,
+} from "@/features/shared/lib/rbac";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+
+export class ShopAssistantHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ShopAssistantHttpError";
+    this.status = status;
+  }
+}
+
+export type ShopAssistantActor = {
+  userId: string;
+  shopId: string;
+  role: string | null;
+  canonicalRole: CanonicalRole;
+  capabilities: ActorCapabilities;
+  supabase: ReturnType<typeof createServerSupabaseRoute>;
+};
+
+export async function requireShopAssistantActor(
+  supabase = createServerSupabaseRoute(),
+): Promise<ShopAssistantActor> {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    throw new ShopAssistantHttpError(401, "Unauthorized");
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, shop_id, role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profileError || !profile?.shop_id) {
+    throw new ShopAssistantHttpError(403, "A shop staff profile is required");
+  }
+
+  const canonicalRole = canonicalizeRole(profile.role);
+  if (canonicalRole === "mechanic") {
+    throw new ShopAssistantHttpError(
+      403,
+      "Use the technician AI inside a work order for technician guidance",
+    );
+  }
+
+  if (
+    canonicalRole === "customer" ||
+    canonicalRole === "driver" ||
+    canonicalRole === "unknown"
+  ) {
+    throw new ShopAssistantHttpError(
+      403,
+      "Your role does not have access to the shop-wide assistant",
+    );
+  }
+
+  const capabilities = getActorCapabilities({ role: profile.role });
+
+  return {
+    userId: user.id,
+    shopId: profile.shop_id,
+    role: profile.role,
+    canonicalRole,
+    capabilities,
+    supabase,
+  };
+}
+
+export function shopAssistantErrorStatus(error: unknown): number {
+  return error instanceof ShopAssistantHttpError ? error.status : 500;
+}
+
+export function shopAssistantErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return "Shop assistant request failed";
+}

--- a/features/shop-assistant/server/state/buildShopState.ts
+++ b/features/shop-assistant/server/state/buildShopState.ts
@@ -1,0 +1,358 @@
+import "server-only";
+
+import { syncAssistantNotifications } from "@/features/agent/server/syncAssistantNotifications";
+import type { PersistedAssistantNotification } from "@/features/agent/server/syncAssistantNotifications";
+import type { ActorCapabilities } from "@/features/shared/lib/rbac";
+import { getTechnicianLoadMetricsWithClient } from "@/features/shared/lib/stats/getTechnicianLoadMetricsCore";
+import type { ShopAssistantActor } from "@/features/shop-assistant/server/requireShopAssistantActor";
+import type {
+  ShopAssistantAlert,
+  ShopAssistantState,
+  ShopAssistantSuggestion,
+} from "./types";
+
+const ACTIVE_WORK_ORDER_STATUSES = [
+  "awaiting",
+  "awaiting_approval",
+  "planned",
+  "queued",
+  "in_progress",
+  "on_hold",
+];
+
+const READY_TO_INVOICE_STATUSES = ["completed", "ready_to_invoice"];
+
+function startOfUtcDay(now: Date): string {
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  ).toISOString();
+}
+
+function endOfUtcDay(now: Date): string {
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+  ).toISOString();
+}
+
+function mapNotificationCode(code: string): string {
+  if (code === "parts_waiting_too_long") return "parts_delivery_overdue";
+  if (code === "tech_underutilized_capacity") return "technician_idle";
+  if (code === "invoice_unsent_too_long") return "invoice_ready";
+  return code;
+}
+
+function mapNotification(
+  item: PersistedAssistantNotification,
+): ShopAssistantAlert {
+  return {
+    id: item.id,
+    code: mapNotificationCode(item.code),
+    level:
+      item.level === "critical"
+        ? "critical"
+        : item.level === "warning"
+          ? "warning"
+          : "info",
+    title: item.title,
+    message: item.message,
+    href: item.href ?? undefined,
+    entityType: item.entity_type ?? undefined,
+    entityId: item.entity_id ?? undefined,
+  };
+}
+
+function dedupeAlerts(alerts: ShopAssistantAlert[], limit = 12) {
+  const seen = new Set<string>();
+  const output: ShopAssistantAlert[] = [];
+
+  for (const alert of alerts) {
+    const key = [
+      alert.code,
+      alert.entityType ?? "none",
+      alert.entityId ?? alert.title,
+    ]
+      .join(":")
+      .toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(alert);
+    if (output.length >= limit) break;
+  }
+
+  return output;
+}
+
+function countUniqueAlerts(alerts: ShopAssistantAlert[], codes: string[]): number {
+  const keys = new Set<string>();
+  for (const alert of alerts) {
+    if (!codes.includes(alert.code)) continue;
+    keys.add(alert.entityId ?? `${alert.code}:${alert.title}`);
+  }
+  return keys.size;
+}
+
+function buildHeadline(params: {
+  role: ShopAssistantActor["canonicalRole"];
+  openWorkOrders: number;
+  alertCount: number;
+  readyToInvoice: number;
+  idleTechnicians: number;
+}): string {
+  const { role, openWorkOrders, alertCount, readyToInvoice, idleTechnicians } =
+    params;
+
+  if (role === "parts") {
+    return alertCount > 0
+      ? `${alertCount} parts and workflow signals need review.`
+      : "Parts flow is current across the shop.";
+  }
+  if (role === "advisor" || role === "service") {
+    return `${openWorkOrders} open work orders and ${readyToInvoice} ready billing opportunities are in view.`;
+  }
+  if (role === "lead_hand" || role === "foreman") {
+    return `${openWorkOrders} open work orders with ${idleTechnicians} technician(s) currently available.`;
+  }
+  if (role === "fleet_manager" || role === "dispatcher") {
+    return `${openWorkOrders} active shop work orders are visible with ${alertCount} operational signals.`;
+  }
+  return alertCount > 0
+    ? `${alertCount} shop signals need attention across ${openWorkOrders} open work orders.`
+    : `The shop is current across ${openWorkOrders} open work orders.`;
+}
+
+function addSuggestion(
+  output: ShopAssistantSuggestion[],
+  condition: boolean,
+  suggestion: ShopAssistantSuggestion,
+) {
+  if (condition && !output.some((item) => item.id === suggestion.id)) {
+    output.push(suggestion);
+  }
+}
+
+function buildSuggestions(params: {
+  capabilities: ActorCapabilities;
+  overdueApprovals: number;
+  delayedParts: number;
+  idleTechnicians: number;
+  readyToInvoice: number;
+  stalledWorkOrders: number;
+  todaysBookings: number;
+}): ShopAssistantSuggestion[] {
+  const { capabilities } = params;
+  const suggestions: ShopAssistantSuggestion[] = [];
+
+  addSuggestion(
+    suggestions,
+    capabilities.canAuthorizeQuotes && params.overdueApprovals > 0,
+    {
+      id: "review-overdue-approvals",
+      domain: "work_orders",
+      title: "Clear overdue approvals",
+      description: `${params.overdueApprovals} approval(s) are holding up work.`,
+      prompt: "Show the overdue approvals and the best customer follow-up order.",
+      href: "/quote-review",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canManageParts && params.delayedParts > 0,
+    {
+      id: "review-delayed-parts",
+      domain: "inventory",
+      title: "Review delayed parts",
+      description: `${params.delayedParts} job(s) have delayed parts signals.`,
+      prompt: "Show delayed parts and the affected work orders.",
+      href: "/parts/requests",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canAssignWork && params.idleTechnicians > 0,
+    {
+      id: "rebalance-idle-capacity",
+      domain: "workforce",
+      title: "Use available technician capacity",
+      description: `${params.idleTechnicians} shifted technician(s) have no active job.`,
+      prompt: "Which queued jobs should be assigned to the available technicians?",
+      href: "/dashboard",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canManageBilling && params.readyToInvoice > 0,
+    {
+      id: "finish-ready-invoices",
+      domain: "invoices",
+      title: "Finish ready invoices",
+      description: `${params.readyToInvoice} work order(s) are completed or ready to invoice.`,
+      prompt: "List the work orders ready to invoice and any remaining blockers.",
+      href: "/billing",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canManageWorkOrders && params.stalledWorkOrders > 0,
+    {
+      id: "unstick-stalled-work",
+      domain: "work_orders",
+      title: "Unstick stalled work",
+      description: `${params.stalledWorkOrders} work order(s) have exceeded a workflow threshold.`,
+      prompt: "Prioritize the stalled work orders and recommend the next operational step for each.",
+      href: "/work-orders/view",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canManageScheduling && params.todaysBookings > 0,
+    {
+      id: "review-todays-bookings",
+      domain: "scheduling",
+      title: "Review today’s appointments",
+      description: `${params.todaysBookings} appointment(s) are scheduled for the current shop day.`,
+      prompt: "Summarize today's appointments and flag scheduling conflicts.",
+      href: "/dashboard/appointments",
+    },
+  );
+
+  if (suggestions.length === 0) {
+    suggestions.push({
+      id: "shop-status-check",
+      domain: "reporting",
+      title: "Review the current shop status",
+      description: "Ask for a concise operational summary across the records you can access.",
+      prompt: "Give me the current shop status and the three most useful next steps.",
+      href: "/assistant",
+    });
+  }
+
+  return suggestions.slice(0, 6);
+}
+
+export async function buildShopState(
+  actor: ShopAssistantActor,
+): Promise<ShopAssistantState> {
+  const now = new Date();
+
+  const [persistedNotifications, loadMetrics] = await Promise.all([
+    syncAssistantNotifications({
+      shopId: actor.shopId,
+      userId: actor.userId,
+      role: actor.role,
+    }).catch(() => [] as PersistedAssistantNotification[]),
+    getTechnicianLoadMetricsWithClient(actor.supabase, actor.shopId).catch(
+      () => null,
+    ),
+  ]);
+
+  const dayStartIso = loadMetrics?.dayStartIso ?? startOfUtcDay(now);
+  const dayEndIso = loadMetrics?.dayEndIso ?? endOfUtcDay(now);
+
+  const [openResult, readyResult, bookingsResult] = await Promise.all([
+    actor.supabase
+      .from("work_orders")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", actor.shopId)
+      .in("status", ACTIVE_WORK_ORDER_STATUSES),
+    actor.supabase
+      .from("work_orders")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", actor.shopId)
+      .in("status", READY_TO_INVOICE_STATUSES),
+    actor.supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", actor.shopId)
+      .gte("starts_at", dayStartIso)
+      .lt("starts_at", dayEndIso),
+  ]);
+
+  const idleTechnicians = (loadMetrics?.rows ?? []).filter(
+    (row) =>
+      row.shiftSecondsToday > 0 &&
+      row.currentActiveJobs === 0 &&
+      row.utilizationPct <= 40,
+  );
+
+  const mappedNotifications = persistedNotifications.map(mapNotification);
+  const syntheticAlerts: ShopAssistantAlert[] = [];
+
+  for (const row of idleTechnicians.slice(0, 4)) {
+    syntheticAlerts.push({
+      id: `technician-idle:${row.techId}`,
+      code: "technician_idle",
+      level: "info",
+      title: `${row.name} has available capacity`,
+      message: `${row.name} is on shift with no active job and ${row.utilizationPct}% utilization.`,
+      href: "/dashboard",
+      entityType: "profile",
+      entityId: row.techId,
+    });
+  }
+
+  const readyToInvoice = readyResult.error ? 0 : Number(readyResult.count ?? 0);
+  if (readyToInvoice > 0) {
+    syntheticAlerts.push({
+      id: "invoice-ready:shop",
+      code: "invoice_ready",
+      level: "warning",
+      title: "Work is ready for billing",
+      message: `${readyToInvoice} completed or ready work order(s) should be reviewed for invoicing.`,
+      href: "/billing",
+      entityType: "shop",
+      entityId: actor.shopId,
+    });
+  }
+
+  const alerts = dedupeAlerts([...mappedNotifications, ...syntheticAlerts]);
+  const stalledWorkOrders = countUniqueAlerts(alerts, [
+    "work_order_waiting_too_long",
+    "work_order_on_hold_too_long",
+    "active_job_running_too_long",
+  ]);
+  const overdueApprovals = countUniqueAlerts(alerts, ["approval_waiting"]);
+  const delayedParts = countUniqueAlerts(alerts, ["parts_delivery_overdue"]);
+  const todaysBookings = bookingsResult.error
+    ? 0
+    : Number(bookingsResult.count ?? 0);
+  const openWorkOrders = openResult.error ? 0 : Number(openResult.count ?? 0);
+
+  const metrics = {
+    openWorkOrders,
+    stalledWorkOrders,
+    overdueApprovals,
+    delayedParts,
+    idleTechnicians: idleTechnicians.length,
+    readyToInvoice,
+    todaysBookings,
+    shopUtilizationPct: loadMetrics?.summary.shopUtilizationPct ?? 0,
+  };
+
+  return {
+    generatedAt: new Date().toISOString(),
+    role: actor.canonicalRole,
+    headline: buildHeadline({
+      role: actor.canonicalRole,
+      openWorkOrders,
+      alertCount: alerts.length,
+      readyToInvoice,
+      idleTechnicians: idleTechnicians.length,
+    }),
+    metrics,
+    alerts,
+    suggestions: buildSuggestions({
+      capabilities: actor.capabilities,
+      overdueApprovals,
+      delayedParts,
+      idleTechnicians: idleTechnicians.length,
+      readyToInvoice,
+      stalledWorkOrders,
+      todaysBookings,
+    }),
+  };
+}

--- a/features/shop-assistant/server/state/types.ts
+++ b/features/shop-assistant/server/state/types.ts
@@ -1,0 +1,54 @@
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import type { ShopAssistantDomain } from "@/features/shop-assistant/types";
+
+export type ShopAssistantAlertLevel = "info" | "warning" | "critical";
+
+export type ShopAssistantAlert = {
+  id: string;
+  code: string;
+  level: ShopAssistantAlertLevel;
+  title: string;
+  message: string;
+  href?: string;
+  entityType?: string;
+  entityId?: string;
+};
+
+export type ShopAssistantSuggestion = {
+  id: string;
+  domain: ShopAssistantDomain;
+  title: string;
+  description: string;
+  prompt: string;
+  href?: string;
+};
+
+export type ShopAssistantMetrics = {
+  openWorkOrders: number;
+  stalledWorkOrders: number;
+  overdueApprovals: number;
+  delayedParts: number;
+  idleTechnicians: number;
+  readyToInvoice: number;
+  todaysBookings: number;
+  shopUtilizationPct: number;
+};
+
+export type ShopAssistantState = {
+  generatedAt: string;
+  role: CanonicalRole;
+  headline: string;
+  metrics: ShopAssistantMetrics;
+  alerts: ShopAssistantAlert[];
+  suggestions: ShopAssistantSuggestion[];
+};
+
+export type ShopAssistantStateResponse =
+  | {
+      ok: true;
+      state: ShopAssistantState;
+    }
+  | {
+      ok: false;
+      error: string;
+    };

--- a/features/shop-assistant/server/threadStore.ts
+++ b/features/shop-assistant/server/threadStore.ts
@@ -1,0 +1,385 @@
+import "server-only";
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type {
+  ShopAssistantContext,
+  ShopAssistantMessage,
+  ShopAssistantMessageKind,
+  ShopAssistantMessageRole,
+  ShopAssistantThread,
+  ShopAssistantThreadContext,
+} from "@/features/shop-assistant/types";
+import type { ShopAssistantActor } from "./requireShopAssistantActor";
+import { ShopAssistantHttpError } from "./requireShopAssistantActor";
+
+type AssistantDb = SupabaseClient<any>;
+
+type ThreadRow = {
+  id: string;
+  shop_id: string;
+  user_id: string;
+  title: string;
+  context: unknown;
+  last_message_at: string;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type MessageRow = {
+  id: string;
+  thread_id: string;
+  shop_id: string;
+  user_id: string | null;
+  role: string;
+  kind: string;
+  content: string;
+  payload: unknown;
+  client_message_id: string | null;
+  created_at: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function normalizeThreadContext(
+  value: unknown,
+): ShopAssistantThreadContext {
+  const record = asRecord(value);
+  const domain = optionalString(record.lastDomain);
+
+  return {
+    activeWorkOrderId: optionalString(record.activeWorkOrderId),
+    activeVehicleId: optionalString(record.activeVehicleId),
+    activeCustomerId: optionalString(record.activeCustomerId),
+    activeBookingId: optionalString(record.activeBookingId),
+    activeInvoiceId: optionalString(record.activeInvoiceId),
+    lastDomain:
+      domain === "work_orders" ||
+      domain === "scheduling" ||
+      domain === "inventory" ||
+      domain === "customer_communications" ||
+      domain === "customers" ||
+      domain === "inspections" ||
+      domain === "invoices" ||
+      domain === "workforce" ||
+      domain === "reporting" ||
+      domain === "business_analytics"
+        ? domain
+        : undefined,
+    lastIntent: optionalString(record.lastIntent),
+  };
+}
+
+export function threadContextFromPage(
+  context?: ShopAssistantContext,
+): ShopAssistantThreadContext {
+  return {
+    activeWorkOrderId: optionalString(context?.workOrderId),
+    activeVehicleId: optionalString(context?.vehicleId),
+    activeCustomerId: optionalString(context?.customerId),
+    activeBookingId: optionalString(context?.bookingId),
+    activeInvoiceId: optionalString(context?.invoiceId),
+  };
+}
+
+export function mergeThreadContext(
+  current: ShopAssistantThreadContext,
+  next: ShopAssistantThreadContext,
+): ShopAssistantThreadContext {
+  return Object.fromEntries(
+    Object.entries({ ...current, ...next }).filter(([, value]) => value !== undefined),
+  ) as ShopAssistantThreadContext;
+}
+
+export function mapThread(row: ThreadRow): ShopAssistantThread {
+  return {
+    id: row.id,
+    title: row.title,
+    context: normalizeThreadContext(row.context),
+    lastMessageAt: row.last_message_at,
+    archivedAt: row.archived_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function normalizeRole(value: string): ShopAssistantMessageRole {
+  if (value === "user" || value === "system" || value === "tool") return value;
+  return "assistant";
+}
+
+function normalizeKind(value: string): ShopAssistantMessageKind {
+  if (
+    value === "confirmation" ||
+    value === "action_result" ||
+    value === "error" ||
+    value === "state_update"
+  ) {
+    return value;
+  }
+  return "text";
+}
+
+export function mapMessage(row: MessageRow): ShopAssistantMessage {
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    role: normalizeRole(row.role),
+    kind: normalizeKind(row.kind),
+    content: row.content,
+    payload: asRecord(row.payload),
+    clientMessageId: row.client_message_id,
+    createdAt: row.created_at,
+  };
+}
+
+function dbFor(actor: ShopAssistantActor): AssistantDb {
+  return actor.supabase as unknown as AssistantDb;
+}
+
+export async function listShopAssistantThreads(
+  actor: ShopAssistantActor,
+  limit = 20,
+): Promise<ShopAssistantThread[]> {
+  const { data, error } = await dbFor(actor)
+    .from("shop_assistant_threads")
+    .select(
+      "id, shop_id, user_id, title, context, last_message_at, archived_at, created_at, updated_at",
+    )
+    .eq("shop_id", actor.shopId)
+    .eq("user_id", actor.userId)
+    .is("archived_at", null)
+    .order("last_message_at", { ascending: false })
+    .limit(Math.min(Math.max(limit, 1), 50));
+
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as ThreadRow[]).map(mapThread);
+}
+
+export async function createShopAssistantThread(
+  actor: ShopAssistantActor,
+  pageContext?: ShopAssistantContext,
+): Promise<ShopAssistantThread> {
+  const context = threadContextFromPage(pageContext);
+  const { data, error } = await dbFor(actor)
+    .from("shop_assistant_threads")
+    .insert({
+      shop_id: actor.shopId,
+      user_id: actor.userId,
+      context,
+    })
+    .select(
+      "id, shop_id, user_id, title, context, last_message_at, archived_at, created_at, updated_at",
+    )
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Failed to create shop assistant thread");
+  }
+
+  return mapThread(data as ThreadRow);
+}
+
+export async function getShopAssistantThread(
+  actor: ShopAssistantActor,
+  threadId: string,
+): Promise<ShopAssistantThread> {
+  const { data, error } = await dbFor(actor)
+    .from("shop_assistant_threads")
+    .select(
+      "id, shop_id, user_id, title, context, last_message_at, archived_at, created_at, updated_at",
+    )
+    .eq("id", threadId)
+    .eq("shop_id", actor.shopId)
+    .eq("user_id", actor.userId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) throw new ShopAssistantHttpError(404, "Shop assistant thread not found");
+  return mapThread(data as ThreadRow);
+}
+
+export async function getOrCreateShopAssistantThread(
+  actor: ShopAssistantActor,
+  threadId?: string,
+  pageContext?: ShopAssistantContext,
+): Promise<ShopAssistantThread> {
+  if (threadId?.trim()) {
+    return getShopAssistantThread(actor, threadId.trim());
+  }
+
+  const existing = await listShopAssistantThreads(actor, 1);
+  if (existing[0]) return existing[0];
+  return createShopAssistantThread(actor, pageContext);
+}
+
+export async function loadShopAssistantMessages(
+  actor: ShopAssistantActor,
+  threadId: string,
+  limit = 80,
+): Promise<ShopAssistantMessage[]> {
+  await getShopAssistantThread(actor, threadId);
+
+  const { data, error } = await dbFor(actor)
+    .from("shop_assistant_messages")
+    .select(
+      "id, thread_id, shop_id, user_id, role, kind, content, payload, client_message_id, created_at",
+    )
+    .eq("thread_id", threadId)
+    .eq("shop_id", actor.shopId)
+    .order("created_at", { ascending: true })
+    .order("id", { ascending: true })
+    .limit(Math.min(Math.max(limit, 1), 200));
+
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as MessageRow[]).map(mapMessage);
+}
+
+export async function insertUserMessageIdempotent(params: {
+  actor: ShopAssistantActor;
+  threadId: string;
+  content: string;
+  clientMessageId: string;
+  payload?: Record<string, unknown>;
+}): Promise<{ message: ShopAssistantMessage; created: boolean }> {
+  const { actor, threadId, content, clientMessageId, payload = {} } = params;
+  const db = dbFor(actor);
+
+  const { data, error } = await db
+    .from("shop_assistant_messages")
+    .insert({
+      thread_id: threadId,
+      shop_id: actor.shopId,
+      user_id: actor.userId,
+      role: "user",
+      kind: "text",
+      content,
+      payload,
+      client_message_id: clientMessageId,
+    })
+    .select(
+      "id, thread_id, shop_id, user_id, role, kind, content, payload, client_message_id, created_at",
+    )
+    .maybeSingle();
+
+  if (!error && data) {
+    return { message: mapMessage(data as MessageRow), created: true };
+  }
+
+  if (error?.code !== "23505") {
+    throw new Error(error?.message ?? "Failed to save shop assistant message");
+  }
+
+  const { data: existing, error: existingError } = await db
+    .from("shop_assistant_messages")
+    .select(
+      "id, thread_id, shop_id, user_id, role, kind, content, payload, client_message_id, created_at",
+    )
+    .eq("thread_id", threadId)
+    .eq("client_message_id", clientMessageId)
+    .maybeSingle();
+
+  if (existingError || !existing) {
+    throw new Error(
+      existingError?.message ?? "Failed to restore idempotent shop assistant message",
+    );
+  }
+
+  return { message: mapMessage(existing as MessageRow), created: false };
+}
+
+export async function findAssistantReply(
+  actor: ShopAssistantActor,
+  threadId: string,
+  clientMessageId: string,
+): Promise<ShopAssistantMessage | null> {
+  const { data, error } = await dbFor(actor)
+    .from("shop_assistant_messages")
+    .select(
+      "id, thread_id, shop_id, user_id, role, kind, content, payload, client_message_id, created_at",
+    )
+    .eq("thread_id", threadId)
+    .eq("role", "assistant")
+    .contains("payload", { requestClientMessageId: clientMessageId })
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data ? mapMessage(data as MessageRow) : null;
+}
+
+export async function insertAssistantMessage(params: {
+  actor: ShopAssistantActor;
+  threadId: string;
+  content: string;
+  kind?: ShopAssistantMessageKind;
+  payload?: Record<string, unknown>;
+}): Promise<ShopAssistantMessage> {
+  const {
+    actor,
+    threadId,
+    content,
+    kind = "text",
+    payload = {},
+  } = params;
+
+  const { data, error } = await dbFor(actor)
+    .from("shop_assistant_messages")
+    .insert({
+      thread_id: threadId,
+      shop_id: actor.shopId,
+      user_id: null,
+      role: "assistant",
+      kind,
+      content,
+      payload,
+    })
+    .select(
+      "id, thread_id, shop_id, user_id, role, kind, content, payload, client_message_id, created_at",
+    )
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Failed to save shop assistant reply");
+  }
+
+  return mapMessage(data as MessageRow);
+}
+
+export async function updateShopAssistantThreadContext(params: {
+  actor: ShopAssistantActor;
+  thread: ShopAssistantThread;
+  context: ShopAssistantThreadContext;
+  title?: string;
+}): Promise<ShopAssistantThread> {
+  const merged = mergeThreadContext(params.thread.context, params.context);
+  const update: Record<string, unknown> = { context: merged };
+  if (params.title?.trim()) update.title = params.title.trim().slice(0, 120);
+
+  const { data, error } = await dbFor(params.actor)
+    .from("shop_assistant_threads")
+    .update(update)
+    .eq("id", params.thread.id)
+    .eq("shop_id", params.actor.shopId)
+    .eq("user_id", params.actor.userId)
+    .select(
+      "id, shop_id, user_id, title, context, last_message_at, archived_at, created_at, updated_at",
+    )
+    .single();
+
+  if (error || !data) {
+    throw new Error(error?.message ?? "Failed to update shop assistant thread");
+  }
+
+  return mapThread(data as ThreadRow);
+}

--- a/features/shop-assistant/types.ts
+++ b/features/shop-assistant/types.ts
@@ -1,0 +1,175 @@
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+
+export type ShopAssistantDomain =
+  | "work_orders"
+  | "scheduling"
+  | "inventory"
+  | "customer_communications"
+  | "customers"
+  | "inspections"
+  | "invoices"
+  | "workforce"
+  | "reporting"
+  | "business_analytics";
+
+export type ShopAssistantContext = {
+  workOrderId?: string;
+  vehicleId?: string;
+  customerId?: string;
+  bookingId?: string;
+  invoiceId?: string;
+  pageType?: string;
+  pageTitle?: string;
+};
+
+export type ShopAssistantThreadContext = {
+  activeWorkOrderId?: string;
+  activeVehicleId?: string;
+  activeCustomerId?: string;
+  activeBookingId?: string;
+  activeInvoiceId?: string;
+  lastDomain?: ShopAssistantDomain;
+  lastIntent?: string;
+};
+
+export type ShopAssistantThread = {
+  id: string;
+  title: string;
+  context: ShopAssistantThreadContext;
+  lastMessageAt: string;
+  archivedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ShopAssistantMessageRole =
+  | "user"
+  | "assistant"
+  | "system"
+  | "tool";
+
+export type ShopAssistantMessageKind =
+  | "text"
+  | "confirmation"
+  | "action_result"
+  | "error"
+  | "state_update";
+
+export type ShopAssistantMessage = {
+  id: string;
+  threadId: string;
+  role: ShopAssistantMessageRole;
+  kind: ShopAssistantMessageKind;
+  content: string;
+  payload: Record<string, unknown>;
+  clientMessageId: string | null;
+  createdAt: string;
+  optimistic?: boolean;
+};
+
+export type ShopAssistantActionRisk = "low" | "medium" | "high";
+
+export type ShopAssistantActionStatus =
+  | "pending_confirmation"
+  | "confirmed"
+  | "executing"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "expired";
+
+export type ShopAssistantActionPreview = {
+  id: string;
+  toolName: string;
+  domain: ShopAssistantDomain;
+  risk: ShopAssistantActionRisk;
+  status: ShopAssistantActionStatus;
+  title: string;
+  summary: string;
+  consequences: string[];
+  expiresAt: string;
+};
+
+export type ShopAssistantActionResult = {
+  id: string;
+  toolName: string;
+  domain: ShopAssistantDomain;
+  status: ShopAssistantActionStatus;
+  summary: string;
+  details: Record<string, unknown>;
+  retryable: boolean;
+};
+
+export type ShopAssistantTurn =
+  | {
+      kind: "answer";
+      message: ShopAssistantMessage;
+    }
+  | {
+      kind: "clarification_required";
+      message: ShopAssistantMessage;
+      fields: Array<{
+        name: string;
+        label: string;
+        type: "text" | "select" | "date" | "datetime";
+        options?: Array<{ label: string; value: string }>;
+      }>;
+    }
+  | {
+      kind: "confirmation_required";
+      message: ShopAssistantMessage;
+      action: ShopAssistantActionPreview;
+    }
+  | {
+      kind: "action_result";
+      message: ShopAssistantMessage;
+      action: ShopAssistantActionResult;
+    }
+  | {
+      kind: "error";
+      message: ShopAssistantMessage;
+      retryable: boolean;
+    };
+
+export type ShopAssistantThreadListResponse =
+  | {
+      ok: true;
+      threads: ShopAssistantThread[];
+      activeThreadId: string | null;
+      role: CanonicalRole;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type ShopAssistantMessagesResponse =
+  | {
+      ok: true;
+      thread: ShopAssistantThread;
+      messages: ShopAssistantMessage[];
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type ShopAssistantChatRequest = {
+  question: string;
+  threadId?: string;
+  clientMessageId: string;
+  context?: ShopAssistantContext;
+};
+
+export type ShopAssistantChatResponse =
+  | {
+      ok: true;
+      thread: ShopAssistantThread;
+      messages: ShopAssistantMessage[];
+      turn: ShopAssistantTurn;
+    }
+  | {
+      ok: false;
+      error: string;
+      retryable?: boolean;
+    };

--- a/supabase/migrations/20260721180000_shop_assistant_threads_actions.sql
+++ b/supabase/migrations/20260721180000_shop_assistant_threads_actions.sql
@@ -1,0 +1,371 @@
+-- Durable, shop-scoped conversation and action records for the shop-wide assistant.
+-- The existing technician assistant remains separate and does not use these tables.
+
+create table if not exists public.shop_assistant_threads (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null,
+  user_id uuid not null,
+  title text not null default 'Shop Assistant',
+  context jsonb not null default '{}'::jsonb,
+  last_message_at timestamptz not null default now(),
+  archived_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint shop_assistant_threads_title_not_blank_chk
+    check (length(btrim(title)) > 0)
+);
+
+create index if not exists shop_assistant_threads_owner_recent_idx
+  on public.shop_assistant_threads (shop_id, user_id, last_message_at desc);
+
+create index if not exists shop_assistant_threads_active_idx
+  on public.shop_assistant_threads (shop_id, user_id, last_message_at desc)
+  where archived_at is null;
+
+create table if not exists public.shop_assistant_messages (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null references public.shop_assistant_threads(id) on delete cascade,
+  shop_id uuid not null,
+  user_id uuid,
+  role text not null,
+  kind text not null default 'text',
+  content text not null default '',
+  payload jsonb not null default '{}'::jsonb,
+  client_message_id text,
+  created_at timestamptz not null default now(),
+  constraint shop_assistant_messages_role_chk
+    check (role = any (array['user'::text, 'assistant'::text, 'system'::text, 'tool'::text])),
+  constraint shop_assistant_messages_kind_chk
+    check (kind = any (array['text'::text, 'confirmation'::text, 'action_result'::text, 'error'::text, 'state_update'::text])),
+  constraint shop_assistant_messages_content_size_chk
+    check (length(content) <= 16000)
+);
+
+create unique index if not exists shop_assistant_messages_client_id_uidx
+  on public.shop_assistant_messages (thread_id, client_message_id)
+  where client_message_id is not null;
+
+create index if not exists shop_assistant_messages_thread_created_idx
+  on public.shop_assistant_messages (thread_id, created_at, id);
+
+create table if not exists public.shop_assistant_actions (
+  id uuid primary key default gen_random_uuid(),
+  thread_id uuid not null references public.shop_assistant_threads(id) on delete cascade,
+  shop_id uuid not null,
+  requested_by uuid not null,
+  confirmed_by uuid,
+  tool_name text not null,
+  domain text not null,
+  risk text not null,
+  status text not null default 'pending_confirmation',
+  input jsonb not null default '{}'::jsonb,
+  preview jsonb not null default '{}'::jsonb,
+  result jsonb,
+  error jsonb,
+  idempotency_key text not null,
+  target_versions jsonb not null default '{}'::jsonb,
+  expires_at timestamptz not null,
+  confirmed_at timestamptz,
+  execution_started_at timestamptz,
+  execution_finished_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint shop_assistant_actions_tool_not_blank_chk
+    check (length(btrim(tool_name)) > 0),
+  constraint shop_assistant_actions_domain_not_blank_chk
+    check (length(btrim(domain)) > 0),
+  constraint shop_assistant_actions_risk_chk
+    check (risk = any (array['low'::text, 'medium'::text, 'high'::text])),
+  constraint shop_assistant_actions_status_chk
+    check (status = any (array[
+      'pending_confirmation'::text,
+      'confirmed'::text,
+      'executing'::text,
+      'succeeded'::text,
+      'failed'::text,
+      'cancelled'::text,
+      'expired'::text
+    ])),
+  constraint shop_assistant_actions_idempotency_not_blank_chk
+    check (length(btrim(idempotency_key)) > 0)
+);
+
+create unique index if not exists shop_assistant_actions_idempotency_uidx
+  on public.shop_assistant_actions (shop_id, idempotency_key);
+
+create index if not exists shop_assistant_actions_status_recent_idx
+  on public.shop_assistant_actions (shop_id, status, created_at desc);
+
+create or replace function public.shop_assistant_set_updated_at()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+create or replace function public.shop_assistant_validate_message_thread()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_shop_id uuid;
+  v_user_id uuid;
+begin
+  select t.shop_id, t.user_id
+    into v_shop_id, v_user_id
+  from public.shop_assistant_threads t
+  where t.id = new.thread_id;
+
+  if v_shop_id is null then
+    raise exception 'Shop assistant thread not found';
+  end if;
+
+  if new.shop_id is distinct from v_shop_id then
+    raise exception 'Message shop does not match thread shop';
+  end if;
+
+  if new.role = 'user' and new.user_id is distinct from v_user_id then
+    raise exception 'User message actor does not match thread owner';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.shop_assistant_validate_action_thread()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_shop_id uuid;
+  v_user_id uuid;
+begin
+  select t.shop_id, t.user_id
+    into v_shop_id, v_user_id
+  from public.shop_assistant_threads t
+  where t.id = new.thread_id;
+
+  if v_shop_id is null then
+    raise exception 'Shop assistant thread not found';
+  end if;
+
+  if new.shop_id is distinct from v_shop_id then
+    raise exception 'Action shop does not match thread shop';
+  end if;
+
+  if new.requested_by is distinct from v_user_id then
+    raise exception 'Action requester does not match thread owner';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.shop_assistant_guard_terminal_action()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if old.status = any (array['succeeded'::text, 'failed'::text, 'cancelled'::text, 'expired'::text])
+     and new.status is distinct from old.status then
+    raise exception 'Terminal shop assistant actions cannot transition';
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function public.shop_assistant_touch_thread_after_message()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  update public.shop_assistant_threads
+  set last_message_at = greatest(last_message_at, new.created_at),
+      updated_at = now()
+  where id = new.thread_id;
+  return new;
+end;
+$$;
+
+drop trigger if exists shop_assistant_threads_set_updated_at on public.shop_assistant_threads;
+create trigger shop_assistant_threads_set_updated_at
+before update on public.shop_assistant_threads
+for each row execute function public.shop_assistant_set_updated_at();
+
+drop trigger if exists shop_assistant_actions_set_updated_at on public.shop_assistant_actions;
+create trigger shop_assistant_actions_set_updated_at
+before update on public.shop_assistant_actions
+for each row execute function public.shop_assistant_set_updated_at();
+
+drop trigger if exists shop_assistant_messages_validate_thread on public.shop_assistant_messages;
+create trigger shop_assistant_messages_validate_thread
+before insert or update on public.shop_assistant_messages
+for each row execute function public.shop_assistant_validate_message_thread();
+
+drop trigger if exists shop_assistant_actions_validate_thread on public.shop_assistant_actions;
+create trigger shop_assistant_actions_validate_thread
+before insert or update on public.shop_assistant_actions
+for each row execute function public.shop_assistant_validate_action_thread();
+
+drop trigger if exists shop_assistant_actions_guard_terminal on public.shop_assistant_actions;
+create trigger shop_assistant_actions_guard_terminal
+before update on public.shop_assistant_actions
+for each row execute function public.shop_assistant_guard_terminal_action();
+
+drop trigger if exists shop_assistant_messages_touch_thread on public.shop_assistant_messages;
+create trigger shop_assistant_messages_touch_thread
+after insert on public.shop_assistant_messages
+for each row execute function public.shop_assistant_touch_thread_after_message();
+
+alter table public.shop_assistant_threads enable row level security;
+alter table public.shop_assistant_messages enable row level security;
+alter table public.shop_assistant_actions enable row level security;
+
+drop policy if exists shop_assistant_threads_owner_select on public.shop_assistant_threads;
+create policy shop_assistant_threads_owner_select
+on public.shop_assistant_threads
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = shop_assistant_threads.shop_id
+      and lower(coalesce(p.role, '')) not in ('customer', 'driver', 'mechanic')
+  )
+);
+
+drop policy if exists shop_assistant_threads_owner_insert on public.shop_assistant_threads;
+create policy shop_assistant_threads_owner_insert
+on public.shop_assistant_threads
+for insert
+to authenticated
+with check (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = shop_assistant_threads.shop_id
+      and lower(coalesce(p.role, '')) not in ('customer', 'driver', 'mechanic')
+  )
+);
+
+drop policy if exists shop_assistant_threads_owner_update on public.shop_assistant_threads;
+create policy shop_assistant_threads_owner_update
+on public.shop_assistant_threads
+for update
+to authenticated
+using (user_id = auth.uid())
+with check (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = shop_assistant_threads.shop_id
+  )
+);
+
+drop policy if exists shop_assistant_messages_thread_owner_select on public.shop_assistant_messages;
+create policy shop_assistant_messages_thread_owner_select
+on public.shop_assistant_messages
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.shop_assistant_threads t
+    where t.id = shop_assistant_messages.thread_id
+      and t.shop_id = shop_assistant_messages.shop_id
+      and t.user_id = auth.uid()
+  )
+);
+
+drop policy if exists shop_assistant_messages_thread_owner_insert on public.shop_assistant_messages;
+create policy shop_assistant_messages_thread_owner_insert
+on public.shop_assistant_messages
+for insert
+to authenticated
+with check (
+  (user_id is null or user_id = auth.uid())
+  and exists (
+    select 1
+    from public.shop_assistant_threads t
+    where t.id = shop_assistant_messages.thread_id
+      and t.shop_id = shop_assistant_messages.shop_id
+      and t.user_id = auth.uid()
+  )
+);
+
+drop policy if exists shop_assistant_actions_actor_select on public.shop_assistant_actions;
+create policy shop_assistant_actions_actor_select
+on public.shop_assistant_actions
+for select
+to authenticated
+using (
+  requested_by = auth.uid()
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = shop_assistant_actions.shop_id
+      and lower(coalesce(p.role, '')) = any (array['owner'::text, 'admin'::text, 'manager'::text])
+  )
+);
+
+drop policy if exists shop_assistant_actions_actor_insert on public.shop_assistant_actions;
+create policy shop_assistant_actions_actor_insert
+on public.shop_assistant_actions
+for insert
+to authenticated
+with check (
+  requested_by = auth.uid()
+  and exists (
+    select 1
+    from public.shop_assistant_threads t
+    where t.id = shop_assistant_actions.thread_id
+      and t.shop_id = shop_assistant_actions.shop_id
+      and t.user_id = auth.uid()
+  )
+);
+
+drop policy if exists shop_assistant_actions_actor_update on public.shop_assistant_actions;
+create policy shop_assistant_actions_actor_update
+on public.shop_assistant_actions
+for update
+to authenticated
+using (
+  requested_by = auth.uid()
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = shop_assistant_actions.shop_id
+      and lower(coalesce(p.role, '')) = any (array['owner'::text, 'admin'::text, 'manager'::text])
+  )
+)
+with check (
+  requested_by = auth.uid()
+  or exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.shop_id = shop_assistant_actions.shop_id
+      and lower(coalesce(p.role, '')) = any (array['owner'::text, 'admin'::text, 'manager'::text])
+  )
+);
+
+grant select, insert, update on public.shop_assistant_threads to authenticated;
+grant select, insert on public.shop_assistant_messages to authenticated;
+grant select, insert, update on public.shop_assistant_actions to authenticated;

--- a/tests/shop-assistant-reliability.test.ts
+++ b/tests/shop-assistant-reliability.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const mobilePage = readFileSync("app/mobile/assistant/page.tsx", "utf8");
+const desktopPage = readFileSync("app/assistant/page.tsx", "utf8");
+const hookSource = readFileSync(
+  "features/shop-assistant/hooks/useShopAssistant.ts",
+  "utf8",
+);
+const storeSource = readFileSync(
+  "features/shop-assistant/server/threadStore.ts",
+  "utf8",
+);
+const actorSource = readFileSync(
+  "features/shop-assistant/server/requireShopAssistantActor.ts",
+  "utf8",
+);
+const chatRoute = readFileSync("app/api/shop-assistant/chat/route.ts", "utf8");
+const migration = readFileSync(
+  "supabase/migrations/20260721180000_shop_assistant_threads_actions.sql",
+  "utf8",
+);
+const techHook = readFileSync("features/ai/hooks/useTechAssistant.ts", "utf8");
+
+function occurrences(source: string, value: string): number {
+  return source.split(value).length - 1;
+}
+
+describe("shop assistant reliability contracts", () => {
+  it("renders each mobile turn through one canonical transcript path", () => {
+    expect(mobilePage).toContain("ShopAssistantConversation");
+    expect(occurrences(mobilePage, "<ShopAssistantConversation")).toBe(1);
+    expect(mobilePage).not.toContain("AssistantResponseCard");
+    expect(mobilePage).not.toContain("useAssistant(");
+  });
+
+  it("uses the durable shop assistant hook on desktop and mobile", () => {
+    expect(mobilePage).toContain("useShopAssistant");
+    expect(desktopPage).toContain("useShopAssistant");
+    expect(hookSource).toContain("/api/shop-assistant/threads");
+    expect(hookSource).toContain("/api/shop-assistant/chat");
+    expect(hookSource).toContain("mergeMessages");
+  });
+
+  it("deduplicates optimistic messages and retries with the same client id", () => {
+    expect(hookSource).toContain("serverClientIds");
+    expect(hookSource).toContain("retryRequest");
+    expect(hookSource).toContain("await sendRequest(retryRequest)");
+    expect(storeSource).toContain('error?.code !== "23505"');
+    expect(storeSource).toContain("client_message_id: clientMessageId");
+  });
+
+  it("persists bounded conversation history and correlates one reply per request", () => {
+    expect(chatRoute).toContain("requestClientMessageId");
+    expect(chatRoute).toContain("findAssistantReply");
+    expect(chatRoute).toContain("loadShopAssistantMessages");
+    expect(chatRoute).toContain("conversationMessages(storedMessages)");
+  });
+
+  it("enforces shop ownership and durable idempotency in the database", () => {
+    expect(migration).toContain("shop_assistant_messages_client_id_uidx");
+    expect(migration).toContain("shop_assistant_actions_idempotency_uidx");
+    expect(migration).toContain("enable row level security");
+    expect(migration).toContain("t.user_id = auth.uid()");
+    expect(migration).toContain("p.shop_id = shop_assistant_threads.shop_id");
+  });
+
+  it("keeps technician diagnostics isolated inside the existing work-order assistant", () => {
+    expect(actorSource).toContain('canonicalRole === "mechanic"');
+    expect(chatRoute).toContain("technicianRedirectAnswer");
+    expect(techHook).toContain('postJSON("/api/assistant/answer"');
+    expect(techHook).not.toContain("/api/shop-assistant/chat");
+  });
+});

--- a/tests/shop-assistant-state.test.ts
+++ b/tests/shop-assistant-state.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const stateBuilder = readFileSync(
+  "features/shop-assistant/server/state/buildShopState.ts",
+  "utf8",
+);
+const stateRoute = readFileSync(
+  "app/api/shop-assistant/state/route.ts",
+  "utf8",
+);
+const stateHook = readFileSync(
+  "features/shop-assistant/hooks/useShopAssistantState.ts",
+  "utf8",
+);
+const dashboard = readFileSync(
+  "features/shop-assistant/components/ShopAssistantDashboard.tsx",
+  "utf8",
+);
+const mobilePage = readFileSync("app/mobile/assistant/page.tsx", "utf8");
+const desktopPage = readFileSync("app/assistant/page.tsx", "utf8");
+
+describe("shop assistant live state contracts", () => {
+  it("builds the required shop-wide metrics without an LLM", () => {
+    expect(stateBuilder).toContain("openWorkOrders");
+    expect(stateBuilder).toContain("stalledWorkOrders");
+    expect(stateBuilder).toContain("overdueApprovals");
+    expect(stateBuilder).toContain("delayedParts");
+    expect(stateBuilder).toContain("idleTechnicians");
+    expect(stateBuilder).toContain("readyToInvoice");
+    expect(stateBuilder).toContain("todaysBookings");
+    expect(stateBuilder).not.toContain("getOpenAIClient");
+  });
+
+  it("maps proactive alerts for stalled work, approvals, parts, idle capacity, and invoices", () => {
+    expect(stateBuilder).toContain("work_order_waiting_too_long");
+    expect(stateBuilder).toContain("work_order_on_hold_too_long");
+    expect(stateBuilder).toContain("approval_waiting");
+    expect(stateBuilder).toContain("parts_delivery_overdue");
+    expect(stateBuilder).toContain("technician_idle");
+    expect(stateBuilder).toContain("invoice_ready");
+    expect(stateBuilder).toContain("dedupeAlerts");
+  });
+
+  it("gates suggestions through canonical actor capabilities", () => {
+    expect(stateBuilder).toContain("capabilities.canAuthorizeQuotes");
+    expect(stateBuilder).toContain("capabilities.canManageParts");
+    expect(stateBuilder).toContain("capabilities.canAssignWork");
+    expect(stateBuilder).toContain("capabilities.canManageBilling");
+    expect(stateBuilder).toContain("capabilities.canManageScheduling");
+  });
+
+  it("serves current state through an authenticated no-store route", () => {
+    expect(stateRoute).toContain("requireShopAssistantActor");
+    expect(stateRoute).toContain("buildShopState");
+    expect(stateRoute).toContain('"cache-control": "private, no-store, max-age=0"');
+  });
+
+  it("refreshes while visible instead of appending duplicate dashboard cards", () => {
+    expect(stateHook).toContain("REFRESH_INTERVAL_MS");
+    expect(stateHook).toContain("document.visibilityState");
+    expect(stateHook).toContain("setState(payload.state)");
+    expect(stateHook).not.toContain("setState((current) => [");
+  });
+
+  it("loads the live dashboard before a prompt on desktop and mobile", () => {
+    expect(dashboard).toContain("ShopStateMetricGrid");
+    expect(dashboard).toContain("ShopAlertList");
+    expect(dashboard).toContain("ShopSuggestionList");
+    expect(desktopPage).toContain("<ShopAssistantDashboard");
+    expect(mobilePage).toContain("<ShopAssistantDashboard");
+  });
+});


### PR DESCRIPTION
## Phase 1 — Reliability

- isolates the shop-wide assistant under `/api/shop-assistant/*` while leaving the in-work-order Technician AI on `/api/assistant/answer`
- replaces local-only chat state with durable, shop-scoped threads and messages
- adds client-message idempotency, optimistic-message reconciliation, retry with the same key, and replay protection
- fixes duplicate mobile replies by rendering every turn through one canonical transcript component
- restores the latest conversation after reload and supports creating a new durable thread
- adds RLS-protected assistant action audit storage for the confirmation/execution phases that follow

## Security

- every route authenticates the current user and resolves the actor's shop and canonical role
- mechanics are directed to the existing work-order Technician AI
- customer, driver, unknown, cross-shop, and cross-user access is denied
- RLS is enabled for threads, messages, and actions

## Database

Apply `20260721180000_shop_assistant_threads_actions.sql` before deploying this PR.

## Validation

Focused regression coverage is included in `tests/shop-assistant-reliability.test.ts`. CI should run typecheck, lint, tests, route audit, and the application build.

## Stack

This is PR 1 of 4. The live shop dashboard, tool execution, and multi-agent router are delivered in stacked follow-up PRs.