### PR TITLE
Fix mobile inspection form customer and shell context

### DIFF
--- a/app/api/inspection-form-imports/route.ts
+++ b/app/api/inspection-form-imports/route.ts
@@ -29,7 +29,13 @@ const ALLOWED_MIME_TYPES = new Set([
   "image/tiff",
 ]);
 
-type RelatedRecord = { id: string; name: string | null; business_name?: string | null };
+type RelatedRecord = {
+  id: string;
+  name: string | null;
+  business_name?: string | null;
+  first_name?: string | null;
+  last_name?: string | null;
+};
 type UploadDescriptor = {
   path: string;
   originalName: string;
@@ -37,8 +43,13 @@ type UploadDescriptor = {
   size: number;
 };
 
+const IMPORT_SETUP_ERROR =
+  "Inspection form imports need the latest database update before they can be used.";
+
 function clean(value: unknown, max = 160) {
-  return String(value ?? "").trim().slice(0, max);
+  return String(value ?? "")
+    .trim()
+    .slice(0, max);
 }
 
 function safeFileName(value: string) {
@@ -59,14 +70,63 @@ function customerLabel(customer: {
   );
 }
 
+function isImportSchemaError(error: {
+  code?: string;
+  message?: string;
+  details?: string;
+  hint?: string;
+}) {
+  const detail = [error.message, error.details, error.hint]
+    .filter(Boolean)
+    .join(" ")
+    .toLocaleLowerCase();
+  return (
+    ((error.code === "42703" || error.code === "PGRST204") &&
+      (detail.includes("result_record_id") ||
+        detail.includes("approved_at"))) ||
+    (error.code === "23514" && detail.includes("import_jobs_import_type_check"))
+  );
+}
+
+async function removeUploadedPages(
+  admin: ReturnType<typeof createAdminSupabase>,
+  uploads: UploadDescriptor[],
+) {
+  if (!uploads.length) return;
+  const { error } = await admin.storage
+    .from(BUCKET)
+    .remove(uploads.map((upload) => upload.path));
+  if (error) {
+    console.error("inspection form staged page cleanup failed", {
+      paths: uploads.map((upload) => upload.path),
+      error: error.message,
+    });
+  }
+}
+
 function validateFileDescriptor(value: unknown, index: number) {
   if (!value || typeof value !== "object") return null;
-  const input = value as { name?: unknown; originalName?: unknown; size?: unknown; type?: unknown; mime?: unknown; path?: unknown };
-  const originalName = clean(String(input.name ?? input.originalName ?? ""), 180);
+  const input = value as {
+    name?: unknown;
+    originalName?: unknown;
+    size?: unknown;
+    type?: unknown;
+    mime?: unknown;
+    path?: unknown;
+  };
+  const originalName = clean(
+    String(input.name ?? input.originalName ?? ""),
+    180,
+  );
   const mime = clean(String(input.type ?? input.mime ?? ""), 80).toLowerCase();
   const size = Number(input.size);
   const path = clean(String(input.path ?? ""), 500);
-  if (!originalName || !Number.isFinite(size) || size < 1 || size > MAX_FILE_BYTES) {
+  if (
+    !originalName ||
+    !Number.isFinite(size) ||
+    size < 1 ||
+    size > MAX_FILE_BYTES
+  ) {
     return null;
   }
   if (!ALLOWED_MIME_TYPES.has(mime)) return null;
@@ -80,7 +140,10 @@ async function loadRelatedRecord(
   shopId: string,
 ) {
   if (!id) return null;
-  const columns = table === "customers" ? "id, name, business_name" : "id, name";
+  const columns =
+    table === "customers"
+      ? "id, name, business_name, first_name, last_name"
+      : "id, name";
   const { data } = await supabase
     .from(table)
     .select(columns)
@@ -121,22 +184,41 @@ export async function GET() {
       .limit(500),
   ]);
 
-  if (jobsResult.error || customersResult.error || fleetsResult.error) {
+  if (customersResult.error || fleetsResult.error) {
     console.error("inspection form import directory load failed", {
-      jobs: jobsResult.error?.message,
       customers: customersResult.error?.message,
       fleets: fleetsResult.error?.message,
       shopId: access.profile.shop_id,
     });
-    return NextResponse.json({ error: "Unable to load form imports." }, { status: 500 });
+    return NextResponse.json(
+      { error: "Unable to load form imports." },
+      { status: 500 },
+    );
+  }
+
+  if (jobsResult.error) {
+    console.error("inspection form recent import load failed", {
+      code: jobsResult.error.code,
+      error: jobsResult.error.message,
+      shopId: access.profile.shop_id,
+    });
   }
 
   return NextResponse.json({
     ok: true,
+    importReady: !jobsResult.error,
+    setupError: jobsResult.error
+      ? isImportSchemaError(jobsResult.error)
+        ? IMPORT_SETUP_ERROR
+        : "Unable to verify the form import service. Please try again."
+      : null,
     customers: (customersResult.data ?? [])
       .map((customer) => ({ id: customer.id, label: customerLabel(customer) }))
       .sort((a, b) => a.label.localeCompare(b.label)),
-    fleets: (fleetsResult.data ?? []).map((fleet) => ({ id: fleet.id, label: fleet.name })),
+    fleets: (fleetsResult.data ?? []).map((fleet) => ({
+      id: fleet.id,
+      label: fleet.name,
+    })),
     imports: (jobsResult.data ?? []).map((job) => {
       const summary = normalizeInspectionFormImportSummary(job.summary);
       return {
@@ -169,23 +251,41 @@ export async function POST(req: Request) {
   const contentType = req.headers.get("content-type") ?? "";
 
   if (contentType.includes("application/json")) {
-    const body = (await req.json().catch(() => null)) as
-      | {
-          action?: unknown;
-          files?: unknown;
-          uploads?: unknown;
-          uploadId?: unknown;
-          title?: unknown;
-          vehicleType?: unknown;
-          dutyClass?: unknown;
-          customerId?: unknown;
-          customerName?: unknown;
-          fleetId?: unknown;
-          fleetName?: unknown;
-        }
-      | null;
+    const body = (await req.json().catch(() => null)) as {
+      action?: unknown;
+      files?: unknown;
+      uploads?: unknown;
+      uploadId?: unknown;
+      title?: unknown;
+      vehicleType?: unknown;
+      dutyClass?: unknown;
+      customerId?: unknown;
+      customerName?: unknown;
+      fleetId?: unknown;
+      fleetName?: unknown;
+    } | null;
 
     if (body?.action === "prepare") {
+      const { error: schemaError } = await admin
+        .from("import_jobs")
+        .select("result_record_id, approved_at")
+        .limit(0);
+      if (schemaError) {
+        console.error("inspection form import schema readiness check failed", {
+          code: schemaError.code,
+          error: schemaError.message,
+          shopId,
+        });
+        return NextResponse.json(
+          {
+            error: isImportSchemaError(schemaError)
+              ? IMPORT_SETUP_ERROR
+              : "Unable to verify the form import service. Please try again.",
+          },
+          { status: 503 },
+        );
+      }
+
       const values = Array.isArray(body.files) ? body.files : [];
       if (!values.length || values.length > MAX_PAGES) {
         return NextResponse.json(
@@ -196,7 +296,9 @@ export async function POST(req: Request) {
       const descriptors = values.map(validateFileDescriptor);
       if (descriptors.some((file) => !file)) {
         return NextResponse.json(
-          { error: "Every page must be a supported image no larger than 25 MB." },
+          {
+            error: "Every page must be a supported image no larger than 25 MB.",
+          },
           { status: 400 },
         );
       }
@@ -206,7 +308,9 @@ export async function POST(req: Request) {
       for (const descriptor of descriptors) {
         if (!descriptor) continue;
         const path = `${access.profile.id}/${uploadId}/${String(descriptor.index + 1).padStart(2, "0")}-${safeFileName(descriptor.originalName)}`;
-        const { data, error } = await admin.storage.from(BUCKET).createSignedUploadUrl(path);
+        const { data, error } = await admin.storage
+          .from(BUCKET)
+          .createSignedUploadUrl(path);
         if (error || !data?.token) {
           console.error("inspection form signed upload preparation failed", {
             shopId,
@@ -214,7 +318,9 @@ export async function POST(req: Request) {
             error: error?.message,
           });
           return NextResponse.json(
-            { error: "Unable to prepare secure page uploads. Please try again." },
+            {
+              error: "Unable to prepare secure page uploads. Please try again.",
+            },
             { status: 500 },
           );
         }
@@ -230,25 +336,46 @@ export async function POST(req: Request) {
     }
 
     if (body?.action !== "finalize") {
-      return NextResponse.json({ error: "Invalid upload action." }, { status: 400 });
+      return NextResponse.json(
+        { error: "Invalid upload action." },
+        { status: 400 },
+      );
     }
 
     const uploadId = clean(body.uploadId, 60);
     const values = Array.isArray(body.uploads) ? body.uploads : [];
     const descriptors = values.map(validateFileDescriptor);
-    if (!/^[0-9a-f-]{36}$/i.test(uploadId) || !values.length || values.length > MAX_PAGES || descriptors.some((file) => !file)) {
-      return NextResponse.json({ error: "The prepared upload is invalid or expired." }, { status: 400 });
+    if (
+      !/^[0-9a-f-]{36}$/i.test(uploadId) ||
+      !values.length ||
+      values.length > MAX_PAGES ||
+      descriptors.some((file) => !file)
+    ) {
+      return NextResponse.json(
+        { error: "The prepared upload is invalid or expired." },
+        { status: 400 },
+      );
     }
     const expectedPrefix = `${access.profile.id}/${uploadId}/`;
-    const uploads = descriptors.filter((value): value is NonNullable<typeof value> => Boolean(value));
+    const uploads = descriptors.filter(
+      (value): value is NonNullable<typeof value> => Boolean(value),
+    );
     if (uploads.some((upload) => !upload.path.startsWith(expectedPrefix))) {
-      return NextResponse.json({ error: "The prepared upload does not belong to this user." }, { status: 403 });
+      return NextResponse.json(
+        { error: "The prepared upload does not belong to this user." },
+        { status: 403 },
+      );
     }
     const { data: stored, error: listError } = await admin.storage
       .from(BUCKET)
       .list(`${access.profile.id}/${uploadId}`, { limit: MAX_PAGES + 1 });
     const storedNames = new Set((stored ?? []).map((item) => item.name));
-    if (listError || uploads.some((upload) => !storedNames.has(upload.path.split("/").at(-1) ?? ""))) {
+    if (
+      listError ||
+      uploads.some(
+        (upload) => !storedNames.has(upload.path.split("/").at(-1) ?? ""),
+      )
+    ) {
       return NextResponse.json(
         { error: "One or more pages did not finish uploading. Please retry." },
         { status: 409 },
@@ -269,15 +396,25 @@ export async function POST(req: Request) {
   // signed, direct-to-storage uploads so mobile camera files never cross the
   // hosting provider's request-size limit.
   const formData = await req.formData();
-  const files = formData.getAll("files").filter((value): value is File => value instanceof File);
+  const files = formData
+    .getAll("files")
+    .filter((value): value is File => value instanceof File);
   if (!files.length || files.length > MAX_PAGES) {
-    return NextResponse.json({ error: `Add between 1 and ${MAX_PAGES} form pages.` }, { status: 400 });
+    return NextResponse.json(
+      { error: `Add between 1 and ${MAX_PAGES} form pages.` },
+      { status: 400 },
+    );
   }
-  const descriptors = files.map((file, index) => validateFileDescriptor({
-    name: file.name,
-    type: file.type,
-    size: file.size,
-  }, index));
+  const descriptors = files.map((file, index) =>
+    validateFileDescriptor(
+      {
+        name: file.name,
+        type: file.type,
+        size: file.size,
+      },
+      index,
+    ),
+  );
   if (descriptors.some((file) => !file)) {
     return NextResponse.json(
       { error: "Every page must be a supported image no larger than 25 MB." },
@@ -292,17 +429,32 @@ export async function POST(req: Request) {
       const descriptor = descriptors[index];
       if (!descriptor) continue;
       const path = `${access.profile.id}/${jobId}/${String(index + 1).padStart(2, "0")}-${safeFileName(descriptor.originalName)}`;
-      const { error } = await admin.storage.from(BUCKET).upload(path, files[index], {
-        contentType: descriptor.mime,
-        upsert: false,
-      });
+      const { error } = await admin.storage
+        .from(BUCKET)
+        .upload(path, files[index], {
+          contentType: descriptor.mime,
+          upsert: false,
+        });
       if (error) throw error;
-      uploaded.push({ path, originalName: descriptor.originalName, mime: descriptor.mime, size: descriptor.size });
+      uploaded.push({
+        path,
+        originalName: descriptor.originalName,
+        mime: descriptor.mime,
+        size: descriptor.size,
+      });
     }
   } catch (error) {
-    if (uploaded.length) await admin.storage.from(BUCKET).remove(uploaded.map((item) => item.path));
+    if (uploaded.length)
+      await admin.storage
+        .from(BUCKET)
+        .remove(uploaded.map((item) => item.path));
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to upload the form pages." },
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to upload the form pages.",
+      },
       { status: 500 },
     );
   }
@@ -347,10 +499,18 @@ async function queueInspectionFormImport({
     loadRelatedRecord(admin, "fleets", fleetId, shopId),
   ]);
   if (customerId && !customer) {
-    return NextResponse.json({ error: "Customer not found in this shop." }, { status: 404 });
+    await removeUploadedPages(admin, uploads);
+    return NextResponse.json(
+      { error: "Customer not found in this shop." },
+      { status: 404 },
+    );
   }
   if (fleetId && !fleet) {
-    return NextResponse.json({ error: "Fleet account not found in this shop." }, { status: 404 });
+    await removeUploadedPages(admin, uploads);
+    return NextResponse.json(
+      { error: "Fleet account not found in this shop." },
+      { status: 404 },
+    );
   }
 
   const summary = {
@@ -359,7 +519,13 @@ async function queueInspectionFormImport({
     vehicleType: clean(metadata.vehicleType, 30),
     dutyClass: clean(metadata.dutyClass, 20),
     customerId: customer?.id ?? null,
-    customerName: customer ? customer.business_name || customer.name : clean(metadata.customerName) || null,
+    customerName: customer
+      ? customer.business_name ||
+        customer.name ||
+        [customer.first_name, customer.last_name].filter(Boolean).join(" ") ||
+        clean(metadata.customerName) ||
+        null
+      : clean(metadata.customerName) || null,
     fleetId: fleet?.id ?? null,
     fleetName: fleet?.name ?? (clean(metadata.fleetName) || null),
     draftSections: [],
@@ -377,8 +543,21 @@ async function queueInspectionFormImport({
     summary,
   });
   if (jobError) {
-    console.error("inspection form import job creation failed", { jobId, shopId, error: jobError.message });
-    return NextResponse.json({ error: "Unable to start the form import." }, { status: 500 });
+    await removeUploadedPages(admin, uploads);
+    console.error("inspection form import job creation failed", {
+      jobId,
+      shopId,
+      code: jobError.code,
+      error: jobError.message,
+    });
+    return NextResponse.json(
+      {
+        error: isImportSchemaError(jobError)
+          ? IMPORT_SETUP_ERROR
+          : "Unable to start the form import. Please try again.",
+      },
+      { status: isImportSchemaError(jobError) ? 503 : 500 },
+    );
   }
 
   const { error: rowsError } = await admin.from("import_job_rows").insert(
@@ -395,18 +574,40 @@ async function queueInspectionFormImport({
     })),
   );
   if (rowsError) {
-    await admin.from("import_jobs").delete().eq("id", jobId).eq("shop_id", shopId);
-    console.error("inspection form import page staging failed", { jobId, shopId, error: rowsError.message });
-    return NextResponse.json({ error: "Unable to stage the uploaded form pages." }, { status: 500 });
+    await admin
+      .from("import_jobs")
+      .delete()
+      .eq("id", jobId)
+      .eq("shop_id", shopId);
+    await removeUploadedPages(admin, uploads);
+    console.error("inspection form import page staging failed", {
+      jobId,
+      shopId,
+      error: rowsError.message,
+    });
+    return NextResponse.json(
+      { error: "Unable to stage the uploaded form pages." },
+      { status: 500 },
+    );
   }
 
   after(async () => {
     try {
-      await processInspectionFormImportJobBatch(createAdminSupabase(), jobId, INSPECTION_FORM_IMPORT_BATCH_SIZE);
+      await processInspectionFormImportJobBatch(
+        createAdminSupabase(),
+        jobId,
+        INSPECTION_FORM_IMPORT_BATCH_SIZE,
+      );
     } catch (error) {
-      console.error("inspection form import background kickoff failed", { jobId, error });
+      console.error("inspection form import background kickoff failed", {
+        jobId,
+        error,
+      });
     }
   });
 
-  return NextResponse.json({ ok: true, jobId, status: "queued" }, { status: 202 });
+  return NextResponse.json(
+    { ok: true, jobId, status: "queued" },
+    { status: 202 },
+  );
 }

--- a/app/mobile/inspections/import/page.tsx
+++ b/app/mobile/inspections/import/page.tsx
@@ -13,13 +13,20 @@ export default function MobileInspectionFormImportPage() {
   }, [jobId, router]);
 
   return (
-    <main className="min-h-screen space-y-4 bg-[color:var(--theme-surface-page)] px-4 py-4 text-[color:var(--theme-text-primary)]">
+    <div className="min-h-screen space-y-4 bg-[color:var(--theme-surface-page)] px-4 py-4 text-[color:var(--theme-text-primary)]">
       <header>
-        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">Inspection templates</div>
-        <h1 className="mt-2 font-blackops text-lg uppercase tracking-[0.16em]">Import customer form</h1>
-        <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">Use the camera at the counter or vehicle. Processing continues if you leave this screen.</p>
+        <div className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Inspection templates
+        </div>
+        <h1 className="mt-2 font-blackops text-lg uppercase tracking-[0.16em]">
+          Import customer form
+        </h1>
+        <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+          Use the camera at the counter or vehicle. Processing continues if you
+          leave this screen.
+        </p>
       </header>
       <FleetFormImportCard mobile />
-    </main>
+    </div>
   );
 }

--- a/components/layout/MobileShell.tsx
+++ b/components/layout/MobileShell.tsx
@@ -21,6 +21,7 @@ function getTitleFromPath(pathname: string): string {
   }
   if (pathname.startsWith("/mobile/work-orders")) return "Work orders";
   if (pathname.startsWith("/mobile/appointments")) return "Appointments";
+  if (pathname.startsWith("/mobile/inspections/import")) return "Import form";
   if (pathname.startsWith("/mobile/inspections")) return "Inspections";
   if (pathname.startsWith("/mobile/parts")) return "Parts";
   if (pathname.startsWith("/mobile/messages")) return "Inbox";
@@ -49,14 +50,21 @@ function getTitleFromPath(pathname: string): string {
 function isImmersiveRoute(pathname: string): boolean {
   if (pathname.startsWith("/mobile/jobs/")) return true;
 
+  if (pathname === "/mobile/inspections/import") return false;
+
   // Single-screen inspection runners provide their own Back/header bar. Deeper
-  // routes such as /[id]/run still rely on the shared mobile header.
+  // routes such as /[id]/run and static tools such as /import still rely on the
+  // shared mobile header.
   return /^\/mobile\/inspections\/[^/]+$/.test(pathname);
 }
 
-function shouldIgnoreAnchor(anchor: HTMLAnchorElement, event: MouseEvent): boolean {
+function shouldIgnoreAnchor(
+  anchor: HTMLAnchorElement,
+  event: MouseEvent,
+): boolean {
   if (event.defaultPrevented || event.button !== 0) return true;
-  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return true;
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+    return true;
   if (anchor.hasAttribute("download")) return true;
   if (anchor.dataset.mobileRouteBypass === "true") return true;
 
@@ -93,10 +101,14 @@ export function MobileShell({ children, title }: Props) {
     // Listen at document level so links rendered by portals and shared modals
     // cannot accidentally escape from the mobile application shell.
     document.addEventListener("click", keepNavigationMobile, true);
-    return () => document.removeEventListener("click", keepNavigationMobile, true);
+    return () =>
+      document.removeEventListener("click", keepNavigationMobile, true);
   }, [router]);
 
-  if (pathname === "/mobile/sign-in" || pathname.startsWith("/mobile/sign-in/")) {
+  if (
+    pathname === "/mobile/sign-in" ||
+    pathname.startsWith("/mobile/sign-in/")
+  ) {
     return children;
   }
 
@@ -129,7 +141,9 @@ export function MobileShell({ children, title }: Props) {
             </button>
 
             <div className="min-w-0">
-              <div className="truncate text-sm font-semibold">{resolvedTitle}</div>
+              <div className="truncate text-sm font-semibold">
+                {resolvedTitle}
+              </div>
               <div className="truncate text-[0.62rem] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
                 ProFixIQ Mobile
               </div>

--- a/features/inspections/components/FleetFormImportCard.tsx
+++ b/features/inspections/components/FleetFormImportCard.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { Button } from "@shared/components/ui/Button";
@@ -44,7 +44,116 @@ const STATE_COPY: Record<ImportListItem["state"], string> = {
   approved: "Template saved",
 };
 
-export default function FleetFormImportCard({ mobile = false }: { mobile?: boolean }) {
+function normalizeOptionLabel(value: string) {
+  return value.trim().toLocaleLowerCase();
+}
+
+function matchingOptions(options: Option[], query: string) {
+  const normalizedQuery = normalizeOptionLabel(query);
+  if (!normalizedQuery) return options.slice(0, 8);
+  return options
+    .filter((option) =>
+      normalizeOptionLabel(option.label).includes(normalizedQuery),
+    )
+    .slice(0, 8);
+}
+
+function ImportDirectoryField({
+  label,
+  placeholder,
+  options,
+  value,
+  selectedId,
+  onChange,
+  onSelect,
+}: {
+  label: string;
+  placeholder: string;
+  options: Option[];
+  value: string;
+  selectedId: string;
+  onChange: (value: string, matchingId: string) => void;
+  onSelect: (option: Option) => void;
+}) {
+  const inputId = useId();
+  const listId = useId();
+  const [open, setOpen] = useState(false);
+  const matches = useMemo(
+    () => matchingOptions(options, value),
+    [options, value],
+  );
+  const selected = options.find((option) => option.id === selectedId) ?? null;
+
+  return (
+    <div className="relative text-xs text-[color:var(--theme-text-secondary)]">
+      <label htmlFor={inputId}>{label}</label>
+      <input
+        id={inputId}
+        role="combobox"
+        aria-autocomplete="list"
+        aria-controls={listId}
+        aria-expanded={open}
+        value={value}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onChange={(event) => {
+          const nextValue = event.target.value;
+          const exactMatch = options.find(
+            (option) =>
+              normalizeOptionLabel(option.label) ===
+              normalizeOptionLabel(nextValue),
+          );
+          onChange(nextValue, exactMatch?.id ?? "");
+          setOpen(true);
+        }}
+        placeholder={placeholder}
+        autoComplete="off"
+        className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]"
+      />
+
+      {open && matches.length ? (
+        <div
+          id={listId}
+          role="listbox"
+          className="absolute left-0 right-0 z-30 mt-1 max-h-64 overflow-y-auto rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-1 shadow-[var(--theme-shadow-large)]"
+        >
+          {matches.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              role="option"
+              aria-selected={option.id === selectedId}
+              onPointerDown={(event) => event.preventDefault()}
+              onClick={() => {
+                onSelect(option);
+                setOpen(false);
+              }}
+              className="block w-full rounded-lg px-3 py-3 text-left text-sm text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-subtle)] active:bg-[color:var(--theme-surface-subtle)]"
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {selected ? (
+        <div className="mt-1 text-[0.7rem] font-medium text-emerald-400">
+          Selected: {selected.label}
+        </div>
+      ) : value.trim() ? (
+        <div className="mt-1 text-[0.7rem] text-[color:var(--theme-text-muted)]">
+          Select a match to link the record, or keep this as a typed name.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function FleetFormImportCard({
+  mobile = false,
+}: {
+  mobile?: boolean;
+}) {
   const router = useRouter();
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [files, setFiles] = useState<File[]>([]);
@@ -58,18 +167,32 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
   const [customers, setCustomers] = useState<Option[]>([]);
   const [fleets, setFleets] = useState<Option[]>([]);
   const [imports, setImports] = useState<ImportListItem[]>([]);
+  const [importReady, setImportReady] = useState<boolean | null>(null);
+  const [setupError, setSetupError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const loadImports = useCallback(async () => {
-    const response = await fetch("/api/inspection-form-imports", { cache: "no-store" });
-    const body = (await response.json().catch(() => null)) as
-      | { imports?: ImportListItem[]; customers?: Option[]; fleets?: Option[] }
-      | null;
+    const response = await fetch("/api/inspection-form-imports", {
+      cache: "no-store",
+    });
+    const body = (await response.json().catch(() => null)) as {
+      imports?: ImportListItem[];
+      customers?: Option[];
+      fleets?: Option[];
+      importReady?: boolean;
+      setupError?: string | null;
+      error?: string;
+    } | null;
     if (response.ok) {
       setImports(body?.imports ?? []);
       setCustomers(body?.customers ?? []);
       setFleets(body?.fleets ?? []);
+      setImportReady(body?.importReady ?? true);
+      setSetupError(body?.setupError ?? null);
+    } else {
+      setImportReady(false);
+      setSetupError(body?.error || "Unable to load customers and fleets.");
     }
   }, []);
 
@@ -78,7 +201,11 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
   }, [loadImports]);
 
   useEffect(() => {
-    if (!imports.some((item) => item.state === "queued" || item.state === "processing")) {
+    if (
+      !imports.some(
+        (item) => item.state === "queued" || item.state === "processing",
+      )
+    ) {
       return;
     }
     const interval = window.setInterval(() => {
@@ -89,7 +216,9 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
 
   const addFiles = (incoming: File[]) => {
     setError(null);
-    const invalid = incoming.find((file) => !ACCEPTED.has(file.type) || !file.size);
+    const invalid = incoming.find(
+      (file) => !ACCEPTED.has(file.type) || !file.size,
+    );
     if (invalid) {
       setError(`${invalid.name || "That file"} is not a supported form image.`);
       return;
@@ -113,6 +242,10 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
       setError("Photograph or select at least one page.");
       return;
     }
+    if (importReady === false) {
+      setError(setupError || "Form importing is temporarily unavailable.");
+      return;
+    }
     setSubmitting(true);
     setError(null);
     try {
@@ -128,11 +261,19 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
           })),
         }),
       });
-      const prepareBody = (await prepareResponse.json().catch(() => null)) as
-        | { uploadId?: string; uploads?: SignedUpload[]; error?: string }
-        | null;
-      if (!prepareResponse.ok || !prepareBody?.uploadId || !prepareBody.uploads) {
-        throw new Error(prepareBody?.error || "Unable to prepare the form upload.");
+      const prepareBody = (await prepareResponse.json().catch(() => null)) as {
+        uploadId?: string;
+        uploads?: SignedUpload[];
+        error?: string;
+      } | null;
+      if (
+        !prepareResponse.ok ||
+        !prepareBody?.uploadId ||
+        !prepareBody.uploads
+      ) {
+        throw new Error(
+          prepareBody?.error || "Unable to prepare the form upload.",
+        );
       }
 
       for (let index = 0; index < prepareBody.uploads.length; index += 1) {
@@ -145,7 +286,9 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
             upsert: false,
           });
         if (uploadError) {
-          throw new Error(`Unable to upload page ${index + 1}. ${uploadError.message}`);
+          throw new Error(
+            `Unable to upload page ${index + 1}. ${uploadError.message}`,
+          );
         }
       }
 
@@ -170,9 +313,10 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
           fleetName,
         }),
       });
-      const body = (await response.json().catch(() => null)) as
-        | { jobId?: string; error?: string }
-        | null;
+      const body = (await response.json().catch(() => null)) as {
+        jobId?: string;
+        error?: string;
+      } | null;
       if (!response.ok || !body?.jobId) {
         throw new Error(body?.error || "Unable to finish the form upload.");
       }
@@ -182,7 +326,9 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
           : `/inspections/fleet-review?jobId=${body.jobId}`,
       );
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "Unable to upload the form.");
+      setError(
+        caught instanceof Error ? caught.message : "Unable to upload the form.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -199,62 +345,77 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
             Import customer form
           </div>
           <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-            Photograph every page. You can leave while ProFixIQ reads it and review it on any signed-in device.
+            Photograph every page. You can leave while ProFixIQ reads it and
+            review it on any signed-in device.
           </p>
         </div>
 
         <div className="grid gap-3 md:grid-cols-2">
-          <label className="text-xs text-[color:var(--theme-text-secondary)]">
-            Customer (optional)
-            <input
-              list="inspection-import-customers"
-              value={customerName}
-              onChange={(event) => {
-                const value = event.target.value;
-                setCustomerName(value);
-                setCustomerId(customers.find((option) => option.label.toLocaleLowerCase() === value.trim().toLocaleLowerCase())?.id ?? "");
-              }}
-              placeholder="Search or type a customer name"
-              autoComplete="off"
-              className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]"
-            />
-            <datalist id="inspection-import-customers">
-              {customers.map((option) => <option key={option.id} value={option.label} />)}
-            </datalist>
-          </label>
-          <label className="text-xs text-[color:var(--theme-text-secondary)]">
-            Fleet account (optional)
-            <input
-              list="inspection-import-fleets"
-              value={fleetName}
-              onChange={(event) => {
-                const value = event.target.value;
-                setFleetName(value);
-                setFleetId(fleets.find((option) => option.label.toLocaleLowerCase() === value.trim().toLocaleLowerCase())?.id ?? "");
-              }}
-              placeholder="Search or type a fleet name"
-              autoComplete="off"
-              className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]"
-            />
-            <datalist id="inspection-import-fleets">
-              {fleets.map((option) => <option key={option.id} value={option.label} />)}
-            </datalist>
-          </label>
+          <ImportDirectoryField
+            label="Customer (optional)"
+            placeholder="Search or type a customer name"
+            options={customers}
+            value={customerName}
+            selectedId={customerId}
+            onChange={(value, matchingId) => {
+              setCustomerName(value);
+              setCustomerId(matchingId);
+            }}
+            onSelect={(option) => {
+              setCustomerName(option.label);
+              setCustomerId(option.id);
+            }}
+          />
+          <ImportDirectoryField
+            label="Fleet account (optional)"
+            placeholder="Search or type a fleet name"
+            options={fleets}
+            value={fleetName}
+            selectedId={fleetId}
+            onChange={(value, matchingId) => {
+              setFleetName(value);
+              setFleetId(matchingId);
+            }}
+            onSelect={(option) => {
+              setFleetName(option.label);
+              setFleetId(option.id);
+            }}
+          />
           <label className="text-xs text-[color:var(--theme-text-secondary)] md:col-span-2">
             Template name (optional)
-            <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="ABC Logistics annual inspection" className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]" />
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="ABC Logistics annual inspection"
+              className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]"
+            />
           </label>
           <label className="text-xs text-[color:var(--theme-text-secondary)]">
             Vehicle type
-            <select value={vehicleType} onChange={(e) => setVehicleType(e.target.value)} className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]">
+            <select
+              value={vehicleType}
+              onChange={(e) => setVehicleType(e.target.value)}
+              className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]"
+            >
               <option value="">Not specified</option>
-              <option value="car">Car / SUV</option><option value="truck">Truck / tractor</option><option value="bus">Bus / coach</option><option value="trailer">Trailer</option><option value="mixed">Mixed fleet</option>
+              <option value="car">Car / SUV</option>
+              <option value="truck">Truck / tractor</option>
+              <option value="bus">Bus / coach</option>
+              <option value="trailer">Trailer</option>
+              <option value="mixed">Mixed fleet</option>
             </select>
           </label>
           <label className="text-xs text-[color:var(--theme-text-secondary)]">
             Duty class
-            <select value={dutyClass} onChange={(e) => setDutyClass(e.target.value)} className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]">
-              <option value="">Not specified</option><option value="light">Light duty</option><option value="medium">Medium duty</option><option value="heavy">Heavy duty</option>
+            <select
+              value={dutyClass}
+              onChange={(e) => setDutyClass(e.target.value)}
+              className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)]"
+            >
+              <option value="">Not specified</option>
+              <option value="light">Light duty</option>
+              <option value="medium">Medium duty</option>
+              <option value="heavy">Heavy duty</option>
             </select>
           </label>
         </div>
@@ -262,48 +423,141 @@ export default function FleetFormImportCard({ mobile = false }: { mobile?: boole
         <div className="mt-4 grid grid-cols-2 gap-2">
           <label className="flex min-h-16 cursor-pointer items-center justify-center rounded-2xl border border-[var(--accent-copper)] bg-[color:var(--theme-surface-subtle)] px-3 text-center text-sm font-semibold text-[color:var(--theme-text-primary)]">
             Take photo
-            <input type="file" accept="image/*" capture="environment" className="sr-only" onChange={(e) => { addFiles(Array.from(e.target.files ?? [])); e.target.value = ""; }} />
+            <input
+              type="file"
+              accept="image/*"
+              capture="environment"
+              className="sr-only"
+              onChange={(e) => {
+                addFiles(Array.from(e.target.files ?? []));
+                e.target.value = "";
+              }}
+            />
           </label>
           <label className="flex min-h-16 cursor-pointer items-center justify-center rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 text-center text-sm font-semibold text-[color:var(--theme-text-primary)]">
             Choose photos
-            <input type="file" accept="image/*" multiple className="sr-only" onChange={(e) => { addFiles(Array.from(e.target.files ?? [])); e.target.value = ""; }} />
+            <input
+              type="file"
+              accept="image/*"
+              multiple
+              className="sr-only"
+              onChange={(e) => {
+                addFiles(Array.from(e.target.files ?? []));
+                e.target.value = "";
+              }}
+            />
           </label>
         </div>
 
         {files.length ? (
           <div className="mt-4 space-y-2">
-            <div className="text-xs uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">Pages in reading order</div>
+            <div className="text-xs uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+              Pages in reading order
+            </div>
             {files.map((file, index) => (
-              <div key={`${file.name}-${file.lastModified}-${index}`} className="flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm">
-                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[color:var(--theme-surface-subtle)] font-semibold">{index + 1}</span>
+              <div
+                key={`${file.name}-${file.lastModified}-${index}`}
+                className="flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm"
+              >
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[color:var(--theme-surface-subtle)] font-semibold">
+                  {index + 1}
+                </span>
                 <span className="min-w-0 flex-1 truncate">{file.name}</span>
-                <button type="button" aria-label={`Move page ${index + 1} up`} onClick={() => move(index, -1)} disabled={index === 0} className="px-2 py-1 disabled:opacity-30">↑</button>
-                <button type="button" aria-label={`Move page ${index + 1} down`} onClick={() => move(index, 1)} disabled={index === files.length - 1} className="px-2 py-1 disabled:opacity-30">↓</button>
-                <button type="button" onClick={() => setFiles((current) => current.filter((_, fileIndex) => fileIndex !== index))} className="px-2 py-1 text-red-300">Remove</button>
+                <button
+                  type="button"
+                  aria-label={`Move page ${index + 1} up`}
+                  onClick={() => move(index, -1)}
+                  disabled={index === 0}
+                  className="px-2 py-1 disabled:opacity-30"
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Move page ${index + 1} down`}
+                  onClick={() => move(index, 1)}
+                  disabled={index === files.length - 1}
+                  className="px-2 py-1 disabled:opacity-30"
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setFiles((current) =>
+                      current.filter((_, fileIndex) => fileIndex !== index),
+                    )
+                  }
+                  className="px-2 py-1 text-red-300"
+                >
+                  Remove
+                </button>
               </div>
             ))}
           </div>
         ) : null}
 
-        {error ? <div className="mt-4 rounded-xl border border-red-500/50 bg-red-950/30 p-3 text-sm text-red-200">{error}</div> : null}
-        <Button type="submit" variant="copper" size="lg" isLoading={submitting} disabled={!files.length} className="mt-4 w-full">
+        {setupError ? (
+          <div className="mt-4 rounded-xl border border-amber-500/50 bg-amber-950/30 p-3 text-sm text-amber-100">
+            {setupError}
+          </div>
+        ) : null}
+        {error ? (
+          <div className="mt-4 rounded-xl border border-red-500/50 bg-red-950/30 p-3 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+        <Button
+          type="submit"
+          variant="copper"
+          size="lg"
+          isLoading={submitting}
+          disabled={!files.length || importReady === false}
+          className="mt-4 w-full"
+        >
           Upload and process
         </Button>
       </form>
 
       {imports.length ? (
         <section>
-          <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)]">Recent form imports</h2>
+          <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-primary)]">
+            Recent form imports
+          </h2>
           <div className="mt-2 space-y-2">
             {imports.map((item) => {
-              const href = mobile ? `/mobile/inspections/import/${item.id}` : `/inspections/fleet-review?jobId=${item.id}`;
+              const href = mobile
+                ? `/mobile/inspections/import/${item.id}`
+                : `/inspections/fleet-review?jobId=${item.id}`;
               return (
-                <Link key={item.id} href={href} className="block rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3">
+                <Link
+                  key={item.id}
+                  href={href}
+                  className="block rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3"
+                >
                   <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0"><div className="truncate text-sm font-semibold">{item.title}</div><div className="mt-1 truncate text-xs text-[color:var(--theme-text-secondary)]">{item.customerName || item.fleetName || "Shop template"}</div></div>
-                    <span className="shrink-0 rounded-full border border-[color:var(--theme-border-soft)] px-2 py-1 text-[10px] uppercase tracking-[0.12em]">{STATE_COPY[item.state]}</span>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-semibold">
+                        {item.title}
+                      </div>
+                      <div className="mt-1 truncate text-xs text-[color:var(--theme-text-secondary)]">
+                        {item.customerName || item.fleetName || "Shop template"}
+                      </div>
+                    </div>
+                    <span className="shrink-0 rounded-full border border-[color:var(--theme-border-soft)] px-2 py-1 text-[10px] uppercase tracking-[0.12em]">
+                      {STATE_COPY[item.state]}
+                    </span>
                   </div>
-                  {(item.state === "queued" || item.state === "processing") ? <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[color:var(--theme-surface-inset)]"><div className="h-full bg-[var(--accent-copper)]" style={{ width: `${Math.max(8, Math.round((item.processedPages / Math.max(1, item.totalPages)) * 100))}%` }} /></div> : null}
+                  {item.state === "queued" || item.state === "processing" ? (
+                    <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[color:var(--theme-surface-inset)]">
+                      <div
+                        className="h-full bg-[var(--accent-copper)]"
+                        style={{
+                          width: `${Math.max(8, Math.round((item.processedPages / Math.max(1, item.totalPages)) * 100))}%`,
+                        }}
+                      />
+                    </div>
+                  ) : null}
                 </Link>
               );
             })}

--- a/supabase/migrations/20260722023000_repair_inspection_form_import_schema.sql
+++ b/supabase/migrations/20260722023000_repair_inspection_form_import_schema.sql
@@ -1,0 +1,148 @@
+-- Reassert the durable inspection-form import schema for environments where
+-- the application deploy reached production before the original migration.
+
+alter table public.import_jobs
+  drop constraint if exists import_jobs_import_type_check;
+
+alter table public.import_jobs
+  add constraint import_jobs_import_type_check
+  check (import_type in ('vehicle_history', 'invoices', 'inspection_form'));
+
+alter table public.import_job_rows
+  drop constraint if exists import_job_rows_status_check;
+
+alter table public.import_job_rows
+  add constraint import_job_rows_status_check
+  check (status in ('queued', 'processing', 'imported', 'skipped', 'failed'));
+
+alter table public.import_jobs
+  add column if not exists result_record_id uuid,
+  add column if not exists approved_at timestamptz;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'import_jobs_result_inspection_template_fkey'
+      and conrelid = 'public.import_jobs'::regclass
+  ) then
+    alter table public.import_jobs
+      add constraint import_jobs_result_inspection_template_fkey
+      foreign key (result_record_id)
+      references public.inspection_templates(id)
+      on delete set null;
+  end if;
+end
+$$;
+
+create index if not exists import_jobs_inspection_form_recent_idx
+  on public.import_jobs(shop_id, created_at desc)
+  where import_type = 'inspection_form';
+
+create or replace function public.approve_inspection_form_import(
+  p_job_id uuid,
+  p_title text,
+  p_sections jsonb
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_job public.import_jobs%rowtype;
+  v_template_id uuid;
+  v_title text := nullif(btrim(coalesce(p_title, '')), '');
+  v_actor_shop_id uuid;
+  v_actor_role text;
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select shop_id, lower(btrim(coalesce(role, '')))
+  into v_actor_shop_id, v_actor_role
+  from public.profiles
+  where id = auth.uid();
+
+  if v_actor_shop_id is null
+     or v_actor_shop_id <> public.current_shop_id()
+     or v_actor_role not in ('owner', 'admin', 'manager', 'advisor', 'service') then
+    raise exception 'Not authorized to approve inspection form imports';
+  end if;
+
+  select *
+  into v_job
+  from public.import_jobs
+  where id = p_job_id
+    and shop_id = public.current_shop_id()
+    and import_type = 'inspection_form'
+  for update;
+
+  if not found then
+    raise exception 'Inspection form import not found';
+  end if;
+
+  if v_job.result_record_id is not null then
+    return v_job.result_record_id;
+  end if;
+
+  if v_job.status <> 'completed' then
+    raise exception 'Inspection form import is not ready for approval';
+  end if;
+
+  if v_title is null then
+    raise exception 'Template title is required';
+  end if;
+
+  if jsonb_typeof(p_sections) <> 'array' or jsonb_array_length(p_sections) = 0 then
+    raise exception 'At least one inspection section is required';
+  end if;
+
+  insert into public.inspection_templates (
+    user_id,
+    shop_id,
+    template_name,
+    sections,
+    description,
+    tags,
+    vehicle_type,
+    is_public
+  ) values (
+    auth.uid(),
+    v_job.shop_id,
+    v_title,
+    p_sections,
+    'Imported from a customer inspection form',
+    array['imported', 'customer-form'],
+    nullif(v_job.summary ->> 'vehicleType', ''),
+    false
+  )
+  returning id into v_template_id;
+
+  update public.import_jobs
+  set result_record_id = v_template_id,
+      approved_at = now(),
+      summary = jsonb_set(
+        jsonb_set(
+          jsonb_set(coalesce(summary, '{}'::jsonb), '{state}', '"approved"'::jsonb, true),
+          '{title}',
+          to_jsonb(v_title),
+          true
+        ),
+        '{draftSections}',
+        p_sections,
+        true
+      )
+  where id = v_job.id;
+
+  return v_template_id;
+end;
+$$;
+
+revoke all on function public.approve_inspection_form_import(uuid, text, jsonb) from public;
+grant execute on function public.approve_inspection_form_import(uuid, text, jsonb) to authenticated;
+
+comment on function public.approve_inspection_form_import(uuid, text, jsonb) is
+  'Idempotently creates the canonical inspection template for a completed, current-shop inspection-form import.';

--- a/tests/mobile-inspection-form-import.test.ts
+++ b/tests/mobile-inspection-form-import.test.ts
@@ -13,6 +13,14 @@ describe("mobile inspection form imports", () => {
     expect(migration).toContain("for update");
     expect(migration).toContain("result_record_id");
     expect(migration).toContain("approve_inspection_form_import");
+    const repairMigration = read(
+      "supabase/migrations/20260722023000_repair_inspection_form_import_schema.sql",
+    );
+    expect(repairMigration).toContain("'inspection_form'");
+    expect(repairMigration).toContain(
+      "add column if not exists result_record_id",
+    );
+    expect(repairMigration).toContain("approve_inspection_form_import");
   });
 
   it("keeps upload processing out of the request and resumable by cron", () => {
@@ -58,9 +66,15 @@ describe("mobile inspection form imports", () => {
     expect(importer).toContain("Search or type a fleet name");
     expect(importer).toContain("customerName");
     expect(importer).toContain("fleetName");
+    expect(importer).toContain('role="combobox"');
+    expect(importer).toContain('role="option"');
+    expect(importer).toContain("Selected:");
+    expect(importer).not.toContain("<datalist");
     expect(uploadRoute).toContain('.from("customers")');
     expect(uploadRoute).toContain('.from("fleets")');
     expect(uploadRoute).toContain('.eq("shop_id", access.profile.shop_id)');
+    expect(uploadRoute).toContain("customer.first_name");
+    expect(uploadRoute).toContain("customer.last_name");
   });
 
   it("uploads mobile photos directly with signed storage targets", () => {
@@ -73,6 +87,26 @@ describe("mobile inspection form imports", () => {
     expect(importer).toContain('action: "finalize"');
     expect(uploadRoute).toContain("createSignedUploadUrl");
     expect(uploadRoute).toContain("request-size limit");
+  });
+
+  it("checks schema readiness before upload and preserves directory results", () => {
+    const importer = read(
+      "features/inspections/components/FleetFormImportCard.tsx",
+    );
+    const uploadRoute = read("app/api/inspection-form-imports/route.ts");
+    expect(uploadRoute).toContain("IMPORT_SETUP_ERROR");
+    expect(uploadRoute).toContain("schema readiness check");
+    expect(uploadRoute).toContain("removeUploadedPages");
+    expect(importer).toContain("importReady");
+    expect(importer).toContain("setupError");
+  });
+
+  it("keeps the import tool inside the shared mobile shell", () => {
+    const shell = read("components/layout/MobileShell.tsx");
+    const page = read("app/mobile/inspections/import/page.tsx");
+    expect(shell).toContain('pathname === "/mobile/inspections/import"');
+    expect(shell).toContain('return "Import form"');
+    expect(page).not.toContain("<main");
   });
 
   it("removes the browser-only sessionStorage handoff", () => {


### PR DESCRIPTION
## What changed

- replaces the iOS-unreliable customer/fleet datalists with an in-app searchable selector that binds the selected record ID and confirms the linked record
- preserves customer names sourced from `first_name`/`last_name` when the canonical `name` columns are empty
- keeps `/mobile/inspections/import` inside the shared mobile shell and gives it the correct mobile title/home navigation
- separates customer/fleet directory loading from recent-import loading so one schema error cannot blank valid directory results
- checks import schema readiness before signed photo uploads begin
- cleans staged storage objects when job creation, related-record validation, or row staging fails
- adds a replay-safe repair migration for the inspection-form import schema

## Root cause

The shared mobile shell treated the static `import` route segment as an inspection-session ID and intentionally rendered it as an immersive page. The customer/fleet fields used native `datalist`, which is unreliable on iOS and only bound an ID after an exact text match.

The live database also has not received the inspection-form import migration. That caused the recent-import query to fail, which discarded otherwise valid customer/fleet results, and then rejected `import_type = 'inspection_form'` after the photos had already uploaded.

## Validation

- `tsc --noEmit` passes
- changed-file ESLint passes
- all 8 focused mobile inspection-form import tests pass
- mobile-route import-shell assertions pass
- the broader mobile-route suite retains one unrelated baseline failure for quote-review routing (`/work-orders/abc/quote-review`)
- remote tree exactly matches the locally validated tree (`e80d65fff7de...`)

## Deployment note

Apply `supabase/migrations/20260722023000_repair_inspection_form_import_schema.sql` to the live Supabase project when this PR is deployed. The UI now detects the missing update before uploading photos, but imports cannot process until the database migration is applied.