### PR TITLE
Prioritize installed inspection recovery across clients

### DIFF
--- a/app/api/inspections/save/route.ts
+++ b/app/api/inspections/save/route.ts
@@ -104,30 +104,14 @@ export async function POST(req: NextRequest) {
         ? 409
         : 400;
     if (status === 409) {
-      const { data: canonical } = await supabase
-        .from("inspections")
-        .select("id, summary, updated_at")
-        .eq("shop_id", profile.shop_id)
-        .eq("work_order_line_id", workOrderLineId)
-        .order("updated_at", { ascending: false, nullsFirst: false })
-        .order("id", { ascending: false })
-        .limit(1)
-        .maybeSingle<{
-          id: string;
-          summary: Json | null;
-          updated_at: string | null;
-        }>();
-      const canonicalSession =
-        (canonical?.summary as unknown as InspectionSession | null) ?? null;
-
       return NextResponse.json(
         {
           error: message,
           code: "INSPECTION_REVISION_CONFLICT",
           recoveryRequired: true,
-          canonicalInspectionId: canonical?.id ?? null,
-          serverRevision: canonicalSession?.syncRevision ?? null,
-          serverUpdatedAt: canonical?.updated_at ?? null,
+          workOrderLineId,
+          serverRevision: null,
+          serverUpdatedAt: null,
         },
         { status },
       );
@@ -138,4 +122,3 @@ export async function POST(req: NextRequest) {
 
   return NextResponse.json(data ?? { ok: true });
 }
-

--- a/features/inspections/components/inspection/InspectionConflictRecoveryPanel.tsx
+++ b/features/inspections/components/inspection/InspectionConflictRecoveryPanel.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@shared/components/ui/Button";
+import { cn } from "@shared/lib/utils";
+import {
+  inspectionConflictRows,
+  mergeInspectionConflict,
+  type InspectionConflictChoice,
+} from "@inspections/lib/inspection/conflictRecovery";
+import type {
+  InspectionItem,
+  InspectionSession,
+} from "@inspections/lib/inspection/types";
+
+type LoadResponse = { session?: InspectionSession | null };
+
+function summary(item: InspectionItem): string {
+  const parts = [
+    item.status ? String(item.status).toUpperCase() : "No status",
+    item.value !== null && item.value !== undefined && String(item.value).trim()
+      ? `${item.value}${item.unit ? ` ${item.unit}` : ""}`
+      : null,
+    (item.notes ?? item.note)?.trim() || null,
+    item.parts?.length
+      ? `${item.parts.length} part request${item.parts.length === 1 ? "" : "s"}`
+      : null,
+    typeof item.laborHours === "number" ? `${item.laborHours} labor hr` : null,
+    item.photoUrls?.length
+      ? `${item.photoUrls.length} uploaded photo${item.photoUrls.length === 1 ? "" : "s"}`
+      : null,
+  ].filter(Boolean);
+  return parts.join(" · ");
+}
+
+export default function InspectionConflictRecoveryPanel({
+  deviceSession,
+  workOrderLineId,
+  onResolve,
+}: {
+  deviceSession: InspectionSession;
+  workOrderLineId: string;
+  onResolve: (session: InspectionSession) => Promise<void>;
+}) {
+  const [serverSession, setServerSession] = useState<InspectionSession | null>(
+    null,
+  );
+  const [choices, setChoices] = useState<
+    Record<string, InspectionConflictChoice>
+  >({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({ workOrderLineId });
+        const response = await fetch(`/api/inspections/load?${params}`, {
+          cache: "no-store",
+          credentials: "include",
+        });
+        const json = (await response
+          .json()
+          .catch(() => null)) as LoadResponse | null;
+        if (!response.ok || !json?.session) {
+          throw new Error("Unable to load the shop copy for comparison.");
+        }
+        if (!cancelled) setServerSession(json.session);
+      } catch (caught) {
+        if (!cancelled) {
+          setError(
+            caught instanceof Error
+              ? caught.message
+              : "Unable to load the shop copy.",
+          );
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [workOrderLineId]);
+
+  const rows = useMemo(
+    () =>
+      serverSession ? inspectionConflictRows(deviceSession, serverSession) : [],
+    [deviceSession, serverSession],
+  );
+
+  const apply = async (useServerOnly = false) => {
+    if (!serverSession) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const merged = useServerOnly
+        ? serverSession
+        : mergeInspectionConflict({
+            device: deviceSession,
+            server: serverSession,
+            choices,
+          });
+      await onResolve(merged);
+      toast.success(
+        useServerOnly
+          ? "Shop copy kept. Device conflict cleared."
+          : "Selected inspection details merged and synced.",
+      );
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Recovery could not be saved.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="rounded-2xl border border-amber-400/40 bg-amber-950/20 p-3 text-amber-50 shadow-[var(--theme-shadow-medium)]">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="text-sm font-semibold">
+            Review this device against the shop copy
+          </p>
+          <p className="mt-1 max-w-3xl text-xs text-amber-100/80">
+            Nothing is chosen by time. Select the correct result for each
+            changed item, then sync one reviewed revision. Pending photos remain
+            queued and upload afterward.
+          </p>
+        </div>
+        {serverSession && (
+          <span className="rounded-full border border-amber-300/30 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider">
+            Shop revision {serverSession.syncRevision ?? 0}
+          </span>
+        )}
+      </div>
+
+      {loading && <p className="mt-3 text-xs">Loading shop copy…</p>}
+      {error && <p className="mt-3 text-xs text-red-200">{error}</p>}
+
+      {!loading && serverSession && rows.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {rows.map((row) => {
+            const choice = choices[row.key] ?? "device";
+            return (
+              <div
+                key={row.key}
+                className="rounded-xl border border-white/10 bg-black/15 p-2.5"
+              >
+                <p className="text-xs font-semibold">
+                  {row.sectionTitle} · {row.itemLabel}
+                </p>
+                <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                  {(["device", "server"] as const).map((source) => {
+                    const selected = choice === source;
+                    const item =
+                      source === "device" ? row.deviceItem : row.serverItem;
+                    return (
+                      <button
+                        key={source}
+                        type="button"
+                        onClick={() =>
+                          setChoices((current) => ({
+                            ...current,
+                            [row.key]: source,
+                          }))
+                        }
+                        className={cn(
+                          "rounded-lg border px-3 py-2 text-left transition",
+                          selected
+                            ? "border-[color:var(--accent-copper)] bg-[color:var(--accent-copper-soft)]"
+                            : "border-white/10 bg-black/10",
+                        )}
+                      >
+                        <span className="text-[10px] font-bold uppercase tracking-wider">
+                          {source === "device" ? "This device" : "Shop copy"}
+                        </span>
+                        <span className="mt-1 block text-xs text-current/85">
+                          {summary(item)}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!loading && serverSession && rows.length === 0 && (
+        <p className="mt-3 rounded-lg border border-white/10 bg-black/10 px-3 py-2 text-xs">
+          Item results now match. You can keep the shop copy and clear the stale
+          device operation.
+        </p>
+      )}
+
+      {serverSession && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Button
+            type="button"
+            disabled={saving}
+            onClick={() => void apply(false)}
+          >
+            {saving
+              ? "Syncing…"
+              : rows.length
+                ? "Apply selected & sync"
+                : "Clear resolved conflict"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={saving}
+            onClick={() => void apply(true)}
+          >
+            Keep shop copy
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/features/inspections/hooks/useInspectionAutosave.ts
+++ b/features/inspections/hooks/useInspectionAutosave.ts
@@ -8,12 +8,21 @@ import {
   useState,
 } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import { saveInspectionSession } from "@inspections/lib/inspection/save";
+import {
+  replayQueuedInspectionSaves,
+  saveInspectionSession,
+} from "@inspections/lib/inspection/save";
 import type { InspectionSession } from "@inspections/lib/inspection/types";
 import {
   saveInspectionOfflineDraft,
   type InspectionDraftRecoveryState,
 } from "@inspections/lib/inspection/offlineDrafts";
+import { dismissOfflineMutation } from "@/features/shared/lib/offline/mutations";
+import {
+  automaticallyMergeInspectionConflict,
+  inspectionSyncClientId,
+  inspectionSyncSource,
+} from "@inspections/lib/inspection/conflictRecovery";
 
 export type InspectionSyncState =
   | "hydrating"
@@ -579,6 +588,8 @@ export function useInspectionAutosave({
     async (
       snapshot: InspectionSession,
       requireServer = false,
+      preserveConflictUntilAcknowledged = false,
+      allowAutomaticRecovery = true,
     ): Promise<PersistResult> => {
       if (identityRef.current !== identityKey) {
         return {
@@ -670,6 +681,7 @@ export function useInspectionAutosave({
             supersedesOperationKey: canReuseOperationKey
               ? undefined
               : previousOperationKey,
+            deferSupersededDismissal: preserveConflictUntilAcknowledged,
           },
         );
 
@@ -699,7 +711,7 @@ export function useInspectionAutosave({
         let persistedSnapshot = snapshot;
         if (!result.queued && !result.conflicted) {
           const acknowledgedSnapshot: InspectionSession = {
-            ...snapshot,
+            ...(result.savedSession ?? snapshot),
             id: result.inspectionId ?? snapshot.id,
             syncRevision: result.syncRevision ?? snapshot.syncRevision,
             serverUpdatedAt:
@@ -790,6 +802,34 @@ export function useInspectionAutosave({
               operationKey,
             });
           }
+          if (allowAutomaticRecovery) {
+            try {
+              const params = new URLSearchParams({ workOrderLineId });
+              const response = await fetch(
+                `/api/inspections/load?${params.toString()}`,
+                { credentials: "include", cache: "no-store" },
+              );
+              const json = (await response.json().catch(() => null)) as
+                | { session?: InspectionSession | null }
+                | null;
+              if (response.ok && hasDurableSession(json?.session)) {
+                const merged = automaticallyMergeInspectionConflict({
+                  device: snapshot,
+                  server: json.session,
+                  currentSource: inspectionSyncSource(),
+                  currentClientId: inspectionSyncClientId(),
+                });
+                if (merged) {
+                  latestSessionRef.current = merged;
+                  onRemoteSessionRef.current(merged);
+                  return persistSnapshot(merged, true, true, false);
+                }
+              }
+            } catch {
+              // The protected conflict draft remains available for the rare
+              // manual fallback when automatic recovery cannot finish.
+            }
+          }
           onRecoveryStateRef.current?.("conflicted", operationKey);
         }
         setLastError(message);
@@ -848,6 +888,53 @@ export function useInspectionAutosave({
       return task;
     },
     [enabled, identityKey, persistSnapshot],
+  );
+
+  const resolveConflict = useCallback(
+    async (resolved: InspectionSession): Promise<InspectionSession> => {
+      if (!sessionMatchesWorkOrderLine(resolved, workOrderLineId)) {
+        throw new Error(
+          "Recovered inspection belongs to a different work-order line.",
+        );
+      }
+
+      const staleOperationKey = pendingOperationKeyRef.current;
+      const alreadyCanonical =
+        fingerprint(resolved) === lastServerFingerprintRef.current;
+      latestSessionRef.current = resolved;
+      onRemoteSessionRef.current(resolved);
+
+      const result = await persistSnapshot(resolved, true, true);
+      if (!result.durable) {
+        throw new Error(
+          "The reviewed inspection could not be saved to the shop yet.",
+        );
+      }
+
+      // If every choice kept the already-acknowledged shop copy there is no
+      // replacement write to perform. It is now safe to clear the rejected
+      // operation. Otherwise saveInspectionSession clears it only after ACK.
+      if (alreadyCanonical && staleOperationKey) {
+        await dismissOfflineMutation(staleOperationKey);
+      }
+      pendingOperationKeyRef.current = undefined;
+      pendingOperationFingerprintRef.current = "";
+      lastQueuedFingerprintRef.current = "";
+      await replayQueuedInspectionSaves();
+
+      if (draftKey) {
+        await saveInspectionOfflineDraft({
+          draftKey,
+          session: result.session,
+          state: "editing",
+        });
+      }
+      setLastError(null);
+      setState("saved");
+      onRecoveryStateRef.current?.("editing");
+      return result.session;
+    },
+    [draftKey, persistSnapshot, workOrderLineId],
   );
 
   const flush = useCallback(
@@ -941,6 +1028,7 @@ export function useInspectionAutosave({
     lastError,
     flush,
     flushToServer,
+    resolveConflict,
     refresh: pullLatest,
     label: inspectionSyncLabel(state, locked),
   };

--- a/features/inspections/lib/inspection/conflictRecovery.ts
+++ b/features/inspections/lib/inspection/conflictRecovery.ts
@@ -1,0 +1,218 @@
+import type {
+  InspectionItem,
+  InspectionSession,
+} from "@inspections/lib/inspection/types";
+
+export type InspectionConflictChoice = "device" | "server";
+export type InspectionSyncSource = "installed" | "mobile_web" | "desktop";
+
+const CLIENT_ID_KEY = "profixiq.inspection.sync-client.v1";
+
+export function inspectionSyncSource(): InspectionSyncSource {
+  if (typeof window === "undefined") return "desktop";
+  const standalone =
+    window.matchMedia?.("(display-mode: standalone)").matches ||
+    Boolean((navigator as Navigator & { standalone?: boolean }).standalone);
+  if (standalone) return "installed";
+  return window.matchMedia?.("(max-width: 767px)").matches
+    ? "mobile_web"
+    : "desktop";
+}
+
+export function inspectionSyncClientId(): string {
+  if (typeof window === "undefined") return "server";
+  try {
+    const existing = localStorage.getItem(CLIENT_ID_KEY)?.trim();
+    if (existing) return existing;
+    const created =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `client-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    localStorage.setItem(CLIENT_ID_KEY, created);
+    return created;
+  } catch {
+    return "ephemeral-client";
+  }
+}
+
+export function stampInspectionSyncSource(
+  session: InspectionSession,
+): InspectionSession {
+  return {
+    ...session,
+    syncSource: inspectionSyncSource(),
+    syncClientId: inspectionSyncClientId(),
+  };
+}
+
+function sourcePriority(source: InspectionSyncSource | null | undefined): number {
+  if (source === "installed") return 3;
+  if (source === "mobile_web") return 2;
+  if (source === "desktop") return 1;
+  return 0;
+}
+
+export type InspectionConflictRow = {
+  key: string;
+  sectionIndex: number;
+  itemIndex: number;
+  sectionTitle: string;
+  itemLabel: string;
+  deviceItem: InspectionItem;
+  serverItem: InspectionItem;
+};
+
+const RECOVERABLE_ITEM_FIELDS: Array<keyof InspectionItem> = [
+  "status",
+  "value",
+  "unit",
+  "notes",
+  "note",
+  "photoUrls",
+  "parts",
+  "laborHours",
+  "recommend",
+  "photoRequested",
+  "photoReviewed",
+  "findingReviewed",
+];
+
+function normalized(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function itemLabel(item: InspectionItem, index: number): string {
+  return String(item.item ?? item.name ?? `Item ${index + 1}`).trim();
+}
+
+function itemIdentity(item: InspectionItem, index: number): string {
+  return normalized(item.item ?? item.name) || `index:${index}`;
+}
+
+function comparableItem(item: InspectionItem): Record<string, unknown> {
+  return Object.fromEntries(
+    RECOVERABLE_ITEM_FIELDS.map((field) => [field, item[field] ?? null]),
+  );
+}
+
+function itemsDiffer(device: InspectionItem, server: InspectionItem): boolean {
+  return (
+    JSON.stringify(comparableItem(device)) !==
+    JSON.stringify(comparableItem(server))
+  );
+}
+
+export function inspectionConflictRows(
+  device: InspectionSession,
+  server: InspectionSession,
+): InspectionConflictRow[] {
+  const rows: InspectionConflictRow[] = [];
+
+  server.sections.forEach((serverSection, sectionIndex) => {
+    const deviceSection =
+      device.sections.find(
+        (section) =>
+          normalized(section.title) === normalized(serverSection.title),
+      ) ?? device.sections[sectionIndex];
+    if (!deviceSection) return;
+
+    serverSection.items.forEach((serverItem, itemIndex) => {
+      const identity = itemIdentity(serverItem, itemIndex);
+      const deviceItem =
+        deviceSection.items.find(
+          (item, index) => itemIdentity(item, index) === identity,
+        ) ?? deviceSection.items[itemIndex];
+      if (!deviceItem || !itemsDiffer(deviceItem, serverItem)) return;
+
+      rows.push({
+        key: `${sectionIndex}:${itemIndex}:${identity}`,
+        sectionIndex,
+        itemIndex,
+        sectionTitle: serverSection.title,
+        itemLabel: itemLabel(serverItem, itemIndex),
+        deviceItem,
+        serverItem,
+      });
+    });
+  });
+
+  return rows;
+}
+
+export function mergeInspectionConflict(args: {
+  device: InspectionSession;
+  server: InspectionSession;
+  choices: Record<string, InspectionConflictChoice>;
+}): InspectionSession {
+  const rows = inspectionConflictRows(args.device, args.server);
+  const sections = args.server.sections.map((section) => ({
+    ...section,
+    items: section.items.map((item) => ({ ...item })),
+  }));
+
+  for (const row of rows) {
+    if ((args.choices[row.key] ?? "device") !== "device") continue;
+    sections[row.sectionIndex].items[row.itemIndex] = {
+      ...row.serverItem,
+      ...row.deviceItem,
+      // Uploaded evidence is append-only. Never make choosing one measurement
+      // remove a photo already acknowledged by the other copy.
+      photoUrls: Array.from(
+        new Set([
+          ...(row.serverItem.photoUrls ?? []),
+          ...(row.deviceItem.photoUrls ?? []),
+        ]),
+      ),
+    };
+  }
+
+  return {
+    ...args.server,
+    sections,
+    lastUpdated: new Date().toISOString(),
+    // The canonical revision is the concurrency token for the recovery write.
+    // Device timestamps are deliberately not used to choose a winner.
+    syncRevision: args.server.syncRevision,
+    serverUpdatedAt: args.server.serverUpdatedAt,
+  };
+}
+
+export function automaticallyMergeInspectionConflict(args: {
+  device: InspectionSession;
+  server: InspectionSession;
+  currentSource: InspectionSyncSource;
+  currentClientId: string;
+}): InspectionSession | null {
+  const devicePriority = sourcePriority(args.currentSource);
+  const serverPriority = sourcePriority(args.server.syncSource);
+  const sameClient =
+    Boolean(args.server.syncClientId) &&
+    args.server.syncClientId === args.currentClientId;
+  const rows = inspectionConflictRows(args.device, args.server);
+
+  // A second device at the same tier changing the same item is the only case
+  // that needs a human choice. Every other case follows the declared authoring
+  // priority: installed app, then mobile web, then desktop.
+  if (rows.length > 0 && devicePriority === serverPriority && !sameClient) {
+    return null;
+  }
+
+  const preferDevice = sameClient || devicePriority > serverPriority;
+  const choices = Object.fromEntries(
+    rows.map((row) => [row.key, preferDevice ? "device" : "server"]),
+  ) as Record<string, InspectionConflictChoice>;
+  const merged = mergeInspectionConflict({
+    device: args.device,
+    server: args.server,
+    choices,
+  });
+  return {
+    ...merged,
+    syncSource: args.currentSource,
+    syncClientId: args.currentClientId,
+  };
+}

--- a/features/inspections/lib/inspection/save.ts
+++ b/features/inspections/lib/inspection/save.ts
@@ -7,6 +7,7 @@ import {
   runMutationWithOfflineQueue,
 } from "@/features/shared/lib/offline/mutations";
 import { replayAllOfflineMutations } from "@/features/shared/lib/offline/replay";
+import { stampInspectionSyncSource } from "@inspections/lib/inspection/conflictRecovery";
 
 const ACTION_SAVE_INSPECTION = "inspection:save-session";
 
@@ -20,6 +21,7 @@ type SaveInspectionOptions = {
   operationKey?: string;
   requireServer?: boolean;
   supersedesOperationKey?: string;
+  deferSupersededDismissal?: boolean;
 };
 
 type InspectionSaveResponse = {
@@ -73,6 +75,7 @@ export async function saveInspectionSession(
   inspectionId?: string;
   syncRevision?: number;
   savedAt?: string;
+  savedSession?: InspectionSession;
 }> {
   if (!workOrderLineId) {
     throw new Error("Missing workOrderLineId");
@@ -83,14 +86,19 @@ export async function saveInspectionSession(
     (typeof crypto !== "undefined" && "randomUUID" in crypto
       ? crypto.randomUUID()
       : `${workOrderLineId}:${Date.now()}`);
+  const authoredSession = stampInspectionSyncSource(session);
   const payload: InspectionSavePayload = {
     workOrderLineId,
-    session,
+    session: authoredSession,
     operationKey,
   };
 
   const supersededKey = options.supersedesOperationKey?.trim();
-  if (supersededKey && supersededKey !== operationKey) {
+  if (
+    supersededKey &&
+    supersededKey !== operationKey &&
+    !options.deferSupersededDismissal
+  ) {
     // A distinct key prevents an in-flight replay from acknowledging a newer
     // payload. Queued (not syncing) snapshots are safely coalesced away.
     await dismissOfflineMutation(supersededKey);
@@ -126,6 +134,20 @@ export async function saveInspectionSession(
     serverResponse.current = await postInspectionSave(payload);
   }
 
+  if (
+    supersededKey &&
+    supersededKey !== operationKey &&
+    options.deferSupersededDismissal &&
+    !result.queued &&
+    !result.conflicted &&
+    serverResponse.current
+  ) {
+    // Conflict recovery keeps the rejected device snapshot until the reviewed
+    // replacement has a server acknowledgement. A failed recovery therefore
+    // cannot destroy the only remaining device copy.
+    await dismissOfflineMutation(supersededKey);
+  }
+
   if (typeof navigator !== "undefined" && navigator.onLine) {
     await replayQueuedInspectionSaves();
   }
@@ -136,5 +158,6 @@ export async function saveInspectionSession(
     inspectionId: serverResponse.current?.inspection_id,
     syncRevision: serverResponse.current?.sync_revision,
     savedAt: serverResponse.current?.saved_at,
+    savedSession: authoredSession,
   };
 }

--- a/features/inspections/lib/inspection/types.ts
+++ b/features/inspections/lib/inspection/types.ts
@@ -348,9 +348,10 @@ export interface InspectionSession {
   lastUpdated?: string;
   syncRevision?: number;
   serverUpdatedAt?: string | null;
+  syncSource?: "installed" | "mobile_web" | "desktop";
+  syncClientId?: string | null;
   customer?: SessionCustomer | null;
   vehicle?: SessionVehicle | null;
   sections: InspectionCategory[];
   quote?: Array<QuoteLine | QuoteLineItem>;
 }
-

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -47,6 +47,7 @@ import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionForm
 import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicleHeader";
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
+import InspectionConflictRecoveryPanel from "@inspections/components/inspection/InspectionConflictRecoveryPanel";
 import PageShell from "@/features/shared/components/PageShell";
 import { Button } from "@shared/components/ui/Button";
 import { PANEL_VARIANTS } from "@/features/shared/components/ui/panelHierarchy";
@@ -965,6 +966,7 @@ type SmartMatchRow = {
     flushToServer: flushAutosaveToServer,
     label: autosaveLabel,
     lastError: autosaveError,
+    resolveConflict,
   } = useInspectionAutosave({
     session,
     inspectionId,
@@ -2863,6 +2865,22 @@ type SmartMatchRow = {
           >
             {recoveryMessage}
           </div>
+        )}
+        {recoveryState === "conflicted" && workOrderLineId && (
+          <InspectionConflictRecoveryPanel
+            deviceSession={session}
+            workOrderLineId={workOrderLineId}
+            onResolve={async (resolved) => {
+              const saved = await resolveConflict(resolved);
+              replaceSession(saved);
+              recoveryOperationKeyRef.current = undefined;
+              queuedSessionRef.current = null;
+              setRecoveryState("editing");
+              setRecoveryMessage(
+                "Reviewed inspection is saved and available on all devices.",
+              );
+            }}
+          />
         )}
         <div className={headerCard}>
           <div className="mb-2 flex flex-wrap items-center justify-between gap-2 border-b border-[var(--theme-card-border,var(--theme-border-soft))] pb-2">

--- a/tests/inspection-conflict-recovery.test.ts
+++ b/tests/inspection-conflict-recovery.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  automaticallyMergeInspectionConflict,
+  inspectionConflictRows,
+  mergeInspectionConflict,
+} from "../features/inspections/lib/inspection/conflictRecovery";
+import type { InspectionSession } from "../features/inspections/lib/inspection/types";
+
+function session(
+  revision: number,
+  value: string,
+  notes: string,
+  photoUrls: string[],
+): InspectionSession {
+  return {
+    id: "inspection-1",
+    workOrderId: "work-order-1",
+    workOrderLineId: "line-1",
+    currentSectionIndex: 0,
+    currentItemIndex: 0,
+    isListening: false,
+    status: "in_progress",
+    started: true,
+    completed: false,
+    isPaused: false,
+    syncRevision: revision,
+    sections: [
+      {
+        title: "Hydraulic brakes",
+        items: [
+          {
+            item: "Left front pad",
+            status: "fail",
+            value,
+            unit: "mm",
+            notes,
+            photoUrls,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("inspection conflict recovery", () => {
+  it("compares the canonical item instead of choosing by device timestamp", () => {
+    const rows = inspectionConflictRows(
+      session(1, "2", "Metal to metal", ["device-photo"]),
+      session(4, "8", "", ["server-photo"]),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].deviceItem.value).toBe("2");
+    expect(rows[0].serverItem.value).toBe("8");
+  });
+
+  it("rebases selected device evidence onto the server revision", () => {
+    const device = session(1, "2", "Metal to metal", ["device-photo"]);
+    const server = session(4, "8", "", ["server-photo"]);
+    const row = inspectionConflictRows(device, server)[0];
+    const merged = mergeInspectionConflict({
+      device,
+      server,
+      choices: { [row.key]: "device" },
+    });
+
+    expect(merged.syncRevision).toBe(4);
+    expect(merged.sections[0].items[0]).toMatchObject({
+      value: "2",
+      notes: "Metal to metal",
+      photoUrls: ["server-photo", "device-photo"],
+    });
+  });
+
+  it("keeps the shop item when explicitly selected", () => {
+    const device = session(1, "2", "Device", ["device-photo"]);
+    const server = session(4, "8", "Shop", ["server-photo"]);
+    const row = inspectionConflictRows(device, server)[0];
+    const merged = mergeInspectionConflict({
+      device,
+      server,
+      choices: { [row.key]: "server" },
+    });
+
+    expect(merged.sections[0].items[0]).toEqual(server.sections[0].items[0]);
+  });
+
+  it("automatically gives the installed app priority over desktop", () => {
+    const device = session(1, "2", "Device", ["device-photo"]);
+    const server = {
+      ...session(4, "8", "Desktop", ["server-photo"]),
+      syncSource: "desktop" as const,
+      syncClientId: "desktop-1",
+    };
+    const merged = automaticallyMergeInspectionConflict({
+      device,
+      server,
+      currentSource: "installed",
+      currentClientId: "installed-1",
+    });
+    expect(merged?.sections[0].items[0].value).toBe("2");
+    expect(merged?.syncRevision).toBe(4);
+  });
+
+  it("requires review only for conflicting devices at the same tier", () => {
+    const device = session(1, "2", "Phone A", []);
+    const server = {
+      ...session(4, "3", "Phone B", []),
+      syncSource: "installed" as const,
+      syncClientId: "installed-2",
+    };
+    expect(
+      automaticallyMergeInspectionConflict({
+        device,
+        server,
+        currentSource: "installed",
+        currentClientId: "installed-1",
+      }),
+    ).toBeNull();
+  });
+
+  it("uses mobile web ahead of desktop and keeps installed ahead of desktop", () => {
+    const mobile = session(1, "4", "Mobile web", []);
+    const desktop = {
+      ...session(3, "8", "Desktop", []),
+      syncSource: "desktop" as const,
+      syncClientId: "desktop-1",
+    };
+    expect(
+      automaticallyMergeInspectionConflict({
+        device: mobile,
+        server: desktop,
+        currentSource: "mobile_web",
+        currentClientId: "mobile-web-1",
+      })?.sections[0].items[0].value,
+    ).toBe("4");
+
+    const installed = { ...desktop, syncSource: "installed" as const };
+    expect(
+      automaticallyMergeInspectionConflict({
+        device: desktop,
+        server: installed,
+        currentSource: "desktop",
+        currentClientId: "desktop-2",
+      })?.sections[0].items[0].value,
+    ).toBe("8");
+  });
+});

--- a/tests/inspection-cross-device-reconciliation.test.ts
+++ b/tests/inspection-cross-device-reconciliation.test.ts
@@ -55,7 +55,10 @@ describe("inspection cross-device reconciliation and shared modal styling", () =
     const lineLookup = photoRoute.indexOf(
       '.eq("work_order_line_id", workOrderLineId)',
     );
-    const uuidLookup = photoRoute.indexOf('.eq("id", inspectionId)');
+    const uuidLookup = photoRoute.indexOf(
+      '.eq("id", inspectionId)',
+      lineLookup,
+    );
     expect(lineLookup).toBeGreaterThan(-1);
     expect(uuidLookup).toBeGreaterThan(lineLookup);
     expect(photoRoute).toContain('.eq("shop_id", shopId)');

--- a/tests/inspection-offline-recovery.test.ts
+++ b/tests/inspection-offline-recovery.test.ts
@@ -9,6 +9,12 @@ const autosave = read(
 );
 const save = read("features/inspections/lib/inspection/save.ts");
 const findings = read("features/inspections/lib/inspection/findings/page.tsx");
+const recovery = read(
+  "features/inspections/components/inspection/InspectionConflictRecoveryPanel.tsx",
+);
+const recoveryMerge = read(
+  "features/inspections/lib/inspection/conflictRecovery.ts",
+);
 describe("technician inspection offline recovery", () => {
   it("stores expiring drafts under the authenticated user and shop scope", () => {
     expect(drafts).toContain('const KIND = "inspection-draft"');
@@ -92,5 +98,20 @@ describe("technician inspection offline recovery", () => {
     expect(autosave).toContain("saveInspectionOfflineDraft");
     expect(save).toContain("operationKey,");
     expect(save).toContain("syncRevision: serverResponse.current?.sync_revision");
+  });
+
+  it("requires an explicit server-versus-device recovery decision", () => {
+    expect(screen).toContain("<InspectionConflictRecoveryPanel");
+    expect(recovery).toContain("Nothing is chosen by time");
+    expect(recovery).toContain("Apply selected & sync");
+    expect(recovery).toContain("Keep shop copy");
+    expect(recoveryMerge).toContain("syncRevision: args.server.syncRevision");
+    expect(recoveryMerge).toContain("Uploaded evidence is append-only");
+    expect(autosave).toContain("const resolveConflict = useCallback");
+    expect(autosave).toContain("preserveConflictUntilAcknowledged");
+    expect(save).toContain("deferSupersededDismissal");
+    expect(save).toContain("cannot destroy the only remaining device copy");
+    expect(autosave).toContain("automaticallyMergeInspectionConflict");
+    expect(recoveryMerge).toContain("installed app, then mobile web, then desktop");
   });
 });


### PR DESCRIPTION
## Summary

Makes inspection synchronization follow the intended authoring priority without treating a private browser store as the final record:

1. installed PWA
2. mobile web
3. desktop

Supabase remains the canonical shared revision used by every client and by signing.

## Root cause

The installed app can hold a valid IndexedDB draft and staged photos while the server has a newer revision from mobile web or desktop. Revision locking correctly prevents silent overwrites, but the client previously stopped at a generic/manual conflict instead of automatically rebasing the preferred authoring copy.

## Changes

- Stamps acknowledged inspection saves with client surface and stable device identity.
- Automatically reloads and rebases conflicts using installed → mobile web → desktop priority.
- Keeps server revision as the concurrency token; device timestamps never choose the winner.
- Preserves photo URLs as append-only evidence and replays staged photo uploads after acknowledgement.
- Retains the rejected device snapshot until the replacement is acknowledged by the server.
- Shows item-level manual comparison only when two different devices at the same priority changed the same item.
- Keeps the final signed inspection on the canonical server revision.
- Adds focused conflict-priority, recovery, photo, autosave, and signature regression coverage.

## User impact

An installed app with real measurements, notes, parts requests, and photos can recover automatically after reconnecting. Mobile web becomes the fallback author, desktop the final fallback, and all three continue reading the same server-backed inspection.

## Validation

- TypeScript: passed
- 26 focused Vitest tests: passed
- ESLint: no errors (2 existing hook warnings remain)
- No migration or environment variables required
