### PR TITLE
Fix mobile and desktop inspection synchronization

### DIFF
--- a/app/api/inspections/load/route.ts
+++ b/app/api/inspections/load/route.ts
@@ -26,6 +26,56 @@ function asString(value: unknown): string | null {
     : null;
 }
 
+type InspectionPhotoRow = {
+  item_name: string | null;
+  image_url: string | null;
+};
+
+function normalizeItemName(value: unknown): string {
+  return typeof value === "string"
+    ? value.trim().toLowerCase().replace(/\s+/g, " ")
+    : "";
+}
+
+function mergeCanonicalPhotos(
+  session: InspectionSession,
+  photos: InspectionPhotoRow[],
+): InspectionSession {
+  if (!photos.length) return session;
+
+  const byItem = new Map<string, string[]>();
+  for (const photo of photos) {
+    const itemKey = normalizeItemName(photo.item_name);
+    const url = asString(photo.image_url);
+    if (!itemKey || !url) continue;
+    const current = byItem.get(itemKey) ?? [];
+    if (!current.includes(url)) current.push(url);
+    byItem.set(itemKey, current);
+  }
+  if (!byItem.size) return session;
+
+  const consumed = new Set<string>();
+  return {
+    ...session,
+    sections: (session.sections ?? []).map((section) => ({
+      ...section,
+      items: (section.items ?? []).map((item) => {
+        const key = normalizeItemName(item.item ?? item.name);
+        const canonical = !consumed.has(key) ? byItem.get(key) : undefined;
+        if (!canonical?.length) return item;
+        consumed.add(key);
+        const existing = Array.isArray(item.photoUrls) ? item.photoUrls : [];
+        return {
+          ...item,
+          photoUrls: [...existing, ...canonical].filter(
+            (url, index, all) => all.indexOf(url) === index,
+          ),
+        };
+      }),
+    })),
+  };
+}
+
 export async function GET(req: NextRequest) {
   const supabase = createServerSupabaseRoute();
   const inspectionId = asString(req.nextUrl.searchParams.get("inspectionId"));
@@ -169,12 +219,32 @@ export async function GET(req: NextRequest) {
     });
   }
 
