### PR TITLE
Dismiss abandoned empty parts requests

### DIFF
--- a/app/api/parts/requests/[requestId]/dismiss-empty/route.ts
+++ b/app/api/parts/requests/[requestId]/dismiss-empty/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.trim(),
+    )
+  );
+}
+
+export async function POST(
+  _request: Request,
+  context: { params: Promise<{ requestId: string }> },
+) {
+  const { requestId } = await context.params;
+  if (!isUuid(requestId)) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid requestId." },
+      { status: 400 },
+    );
+  }
+
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ["owner", "admin", "manager", "advisor", "parts"],
+  });
+  if (!access.ok) return access.response;
+
+  const { data: partRequest, error: requestError } = await access.supabase
+    .from("part_requests")
+    .select("id,status,work_order_id")
+    .eq("id", requestId)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+
+  if (requestError) {
+    return NextResponse.json(
+      { ok: false, error: "Unable to load the parts request." },
+      { status: 500 },
+    );
+  }
+  if (!partRequest) {
+    return NextResponse.json(
+      { ok: false, error: "Parts request not found." },
+      { status: 404 },
+    );
+  }
+  if (partRequest.status === "cancelled") {
+    return NextResponse.json({
+      ok: true,
+      idempotent: true,
+      requestId,
+      status: "cancelled",
+    });
+  }
+  if (partRequest.status !== "requested") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          "Only an unpriced request that has not entered the parts workflow can be dismissed.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const { count, error: itemError } = await access.supabase
+    .from("part_request_items")
+    .select("id", { count: "exact", head: true })
+    .eq("request_id", requestId)
+    .eq("shop_id", access.profile.shop_id);
+
+  if (itemError) {
+    return NextResponse.json(
+      { ok: false, error: "Unable to verify that the request is empty." },
+      { status: 500 },
+    );
+  }
+  if ((count ?? 0) > 0) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "This request contains parts and cannot be dismissed as empty.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const { data: updated, error: updateError } = await access.supabase
+    .from("part_requests")
+    .update({ status: "cancelled" })
+    .eq("id", requestId)
+    .eq("shop_id", access.profile.shop_id)
+    .eq("status", "requested")
+    .select("id,status")
+    .maybeSingle();
+
+  if (updateError) {
+    return NextResponse.json(
+      { ok: false, error: "Unable to dismiss the empty parts request." },
+      { status: 500 },
+    );
+  }
+  if (!updated) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "The request changed before it could be dismissed. Refresh and review it.",
+      },
+      { status: 409 },
+    );
+  }
+
+  await logOperationalEvent({
+    supabase: access.supabase,
+    event: "parts_request_empty_dismissed",
+    actorId: access.profile.id,
+    entityType: "part_requests",
+    entityId: requestId,
+    details: {
+      shop_id: access.profile.shop_id,
+      work_order_id: partRequest.work_order_id,
+      previous_status: partRequest.status,
+      status: updated.status,
+    },
+  });
+
+  return NextResponse.json({
+    ok: true,
+    idempotent: false,
+    requestId,
+    status: updated.status,
+  });
+}

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -18,6 +18,7 @@ import { toast } from "sonner";
 import type { Database } from "@shared/types/types/supabase";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import PickOrderTaskModal from "@/features/parts/components/PickOrderTaskModal";
