### PR TITLE
Repair installed-app inspection sync and recover evidence

### DIFF
--- a/app/api/inspections/load/route.ts
+++ b/app/api/inspections/load/route.ts
@@ -315,11 +315,47 @@ export async function GET(req: NextRequest) {
   }
 
   let canonicalPhotos: InspectionPhotoRow[] = [];
-  if (canonicalInspectionId) {
+  let photoInspectionIds = canonicalInspectionId
+    ? [canonicalInspectionId]
+    : [];
+
+  if (resolvedWorkOrderLineId) {
+    // Evidence is append-only. Recover uploads made by older installed PWAs
+    // against any historical inspection UUID for this same work-order line.
+    const { data: relatedInspections, error: relatedInspectionError } =
+      await supabase
+        .from("inspections")
+        .select("id")
+        .eq("shop_id", shopId)
+        .eq("work_order_line_id", resolvedWorkOrderLineId);
+
+    if (relatedInspectionError) {
+      console.error(
+        "[inspections/load] historical inspection lookup failed",
+        relatedInspectionError,
+      );
+    } else {
+      photoInspectionIds = Array.from(
+        new Set(
+          (relatedInspections ?? [])
+            .map((row) => asString(row.id))
+            .filter((id): id is string => Boolean(id)),
+        ),
+      );
+      if (
+        canonicalInspectionId &&
+        !photoInspectionIds.includes(canonicalInspectionId)
+      ) {
+        photoInspectionIds.unshift(canonicalInspectionId);
+      }
+    }
+  }
+
+  if (photoInspectionIds.length) {
     const { data: photoRows, error: photoError } = await supabase
       .from("inspection_photos")
       .select("item_name, image_url")
-      .eq("inspection_id", canonicalInspectionId)
+      .in("inspection_id", photoInspectionIds)
       .order("created_at", { ascending: true });
 
     if (photoError) {

--- a/app/api/inspections/photos/upload/route.ts
+++ b/app/api/inspections/photos/upload/route.ts
@@ -127,10 +127,40 @@ async function ensureInspectionRow(args: {
 > {
   const { supabase, inspectionId, shopId, workOrderId, workOrderLineId } = args;
 
+  // The work-order line is the canonical inspection identity. Installed PWAs
+  // may replay an older device-local inspection UUID after the canonical row
+  // has advanced, so resolve by line before trusting the client UUID.
+  if (workOrderLineId) {
+    const { data: existingByLine, error: existingByLineErr } = await supabase
+      .from("inspections")
+      .select("id")
+      .eq("shop_id", shopId)
+      .eq("work_order_line_id", workOrderLineId)
+      .order("updated_at", { ascending: false, nullsFirst: false })
+      .order("id", { ascending: false })
+      .limit(1)
+      .maybeSingle<{ id: string }>();
+
+    if (existingByLineErr) {
+      console.error(
+        "[inspections/photos/upload] canonical inspection lookup failed",
+        existingByLineErr,
+      );
+      return { ok: false, error: existingByLineErr.message };
+    }
+
+    if (existingByLine?.id) {
+      return { ok: true, inspectionId: existingByLine.id };
+    }
+  }
+
+  // Legacy standalone inspections do not have a work-order line. Keep their
+  // UUID fallback shop-scoped, but never let it override a supplied line.
   const { data: existingById, error: existingByIdErr } = await supabase
     .from("inspections")
     .select("id")
     .eq("id", inspectionId)
+    .eq("shop_id", shopId)
     .maybeSingle<{ id: string }>();
 
   if (existingByIdErr) {
@@ -143,26 +173,6 @@ async function ensureInspectionRow(args: {
 
   if (existingById?.id) {
     return { ok: true, inspectionId: existingById.id };
-  }
-
-  if (workOrderLineId) {
-    const { data: existingByLine, error: existingByLineErr } = await supabase
-      .from("inspections")
-      .select("id")
-      .eq("work_order_line_id", workOrderLineId)
-      .maybeSingle<{ id: string }>();
-
-    if (existingByLineErr) {
-      console.error(
-        "[inspections/photos/upload] inspection exists check by work_order_line_id failed",
-        existingByLineErr,
-      );
-      return { ok: false, error: existingByLineErr.message };
-    }
-
-    if (existingByLine?.id) {
-      return { ok: true, inspectionId: existingByLine.id };
-    }
   }
 
   let vehicleId: string | null = null;
@@ -264,7 +274,7 @@ export async function POST(req: NextRequest) {
         error: "Unable to resolve shop for inspection photo upload",
         debug: {
           source: resolved.source,
-          inspectionId: requestedInspectionId,
+          inspectionId: resolvedInspectionId,
           workOrderId,
           workOrderLineId,
         },

--- a/app/api/inspections/photos/upload/route.ts
+++ b/app/api/inspections/photos/upload/route.ts
@@ -274,7 +274,7 @@ export async function POST(req: NextRequest) {
         error: "Unable to resolve shop for inspection photo upload",
         debug: {
           source: resolved.source,
-          inspectionId: resolvedInspectionId,
+          inspectionId: requestedInspectionId,
           workOrderId,
           workOrderLineId,
         },
@@ -364,7 +364,7 @@ export async function POST(req: NextRequest) {
       if (shopId && mediaUrl) {
         const mediaEvent = await buildInspectionMediaCapturedEvent({
           shopId,
-          inspectionId: requestedInspectionId,
+          inspectionId: resolvedInspectionId,
           workOrderId,
           itemName,
           notes,

--- a/app/api/inspections/save/route.ts
+++ b/app/api/inspections/save/route.ts
@@ -103,6 +103,36 @@ export async function POST(req: NextRequest) {
       lower.includes("conflict")
         ? 409
         : 400;
+    if (status === 409) {
+      const { data: canonical } = await supabase
+        .from("inspections")
+        .select("id, summary, updated_at")
+        .eq("shop_id", profile.shop_id)
+        .eq("work_order_line_id", workOrderLineId)
+        .order("updated_at", { ascending: false, nullsFirst: false })
+        .order("id", { ascending: false })
+        .limit(1)
+        .maybeSingle<{
+          id: string;
+          summary: Json | null;
+          updated_at: string | null;
+        }>();
+      const canonicalSession =
+        (canonical?.summary as unknown as InspectionSession | null) ?? null;
+
+      return NextResponse.json(
+        {
+          error: message,
+          code: "INSPECTION_REVISION_CONFLICT",
+          recoveryRequired: true,
+          canonicalInspectionId: canonical?.id ?? null,
+          serverRevision: canonicalSession?.syncRevision ?? null,
+          serverUpdatedAt: canonical?.updated_at ?? null,
+        },
+        { status },
+      );
+    }
+
     return NextResponse.json({ error: message }, { status });
   }
 

--- a/tests/inspection-cross-device-reconciliation.test.ts
+++ b/tests/inspection-cross-device-reconciliation.test.ts
@@ -14,6 +14,12 @@ const genericScreen = readFileSync(
   "features/inspections/screens/GenericInspectionScreen.tsx",
   "utf8",
 );
+const loadRoute = readFileSync("app/api/inspections/load/route.ts", "utf8");
+const saveRoute = readFileSync("app/api/inspections/save/route.ts", "utf8");
+const photoRoute = readFileSync(
+  "app/api/inspections/photos/upload/route.ts",
+  "utf8",
+);
 
 describe("inspection cross-device reconciliation and shared modal styling", () => {
   it("reconciles both canonical persistence tables", () => {
@@ -43,5 +49,30 @@ describe("inspection cross-device reconciliation and shared modal styling", () =
     expect(inspectionModal).toContain("var(--font-blackops)");
     expect(genericScreen).toContain("rounded-[22px]");
     expect(genericScreen).toContain("keep every device in sync");
+  });
+
+  it("resolves installed-app photo uploads by canonical work-order line", () => {
+    const lineLookup = photoRoute.indexOf(
+      '.eq("work_order_line_id", workOrderLineId)',
+    );
+    const uuidLookup = photoRoute.indexOf('.eq("id", inspectionId)');
+    expect(lineLookup).toBeGreaterThan(-1);
+    expect(uuidLookup).toBeGreaterThan(lineLookup);
+    expect(photoRoute).toContain('.eq("shop_id", shopId)');
+  });
+
+  it("recovers append-only evidence from every inspection row for the line", () => {
+    expect(loadRoute).toContain("photoInspectionIds");
+    expect(loadRoute).toContain(
+      '.eq("work_order_line_id", resolvedWorkOrderLineId)',
+    );
+    expect(loadRoute).toContain('.in("inspection_id", photoInspectionIds)');
+  });
+
+  it("returns a structured revision conflict without discarding device work", () => {
+    expect(saveRoute).toContain('"INSPECTION_REVISION_CONFLICT"');
+    expect(saveRoute).toContain("recoveryRequired: true");
+    expect(saveRoute).toContain("serverRevision:");
+    expect(saveRoute).toContain("serverUpdatedAt:");
   });
 });


### PR DESCRIPTION
## Summary

Repairs the remaining installed-PWA inspection split without deleting or invalidating device-local recovery data.

## Root cause

An installed PWA can replay an older device-local `inspectionId` after the current web app has selected a newer canonical inspection row for the same work-order line. Photo uploads trusted that stale UUID first, and the load endpoint queried photos only from the newest row. Measurements correctly used revision locking, but revision conflicts were returned as generic save errors without enough canonical metadata for controlled recovery.

## Changes

- Resolves photo uploads by shop-scoped `work_order_line_id` before trusting a client inspection UUID.
- Preserves the UUID fallback only for legacy standalone inspections.
- Loads append-only photo evidence from every historical inspection row for the same work-order line.
- Keeps the newest inspection row as the canonical session/measurement source.
- Returns structured `INSPECTION_REVISION_CONFLICT` responses with canonical inspection ID, server revision, and server update time.
- Keeps `lastUpdated` informational; it does not silently choose a winning device.
- Adds regression coverage for stale installed-app uploads, historical evidence recovery, and protected revision conflicts.

## Truth model

- Identity: `work_order_line_id`
- Canonical editable state: highest server-acknowledged `syncRevision`
- Photos: append-only evidence across rows belonging to that line
- Device drafts: protected recovery copies until acknowledged
- Device timestamps: display/audit information only

## Safety

This PR does not delete duplicate inspection rows, local drafts, staged photo blobs, or queued mutations. It does not auto-merge conflicting measurements because doing so could overwrite valid technician work. A revision conflict is preserved explicitly for controlled recovery.

## Validation

- Branch is based on current `main`.
- Four scoped files changed.
- Static regression coverage updated.
- GitHub/Vercel checks are pending.
- No database migration or environment variable is required.
