### PR TITLE
Fix portal work-order navigation and advisor messaging

### DIFF
--- a/app/api/chat/context-options/route.ts
+++ b/app/api/chat/context-options/route.ts
@@ -14,7 +14,12 @@ type ContextOption = {
   secondary: string | null;
 };
 
-export async function GET(): Promise<NextResponse> {
+type RecipientOption = {
+  id: string;
+  label: string;
+};
+
+export async function GET(req: Request): Promise<NextResponse> {
   const userClient = createServerSupabaseRoute();
   const {
     data: { user },
@@ -22,7 +27,15 @@ export async function GET(): Promise<NextResponse> {
   if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
   const admin = createAdminSupabase();
-  const actorResult = await resolveMessagingActor({ supabase: admin, actorUserId: user.id });
+  const preferredKind =
+    new URL(req.url).searchParams.get("actor") === "customer"
+      ? "customer"
+      : undefined;
+  const actorResult = await resolveMessagingActor({
+    supabase: admin,
+    actorUserId: user.id,
+    preferredKind,
+  });
   if (!actorResult.ok) {
     return NextResponse.json({ error: actorResult.error }, { status: actorResult.status });
   }
@@ -32,7 +45,12 @@ export async function GET(): Promise<NextResponse> {
 
   const customerId = actorResult.actor.customerId;
   const shopId = actorResult.actor.shopId;
-  const [{ data: workOrders, error: workOrderError }, { data: bookings, error: bookingError }, { data: vehicles, error: vehicleError }] =
+  const [
+    { data: workOrders, error: workOrderError },
+    { data: bookings, error: bookingError },
+    { data: vehicles, error: vehicleError },
+    { data: advisors, error: advisorError },
+  ] =
     await Promise.all([
       admin
         .from("work_orders")
@@ -55,9 +73,17 @@ export async function GET(): Promise<NextResponse> {
         .eq("customer_id", customerId)
         .order("created_at", { ascending: false })
         .limit(25),
+      admin
+        .from("profiles")
+        .select("id, user_id, full_name, email")
+        .eq("shop_id", shopId)
+        .eq("role", "advisor")
+        .order("full_name", { ascending: true })
+        .limit(50),
     ]);
 
-  const queryError = workOrderError ?? bookingError ?? vehicleError;
+  const queryError =
+    workOrderError ?? bookingError ?? vehicleError ?? advisorError;
   if (queryError) {
     return NextResponse.json({ error: queryError.message }, { status: 500 });
   }
@@ -85,5 +111,19 @@ export async function GET(): Promise<NextResponse> {
     })),
   ];
 
-  return NextResponse.json({ options });
+  const recipients: RecipientOption[] = (advisors ?? [])
+    .map((advisor) => ({
+      id: advisor.user_id ?? advisor.id,
+      label:
+        advisor.full_name?.trim() ||
+        advisor.email?.trim() ||
+        "Service advisor",
+    }))
+    .filter(
+      (advisor, index, rows) =>
+        Boolean(advisor.id) &&
+        rows.findIndex((candidate) => candidate.id === advisor.id) === index,
+    );
+
+  return NextResponse.json({ options, recipients });
 }

--- a/app/api/chat/my-conversations/route.ts
+++ b/app/api/chat/my-conversations/route.ts
@@ -54,7 +54,7 @@ function customerName(row: {
   );
 }
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(req: Request): Promise<NextResponse> {
   const userClient = createServerSupabaseRoute();
   const {
     data: { user },
@@ -63,7 +63,15 @@ export async function GET(): Promise<NextResponse> {
   if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
   const admin = createAdminSupabase();
-  const actorResult = await resolveMessagingActor({ supabase: admin, actorUserId: user.id });
+  const preferredKind =
+    new URL(req.url).searchParams.get("actor") === "customer"
+      ? "customer"
+      : undefined;
+  const actorResult = await resolveMessagingActor({
+    supabase: admin,
+    actorUserId: user.id,
+    preferredKind,
+  });
   if (!actorResult.ok) {
     return NextResponse.json({ error: actorResult.error }, { status: actorResult.status });
   }

--- a/app/api/chat/start-conversation/route.ts
+++ b/app/api/chat/start-conversation/route.ts
@@ -27,16 +27,20 @@ export async function POST(req: Request): Promise<NextResponse> {
     title?: string | null;
     is_broadcast?: boolean;
     request_id?: string;
+    actor_kind?: "customer";
   } | null;
 
   const admin = createAdminSupabase();
+  const requestedParticipantIds = body?.participant_ids ?? [];
 
   const createAccess = await authorizeConversationCreate({
     supabase: admin,
     actorUserId: user.id,
-    participantUserIds: body?.participant_ids ?? [],
+    participantUserIds: requestedParticipantIds,
     channel: body?.channel ?? "internal",
     customerId: body?.customer_id ?? null,
+    preferredActorKind:
+      body?.actor_kind === "customer" ? "customer" : undefined,
   });
 
   if (!createAccess.ok) {
@@ -78,7 +82,8 @@ export async function POST(req: Request): Promise<NextResponse> {
   if (
     createAccess.actor.kind === "customer" &&
     createAccess.customerId &&
-    context.anchors.work_order_id
+    context.anchors.work_order_id &&
+    requestedParticipantIds.length === 0
   ) {
     const { data: workOrder, error: workOrderError } = await admin
       .from("work_orders")

--- a/app/portal/work-orders/view/[id]/page.tsx
+++ b/app/portal/work-orders/view/[id]/page.tsx
@@ -339,7 +339,7 @@ export default async function PortalWorkOrderViewerPage({
           }
           lines={lines}
           parts={parts}
-          backHref="/portal/history"
+          backHref="/portal"
           title="Work order"
           subtitle="Read-only view (customer portal)."
           invoicePdfUrl={wo.invoice_pdf_url ?? null}

--- a/features/ai/lib/chat/authorization.ts
+++ b/features/ai/lib/chat/authorization.ts
@@ -44,18 +44,57 @@ type LifecycleAction = "delete" | "manage_participants" | "read_participants";
 export async function resolveMessagingActor({
   supabase,
   actorUserId,
+  preferredKind,
 }: {
   supabase: SupabaseClient<Database>;
   actorUserId: string;
+  preferredKind?: MessagingActor["kind"];
 }): Promise<{ ok: true; actor: MessagingActor } | AccessFailure> {
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("id, user_id, shop_id, role")
-    .or(`user_id.eq.${actorUserId},id.eq.${actorUserId}`)
-    .maybeSingle();
+  const [
+    { data: profile, error: profileError },
+    { data: customer, error: customerError },
+  ] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("id, user_id, shop_id, role")
+      .or(`user_id.eq.${actorUserId},id.eq.${actorUserId}`)
+      .maybeSingle(),
+    supabase
+      .from("customers")
+      .select("id, user_id, shop_id")
+      .eq("user_id", actorUserId)
+      .maybeSingle(),
+  ]);
 
-  if (profileError) {
-    return { ok: false, status: 500, error: profileError.message };
+  const actorError = profileError ?? customerError;
+  if (actorError) {
+    return { ok: false, status: 500, error: actorError.message };
+  }
+
+  const profileRole = (profile?.role ?? "").trim().toLowerCase();
+  if (
+    customer?.shop_id &&
+    (preferredKind === "customer" || profileRole === "customer")
+  ) {
+    return {
+      ok: true,
+      actor: {
+        kind: "customer",
+        userId: actorUserId,
+        customerId: customer.id,
+        shopId: customer.shop_id,
+        role: null,
+        profileId: null,
+      },
+    };
+  }
+
+  if (preferredKind === "customer") {
+    return {
+      ok: false,
+      status: 403,
+      error: "Messaging requires a customer record linked to this portal account",
+    };
   }
 
   if (profile?.shop_id) {
@@ -70,16 +109,6 @@ export async function resolveMessagingActor({
         customerId: null,
       },
     };
-  }
-
-  const { data: customer, error: customerError } = await supabase
-    .from("customers")
-    .select("id, user_id, shop_id")
-    .eq("user_id", actorUserId)
-    .maybeSingle();
-
-  if (customerError) {
-    return { ok: false, status: 500, error: customerError.message };
   }
 
   if (customer?.shop_id) {
@@ -233,12 +262,14 @@ export async function authorizeConversationCreate({
   participantUserIds,
   channel = "internal",
   customerId = null,
+  preferredActorKind,
 }: {
   supabase: SupabaseClient<Database>;
   actorUserId: string;
   participantUserIds: string[];
   channel?: MessagingChannel;
   customerId?: string | null;
+  preferredActorKind?: MessagingActor["kind"];
 }): Promise<
   | {
       ok: true;
@@ -251,7 +282,11 @@ export async function authorizeConversationCreate({
     }
   | AccessFailure
 > {
-  const actorResult = await resolveMessagingActor({ supabase, actorUserId });
+  const actorResult = await resolveMessagingActor({
+    supabase,
+    actorUserId,
+    preferredKind: preferredActorKind,
+  });
   if (!actorResult.ok) return actorResult;
 
   const actor = actorResult.actor;

--- a/features/chat/components/PortalMessagesWorkspace.tsx
+++ b/features/chat/components/PortalMessagesWorkspace.tsx
@@ -47,6 +47,11 @@ type ContextOption = {
   secondary: string | null;
 };
 
+type RecipientOption = {
+  id: string;
+  label: string;
+};
+
 export default function PortalMessagesWorkspace(): JSX.Element {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const searchParams = useSearchParams();
@@ -65,6 +70,10 @@ export default function PortalMessagesWorkspace(): JSX.Element {
   const [subject, setSubject] = useState("");
   const [contextKey, setContextKey] = useState("");
   const [contextOptions, setContextOptions] = useState<ContextOption[]>([]);
+  const [recipientUserId, setRecipientUserId] = useState("");
+  const [recipientOptions, setRecipientOptions] = useState<RecipientOption[]>(
+    [],
+  );
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(
@@ -77,7 +86,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
   const draftTargetId = "portal:new-conversation";
 
   const loadConversations = useCallback(async () => {
-    const response = await fetch("/api/chat/my-conversations", {
+    const response = await fetch("/api/chat/my-conversations?actor=customer", {
       credentials: "include",
     });
     if (!response.ok) throw new Error("Could not load messages");
@@ -90,13 +99,21 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     void supabase.auth.getSession().then(({ data }) => {
       setUserId(data.session?.user.id ?? null);
     });
-    void fetch("/api/chat/context-options", { credentials: "include" })
+    void fetch("/api/chat/context-options?actor=customer", {
+      credentials: "include",
+    })
       .then((response) => response.json())
       .then((contextPayload) => {
-        const options = (contextPayload as { options?: ContextOption[] })
-          .options;
+        const payload = contextPayload as {
+          options?: ContextOption[];
+          recipients?: RecipientOption[];
+        };
+        const options = payload.options;
         const safeOptions = Array.isArray(options) ? options : [];
         setContextOptions(safeOptions);
+        setRecipientOptions(
+          Array.isArray(payload.recipients) ? payload.recipients : [],
+        );
         if (
           requestedContextKey &&
           safeOptions.some(
@@ -202,8 +219,9 @@ export default function PortalMessagesWorkspace(): JSX.Element {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           request_id: requestId,
+          actor_kind: "customer",
           channel: "customer",
-          participant_ids: [],
+          participant_ids: recipientUserId ? [recipientUserId] : [],
           context_type: selectedContext?.type ?? null,
           context_id: selectedContext?.id ?? null,
           title:
@@ -236,6 +254,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
       setMessage("");
       setSubject("");
       setContextKey("");
+      setRecipientUserId("");
       setNewThread(false);
       setActiveId(created.id);
       if (draftScope) {
@@ -389,6 +408,19 @@ export default function PortalMessagesWorkspace(): JSX.Element {
                 maxLength={160}
                 className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm"
               />
+              <select
+                value={recipientUserId}
+                onChange={(event) => setRecipientUserId(event.target.value)}
+                aria-label="Message recipient"
+                className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm"
+              >
+                <option value="">Assigned advisor or service team</option>
+                {recipientOptions.map((recipient) => (
+                  <option key={recipient.id} value={recipient.id}>
+                    {recipient.label}
+                  </option>
+                ))}
+              </select>
               <select
                 value={contextKey}
                 onChange={(event) => setContextKey(event.target.value)}

--- a/tests/portal-messaging-navigation.test.ts
+++ b/tests/portal-messaging-navigation.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = (path: string) => readFileSync(path, "utf8");
+
+describe("portal work-order navigation and messaging", () => {
+  it("returns from a portal work order to the portal dashboard", () => {
+    const page = source("app/portal/work-orders/view/[id]/page.tsx");
+
+    expect(page).toContain('backHref="/portal"');
+    expect(page).not.toContain('backHref="/portal/history"');
+  });
+
+  it("treats customer profiles as customers and exposes advisor selection", () => {
+    const authorization = source(
+      "features/ai/lib/chat/authorization.ts",
+    );
+    const contextRoute = source("app/api/chat/context-options/route.ts");
+    const startRoute = source("app/api/chat/start-conversation/route.ts");
+    const workspace = source(
+      "features/chat/components/PortalMessagesWorkspace.tsx",
+    );
+
+    expect(authorization).toContain('preferredKind === "customer"');
+    expect(authorization).toContain('profileRole === "customer"');
+    expect(contextRoute).toContain('.eq("role", "advisor")');
+    expect(contextRoute).toContain("recipients");
+    expect(workspace).toContain('aria-label="Message recipient"');
+    expect(workspace).toContain(
+      "/api/chat/my-conversations?actor=customer",
+    );
+    expect(workspace).toContain("actor_kind: \"customer\"");
+    expect(workspace).toContain(
+      "Assigned advisor or service team",
+    );
+    expect(workspace).toContain(
+      "participant_ids: recipientUserId ? [recipientUserId] : []",
+    );
+    expect(startRoute).toContain(
+      "requestedParticipantIds.length === 0",
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

- the portal work-order viewer hard-coded its back destination to `/portal/history`
- messaging resolved any shop-linked profile as staff before considering the linked customer record, so portal users could hit `Select a customer for this conversation`
- the portal composer did not load or submit an advisor recipient

## What changed

- returns from a portal work order to the portal dashboard
- lets portal chat explicitly resolve the authenticated account as its linked customer, while preserving normal staff identity in the internal inbox
- adds an advisor selector populated only from same-shop advisor profiles
- defaults to the assigned work-order advisor or service team when the customer does not choose someone
- preserves management coverage for automatically routed work-order messages
- adds focused regression coverage for navigation, portal actor resolution, advisor selection, and recipient submission

## Safety

All advisor choices are revalidated server-side against same-shop profiles. The customer identity must be linked through `customers.user_id`; the client cannot supply an arbitrary customer. Internal messaging behavior remains the default unless the portal explicitly requests customer mode.

## Validation

- TypeScript (`tsc --noEmit`): passed
- targeted ESLint: passed
- focused Vitest: 2 tests passed
- `git diff --check`: passed

## Database and environment

No migration, backfill, environment variable, or third-party configuration change is required.