### PR TITLE
Make empty parts request dismissal atomic

### DIFF
--- a/app/api/parts/requests/[requestId]/dismiss-empty/route.ts
+++ b/app/api/parts/requests/[requestId]/dismiss-empty/route.ts
@@ -1,10 +1,28 @@
 import { NextResponse } from "next/server";
-import {
-  DISMISSIBLE_EMPTY_PART_REQUEST_STATUSES,
-  isDismissibleEmptyPartRequestStatus,
-} from "@/features/parts/lib/requests/empty-request";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
+
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+type DismissResult = {
+  ok?: boolean;
+  idempotent?: boolean;
+  request_id?: string;
+  work_order_id?: string | null;
+  previous_status?: string;
+  status?: string;
+};
 
 function isUuid(value: unknown): value is string {
   return (
@@ -13,6 +31,24 @@ function isUuid(value: unknown): value is string {
       value.trim(),
     )
   );
+}
+
+function rpcErrorMessage(error: RpcError): string {
+  return [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+}
+
+function rpcErrorStatus(error: RpcError): number {
+  const message = rpcErrorMessage(error).toUpperCase();
+  if (
+    message.includes("AUTHENTICATION") ||
+    message.includes("ACCESS_DENIED") ||
+    message.includes("ROLE_ACCESS_DENIED") ||
+    message.includes("ACTOR_MISMATCH")
+  ) {
+    return 403;
+  }
+  if (message.includes("NOT_FOUND_FOR_SHOP")) return 404;
+  return 409;
 }
 
 export async function POST(
@@ -32,109 +68,51 @@ export async function POST(
   });
   if (!access.ok) return access.response;
 
-  const { data: partRequest, error: requestError } = await access.supabase
-    .from("part_requests")
-    .select("id,status,work_order_id")
-    .eq("id", requestId)
-    .eq("shop_id", access.profile.shop_id)
-    .maybeSingle();
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("parts_dismiss_empty_request_atomic", {
+    p_shop_id: access.profile.shop_id,
+    p_request_id: requestId,
+    p_actor_user_id: access.profile.id,
+  });
 
-  if (requestError) {
+  if (error) {
     return NextResponse.json(
-      { ok: false, error: "Unable to load the parts request." },
-      { status: 500 },
+      { ok: false, error: rpcErrorMessage(error) },
+      { status: rpcErrorStatus(error) },
     );
   }
-  if (!partRequest) {
+
+  const result = (data ?? {}) as DismissResult;
+  if (!result.ok || result.status !== "cancelled") {
     return NextResponse.json(
-      { ok: false, error: "Parts request not found." },
-      { status: 404 },
+      {
+        ok: false,
+        error: "The empty parts request was not dismissed.",
+      },
+      { status: 409 },
     );
   }
-  if (partRequest.status === "cancelled") {
-    return NextResponse.json({
-      ok: true,
-      idempotent: true,
-      requestId,
-      status: "cancelled",
+
+  if (!result.idempotent) {
+    await logOperationalEvent({
+      supabase: access.supabase,
+      event: "parts_request_empty_dismissed",
+      actorId: access.profile.id,
+      entityType: "part_requests",
+      entityId: requestId,
+      details: {
+        shop_id: access.profile.shop_id,
+        work_order_id: result.work_order_id ?? null,
+        previous_status: result.previous_status ?? null,
+        status: result.status,
+      },
     });
   }
-  if (!isDismissibleEmptyPartRequestStatus(partRequest.status)) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error:
-          "Only an empty request without physical parts activity can be dismissed.",
-      },
-      { status: 409 },
-    );
-  }
-
-  const { count, error: itemError } = await access.supabase
-    .from("part_request_items")
-    .select("id", { count: "exact", head: true })
-    .eq("request_id", requestId)
-    .eq("shop_id", access.profile.shop_id);
-
-  if (itemError) {
-    return NextResponse.json(
-      { ok: false, error: "Unable to verify that the request is empty." },
-      { status: 500 },
-    );
-  }
-  if ((count ?? 0) > 0) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error: "This request contains parts and cannot be dismissed as empty.",
-      },
-      { status: 409 },
-    );
-  }
-
-  const { data: updated, error: updateError } = await access.supabase
-    .from("part_requests")
-    .update({ status: "cancelled" })
-    .eq("id", requestId)
-    .eq("shop_id", access.profile.shop_id)
-    .in("status", [...DISMISSIBLE_EMPTY_PART_REQUEST_STATUSES])
-    .select("id,status")
-    .maybeSingle();
-
-  if (updateError) {
-    return NextResponse.json(
-      { ok: false, error: "Unable to dismiss the empty parts request." },
-      { status: 500 },
-    );
-  }
-  if (!updated) {
-    return NextResponse.json(
-      {
-        ok: false,
-        error: "The request changed before it could be dismissed. Refresh and review it.",
-      },
-      { status: 409 },
-    );
-  }
-
-  await logOperationalEvent({
-    supabase: access.supabase,
-    event: "parts_request_empty_dismissed",
-    actorId: access.profile.id,
-    entityType: "part_requests",
-    entityId: requestId,
-    details: {
-      shop_id: access.profile.shop_id,
-      work_order_id: partRequest.work_order_id,
-      previous_status: partRequest.status,
-      status: updated.status,
-    },
-  });
 
   return NextResponse.json({
     ok: true,
-    idempotent: false,
+    idempotent: result.idempotent === true,
     requestId,
-    status: updated.status,
+    status: result.status,
   });
 }

