### PR TITLE
Add live role-aware shop intelligence

### DIFF
--- a/app/api/shop-assistant/state/route.ts
+++ b/app/api/shop-assistant/state/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import {
+  requireShopAssistantActor,
+  shopAssistantErrorMessage,
+  shopAssistantErrorStatus,
+} from "@/features/shop-assistant/server/requireShopAssistantActor";
+import { buildShopState } from "@/features/shop-assistant/server/state/buildShopState";
+import type { ShopAssistantStateResponse } from "@/features/shop-assistant/server/state/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const actor = await requireShopAssistantActor();
+    const state = await buildShopState(actor);
+
+    return NextResponse.json<ShopAssistantStateResponse>(
+      { ok: true, state },
+      {
+        headers: {
+          "cache-control": "private, no-store, max-age=0",
+        },
+      },
+    );
+  } catch (error: unknown) {
+    return NextResponse.json<ShopAssistantStateResponse>(
+      { ok: false, error: shopAssistantErrorMessage(error) },
+      { status: shopAssistantErrorStatus(error) },
+    );
+  }
+}

--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -8,15 +8,16 @@ import { useSearchParams } from "next/navigation";
 import PageShell from "@/features/shared/components/PageShell";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 import ShopAssistantConversation from "@/features/shop-assistant/components/ShopAssistantConversation";