-  const hydratedSession: InspectionSession = {
-    ...session,
-    id: inspectionRow?.id ?? session.id ?? inspectionId ?? "",
-    workOrderId: inspectionRow?.work_order_id ?? session.workOrderId ?? null,
-    workOrderLineId: resolvedWorkOrderLineId ?? session.workOrderLineId ?? null,
-  };
+  const canonicalInspectionId =
+    inspectionRow?.id ?? session.id ?? inspectionId ?? "";
+  let canonicalPhotos: InspectionPhotoRow[] = [];
+  if (canonicalInspectionId) {
+    const { data: photoRows, error: photoError } = await supabase
+      .from("inspection_photos")
+      .select("item_name, image_url")
+      .eq("inspection_id", canonicalInspectionId)
+      .order("created_at", { ascending: true });
+
+    if (photoError) {
+      console.error("[inspections/load] canonical photo hydration failed", photoError);
+    } else {
+      canonicalPhotos = (photoRows ?? []) as InspectionPhotoRow[];
+    }
+  }
+
+  const hydratedSession = mergeCanonicalPhotos(
+    {
+      ...session,
+      id: canonicalInspectionId,
+      workOrderId: inspectionRow?.work_order_id ?? session.workOrderId ?? null,
+      workOrderLineId: resolvedWorkOrderLineId ?? session.workOrderLineId ?? null,
+    },
+    canonicalPhotos,
+  );
 
   return NextResponse.json({
     session: hydratedSession,

--- a/app/api/inspections/load/route.ts
+++ b/app/api/inspections/load/route.ts
@@ -31,6 +31,32 @@ type InspectionPhotoRow = {
   image_url: string | null;
 };
 
+type WorkOrderContextRow = {
+  customer_id: string | null;
+  vehicle_id: string | null;
+};
+type CustomerContextRow = {
+  first_name: string | null;
+  last_name: string | null;
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  city: string | null;
+  province: string | null;
+  postal_code: string | null;
+};
+type VehicleContextRow = {
+  year: number | null;
+  make: string | null;
+  model: string | null;
+  vin: string | null;
+  license_plate: string | null;
+  mileage: string | null;
+  color: string | null;
+  unit_number: string | null;
+  engine_hours: number | null;
+};
+
 function normalizeItemName(value: unknown): string {
   return typeof value === "string"
     ? value.trim().toLowerCase().replace(/\s+/g, " ")
@@ -231,6 +257,63 @@ export async function GET(req: NextRequest) {
 
   const canonicalInspectionId =
     inspectionRow?.id ?? session.id ?? inspectionId ?? "";
+  const canonicalWorkOrderId =
+    inspectionRow?.work_order_id ?? session.workOrderId ?? null;
+
+  let customerContext: CustomerContextRow | null = null;
+  let vehicleContext: VehicleContextRow | null = null;
+  if (canonicalWorkOrderId) {
+    const { data: workOrder, error: workOrderError } = await supabase
+      .from("work_orders")
+      .select("customer_id, vehicle_id")
+      .eq("id", canonicalWorkOrderId)
+      .eq("shop_id", shopId)
+      .maybeSingle<WorkOrderContextRow>();
+
+    if (workOrderError) {
+      console.error("[inspections/load] work-order context failed", workOrderError);
+    } else if (workOrder) {
+      const [customerResult, vehicleResult] = await Promise.all([
+        workOrder.customer_id
+          ? supabase
+              .from("customers")
+              .select(
+                "first_name, last_name, phone, email, address, city, province, postal_code",
+              )
+              .eq("id", workOrder.customer_id)
+              .eq("shop_id", shopId)
+              .maybeSingle<CustomerContextRow>()
+          : Promise.resolve({ data: null, error: null }),
+        workOrder.vehicle_id
+          ? supabase
+              .from("vehicles")
+              .select(
+                "year, make, model, vin, license_plate, mileage, color, unit_number, engine_hours",
+              )
+              .eq("id", workOrder.vehicle_id)
+              .eq("shop_id", shopId)
+              .maybeSingle<VehicleContextRow>()
+          : Promise.resolve({ data: null, error: null }),
+      ]);
+      if (customerResult.error) {
+        console.error(
+          "[inspections/load] customer context failed",
+          customerResult.error,
+        );
+      } else {
+        customerContext = customerResult.data;
+      }
+      if (vehicleResult.error) {
+        console.error(
+          "[inspections/load] vehicle context failed",
+          vehicleResult.error,
+        );
+      } else {
+        vehicleContext = vehicleResult.data;
+      }
+    }
+  }
+
   let canonicalPhotos: InspectionPhotoRow[] = [];
   if (canonicalInspectionId) {
     const { data: photoRows, error: photoError } = await supabase
@@ -250,8 +333,38 @@ export async function GET(req: NextRequest) {
     {
       ...session,
       id: canonicalInspectionId,
-      workOrderId: inspectionRow?.work_order_id ?? session.workOrderId ?? null,
+      workOrderId: canonicalWorkOrderId,
       workOrderLineId: resolvedWorkOrderLineId ?? session.workOrderLineId ?? null,
+      customer: customerContext
+        ? {
+            ...(session.customer ?? {}),
+            first_name: customerContext.first_name ?? "",
+            last_name: customerContext.last_name ?? "",
+            phone: customerContext.phone ?? "",
+            email: customerContext.email ?? "",
+            address: customerContext.address ?? "",
+            city: customerContext.city ?? "",
+            province: customerContext.province ?? "",
+            postal_code: customerContext.postal_code ?? "",
+          }
+        : session.customer,
+      vehicle: vehicleContext
+        ? {
+            ...(session.vehicle ?? {}),
+            year: vehicleContext.year != null ? String(vehicleContext.year) : "",
+            make: vehicleContext.make ?? "",
+            model: vehicleContext.model ?? "",
+            vin: vehicleContext.vin ?? "",
+            license_plate: vehicleContext.license_plate ?? "",
+            mileage: vehicleContext.mileage ?? "",
+            color: vehicleContext.color ?? "",
+            unit_number: vehicleContext.unit_number ?? "",
+            engine_hours:
+              vehicleContext.engine_hours != null
+                ? String(vehicleContext.engine_hours)
+                : "",
+          }
+        : session.vehicle,
     },
     canonicalPhotos,
   );

--- a/app/api/inspections/load/route.ts
+++ b/app/api/inspections/load/route.ts
@@ -98,11 +98,21 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: profile, error: profileError } = await supabase
+  let profileResult = await supabase
     .from("profiles")
     .select("shop_id")
     .eq("id", user.id)
     .maybeSingle<{ shop_id: string | null }>();
+  if (!profileResult.data && !profileResult.error) {
+    profileResult = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("user_id", user.id)
+      .limit(1)
+      .maybeSingle<{ shop_id: string | null }>();
+  }
+  const profile = profileResult.data;
+  const profileError = profileResult.error;
 
   const shopId = profile?.shop_id ?? null;
   if (profileError || !shopId) {

--- a/app/api/inspections/save/route.ts
+++ b/app/api/inspections/save/route.ts
@@ -58,11 +58,21 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { data: profile, error: profileError } = await supabase
+  let profileResult = await supabase
     .from("profiles")
     .select("shop_id")
     .eq("id", user.id)
     .maybeSingle<{ shop_id: string | null }>();
+  if (!profileResult.data && !profileResult.error) {
+    profileResult = await supabase
+      .from("profiles")
+      .select("shop_id")
+      .eq("user_id", user.id)
+      .limit(1)
+      .maybeSingle<{ shop_id: string | null }>();
+  }
+  const profile = profileResult.data;
+  const profileError = profileResult.error;
   if (profileError || !profile?.shop_id) {
     return NextResponse.json(
       { error: "Unable to resolve actor shop." },

--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -211,14 +211,27 @@ export async function POST(req: NextRequest) {
   const requestedInspectionId = cleanUuid(bodyUnknown.inspectionId);
   const workOrderLineId = cleanUuid(bodyUnknown.workOrderLineId);
 
-  const { data: profile, error: profileError } = await supabase
+  const profileColumns =
+    "shop_id, full_name, tech_signature_path, tech_signature_hash, role";
+  let profileResult = await supabase
     .from("profiles")
-    .select(
-      "shop_id, full_name, tech_signature_path, tech_signature_hash, role",
-    )
+    .select(profileColumns)
     .eq("id", user.id)
     .maybeSingle<ProfileRow>();
 
+  // Older and imported staff profiles can keep the auth identity in user_id
+  // while id remains the employee/profile identity. Both are valid in ProFixIQ.
+  if (!profileResult.data && !profileResult.error) {
+    profileResult = await supabase
+      .from("profiles")
+      .select(profileColumns)
+      .eq("user_id", user.id)
+      .limit(1)
+      .maybeSingle<ProfileRow>();
+  }
+
+  const profile = profileResult.data;
+  const profileError = profileResult.error;
   if (profileError) {
     return NextResponse.json(
       { error: `Unable to read profile: ${profileError.message}` },

--- a/app/mobile/inspections/[id]/page.tsx
+++ b/app/mobile/inspections/[id]/page.tsx
@@ -166,6 +166,70 @@ export default function MobileInspectionRunnerPage() {
           String(data.vehicle_type ?? ""),
           gridOverride,
         );
+
+        // The work order is the canonical source for inspection identity context.
+        // Mobile routes intentionally keep query strings small, so hydrate the
+        // customer and vehicle here instead of starting a blank device-only copy.
+        let workOrderContext: Record<string, string> = {};
+        if (workOrderId) {
+          const { data: workOrder, error: workOrderError } = await supabase
+            .from("work_orders")
+            .select("customer_id, vehicle_id")
+            .eq("id", workOrderId)
+            .maybeSingle();
+
+          if (workOrderError) throw workOrderError;
+
+          const [customerResult, vehicleResult] = await Promise.all([
+            workOrder?.customer_id
+              ? supabase
+                  .from("customers")
+                  .select(
+                    "first_name, last_name, phone, email, address, city, province, postal_code",
+                  )
+                  .eq("id", workOrder.customer_id)
+                  .maybeSingle()
+              : Promise.resolve({ data: null, error: null }),
+            workOrder?.vehicle_id
+              ? supabase
+                  .from("vehicles")
+                  .select(
+                    "year, make, model, vin, license_plate, mileage, color, unit_number, engine_hours",
+                  )
+                  .eq("id", workOrder.vehicle_id)
+                  .maybeSingle()
+              : Promise.resolve({ data: null, error: null }),
+          ]);
+
+          if (customerResult.error) throw customerResult.error;
+          if (vehicleResult.error) throw vehicleResult.error;
+
+          const put = (key: string, value: unknown) => {
+            if (value !== null && value !== undefined && String(value).trim()) {
+              workOrderContext[key] = String(value);
+            }
+          };
+          const customer = customerResult.data;
+          const vehicle = vehicleResult.data;
+          put("first_name", customer?.first_name);
+          put("last_name", customer?.last_name);
+          put("phone", customer?.phone);
+          put("email", customer?.email);
+          put("address", customer?.address);
+          put("city", customer?.city);
+          put("province", customer?.province);
+          put("postal_code", customer?.postal_code);
+          put("year", vehicle?.year);
+          put("make", vehicle?.make);
+          put("model", vehicle?.model);
+          put("vin", vehicle?.vin);
+          put("license_plate", vehicle?.license_plate);
+          put("mileage", vehicle?.mileage);
+          put("color", vehicle?.color);
+          put("unit_number", vehicle?.unit_number);
+          put("engine_hours", vehicle?.engine_hours);
+        }
+
         const runtimeParams: Record<string, string> = {};
         new URLSearchParams(searchKey).forEach((value, key) => {
           runtimeParams[key] = value;
@@ -177,6 +241,7 @@ export default function MobileInspectionRunnerPage() {
         if (workOrderId) runtimeParams.workOrderId = workOrderId;
         runtimeParams.templateId = templateId;
         runtimeParams.template = "generic";
+        Object.assign(runtimeParams, workOrderContext);
 
         sessionStorage.setItem("inspection:sections", JSON.stringify(sections));
         sessionStorage.setItem(

--- a/features/inspections/components/inspection/InspectionSignaturePanel.tsx
+++ b/features/inspections/components/inspection/InspectionSignaturePanel.tsx
@@ -158,12 +158,21 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
         } = await supabase.auth.getUser();
         if (!user?.id) return;
 
-        const { data, error } = await supabase
+        let profileResult = await supabase
           .from("profiles")
           .select("full_name")
           .eq("id", user.id)
           .maybeSingle<ProfileResponse>();
-        if (error) return;
+        if (!profileResult.data && !profileResult.error) {
+          profileResult = await supabase
+            .from("profiles")
+            .select("full_name")
+            .eq("user_id", user.id)
+            .limit(1)
+            .maybeSingle<ProfileResponse>();
+        }
+        if (profileResult.error) return;
+        const data = profileResult.data;
 
         const authMetadataName =
           typeof user.user_metadata?.full_name === "string"

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -3179,7 +3179,7 @@ type SmartMatchRow = {
                               handleAddAxleForSection(sectionIndex, axleLabel)
                             }
                             onSpecHint={(metricLabel: string) =>
-                              _props.onSpecHint?.({
+                              props.onSpecHint?.({
                                 source: "air_corner",
                                 label: metricLabel,
                                 meta: { sectionTitle: section.title },
@@ -3219,7 +3219,7 @@ type SmartMatchRow = {
                                 handleAddTireAxleForSection(sectionIndex, axleLabel)
                               }
                               onSpecHint={(metricLabel: string) =>
-                                _props.onSpecHint?.({
+                                props.onSpecHint?.({
                                   source: "tire",
                                   label: metricLabel,
                                   meta: { sectionTitle: section.title },
@@ -3257,7 +3257,7 @@ type SmartMatchRow = {
                             items={itemsWithHints}
                             unitHint={(label: string) => unitHintGeneric(label, unit)}
                             onSpecHint={(label: string) =>
-                              _props.onSpecHint?.({
+                              props.onSpecHint?.({
                                 source: "corner",
                                 label,
                                 meta: { sectionTitle: section.title },

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -608,7 +608,7 @@ function buildInterpretCtxForSpeech(args: {
 /* -------------------------------------------------------------------- */
 
 export default function GenericInspectionScreen(
-  _props: GenericInspectionScreenProps,
+  props: GenericInspectionScreenProps,
 ): JSX.Element {
   const routeSp = useSearchParams();
   const router = useRouter();
@@ -636,31 +636,30 @@ type SmartMatchRow = {
 };
 
   const sp = useMemo(() => {
+    const merged = new URLSearchParams();
     const staged = readStaged<Record<string, string>>("inspection:params");
 
-    if (staged && Object.keys(staged).length > 0) {
-      const merged = new URLSearchParams();
+    // Direct-route params form the base. The mobile runner stages its context
+    // because it prepares the template client-side. A desktop modal passes the
+    // exact inspection source as props and must win over any stale staged run.
+    routeSp.forEach((value, key) => merged.set(key, value));
+    Object.entries(staged ?? {}).forEach(([key, value]) => {
+      if (value != null) merged.set(key, String(value));
+    });
+    Object.entries(props.params ?? {}).forEach(([key, value]) => {
+      if (value != null) merged.set(key, String(value));
+    });
 
-      // URL first
-      routeSp.forEach((value, key) => merged.set(key, value));
-
-      // staged second (wins)
-      Object.entries(staged).forEach(([key, value]) => {
-        if (value != null) merged.set(key, String(value));
-      });
-
-      return merged;
-    }
-
-    return routeSp;
-  }, [routeSp]);
+    return merged;
+  }, [props.params, routeSp]);
 
   const isEmbed = useMemo(
     () =>
+      props.embed === true ||
       ["1", "true", "yes"].includes(
         (sp.get("embed") || sp.get("compact") || "").toLowerCase(),
       ),
-    [sp],
+    [props.embed, sp],
   );
 
   const workOrderId = sp.get("workOrderId") || null;
@@ -673,6 +672,9 @@ type SmartMatchRow = {
     (typeof window !== "undefined"
       ? sessionStorage.getItem("inspection:title")
       : null) ||
+    sp.get("templateName") ||
+    sp.get("template_name") ||
+    props.template ||
     sp.get("template") ||
     "Inspection";
 

--- a/supabase/migrations/20260721173000_inspection_signature_profile_identity.sql
+++ b/supabase/migrations/20260721173000_inspection_signature_profile_identity.sql
@@ -1,0 +1,267 @@
+-- Keep technician signing aligned with the profile identity used by settings.
+-- Imported/legacy staff may link auth.users through profiles.user_id while
+-- profiles.id remains the employee identity and signature storage namespace.
+
+create or replace function public.sign_inspection(
+  p_inspection_id uuid,
+  p_role text,
+  p_signed_name text,
+  p_expected_sync_revision bigint,
+  p_signature_image_path text default null,
+  p_signature_hash text default null
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor_user_id uuid := auth.uid();
+  v_inspection_shop_id uuid;
+  v_inspection_locked boolean := false;
+  v_inspection_completed boolean := false;
+  v_inspection_is_draft boolean := true;
+  v_inspection_finalized_at timestamptz;
+  v_signing_cycle bigint := 0;
+  v_inspection_summary jsonb := '{}'::jsonb;
+  v_inspection_revision bigint := 0;
+  v_signature_id uuid;
+  v_signature_actor uuid;
+  v_signature_name text;
+  v_now timestamptz := clock_timestamp();
+  v_effective_name text := nullif(trim(p_signed_name), '');
+  v_effective_path text := nullif(trim(p_signature_image_path), '');
+  v_effective_hash text := nullif(trim(p_signature_hash), '');
+  v_profile record;
+begin
+  if v_actor_user_id is null then
+    raise exception using errcode = 'P0001', message = 'Authentication is required.';
+  end if;
+
+  if p_role is null or p_role not in ('technician', 'customer', 'advisor') then
+    raise exception using errcode = 'P0001', message = 'Unsupported inspection signature role.';
+  end if;
+
+  if p_expected_sync_revision is null or p_expected_sync_revision < 1 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'A saved inspection revision is required before signing.';
+  end if;
+
+  select
+    i.shop_id,
+    coalesce(i.locked, false),
+    coalesce(i.completed, false),
+    coalesce(i.is_draft, true),
+    i.finalized_at,
+    coalesce(i.signing_cycle, 0),
+    coalesce(i.summary, '{}'::jsonb)
+  into
+    v_inspection_shop_id,
+    v_inspection_locked,
+    v_inspection_completed,
+    v_inspection_is_draft,
+    v_inspection_finalized_at,
+    v_signing_cycle,
+    v_inspection_summary
+  from public.inspections i
+  where i.id = p_inspection_id
+  for update;
+
+  if not found then
+    raise exception using errcode = 'P0001', message = 'Inspection was not found.';
+  end if;
+
+  if coalesce(v_inspection_summary->>'syncRevision', '') ~ '^[0-9]+$' then
+    v_inspection_revision :=
+      (v_inspection_summary->>'syncRevision')::bigint;
+  end if;
+
+  if p_expected_sync_revision <> v_inspection_revision then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection changed on another device before signing. Review the latest version and sign again.';
+  end if;
+
+  select
+    p.id,
+    p.shop_id,
+    p.role,
+    p.full_name,
+    p.tech_signature_path,
+    p.tech_signature_hash
+  into v_profile
+  from public.profiles p
+  where p.id = v_actor_user_id
+     or p.user_id = v_actor_user_id
+  order by case when p.id = v_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if not found or v_profile.shop_id is distinct from v_inspection_shop_id then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection does not belong to the authenticated user shop.';
+  end if;
+
+  if p_role = 'advisor' then
+    if lower(coalesce(v_profile.role::text, '')) not in (
+      'advisor',
+      'service_advisor',
+      'service advisor',
+      'owner',
+      'admin',
+      'manager'
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'Authenticated user cannot sign as service advisor.';
+    end if;
+
+    v_effective_name := coalesce(
+      nullif(trim(v_profile.full_name), ''),
+      nullif(trim(auth.jwt() -> 'user_metadata' ->> 'full_name'), ''),
+      nullif(trim(auth.jwt() -> 'user_metadata' ->> 'name'), '')
+    );
+  end if;
+
+  if p_role = 'technician' then
+    if lower(coalesce(v_profile.role::text, '')) not in (
+      'technician',
+      'tech',
+      'mechanic',
+      'owner',
+      'admin',
+      'manager',
+      'foreman',
+      'lead_hand',
+      'lead hand'
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'Authenticated user cannot sign as technician.';
+    end if;
+
+    v_effective_name := coalesce(
+      nullif(trim(v_profile.full_name), ''),
+      nullif(trim(auth.jwt() -> 'user_metadata' ->> 'full_name'), ''),
+      nullif(trim(auth.jwt() -> 'user_metadata' ->> 'name'), '')
+    );
+    v_effective_path := nullif(trim(v_profile.tech_signature_path), '');
+    v_effective_hash := nullif(trim(v_profile.tech_signature_hash), '');
+
+    if v_effective_path is null
+       or v_effective_hash is null
+       or v_effective_hash !~ '^[0-9a-fA-F]{64}$'
+       or not (
+         v_effective_path =
+           'tech-signatures/' || v_profile.id::text || '.png'
+         or v_effective_path =
+           'tech-signatures/' || v_profile.id::text || '/' ||
+           lower(v_effective_hash) || '.png'
+       )
+       or not exists (
+         select 1
+         from storage.objects o
+         where o.bucket_id = 'signatures'
+           and o.name = v_effective_path
+       ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'No valid saved technician signature exists in this profile.';
+    end if;
+  end if;
+
+  if v_effective_name is null then
+    raise exception using errcode = 'P0001', message = 'Signed name is required.';
+  end if;
+
+  -- Only this exact atomic reopen generation and server revision can satisfy
+  -- an idempotent retry. Older evidence remains queryable but cannot suppress
+  -- a new signing cycle.
+  select s.id, s.signed_by, s.signed_name
+    into v_signature_id, v_signature_actor, v_signature_name
+  from public.inspection_signatures s
+  where s.inspection_id = p_inspection_id
+    and s.role = p_role
+    and s.signing_cycle = v_signing_cycle
+    and s.signed_sync_revision = v_inspection_revision
+  order by s.signed_at desc nulls last, s.id desc
+  limit 1
+  for update;
+
+  if found then
+    if (
+      v_inspection_locked
+      or v_inspection_completed
+      or not v_inspection_is_draft
+      or v_inspection_finalized_at is not null
+    ) and v_signature_actor = v_actor_user_id
+      and (
+        p_role in ('technician', 'advisor')
+        or v_signature_name is not distinct from v_effective_name
+      ) then
+      return;
+    end if;
+
+    raise exception using
+      errcode = 'P0001',
+      message = 'This inspection revision is already signed for that role.';
+  end if;
+
+  insert into public.inspection_signatures (
+    inspection_id,
+    role,
+    signed_by,
+    signed_name,
+    signature_image_path,
+    signature_hash,
+    signing_cycle,
+    signed_sync_revision,
+    signed_summary_hash,
+    signed_summary,
+    signed_at
+  ) values (
+    p_inspection_id,
+    p_role,
+    v_actor_user_id,
+    v_effective_name,
+    v_effective_path,
+    v_effective_hash,
+    v_signing_cycle,
+    v_inspection_revision,
+    encode(
+      extensions.digest(
+        convert_to(v_inspection_summary::text, 'UTF8'),
+        'sha256'
+      ),
+      'hex'
+    ),
+    v_inspection_summary,
+    v_now
+  );
+
+  -- The first role finalizes the snapshot. Additional roles can append their
+  -- own immutable evidence without rewriting the already-finalized row.
+  if not v_inspection_locked
+     and not v_inspection_completed
+     and v_inspection_is_draft
+     and v_inspection_finalized_at is null then
+    perform set_config('profixiq.inspection_sign', 'on', true);
+    update public.inspections
+    set locked = true,
+        completed = true,
+        is_draft = false,
+        status = 'completed',
+        finalized_at = v_now,
+        finalized_by = v_actor_user_id,
+        updated_at = v_now
+    where id = p_inspection_id;
+  end if;
+end;
+$$;
+
+revoke all on function public.sign_inspection(
+  uuid, text, text, bigint, text, text
+) from public;
+grant execute on function public.sign_inspection(
+  uuid, text, text, bigint, text, text
+) to authenticated, service_role;

--- a/tests/inspection-autosave-realtime-signatures.test.ts
+++ b/tests/inspection-autosave-realtime-signatures.test.ts
@@ -19,6 +19,7 @@ const signaturePanel = readFileSync(
 );
 const signRoute = readFileSync("app/api/inspections/sign/route.ts", "utf8");
 const loadRoute = readFileSync("app/api/inspections/load/route.ts", "utf8");
+const saveRoute = readFileSync("app/api/inspections/save/route.ts", "utf8");
 const migration = readFileSync(
   "supabase/migrations/20260721160000_inspection_live_autosave_signature_hardening.sql",
   "utf8",
@@ -103,6 +104,8 @@ describe("inspection autosave, realtime, and signatures", () => {
   });
 
   it("resolves linked profile identities for technician signatures", () => {
+    expect(loadRoute).toContain('.eq("user_id", user.id)');
+    expect(saveRoute).toContain('.eq("user_id", user.id)');
     expect(signRoute).toContain('.eq("user_id", user.id)');
     expect(signaturePanel).toContain('.eq("user_id", user.id)');
     expect(signatureIdentityMigration).toContain(

--- a/tests/inspection-autosave-realtime-signatures.test.ts
+++ b/tests/inspection-autosave-realtime-signatures.test.ts
@@ -101,6 +101,9 @@ describe("inspection autosave, realtime, and signatures", () => {
     expect(loadRoute).toContain('.from("inspection_photos")');
     expect(loadRoute).toContain("mergeCanonicalPhotos");
     expect(loadRoute).toContain("canonicalInspectionId");
+    expect(loadRoute).toContain("canonicalWorkOrderId");
+    expect(loadRoute).toContain("customerContext");
+    expect(loadRoute).toContain("vehicleContext");
   });
 
   it("resolves linked profile identities for technician signatures", () => {

--- a/tests/inspection-autosave-realtime-signatures.test.ts
+++ b/tests/inspection-autosave-realtime-signatures.test.ts
@@ -31,6 +31,14 @@ const mobileSettings = readFileSync(
   "features/mobile/settings/MobileSettingsScreen.tsx",
   "utf8",
 );
+const mobileRunner = readFileSync(
+  "app/mobile/inspections/[id]/page.tsx",
+  "utf8",
+);
+const signatureIdentityMigration = readFileSync(
+  "supabase/migrations/20260721173000_inspection_signature_profile_identity.sql",
+  "utf8",
+);
 
 describe("inspection autosave, realtime, and signatures", () => {
   it("debounces every session update into the canonical server writer", () => {
@@ -79,6 +87,30 @@ describe("inspection autosave, realtime, and signatures", () => {
     expect(desktopSettings).toContain("upsert: false");
     expect(mobileSettings).toContain("upsert: false");
     expect(migration).toContain("prevent_technician_signature_mutation");
+  });
+
+  it("uses the work-order line as the shared mobile and desktop identity", () => {
+    expect(genericScreen).toContain("Object.entries(props.params ?? {})");
+    expect(genericScreen).toContain("props.embed === true");
+    expect(mobileRunner).toContain('.from("work_orders")');
+    expect(mobileRunner).toContain("Object.assign(runtimeParams, workOrderContext)");
+  });
+
+  it("hydrates canonical media independently of the device autosave", () => {
+    expect(loadRoute).toContain('.from("inspection_photos")');
+    expect(loadRoute).toContain("mergeCanonicalPhotos");
+    expect(loadRoute).toContain("canonicalInspectionId");
+  });
+
+  it("resolves linked profile identities for technician signatures", () => {
+    expect(signRoute).toContain('.eq("user_id", user.id)');
+    expect(signaturePanel).toContain('.eq("user_id", user.id)');
+    expect(signatureIdentityMigration).toContain(
+      "or p.user_id = v_actor_user_id",
+    );
+    expect(signatureIdentityMigration).toContain(
+      "'tech-signatures/' || v_profile.id::text || '/'",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Unifies mobile and desktop inspections around the canonical work-order-line inspection and fixes profile-backed technician signing.

## Root cause

- `GenericInspectionScreen` ignored the params supplied by the desktop inspection modal and instead read the current page URL/global session storage. Desktop and mobile could therefore open different local inspection identities for the same job.
- The mobile runner did not hydrate customer or vehicle fields from the work order.
- Photo URLs were only carried in the browser session snapshot after upload; an interrupted follow-up autosave left the durable `inspection_photos` row invisible on another device.
- Inspection load, save, signing UI, signing API, and the signing RPC assumed `profiles.id = auth.uid()`. Imported/linked staff profiles can use `profiles.user_id`, while signature storage is namespaced by the actual profile ID.

## Changes

- Give component-supplied inspection params highest precedence in the shared generic runner.
- Hydrate mobile customer and vehicle context from the work order.
- Hydrate server-loaded inspection snapshots with canonical work-order customer/vehicle data.
- Merge durable `inspection_photos` rows into the correct inspection item during load.
- Resolve both direct and `user_id`-linked profile identities in inspection load/save/signing.
- Add a forward-only migration updating `sign_inspection` to validate the saved signature under the actual profile ID.
- Extend inspection autosave/realtime/signature regression coverage.

## Expected result

Starting or editing an inspection on mobile is visible when the same work-order inspection opens in the desktop app, including item results and photos. Customer/vehicle information appears on mobile, and technician Sign applies the immutable saved profile signature.

## Validation

- Static branch diff reviewed.
- Regression assertions added in `tests/inspection-autosave-realtime-signatures.test.ts`.
- GitHub Actions run #22 passed: full TypeScript typecheck, scoped lint, and Phase 6 technician mobile reliability tests.
- Supabase preview database, services, and APIs deployed successfully.
- The first CI run exposed three stale `_props` references after activating the previously ignored component props; those were corrected and the rerun passed.
- Vercel preview still reports a deployment error without exposing build detail through the GitHub status payload. The PR remains mergeable; inspect the linked Vercel deployment before merging.
- Branch began before PR #1135 merged and is currently two commits behind `main`; GitHub reports it mergeable and the mobile import files do not overlap this change.

## Database

Adds `20260721173000_inspection_signature_profile_identity.sql`. It replaces the existing signing function forward-only; no existing migration is modified.

## Manual test

1. Open one inspection from a mobile work order and record results plus photos.
2. Wait for **Saved to shop • syncs across devices**.
3. Open the same line from the desktop work order modal and confirm results, customer, vehicle, and photos.
4. Sign as the technician on mobile and desktop using the saved Tech Settings signature.