--- a/supabase/migrations/20260723210000_atomic_empty_part_request_dismiss.sql
+++ b/supabase/migrations/20260723210000_atomic_empty_part_request_dismiss.sql
@@ -1,0 +1,146 @@
+begin;
+
+create or replace function public.parts_dismiss_empty_request_atomic(
+  p_shop_id uuid,
+  p_request_id uuid,
+  p_actor_user_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_authenticated_user_id uuid := auth.uid();
+  v_actor_role text;
+  v_request public.part_requests%rowtype;
+  v_previous_status text;
+begin
+  if p_shop_id is null or p_request_id is null then
+    raise exception using
+      errcode = '22023',
+      message = 'PARTS_DISMISS_SCOPE_REQUIRED';
+  end if;
+
+  if coalesce(auth.role(), '') <> 'service_role' then
+    if v_authenticated_user_id is null then
+      raise exception using
+        errcode = '42501',
+        message = 'PARTS_AUTHENTICATION_REQUIRED';
+    end if;
+
+    if p_actor_user_id is null
+       or v_authenticated_user_id is distinct from p_actor_user_id then
+      raise exception using
+        errcode = '42501',
+        message = 'PARTS_ACTOR_MISMATCH';
+    end if;
+
+    select lower(trim(coalesce(profile.role::text, '')))
+      into v_actor_role
+    from public.profiles profile
+    where profile.shop_id = p_shop_id
+      and (
+        profile.id = v_authenticated_user_id
+        or profile.user_id = v_authenticated_user_id
+      )
+    order by (profile.id = v_authenticated_user_id) desc
+    limit 1;
+
+    if v_actor_role is null then
+      raise exception using
+        errcode = '42501',
+        message = 'PARTS_SHOP_ACCESS_DENIED';
+    end if;
+
+    if v_actor_role not in (
+      'owner',
+      'admin',
+      'manager',
+      'advisor',
+      'parts'
+    ) then
+      raise exception using
+        errcode = '42501',
+        message = 'PARTS_ROLE_ACCESS_DENIED';
+    end if;
+  end if;
+
+  select request_row.*
+    into v_request
+  from public.part_requests request_row
+  where request_row.id = p_request_id
+    and request_row.shop_id = p_shop_id
+  for update;
+
+  if not found then
+    raise exception using
+      errcode = 'P0002',
+      message = 'PARTS_REQUEST_NOT_FOUND_FOR_SHOP';
+  end if;
+
+  if v_request.status::text = 'cancelled' then
+    return jsonb_build_object(
+      'ok', true,
+      'idempotent', true,
+      'request_id', v_request.id,
+      'work_order_id', v_request.work_order_id,
+      'previous_status', 'cancelled',
+      'status', 'cancelled'
+    );
+  end if;
+
+  if v_request.status::text not in ('requested', 'quoted', 'approved') then
+    raise exception using
+      errcode = 'P0001',
+      message = 'PARTS_REQUEST_NOT_DISMISSIBLE';
+  end if;
+
+  if exists (
+    select 1
+    from public.part_request_items item
+    where item.request_id = p_request_id
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'PARTS_REQUEST_NOT_EMPTY';
+  end if;
+
+  v_previous_status := v_request.status::text;
+
+  update public.part_requests
+  set status = 'cancelled'::public.part_request_status
+  where id = p_request_id
+    and shop_id = p_shop_id;
+
+  if not found then
+    raise exception using
+      errcode = 'P0001',
+      message = 'PARTS_REQUEST_DISMISS_FAILED';
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'request_id', v_request.id,
+    'work_order_id', v_request.work_order_id,
+    'previous_status', v_previous_status,
+    'status', 'cancelled'
+  );
+end;
+$$;
+
+revoke all on function public.parts_dismiss_empty_request_atomic(
+  uuid,
+  uuid,
+  uuid
+) from public, anon;
+
+grant execute on function public.parts_dismiss_empty_request_atomic(
+  uuid,
+  uuid,
+  uuid
+) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/parts/empty-part-request-dismiss-route.test.ts
+++ b/tests/parts/empty-part-request-dismiss-route.test.ts
@@ -13,108 +13,27 @@ vi.mock("@/features/work-orders/server/logOperationalEvent", () => ({
   logOperationalEvent: mocks.logOperationalEvent,
 }));
 
-type MockOptions = {
-  status?:
-    | "requested"
-    | "quoted"
-    | "approved"
-    | "partially_ordered"
-    | "cancelled";
-  itemCount?: number;
-  requestMissing?: boolean;
-  updateMissing?: boolean;
+const requestId = "11111111-1111-4111-8111-111111111111";
+
+type RpcResult = {
+  data: unknown;
+  error: {
+    message: string;
+    details?: string | null;
+    hint?: string | null;
+  } | null;
 };
 
-function buildSupabase(options: MockOptions = {}) {
-  const requestFilters: Array<[string, unknown]> = [];
-  const itemFilters: Array<[string, unknown]> = [];
-  const updateFilters: Array<[string, unknown]> = [];
-  const update = vi.fn();
-
-  const requestReadBuilder = {
-    select: vi.fn(),
-    eq: vi.fn(),
-    maybeSingle: vi.fn(async () => ({
-      data: options.requestMissing
-        ? null
-        : {
-            id: "11111111-1111-4111-8111-111111111111",
-            status: options.status ?? "requested",
-            work_order_id: "work-order-1",
-          },
-      error: null,
-    })),
-  };
-  requestReadBuilder.select.mockReturnValue(requestReadBuilder);
-  requestReadBuilder.eq.mockImplementation((key: string, value: unknown) => {
-    requestFilters.push([key, value]);
-    return requestReadBuilder;
-  });
-
-  const itemBuilder = {
-    select: vi.fn(),
-    eq: vi.fn(),
-    then: (
-      resolve: (value: { count: number; error: null }) => unknown,
-    ) => resolve({ count: options.itemCount ?? 0, error: null }),
-  };
-  itemBuilder.select.mockReturnValue(itemBuilder);
-  itemBuilder.eq.mockImplementation((key: string, value: unknown) => {
-    itemFilters.push([key, value]);
-    return itemBuilder;
-  });
-
-  const updateBuilder = {
-    eq: vi.fn(),
-    in: vi.fn(),
-    select: vi.fn(),
-    maybeSingle: vi.fn(async () => ({
-      data: options.updateMissing
-        ? null
-        : {
-            id: "11111111-1111-4111-8111-111111111111",
-            status: "cancelled",
-          },
-      error: null,
-    })),
-  };
-  updateBuilder.eq.mockImplementation((key: string, value: unknown) => {
-    updateFilters.push([key, value]);
-    return updateBuilder;
-  });
-  updateBuilder.in.mockImplementation((key: string, value: unknown) => {
-    updateFilters.push([key, value]);
-    return updateBuilder;
-  });
-  updateBuilder.select.mockReturnValue(updateBuilder);
-  update.mockReturnValue(updateBuilder);
-
-  let requestCalls = 0;
-  const supabase = {
-    from: vi.fn((table: string) => {
-      if (table === "part_request_items") return itemBuilder;
-      if (table === "part_requests") {
-        requestCalls += 1;
-        return requestCalls === 1
-          ? requestReadBuilder
-          : { update };
-      }
-      throw new Error(`Unexpected table ${table}`);
-    }),
-  };
-
+function buildSupabase(result: RpcResult) {
   return {
-    supabase,
-    update,
-    requestFilters,
-    itemFilters,
-    updateFilters,
+    rpc: vi.fn(async () => result),
+    from: vi.fn(() => {
+      throw new Error("The route must not write part_requests directly.");
+    }),
   };
 }
 
-async function post(
-  supabase: ReturnType<typeof buildSupabase>["supabase"],
-) {
+async function post(supabase: ReturnType<typeof buildSupabase>) {
   mocks.requireShopScopedApiAccess.mockResolvedValue({
     ok: true,
     profile: { id: "actor-1", shop_id: "shop-1" },
@@ -124,9 +43,7 @@ async function post(
     "../../app/api/parts/requests/[requestId]/dismiss-empty/route"
   );
   return POST(new Request("http://localhost"), {
-    params: Promise.resolve({
-      requestId: "11111111-1111-4111-8111-111111111111",
-    }),
+    params: Promise.resolve({ requestId }),
   });
 }
 
@@ -135,56 +52,53 @@ describe("dismiss empty parts request route", () => {
     vi.clearAllMocks();
   });
 
-  it.each(["requested", "quoted", "approved"] as const)(
-    "cancels an empty %s record after a shop-scoped empty check",
-    async (status) => {
-      const db = buildSupabase({ status });
-      const response = await post(db.supabase);
-
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
+  it("delegates dismissal to the shop-scoped atomic RPC", async () => {
+    const db = buildSupabase({
+      data: {
         ok: true,
         idempotent: false,
+        request_id: requestId,
+        work_order_id: "work-order-1",
+        previous_status: "approved",
         status: "cancelled",
-      });
-      expect(db.requestFilters).toEqual([
-        ["id", "11111111-1111-4111-8111-111111111111"],
-        ["shop_id", "shop-1"],
-      ]);
-      expect(db.itemFilters).toEqual([
-        ["request_id", "11111111-1111-4111-8111-111111111111"],
-        ["shop_id", "shop-1"],
-      ]);
-      expect(db.update).toHaveBeenCalledWith({ status: "cancelled" });
-      expect(db.updateFilters).toEqual([
-        ["id", "11111111-1111-4111-8111-111111111111"],
-        ["shop_id", "shop-1"],
-        ["status", ["requested", "quoted", "approved"]],
-      ]);
-      expect(mocks.logOperationalEvent).toHaveBeenCalledOnce();
-    },
-  );
+      },
+      error: null,
+    });
 
-  it("rejects a request that contains items", async () => {
-    const db = buildSupabase({ status: "approved", itemCount: 1 });
-    const response = await post(db.supabase);
+    const response = await post(db);
 
-    expect(response.status).toBe(409);
-    expect(db.update).not.toHaveBeenCalled();
-    expect(mocks.logOperationalEvent).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      idempotent: false,
+      requestId,
+      status: "cancelled",
+    });
+    expect(mocks.requireShopScopedApiAccess).toHaveBeenCalledWith({
+      allowRoles: ["owner", "admin", "manager", "advisor", "parts"],
+    });
+    expect(db.rpc).toHaveBeenCalledWith("parts_dismiss_empty_request_atomic", {
+      p_shop_id: "shop-1",
+      p_request_id: requestId,
+      p_actor_user_id: "actor-1",
+    });
+    expect(db.from).not.toHaveBeenCalled();
+    expect(mocks.logOperationalEvent).toHaveBeenCalledOnce();
   });
 
-  it("rejects requests that reached physical parts operations", async () => {
-    const db = buildSupabase({ status: "partially_ordered" });
-    const response = await post(db.supabase);
+  it("treats a repeated atomic cancellation as a successful replay", async () => {
+    const db = buildSupabase({
+      data: {
+        ok: true,
+        idempotent: true,
+        request_id: requestId,
+        previous_status: "cancelled",
+        status: "cancelled",
+      },
+      error: null,
+    });
 
-    expect(response.status).toBe(409);
-    expect(db.update).not.toHaveBeenCalled();
-  });
-
-  it("treats repeated cancellation as idempotent", async () => {
-    const db = buildSupabase({ status: "cancelled" });
-    const response = await post(db.supabase);
+    const response = await post(db);
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({
@@ -192,6 +106,34 @@ describe("dismiss empty parts request route", () => {
       idempotent: true,
       status: "cancelled",
     });
-    expect(db.update).not.toHaveBeenCalled();
+    expect(mocks.logOperationalEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["PARTS_ROLE_ACCESS_DENIED", 403],
+    ["PARTS_REQUEST_NOT_FOUND_FOR_SHOP", 404],
+    ["PARTS_REQUEST_NOT_EMPTY", 409],
+  ])("maps %s to HTTP %s", async (message, status) => {
+    const db = buildSupabase({
+      data: null,
+      error: { message },
+    });
+
+    const response = await post(db);
+
+    expect(response.status).toBe(status);
+    expect(mocks.logOperationalEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed request IDs before authorization or mutation", async () => {
+    const { POST } = await import(
+      "../../app/api/parts/requests/[requestId]/dismiss-empty/route"
+    );
+    const response = await POST(new Request("http://localhost"), {
+      params: Promise.resolve({ requestId: "not-a-uuid" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.requireShopScopedApiAccess).not.toHaveBeenCalled();
   });
 });

--- a/tests/parts/empty-part-request-dismiss-rpc.test.ts
+++ b/tests/parts/empty-part-request-dismiss-rpc.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migrationPath = resolve(
+  process.cwd(),
+  "supabase/migrations/20260723210000_atomic_empty_part_request_dismiss.sql",
+);
+const sql = readFileSync(migrationPath, "utf8");
+
+describe("atomic empty parts request dismissal SQL", () => {
+  it("owns the mutation inside one locked SECURITY DEFINER function", () => {
+    expect(sql).toMatch(
+      /create or replace function public\.parts_dismiss_empty_request_atomic/,
+    );
+    expect(sql).toMatch(/security definer/i);
+    expect(sql).toMatch(/set search_path = public/i);
+    expect(sql).toMatch(/for update/i);
+    expect(sql).toMatch(
+      /set status = 'cancelled'::public\.part_request_status/i,
+    );
+  });
+
+  it("checks direct callers, tenant scope, roles, status, and all child items", () => {
+    expect(sql).toContain("auth.uid()");
+    expect(sql).toContain("PARTS_ACTOR_MISMATCH");
+    expect(sql).toContain("profile.shop_id = p_shop_id");
+    expect(sql).toContain("PARTS_ROLE_ACCESS_DENIED");
+    expect(sql).toContain(
+      "v_request.status::text not in ('requested', 'quoted', 'approved')",
+    );
+    expect(sql).toMatch(
+      /from public\.part_request_items item\s+where item\.request_id = p_request_id/i,
+    );
+  });
+
+  it("is idempotent and exposes no anonymous execution path", () => {
+    expect(sql).toContain("'idempotent', true");
+    expect(sql).toMatch(
+      /revoke all on function public\.parts_dismiss_empty_request_atomic[\s\S]*from public, anon/i,
+    );
+    expect(sql).toMatch(
+      /grant execute on function public\.parts_dismiss_empty_request_atomic[\s\S]*to authenticated, service_role/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the production **Dismiss** failure shown for EL000001 and EL000002 after PRs #1179 and #1180.

## Root cause

The card and API now agree that zero-item `requested`, `quoted`, and `approved` requests are eligible, but the API still performs a direct browser-session update against `part_requests`. Production RLS allows the request to be read while filtering the update to zero rows, so the route returns:

> The request changed before it could be dismissed. Refresh and review it.

This was not a stale deployment or another UI status mismatch.

## What changed

- Adds a forward-only `parts_dismiss_empty_request_atomic` RPC.
- Moves the status transition into one locked database command.
- Makes an already-cancelled request an idempotent success.
- Rejects requests with any child item, including legacy items whose `shop_id` may be null.
- Accepts only empty `requested`, `quoted`, or `approved` parents.
- Verifies the authenticated actor, actor identity, shop membership, and allowed role inside the SECURITY DEFINER function.
- Rejects cross-shop direct RPC calls.
- Revokes anonymous/public execution and grants only authenticated/service-role execution.
- Changes the protected API route to delegate to the RPC rather than issuing an RLS-filtered table update.
- Preserves the existing best-effort operational audit event for successful non-replay dismissals.

## Authorization

Allowed roles remain exactly: owner, admin, manager, advisor, and parts.

Authorization is enforced twice:

1. the application route via `requireShopScopedApiAccess`
2. the directly callable database function via `auth.uid()`, actor-match, role, and shop checks

## Validation

- Branch is based exactly on deployed `main` at `f628bb5b`.
- Four scoped files; zero unrelated changes.
- TypeScript files were formatted with Prettier.
- Focused route tests cover RPC delegation, idempotent replay, invalid IDs, permission denial, cross-shop/not-found behavior, and populated-request rejection.
- SQL contract tests cover SECURITY DEFINER hardening, row locking, actor/shop/role checks, child-item rejection, idempotency, and grants.
- GitHub Actions and Vercel must pass before merge.
- A real database runtime test remains required because this workspace has no ProFixIQ checkout or disposable Supabase instance.

## Database / deployment

Adds one forward migration:

`supabase/migrations/20260723210000_atomic_empty_part_request_dismiss.sql`

Do not edit an older migration. Do not run this against production until the PR is reviewed, merged, and the migration is explicitly approved.

Merging/deploying the web code without applying this migration will leave Dismiss unavailable because the RPC will not exist.

## Production smoke test after approved migration + deployment

1. Open Parts Requests as owner/admin/manager/advisor/parts.
2. On EL000001 or EL000002, press **Dismiss**.
3. Confirm every empty request leaves Needs Quote and remains under Completed history.
4. Repeat the action and confirm it succeeds without another state change.
5. Confirm a populated request never shows Dismiss and direct API/RPC attempts are rejected.
6. Confirm a user from another shop cannot dismiss the request.