### PR TITLE
Reconcile parts counts and draft work-order deletion

### DIFF
--- a/app/api/work-orders/[id]/delete-draft/route.ts
+++ b/app/api/work-orders/[id]/delete-draft/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type RpcError = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+};
+
+type RpcClient = {
+  rpc: (
+    name: string,
+    args: Record<string, unknown>,
+  ) => PromiseLike<{ data: unknown; error: RpcError | null }>;
+};
+
+type DeleteDraftResult = {
+  ok?: boolean;
+  idempotent?: boolean;
+  work_order_id?: string;
+  deleted?: boolean;
+};
+
+function isUuid(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value.trim(),
+    )
+  );
+}
+
+function rpcErrorMessage(error: RpcError): string {
+  return [error.message, error.details, error.hint].filter(Boolean).join(" — ");
+}
+
+function rpcErrorStatus(error: RpcError): number {
+  const message = rpcErrorMessage(error).toUpperCase();
+  if (
+    message.includes("AUTHENTICATION") ||
+    message.includes("ACCESS_DENIED") ||
+    message.includes("ROLE_ACCESS_DENIED") ||
+    message.includes("ACTOR_MISMATCH")
+  ) {
+    return 403;
+  }
+  if (message.includes("NOT_FOUND_FOR_SHOP")) return 404;
+  return 409;
+}
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  if (!isUuid(id)) {
+    return NextResponse.json(
+      { ok: false, error: "Invalid work order id." },
+      { status: 400 },
+    );
+  }
+
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
+
+  const operationKey = `${access.profile.shop_id}:delete-draft-work-order:${id}`;
+  const rpc = access.supabase as unknown as RpcClient;
+  const { data, error } = await rpc.rpc("work_order_delete_draft_atomic", {
+    p_shop_id: access.profile.shop_id,
+    p_work_order_id: id,
+    p_operation_key: operationKey,
+    p_actor_user_id: access.profile.id,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: rpcErrorMessage(error) },
+      { status: rpcErrorStatus(error) },
+    );
+  }
+
+  const result = (data ?? {}) as DeleteDraftResult;
+  if (!result.ok || !result.deleted) {
+    return NextResponse.json(
+      { ok: false, error: "The work order was not deleted." },
+      { status: 409 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    idempotent: result.idempotent === true,
+    workOrderId: result.work_order_id ?? id,
+    deleted: true,
+  });
+}

--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -27,6 +27,7 @@ import {
   type PartsRequestStage,
   type PartsRequestStageItem,
 } from "@/features/parts/lib/status-display";
+import { isPartRequestItemAwaitingReceiving } from "@/features/parts/lib/open-parts-obligations";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -50,6 +51,7 @@ type DashboardRequestItem = Pick<
   | "qty_reserved"
   | "qty_consumed"
   | "qty_returned"
+  | "po_id"
 >;
 
 type RecentMove = Pick<
