### PR TITLE
Polish inspection layout and clarify sync failures

### DIFF
--- a/features/inspections/hooks/useInspectionAutosave.ts
+++ b/features/inspections/hooks/useInspectionAutosave.ts
@@ -174,6 +174,21 @@ function errorStatus(error: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function inspectionSyncErrorMessage(error: unknown): string {
+  const raw =
+    error instanceof Error ? error.message : "Inspection autosave failed.";
+
+  if (
+    raw
+      .toLowerCase()
+      .includes("no unique or exclusion constraint matching the on conflict")
+  ) {
+    return "Inspection sync needs a server update. Your work remains safe on this device.";
+  }
+
+  return raw;
+}
+
 export function inspectionSyncLabel(
   state: InspectionSyncState,
   locked = false,
@@ -761,8 +776,7 @@ export function useInspectionAutosave({
         };
       } catch (error) {
         if (identityRef.current !== identityKey) throw error;
-        const message =
-          error instanceof Error ? error.message : "Inspection autosave failed.";
+        const message = inspectionSyncErrorMessage(error);
         const conflicted = errorStatus(error) === 409;
         pendingOperationKeyRef.current = operationKey;
         pendingOperationFingerprintRef.current = nextFingerprint;
@@ -780,7 +794,7 @@ export function useInspectionAutosave({
         }
         setLastError(message);
         setState(conflicted ? "conflicted" : "error");
-        throw error;
+        throw new Error(message);
       }
     },
     [draftKey, identityKey, locked, workOrderLineId],

--- a/features/inspections/lib/inspection/SectionDisplay.tsx
+++ b/features/inspections/lib/inspection/SectionDisplay.tsx
@@ -274,90 +274,99 @@ export default function SectionDisplay(props: SectionDisplayProps) {
   return (
     <div>
       {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--theme-card-border,var(--theme-border-soft))] pb-4">
-        {gridSection ? (
-          <div>
-            <div className="text-left text-lg font-semibold tracking-[-0.02em] text-[var(--theme-text-primary,var(--theme-text-primary))] md:text-xl">
-              {showGridFindings ? "Findings & evidence" : resolvedTitle}
+      <div className="grid gap-4 border-b border-[var(--theme-card-border,var(--theme-border-soft))] pb-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+        <div className="min-w-0">
+          {gridSection ? (
+            <div>
+              <div className="text-left text-lg font-semibold tracking-[-0.02em] text-[var(--theme-text-primary,var(--theme-text-primary))] md:text-xl">
+                {showGridFindings ? "Findings & evidence" : resolvedTitle}
+              </div>
+              {showGridFindings ? (
+                <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  Status, notes, photos, parts and labor saved on the same inspection items as the measurements above.
+                </p>
+              ) : null}
             </div>
-            {showGridFindings ? (
-              <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                Status, notes, photos, parts and labor saved on the same inspection items as the measurements above.
-              </p>
-            ) : null}
-          </div>
-        ) : (
-          <button
-            onClick={toggleOpen}
-            className="text-left text-lg font-semibold tracking-[-0.02em] text-[var(--theme-text-primary,var(--theme-text-primary))] transition-opacity hover:opacity-80 md:text-xl"
-            aria-expanded={open}
-            type="button"
-          >
-            {resolvedTitle}
-          </button>
-        )}
+          ) : (
+            <button
+              onClick={toggleOpen}
+              className="text-left text-lg font-semibold tracking-[-0.02em] text-[var(--theme-text-primary,var(--theme-text-primary))] transition-opacity hover:opacity-80 md:text-xl"
+              aria-expanded={open}
+              type="button"
+            >
+              {resolvedTitle}
+            </button>
+          )}
 
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="hidden items-center gap-1.5 md:flex">
+          <div
+            className="mt-3 flex flex-wrap items-center gap-1.5"
+            aria-label="Section item counts"
+          >
             <StatusBadge variant="success">{stats.ok} OK</StatusBadge>
             <StatusBadge variant="danger">{stats.fail} FAIL</StatusBadge>
             <StatusBadge variant="info">{stats.na} NA</StatusBadge>
             <StatusBadge variant="warning">{stats.recommend} REC</StatusBadge>
             <StatusBadge variant="neutral">{stats.unset} Open</StatusBadge>
           </div>
-
-          {showBulkButtons ? (
-            <div className="flex flex-wrap items-center gap-1">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 border-emerald-500/35 bg-emerald-50 px-2 text-[11px] text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/25 dark:text-emerald-200"
-                onClick={() => markAll("ok")}
-                type="button"
-              >
-                All OK
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 border-red-500/30 px-2 text-[11px] text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/25"
-                onClick={() => markAll("fail")}
-                type="button"
-              >
-                All FAIL
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 border-sky-500/30 px-2 text-[11px] text-sky-700 hover:bg-sky-50 dark:text-sky-200 dark:hover:bg-sky-950/25"
-                onClick={() => markAll("na")}
-                type="button"
-              >
-                All NA
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 border-amber-500/35 px-2 text-[11px] text-amber-800 hover:bg-amber-50 dark:text-amber-200 dark:hover:bg-amber-950/25"
-                onClick={() => markAll("recommend")}
-                type="button"
-              >
-                All REC
-              </Button>
-
-              <Button
-                variant="ghost"
-                size="sm"
-                className="ml-1 h-7 px-2 text-[11px]"
-                onClick={toggleOpen}
-                aria-expanded={open}
-                type="button"
-              >
-                {open ? "Collapse" : "Expand"}
-              </Button>
-            </div>
-          ) : null}
         </div>
+
+        {showBulkButtons ? (
+          <div
+            className="flex flex-wrap items-center gap-1.5 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-1.5 shadow-sm"
+            aria-label="Bulk section actions"
+          >
+            <span className="px-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
+              Set section
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 rounded-xl border-emerald-500/35 bg-emerald-50 px-3 text-[11px] text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-950/25 dark:text-emerald-200"
+              onClick={() => markAll("ok")}
+              type="button"
+            >
+              All OK
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 rounded-xl border-red-500/30 px-3 text-[11px] text-red-700 hover:bg-red-50 dark:text-red-200 dark:hover:bg-red-950/25"
+              onClick={() => markAll("fail")}
+              type="button"
+            >
+              All FAIL
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 rounded-xl border-sky-500/30 px-3 text-[11px] text-sky-700 hover:bg-sky-50 dark:text-sky-200 dark:hover:bg-sky-950/25"
+              onClick={() => markAll("na")}
+              type="button"
+            >
+              All NA
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 rounded-xl border-amber-500/35 px-3 text-[11px] text-amber-800 hover:bg-amber-50 dark:text-amber-200 dark:hover:bg-amber-950/25"
+              onClick={() => markAll("recommend")}
+              type="button"
+            >
+              All REC
+            </Button>
+            <span className="mx-0.5 hidden h-5 w-px bg-[color:var(--theme-border-soft)] sm:block" />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 rounded-xl px-3 text-[11px]"
+              onClick={toggleOpen}
+              aria-expanded={open}
+              type="button"
+            >
+              {open ? "Collapse" : "Expand"}
+            </Button>
+          </div>
+        ) : null}
       </div>
 
       {/* Body */}

--- a/features/inspections/lib/inspection/ui/CornerGrid.tsx
+++ b/features/inspections/lib/inspection/ui/CornerGrid.tsx
@@ -172,7 +172,7 @@ export default function CornerGrid(props: CornerGridProps) {
     <div className="grid w-full gap-3">
       <div className="flex items-center justify-between gap-3 px-1">
         <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
-          Corner Grid – Hydraulic Brakes (sketch layout)
+          Hydraulic brake measurements
         </div>
 
         <button
@@ -199,12 +199,8 @@ export default function CornerGrid(props: CornerGridProps) {
                 Front
               </div>
 
-              {/* LF | spacer(body) | RF */}
-              <div className="grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(170px,1fr)_64px_minmax(170px,1fr)]">
+              <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-2">
                 {Stack("LF")}
-                <div className="flex h-full items-center justify-center">
-                  <div className="h-[110px] w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]" />
-                </div>
                 {Stack("RF")}
               </div>
             </div>
@@ -218,20 +214,12 @@ export default function CornerGrid(props: CornerGridProps) {
                 Rear
               </div>
 
-              {/* LR | spacer(body) | RR */}
-              <div className="grid grid-cols-1 items-start gap-3 md:grid-cols-[minmax(170px,1fr)_64px_minmax(170px,1fr)]">
+              <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-2">
                 {Stack("LR")}
-                <div className="flex h-full items-center justify-center">
-                  <div className="h-[110px] w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]" />
-                </div>
                 {Stack("RR")}
               </div>
             </div>
 
-            {/* Labels legend */}
-            <div className="pt-1 text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
-              Pads/Shoes + Rotor/Drum are stacked per corner (matches sketch)
-            </div>
           </div>
         </div>
       ) : null}

--- a/tests/inspection-premium-layout-signing.test.ts
+++ b/tests/inspection-premium-layout-signing.test.ts
@@ -12,10 +12,6 @@ const sectionDisplay = read(
 const autosave = read(
   "features/inspections/hooks/useInspectionAutosave.ts",
 );
-const migration = read(
-  "supabase/migrations/20260721234500_reinstall_inspection_writer_and_signer.sql",
-);
-
 describe("premium inspection layout and signing repair", () => {
   it("renders the hydraulic corner grid without decorative empty cells or sketch copy", () => {
     expect(cornerGrid).toContain("Hydraulic brake measurements");
@@ -32,17 +28,10 @@ describe("premium inspection layout and signing repair", () => {
     expect(sectionDisplay).toContain("lg:grid-cols-[minmax(0,1fr)_auto]");
   });
 
-  it("reinstalls conflict-target-free canonical save and signing functions", () => {
-    expect(migration).toContain(
-      "create or replace function public.save_inspection_progress_atomic",
-    );
-    expect(migration).toContain(
-      "create or replace function public.sign_inspection",
-    );
-    expect(migration).not.toContain("on conflict (work_order_line_id)");
-    expect(migration).not.toContain("on conflict (inspection_id, role)");
+  it("does not expose raw database conflict details to technicians", () => {
     expect(autosave).toContain(
       "Your work remains safe on this device.",
     );
+    expect(autosave).toContain("inspectionSyncErrorMessage");
   });
 });

--- a/tests/inspection-premium-layout-signing.test.ts
+++ b/tests/inspection-premium-layout-signing.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const cornerGrid = read(
+  "features/inspections/lib/inspection/ui/CornerGrid.tsx",
+);
+const sectionDisplay = read(
+  "features/inspections/lib/inspection/SectionDisplay.tsx",
+);
+const autosave = read(
+  "features/inspections/hooks/useInspectionAutosave.ts",
+);
+const migration = read(
+  "supabase/migrations/20260721234500_reinstall_inspection_writer_and_signer.sql",
+);
+
+describe("premium inspection layout and signing repair", () => {
+  it("renders the hydraulic corner grid without decorative empty cells or sketch copy", () => {
+    expect(cornerGrid).toContain("Hydraulic brake measurements");
+    expect(cornerGrid).toContain("md:grid-cols-2");
+    expect(cornerGrid).not.toContain("spacer(body)");
+    expect(cornerGrid).not.toContain("matches sketch");
+    expect(cornerGrid).not.toContain('h-[110px]');
+  });
+
+  it("separates item counts from bulk status actions", () => {
+    expect(sectionDisplay).toContain('aria-label="Section item counts"');
+    expect(sectionDisplay).toContain('aria-label="Bulk section actions"');
+    expect(sectionDisplay).toContain("Set section");
+    expect(sectionDisplay).toContain("lg:grid-cols-[minmax(0,1fr)_auto]");
+  });
+
+  it("reinstalls conflict-target-free canonical save and signing functions", () => {
+    expect(migration).toContain(
+      "create or replace function public.save_inspection_progress_atomic",
+    );
+    expect(migration).toContain(
+      "create or replace function public.sign_inspection",
+    );
+    expect(migration).not.toContain("on conflict (work_order_line_id)");
+    expect(migration).not.toContain("on conflict (inspection_id, role)");
+    expect(autosave).toContain(
+      "Your work remains safe on this device.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Refines the generic inspection experience to reduce visual noise and make section controls feel intentional and premium.

## What changed

- Removed the two decorative empty center boxes from the hydraulic corner grid.
- Removed the “Pads/Shoes + Rotor/Drum are stacked per corner (matches sketch)” helper copy.
- Renamed the compact grid heading to “Hydraulic brake measurements.”
- Separated read-only section counts from bulk status actions.
- Grouped “All OK / All FAIL / All NA / All REC / Collapse” in a dedicated **Set section** control surface.
- Keeps count badges visible at tablet/mobile widths.
- Replaces raw PostgreSQL conflict text with a safe, actionable technician message.
- Added focused regression coverage.

## Signing diagnosis

The screenshot’s signing failure occurs during the required pre-sign autosave. Production is still executing an older `save_inspection_progress_atomic` function containing `ON CONFLICT (work_order_line_id)`, but that environment does not have the corresponding unique constraint. The saved signature itself is not the failing operation.

The permanent repair is a forward migration that reinstalls the current conflict-target-free atomic writer and revision-aware signing function. Because those are security-definer functions controlling shop authorization, concurrency, locking and finalization, that migration is intentionally not included until explicitly approved.

## Validation

- Branch is based on current `main`.
- Four files changed.
- Regression coverage added for the layout and technician-safe error behavior.
- GitHub/Vercel checks pending.
