### PR TITLE
Phase 1: make the shop assistant reliable and action-aware

### DIFF
--- a/app/api/assistant/actions/[id]/route.ts
+++ b/app/api/assistant/actions/[id]/route.ts
@@ -1,0 +1,263 @@
+import { NextResponse } from "next/server";
+import type { Json } from "@shared/types/types/supabase";
+import type { AssistantExecutionResult } from "@/features/agent/assistant/types";
+import { executeShopAssistantAction } from "@/features/assistant/server/shopAssistantActionExecutor";
+import { asShopAssistantClient } from "@/features/assistant/server/shopAssistantDatabase";
+import {
+  appendAssistantMessage,
+  loadAssistantActionRequest,
+  updateAssistantActionRequest,
+} from "@/features/assistant/server/shopAssistantPersistence";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type RouteContext = { params: Promise<{ id: string }> };
+type DecisionBody = { decision?: "confirm" | "cancel" };
+
+function storedExecution(value: Json | null): AssistantExecutionResult | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, Json | undefined>;
+  if (
+    typeof record.actionId !== "string" ||
+    typeof record.toolName !== "string" ||
+    (record.status !== "succeeded" &&
+      record.status !== "failed" &&
+      record.status !== "cancelled") ||
+    typeof record.summary !== "string"
+  ) {
+    return null;
+  }
+
+  return value as unknown as AssistantExecutionResult;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const { id } = await context.params;
+  if (!UUID_PATTERN.test(id)) {
+    return NextResponse.json({ error: "Invalid action id" }, { status: 400 });
+  }
+
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as DecisionBody | null;
+  if (body?.decision !== "confirm" && body?.decision !== "cancel") {
+    return NextResponse.json(
+      { error: "Decision must be confirm or cancel" },
+      { status: 400 },
+    );
+  }
+
+  const client = asShopAssistantClient(access.supabase);
+
+  try {
+    const action = await loadAssistantActionRequest(client, {
+      actionId: id,
+      shopId: access.profile.shop_id,
+      userId: access.profile.id,
+    });
+
+    if (!action) {
+      return NextResponse.json({ error: "Action not found" }, { status: 404 });
+    }
+
+    const previousExecution = storedExecution(action.result);
+    if (previousExecution) {
+      return NextResponse.json({
+        ok: true,
+        conversationId: action.conversation_id,
+        execution: previousExecution,
+      });
+    }
+
+    if (body.decision === "cancel") {
+      if (action.status !== "pending") {
+        return NextResponse.json(
+          { error: `Action is already ${action.status}` },
+          { status: 409 },
+        );
+      }
+
+      const execution: AssistantExecutionResult = {
+        actionId: action.id,
+        toolName: action.tool_name,
+        status: "cancelled",
+        summary: `${action.label} was cancelled. No shop records were changed.`,
+        details: [],
+        affectedRecords: [],
+      };
+
+      const updated = await updateAssistantActionRequest(client, {
+        actionId: action.id,
+        shopId: access.profile.shop_id,
+        userId: access.profile.id,
+        expectedStatus: "pending",
+        patch: {
+          status: "cancelled",
+          result: execution as unknown as Json,
+          executed_at: new Date().toISOString(),
+        },
+      });
+
+      if (!updated) {
+        return NextResponse.json(
+          { error: "Action changed before it could be cancelled" },
+          { status: 409 },
+        );
+      }
+
+      await appendAssistantMessage(client, {
+        conversationId: action.conversation_id,
+        shopId: access.profile.shop_id,
+        userId: access.profile.id,
+        role: "assistant",
+        content: execution.summary,
+        requestId: `action:${action.id}:cancel`,
+        payload: { execution },
+      });
+
+      return NextResponse.json({
+        ok: true,
+        conversationId: action.conversation_id,
+        execution,
+      });
+    }
+
+    if (action.status !== "pending") {
+      return NextResponse.json(
+        { error: `Action is already ${action.status}` },
+        { status: 409 },
+      );
+    }
+
+    if (new Date(action.expires_at).getTime() <= Date.now()) {
+      await updateAssistantActionRequest(client, {
+        actionId: action.id,
+        shopId: access.profile.shop_id,
+        userId: access.profile.id,
+        expectedStatus: "pending",
+        patch: {
+          status: "expired",
+          error_message: "Confirmation window expired",
+          executed_at: new Date().toISOString(),
+        },
+      });
+      return NextResponse.json(
+        { error: "This action expired. Ask the assistant to prepare it again." },
+        { status: 409 },
+      );
+    }
+
+    const claimed = await updateAssistantActionRequest(client, {
+      actionId: action.id,
+      shopId: access.profile.shop_id,
+      userId: access.profile.id,
+      expectedStatus: "pending",
+      patch: {
+        status: "executing",
+        confirmed_by: access.profile.id,
+        confirmed_at: new Date().toISOString(),
+      },
+    });
+
+    if (!claimed) {
+      return NextResponse.json(
+        { error: "Action changed before it could be confirmed" },
+        { status: 409 },
+      );
+    }
+
+    try {
+      const execution = await executeShopAssistantAction({
+        client,
+        actionId: action.id,
+        shopId: access.profile.shop_id,
+        profileId: access.profile.id,
+        role: access.profile.role,
+        toolName: action.tool_name,
+        input: action.input,
+      });
+
+      await updateAssistantActionRequest(client, {
+        actionId: action.id,
+        shopId: access.profile.shop_id,
+        userId: access.profile.id,
+        expectedStatus: "executing",
+        patch: {
+          status: "succeeded",
+          result: execution as unknown as Json,
+          error_message: null,
+          executed_at: new Date().toISOString(),
+        },
+      });
+
+      await appendAssistantMessage(client, {
+        conversationId: action.conversation_id,
+        shopId: access.profile.shop_id,
+        userId: access.profile.id,
+        role: "assistant",
+        content: [execution.summary, ...execution.details].join("\n"),
+        requestId: `action:${action.id}:result`,
+        payload: { execution },
+      });
+
+      return NextResponse.json({
+        ok: true,
+        conversationId: action.conversation_id,
+        execution,
+      });
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : "The requested action failed";
+      const execution: AssistantExecutionResult = {
+        actionId: action.id,
+        toolName: action.tool_name,
+        status: "failed",
+        summary: `I could not complete ${action.label.toLowerCase()}.`,
+        details: [message],
+        affectedRecords: [],
+      };
+
+      await updateAssistantActionRequest(client, {
+        actionId: action.id,
+        shopId: access.profile.shop_id,
+        userId: access.profile.id,
+        expectedStatus: "executing",
+        patch: {
+          status: "failed",
+          result: execution as unknown as Json,
+          error_message: message,
+          executed_at: new Date().toISOString(),
+        },
+      });
+
+      await appendAssistantMessage(client, {
+        conversationId: action.conversation_id,
+        shopId: access.profile.shop_id,
+        userId: access.profile.id,
+        role: "assistant",
+        content: [execution.summary, message].join("\n"),
+        requestId: `action:${action.id}:result`,
+        payload: { execution },
+      });
+
+      return NextResponse.json({
+        ok: true,
+        conversationId: action.conversation_id,
+        execution,
+      });
+    }
+  } catch (error: unknown) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to process assistant action",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/assistant/answer/route.ts
+++ b/app/api/assistant/answer/route.ts
@@ -1,64 +1,34 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-
 import { answerAssistant } from "@/features/agent/assistant/server/answerAssistant";
+import { AssistantContextValidationError } from "@/features/agent/assistant/server/trustedContext";
 import type {
   AssistantAskRequest,
   AssistantAskResponse,
 } from "@/features/agent/assistant/types";
