### PR TITLE
Add local-first vehicle intake VIN scanning

### DIFF
--- a/app/vehicle/VinCaptureModal.tsx
+++ b/app/vehicle/VinCaptureModal.tsx
@@ -41,7 +41,7 @@ type Props = {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   children?: React.ReactNode;
-  /** Existing server route used only for optional online enrichment. */
+  /** Existing server route retained for the manual form action. */
   action?: string;
 };
 
@@ -190,7 +190,7 @@ export default function VinCaptureModal({
     [userId],
   );
 
-  const handleFoundVin = useCallback(
+  const handleManualVin = useCallback(
     async (rawVin: string) => {
       const normalized = normalizeVinInput(rawVin);
       if (!normalized.isValid) {
@@ -203,6 +203,41 @@ export default function VinCaptureModal({
       setIsDecoding(true);
       setCaptureError(null);
 
+      try {
+        const decoded = await decodeVin(normalized.vin, userId);
+        if (decoded.error) {
+          setCaptureError(decoded.error);
+          return;
+        }
+
+        const enriched = decoded as DecodeVinResponseExtended;
+        applyDecodedVehicle(normalized.vin, enriched);
+        fetchRecallData(normalized.vin, enriched);
+        setOpen(false);
+      } catch {
+        setCaptureError(
+          "VIN decoding is temporarily unavailable. The VIN can still be entered directly in the vehicle form.",
+        );
+      } finally {
+        captureLockRef.current = false;
+        setIsDecoding(false);
+      }
+    },
+    [applyDecodedVehicle, fetchRecallData, setOpen, userId],
+  );
+
+  const handleScannedVin = useCallback(
+    (rawVin: string) => {
+      const normalized = normalizeVinInput(rawVin);
+      if (!normalized.isValid) {
+        setCaptureError(normalized.message);
+        return;
+      }
+      if (captureLockRef.current) return;
+
+      captureLockRef.current = true;
+      setCaptureError(null);
+
       const local = decodeVinLocally(normalized.vin);
       const localDecoded: DecodeVinResponseExtended = {
         year: local?.year ?? null,
@@ -210,16 +245,13 @@ export default function VinCaptureModal({
         manufacturer: local?.manufacturer ?? null,
       };
 
-      // The VIN and locally-known fields land immediately. This keeps intake fast
-      // and functional without network or a third-party scan/OCR service.
+      // Scanning is local-first: the VIN and known fields land immediately and
+      // the camera modal closes without waiting for network enrichment.
       applyDecodedVehicle(normalized.vin, localDecoded);
       setOpen(false);
-      setIsDecoding(false);
 
       if (typeof navigator !== "undefined" && !navigator.onLine) return;
 
-      // Existing vPIC decoding remains optional background enrichment. A failure
-      // leaves the locally captured VIN and manual form untouched.
       void decodeVin(normalized.vin, userId)
         .then((decoded) => {
           if (decoded.error) return;
@@ -228,7 +260,7 @@ export default function VinCaptureModal({
           fetchRecallData(normalized.vin, enriched);
         })
         .catch(() => {
-          // Intake is already complete locally.
+          // Local intake is already complete.
         });
     },
     [applyDecodedVehicle, fetchRecallData, setOpen, userId],
@@ -256,7 +288,7 @@ export default function VinCaptureModal({
         <VinCaptureModalContent
           action={action}
           userId={userId}
-          onManualSubmit={handleFoundVin}
+          onManualSubmit={handleManualVin}
           isDecoding={isDecoding}
           error={captureError}
           onClearError={() => setCaptureError(null)}
@@ -266,7 +298,7 @@ export default function VinCaptureModal({
           }}
           scanSlot={
             <VehicleIntakeScanner
-              onFoundVin={(vin) => void handleFoundVin(vin)}
+              onFoundVin={handleScannedVin}
               onError={setCaptureError}
               isBusy={isDecoding}
             />

--- a/app/vehicle/VinCaptureModal.tsx
+++ b/app/vehicle/VinCaptureModal.tsx
@@ -1,25 +1,18 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-import ModalShell from "@/features/shared/components/ModalShell";
-import VinCaptureModalContent from "@/features/vehicles/components/VinCaptureModal";
-import { decodeVin, mapDecodedVinToVehicleSelectValues } from "@/features/shared/lib/vin/decodeVin";
-import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
-import { useWorkOrderDraft } from "app/work-orders/state/useWorkOrderDraft";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-// Optional: tame TS around experimental BarcodeDetector
-declare global {
-  interface Window {
-    BarcodeDetector?: new (opts?: { formats?: string[] }) => {
-      detect: (source: CanvasImageSource) => Promise<Array<{ rawValue?: string }>>;
-    };
-  }
-}
+import ModalShell from "@/features/shared/components/ModalShell";
+import {
+  decodeVin,
+  mapDecodedVinToVehicleSelectValues,
+  type DecodedVin,
+} from "@/features/shared/lib/vin/decodeVin";
+import { decodeVinLocally } from "@/features/shared/lib/vin/localDecodeVin";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+import VehicleIntakeScanner from "@/features/vehicles/components/VehicleIntakeScanner";
+import VinCaptureModalContent from "@/features/vehicles/components/VinCaptureModal";
+import { useWorkOrderDraft } from "app/work-orders/state/useWorkOrderDraft";
 
 export type VinDecodedDetail = {
   vin: string;
@@ -31,8 +24,6 @@ export type VinDecodedDetail = {
   engine?: string | null;
   engineFamily?: string | null;
   engineType?: string | null;
-
-  // extra fields from /api/vin
   engineDisplacementL?: string | null;
   engineCylinders?: string | null;
   fuelType?: string | null;
@@ -50,13 +41,11 @@ type Props = {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   children?: React.ReactNode;
-  /** server route that upserts (defaults to /api/vin) */
+  /** Existing server route used only for optional online enrichment. */
   action?: string;
 };
 
-type DecodeVinResponse = Awaited<ReturnType<typeof decodeVin>>;
-
-type DecodeVinResponseExtended = DecodeVinResponse & {
+type DecodeVinResponseExtended = DecodedVin & {
   engineDisplacementL?: string | null;
   engineCylinders?: string | null;
   fuelType?: string | null;
@@ -68,222 +57,33 @@ type DecodeVinResponseExtended = DecodeVinResponse & {
   gvwr?: string | null;
 };
 
-function isLikelyVin(s: string) {
-  return normalizeVinInput(s).isValid;
-}
+function buildDecodedDetail(
+  vin: string,
+  decoded: DecodeVinResponseExtended,
+): VinDecodedDetail {
+  const mapped = mapDecodedVinToVehicleSelectValues(decoded);
 
-const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
-
-function describeOcrError(status: number, fallback?: string | null) {
-  if (status === 413) return "Image is too large. Upload an image 8 MB or smaller, or enter the VIN manually.";
-  if (status === 415) return "Unsupported image type. Upload a JPEG, PNG, WebP, HEIC, or enter the VIN manually.";
-  return fallback || "Could not read a VIN from this image. Retake the photo, upload another, or enter it manually.";
-}
-
-/** Scanner pane used in scanSlot */
-function ScannerPane({
-  onFoundVin,
-  onError,
-  isBusy,
-}: {
-  userId: string;
-  onFoundVin: (vin: string) => void;
-  onError: (message: string) => void;
-  isBusy: boolean;
-}) {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [active, setActive] = useState(false);
-  const lockedRef = useRef(false);
-
-  useEffect(() => {
-    let stream: MediaStream | null = null;
-    let raf = 0;
-    let detector:
-      | InstanceType<NonNullable<typeof window.BarcodeDetector>>
-      | null = null;
-
-    const start = async () => {
-      setError(null);
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: "environment" },
-          audio: false,
-        });
-        if (!videoRef.current) return;
-        videoRef.current.srcObject = stream;
-        await videoRef.current.play();
-        setActive(true);
-
-        if (window.BarcodeDetector) {
-          detector = new window.BarcodeDetector({
-            formats: ["code_39", "code_128", "pdf417", "data_matrix"],
-          });
-
-          const scan = async () => {
-            if (!videoRef.current || lockedRef.current) return;
-            try {
-              const bitmap = await createImageBitmap(videoRef.current);
-              const codes = await detector!.detect(bitmap);
-              if (codes?.length) {
-                for (const c of codes) {
-                  const raw = String(c.rawValue ?? "");
-                  const cleaned = normalizeVinInput(raw);
-                  if (cleaned.isValid) {
-                    lockedRef.current = true;
-                    onFoundVin(cleaned.vin);
-                    return;
-                  }
-                }
-              }
-            } catch {
-              /* ignore transient decode errors */
-            }
-            raf = requestAnimationFrame(scan);
-          };
-          raf = requestAnimationFrame(scan);
-        } else {
-          const message =
-            "Live barcode detection is not supported in this browser. Upload a photo or enter the VIN manually.";
-          setError(message);
-          onError(message);
-        }
-      } catch {
-        const message =
-          "Camera unavailable. Upload a photo or enter the VIN manually.";
-        setError(message);
-        onError(message);
-      }
-    };
-
-    start();
-
-    return () => {
-      cancelAnimationFrame(raf);
-      setActive(false);
-      try {
-        stream?.getTracks()?.forEach((t) => t.stop());
-      } catch {
-        /* no-op */
-      }
-    };
-  }, [onError, onFoundVin]);
-
-  return (
-    <div
-      className={`space-y-3 ${
-        isBusy ? "ring-2 ring-cyan-500/60 rounded-md animate-pulse" : ""
-      }`}
-    >
-      {isBusy && (
-        <div className="flex items-center gap-2 rounded border border-cyan-500/50 bg-[color:var(--desktop-item-bg)] px-3 py-2">
-          <span className="inline-block h-4 w-4 rounded-full border-2 border-cyan-400 border-t-transparent animate-spin" />
-          <span className="text-xs text-cyan-100">
-            Decoding VIN… this can take a moment
-          </span>
-        </div>
-      )}
-
-      <div className="rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-2">
-        <video
-          ref={videoRef}
-          className="aspect-video w-full rounded bg-[color:var(--theme-surface-page)]"
-          playsInline
-          muted
-          autoPlay
-        />
-      </div>
-
-      {error ? (
-        <div className="text-xs text-[color:var(--theme-text-primary)]">{error}</div>
-      ) : (
-        <div className="text-xs text-[color:var(--theme-text-secondary)]">
-          {active
-            ? "Point the camera at the VIN barcode / label…"
-            : "Initializing camera…"}
-        </div>
-      )}
-
-      {/* Photo upload → OCR route */}
-      <div className="rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-3">
-        <div className="mb-2 text-sm text-[color:var(--theme-text-primary)]">
-          Or upload a photo of the VIN label
-        </div>
-        <input
-          type="file"
-          accept="image/*"
-          capture="environment"
-          disabled={isBusy}
-          className="block w-full text-xs text-[color:var(--theme-text-secondary)] file:mr-3 file:rounded file:border-0 file:bg-[linear-gradient(135deg,rgba(197,122,74,0.9),rgba(197,122,74,0.75))] file:px-3 file:py-1.5 file:text-sm file:font-semibold file:text-[color:var(--theme-text-on-accent)] hover:file:bg-[linear-gradient(135deg,rgba(197,122,74,1),rgba(197,122,74,0.85))] disabled:opacity-60"
-          onChange={async (e) => {
-            if (isBusy) return;
-            const file = e.target.files?.[0];
-            if (!file) return;
-
-            if (!file.type.startsWith("image/")) {
-              onError("Unsupported file type. Upload an image or enter the VIN manually.");
-              e.target.value = "";
-              return;
-            }
-
-            if (file.size > MAX_IMAGE_BYTES) {
-              onError("Image is too large. Upload an image 8 MB or smaller, or enter the VIN manually.");
-              e.target.value = "";
-              return;
-            }
-
-            try {
-              const formData = new FormData();
-              formData.append("image", file);
-
-              const res = await fetch("/api/vin/extract-from-image", {
-                method: "POST",
-                body: formData,
-              });
-
-              if (!res.ok) {
-                const body = (await res.json().catch(() => ({}))) as {
-                  error?: string | null;
-                };
-                onError(describeOcrError(res.status, body.error));
-                e.target.value = "";
-                return;
-              }
-
-              const data = (await res.json()) as { vin?: string | null };
-              const extractedVin = normalizeVinInput(data?.vin);
-              const vin = extractedVin.vin;
-              if (!extractedVin.isValid || !isLikelyVin(vin)) {
-                onError(
-                  "No clear VIN found in the photo. Retake it, upload another photo, or type the VIN manually.",
-                );
-                e.target.value = "";
-                return;
-              }
-
-              onFoundVin(vin);
-            } catch (err) {
-              console.error(err);
-              onError(
-                "OCR failed while reading the photo. Try again, upload another photo, or enter the VIN manually.",
-              );
-            } finally {
-              e.target.value = "";
-            }
-          }}
-        />
-        <div className="mt-2 text-[11px] text-[color:var(--theme-text-muted)]">
-          Tip: Take a close, well-lit photo of the VIN sticker on the door frame or
-          dash.
-        </div>
-      </div>
-
-      <div className="text-[11px] text-[color:var(--theme-text-muted)]">
-        We will decode with NHTSA and fill the vehicle form; you stay in control
-        of saving.
-      </div>
-    </div>
-  );
+  return {
+    vin,
+    year: decoded.year ?? null,
+    make: decoded.make ?? null,
+    model: decoded.model ?? null,
+    trim: decoded.trim ?? null,
+    submodel: decoded.submodel ?? decoded.trim ?? null,
+    engine: decoded.engine ?? null,
+    engineFamily: decoded.engineFamily ?? null,
+    engineType: decoded.engineType ?? null,
+    engineDisplacementL: decoded.engineDisplacementL ?? null,
+    engineCylinders: decoded.engineCylinders ?? null,
+    fuelType: mapped.fuel_type ?? null,
+    transmission: mapped.transmission ?? null,
+    transmissionType:
+      decoded.transmissionType ?? decoded.transmission ?? null,
+    driveType: mapped.drivetrain ?? null,
+    bodyClass: decoded.bodyClass ?? null,
+    manufacturer: decoded.manufacturer ?? null,
+    gvwr: decoded.gvwr ?? null,
+  };
 }
 
 export default function VinCaptureModal({
@@ -297,23 +97,31 @@ export default function VinCaptureModal({
   const [internalOpen, setInternalOpen] = useState(false);
   const [isDecoding, setIsDecoding] = useState(false);
   const [captureError, setCaptureError] = useState<string | null>(null);
+  const captureLockRef = useRef(false);
 
   const isControlled = typeof open === "boolean";
   const isOpen = isControlled ? (open as boolean) : internalOpen;
 
   const setOpen = useCallback(
-    (val: boolean) => {
-      if (isControlled) onOpenChange?.(val);
-      else setInternalOpen(val);
+    (value: boolean) => {
+      if (isControlled) onOpenChange?.(value);
+      else setInternalOpen(value);
     },
     [isControlled, onOpenChange],
   );
 
-  const setVehicleDraft = useWorkOrderDraft((s) => s.setVehicle);
+  const setVehicleDraft = useWorkOrderDraft((state) => state.setVehicle);
+  const onDecodedRef = useRef<Props["onDecoded"]>(onDecoded);
 
-  // Lock body scroll when modal is open
+  useEffect(() => {
+    onDecodedRef.current = onDecoded;
+  }, [onDecoded]);
+
   useEffect(() => {
     if (!isOpen) return;
+    captureLockRef.current = false;
+    setCaptureError(null);
+
     const original = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     return () => {
@@ -321,113 +129,110 @@ export default function VinCaptureModal({
     };
   }, [isOpen]);
 
-  // Keep latest onDecoded
-  const onDecodedRef = useRef<Props["onDecoded"]>(onDecoded);
-  useEffect(() => {
-    onDecodedRef.current = onDecoded;
-  }, [onDecoded]);
+  const applyDecodedVehicle = useCallback(
+    (vin: string, decoded: DecodeVinResponseExtended) => {
+      const mapped = mapDecodedVinToVehicleSelectValues(decoded);
 
-  // Listen for result events (if server form posts and emits later)
+      setVehicleDraft({
+        vin,
+        year: decoded.year ?? null,
+        make: decoded.make ?? null,
+        model: decoded.model ?? null,
+        trim: decoded.trim ?? null,
+        submodel: decoded.submodel ?? decoded.trim ?? null,
+        engine: decoded.engine ?? null,
+        engine_family: decoded.engineFamily ?? null,
+        engine_type: decoded.engineType ?? null,
+        transmission_type:
+          decoded.transmissionType ?? decoded.transmission ?? null,
+        fuel_type: mapped.fuel_type ?? null,
+        drivetrain: mapped.drivetrain ?? null,
+        transmission: mapped.transmission ?? null,
+      });
+
+      onDecodedRef.current?.(buildDecodedDetail(vin, decoded));
+    },
+    [setVehicleDraft],
+  );
+
   useEffect(() => {
-    const handler = (evt: Event) => {
-      const ce = evt as CustomEvent<VinDecodedDetail>;
-      const detail = ce?.detail;
-      if (detail?.vin) {
-        onDecodedRef.current?.(detail);
-        setOpen(false);
-      }
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<VinDecodedDetail>)?.detail;
+      if (!detail?.vin) return;
+      onDecodedRef.current?.(detail);
+      setOpen(false);
     };
+
     window.addEventListener("vin:decoded", handler as EventListener);
     return () =>
       window.removeEventListener("vin:decoded", handler as EventListener);
   }, [setOpen]);
 
-  const handleFoundVin = useCallback(
-    async (vin: string) => {
-      const normalizedVin = normalizeVinInput(vin);
-      if (!normalizedVin.isValid) {
-        setCaptureError(normalizedVin.message);
-        return;
-      }
-      if (isDecoding) return; // prevent double fires
-      setIsDecoding(true);
-      try {
-        const resp = await decodeVin(normalizedVin.vin, userId);
-        if (resp?.error) {
-          setCaptureError(resp.error);
-          return;
-        }
+  const fetchRecallData = useCallback(
+    (vin: string, decoded: DecodeVinResponseExtended) => {
+      if (!decoded.year || !decoded.make || !decoded.model) return;
 
-        const extended = resp as DecodeVinResponseExtended;
-        const mapped = mapDecodedVinToVehicleSelectValues(extended);
-
-        // hydrate shared draft
-        setVehicleDraft({
-          vin: normalizedVin.vin,
-          year: resp.year ?? null,
-          make: resp.make ?? null,
-          model: resp.model ?? null,
-          trim: resp.trim ?? null,
-          submodel: resp.submodel ?? resp.trim ?? null,
-          engine: resp.engine ?? null,
-          engine_family: resp.engineFamily ?? null,
-          engine_type: resp.engineType ?? null,
-          transmission_type: resp.transmissionType ?? extended.transmission ?? null,
-          fuel_type: mapped.fuel_type ?? null,
-          drivetrain: mapped.drivetrain ?? null,
-          transmission: mapped.transmission ?? null,
-        });
-
-        const detail: VinDecodedDetail = {
-          vin: normalizedVin.vin,
-          year: resp.year ?? null,
-          make: resp.make ?? null,
-          model: resp.model ?? null,
-          trim: resp.trim ?? null,
-          submodel: resp.submodel ?? resp.trim ?? null,
-          engine: resp.engine ?? null,
-          engineFamily: resp.engineFamily ?? null,
-          engineType: resp.engineType ?? null,
-          engineDisplacementL: extended.engineDisplacementL ?? null,
-          engineCylinders: extended.engineCylinders ?? null,
-          fuelType: mapped.fuel_type ?? null,
-          transmission: mapped.transmission ?? null,
-          transmissionType: resp.transmissionType ?? extended.transmission ?? null,
-          driveType: mapped.drivetrain ?? null,
-          bodyClass: extended.bodyClass ?? null,
-          manufacturer: extended.manufacturer ?? null,
-          gvwr: extended.gvwr ?? null,
-        };
-
-        onDecodedRef.current?.(detail);
-
-        // fire-and-forget recalls fetch
-        try {
-          void fetch("/api/recalls/fetch", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              vin: normalizedVin.vin,
-              year: resp.year ?? undefined,
-              make: resp.make ?? undefined,
-              model: resp.model ?? undefined,
-              user_id: userId,
-            }),
-            keepalive: true,
-          });
-        } catch {
-          /* non-blocking */
-        }
-
-        setCaptureError(null);
-        setOpen(false);
-      } finally {
-        setIsDecoding(false);
-      }
+      void fetch("/api/recalls/fetch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          vin,
+          year: decoded.year,
+          make: decoded.make,
+          model: decoded.model,
+          user_id: userId,
+        }),
+        keepalive: true,
+      }).catch(() => {
+        // Recall enrichment must never block vehicle intake.
+      });
     },
-    [userId, setVehicleDraft, setOpen, isDecoding],
+    [userId],
   );
 
+  const handleFoundVin = useCallback(
+    async (rawVin: string) => {
+      const normalized = normalizeVinInput(rawVin);
+      if (!normalized.isValid) {
+        setCaptureError(normalized.message);
+        return;
+      }
+      if (captureLockRef.current) return;
+
+      captureLockRef.current = true;
+      setIsDecoding(true);
+      setCaptureError(null);
+
+      const local = decodeVinLocally(normalized.vin);
+      const localDecoded: DecodeVinResponseExtended = {
+        year: local?.year ?? null,
+        make: local?.make ?? null,
+        manufacturer: local?.manufacturer ?? null,
+      };
+
+      // The VIN and locally-known fields land immediately. This keeps intake fast
+      // and functional without network or a third-party scan/OCR service.
+      applyDecodedVehicle(normalized.vin, localDecoded);
+      setOpen(false);
+      setIsDecoding(false);
+
+      if (typeof navigator !== "undefined" && !navigator.onLine) return;
+
+      // Existing vPIC decoding remains optional background enrichment. A failure
+      // leaves the locally captured VIN and manual form untouched.
+      void decodeVin(normalized.vin, userId)
+        .then((decoded) => {
+          if (decoded.error) return;
+          const enriched = decoded as DecodeVinResponseExtended;
+          applyDecodedVehicle(normalized.vin, enriched);
+          fetchRecallData(normalized.vin, enriched);
+        })
+        .catch(() => {
+          // Intake is already complete locally.
+        });
+    },
+    [applyDecodedVehicle, fetchRecallData, setOpen, userId],
+  );
 
   return (
     <>
@@ -444,8 +249,8 @@ export default function VinCaptureModal({
       <ModalShell
         isOpen={isOpen}
         onClose={() => setOpen(false)}
-        title="Add Vehicle by VIN"
-        size="md"
+        title="Vehicle Intake Scan"
+        size="lg"
         hideFooter={true}
       >
         <VinCaptureModalContent
@@ -460,9 +265,8 @@ export default function VinCaptureModal({
             setOpen(false);
           }}
           scanSlot={
-            <ScannerPane
-              userId={userId}
-              onFoundVin={handleFoundVin}
+            <VehicleIntakeScanner
+              onFoundVin={(vin) => void handleFoundVin(vin)}
               onError={setCaptureError}
               isBusy={isDecoding}
             />

--- a/features/shared/lib/vin/localDecodeVin.ts
+++ b/features/shared/lib/vin/localDecodeVin.ts
@@ -1,0 +1,125 @@
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+
+export type LocalVinDecode = {
+  vin: string;
+  year: string | null;
+  make: string | null;
+  manufacturer: string | null;
+  country: string | null;
+};
+
+const MODEL_YEAR_CODES = "ABCDEFGHJKLMNPRSTVWXY123456789";
+
+const COUNTRY_BY_PREFIX: Readonly<Record<string, string>> = {
+  "1": "United States",
+  "2": "Canada",
+  "3": "Mexico",
+  "4": "United States",
+  "5": "United States",
+  J: "Japan",
+  K: "South Korea",
+  L: "China",
+  S: "United Kingdom",
+  V: "France / Spain",
+  W: "Germany",
+  Y: "Sweden / Finland",
+  Z: "Italy",
+};
+
+const WMI_MAKES: Readonly<
+  Record<string, { make: string; manufacturer?: string }>
+> = {
+  "1FA": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "1FB": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "1FC": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "1FD": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "1FM": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "1FT": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "1ZV": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "2FA": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "2FB": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "2FM": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "2FT": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "3FA": { make: "Ford", manufacturer: "Ford Motor Company" },
+  "1G1": { make: "Chevrolet", manufacturer: "General Motors" },
+  "1GC": { make: "Chevrolet", manufacturer: "General Motors" },
+  "1GN": { make: "Chevrolet", manufacturer: "General Motors" },
+  "1GT": { make: "GMC", manufacturer: "General Motors" },
+  "1GY": { make: "Cadillac", manufacturer: "General Motors" },
+  "1C4": { make: "Jeep", manufacturer: "Stellantis" },
+  "1C6": { make: "Ram", manufacturer: "Stellantis" },
+  "1D7": { make: "Dodge", manufacturer: "Stellantis" },
+  "2C3": { make: "Chrysler", manufacturer: "Stellantis" },
+  "3C6": { make: "Ram", manufacturer: "Stellantis" },
+  "1HG": { make: "Honda", manufacturer: "Honda" },
+  "2HG": { make: "Honda", manufacturer: "Honda" },
+  "2HK": { make: "Honda", manufacturer: "Honda" },
+  "5FN": { make: "Honda", manufacturer: "Honda" },
+  "19X": { make: "Acura", manufacturer: "Honda" },
+  JHM: { make: "Honda", manufacturer: "Honda" },
+  JH4: { make: "Acura", manufacturer: "Honda" },
+  "1N4": { make: "Nissan", manufacturer: "Nissan" },
+  "1N6": { make: "Nissan", manufacturer: "Nissan" },
+  "3N1": { make: "Nissan", manufacturer: "Nissan" },
+  "5N1": { make: "Nissan", manufacturer: "Nissan" },
+  JN1: { make: "Nissan", manufacturer: "Nissan" },
+  JN8: { make: "Nissan", manufacturer: "Nissan" },
+  "2T1": { make: "Toyota", manufacturer: "Toyota" },
+  "4T1": { make: "Toyota", manufacturer: "Toyota" },
+  "4T3": { make: "Toyota", manufacturer: "Toyota" },
+  "5TD": { make: "Toyota", manufacturer: "Toyota" },
+  "2T2": { make: "Lexus", manufacturer: "Toyota" },
+  JTD: { make: "Toyota", manufacturer: "Toyota" },
+  JTE: { make: "Toyota", manufacturer: "Toyota" },
+  JTH: { make: "Lexus", manufacturer: "Toyota" },
+  KMH: { make: "Hyundai", manufacturer: "Hyundai Motor Group" },
+  KND: { make: "Kia", manufacturer: "Hyundai Motor Group" },
+  "5NP": { make: "Hyundai", manufacturer: "Hyundai Motor Group" },
+  "5XX": { make: "Kia", manufacturer: "Hyundai Motor Group" },
+  WVW: { make: "Volkswagen", manufacturer: "Volkswagen Group" },
+  WAU: { make: "Audi", manufacturer: "Volkswagen Group" },
+  WBA: { make: "BMW", manufacturer: "BMW Group" },
+  WBS: { make: "BMW", manufacturer: "BMW Group" },
+  WDD: { make: "Mercedes-Benz", manufacturer: "Mercedes-Benz Group" },
+  WP0: { make: "Porsche", manufacturer: "Volkswagen Group" },
+  WP1: { make: "Porsche", manufacturer: "Volkswagen Group" },
+  YV1: { make: "Volvo", manufacturer: "Volvo Cars" },
+  YV4: { make: "Volvo", manufacturer: "Volvo Cars" },
+};
+
+export function decodeVinModelYear(
+  input: unknown,
+  referenceYear = new Date().getFullYear(),
+): string | null {
+  const normalized = normalizeVinInput(input);
+  if (!normalized.isValid) return null;
+
+  const codeIndex = MODEL_YEAR_CODES.indexOf(normalized.vin[9]);
+  if (codeIndex < 0) return null;
+
+  const firstCycleYear = 1980 + codeIndex;
+  const candidates: number[] = [];
+  for (let year = firstCycleYear; year <= referenceYear + 1; year += 30) {
+    candidates.push(year);
+  }
+
+  const plausible = candidates.filter((year) => year >= 1980 && year <= referenceYear + 1);
+  if (!plausible.length) return null;
+  return String(plausible[plausible.length - 1]);
+}
+
+export function decodeVinLocally(input: unknown): LocalVinDecode | null {
+  const normalized = normalizeVinInput(input);
+  if (!normalized.isValid) return null;
+
+  const wmi = normalized.vin.slice(0, 3);
+  const makeEntry = WMI_MAKES[wmi] ?? null;
+
+  return {
+    vin: normalized.vin,
+    year: decodeVinModelYear(normalized.vin),
+    make: makeEntry?.make ?? null,
+    manufacturer: makeEntry?.manufacturer ?? makeEntry?.make ?? null,
+    country: COUNTRY_BY_PREFIX[normalized.vin[0]] ?? null,
+  };
+}

--- a/features/shared/lib/vin/vinCapture.ts
+++ b/features/shared/lib/vin/vinCapture.ts
@@ -1,0 +1,156 @@
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+
+const VIN_WEIGHTS = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2] as const;
+
+const VIN_TRANSLITERATION: Readonly<Record<string, number>> = {
+  A: 1,
+  B: 2,
+  C: 3,
+  D: 4,
+  E: 5,
+  F: 6,
+  G: 7,
+  H: 8,
+  J: 1,
+  K: 2,
+  L: 3,
+  M: 4,
+  N: 5,
+  P: 7,
+  R: 9,
+  S: 2,
+  T: 3,
+  U: 4,
+  V: 5,
+  W: 6,
+  X: 7,
+  Y: 8,
+  Z: 9,
+};
+
+export type VinCaptureCandidate = {
+  vin: string;
+  checksumValid: boolean;
+  score: number;
+};
+
+export type StableVinResult = VinCaptureCandidate & {
+  matches: number;
+  requiredMatches: number;
+};
+
+function transliterateVinCharacter(character: string): number | null {
+  if (/^[0-9]$/.test(character)) return Number(character);
+  return VIN_TRANSLITERATION[character] ?? null;
+}
+
+export function calculateVinCheckDigit(input: unknown): string | null {
+  const normalized = normalizeVinInput(input);
+  if (!normalized.isValid) return null;
+
+  let total = 0;
+  for (let index = 0; index < normalized.vin.length; index += 1) {
+    const value = transliterateVinCharacter(normalized.vin[index]);
+    if (value === null) return null;
+    total += value * VIN_WEIGHTS[index];
+  }
+
+  const remainder = total % 11;
+  return remainder === 10 ? "X" : String(remainder);
+}
+
+export function hasValidVinChecksum(input: unknown): boolean {
+  const normalized = normalizeVinInput(input);
+  if (!normalized.isValid) return false;
+  const expected = calculateVinCheckDigit(normalized.vin);
+  return expected !== null && normalized.vin[8] === expected;
+}
+
+function addCandidate(
+  values: Map<string, VinCaptureCandidate>,
+  rawCandidate: string,
+  exactLength: boolean,
+) {
+  const normalized = normalizeVinInput(rawCandidate);
+  if (!normalized.isValid) return;
+
+  const checksumValid = hasValidVinChecksum(normalized.vin);
+  const score = (checksumValid ? 100 : 0) + (exactLength ? 20 : 0);
+  const current = values.get(normalized.vin);
+
+  if (!current || score > current.score) {
+    values.set(normalized.vin, {
+      vin: normalized.vin,
+      checksumValid,
+      score,
+    });
+  }
+}
+
+export function extractVinCandidates(input: unknown): VinCaptureCandidate[] {
+  const raw = String(input ?? "").trim().toUpperCase().slice(0, 256);
+  if (!raw) return [];
+
+  const candidates = new Map<string, VinCaptureCandidate>();
+  addCandidate(candidates, raw, true);
+
+  const compact = raw.replace(/[^A-Z0-9]/g, "");
+  if (compact.length === 17) {
+    addCandidate(candidates, compact, true);
+  } else if (compact.length > 17) {
+    for (let index = 0; index <= compact.length - 17; index += 1) {
+      addCandidate(candidates, compact.slice(index, index + 17), false);
+    }
+  }
+
+  const tokenMatches = raw.match(/[A-HJ-NPR-Z0-9]{17}/g) ?? [];
+  tokenMatches.forEach((match) => addCandidate(candidates, match, true));
+
+  return [...candidates.values()].sort(
+    (left, right) => right.score - left.score || left.vin.localeCompare(right.vin),
+  );
+}
+
+export function chooseStableVin(
+  observations: readonly string[],
+  options?: {
+    checksumMatches?: number;
+    repeatedMatches?: number;
+  },
+): StableVinResult | null {
+  const checksumMatches = Math.max(1, options?.checksumMatches ?? 2);
+  const repeatedMatches = Math.max(checksumMatches, options?.repeatedMatches ?? 3);
+  const counts = new Map<string, { candidate: VinCaptureCandidate; matches: number }>();
+
+  observations.forEach((observation) => {
+    extractVinCandidates(observation).forEach((candidate) => {
+      const current = counts.get(candidate.vin);
+      counts.set(candidate.vin, {
+        candidate,
+        matches: (current?.matches ?? 0) + 1,
+      });
+    });
+  });
+
+  const ranked = [...counts.values()].sort((left, right) => {
+    if (left.candidate.checksumValid !== right.candidate.checksumValid) {
+      return left.candidate.checksumValid ? -1 : 1;
+    }
+    return right.matches - left.matches || right.candidate.score - left.candidate.score;
+  });
+
+  for (const entry of ranked) {
+    const requiredMatches = entry.candidate.checksumValid
+      ? checksumMatches
+      : repeatedMatches;
+    if (entry.matches >= requiredMatches) {
+      return {
+        ...entry.candidate,
+        matches: entry.matches,
+        requiredMatches,
+      };
+    }
+  }
+
+  return null;
+}

--- a/features/vehicles/components/VehicleIntakeScanner.tsx
+++ b/features/vehicles/components/VehicleIntakeScanner.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  chooseStableVin,
+  extractVinCandidates,
+} from "@/features/shared/lib/vin/vinCapture";
+
+type BarcodeResult = { rawValue?: string | null };
+type BarcodeDetectorLike = {
+  detect: (source: CanvasImageSource) => Promise<BarcodeResult[]>;
+};
+type BarcodeDetectorConstructor = new (options?: {
+  formats?: string[];
+}) => BarcodeDetectorLike;
+
+type QuaggaResult = {
+  codeResult?: {
+    code?: string | null;
+  } | null;
+};
+
+type QuaggaLike = {
+  decodeSingle: (
+    config: Record<string, unknown>,
+    callback: (result: QuaggaResult | null) => void,
+  ) => void;
+};
+
+type Observation = {
+  raw: string;
+  capturedAt: number;
+};
+
+type CameraCapabilities = MediaTrackCapabilities & {
+  torch?: boolean;
+};
+
+type Props = {
+  onFoundVin: (vin: string) => void;
+  onError: (message: string) => void;
+  isBusy: boolean;
+};
+
+const OBSERVATION_WINDOW_MS = 2_200;
+const LOCAL_SCAN_INTERVAL_MS = 260;
+const QUAGGA_INTERVAL_MS = 850;
+
+function getBarcodeDetector(): BarcodeDetectorConstructor | null {
+  if (typeof window === "undefined") return null;
+  return (
+    window as Window & {
+      BarcodeDetector?: BarcodeDetectorConstructor;
+    }
+  ).BarcodeDetector ?? null;
+}
+
+async function loadQuagga(): Promise<QuaggaLike> {
+  const module = (await import("@ericblade/quagga2")) as unknown as {
+    default?: QuaggaLike;
+  } & QuaggaLike;
+  return module.default ?? module;
+}
+
+function drawVideoRegion(video: HTMLVideoElement, canvas: HTMLCanvasElement) {
+  const sourceWidth = video.videoWidth;
+  const sourceHeight = video.videoHeight;
+  if (!sourceWidth || !sourceHeight) return false;
+
+  const cropWidth = Math.round(sourceWidth * 0.88);
+  const cropHeight = Math.round(sourceHeight * 0.42);
+  const sourceX = Math.round((sourceWidth - cropWidth) / 2);
+  const sourceY = Math.round((sourceHeight - cropHeight) / 2);
+  const outputWidth = Math.min(1280, cropWidth);
+  const outputHeight = Math.max(240, Math.round((cropHeight / cropWidth) * outputWidth));
+
+  canvas.width = outputWidth;
+  canvas.height = outputHeight;
+  const context = canvas.getContext("2d", { willReadFrequently: true });
+  if (!context) return false;
+
+  context.drawImage(
+    video,
+    sourceX,
+    sourceY,
+    cropWidth,
+    cropHeight,
+    0,
+    0,
+    outputWidth,
+    outputHeight,
+  );
+  return true;
+}
+
+function decodeCanvasWithQuagga(canvas: HTMLCanvasElement): Promise<string | null> {
+  return loadQuagga().then(
+    (quagga) =>
+      new Promise((resolve) => {
+        quagga.decodeSingle(
+          {
+            src: canvas.toDataURL("image/jpeg", 0.82),
+            numOfWorkers: 0,
+            locate: true,
+            inputStream: {
+              size: 1280,
+            },
+            locator: {
+              patchSize: "medium",
+              halfSample: true,
+            },
+            decoder: {
+              readers: ["code_39_reader", "code_128_reader"],
+              multiple: false,
+            },
+          },
+          (result) => resolve(result?.codeResult?.code?.trim() || null),
+        );
+      }),
+  );
+}
+
+async function drawImageFile(file: File, canvas: HTMLCanvasElement) {
+  if (typeof createImageBitmap === "function") {
+    const bitmap = await createImageBitmap(file);
+    try {
+      const maxWidth = 1800;
+      const scale = Math.min(1, maxWidth / bitmap.width);
+      canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+      canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+      const context = canvas.getContext("2d", { willReadFrequently: true });
+      if (!context) throw new Error("Canvas unavailable");
+      context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+      return;
+    } finally {
+      bitmap.close();
+    }
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    image.src = objectUrl;
+    await image.decode();
+    const maxWidth = 1800;
+    const scale = Math.min(1, maxWidth / image.naturalWidth);
+    canvas.width = Math.max(1, Math.round(image.naturalWidth * scale));
+    canvas.height = Math.max(1, Math.round(image.naturalHeight * scale));
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) throw new Error("Canvas unavailable");
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+export default function VehicleIntakeScanner({
+  onFoundVin,
+  onError,
+  isBusy,
+}: Props) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const observationsRef = useRef<Observation[]>([]);
+  const scanInFlightRef = useRef(false);
+  const lockedRef = useRef(false);
+  const lastQuaggaAtRef = useRef(0);
+  const lastCandidateAtRef = useRef(0);
+  const onFoundVinRef = useRef(onFoundVin);
+  const onErrorRef = useRef(onError);
+
+  const [status, setStatus] = useState("Starting camera…");
+  const [cameraReady, setCameraReady] = useState(false);
+  const [cameraError, setCameraError] = useState<string | null>(null);
+  const [torchAvailable, setTorchAvailable] = useState(false);
+  const [torchOn, setTorchOn] = useState(false);
+  const [photoBusy, setPhotoBusy] = useState(false);
+
+  useEffect(() => {
+    onFoundVinRef.current = onFoundVin;
+  }, [onFoundVin]);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+
+  const acceptObservation = useCallback((raw: string) => {
+    if (lockedRef.current) return false;
+
+    const candidates = extractVinCandidates(raw);
+    if (!candidates.length) return false;
+
+    const now = Date.now();
+    lastCandidateAtRef.current = now;
+    observationsRef.current = [
+      ...observationsRef.current.filter(
+        (entry) => now - entry.capturedAt <= OBSERVATION_WINDOW_MS,
+      ),
+      { raw, capturedAt: now },
+    ];
+
+    const leadingCandidate = candidates[0];
+    setStatus(
+      leadingCandidate.checksumValid
+        ? "VIN found — hold steady"
+        : "Reading VIN — hold steady",
+    );
+
+    const stable = chooseStableVin(
+      observationsRef.current.map((entry) => entry.raw),
+    );
+    if (!stable) return true;
+
+    lockedRef.current = true;
+    setStatus("VIN captured");
+    if (typeof navigator.vibrate === "function") navigator.vibrate(60);
+    onFoundVinRef.current(stable.vin);
+    return true;
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let intervalId: number | null = null;
+    let detector: BarcodeDetectorLike | null = null;
+
+    const start = async () => {
+      try {
+        if (!navigator.mediaDevices?.getUserMedia) {
+          throw new Error("Camera capture is not supported in this browser.");
+        }
+
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            facingMode: { ideal: "environment" },
+            width: { ideal: 1920 },
+            height: { ideal: 1080 },
+          },
+          audio: false,
+        });
+
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
+        streamRef.current = stream;
+        const video = videoRef.current;
+        if (!video) return;
+        video.srcObject = stream;
+        await video.play();
+
+        const videoTrack = stream.getVideoTracks()[0];
+        const capabilities = videoTrack?.getCapabilities?.() as
+          | CameraCapabilities
+          | undefined;
+        setTorchAvailable(Boolean(capabilities?.torch));
+
+        const Detector = getBarcodeDetector();
+        if (Detector) {
+          try {
+            detector = new Detector({
+              formats: ["code_39", "code_128", "pdf417", "data_matrix"],
+            });
+          } catch {
+            detector = new Detector();
+          }
+        }
+
+        setCameraReady(true);
+        setCameraError(null);
+        setStatus("Center the VIN barcode in the guide");
+
+        intervalId = window.setInterval(async () => {
+          if (
+            cancelled ||
+            lockedRef.current ||
+            scanInFlightRef.current ||
+            isBusy ||
+            video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA
+          ) {
+            return;
+          }
+
+          scanInFlightRef.current = true;
+          try {
+            let sawCandidate = false;
+            if (detector) {
+              try {
+                const results = await detector.detect(video);
+                for (const result of results) {
+                  if (result.rawValue && acceptObservation(result.rawValue)) {
+                    sawCandidate = true;
+                  }
+                }
+              } catch {
+                detector = null;
+              }
+            }
+
+            const now = Date.now();
+            const shouldRunQuagga =
+              !sawCandidate &&
+              now - lastQuaggaAtRef.current >= QUAGGA_INTERVAL_MS &&
+              now - lastCandidateAtRef.current >= LOCAL_SCAN_INTERVAL_MS;
+
+            if (shouldRunQuagga && canvasRef.current) {
+              lastQuaggaAtRef.current = now;
+              if (drawVideoRegion(video, canvasRef.current)) {
+                const decoded = await decodeCanvasWithQuagga(canvasRef.current);
+                if (decoded) acceptObservation(decoded);
+              }
+            }
+
+            if (now - lastCandidateAtRef.current > 1_800) {
+              setStatus("Center the VIN barcode in the guide");
+            }
+          } catch {
+            // Individual frame failures are expected while the camera moves.
+          } finally {
+            scanInFlightRef.current = false;
+          }
+        }, LOCAL_SCAN_INTERVAL_MS);
+      } catch (error) {
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : "Camera unavailable. Upload a VIN-label photo or enter the VIN manually.";
+        setCameraError(message);
+        setStatus("Camera unavailable");
+        onErrorRef.current(message);
+      }
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== null) window.clearInterval(intervalId);
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+      scanInFlightRef.current = false;
+    };
+  }, [acceptObservation, isBusy]);
+
+  const toggleTorch = useCallback(async () => {
+    const track = streamRef.current?.getVideoTracks()[0];
+    if (!track || !torchAvailable) return;
+
+    const next = !torchOn;
+    try {
+      await track.applyConstraints({
+        advanced: [{ torch: next } as MediaTrackConstraintSet],
+      });
+      setTorchOn(next);
+    } catch {
+      setTorchAvailable(false);
+    }
+  }, [torchAvailable, torchOn]);
+
+  const handlePhoto = useCallback(
+    async (file: File | null) => {
+      if (!file || !canvasRef.current || photoBusy || isBusy) return;
+      setPhotoBusy(true);
+      setCameraError(null);
+      setStatus("Reading VIN label photo…");
+
+      try {
+        await drawImageFile(file, canvasRef.current);
+
+        const Detector = getBarcodeDetector();
+        if (Detector) {
+          try {
+            const detector = new Detector();
+            const results = await detector.detect(canvasRef.current);
+            for (const result of results) {
+              if (result.rawValue) {
+                observationsRef.current.push(
+                  { raw: result.rawValue, capturedAt: Date.now() },
+                  { raw: result.rawValue, capturedAt: Date.now() },
+                );
+                if (acceptObservation(result.rawValue)) return;
+              }
+            }
+          } catch {
+            // Quagga remains available as the local fallback.
+          }
+        }
+
+        const decoded = await decodeCanvasWithQuagga(canvasRef.current);
+        if (decoded) {
+          observationsRef.current.push(
+            { raw: decoded, capturedAt: Date.now() },
+            { raw: decoded, capturedAt: Date.now() },
+          );
+          if (acceptObservation(decoded)) return;
+        }
+
+        const message =
+          "No VIN barcode was found in that photo. Retake the door-label photo or enter the VIN manually.";
+        setCameraError(message);
+        setStatus("VIN barcode not found");
+        onErrorRef.current(message);
+      } catch {
+        const message =
+          "That photo could not be read locally. Retake the VIN-label photo or enter the VIN manually.";
+        setCameraError(message);
+        setStatus("Photo could not be read");
+        onErrorRef.current(message);
+      } finally {
+        setPhotoBusy(false);
+      }
+    },
+    [acceptObservation, isBusy, photoBusy],
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="relative overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)] bg-black">
+        <video
+          ref={videoRef}
+          className="aspect-[4/3] w-full object-cover sm:aspect-video"
+          playsInline
+          muted
+          autoPlay
+        />
+
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-5">
+          <div className="relative h-[38%] w-[92%] rounded-xl border-2 border-white/80 shadow-[0_0_0_999px_rgba(0,0,0,0.34)]">
+            <span className="absolute -left-0.5 -top-0.5 h-5 w-5 rounded-tl-xl border-l-4 border-t-4 border-[var(--accent-copper-light)]" />
+            <span className="absolute -right-0.5 -top-0.5 h-5 w-5 rounded-tr-xl border-r-4 border-t-4 border-[var(--accent-copper-light)]" />
+            <span className="absolute -bottom-0.5 -left-0.5 h-5 w-5 rounded-bl-xl border-b-4 border-l-4 border-[var(--accent-copper-light)]" />
+            <span className="absolute -bottom-0.5 -right-0.5 h-5 w-5 rounded-br-xl border-b-4 border-r-4 border-[var(--accent-copper-light)]" />
+          </div>
+        </div>
+
+        <div className="absolute inset-x-3 bottom-3 flex items-center justify-between gap-2">
+          <div className="rounded-full border border-white/20 bg-black/70 px-3 py-1.5 text-[11px] font-semibold text-white backdrop-blur">
+            {isBusy ? "Adding vehicle…" : status}
+          </div>
+          {torchAvailable ? (
+            <button
+              type="button"
+              onClick={() => void toggleTorch()}
+              className="rounded-full border border-white/25 bg-black/70 px-3 py-1.5 text-[11px] font-semibold text-white backdrop-blur"
+            >
+              {torchOn ? "Light off" : "Light on"}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {cameraError ? (
+        <div className="rounded-lg border border-amber-500/35 bg-amber-950/25 px-3 py-2 text-xs text-amber-100">
+          {cameraError}
+        </div>
+      ) : null}
+
+      <label className="block cursor-pointer rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-center text-xs font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-subtle)]">
+        {photoBusy ? "Reading photo…" : "Use VIN-label photo"}
+        <input
+          type="file"
+          accept="image/*"
+          capture="environment"
+          disabled={photoBusy || isBusy}
+          className="sr-only"
+          onChange={(event) => {
+            const file = event.target.files?.[0] ?? null;
+            void handlePhoto(file);
+            event.target.value = "";
+          }}
+        />
+      </label>
+
+      <div className="space-y-1 text-[11px] text-[color:var(--theme-text-muted)]">
+        <p>
+          Runs on this device using the VIN barcode. No image or scan is sent to a third-party API.
+        </p>
+        <p>
+          Best target: the barcode on the driver-door label. Dashboard VIN text can still be entered manually.
+        </p>
+        {!cameraReady && !cameraError ? <p>Requesting camera access…</p> : null}
+      </div>
+
+      <canvas ref={canvasRef} className="hidden" aria-hidden="true" />
+    </div>
+  );
+}

--- a/features/vehicles/components/VinCaptureModal.tsx
+++ b/features/vehicles/components/VinCaptureModal.tsx
@@ -61,7 +61,7 @@ export default function VinCaptureModalContent({
               onClick={onClearError}
               className="rounded-full border border-red-300/50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-red-50 hover:bg-red-400/10"
             >
-              Try again
+              Dismiss
             </button>
             <button
               type="button"
@@ -75,13 +75,31 @@ export default function VinCaptureModalContent({
       ) : null}
 
       <div className="grid gap-6 sm:grid-cols-2">
-        {/* Manual Entry */}
-        <section className="rounded-2xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-[var(--theme-shadow-medium)]">
+        <section className="order-1 rounded-2xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-[var(--theme-shadow-medium)] sm:order-2">
+          <h3 className="font-blackops text-[0.75rem] tracking-[0.18em] text-orange-300">
+            INTAKE SCAN
+          </h3>
+          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+            Aim at the driver-door VIN barcode. Capture completes automatically.
+          </p>
+
+          <div className="mt-3 min-h-[220px] rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-3">
+            {scanSlot ? (
+              scanSlot
+            ) : (
+              <div className="flex h-full items-center justify-center text-sm text-[color:var(--theme-text-muted)]">
+                Scanner not loaded
+              </div>
+            )}
+          </div>
+        </section>
+
+        <section className="order-2 rounded-2xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-[var(--theme-shadow-medium)] sm:order-1">
           <h3 className="font-blackops text-[0.75rem] tracking-[0.18em] text-orange-300">
             MANUAL ENTRY
           </h3>
           <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Enter a valid 17-character VIN. No I, O, or Q.
+            Existing manual entry stays available at all times.
           </p>
 
           <form
@@ -118,37 +136,17 @@ export default function VinCaptureModalContent({
 
             <div className="flex flex-wrap items-center justify-between gap-3">
               <span className="text-[11px] text-[color:var(--theme-text-muted)]">
-                Decoded via NHTSA vPIC
+                VIN fills instantly; details enrich online in the background
               </span>
               <button
                 type="submit"
                 disabled={isDecoding}
                 className="rounded-full border border-orange-500 bg-[color:var(--theme-surface-overlay)] px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.2em] text-orange-100 hover:bg-orange-500/10 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                {isDecoding ? "Decoding…" : "Decode VIN"}
+                {isDecoding ? "Adding…" : "Use VIN"}
               </button>
             </div>
           </form>
-        </section>
-
-        {/* Scanner card */}
-        <section className="rounded-2xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-[var(--theme-shadow-medium)]">
-          <h3 className="font-blackops text-[0.75rem] tracking-[0.18em] text-orange-300">
-            SCAN VIN
-          </h3>
-          <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-            Use the camera or upload a photo of the VIN label.
-          </p>
-
-          <div className="mt-3 min-h-[220px] rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-3">
-            {scanSlot ? (
-              scanSlot
-            ) : (
-              <div className="flex h-full items-center justify-center text-sm text-[color:var(--theme-text-muted)]">
-                Scanner not loaded
-              </div>
-            )}
-          </div>
         </section>
       </div>
     </div>

--- a/tests/vin-intake-scan.test.ts
+++ b/tests/vin-intake-scan.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeVinLocally } from "@/features/shared/lib/vin/localDecodeVin";
+import {
+  calculateVinCheckDigit,
+  chooseStableVin,
+  extractVinCandidates,
+  hasValidVinChecksum,
+} from "@/features/shared/lib/vin/vinCapture";
+
+const VALID_VIN = "1HGCM82633A004352";
+
+describe("local VIN intake scan", () => {
+  it("extracts a VIN from a prefixed barcode value", () => {
+    const candidates = extractVinCandidates(`VIN:${VALID_VIN}`);
+
+    expect(candidates[0]).toMatchObject({
+      vin: VALID_VIN,
+      checksumValid: true,
+    });
+  });
+
+  it("calculates and validates the VIN check digit", () => {
+    expect(calculateVinCheckDigit(VALID_VIN)).toBe("3");
+    expect(hasValidVinChecksum(VALID_VIN)).toBe(true);
+    expect(hasValidVinChecksum("1HGCM82643A004352")).toBe(false);
+  });
+
+  it("accepts checksum-confirmed VINs after two matching frames", () => {
+    const result = chooseStableVin([VALID_VIN, VALID_VIN]);
+
+    expect(result).toMatchObject({
+      vin: VALID_VIN,
+      checksumValid: true,
+      matches: 2,
+      requiredMatches: 2,
+    });
+  });
+
+  it("requires three matching frames when a global VIN does not use the check digit", () => {
+    const vinWithoutMatchingCheckDigit = "1HGCM82643A004352";
+
+    expect(
+      chooseStableVin([
+        vinWithoutMatchingCheckDigit,
+        vinWithoutMatchingCheckDigit,
+      ]),
+    ).toBeNull();
+
+    expect(
+      chooseStableVin([
+        vinWithoutMatchingCheckDigit,
+        vinWithoutMatchingCheckDigit,
+        vinWithoutMatchingCheckDigit,
+      ]),
+    ).toMatchObject({
+      vin: vinWithoutMatchingCheckDigit,
+      checksumValid: false,
+      matches: 3,
+      requiredMatches: 3,
+    });
+  });
+
+  it("provides a local year and common make without a network request", () => {
+    expect(decodeVinLocally(VALID_VIN)).toMatchObject({
+      vin: VALID_VIN,
+      year: "2003",
+      make: "Honda",
+      manufacturer: "Honda",
+      country: "United States",
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- replaces the VIN modal's scanner pane with a local-first vehicle intake scanner
- uses repeated-frame consensus and VIN check-digit scoring before accepting a scan
- uses native `BarcodeDetector` when available and the existing Quagga2 dependency as the on-device fallback
- supports live camera capture, driver-door label photo capture, torch control, automatic completion, and haptic confirmation
- keeps the existing manual VIN entry and online vPIC decode behavior intact
- fills scanned VIN/year/common make immediately, then enriches vehicle details and recalls in the background when online
- adds focused tests for VIN extraction, checksum validation, frame consensus, and local decoding

## Why

The existing scan path depended on browser barcode support or server-side image OCR, accepted the first structurally valid result, and waited for network decoding before completing. The new path makes scanning fast and usable without a third-party scan/OCR API while preserving manual entry as the reliable fallback.

## Validation

- added `tests/vin-intake-scan.test.ts`
- repository CI should run typecheck, lint, and test coverage on this draft PR

## Manual QA

1. Open desktop or mobile work-order creation.
2. Select **Add by VIN / Scan**.
3. Aim at a Code 39/128 VIN barcode on a driver-door label.
4. Confirm the modal closes automatically and VIN/year/make populate immediately.
5. Confirm model/engine details populate shortly afterward when online.
6. Disable network and repeat; VIN/local fields should still populate.
7. Confirm manual VIN entry still waits for normal decode and fills the existing form exactly as before.