+import ShopAssistantDashboard from "@/features/shop-assistant/components/ShopAssistantDashboard";
 import { useShopAssistant } from "@/features/shop-assistant/hooks/useShopAssistant";
 import type { ShopAssistantContext } from "@/features/shop-assistant/types";
 import { Button } from "@shared/components/ui/Button";
 
 const EXAMPLE_PROMPTS = [
   "Which work orders are waiting on approvals right now?",
-  "Summarize open inspections with safety concerns from this week.",
+  "Summarize the jobs delayed by parts.",
   "What changed today across bookings, invoices, and technician activity?",
-  "Show repeat issues for this vehicle and what we recommended last time.",
+  "Which queued jobs should be assigned next?",
 ];
 
 function optionalParam(params: URLSearchParams, key: string): string | undefined {
@@ -68,20 +69,6 @@ export default function AssistantPage() {
     clearConversation,
   } = useShopAssistant(contextKey);
 
-  const contextChips = useMemo(
-    () => [
-      { label: "Shop-wide", active: true },
-      {
-        label: "Current page",
-        active: Boolean(context.pageType || context.pageTitle),
-      },
-      { label: "Current customer", active: Boolean(context.customerId) },
-      { label: "Current vehicle", active: Boolean(context.vehicleId) },
-      { label: "Current work order", active: Boolean(context.workOrderId) },
-    ],
-    [context],
-  );
-
   const submit = async () => {
     const value = query.trim();
     if (!value || sending) return;
@@ -92,79 +79,72 @@ export default function AssistantPage() {
   return (
     <PageShell
       title="Shop Assistant"
-      description="Your durable, shop-wide operations conversation across work orders, customers, scheduling, parts, billing, and workforce."
+      description="Live shop intelligence, proactive alerts, and a durable operations conversation."
     >
-      <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
-        <div className="desktop-panel-soft p-4">
-          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-            Assistant scope
+      <div className="space-y-4">
+        <ShopAssistantDashboard
+          onPrompt={setQuery}
+          refreshToken={messages.at(-1)?.id}
+        />
+
+        <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
+          <div className="desktop-panel-soft p-4">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+              Shop conversation
+            </div>
+            <p className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
+              Ask questions or request operational actions across the shop. Diagnostic
+              guidance remains inside each work order&apos;s Technician AI.
+            </p>
           </div>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {contextChips.map((chip) => (
-              <span
-                key={chip.label}
-                className={`desktop-pill px-3 py-1 text-xs ${
-                  chip.active
-                    ? "border-[color:var(--brand-accent,#E39A6E)]/55 bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_16%,transparent)] text-[color:var(--brand-accent,#E39A6E)]"
-                    : "text-[color:var(--theme-text-secondary)]"
-                }`}
+
+          <ShopAssistantConversation
+            messages={messages}
+            loading={loading}
+            error={error}
+            canRetry={canRetry}
+            onRetry={() => void retry()}
+            className="max-h-[34rem]"
+          />
+
+          <textarea
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Ask about shop operations or request an action…"
+            className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-[color:var(--theme-text-primary)]"
+          />
+
+          <div className="flex flex-wrap gap-2">
+            {EXAMPLE_PROMPTS.map((example) => (
+              <button
+                key={example}
+                type="button"
+                className="desktop-pill px-3 py-1 text-xs text-[color:var(--theme-text-secondary)] hover:border-[color:var(--brand-accent,#E39A6E)]/50 hover:text-[color:var(--brand-accent,#E39A6E)]"
+                onClick={() => setQuery(example)}
               >
-                {chip.label}
-              </span>
+                {example}
+              </button>
             ))}
           </div>
-          <p className="mt-3 text-xs text-[color:var(--theme-text-secondary)]">
-            Conversations persist across reloads. Diagnostic guidance remains inside
-            each work order&apos;s Technician AI.
-          </p>
-        </div>
 
-        <ShopAssistantConversation
-          messages={messages}
-          loading={loading}
-          error={error}
-          canRetry={canRetry}
-          onRetry={() => void retry()}
-          className="max-h-[34rem]"
-        />
-
-        <textarea
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Ask about shop operations or request an action…"
-          className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-[color:var(--theme-text-primary)]"
-        />
-
-        <div className="flex flex-wrap gap-2">
-          {EXAMPLE_PROMPTS.map((example) => (
-            <button
-              key={example}
+          <div className="flex items-center justify-between gap-3">
+            <Button
               type="button"
-              className="desktop-pill px-3 py-1 text-xs text-[color:var(--theme-text-secondary)] hover:border-[color:var(--brand-accent,#E39A6E)]/50 hover:text-[color:var(--brand-accent,#E39A6E)]"
-              onClick={() => setQuery(example)}
+              variant="ghost"
+              disabled={loading || sending}
+              onClick={() => void clearConversation(context)}
             >
-              {example}
-            </button>
-          ))}
-        </div>
-
-        <div className="flex items-center justify-between gap-3">
-          <Button
-            type="button"
-            variant="ghost"
-            disabled={loading || sending}
-            onClick={() => void clearConversation(context)}
-          >
-            New conversation
-          </Button>
-          <Button
-            type="button"
-            onClick={() => void submit()}
-            isLoading={sending}
-            disabled={loading || sending || !query.trim()}
-          >
-            Send
-          </Button>
+              New conversation
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void submit()}
+              isLoading={sending}
+              disabled={loading || sending || !query.trim()}
+            >
+              Send
+            </Button>
+          </div>
         </div>
       </div>
     </PageShell>

--- a/app/mobile/assistant/page.tsx
+++ b/app/mobile/assistant/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
 import ShopAssistantConversation from "@/features/shop-assistant/components/ShopAssistantConversation";
+import ShopAssistantDashboard from "@/features/shop-assistant/components/ShopAssistantDashboard";
 import { useShopAssistant } from "@/features/shop-assistant/hooks/useShopAssistant";
 import type { ShopAssistantContext } from "@/features/shop-assistant/types";
 import { Button } from "@shared/components/ui/Button";
@@ -64,34 +65,12 @@ export default function MobileAssistantPage() {
     await send(value, context);
   };
 
-  const contextLabel = [
-    context.workOrderId ? "Work order" : null,
-    context.vehicleId ? "Vehicle" : null,
-    context.customerId ? "Customer" : null,
-    context.bookingId ? "Appointment" : null,
-  ]
-    .filter(Boolean)
-    .join(" • ");
-
   return (
     <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
-      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
-        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
-          Shop assistant
-        </div>
-        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
-          Run the shop from one conversation
-        </h1>
-        <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-          Ask across work orders, customers, scheduling, parts, billing, and shop
-          operations. This conversation is restored when you return.
-        </p>
-        {contextLabel ? (
-          <div className="mt-3 inline-flex rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Context: {contextLabel}
-          </div>
-        ) : null}
-      </section>
+      <ShopAssistantDashboard
+        onPrompt={setQuestion}
+        refreshToken={messages.at(-1)?.id}
+      />
 
       <ShopAssistantConversation
         messages={messages}
@@ -107,7 +86,7 @@ export default function MobileAssistantPage() {
           htmlFor="mobile-assistant-question"
           className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]"
         >
-          Message
+          Shop conversation
         </label>
         <textarea
           id="mobile-assistant-question"

--- a/features/shop-assistant/components/ShopAlertList.tsx
+++ b/features/shop-assistant/components/ShopAlertList.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import Link from "next/link";
+
+import type { ShopAssistantAlert } from "@/features/shop-assistant/server/state/types";
+
+type Props = {
+  alerts: ShopAssistantAlert[];
+};
+
+function levelClasses(level: ShopAssistantAlert["level"]): string {
+  if (level === "critical") {
+    return "border-red-400/35 bg-red-500/10";
+  }
+  if (level === "warning") {
+    return "border-amber-400/35 bg-amber-500/10";
+  }
+  return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]";
+}
+
+export default function ShopAlertList({ alerts }: Props) {
+  if (alerts.length === 0) {
+    return (
+      <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+        No proactive shop alerts are active right now.
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="Proactive shop alerts" className="space-y-2">
+      {alerts.slice(0, 8).map((alert) => {
+        const content = (
+          <>
+            <div className="flex items-start justify-between gap-3">
+              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                {alert.title}
+              </div>
+              <span className="rounded-full border border-current/20 px-2 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.1em] text-[color:var(--theme-text-secondary)]">
+                {alert.level}
+              </span>
+            </div>
+            <div className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+              {alert.message}
+            </div>
+          </>
+        );
+
+        const className = `block rounded-2xl border p-3 transition ${levelClasses(
+          alert.level,
+        )} ${alert.href ? "hover:border-[color:var(--brand-accent,#E39A6E)]/55" : ""}`;
+
+        return alert.href ? (
+          <Link key={alert.id} href={alert.href} className={className}>
+            {content}
+          </Link>
+        ) : (
+          <div key={alert.id} className={className}>
+            {content}
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/features/shop-assistant/components/ShopAssistantDashboard.tsx
+++ b/features/shop-assistant/components/ShopAssistantDashboard.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import ShopAlertList from "@/features/shop-assistant/components/ShopAlertList";
+import ShopStateMetricGrid from "@/features/shop-assistant/components/ShopStateMetricGrid";
+import ShopSuggestionList from "@/features/shop-assistant/components/ShopSuggestionList";
+import { useShopAssistantState } from "@/features/shop-assistant/hooks/useShopAssistantState";
+
+type Props = {
+  onPrompt: (prompt: string) => void;
+  refreshToken?: string | number;
+};
+
+function roleLabel(role: string): string {
+  return role.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export default function ShopAssistantDashboard({
+  onPrompt,
+  refreshToken,
+}: Props) {
+  const { state, loading, error, refresh } =
+    useShopAssistantState(refreshToken);
+
+  if (loading && !state) {
+    return (
+      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+        Loading the live shop picture…
+      </section>
+    );
+  }
+
+  if (!state) {
+    return (
+      <section className="rounded-3xl border border-red-400/30 bg-red-500/10 p-4 text-sm text-[color:var(--theme-text-primary)]">
+        <div>{error ?? "The live shop picture is unavailable."}</div>
+        <button
+          type="button"
+          className="mt-3 rounded-full border border-current/30 px-3 py-1 text-xs font-semibold"
+          onClick={() => void refresh()}
+        >
+          Try again
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+            {roleLabel(state.role)} view • live shop state
+          </div>
+          <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+            {state.headline}
+          </h1>
+          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+            Updated {new Date(state.generatedAt).toLocaleTimeString([], {
+              hour: "numeric",
+              minute: "2-digit",
+            })}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]"
+          onClick={() => void refresh()}
+        >
+          Refresh
+        </button>
+      </header>
+
+      <ShopStateMetricGrid metrics={state.metrics} />
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <div>
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            Needs attention
+          </h2>
+          <ShopAlertList alerts={state.alerts} />
+        </div>
+        <div>
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+            Suggested next moves
+          </h2>
+          <ShopSuggestionList
+            suggestions={state.suggestions}
+            onSelect={onPrompt}
+          />
+        </div>
+      </div>
+
+      {error ? (
+        <div className="text-xs text-amber-300">
+          The latest background refresh failed; showing the most recent shop state.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/features/shop-assistant/components/ShopStateMetricGrid.tsx
+++ b/features/shop-assistant/components/ShopStateMetricGrid.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import type { ShopAssistantMetrics } from "@/features/shop-assistant/server/state/types";
+
+type Props = {
+  metrics: ShopAssistantMetrics;
+};
+
+const METRICS: Array<{
+  key: keyof ShopAssistantMetrics;
+  label: string;
+  suffix?: string;
+}> = [
+  { key: "openWorkOrders", label: "Open work orders" },
+  { key: "stalledWorkOrders", label: "Stalled" },
+  { key: "overdueApprovals", label: "Overdue approvals" },
+  { key: "delayedParts", label: "Delayed parts" },
+  { key: "idleTechnicians", label: "Available techs" },
+  { key: "readyToInvoice", label: "Ready to invoice" },
+  { key: "todaysBookings", label: "Today’s bookings" },
+  { key: "shopUtilizationPct", label: "Utilization", suffix: "%" },
+];
+
+export default function ShopStateMetricGrid({ metrics }: Props) {
+  return (
+    <section aria-label="Live shop metrics" className="grid grid-cols-2 gap-2 md:grid-cols-4">
+      {METRICS.map((metric) => (
+        <div
+          key={metric.key}
+          className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3"
+        >
+          <div className="text-2xl font-semibold tabular-nums text-[color:var(--theme-text-primary)]">
+            {metrics[metric.key]}
+            {metric.suffix ?? ""}
+          </div>
+          <div className="mt-1 text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)]">
+            {metric.label}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/features/shop-assistant/components/ShopSuggestionList.tsx
+++ b/features/shop-assistant/components/ShopSuggestionList.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import Link from "next/link";
+
+import type { ShopAssistantSuggestion } from "@/features/shop-assistant/server/state/types";
+
+type Props = {
+  suggestions: ShopAssistantSuggestion[];
+  onSelect: (prompt: string) => void;
+};
+
+export default function ShopSuggestionList({ suggestions, onSelect }: Props) {
+  return (
+    <section aria-label="Suggested shop actions" className="grid gap-2 md:grid-cols-2">
+      {suggestions.map((suggestion) => (
+        <div
+          key={suggestion.id}
+          className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3"
+        >
+          <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            {suggestion.title}
+          </div>
+          <div className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+            {suggestion.description}
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              className="rounded-full border border-[color:var(--brand-accent,#E39A6E)]/45 bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_12%,transparent)] px-3 py-1 text-xs font-semibold text-[color:var(--brand-accent,#E39A6E)]"
+              onClick={() => onSelect(suggestion.prompt)}
+            >
+              Ask assistant
+            </button>
+            {suggestion.href ? (
+              <Link
+                href={suggestion.href}
+                className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]"
+              >
+                Open
+              </Link>
+            ) : null}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/features/shop-assistant/hooks/useShopAssistantState.ts
+++ b/features/shop-assistant/hooks/useShopAssistantState.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type {
+  ShopAssistantState,
+  ShopAssistantStateResponse,
+} from "@/features/shop-assistant/server/state/types";
+
+const REFRESH_INTERVAL_MS = 45_000;
+
+export function useShopAssistantState(refreshToken?: string | number) {
+  const [state, setState] = useState<ShopAssistantState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef<AbortController | null>(null);
+
+  const refresh = useCallback(async () => {
+    requestRef.current?.abort();
+    const controller = new AbortController();
+    requestRef.current = controller;
+
+    try {
+      setError(null);
+      const response = await fetch("/api/shop-assistant/state", {
+        cache: "no-store",
+        signal: controller.signal,
+      });
+      const payload = (await response.json().catch(() => ({}))) as
+        | ShopAssistantStateResponse
+        | { ok?: false; error?: string };
+
+      if (!response.ok || payload.ok !== true) {
+        throw new Error(
+          payload.ok === false && payload.error
+            ? payload.error
+            : "Failed to load live shop state",
+        );
+      }
+
+      setState(payload.state);
+    } catch (refreshError: unknown) {
+      if (controller.signal.aborted) return;
+      setError(
+        refreshError instanceof Error
+          ? refreshError.message
+          : "Failed to load live shop state",
+      );
+    } finally {
+      if (requestRef.current === controller) requestRef.current = null;
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+
+    const interval = window.setInterval(() => {
+      if (document.visibilityState === "visible") void refresh();
+    }, REFRESH_INTERVAL_MS);
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      requestRef.current?.abort();
+    };
+  }, [refresh, refreshToken]);
+
+  return { state, loading, error, refresh };
+}

--- a/features/shop-assistant/server/state/buildShopState.ts
+++ b/features/shop-assistant/server/state/buildShopState.ts
@@ -1,0 +1,358 @@
+import "server-only";
+
+import { syncAssistantNotifications } from "@/features/agent/server/syncAssistantNotifications";
+import type { PersistedAssistantNotification } from "@/features/agent/server/syncAssistantNotifications";
+import type { ActorCapabilities } from "@/features/shared/lib/rbac";
+import { getTechnicianLoadMetricsWithClient } from "@/features/shared/lib/stats/getTechnicianLoadMetricsCore";
+import type { ShopAssistantActor } from "@/features/shop-assistant/server/requireShopAssistantActor";
+import type {
+  ShopAssistantAlert,
+  ShopAssistantState,
+  ShopAssistantSuggestion,
+} from "./types";
+
+const ACTIVE_WORK_ORDER_STATUSES = [
+  "awaiting",
+  "awaiting_approval",
+  "planned",
+  "queued",
+  "in_progress",
+  "on_hold",
+];
+
+const READY_TO_INVOICE_STATUSES = ["completed", "ready_to_invoice"];
+
+function startOfUtcDay(now: Date): string {
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  ).toISOString();
+}
+
+function endOfUtcDay(now: Date): string {
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1),
+  ).toISOString();
+}
+
+function mapNotificationCode(code: string): string {
+  if (code === "parts_waiting_too_long") return "parts_delivery_overdue";
+  if (code === "tech_underutilized_capacity") return "technician_idle";
+  if (code === "invoice_unsent_too_long") return "invoice_ready";
+  return code;
+}
+
+function mapNotification(
+  item: PersistedAssistantNotification,
+): ShopAssistantAlert {
+  return {
+    id: item.id,
+    code: mapNotificationCode(item.code),
+    level:
+      item.level === "critical"
+        ? "critical"
+        : item.level === "warning"
+          ? "warning"
+          : "info",
+    title: item.title,
+    message: item.message,
+    href: item.href ?? undefined,
+    entityType: item.entity_type ?? undefined,
+    entityId: item.entity_id ?? undefined,
+  };
+}
+
+function dedupeAlerts(alerts: ShopAssistantAlert[], limit = 12) {
+  const seen = new Set<string>();
+  const output: ShopAssistantAlert[] = [];
+
+  for (const alert of alerts) {
+    const key = [
+      alert.code,
+      alert.entityType ?? "none",
+      alert.entityId ?? alert.title,
+    ]
+      .join(":")
+      .toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    output.push(alert);
+    if (output.length >= limit) break;
+  }
+
+  return output;
+}
+
+function countUniqueAlerts(alerts: ShopAssistantAlert[], codes: string[]): number {
+  const keys = new Set<string>();
+  for (const alert of alerts) {
+    if (!codes.includes(alert.code)) continue;
+    keys.add(alert.entityId ?? `${alert.code}:${alert.title}`);
+  }
+  return keys.size;
+}
+
+function buildHeadline(params: {
+  role: ShopAssistantActor["canonicalRole"];
+  openWorkOrders: number;
+  alertCount: number;
+  readyToInvoice: number;
+  idleTechnicians: number;
+}): string {
+  const { role, openWorkOrders, alertCount, readyToInvoice, idleTechnicians } =
+    params;
+
+  if (role === "parts") {
+    return alertCount > 0
+      ? `${alertCount} parts and workflow signals need review.`
+      : "Parts flow is current across the shop.";
+  }
+  if (role === "advisor" || role === "service") {
+    return `${openWorkOrders} open work orders and ${readyToInvoice} ready billing opportunities are in view.`;
+  }
+  if (role === "lead_hand" || role === "foreman") {
+    return `${openWorkOrders} open work orders with ${idleTechnicians} technician(s) currently available.`;
+  }
+  if (role === "fleet_manager" || role === "dispatcher") {
+    return `${openWorkOrders} active shop work orders are visible with ${alertCount} operational signals.`;
+  }
+  return alertCount > 0
+    ? `${alertCount} shop signals need attention across ${openWorkOrders} open work orders.`
+    : `The shop is current across ${openWorkOrders} open work orders.`;
+}
+
+function addSuggestion(
+  output: ShopAssistantSuggestion[],
+  condition: boolean,
+  suggestion: ShopAssistantSuggestion,
+) {
+  if (condition && !output.some((item) => item.id === suggestion.id)) {
+    output.push(suggestion);
+  }
+}
+
+function buildSuggestions(params: {
+  capabilities: ActorCapabilities;
+  overdueApprovals: number;
+  delayedParts: number;
+  idleTechnicians: number;
+  readyToInvoice: number;
+  stalledWorkOrders: number;
+  todaysBookings: number;
+}): ShopAssistantSuggestion[] {
+  const { capabilities } = params;
+  const suggestions: ShopAssistantSuggestion[] = [];
+
+  addSuggestion(
+    suggestions,
+    capabilities.canAuthorizeQuotes && params.overdueApprovals > 0,
+    {
+      id: "review-overdue-approvals",
+      domain: "work_orders",
+      title: "Clear overdue approvals",
+      description: `${params.overdueApprovals} approval(s) are holding up work.`,
+      prompt: "Show the overdue approvals and the best customer follow-up order.",
+      href: "/quote-review",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canManageParts && params.delayedParts > 0,
+    {
+      id: "review-delayed-parts",
+      domain: "inventory",
+      title: "Review delayed parts",
+      description: `${params.delayedParts} job(s) have delayed parts signals.`,
+      prompt: "Show delayed parts and the affected work orders.",
+      href: "/parts/requests",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canAssignWork && params.idleTechnicians > 0,
+    {
+      id: "rebalance-idle-capacity",
+      domain: "workforce",
+      title: "Use available technician capacity",
+      description: `${params.idleTechnicians} shifted technician(s) have no active job.`,
+      prompt: "Which queued jobs should be assigned to the available technicians?",
+      href: "/dashboard",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canManageBilling && params.readyToInvoice > 0,
+    {
+      id: "finish-ready-invoices",
+      domain: "invoices",
+      title: "Finish ready invoices",
+      description: `${params.readyToInvoice} work order(s) are completed or ready to invoice.`,
+      prompt: "List the work orders ready to invoice and any remaining blockers.",
+      href: "/billing",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canManageWorkOrders && params.stalledWorkOrders > 0,
+    {
+      id: "unstick-stalled-work",
+      domain: "work_orders",
+      title: "Unstick stalled work",
+      description: `${params.stalledWorkOrders} work order(s) have exceeded a workflow threshold.`,
+      prompt: "Prioritize the stalled work orders and recommend the next operational step for each.",
+      href: "/work-orders/view",
+    },
+  );
+
+  addSuggestion(
+    suggestions,
+    capabilities.canManageScheduling && params.todaysBookings > 0,
+    {
+      id: "review-todays-bookings",
+      domain: "scheduling",
+      title: "Review today’s appointments",
+      description: `${params.todaysBookings} appointment(s) are scheduled for the current shop day.`,
+      prompt: "Summarize today's appointments and flag scheduling conflicts.",
+      href: "/dashboard/appointments",
+    },
+  );
+
+  if (suggestions.length === 0) {
+    suggestions.push({
+      id: "shop-status-check",
+      domain: "reporting",
+      title: "Review the current shop status",
+      description: "Ask for a concise operational summary across the records you can access.",
+      prompt: "Give me the current shop status and the three most useful next steps.",
+      href: "/assistant",
+    });
+  }
+
+  return suggestions.slice(0, 6);
+}
+
+export async function buildShopState(
+  actor: ShopAssistantActor,
+): Promise<ShopAssistantState> {
+  const now = new Date();
+
+  const [persistedNotifications, loadMetrics] = await Promise.all([
+    syncAssistantNotifications({
+      shopId: actor.shopId,
+      userId: actor.userId,
+      role: actor.role,
+    }).catch(() => [] as PersistedAssistantNotification[]),
+    getTechnicianLoadMetricsWithClient(actor.supabase, actor.shopId).catch(
+      () => null,
+    ),
+  ]);
+
+  const dayStartIso = loadMetrics?.dayStartIso ?? startOfUtcDay(now);
+  const dayEndIso = loadMetrics?.dayEndIso ?? endOfUtcDay(now);
+
+  const [openResult, readyResult, bookingsResult] = await Promise.all([
+    actor.supabase
+      .from("work_orders")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", actor.shopId)
+      .in("status", ACTIVE_WORK_ORDER_STATUSES),
+    actor.supabase
+      .from("work_orders")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", actor.shopId)
+      .in("status", READY_TO_INVOICE_STATUSES),
+    actor.supabase
+      .from("bookings")
+      .select("id", { count: "exact", head: true })
+      .eq("shop_id", actor.shopId)
+      .gte("starts_at", dayStartIso)
+      .lt("starts_at", dayEndIso),
+  ]);
+
+  const idleTechnicians = (loadMetrics?.rows ?? []).filter(
+    (row) =>
+      row.shiftSecondsToday > 0 &&
+      row.currentActiveJobs === 0 &&
+      row.utilizationPct <= 40,
+  );
+
+  const mappedNotifications = persistedNotifications.map(mapNotification);
+  const syntheticAlerts: ShopAssistantAlert[] = [];
+
+  for (const row of idleTechnicians.slice(0, 4)) {
+    syntheticAlerts.push({
+      id: `technician-idle:${row.techId}`,
+      code: "technician_idle",
+      level: "info",
+      title: `${row.name} has available capacity`,
+      message: `${row.name} is on shift with no active job and ${row.utilizationPct}% utilization.`,
+      href: "/dashboard",
+      entityType: "profile",
+      entityId: row.techId,
+    });
+  }
+
+  const readyToInvoice = readyResult.error ? 0 : Number(readyResult.count ?? 0);
+  if (readyToInvoice > 0) {
+    syntheticAlerts.push({
+      id: "invoice-ready:shop",
+      code: "invoice_ready",
+      level: "warning",
+      title: "Work is ready for billing",
+      message: `${readyToInvoice} completed or ready work order(s) should be reviewed for invoicing.`,
+      href: "/billing",
+      entityType: "shop",
+      entityId: actor.shopId,
+    });
+  }
+
+  const alerts = dedupeAlerts([...mappedNotifications, ...syntheticAlerts]);
+  const stalledWorkOrders = countUniqueAlerts(alerts, [
+    "work_order_waiting_too_long",
+    "work_order_on_hold_too_long",
+    "active_job_running_too_long",
+  ]);
+  const overdueApprovals = countUniqueAlerts(alerts, ["approval_waiting"]);
+  const delayedParts = countUniqueAlerts(alerts, ["parts_delivery_overdue"]);
+  const todaysBookings = bookingsResult.error
+    ? 0
+    : Number(bookingsResult.count ?? 0);
+  const openWorkOrders = openResult.error ? 0 : Number(openResult.count ?? 0);
+
+  const metrics = {
+    openWorkOrders,
+    stalledWorkOrders,
+    overdueApprovals,
+    delayedParts,
+    idleTechnicians: idleTechnicians.length,
+    readyToInvoice,
+    todaysBookings,
+    shopUtilizationPct: loadMetrics?.summary.shopUtilizationPct ?? 0,
+  };
+
+  return {
+    generatedAt: new Date().toISOString(),
+    role: actor.canonicalRole,
+    headline: buildHeadline({
+      role: actor.canonicalRole,
+      openWorkOrders,
+      alertCount: alerts.length,
+      readyToInvoice,
+      idleTechnicians: idleTechnicians.length,
+    }),
+    metrics,
+    alerts,
+    suggestions: buildSuggestions({
+      capabilities: actor.capabilities,
+      overdueApprovals,
+      delayedParts,
+      idleTechnicians: idleTechnicians.length,
+      readyToInvoice,
+      stalledWorkOrders,
+      todaysBookings,
+    }),
+  };
+}

--- a/features/shop-assistant/server/state/types.ts
+++ b/features/shop-assistant/server/state/types.ts
@@ -1,0 +1,54 @@
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import type { ShopAssistantDomain } from "@/features/shop-assistant/types";
+
+export type ShopAssistantAlertLevel = "info" | "warning" | "critical";
+
+export type ShopAssistantAlert = {
+  id: string;
+  code: string;
+  level: ShopAssistantAlertLevel;
+  title: string;
+  message: string;
+  href?: string;
+  entityType?: string;
+  entityId?: string;
+};
+
+export type ShopAssistantSuggestion = {
+  id: string;
+  domain: ShopAssistantDomain;
+  title: string;
+  description: string;
+  prompt: string;
+  href?: string;
+};
+
+export type ShopAssistantMetrics = {
+  openWorkOrders: number;
+  stalledWorkOrders: number;
+  overdueApprovals: number;
+  delayedParts: number;
+  idleTechnicians: number;
+  readyToInvoice: number;
+  todaysBookings: number;
+  shopUtilizationPct: number;
+};
+
+export type ShopAssistantState = {
+  generatedAt: string;
+  role: CanonicalRole;
+  headline: string;
+  metrics: ShopAssistantMetrics;
+  alerts: ShopAssistantAlert[];
+  suggestions: ShopAssistantSuggestion[];
+};
+
+export type ShopAssistantStateResponse =
+  | {
+      ok: true;
+      state: ShopAssistantState;
+    }
+  | {
+      ok: false;
+      error: string;
+    };

--- a/tests/shop-assistant-state.test.ts
+++ b/tests/shop-assistant-state.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const stateBuilder = readFileSync(
+  "features/shop-assistant/server/state/buildShopState.ts",
+  "utf8",
+);
+const stateRoute = readFileSync(
+  "app/api/shop-assistant/state/route.ts",
+  "utf8",
+);
+const stateHook = readFileSync(
+  "features/shop-assistant/hooks/useShopAssistantState.ts",
+  "utf8",
+);
+const dashboard = readFileSync(
+  "features/shop-assistant/components/ShopAssistantDashboard.tsx",
+  "utf8",
+);
+const mobilePage = readFileSync("app/mobile/assistant/page.tsx", "utf8");
+const desktopPage = readFileSync("app/assistant/page.tsx", "utf8");
+
+describe("shop assistant live state contracts", () => {
+  it("builds the required shop-wide metrics without an LLM", () => {
+    expect(stateBuilder).toContain("openWorkOrders");
+    expect(stateBuilder).toContain("stalledWorkOrders");
+    expect(stateBuilder).toContain("overdueApprovals");
+    expect(stateBuilder).toContain("delayedParts");
+    expect(stateBuilder).toContain("idleTechnicians");
+    expect(stateBuilder).toContain("readyToInvoice");
+    expect(stateBuilder).toContain("todaysBookings");
+    expect(stateBuilder).not.toContain("getOpenAIClient");
+  });
+
+  it("maps proactive alerts for stalled work, approvals, parts, idle capacity, and invoices", () => {
+    expect(stateBuilder).toContain("work_order_waiting_too_long");
+    expect(stateBuilder).toContain("work_order_on_hold_too_long");
+    expect(stateBuilder).toContain("approval_waiting");
+    expect(stateBuilder).toContain("parts_delivery_overdue");
+    expect(stateBuilder).toContain("technician_idle");
+    expect(stateBuilder).toContain("invoice_ready");
+    expect(stateBuilder).toContain("dedupeAlerts");
+  });
+
+  it("gates suggestions through canonical actor capabilities", () => {
+    expect(stateBuilder).toContain("capabilities.canAuthorizeQuotes");
+    expect(stateBuilder).toContain("capabilities.canManageParts");
+    expect(stateBuilder).toContain("capabilities.canAssignWork");
+    expect(stateBuilder).toContain("capabilities.canManageBilling");
+    expect(stateBuilder).toContain("capabilities.canManageScheduling");
+  });
+
+  it("serves current state through an authenticated no-store route", () => {
+    expect(stateRoute).toContain("requireShopAssistantActor");
+    expect(stateRoute).toContain("buildShopState");
+    expect(stateRoute).toContain('"cache-control": "private, no-store, max-age=0"');
+  });
+
+  it("refreshes while visible instead of appending duplicate dashboard cards", () => {
+    expect(stateHook).toContain("REFRESH_INTERVAL_MS");
+    expect(stateHook).toContain("document.visibilityState");
+    expect(stateHook).toContain("setState(payload.state)");
+    expect(stateHook).not.toContain("setState((current) => [");
+  });
+
+  it("loads the live dashboard before a prompt on desktop and mobile", () => {
+    expect(dashboard).toContain("ShopStateMetricGrid");
+    expect(dashboard).toContain("ShopAlertList");
+    expect(dashboard).toContain("ShopSuggestionList");
+    expect(desktopPage).toContain("<ShopAssistantDashboard");
+    expect(mobilePage).toContain("<ShopAssistantDashboard");
+  });
+});


### PR DESCRIPTION
## Phase 2 — Shop Intelligence

- replaces the static assistant landing experience with a live shop-wide operating picture on desktop and mobile
- adds deterministic metrics for open/stalled work, overdue approvals, delayed parts, available technician capacity, ready billing work, today’s bookings, and shop utilization
- reuses the existing operational notification and technician-load systems
- maps proactive alerts for stalled work orders, approvals, parts delays, idle technicians, and ready-to-invoice work
- creates capability-gated suggestions for owners/managers, advisors/service, parts staff, and lead-hand/foreman roles
- refreshes every 45 seconds while visible, on page return, on demand, and after conversation changes
- does not introduce an always-running or background LLM

## Security and tenancy

The state route uses the Phase 1 shop-assistant actor guard. Every query remains explicitly scoped to the authenticated actor’s shop and is still subject to Supabase RLS.

## Validation

Focused contract coverage is included in `tests/shop-assistant-state.test.ts`.

## Stack

This is PR 2 of 4 and targets the Phase 1 reliability branch. Merge PR #1136 first, then retarget this PR to `main`.