-import { AssistantContextValidationError } from "@/features/agent/assistant/server/trustedContext";
+import { handleShopAssistantRequest } from "@/features/assistant/server/handleShopAssistantRequest";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-async function requireUser(
-  supabase: ReturnType<typeof createServerSupabaseRoute>,
-) {
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser();
-
-  if (error || !user) return null;
-  return user;
-}
-
-async function resolveProfile(
-  supabase: ReturnType<typeof createServerSupabaseRoute>,
-  userId: string,
-): Promise<{ shopId: string | null; role: string | null }> {
-  const { data, error } = await supabase
-    .from("profiles")
-    .select("shop_id, role")
-    .eq("id", userId)
-    .maybeSingle();
-
-  if (error) {
-    return { shopId: null, role: null };
-  }
-
-  return {
-    shopId: data?.shop_id ?? null,
-    role: data?.role ?? null,
-  };
+function invalidConversationHistory(body: AssistantAskRequest): boolean {
+  return Boolean(
+    body.messages !== undefined &&
+      (!Array.isArray(body.messages) ||
+        body.messages.length > 20 ||
+        body.messages.some(
+          (message) =>
+            !message ||
+            (message.role !== "user" && message.role !== "assistant") ||
+            typeof message.content !== "string" ||
+            message.content.length > 4000,
+        )),
+  );
 }
 
 export async function POST(request: Request) {
-  const supabase = createServerSupabaseRoute();
-
-  const user = await requireUser(supabase);
-  if (!user) {
-    return NextResponse.json<AssistantAskResponse>(
-      { ok: false, error: "Unauthorized" },
-      { status: 401 },
-    );
-  }
-
-  const profile = await resolveProfile(supabase, user.id);
-  if (!profile.shopId) {
-    return NextResponse.json<AssistantAskResponse>(
-      { ok: false, error: "No shop found for user" },
-      { status: 400 },
-    );
-  }
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
 
   let body: AssistantAskRequest;
   try {
@@ -82,17 +52,34 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
-  if (body.messages !== undefined && (!Array.isArray(body.messages) ||
-    body.messages.length > 20 || body.messages.some((message) =>
-      !message || (message.role !== "user" && message.role !== "assistant") ||
-      typeof message.content !== "string" || message.content.length > 4000))) {
+  if (body.surface !== undefined && body.surface !== "shop" && body.surface !== "technician") {
+    return NextResponse.json<AssistantAskResponse>(
+      { ok: false, error: "Assistant surface is invalid" },
+      { status: 400 },
+    );
+  }
+  if (body.conversationId !== undefined && !UUID_PATTERN.test(body.conversationId)) {
+    return NextResponse.json<AssistantAskResponse>(
+      { ok: false, error: "Conversation id is invalid" },
+      { status: 400 },
+    );
+  }
+  if (body.clientRequestId !== undefined && !UUID_PATTERN.test(body.clientRequestId)) {
+    return NextResponse.json<AssistantAskResponse>(
+      { ok: false, error: "Client request id is invalid" },
+      { status: 400 },
+    );
+  }
+  if (invalidConversationHistory(body)) {
     return NextResponse.json<AssistantAskResponse>(
       { ok: false, error: "Conversation history is invalid" },
       { status: 400 },
     );
   }
-  if (body.imageAttachments !== undefined &&
-    (!Array.isArray(body.imageAttachments) || body.imageAttachments.length > 3)) {
+  if (
+    body.imageAttachments !== undefined &&
+    (!Array.isArray(body.imageAttachments) || body.imageAttachments.length > 3)
+  ) {
     return NextResponse.json<AssistantAskResponse>(
       { ok: false, error: "Too many image attachments" },
       { status: 400 },
@@ -100,12 +87,21 @@ export async function POST(request: Request) {
   }
 
   try {
-    const answer = await answerAssistant({
-      shopId: profile.shopId,
-      userId: user.id,
-      role: profile.role,
-      request: body,
-    });
+    const answer =
+      body.surface === "shop"
+        ? await handleShopAssistantRequest({
+            supabase: access.supabase,
+            shopId: access.profile.shop_id,
+            userId: access.profile.id,
+            role: access.profile.role,
+            request: body,
+          })
+        : await answerAssistant({
+            shopId: access.profile.shop_id,
+            userId: access.profile.id,
+            role: access.profile.role,
+            request: body,
+          });
 
     return NextResponse.json<AssistantAskResponse>({
       ok: true,

--- a/app/api/assistant/conversations/[id]/route.ts
+++ b/app/api/assistant/conversations/[id]/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { asShopAssistantClient } from "@/features/assistant/server/shopAssistantDatabase";
+import {
+  deleteAssistantConversation,
+  listAssistantMessages,
+  loadAssistantConversation,
+} from "@/features/assistant/server/shopAssistantPersistence";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_: Request, context: RouteContext) {
+  const { id } = await context.params;
+  if (!UUID_PATTERN.test(id)) {
+    return NextResponse.json({ error: "Invalid conversation id" }, { status: 400 });
+  }
+
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  try {
+    const client = asShopAssistantClient(access.supabase);
+    const conversation = await loadAssistantConversation(client, {
+      conversationId: id,
+      shopId: access.profile.shop_id,
+      userId: access.profile.id,
+    });
+
+    if (!conversation) {
+      return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    const messages = await listAssistantMessages(client, {
+      conversationId: id,
+      shopId: access.profile.shop_id,
+      userId: access.profile.id,
+      limit: 50,
+    });
+
+    return NextResponse.json({
+      ok: true,
+      conversation: {
+        id: conversation.id,
+        context: conversation.context,
+        lastIntent: conversation.last_intent,
+        updatedAt: conversation.updated_at,
+      },
+      messages,
+    });
+  } catch (error: unknown) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to load assistant conversation",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(_: Request, context: RouteContext) {
+  const { id } = await context.params;
+  if (!UUID_PATTERN.test(id)) {
+    return NextResponse.json({ error: "Invalid conversation id" }, { status: 400 });
+  }
+
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  try {
+    const deleted = await deleteAssistantConversation(
+      asShopAssistantClient(access.supabase),
+      {
+        conversationId: id,
+        shopId: access.profile.shop_id,
+        userId: access.profile.id,
+      },
+    );
+
+    if (!deleted) {
+      return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error: unknown) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to clear assistant conversation",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -9,43 +9,67 @@ import { Button } from "@shared/components/ui/Button";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 import { useAssistant } from "@/features/assistant/hooks/useAssistant";
+import AssistantConversation from "@/features/assistant/components/AssistantConversation";
 import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
 import type { AssistantContext } from "@/features/assistant/types/assistant";
 
 const EXAMPLE_PROMPTS = [
   "Which work orders are waiting on approvals right now?",
-  "Summarize open inspections with safety concerns from this week.",
+  "Put WO EL00005 on hold for parts.",
   "What changed today across bookings, invoices, and technician activity?",
   "Show repeat issues for this vehicle and what we recommended last time.",
 ];
 
 export default function AssistantPage() {
   const [query, setQuery] = useState("");
-  const { ask, loading, data } = useAssistant();
   const searchParams = useSearchParams();
+  const searchKey = searchParams.toString();
 
   const context = useMemo<AssistantContext>(() => {
-    const workOrderId = searchParams.get("workOrderId") ?? undefined;
-    const vehicleId = searchParams.get("vehicleId") ?? undefined;
-    const customerId = searchParams.get("customerId") ?? undefined;
-    const bookingId = searchParams.get("bookingId") ?? undefined;
-    const pageType = searchParams.get("pageType") ?? undefined;
-    const pageTitle = searchParams.get("pageTitle") ?? undefined;
-
+    const params = new URLSearchParams(searchKey);
     return {
-      workOrderId,
-      vehicleId,
-      customerId,
-      bookingId,
-      pageType,
-      pageTitle,
+      workOrderId: params.get("workOrderId") ?? undefined,
+      vehicleId: params.get("vehicleId") ?? undefined,
+      customerId: params.get("customerId") ?? undefined,
+      bookingId: params.get("bookingId") ?? undefined,
+      pageType: params.get("pageType") ?? undefined,
+      pageTitle: params.get("pageTitle") ?? undefined,
     };
-  }, [searchParams]);
+  }, [searchKey]);
+
+  const contextKey = useMemo(
+    () =>
+      [
+        context.pageType,
+        context.workOrderId,
+        context.vehicleId,
+        context.customerId,
+        context.bookingId,
+      ]
+        .filter(Boolean)
+        .join(":"),
+    [context],
+  );
+
+  const {
+    ask,
+    loading,
+    hydrating,
+    actionLoading,
+    data,
+    messages,
+    confirmAction,
+    cancelAction,
+    clearConversation,
+  } = useAssistant(contextKey);
 
   const contextChips = useMemo(
     () => [
       { label: "Shop-wide", active: true },
-      { label: "Current page", active: Boolean(context.pageType || context.pageTitle) },
+      {
+        label: "Current page",
+        active: Boolean(context.pageType || context.pageTitle),
+      },
       { label: "Current customer", active: Boolean(context.customerId) },
       { label: "Current vehicle", active: Boolean(context.vehicleId) },
       { label: "Current work order", active: Boolean(context.workOrderId) },
@@ -53,10 +77,17 @@ export default function AssistantPage() {
     [context],
   );
 
+  const submit = async () => {
+    const value = query.trim();
+    if (!value || loading) return;
+    await ask(value, context);
+    setQuery("");
+  };
+
   return (
     <PageShell
       title="Shop Assistant"
-      description="Your universal shop intelligence surface for questions, explanations, and cross-record history."
+      description="Shop-wide intelligence, durable conversation memory, and reviewable operational actions."
     >
       <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
         <div className="desktop-panel-soft p-4">
@@ -77,17 +108,26 @@ export default function AssistantPage() {
               </span>
             ))}
           </div>
-          <p className="mt-3 text-xs text-[color:var(--theme-text-secondary)]">
+          <p className="mt-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
             Ask across work orders, customers, vehicles, inspections, approvals,
-            bookings, invoices, fleet, parts, and staff/shop activity. Current-page
-            context is applied when available.
+            bookings, invoices, fleet, parts, and staff activity. Action requests
+            are separated from questions and require confirmation before records
+            change.
           </p>
         </div>
 
+        {hydrating ? (
+          <div className="desktop-panel-soft p-4 text-sm text-[color:var(--theme-text-secondary)]">
+            Restoring the conversation…
+          </div>
+        ) : (
+          <AssistantConversation messages={messages} />
+        )}
+
         <textarea
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Ask a shop question, request an explanation, or compare records..."
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Ask a shop question or request a reviewed action..."
           className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-[color:var(--theme-text-primary)]"
         />
 
@@ -104,17 +144,30 @@ export default function AssistantPage() {
           ))}
         </div>
 
-        <div className="mt-4 flex justify-center">
+        <div className="mt-4 flex items-center justify-between gap-3">
           <Button
-            onClick={() => ask(query, context)}
+            variant="ghost"
+            disabled={loading || hydrating || messages.length === 0}
+            onClick={() => void clearConversation()}
+          >
+            Clear conversation
+          </Button>
+          <Button
+            onClick={() => void submit()}
             isLoading={loading}
-            disabled={!query.trim()}
+            disabled={hydrating || !query.trim()}
           >
             Ask Assistant
           </Button>
         </div>
 
-        <AssistantResponseCard data={data} />
+        <AssistantResponseCard
+          data={data}
+          showAnswer={false}
+          actionLoading={actionLoading}
+          onConfirmAction={confirmAction}
+          onCancelAction={cancelAction}
+        />
       </div>
     </PageShell>
   );

--- a/app/mobile/assistant/page.tsx
+++ b/app/mobile/assistant/page.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
+import AssistantConversation from "@/features/assistant/components/AssistantConversation";
 import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
 import { useAssistant } from "@/features/assistant/hooks/useAssistant";
 import type { AssistantContext } from "@/features/assistant/types/assistant";
@@ -43,8 +44,17 @@ export default function MobileAssistantPage() {
         .join(":"),
     [context],
   );
-  const { ask, loading, data, messages, clearConversation } =
-    useAssistant(contextKey);
+  const {
+    ask,
+    loading,
+    hydrating,
+    actionLoading,
+    data,
+    messages,
+    confirmAction,
+    cancelAction,
+    clearConversation,
+  } = useAssistant(contextKey);
 
   const submit = async () => {
     const value = question.trim();
@@ -69,11 +79,11 @@ export default function MobileAssistantPage() {
           Shop assistant
         </div>
         <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
-          Ask a question
+          Ask or take action
         </h1>
         <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-          This is a deliberate question-and-answer tool. It does not change work
-          orders, appointments, parts, or shop records automatically.
+          Ask across the shop or request an operational change. Record changes are
+          shown for review and require confirmation before they run.
         </p>
         {contextLabel ? (
           <div className="mt-3 inline-flex rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]">
@@ -82,35 +92,26 @@ export default function MobileAssistantPage() {
         ) : null}
       </section>
 
-      {messages.length > 0 ? (
-        <section className="max-h-64 space-y-2 overflow-y-auto rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3">
-          {messages.slice(-8).map((message, index) => (
-            <div
-              key={`${message.role}-${index}-${message.content.slice(0, 20)}`}
-              className={`rounded-2xl px-3 py-2 text-sm leading-5 ${
-                message.role === "user"
-                  ? "ml-6 bg-[color:var(--accent-copper)] text-white"
-                  : "mr-6 border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)]"
-              }`}
-            >
-              {message.content}
-            </div>
-          ))}
+      {hydrating ? (
+        <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+          Restoring the conversation…
         </section>
-      ) : null}
+      ) : (
+        <AssistantConversation messages={messages} compact />
+      )}
 
       <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
         <label
           htmlFor="mobile-assistant-question"
           className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]"
         >
-          Question
+          Question or command
         </label>
         <textarea
           id="mobile-assistant-question"
           value={question}
           onChange={(event) => setQuestion(event.target.value)}
-          placeholder="Ask about shop status, a customer, a work order, parts, appointments, or fleet operations."
+          placeholder="Ask about shop status or request a reviewed action, such as putting a work order on hold for parts."
           className="mt-2 min-h-32 w-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)] focus:ring-2 focus:ring-[var(--accent-copper-soft)]/30"
         />
         <div className="mt-3 flex items-center justify-between gap-2">
@@ -118,9 +119,9 @@ export default function MobileAssistantPage() {
             type="button"
             variant="ghost"
             size="sm"
-            disabled={loading || messages.length === 0}
+            disabled={loading || hydrating || messages.length === 0}
             onClick={() => {
-              clearConversation();
+              void clearConversation();
               setQuestion("");
             }}
           >
@@ -130,7 +131,7 @@ export default function MobileAssistantPage() {
             type="button"
             variant="copper"
             size="sm"
-            disabled={loading || !question.trim()}
+            disabled={loading || hydrating || !question.trim()}
             isLoading={loading}
             onClick={() => void submit()}
           >
@@ -139,7 +140,13 @@ export default function MobileAssistantPage() {
         </div>
       </section>
 
-      <AssistantResponseCard data={data} />
+      <AssistantResponseCard
+        data={data}
+        showAnswer={false}
+        actionLoading={actionLoading}
+        onConfirmAction={confirmAction}
+        onCancelAction={cancelAction}
+      />
     </div>
   );
 }

--- a/features/agent/assistant/types.ts
+++ b/features/agent/assistant/types.ts
@@ -63,6 +63,50 @@ export type AssistantResolvedContext = {
   fleetUnitId?: string;
 };
 
+export type AssistantActionRisk = "low" | "medium" | "high";
+
+export type AssistantPendingAction = {
+  id: string;
+  toolName: string;
+  domain: string;
+  label: string;
+  summary: string;
+  riskLevel: AssistantActionRisk;
+  status: "pending_confirmation";
+  expiresAt: string;
+  input: Record<string, unknown>;
+};
+
+export type AssistantExecutionResult = {
+  actionId: string;
+  toolName: string;
+  status: "succeeded" | "failed" | "cancelled";
+  summary: string;
+  details: string[];
+  affectedRecords: AssistantEntity[];
+};
+
+export type AssistantIntent =
+  | "customer_visit_history"
+  | "vehicle_history"
+  | "shop_status"
+  | "stalled_work_orders"
+  | "bookings"
+  | "tech_current_work"
+  | "pending_approvals"
+  | "work_order_status"
+  | "parts_inventory"
+  | "parts_blockers"
+  | "parts_purchasing"
+  | "fleet_history"
+  | "fleet_requests"
+  | "authoring_menu_item"
+  | "authoring_inspection_template"
+  | "authoring_bundle_draft"
+  | "action_request"
+  | "tool_result"
+  | "unknown";
+
 export type AssistantAnswer = {
   summary: string;
   bullets: string[];
@@ -71,24 +115,10 @@ export type AssistantAnswer = {
   actions: AssistantAction[];
   resolvedContext?: AssistantResolvedContext;
   partSuggestions?: CanonicalPartSuggestion[];
-  intent:
-    | "customer_visit_history"
-    | "vehicle_history"
-    | "shop_status"
-    | "stalled_work_orders"
-    | "bookings"
-    | "tech_current_work"
-    | "pending_approvals"
-    | "work_order_status"
-    | "parts_inventory"
-    | "parts_blockers"
-    | "parts_purchasing"
-    | "fleet_history"
-    | "fleet_requests"
-    | "authoring_menu_item"
-    | "authoring_inspection_template"
-    | "authoring_bundle_draft"
-    | "unknown";
+  intent: AssistantIntent;
+  conversationId?: string;
+  pendingAction?: AssistantPendingAction;
+  execution?: AssistantExecutionResult;
 };
 
 export type AssistantAskContext = {
@@ -121,8 +151,13 @@ export type AssistantVehicleContext = {
   model?: string | null;
 };
 
+export type AssistantSurface = "shop" | "technician";
+
 export type AssistantAskRequest = {
   question: string;
+  surface?: AssistantSurface;
+  conversationId?: string;
+  clientRequestId?: string;
   context?: AssistantAskContext;
   session?: AssistantAskSession;
   messages?: AssistantConversationMessage[];

--- a/features/assistant/components/AssistantConversation.tsx
+++ b/features/assistant/components/AssistantConversation.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { AssistantConversationMessage } from "../types/assistant";
+
+type Props = {
+  messages: AssistantConversationMessage[];
+  compact?: boolean;
+};
+
+export default function AssistantConversation({
+  messages,
+  compact = false,
+}: Props) {
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [messages.length]);
+
+  if (messages.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Assistant conversation"
+      className={`${compact ? "max-h-72" : "max-h-[32rem]"} space-y-2 overflow-y-auto rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3`}
+    >
+      {messages.map((message) => (
+        <div
+          key={message.id}
+          className={`whitespace-pre-line rounded-2xl px-3 py-2 text-sm leading-6 ${
+            message.role === "user"
+              ? "ml-6 bg-[color:var(--accent-copper)] text-white"
+              : "mr-6 border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)]"
+          }`}
+        >
+          {message.content}
+        </div>
+      ))}
+      <div ref={endRef} />
+    </section>
+  );
+}

--- a/features/assistant/components/AssistantResponseCard.tsx
+++ b/features/assistant/components/AssistantResponseCard.tsx
@@ -8,8 +8,11 @@ import { buildPlannerHref } from "../lib/buildPlannerHref";
 
 type Props = {
   data: AssistantResponse | { error: string } | null;
+  onConfirmAction?: (actionId: string) => void | Promise<void>;
+  onCancelAction?: (actionId: string) => void | Promise<void>;
+  actionLoading?: string | null;
+  showAnswer?: boolean;
 };
-
 
 function fitmentLabel(value: string): string {
   if (value === "confirmed_fit") return "Confirmed fit";
@@ -26,7 +29,19 @@ function normalizePlannerActionLabel(label: string): string {
   return label;
 }
 
-export default function AssistantResponseCard({ data }: Props) {
+function riskLabel(value: "low" | "medium" | "high"): string {
+  if (value === "high") return "High-impact change";
+  if (value === "medium") return "Operational change";
+  return "Low-impact change";
+}
+
+export default function AssistantResponseCard({
+  data,
+  onConfirmAction,
+  onCancelAction,
+  actionLoading = null,
+  showAnswer = true,
+}: Props) {
   if (!data) return null;
 
   if ("error" in data) {
@@ -37,44 +52,149 @@ export default function AssistantResponseCard({ data }: Props) {
     );
   }
 
-  return (
-    <div className="mt-6 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5">
-      <div className="mb-2 text-xs uppercase text-[color:var(--theme-text-secondary)]">Direct answer</div>
-      <div className="whitespace-pre-line text-sm text-[color:var(--theme-text-primary)]">{data.summary}</div>
+  const pending = data.pendingAction;
+  const execution = data.execution;
 
-      {data.bullets.length > 0 ? (
-        <div className="mt-4">
-          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">Supporting evidence & context</div>
-          <ul className="space-y-1">
-            {data.bullets.map((bullet, i) => (
-              <li key={`${bullet}-${i}`} className="text-sm text-[color:var(--theme-text-primary)]">
-                • {bullet}
-              </li>
-            ))}
-          </ul>
-        </div>
+  return (
+    <div className="mt-6 space-y-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5">
+      {pending ? (
+        <section className="rounded-2xl border border-amber-400/30 bg-amber-500/10 p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-200">
+              Confirmation required
+            </div>
+            <div className="rounded-full border border-amber-300/30 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-amber-100">
+              {riskLabel(pending.riskLevel)}
+            </div>
+          </div>
+          <div className="mt-3 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            {pending.label}
+          </div>
+          <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+            {pending.summary}
+          </p>
+          <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
+            No record has changed yet. This request expires at{" "}
+            {new Date(pending.expiresAt).toLocaleTimeString([], {
+              hour: "numeric",
+              minute: "2-digit",
+            })}
+            .
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={Boolean(actionLoading)}
+              onClick={() => void onConfirmAction?.(pending.id)}
+              className="rounded-full bg-[var(--accent-copper)] px-4 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {actionLoading === pending.id ? "Working…" : "Confirm change"}
+            </button>
+            <button
+              type="button"
+              disabled={Boolean(actionLoading)}
+              onClick={() => void onCancelAction?.(pending.id)}
+              className="rounded-full border border-[color:var(--theme-border-soft)] px-4 py-2 text-xs font-semibold text-[color:var(--theme-text-secondary)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </section>
       ) : null}
 
+      {execution ? (
+        <section
+          className={`rounded-2xl border p-4 ${
+            execution.status === "succeeded"
+              ? "border-emerald-400/30 bg-emerald-500/10"
+              : execution.status === "failed"
+                ? "border-red-400/30 bg-red-500/10"
+                : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]"
+          }`}
+        >
+          <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            {execution.status === "succeeded"
+              ? "Action completed"
+              : execution.status === "failed"
+                ? "Action failed"
+                : "Action cancelled"}
+          </div>
+          <div className="mt-2 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            {execution.summary}
+          </div>
+          {execution.details.length > 0 ? (
+            <ul className="mt-2 space-y-1 text-xs text-[color:var(--theme-text-secondary)]">
+              {execution.details.map((detail) => (
+                <li key={detail}>• {detail}</li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+      ) : null}
+
+      {showAnswer ? (
+        <section>
+          <div className="mb-2 text-xs uppercase text-[color:var(--theme-text-secondary)]">
+            Direct answer
+          </div>
+          <div className="whitespace-pre-line text-sm text-[color:var(--theme-text-primary)]">
+            {data.summary}
+          </div>
+
+          {data.bullets.length > 0 ? (
+            <div className="mt-4">
+              <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">
+                Supporting evidence &amp; context
+              </div>
+              <ul className="space-y-1">
+                {data.bullets.map((bullet) => (
+                  <li
+                    key={bullet}
+                    className="text-sm text-[color:var(--theme-text-primary)]"
+                  >
+                    • {bullet}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
 
       {data.partSuggestions && data.partSuggestions.length > 0 ? (
-        <div className="mt-4 space-y-2">
-          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">Suggested parts (review first)</div>
+        <div className="space-y-2">
+          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">
+            Suggested parts (review first)
+          </div>
           {data.partSuggestions.map((part) => (
-            <div key={part.candidateId} className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
+            <div
+              key={part.candidateId}
+              className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3"
+            >
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">{part.title}</div>
+                  <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                    {part.title}
+                  </div>
                   <div className="text-xs text-[color:var(--theme-text-secondary)]">
-                    {part.sku ? `${part.sku} • ` : ""}Qty {part.quantitySuggestion} • {fitmentLabel(part.fitmentConfidence)}
+                    {part.sku ? `${part.sku} • ` : ""}Qty{" "}
+                    {part.quantitySuggestion} •{" "}
+                    {fitmentLabel(part.fitmentConfidence)}
                   </div>
                 </div>
-                <div className="text-[11px] text-[color:var(--theme-text-secondary)]">rank {Math.round(part.rankScore)}</div>
+                <div className="text-[11px] text-[color:var(--theme-text-secondary)]">
+                  rank {Math.round(part.rankScore)}
+                </div>
               </div>
-              <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">{part.reviewRecommendation}</div>
+              <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
+                {part.reviewRecommendation}
+              </div>
               {part.warnings.length > 0 ? (
                 <ul className="mt-2 space-y-1 text-xs text-amber-300">
                   {part.warnings.slice(0, 2).map((warning) => (
-                    <li key={`${part.candidateId}-${warning.type}`}>• {warning.message}</li>
+                    <li key={`${part.candidateId}-${warning.type}`}>
+                      • {warning.message}
+                    </li>
                   ))}
                 </ul>
               ) : null}
@@ -95,19 +215,26 @@ export default function AssistantResponseCard({ data }: Props) {
       ) : null}
 
       {data.relatedRecords && data.relatedRecords.length > 0 ? (
-        <div className="mt-4 space-y-2">
-          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">Related records</div>
-          {data.relatedRecords.slice(0, 6).map((record, i) => (
+        <div className="space-y-2">
+          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">
+            Related records
+          </div>
+          {data.relatedRecords.slice(0, 6).map((record, index) => (
             <div
-              key={`${record.label}-${record.href ?? i}`}
+              key={`${record.id ?? record.label}-${record.href ?? index}`}
               className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3"
             >
               {record.href ? (
-                <Link href={record.href} className="text-sm font-semibold text-orange-200 hover:text-orange-100">
+                <Link
+                  href={record.href}
+                  className="text-sm font-semibold text-orange-200 hover:text-orange-100"
+                >
                   {record.label}
                 </Link>
               ) : (
-                <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">{record.label}</div>
+                <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  {record.label}
+                </div>
               )}
               <div className="text-xs text-[color:var(--theme-text-secondary)]">
                 {record.type ? record.type.replaceAll("_", " ") : "record"}
@@ -116,28 +243,36 @@ export default function AssistantResponseCard({ data }: Props) {
           ))}
         </div>
       ) : data.notifications.length > 0 ? (
-        <div className="mt-4 space-y-2">
-          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">Related records</div>
-          {data.notifications.slice(0, 3).map((notification, i) => (
+        <div className="space-y-2">
+          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">
+            Related records
+          </div>
+          {data.notifications.slice(0, 3).map((notification, index) => (
             <div
-              key={`${notification.code}-${notification.entityId ?? i}`}
+              key={`${notification.code}-${notification.entityId ?? index}`}
               className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3"
             >
-              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">{notification.title}</div>
-              <div className="text-xs text-[color:var(--theme-text-secondary)]">{notification.message}</div>
+              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                {notification.title}
+              </div>
+              <div className="text-xs text-[color:var(--theme-text-secondary)]">
+                {notification.message}
+              </div>
             </div>
           ))}
         </div>
       ) : null}
 
       {data.actions.length > 0 ? (
-        <div className="mt-4">
-          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">Suggested next actions</div>
+        <div>
+          <div className="mb-2 text-xs text-[color:var(--theme-text-secondary)]">
+            Suggested next actions
+          </div>
           <div className="flex flex-wrap gap-2">
-            {data.actions.map((action, i) =>
+            {data.actions.map((action, index) =>
               action.kind === "planner" ? (
                 <Link
-                  key={`${action.label}-${i}`}
+                  key={`${action.label}-${index}`}
                   href={buildPlannerHref(action.plannerPayload)}
                   className="rounded-full border border-orange-400/40 bg-orange-500/10 px-3 py-1 text-xs text-orange-300"
                 >
@@ -145,7 +280,7 @@ export default function AssistantResponseCard({ data }: Props) {
                 </Link>
               ) : (
                 <Link
-                  key={`${action.href}-${i}`}
+                  key={`${action.href}-${index}`}
                   href={action.href}
                   className="rounded-full border border-orange-400/40 px-3 py-1 text-xs text-orange-300"
                 >

--- a/features/assistant/hooks/useAssistant.ts
+++ b/features/assistant/hooks/useAssistant.ts
@@ -2,14 +2,21 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { CanonicalPartSuggestion } from "@/features/parts/types/partSuggestions";
+import {
+  dedupeAssistantBullets,
+  dedupeAssistantText,
+} from "@/features/assistant/lib/assistantText";
 import type {
   AssistantAction,
   AssistantContext,
+  AssistantConversationMessage,
+  AssistantExecutionResult,
   AssistantNotification,
+  AssistantPendingAction,
   AssistantResponse,
 } from "../types/assistant";
-import type { CanonicalPartSuggestion } from "@/features/parts/types/partSuggestions";
 
 type AssistantError = {
   error: string;
@@ -40,6 +47,9 @@ type ApiEntity = {
   href?: string;
 };
 
+type ApiPendingAction = AssistantPendingAction;
+type ApiExecutionResult = AssistantExecutionResult;
+
 type ApiAnswer = {
   summary: string;
   bullets?: string[];
@@ -48,6 +58,9 @@ type ApiAnswer = {
   actions?: ApiAnswerAction[];
   partSuggestions?: CanonicalPartSuggestion[];
   intent?: string;
+  conversationId?: string;
+  pendingAction?: ApiPendingAction;
+  execution?: ApiExecutionResult;
   resolvedContext?: {
     workOrderId?: string;
     customerId?: string;
@@ -76,10 +89,26 @@ type AssistantSession = {
   lastIntent?: string;
 };
 
-type ConversationMessage = {
-  role: "user" | "assistant";
-  content: string;
+type ConversationResponse = {
+  ok: true;
+  conversation: {
+    id: string;
+    context?: Record<string, unknown>;
+    lastIntent?: string | null;
+  };
+  messages: AssistantConversationMessage[];
 };
+
+type ActionDecisionResponse =
+  | {
+      ok: true;
+      conversationId: string;
+      execution: AssistantExecutionResult;
+    }
+  | {
+      ok?: false;
+      error: string;
+    };
 
 function notificationLevelFromType(type?: string): AssistantNotification["level"] {
   if (type === "alert") return "warning";
@@ -121,12 +150,19 @@ function toPlannerPayload(
           ? context.vehicleId
           : fallbackContext?.vehicleId,
       customerQuery:
-        typeof context.customerQuery === "string" ? context.customerQuery : undefined,
-      plateOrVin: typeof context.plateOrVin === "string" ? context.plateOrVin : undefined,
+        typeof context.customerQuery === "string"
+          ? context.customerQuery
+          : undefined,
+      plateOrVin:
+        typeof context.plateOrVin === "string"
+          ? context.plateOrVin
+          : undefined,
       allowCreate:
         typeof context.allowCreate === "boolean" ? context.allowCreate : false,
       emailInvoiceTo:
-        typeof context.emailInvoiceTo === "string" ? context.emailInvoiceTo : undefined,
+        typeof context.emailInvoiceTo === "string"
+          ? context.emailInvoiceTo
+          : undefined,
       lane:
         context.lane === "parts_follow_up" ||
         context.lane === "low_inventory_reorder" ||
@@ -143,7 +179,12 @@ function toPlannerPayload(
   };
 }
 
-function mapAnswerToResponse(answer: ApiAnswer, context?: AssistantContext): AssistantResponse {
+function mapAnswerToResponse(
+  answer: ApiAnswer,
+  context?: AssistantContext,
+): AssistantResponse {
+  const summary = dedupeAssistantText(answer.summary);
+  const bullets = dedupeAssistantBullets(summary, answer.bullets ?? []);
   const actions: AssistantAction[] = (answer.actions ?? [])
     .map((action) => {
       if (action.type === "planner") {
@@ -165,97 +206,354 @@ function mapAnswerToResponse(answer: ApiAnswer, context?: AssistantContext): Ass
       type: "link",
     })),
     ...(answer.entities ?? []).map((item) => ({
+      id: item.id,
       label: item.label,
       href: item.href,
       type: item.type,
     })),
   ].slice(0, 8);
 
-  const notifications: AssistantNotification[] = relatedRecords.slice(0, 6).map((item, idx) => ({
-    level: notificationLevelFromType(item.type),
-    code: `record_${idx + 1}`,
-    title: item.label,
-    message: item.type ? `Related ${item.type.replaceAll("_", " ")}` : "Related record",
-    href: item.href,
-    entityType: item.type,
-  }));
+  const notifications: AssistantNotification[] = relatedRecords
+    .slice(0, 6)
+    .map((item, index) => ({
+      level: notificationLevelFromType(item.type),
+      code: `record_${index + 1}`,
+      title: item.label,
+      message: item.type
+        ? `Related ${item.type.replaceAll("_", " ")}`
+        : "Related record",
+      href: item.href,
+      entityType: item.type,
+      entityId: item.id,
+    }));
 
   return {
-    summary: answer.summary,
-    bullets: (answer.bullets ?? []).filter(Boolean).slice(0, 6),
+    summary,
+    bullets,
     actions,
     notifications,
     relatedRecords,
     partSuggestions: (answer.partSuggestions ?? []).slice(0, 5),
+    conversationId: answer.conversationId,
+    pendingAction: answer.pendingAction,
+    execution: answer.execution,
+  };
+}
+
+function transcriptContent(answer: ApiAnswer): string {
+  const summary = dedupeAssistantText(answer.summary);
+  return [summary, ...dedupeAssistantBullets(summary, answer.bullets ?? [])]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function appendUniqueMessage(
+  messages: AssistantConversationMessage[],
+  message: AssistantConversationMessage,
+): AssistantConversationMessage[] {
+  const comparable = dedupeAssistantText(message.content).toLowerCase();
+  const last = messages.at(-1);
+  if (
+    last?.role === message.role &&
+    dedupeAssistantText(last.content).toLowerCase() === comparable
+  ) {
+    return messages;
+  }
+  return [...messages, message].slice(-50);
+}
+
+function sessionFromConversation(
+  context: Record<string, unknown> | undefined,
+  lastIntent?: string | null,
+): AssistantSession {
+  return {
+    workOrderId:
+      typeof context?.workOrderId === "string" ? context.workOrderId : undefined,
+    customerId:
+      typeof context?.customerId === "string" ? context.customerId : undefined,
+    vehicleId:
+      typeof context?.vehicleId === "string" ? context.vehicleId : undefined,
+    bookingId:
+      typeof context?.bookingId === "string" ? context.bookingId : undefined,
+    fleetUnitId:
+      typeof context?.fleetUnitId === "string" ? context.fleetUnitId : undefined,
+    lastIntent: lastIntent ?? undefined,
   };
 }
 
 export function useAssistant(resetKey?: string) {
+  const storageKey = `profixiq:shop-assistant:conversation:${resetKey ?? "global"}`;
   const [loading, setLoading] = useState(false);
+  const [hydrating, setHydrating] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [data, setData] = useState<AssistantResponse | AssistantError | null>(null);
   const [session, setSession] = useState<AssistantSession>({});
-  const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [messages, setMessages] = useState<AssistantConversationMessage[]>([]);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+
+  const messagesRef = useRef<AssistantConversationMessage[]>([]);
+  const sessionRef = useRef<AssistantSession>({});
+  const conversationIdRef = useRef<string | null>(null);
+  const requestInFlight = useRef(false);
+
+  const replaceMessages = useCallback(
+    (
+      next:
+        | AssistantConversationMessage[]
+        | ((current: AssistantConversationMessage[]) => AssistantConversationMessage[]),
+    ) => {
+      setMessages((current) => {
+        const value = typeof next === "function" ? next(current) : next;
+        messagesRef.current = value;
+        return value;
+      });
+    },
+    [],
+  );
+
+  const replaceSession = useCallback(
+    (next: AssistantSession | ((current: AssistantSession) => AssistantSession)) => {
+      setSession((current) => {
+        const value = typeof next === "function" ? next(current) : next;
+        sessionRef.current = value;
+        return value;
+      });
+    },
+    [],
+  );
+
+  const rememberConversation = useCallback(
+    (id: string | null) => {
+      conversationIdRef.current = id;
+      setConversationId(id);
+      if (typeof window === "undefined") return;
+      if (id) window.localStorage.setItem(storageKey, id);
+      else window.localStorage.removeItem(storageKey);
+    },
+    [storageKey],
+  );
 
   useEffect(() => {
-    setData(null);
-    setSession({});
-    setMessages([]);
-  }, [resetKey]);
+    let cancelled = false;
+    const controller = new AbortController();
 
-  async function ask(query: string, context?: AssistantContext) {
-    setLoading(true);
-    setData(null);
-    const conversation = messages
-      .concat({ role: "user", content: query })
-      .slice(-19);
-    setMessages(conversation);
+    const storedId =
+      typeof window !== "undefined" ? window.localStorage.getItem(storageKey) : null;
 
-    try {
-      const res = await fetch("/api/assistant/answer", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          question: query,
-          context,
-          session,
-          messages: conversation,
-        }),
+    setData(null);
+    replaceSession({});
+    replaceMessages([]);
+    conversationIdRef.current = null;
+    setConversationId(null);
+    if (!storedId) {
+      setHydrating(false);
+      return () => {
+        cancelled = true;
+        controller.abort();
+      };
+    }
+
+    setHydrating(true);
+    void fetch(`/api/assistant/conversations/${encodeURIComponent(storedId)}`, {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Conversation unavailable");
+        return (await response.json()) as ConversationResponse;
+      })
+      .then((json) => {
+        if (cancelled || !json.ok) return;
+        rememberConversation(json.conversation.id);
+        replaceMessages(json.messages.slice(-50));
+        replaceSession(
+          sessionFromConversation(
+            json.conversation.context,
+            json.conversation.lastIntent,
+          ),
+        );
+      })
+      .catch((error: unknown) => {
+        if (cancelled || (error instanceof DOMException && error.name === "AbortError")) {
+          return;
+        }
+        window.localStorage.removeItem(storageKey);
+      })
+      .finally(() => {
+        if (!cancelled) setHydrating(false);
       });
 
-      const json = (await res.json()) as AskResponse;
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [rememberConversation, replaceMessages, replaceSession, storageKey]);
 
-      if (!res.ok || !json.ok) {
-        setData({ error: json.ok ? "Assistant request failed" : json.error });
-        return;
+  const ask = useCallback(
+    async (query: string, context?: AssistantContext) => {
+      const question = query.trim();
+      if (!question || requestInFlight.current) return;
+
+      requestInFlight.current = true;
+      setLoading(true);
+      setData(null);
+
+      const requestId = crypto.randomUUID();
+      const optimisticUserMessage: AssistantConversationMessage = {
+        id: requestId,
+        role: "user",
+        content: question,
+        createdAt: new Date().toISOString(),
+      };
+      const conversation = appendUniqueMessage(
+        messagesRef.current,
+        optimisticUserMessage,
+      );
+      replaceMessages(conversation);
+
+      try {
+        const response = await fetch("/api/assistant/answer", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            question,
+            surface: "shop",
+            conversationId: conversationIdRef.current,
+            clientRequestId: requestId,
+            context,
+            session: sessionRef.current,
+            messages: conversation.slice(-20).map(({ role, content }) => ({
+              role,
+              content,
+            })),
+          }),
+        });
+
+        const json = (await response.json()) as AskResponse;
+        if (!response.ok || !json.ok) {
+          setData({
+            error: json.ok ? "Assistant request failed" : json.error,
+          });
+          return;
+        }
+
+        if (json.answer.conversationId) {
+          rememberConversation(json.answer.conversationId);
+        }
+
+        replaceSession((previous) => ({
+          ...previous,
+          ...json.answer.resolvedContext,
+          lastIntent: json.answer.intent,
+        }));
+
+        setData(mapAnswerToResponse(json.answer, context));
+        replaceMessages((current) =>
+          appendUniqueMessage(current, {
+            id: `${requestId}:assistant`,
+            role: "assistant",
+            content: transcriptContent(json.answer),
+            createdAt: new Date().toISOString(),
+          }),
+        );
+      } catch {
+        setData({ error: "Failed to fetch" });
+      } finally {
+        requestInFlight.current = false;
+        setLoading(false);
       }
+    },
+    [rememberConversation, replaceMessages, replaceSession],
+  );
 
-      const nextContext = json.answer.resolvedContext;
-      setSession((prev) => ({
-        ...prev,
-        ...nextContext,
-        lastIntent: json.answer.intent,
-      }));
+  const decideAction = useCallback(
+    async (actionId: string, decision: "confirm" | "cancel") => {
+      if (actionLoading) return;
+      setActionLoading(actionId);
 
-      setData(mapAnswerToResponse(json.answer, context));
-      const nextMessages = conversation.concat({
-          role: "assistant",
-          content: [json.answer.summary, ...(json.answer.bullets ?? [])]
-            .filter(Boolean)
-            .join("\n"),
-        }).slice(-20);
-      setMessages(nextMessages);
-    } catch {
-      setData({ error: "Failed to fetch" });
-    } finally {
-      setLoading(false);
-    }
-  }
+      try {
+        const response = await fetch(
+          `/api/assistant/actions/${encodeURIComponent(actionId)}`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ decision }),
+          },
+        );
+        const json = (await response.json()) as ActionDecisionResponse;
+        if (!response.ok || !json.ok) {
+          setData({ error: "error" in json ? json.error : "Action request failed" });
+          return;
+        }
 
-  function clearConversation() {
+        rememberConversation(json.conversationId);
+        setData((current) => {
+          const base = current && !("error" in current) ? current : null;
+          return {
+            summary: json.execution.summary,
+            bullets: json.execution.details,
+            actions: base?.actions ?? [],
+            notifications: base?.notifications ?? [],
+            relatedRecords: json.execution.affectedRecords,
+            partSuggestions: base?.partSuggestions,
+            conversationId: json.conversationId,
+            execution: json.execution,
+          };
+        });
+        replaceMessages((current) =>
+          appendUniqueMessage(current, {
+            id: `action:${actionId}:${json.execution.status}`,
+            role: "assistant",
+            content: [
+              json.execution.summary,
+              ...json.execution.details,
+            ].join("\n"),
+            createdAt: new Date().toISOString(),
+          }),
+        );
+      } catch {
+        setData({ error: "Failed to process the assistant action" });
+      } finally {
+        setActionLoading(null);
+      }
+    },
+    [actionLoading, rememberConversation, replaceMessages],
+  );
+
+  const confirmAction = useCallback(
+    (actionId: string) => decideAction(actionId, "confirm"),
+    [decideAction],
+  );
+
+  const cancelAction = useCallback(
+    (actionId: string) => decideAction(actionId, "cancel"),
+    [decideAction],
+  );
+
+  const clearConversation = useCallback(async () => {
+    const id = conversationIdRef.current;
     setData(null);
-    setSession({});
-    setMessages([]);
-  }
+    replaceSession({});
+    replaceMessages([]);
+    rememberConversation(null);
 
-  return { ask, loading, data, messages, clearConversation };
+    if (!id) return;
+    await fetch(`/api/assistant/conversations/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    }).catch(() => undefined);
+  }, [rememberConversation, replaceMessages, replaceSession]);
+
+  return {
+    ask,
+    loading,
+    hydrating,
+    actionLoading,
+    data,
+    session,
+    messages,
+    conversationId,
+    confirmAction,
+    cancelAction,
+    clearConversation,
+  };
 }

--- a/features/assistant/lib/assistantText.ts
+++ b/features/assistant/lib/assistantText.ts
@@ -1,0 +1,84 @@
+import type { AssistantAnswer } from "@/features/agent/assistant/types";
+
+function normalizeComparable(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[•*_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/[.!?]+$/g, "")
+    .trim();
+}
+
+function splitSentences(value: string): string[] {
+  return value
+    .split(/(?<=[.!?])\s+(?=[A-Z0-9])/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function collapseRepeatedHalf(value: string): string {
+  const words = value.split(/\s+/).filter(Boolean);
+  if (words.length < 10 || words.length % 2 !== 0) return value;
+
+  const midpoint = words.length / 2;
+  const first = words.slice(0, midpoint).join(" ");
+  const second = words.slice(midpoint).join(" ");
+  return normalizeComparable(first) === normalizeComparable(second) ? first : value;
+}
+
+export function dedupeAssistantText(value: string): string {
+  const compact = collapseRepeatedHalf(value.replace(/\s+/g, " ").trim());
+  const sentences = splitSentences(compact);
+  if (sentences.length <= 1) return compact;
+
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const sentence of sentences) {
+    const key = normalizeComparable(sentence);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    unique.push(sentence);
+  }
+
+  return unique.join(" ").trim();
+}
+
+export function dedupeAssistantBullets(
+  summary: string,
+  bullets: string[],
+  limit = 6,
+): string[] {
+  const summaryKey = normalizeComparable(summary);
+  const seen = new Set<string>();
+  const unique: string[] = [];
+
+  for (const raw of bullets) {
+    const bullet = dedupeAssistantText(raw);
+    const key = normalizeComparable(bullet);
+    if (!key || key === summaryKey || seen.has(key)) continue;
+    seen.add(key);
+    unique.push(bullet);
+    if (unique.length >= limit) break;
+  }
+
+  return unique;
+}
+
+export function normalizeShopAssistantAnswer(
+  answer: AssistantAnswer,
+): AssistantAnswer {
+  const summary = dedupeAssistantText(answer.summary);
+  const bullets = dedupeAssistantBullets(summary, answer.bullets ?? []);
+
+  return {
+    ...answer,
+    summary,
+    bullets,
+  };
+}
+
+export function assistantAnswerTranscriptText(answer: AssistantAnswer): string {
+  return [answer.summary, ...dedupeAssistantBullets(answer.summary, answer.bullets)]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/features/assistant/server/handleShopAssistantRequest.ts
+++ b/features/assistant/server/handleShopAssistantRequest.ts
@@ -1,0 +1,219 @@
+import { randomUUID } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { answerAssistant } from "@/features/agent/assistant/server/answerAssistant";
+import type {
+  AssistantAnswer,
+  AssistantAskRequest,
+} from "@/features/agent/assistant/types";
+import { asShopAssistantClient } from "./shopAssistantDatabase";
+import { classifyShopAssistantIntent } from "./shopAssistantIntent";
+import {
+  appendAssistantMessage,
+  createAssistantActionRequest,
+  ensureAssistantConversation,
+  listAssistantMessages,
+  stableHash,
+  toPendingAssistantAction,
+  updateAssistantConversationState,
+} from "./shopAssistantPersistence";
+import {
+  assistantAnswerTranscriptText,
+  normalizeShopAssistantAnswer,
+} from "@/features/assistant/lib/assistantText";
+
+function resolvedRequestContext(request: AssistantAskRequest) {
+  return {
+    workOrderId: request.context?.workOrderId ?? request.session?.workOrderId,
+    customerId: request.context?.customerId ?? request.session?.customerId,
+    vehicleId: request.context?.vehicleId ?? request.session?.vehicleId,
+    bookingId: request.context?.bookingId ?? request.session?.bookingId,
+    fleetUnitId: request.context?.fleetUnitId ?? request.session?.fleetUnitId,
+  };
+}
+
+function contextRecord(request: AssistantAskRequest): Record<string, unknown> {
+  return {
+    ...resolvedRequestContext(request),
+    pageType: request.context?.pageType,
+    pageTitle: request.context?.pageTitle,
+  };
+}
+
+function actionRequestAnswer(params: {
+  conversationId: string;
+  summary: string;
+  pendingAction: NonNullable<AssistantAnswer["pendingAction"]>;
+  request: AssistantAskRequest;
+}): AssistantAnswer {
+  return {
+    intent: "action_request",
+    summary: params.summary,
+    bullets: [
+      "Nothing changes until you confirm.",
+      "Your role and shop scope will be checked again at execution time.",
+    ],
+    links: [],
+    entities: [],
+    actions: [],
+    resolvedContext: resolvedRequestContext(params.request),
+    conversationId: params.conversationId,
+    pendingAction: params.pendingAction,
+  };
+}
+
+function clarificationAnswer(params: {
+  conversationId: string;
+  summary: string;
+  plannerGoal?: string;
+  request: AssistantAskRequest;
+}): AssistantAnswer {
+  return {
+    intent: "action_request",
+    summary: params.summary,
+    bullets: [],
+    links: [],
+    entities: [],
+    actions: params.plannerGoal
+      ? [
+          {
+            type: "planner",
+            label: "Review in Planner",
+            goal: params.plannerGoal,
+            context: {
+              planner: "ops",
+              ...resolvedRequestContext(params.request),
+            },
+          },
+        ]
+      : [],
+    resolvedContext: resolvedRequestContext(params.request),
+    conversationId: params.conversationId,
+  };
+}
+
+export async function handleShopAssistantRequest(params: {
+  supabase: SupabaseClient;
+  shopId: string;
+  userId: string;
+  role: string | null;
+  request: AssistantAskRequest;
+}): Promise<AssistantAnswer> {
+  const client = asShopAssistantClient(params.supabase);
+  const requestId = params.request.clientRequestId?.trim() || randomUUID();
+  const conversation = await ensureAssistantConversation(client, {
+    conversationId: params.request.conversationId,
+    shopId: params.shopId,
+    userId: params.userId,
+    context: contextRecord(params.request),
+    firstQuestion: params.request.question,
+  });
+
+  await appendAssistantMessage(client, {
+    conversationId: conversation.id,
+    shopId: params.shopId,
+    userId: params.userId,
+    role: "user",
+    content: params.request.question,
+    requestId,
+    payload: { context: contextRecord(params.request) },
+  });
+
+  const history = await listAssistantMessages(client, {
+    conversationId: conversation.id,
+    shopId: params.shopId,
+    userId: params.userId,
+    limit: 30,
+  });
+
+  const intent = classifyShopAssistantIntent(
+    params.request.question,
+    params.request.context,
+  );
+
+  let answer: AssistantAnswer;
+
+  if (intent.kind === "action") {
+    const actionRequest = await createAssistantActionRequest(client, {
+      conversationId: conversation.id,
+      shopId: params.shopId,
+      userId: params.userId,
+      toolName: intent.toolName,
+      domain: intent.domain,
+      label: intent.label,
+      summary: intent.summary,
+      riskLevel: intent.riskLevel,
+      input: intent.input,
+      idempotencyKey: stableHash(
+        params.shopId,
+        params.userId,
+        requestId,
+        intent.toolName,
+        JSON.stringify(intent.input),
+      ),
+    });
+
+    const pendingAction = toPendingAssistantAction(actionRequest);
+    answer = actionRequestAnswer({
+      conversationId: conversation.id,
+      summary: `I recognized this as an action: ${intent.summary} Review it below before I make the change.`,
+      pendingAction,
+      request: params.request,
+    });
+  } else if (intent.kind === "clarification") {
+    answer = clarificationAnswer({
+      conversationId: conversation.id,
+      summary: intent.summary,
+      plannerGoal: intent.plannerGoal,
+      request: params.request,
+    });
+  } else {
+    const rawAnswer = await answerAssistant({
+      shopId: params.shopId,
+      userId: params.userId,
+      role: params.role,
+      request: {
+        ...params.request,
+        surface: "shop",
+        conversationId: conversation.id,
+        clientRequestId: requestId,
+        messages: history.slice(-20).map(({ role, content }) => ({
+          role,
+          content,
+        })),
+      },
+    });
+
+    answer = normalizeShopAssistantAnswer({
+      ...rawAnswer,
+      conversationId: conversation.id,
+    });
+  }
+
+  await appendAssistantMessage(client, {
+    conversationId: conversation.id,
+    shopId: params.shopId,
+    userId: params.userId,
+    role: "assistant",
+    content: assistantAnswerTranscriptText(answer),
+    requestId,
+    payload: {
+      intent: answer.intent,
+      pendingAction: answer.pendingAction,
+      execution: answer.execution,
+      resolvedContext: answer.resolvedContext,
+    },
+  });
+
+  await updateAssistantConversationState(client, {
+    conversationId: conversation.id,
+    shopId: params.shopId,
+    userId: params.userId,
+    context: {
+      ...contextRecord(params.request),
+      ...answer.resolvedContext,
+    },
+    lastIntent: answer.intent,
+  });
+
+  return answer;
+}

--- a/features/assistant/server/shopAssistantActionExecutor.ts
+++ b/features/assistant/server/shopAssistantActionExecutor.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import type {
+  AssistantEntity,
+  AssistantExecutionResult,
+} from "@/features/agent/assistant/types";
+import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import type { Json } from "@shared/types/types/supabase";
+import type { ShopAssistantSupabaseClient } from "./shopAssistantDatabase";
+
+const SetWorkOrderHoldInput = z.object({
+  workOrderReference: z.string().trim().min(1).max(100),
+  reason: z.string().trim().min(3).max(240),
+});
+
+function asRecord(value: Json | null): Record<string, Json | undefined> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, Json | undefined>)
+    : {};
+}
+
+function stringValue(
+  record: Record<string, Json | undefined>,
+  key: string,
+): string | null {
+  const value = record[key];
+  return typeof value === "string" ? value : null;
+}
+
+function numberValue(
+  record: Record<string, Json | undefined>,
+  key: string,
+): number | null {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export async function executeShopAssistantAction(params: {
+  client: ShopAssistantSupabaseClient;
+  actionId: string;
+  shopId: string;
+  profileId: string;
+  role: string | null;
+  toolName: string;
+  input: Json;
+}): Promise<AssistantExecutionResult> {
+  const actor = getActorCapabilities({ role: params.role });
+
+  if (params.toolName === "set_work_order_hold") {
+    if (!actor.canManageWorkOrders) {
+      throw new Error("Your role cannot place shop work orders on hold.");
+    }
+
+    const input = SetWorkOrderHoldInput.parse(params.input);
+    const { data, error } = await params.client.rpc(
+      "assistant_set_work_order_hold",
+      {
+        p_shop_id: params.shopId,
+        p_actor_profile_id: params.profileId,
+        p_work_order_reference: input.workOrderReference,
+        p_reason: input.reason,
+      },
+    );
+
+    if (error) throw new Error(error.message);
+
+    const result = asRecord(data);
+    const workOrderId = stringValue(result, "work_order_id");
+    const reference =
+      stringValue(result, "work_order_reference") ?? input.workOrderReference;
+    const affectedLineCount = numberValue(result, "affected_line_count") ?? 0;
+    const affectedRecords: AssistantEntity[] = workOrderId
+      ? [
+          {
+            type: "work_order",
+            id: workOrderId,
+            label: `WO #${reference}`,
+            href: `/work-orders/${workOrderId}`,
+          },
+        ]
+      : [];
+
+    return {
+      actionId: params.actionId,
+      toolName: params.toolName,
+      status: "succeeded",
+      summary: `WO #${reference} is now on hold for ${input.reason.toLowerCase()}.`,
+      details: [
+        `${affectedLineCount} active line${affectedLineCount === 1 ? " was" : "s were"} placed on hold.`,
+        "The change was recorded in the shop audit log.",
+      ],
+      affectedRecords,
+    };
+  }
+
+  throw new Error(`Unsupported assistant tool: ${params.toolName}`);
+}

--- a/features/assistant/server/shopAssistantDatabase.ts
+++ b/features/assistant/server/shopAssistantDatabase.ts
@@ -1,0 +1,166 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Json } from "@shared/types/types/supabase";
+
+export type AssistantConversationRow = {
+  id: string;
+  shop_id: string;
+  user_id: string;
+  title: string | null;
+  context: Json;
+  last_intent: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AssistantMessageRow = {
+  id: string;
+  conversation_id: string;
+  shop_id: string;
+  user_id: string;
+  role: "user" | "assistant";
+  content: string;
+  payload: Json;
+  message_key: string;
+  created_at: string;
+};
+
+export type AssistantActionRequestStatus =
+  | "pending"
+  | "executing"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "expired";
+
+export type AssistantActionRequestRow = {
+  id: string;
+  conversation_id: string;
+  shop_id: string;
+  requested_by: string;
+  confirmed_by: string | null;
+  tool_name: string;
+  domain: string;
+  label: string;
+  summary: string;
+  risk_level: "low" | "medium" | "high";
+  input: Json;
+  result: Json | null;
+  error_message: string | null;
+  status: AssistantActionRequestStatus;
+  idempotency_key: string;
+  expires_at: string;
+  confirmed_at: string | null;
+  executed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type AssistantPersistenceDatabase = {
+  public: {
+    Tables: {
+      assistant_conversations: {
+        Row: AssistantConversationRow;
+        Insert: {
+          id?: string;
+          shop_id: string;
+          user_id: string;
+          title?: string | null;
+          context?: Json;
+          last_intent?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<
+          Pick<
+            AssistantConversationRow,
+            "title" | "context" | "last_intent" | "updated_at"
+          >
+        >;
+        Relationships: [];
+      };
+      assistant_messages: {
+        Row: AssistantMessageRow;
+        Insert: {
+          id?: string;
+          conversation_id: string;
+          shop_id: string;
+          user_id: string;
+          role: "user" | "assistant";
+          content: string;
+          payload?: Json;
+          message_key: string;
+          created_at?: string;
+        };
+        Update: never;
+        Relationships: [];
+      };
+      assistant_action_requests: {
+        Row: AssistantActionRequestRow;
+        Insert: {
+          id?: string;
+          conversation_id: string;
+          shop_id: string;
+          requested_by: string;
+          confirmed_by?: string | null;
+          tool_name: string;
+          domain: string;
+          label: string;
+          summary: string;
+          risk_level?: "low" | "medium" | "high";
+          input?: Json;
+          result?: Json | null;
+          error_message?: string | null;
+          status?: AssistantActionRequestStatus;
+          idempotency_key: string;
+          expires_at?: string;
+          confirmed_at?: string | null;
+          executed_at?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<
+          Pick<
+            AssistantActionRequestRow,
+            | "confirmed_by"
+            | "result"
+            | "error_message"
+            | "status"
+            | "expires_at"
+            | "confirmed_at"
+            | "executed_at"
+            | "updated_at"
+          >
+        >;
+        Relationships: [];
+      };
+    };
+    Views: Record<string, never>;
+    Functions: {
+      assistant_set_work_order_hold: {
+        Args: {
+          p_shop_id: string;
+          p_actor_profile_id: string;
+          p_work_order_reference: string;
+          p_reason: string;
+        };
+        Returns: Json;
+      };
+    };
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+};
+
+export type ShopAssistantSupabaseClient =
+  SupabaseClient<AssistantPersistenceDatabase>;
+
+/**
+ * The migration and this narrow database overlay are kept together until the
+ * next generated Supabase type refresh. It avoids weakening the application-wide
+ * client type while allowing the newly added assistant tables to be used safely.
+ */
+export function asShopAssistantClient(
+  client: unknown,
+): ShopAssistantSupabaseClient {
+  return client as ShopAssistantSupabaseClient;
+}

--- a/features/assistant/server/shopAssistantIntent.ts
+++ b/features/assistant/server/shopAssistantIntent.ts
@@ -1,0 +1,143 @@
+import type { AssistantAskContext } from "@/features/agent/assistant/types";
+
+export type ShopAssistantActionIntent = {
+  kind: "action";
+  domain: "work_orders";
+  toolName: "set_work_order_hold";
+  label: string;
+  summary: string;
+  riskLevel: "medium";
+  input: {
+    workOrderReference: string;
+    reason: string;
+  };
+};
+
+export type ShopAssistantIntent =
+  | ShopAssistantActionIntent
+  | { kind: "query" }
+  | {
+      kind: "clarification";
+      domain: string;
+      summary: string;
+      plannerGoal?: string;
+    };
+
+const INFORMATIONAL_PREFIX =
+  /^(what|which|who|when|where|why|how|show|list|find|tell|is|are|do|does|did|can i see|give me)\b/i;
+const ACTION_PREFIX =
+  /^(please\s+)?(can you\s+|could you\s+|will you\s+|would you\s+)?(put|place|mark|set|hold|pause|create|add|send|email|message|text|reschedule|schedule|book|move|assign|approve|reject|decline|order|receive|invoice|complete|close|cancel|update|change|remove|release)\b/i;
+
+function normalizeQuestion(question: string): string {
+  return question.replace(/\s+/g, " ").trim();
+}
+
+function looksLikeHoldAction(question: string): boolean {
+  const q = normalizeQuestion(question);
+  if (!q || INFORMATIONAL_PREFIX.test(q)) return false;
+
+  const hasImperative =
+    /^(please\s+)?(can you\s+|could you\s+|will you\s+|would you\s+)?(put|place|mark|set|hold|pause)\b/i.test(
+      q,
+    );
+  const hasHoldLanguage = /\b(on\s+hold|hold\s+for|hold\s+until|pause)\b/i.test(q);
+  return hasImperative && hasHoldLanguage;
+}
+
+function extractWorkOrderReference(question: string): string | null {
+  const explicit = question.match(
+    /\b(?:work\s*order|wo)\s*#?\s*([a-z0-9][a-z0-9-]{2,})\b/i,
+  )?.[1];
+  if (explicit) return explicit.toUpperCase();
+
+  const hash = question.match(/#\s*([a-z]{1,6}\d{3,}|[0-9a-f-]{36})\b/i)?.[1];
+  if (hash) return hash.toUpperCase();
+
+  const customId = question.match(/\b([a-z]{1,6}\d{3,})\b/i)?.[1];
+  return customId ? customId.toUpperCase() : null;
+}
+
+function extractHoldReason(question: string): string {
+  const q = question.toLowerCase();
+  if (/\b(parts?|part order|backorder|backordered)\b/.test(q)) {
+    return "Awaiting parts";
+  }
+  if (/\b(customer|authorization|authorisation|approval)\b/.test(q)) {
+    return "Awaiting customer authorization";
+  }
+  if (/\b(additional info|more info|information)\b/.test(q)) {
+    return "Need additional info";
+  }
+  if (/\bassist|assistance|foreman|lead hand\b/.test(q)) {
+    return "Hold for assistance";
+  }
+
+  const custom = question.match(/\b(?:on\s+hold|hold)\s+for\s+(.+?)(?:[.!?]|$)/i)?.[1];
+  if (custom?.trim()) {
+    const normalized = custom.trim();
+    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  }
+
+  return "Operational hold";
+}
+
+function actionDomain(question: string): string {
+  const q = question.toLowerCase();
+  if (/\b(appointment|booking|schedule|reschedule)\b/.test(q)) return "scheduling";
+  if (/\b(part|inventory|purchase order|po\b|receive)\b/.test(q)) return "inventory";
+  if (/\b(message|email|text|notify|call customer)\b/.test(q)) return "messaging";
+  if (/\b(customer|vehicle)\b/.test(q)) return "customers";
+  if (/\b(inspection|dvi)\b/.test(q)) return "inspections";
+  if (/\b(invoice|payment|estimate|quote|approval)\b/.test(q)) return "invoices";
+  if (/\b(technician|tech|employee|shift|workforce|assign)\b/.test(q)) return "workforce";
+  return "work_orders";
+}
+
+export function classifyShopAssistantIntent(
+  question: string,
+  context?: AssistantAskContext,
+): ShopAssistantIntent {
+  const normalized = normalizeQuestion(question);
+
+  if (looksLikeHoldAction(normalized)) {
+    const reference =
+      extractWorkOrderReference(normalized) ?? context?.workOrderId ?? null;
+
+    if (!reference) {
+      return {
+        kind: "clarification",
+        domain: "work_orders",
+        summary:
+          "I recognized a request to place a work order on hold. Which work order should I use?",
+      };
+    }
+
+    const reason = extractHoldReason(normalized);
+    const displayReference = extractWorkOrderReference(normalized) ?? "the current work order";
+    return {
+      kind: "action",
+      domain: "work_orders",
+      toolName: "set_work_order_hold",
+      label: `Place ${displayReference} on hold`,
+      summary: `Place ${displayReference} on hold with the reason “${reason}”.`,
+      riskLevel: "medium",
+      input: {
+        workOrderReference: reference,
+        reason,
+      },
+    };
+  }
+
+  if (ACTION_PREFIX.test(normalized) && !INFORMATIONAL_PREFIX.test(normalized)) {
+    const domain = actionDomain(normalized);
+    return {
+      kind: "clarification",
+      domain,
+      summary:
+        "I recognized this as an action request, so I will not answer it as a status question. This action needs a supported, reviewable tool before it can run.",
+      plannerGoal: normalized,
+    };
+  }
+
+  return { kind: "query" };
+}

--- a/features/assistant/server/shopAssistantPersistence.ts
+++ b/features/assistant/server/shopAssistantPersistence.ts
@@ -1,0 +1,359 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { Json } from "@shared/types/types/supabase";
+import type {
+  AssistantActionRisk,
+  AssistantConversationMessage,
+  AssistantPendingAction,
+} from "@/features/agent/assistant/types";
+import type {
+  AssistantActionRequestRow,
+  AssistantConversationRow,
+  AssistantMessageRow,
+  ShopAssistantSupabaseClient,
+} from "./shopAssistantDatabase";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type PersistedConversationMessage = AssistantConversationMessage & {
+  id: string;
+  createdAt: string;
+};
+
+export function stableHash(...parts: string[]): string {
+  return createHash("sha256").update(parts.join("\u001f")).digest("hex");
+}
+
+function isUuid(value: string | null | undefined): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+function asJson(value: Record<string, unknown> | undefined): Json {
+  return (value ?? {}) as Json;
+}
+
+function defaultConversationTitle(question?: string): string | null {
+  const normalized = question?.replace(/\s+/g, " ").trim();
+  if (!normalized) return null;
+  return normalized.length > 72 ? `${normalized.slice(0, 69)}...` : normalized;
+}
+
+export async function ensureAssistantConversation(
+  client: ShopAssistantSupabaseClient,
+  params: {
+    conversationId?: string;
+    shopId: string;
+    userId: string;
+    context?: Record<string, unknown>;
+    firstQuestion?: string;
+  },
+): Promise<AssistantConversationRow> {
+  if (isUuid(params.conversationId)) {
+    const { data: existing, error } = await client
+      .from("assistant_conversations")
+      .select("*")
+      .eq("id", params.conversationId)
+      .eq("shop_id", params.shopId)
+      .eq("user_id", params.userId)
+      .maybeSingle();
+
+    if (error) throw new Error(error.message);
+    if (existing) {
+      const nextContext = asJson(params.context);
+      const { data: updated, error: updateError } = await client
+        .from("assistant_conversations")
+        .update({ context: nextContext, updated_at: new Date().toISOString() })
+        .eq("id", existing.id)
+        .eq("shop_id", params.shopId)
+        .eq("user_id", params.userId)
+        .select("*")
+        .single();
+
+      if (updateError) throw new Error(updateError.message);
+      return updated;
+    }
+  }
+
+  const { data, error } = await client
+    .from("assistant_conversations")
+    .insert({
+      id: randomUUID(),
+      shop_id: params.shopId,
+      user_id: params.userId,
+      title: defaultConversationTitle(params.firstQuestion),
+      context: asJson(params.context),
+    })
+    .select("*")
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function loadAssistantConversation(
+  client: ShopAssistantSupabaseClient,
+  params: { conversationId: string; shopId: string; userId: string },
+): Promise<AssistantConversationRow | null> {
+  if (!isUuid(params.conversationId)) return null;
+
+  const { data, error } = await client
+    .from("assistant_conversations")
+    .select("*")
+    .eq("id", params.conversationId)
+    .eq("shop_id", params.shopId)
+    .eq("user_id", params.userId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function updateAssistantConversationState(
+  client: ShopAssistantSupabaseClient,
+  params: {
+    conversationId: string;
+    shopId: string;
+    userId: string;
+    context?: Record<string, unknown>;
+    lastIntent?: string;
+  },
+): Promise<void> {
+  const { error } = await client
+    .from("assistant_conversations")
+    .update({
+      context: asJson(params.context),
+      last_intent: params.lastIntent ?? null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", params.conversationId)
+    .eq("shop_id", params.shopId)
+    .eq("user_id", params.userId);
+
+  if (error) throw new Error(error.message);
+}
+
+export async function appendAssistantMessage(
+  client: ShopAssistantSupabaseClient,
+  params: {
+    conversationId: string;
+    shopId: string;
+    userId: string;
+    role: "user" | "assistant";
+    content: string;
+    requestId: string;
+    payload?: Record<string, unknown>;
+  },
+): Promise<AssistantMessageRow> {
+  const content = params.content.replace(/\s+$/g, "").trim();
+  if (!content) throw new Error("Assistant message content is required");
+
+  const messageKey = stableHash(
+    params.conversationId,
+    params.role,
+    params.requestId,
+  );
+
+  const { data, error } = await client
+    .from("assistant_messages")
+    .upsert(
+      {
+        conversation_id: params.conversationId,
+        shop_id: params.shopId,
+        user_id: params.userId,
+        role: params.role,
+        content,
+        payload: asJson(params.payload),
+        message_key: messageKey,
+      },
+      {
+        onConflict: "conversation_id,message_key",
+        ignoreDuplicates: true,
+      },
+    )
+    .select("*")
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (data) return data;
+
+  const { data: existing, error: existingError } = await client
+    .from("assistant_messages")
+    .select("*")
+    .eq("conversation_id", params.conversationId)
+    .eq("message_key", messageKey)
+    .single();
+
+  if (existingError) throw new Error(existingError.message);
+  return existing;
+}
+
+export async function listAssistantMessages(
+  client: ShopAssistantSupabaseClient,
+  params: {
+    conversationId: string;
+    shopId: string;
+    userId: string;
+    limit?: number;
+  },
+): Promise<PersistedConversationMessage[]> {
+  const limit = Math.max(1, Math.min(params.limit ?? 40, 80));
+  const { data, error } = await client
+    .from("assistant_messages")
+    .select("id, role, content, created_at")
+    .eq("conversation_id", params.conversationId)
+    .eq("shop_id", params.shopId)
+    .eq("user_id", params.userId)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(error.message);
+
+  return (data ?? [])
+    .slice()
+    .reverse()
+    .map((message) => ({
+      id: message.id,
+      role: message.role,
+      content: message.content,
+      createdAt: message.created_at,
+    }));
+}
+
+export async function deleteAssistantConversation(
+  client: ShopAssistantSupabaseClient,
+  params: { conversationId: string; shopId: string; userId: string },
+): Promise<boolean> {
+  if (!isUuid(params.conversationId)) return false;
+
+  const { data, error } = await client
+    .from("assistant_conversations")
+    .delete()
+    .eq("id", params.conversationId)
+    .eq("shop_id", params.shopId)
+    .eq("user_id", params.userId)
+    .select("id")
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return Boolean(data);
+}
+
+export async function createAssistantActionRequest(
+  client: ShopAssistantSupabaseClient,
+  params: {
+    conversationId: string;
+    shopId: string;
+    userId: string;
+    toolName: string;
+    domain: string;
+    label: string;
+    summary: string;
+    riskLevel: AssistantActionRisk;
+    input: Record<string, unknown>;
+    idempotencyKey: string;
+  },
+): Promise<AssistantActionRequestRow> {
+  const { data, error } = await client
+    .from("assistant_action_requests")
+    .upsert(
+      {
+        conversation_id: params.conversationId,
+        shop_id: params.shopId,
+        requested_by: params.userId,
+        tool_name: params.toolName,
+        domain: params.domain,
+        label: params.label,
+        summary: params.summary,
+        risk_level: params.riskLevel,
+        input: asJson(params.input),
+        idempotency_key: params.idempotencyKey,
+      },
+      { onConflict: "shop_id,idempotency_key", ignoreDuplicates: true },
+    )
+    .select("*")
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (data) return data;
+
+  const { data: existing, error: existingError } = await client
+    .from("assistant_action_requests")
+    .select("*")
+    .eq("shop_id", params.shopId)
+    .eq("idempotency_key", params.idempotencyKey)
+    .single();
+
+  if (existingError) throw new Error(existingError.message);
+  return existing;
+}
+
+export async function loadAssistantActionRequest(
+  client: ShopAssistantSupabaseClient,
+  params: { actionId: string; shopId: string; userId: string },
+): Promise<AssistantActionRequestRow | null> {
+  if (!isUuid(params.actionId)) return null;
+
+  const { data, error } = await client
+    .from("assistant_action_requests")
+    .select("*")
+    .eq("id", params.actionId)
+    .eq("shop_id", params.shopId)
+    .eq("requested_by", params.userId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export async function updateAssistantActionRequest(
+  client: ShopAssistantSupabaseClient,
+  params: {
+    actionId: string;
+    shopId: string;
+    userId: string;
+    expectedStatus?: AssistantActionRequestRow["status"];
+    patch: Partial<
+      Pick<
+        AssistantActionRequestRow,
+        | "status"
+        | "confirmed_by"
+        | "confirmed_at"
+        | "executed_at"
+        | "result"
+        | "error_message"
+        | "expires_at"
+      >
+    >;
+  },
+): Promise<AssistantActionRequestRow | null> {
+  let query = client
+    .from("assistant_action_requests")
+    .update({ ...params.patch, updated_at: new Date().toISOString() })
+    .eq("id", params.actionId)
+    .eq("shop_id", params.shopId)
+    .eq("requested_by", params.userId);
+
+  if (params.expectedStatus) {
+    query = query.eq("status", params.expectedStatus);
+  }
+
+  const { data, error } = await query.select("*").maybeSingle();
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+export function toPendingAssistantAction(
+  row: AssistantActionRequestRow,
+): AssistantPendingAction {
+  return {
+    id: row.id,
+    toolName: row.tool_name,
+    domain: row.domain,
+    label: row.label,
+    summary: row.summary,
+    riskLevel: row.risk_level,
+    status: "pending_confirmation",
+    expiresAt: row.expires_at,
+    input: (row.input ?? {}) as Record<string, unknown>,
+  };
+}

--- a/features/assistant/types/assistant.ts
+++ b/features/assistant/types/assistant.ts
@@ -57,9 +57,31 @@ export type AssistantNotification = {
 };
 
 export type AssistantRelatedRecord = {
+  id?: string;
   label: string;
   href?: string;
   type?: string;
+};
+
+export type AssistantPendingAction = {
+  id: string;
+  toolName: string;
+  domain: string;
+  label: string;
+  summary: string;
+  riskLevel: "low" | "medium" | "high";
+  status: "pending_confirmation";
+  expiresAt: string;
+  input: Record<string, unknown>;
+};
+
+export type AssistantExecutionResult = {
+  actionId: string;
+  toolName: string;
+  status: "succeeded" | "failed" | "cancelled";
+  summary: string;
+  details: string[];
+  affectedRecords: AssistantRelatedRecord[];
 };
 
 export type AssistantResponse = {
@@ -69,4 +91,14 @@ export type AssistantResponse = {
   notifications: AssistantNotification[];
   relatedRecords?: AssistantRelatedRecord[];
   partSuggestions?: CanonicalPartSuggestion[];
+  conversationId?: string;
+  pendingAction?: AssistantPendingAction;
+  execution?: AssistantExecutionResult;
+};
+
+export type AssistantConversationMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: string;
 };

--- a/supabase/migrations/20260721100000_shop_assistant_reliability.sql
+++ b/supabase/migrations/20260721100000_shop_assistant_reliability.sql
@@ -1,0 +1,302 @@
+begin;
+
+create table if not exists public.assistant_conversations (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title text,
+  context jsonb not null default '{}'::jsonb,
+  last_intent text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists assistant_conversations_user_activity_idx
+  on public.assistant_conversations(user_id, updated_at desc);
+create index if not exists assistant_conversations_shop_activity_idx
+  on public.assistant_conversations(shop_id, updated_at desc);
+
+create table if not exists public.assistant_messages (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.assistant_conversations(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  role text not null check (role in ('user', 'assistant')),
+  content text not null check (length(trim(content)) > 0),
+  payload jsonb not null default '{}'::jsonb,
+  message_key text not null,
+  created_at timestamptz not null default now(),
+  unique (conversation_id, message_key)
+);
+
+create index if not exists assistant_messages_conversation_activity_idx
+  on public.assistant_messages(conversation_id, created_at asc);
+create index if not exists assistant_messages_shop_activity_idx
+  on public.assistant_messages(shop_id, created_at desc);
+
+create table if not exists public.assistant_action_requests (
+  id uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references public.assistant_conversations(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  requested_by uuid not null references auth.users(id) on delete cascade,
+  confirmed_by uuid references auth.users(id) on delete set null,
+  tool_name text not null check (length(trim(tool_name)) > 0),
+  domain text not null check (length(trim(domain)) > 0),
+  label text not null check (length(trim(label)) > 0),
+  summary text not null check (length(trim(summary)) > 0),
+  risk_level text not null default 'medium' check (risk_level in ('low', 'medium', 'high')),
+  input jsonb not null default '{}'::jsonb,
+  result jsonb,
+  error_message text,
+  status text not null default 'pending' check (
+    status in ('pending', 'executing', 'succeeded', 'failed', 'cancelled', 'expired')
+  ),
+  idempotency_key text not null,
+  expires_at timestamptz not null default (now() + interval '15 minutes'),
+  confirmed_at timestamptz,
+  executed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (shop_id, idempotency_key)
+);
+
+create index if not exists assistant_action_requests_pending_idx
+  on public.assistant_action_requests(shop_id, requested_by, status, expires_at);
+create index if not exists assistant_action_requests_conversation_idx
+  on public.assistant_action_requests(conversation_id, created_at desc);
+
+create or replace function public.touch_shop_assistant_updated_at()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists assistant_conversations_touch_updated_at on public.assistant_conversations;
+create trigger assistant_conversations_touch_updated_at
+before update on public.assistant_conversations
+for each row execute function public.touch_shop_assistant_updated_at();
+
+drop trigger if exists assistant_action_requests_touch_updated_at on public.assistant_action_requests;
+create trigger assistant_action_requests_touch_updated_at
+before update on public.assistant_action_requests
+for each row execute function public.touch_shop_assistant_updated_at();
+
+alter table public.assistant_conversations enable row level security;
+alter table public.assistant_messages enable row level security;
+alter table public.assistant_action_requests enable row level security;
+
+drop policy if exists assistant_conversations_owner_select on public.assistant_conversations;
+create policy assistant_conversations_owner_select
+  on public.assistant_conversations for select to authenticated
+  using (user_id = auth.uid() and shop_id = public.current_shop_id());
+
+drop policy if exists assistant_conversations_owner_insert on public.assistant_conversations;
+create policy assistant_conversations_owner_insert
+  on public.assistant_conversations for insert to authenticated
+  with check (user_id = auth.uid() and shop_id = public.current_shop_id());
+
+drop policy if exists assistant_conversations_owner_update on public.assistant_conversations;
+create policy assistant_conversations_owner_update
+  on public.assistant_conversations for update to authenticated
+  using (user_id = auth.uid() and shop_id = public.current_shop_id())
+  with check (user_id = auth.uid() and shop_id = public.current_shop_id());
+
+drop policy if exists assistant_conversations_owner_delete on public.assistant_conversations;
+create policy assistant_conversations_owner_delete
+  on public.assistant_conversations for delete to authenticated
+  using (user_id = auth.uid() and shop_id = public.current_shop_id());
+
+drop policy if exists assistant_messages_owner_select on public.assistant_messages;
+create policy assistant_messages_owner_select
+  on public.assistant_messages for select to authenticated
+  using (user_id = auth.uid() and shop_id = public.current_shop_id());
+
+drop policy if exists assistant_messages_owner_insert on public.assistant_messages;
+create policy assistant_messages_owner_insert
+  on public.assistant_messages for insert to authenticated
+  with check (
+    user_id = auth.uid()
+    and shop_id = public.current_shop_id()
+    and exists (
+      select 1
+      from public.assistant_conversations conversation
+      where conversation.id = conversation_id
+        and conversation.user_id = auth.uid()
+        and conversation.shop_id = assistant_messages.shop_id
+    )
+  );
+
+drop policy if exists assistant_action_requests_owner_select on public.assistant_action_requests;
+create policy assistant_action_requests_owner_select
+  on public.assistant_action_requests for select to authenticated
+  using (requested_by = auth.uid() and shop_id = public.current_shop_id());
+
+drop policy if exists assistant_action_requests_owner_insert on public.assistant_action_requests;
+create policy assistant_action_requests_owner_insert
+  on public.assistant_action_requests for insert to authenticated
+  with check (
+    requested_by = auth.uid()
+    and shop_id = public.current_shop_id()
+    and exists (
+      select 1
+      from public.assistant_conversations conversation
+      where conversation.id = conversation_id
+        and conversation.user_id = auth.uid()
+        and conversation.shop_id = assistant_action_requests.shop_id
+    )
+  );
+
+drop policy if exists assistant_action_requests_owner_update on public.assistant_action_requests;
+create policy assistant_action_requests_owner_update
+  on public.assistant_action_requests for update to authenticated
+  using (requested_by = auth.uid() and shop_id = public.current_shop_id())
+  with check (requested_by = auth.uid() and shop_id = public.current_shop_id());
+
+revoke all on table public.assistant_conversations from anon;
+revoke all on table public.assistant_messages from anon;
+revoke all on table public.assistant_action_requests from anon;
+
+grant select, insert, update, delete on table public.assistant_conversations to authenticated;
+grant select, insert on table public.assistant_messages to authenticated;
+grant select, insert, update on table public.assistant_action_requests to authenticated;
+grant all on table public.assistant_conversations to service_role;
+grant all on table public.assistant_messages to service_role;
+grant all on table public.assistant_action_requests to service_role;
+
+create or replace function public.assistant_set_work_order_hold(
+  p_shop_id uuid,
+  p_actor_profile_id uuid,
+  p_work_order_reference text,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor public.profiles%rowtype;
+  v_work_order public.work_orders%rowtype;
+  v_reference text;
+  v_reason text;
+  v_line_count integer := 0;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  select * into v_actor
+  from public.profiles profile
+  where profile.id = p_actor_profile_id
+    and profile.shop_id = p_shop_id
+    and (profile.id = auth.uid() or profile.user_id = auth.uid());
+
+  if not found then
+    raise exception 'Profile is not authorized for this shop';
+  end if;
+
+  if coalesce(v_actor.role, '') not in (
+    'owner', 'admin', 'manager', 'advisor', 'service', 'lead_hand', 'foreman'
+  ) then
+    raise exception 'Forbidden';
+  end if;
+
+  v_reference := upper(
+    regexp_replace(trim(coalesce(p_work_order_reference, '')), '^(WO[[:space:]]*#?|#)[[:space:]]*', '', 'i')
+  );
+  v_reason := nullif(trim(coalesce(p_reason, '')), '');
+
+  if v_reference = '' then
+    raise exception 'Work order reference is required';
+  end if;
+  if v_reason is null then
+    raise exception 'Hold reason is required';
+  end if;
+
+  select * into v_work_order
+  from public.work_orders work_order
+  where work_order.shop_id = p_shop_id
+    and (
+      work_order.id::text = trim(p_work_order_reference)
+      or upper(coalesce(work_order.custom_id, '')) = v_reference
+    )
+  limit 1
+  for update;
+
+  if not found then
+    raise exception 'Work order not found in this shop';
+  end if;
+
+  if lower(coalesce(v_work_order.status, '')) in (
+    'completed', 'ready_to_invoice', 'invoiced', 'cancelled', 'canceled', 'void', 'closed'
+  ) then
+    raise exception 'Completed or closed work orders cannot be placed on hold';
+  end if;
+
+  if exists (
+    select 1
+    from public.work_order_line_labor_segments segment
+    join public.work_order_lines line on line.id = segment.work_order_line_id
+    where line.shop_id = p_shop_id
+      and line.work_order_id = v_work_order.id
+      and segment.ended_at is null
+  ) then
+    raise exception 'Stop active technician labor before placing this work order on hold';
+  end if;
+
+  update public.work_order_lines line
+  set status = 'on_hold',
+      hold_reason = v_reason,
+      on_hold_since = coalesce(line.on_hold_since, now()),
+      updated_at = now()
+  where line.shop_id = p_shop_id
+    and line.work_order_id = v_work_order.id
+    and line.voided_at is null
+    and lower(coalesce(line.status, '')) not in (
+      'completed', 'ready_to_invoice', 'invoiced', 'cancelled', 'canceled', 'void', 'declined'
+    );
+
+  get diagnostics v_line_count = row_count;
+
+  update public.work_orders
+  set status = 'on_hold',
+      updated_at = now()
+  where id = v_work_order.id
+    and shop_id = p_shop_id;
+
+  insert into public.audit_logs (
+    shop_id, actor_id, action, target_table, target_id, metadata
+  ) values (
+    p_shop_id,
+    v_actor.id,
+    'assistant.work_order.hold',
+    'work_orders',
+    v_work_order.id,
+    jsonb_build_object(
+      'work_order_reference', coalesce(v_work_order.custom_id, v_work_order.id::text),
+      'reason', v_reason,
+      'line_count', v_line_count,
+      'source', 'shop_assistant'
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'work_order_id', v_work_order.id,
+    'work_order_reference', coalesce(v_work_order.custom_id, v_work_order.id::text),
+    'status', 'on_hold',
+    'reason', v_reason,
+    'affected_line_count', v_line_count
+  );
+end;
+$$;
+
+revoke all on function public.assistant_set_work_order_hold(uuid, uuid, text, text) from public, anon;
+grant execute on function public.assistant_set_work_order_hold(uuid, uuid, text, text) to authenticated, service_role;
+
+commit;

--- a/tests/mobile-native-route-audit.test.ts
+++ b/tests/mobile-native-route-audit.test.ts
@@ -67,7 +67,7 @@ describe("mobile-native navigation", () => {
       "Service requests",
     );
     expect(read("app/mobile/offline/page.tsx")).toContain("Offline &amp; sync");
-    expect(read("app/mobile/assistant/page.tsx")).toContain("Ask a question");
+    expect(read("app/mobile/assistant/page.tsx")).toContain("Ask or take action");
   });
 
   it("uses the existing shop-scoped operations payload", () => {

--- a/tests/shop-assistant-reliability.test.ts
+++ b/tests/shop-assistant-reliability.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { classifyShopAssistantIntent } from "@/features/assistant/server/shopAssistantIntent";
+import {
+  dedupeAssistantBullets,
+  dedupeAssistantText,
+} from "@/features/assistant/lib/assistantText";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("shop assistant reliability", () => {
+  it("classifies a work-order hold command before informational routing", () => {
+    const intent = classifyShopAssistantIntent(
+      "Put EL00005 on hold for parts",
+    );
+
+    expect(intent.kind).toBe("action");
+    if (intent.kind !== "action") return;
+    expect(intent.toolName).toBe("set_work_order_hold");
+    expect(intent.input).toEqual({
+      workOrderReference: "EL00005",
+      reason: "Awaiting parts",
+    });
+  });
+
+  it("does not mistake a hold-status question for a mutation", () => {
+    expect(
+      classifyShopAssistantIntent("Which work orders are on hold right now?"),
+    ).toEqual({ kind: "query" });
+  });
+
+  it("keeps unsupported action requests out of the informational answer path", () => {
+    const intent = classifyShopAssistantIntent(
+      "Email every customer whose vehicle is ready",
+    );
+    expect(intent.kind).toBe("clarification");
+  });
+
+  it("removes repeated answer text and summary-equivalent bullets", () => {
+    const summary = dedupeAssistantText(
+      "I found 3 stale work orders. I found 3 stale work orders.",
+    );
+    expect(summary).toBe("I found 3 stale work orders.");
+    expect(
+      dedupeAssistantBullets(summary, [
+        "I found 3 stale work orders.",
+        "WO #EL00003 is queued.",
+        "WO #EL00003 is queued.",
+      ]),
+    ).toEqual(["WO #EL00003 is queued."]);
+  });
+
+  it("persists conversations and gates writes behind confirmation", () => {
+    const migration = read(
+      "supabase/migrations/20260721100000_shop_assistant_reliability.sql",
+    );
+    expect(migration).toContain("create table if not exists public.assistant_conversations");
+    expect(migration).toContain("create table if not exists public.assistant_messages");
+    expect(migration).toContain("create table if not exists public.assistant_action_requests");
+    expect(migration).toContain("enable row level security");
+    expect(migration).toContain("assistant_set_work_order_hold");
+
+    const answerRoute = read("app/api/assistant/answer/route.ts");
+    expect(answerRoute).toContain('body.surface === "shop"');
+    expect(answerRoute).toContain("handleShopAssistantRequest");
+
+    const actionRoute = read("app/api/assistant/actions/[id]/route.ts");
+    expect(actionRoute).toContain('decision !== "confirm"');
+    expect(actionRoute).toContain('expectedStatus: "pending"');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the reliability foundation for the shop-wide assistant while leaving the technician AI assistant inside work orders unchanged.

- removes duplicate answer/bullet rendering
- adds durable, shop-scoped conversation memory
- separates commands from informational questions before legacy Q&A routing
- adds explicit confirm/cancel execution for safe mutations
- implements the first audited action: place a work order on hold
- revalidates shop, user, role, action state, expiry, and idempotency at execution time
- adds RLS-backed conversation, message, and action-request storage

## Safety and tenancy

- all new API paths use `requireShopScopedApiAccess`
- conversations/actions are restricted to the requesting user and current shop
- mutations remain pending until confirmed
- the work-order hold mutation is performed by a security-definer RPC with role/shop checks, terminal-state checks, active-labor checks, and audit logging

## Technician assistant boundary

The existing technician diagnostic assistant is not replaced or rerouted. Only requests explicitly sent with `surface: "shop"` use the new shop-assistant orchestration layer.

## Validation

- added `tests/shop-assistant-reliability.test.ts`
- TypeScript syntax validation completed for all changed files

## Stack

1. **This PR — Phase 1: Reliability**
2. Phase 2: Shop Intelligence (will target this branch)
3. Phase 3: Unified Tool Registry (will target Phase 2)
4. Phase 4: Multi-Agent Orchestration (will target Phase 3)