+import { isDismissibleEmptyPartRequestBucket } from "@/features/parts/lib/requests/empty-request";
 import {
   earliestPartsRequestStage,
   isPartsRequestItemHandedOff,
@@ -367,18 +368,30 @@ function ProgressRail({ bucket }: { bucket: WoBucket }) {
 
 function QueueCard({
   bucket,
+  dismissingEmpty,
   handingOff,
+  onDismissEmpty,
   onHandoff,
   onOpenPickOrder,
 }: {
   bucket: WoBucket;
+  dismissingEmpty: boolean;
   handingOff: boolean;
+  onDismissEmpty: (bucket: WoBucket) => Promise<void>;
   onHandoff: (bucket: WoBucket) => Promise<void>;
   onOpenPickOrder: (bucket: WoBucket) => void;
 }) {
   const meta = bucket.stage === "completed" ? null : STAGE_META[bucket.stage];
   const href = requestHref(bucket);
-  const nextAction = meta?.next ?? "Review the completed request history.";
+  const canDismissEmpty = isDismissibleEmptyPartRequestBucket(
+    bucket.models.map((model) => ({
+      status: model.request.status,
+      itemCount: model.items.length,
+    })),
+  );
+  const nextAction = canDismissEmpty
+    ? "No parts were added. Dismiss this abandoned request or open it to review."
+    : (meta?.next ?? "Review the completed request history.");
 
   return (
     <article className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-3 shadow-[var(--theme-shadow-soft)]">
@@ -398,7 +411,11 @@ function QueueCard({
             </p>
           ) : null}
         </div>
-        {meta ? (
+        {canDismissEmpty ? (
+          <span className="max-w-[48%] truncate rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[10px] font-semibold text-[color:var(--theme-text-secondary)]">
+            Empty request
+          </span>
+        ) : meta ? (
           <span
             className={`max-w-[48%] truncate rounded-md border px-2 py-1 text-[10px] font-semibold ${meta.pill}`}
           >
@@ -455,7 +472,24 @@ function QueueCard({
 
       <ProgressRail bucket={bucket} />
 
-      {bucket.stage === "ready_for_tech" ? (
+      {canDismissEmpty ? (
+        <div className="mt-3 grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            onClick={() => void onDismissEmpty(bucket)}
+            disabled={dismissingEmpty}
+            className="inline-flex min-h-10 items-center justify-center rounded-lg border border-rose-400/45 bg-rose-500/10 px-3 py-2 text-xs font-semibold text-rose-200 transition hover:bg-rose-500/20 disabled:cursor-wait disabled:opacity-60"
+          >
+            {dismissingEmpty ? "Dismissing…" : "Dismiss"}
+          </button>
+          <Link
+            href={href}
+            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-[color:var(--theme-border-strong)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-overlay)]"
+          >
+            Review <span aria-hidden>→</span>
+          </Link>
+        </div>
+      ) : bucket.stage === "ready_for_tech" ? (
         <button
           type="button"
           onClick={() => void onHandoff(bucket)}
@@ -537,6 +571,9 @@ export default function PartsRequestsPage(): JSX.Element {
   const [search, setSearch] = useState("");
   const [tab, setTab] = useState<QueueTab>("active");
   const [stageFilter, setStageFilter] = useState<StageFilter>("all");
+  const [dismissingWorkOrder, setDismissingWorkOrder] = useState<string | null>(
+    null,
+  );
   const [handingOffWorkOrder, setHandingOffWorkOrder] = useState<string | null>(
     null,
   );
@@ -741,6 +778,67 @@ export default function PartsRequestsPage(): JSX.Element {
       total +
       model.items.filter((item) => String(item.status) !== "cancelled").length,
     0,
+  );
+
+  const dismissEmptyRequests = useCallback(
+    async (bucket: WoBucket) => {
+      if (dismissingWorkOrder) return;
+
+      const canDismiss = isDismissibleEmptyPartRequestBucket(
+        bucket.models.map((model) => ({
+          status: model.request.status,
+          itemCount: model.items.length,
+        })),
+      );
+      if (!canDismiss) {
+        toast.error(
+          "Only abandoned requests with no parts or pricing can be dismissed.",
+        );
+        return;
+      }
+
+      const requestCount = bucket.models.length;
+      const confirmed = window.confirm(
+        `Dismiss ${requestCount === 1 ? "this empty parts request" : `these ${requestCount} empty parts requests`}? The records will remain in Completed history.`,
+      );
+      if (!confirmed) return;
+
+      setDismissingWorkOrder(bucket.workOrderId);
+      const toastId = toast.loading("Dismissing empty parts requests…");
+      try {
+        for (const model of bucket.models) {
+          const response = await fetch(
+            `/api/parts/requests/${model.request.id}/dismiss-empty`,
+            { method: "POST" },
+          );
+          const payload = (await response.json().catch(() => null)) as {
+            error?: string;
+          } | null;
+          if (!response.ok) {
+            throw new Error(
+              payload?.error || "Unable to dismiss the empty parts request.",
+            );
+          }
+        }
+
+        toast.success(
+          `${requestCount === 1 ? "Request" : "Requests"} moved to Completed history.`,
+          { id: toastId },
+        );
+        await reload();
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Unable to dismiss the empty parts requests.",
+          { id: toastId },
+        );
+        await reload();
+      } finally {
+        setDismissingWorkOrder(null);
+      }
+    },
+    [dismissingWorkOrder, reload],
   );
 
   const completeHandoff = useCallback(
@@ -948,7 +1046,11 @@ export default function PartsRequestsPage(): JSX.Element {
                       <QueueCard
                         key={bucket.workOrderId}
                         bucket={bucket}
+                        dismissingEmpty={
+                          dismissingWorkOrder === bucket.workOrderId
+                        }
                         handingOff={handingOffWorkOrder === bucket.workOrderId}
+                        onDismissEmpty={dismissEmptyRequests}
                         onHandoff={completeHandoff}
                         onOpenPickOrder={setPickOrderBucket}
                       />
@@ -969,7 +1071,9 @@ export default function PartsRequestsPage(): JSX.Element {
             <QueueCard
               key={bucket.workOrderId}
               bucket={bucket}
+              dismissingEmpty={false}
               handingOff={false}
+              onDismissEmpty={dismissEmptyRequests}
               onHandoff={completeHandoff}
               onOpenPickOrder={setPickOrderBucket}
             />

--- a/docs/audits/api-route-boundary-inventory.json
+++ b/docs/audits/api-route-boundary-inventory.json
@@ -2940,6 +2940,24 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/parts/requests/[requestId]/dismiss-empty/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/parts/requests/[requestId]/handoff/route.ts",
     "methods": [
       "POST"

--- a/docs/audits/api-route-boundary-inventory.md
+++ b/docs/audits/api-route-boundary-inventory.md
@@ -1,16 +1,16 @@
 # API Route Boundary Inventory (Static Heuristic)
 
-Generated: 2026-07-23T18:01:07.764Z
+Generated: 2026-07-23T19:22:41.647Z
 
 ## Summary
-- Total route count: **372**
+- Total route count: **373**
 - Routes exporting GET: **118**
-- Routes exporting POST: **265**
+- Routes exporting POST: **266**
 - Routes exporting PUT: **9**
 - Routes exporting PATCH: **21**
 - Routes exporting DELETE: **11**
 - Routes with service-role pattern: **24**
-- Routes using requireShopScopedApiAccess: **108**
+- Routes using requireShopScopedApiAccess: **109**
 - Routes with auth.getUser references: **147**
 
 ## High-Risk Routes

--- a/features/parts/lib/requests/empty-request.ts
+++ b/features/parts/lib/requests/empty-request.ts
@@ -1,0 +1,22 @@
+export type EmptyPartRequestCandidate = {
+  status: unknown;
+  itemCount: number;
+};
+
+/**
+ * Empty request cards are safe to dismiss only before pricing or physical
+ * parts activity begins. Keeping this rule shared prevents the card UI from
+ * offering cancellation for partially built or operational requests.
+ */
+export function isDismissibleEmptyPartRequestBucket(
+  requests: readonly EmptyPartRequestCandidate[],
+): boolean {
+  return (
+    requests.length > 0 &&
+    requests.every(
+      (request) =>
+        String(request.status ?? "").toLowerCase() === "requested" &&
+        request.itemCount === 0,
+    )
+  );
+}

--- a/tests/parts/empty-part-request-cancellation.test.ts
+++ b/tests/parts/empty-part-request-cancellation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isDismissibleEmptyPartRequestBucket } from "../../features/parts/lib/requests/empty-request";
+
+describe("empty parts request cancellation", () => {
+  it("allows one or more requested records with no items to be dismissed", () => {
+    expect(
+      isDismissibleEmptyPartRequestBucket([
+        { status: "requested", itemCount: 0 },
+        { status: "requested", itemCount: 0 },
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not treat a partially built request as abandoned", () => {
+    expect(
+      isDismissibleEmptyPartRequestBucket([
+        { status: "requested", itemCount: 0 },
+        { status: "requested", itemCount: 1 },
+      ]),
+    ).toBe(false);
+  });
+
+  it.each(["quoted", "approved", "fulfilled", "cancelled"])(
+    "does not offer dismissal after the request reaches %s",
+    (status) => {
+      expect(
+        isDismissibleEmptyPartRequestBucket([{ status, itemCount: 0 }]),
+      ).toBe(false);
+    },
+  );
+
+  it("does not offer dismissal for an empty card model", () => {
+    expect(isDismissibleEmptyPartRequestBucket([])).toBe(false);
+  });
+});

--- a/tests/parts/empty-part-request-dismiss-route.test.ts
+++ b/tests/parts/empty-part-request-dismiss-route.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireShopScopedApiAccess: vi.fn(),
+  logOperationalEvent: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireShopScopedApiAccess,
+}));
+
+vi.mock("@/features/work-orders/server/logOperationalEvent", () => ({
+  logOperationalEvent: mocks.logOperationalEvent,
+}));
+
+type MockOptions = {
+  status?: "requested" | "quoted" | "approved" | "cancelled";
+  itemCount?: number;
+  requestMissing?: boolean;
+  updateMissing?: boolean;
+};
+
+function buildSupabase(options: MockOptions = {}) {
+  const requestFilters: Array<[string, unknown]> = [];
+  const itemFilters: Array<[string, unknown]> = [];
+  const updateFilters: Array<[string, unknown]> = [];
+  const update = vi.fn();
+
+  const requestReadBuilder = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn(async () => ({
+      data: options.requestMissing
+        ? null
+        : {
+            id: "11111111-1111-4111-8111-111111111111",
+            status: options.status ?? "requested",
+            work_order_id: "work-order-1",
+          },
+      error: null,
+    })),
+  };
+  requestReadBuilder.select.mockReturnValue(requestReadBuilder);
+  requestReadBuilder.eq.mockImplementation((key: string, value: unknown) => {
+    requestFilters.push([key, value]);
+    return requestReadBuilder;
+  });
+
+  const itemBuilder = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    then: (
+      resolve: (value: { count: number; error: null }) => unknown,
+    ) => resolve({ count: options.itemCount ?? 0, error: null }),
+  };
+  itemBuilder.select.mockReturnValue(itemBuilder);
+  itemBuilder.eq.mockImplementation((key: string, value: unknown) => {
+    itemFilters.push([key, value]);
+    return itemBuilder;
+  });
+
+  const updateBuilder = {
+    eq: vi.fn(),
+    select: vi.fn(),
+    maybeSingle: vi.fn(async () => ({
+      data: options.updateMissing
+        ? null
+        : {
+            id: "11111111-1111-4111-8111-111111111111",
+            status: "cancelled",
+          },
+      error: null,
+    })),
+  };
+  updateBuilder.eq.mockImplementation((key: string, value: unknown) => {
+    updateFilters.push([key, value]);
+    return updateBuilder;
+  });
+  updateBuilder.select.mockReturnValue(updateBuilder);
+  update.mockReturnValue(updateBuilder);
+
+  let requestCalls = 0;
+  const supabase = {
+    from: vi.fn((table: string) => {
+      if (table === "part_request_items") return itemBuilder;
+      if (table === "part_requests") {
+        requestCalls += 1;
+        return requestCalls === 1
+          ? requestReadBuilder
+          : { update };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    }),
+  };
+
+  return {
+    supabase,
+    update,
+    requestFilters,
+    itemFilters,
+    updateFilters,
+  };
+}
+
+async function post(
+  supabase: ReturnType<typeof buildSupabase>["supabase"],
+) {
+  mocks.requireShopScopedApiAccess.mockResolvedValue({
+    ok: true,
+    profile: { id: "actor-1", shop_id: "shop-1" },
+    supabase,
+  });
+  const { POST } = await import(
+    "../../app/api/parts/requests/[requestId]/dismiss-empty/route"
+  );
+  return POST(new Request("http://localhost"), {
+    params: Promise.resolve({
+      requestId: "11111111-1111-4111-8111-111111111111",
+    }),
+  });
+}
+
+describe("dismiss empty parts request route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cancels a requested record only after a shop-scoped empty check", async () => {
+    const db = buildSupabase();
+    const response = await post(db.supabase);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      idempotent: false,
+      status: "cancelled",
+    });
+    expect(db.requestFilters).toEqual([
+      ["id", "11111111-1111-4111-8111-111111111111"],
+      ["shop_id", "shop-1"],
+    ]);
+    expect(db.itemFilters).toEqual([
+      ["request_id", "11111111-1111-4111-8111-111111111111"],
+      ["shop_id", "shop-1"],
+    ]);
+    expect(db.update).toHaveBeenCalledWith({ status: "cancelled" });
+    expect(db.updateFilters).toEqual([
+      ["id", "11111111-1111-4111-8111-111111111111"],
+      ["shop_id", "shop-1"],
+      ["status", "requested"],
+    ]);
+    expect(mocks.logOperationalEvent).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a request that contains items", async () => {
+    const db = buildSupabase({ itemCount: 1 });
+    const response = await post(db.supabase);
+
+    expect(response.status).toBe(409);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(mocks.logOperationalEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests that already entered quoting or operations", async () => {
+    const db = buildSupabase({ status: "quoted" });
+    const response = await post(db.supabase);
+
+    expect(response.status).toBe(409);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("treats repeated cancellation as idempotent", async () => {
+    const db = buildSupabase({ status: "cancelled" });
+    const response = await post(db.supabase);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      idempotent: true,
+      status: "cancelled",
+    });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a safe way to dismiss abandoned parts-request cards that contain no request items, instead of leaving them in **Needs Quote** with a misleading **Finish quote** action.

## Root cause

The parts queue grouped requests by work order and treated every initial-stage request as quote work, even when the request records had zero items. Those empty records could not appear in Quote Review, and the UI provided no audited way to remove them from the active queue.

## What changed

- Shows **Empty request** on eligible work-order cards.
- Replaces the misleading finish-quote action with **Dismiss** and **Review**.
- Moves eligible empty request records to Completed history without deleting them.
- Adds a protected shop-scoped API route for dismissal.
- Limits the action to owner, admin, manager, advisor, and parts roles.
- Revalidates request status and item count on the server.
- Treats a repeated cancellation as a successful idempotent replay.
- Records a best-effort operational audit event.
- Refreshes the API route boundary inventory from 372 to 373 routes.

## Safety

Dismissal is allowed only when every request in the work-order bucket is still in the initial `requested` state and contains zero parts-request items. Populated, quoted, approved, fulfilled, handed-off, or otherwise progressed requests are rejected. The server resolves the active shop from authenticated context and independently verifies tenant ownership.

No records are deleted, and no database permission, RLS policy, or migration is changed.

## Validation

- Vitest: **1,206 passed, 0 failed, 2 skipped**
- TypeScript: passed
- Targeted ESLint: passed
- Production build: passed
- API route inventory: passed, **373 routes**
- Diff integrity: passed
- Remote branch: exactly one commit ahead of `main`, zero behind
- Remote Git tree matches the validated local tree exactly

## Database

No migration or backfill required. No production database operation was performed.

## Environment variables

None required.

## Manual verification

After remote checks pass:

1. Open Parts Requests with a work-order card containing only empty `requested` records.
2. Confirm the card shows **Empty request**, **Dismiss**, and **Review**.
3. Dismiss it and confirm it leaves the active queue and appears in Completed history.
4. Repeat against a populated or progressed request and confirm dismissal is unavailable/rejected.
5. Verify on phone/iPad and desktop for an authorized role.
