### PR TITLE
Fix parts flow runtime schema mismatches

### DIFF
--- a/features/work-orders/lib/parts/consumePart.ts
+++ b/features/work-orders/lib/parts/consumePart.ts
@@ -8,25 +8,16 @@ import { ensureMainLocation } from "@parts/lib/locations";
 
 type DB = Database;
 
-type StockMoveRow = DB["public"]["Tables"]["stock_moves"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 
 export type ConsumePartInput = {
   work_order_line_id: string;
   part_id: string;
-  qty: number; // positive number means "consume qty"
+  qty: number; // positive number means "attach qty"
   location_id?: string; // optional; defaults to MAIN for the WO's shop
   unit_cost?: number; // optional override from UI (NO nulls)
   availability?: string | null; // accepted but not stored yet
 };
-
-function extractStockMoveId(data: unknown): string | null {
-  if (typeof data === "string" && data.length > 0) return data;
-  if (!data || typeof data !== "object") return null;
-  const maybe = data as Partial<StockMoveRow>;
-  const id = maybe.id;
-  return typeof id === "string" && id.length > 0 ? id : null;
-}
 
 function asFiniteNumber(v: unknown): number | null {
   const n = typeof v === "number" ? v : Number(v);
@@ -150,34 +141,15 @@ export async function consumePart(input: ConsumePartInput) {
 
   const qtyAbs = Math.abs(input.qty);
 
-  // 5) Create stock move (consume = negative)
-  // NOTE: apply_stock_move returns a stock move UUID in the current schema.
-  const { data: moveRow, error: mErr } = await supabase.rpc("apply_stock_move", {
-    p_part: input.part_id,
-    p_loc: locationId,
-    p_qty: -qtyAbs,
-    p_reason: "consume",
-    p_ref_kind: "work_order",
-    p_ref_id: workOrderId,
-  });
-
-  if (mErr) throw mErr;
-
-  const moveId = extractStockMoveId(moveRow);
-  if (!moveId) {
-    throw new Error("Inventory move failed: apply_stock_move returned no id");
-  }
-
-  // 6) Create allocation row (link to move)
-  // CRITICAL: include shop_id to satisfy shop-scoped policies (shop_id = current_shop_id())
-  const baseInsert = {
+  // Match the generic inspection / quote attach path: create a pending allocation
+  // record and let lifecycle handoff perform the physical stock issue.
+  const baseInsert: DB["public"]["Tables"]["work_order_part_allocations"]["Insert"] = {
     shop_id: shopId,
     work_order_id: workOrderId,
     work_order_line_id: input.work_order_line_id,
     part_id: input.part_id,
     location_id: locationId,
     qty: qtyAbs,
-    stock_move_id: moveId,
   };
 
   const allocInsert =
@@ -193,11 +165,11 @@ export async function consumePart(input: ConsumePartInput) {
 
   if (aErr) throw aErr;
 
-  // 7) Revalidate the WO page
+  // 5) Revalidate the WO page
   revalidatePath(`/work-orders/${workOrderId}`);
 
   const allocationId =
     alloc && typeof alloc.id === "string" ? alloc.id : undefined;
 
-  return { allocationId, moveId };
+  return { allocationId };
 }

--- a/supabase/migrations/20260723044000_fix_parts_handoff_runtime_shape.sql
+++ b/supabase/migrations/20260723044000_fix_parts_handoff_runtime_shape.sql
@@ -1,0 +1,191 @@
+begin;
+
+-- Restore the working parts handoff function shape and keep the enum-safe status
+-- assignment. The previous patch mixed in an older work_order_parts/stock_moves
+-- shape (`quantity_reserved`, `move_type`, `quantity`) that does not exist in
+-- the current production schema.
+create or replace function public.parts_issue_work_order_part(
+  p_work_order_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_idempotency_key text
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_wop public.work_order_parts%rowtype;
+  v_existing public.stock_moves%rowtype;
+  v_alloc public.work_order_part_allocations%rowtype;
+  v_move_id uuid;
+  v_item public.part_request_items%rowtype;
+  v_net_issued numeric;
+  v_status public.part_request_item_status;
+begin
+  if p_qty <= 0 then
+    raise exception 'Issue quantity must be greater than zero.';
+  end if;
+  if coalesce(trim(p_idempotency_key), '') = '' then
+    raise exception 'A stable idempotency key is required.';
+  end if;
+
+  select * into v_wop
+  from public.work_order_parts
+  where id = p_work_order_part_id
+    and is_active
+  for update;
+  if not found then
+    raise exception 'Active work-order part not found.';
+  end if;
+  perform public.parts_assert_work_order_mutable(
+    v_wop.shop_id,
+    v_wop.work_order_id
+  );
+
+  select * into v_existing
+  from public.stock_moves
+  where shop_id = v_wop.shop_id
+    and idempotency_key = p_idempotency_key
+  for update;
+  if found then
+    return coalesce(v_existing.metadata, '{}'::jsonb)
+      || jsonb_build_object(
+        'ok', true,
+        'idempotent', true,
+        'stock_move_id', v_existing.id
+      );
+  end if;
+
+  select * into v_alloc
+  from public.work_order_part_allocations
+  where work_order_part_id = v_wop.id
+    and location_id = p_location_id
+  for update;
+  if not found or v_alloc.qty < p_qty then
+    raise exception 'Allocation is insufficient for issue.';
+  end if;
+  if coalesce(v_wop.quantity_allocated, 0) < p_qty then
+    raise exception 'Cannot issue more than allocated quantity.';
+  end if;
+  if public.parts_on_hand(
+    v_wop.shop_id,
+    v_wop.part_id,
+    p_location_id
+  ) < p_qty then
+    raise exception 'Cannot issue more than physical on-hand quantity.';
+  end if;
+
+  if v_wop.source_parts_request_item_id is not null then
+    select * into v_item
+    from public.part_request_items
+    where id = v_wop.source_parts_request_item_id
+    for update;
+  end if;
+
+  insert into public.stock_moves (
+    part_id,
+    location_id,
+    qty_change,
+    reason,
+    reference_kind,
+    reference_id,
+    created_by,
+    shop_id,
+    idempotency_key,
+    work_order_part_id,
+    part_request_item_id,
+    metadata,
+    lifecycle_quantity
+  ) values (
+    v_wop.part_id,
+    p_location_id,
+    -p_qty,
+    'consume',
+    'work_order_part',
+    v_wop.id,
+    auth.uid(),
+    v_wop.shop_id,
+    p_idempotency_key,
+    v_wop.id,
+    v_wop.source_parts_request_item_id,
+    jsonb_build_object('qty_issued', p_qty, 'operation', 'issue'),
+    p_qty
+  ) returning id into v_move_id;
+
+  if v_alloc.qty = p_qty then
+    delete from public.work_order_part_allocations
+    where id = v_alloc.id;
+  else
+    update public.work_order_part_allocations
+    set qty = v_alloc.qty - p_qty,
+        stock_move_id = v_move_id
+    where id = v_alloc.id;
+  end if;
+
+  update public.work_order_parts
+  set quantity_allocated = greatest(
+        coalesce(quantity_allocated, 0) - p_qty,
+        0
+      ),
+      quantity_consumed = coalesce(quantity_consumed, 0) + p_qty,
+      updated_at = now()
+  where id = v_wop.id;
+
+  if v_wop.source_parts_request_item_id is not null then
+    v_net_issued := coalesce(v_item.qty_consumed, 0)
+      + p_qty
+      - coalesce(v_item.qty_returned, 0);
+    v_status := case
+      when v_net_issued < greatest(
+        coalesce(v_item.qty_requested, v_item.qty, 0),
+        0
+      ) then 'partially_consumed'::public.part_request_item_status
+      else 'consumed'::public.part_request_item_status
+    end;
+
+    update public.part_request_items
+    set qty_reserved = greatest(coalesce(qty_reserved, 0) - p_qty, 0),
+        qty_consumed = coalesce(qty_consumed, 0) + p_qty,
+        status = v_status,
+        updated_at = now()
+    where id = v_wop.source_parts_request_item_id;
+  end if;
+
+  perform public.parts_reconcile_work_order_part(v_wop.id);
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'work_order_part_id', v_wop.id,
+    'stock_move_id', v_move_id,
+    'issued_qty', p_qty,
+    'net_issued_qty',
+      coalesce(v_wop.quantity_consumed, 0)
+        + p_qty
+        - coalesce(v_wop.quantity_returned, 0),
+    'on_hand_after', public.parts_on_hand(
+      v_wop.shop_id,
+      v_wop.part_id,
+      p_location_id
+    )
+  );
+end;
+$$;
+
+revoke all on function public.parts_issue_work_order_part(
+  uuid,
+  uuid,
+  numeric,
+  text
+) from public, anon;
+grant execute on function public.parts_issue_work_order_part(
+  uuid,
+  uuid,
+  numeric,
+  text
+) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/work-order-use-part-regression.test.ts
+++ b/tests/work-order-use-part-regression.test.ts
@@ -10,34 +10,40 @@ describe("work order Use Part regression", () => {
     "features/parts/components/PartsDrawer.tsx",
     "utf8",
   );
-  const handoffEnumCastMigration = readFileSync(
-    "supabase/migrations/20260722140500_fix_parts_issue_status_enum_cast.sql",
+  const handoffRuntimeShapeMigration = readFileSync(
+    "supabase/migrations/20260723044000_fix_parts_handoff_runtime_shape.sql",
     "utf8",
   );
 
-  it("accepts the UUID returned by apply_stock_move", () => {
+  it("uses the generic inspection allocation shape when attaching inventory parts", () => {
+    expect(consumePartSource).not.toContain('rpc("apply_stock_move"');
+    expect(consumePartSource).not.toContain("stock_move_id: moveId");
     expect(consumePartSource).toContain(
-      'if (typeof data === "string" && data.length > 0) return data;',
+      'DB["public"]["Tables"]["work_order_part_allocations"]["Insert"]',
     );
-    expect(consumePartSource).toContain(
-      "apply_stock_move returns a stock move UUID",
-    );
+    expect(consumePartSource).toContain("work_order_line_id: input.work_order_line_id");
+    expect(consumePartSource).toContain("location_id: locationId");
   });
 
   it("surfaces inventory attachment failures from the drawer", () => {
     expect(partsDrawerSource).toContain("throw e;");
   });
 
-  it("casts handoff item statuses to the enum type", () => {
-    expect(handoffEnumCastMigration).toContain(
+  it("keeps handoff aligned with the current lifecycle schema and enum type", () => {
+    expect(handoffRuntimeShapeMigration).toContain(
       "v_status public.part_request_item_status;",
     );
-    expect(handoffEnumCastMigration).toContain(
+    expect(handoffRuntimeShapeMigration).toContain("quantity_allocated");
+    expect(handoffRuntimeShapeMigration).not.toContain("quantity_reserved");
+    expect(handoffRuntimeShapeMigration).toContain("qty_change");
+    expect(handoffRuntimeShapeMigration).toContain("reason");
+    expect(handoffRuntimeShapeMigration).not.toContain("move_type");
+    expect(handoffRuntimeShapeMigration).toContain(
       "'partially_consumed'::public.part_request_item_status",
     );
-    expect(handoffEnumCastMigration).toContain(
+    expect(handoffRuntimeShapeMigration).toContain(
       "'consumed'::public.part_request_item_status",
     );
-    expect(handoffEnumCastMigration).toContain("status = v_status");
+    expect(handoffRuntimeShapeMigration).toContain("status = v_status");
   });
 });


### PR DESCRIPTION
Fixes the two runtime failures seen after the prior parts-flow merge.

Changes:
- Match work-order Add Part to the generic inspection / quote allocation path by inserting `work_order_part_allocations` directly without pre-creating a stock move.
- Add a corrective migration for `parts_issue_work_order_part` that restores the current lifecycle schema shape (`quantity_allocated`, `qty_change`, `reason`, etc.) while preserving enum-safe status assignment.
- Update regression coverage so these two schema mismatches are guarded.

This should address:
- Add Part server render error on work orders
- Complete handoff error: `record v_wop has no field quantity_reserved`