### PR TITLE
Repair VIN label capture with printed-text fallback

### DIFF
--- a/app/api/vin/extract-from-image/route.ts
+++ b/app/api/vin/extract-from-image/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
-import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+
+import { pickBestOcrVin } from "@/features/shared/lib/vin/vinCapture";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
 
-const openai = getOpenAIClient();
+export const runtime = "nodejs";
 
+const openai = getOpenAIClient();
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = new Set([
   "image/jpeg",
@@ -15,41 +17,10 @@ const ALLOWED_IMAGE_TYPES = new Set([
   "image/heif",
 ]);
 
-function findVinLike(text: string): string | null {
-  const direct = normalizeVinInput(text);
-  if (direct.isValid) return direct.vin;
-
-  const candidates = text
-    .toUpperCase()
-    .match(/[A-Z0-9][A-Z0-9\s\-_.:/\\|]{15,}[A-Z0-9]/g);
-
-  for (const candidate of candidates ?? []) {
-    const normalized = normalizeVinInput(candidate);
-    if (normalized.isValid) return normalized.vin;
-  }
-
-  return null;
-}
-
 export async function POST(req: NextRequest) {
   try {
-    const supabase = await createServerSupabaseRSC();
-    const { data: userData, error: userError } = await supabase.auth.getUser();
-    const userId = userData.user?.id ?? null;
-
-    if (userError || !userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const { data: profile, error: profileError } = await supabase
-      .from("profiles")
-      .select("shop_id")
-      .eq("id", userId)
-      .maybeSingle();
-
-    if (profileError || !profile?.shop_id) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const access = await requireShopScopedApiAccess();
+    if (!access.ok) return access.response;
 
     const formData = await req.formData();
     const file = formData.get("image") as File | null;
@@ -74,23 +45,23 @@ export async function POST(req: NextRequest) {
 
     const bytes = Buffer.from(await file.arrayBuffer());
     const base64 = bytes.toString("base64");
-    const dataUrl = "data:" + file.type + ";base64," + base64;
+    const dataUrl = `data:${file.type};base64,${base64}`;
 
     const completion = await openai.chat.completions.create({
       model: getOpenAIModelForPurpose("vision"),
-      max_tokens: 50,
+      max_tokens: 80,
       messages: [
         {
           role: "system",
           content:
-            "You extract VINs from vehicle photos. A VIN is exactly 17 characters, using digits and capital letters except I, O, Q. If you cannot confidently see a VIN, respond with ONLY the word NONE.",
+            "Read the human-readable VIN printed on a vehicle compliance label. Prefer the 17-character text next to VIN: and do not try to describe or decode the barcode. A VIN uses digits and capital letters except I, O, and Q. Reply with only the VIN. If no complete VIN is confidently readable, reply with only NONE.",
         },
         {
           role: "user",
           content: [
             {
               type: "text",
-              text: "Read the VIN from this image. Reply ONLY with the VIN or NONE.",
+              text: "Extract the complete printed VIN from this vehicle label. Reply only with the VIN or NONE.",
             },
             {
               type: "image_url",
@@ -107,16 +78,26 @@ export async function POST(req: NextRequest) {
       completion.choices[0]?.message?.content?.toString().trim() ?? "";
 
     if (!raw || raw.toUpperCase() === "NONE") {
-      return NextResponse.json({ vin: null });
+      return NextResponse.json({ vin: null, confidence: "none" });
     }
 
-    const vin = findVinLike(raw);
-    return NextResponse.json({ vin: vin ?? null });
+    const candidate = pickBestOcrVin(raw);
+    if (!candidate) {
+      return NextResponse.json({ vin: null, confidence: "none" });
+    }
+
+    return NextResponse.json({
+      vin: candidate.vin,
+      checksumValid: candidate.checksumValid,
+      confidence: candidate.checksumValid
+        ? "checksum_confirmed"
+        : "exact_text",
+    });
   } catch (err) {
     console.error("VIN extract error", err);
     return NextResponse.json(
       { error: "Failed to extract VIN from image" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/vehicle/VinCaptureModal.tsx
+++ b/app/vehicle/VinCaptureModal.tsx
@@ -245,8 +245,6 @@ export default function VinCaptureModal({
         manufacturer: local?.manufacturer ?? null,
       };
 
-      // Scanning is local-first: the VIN and known fields land immediately and
-      // the camera modal closes without waiting for network enrichment.
       applyDecodedVehicle(normalized.vin, localDecoded);
       setOpen(false);
 
@@ -299,7 +297,6 @@ export default function VinCaptureModal({
           scanSlot={
             <VehicleIntakeScanner
               onFoundVin={handleScannedVin}
-              onError={setCaptureError}
               isBusy={isDecoding}
             />
           }

--- a/features/shared/lib/vin/vinCapture.ts
+++ b/features/shared/lib/vin/vinCapture.ts
@@ -28,10 +28,37 @@ const VIN_TRANSLITERATION: Readonly<Record<string, number>> = {
   Z: 9,
 };
 
+const OCR_CHARACTER_OPTIONS: Readonly<Record<string, readonly string[]>> = {
+  O: ["0"],
+  Q: ["0"],
+  I: ["1"],
+  B: ["B", "8"],
+  "8": ["8", "B"],
+  G: ["G", "6"],
+  "6": ["6", "G"],
+  S: ["S", "5"],
+  "5": ["5", "S"],
+  Z: ["Z", "2"],
+  "2": ["2", "Z"],
+  L: ["L", "1"],
+  "1": ["1", "L"],
+  D: ["D", "0"],
+  "0": ["0", "D"],
+};
+
+const MAX_OCR_CORRECTIONS = 4;
+const MAX_OCR_VARIANTS = 128;
+const MAX_OCR_WINDOWS = 160;
+
 export type VinCaptureCandidate = {
   vin: string;
   checksumValid: boolean;
   score: number;
+};
+
+export type OcrVinCandidate = VinCaptureCandidate & {
+  corrections: number;
+  contextBoost: number;
 };
 
 export type StableVinResult = VinCaptureCandidate & {
@@ -109,6 +136,149 @@ export function extractVinCandidates(input: unknown): VinCaptureCandidate[] {
   return [...candidates.values()].sort(
     (left, right) => right.score - left.score || left.vin.localeCompare(right.vin),
   );
+}
+
+function addOcrWindows(
+  output: Array<{ value: string; contextBoost: number }>,
+  compact: string,
+  contextBoost: number,
+) {
+  if (output.length >= MAX_OCR_WINDOWS) return;
+  if (compact.length < 17) return;
+
+  if (compact.length === 17) {
+    output.push({ value: compact, contextBoost });
+    return;
+  }
+
+  const remaining = MAX_OCR_WINDOWS - output.length;
+  const windowCount = Math.min(compact.length - 16, remaining);
+  for (let index = 0; index < windowCount; index += 1) {
+    output.push({ value: compact.slice(index, index + 17), contextBoost });
+  }
+}
+
+function collectOcrWindows(input: unknown): Array<{ value: string; contextBoost: number }> {
+  const raw = String(input ?? "").trim().toUpperCase().slice(0, 2_048);
+  if (!raw) return [];
+
+  const windows: Array<{ value: string; contextBoost: number }> = [];
+  const chunks = [raw, ...raw.split(/\r?\n/)].filter(Boolean);
+
+  for (const chunk of chunks) {
+    if (windows.length >= MAX_OCR_WINDOWS) break;
+
+    const hasVinContext = /\bVIN\b|VEHICLE\s+IDENTIFICATION/.test(chunk);
+    const contextBoost = hasVinContext ? 35 : 0;
+    const compact = chunk.replace(/[^A-Z0-9]/g, "");
+
+    addOcrWindows(windows, compact, contextBoost);
+
+    const withoutVinLabel = compact.replace(/^VIN/, "");
+    if (withoutVinLabel !== compact) {
+      addOcrWindows(windows, withoutVinLabel, contextBoost + 15);
+    }
+
+    const tokenMatches = chunk.match(/[A-Z0-9][A-Z0-9\s\-_.:/\\|]{15,34}[A-Z0-9]/g) ?? [];
+    for (const token of tokenMatches) {
+      if (windows.length >= MAX_OCR_WINDOWS) break;
+      addOcrWindows(
+        windows,
+        token.replace(/[^A-Z0-9]/g, ""),
+        contextBoost,
+      );
+    }
+  }
+
+  const unique = new Map<string, { value: string; contextBoost: number }>();
+  for (const entry of windows) {
+    const existing = unique.get(entry.value);
+    if (!existing || entry.contextBoost > existing.contextBoost) {
+      unique.set(entry.value, entry);
+    }
+  }
+  return [...unique.values()];
+}
+
+function buildOcrVariants(value: string): Array<{ value: string; corrections: number }> {
+  let states: Array<{ value: string; corrections: number }> = [
+    { value: "", corrections: 0 },
+  ];
+
+  for (const character of value) {
+    const options = OCR_CHARACTER_OPTIONS[character] ?? [character];
+    const next = new Map<string, number>();
+
+    for (const state of states) {
+      for (const option of options) {
+        const corrections = state.corrections + (option === character ? 0 : 1);
+        if (corrections > MAX_OCR_CORRECTIONS) continue;
+
+        const candidate = `${state.value}${option}`;
+        const prior = next.get(candidate);
+        if (prior === undefined || corrections < prior) {
+          next.set(candidate, corrections);
+        }
+      }
+    }
+
+    states = [...next.entries()]
+      .map(([candidate, corrections]) => ({ value: candidate, corrections }))
+      .sort(
+        (left, right) =>
+          left.corrections - right.corrections || left.value.localeCompare(right.value),
+      )
+      .slice(0, MAX_OCR_VARIANTS);
+  }
+
+  return states;
+}
+
+export function extractVinCandidatesFromOcr(input: unknown): OcrVinCandidate[] {
+  const candidates = new Map<string, OcrVinCandidate>();
+
+  for (const window of collectOcrWindows(input)) {
+    for (const variant of buildOcrVariants(window.value)) {
+      const normalized = normalizeVinInput(variant.value);
+      if (!normalized.isValid) continue;
+
+      const checksumValid = hasValidVinChecksum(normalized.vin);
+      const score =
+        (checksumValid ? 250 : 0) +
+        window.contextBoost +
+        40 -
+        variant.corrections * 12;
+      const current = candidates.get(normalized.vin);
+
+      if (!current || score > current.score) {
+        candidates.set(normalized.vin, {
+          vin: normalized.vin,
+          checksumValid,
+          score,
+          corrections: variant.corrections,
+          contextBoost: window.contextBoost,
+        });
+      }
+    }
+  }
+
+  return [...candidates.values()].sort(
+    (left, right) =>
+      Number(right.checksumValid) - Number(left.checksumValid) ||
+      right.score - left.score ||
+      left.corrections - right.corrections ||
+      left.vin.localeCompare(right.vin),
+  );
+}
+
+export function pickBestOcrVin(input: unknown): OcrVinCandidate | null {
+  const candidates = extractVinCandidatesFromOcr(input);
+  const checksumConfirmed = candidates.find((candidate) => candidate.checksumValid);
+  if (checksumConfirmed) return checksumConfirmed;
+
+  // Never invent a non-checksummed VIN through character substitution. Exact OCR
+  // output remains available for markets where position nine is not a check digit.
+  return candidates.find((candidate) => candidate.corrections === 0) ?? null;
 }
 
 export function chooseStableVin(

--- a/features/vehicles/components/VehicleIntakeScanner.tsx
+++ b/features/vehicles/components/VehicleIntakeScanner.tsx
@@ -40,7 +40,6 @@ type CameraCapabilities = MediaTrackCapabilities & {
 
 type Props = {
   onFoundVin: (vin: string) => void;
-  onError: (message: string) => void;
   isBusy: boolean;
 };
 
@@ -52,10 +51,22 @@ type QuaggaPass = {
   readers: string[];
 };
 
+type VinImageResponse = {
+  vin?: string | null;
+  error?: string;
+};
+
 const OBSERVATION_WINDOW_MS = 2_400;
 const LOCAL_SCAN_INTERVAL_MS = 280;
 const QUAGGA_INTERVAL_MS = 900;
 const QUAGGA_PASS_TIMEOUT_MS = 4_000;
+const IMAGE_READ_TIMEOUT_MS = 25_000;
+
+const VIN_READERS = [
+  "code_39_vin_reader",
+  "code_39_reader",
+  "code_128_reader",
+] as const;
 
 const LIVE_QUAGGA_PASSES: readonly QuaggaPass[] = [
   {
@@ -63,14 +74,14 @@ const LIVE_QUAGGA_PASSES: readonly QuaggaPass[] = [
     halfSample: false,
     patchSize: "small",
     inputSize: 0,
-    readers: ["code_39_vin_reader", "code_39_reader", "code_128_reader"],
+    readers: [...VIN_READERS],
   },
   {
     locate: true,
     halfSample: false,
     patchSize: "small",
     inputSize: 0,
-    readers: ["code_39_vin_reader", "code_39_reader", "code_128_reader"],
+    readers: [...VIN_READERS],
   },
 ];
 
@@ -80,21 +91,21 @@ const PHOTO_QUAGGA_PASSES: readonly QuaggaPass[] = [
     halfSample: false,
     patchSize: "x-small",
     inputSize: 0,
-    readers: ["code_39_vin_reader", "code_39_reader", "code_128_reader"],
+    readers: [...VIN_READERS],
   },
   {
     locate: true,
     halfSample: true,
     patchSize: "small",
     inputSize: 1600,
-    readers: ["code_39_vin_reader", "code_39_reader", "code_128_reader"],
+    readers: [...VIN_READERS],
   },
   {
     locate: false,
     halfSample: false,
     patchSize: "small",
     inputSize: 0,
-    readers: ["code_39_vin_reader", "code_39_reader", "code_128_reader"],
+    readers: [...VIN_READERS],
   },
 ];
 
@@ -124,8 +135,6 @@ function drawVideoRegion(video: HTMLVideoElement, canvas: HTMLCanvasElement) {
   const sourceHeight = video.videoHeight;
   if (!sourceWidth || !sourceHeight) return false;
 
-  // Keep the crop aligned with the visible guide, but retain enough vertical area
-  // for labels that are slightly above or below center on a handheld phone.
   const cropWidth = Math.round(sourceWidth * 0.94);
   const cropHeight = Math.round(sourceHeight * 0.52);
   const sourceX = Math.round((sourceWidth - cropWidth) / 2);
@@ -153,6 +162,84 @@ function drawVideoRegion(video: HTMLVideoElement, canvas: HTMLCanvasElement) {
     outputHeight,
   );
   return true;
+}
+
+function drawFullVideoFrame(video: HTMLVideoElement, canvas: HTMLCanvasElement) {
+  const sourceWidth = video.videoWidth;
+  const sourceHeight = video.videoHeight;
+  if (!sourceWidth || !sourceHeight) return false;
+
+  const maxDimension = 2400;
+  const scale = Math.min(
+    1,
+    maxDimension / Math.max(sourceWidth, sourceHeight),
+  );
+  canvas.width = Math.max(1, Math.round(sourceWidth * scale));
+  canvas.height = Math.max(1, Math.round(sourceHeight * scale));
+
+  const context = canvas.getContext("2d", { willReadFrequently: true });
+  if (!context) return false;
+  context.drawImage(video, 0, 0, canvas.width, canvas.height);
+  return true;
+}
+
+async function drawImageFile(file: File, canvas: HTMLCanvasElement) {
+  if (typeof createImageBitmap === "function") {
+    const bitmap = await createImageBitmap(file);
+    try {
+      const maxDimension = 2400;
+      const scale = Math.min(
+        1,
+        maxDimension / Math.max(bitmap.width, bitmap.height),
+      );
+      canvas.width = Math.max(1, Math.round(bitmap.width * scale));
+      canvas.height = Math.max(1, Math.round(bitmap.height * scale));
+      const context = canvas.getContext("2d", { willReadFrequently: true });
+      if (!context) throw new Error("Canvas unavailable");
+      context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+      return;
+    } finally {
+      bitmap.close();
+    }
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const image = new Image();
+    image.src = objectUrl;
+    await image.decode();
+    const maxDimension = 2400;
+    const scale = Math.min(
+      1,
+      maxDimension / Math.max(image.naturalWidth, image.naturalHeight),
+    );
+    canvas.width = Math.max(1, Math.round(image.naturalWidth * scale));
+    canvas.height = Math.max(1, Math.round(image.naturalHeight * scale));
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    if (!context) throw new Error("Canvas unavailable");
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function canvasToJpegFile(
+  canvas: HTMLCanvasElement,
+  fileName: string,
+): Promise<File> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("Could not prepare VIN label image."));
+          return;
+        }
+        resolve(new File([blob], fileName, { type: "image/jpeg" }));
+      },
+      "image/jpeg",
+      0.9,
+    );
+  });
 }
 
 async function decodeQuaggaPass(
@@ -217,49 +304,62 @@ async function decodeCanvasWithQuagga(
   return null;
 }
 
-async function drawImageFile(file: File, canvas: HTMLCanvasElement) {
-  if (typeof createImageBitmap === "function") {
-    const bitmap = await createImageBitmap(file);
-    try {
-      const maxDimension = 2400;
-      const scale = Math.min(
-        1,
-        maxDimension / Math.max(bitmap.width, bitmap.height),
-      );
-      canvas.width = Math.max(1, Math.round(bitmap.width * scale));
-      canvas.height = Math.max(1, Math.round(bitmap.height * scale));
-      const context = canvas.getContext("2d", { willReadFrequently: true });
-      if (!context) throw new Error("Canvas unavailable");
-      context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
-      return;
-    } finally {
-      bitmap.close();
-    }
-  }
+async function detectBarcodeOnCanvas(
+  canvas: HTMLCanvasElement,
+): Promise<string | null> {
+  const Detector = getBarcodeDetector();
+  if (!Detector) return null;
 
-  const objectUrl = URL.createObjectURL(file);
   try {
-    const image = new Image();
-    image.src = objectUrl;
-    await image.decode();
-    const maxDimension = 2400;
-    const scale = Math.min(
-      1,
-      maxDimension / Math.max(image.naturalWidth, image.naturalHeight),
+    const detector = new Detector({
+      formats: ["code_39", "code_128", "pdf417", "data_matrix"],
+    });
+    const results = await detector.detect(canvas);
+    return (
+      results.find(
+        (result) =>
+          result.rawValue && extractVinCandidates(result.rawValue).length > 0,
+      )?.rawValue?.trim() ?? null
     );
-    canvas.width = Math.max(1, Math.round(image.naturalWidth * scale));
-    canvas.height = Math.max(1, Math.round(image.naturalHeight * scale));
-    const context = canvas.getContext("2d", { willReadFrequently: true });
-    if (!context) throw new Error("Canvas unavailable");
-    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+  } catch {
+    return null;
+  }
+}
+
+async function readPrintedVin(file: File): Promise<string | null> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(
+    () => controller.abort(),
+    IMAGE_READ_TIMEOUT_MS,
+  );
+
+  try {
+    const formData = new FormData();
+    formData.append("image", file, file.name);
+
+    const response = await fetch("/api/vin/extract-from-image", {
+      method: "POST",
+      body: formData,
+      signal: controller.signal,
+    });
+    const body = (await response.json().catch(() => null)) as
+      | VinImageResponse
+      | null;
+
+    if (!response.ok) {
+      throw new Error(body?.error || "Printed VIN reading failed.");
+    }
+
+    return typeof body?.vin === "string" && body.vin.trim()
+      ? body.vin.trim()
+      : null;
   } finally {
-    URL.revokeObjectURL(objectUrl);
+    window.clearTimeout(timeoutId);
   }
 }
 
 export default function VehicleIntakeScanner({
   onFoundVin,
-  onError,
   isBusy,
 }: Props) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -267,11 +367,12 @@ export default function VehicleIntakeScanner({
   const streamRef = useRef<MediaStream | null>(null);
   const observationsRef = useRef<Observation[]>([]);
   const scanInFlightRef = useRef(false);
+  const stillCaptureInFlightRef = useRef(false);
   const lockedRef = useRef(false);
   const lastQuaggaAtRef = useRef(0);
   const lastCandidateAtRef = useRef(0);
   const onFoundVinRef = useRef(onFoundVin);
-  const onErrorRef = useRef(onError);
+  const isBusyRef = useRef(isBusy);
 
   const [status, setStatus] = useState("Starting camera…");
   const [cameraReady, setCameraReady] = useState(false);
@@ -279,14 +380,15 @@ export default function VehicleIntakeScanner({
   const [torchAvailable, setTorchAvailable] = useState(false);
   const [torchOn, setTorchOn] = useState(false);
   const [photoBusy, setPhotoBusy] = useState(false);
+  const [captureBusy, setCaptureBusy] = useState(false);
 
   useEffect(() => {
     onFoundVinRef.current = onFoundVin;
   }, [onFoundVin]);
 
   useEffect(() => {
-    onErrorRef.current = onError;
-  }, [onError]);
+    isBusyRef.current = isBusy;
+  }, [isBusy]);
 
   const acceptObservation = useCallback((raw: string) => {
     if (lockedRef.current) return false;
@@ -322,7 +424,7 @@ export default function VehicleIntakeScanner({
     return true;
   }, []);
 
-  const acceptPhotoObservation = useCallback(
+  const acceptConfirmedObservation = useCallback(
     (raw: string) => {
       const now = Date.now();
       observationsRef.current.push(
@@ -332,6 +434,26 @@ export default function VehicleIntakeScanner({
       return acceptObservation(raw);
     },
     [acceptObservation],
+  );
+
+  const decodeStillCanvas = useCallback(
+    async (canvas: HTMLCanvasElement, fileName: string) => {
+      const nativeDecoded = await detectBarcodeOnCanvas(canvas);
+      if (nativeDecoded && acceptConfirmedObservation(nativeDecoded)) return true;
+
+      const quaggaDecoded = await decodeCanvasWithQuagga(canvas, "photo");
+      if (quaggaDecoded && acceptConfirmedObservation(quaggaDecoded)) return true;
+
+      if (typeof navigator !== "undefined" && !navigator.onLine) return false;
+
+      setStatus("Reading printed VIN…");
+      const jpegFile = await canvasToJpegFile(canvas, fileName);
+      const printedVin = await readPrintedVin(jpegFile);
+      if (printedVin && acceptConfirmedObservation(printedVin)) return true;
+
+      return false;
+    },
+    [acceptConfirmedObservation],
   );
 
   useEffect(() => {
@@ -382,20 +504,19 @@ export default function VehicleIntakeScanner({
           }
         }
 
-        // Warm the local fallback while the user positions the camera. This avoids
-        // making the first iOS scan wait for the dynamic import.
         void loadQuagga().catch(() => null);
 
         setCameraReady(true);
         setCameraError(null);
-        setStatus("Center the VIN barcode in the guide");
+        setStatus("Center the printed VIN and barcode in the guide");
 
         intervalId = window.setInterval(async () => {
           if (
             cancelled ||
             lockedRef.current ||
             scanInFlightRef.current ||
-            isBusy ||
+            stillCaptureInFlightRef.current ||
+            isBusyRef.current ||
             video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA
           ) {
             return;
@@ -435,7 +556,7 @@ export default function VehicleIntakeScanner({
             }
 
             if (now - lastCandidateAtRef.current > 1_800) {
-              setStatus("Center the VIN barcode in the guide");
+              setStatus("Center the printed VIN and barcode in the guide");
             }
           } catch {
             // Individual frame failures are expected while the camera moves.
@@ -447,10 +568,9 @@ export default function VehicleIntakeScanner({
         const message =
           error instanceof Error && error.message
             ? error.message
-            : "Camera unavailable. Upload a VIN-label photo or enter the VIN manually.";
+            : "Camera unavailable. Choose a VIN-label photo or enter the VIN manually.";
         setCameraError(message);
         setStatus("Camera unavailable");
-        onErrorRef.current(message);
       }
     };
 
@@ -462,8 +582,9 @@ export default function VehicleIntakeScanner({
       streamRef.current?.getTracks().forEach((track) => track.stop());
       streamRef.current = null;
       scanInFlightRef.current = false;
+      stillCaptureInFlightRef.current = false;
     };
-  }, [acceptObservation, isBusy]);
+  }, [acceptObservation]);
 
   const toggleTorch = useCallback(async () => {
     const track = streamRef.current?.getVideoTracks()[0];
@@ -480,59 +601,100 @@ export default function VehicleIntakeScanner({
     }
   }, [torchAvailable, torchOn]);
 
+  const handleLiveCapture = useCallback(async () => {
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    if (
+      !video ||
+      !canvas ||
+      !cameraReady ||
+      stillCaptureInFlightRef.current ||
+      isBusyRef.current
+    ) {
+      return;
+    }
+
+    stillCaptureInFlightRef.current = true;
+    setCaptureBusy(true);
+    setCameraError(null);
+    setStatus("Capturing VIN label…");
+
+    try {
+      if (!drawFullVideoFrame(video, canvas)) {
+        throw new Error("The camera frame is not ready yet.");
+      }
+
+      const found = await decodeStillCanvas(canvas, "vin-label-camera.jpg");
+      if (found) return;
+
+      const message = navigator.onLine
+        ? "No complete VIN was found. Move closer so the printed VIN is sharp and fully visible, then capture again."
+        : "No VIN barcode was found while offline. Connect to the internet for printed-VIN reading or enter it manually.";
+      setCameraError(message);
+      setStatus("VIN not found");
+    } catch (error) {
+      const message =
+        error instanceof Error && error.name === "AbortError"
+          ? "VIN reading timed out. Capture the label again or enter the VIN manually."
+          : error instanceof Error && error.message
+            ? error.message
+            : "The VIN label could not be read. Capture it again or enter the VIN manually.";
+      setCameraError(message);
+      setStatus("VIN label could not be read");
+    } finally {
+      stillCaptureInFlightRef.current = false;
+      setCaptureBusy(false);
+    }
+  }, [cameraReady, decodeStillCanvas]);
+
   const handlePhoto = useCallback(
     async (file: File | null) => {
-      if (!file || !canvasRef.current || photoBusy || isBusy) return;
+      if (
+        !file ||
+        !canvasRef.current ||
+        photoBusy ||
+        stillCaptureInFlightRef.current ||
+        isBusyRef.current
+      ) {
+        return;
+      }
+
+      stillCaptureInFlightRef.current = true;
       setPhotoBusy(true);
       setCameraError(null);
       setStatus("Reading VIN label photo…");
 
       try {
         await drawImageFile(file, canvasRef.current);
-
-        const Detector = getBarcodeDetector();
-        if (Detector) {
-          try {
-            const detector = new Detector({
-              formats: ["code_39", "code_128", "pdf417", "data_matrix"],
-            });
-            const results = await detector.detect(canvasRef.current);
-            for (const result of results) {
-              if (
-                result.rawValue &&
-                acceptPhotoObservation(result.rawValue)
-              ) {
-                return;
-              }
-            }
-          } catch {
-            // Quagga remains available as the local fallback.
-          }
-        }
-
-        const decoded = await decodeCanvasWithQuagga(
+        const found = await decodeStillCanvas(
           canvasRef.current,
-          "photo",
+          "vin-label-photo.jpg",
         );
-        if (decoded && acceptPhotoObservation(decoded)) return;
+        if (found) return;
 
-        const message =
-          "No VIN barcode was found in that photo. Fill the frame with the barcode, keep the label level, or enter the printed VIN manually.";
+        const message = navigator.onLine
+          ? "No complete VIN was found in that photo. Retake it closer and keep the full printed VIN sharp and visible."
+          : "No VIN barcode was found while offline. Connect to the internet for printed-VIN reading or enter it manually.";
         setCameraError(message);
-        setStatus("VIN barcode not found");
-        onErrorRef.current(message);
-      } catch {
+        setStatus("VIN not found");
+      } catch (error) {
         const message =
-          "That photo could not be read locally. Retake the VIN-label photo or enter the VIN manually.";
+          error instanceof Error && error.name === "AbortError"
+            ? "VIN reading timed out. Retake the label photo or enter the VIN manually."
+            : error instanceof Error && error.message
+              ? error.message
+              : "That photo could not be read. Retake the VIN-label photo or enter the VIN manually.";
         setCameraError(message);
         setStatus("Photo could not be read");
-        onErrorRef.current(message);
       } finally {
+        stillCaptureInFlightRef.current = false;
         setPhotoBusy(false);
       }
     },
-    [acceptPhotoObservation, isBusy, photoBusy],
+    [decodeStillCanvas, photoBusy],
   );
+
+  const scannerBusy = isBusy || photoBusy || captureBusy;
 
   return (
     <div className="space-y-3">
@@ -546,7 +708,7 @@ export default function VehicleIntakeScanner({
         />
 
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-5">
-          <div className="relative h-[42%] w-[94%] rounded-xl border-2 border-white/80 shadow-[0_0_0_999px_rgba(0,0,0,0.34)]">
+          <div className="relative h-[52%] w-[94%] rounded-xl border-2 border-white/80 shadow-[0_0_0_999px_rgba(0,0,0,0.34)]">
             <span className="absolute -left-0.5 -top-0.5 h-5 w-5 rounded-tl-xl border-l-4 border-t-4 border-[var(--accent-copper-light)]" />
             <span className="absolute -right-0.5 -top-0.5 h-5 w-5 rounded-tr-xl border-r-4 border-t-4 border-[var(--accent-copper-light)]" />
             <span className="absolute -bottom-0.5 -left-0.5 h-5 w-5 rounded-bl-xl border-b-4 border-l-4 border-[var(--accent-copper-light)]" />
@@ -576,28 +738,39 @@ export default function VehicleIntakeScanner({
         </div>
       ) : null}
 
-      <label className="block cursor-pointer rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-center text-xs font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-subtle)]">
-        {photoBusy ? "Reading photo…" : "Use VIN-label photo"}
-        <input
-          type="file"
-          accept="image/*"
-          capture="environment"
-          disabled={photoBusy || isBusy}
-          className="sr-only"
-          onChange={(event) => {
-            const file = event.target.files?.[0] ?? null;
-            void handlePhoto(file);
-            event.target.value = "";
-          }}
-        />
-      </label>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <button
+          type="button"
+          disabled={!cameraReady || scannerBusy}
+          onClick={() => void handleLiveCapture()}
+          className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-3 text-center text-xs font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-overlay)] disabled:cursor-not-allowed disabled:opacity-55"
+        >
+          {captureBusy ? "Reading label…" : "Capture VIN label"}
+        </button>
+
+        <label className="block cursor-pointer rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-3 py-3 text-center text-xs font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-subtle)] has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-55">
+          {photoBusy ? "Reading photo…" : "Choose VIN-label photo"}
+          <input
+            type="file"
+            accept="image/*"
+            capture="environment"
+            disabled={scannerBusy}
+            className="sr-only"
+            onChange={(event) => {
+              const file = event.target.files?.[0] ?? null;
+              void handlePhoto(file);
+              event.target.value = "";
+            }}
+          />
+        </label>
+      </div>
 
       <div className="space-y-1 text-[11px] text-[color:var(--theme-text-muted)]">
         <p>
-          Runs on this device using the VIN barcode. No image or scan is sent to a third-party API.
+          Live barcode scanning stays on this device. Capture or choose the full label to read the printed VIN when the barcode is not supported.
         </p>
         <p>
-          Best target: fill the guide with the long barcode on the driver-door label and hold the phone level.
+          Best target: include both the printed 17-character VIN and the long barcode, keep the phone level, and move close enough for sharp text.
         </p>
         {!cameraReady && !cameraError ? <p>Requesting camera access…</p> : null}
       </div>

--- a/tests/vin-intake-scan.test.ts
+++ b/tests/vin-intake-scan.test.ts
@@ -7,15 +7,22 @@ import {
   chooseStableVin,
   extractVinCandidates,
   hasValidVinChecksum,
+  pickBestOcrVin,
 } from "@/features/shared/lib/vin/vinCapture";
 
 const VALID_VIN = "1HGCM82633A004352";
+const FORD_LABEL_VIN = "1FD0W5HT4FED33898";
 const scannerSource = readFileSync(
   "features/vehicles/components/VehicleIntakeScanner.tsx",
   "utf8",
 );
+const modalSource = readFileSync("app/vehicle/VinCaptureModal.tsx", "utf8");
+const imageRouteSource = readFileSync(
+  "app/api/vin/extract-from-image/route.ts",
+  "utf8",
+);
 
-describe("local VIN intake scan", () => {
+describe("VIN intake scan", () => {
   it("extracts a VIN from a prefixed barcode value", () => {
     const candidates = extractVinCandidates(`VIN:${VALID_VIN}`);
 
@@ -29,6 +36,21 @@ describe("local VIN intake scan", () => {
     expect(calculateVinCheckDigit(VALID_VIN)).toBe("3");
     expect(hasValidVinChecksum(VALID_VIN)).toBe(true);
     expect(hasValidVinChecksum("1HGCM82643A004352")).toBe(false);
+  });
+
+  it("corrects a printed Ford VIN when OCR reads O instead of zero", () => {
+    expect(pickBestOcrVin("VIN: 1FDOW5HT4FED33898")).toMatchObject({
+      vin: FORD_LABEL_VIN,
+      checksumValid: true,
+      corrections: 1,
+    });
+  });
+
+  it("extracts a spaced printed VIN from label text", () => {
+    expect(pickBestOcrVin("VIN 1FDO W5HT4 FED33898")).toMatchObject({
+      vin: FORD_LABEL_VIN,
+      checksumValid: true,
+    });
   });
 
   it("accepts checksum-confirmed VINs after two matching frames", () => {
@@ -84,8 +106,21 @@ describe("local VIN intake scan", () => {
     expect(scannerSource).toContain('mode: "live" | "photo"');
   });
 
-  it("keeps local scan images out of third-party extraction routes", () => {
-    expect(scannerSource).not.toContain("/api/vin/extract-from-image");
-    expect(scannerSource).not.toContain("FormData");
+  it("reads printed VIN text after local barcode decoding fails", () => {
+    expect(scannerSource).toContain('fetch("/api/vin/extract-from-image"');
+    expect(scannerSource).toContain("canvasToJpegFile");
+    expect(scannerSource).toContain("drawFullVideoFrame");
+    expect(scannerSource).toContain("Capture VIN label");
+    expect(scannerSource).toContain("Reading printed VIN");
+  });
+
+  it("uses shop-scoped access and checksum-aware OCR extraction", () => {
+    expect(imageRouteSource).toContain("requireShopScopedApiAccess");
+    expect(imageRouteSource).toContain("pickBestOcrVin");
+    expect(imageRouteSource).toContain("checksum_confirmed");
+  });
+
+  it("does not duplicate scanner errors in the parent modal", () => {
+    expect(modalSource).not.toContain("onError={setCaptureError}");
   });
 });


### PR DESCRIPTION
## Summary

Repairs the VIN scanner using the exact failure seen on the Ford compliance label: the printed 17-character VIN is clearly readable, but the manufacturer barcode is not decoded by the browser barcode stack.

## Root cause

The merged scanner only attempted native `BarcodeDetector` and Quagga. The **Use VIN-label photo** action did not perform printed-text extraction at all, even though ProFixIQ already had an authenticated image-reading route. Live capture also had no explicit still-frame action, so iPhone users were left waiting for an unsupported barcode to decode.

## Changes

- keeps native and Quagga VIN barcode scanning as the fast on-device path
- adds a prominent **Capture VIN label** action for the live camera
- converts live frames and selected photos to compressed JPEG before extraction, avoiding iPhone HEIC transport issues
- retries native and Quagga decoding against the still image first
- invokes the existing authenticated printed-VIN image route only after local barcode decoding fails
- updates the image route to use `requireShopScopedApiAccess`
- prompts vision extraction to read the human-readable VIN next to `VIN:` rather than the barcode
- adds checksum-aware OCR correction for common confusions such as `O` versus `0`
- validates against the exact Ford VIN from QA: `1FD0W5HT4FED33898`
- removes the duplicated scanner error banner from the parent modal
- keeps manual VIN entry, local immediate population, online vehicle enrichment, and recall lookup unchanged

## Privacy and behavior

- continuous live barcode scanning remains on-device
- an image is sent only after the user taps **Capture VIN label** or chooses a label photo and local barcode decoding cannot identify the VIN
- this flow does not save the captured image into vehicle media

## Manual QA

1. Open **Add by VIN / Scan** on iPhone.
2. Center both the printed VIN and barcode from the driver-door label.
3. Tap **Capture VIN label**.
4. Confirm `1FD0W5HT4FED33898` is detected and the modal closes.
5. Confirm VIN/year/make populate immediately and remaining vehicle details enrich afterward.
6. Repeat using **Choose VIN-label photo** with the previously supplied Ford label image.
7. Confirm a failed capture displays one local error message, not duplicate banners.
8. Confirm manual VIN entry remains unchanged.

## Validation

Focused regression coverage now verifies:

- VIN checksum behavior
- Ford-label `O` to `0` correction
- spaced printed VIN extraction
- VIN-specific iOS Quagga fallback
- printed-text endpoint invocation
- shop-scoped route access
- duplicate error-banner removal

No database migration or environment-variable change is required.