### PR TITLE
Phase 2: add live shop intelligence and proactive alerts

### DIFF
--- a/app/api/assistant/shop-state/route.ts
+++ b/app/api/assistant/shop-state/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { getShopAssistantStateForActor } from "@/features/assistant/server/shopStateStore";
+import type { SuggestedActionContext } from "@/features/assistant/types/suggested-actions";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+function optionalParam(url: URL, key: string): string | undefined {
+  const value = url.searchParams.get(key)?.trim();
+  if (!value || value.length > 160) return undefined;
+  return value;
+}
+
+export async function GET(request: Request) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
+  const url = new URL(request.url);
+  const context: SuggestedActionContext = {
+    workOrderId: optionalParam(url, "workOrderId"),
+    customerId: optionalParam(url, "customerId"),
+    vehicleId: optionalParam(url, "vehicleId"),
+    bookingId: optionalParam(url, "bookingId"),
+    pageType: optionalParam(url, "pageType"),
+    pageTitle: optionalParam(url, "pageTitle"),
+  };
+
+  try {
+    const state = await getShopAssistantStateForActor({
+      shopId: access.profile.shop_id,
+      userId: access.profile.id,
+      role: access.profile.role,
+      force: url.searchParams.get("refresh") === "1",
+      context,
+    });
+
+    return NextResponse.json(
+      { ok: true, state },
+      { headers: { "cache-control": "private, no-store" } },
+    );
+  } catch (error: unknown) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to build the live shop summary",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/assistant/page.tsx
+++ b/app/assistant/page.tsx
@@ -9,15 +9,17 @@ import { Button } from "@shared/components/ui/Button";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 import { useAssistant } from "@/features/assistant/hooks/useAssistant";
+import { useShopState } from "@/features/assistant/hooks/useShopState";
 import AssistantConversation from "@/features/assistant/components/AssistantConversation";
 import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
