### PR TITLE
Audit completion readiness and repair mobile route integrity

### DIFF
--- a/docs/audits/api-route-boundary-inventory.json
+++ b/docs/audits/api-route-boundary-inventory.json
@@ -11,7 +11,7 @@
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "customer_or_portal",
+    "routeClassGuess": "public_or_token",
     "riskFlags": [
       "has_stronger_boundary_signal"
     ],
@@ -667,7 +667,7 @@
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
+    "hasShopReference": false,
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [
@@ -700,6 +700,22 @@
     "hasShopReference": false,
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/auth/sign-in/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -859,6 +875,41 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/branding/invoice-design/route.ts",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/branding/invoice-preview/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/branding/profile/route.ts",
     "methods": [
       "GET",
@@ -923,7 +974,7 @@
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
@@ -1005,6 +1056,22 @@
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/chat/offline-scope/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -1195,7 +1262,7 @@
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
@@ -1234,6 +1301,24 @@
   },
   {
     "path": "app/api/demo/shop-boost/share/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/demo/shop-boost/uploads/route.ts",
     "methods": [
       "POST"
     ],
@@ -1292,14 +1377,16 @@
       "GET"
     ],
     "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -1340,14 +1427,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -1483,6 +1572,62 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/inspection-form-imports/[jobId]/approve/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/inspection-form-imports/[jobId]/route.ts",
+    "methods": [
+      "GET",
+      "PATCH"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/inspection-form-imports/route.ts",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/inspections/build-from-prompt/route.ts",
     "methods": [
       "POST"
@@ -1515,22 +1660,6 @@
       "mutating_without_obvious_auth_marker"
     ],
     "riskLevel": "high"
-  },
-  {
-    "path": "app/api/inspections/complete/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "public_or_token",
-    "riskFlags": [],
-    "riskLevel": "low"
   },
   {
     "path": "app/api/inspections/finalize/pdf/route.ts",
@@ -1572,11 +1701,11 @@
     "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
+    "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
+    "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -1592,7 +1721,7 @@
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "public_or_token",
+    "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -1606,8 +1735,8 @@
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
-    "hasRoleOrCapabilityReference": true,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
     "riskLevel": "low"
@@ -1625,22 +1754,6 @@
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/inspections/session/create/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -1705,40 +1818,6 @@
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
-  },
-  {
-    "path": "app/api/inspections/submit/pdf/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
-  },
-  {
-    "path": "app/api/inspections/submit/route.ts",
-    "methods": [
-      "POST"
-    ],
-    "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -2433,6 +2512,102 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/offline/advisor-day/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/offline/advisor-work-order-drafts/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/offline/mutations/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/offline/parts-request-drafts/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/offline/session-check/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/offline/technician-work-orders/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts",
     "methods": [
       "POST"
@@ -2765,19 +2940,39 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/parts/requests/[requestId]/handoff/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/parts/requests/create/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
-    "hasRoleOrCapabilityReference": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "public_or_token",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -2975,6 +3170,24 @@
     "riskLevel": "high"
   },
   {
+    "path": "app/api/parts/requests/pick-task/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/parts/work-order-parts/[partId]/issue/route.ts",
     "methods": [
       "POST"
@@ -3135,18 +3348,21 @@
   {
     "path": "app/api/payroll-time/periods/route.ts",
     "methods": [
-      "GET"
+      "GET",
+      "PUT"
     ],
-    "isMutating": false,
+    "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
-    "riskLevel": "low"
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
   },
   {
     "path": "app/api/payroll-time/rebuild/route.ts",
@@ -3430,7 +3646,23 @@
     "riskLevel": "low"
   },
   {
-    "path": "app/api/portal/invites/accept/route.ts",
+    "path": "app/api/portal/enrollment/[slug]/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/portal/fleet/invites/accept/route.ts",
     "methods": [
       "POST"
     ],
@@ -3440,6 +3672,57 @@
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/portal/fleet/invites/preview/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/portal/fleet/invites/route.ts",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/portal/invites/accept/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
@@ -3489,6 +3772,23 @@
     "hasServiceRolePattern": false,
     "hasShopReference": false,
     "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/portal/qr/campaign/route.ts",
+    "methods": [
+      "GET",
+      "PATCH"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
@@ -3581,7 +3881,7 @@
     "isMutating": true,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
@@ -3664,7 +3964,7 @@
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
@@ -4142,6 +4442,109 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/shop-assistant/actions/[actionId]/cancel/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/shop-assistant/actions/[actionId]/confirm/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
+    "path": "app/api/shop-assistant/chat/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/shop-assistant/state/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/shop-assistant/threads/[threadId]/messages/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/shop-assistant/threads/route.ts",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "mutating_without_obvious_auth_marker"
+    ],
+    "riskLevel": "high"
+  },
+  {
     "path": "app/api/shop-boost/ai/recommendations/route.ts",
     "methods": [
       "GET",
@@ -4267,14 +4670,34 @@
       "PATCH"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/shop-boost/review-items/apply-safe/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4315,14 +4738,16 @@
       "GET"
     ],
     "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4833,14 +5258,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
+    "hasShopReference": false,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4857,6 +5284,24 @@
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/webhooks/sendgrid/events/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "webhook",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -5072,7 +5517,7 @@
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "customer_or_portal",
+    "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -5096,6 +5541,24 @@
     "riskLevel": "high"
   },
   {
+    "path": "app/api/work-orders/[id]/lines/[lineId]/parts-request/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/work-orders/[id]/mark-ready/route.ts",
     "methods": [
       "POST"
@@ -5114,11 +5577,47 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/work-orders/[id]/quote-history-insights/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "public_or_token",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/work-orders/[id]/send-quote/route.ts",
     "methods": [
       "POST"
     ],
     "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/work-orders/[id]/vehicle-history/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
     "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
@@ -5220,6 +5719,24 @@
       "service_role_with_shop_identifier_input_or_reference"
     ],
     "riskLevel": "medium"
+  },
+  {
+    "path": "app/api/work-orders/documentation/rewrite/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
   },
   {
     "path": "app/api/work-orders/dtc-suggest/route.ts",
@@ -5548,7 +6065,7 @@
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "staff_or_admin",
+    "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
   },

--- a/docs/audits/api-route-boundary-inventory.md
+++ b/docs/audits/api-route-boundary-inventory.md
@@ -1,17 +1,17 @@
 # API Route Boundary Inventory (Static Heuristic)
 
-Generated: 2026-07-15T22:11:22.917Z
+Generated: 2026-07-23T17:22:41.534Z
 
 ## Summary
-- Total route count: **343**
-- Routes exporting GET: **100**
-- Routes exporting POST: **250**
-- Routes exporting PUT: **8**
-- Routes exporting PATCH: **19**
+- Total route count: **372**
+- Routes exporting GET: **118**
+- Routes exporting POST: **265**
+- Routes exporting PUT: **9**
+- Routes exporting PATCH: **21**
 - Routes exporting DELETE: **11**
 - Routes with service-role pattern: **24**
-- Routes using requireShopScopedApiAccess: **91**
-- Routes with auth.getUser references: **146**
+- Routes using requireShopScopedApiAccess: **108**
+- Routes with auth.getUser references: **147**
 
 ## High-Risk Routes
 - `app/api/ai/interpret/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -20,15 +20,16 @@ Generated: 2026-07-15T22:11:22.917Z
 - `app/api/branding/assets/[id]/archive/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/delete/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/favorite/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/branding/invoice-design/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/user-preferences/reset/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/user-preferences/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/dashboard/layout/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/demo/shop-boost/share/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/demo/shop-boost/uploads/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/diag/log/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/dtc-suggest/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/fleet/service-requests/convert-to-work-order/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/inspections/build/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/inspections/submit/pdf/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/connect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/disconnect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/invoice/[id]/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -53,10 +54,14 @@ Generated: 2026-07-15T22:11:22.917Z
 - `app/api/payments/checkout/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/approve/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/export/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/payroll-time/periods/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/rebuild/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/settings/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/recalls/fetch/route.ts` | methods: POST | riskFlags: mutating_with_service_role_without_obvious_auth_or_boundary
 - `app/api/scheduling/shifts/[id]/route.ts` | methods: PATCH, DELETE | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/shop-assistant/actions/[actionId]/cancel/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/shop-assistant/actions/[actionId]/confirm/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/shop-assistant/threads/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop-boost/intakes/run/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop/owner-pin/clear/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shopreel/drafts/[id]/route.ts` | methods: PATCH | riskFlags: mutating_without_obvious_auth_marker
@@ -133,22 +138,23 @@ Generated: 2026-07-15T22:11:22.917Z
 - `app/api/branding/assets/[id]/archive/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/delete/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/favorite/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/branding/invoice-design/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/user-preferences/reset/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/user-preferences/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/dashboard/layout/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/demo/shop-boost/share/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/demo/shop-boost/uploads/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/diag/log/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/dtc-suggest/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/fleet/service-requests/convert-to-work-order/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/inspections/build/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/inspections/load/route.ts` | methods: GET | riskFlags: none
-- `app/api/inspections/submit/pdf/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/connect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/disconnect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/invoice/[id]/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/status/route.ts` | methods: GET | riskFlags: none
 - `app/api/maintenance/suggestions/dismiss/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/mobile/home-payload/route.ts` | methods: GET | riskFlags: none
+- `app/api/offline/session-check/route.ts` | methods: GET | riskFlags: none
 - `app/api/onboarding-v2/guided/sessions/[sessionId]/existing-system/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/onboarding-v2/guided/sessions/[sessionId]/route.ts` | methods: GET, PATCH | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/onboarding-v2/guided/sessions/[sessionId]/steps/[stepKey]/answer/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -171,11 +177,16 @@ Generated: 2026-07-15T22:11:22.917Z
 - `app/api/payroll-time/export/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/exports/[batchId]/download/route.ts` | methods: GET | riskFlags: none
 - `app/api/payroll-time/exports/route.ts` | methods: GET | riskFlags: none
-- `app/api/payroll-time/periods/route.ts` | methods: GET | riskFlags: none
+- `app/api/payroll-time/periods/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/rebuild/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/settings/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/scheduling/shifts/[id]/route.ts` | methods: PATCH, DELETE | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/settings/update/shop/owner-pin/set/route.ts` | methods: none | riskFlags: none
+- `app/api/shop-assistant/actions/[actionId]/cancel/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/shop-assistant/actions/[actionId]/confirm/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/shop-assistant/state/route.ts` | methods: GET | riskFlags: none
+- `app/api/shop-assistant/threads/[threadId]/messages/route.ts` | methods: GET | riskFlags: none
+- `app/api/shop-assistant/threads/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop-boost/intakes/run/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop/owner-pin/clear/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shopreel/drafts/[id]/route.ts` | methods: PATCH | riskFlags: mutating_without_obvious_auth_marker

--- a/docs/audits/profixiq-completion-map-2026-07-23.md
+++ b/docs/audits/profixiq-completion-map-2026-07-23.md
@@ -1,0 +1,209 @@
+# ProFixIQ completion map — 2026-07-23
+
+## Decision
+
+**Deployment readiness: NO-GO.**
+
+Current `main` is deployable by Vercel and passes TypeScript, but it is not
+release-verified:
+
+- `main` at `27bd6efe` has a successful Vercel status.
+- TypeScript completed successfully with `tsc --noEmit`.
+- The API route inventory completed successfully and now covers 372 routes.
+- The complete Vitest run reported 48 failed tests, 1,136 passed tests, and 2
+  skipped database integration tests.
+- The two skipped tests are the live parts lifecycle database integration
+  suite. That means the newest Add Part, Use Part, handoff, consumption,
+  authorization, and replay changes are not yet proven against a running
+  Supabase schema in this audit environment.
+- No authenticated multi-role browser run, production-like database replay,
+  Stripe test-mode checkout, customer/fleet portal session, two-device
+  inspection session, or offline device pilot was executed during this audit.
+
+The failed test count is not equivalent to 48 confirmed product defects.
+Most failures are source-shape assertions that still expect code which was
+replaced by newer atomic RPCs, renamed migrations, moved mobile components, or
+changed copy. They still make the release gate unusable: genuine regressions
+cannot be distinguished from stale contracts until they are reconciled.
+
+## Status language
+
+- **Code-complete**: the canonical implementation exists and focused automated
+  evidence passes.
+- **Partial**: meaningful implementation exists, but a required path,
+  verification layer, or lifecycle edge remains incomplete.
+- **Broken**: a reachable current-main path is demonstrably wrong.
+- **Duplicated**: more than one active or reviewable implementation claims the
+  same responsibility.
+- **Unverified**: implementation may be correct, but the required runtime
+  evidence was not available.
+- **Blocked**: an external configuration, environment, migration application,
+  or product decision is required before verification can finish.
+
+## Evidence baseline
+
+| Evidence | Result | Meaning |
+| --- | --- | --- |
+| Repository | `EdwardLakin/ProFixIQ` | Public repository, default branch `main` |
+| Audited main | `27bd6efe` | Merge of PR #1176, canonical parts transaction repair |
+| Main deployment check | Vercel success | Build/deployment provider accepted current main |
+| TypeScript | Pass | Current main compiles under the installed TypeScript project |
+| API route audit | Pass; 372 routes | Static inventory completed; it is not an authorization proof |
+| API risk heuristic | 62 high, 21 medium, 289 low | Every high/medium result still needs human flow review; false positives are expected |
+| Full Vitest | 48 failed, 1,136 passed, 2 skipped | Repository-wide release gate is red |
+| Schema files | 120 migrations, 11 manual SQL files | Migration history is large and manual SQL remains a second delivery surface |
+| Latest migration | `20260723114500_canonical_use_part_runtime_security.sql` | Latest schema work is the direct Use Part runtime/security repair |
+| Generated DB types | Typecheck pass | Types and current code compile; this does not prove deployed schema parity |
+
+## Single completion map
+
+| Workstream | Current classification | Evidence on current main | Missing evidence or blocker | Next completion gate |
+| --- | --- | --- | --- | --- |
+| Authentication | **Code-complete; runtime-unverified** | `tests/user-auth-normalization.test.ts` and `tests/auth-portal-hardening.test.ts` passed; staff creation includes rollback coverage; portal identity has hardened invite/activation routes | No owner/advisor/technician/fleet/customer login matrix was run; reset, invite, username-only, and revoked-session behavior remain production-like smoke items | Create isolated users for every role and run login, reset, invite, logout, revoked-session, and cross-shop denial tests |
+| Guided onboarding | **Partial; duplicated** | Guided onboarding analysis and page-panel suites passed; canonical guided session routes and tables exist | `tests/guided-onboarding-v2-foundation.test.ts` has a stale navigation assertion; PRs #947 and #950 duplicate the same onboarding evidence change; signup-to-first-work-order runtime was not tested | Reconcile the test with current navigation, choose/close the duplicate PRs, then run new-shop signup → import/scratch → settings → first work order |
+| Work-order creation | **Code-complete; runtime-unverified** | `tests/create-work-order-customer-vehicle-save.test.ts` passed; current routes support customer/vehicle save, suggested-line attachment, intake, and canonical line creation | No browser test proved search selection, manual customer/fleet entry, save, refresh, and second-device visibility together | Run owner/advisor desktop and mobile creation with existing and new customers, multiple vehicles, suggested maintenance, and refresh on a second device |
+| Inspections | **Partial; high regression risk** | Canonical identity, cross-device reconciliation, autosave, offline recovery, photo staging, and recent publication-guard suites passed; main includes the versioned writer and canonical-source migrations | Six inspection contract files fail because they expect superseded writer/reopen/UI shapes; no installed-app two-device run was performed; deployment order of the recent inspection migrations was not checked against a live non-production database | Reconcile the six contracts to the canonical writer, replay migrations into a clean Supabase environment, then run phone/desktop simultaneous edit, photo, signature, finalize, reopen, PDF, and conflict recovery |
+| Quoting and approvals | **Code-complete; runtime-unverified** | Phase 5 quote lifecycle, shop decision, quote send, history relevance, and Phase 8 approval consistency coverage is present; decisions route through atomic commands | Inspection-to-quote source contracts include stale failures; no customer and fleet replay test proved one decision and one set of downstream effects | Run failed inspection → quote → send → approve/decline/defer twice for customer and fleet; confirm exactly one line decision, parts release, status transition, and audit record |
+| Parts lifecycle | **Code-complete on latest main; database-runtime-unverified** | PR #1176 is on main; focused part picker, async handoff, SQL authorization/idempotency, Add Part, Use Part, receiving, allocation, return, and invoice-parts suites mostly passed | Two database integration tests were skipped; four workbench tests still assert the pre-RPC implementation; production-like migration/schema parity is unknown | Run the full parts DB integration suite against clean replayed schema, then smoke request → quote → approval → pick/order → receive → allocate → handoff → use → return |
+| Technician handoff and consumption | **Code-complete on latest main; database-runtime-unverified** | Latest migrations and routes use the atomic handoff/use transaction, stable operation keys, shop authorization, replay receipts, and net-issued invoice quantities | Same skipped runtime suite as parts; no technician UI double-submit/network-loss test in this audit | Execute handoff and Use Part as parts staff and assigned technician, repeat every request, lose network after commit, and prove one stock move, one consumption result, and one invoice quantity |
+| Invoicing | **Partial; runtime-unverified** | Immutable invoice versions, payment event ledger, manual payment, PDF renderer, closeout gate, and live invoice safety suites exist; premium PDF unit tests passed | The seven Phase 1 source-contract tests are stale after migration/route changes; PR #1119 (font embedding) has a failed Vercel status; no full invoice/payment/receipt/void/reissue run was performed | Reconcile Phase 1 contracts, decide whether #1119 is still needed, then run issue → PDF → partial/full payment → receipt → refund/reversal → void/reissue using test-mode providers |
+| Customer and fleet portals | **Partial; runtime-unverified** | Portal invite, booking, request, approval, mobile refactor, service/quote request, navigation, and advisor-message coverage passed; recent portal source markers are on main | No real invite callback, mobile customer session, fleet session, advisor routing, payment, or account-revocation run was performed | Run customer and fleet invite acceptance on phone, list/detail visibility, quote decisions, Message Shop routing, invoice/payment, profile, logout, and cross-customer denial |
+| Workforce | **Partial; runtime-unverified** | Workforce activity, time reliability, corrections, admin actionability, documents, and payroll review implementations exist; canonical shift and labor RPCs are present | Four workforce/job-punch contracts are stale or reference removed paths; one suite reads a renamed migration; no authenticated punch-in/out, break, hold/resume, correction, or payroll close run was performed | Replace stale source assertions with RPC behavior tests and run shift start/break/end, line start/hold/release/finish, correction audit, pay-period refresh, and cross-shop denial |
+| Messaging | **Code-complete; runtime-unverified** | Conversation authorization, participant scope, offline drafts, portal navigation, and advisor-directed portal messaging tests passed | No two-account realtime test, offline/reconnect draft race, attachment, or revoked-participant test was run | Test staff↔staff and customer↔advisor messages on two devices, including offline draft, reconnect, attachment, notification, and removed membership |
+| Mobile routing | **Broken on main; fixed on this branch** | The shared resolver is used by middleware, the mobile shell, assistant entries, dashboard primitives, and previous-page controls | On main, `/work-orders/<UUID>` could be truncated because `/work-orders/view` was treated as a prefix without verifying the boundary; canonical `/quote-review/<id>` also had no mobile mapping | Merge only after the 27-case route suite, TypeScript, lint, build, and role-based phone smoke pass |
+| Offline synchronization | **Partial; pilot-blocked** | Mutation receipts, session re-verification, technician/advisor/parts caches, photo staging, conflict handling, diagnostics, and resilience tests mostly passed | One update-activation assertion is stale; the two-device/device-quota/update/eviction pilot in `docs/offline-shop-pilot.md` has not been executed | Complete every pilot matrix row on iOS/iPadOS, Android, and desktop PWA; do not expand release until all rows pass |
+| AI features | **Partial; open PR blocked** | Main has provider abstraction, safe display/serialization, usage, action approvals, deterministic closeout, and reliable shop-assistant conversation/action tests | PR #1143 is 86 commits, its Shop Assistant workflow failed TypeScript because `@shared/types/types/supabase-shop-assistant` was missing, and Vercel failed; current main does not contain that complete orchestration layer; one structured-output unit test also falls back unexpectedly in the full suite | Rebase or replace #1143 from current main, restore generated-type ownership, pass action authorization/idempotency/runtime tests, and keep technician diagnosis non-executable |
+| Billing | **Partial; externally blocked** | Canonical Stripe webhook aliasing, signature validation, subscription synchronization, server-derived checkout, payment ledger, and API-version coverage exist | One webhook test expects obsolete error copy; no Stripe test-mode signup, checkout, renewal, failed payment, cancellation, seat limit, or replay was run; provider dashboard configuration was not inspected | Run Stripe test-mode lifecycle with repeated webhooks and verify canonical shop subscription fields, access changes, and no duplicate financial events |
+| Schema and RLS | **Partial; replay-unverified** | 120 additive migrations, generated types, numerous RLS policies, narrow RPC grants, and the latest direct Use Part authorization repair are present | 11 manual SQL files remain outside the migration chain; three workforce contract tests still treat manual SQL as authority; the static API audit flags 83 high/medium routes for review; no clean replay or direct-RPC cross-shop matrix was run | Establish migrations as the only production authority, map or retire manual SQL, clean-replay locally, then test every privileged RPC both through the API and directly as authorized/unauthorized users |
+| Deployment readiness | **NO-GO** | Current main Vercel status is green and TypeScript/API inventory pass | Full tests are red, database integration is skipped, mobile routing is broken on main, two current PRs fail Vercel, migrations are not replay-verified here, and required role/device/provider smokes are absent | Restore a trustworthy green gate, complete clean-schema/runtime tests, and attach the exact multi-role/mobile/offline/provider smoke evidence before any production deployment |
+
+## Open pull-request disposition
+
+There are 16 open PRs.
+
+### Current but blocked
+
+- **#1143 — Shop assistant orchestration:** mergeable according to GitHub, but
+  Vercel failed and the dedicated workflow failed TypeScript on a missing
+  Supabase assistant type module. It is also 86 commits behind a rapidly
+  changing main and must be rebased or rebuilt, not merged as-is.
+- **#1119 — Invoice PDF fonts:** one commit and mergeable, but Vercel failed.
+  Confirm whether main's current PDF renderer already supersedes it before
+  repairing or closing it.
+
+### Duplicated or stale
+
+- **#947 and #950** have the same onboarding-evidence title and intent. Select
+  at most one after comparing with current main.
+- **#921, #910, #906, #460, #445, #357, #354, #352, #271, and #266** predate
+  the current July 23 lifecycle work. Most are now conflicting. Their old
+  green Vercel checks prove only their historical snapshots, not compatibility
+  with current main.
+- **#2** is an obsolete draft migration placeholder and must never be used as
+  schema authority.
+- **#1** is an obsolete schema-dump workflow proposal with a failed Vercel
+  status.
+
+No PR was closed, merged, or changed by this audit.
+
+## Priority order
+
+1. **P0 — Restore a trustworthy release gate.** Classify and reconcile the
+   remaining 47 failures after this branch's mobile fix. Replace source-string
+   assertions with behavior or SQL-contract tests where possible. Do not make
+   tests green by restoring superseded non-atomic code.
+2. **P0 — Prove the canonical shop golden path against a clean database.**
+   Work order → inspection → recommendation/quote → approval → parts
+   order/pick/receive → handoff/use/return → cause/correction → invoice →
+   payment/receipt. Repeat retryable actions and test direct RPC denial.
+3. **P0 — Replay the complete migration chain in non-production.** Compare the
+   resulting schema/functions/policies to generated types and current route
+   calls. Resolve manual-SQL ownership without editing historical migrations.
+4. **P0 — Complete installed inspection and offline pilots.** Two-device
+   editing, staged photos, session expiry, network loss after commit, conflict
+   recovery, update activation, storage pressure, and account switching.
+5. **P1 — Complete auth/portal/workforce/billing role matrices.** These have
+   substantial code but insufficient production-like evidence.
+6. **P1 — Rebase or replace the assistant orchestration PR.** AI expansion
+   follows operational truth and release-gate repair; it must not bypass
+   canonical domain commands.
+7. **P2 — Close or supersede stale PRs.** This removes misleading green checks
+   and duplicate implementations from the review surface.
+
+## Completed workstream: mobile route integrity
+
+### Root cause
+
+`firstPathSegmentAfter()` sliced a pathname at the supplied prefix length
+without first proving that the pathname was actually at or below that prefix.
+`mapWorkOrderPath()` probes `/work-orders/view` before parsing a normal work
+order ID. A UUID path such as `/work-orders/9c2a...` was therefore sliced in
+the middle and redirected to the wrong mobile work-order ID. Similar
+`startsWith()` checks also accepted lookalike paths such as `pretrips` as
+`pretrip`.
+
+The canonical desktop quote route `/quote-review/<work-order-id>` was not
+mapped at all, so quote links opened from mobile could escape to the desktop
+surface.
+
+### Implemented correction
+
+- Added segment-boundary matching for every recognized mobile route family.
+- Made dynamic segment extraction fail closed unless the prefix is an exact
+  path boundary.
+- Preserved full UUID work-order IDs.
+- Mapped canonical and compatibility quote-review routes to the mobile
+  work-order detail.
+- Consumed the legacy `woId` query parameter once it is converted into the
+  mobile path while preserving unrelated query parameters and hashes.
+- Added regression cases for full UUIDs, view routes, canonical quote review,
+  legacy quote review, query/hash preservation, and lookalike route names.
+
+### Safety
+
+This change performs no database access and changes no authorization,
+membership, RLS, schema, business status, or mutation behavior. Middleware and
+the client shell continue to use the same resolver; only known path-boundary
+classification and destination integrity change. External, portal, API, and
+shared-auth routes still return no mobile rewrite.
+
+### Branch verification
+
+- The focused mobile route suite passes all 27 cases, including full UUIDs,
+  canonical and compatibility quote-review links, query/hash preservation, and
+  lookalike route boundaries.
+- TypeScript and targeted ESLint pass.
+- The API route audit passes and inventories all 372 current routes.
+- A production Next.js build completes with local placeholder values for
+  required build-time secrets. No external service or production environment
+  was contacted.
+- The complete branch suite reports 47 failed, 1,142 passed, and 2 skipped
+  tests across 205 files. The mobile route suite is no longer among the failed
+  files; 28 other files remain red. This is an improvement over the audited
+  main baseline, not a release-ready result.
+- Authenticated role/device verification remains the required manual gate
+  below because this audit environment has no seeded test identities or
+  running non-production Supabase instance.
+
+## Required smoke test for this branch
+
+1. On an iPhone/iPad-sized viewport, sign in separately as owner, advisor,
+   manager/foreman, and technician.
+2. Open a work order whose route uses a UUID from each role dashboard. Confirm
+   the exact same UUID appears in `/mobile/work-orders/<id>`.
+3. Paste `/work-orders/<UUID>` directly into the browser on a mobile device.
+   Confirm middleware redirects to the exact mobile record.
+4. Open `/work-orders/view/<UUID>?tab=parts#handoff`; confirm the UUID, query,
+   and hash survive.
+5. Open `/work-orders/<UUID>/quote-review`,
+   `/quote-review/<UUID>`, and
+   `/work-orders/quote-review?woId=<UUID>`. Confirm each stays in the mobile
+   shell and opens that work order.
+6. Tap quote links from the mobile work-order page, advisor notifications,
+   assistant results, and the previous-page control.
+7. Open work-order board, create, customer, fleet pretrip, messages,
+   inspections, parts, offline, assistant, planner, settings, and reports
+   links. Confirm none land on a desktop page.
+8. Confirm portal, external, `mailto:`, reset-password, and API links are not
+   rewritten.
+9. Repeat with the device installed as a PWA and with a cold start.

--- a/features/mobile/navigation/mobile-route-continuity.ts
+++ b/features/mobile/navigation/mobile-route-continuity.ts
@@ -11,20 +11,56 @@ function withSuffix(pathname: string, search: string, hash: string): string {
   return `${pathname}${search}${hash}`;
 }
 
+function isPathAtOrBelow(pathname: string, route: string): boolean {
+  const normalizedRoute = route.endsWith("/")
+    ? route.replace(/\/+$/, "")
+    : route;
+  return (
+    pathname === normalizedRoute || pathname.startsWith(`${normalizedRoute}/`)
+  );
+}
+
 function firstPathSegmentAfter(pathname: string, prefix: string): string | null {
-  const remainder = pathname.slice(prefix.length).replace(/^\/+/, "");
+  const normalizedPrefix = prefix.endsWith("/")
+    ? prefix.replace(/\/+$/, "")
+    : prefix;
+  if (!isPathAtOrBelow(pathname, normalizedPrefix)) return null;
+
+  const remainder = pathname
+    .slice(normalizedPrefix.length)
+    .replace(/^\/+/, "");
   const segment = remainder.split("/")[0]?.trim();
   return segment || null;
 }
 
-function mapWorkOrderPath(pathname: string): string {
+function mapWorkOrderPath(
+  pathname: string,
+  searchParams: URLSearchParams,
+): string {
   if (pathname === "/work-orders" || pathname === "/work-orders/") {
     return "/mobile/work-orders";
   }
-  if (pathname.startsWith("/work-orders/board")) return "/mobile/dispatch";
   if (
-    pathname.startsWith("/work-orders/create") ||
-    pathname.startsWith("/work-orders/new")
+    pathname === "/work-orders/view" ||
+    pathname === "/work-orders/view/"
+  ) {
+    return "/mobile/work-orders";
+  }
+  if (
+    pathname === "/work-orders/quote-review" ||
+    pathname === "/work-orders/quote-review/"
+  ) {
+    const workOrderId = searchParams.get("woId")?.trim();
+    return workOrderId
+      ? `/mobile/work-orders/${encodeURIComponent(workOrderId)}`
+      : "/mobile/work-orders";
+  }
+  if (isPathAtOrBelow(pathname, "/work-orders/board")) {
+    return "/mobile/dispatch";
+  }
+  if (
+    isPathAtOrBelow(pathname, "/work-orders/create") ||
+    isPathAtOrBelow(pathname, "/work-orders/new")
   ) {
     return "/mobile/work-orders/create";
   }
@@ -39,16 +75,16 @@ function mapWorkOrderPath(pathname: string): string {
 }
 
 function mapInspectionPath(pathname: string): string {
-  if (pathname.startsWith("/inspections/fleet-import")) {
+  if (isPathAtOrBelow(pathname, "/inspections/fleet-import")) {
     return "/mobile/inspections/import";
   }
-  if (pathname.startsWith("/inspections/fleet-review")) {
+  if (isPathAtOrBelow(pathname, "/inspections/fleet-review")) {
     return "/mobile/inspections/import";
   }
-  if (pathname.startsWith("/inspections/maintenance-50-air")) {
+  if (isPathAtOrBelow(pathname, "/inspections/maintenance-50-air")) {
     return "/mobile/inspections/maintenance-50-air";
   }
-  if (pathname.startsWith("/inspections/maintenance-50")) {
+  if (isPathAtOrBelow(pathname, "/inspections/maintenance-50")) {
     return "/mobile/inspections/maintenance-50";
   }
 
@@ -66,6 +102,13 @@ function mapInspectionPath(pathname: string): string {
     : "/mobile/inspections";
 }
 
+function mapQuoteReviewPath(pathname: string): string {
+  const workOrderId = firstPathSegmentAfter(pathname, "/quote-review");
+  return workOrderId
+    ? `/mobile/work-orders/${workOrderId}`
+    : "/mobile/work-orders";
+}
+
 function mapMessagePath(pathname: string): string {
   const suffix = pathname.slice("/messages".length);
   return `/mobile/messages${suffix}`;
@@ -77,16 +120,16 @@ function mapCustomerPath(pathname: string): string {
 }
 
 function mapFleetPath(pathname: string): string {
-  if (pathname.startsWith("/fleet/service-requests")) {
+  if (isPathAtOrBelow(pathname, "/fleet/service-requests")) {
     return "/mobile/fleet/service-requests";
   }
-  if (pathname.startsWith("/fleet/pretrip")) {
+  if (isPathAtOrBelow(pathname, "/fleet/pretrip")) {
     const unitId = firstPathSegmentAfter(pathname, "/fleet/pretrip");
     return unitId
       ? `/mobile/fleet/pretrip/${unitId}`
       : "/mobile/fleet/pretrip";
   }
-  if (pathname.startsWith("/fleet/assets")) {
+  if (isPathAtOrBelow(pathname, "/fleet/assets")) {
     const unitId = firstPathSegmentAfter(pathname, "/fleet/assets");
     return unitId
       ? `/mobile/fleet?unit=${encodeURIComponent(unitId)}`
@@ -96,20 +139,20 @@ function mapFleetPath(pathname: string): string {
 }
 
 function mapDashboardPath(pathname: string): string {
-  if (pathname.startsWith("/dashboard/workforce")) {
+  if (isPathAtOrBelow(pathname, "/dashboard/workforce")) {
     return "/mobile/workforce/attendance";
   }
   if (
-    pathname.startsWith("/dashboard/admin/people") ||
-    pathname.startsWith("/dashboard/admin/employees") ||
-    pathname.startsWith("/dashboard/technicians")
+    isPathAtOrBelow(pathname, "/dashboard/admin/people") ||
+    isPathAtOrBelow(pathname, "/dashboard/admin/employees") ||
+    isPathAtOrBelow(pathname, "/dashboard/technicians")
   ) {
     return "/mobile/technicians";
   }
-  if (pathname.startsWith("/dashboard/appointments")) {
+  if (isPathAtOrBelow(pathname, "/dashboard/appointments")) {
     return "/mobile/appointments";
   }
-  if (pathname.startsWith("/dashboard/reports")) {
+  if (isPathAtOrBelow(pathname, "/dashboard/reports")) {
     return "/mobile/reports";
   }
   return "/mobile";
@@ -140,47 +183,58 @@ export function resolveMobileHref(rawHref: string | null | undefined): string | 
 
   if (parsed.origin !== MOBILE_ORIGIN) return null;
 
-  const { pathname, search, hash } = parsed;
-  if (pathname.startsWith("/mobile")) {
+  const { pathname, hash } = parsed;
+  let search = parsed.search;
+  if (isPathAtOrBelow(pathname, "/mobile")) {
     return withSuffix(pathname, search, hash);
   }
 
   let mobilePath: string | null = null;
 
-  if (pathname === "/" || pathname.startsWith("/dashboard")) {
+  if (pathname === "/" || isPathAtOrBelow(pathname, "/dashboard")) {
     mobilePath = pathname === "/" ? "/mobile" : mapDashboardPath(pathname);
-  } else if (pathname.startsWith("/work-orders")) {
-    mobilePath = mapWorkOrderPath(pathname);
-  } else if (pathname.startsWith("/tech/queue")) {
+  } else if (isPathAtOrBelow(pathname, "/work-orders")) {
+    mobilePath = mapWorkOrderPath(pathname, parsed.searchParams);
+    if (
+      (pathname === "/work-orders/quote-review" ||
+        pathname === "/work-orders/quote-review/") &&
+      parsed.searchParams.has("woId")
+    ) {
+      parsed.searchParams.delete("woId");
+      search = parsed.search;
+    }
+  } else if (isPathAtOrBelow(pathname, "/quote-review")) {
+    mobilePath = mapQuoteReviewPath(pathname);
+  } else if (isPathAtOrBelow(pathname, "/tech/queue")) {
     mobilePath = "/mobile/tech/queue";
-  } else if (pathname.startsWith("/tech/performance")) {
+  } else if (isPathAtOrBelow(pathname, "/tech/performance")) {
     mobilePath = "/mobile/tech/performance";
-  } else if (pathname.startsWith("/appointments")) {
+  } else if (isPathAtOrBelow(pathname, "/appointments")) {
     mobilePath = "/mobile/appointments";
-  } else if (pathname.startsWith("/inspections")) {
+  } else if (isPathAtOrBelow(pathname, "/inspections")) {
     mobilePath = mapInspectionPath(pathname);
-  } else if (pathname.startsWith("/parts")) {
+  } else if (isPathAtOrBelow(pathname, "/parts")) {
     mobilePath = "/mobile/parts";
-  } else if (pathname.startsWith("/messages")) {
+  } else if (isPathAtOrBelow(pathname, "/messages")) {
     mobilePath = mapMessagePath(pathname);
-  } else if (pathname.startsWith("/customers")) {
+  } else if (isPathAtOrBelow(pathname, "/customers")) {
     mobilePath = mapCustomerPath(pathname);
-  } else if (pathname.startsWith("/fleet")) {
+  } else if (isPathAtOrBelow(pathname, "/fleet")) {
     mobilePath = mapFleetPath(pathname);
-  } else if (pathname.startsWith("/offline")) {
+  } else if (isPathAtOrBelow(pathname, "/offline")) {
     mobilePath = "/mobile/offline";
   } else if (
-    pathname.startsWith("/assistant") ||
-    pathname.startsWith("/ai/assistant")
+    isPathAtOrBelow(pathname, "/assistant") ||
+    isPathAtOrBelow(pathname, "/ai/assistant")
   ) {
     mobilePath = "/mobile/assistant";
-  } else if (pathname.startsWith("/agent/planner")) {
+  } else if (isPathAtOrBelow(pathname, "/agent/planner")) {
     mobilePath = "/mobile/planner";
-  } else if (pathname.startsWith("/settings")) {
+  } else if (isPathAtOrBelow(pathname, "/settings")) {
     mobilePath = "/mobile/settings";
-  } else if (pathname.startsWith("/reports")) {
+  } else if (isPathAtOrBelow(pathname, "/reports")) {
     mobilePath = "/mobile/reports";
-  } else if (pathname.startsWith("/technicians")) {
+  } else if (isPathAtOrBelow(pathname, "/technicians")) {
     mobilePath = "/mobile/technicians";
   } else if (pathname === "/sign-in") {
     mobilePath = "/mobile/sign-in";

--- a/tests/mobile-route-continuity.test.ts
+++ b/tests/mobile-route-continuity.test.ts
@@ -15,6 +15,22 @@ describe("mobile route continuity", () => {
     ["/work-orders/board", "/mobile/dispatch"],
     ["/work-orders/create", "/mobile/work-orders/create"],
     ["/work-orders/abc/quote-review", "/mobile/work-orders/abc"],
+    [
+      "/work-orders/9c2a12b0-7708-4d5f-a776-532c25022337",
+      "/mobile/work-orders/9c2a12b0-7708-4d5f-a776-532c25022337",
+    ],
+    [
+      "/work-orders/view/9c2a12b0-7708-4d5f-a776-532c25022337?tab=parts#handoff",
+      "/mobile/work-orders/9c2a12b0-7708-4d5f-a776-532c25022337?tab=parts#handoff",
+    ],
+    [
+      "/quote-review/9c2a12b0-7708-4d5f-a776-532c25022337",
+      "/mobile/work-orders/9c2a12b0-7708-4d5f-a776-532c25022337",
+    ],
+    [
+      "/work-orders/quote-review?woId=9c2a12b0-7708-4d5f-a776-532c25022337",
+      "/mobile/work-orders/9c2a12b0-7708-4d5f-a776-532c25022337",
+    ],
     ["/tech/queue", "/mobile/tech/queue"],
     ["/appointments?day=2026-07-19", "/mobile/appointments?day=2026-07-19"],
     [
@@ -43,6 +59,14 @@ describe("mobile route continuity", () => {
     expect(resolveMobileHref("/portal/fleet")).toBeNull();
     expect(resolveMobileHref("/forgot-password?redirect=%2Fmobile")).toBeNull();
     expect(requireMobileHref("/unknown-internal-route")).toBe("/mobile");
+  });
+
+  it("does not treat similar route names as dynamic record prefixes", () => {
+    expect(resolveMobileHref("/work-orders/viewer")).toBe(
+      "/mobile/work-orders/viewer",
+    );
+    expect(resolveMobileHref("/customers-list/customer-1")).toBeNull();
+    expect(resolveMobileHref("/fleet/pretrips/unit-1")).toBe("/mobile/fleet");
   });
 
   it("installs client and server guards for desktop links opened on mobile", () => {


### PR DESCRIPTION
## What changed

- Adds a single evidence-backed completion map across authentication, onboarding, work-order creation, inspections, quoting/approvals, parts, technician handoff/consumption, invoicing, portals, workforce, messaging, mobile routing, offline synchronization, AI, billing, schema/RLS, and deployment readiness.
- Audits all 16 currently open PRs and records blocked, duplicated, stale, or obsolete work.
- Refreshes the API boundary inventory from 343 to all 372 current routes.
- Repairs the highest-priority isolated workstream found during the audit: mobile work-order and quote-route integrity.
- Adds regression coverage for full UUID routes, canonical and compatibility quote-review routes, query/hash preservation, and lookalike path boundaries.

## Root cause

`firstPathSegmentAfter()` sliced a pathname at the supplied prefix length without proving the pathname was at or below that prefix. Because work-order mapping checked `/work-orders/view` before the general work-order route, a normal `/work-orders/<UUID>` could be truncated and redirected to the wrong mobile record. Canonical `/quote-review/<id>` links also had no mobile mapping. Broad `startsWith()` checks accepted lookalike route names.

## Impact and safety

The shared resolver is used by middleware, MobileShell link interception, assistant entry links, dashboard primitives, and previous-page controls. The fix preserves exact work-order identity and keeps quote navigation inside the mobile surface.

This change performs no database access and changes no schema, RLS, authorization, membership, status transition, or mutation behavior. External, portal, API, and shared-auth destinations remain excluded from mobile rewriting.

## Validation

- `vitest run tests/mobile-route-continuity.test.ts` — pass, 27/27
- `tsc --noEmit` — pass
- Targeted ESLint — pass
- `node scripts/audit-api-routes.mjs` — pass, 372 routes
- `next build` with local placeholder build-time secrets — pass; no external or production service contacted
- Complete Vitest branch run — **47 failed, 1,142 passed, 2 skipped across 205 files**. This improves the audited main baseline from 48 failures, but remains a release blocker. The two skipped tests are live parts database integration tests.

## Release decision

**NO-GO.** Do not deploy this branch based on this PR. The completion map documents the required release gates, including clean migration replay, database-runtime parts verification, role/device/provider smoke tests, inspection/offline pilots, and reconciliation of the remaining 47 tests.

## Database and environment

- No migration required.
- No production migration or data operation performed.
- No production environment modified.
- No new environment variables introduced.

## Manual verification still required

Run the role-based phone/PWA smoke checklist in `docs/audits/profixiq-completion-map-2026-07-23.md` against a seeded non-production environment before marking ready for review.