### PR TITLE
Fix inspection sync fallback and modal theme

### DIFF
--- a/app/mobile/inspections/page.tsx
+++ b/app/mobile/inspections/page.tsx
@@ -10,6 +10,8 @@ import { canonicalizeRole } from "@/features/shared/lib/rbac";
 
 type InspectionRow = {
   id: string;
+  work_order_id: string | null;
+  work_order_line_id: string | null;
   custom_id: string | null;
   status: string | null;
   created_at: string | null;
@@ -61,7 +63,7 @@ export default function MobileInspectionsListPage() {
         const { data, error: queryError } = await supabase
           .from("inspection_sessions")
           .select(
-            "id, custom_id, status, created_at, customer_name, vehicle_label",
+            "id, work_order_id, work_order_line_id, custom_id, status, created_at, customer_name, vehicle_label",
           )
           .order("created_at", { ascending: false })
           .limit(50);
@@ -72,6 +74,8 @@ export default function MobileInspectionsListPage() {
         setRows(
           (data ?? []).map((row) => ({
             id: row.id,
+            work_order_id: row.work_order_id ?? null,
+            work_order_line_id: row.work_order_line_id ?? null,
             custom_id: row.custom_id ?? null,
             status: row.status ?? null,
             created_at: row.created_at ?? null,
@@ -165,10 +169,15 @@ export default function MobileInspectionsListPage() {
               ? format(new Date(row.created_at), "PP p")
               : "—";
 
+            const canonicalHref =
+              row.work_order_id && row.work_order_line_id
+                ? `/mobile/work-orders/${row.work_order_id}?focus=${encodeURIComponent(row.work_order_line_id)}`
+                : "/mobile/work-orders";
+
             return (
               <Link
                 key={row.id}
-                href={`/mobile/inspections/${row.id}`}
+                href={canonicalHref}
                 className="block rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-sm text-[color:var(--theme-text-primary)] shadow-sm shadow-[var(--theme-shadow-medium)] active:scale-[0.99]"
               >
                 <div className="flex items-center justify-between gap-2">
@@ -189,9 +198,14 @@ export default function MobileInspectionsListPage() {
                       {row.vehicle_label ?? "No vehicle"}
                     </div>
                   </div>
-                  <span className="ml-2 shrink-0 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
-                    {created}
-                  </span>
+                  <div className="ml-2 shrink-0 text-right">
+                    <div className="text-[0.7rem] text-[color:var(--theme-text-secondary)]">
+                      {created}
+                    </div>
+                    <div className="mt-1 text-[0.6rem] font-semibold uppercase tracking-[0.12em] text-[var(--accent-copper)]">
+                      Open canonical job
+                    </div>
+                  </div>
                 </div>
               </Link>
             );

--- a/features/inspections/components/InspectionModal.tsx
+++ b/features/inspections/components/InspectionModal.tsx
@@ -228,33 +228,42 @@ export default function InspectionModal({
   }, [open]);
 
   const panelWidth = compact ? "max-w-6xl" : "max-w-[1440px]";
-  const bodyHeight = compact ? "h-[78vh]" : "h-[calc(94vh-64px)]";
+  const bodyHeight = compact ? "h-[82vh]" : "h-[calc(96vh-64px)]";
 
   const cardBase =
-    "overflow-hidden rounded-[1.5rem] border border-[color:var(--theme-border-strong)] " +
-    "bg-[color:var(--theme-surface-panel-strong)] " +
-    "shadow-[0_32px_90px_rgba(15,23,42,0.28)]";
+    "overflow-hidden rounded-[26px] border border-[color:var(--theme-border-soft)] " +
+    "bg-[var(--theme-gradient-panel)] text-[color:var(--theme-text-primary)] " +
+    "shadow-[var(--theme-shadow-medium)]";
 
-  const innerShell = "bg-[color:var(--theme-surface-page)]";
+  const innerShell = "bg-[var(--theme-gradient-panel)]";
 
   return (
     <Dialog
       open={open}
       // ✅ Backdrop click + Esc will call close()
       onClose={close}
-      className="pfq-inspection-modal fixed inset-0 z-[300] flex items-center justify-center px-2 py-3 sm:px-4 sm:py-5"
+      className="pfq-inspection-modal fixed inset-0 z-[500] flex items-center justify-center px-2 py-3 sm:px-4 sm:py-5"
     >
       {/* clickable dimmed backdrop */}
-      <div className="fixed inset-0 z-[290] bg-slate-950/55 backdrop-blur-[3px]" aria-hidden />
+      <div
+        className="fixed inset-0 bg-[color:var(--theme-surface-inset)]/90 backdrop-blur-md"
+        aria-hidden
+      />
 
       <Dialog.Panel
-        className={`relative z-[310] mx-auto w-full ${panelWidth} ${cardBase}`}
+        className={`relative z-[510] mx-auto w-full ${panelWidth} ${cardBase}`}
         onClick={(e) => e.stopPropagation()}
       >
+        <div className="absolute inset-x-0 top-0 z-20 h-[3px] bg-[linear-gradient(90deg,rgba(184,115,51,0),rgba(184,115,51,0.95),rgba(253,186,116,0.95),rgba(184,115,51,0))]" />
+        <div className="pointer-events-none absolute inset-x-10 top-0 z-10 h-24 bg-[radial-gradient(circle_at_top,rgba(184,115,51,0.14),transparent_72%)]" />
+
         {/* Header */}
-        <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel-strong)] px-4 py-3 sm:px-5">
+        <div className="relative flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 sm:px-5">
           <div className="min-w-0">
-            <Dialog.Title className="text-base font-semibold tracking-[-0.02em] text-[color:var(--theme-text-primary)] sm:text-lg">
+            <Dialog.Title
+              className="truncate text-[0.8rem] uppercase tracking-[0.22em] text-[color:var(--theme-text-primary)]"
+              style={{ fontFamily: "var(--font-blackops), system-ui, sans-serif" }}
+            >
               {title}
             </Dialog.Title>
 
@@ -271,14 +280,14 @@ export default function InspectionModal({
             <button
               type="button"
               onClick={() => setCompact((v) => !v)}
-              className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--brand-primary)]"
+              className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper-soft)] hover:bg-[color:var(--theme-surface-subtle)]"
             >
               {compact ? "Expand" : "Shrink"}
             </button>
             <button
               type="button"
               onClick={close}
-              className="grid h-9 w-9 place-items-center rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-sm text-[color:var(--theme-text-secondary)] transition hover:border-[color:var(--brand-primary)] hover:text-[color:var(--theme-text-primary)]"
+              className="grid h-8 w-8 place-items-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[0.78rem] text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper-soft)] hover:bg-[color:var(--theme-surface-subtle)] active:scale-95"
               aria-label="Close inspection"
             >
               ✕

--- a/features/inspections/hooks/useInspectionAutosave.ts
+++ b/features/inspections/hooks/useInspectionAutosave.ts
@@ -64,6 +64,12 @@ type RealtimeInspectionRow = {
   work_order_line_id?: string | null;
 };
 
+type RealtimeSessionRow = {
+  state?: unknown;
+  updated_at?: string | null;
+  work_order_line_id?: string | null;
+};
+
 type PersistResult = {
   session: InspectionSession;
   durable: boolean;
@@ -482,7 +488,32 @@ export function useInspectionAutosave({
           }
         },
       )
-      .subscribe();
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "inspection_sessions",
+          filter: `work_order_line_id=eq.${workOrderLineId}`,
+        },
+        (payload) => {
+          if (payload.eventType === "DELETE") return;
+          const row = (payload.new ?? {}) as RealtimeSessionRow;
+          if (hasDurableSession(row.state)) {
+            applyRemote(row.state, { updatedAt: row.updated_at ?? null });
+          }
+        },
+      )
+      .subscribe((status) => {
+        // Reconcile once the channel is live. This closes the gap between the
+        // initial HTTP load and Realtime subscription without trusting event
+        // delivery as the only cross-device transport.
+        if (status === "SUBSCRIBED") {
+          void pullLatest().catch(() => {
+            // The periodic canonical refresh remains available as fallback.
+          });
+        }
+      });
 
     return () => {
       void supabase.removeChannel(channel);
@@ -491,9 +522,40 @@ export function useInspectionAutosave({
     applyRemote,
     applyRemoteMeta,
     enabled,
+    pullLatest,
     supabase,
     workOrderLineId,
   ]);
+
+  useEffect(() => {
+    if (!enabled || !hydrated || !workOrderLineId) return;
+
+    const refreshCanonical = () => {
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState !== "visible"
+      ) {
+        return;
+      }
+      if (typeof navigator !== "undefined" && !navigator.onLine) return;
+
+      void pullLatest().catch(() => {
+        // Realtime can still deliver while a refresh request fails. The next
+        // interval/focus event retries without changing the local draft.
+      });
+    };
+
+    // Realtime is the fast path. A lightweight canonical refresh is the
+    // reliability path for suspended mobile sockets and separately stored
+    // inspection photos, which do not update the inspections row themselves.
+    const interval = window.setInterval(refreshCanonical, 5000);
+    document.addEventListener("visibilitychange", refreshCanonical);
+
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", refreshCanonical);
+    };
+  }, [enabled, hydrated, pullLatest, workOrderLineId]);
 
   const persistSnapshot = useCallback(
     async (

--- a/features/inspections/hooks/useInspectionAutosave.ts
+++ b/features/inspections/hooks/useInspectionAutosave.ts
@@ -500,7 +500,10 @@ export function useInspectionAutosave({
           if (payload.eventType === "DELETE") return;
           const row = (payload.new ?? {}) as RealtimeSessionRow;
           if (hasDurableSession(row.state)) {
-            applyRemote(row.state, { updatedAt: row.updated_at ?? null });
+            // Session rows carry progress only. Lock/finalization metadata comes
+            // from the canonical inspections row so a progress event can never
+            // temporarily unlock a signed inspection.
+            applyRemote(row.state);
           }
         },
       )

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -2735,8 +2735,8 @@ type SmartMatchRow = {
     ? "relative mx-auto max-w-[1280px] px-3 py-4 pb-6 md:px-5 md:py-5"
     : "relative mx-auto max-w-5xl px-3 md:px-4 py-6 pb-[calc(9.5rem+env(safe-area-inset-bottom))]";
 
-  const headerCard = `${PANEL_VARIANTS.primary} rounded-2xl px-4 py-4 md:px-5 md:py-5 mb-3`;
-  const sectionCard = `${PANEL_VARIANTS.primary} rounded-2xl px-3 py-3 md:px-5 md:py-5 mb-4`;
+  const headerCard = `${PANEL_VARIANTS.primary} rounded-[22px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] px-4 py-4 shadow-[var(--theme-shadow-medium)] md:px-5 md:py-5 mb-3`;
+  const sectionCard = `${PANEL_VARIANTS.primary} rounded-[22px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] px-3 py-3 shadow-[var(--theme-shadow-soft)] md:px-5 md:py-5 mb-4`;
   const supportCard = "space-y-3";
   const passiveCard = `${PANEL_VARIANTS.passive} rounded-xl px-3 py-2.5 md:px-4 md:py-3`;
 
@@ -3476,7 +3476,7 @@ type SmartMatchRow = {
   return (
     <PageShell
       title={session?.templateitem || templateName || "Inspection"}
-      description="Run guided inspections, capture notes, and push items into work orders."
+      description="Complete a free-form inspection, capture evidence, and keep every device in sync."
     >
       {body}
     </PageShell>

--- a/tests/inspection-cross-device-reconciliation.test.ts
+++ b/tests/inspection-cross-device-reconciliation.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const autosave = readFileSync(
+  "features/inspections/hooks/useInspectionAutosave.ts",
+  "utf8",
+);
+const mobileList = readFileSync("app/mobile/inspections/page.tsx", "utf8");
+const inspectionModal = readFileSync(
+  "features/inspections/components/InspectionModal.tsx",
+  "utf8",
+);
+const genericScreen = readFileSync(
+  "features/inspections/screens/GenericInspectionScreen.tsx",
+  "utf8",
+);
+
+describe("inspection cross-device reconciliation and shared modal styling", () => {
+  it("reconciles both canonical persistence tables", () => {
+    expect(autosave).toContain('table: "inspections"');
+    expect(autosave).toContain('table: "inspection_sessions"');
+    expect(autosave).toContain("if (hasDurableSession(row.state))");
+    expect(autosave).toContain('status === "SUBSCRIBED"');
+  });
+
+  it("refreshes the canonical load endpoint while the screen is visible", () => {
+    expect(autosave).toContain("window.setInterval(refreshCanonical, 5000)");
+    expect(autosave).toContain('document.visibilityState !== "visible"');
+    expect(autosave).toContain("void pullLatest()");
+  });
+
+  it("never routes a session id as a work-order-line id", () => {
+    expect(mobileList).toContain("work_order_line_id");
+    expect(mobileList).toContain("row.work_order_id && row.work_order_line_id");
+    expect(mobileList).toContain("/mobile/work-orders/");
+    expect(mobileList).not.toContain("href={\`/mobile/inspections/\${row.id}\`}");
+  });
+
+  it("matches the shared copper modal treatment", () => {
+    expect(inspectionModal).toContain("rounded-[26px]");
+    expect(inspectionModal).toContain("theme-gradient-panel");
+    expect(inspectionModal).toContain("accent-copper-soft");
+    expect(inspectionModal).toContain("var(--font-blackops)");
+    expect(genericScreen).toContain("rounded-[22px]");
+    expect(genericScreen).toContain("keep every device in sync");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the remaining mobile/desktop inspection synchronization gaps and aligns the inspection modal/generic inspection surface with the shared ProFixIQ modal theme.

## Root cause

Two separate reliability gaps remained after the canonical save migration:

1. The mobile Inspections list linked with `inspection_sessions.id`, while the runner treats the route id as `work_order_line_id`. Opening from that list could therefore mount the shared screen under the wrong canonical identity.
2. Cross-device refresh depended too heavily on one Realtime event from `inspections`. Mobile browsers can suspend sockets, and uploaded `inspection_photos` do not update the inspection row, so another device could remain stale even though the canonical save/photo upload succeeded.

## Changes

- Routes recent mobile inspections through their canonical work order and work-order line.
- Subscribes to both canonical progress tables.
- Reconciles immediately when the Realtime channel becomes active.
- Refreshes the canonical load endpoint every five seconds while the inspection is visible and online.
- Preserves dirty local edits and queued offline recovery through the existing revision arbitration.
- Keeps lock/finalization metadata authoritative to the `inspections` row.
- Pulls canonical photo rows through the existing load route, so mobile uploads appear on desktop without reopening.
- Restyles the inspection modal with the shared copper accent, inset header, Black Ops title, gradient panel, rounded shell, backdrop, and controls.
- Aligns generic inspection header/section cards with the same surface hierarchy.
- Adds regression coverage for identity routing, dual-table reconciliation, polling fallback, and modal styling.

## Validation

- Branch is based on current `main` with no divergence.
- Diff is limited to four implementation files and one regression test.
- Static regression assertions added.
- GitHub/Vercel/TypeScript checks are pending; this connector workspace has no local repository checkout or GitHub CLI.
