### PR TITLE
Fix inspection realtime publication guard

### DIFF
--- a/supabase/migrations/20260723023000_canonical_inspection_source.sql
+++ b/supabase/migrations/20260723023000_canonical_inspection_source.sql
@@ -508,10 +508,11 @@ do $$
 begin
   if exists (
     select 1
-    from pg_publication_tables
-    where pubname = 'supabase_realtime'
-      and schemaname = 'public'
-      and tablename = 'inspection_sessions'
+    from pg_publication p
+    join pg_publication_rel pr
+      on pr.prpubid = p.oid
+    where p.pubname = 'supabase_realtime'
+      and pr.prrelid = 'public.inspection_sessions'::regclass
   ) then
     alter publication supabase_realtime drop table public.inspection_sessions;
   end if;
@@ -523,3 +524,4 @@ comment on table public.inspection_sessions is
 
 notify pgrst, 'reload schema';
 commit;
+

--- a/tests/inspection-single-source-contract.test.ts
+++ b/tests/inspection-single-source-contract.test.ts
@@ -33,6 +33,11 @@ describe("canonical inspection source contract", () => {
     expect(migration).toContain(
       "alter publication supabase_realtime drop table public.inspection_sessions",
     );
+    expect(migration).toContain("from pg_publication p");
+    expect(migration).toContain("join pg_publication_rel pr");
+    expect(migration).toContain(
+      "pr.prrelid = 'public.inspection_sessions'::regclass",
+    );
     expect(autosave).not.toContain('table: "inspection_sessions"');
   });
 
@@ -61,3 +66,4 @@ describe("canonical inspection source contract", () => {
     expect(findings).not.toContain("inspection:draft-updated");
   });
 });
+


### PR DESCRIPTION
### Root cause

The canonical inspection migration checked `pg_publication_tables` before removing `inspection_sessions` from `supabase_realtime`. That view can include tables inherited from a `FOR ALL TABLES` publication even when the relation is not an explicit member, so `ALTER PUBLICATION ... DROP TABLE` failed with SQLSTATE `42704`.

### What changed

- Check direct membership through `pg_publication` and `pg_publication_rel`.
- Drop `inspection_sessions` only when it was explicitly added to `supabase_realtime`.
- Added a regression contract for the catalog query.

### Why this is safe

- The failed migration attempt was transactional and rolled back.
- No inspection or session data is deleted.
- Explicit realtime membership is still removed as intended.
- All-tables publications remain unchanged.

### Deployment note

Rerun `20260723023000_canonical_inspection_source.sql` after this fix is merged. No new environment variables are required.