### PR TITLE
Remove shop create-flow quick intake

### DIFF
--- a/app/work-orders/create/page.tsx
+++ b/app/work-orders/create/page.tsx
@@ -1,11 +1,11 @@
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-import CreateWorkOrderPage from "@/features/work-orders/app/work-orders/create/page";
+import ShopCreateWorkOrderPage from "@/features/work-orders/app/work-orders/create/ShopCreateWorkOrderPage";
 import { ROLE_GROUPS } from "@/features/shared/lib/rbac";
 import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
 
 export default async function GuardedCreateWorkOrderPage() {
   await requireShopPageAccess({ allowRoles: ROLE_GROUPS.workOrderCreators });
-  return <CreateWorkOrderPage />;
+  return <ShopCreateWorkOrderPage />;
 }

--- a/features/work-orders/app/work-orders/create/ShopCreateWorkOrderPage.tsx
+++ b/features/work-orders/app/work-orders/create/ShopCreateWorkOrderPage.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+
+import CreateWorkOrderPage from "./page";
+
+const LEGACY_QUICK_INTAKE_DISMISS_KEY = "pfq.create.intake.dismiss.v1";
+
+/**
+ * Shop work-order creation intentionally skips the legacy post-save intake modal.
+ * Portal appointment intake remains available through its dedicated portal route.
+ */
+export default function ShopCreateWorkOrderPage() {
+  useState(() => {
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.setItem(LEGACY_QUICK_INTAKE_DISMISS_KEY, "1");
+      } catch {
+        // Storage can be unavailable in private/restricted browser contexts.
+      }
+    }
+    return true;
+  });
+
+  return <CreateWorkOrderPage />;
+}

--- a/tests/shop-create-quick-intake-removal.test.ts
+++ b/tests/shop-create-quick-intake-removal.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const shopCreateRoute = readFileSync("app/work-orders/create/page.tsx", "utf8");
+const shopCreateWrapper = readFileSync(
+  "features/work-orders/app/work-orders/create/ShopCreateWorkOrderPage.tsx",
+  "utf8",
+);
+const portalIntakeRoute = readFileSync(
+  "app/portal/work-orders/[id]/intake/page.tsx",
+  "utf8",
+);
+
+describe("shop create quick intake removal", () => {
+  it("routes shop work-order creation through the no-intake wrapper", () => {
+    expect(shopCreateRoute).toContain("ShopCreateWorkOrderPage");
+    expect(shopCreateRoute).not.toContain(
+      'import CreateWorkOrderPage from "@/features/work-orders/app/work-orders/create/page"',
+    );
+  });
+
+  it("suppresses the legacy post-save quick-intake trigger", () => {
+    expect(shopCreateWrapper).toContain("pfq.create.intake.dismiss.v1");
+    expect(shopCreateWrapper).toContain("localStorage.setItem");
+    expect(shopCreateWrapper).toContain("<CreateWorkOrderPage />");
+  });
+
+  it("keeps portal appointment intake available", () => {
+    expect(portalIntakeRoute).toContain('mode="portal"');
+  });
+});


### PR DESCRIPTION
## Summary

Removes the legacy post-save quick-intake prompt from the guarded shop work-order creation route.

## What changed

- routes `/work-orders/create` through a shop-specific wrapper
- suppresses the legacy `pfq.create.intake.dismiss.v1` post-save intake trigger before the create page mounts
- keeps the existing customer/vehicle form, VIN scan entry point, work-order creation, maintenance suggestions, menu jobs, manual lines, and approval handoff unchanged
- keeps the dedicated portal work-order intake route available
- adds regression coverage proving the shop route no longer renders the raw create page directly and portal intake remains intact

## Why

Shop staff need the fast create-work-order flow without a questionnaire appearing after save. Diagnostic detail collection should remain conditional in the portal appointment experience rather than interrupting internal work-order creation.

## Scope

- no database changes
- no API changes
- no portal intake changes
- no mobile work-order create changes
- no scanner changes

## Manual QA

1. Open shop **Create Work Order**.
2. Create a new work order.
3. Confirm no quick-intake modal appears after the customer/vehicle/work order is saved.
4. Confirm the user continues directly to the normal approval flow.
5. Open a portal work order and confirm **Complete intake** remains available there.