### PR TITLE
Fix mobile inspection Vercel build

### DIFF
--- a/app/mobile/inspections/[id]/page.tsx
+++ b/app/mobile/inspections/[id]/page.tsx
@@ -170,7 +170,7 @@ export default function MobileInspectionRunnerPage() {
         // The work order is the canonical source for inspection identity context.
         // Mobile routes intentionally keep query strings small, so hydrate the
         // customer and vehicle here instead of starting a blank device-only copy.
-        let workOrderContext: Record<string, string> = {};
+        const workOrderContext: Record<string, string> = {};
         if (workOrderId) {
           const { data: workOrder, error: workOrderError } = await supabase
             .from("work_orders")


### PR DESCRIPTION
## Summary

Fixes the Vercel production build failure introduced after the inspection synchronization merge.

## Root cause

`app/mobile/inspections/[id]/page.tsx` declared `workOrderContext` with `let`, but the binding is never reassigned. The production Next.js lint step treats `prefer-const` as an error and stopped `pnpm build`.

## Change

- Change the binding from `let` to `const`.
- The object remains mutable, so the existing customer/vehicle hydration behavior is unchanged.

## Validation

- Branch is based on current `main`.
- Scoped comparison contains one declaration-only change in one file.
- Vercel and GitHub checks should be treated as authoritative for the full build.

## Database

No migration required.