### PR TITLE
Fix legacy inspection backfill timestamps

### DIFF
--- a/supabase/migrations/20260723023000_canonical_inspection_source.sql
+++ b/supabase/migrations/20260723023000_canonical_inspection_source.sql
@@ -75,6 +75,7 @@ insert into public.inspections (
   completed,
   locked,
   status,
+  created_at,
   updated_at
 )
 select
@@ -90,7 +91,7 @@ select
     'workOrderId', l.work_order_id,
     'workOrderLineId', l.work_order_line_id,
     'syncRevision', l.legacy_revision,
-    'serverUpdatedAt', l.updated_at
+    'serverUpdatedAt', coalesce(l.updated_at, now())
   ),
   false,
   l.legacy_revision,
@@ -98,6 +99,7 @@ select
   l.is_completed,
   l.is_completed,
   case when l.is_completed then 'completed' else 'draft' end,
+  coalesce(l.updated_at, now()),
   coalesce(l.updated_at, now())
 from legacy_materialized l;
 

--- a/tests/inspection-versioned-writer-migration.test.ts
+++ b/tests/inspection-versioned-writer-migration.test.ts
@@ -46,6 +46,10 @@ describe("versioned canonical inspection writer migration", () => {
     expect(migration).toContain("insert into public.inspections (");
     expect(migration).toContain("from legacy_materialized l");
     expect(migration).toContain("not exists (");
+    expect(migration).toContain("created_at,\n  updated_at");
+    expect(migration).toContain(
+      "coalesce(l.updated_at, now()),\n  coalesce(l.updated_at, now())",
+    );
   });
 
   it("keeps the canonical marker and row behind database-managed workflows", () => {


### PR DESCRIPTION
### Root cause

PR #1166 creates new `inspections` rows from older `inspection_sessions` progress. The new row defaulted `created_at` to the current time while retaining the legacy session's older `updated_at`, which violates `inspections_updated_after_created_chk`.

### What changed

- Set both `created_at` and `updated_at` on materialized legacy inspection rows to the legacy session timestamp.
- Use the same effective timestamp for `summary.serverUpdatedAt`.
- Added a regression contract for timestamp ordering.

### Why this is safe

- The failed migration attempt was transactional and rolled back.
- No inspection or session data is deleted.
- Historical timestamps are preserved instead of rewritten to the deployment time.
- The change affects only session-only rows materialized during the canonical migration.

### Deployment note

Rerun `20260723023000_canonical_inspection_source.sql` after this fix is merged. No new environment variables are required.