### PR TITLE
Merge parts flow fixes into main

### DIFF
--- a/features/parts/actions.ts
+++ b/features/parts/actions.ts
@@ -20,6 +20,7 @@ export type StockMoveReason =
   | "return_out";
 
 function extractStockMoveId(data: unknown): string | null {
+  if (typeof data === "string" && data.length > 0) return data;
   if (!data || typeof data !== "object") return null;
   const maybe = data as Partial<StockMoveRow>;
   return typeof maybe.id === "string" && maybe.id.length > 0 ? maybe.id : null;
@@ -55,7 +56,7 @@ export async function createPart(input: {
  *
  * SQL:
  *   apply_stock_move(p_part uuid, p_loc uuid, p_qty numeric, p_reason text, p_ref_kind text, p_ref_id uuid)
- *   RETURNS stock_moves
+ *   RETURNS uuid
  */
 export async function adjustStock(input: {
   part_id: string;

--- a/features/parts/components/PartsDrawer.tsx
+++ b/features/parts/components/PartsDrawer.tsx
@@ -77,6 +77,7 @@ export default function PartsDrawer({
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "Failed to use part.";
         toast.error(msg);
+        throw e;
       }
     },
     [emitClose, workOrderLineId],

--- a/features/work-orders/lib/parts/consumePart.ts
+++ b/features/work-orders/lib/parts/consumePart.ts
@@ -21,6 +21,7 @@ export type ConsumePartInput = {
 };
 
 function extractStockMoveId(data: unknown): string | null {
+  if (typeof data === "string" && data.length > 0) return data;
   if (!data || typeof data !== "object") return null;
   const maybe = data as Partial<StockMoveRow>;
   const id = maybe.id;
@@ -150,7 +151,7 @@ export async function consumePart(input: ConsumePartInput) {
   const qtyAbs = Math.abs(input.qty);
 
   // 5) Create stock move (consume = negative)
-  // NOTE: apply_stock_move RETURNS stock_moves row, not uuid
+  // NOTE: apply_stock_move returns a stock move UUID in the current schema.
   const { data: moveRow, error: mErr } = await supabase.rpc("apply_stock_move", {
     p_part: input.part_id,
     p_loc: locationId,

--- a/supabase/migrations/20260722140500_fix_parts_issue_status_enum_cast.sql
+++ b/supabase/migrations/20260722140500_fix_parts_issue_status_enum_cast.sql
@@ -1,0 +1,184 @@
+begin;
+
+-- The handoff flow issues staged allocations through parts_issue_work_order_part.
+-- Its local CASE result was inferred as text, which fails when assigned to the
+-- part_request_items.status enum during "Complete handoff".
+create or replace function public.parts_issue_work_order_part(
+  p_work_order_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_wop public.work_order_parts%rowtype;
+  v_existing public.stock_moves%rowtype;
+  v_alloc public.work_order_part_allocations%rowtype;
+  v_move_id uuid;
+  v_item public.part_request_items%rowtype;
+  v_net_issued numeric;
+  v_status public.part_request_item_status;
+begin
+  if p_qty <= 0 then
+    raise exception 'Issue quantity must be greater than zero.';
+  end if;
+  if coalesce(trim(p_idempotency_key), '') = '' then
+    raise exception 'A stable idempotency key is required.';
+  end if;
+
+  select * into v_wop
+  from public.work_order_parts
+  where id = p_work_order_part_id
+    and is_active
+  for update;
+  if not found then
+    raise exception 'Active work-order part not found.';
+  end if;
+
+  if v_wop.shop_id is null then
+    raise exception 'Work-order part is missing shop context.';
+  end if;
+  if v_wop.part_id is null then
+    raise exception 'Work-order part is missing part_id.';
+  end if;
+  if p_qty > greatest(coalesce(v_wop.quantity_reserved, 0), 0) then
+    raise exception 'Issue quantity exceeds reserved quantity.';
+  end if;
+
+  select * into v_existing
+  from public.stock_moves
+  where shop_id = v_wop.shop_id
+    and idempotency_key = p_idempotency_key
+  limit 1;
+  if found then
+    return jsonb_build_object(
+      'ok', true,
+      'idempotent', true,
+      'work_order_part_id', v_wop.id,
+      'stock_move_id', v_existing.id,
+      'issued_qty', v_existing.quantity
+    );
+  end if;
+
+  select * into v_alloc
+  from public.work_order_part_allocations
+  where work_order_part_id = v_wop.id
+    and location_id = p_location_id
+    and qty >= p_qty
+  order by id
+  limit 1
+  for update;
+  if not found then
+    raise exception 'Reserved allocation not found for this location.';
+  end if;
+
+  if v_wop.source_parts_request_item_id is not null then
+    select * into v_item
+    from public.part_request_items
+    where id = v_wop.source_parts_request_item_id
+    for update;
+  end if;
+
+  insert into public.stock_moves (
+    shop_id,
+    part_id,
+    location_id,
+    move_type,
+    quantity,
+    work_order_id,
+    work_order_part_id,
+    part_request_item_id,
+    source,
+    source_id,
+    metadata,
+    idempotency_key
+  ) values (
+    v_wop.shop_id,
+    v_wop.part_id,
+    p_location_id,
+    'issue',
+    p_qty,
+    v_wop.work_order_id,
+    v_wop.id,
+    v_wop.source_parts_request_item_id,
+    'work_order_part_issue',
+    v_wop.id,
+    jsonb_build_object('qty_consumed', p_qty, 'operation', 'issue_to_repair'),
+    p_idempotency_key
+  )
+  returning id into v_move_id;
+
+  if v_alloc.qty = p_qty then
+    delete from public.work_order_part_allocations
+    where id = v_alloc.id;
+  else
+    update public.work_order_part_allocations
+    set qty = qty - p_qty,
+        updated_at = now()
+    where id = v_alloc.id;
+  end if;
+
+  update public.work_order_parts
+  set quantity_reserved = greatest(coalesce(quantity_reserved, 0) - p_qty, 0),
+      quantity_consumed = coalesce(quantity_consumed, 0) + p_qty,
+      updated_at = now()
+  where id = v_wop.id;
+
+  if v_wop.source_parts_request_item_id is not null then
+    v_net_issued := coalesce(v_item.qty_consumed, 0)
+      + p_qty
+      - coalesce(v_item.qty_returned, 0);
+    v_status := case
+      when v_net_issued < greatest(
+        coalesce(v_item.qty_requested, v_item.qty, 0),
+        0
+      ) then 'partially_consumed'::public.part_request_item_status
+      else 'consumed'::public.part_request_item_status
+    end;
+
+    update public.part_request_items
+    set qty_reserved = greatest(coalesce(qty_reserved, 0) - p_qty, 0),
+        qty_consumed = coalesce(qty_consumed, 0) + p_qty,
+        status = v_status,
+        updated_at = now()
+    where id = v_wop.source_parts_request_item_id;
+  end if;
+
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'work_order_part_id', v_wop.id,
+    'stock_move_id', v_move_id,
+    'issued_qty', p_qty,
+    'net_issued_qty',
+      coalesce(v_wop.quantity_consumed, 0)
+        + p_qty
+        - coalesce(v_wop.quantity_returned, 0),
+    'on_hand_after', public.parts_on_hand(
+      v_wop.shop_id,
+      v_wop.part_id,
+      p_location_id
+    )
+  );
+end;
+$$;
+
+revoke all on function public.parts_issue_work_order_part(
+  uuid,
+  uuid,
+  numeric,
+  text
+) from public, anon;
+grant execute on function public.parts_issue_work_order_part(
+  uuid,
+  uuid,
+  numeric,
+  text
+) to authenticated;
+
+commit;

--- a/tests/work-order-use-part-regression.test.ts
+++ b/tests/work-order-use-part-regression.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("work order Use Part regression", () => {
+  const consumePartSource = readFileSync(
+    "features/work-orders/lib/parts/consumePart.ts",
+    "utf8",
+  );
+  const partsDrawerSource = readFileSync(
+    "features/parts/components/PartsDrawer.tsx",
+    "utf8",
+  );
+  const handoffEnumCastMigration = readFileSync(
+    "supabase/migrations/20260722140500_fix_parts_issue_status_enum_cast.sql",
+    "utf8",
+  );
+
+  it("accepts the UUID returned by apply_stock_move", () => {
+    expect(consumePartSource).toContain(
+      'if (typeof data === "string" && data.length > 0) return data;',
+    );
+    expect(consumePartSource).toContain(
+      "apply_stock_move returns a stock move UUID",
+    );
+  });
+
+  it("surfaces inventory attachment failures from the drawer", () => {
+    expect(partsDrawerSource).toContain("throw e;");
+  });
+
+  it("casts handoff item statuses to the enum type", () => {
+    expect(handoffEnumCastMigration).toContain(
+      "v_status public.part_request_item_status;",
+    );
+    expect(handoffEnumCastMigration).toContain(
+      "'partially_consumed'::public.part_request_item_status",
+    );
+    expect(handoffEnumCastMigration).toContain(
+      "'consumed'::public.part_request_item_status",
+    );
+    expect(handoffEnumCastMigration).toContain("status = v_status");
+  });
+});


### PR DESCRIPTION
Clean merge of the parts-flow fixes onto current `main`.

Includes:
- Accept UUID returns from `apply_stock_move` in parts actions and work-order part consumption
- Keep work-order part drawer errors visible instead of silently closing
- Fix Complete handoff enum assignment by casting status values to `part_request_item_status`
- Add regression coverage for the Use Part and handoff enum fixes

This avoids merging the older `agent/canonical-inspection-reset` branch history directly into `main`.