### PR TITLE
Repair canonical inspection writer recovery

### DIFF
--- a/app/api/inspections/save/route.ts
+++ b/app/api/inspections/save/route.ts
@@ -7,13 +7,43 @@ import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server
 import type { Json } from "@shared/types/types/supabase";
 import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
 
-type RpcError = { message: string; details?: string | null; hint?: string | null };
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+  code?: string | null;
+};
 type RpcClient = {
   rpc: (
     name: string,
     args: Record<string, unknown>,
   ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
 };
+
+const SCHEMA_COMPATIBILITY_ERROR =
+  "no unique or exclusion constraint matching the on conflict";
+
+function isInspectionRevisionConflict(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("inspection save conflicts with a newer server version") ||
+    lower.includes("inspection is finalized and locked") ||
+    lower.includes("inspection was finalized while autosave was in progress")
+  );
+}
+
+function isMissingVersionedWriter(error: RpcError | null): boolean {
+  if (!error) return false;
+  const message = [error.message, error.details, error.hint]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return (
+    error.code === "PGRST202" ||
+    (message.includes("save_inspection_progress_v2_atomic") &&
+      (message.includes("not find") || message.includes("does not exist")))
+  );
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -81,27 +111,51 @@ export async function POST(req: NextRequest) {
   }
 
   const rpc = supabase as unknown as RpcClient;
-  const { data, error } = await rpc.rpc("save_inspection_progress_atomic", {
+  const rpcArgs = {
     p_shop_id: profile.shop_id,
     p_work_order_line_id: workOrderLineId,
     p_actor_user_id: user.id,
     p_session: session as unknown as Json,
     p_operation_key: `${profile.shop_id}:inspection-progress:${operationKey}`,
     p_at: new Date().toISOString(),
-  });
+  };
+  let { data, error } = await rpc.rpc(
+    "save_inspection_progress_v2_atomic",
+    rpcArgs,
+  );
+
+  // Keep deploy order safe: application instances may update before the new
+  // migration reaches PostgREST. Once v2 exists, every save uses it and can no
+  // longer resolve to the drifted legacy implementation.
+  if (isMissingVersionedWriter(error)) {
+    ({ data, error } = await rpc.rpc("save_inspection_progress_atomic", rpcArgs));
+  }
 
   if (error) {
     const message = [error.message, error.details, error.hint]
       .filter(Boolean)
       .join(" — ");
     const lower = message.toLowerCase();
-    const status =
-      lower.includes("locked") ||
-      lower.includes("finalized") ||
-      lower.includes("not found") ||
-      lower.includes("newer server version") ||
-      lower.includes("conflict")
-        ? 409
+    // PostgreSQL uses "ON CONFLICT" in schema errors. Never classify that
+    // wording as a user-data revision conflict: doing so permanently strands
+    // an otherwise retryable mobile snapshot in IndexedDB.
+    if (lower.includes(SCHEMA_COMPATIBILITY_ERROR)) {
+      return NextResponse.json(
+        {
+          error:
+            "Inspection sync is temporarily unavailable while the server writer is updated.",
+          code: "INSPECTION_WRITER_UNAVAILABLE",
+          retryable: true,
+          workOrderLineId,
+        },
+        { status: 503 },
+      );
+    }
+
+    const status = isInspectionRevisionConflict(message)
+      ? 409
+      : lower.includes("work-order line not found")
+        ? 404
         : 400;
     if (status === 409) {
       return NextResponse.json(

--- a/features/inspections/lib/inspection/offlineDrafts.ts
+++ b/features/inspections/lib/inspection/offlineDrafts.ts
@@ -10,11 +10,21 @@ import {
   hydrateOfflineMutationQueue,
   listOfflineMutations,
   resolveOfflineMutationScope,
+  retryOfflineMutation,
   type OfflineMutationScope,
 } from "@/features/shared/lib/offline/mutations";
 
 const KIND = "inspection-draft";
 const MAX_AGE_MS = 1000 * 60 * 60 * 24 * 14;
+
+function isLegacyInspectionWriterFailure(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    value
+      .toLowerCase()
+      .includes("no unique or exclusion constraint matching the on conflict")
+  );
+}
 
 export type InspectionDraftRecoveryState = "editing" | "queued" | "conflicted";
 
@@ -111,6 +121,20 @@ export async function getInspectionOfflineDraft(args: {
         ? (queuedSessionCandidate as InspectionSession)
         : null;
     if (queued.status === "conflicted") {
+      if (isLegacyInspectionWriterFailure(queued.lastError)) {
+        // Older clients mistook PostgreSQL's `ON CONFLICT` schema wording for
+        // an inspection revision conflict. Revive only that known-safe failure
+        // with the same payload and idempotency key; real revision conflicts
+        // remain protected and require a canonical reconciliation path.
+        await retryOfflineMutation(draft.operationKey);
+        const retrying = {
+          ...draft,
+          session: queuedSession ?? draft.session,
+          state: "queued" as const,
+        };
+        await saveInspectionOfflineDraft(retrying);
+        return retrying;
+      }
       // The queued payload is the exact device snapshot rejected by the
       // server. It is safer than a later screen/localStorage copy, which may
       // already have been replaced by a canonical load. Never dismiss or

--- a/supabase/migrations/20260722193000_versioned_canonical_inspection_writer.sql
+++ b/supabase/migrations/20260722193000_versioned_canonical_inspection_writer.sql
@@ -1,0 +1,335 @@
+begin;
+
+-- Install a versioned canonical writer so a database that already recorded an
+-- earlier migration cannot keep serving the legacy ON CONFLICT implementation.
+-- The API prefers this function and retains the original name only as a rolling-
+-- deployment fallback until this migration reaches every environment.
+-- Some deployed environments retained an older writer whose conflict target
+-- did not have a matching unique constraint.
+-- This definition preserves shop authorization, revision checks, idempotency,
+-- profile identity compatibility, locking, and finalization behavior.
+-- The API resolves shops through either profiles.id or profiles.user_id.
+-- Keep the atomic writer on the same identity contract so linked/imported
+-- technicians can persist the canonical inspection instead of remaining local.
+create or replace function public.save_inspection_progress_v2_atomic(
+  p_shop_id uuid,
+  p_work_order_line_id uuid,
+  p_actor_user_id uuid,
+  p_session jsonb,
+  p_operation_key text,
+  p_at timestamptz default now()
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_line record;
+  v_existing_result jsonb;
+  v_existing_summary jsonb := '{}'::jsonb;
+  v_canonical_session jsonb;
+  v_session_id uuid;
+  v_inspection_id uuid;
+  -- `p_at` remains in the public signature for forward compatibility, but a
+  -- caller-controlled timestamp cannot be used as a concurrency token.
+  v_now timestamptz := clock_timestamp();
+  v_result jsonb;
+  v_server_revision bigint := 0;
+  v_client_revision bigint := 0;
+  v_next_revision bigint;
+  v_server_updated_at timestamptz;
+  v_client_updated_at timestamptz;
+  v_inspection_exists boolean := false;
+  v_inspection_locked boolean := false;
+  v_inspection_completed boolean := false;
+  v_inspection_is_draft boolean := true;
+  v_inspection_status text := 'draft';
+  v_inspection_finalized_at timestamptz;
+  v_inspection_finalized_by uuid;
+  v_session_fingerprint text := md5(p_session::text);
+begin
+  if auth.uid() is not null and auth.uid() <> p_actor_user_id then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Authenticated actor does not match the inspection actor.';
+  end if;
+
+  if nullif(trim(p_operation_key), '') is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'A stable operation key is required.';
+  end if;
+
+  if p_session is null or jsonb_typeof(p_session) <> 'object' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection session payload must be a JSON object.';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles p
+    where (p.id = p_actor_user_id or p.user_id = p_actor_user_id)
+      and p.shop_id = p_shop_id
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Actor is not a member of this shop.';
+  end if;
+
+  select wol.id, wol.work_order_id, wol.shop_id
+    into v_line
+  from public.work_order_lines wol
+  where wol.id = p_work_order_line_id
+    and wol.shop_id = p_shop_id
+  for update;
+
+  if not found or v_line.work_order_id is null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Work-order line not found for shop.';
+  end if;
+
+  -- Authorization and line scope are checked before idempotency lookup because
+  -- this SECURITY DEFINER function is callable directly by authenticated users.
+  -- Locking the line first also makes simultaneous retries with the same key
+  -- observe the committed idempotency result instead of a false revision clash.
+  select mok.result
+    into v_existing_result
+  from public.mobile_operation_keys mok
+  where mok.shop_id = p_shop_id
+    and mok.operation_name = 'save_inspection_progress'
+    and mok.operation_key = p_operation_key;
+
+  if found then
+    if coalesce(v_existing_result->>'session_fingerprint', '') is distinct from
+       v_session_fingerprint then
+      raise exception using
+        errcode = 'P0001',
+        message = 'Inspection operation key was reused for a different snapshot.';
+    end if;
+    return v_existing_result || jsonb_build_object('idempotent', true);
+  end if;
+
+  -- Lock only the deterministic canonical row. Historical duplicates may
+  -- contain old finalized evidence and must not block an active canonical draft.
+  select
+    i.id,
+    coalesce(i.summary, '{}'::jsonb),
+    coalesce(i.locked, false),
+    coalesce(i.completed, false),
+    coalesce(i.is_draft, true),
+    coalesce(i.status, 'draft'),
+    i.finalized_at,
+    i.finalized_by,
+    i.updated_at
+  into
+    v_inspection_id,
+    v_existing_summary,
+    v_inspection_locked,
+    v_inspection_completed,
+    v_inspection_is_draft,
+    v_inspection_status,
+    v_inspection_finalized_at,
+    v_inspection_finalized_by,
+    v_server_updated_at
+  from public.inspections i
+  where i.work_order_line_id = p_work_order_line_id
+    and i.shop_id = p_shop_id
+  order by i.updated_at desc nulls last, i.id desc
+  limit 1
+  for update;
+
+  if found then
+    v_inspection_exists := true;
+    if (
+      v_inspection_locked
+      or v_inspection_completed
+      or not v_inspection_is_draft
+      or v_inspection_finalized_at is not null
+      or v_inspection_finalized_by is not null
+      or lower(v_inspection_status) in ('completed', 'finalized', 'signed')
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'Inspection is finalized and locked. Reopen is required before editing.';
+    end if;
+
+    if coalesce(v_existing_summary->>'syncRevision', '') ~ '^[0-9]+$' then
+      v_server_revision := (v_existing_summary->>'syncRevision')::bigint;
+    end if;
+  else
+    insert into public.inspections (
+      work_order_id,
+      work_order_line_id,
+      shop_id,
+      user_id,
+      summary,
+      is_draft,
+      completed,
+      locked,
+      status,
+      finalized_at,
+      finalized_by,
+      updated_at
+    ) values (
+      v_line.work_order_id,
+      p_work_order_line_id,
+      p_shop_id,
+      p_actor_user_id,
+      p_session,
+      true,
+      false,
+      false,
+      'draft',
+      null,
+      null,
+      v_now
+    )
+    returning id into v_inspection_id;
+  end if;
+
+  if coalesce(p_session->>'syncRevision', '') ~ '^[0-9]+$' then
+    v_client_revision := (p_session->>'syncRevision')::bigint;
+  end if;
+
+  if v_inspection_exists and v_client_revision <> v_server_revision then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection save conflicts with a newer server version.';
+  end if;
+
+  v_next_revision := v_server_revision + 1;
+  v_canonical_session :=
+    p_session || jsonb_build_object(
+      'id', v_inspection_id,
+      'workOrderId', v_line.work_order_id,
+      'workOrderLineId', p_work_order_line_id,
+      'syncRevision', v_next_revision,
+      'serverUpdatedAt', v_now
+    );
+
+  update public.inspections
+  set work_order_id = v_line.work_order_id,
+      work_order_line_id = p_work_order_line_id,
+      shop_id = p_shop_id,
+      user_id = p_actor_user_id,
+      summary = v_canonical_session,
+      is_draft = true,
+      completed = false,
+      locked = false,
+      status = 'draft',
+      finalized_at = null,
+      finalized_by = null,
+      updated_at = v_now
+  where id = v_inspection_id
+    and shop_id = p_shop_id
+    and not coalesce(locked, false)
+    and not coalesce(completed, false)
+    and coalesce(is_draft, true)
+    and lower(coalesce(status, 'draft')) not in (
+      'completed',
+      'finalized',
+      'signed'
+    );
+
+  if not found then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Inspection was finalized while autosave was in progress.';
+  end if;
+
+  select s.id
+    into v_session_id
+  from public.inspection_sessions s
+  where s.work_order_line_id = p_work_order_line_id
+  order by s.updated_at desc nulls last, s.id desc
+  limit 1
+  for update;
+
+  if found then
+    update public.inspection_sessions
+    set work_order_id = v_line.work_order_id,
+        user_id = p_actor_user_id,
+        state = v_canonical_session,
+        updated_at = v_now
+    where id = v_session_id;
+  else
+    insert into public.inspection_sessions (
+      work_order_id,
+      work_order_line_id,
+      user_id,
+      state,
+      updated_at
+    ) values (
+      v_line.work_order_id,
+      p_work_order_line_id,
+      p_actor_user_id,
+      v_canonical_session,
+      v_now
+    )
+    returning id into v_session_id;
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'inspection_id', v_inspection_id,
+    'inspection_session_id', v_session_id,
+    'work_order_id', v_line.work_order_id,
+    'work_order_line_id', p_work_order_line_id,
+    'sync_revision', v_next_revision,
+    'saved_at', v_now,
+    'session_fingerprint', v_session_fingerprint,
+    'idempotent', false
+  );
+
+  insert into public.mobile_operation_keys (
+    shop_id,
+    operation_name,
+    operation_key,
+    actor_user_id,
+    work_order_id,
+    work_order_line_id,
+    result
+  ) values (
+    p_shop_id,
+    'save_inspection_progress',
+    p_operation_key,
+    p_actor_user_id,
+    v_line.work_order_id,
+    p_work_order_line_id,
+    v_result
+  );
+
+  return v_result;
+exception
+  when unique_violation then
+    select mok.result
+      into v_existing_result
+    from public.mobile_operation_keys mok
+    where mok.shop_id = p_shop_id
+      and mok.operation_name = 'save_inspection_progress'
+      and mok.operation_key = p_operation_key;
+
+    if found then
+      if coalesce(v_existing_result->>'session_fingerprint', '') is distinct from
+         v_session_fingerprint then
+        raise exception using
+          errcode = 'P0001',
+          message = 'Inspection operation key was reused for a different snapshot.';
+      end if;
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+
+    raise;
+end;
+$$;
+
+revoke all on function public.save_inspection_progress_v2_atomic(
+  uuid, uuid, uuid, jsonb, text, timestamptz
+) from public;
+grant execute on function public.save_inspection_progress_v2_atomic(
+  uuid, uuid, uuid, jsonb, text, timestamptz
+) to authenticated, service_role;
+
+commit;

--- a/tests/inspection-conflict-containment.test.ts
+++ b/tests/inspection-conflict-containment.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   hydrateOfflineMutationQueue: vi.fn(),
   listOfflineMutations: vi.fn(),
   resolveOfflineMutationScope: vi.fn(),
+  retryOfflineMutation: vi.fn(),
 }));
 
 vi.mock("@/features/shared/lib/offline/database", () => ({
@@ -19,6 +20,7 @@ vi.mock("@/features/shared/lib/offline/mutations", () => ({
   hydrateOfflineMutationQueue: mocks.hydrateOfflineMutationQueue,
   listOfflineMutations: mocks.listOfflineMutations,
   resolveOfflineMutationScope: mocks.resolveOfflineMutationScope,
+  retryOfflineMutation: mocks.retryOfflineMutation,
 }));
 
 import { getInspectionOfflineDraft } from "../features/inspections/lib/inspection/offlineDrafts";
@@ -92,5 +94,38 @@ describe("inspection conflict containment", () => {
     expect(recovered?.operationKey).toBe("operation-1");
     expect(recovered?.session).toEqual(rejectedMobile);
     expect(recovered?.session.sections[0].items[0].value).toBe("2");
+  });
+
+  it("retries the legacy writer schema failure without changing its mobile payload", async () => {
+    const rejectedMobile = session("2", "2026-07-22T17:00:00.000Z");
+
+    mocks.getOfflineSnapshot.mockResolvedValue({
+      data: {
+        draftKey: "inspection-draft:line:line-1",
+        session: rejectedMobile,
+        savedAt: "2026-07-22T17:00:00.000Z",
+        state: "conflicted",
+        operationKey: "operation-1",
+      },
+    });
+    mocks.listOfflineMutations.mockReturnValue([
+      {
+        clientMutationId: "operation-1",
+        status: "conflicted",
+        lastError:
+          "there is no unique or exclusion constraint matching the ON CONFLICT specification",
+        payload: { session: rejectedMobile },
+      },
+    ]);
+
+    const recovered = await getInspectionOfflineDraft({
+      draftKey: "inspection-draft:line:line-1",
+      sessionHint: rejectedMobile,
+    });
+
+    expect(mocks.retryOfflineMutation).toHaveBeenCalledWith("operation-1");
+    expect(recovered?.state).toBe("queued");
+    expect(recovered?.operationKey).toBe("operation-1");
+    expect(recovered?.session).toEqual(rejectedMobile);
   });
 });

--- a/tests/inspection-save-error-classification.test.ts
+++ b/tests/inspection-save-error-classification.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const route = readFileSync("app/api/inspections/save/route.ts", "utf8");
+
+describe("inspection save error classification", () => {
+  it("prefers the versioned canonical writer with a rolling-deploy fallback", () => {
+    expect(route).toContain('"save_inspection_progress_v2_atomic"');
+    expect(route).toContain("isMissingVersionedWriter(error)");
+    expect(route).toContain('rpc("save_inspection_progress_atomic", rpcArgs)');
+  });
+
+  it("keeps writer schema drift retryable instead of calling it a revision conflict", () => {
+    expect(route).toContain("SCHEMA_COMPATIBILITY_ERROR");
+    expect(route).toContain('code: "INSPECTION_WRITER_UNAVAILABLE"');
+    expect(route).toContain("retryable: true");
+    expect(route).toContain("{ status: 503 }");
+    expect(route).not.toContain('lower.includes("conflict")');
+  });
+
+  it("limits 409 responses to actual inspection lifecycle conflicts", () => {
+    expect(route).toContain("isInspectionRevisionConflict(message)");
+    expect(route).toContain(
+      'lower.includes("inspection save conflicts with a newer server version")',
+    );
+    expect(route).toContain('code: "INSPECTION_REVISION_CONFLICT"');
+  });
+});

--- a/tests/inspection-versioned-writer-migration.test.ts
+++ b/tests/inspection-versioned-writer-migration.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260722193000_versioned_canonical_inspection_writer.sql",
+  "utf8",
+);
+
+describe("versioned canonical inspection writer migration", () => {
+  it("installs a new RPC identity without unsafe line-level upserts", () => {
+    expect(migration).toContain(
+      "create or replace function public.save_inspection_progress_v2_atomic",
+    );
+    expect(migration).not.toContain("on conflict (work_order_line_id)");
+    expect(migration).toContain("from public.inspections i");
+    expect(migration).toContain("update public.inspections");
+    expect(migration).toContain("from public.inspection_sessions s");
+    expect(migration).toContain("update public.inspection_sessions");
+  });
+
+  it("preserves tenant authorization, revisions, and idempotency", () => {
+    expect(migration).toContain("auth.uid() <> p_actor_user_id");
+    expect(migration).toContain("and wol.shop_id = p_shop_id");
+    expect(migration).toContain("p.user_id = p_actor_user_id");
+    expect(migration).toContain("v_client_revision <> v_server_revision");
+    expect(migration).toContain("mobile_operation_keys");
+    expect(migration).toContain("session_fingerprint");
+  });
+});

--- a/tests/phase6-inspection-progress-route.test.ts
+++ b/tests/phase6-inspection-progress-route.test.ts
@@ -41,8 +41,9 @@ describe("Phase 6 inspection progress route", () => {
     expect(client).toContain(
       "syncRevision: serverResponse.current?.sync_revision",
     );
-    expect(route).toContain('lower.includes("newer server version")');
+    expect(route).toContain("isInspectionRevisionConflict(message)");
     expect(route).toContain("? 409");
+    expect(route).toContain("INSPECTION_WRITER_UNAVAILABLE");
+    expect(route).toContain("{ status: 503 }");
   });
 });
-


### PR DESCRIPTION
## Summary

Repairs the inspection save path that leaves installed-app drafts permanently blocked after a database compatibility failure.

## Root cause

The installed app preserved the correct mobile payload, but an earlier database/RPC compatibility failure was stored as a permanent revision conflict. Reopening the inspection restored that blocked state and refused to retry the same protected operation, so signing remained unavailable even after the original database function was repaired.

Reusing the old RPC name also allowed production schema drift to keep resolving to an incompatible writer.

## Changes

- Adds a versioned canonical inspection writer RPC (`save_inspection_progress_v2`).
- Switches the save API to prefer the v2 writer with a rolling-deploy fallback.
- Classifies database/schema compatibility errors as retryable 503 responses instead of revision conflicts.
- Revives only legacy operations that were previously misclassified by this known compatibility failure.
- Preserves the original payload and idempotency key during retry.
- Leaves genuine revision conflicts protected and does not add manual clear/override controls.
- Adds focused migration, error-classification, containment, and Phase 6 regression tests.

## User impact

An existing installed-app inspection trapped by the earlier compatibility error can retry its protected mobile payload automatically after deployment. A genuine concurrent edit still remains blocked for safe review.

## Validation

- TypeScript: passed
- Focused inspection/mobile tests: 35 passed
- ESLint: passed
- Remote comparison: 7 files, 1 commit ahead of `main`, 0 divergence

## Deployment

This PR includes the forward migration:

`supabase/migrations/20260722193000_versioned_canonical_inspection_writer.sql`

The migration must be applied in the production Supabase project for the v2 writer to become canonical. The API fallback keeps rolling deployment safe while application and database changes propagate.