@@ -96,12 +98,6 @@ const PARTS_REQUEST_STATUSES: RequestRow["status"][] = [
 
 function panelClass(extra = "") {
   return `rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] ${extra}`;
-}
-
-function approvedReceivingQty(
-  item: Pick<RequestItemRow, "qty_approved">,
-) {
-  return Math.max(0, Number(item.qty_approved ?? 0));
 }
 
 function requestStageItem(item: DashboardRequestItem): PartsRequestStageItem {
@@ -343,7 +339,7 @@ export default function PartsDashboardPage(): JSX.Element {
           const page = await supabase
             .from("part_request_items")
             .select(
-              "request_id,status,description,part_id,quoted_price,unit_price,qty,qty_requested,qty_approved,qty_ordered,qty_received,qty_reserved,qty_consumed,qty_returned",
+              "request_id,status,description,part_id,quoted_price,unit_price,qty,qty_requested,qty_approved,qty_ordered,qty_received,qty_reserved,qty_consumed,qty_returned,po_id",
             )
             .in("request_id", requestIdChunk)
             .order("id", { ascending: true })
@@ -389,16 +385,11 @@ export default function PartsDashboardPage(): JSX.Element {
       );
       setOpenPoCount(openPoRes.count ?? 0);
       setReceiveQueueCount(
-        items.filter((item) => {
-          const target = approvedReceivingQty(item);
-          return (
+        items.filter(
+          (item) =>
             activeIds.has(item.request_id) &&
-            String(item.status).toLowerCase() !== "cancelled" &&
-            target > 0 &&
-            Number(item.qty_received ?? 0) < target &&
-            Number(item.qty_consumed ?? 0) < target
-          );
-        }).length,
+            isPartRequestItemAwaitingReceiving(item),
+        ).length,
       );
 
       const nextFlow: FlowCounts = {

--- a/app/parts/receiving/page.tsx
+++ b/app/parts/receiving/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/features/parts/lib/trust-signals";
 import { partIdentifierLabel, toPartDisplaySummary } from "@/features/parts/lib/part-display";
 import type { ReceiveDrawerItem } from "@/features/parts/components/ReceiveDrawer";
+import { isPartRequestItemAwaitingReceiving } from "@/features/parts/lib/open-parts-obligations";
 import PageShell from "@/features/shared/components/PageShell";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
@@ -149,7 +150,7 @@ export default function ReceivingInboxPage(): JSX.Element {
           work_order_id: null,
         };
       })
-      .filter((x) => x.po_id !== null && x.qty_ordered > 0 && x.qty_remaining > 0);
+      .filter((item) => isPartRequestItemAwaitingReceiving(item));
 
     setItems(normalized);
     setLastUpdated(new Date());

--- a/docs/audits/api-route-boundary-inventory.json
+++ b/docs/audits/api-route-boundary-inventory.json
@@ -5488,6 +5488,24 @@
     "riskLevel": "medium"
   },
   {
+    "path": "app/api/work-orders/[id]/delete-draft/route.ts",
+    "methods": [
+      "DELETE"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/work-orders/[id]/financial-lock/route.ts",
     "methods": [
       "GET"

--- a/docs/audits/api-route-boundary-inventory.md
+++ b/docs/audits/api-route-boundary-inventory.md
@@ -1,16 +1,16 @@
 # API Route Boundary Inventory (Static Heuristic)
 
-Generated: 2026-07-23T19:22:41.647Z
+Generated: 2026-07-24T01:17:51.914Z
 
 ## Summary
-- Total route count: **373**
+- Total route count: **374**
 - Routes exporting GET: **118**
 - Routes exporting POST: **266**
 - Routes exporting PUT: **9**
 - Routes exporting PATCH: **21**
-- Routes exporting DELETE: **11**
+- Routes exporting DELETE: **12**
 - Routes with service-role pattern: **24**
-- Routes using requireShopScopedApiAccess: **109**
+- Routes using requireShopScopedApiAccess: **110**
 - Routes with auth.getUser references: **147**
 
 ## High-Risk Routes

--- a/features/parts/lib/open-parts-obligations.ts
+++ b/features/parts/lib/open-parts-obligations.ts
@@ -1,0 +1,183 @@
+import type { WorkOrderBoardRow } from "@/features/shared/lib/workboard/types";
+
+const TERMINAL_REQUEST_STATUSES = new Set([
+  "cancelled",
+  "deferred",
+  "fulfilled",
+  "rejected",
+  "returned",
+]);
+
+const TERMINAL_ITEM_STATUSES = new Set([
+  "cancelled",
+  "consumed",
+  "fulfilled",
+  "returned",
+]);
+
+const OPERATIONAL_REQUEST_STATUSES = new Set([
+  "approved",
+  "partially_consumed",
+  "partially_ordered",
+  "partially_returned",
+]);
+
+const OPERATIONAL_ITEM_STATUSES = new Set([
+  "approved",
+  "ordered",
+  "partially_received",
+  "picked",
+  "picking",
+  "received",
+  "reserved",
+]);
+
+const RECEIVING_ITEM_STATUSES = new Set([
+  "ordered",
+  "partially_ordered",
+  "partially_received",
+]);
+
+export type OpenPartsRequest = {
+  id: string;
+  work_order_id: string | null;
+  status: string | null;
+};
+
+export type OpenPartsItem = {
+  request_id: string;
+  status: string | null;
+  po_id?: string | null;
+  qty?: unknown;
+  qty_requested?: unknown;
+  qty_approved?: unknown;
+  qty_ordered?: unknown;
+  qty_received?: unknown;
+  qty_reserved?: unknown;
+  qty_consumed?: unknown;
+  qty_returned?: unknown;
+};
+
+function quantity(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? Math.max(parsed, 0) : 0;
+}
+
+function normalizedStatus(value: string | null | undefined): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function targetQuantity(item: OpenPartsItem): number {
+  return Math.max(
+    quantity(item.qty_approved),
+    quantity(item.qty_ordered),
+    quantity(item.qty_requested),
+    quantity(item.qty),
+  );
+}
+
+function netHandedOffQuantity(item: OpenPartsItem): number {
+  return Math.max(quantity(item.qty_consumed) - quantity(item.qty_returned), 0);
+}
+
+export function isPartRequestItemAwaitingReceiving(
+  item: OpenPartsItem,
+): boolean {
+  const ordered = quantity(item.qty_ordered);
+  const received = quantity(item.qty_received);
+  return (
+    Boolean(item.po_id) &&
+    ordered > 0 &&
+    received < ordered &&
+    RECEIVING_ITEM_STATUSES.has(normalizedStatus(item.status))
+  );
+}
+
+export function isOpenPartsObligation(
+  requestStatus: string | null | undefined,
+  item: OpenPartsItem,
+): boolean {
+  const normalizedRequestStatus = normalizedStatus(requestStatus);
+  const normalizedItemStatus = normalizedStatus(item.status);
+  if (
+    TERMINAL_REQUEST_STATUSES.has(normalizedRequestStatus) ||
+    TERMINAL_ITEM_STATUSES.has(normalizedItemStatus)
+  ) {
+    return false;
+  }
+
+  const target = targetQuantity(item);
+  if (target <= 0 || netHandedOffQuantity(item) >= target) {
+    return false;
+  }
+
+  return (
+    OPERATIONAL_REQUEST_STATUSES.has(normalizedRequestStatus) ||
+    OPERATIONAL_ITEM_STATUSES.has(normalizedItemStatus) ||
+    quantity(item.qty_ordered) > 0 ||
+    quantity(item.qty_received) > 0 ||
+    quantity(item.qty_reserved) > 0
+  );
+}
+
+export function countOpenPartsObligationsByWorkOrder(
+  requests: OpenPartsRequest[],
+  items: OpenPartsItem[],
+): Map<string, number> {
+  const requestById = new Map(requests.map((request) => [request.id, request]));
+  const counts = new Map<string, number>();
+
+  for (const item of items) {
+    const request = requestById.get(item.request_id);
+    if (
+      !request?.work_order_id ||
+      !isOpenPartsObligation(request.status, item)
+    ) {
+      continue;
+    }
+    counts.set(
+      request.work_order_id,
+      (counts.get(request.work_order_id) ?? 0) + 1,
+    );
+  }
+
+  return counts;
+}
+
+export function reconcileBoardPartsState(
+  rows: WorkOrderBoardRow[],
+  openCounts: Map<string, number>,
+  activeLaborWorkOrderIds: ReadonlySet<string>,
+): WorkOrderBoardRow[] {
+  return rows.map((row) => {
+    const openCount = openCounts.get(row.work_order_id) ?? 0;
+    const staleWaitingState =
+      openCount === 0 &&
+      (row.has_waiting_parts === true ||
+        Number(row.parts_blocker_count ?? 0) > 0 ||
+        Number(row.jobs_waiting_parts ?? 0) > 0 ||
+        row.overall_stage === "waiting_parts");
+
+    if (!staleWaitingState) {
+      return activeLaborWorkOrderIds.has(row.work_order_id) &&
+        row.overall_stage !== "completed"
+        ? { ...row, overall_stage: "in_progress" }
+        : row;
+    }
+
+    return {
+      ...row,
+      has_waiting_parts: false,
+      parts_blocker_count: 0,
+      jobs_waiting_parts: 0,
+      overall_stage:
+        row.overall_stage === "waiting_parts"
+          ? activeLaborWorkOrderIds.has(row.work_order_id)
+            ? "in_progress"
+            : "awaiting"
+          : row.overall_stage,
+    };
+  });
+}

--- a/features/shared/components/workboard/WorkOrderBoard.tsx
+++ b/features/shared/components/workboard/WorkOrderBoard.tsx
@@ -225,16 +225,17 @@ export default function WorkOrderBoard(props: {
   const [stageFilter, setStageFilter] = useState<FilterKey>(
     props.initialStage ?? "all",
   );
+  const [riskOnly, setRiskOnly] = useState(false);
   const [query, setQuery] = useState("");
   const [advisor, setAdvisor] = useState("all");
   const [technician, setTechnician] = useState("all");
   const [priority, setPriority] = useState("all");
   const [waiter, setWaiter] = useState("all");
 
-  useEffect(
-    () => setStageFilter(props.initialStage ?? "all"),
-    [props.initialStage],
-  );
+  useEffect(() => {
+    setStageFilter(props.initialStage ?? "all");
+    setRiskOnly(false);
+  }, [props.initialStage]);
 
   const advisorOptions = useMemo(
     () =>
@@ -279,6 +280,9 @@ export default function WorkOrderBoard(props: {
         .toLowerCase();
       return (
         (stageFilter === "all" || row.overall_stage === stageFilter) &&
+        (!riskOnly ||
+          row.risk_level === "warn" ||
+          row.risk_level === "danger") &&
         (!q || searchable.includes(q)) &&
         (advisor === "all" || row.advisor_name === advisor) &&
         (technician === "all" ||
@@ -288,7 +292,7 @@ export default function WorkOrderBoard(props: {
         (waiter === "all" || (waiter === "yes") === Boolean(row.is_waiter))
       );
     });
-  }, [advisor, priority, query, rows, stageFilter, technician, waiter]);
+  }, [advisor, priority, query, riskOnly, rows, stageFilter, technician, waiter]);
 
   const count = (stage: WorkOrderBoardStage) =>
     rows.filter((row) => row.overall_stage === stage).length;
@@ -309,30 +313,35 @@ export default function WorkOrderBoard(props: {
     value: number;
     icon: LucideIcon;
     tone: string;
+    filter: "risk" | Exclude<WorkOrderBoardStage, "empty">;
   }> = [
     {
       label: "At risk",
       value: atRisk,
       icon: AlertTriangle,
       tone: "text-orange-600",
+      filter: "risk",
     },
     {
       label: "Ready to work",
       value: count("awaiting"),
       icon: CheckCircle2,
       tone: "text-blue-600",
+      filter: "awaiting",
     },
     {
       label: "Waiting parts",
       value: count("waiting_parts"),
       icon: Clock3,
       tone: "text-amber-600",
+      filter: "waiting_parts",
     },
     {
       label: "Ready to invoice",
       value: count("completed"),
       icon: ClipboardCheck,
       tone: "text-emerald-600",
+      filter: "completed",
     },
   ];
 
@@ -414,42 +423,37 @@ export default function WorkOrderBoard(props: {
       </header>
 
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-        {summaryCards.map(({ label, value, icon: Icon, tone }) => (
-          <div
-            key={String(label)}
-            className="flex items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3"
-          >
-            <Icon className={`h-5 w-5 ${tone}`} />
-            <span className="flex-1 text-sm font-semibold">{label}</span>
-            <strong className={`text-xl ${tone}`}>{value}</strong>
-          </div>
-        ))}
-      </div>
-
-      <div
-        className="flex gap-1 overflow-x-auto"
-        aria-label="Board stage views"
-      >
-        {(
-          [
-            ["all", "All"],
-            ["awaiting", "Awaiting"],
-            ["in_progress", "In progress"],
-            ["awaiting_approval", "Awaiting approval"],
-            ["waiting_parts", "Waiting parts"],
-            ["on_hold", "On hold"],
-            ["completed", "Ready to invoice"],
-          ] as Array<[FilterKey, string]>
-        ).map(([key, label]) => (
-          <button
-            key={key}
-            type="button"
-            onClick={() => setStageFilter(key)}
-            className={`whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-semibold ${stageFilter === key ? "border-[var(--brand-primary,#C1663B)] bg-[var(--brand-primary,#C1663B)]/10 text-[var(--brand-primary,#C1663B)]" : "border-[color:var(--theme-border-soft)] text-[color:var(--theme-text-secondary)]"}`}
-          >
-            {label}
-          </button>
-        ))}
+        {summaryCards.map(({ label, value, icon: Icon, tone, filter }) => {
+          const selected =
+            filter === "risk"
+              ? riskOnly
+              : !riskOnly && stageFilter === filter;
+          return (
+            <button
+              key={String(label)}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => {
+                if (filter === "risk") {
+                  setRiskOnly((current) => !current);
+                  setStageFilter("all");
+                  return;
+                }
+                setRiskOnly(false);
+                setStageFilter(selected ? "all" : filter);
+              }}
+              className={`flex items-center gap-3 rounded-xl border bg-[color:var(--theme-surface-inset)] px-4 py-3 text-left transition hover:border-[var(--brand-primary,#C1663B)]/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-primary,#C1663B)]/60 ${
+                selected
+                  ? "border-[var(--brand-primary,#C1663B)] shadow-[0_0_0_1px_color-mix(in_srgb,var(--brand-primary,#C1663B)_35%,transparent)]"
+                  : "border-[color:var(--theme-border-soft)]"
+              }`}
+            >
+              <Icon className={`h-5 w-5 ${tone}`} />
+              <span className="flex-1 text-sm font-semibold">{label}</span>
+              <strong className={`text-xl ${tone}`}>{value}</strong>
+            </button>
+          );
+        })}
       </div>
 
       {loading ? (

--- a/features/shared/hooks/useWorkOrderBoard.ts
+++ b/features/shared/hooks/useWorkOrderBoard.ts
@@ -3,6 +3,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { WorkOrderBoardRow, WorkOrderBoardVariant } from "../lib/workboard/types";
+import {
+  countOpenPartsObligationsByWorkOrder,
+  reconcileBoardPartsState,
+  type OpenPartsItem,
+  type OpenPartsRequest,
+} from "@/features/parts/lib/open-parts-obligations";
 
 type ViewName =
   | "v_work_order_board_cards_shop"
@@ -61,24 +67,55 @@ export function useWorkOrderBoard(
     }
 
     const workOrderIds = boardRows.map((row) => row.work_order_id);
-    const { data: activeSegments } = await supabase
-      .from("work_order_line_labor_segments")
-      .select("work_order_id")
-      .in("work_order_id", workOrderIds)
-      .is("ended_at", null);
+    const [activeSegmentsResult, requestResults] = await Promise.all([
+      supabase
+        .from("work_order_line_labor_segments")
+        .select("work_order_id")
+        .in("work_order_id", workOrderIds)
+        .is("ended_at", null),
+      Promise.all(
+        Array.from(
+          { length: Math.ceil(workOrderIds.length / 200) },
+          (_, index) =>
+            supabase
+              .from("part_requests")
+              .select("id,work_order_id,status")
+              .in("work_order_id", workOrderIds.slice(index * 200, index * 200 + 200)),
+        ),
+      ),
+    ]);
 
     const activeWorkOrderIds = new Set(
-      (activeSegments ?? [])
+      (activeSegmentsResult.data ?? [])
         .map((segment) => segment.work_order_id)
         .filter((id): id is string => typeof id === "string" && id.length > 0),
     );
 
+    const requests = requestResults.flatMap((result) =>
+      result.error ? [] : ((result.data ?? []) as OpenPartsRequest[]),
+    );
+    const requestIds = requests.map((request) => request.id);
+    const itemResults = await Promise.all(
+      Array.from(
+        { length: Math.ceil(requestIds.length / 200) },
+        (_, index) =>
+          supabase
+            .from("part_request_items")
+            .select(
+              "request_id,status,po_id,qty,qty_requested,qty_approved,qty_ordered,qty_received,qty_reserved,qty_consumed,qty_returned",
+            )
+            .in("request_id", requestIds.slice(index * 200, index * 200 + 200)),
+      ),
+    );
+    const items = itemResults.flatMap((result) =>
+      result.error ? [] : ((result.data ?? []) as OpenPartsItem[]),
+    );
+
     setRows(
-      boardRows.map((row) =>
-        activeWorkOrderIds.has(row.work_order_id) &&
-        row.overall_stage !== "completed"
-          ? { ...row, overall_stage: "in_progress" }
-          : row,
+      reconcileBoardPartsState(
+        boardRows,
+        countOpenPartsObligationsByWorkOrder(requests, items),
+        activeWorkOrderIds,
       ),
     );
     setLoading(false);

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -745,21 +745,15 @@ export default function WorkOrdersView(): JSX.Element {
       const prev = rows;
       setRows((r) => r.filter((x) => x.id !== id));
 
-      const { error: lineErr } = await supabase
-        .from("work_order_lines")
-        .delete()
-        .eq("work_order_id", id);
+      const response = await fetch(`/api/work-orders/${id}/delete-draft`, {
+        method: "DELETE",
+      });
+      const result = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
 
-      if (lineErr) {
-        alert(`Failed to delete job lines: ${lineErr.message}`);
-        setRows(prev);
-        return;
-      }
-
-      const { error } = await supabase.from("work_orders").delete().eq("id", id);
-
-      if (error) {
-        alert(`Failed to delete: ${error.message}`);
+      if (!response.ok) {
+        alert(result?.error ?? "Failed to delete the work order.");
         setRows(prev);
       } else {
         setTechRollupByWo((m) => {
@@ -769,7 +763,7 @@ export default function WorkOrdersView(): JSX.Element {
         });
       }
     },
-    [rows, supabase],
+    [rows],
   );
 
   const handleAssignAll = useCallback(

--- a/supabase/migrations/20260724010000_atomic_draft_work_order_delete.sql
+++ b/supabase/migrations/20260724010000_atomic_draft_work_order_delete.sql
@@ -1,0 +1,303 @@
+begin;
+
+create or replace function public.work_order_delete_draft_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_operation_key text,
+  p_actor_user_id uuid
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_authenticated_user_id uuid := auth.uid();
+  v_actor_role text;
+  v_work_order public.work_orders%rowtype;
+  v_operation public.parts_operation_keys;
+  v_result jsonb;
+begin
+  if p_shop_id is null or p_work_order_id is null then
+    raise exception using
+      errcode = '22023',
+      message = 'WORK_ORDER_DELETE_SCOPE_REQUIRED';
+  end if;
+
+  if coalesce(trim(p_operation_key), '') = ''
+     or p_operation_key <> (
+       p_shop_id::text || ':delete-draft-work-order:' || p_work_order_id::text
+     ) then
+    raise exception using
+      errcode = '22023',
+      message = 'WORK_ORDER_DELETE_OPERATION_KEY_INVALID';
+  end if;
+
+  if coalesce(auth.role(), '') <> 'service_role' then
+    if v_authenticated_user_id is null then
+      raise exception using
+        errcode = '42501',
+        message = 'WORK_ORDER_DELETE_AUTHENTICATION_REQUIRED';
+    end if;
+
+    if p_actor_user_id is null
+       or v_authenticated_user_id is distinct from p_actor_user_id then
+      raise exception using
+        errcode = '42501',
+        message = 'WORK_ORDER_DELETE_ACTOR_MISMATCH';
+    end if;
+
+    select lower(trim(coalesce(profile.role::text, '')))
+      into v_actor_role
+    from public.profiles profile
+    where profile.shop_id = p_shop_id
+      and (
+        profile.id = v_authenticated_user_id
+        or profile.user_id = v_authenticated_user_id
+      )
+    order by (profile.id = v_authenticated_user_id) desc
+    limit 1;
+
+    if v_actor_role is null then
+      raise exception using
+        errcode = '42501',
+        message = 'WORK_ORDER_DELETE_SHOP_ACCESS_DENIED';
+    end if;
+
+    if v_actor_role not in ('owner', 'admin') then
+      raise exception using
+        errcode = '42501',
+        message = 'WORK_ORDER_DELETE_ROLE_ACCESS_DENIED';
+    end if;
+  end if;
+
+  v_operation := public.parts_begin_operation(
+    p_shop_id,
+    p_operation_key,
+    'delete_draft_work_order',
+    'work_order',
+    p_work_order_id,
+    p_actor_user_id
+  );
+  if v_operation.completed_at is not null then
+    return coalesce(v_operation.result, '{}'::jsonb)
+      || jsonb_build_object('idempotent', true);
+  end if;
+
+  select work_order_row.*
+    into v_work_order
+  from public.work_orders work_order_row
+  where work_order_row.id = p_work_order_id
+    and work_order_row.shop_id = p_shop_id
+  for update;
+
+  if not found then
+    raise exception using
+      errcode = 'P0002',
+      message = 'WORK_ORDER_DELETE_NOT_FOUND_FOR_SHOP';
+  end if;
+
+  if lower(coalesce(v_work_order.status::text, '')) not in (
+    'awaiting',
+    'awaiting_inspection',
+    'draft',
+    'new',
+    'pending',
+    'queued'
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_DELETE_NOT_DRAFT';
+  end if;
+
+  if public.work_order_is_financially_locked(p_shop_id, p_work_order_id)
+     or coalesce(v_work_order.invoice_total, 0) <> 0
+     or coalesce(v_work_order.labor_total, 0) <> 0
+     or coalesce(v_work_order.parts_total, 0) <> 0
+     or v_work_order.customer_approval_at is not null
+     or v_work_order.customer_agreed_at is not null then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_DELETE_FINANCIAL_OR_APPROVAL_HISTORY';
+  end if;
+
+  if exists (
+    select 1
+    from public.invoices invoice_row
+    where invoice_row.shop_id = p_shop_id
+      and invoice_row.work_order_id = p_work_order_id
+  ) or exists (
+    select 1
+    from public.payments payment_row
+    where payment_row.shop_id = p_shop_id
+      and payment_row.work_order_id = p_work_order_id
+  ) or exists (
+    select 1
+    from public.supplier_orders supplier_order
+    where supplier_order.shop_id = p_shop_id
+      and supplier_order.work_order_id = p_work_order_id
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_DELETE_FINANCIAL_OR_SUPPLIER_HISTORY';
+  end if;
+
+  if exists (
+    select 1
+    from public.work_order_line_labor_segments labor_segment
+    where labor_segment.shop_id = p_shop_id
+      and labor_segment.work_order_id = p_work_order_id
+  ) or exists (
+    select 1
+    from public.inspections inspection_row
+    where inspection_row.shop_id = p_shop_id
+      and inspection_row.work_order_id = p_work_order_id
+  ) or exists (
+    select 1
+    from public.inspection_sessions inspection_session
+    where inspection_session.work_order_id = p_work_order_id
+  ) or exists (
+    select 1
+    from public.work_order_quote_lines quote_line
+    where quote_line.shop_id = p_shop_id
+      and quote_line.work_order_id = p_work_order_id
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_DELETE_OPERATIONAL_HISTORY';
+  end if;
+
+  if exists (
+    select 1
+    from public.work_order_parts work_order_part
+    where work_order_part.shop_id = p_shop_id
+      and work_order_part.work_order_id = p_work_order_id
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_DELETE_PARTS_HISTORY';
+  end if;
+
+  if exists (
+    select 1
+    from public.part_requests request_row
+    where request_row.shop_id = p_shop_id
+      and request_row.work_order_id = p_work_order_id
+      and lower(coalesce(request_row.status::text, '')) not in (
+        'cancelled',
+        'deferred',
+        'quoted',
+        'rejected',
+        'requested'
+      )
+  ) or exists (
+    select 1
+    from public.part_request_items item
+    join public.part_requests request_row
+      on request_row.id = item.request_id
+     and request_row.shop_id = p_shop_id
+    where request_row.work_order_id = p_work_order_id
+      and (
+        lower(coalesce(item.status::text, '')) not in (
+          'awaiting_customer_approval',
+          'cancelled',
+          'quoted',
+          'requested'
+        )
+        or coalesce(item.approved, false)
+        or coalesce(item.qty_approved, 0) > 0
+        or coalesce(item.qty_reserved, 0) > 0
+        or coalesce(item.qty_picked, 0) > 0
+        or coalesce(item.qty_ordered, 0) > 0
+        or coalesce(item.qty_received, 0) > 0
+        or coalesce(item.qty_consumed, 0) > 0
+        or coalesce(item.qty_returned, 0) > 0
+        or item.po_id is not null
+        or item.source_work_order_part_id is not null
+      )
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_DELETE_ACTIVE_PARTS_HISTORY';
+  end if;
+
+  if exists (
+    select 1
+    from public.work_order_lines work_order_line
+    where work_order_line.shop_id = p_shop_id
+      and work_order_line.work_order_id = p_work_order_id
+      and (
+        lower(coalesce(work_order_line.status::text, '')) not in (
+          'awaiting',
+          'awaiting_approval',
+          'new',
+          'pending',
+          'queued'
+        )
+        or work_order_line.punched_in_at is not null
+        or work_order_line.punched_out_at is not null
+        or nullif(trim(coalesce(work_order_line.cause, '')), '') is not null
+        or nullif(trim(coalesce(work_order_line.correction, '')), '') is not null
+      )
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_DELETE_ACTIVE_LABOR_HISTORY';
+  end if;
+
+  delete from public.part_request_items item
+  using public.part_requests request_row
+  where item.request_id = request_row.id
+    and request_row.shop_id = p_shop_id
+    and request_row.work_order_id = p_work_order_id;
+
+  delete from public.part_request_lines request_line
+  using public.part_requests request_row
+  where request_line.request_id = request_row.id
+    and request_row.shop_id = p_shop_id
+    and request_row.work_order_id = p_work_order_id;
+
+  delete from public.part_requests request_row
+  where request_row.shop_id = p_shop_id
+    and request_row.work_order_id = p_work_order_id;
+
+  delete from public.work_order_lines work_order_line
+  where work_order_line.shop_id = p_shop_id
+    and work_order_line.work_order_id = p_work_order_id;
+
+  delete from public.work_orders work_order_row
+  where work_order_row.id = p_work_order_id
+    and work_order_row.shop_id = p_shop_id;
+
+  if not found then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_DELETE_FAILED';
+  end if;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'deleted', true,
+    'work_order_id', p_work_order_id
+  );
+  return public.parts_complete_operation(v_operation.id, v_result);
+end;
+$$;
+
+revoke all on function public.work_order_delete_draft_atomic(
+  uuid,
+  uuid,
+  text,
+  uuid
+) from public, anon;
+
+grant execute on function public.work_order_delete_draft_atomic(
+  uuid,
+  uuid,
+  text,
+  uuid
+) to authenticated, service_role;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/inspection-active-work-parts-regressions.test.ts
+++ b/tests/inspection-active-work-parts-regressions.test.ts
@@ -10,6 +10,10 @@ const boardHook = readFileSync(
   "features/shared/hooks/useWorkOrderBoard.ts",
   "utf8",
 );
+const openPartsObligations = readFileSync(
+  "features/parts/lib/open-parts-obligations.ts",
+  "utf8",
+);
 const sectionDisplay = readFileSync(
   "features/inspections/lib/inspection/SectionDisplay.tsx",
   "utf8",
@@ -36,7 +40,8 @@ describe("active work and inspection parts regressions", () => {
   it("treats an active labor segment as authoritative in-progress work", () => {
     expect(boardHook).toContain('"work_order_line_labor_segments"');
     expect(boardHook).toContain('.is("ended_at", null)');
-    expect(boardHook).toContain('overall_stage: "in_progress"');
+    expect(boardHook).toContain("reconcileBoardPartsState");
+    expect(openPartsObligations).toContain('overall_stage: "in_progress"');
     expect(boardHook).toContain('table: "work_order_line_labor_segments"');
   });
 
@@ -72,4 +77,3 @@ describe("active work and inspection parts regressions", () => {
     );
   });
 });
-

--- a/tests/parts-dashboard-redesign.test.ts
+++ b/tests/parts-dashboard-redesign.test.ts
@@ -23,7 +23,8 @@ describe("Parts dashboard redesign", () => {
   });
 
   it("uses the shared lifecycle derivation and paged totals", () => {
-    expect(source).toContain("function approvedReceivingQty");
+    expect(source).toContain("isPartRequestItemAwaitingReceiving");
+    expect(source).toContain("po_id");
     expect(source).toContain("toPartsRequestStage");
     expect(source).toContain("earliestPartsRequestStage");
     expect(source).toContain("stagesByWorkOrder");

--- a/tests/parts/open-parts-obligations.test.ts
+++ b/tests/parts/open-parts-obligations.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  countOpenPartsObligationsByWorkOrder,
+  isOpenPartsObligation,
+  isPartRequestItemAwaitingReceiving,
+  reconcileBoardPartsState,
+} from "@/features/parts/lib/open-parts-obligations";
+import type { WorkOrderBoardRow } from "@/features/shared/lib/workboard/types";
+
+describe("canonical open parts obligations", () => {
+  it("matches the receiving inbox contract instead of counting un-ordered approvals", () => {
+    expect(
+      isPartRequestItemAwaitingReceiving({
+        request_id: "request-1",
+        status: "approved",
+        po_id: null,
+        qty_ordered: 0,
+        qty_received: 0,
+      }),
+    ).toBe(false);
+    expect(
+      isPartRequestItemAwaitingReceiving({
+        request_id: "request-1",
+        status: "ordered",
+        po_id: "po-1",
+        qty_ordered: 2,
+        qty_received: 1,
+      }),
+    ).toBe(true);
+    expect(
+      isPartRequestItemAwaitingReceiving({
+        request_id: "request-1",
+        status: "ordered",
+        po_id: "po-1",
+        qty_ordered: 2,
+        qty_received: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("stops treating handed-off and cancelled items as waiting parts", () => {
+    expect(
+      isOpenPartsObligation("approved", {
+        request_id: "request-1",
+        status: "consumed",
+        qty_approved: 2,
+        qty_consumed: 2,
+        qty_returned: 0,
+      }),
+    ).toBe(false);
+    expect(
+      isOpenPartsObligation("cancelled", {
+        request_id: "request-2",
+        status: "requested",
+        qty_requested: 1,
+      }),
+    ).toBe(false);
+    expect(
+      isOpenPartsObligation("approved", {
+        request_id: "request-3",
+        status: "received",
+        qty_approved: 1,
+        qty_received: 1,
+        qty_consumed: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("counts only canonical open obligations by work order", () => {
+    const counts = countOpenPartsObligationsByWorkOrder(
+      [
+        { id: "request-open", work_order_id: "wo-1", status: "approved" },
+        { id: "request-done", work_order_id: "wo-2", status: "fulfilled" },
+      ],
+      [
+        {
+          request_id: "request-open",
+          status: "ordered",
+          qty_approved: 1,
+          qty_ordered: 1,
+        },
+        {
+          request_id: "request-done",
+          status: "consumed",
+          qty_approved: 1,
+          qty_consumed: 1,
+        },
+      ],
+    );
+
+    expect(counts.get("wo-1")).toBe(1);
+    expect(counts.has("wo-2")).toBe(false);
+  });
+
+  it("repairs a stale waiting-parts board row after handoff", () => {
+    const row: WorkOrderBoardRow = {
+      work_order_id: "wo-handed-off",
+      custom_id: "EL000005",
+      display_name: "Test customer",
+      unit_label: null,
+      vehicle_label: null,
+      jobs_total: 1,
+      jobs_completed: 0,
+      progress_pct: 0,
+      overall_stage: "waiting_parts",
+      risk_level: "none",
+      has_waiting_parts: true,
+      parts_blocker_count: 1,
+      jobs_waiting_parts: 1,
+    };
+
+    expect(reconcileBoardPartsState([row], new Map(), new Set())).toEqual([
+      expect.objectContaining({
+        overall_stage: "awaiting",
+        has_waiting_parts: false,
+        parts_blocker_count: 0,
+        jobs_waiting_parts: 0,
+      }),
+    ]);
+  });
+});

--- a/tests/parts/parts-line-pick-order-release.test.ts
+++ b/tests/parts/parts-line-pick-order-release.test.ts
@@ -28,6 +28,10 @@ const dismissMigration = readFileSync(
   "utf8",
 );
 const receiving = readFileSync("app/parts/receiving/page.tsx", "utf8");
+const openPartsObligations = readFileSync(
+  "features/parts/lib/open-parts-obligations.ts",
+  "utf8",
+);
 const notifications = readFileSync(
   "features/agent/server/syncAssistantNotifications.ts",
   "utf8",
@@ -106,7 +110,8 @@ describe("work-order line parts release and Pick / Order flow", () => {
     expect(receiving).toContain('.not("po_id", "is", null)');
     expect(receiving).toContain('.gt("qty_ordered", 0)');
     expect(receiving).toContain("ordered - received");
-    expect(receiving).toContain("x.po_id !== null");
+    expect(receiving).toContain("isPartRequestItemAwaitingReceiving");
+    expect(openPartsObligations).toContain("Boolean(item.po_id)");
     expect(receiving).toContain("it.qty_received} / {it.qty_ordered} ordered");
   });
 

--- a/tests/phase-d1-dashboard-links.test.tsx
+++ b/tests/phase-d1-dashboard-links.test.tsx
@@ -113,7 +113,7 @@ describe("WorkOrderBoard stage query initialization", () => {
     expect(parseWorkOrderBoardStageFilter(undefined)).toBe("all");
   });
 
-  it("initializes the visible board from a valid stage and still allows manual filter changes", async () => {
+  it("initializes the visible board from a valid stage and lets its summary card clear the filter", async () => {
     const user = userEvent.setup();
     const { rerender } = render(
       <WorkOrderBoard variant="shop" title="Board" initialStage="waiting_parts" />,
@@ -122,12 +122,22 @@ describe("WorkOrderBoard stage query initialization", () => {
     expect(screen.getByText("WO-WAITING")).toBeInTheDocument();
     expect(screen.queryByText("WO-HOLD")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /on hold/i }));
+    await user.click(screen.getByRole("button", { name: /waiting parts/i }));
+    expect(screen.getByText("WO-WAITING")).toBeInTheDocument();
     expect(screen.getByText("WO-HOLD")).toBeInTheDocument();
-    expect(screen.queryByText("WO-WAITING")).not.toBeInTheDocument();
 
     rerender(<WorkOrderBoard variant="shop" title="Board" initialStage="awaiting_approval" />);
     expect(screen.getByText("WO-APPROVAL")).toBeInTheDocument();
     expect(screen.queryByText("WO-HOLD")).not.toBeInTheDocument();
+  });
+
+  it("uses the four summary cards as filters and removes the duplicate pill row", () => {
+    render(<WorkOrderBoard variant="shop" title="Board" />);
+
+    expect(screen.getByRole("button", { name: /at risk/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /ready to work/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /waiting parts/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /ready to invoice/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Board stage views")).not.toBeInTheDocument();
   });
 });

--- a/tests/work-orders/draft-work-order-delete.test.ts
+++ b/tests/work-orders/draft-work-order-delete.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const route = readFileSync(
+  "app/api/work-orders/[id]/delete-draft/route.ts",
+  "utf8",
+);
+const client = readFileSync(
+  "features/work-orders/app/work-orders/view/page.tsx",
+  "utf8",
+);
+const migration = readFileSync(
+  "supabase/migrations/20260724010000_atomic_draft_work_order_delete.sql",
+  "utf8",
+);
+
+describe("guarded draft work-order deletion", () => {
+  it("routes the UI through one shop-scoped owner/admin command", () => {
+    expect(client).toContain("/delete-draft");
+    expect(client).not.toMatch(
+      /from\("work_order_lines"\)\s*\.delete\(\)[\s\S]{0,180}from\("work_orders"\)\s*\.delete\(\)/,
+    );
+    expect(route).toContain('allowRoles: ["owner", "admin"]');
+    expect(route).toContain('"work_order_delete_draft_atomic"');
+    expect(route).toContain("access.profile.shop_id");
+  });
+
+  it("requires tenant-scoped idempotency and direct-call authorization", () => {
+    expect(migration).toContain("security definer");
+    expect(migration).toContain("WORK_ORDER_DELETE_ACTOR_MISMATCH");
+    expect(migration).toContain("WORK_ORDER_DELETE_SHOP_ACCESS_DENIED");
+    expect(migration).toContain("WORK_ORDER_DELETE_ROLE_ACCESS_DENIED");
+    expect(migration).toContain(
+      "p_shop_id::text || ':delete-draft-work-order:'",
+    );
+    expect(migration).toContain("public.parts_begin_operation");
+    expect(migration).toContain("public.parts_complete_operation");
+    expect(migration).toContain("'idempotent', true");
+  });
+
+  it("refuses operational, parts, labor, inspection, and financial history", () => {
+    for (const table of [
+      "public.invoices",
+      "public.payments",
+      "public.supplier_orders",
+      "public.work_order_line_labor_segments",
+      "public.inspections",
+      "public.inspection_sessions",
+      "public.work_order_quote_lines",
+      "public.work_order_parts",
+      "public.part_request_items",
+    ]) {
+      expect(migration).toContain(table);
+    }
+    expect(migration).toContain(
+      "WORK_ORDER_DELETE_FINANCIAL_OR_APPROVAL_HISTORY",
+    );
+    expect(migration).toContain("WORK_ORDER_DELETE_ACTIVE_PARTS_HISTORY");
+    expect(migration).toContain("WORK_ORDER_DELETE_ACTIVE_LABOR_HISTORY");
+  });
+
+  it("removes abandoned request anchors before work-order lines", () => {
+    const itemDelete = migration.indexOf(
+      "delete from public.part_request_items",
+    );
+    const requestDelete = migration.indexOf("delete from public.part_requests");
+    const lineDelete = migration.indexOf("delete from public.work_order_lines");
+    const workOrderDelete = migration.indexOf("delete from public.work_orders");
+
+    expect(itemDelete).toBeGreaterThan(-1);
+    expect(itemDelete).toBeLessThan(requestDelete);
+    expect(requestDelete).toBeLessThan(lineDelete);
+    expect(lineDelete).toBeLessThan(workOrderDelete);
+  });
+});


### PR DESCRIPTION
## Root cause

Parts Dashboard, Receiving Inbox, and Work Order Board used different definitions of open parts work. The board trusted legacy waiting-parts flags after handoff/cancellation, the dashboard counted approved shortages before a PO made them receivable, and work-order deletion bypassed immutable parts-request anchors.

## What changed

- Share one quantity-aware definition for open parts obligations and receiving eligibility.
- Exclude handed-off and cancelled-only parts from Waiting Parts.
- Make the four Work Order Board summary tiles the filters and remove the duplicate stage-pill row.
- Route draft work-order deletion through an owner/admin-only atomic RPC.
- Permit cleanup only for abandoned, non-operational request remnants while refusing labor, inspection, ordered/received/handed-off, supplier, approval, invoice, payment, or financial history.
- Refresh the API boundary inventory to 374 routes.

## Why safe

The database command independently verifies the authenticated actor, shop scope, role, deterministic operation key, draft status, and absence of operational or financial history. It locks the work order, is idempotent, preserves the existing immutable-anchor protections, and exposes no anonymous execution path.

## Validation

- Vitest: 1,224 passed, 0 failed, 2 skipped
- TypeScript: passed
- Targeted ESLint: passed (two pre-existing receiving-page hook warnings)
- Production build: passed with temporary local placeholders
- API inventory: passed, 374 routes
- Diff integrity: passed
- Remote branch: one commit ahead, zero behind `main`

## Database

Includes one forward migration: `20260724010000_atomic_draft_work_order_delete.sql`. It has not been applied to production by this PR creation workflow.

## Environment variables

No new variables. Build placeholders were temporary and were not persisted.

## Deployment / manual verification

Do not treat the web deployment alone as complete. After merge, explicitly apply the forward migration, then smoke-test:

1. Parts Dashboard receiving total equals Receiving Inbox.
2. Handed-off/cancelled-only work orders no longer count as Waiting Parts.
3. Each top summary tile filters and toggles correctly.
4. An EL000004-style draft with only abandoned request remnants can be deleted.
5. Work orders with real operational or financial history remain blocked.

## Remaining risk

The two existing live database-integration tests remain skipped, so production database behavior still needs the explicit post-migration smoke test above.