### PR TITLE
Fix empty parts request dismissal eligibility

### DIFF
--- a/app/api/parts/requests/[requestId]/dismiss-empty/route.ts
+++ b/app/api/parts/requests/[requestId]/dismiss-empty/route.ts
@@ -1,4 +1,8 @@
 import { NextResponse } from "next/server";
+import {
+  DISMISSIBLE_EMPTY_PART_REQUEST_STATUSES,
+  isDismissibleEmptyPartRequestStatus,
+} from "@/features/parts/lib/requests/empty-request";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
 
@@ -55,12 +59,12 @@ export async function POST(
       status: "cancelled",
     });
   }
-  if (partRequest.status !== "requested") {
+  if (!isDismissibleEmptyPartRequestStatus(partRequest.status)) {
     return NextResponse.json(
       {
         ok: false,
         error:
-          "Only an unpriced request that has not entered the parts workflow can be dismissed.",
+          "Only an empty request without physical parts activity can be dismissed.",
       },
       { status: 409 },
     );
@@ -93,7 +97,7 @@ export async function POST(
     .update({ status: "cancelled" })
     .eq("id", requestId)
     .eq("shop_id", access.profile.shop_id)
-    .eq("status", "requested")
+    .in("status", [...DISMISSIBLE_EMPTY_PART_REQUEST_STATUSES])
     .select("id,status")
     .maybeSingle();
 

--- a/features/parts/lib/requests/empty-request.ts
+++ b/features/parts/lib/requests/empty-request.ts
@@ -3,10 +3,30 @@ export type EmptyPartRequestCandidate = {
   itemCount: number;
 };
 
+export const DISMISSIBLE_EMPTY_PART_REQUEST_STATUSES = [
+  "requested",
+  "quoted",
+  "approved",
+] as const;
+
+const dismissibleEmptyStatuses = new Set<string>(
+  DISMISSIBLE_EMPTY_PART_REQUEST_STATUSES,
+);
+
+export function isDismissibleEmptyPartRequestStatus(
+  status: unknown,
+): boolean {
+  return dismissibleEmptyStatuses.has(
+    String(status ?? "")
+      .trim()
+      .toLowerCase(),
+  );
+}
+
 /**
- * Empty request cards are safe to dismiss only before pricing or physical
- * parts activity begins. Keeping this rule shared prevents the card UI from
- * offering cancellation for partially built or operational requests.
+ * A request can be dismissed when it has no parts and has not reached a
+ * physical parts state. Requested, quoted, and approved parents are all
+ * pre-operational when they contain no item rows.
  */
 export function isDismissibleEmptyPartRequestBucket(
   requests: readonly EmptyPartRequestCandidate[],
@@ -15,8 +35,8 @@ export function isDismissibleEmptyPartRequestBucket(
     requests.length > 0 &&
     requests.every(
       (request) =>
-        String(request.status ?? "").toLowerCase() === "requested" &&
-        request.itemCount === 0,
+        request.itemCount === 0 &&
+        isDismissibleEmptyPartRequestStatus(request.status),
     )
   );
 }

--- a/tests/parts/empty-part-request-cancellation.test.ts
+++ b/tests/parts/empty-part-request-cancellation.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from "vitest";
 import { isDismissibleEmptyPartRequestBucket } from "../../features/parts/lib/requests/empty-request";
 
 describe("empty parts request cancellation", () => {
-  it("allows one or more requested records with no items to be dismissed", () => {
+  it("allows empty pre-operational request states to be dismissed together", () => {
     expect(
       isDismissibleEmptyPartRequestBucket([
         { status: "requested", itemCount: 0 },
-        { status: "requested", itemCount: 0 },
+        { status: "quoted", itemCount: 0 },
+        { status: "approved", itemCount: 0 },
       ]),
     ).toBe(true);
   });
@@ -15,19 +16,25 @@ describe("empty parts request cancellation", () => {
     expect(
       isDismissibleEmptyPartRequestBucket([
         { status: "requested", itemCount: 0 },
-        { status: "requested", itemCount: 1 },
+        { status: "quoted", itemCount: 1 },
       ]),
     ).toBe(false);
   });
 
-  it.each(["quoted", "approved", "fulfilled", "cancelled"])(
-    "does not offer dismissal after the request reaches %s",
-    (status) => {
-      expect(
-        isDismissibleEmptyPartRequestBucket([{ status, itemCount: 0 }]),
-      ).toBe(false);
-    },
-  );
+  it.each([
+    "partially_ordered",
+    "partially_consumed",
+    "partially_returned",
+    "returned",
+    "fulfilled",
+    "rejected",
+    "deferred",
+    "cancelled",
+  ])("does not offer dismissal after the request reaches %s", (status) => {
+    expect(
+      isDismissibleEmptyPartRequestBucket([{ status, itemCount: 0 }]),
+    ).toBe(false);
+  });
 
   it("does not offer dismissal for an empty card model", () => {
     expect(isDismissibleEmptyPartRequestBucket([])).toBe(false);

--- a/tests/parts/empty-part-request-dismiss-route.test.ts
+++ b/tests/parts/empty-part-request-dismiss-route.test.ts
@@ -14,7 +14,12 @@ vi.mock("@/features/work-orders/server/logOperationalEvent", () => ({
 }));
 
 type MockOptions = {
-  status?: "requested" | "quoted" | "approved" | "cancelled";
+  status?:
+    | "requested"
+    | "quoted"
+    | "approved"
+    | "partially_ordered"
+    | "cancelled";
   itemCount?: number;
   requestMissing?: boolean;
   updateMissing?: boolean;
@@ -61,6 +66,7 @@ function buildSupabase(options: MockOptions = {}) {
 
   const updateBuilder = {
     eq: vi.fn(),
+    in: vi.fn(),
     select: vi.fn(),
     maybeSingle: vi.fn(async () => ({
       data: options.updateMissing
@@ -73,6 +79,10 @@ function buildSupabase(options: MockOptions = {}) {
     })),
   };
   updateBuilder.eq.mockImplementation((key: string, value: unknown) => {
+    updateFilters.push([key, value]);
+    return updateBuilder;
+  });
+  updateBuilder.in.mockImplementation((key: string, value: unknown) => {
     updateFilters.push([key, value]);
     return updateBuilder;
   });
@@ -125,35 +135,38 @@ describe("dismiss empty parts request route", () => {
     vi.clearAllMocks();
   });
 
-  it("cancels a requested record only after a shop-scoped empty check", async () => {
-    const db = buildSupabase();
-    const response = await post(db.supabase);
+  it.each(["requested", "quoted", "approved"] as const)(
+    "cancels an empty %s record after a shop-scoped empty check",
+    async (status) => {
+      const db = buildSupabase({ status });
+      const response = await post(db.supabase);
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      ok: true,
-      idempotent: false,
-      status: "cancelled",
-    });
-    expect(db.requestFilters).toEqual([
-      ["id", "11111111-1111-4111-8111-111111111111"],
-      ["shop_id", "shop-1"],
-    ]);
-    expect(db.itemFilters).toEqual([
-      ["request_id", "11111111-1111-4111-8111-111111111111"],
-      ["shop_id", "shop-1"],
-    ]);
-    expect(db.update).toHaveBeenCalledWith({ status: "cancelled" });
-    expect(db.updateFilters).toEqual([
-      ["id", "11111111-1111-4111-8111-111111111111"],
-      ["shop_id", "shop-1"],
-      ["status", "requested"],
-    ]);
-    expect(mocks.logOperationalEvent).toHaveBeenCalledOnce();
-  });
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: true,
+        idempotent: false,
+        status: "cancelled",
+      });
+      expect(db.requestFilters).toEqual([
+        ["id", "11111111-1111-4111-8111-111111111111"],
+        ["shop_id", "shop-1"],
+      ]);
+      expect(db.itemFilters).toEqual([
+        ["request_id", "11111111-1111-4111-8111-111111111111"],
+        ["shop_id", "shop-1"],
+      ]);
+      expect(db.update).toHaveBeenCalledWith({ status: "cancelled" });
+      expect(db.updateFilters).toEqual([
+        ["id", "11111111-1111-4111-8111-111111111111"],
+        ["shop_id", "shop-1"],
+        ["status", ["requested", "quoted", "approved"]],
+      ]);
+      expect(mocks.logOperationalEvent).toHaveBeenCalledOnce();
+    },
+  );
 
   it("rejects a request that contains items", async () => {
-    const db = buildSupabase({ itemCount: 1 });
+    const db = buildSupabase({ status: "approved", itemCount: 1 });
     const response = await post(db.supabase);
 
     expect(response.status).toBe(409);
@@ -161,8 +174,8 @@ describe("dismiss empty parts request route", () => {
     expect(mocks.logOperationalEvent).not.toHaveBeenCalled();
   });
 
-  it("rejects requests that already entered quoting or operations", async () => {
-    const db = buildSupabase({ status: "quoted" });
+  it("rejects requests that reached physical parts operations", async () => {
+    const db = buildSupabase({ status: "partially_ordered" });
     const response = await post(db.supabase);
 
     expect(response.status).toBe(409);


### PR DESCRIPTION
## Summary

Fixes the merged empty-request dismissal so the production cards shown for EL000001 and EL000002 can actually expose **Dismiss**.

## Root cause

PR #1179 treated a zero-item request as dismissible only when its raw parent status was exactly `requested`. The Parts queue, however, classifies zero-item `requested`, `quoted`, and `approved` parents as **Needs Quote**. A work-order bucket containing any quoted or approved empty record therefore kept the misleading **Finish quote** action even though it displayed 0 items.

The existing parts lifecycle migration already treats `requested`, `quoted`, and `approved` parents as non-physical when no item activity exists.

## What changed

- Uses one shared status rule in the card and protected API.
- Allows zero-item `requested`, `quoted`, and `approved` requests to be dismissed.
- Still rejects any request with an item.
- Still rejects partially ordered, consumed, returned, fulfilled, declined/deferred, and other terminal or physical states.
- Revalidates the allowed status during the guarded update to handle concurrent state changes.
- Preserves shop scope, role restrictions, idempotent replay, and audit logging from #1179.

## Validation

- Focused eligibility check passed locally for mixed requested/quoted/approved empty buckets.
- Branch is four scoped files ahead of current `main` and zero behind.
- Remote GitHub Actions and Vercel checks should complete before merge.

## Database / production

No migration, backfill, production data change, merge, or deployment was performed.

## Manual smoke test after deployment

1. Open Parts Requests.
2. Confirm EL000001 and EL000002 show **Empty request**, **Dismiss**, and **Review**.
3. Dismiss each card.
4. Confirm it leaves Needs Quote and remains in Completed history.
5. Confirm populated and operational request cards never show Dismiss.
