### PR TITLE
Fix mobile inspection form uploads and customer lookup

### DIFF
--- a/app/api/inspection-form-imports/route.ts
+++ b/app/api/inspection-form-imports/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { after, NextResponse } from "next/server";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -29,13 +30,47 @@ const ALLOWED_MIME_TYPES = new Set([
 ]);
 
 type RelatedRecord = { id: string; name: string | null; business_name?: string | null };
+type UploadDescriptor = {
+  path: string;
+  originalName: string;
+  mime: string;
+  size: number;
+};
 
-function clean(value: FormDataEntryValue | null, max = 160) {
+function clean(value: unknown, max = 160) {
   return String(value ?? "").trim().slice(0, max);
 }
 
 function safeFileName(value: string) {
   return value.replace(/[^a-zA-Z0-9._-]+/g, "-").toLowerCase() || "page.jpg";
+}
+
+function customerLabel(customer: {
+  business_name: string | null;
+  name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+}) {
+  return (
+    customer.business_name ||
+    customer.name ||
+    [customer.first_name, customer.last_name].filter(Boolean).join(" ") ||
+    "Customer"
+  );
+}
+
+function validateFileDescriptor(value: unknown, index: number) {
+  if (!value || typeof value !== "object") return null;
+  const input = value as { name?: unknown; originalName?: unknown; size?: unknown; type?: unknown; mime?: unknown; path?: unknown };
+  const originalName = clean(String(input.name ?? input.originalName ?? ""), 180);
+  const mime = clean(String(input.type ?? input.mime ?? ""), 80).toLowerCase();
+  const size = Number(input.size);
+  const path = clean(String(input.path ?? ""), 500);
+  if (!originalName || !Number.isFinite(size) || size < 1 || size > MAX_FILE_BYTES) {
+    return null;
+  }
+  if (!ALLOWED_MIME_TYPES.has(mime)) return null;
+  return { originalName, mime, size, path, index };
 }
 
 async function loadRelatedRecord(
@@ -61,23 +96,48 @@ export async function GET() {
   });
   if (!access.ok) return access.response;
 
-  const { data, error } = await access.supabase
-    .from("import_jobs")
-    .select(
-      "id, status, total_rows, processed_rows, error_message, summary, result_record_id, created_at, updated_at, approved_at",
-    )
-    .eq("shop_id", access.profile.shop_id)
-    .eq("import_type", "inspection_form")
-    .order("created_at", { ascending: false })
-    .limit(20);
+  const admin = createAdminSupabase();
+  const [jobsResult, customersResult, fleetsResult] = await Promise.all([
+    admin
+      .from("import_jobs")
+      .select(
+        "id, status, total_rows, processed_rows, error_message, summary, result_record_id, created_at, updated_at, approved_at",
+      )
+      .eq("shop_id", access.profile.shop_id)
+      .eq("import_type", "inspection_form")
+      .order("created_at", { ascending: false })
+      .limit(20),
+    admin
+      .from("customers")
+      .select("id, name, business_name, first_name, last_name")
+      .eq("shop_id", access.profile.shop_id)
+      .order("updated_at", { ascending: false })
+      .limit(500),
+    admin
+      .from("fleets")
+      .select("id, name")
+      .eq("shop_id", access.profile.shop_id)
+      .order("name", { ascending: true })
+      .limit(500),
+  ]);
 
-  if (error) {
+  if (jobsResult.error || customersResult.error || fleetsResult.error) {
+    console.error("inspection form import directory load failed", {
+      jobs: jobsResult.error?.message,
+      customers: customersResult.error?.message,
+      fleets: fleetsResult.error?.message,
+      shopId: access.profile.shop_id,
+    });
     return NextResponse.json({ error: "Unable to load form imports." }, { status: 500 });
   }
 
   return NextResponse.json({
     ok: true,
-    imports: (data ?? []).map((job) => {
+    customers: (customersResult.data ?? [])
+      .map((customer) => ({ id: customer.id, label: customerLabel(customer) }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    fleets: (fleetsResult.data ?? []).map((fleet) => ({ id: fleet.id, label: fleet.name })),
+    imports: (jobsResult.data ?? []).map((job) => {
       const summary = normalizeInspectionFormImportSummary(job.summary);
       return {
         id: job.id,
@@ -104,41 +164,187 @@ export async function POST(req: Request) {
   });
   if (!access.ok) return access.response;
 
-  const formData = await req.formData();
-  const files = formData
-    .getAll("files")
-    .filter((value): value is File => value instanceof File);
-  if (!files.length) {
-    return NextResponse.json({ error: "Add at least one form page." }, { status: 400 });
+  const shopId = access.profile.shop_id;
+  const admin = createAdminSupabase();
+  const contentType = req.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    const body = (await req.json().catch(() => null)) as
+      | {
+          action?: unknown;
+          files?: unknown;
+          uploads?: unknown;
+          uploadId?: unknown;
+          title?: unknown;
+          vehicleType?: unknown;
+          dutyClass?: unknown;
+          customerId?: unknown;
+          customerName?: unknown;
+          fleetId?: unknown;
+          fleetName?: unknown;
+        }
+      | null;
+
+    if (body?.action === "prepare") {
+      const values = Array.isArray(body.files) ? body.files : [];
+      if (!values.length || values.length > MAX_PAGES) {
+        return NextResponse.json(
+          { error: `Choose between 1 and ${MAX_PAGES} form pages.` },
+          { status: 400 },
+        );
+      }
+      const descriptors = values.map(validateFileDescriptor);
+      if (descriptors.some((file) => !file)) {
+        return NextResponse.json(
+          { error: "Every page must be a supported image no larger than 25 MB." },
+          { status: 400 },
+        );
+      }
+
+      const uploadId = randomUUID();
+      const uploads: Array<UploadDescriptor & { token: string }> = [];
+      for (const descriptor of descriptors) {
+        if (!descriptor) continue;
+        const path = `${access.profile.id}/${uploadId}/${String(descriptor.index + 1).padStart(2, "0")}-${safeFileName(descriptor.originalName)}`;
+        const { data, error } = await admin.storage.from(BUCKET).createSignedUploadUrl(path);
+        if (error || !data?.token) {
+          console.error("inspection form signed upload preparation failed", {
+            shopId,
+            uploadId,
+            error: error?.message,
+          });
+          return NextResponse.json(
+            { error: "Unable to prepare secure page uploads. Please try again." },
+            { status: 500 },
+          );
+        }
+        uploads.push({
+          path,
+          token: data.token,
+          originalName: descriptor.originalName,
+          mime: descriptor.mime,
+          size: descriptor.size,
+        });
+      }
+      return NextResponse.json({ ok: true, uploadId, uploads });
+    }
+
+    if (body?.action !== "finalize") {
+      return NextResponse.json({ error: "Invalid upload action." }, { status: 400 });
+    }
+
+    const uploadId = clean(body.uploadId, 60);
+    const values = Array.isArray(body.uploads) ? body.uploads : [];
+    const descriptors = values.map(validateFileDescriptor);
+    if (!/^[0-9a-f-]{36}$/i.test(uploadId) || !values.length || values.length > MAX_PAGES || descriptors.some((file) => !file)) {
+      return NextResponse.json({ error: "The prepared upload is invalid or expired." }, { status: 400 });
+    }
+    const expectedPrefix = `${access.profile.id}/${uploadId}/`;
+    const uploads = descriptors.filter((value): value is NonNullable<typeof value> => Boolean(value));
+    if (uploads.some((upload) => !upload.path.startsWith(expectedPrefix))) {
+      return NextResponse.json({ error: "The prepared upload does not belong to this user." }, { status: 403 });
+    }
+    const { data: stored, error: listError } = await admin.storage
+      .from(BUCKET)
+      .list(`${access.profile.id}/${uploadId}`, { limit: MAX_PAGES + 1 });
+    const storedNames = new Set((stored ?? []).map((item) => item.name));
+    if (listError || uploads.some((upload) => !storedNames.has(upload.path.split("/").at(-1) ?? ""))) {
+      return NextResponse.json(
+        { error: "One or more pages did not finish uploading. Please retry." },
+        { status: 409 },
+      );
+    }
+
+    return queueInspectionFormImport({
+      admin,
+      jobId: uploadId,
+      shopId,
+      actorId: access.profile.id,
+      uploads,
+      metadata: body,
+    });
   }
-  if (files.length > MAX_PAGES) {
+
+  // Compatibility for the legacy single-request uploader. New clients use
+  // signed, direct-to-storage uploads so mobile camera files never cross the
+  // hosting provider's request-size limit.
+  const formData = await req.formData();
+  const files = formData.getAll("files").filter((value): value is File => value instanceof File);
+  if (!files.length || files.length > MAX_PAGES) {
+    return NextResponse.json({ error: `Add between 1 and ${MAX_PAGES} form pages.` }, { status: 400 });
+  }
+  const descriptors = files.map((file, index) => validateFileDescriptor({
+    name: file.name,
+    type: file.type,
+    size: file.size,
+  }, index));
+  if (descriptors.some((file) => !file)) {
     return NextResponse.json(
-      { error: `Upload ${MAX_PAGES} pages or fewer at a time.` },
+      { error: "Every page must be a supported image no larger than 25 MB." },
       { status: 400 },
     );
   }
 
-  for (const file of files) {
-    if (!file.size || file.size > MAX_FILE_BYTES) {
-      return NextResponse.json(
-        { error: `${file.name || "A page"} must be between 1 byte and 25 MB.` },
-        { status: 400 },
-      );
+  const jobId = randomUUID();
+  const uploaded: UploadDescriptor[] = [];
+  try {
+    for (let index = 0; index < files.length; index += 1) {
+      const descriptor = descriptors[index];
+      if (!descriptor) continue;
+      const path = `${access.profile.id}/${jobId}/${String(index + 1).padStart(2, "0")}-${safeFileName(descriptor.originalName)}`;
+      const { error } = await admin.storage.from(BUCKET).upload(path, files[index], {
+        contentType: descriptor.mime,
+        upsert: false,
+      });
+      if (error) throw error;
+      uploaded.push({ path, originalName: descriptor.originalName, mime: descriptor.mime, size: descriptor.size });
     }
-    if (!ALLOWED_MIME_TYPES.has(file.type)) {
-      return NextResponse.json(
-        { error: `${file.name || "A page"} is not a supported image.` },
-        { status: 400 },
-      );
-    }
+  } catch (error) {
+    if (uploaded.length) await admin.storage.from(BUCKET).remove(uploaded.map((item) => item.path));
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to upload the form pages." },
+      { status: 500 },
+    );
   }
 
-  const shopId = access.profile.shop_id;
-  const customerId = clean(formData.get("customerId"), 60);
-  const fleetId = clean(formData.get("fleetId"), 60);
+  return queueInspectionFormImport({
+    admin,
+    jobId,
+    shopId,
+    actorId: access.profile.id,
+    uploads: uploaded.map((upload, index) => ({ ...upload, index })),
+    metadata: {
+      title: formData.get("title"),
+      vehicleType: formData.get("vehicleType"),
+      dutyClass: formData.get("dutyClass"),
+      customerId: formData.get("customerId"),
+      customerName: formData.get("customerName"),
+      fleetId: formData.get("fleetId"),
+      fleetName: formData.get("fleetName"),
+    },
+  });
+}
+
+async function queueInspectionFormImport({
+  admin,
+  jobId,
+  shopId,
+  actorId,
+  uploads,
+  metadata,
+}: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  jobId: string;
+  shopId: string;
+  actorId: string;
+  uploads: Array<UploadDescriptor & { index: number }>;
+  metadata: Record<string, unknown>;
+}) {
+  const customerId = clean(metadata.customerId, 60);
+  const fleetId = clean(metadata.fleetId, 60);
   const [customer, fleet] = await Promise.all([
-    loadRelatedRecord(access.supabase, "customers", customerId, shopId),
-    loadRelatedRecord(access.supabase, "fleets", fleetId, shopId),
+    loadRelatedRecord(admin, "customers", customerId, shopId),
+    loadRelatedRecord(admin, "fleets", fleetId, shopId),
   ]);
   if (customerId && !customer) {
     return NextResponse.json({ error: "Customer not found in this shop." }, { status: 404 });
@@ -147,92 +353,60 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Fleet account not found in this shop." }, { status: 404 });
   }
 
-  const title = clean(formData.get("title")) || "Imported Inspection Form";
-  const vehicleType = clean(formData.get("vehicleType"), 30);
-  const dutyClass = clean(formData.get("dutyClass"), 20);
   const summary = {
     state: "queued",
-    title,
-    vehicleType,
-    dutyClass,
+    title: clean(metadata.title) || "Imported Inspection Form",
+    vehicleType: clean(metadata.vehicleType, 30),
+    dutyClass: clean(metadata.dutyClass, 20),
     customerId: customer?.id ?? null,
-    customerName: customer ? customer.business_name || customer.name : null,
+    customerName: customer ? customer.business_name || customer.name : clean(metadata.customerName) || null,
     fleetId: fleet?.id ?? null,
-    fleetName: fleet?.name ?? null,
+    fleetName: fleet?.name ?? (clean(metadata.fleetName) || null),
     draftSections: [],
     extractedText: "",
     failedPages: [],
   };
 
-  const admin = createAdminSupabase();
-  const { data: job, error: jobError } = await admin
-    .from("import_jobs")
-    .insert({
-      shop_id: shopId,
-      created_by: access.profile.id,
-      import_type: "inspection_form",
-      status: "queued",
-      total_rows: files.length,
-      summary,
-    })
-    .select("id")
-    .single();
-  if (jobError || !job?.id) {
+  const { error: jobError } = await admin.from("import_jobs").insert({
+    id: jobId,
+    shop_id: shopId,
+    created_by: actorId,
+    import_type: "inspection_form",
+    status: "queued",
+    total_rows: uploads.length,
+    summary,
+  });
+  if (jobError) {
+    console.error("inspection form import job creation failed", { jobId, shopId, error: jobError.message });
     return NextResponse.json({ error: "Unable to start the form import." }, { status: 500 });
   }
 
-  const uploadedPaths: string[] = [];
-  try {
-    const stagedRows: Array<Record<string, unknown>> = [];
-    for (let index = 0; index < files.length; index += 1) {
-      const file = files[index];
-      const storagePath = `${access.profile.id}/${job.id}/${String(index + 1).padStart(2, "0")}-${safeFileName(file.name)}`;
-      const { error: uploadError } = await access.supabase.storage
-        .from(BUCKET)
-        .upload(storagePath, file, { contentType: file.type, upsert: false });
-      if (uploadError) throw uploadError;
-      uploadedPaths.push(storagePath);
-      stagedRows.push({
-        job_id: job.id,
-        shop_id: shopId,
-        row_number: index + 1,
-        status: "queued",
-        raw_row: {
-          storagePath,
-          originalName: file.name,
-          mime: file.type,
-        },
-      });
-    }
-
-    const { error: rowsError } = await admin.from("import_job_rows").insert(stagedRows);
-    if (rowsError) throw rowsError;
-  } catch (error) {
-    if (uploadedPaths.length) await admin.storage.from(BUCKET).remove(uploadedPaths);
-    await admin.from("import_jobs").delete().eq("id", job.id).eq("shop_id", shopId);
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to upload the form pages." },
-      { status: 500 },
-    );
+  const { error: rowsError } = await admin.from("import_job_rows").insert(
+    uploads.map((upload, index) => ({
+      job_id: jobId,
+      shop_id: shopId,
+      row_number: index + 1,
+      status: "queued",
+      raw_row: {
+        storagePath: upload.path,
+        originalName: upload.originalName,
+        mime: upload.mime,
+      },
+    })),
+  );
+  if (rowsError) {
+    await admin.from("import_jobs").delete().eq("id", jobId).eq("shop_id", shopId);
+    console.error("inspection form import page staging failed", { jobId, shopId, error: rowsError.message });
+    return NextResponse.json({ error: "Unable to stage the uploaded form pages." }, { status: 500 });
   }
 
   after(async () => {
     try {
-      await processInspectionFormImportJobBatch(
-        createAdminSupabase(),
-        job.id,
-        INSPECTION_FORM_IMPORT_BATCH_SIZE,
-      );
+      await processInspectionFormImportJobBatch(createAdminSupabase(), jobId, INSPECTION_FORM_IMPORT_BATCH_SIZE);
     } catch (error) {
-      console.error("inspection form import background kickoff failed", {
-        jobId: job.id,
-        error,
-      });
+      console.error("inspection form import background kickoff failed", { jobId, error });
     }
   });
 
-  return NextResponse.json(
-    { ok: true, jobId: job.id, status: "queued" },
-    { status: 202 },
-  );
+  return NextResponse.json({ ok: true, jobId, status: "queued" }, { status: 202 });
 }

--- a/features/inspections/components/FleetFormImportCard.tsx
+++ b/features/inspections/components/FleetFormImportCard.tsx
@@ -8,6 +8,13 @@ import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Button } from "@shared/components/ui/Button";
 
 type Option = { id: string; label: string };
+type SignedUpload = {
+  path: string;
+  token: string;
+  originalName: string;
+  mime: string;
+  size: number;
+};
 type ImportListItem = {
   id: string;
   state: "queued" | "processing" | "ready_for_review" | "failed" | "approved";
@@ -46,6 +53,8 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
   const [dutyClass, setDutyClass] = useState("");
   const [customerId, setCustomerId] = useState("");
   const [fleetId, setFleetId] = useState("");
+  const [customerName, setCustomerName] = useState("");
+  const [fleetName, setFleetName] = useState("");
   const [customers, setCustomers] = useState<Option[]>([]);
   const [fleets, setFleets] = useState<Option[]>([]);
   const [imports, setImports] = useState<ImportListItem[]>([]);
@@ -55,9 +64,13 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
   const loadImports = useCallback(async () => {
     const response = await fetch("/api/inspection-form-imports", { cache: "no-store" });
     const body = (await response.json().catch(() => null)) as
-      | { imports?: ImportListItem[] }
+      | { imports?: ImportListItem[]; customers?: Option[]; fleets?: Option[] }
       | null;
-    if (response.ok) setImports(body?.imports ?? []);
+    if (response.ok) {
+      setImports(body?.imports ?? []);
+      setCustomers(body?.customers ?? []);
+      setFleets(body?.fleets ?? []);
+    }
   }, []);
 
   useEffect(() => {
@@ -73,37 +86,6 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
     }, 5000);
     return () => window.clearInterval(interval);
   }, [imports, loadImports]);
-
-  useEffect(() => {
-    let active = true;
-    void (async () => {
-      const [customerResult, fleetResult] = await Promise.all([
-        supabase
-          .from("customers")
-          .select("id, name, business_name, first_name, last_name")
-          .order("name", { ascending: true })
-          .limit(200),
-        supabase.from("fleets").select("id, name").order("name").limit(100),
-      ]);
-      if (!active) return;
-      setCustomers(
-        (customerResult.data ?? []).map((customer) => ({
-          id: customer.id,
-          label:
-            customer.business_name ||
-            customer.name ||
-            [customer.first_name, customer.last_name].filter(Boolean).join(" ") ||
-            "Customer",
-        })),
-      );
-      setFleets(
-        (fleetResult.data ?? []).map((fleet) => ({ id: fleet.id, label: fleet.name })),
-      );
-    })();
-    return () => {
-      active = false;
-    };
-  }, [supabase]);
 
   const addFiles = (incoming: File[]) => {
     setError(null);
@@ -134,22 +116,65 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
     setSubmitting(true);
     setError(null);
     try {
-      const data = new FormData();
-      files.forEach((file) => data.append("files", file));
-      data.set("title", title);
-      data.set("vehicleType", vehicleType);
-      data.set("dutyClass", dutyClass);
-      data.set("customerId", customerId);
-      data.set("fleetId", fleetId);
+      const prepareResponse = await fetch("/api/inspection-form-imports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "prepare",
+          files: files.map((file) => ({
+            name: file.name,
+            size: file.size,
+            type: file.type,
+          })),
+        }),
+      });
+      const prepareBody = (await prepareResponse.json().catch(() => null)) as
+        | { uploadId?: string; uploads?: SignedUpload[]; error?: string }
+        | null;
+      if (!prepareResponse.ok || !prepareBody?.uploadId || !prepareBody.uploads) {
+        throw new Error(prepareBody?.error || "Unable to prepare the form upload.");
+      }
+
+      for (let index = 0; index < prepareBody.uploads.length; index += 1) {
+        const upload = prepareBody.uploads[index];
+        const file = files[index];
+        const { error: uploadError } = await supabase.storage
+          .from("fleet-forms")
+          .uploadToSignedUrl(upload.path, upload.token, file, {
+            contentType: upload.mime,
+            upsert: false,
+          });
+        if (uploadError) {
+          throw new Error(`Unable to upload page ${index + 1}. ${uploadError.message}`);
+        }
+      }
+
       const response = await fetch("/api/inspection-form-imports", {
         method: "POST",
-        body: data,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          action: "finalize",
+          uploadId: prepareBody.uploadId,
+          uploads: prepareBody.uploads.map((upload) => ({
+            path: upload.path,
+            originalName: upload.originalName,
+            mime: upload.mime,
+            size: upload.size,
+          })),
+          title,
+          vehicleType,
+          dutyClass,
+          customerId,
+          customerName,
+          fleetId,
+          fleetName,
+        }),
       });
       const body = (await response.json().catch(() => null)) as
         | { jobId?: string; error?: string }
         | null;
       if (!response.ok || !body?.jobId) {
-        throw new Error(body?.error || "Unable to upload the form.");
+        throw new Error(body?.error || "Unable to finish the form upload.");
       }
       router.push(
         mobile
@@ -181,17 +206,39 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
         <div className="grid gap-3 md:grid-cols-2">
           <label className="text-xs text-[color:var(--theme-text-secondary)]">
             Customer (optional)
-            <select value={customerId} onChange={(e) => setCustomerId(e.target.value)} className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]">
-              <option value="">No customer selected</option>
-              {customers.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
-            </select>
+            <input
+              list="inspection-import-customers"
+              value={customerName}
+              onChange={(event) => {
+                const value = event.target.value;
+                setCustomerName(value);
+                setCustomerId(customers.find((option) => option.label.toLocaleLowerCase() === value.trim().toLocaleLowerCase())?.id ?? "");
+              }}
+              placeholder="Search or type a customer name"
+              autoComplete="off"
+              className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]"
+            />
+            <datalist id="inspection-import-customers">
+              {customers.map((option) => <option key={option.id} value={option.label} />)}
+            </datalist>
           </label>
           <label className="text-xs text-[color:var(--theme-text-secondary)]">
             Fleet account (optional)
-            <select value={fleetId} onChange={(e) => setFleetId(e.target.value)} className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]">
-              <option value="">No fleet selected</option>
-              {fleets.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
-            </select>
+            <input
+              list="inspection-import-fleets"
+              value={fleetName}
+              onChange={(event) => {
+                const value = event.target.value;
+                setFleetName(value);
+                setFleetId(fleets.find((option) => option.label.toLocaleLowerCase() === value.trim().toLocaleLowerCase())?.id ?? "");
+              }}
+              placeholder="Search or type a fleet name"
+              autoComplete="off"
+              className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]"
+            />
+            <datalist id="inspection-import-fleets">
+              {fleets.map((option) => <option key={option.id} value={option.label} />)}
+            </datalist>
           </label>
           <label className="text-xs text-[color:var(--theme-text-secondary)] md:col-span-2">
             Template name (optional)

--- a/tests/mobile-inspection-form-import.test.ts
+++ b/tests/mobile-inspection-form-import.test.ts
@@ -49,6 +49,32 @@ describe("mobile inspection form imports", () => {
     expect(review).toContain("Copy desktop link");
   });
 
+  it("supports typed customer and fleet names from a server-scoped directory", () => {
+    const importer = read(
+      "features/inspections/components/FleetFormImportCard.tsx",
+    );
+    const uploadRoute = read("app/api/inspection-form-imports/route.ts");
+    expect(importer).toContain("Search or type a customer name");
+    expect(importer).toContain("Search or type a fleet name");
+    expect(importer).toContain("customerName");
+    expect(importer).toContain("fleetName");
+    expect(uploadRoute).toContain('.from("customers")');
+    expect(uploadRoute).toContain('.from("fleets")');
+    expect(uploadRoute).toContain('.eq("shop_id", access.profile.shop_id)');
+  });
+
+  it("uploads mobile photos directly with signed storage targets", () => {
+    const importer = read(
+      "features/inspections/components/FleetFormImportCard.tsx",
+    );
+    const uploadRoute = read("app/api/inspection-form-imports/route.ts");
+    expect(importer).toContain("uploadToSignedUrl");
+    expect(importer).toContain('action: "prepare"');
+    expect(importer).toContain('action: "finalize"');
+    expect(uploadRoute).toContain("createSignedUploadUrl");
+    expect(uploadRoute).toContain("request-size limit");
+  });
+
   it("removes the browser-only sessionStorage handoff", () => {
     expect(read("app/inspections/fleet-review/page.tsx")).not.toContain(
       "sessionStorage",


### PR DESCRIPTION
## What changed

- replaces the fixed customer and fleet dropdowns with searchable inputs that also allow a manually typed name
- loads customer and fleet suggestions through the authenticated API with an explicit shop scope
- uploads each page directly to storage through a short-lived signed target
- finalizes the durable import only after every uploaded object is verified
- keeps the legacy multipart endpoint compatible while moving its storage write behind the server boundary
- adds regression coverage for typed names, shop-scoped directories, and signed mobile uploads

## Root cause

The merged importer queried directories directly from the browser and limited them to fixed dropdown result sets, so users could neither search/type a missing name nor reliably see records when browser RLS did not return the expected rows.

It also sent all full-size phone photos through one hosted API request and then performed browser-scoped storage writes. That made uploads vulnerable to request-size limits and storage-policy failures, which surfaced as the generic “Unable to upload form” message.

## User impact

Owners and advisors can now select an existing customer/fleet or type a name manually. Multi-page phone uploads bypass the API request-size limit, return a page-specific error when needed, and only enter the background queue after storage verification succeeds.

## Validation

- changed-file ESLint passes
- full TypeScript type-check passes
- 14 focused import and worker tests pass
- git diff validation passes
- remote tree matches the validated local tree exactly