+import ShopAssistantOverview from "@/features/assistant/components/ShopAssistantOverview";
 import type { AssistantContext } from "@/features/assistant/types/assistant";
 
 const EXAMPLE_PROMPTS = [
-  "Which work orders are waiting on approvals right now?",
+  "How is the shop doing right now?",
+  "Which approvals are blocking revenue today?",
   "Put WO EL00005 on hold for parts.",
-  "What changed today across bookings, invoices, and technician activity?",
-  "Show repeat issues for this vehicle and what we recommended last time.",
+  "What should the service desk handle next?",
 ];
 
 export default function AssistantPage() {
@@ -62,6 +64,7 @@ export default function AssistantPage() {
     cancelAction,
     clearConversation,
   } = useAssistant(contextKey);
+  const shopState = useShopState(context);
 
   const contextChips = useMemo(
     () => [
@@ -87,87 +90,96 @@ export default function AssistantPage() {
   return (
     <PageShell
       title="Shop Assistant"
-      description="Shop-wide intelligence, durable conversation memory, and reviewable operational actions."
+      description="A live operating surface for shop intelligence, proactive attention items, and confirmed actions."
     >
-      <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
-        <div className="desktop-panel-soft p-4">
-          <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-            Assistant scope
+      <div className="space-y-4">
+        <ShopAssistantOverview
+          state={shopState.state}
+          loading={shopState.loading}
+          refreshing={shopState.refreshing}
+          error={shopState.error}
+          onRefresh={shopState.refresh}
+        />
+
+        <div className={`${ui.panel} ${ui.panelPadding} space-y-4`}>
+          <div className="desktop-panel-soft p-4">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+              Conversation scope
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {contextChips.map((chip) => (
+                <span
+                  key={chip.label}
+                  className={`desktop-pill px-3 py-1 text-xs ${
+                    chip.active
+                      ? "border-[color:var(--brand-accent,#E39A6E)]/55 bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_16%,transparent)] text-[color:var(--brand-accent,#E39A6E)]"
+                      : "text-[color:var(--theme-text-secondary)]"
+                  }`}
+                >
+                  {chip.label}
+                </span>
+              ))}
+            </div>
+            <p className="mt-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+              Ask across work orders, customers, vehicles, approvals, bookings,
+              invoices, fleet, parts, reporting, and staff activity. Record changes
+              remain reviewable and require confirmation.
+            </p>
           </div>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {contextChips.map((chip) => (
-              <span
-                key={chip.label}
-                className={`desktop-pill px-3 py-1 text-xs ${
-                  chip.active
-                    ? "border-[color:var(--brand-accent,#E39A6E)]/55 bg-[color:color-mix(in_srgb,var(--brand-accent,#E39A6E)_16%,transparent)] text-[color:var(--brand-accent,#E39A6E)]"
-                    : "text-[color:var(--theme-text-secondary)]"
-                }`}
+
+          {hydrating ? (
+            <div className="desktop-panel-soft p-4 text-sm text-[color:var(--theme-text-secondary)]">
+              Restoring the conversation…
+            </div>
+          ) : (
+            <AssistantConversation messages={messages} />
+          )}
+
+          <textarea
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Ask about the live shop or request a reviewed action..."
+            className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-[color:var(--theme-text-primary)]"
+          />
+
+          <div className="flex flex-wrap gap-2">
+            {EXAMPLE_PROMPTS.map((example) => (
+              <button
+                key={example}
+                type="button"
+                className="desktop-pill px-3 py-1 text-xs text-[color:var(--theme-text-secondary)] hover:border-[color:var(--brand-accent,#E39A6E)]/50 hover:text-[color:var(--brand-accent,#E39A6E)]"
+                onClick={() => setQuery(example)}
               >
-                {chip.label}
-              </span>
+                {example}
+              </button>
             ))}
           </div>
-          <p className="mt-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
-            Ask across work orders, customers, vehicles, inspections, approvals,
-            bookings, invoices, fleet, parts, and staff activity. Action requests
-            are separated from questions and require confirmation before records
-            change.
-          </p>
-        </div>
 
-        {hydrating ? (
-          <div className="desktop-panel-soft p-4 text-sm text-[color:var(--theme-text-secondary)]">
-            Restoring the conversation…
-          </div>
-        ) : (
-          <AssistantConversation messages={messages} />
-        )}
-
-        <textarea
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Ask a shop question or request a reviewed action..."
-          className="desktop-input min-h-[120px] w-full resize-y rounded-2xl px-3 py-2 text-[color:var(--theme-text-primary)]"
-        />
-
-        <div className="flex flex-wrap gap-2">
-          {EXAMPLE_PROMPTS.map((example) => (
-            <button
-              key={example}
-              type="button"
-              className="desktop-pill px-3 py-1 text-xs text-[color:var(--theme-text-secondary)] hover:border-[color:var(--brand-accent,#E39A6E)]/50 hover:text-[color:var(--brand-accent,#E39A6E)]"
-              onClick={() => setQuery(example)}
+          <div className="mt-4 flex items-center justify-between gap-3">
+            <Button
+              variant="ghost"
+              disabled={loading || hydrating || messages.length === 0}
+              onClick={() => void clearConversation()}
             >
-              {example}
-            </button>
-          ))}
-        </div>
+              Clear conversation
+            </Button>
+            <Button
+              onClick={() => void submit()}
+              isLoading={loading}
+              disabled={hydrating || !query.trim()}
+            >
+              Ask Assistant
+            </Button>
+          </div>
 
-        <div className="mt-4 flex items-center justify-between gap-3">
-          <Button
-            variant="ghost"
-            disabled={loading || hydrating || messages.length === 0}
-            onClick={() => void clearConversation()}
-          >
-            Clear conversation
-          </Button>
-          <Button
-            onClick={() => void submit()}
-            isLoading={loading}
-            disabled={hydrating || !query.trim()}
-          >
-            Ask Assistant
-          </Button>
+          <AssistantResponseCard
+            data={data}
+            showAnswer={false}
+            actionLoading={actionLoading}
+            onConfirmAction={confirmAction}
+            onCancelAction={cancelAction}
+          />
         </div>
-
-        <AssistantResponseCard
-          data={data}
-          showAnswer={false}
-          actionLoading={actionLoading}
-          onConfirmAction={confirmAction}
-          onCancelAction={cancelAction}
-        />
       </div>
     </PageShell>
   );

--- a/app/mobile/assistant/page.tsx
+++ b/app/mobile/assistant/page.tsx
@@ -5,7 +5,9 @@ import { useMemo, useState } from "react";
 
 import AssistantConversation from "@/features/assistant/components/AssistantConversation";
 import AssistantResponseCard from "@/features/assistant/components/AssistantResponseCard";
+import ShopAssistantOverview from "@/features/assistant/components/ShopAssistantOverview";
 import { useAssistant } from "@/features/assistant/hooks/useAssistant";
+import { useShopState } from "@/features/assistant/hooks/useShopState";
 import type { AssistantContext } from "@/features/assistant/types/assistant";
 import { Button } from "@shared/components/ui/Button";
 
@@ -55,6 +57,7 @@ export default function MobileAssistantPage() {
     cancelAction,
     clearConversation,
   } = useAssistant(contextKey);
+  const shopState = useShopState(context);
 
   const submit = async () => {
     const value = question.trim();
@@ -74,23 +77,20 @@ export default function MobileAssistantPage() {
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-4 px-3 py-3 sm:px-4">
-      <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
-        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
-          Shop assistant
+      <ShopAssistantOverview
+        state={shopState.state}
+        loading={shopState.loading}
+        refreshing={shopState.refreshing}
+        error={shopState.error}
+        onRefresh={shopState.refresh}
+        compact
+      />
+
+      {contextLabel ? (
+        <div className="inline-flex rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]">
+          Context: {contextLabel}
         </div>
-        <h1 className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">
-          Ask or take action
-        </h1>
-        <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-          Ask across the shop or request an operational change. Record changes are
-          shown for review and require confirmation before they run.
-        </p>
-        {contextLabel ? (
-          <div className="mt-3 inline-flex rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Context: {contextLabel}
-          </div>
-        ) : null}
-      </section>
+      ) : null}
 
       {hydrating ? (
         <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
@@ -105,13 +105,13 @@ export default function MobileAssistantPage() {
           htmlFor="mobile-assistant-question"
           className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]"
         >
-          Question or command
+          Ask or take action
         </label>
         <textarea
           id="mobile-assistant-question"
           value={question}
           onChange={(event) => setQuestion(event.target.value)}
-          placeholder="Ask about shop status or request a reviewed action, such as putting a work order on hold for parts."
+          placeholder="Ask how the shop is doing or request a reviewed operational action."
           className="mt-2 min-h-32 w-full rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper-soft)] focus:ring-2 focus:ring-[var(--accent-copper-soft)]/30"
         />
         <div className="mt-3 flex items-center justify-between gap-2">

--- a/features/assistant/components/ShopAssistantOverview.tsx
+++ b/features/assistant/components/ShopAssistantOverview.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import Link from "next/link";
+import type {
+  ShopAssistantAlert,
+  ShopAssistantMetric,
+  ShopAssistantState,
+} from "../types/shopState";
+
+type Props = {
+  state: ShopAssistantState | null;
+  loading?: boolean;
+  refreshing?: boolean;
+  error?: string | null;
+  compact?: boolean;
+  onRefresh?: () => void | Promise<void>;
+};
+
+function metricClass(metric: ShopAssistantMetric): string {
+  if (metric.tone === "critical") return "border-red-400/35 bg-red-500/10";
+  if (metric.tone === "warning") return "border-amber-400/35 bg-amber-500/10";
+  if (metric.tone === "info") return "border-sky-400/25 bg-sky-500/5";
+  return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]";
+}
+
+function alertClass(alert: ShopAssistantAlert): string {
+  if (alert.level === "critical") return "border-red-400/35 bg-red-500/10";
+  if (alert.level === "warning") return "border-amber-400/35 bg-amber-500/10";
+  return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]";
+}
+
+export default function ShopAssistantOverview({
+  state,
+  loading = false,
+  refreshing = false,
+  error = null,
+  compact = false,
+  onRefresh,
+}: Props) {
+  return (
+    <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-4 shadow-[var(--theme-shadow-medium)]">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+            Shop assistant
+          </div>
+          <h1 className={`${compact ? "text-2xl" : "text-3xl"} mt-2 font-semibold text-[color:var(--theme-text-primary)]`}>
+            Shop command center
+          </h1>
+          <p className="mt-1 max-w-3xl text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+            Live operational state, proactive alerts, role-aware suggestions, and
+            confirmed actions across the shop.
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={loading || refreshing}
+          onClick={() => void onRefresh?.()}
+          className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs font-semibold text-[color:var(--theme-text-secondary)] disabled:opacity-50"
+        >
+          {refreshing ? "Refreshing…" : "Refresh"}
+        </button>
+      </div>
+
+      {error ? (
+        <div className="mt-4 rounded-2xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-200">
+          {error}
+        </div>
+      ) : null}
+
+      {loading && !state ? (
+        <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+          Building the live shop summary…
+        </div>
+      ) : null}
+
+      {state?.scope === "technician" ? (
+        <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
+          <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            Technician guidance stays inside the work order
+          </div>
+          <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+            Open an assigned work order to use the existing technician assistant for
+            diagnostics and job guidance.
+          </p>
+        </div>
+      ) : null}
+
+      {state && state.scope !== "technician" && state.metrics.length > 0 ? (
+        <div className={`mt-4 grid gap-2 ${compact ? "grid-cols-2" : "grid-cols-2 md:grid-cols-4"}`}>
+          {state.metrics.map((metric) => {
+            const content = (
+              <>
+                <div className="text-2xl font-semibold text-[color:var(--theme-text-primary)]">
+                  {metric.value}
+                </div>
+                <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  {metric.label}
+                </div>
+              </>
+            );
+
+            return metric.href ? (
+              <Link
+                key={metric.key}
+                href={metric.href}
+                className={`rounded-2xl border p-3 ${metricClass(metric)}`}
+              >
+                {content}
+              </Link>
+            ) : (
+              <div
+                key={metric.key}
+                className={`rounded-2xl border p-3 ${metricClass(metric)}`}
+              >
+                {content}
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {state && state.scope !== "technician" ? (
+        <div className={`mt-4 grid gap-4 ${compact ? "" : "lg:grid-cols-2"}`}>
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+              Needs attention
+            </div>
+            <div className="mt-2 space-y-2">
+              {state.alerts.length === 0 ? (
+                <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-secondary)]">
+                  No overdue operational alerts are visible for your role.
+                </div>
+              ) : (
+                state.alerts.slice(0, compact ? 4 : 6).map((alert) => {
+                  const body = (
+                    <>
+                      <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                        {alert.title}
+                      </div>
+                      <div className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                        {alert.message}
+                      </div>
+                    </>
+                  );
+
+                  return alert.href ? (
+                    <Link
+                      key={alert.id}
+                      href={alert.href}
+                      className={`block rounded-2xl border p-3 ${alertClass(alert)}`}
+                    >
+                      {body}
+                    </Link>
+                  ) : (
+                    <div
+                      key={alert.id}
+                      className={`rounded-2xl border p-3 ${alertClass(alert)}`}
+                    >
+                      {body}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </div>
+
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+              Suggested next moves
+            </div>
+            <div className="mt-2 space-y-2">
+              {state.suggestions.length === 0 ? (
+                <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-secondary)]">
+                  No additional suggestions are available for your role right now.
+                </div>
+              ) : (
+                state.suggestions.slice(0, compact ? 4 : 6).map((suggestion) => (
+                  <Link
+                    key={suggestion.id}
+                    href={compact ? suggestion.href : suggestion.plannerHref ?? suggestion.href}
+                    className="block rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3"
+                  >
+                    <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                      {suggestion.title}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                      {suggestion.description}
+                    </div>
+                  </Link>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {state ? (
+        <div className="mt-3 text-[10px] text-[color:var(--theme-text-muted)]">
+          Updated {new Date(state.generatedAt).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })} · {state.timezone}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/features/assistant/hooks/useShopState.ts
+++ b/features/assistant/hooks/useShopState.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { AssistantContext } from "../types/assistant";
+import type { ShopAssistantState } from "../types/shopState";
+
+type ShopStateResponse =
+  | { ok: true; state: ShopAssistantState }
+  | { ok: false; error: string };
+
+function queryString(context?: AssistantContext, force = false): string {
+  const params = new URLSearchParams();
+  if (context?.workOrderId) params.set("workOrderId", context.workOrderId);
+  if (context?.customerId) params.set("customerId", context.customerId);
+  if (context?.vehicleId) params.set("vehicleId", context.vehicleId);
+  if (context?.bookingId) params.set("bookingId", context.bookingId);
+  if (context?.pageType) params.set("pageType", context.pageType);
+  if (context?.pageTitle) params.set("pageTitle", context.pageTitle);
+  if (force) params.set("refresh", "1");
+  return params.toString();
+}
+
+export function useShopState(context?: AssistantContext) {
+  const contextKey = useMemo(() => queryString(context), [context]);
+  const [state, setState] = useState<ShopAssistantState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const requestVersion = useRef(0);
+
+  const load = useCallback(
+    async (force = false, signal?: AbortSignal) => {
+      const version = ++requestVersion.current;
+      if (force) setRefreshing(true);
+      else setLoading(true);
+      setError(null);
+
+      try {
+        const suffix = queryString(context, force);
+        const response = await fetch(
+          `/api/assistant/shop-state${suffix ? `?${suffix}` : ""}`,
+          { cache: "no-store", signal },
+        );
+        const json = (await response.json()) as ShopStateResponse;
+        if (!response.ok || !json.ok) {
+          throw new Error(json.ok ? "Shop summary request failed" : json.error);
+        }
+        if (version === requestVersion.current) setState(json.state);
+      } catch (caught: unknown) {
+        if (caught instanceof DOMException && caught.name === "AbortError") return;
+        if (version === requestVersion.current) {
+          setError(
+            caught instanceof Error
+              ? caught.message
+              : "Failed to load the live shop summary",
+          );
+        }
+      } finally {
+        if (version === requestVersion.current) {
+          setLoading(false);
+          setRefreshing(false);
+        }
+      }
+    },
+    [context],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(false, controller.signal);
+    const interval = window.setInterval(() => void load(false), 60_000);
+
+    return () => {
+      controller.abort();
+      window.clearInterval(interval);
+    };
+  }, [contextKey, load]);
+
+  return {
+    state,
+    loading,
+    refreshing,
+    error,
+    refresh: () => load(true),
+  };
+}

--- a/features/assistant/server/buildShopState.ts
+++ b/features/assistant/server/buildShopState.ts
@@ -1,0 +1,222 @@
+import { getOpsNotifications } from "@/features/agent/server/getOpsNotifications";
+import { getServerSupabase } from "@/features/agent/server/supabase";
+import { getShopDayRange } from "@shared/lib/utils/shopDayWindow";
+import type {
+  ShopAssistantAlert,
+  ShopAssistantBaseState,
+  ShopAssistantMetric,
+} from "../types/shopState";
+
+const OPEN_WORK_ORDER_STATUSES = [
+  "awaiting",
+  "awaiting_approval",
+  "queued",
+  "on_hold",
+  "planned",
+  "in_progress",
+];
+
+const STALLED_CODES = new Set([
+  "work_order_on_hold_too_long",
+  "work_order_waiting_too_long",
+  "active_job_running_too_long",
+]);
+
+function normalizedInvoiceStatus(value: string | null): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replaceAll(" ", "_");
+}
+
+function metricTone(
+  value: number,
+  warningAt: number,
+  criticalAt?: number,
+): ShopAssistantMetric["tone"] {
+  if (criticalAt !== undefined && value >= criticalAt) return "critical";
+  if (value >= warningAt) return "warning";
+  return value > 0 ? "info" : "neutral";
+}
+
+function uniqueEntityCount(
+  alerts: ShopAssistantAlert[],
+  predicate: (alert: ShopAssistantAlert) => boolean,
+): number {
+  const keys = new Set<string>();
+  for (const alert of alerts) {
+    if (!predicate(alert)) continue;
+    keys.add(alert.entityId ?? `${alert.code}:${alert.message}`);
+  }
+  return keys.size;
+}
+
+function parseLeadingCount(message: string): number {
+  const value = Number(message.match(/^\s*(\d+)/)?.[1] ?? 0);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function dedupeAlerts(alerts: ShopAssistantAlert[]): ShopAssistantAlert[] {
+  const seen = new Set<string>();
+  const result: ShopAssistantAlert[] = [];
+
+  for (const alert of alerts) {
+    const key = [alert.code, alert.entityId ?? "", alert.message].join("::");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(alert);
+  }
+
+  return result;
+}
+
+export async function buildShopAssistantBaseState(
+  shopId: string,
+): Promise<ShopAssistantBaseState> {
+  const supabase = getServerSupabase();
+
+  const { data: shop, error: shopError } = await supabase
+    .from("shops")
+    .select("timezone")
+    .eq("id", shopId)
+    .maybeSingle();
+
+  if (shopError) throw new Error(shopError.message);
+
+  const day = getShopDayRange(shop?.timezone ?? "UTC");
+
+  const [notifications, activeWorkOrders, bookingsToday, invoiceRows] =
+    await Promise.all([
+      getOpsNotifications(shopId),
+      supabase
+        .from("work_orders")
+        .select("id", { count: "exact", head: true })
+        .eq("shop_id", shopId)
+        .in("status", OPEN_WORK_ORDER_STATUSES),
+      supabase
+        .from("bookings")
+        .select("id", { count: "exact", head: true })
+        .eq("shop_id", shopId)
+        .gte("starts_at", day.start)
+        .lt("starts_at", day.end),
+      supabase
+        .from("v_portal_invoices")
+        .select("work_order_id, status, invoice_sent_at")
+        .eq("shop_id", shopId)
+        .is("invoice_sent_at", null)
+        .limit(500),
+    ]);
+
+  if (activeWorkOrders.error) throw new Error(activeWorkOrders.error.message);
+  if (bookingsToday.error) throw new Error(bookingsToday.error.message);
+  if (invoiceRows.error) throw new Error(invoiceRows.error.message);
+
+  const alerts = dedupeAlerts(
+    notifications.map((notification, index) => ({
+      id: `${notification.code}:${notification.entityId ?? index}`,
+      level:
+        notification.level === "urgent"
+          ? ("critical" as const)
+          : notification.level,
+      code: notification.code,
+      title: notification.title,
+      message: notification.message,
+      href: notification.href,
+      entityType: notification.entityType,
+      entityId: notification.entityId,
+      createdAt: notification.createdAt,
+    })),
+  ).slice(0, 24);
+
+  const stalled = uniqueEntityCount(alerts, (alert) =>
+    STALLED_CODES.has(alert.code),
+  );
+  const approvals = uniqueEntityCount(
+    alerts,
+    (alert) =>
+      alert.code === "approval_waiting" || alert.code === "quote_waiting",
+  );
+  const delayedParts = uniqueEntityCount(
+    alerts,
+    (alert) => alert.code === "parts_waiting_too_long",
+  );
+  const idleTechnicians = alerts
+    .filter((alert) => alert.code === "tech_underutilized_capacity")
+    .reduce(
+      (maximum, alert) => Math.max(maximum, parseLeadingCount(alert.message)),
+      0,
+    );
+  const readyToInvoice = (invoiceRows.data ?? []).filter((row) =>
+    ["ready_to_invoice", "completed", "invoiced"].includes(
+      normalizedInvoiceStatus(row.status),
+    ),
+  ).length;
+
+  const metrics: ShopAssistantMetric[] = [
+    {
+      key: "active_work_orders",
+      label: "Active work orders",
+      value: activeWorkOrders.count ?? 0,
+      tone: "info",
+      href: "/work-orders",
+    },
+    {
+      key: "stalled_work_orders",
+      label: "Stalled work orders",
+      value: stalled,
+      tone: metricTone(stalled, 1, 4),
+      href: "/work-orders",
+    },
+    {
+      key: "overdue_approvals",
+      label: "Overdue approvals",
+      value: approvals,
+      tone: metricTone(approvals, 1, 4),
+      href: "/work-orders",
+    },
+    {
+      key: "delayed_parts",
+      label: "Delayed parts",
+      value: delayedParts,
+      tone: metricTone(delayedParts, 1, 4),
+      href: "/parts",
+    },
+    {
+      key: "idle_technicians",
+      label: "Idle technicians",
+      value: idleTechnicians,
+      tone: metricTone(idleTechnicians, 1, 3),
+      href: "/dashboard",
+    },
+    {
+      key: "ready_to_invoice",
+      label: "Ready to invoice",
+      value: readyToInvoice,
+      tone: metricTone(readyToInvoice, 1, 5),
+      href: "/portal/invoices",
+    },
+    {
+      key: "appointments_today",
+      label: "Appointments today",
+      value: bookingsToday.count ?? 0,
+      tone: "info",
+      href: "/dashboard/appointments",
+    },
+  ];
+
+  const generatedAt = new Date();
+  return {
+    shopId,
+    timezone: day.timezone,
+    localDayKey: new Intl.DateTimeFormat("en-CA", {
+      timeZone: day.timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(generatedAt),
+    generatedAt: generatedAt.toISOString(),
+    staleAfter: new Date(generatedAt.getTime() + 60_000).toISOString(),
+    metrics,
+    alerts,
+  };
+}

--- a/features/assistant/server/shopAssistantDatabase.ts
+++ b/features/assistant/server/shopAssistantDatabase.ts
@@ -24,6 +24,15 @@ export type AssistantMessageRow = {
   created_at: string;
 };
 
+export type AssistantShopStateRow = {
+  shop_id: string;
+  snapshot: Json;
+  version: number;
+  refreshed_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
 export type AssistantActionRequestStatus =
   | "pending"
   | "executing"
@@ -58,6 +67,24 @@ export type AssistantActionRequestRow = {
 type AssistantPersistenceDatabase = {
   public: {
     Tables: {
+      assistant_shop_states: {
+        Row: AssistantShopStateRow;
+        Insert: {
+          shop_id: string;
+          snapshot?: Json;
+          version?: number;
+          refreshed_at?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: Partial<
+          Pick<
+            AssistantShopStateRow,
+            "snapshot" | "version" | "refreshed_at" | "updated_at"
+          >
+        >;
+        Relationships: [];
+      };
       assistant_conversations: {
         Row: AssistantConversationRow;
         Insert: {
@@ -155,8 +182,8 @@ export type ShopAssistantSupabaseClient =
   SupabaseClient<AssistantPersistenceDatabase>;
 
 /**
- * The migration and this narrow database overlay are kept together until the
- * next generated Supabase type refresh. It avoids weakening the application-wide
+ * Migrations and this narrow database overlay are kept together until the next
+ * generated Supabase type refresh. It avoids weakening the application-wide
  * client type while allowing the newly added assistant tables to be used safely.
  */
 export function asShopAssistantClient(

--- a/features/assistant/server/shopStateStore.ts
+++ b/features/assistant/server/shopStateStore.ts
@@ -1,0 +1,247 @@
+import { createClient } from "@supabase/supabase-js";
+import { getSuggestedActions } from "@/features/assistant/server/getSuggestedActions";
+import {
+  canonicalizeRole,
+  getActorCapabilities,
+} from "@/features/shared/lib/rbac";
+import type { Json } from "@shared/types/types/supabase";
+import type { SuggestedActionContext } from "../types/suggested-actions";
+import type {
+  ShopAssistantAlert,
+  ShopAssistantBaseState,
+  ShopAssistantMetric,
+  ShopAssistantState,
+  ShopAssistantSuggestion,
+} from "../types/shopState";
+import { buildShopAssistantBaseState } from "./buildShopState";
+import { asShopAssistantClient } from "./shopAssistantDatabase";
+
+function createAssistantAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceRoleKey) {
+    throw new Error("Shop Assistant state requires Supabase service credentials");
+  }
+
+  return asShopAssistantClient(
+    createClient(url, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    }),
+  );
+}
+
+function isBaseState(value: unknown): value is ShopAssistantBaseState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.shopId === "string" &&
+    typeof record.timezone === "string" &&
+    typeof record.generatedAt === "string" &&
+    typeof record.staleAfter === "string" &&
+    Array.isArray(record.metrics) &&
+    Array.isArray(record.alerts)
+  );
+}
+
+function metricVisible(
+  metric: ShopAssistantMetric,
+  actor: ReturnType<typeof getActorCapabilities>,
+): boolean {
+  switch (metric.key) {
+    case "active_work_orders":
+    case "stalled_work_orders":
+      return actor.canViewShopWideData || actor.canManageWorkOrders;
+    case "overdue_approvals":
+      return actor.canAuthorizeQuotes || actor.canViewShopWideData;
+    case "delayed_parts":
+      return actor.canManageParts || actor.canViewShopWideData;
+    case "idle_technicians":
+      return actor.canManageWorkforce || actor.canAssignWork;
+    case "ready_to_invoice":
+      return actor.canViewFinancials || actor.canAuthorizeQuotes;
+    case "appointments_today":
+      return actor.canManageScheduling || actor.canViewShopWideData;
+    default:
+      return false;
+  }
+}
+
+function alertVisible(
+  alert: ShopAssistantAlert,
+  actor: ReturnType<typeof getActorCapabilities>,
+): boolean {
+  if (alert.code.includes("invoice")) {
+    return actor.canViewFinancials || actor.canAuthorizeQuotes;
+  }
+  if (
+    alert.code.includes("parts") ||
+    alert.code.includes("inventory") ||
+    alert.entityType === "part"
+  ) {
+    return actor.canManageParts || actor.canViewShopWideData;
+  }
+  if (
+    alert.code.includes("tech_") ||
+    alert.code.includes("shop_") ||
+    alert.entityType === "profile"
+  ) {
+    return actor.canManageWorkforce || actor.canAssignWork;
+  }
+  if (alert.code.includes("approval") || alert.code.includes("quote")) {
+    return actor.canAuthorizeQuotes || actor.canViewShopWideData;
+  }
+  if (alert.entityType === "booking") {
+    return actor.canManageScheduling || actor.canViewShopWideData;
+  }
+  return actor.canManageWorkOrders || actor.canViewShopWideData;
+}
+
+function suggestionLevel(
+  value: "info" | "warning" | "critical",
+): ShopAssistantSuggestion["level"] {
+  return value;
+}
+
+function technicianBoundaryState(params: {
+  shopId: string;
+  role: string;
+}): ShopAssistantState {
+  const generatedAt = new Date();
+  return {
+    shopId: params.shopId,
+    timezone: "UTC",
+    localDayKey: generatedAt.toISOString().slice(0, 10),
+    generatedAt: generatedAt.toISOString(),
+    staleAfter: new Date(generatedAt.getTime() + 60_000).toISOString(),
+    role: params.role,
+    scope: "technician",
+    metrics: [],
+    alerts: [],
+    suggestions: [
+      {
+        id: "technician-assistant-boundary",
+        level: "info",
+        title: "Use the assistant inside the work order",
+        description:
+          "Technician diagnostics and job guidance remain inside each assigned work order.",
+        href: "/work-orders",
+      },
+    ],
+  };
+}
+
+export function filterShopAssistantBaseStateForActor(params: {
+  base: ShopAssistantBaseState;
+  role: string | null;
+  suggestions?: ShopAssistantSuggestion[];
+}): ShopAssistantState {
+  const actor = getActorCapabilities({ role: params.role });
+  const role = actor.canonicalRole;
+
+  if (role === "mechanic") {
+    return technicianBoundaryState({
+      shopId: params.base.shopId,
+      role,
+    });
+  }
+
+  return {
+    ...params.base,
+    role,
+    scope: actor.canViewShopWideData ? "shop" : "limited",
+    metrics: params.base.metrics.filter((metric) => metricVisible(metric, actor)),
+    alerts: params.base.alerts.filter((alert) => alertVisible(alert, actor)),
+    suggestions: params.suggestions ?? [],
+  };
+}
+
+async function loadCachedBaseState(
+  shopId: string,
+): Promise<ShopAssistantBaseState | null> {
+  const client = createAssistantAdminClient();
+  const { data, error } = await client
+    .from("assistant_shop_states")
+    .select("snapshot")
+    .eq("shop_id", shopId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return isBaseState(data?.snapshot) ? data.snapshot : null;
+}
+
+async function saveBaseState(state: ShopAssistantBaseState): Promise<void> {
+  const client = createAssistantAdminClient();
+  const timestamp = new Date().toISOString();
+  const { error } = await client.from("assistant_shop_states").upsert(
+    {
+      shop_id: state.shopId,
+      snapshot: state as unknown as Json,
+      version: 1,
+      refreshed_at: state.generatedAt,
+      updated_at: timestamp,
+    },
+    { onConflict: "shop_id" },
+  );
+
+  if (error) throw new Error(error.message);
+}
+
+export async function getOrRefreshShopAssistantBaseState(params: {
+  shopId: string;
+  force?: boolean;
+}): Promise<ShopAssistantBaseState> {
+  if (!params.force) {
+    const cached = await loadCachedBaseState(params.shopId);
+    if (cached && new Date(cached.staleAfter).getTime() > Date.now()) {
+      return cached;
+    }
+  }
+
+  const base = await buildShopAssistantBaseState(params.shopId);
+  await saveBaseState(base);
+  return base;
+}
+
+export async function getShopAssistantStateForActor(params: {
+  shopId: string;
+  userId: string;
+  role: string | null;
+  force?: boolean;
+  context?: SuggestedActionContext;
+}): Promise<ShopAssistantState> {
+  const canonicalRole = canonicalizeRole(params.role);
+  if (canonicalRole === "mechanic") {
+    return technicianBoundaryState({
+      shopId: params.shopId,
+      role: canonicalRole,
+    });
+  }
+
+  const base = await getOrRefreshShopAssistantBaseState({
+    shopId: params.shopId,
+    force: params.force,
+  });
+  const suggested = await getSuggestedActions({
+    shopId: params.shopId,
+    userId: params.userId,
+    role: params.role,
+    context: params.context,
+  });
+
+  const suggestions: ShopAssistantSuggestion[] = suggested.items.map((item) => ({
+    id: item.id,
+    level: suggestionLevel(item.level),
+    title: item.title,
+    description: item.description,
+    href: item.href,
+    plannerHref: item.plannerHref,
+    entityType: item.entityType,
+    entityId: item.entityId,
+  }));
+
+  return filterShopAssistantBaseStateForActor({
+    base,
+    role: params.role,
+    suggestions,
+  });
+}

--- a/features/assistant/types/shopState.ts
+++ b/features/assistant/types/shopState.ts
@@ -1,0 +1,55 @@
+export type ShopAssistantMetricKey =
+  | "active_work_orders"
+  | "stalled_work_orders"
+  | "overdue_approvals"
+  | "delayed_parts"
+  | "idle_technicians"
+  | "ready_to_invoice"
+  | "appointments_today";
+
+export type ShopAssistantMetric = {
+  key: ShopAssistantMetricKey;
+  label: string;
+  value: number;
+  tone: "neutral" | "info" | "warning" | "critical";
+  href?: string;
+};
+
+export type ShopAssistantAlert = {
+  id: string;
+  level: "info" | "warning" | "critical";
+  code: string;
+  title: string;
+  message: string;
+  href?: string;
+  entityType?: string;
+  entityId?: string;
+  createdAt?: string;
+};
+
+export type ShopAssistantSuggestion = {
+  id: string;
+  level: "info" | "warning" | "critical";
+  title: string;
+  description: string;
+  href: string;
+  plannerHref?: string;
+  entityType?: string;
+  entityId?: string;
+};
+
+export type ShopAssistantBaseState = {
+  shopId: string;
+  timezone: string;
+  localDayKey: string;
+  generatedAt: string;
+  staleAfter: string;
+  metrics: ShopAssistantMetric[];
+  alerts: ShopAssistantAlert[];
+};
+
+export type ShopAssistantState = ShopAssistantBaseState & {
+  role: string;
+  scope: "shop" | "limited" | "technician";
+  suggestions: ShopAssistantSuggestion[];
+};

--- a/supabase/migrations/20260721110000_shop_assistant_state.sql
+++ b/supabase/migrations/20260721110000_shop_assistant_state.sql
@@ -1,0 +1,29 @@
+begin;
+
+create table if not exists public.assistant_shop_states (
+  shop_id uuid primary key references public.shops(id) on delete cascade,
+  snapshot jsonb not null default '{}'::jsonb,
+  version integer not null default 1 check (version > 0),
+  refreshed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists assistant_shop_states_refreshed_idx
+  on public.assistant_shop_states(refreshed_at desc);
+
+alter table public.assistant_shop_states enable row level security;
+
+drop policy if exists assistant_shop_states_shop_select on public.assistant_shop_states;
+create policy assistant_shop_states_shop_select
+  on public.assistant_shop_states for select to authenticated
+  using (shop_id = public.current_shop_id());
+
+revoke all on table public.assistant_shop_states from anon;
+grant select on table public.assistant_shop_states to authenticated;
+grant all on table public.assistant_shop_states to service_role;
+
+comment on table public.assistant_shop_states is
+  'Cached, shop-scoped world state for the shop-wide assistant. Service-role code is the only writer.';
+
+commit;

--- a/tests/mobile-native-route-audit.test.ts
+++ b/tests/mobile-native-route-audit.test.ts
@@ -67,7 +67,9 @@ describe("mobile-native navigation", () => {
       "Service requests",
     );
     expect(read("app/mobile/offline/page.tsx")).toContain("Offline &amp; sync");
-    expect(read("app/mobile/assistant/page.tsx")).toContain("Ask or take action");
+    expect(read("app/mobile/assistant/page.tsx")).toContain(
+      "Shop command center",
+    );
   });
 
   it("uses the existing shop-scoped operations payload", () => {

--- a/tests/shop-assistant-intelligence.test.ts
+++ b/tests/shop-assistant-intelligence.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { filterShopAssistantBaseStateForActor } from "@/features/assistant/server/shopStateStore";
+import type { ShopAssistantBaseState } from "@/features/assistant/types/shopState";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const BASE_STATE: ShopAssistantBaseState = {
+  shopId: "00000000-0000-4000-8000-000000000001",
+  timezone: "UTC",
+  localDayKey: "2026-07-21",
+  generatedAt: "2026-07-21T12:00:00.000Z",
+  staleAfter: "2026-07-21T12:01:00.000Z",
+  metrics: [
+    {
+      key: "active_work_orders",
+      label: "Active work orders",
+      value: 8,
+      tone: "info",
+    },
+    {
+      key: "idle_technicians",
+      label: "Idle technicians",
+      value: 2,
+      tone: "warning",
+    },
+    {
+      key: "ready_to_invoice",
+      label: "Ready to invoice",
+      value: 3,
+      tone: "warning",
+    },
+  ],
+  alerts: [
+    {
+      id: "wo:1",
+      level: "warning",
+      code: "work_order_waiting_too_long",
+      title: "Queued too long",
+      message: "WO #1 is stale.",
+    },
+    {
+      id: "invoice:1",
+      level: "warning",
+      code: "invoice_unsent_too_long",
+      title: "Invoice unsent",
+      message: "Invoice needs attention.",
+    },
+  ],
+};
+
+describe("shop assistant intelligence", () => {
+  it("keeps owner metrics and alerts shop-wide", () => {
+    const state = filterShopAssistantBaseStateForActor({
+      base: BASE_STATE,
+      role: "owner",
+    });
+    expect(state.scope).toBe("shop");
+    expect(state.metrics).toHaveLength(3);
+    expect(state.alerts).toHaveLength(2);
+  });
+
+  it("preserves the existing in-work-order technician assistant boundary", () => {
+    const state = filterShopAssistantBaseStateForActor({
+      base: BASE_STATE,
+      role: "mechanic",
+    });
+    expect(state.scope).toBe("technician");
+    expect(state.metrics).toEqual([]);
+    expect(state.alerts).toEqual([]);
+  });
+
+  it("adds a persisted live shop-state cache and role-aware route", () => {
+    const migration = read(
+      "supabase/migrations/20260721110000_shop_assistant_state.sql",
+    );
+    expect(migration).toContain(
+      "create table if not exists public.assistant_shop_states",
+    );
+    expect(migration).toContain("enable row level security");
+    expect(migration).toContain(
+      "grant all on table public.assistant_shop_states to service_role",
+    );
+
+    const route = read("app/api/assistant/shop-state/route.ts");
+    expect(route).toContain("requireShopScopedApiAccess");
+    expect(route).toContain("getShopAssistantStateForActor");
+
+    const desktop = read("app/assistant/page.tsx");
+    const mobile = read("app/mobile/assistant/page.tsx");
+    expect(desktop).toContain("ShopAssistantOverview");
+    expect(mobile).toContain("ShopAssistantOverview");
+  });
+});


### PR DESCRIPTION
## Summary

Builds the shop-wide operating surface on top of Phase 1 reliability.

- replaces the static assistant landing panel with a live Shop Command Center on desktop and mobile
- adds live counts for active/stalled work orders, overdue approvals, delayed parts, idle technicians, ready-to-invoice work, and today's appointments
- surfaces proactive alerts from the existing operations notification engine
- adds role-aware suggested next moves using the existing RBAC/capability model
- persists a short-lived, shop-scoped world-state snapshot so every request does not rebuild the same operational picture
- refreshes automatically every 60 seconds and supports manual refresh

## Role and technician boundaries

- shop-wide metrics and alerts are filtered by the actor's capabilities
- mechanics do not receive shop-wide state through this surface
- technician diagnostic guidance remains in the existing assistant embedded inside each assigned work order

## Data and security

- adds `assistant_shop_states` with RLS and current-shop read access
- only service-role server code writes cached snapshots
- the API route still requires authenticated shop-scoped access

## Validation

- adds `tests/shop-assistant-intelligence.test.ts`
- updates the mobile native route audit for the new command-center copy

## Stack order

1. Phase 1 — Reliability (#1137)
2. **This PR — Shop Intelligence**
3. Phase 3 — Unified Tool Registry
4. Phase 4 — Multi-Agent Orchestration
