### PR TITLE
Rebuild vendor integrations as an operational workspace

### DIFF
--- a/app/api/parts/vendors/route.ts
+++ b/app/api/parts/vendors/route.ts
@@ -1,0 +1,236 @@
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { normalizeVendorName } from "@/features/parts/lib/vendorWorkspace";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+
+type DB = Database;
+type SupplierInsert = DB["public"]["Tables"]["suppliers"]["Insert"];
+type SupplierUpdate = DB["public"]["Tables"]["suppliers"]["Update"];
+
+type VendorBody = {
+  id?: unknown;
+  name?: unknown;
+  accountNo?: unknown;
+  email?: unknown;
+  phone?: unknown;
+  notes?: unknown;
+  isActive?: unknown;
+};
+
+const VENDOR_SELECT =
+  "id, name, account_no, email, phone, notes, is_active, created_at, created_by, shop_id";
+
+function optionalText(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): { ok: true; value: string | null } | { ok: false; error: string } {
+  if (value == null) return { ok: true, value: null };
+  if (typeof value !== "string") return { ok: false, error: `${field} must be text.` };
+  const trimmed = value.trim();
+  if (!trimmed) return { ok: true, value: null };
+  if (trimmed.length > maxLength) {
+    return { ok: false, error: `${field} must be ${maxLength} characters or fewer.` };
+  }
+  return { ok: true, value: trimmed };
+}
+
+function parseVendorBody(body: VendorBody):
+  | {
+      ok: true;
+      vendor: {
+        name: string;
+        accountNo: string | null;
+        email: string | null;
+        phone: string | null;
+        notes: string | null;
+        isActive: boolean;
+      };
+    }
+  | { ok: false; error: string } {
+  if (typeof body.name !== "string" || !body.name.trim()) {
+    return { ok: false, error: "Vendor name is required." };
+  }
+  const name = body.name.trim();
+  if (name.length > 160) {
+    return { ok: false, error: "Vendor name must be 160 characters or fewer." };
+  }
+
+  const accountNo = optionalText(body.accountNo, "Account number", 120);
+  if (!accountNo.ok) return accountNo;
+  const email = optionalText(body.email, "Email", 254);
+  if (!email.ok) return email;
+  if (email.value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value)) {
+    return { ok: false, error: "Enter a valid vendor email address." };
+  }
+  const phone = optionalText(body.phone, "Phone", 80);
+  if (!phone.ok) return phone;
+  const notes = optionalText(body.notes, "Notes", 2000);
+  if (!notes.ok) return notes;
+
+  return {
+    ok: true,
+    vendor: {
+      name,
+      accountNo: accountNo.value,
+      email: email.value,
+      phone: phone.value,
+      notes: notes.value,
+      isActive: typeof body.isActive === "boolean" ? body.isActive : true,
+    },
+  };
+}
+
+async function requireVendorAccess() {
+  return requireShopScopedApiAccess({ requiredCapability: "canManageParts" });
+}
+
+async function findNormalizedDuplicate(args: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  name: string;
+  excludeId?: string;
+}): Promise<{ id: string; name: string } | null> {
+  const { data, error } = await args.supabase
+    .from("suppliers")
+    .select("id, name")
+    .eq("shop_id", args.shopId)
+    .limit(1000);
+  if (error) throw error;
+
+  const wanted = normalizeVendorName(args.name);
+  return (
+    (data ?? []).find(
+      (row) =>
+        row.id !== args.excludeId && normalizeVendorName(row.name) === wanted,
+    ) ?? null
+  );
+}
+
+export async function POST(request: Request) {
+  const access = await requireVendorAccess();
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as VendorBody | null;
+  if (!body) {
+    return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
+  }
+  const parsed = parseVendorBody(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  try {
+    const duplicate = await findNormalizedDuplicate({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      name: parsed.vendor.name,
+    });
+    if (duplicate) {
+      return NextResponse.json(
+        {
+          error: `A vendor named “${duplicate.name}” already exists.`,
+          vendorId: duplicate.id,
+        },
+        { status: 409 },
+      );
+    }
+
+    const insert: SupplierInsert = {
+      shop_id: access.profile.shop_id,
+      created_by: access.profile.id,
+      name: parsed.vendor.name,
+      account_no: parsed.vendor.accountNo,
+      email: parsed.vendor.email,
+      phone: parsed.vendor.phone,
+      notes: parsed.vendor.notes,
+      is_active: parsed.vendor.isActive,
+    };
+    const { data, error } = await access.supabase
+      .from("suppliers")
+      .insert(insert)
+      .select(VENDOR_SELECT)
+      .single();
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true, vendor: data }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to create vendor.",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: Request) {
+  const access = await requireVendorAccess();
+  if (!access.ok) return access.response;
+
+  const body = (await request.json().catch(() => null)) as VendorBody | null;
+  if (!body || typeof body.id !== "string") {
+    return NextResponse.json({ error: "A vendor id is required." }, { status: 400 });
+  }
+  const id = body.id.trim();
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id)) {
+    return NextResponse.json({ error: "A valid vendor id is required." }, { status: 400 });
+  }
+  const parsed = parseVendorBody(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  try {
+    const duplicate = await findNormalizedDuplicate({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      name: parsed.vendor.name,
+      excludeId: id,
+    });
+    if (duplicate) {
+      return NextResponse.json(
+        {
+          error: `A vendor named “${duplicate.name}” already exists.`,
+          vendorId: duplicate.id,
+        },
+        { status: 409 },
+      );
+    }
+
+    const update: SupplierUpdate = {
+      name: parsed.vendor.name,
+      account_no: parsed.vendor.accountNo,
+      email: parsed.vendor.email,
+      phone: parsed.vendor.phone,
+      notes: parsed.vendor.notes,
+      is_active: parsed.vendor.isActive,
+    };
+    const { data, error } = await access.supabase
+      .from("suppliers")
+      .update(update)
+      .eq("id", id)
+      .eq("shop_id", access.profile.shop_id)
+      .select(VENDOR_SELECT)
+      .maybeSingle();
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    if (!data) {
+      return NextResponse.json(
+        { error: "Vendor not found for this shop." },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ ok: true, vendor: data });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: error instanceof Error ? error.message : "Failed to update vendor.",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/parts/vendors/page.tsx
+++ b/app/parts/vendors/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { Pencil, Plus, PlugZap } from "lucide-react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
+import {
+  buildVendorWorkspace,
+  hasVendorValue,
+  type VendorDirectoryItem,
+  type VendorOperationalState,
+  type VendorWorkspaceSummary,
+} from "@/features/parts/lib/vendorWorkspace";
 
 type DB = Database;
 type SupplierRow = DB["public"]["Tables"]["suppliers"]["Row"];
@@ -14,624 +22,980 @@ type PurchaseOrderRow = DB["public"]["Tables"]["purchase_orders"]["Row"];
 type PurchaseOrderLineRow = DB["public"]["Tables"]["purchase_order_lines"]["Row"];
 type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
 
-type VendorDirectoryItem = {
-  supplier: SupplierRow;
-  linkedPartsCount: number;
-  openPoCount: number;
-  pendingReceivingCount: number;
-  lastActivityAt: string | null;
-  readiness: "Ready" | "Missing contact" | "Missing account/code" | "No linked parts" | "Needs review";
-  issues: string[];
+type VendorDraft = {
+  name: string;
+  accountNo: string;
+  email: string;
+  phone: string;
+  notes: string;
+  isActive: boolean;
 };
 
-type DerivedState = {
-  totalVendors: number | null;
-  vendorsWithLinkedParts: number | null;
-  vendorsMissingContact: number | null;
-  vendorsMissingAccount: number | null;
-  vendorsMissingContactOrAccount: number | null;
-  partsMissingVendorLink: number | null;
-  openPurchaseOrders: number | null;
-  pendingReceivingQueue: number | null;
-  duplicateVendorCandidates: number | null;
-  partsWithSupplierTextNoCanonicalLink: number | null;
-  poItemsWithVendorTextNoVendorLink: number | null;
-  openPoWithoutVendorRecord: number | null;
-  integrationReadiness: {
-    partsTech: string;
-    quickBooks: string;
-    supplierApi: string;
+const EMPTY_SUMMARY: VendorWorkspaceSummary = {
+  totalVendors: 0,
+  vendorsNeedingSetup: 0,
+  openPurchaseOrders: 0,
+  pendingReceiving: 0,
+  catalogLinkedParts: 0,
+  legacyUnlinkedParts: 0,
+  partsWithoutVendorReference: 0,
+  duplicateVendorCandidates: 0,
+  openPoWithoutVendorRecord: 0,
+  requestRowsWithoutVendorRecord: 0,
+};
+
+const EMPTY_DRAFT: VendorDraft = {
+  name: "",
+  accountNo: "",
+  email: "",
+  phone: "",
+  notes: "",
+  isActive: true,
+};
+
+const DIRECTORY_STATES: VendorOperationalState[] = [
+  "Receiving",
+  "On order",
+  "Needs setup",
+  "Active",
+  "No activity",
+  "Inactive",
+];
+
+function formatCount(value: number): string {
+  return value.toLocaleString();
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "No purchase activity";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "No purchase activity" : date.toLocaleDateString();
+}
+
+function stateTone(state: VendorOperationalState): string {
+  switch (state) {
+    case "Receiving":
+      return "border-sky-500/35 bg-sky-500/10 text-sky-200";
+    case "On order":
+      return "border-violet-500/35 bg-violet-500/10 text-violet-200";
+    case "Needs setup":
+      return "border-amber-500/35 bg-amber-500/10 text-amber-200";
+    case "Active":
+      return "border-emerald-500/35 bg-emerald-500/10 text-emerald-200";
+    case "Inactive":
+      return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-muted)]";
+    default:
+      return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-secondary)]";
+  }
+}
+
+async function resolveShopContext(
+  supabase: ReturnType<typeof createBrowserSupabase>,
+): Promise<{ shopId: string; role: string }> {
+  const { data: userResult } = await supabase.auth.getUser();
+  const userId = userResult.user?.id ?? null;
+  if (!userId) return { shopId: "", role: "" };
+
+  const { data: byUserId } = await supabase
+    .from("profiles")
+    .select("shop_id, role")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (byUserId?.shop_id) {
+    return { shopId: String(byUserId.shop_id), role: String(byUserId.role ?? "") };
+  }
+
+  const { data: byId } = await supabase
+    .from("profiles")
+    .select("shop_id, role")
+    .eq("id", userId)
+    .maybeSingle();
+  return {
+    shopId: String(byId?.shop_id ?? ""),
+    role: String(byId?.role ?? ""),
   };
-  warnings: string[];
-};
-
-const OPEN_PO_STATUSES = ["draft", "open", "sent", "ordered", "partially_received", "receiving"];
-
-function norm(v: string | null | undefined): string {
-  return String(v ?? "")
-    .toLowerCase()
-    .replace(/[\s\-_.]+/g, " ")
-    .replace(/[^a-z0-9 ]/g, "")
-    .trim();
 }
 
-function hasValue(v: string | null | undefined): boolean {
-  return typeof v === "string" && v.trim().length > 0;
-}
-
-function readinessForVendor(v: VendorDirectoryItem): VendorDirectoryItem["readiness"] {
-  const missingContact = !hasValue(v.supplier.email) && !hasValue(v.supplier.phone);
-  const missingAccount = !hasValue(v.supplier.account_no);
-  const noLinkedParts = v.linkedPartsCount === 0;
-
-  if (!missingContact && !missingAccount && !noLinkedParts) return "Ready";
-  if (missingContact && missingAccount) return "Needs review";
-  if (missingContact) return "Missing contact";
-  if (missingAccount) return "Missing account/code";
-  return "No linked parts";
-}
-
-function readinessTone(readiness: VendorDirectoryItem["readiness"]): string {
-  if (readiness === "Ready") return "border-emerald-500/35 bg-emerald-500/10 text-emerald-200";
-  if (readiness === "Needs review") return "border-rose-500/35 bg-rose-500/10 text-rose-200";
-  if (readiness === "No linked parts") return "border-amber-500/35 bg-amber-500/10 text-amber-200";
-  return "border-sky-500/35 bg-sky-500/10 text-sky-200";
-}
-
-function formatCount(v: number | null): string {
-  if (v == null) return "Not available";
-  return v.toLocaleString();
-}
-
-function formatDate(v: string | null): string {
-  if (!v) return "No activity";
-  const d = new Date(v);
-  if (Number.isNaN(d.getTime())) return "No activity";
-  return d.toLocaleDateString();
-}
-
-async function resolveShopId(supabase: ReturnType<typeof createBrowserSupabase>): Promise<string> {
-  const { data: userRes } = await supabase.auth.getUser();
-  const uid = userRes.user?.id ?? null;
-  if (!uid) return "";
-  const { data: profA } = await supabase.from("profiles").select("shop_id").eq("user_id", uid).maybeSingle();
-  if (profA?.shop_id) return String(profA.shop_id);
-  const { data: profB } = await supabase.from("profiles").select("shop_id").eq("id", uid).maybeSingle();
-  return String(profB?.shop_id ?? "");
-}
-
-async function fetchAllRows<T>(fetchPage: (from: number, to: number) => Promise<T[]>): Promise<T[]> {
+async function fetchAllRows<T>(
+  fetchPage: (from: number, to: number) => Promise<T[]>,
+): Promise<T[]> {
   const pageSize = 1000;
-  const all: T[] = [];
+  const rows: T[] = [];
   let from = 0;
 
   while (true) {
-    const to = from + pageSize - 1;
-    const rows = await fetchPage(from, to);
-    all.push(...rows);
-    if (rows.length < pageSize) break;
+    const page = await fetchPage(from, from + pageSize - 1);
+    rows.push(...page);
+    if (page.length < pageSize) break;
     from += pageSize;
   }
-
-  return all;
+  return rows;
 }
 
-function KpiCard({ title, value, hint, href }: { title: string; value: string; hint?: string; href?: string }) {
+function MetricCard({
+  label,
+  value,
+  detail,
+  onClick,
+  href,
+}: {
+  label: string;
+  value: number;
+  detail: string;
+  onClick?: () => void;
+  href?: string;
+}) {
   const content = (
-    <div className={`${ui.itemCard} px-4 py-3`}>
-      <p className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">{title}</p>
-      <p className="mt-2 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{value}</p>
-      {hint ? <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">{hint}</p> : null}
+    <div className={`${ui.itemCard} h-full px-4 py-3 text-left transition hover:border-[color:var(--desktop-border-strong)]`}>
+      <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+        {label}
+      </p>
+      <p className="mt-2 text-2xl font-semibold tabular-nums text-[color:var(--theme-text-primary)]">
+        {formatCount(value)}
+      </p>
+      <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">{detail}</p>
     </div>
   );
 
-  if (!href) return content;
-  return <Link href={href} className="block">{content}</Link>;
+  if (href) {
+    return (
+      <Link href={href} className="block min-w-0">
+        {content}
+      </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <button type="button" onClick={onClick} className="min-w-0">
+        {content}
+      </button>
+    );
+  }
+  return content;
+}
+
+function IntegrationCard({
+  name,
+  status,
+  description,
+  action,
+}: {
+  name: string;
+  status: "Available now" | "Planned";
+  description: string;
+  action?: React.ReactNode;
+}) {
+  const live = status === "Available now";
+  return (
+    <div className={`${ui.itemCard} flex h-full flex-col justify-between gap-4 p-4`}>
+      <div>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <PlugZap className="h-4 w-4 text-[color:var(--theme-text-secondary)]" />
+            <h3 className="font-semibold text-[color:var(--theme-text-primary)]">{name}</h3>
+          </div>
+          <span
+            className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] ${
+              live
+                ? "border-emerald-500/35 bg-emerald-500/10 text-emerald-200"
+                : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-muted)]"
+            }`}
+          >
+            {status}
+          </span>
+        </div>
+        <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+          {description}
+        </p>
+      </div>
+      {action ? <div>{action}</div> : null}
+    </div>
+  );
+}
+
+function VendorModal({
+  open,
+  draft,
+  editing,
+  busy,
+  error,
+  onChange,
+  onClose,
+  onSubmit,
+}: {
+  open: boolean;
+  draft: VendorDraft;
+  editing: boolean;
+  busy: boolean;
+  error: string | null;
+  onChange: (draft: VendorDraft) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+}) {
+  if (!open) return null;
+  const inputClass = `${ui.input} w-full`;
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-end justify-center bg-[color:var(--theme-surface-overlay)] p-0 sm:items-center sm:p-4"
+      onMouseDown={onClose}
+    >
+      <div
+        className="max-h-[92dvh] w-full overflow-y-auto rounded-t-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg)] p-5 shadow-2xl sm:max-w-2xl sm:rounded-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="vendor-form-title"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+              Vendor record
+            </p>
+            <h2 id="vendor-form-title" className="mt-1 text-xl font-semibold">
+              {editing ? "Edit vendor" : "Add vendor"}
+            </h2>
+          </div>
+          <button type="button" className={ui.buttonSecondary} onClick={onClose} disabled={busy}>
+            Close
+          </button>
+        </div>
+
+        <div className="mt-5 grid gap-4 sm:grid-cols-2">
+          <label className="sm:col-span-2">
+            <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+              Vendor name
+            </span>
+            <input
+              className={inputClass}
+              value={draft.name}
+              onChange={(event) => onChange({ ...draft, name: event.target.value })}
+              autoFocus
+            />
+          </label>
+          <label>
+            <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+              Account number / vendor code
+            </span>
+            <input
+              className={inputClass}
+              value={draft.accountNo}
+              onChange={(event) => onChange({ ...draft, accountNo: event.target.value })}
+            />
+          </label>
+          <label>
+            <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+              Phone
+            </span>
+            <input
+              className={inputClass}
+              value={draft.phone}
+              onChange={(event) => onChange({ ...draft, phone: event.target.value })}
+              inputMode="tel"
+            />
+          </label>
+          <label className="sm:col-span-2">
+            <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+              Email
+            </span>
+            <input
+              className={inputClass}
+              value={draft.email}
+              onChange={(event) => onChange({ ...draft, email: event.target.value })}
+              type="email"
+              inputMode="email"
+            />
+          </label>
+          <label className="sm:col-span-2">
+            <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+              Notes
+            </span>
+            <textarea
+              className={`${inputClass} min-h-24 resize-y`}
+              value={draft.notes}
+              onChange={(event) => onChange({ ...draft, notes: event.target.value })}
+            />
+          </label>
+          <label className="flex items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-3 text-sm sm:col-span-2">
+            <input
+              type="checkbox"
+              checked={draft.isActive}
+              onChange={(event) => onChange({ ...draft, isActive: event.target.checked })}
+            />
+            Active vendor
+          </label>
+        </div>
+
+        {error ? (
+          <div className="mt-4 rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button type="button" className={ui.buttonSecondary} onClick={onClose} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className={ui.buttonPrimary} onClick={onSubmit} disabled={busy}>
+            {busy ? "Saving…" : editing ? "Save changes" : "Add vendor"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default function PartsVendorsPage(): JSX.Element {
   const supabase = useMemo(() => createBrowserSupabase(), []);
-
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [shopId, setShopId] = useState("");
-
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [role, setRole] = useState("");
   const [vendors, setVendors] = useState<SupplierRow[]>([]);
   const [directory, setDirectory] = useState<VendorDirectoryItem[]>([]);
-  const [derived, setDerived] = useState<DerivedState>({
-    totalVendors: null,
-    vendorsWithLinkedParts: null,
-    vendorsMissingContact: null,
-    vendorsMissingAccount: null,
-    vendorsMissingContactOrAccount: null,
-    partsMissingVendorLink: null,
-    openPurchaseOrders: null,
-    pendingReceivingQueue: null,
-    duplicateVendorCandidates: null,
-    partsWithSupplierTextNoCanonicalLink: null,
-    poItemsWithVendorTextNoVendorLink: null,
-    openPoWithoutVendorRecord: null,
-    integrationReadiness: {
-      partsTech: "Not enough baseline vendor + parts linkage data yet.",
-      quickBooks: "Vendor master completeness is not yet sufficient for deterministic sync prep.",
-      supplierApi: "PO/receiving linkage coverage is incomplete.",
-    },
-    warnings: [],
-  });
-
+  const [summary, setSummary] = useState<VendorWorkspaceSummary>(EMPTY_SUMMARY);
   const [search, setSearch] = useState("");
-  const [readinessFilter, setReadinessFilter] = useState<string>("all");
+  const [stateFilter, setStateFilter] = useState<string>("all");
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingVendor, setEditingVendor] = useState<SupplierRow | null>(null);
+  const [draft, setDraft] = useState<VendorDraft>(EMPTY_DRAFT);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+
     void (async () => {
       setLoading(true);
       setError(null);
+      setWarnings([]);
+      const context = await resolveShopContext(supabase);
+      if (cancelled) return;
+      setRole(context.role.toLowerCase());
 
-      const sid = await resolveShopId(supabase);
-      setShopId(sid);
-
-      if (!sid) {
-        setError("Unable to resolve shop context.");
+      if (!context.shopId) {
+        setError("Unable to resolve the current shop.");
         setLoading(false);
         return;
       }
 
-      const warnings: string[] = [];
-
-      const vendorCountQ = supabase.from("suppliers").select("id", { head: true, count: "exact" }).eq("shop_id", sid);
-      const openPoCountQ = supabase
-        .from("purchase_orders")
-        .select("id", { head: true, count: "exact" })
-        .eq("shop_id", sid)
-        .in("status", OPEN_PO_STATUSES);
-
-      const [vendorCountRes, openPoCountRes] = await Promise.all([vendorCountQ, openPoCountQ]);
-
-      if (vendorCountRes.error) warnings.push(`Total vendors unavailable: ${vendorCountRes.error.message}`);
-      if (openPoCountRes.error) warnings.push(`Open PO count unavailable: ${openPoCountRes.error.message}`);
-
-      const supplierRows = await fetchAllRows<SupplierRow>(async (from, to) => {
-        const res = await supabase
+      const loadWarnings: string[] = [];
+      const suppliers = await fetchAllRows<SupplierRow>(async (from, to) => {
+        const result = await supabase
           .from("suppliers")
-          .select("id, name, account_no, email, phone, is_active, created_at, created_by, notes, shop_id")
-          .eq("shop_id", sid)
+          .select("id, name, account_no, email, phone, notes, is_active, created_at, created_by, shop_id")
+          .eq("shop_id", context.shopId)
           .order("name", { ascending: true })
           .range(from, to);
-        if (res.error) {
-          warnings.push(`Vendor directory load error: ${res.error.message}`);
+        if (result.error) {
+          loadWarnings.push(`Vendors: ${result.error.message}`);
           return [];
         }
-        return (res.data ?? []) as SupplierRow[];
+        return (result.data ?? []) as SupplierRow[];
       });
 
-      const partsRows = await fetchAllRows<Pick<PartRow, "id" | "shop_id" | "supplier" | "part_number" | "sku" | "name">>(async (from, to) => {
-        const res = await supabase
-          .from("parts")
-          .select("id, shop_id, supplier, part_number, sku, name")
-          .eq("shop_id", sid)
-          .order("id", { ascending: true })
-          .range(from, to);
-        if (res.error) {
-          warnings.push(`Parts linkage scan unavailable: ${res.error.message}`);
-          return [];
-        }
-        return (res.data ?? []) as Array<Pick<PartRow, "id" | "shop_id" | "supplier" | "part_number" | "sku" | "name">>;
-      });
-
-      const poRows = await fetchAllRows<Pick<PurchaseOrderRow, "id" | "supplier_id" | "status" | "created_at">>(async (from, to) => {
-        const res = await supabase
-          .from("purchase_orders")
-          .select("id, supplier_id, status, created_at")
-          .eq("shop_id", sid)
-          .order("created_at", { ascending: false })
-          .range(from, to);
-        if (res.error) {
-          warnings.push(`PO data load unavailable: ${res.error.message}`);
-          return [];
-        }
-        return (res.data ?? []) as Array<Pick<PurchaseOrderRow, "id" | "supplier_id" | "status" | "created_at">>;
-      });
-
-      const poLineRows = await fetchAllRows<Pick<PurchaseOrderLineRow, "id" | "po_id" | "part_id" | "created_at">>(async (from, to) => {
-        const res = await supabase
-          .from("purchase_order_lines")
-          .select("id, po_id, part_id, created_at")
-          .order("created_at", { ascending: false })
-          .range(from, to);
-        if (res.error) {
-          warnings.push(`PO line linkage scan unavailable: ${res.error.message}`);
-          return [];
-        }
-        return (res.data ?? []) as Array<Pick<PurchaseOrderLineRow, "id" | "po_id" | "part_id" | "created_at">>;
-      });
-
-      const barcodeLinks = await fetchAllRows<{ supplier_id: string | null; part_id: string | null }>(async (from, to) => {
-        const res = await supabase
-          .from("parts_barcodes")
-          .select("supplier_id, part_id")
-          .eq("shop_id", sid)
-          .range(from, to);
-        if (res.error) {
-          warnings.push(`Parts barcode linkage scan unavailable: ${res.error.message}`);
-          return [];
-        }
-        return (res.data ?? []) as Array<{ supplier_id: string | null; part_id: string | null }>;
-      });
-
-      const partRequestRows = await fetchAllRows<Pick<PartRequestItemRow, "id" | "po_id" | "qty_approved" | "qty_received" | "vendor" | "vendor_id">>(async (from, to) => {
-        const res = await supabase
-          .from("part_request_items")
-          .select("id, po_id, qty_approved, qty_received, vendor, vendor_id")
-          .eq("shop_id", sid)
-          .order("created_at", { ascending: false })
-          .range(from, to);
-        if (res.error) {
-          warnings.push(`Receiving queue scan unavailable: ${res.error.message}`);
-          return [];
-        }
-        return (res.data ?? []) as Array<Pick<PartRequestItemRow, "id" | "po_id" | "qty_approved" | "qty_received" | "vendor" | "vendor_id">>;
-      });
-
-      const supplierById = new Map<string, SupplierRow>();
-      supplierRows.forEach((row) => supplierById.set(String(row.id), row));
-
-      const poById = new Map<string, Pick<PurchaseOrderRow, "id" | "supplier_id" | "status" | "created_at">>();
-      poRows.forEach((row) => poById.set(String(row.id), row));
-
-      const partIdsBySupplier = new Map<string, Set<string>>();
-      const openPoCountBySupplier = new Map<string, number>();
-      const pendingReceivingBySupplier = new Map<string, number>();
-      const lastActivityBySupplier = new Map<string, string>();
-      const linkedPartIdsAll = new Set<string>();
-
-      for (const row of poRows) {
-        const supplierId = String(row.supplier_id ?? "");
-        if (!supplierId) continue;
-
-        if (OPEN_PO_STATUSES.includes(String(row.status ?? "").toLowerCase())) {
-          openPoCountBySupplier.set(supplierId, (openPoCountBySupplier.get(supplierId) ?? 0) + 1);
-        }
-
-        const ts = row.created_at ?? null;
-        if (ts) {
-          const prev = lastActivityBySupplier.get(supplierId);
-          if (!prev || new Date(ts).getTime() > new Date(prev).getTime()) {
-            lastActivityBySupplier.set(supplierId, ts);
+      const [
+        parts,
+        purchaseOrders,
+        purchaseOrderLines,
+        requestItems,
+        barcodeLinks,
+        vendorPartNumberLinks,
+      ] = await Promise.all([
+        fetchAllRows<Pick<PartRow, "id" | "supplier" | "part_number" | "sku">>(
+          async (from, to) => {
+            const result = await supabase
+              .from("parts")
+              .select("id, supplier, part_number, sku")
+              .eq("shop_id", context.shopId)
+              .order("id", { ascending: true })
+              .range(from, to);
+            if (result.error) {
+              loadWarnings.push(`Inventory vendor references: ${result.error.message}`);
+              return [];
+            }
+            return result.data ?? [];
+          },
+        ),
+        fetchAllRows<
+          Pick<PurchaseOrderRow, "id" | "supplier_id" | "status" | "created_at">
+        >(async (from, to) => {
+          const result = await supabase
+            .from("purchase_orders")
+            .select("id, supplier_id, status, created_at")
+            .eq("shop_id", context.shopId)
+            .order("created_at", { ascending: false })
+            .range(from, to);
+          if (result.error) {
+            loadWarnings.push(`Purchase orders: ${result.error.message}`);
+            return [];
           }
-        }
-      }
+          return result.data ?? [];
+        }),
+        fetchAllRows<Pick<PurchaseOrderLineRow, "po_id" | "part_id">>(
+          async (from, to) => {
+            const result = await supabase
+              .from("purchase_order_lines")
+              .select("po_id, part_id")
+              .range(from, to);
+            if (result.error) {
+              loadWarnings.push(`Purchase-order part history: ${result.error.message}`);
+              return [];
+            }
+            return result.data ?? [];
+          },
+        ),
+        fetchAllRows<
+          Pick<
+            PartRequestItemRow,
+            "po_id" | "qty_approved" | "qty_received" | "vendor" | "vendor_id"
+          >
+        >(async (from, to) => {
+          const result = await supabase
+            .from("part_request_items")
+            .select("po_id, qty_approved, qty_received, vendor, vendor_id")
+            .eq("shop_id", context.shopId)
+            .range(from, to);
+          if (result.error) {
+            loadWarnings.push(`Receiving queue: ${result.error.message}`);
+            return [];
+          }
+          return result.data ?? [];
+        }),
+        fetchAllRows<{ supplier_id: string | null; part_id: string | null }>(
+          async (from, to) => {
+            const result = await supabase
+              .from("parts_barcodes")
+              .select("supplier_id, part_id")
+              .eq("shop_id", context.shopId)
+              .range(from, to);
+            if (result.error) {
+              loadWarnings.push(`Barcode vendor links: ${result.error.message}`);
+              return [];
+            }
+            return result.data ?? [];
+          },
+        ),
+        fetchAllRows<{ supplier_id: string | null; part_id: string | null }>(
+          async (from, to) => {
+            const result = await supabase
+              .from("vendor_part_numbers")
+              .select("supplier_id, part_id")
+              .eq("shop_id", context.shopId)
+              .range(from, to);
+            if (result.error) {
+              loadWarnings.push(`Vendor catalog links: ${result.error.message}`);
+              return [];
+            }
+            return result.data ?? [];
+          },
+        ),
+      ]);
 
-      for (const row of poLineRows) {
-        const po = poById.get(String(row.po_id));
-        const supplierId = String(po?.supplier_id ?? "");
-        const partId = String(row.part_id ?? "");
-        if (!supplierId || !partId) continue;
-
-        const existing = partIdsBySupplier.get(supplierId) ?? new Set<string>();
-        existing.add(partId);
-        partIdsBySupplier.set(supplierId, existing);
-        linkedPartIdsAll.add(partId);
-      }
-
-      for (const row of barcodeLinks) {
-        const supplierId = String(row.supplier_id ?? "");
-        const partId = String(row.part_id ?? "");
-        if (!supplierId || !partId) continue;
-
-        const existing = partIdsBySupplier.get(supplierId) ?? new Set<string>();
-        existing.add(partId);
-        partIdsBySupplier.set(supplierId, existing);
-        linkedPartIdsAll.add(partId);
-      }
-
-      for (const row of partRequestRows) {
-        const approved = Number(row.qty_approved ?? 0);
-        const received = Number(row.qty_received ?? 0);
-        if (!(approved > received)) continue;
-
-        const po = row.po_id ? poById.get(String(row.po_id)) : null;
-        const supplierId = String(po?.supplier_id ?? "");
-        if (!supplierId) continue;
-
-        pendingReceivingBySupplier.set(supplierId, (pendingReceivingBySupplier.get(supplierId) ?? 0) + 1);
-      }
-
-      const duplicateBuckets = new Map<string, SupplierRow[]>();
-      for (const v of supplierRows) {
-        const key = norm(v.name);
-        if (!key) continue;
-        const bucket = duplicateBuckets.get(key) ?? [];
-        bucket.push(v);
-        duplicateBuckets.set(key, bucket);
-      }
-
-      const duplicateCandidateCount = Array.from(duplicateBuckets.values()).reduce((sum, bucket) => {
-        if (bucket.length < 2) return sum;
-        return sum + bucket.length;
-      }, 0);
-
-      const vendorsMissingContact = supplierRows.filter((v) => !hasValue(v.email) && !hasValue(v.phone)).length;
-      const vendorsMissingAccount = supplierRows.filter((v) => !hasValue(v.account_no)).length;
-
-      const partsMissingVendorLink = partsRows.filter((p) => {
-        const hasSupplierText = hasValue(p.supplier);
-        const hasCanonicalLink = linkedPartIdsAll.has(String(p.id));
-        return !hasSupplierText && !hasCanonicalLink;
-      }).length;
-
-      const partsWithSupplierTextNoCanonicalLink = partsRows.filter((p) => hasValue(p.supplier) && !linkedPartIdsAll.has(String(p.id))).length;
-
-      const poItemsWithVendorTextNoVendorLink = partRequestRows.filter((r) => hasValue(r.vendor) && !hasValue(r.vendor_id)).length;
-
-      const openPoWithoutVendorRecord = poRows.filter((po) => {
-        const isOpen = OPEN_PO_STATUSES.includes(String(po.status ?? "").toLowerCase());
-        if (!isOpen) return false;
-        return !supplierById.has(String(po.supplier_id ?? ""));
-      }).length;
-
-      const directoryRows: VendorDirectoryItem[] = supplierRows.map((supplier) => {
-        const sidRow = String(supplier.id);
-        const linkedPartsCount = (partIdsBySupplier.get(sidRow) ?? new Set<string>()).size;
-        const openPoCount = openPoCountBySupplier.get(sidRow) ?? 0;
-        const pendingReceivingCount = pendingReceivingBySupplier.get(sidRow) ?? 0;
-        const issues: string[] = [];
-
-        if (!hasValue(supplier.email) && !hasValue(supplier.phone)) issues.push("Missing contact email/phone");
-        if (!hasValue(supplier.account_no)) issues.push("Missing account number/vendor code");
-        if (linkedPartsCount === 0) issues.push("No linked parts detected");
-
-        const dupeBucket = duplicateBuckets.get(norm(supplier.name)) ?? [];
-        if (dupeBucket.length > 1) issues.push("Possible duplicate vendor name");
-
-        const row: VendorDirectoryItem = {
-          supplier,
-          linkedPartsCount,
-          openPoCount,
-          pendingReceivingCount,
-          lastActivityAt: lastActivityBySupplier.get(sidRow) ?? null,
-          readiness: "Needs review",
-          issues,
-        };
-        row.readiness = readinessForVendor(row);
-        return row;
+      if (cancelled) return;
+      const workspace = buildVendorWorkspace({
+        suppliers,
+        parts,
+        purchaseOrders,
+        purchaseOrderLines,
+        requestItems,
+        barcodeLinks,
+        vendorPartNumberLinks,
       });
-
-      const vendorsWithLinkedParts = directoryRows.filter((d) => d.linkedPartsCount > 0).length;
-
-      const withContact = supplierRows.filter((v) => hasValue(v.email) || hasValue(v.phone)).length;
-      const withAccount = supplierRows.filter((v) => hasValue(v.account_no)).length;
-      const poLinkedCoverage = poRows.length === 0 ? 1 : (poRows.length - openPoWithoutVendorRecord) / poRows.length;
-      const partsLinkedCoverage = partsRows.length === 0 ? 1 : (partsRows.length - partsMissingVendorLink) / partsRows.length;
-
-      const partsTech =
-        supplierRows.length > 0 && withContact > 0 && withAccount > 0 && partsLinkedCoverage >= 0.4
-          ? "Baseline vendor + part linkage exists for preparation."
-          : "Needs more complete vendor account/contact data and part linkage before activation prep.";
-
-      const quickBooks =
-        supplierRows.length > 0 && withAccount > 0 && withContact > 0
-          ? "Vendor master has core fields for export preparation."
-          : "Missing vendor account/contact completeness for sync preparation.";
-
-      const supplierApi =
-        supplierRows.length > 0 && poLinkedCoverage >= 0.8
-          ? "PO linkage is mostly connected for API prep planning."
-          : "PO linkage gaps remain (some records are not deterministically linked to vendor records).";
-
-      setVendors(supplierRows);
-      setDirectory(directoryRows);
-      setDerived({
-        totalVendors: vendorCountRes.count ?? supplierRows.length,
-        vendorsWithLinkedParts,
-        vendorsMissingContact,
-        vendorsMissingAccount,
-        vendorsMissingContactOrAccount: supplierRows.filter((v) => !hasValue(v.account_no) || (!hasValue(v.email) && !hasValue(v.phone))).length,
-        partsMissingVendorLink,
-        openPurchaseOrders: openPoCountRes.count ?? null,
-        pendingReceivingQueue: partRequestRows.filter((r) => Number(r.qty_approved ?? 0) > Number(r.qty_received ?? 0)).length,
-        duplicateVendorCandidates: duplicateCandidateCount,
-        partsWithSupplierTextNoCanonicalLink,
-        poItemsWithVendorTextNoVendorLink,
-        openPoWithoutVendorRecord,
-        integrationReadiness: {
-          partsTech,
-          quickBooks,
-          supplierApi,
-        },
-        warnings,
-      });
-
+      setVendors(suppliers);
+      setDirectory(workspace.directory);
+      setSummary(workspace.summary);
+      setWarnings(loadWarnings);
       setLoading(false);
-    })();
-  }, [supabase]);
+    })().catch((loadError: unknown) => {
+      if (cancelled) return;
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Unable to load vendor workspace.",
+      );
+      setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshToken, supabase]);
 
   const filteredDirectory = useMemo(() => {
-    const q = search.trim().toLowerCase();
-
+    const query = search.trim().toLowerCase();
     return directory.filter((row) => {
-      if (readinessFilter !== "all" && row.readiness !== readinessFilter) return false;
-      if (!q) return true;
-
-      const hay = [
+      if (
+        stateFilter === "needs_setup" &&
+        !(
+          (!hasVendorValue(row.supplier.email) && !hasVendorValue(row.supplier.phone)) ||
+          !hasVendorValue(row.supplier.account_no)
+        )
+      ) {
+        return false;
+      }
+      if (
+        stateFilter === "duplicates" &&
+        !row.issues.includes("Possible duplicate vendor record")
+      ) {
+        return false;
+      }
+      if (
+        stateFilter !== "all" &&
+        stateFilter !== "needs_setup" &&
+        stateFilter !== "duplicates" &&
+        row.state !== stateFilter
+      ) {
+        return false;
+      }
+      if (!query) return true;
+      return [
         row.supplier.name,
         row.supplier.account_no,
         row.supplier.email,
         row.supplier.phone,
       ]
-        .map((v) => String(v ?? "").toLowerCase())
-        .join(" ");
-
-      return hay.includes(q);
+        .map((value) => String(value ?? "").toLowerCase())
+        .join(" ")
+        .includes(query);
     });
-  }, [directory, readinessFilter, search]);
+  }, [directory, search, stateFilter]);
+
+  const canManageConnections = role === "owner" || role === "admin";
+
+  const openCreate = useCallback(() => {
+    setEditingVendor(null);
+    setDraft(EMPTY_DRAFT);
+    setSaveError(null);
+    setModalOpen(true);
+  }, []);
+
+  const openEdit = useCallback((vendor: SupplierRow) => {
+    setEditingVendor(vendor);
+    setDraft({
+      name: vendor.name,
+      accountNo: vendor.account_no ?? "",
+      email: vendor.email ?? "",
+      phone: vendor.phone ?? "",
+      notes: vendor.notes ?? "",
+      isActive: vendor.is_active,
+    });
+    setSaveError(null);
+    setModalOpen(true);
+  }, []);
+
+  const saveVendor = useCallback(async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const response = await fetch("/api/parts/vendors", {
+        method: editingVendor ? "PATCH" : "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ...(editingVendor ? { id: editingVendor.id } : {}),
+          ...draft,
+        }),
+      });
+      const result = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(result.error || "Unable to save vendor.");
+      }
+      setModalOpen(false);
+      setEditingVendor(null);
+      setDraft(EMPTY_DRAFT);
+      setRefreshToken((value) => value + 1);
+    } catch (saveFailure) {
+      setSaveError(
+        saveFailure instanceof Error ? saveFailure.message : "Unable to save vendor.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, editingVendor]);
 
   return (
-    <div className="relative p-5 text-[color:var(--theme-text-primary)] fade-in md:p-6">
+    <div className="relative p-4 text-[color:var(--theme-text-primary)] fade-in sm:p-5 md:p-6">
       <PageShell
-        eyebrow="Parts · Vendor operations"
-        title="Vendor Command Center"
-        description="Manage supplier readiness, linked parts, purchase activity, and integration preparation."
+        eyebrow="Parts · Purchasing"
+        title="Vendors"
+        description="Manage the supplier records used by parts requests, purchase orders, receiving, and vendor catalog matching."
         actions={
           <div className="flex flex-wrap gap-2">
-            <Link href="/parts" className={ui.buttonSecondary}>Parts Dashboard</Link>
-            <Link href="/parts/inventory" className={ui.buttonSecondary}>Inventory</Link>
-            <Link href="/parts/po" className={ui.buttonSecondary}>Purchase Orders</Link>
-            <Link href="/parts/receiving" className={ui.buttonSecondary}>Receiving Inbox</Link>
-            <Link href="/parts/requests" className={ui.buttonSecondary}>Parts Requests</Link>
-            <Link href="/parts/receive" className={ui.buttonSecondary}>Scan to Receive</Link>
+            <button type="button" className={ui.buttonPrimary} onClick={openCreate}>
+              <Plus className="mr-1.5 inline h-4 w-4" />
+              Add vendor
+            </button>
+            <Link href="/parts/po" className={ui.buttonSecondary}>
+              Purchase orders
+            </Link>
+            <Link href="/parts/receiving" className={ui.buttonSecondary}>
+              Receiving
+            </Link>
           </div>
         }
       >
         <div className="space-y-4">
-          {error ? <div className="desktop-panel-soft border border-rose-500/30 bg-rose-950/30 p-3 text-sm text-rose-200">{error}</div> : null}
-
-          <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-            <KpiCard title="Total vendors" value={loading ? "…" : formatCount(derived.totalVendors)} />
-            <KpiCard title="Vendors with linked parts" value={loading ? "…" : formatCount(derived.vendorsWithLinkedParts)} />
-            <KpiCard title="Vendors missing contact/account setup" value={loading ? "…" : formatCount(derived.vendorsMissingContactOrAccount)} hint="Missing either contact info or account number." />
-            <KpiCard title="Parts missing vendor link" value={loading ? "…" : formatCount(derived.partsMissingVendorLink)} href="/parts/inventory" />
-            <KpiCard title="Open purchase orders" value={loading ? "…" : formatCount(derived.openPurchaseOrders)} href="/parts/po" />
-            <KpiCard title="Pending receiving / queue" value={loading ? "…" : formatCount(derived.pendingReceivingQueue)} href="/parts/receiving" />
-            <KpiCard title="Duplicate vendor candidates" value={loading ? "…" : formatCount(derived.duplicateVendorCandidates)} hint="Normalized exact-name duplicate detection." />
-          </section>
-
-          <section className="grid gap-3 lg:grid-cols-2">
-            <div className="desktop-panel-soft p-4">
-              <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Vendor readiness / data quality</p>
-              <ul className="mt-3 space-y-2 text-sm text-[color:var(--theme-text-primary)]">
-                <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Vendors missing contact email/phone</span><strong>{loading ? "…" : formatCount(derived.vendorsMissingContact)}</strong></li>
-                <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Vendors missing account number/vendor code</span><strong>{loading ? "…" : formatCount(derived.vendorsMissingAccount)}</strong></li>
-                <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Vendor records with no linked parts</span><strong>{loading ? "…" : directory.filter((d) => d.linkedPartsCount === 0).length.toLocaleString()}</strong></li>
-                <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Parts with vendor text but no canonical vendor link</span><strong>{loading ? "…" : formatCount(derived.partsWithSupplierTextNoCanonicalLink)}</strong></li>
-                <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>PO/request rows with vendor text but no vendor link</span><strong>{loading ? "…" : formatCount(derived.poItemsWithVendorTextNoVendorLink)}</strong></li>
-                <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Open purchase orders with missing vendor record</span><strong>{loading ? "…" : formatCount(derived.openPoWithoutVendorRecord)}</strong></li>
-              </ul>
+          {error ? (
+            <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-200">
+              {error}
             </div>
+          ) : null}
 
-            <div className="desktop-panel-soft p-4">
-              <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Integration readiness</p>
-              <h2 className="mt-2 text-base font-semibold text-[color:var(--theme-text-primary)]">Preparation only — live integrations not connected yet.</h2>
-              <ul className="mt-3 space-y-2 text-sm text-[color:var(--theme-text-primary)]">
-                <li className="desktop-item-card px-3 py-2"><span className="font-semibold text-[color:var(--theme-text-primary)]">PartsTech readiness:</span> {derived.integrationReadiness.partsTech}</li>
-                <li className="desktop-item-card px-3 py-2"><span className="font-semibold text-[color:var(--theme-text-primary)]">QuickBooks vendor sync readiness:</span> {derived.integrationReadiness.quickBooks}</li>
-                <li className="desktop-item-card px-3 py-2"><span className="font-semibold text-[color:var(--theme-text-primary)]">Supplier API readiness:</span> {derived.integrationReadiness.supplierApi}</li>
-              </ul>
-            </div>
-          </section>
-
-          <section className="desktop-panel-soft p-4">
-            <div className="flex flex-wrap items-center justify-between gap-3">
+          <section aria-labelledby="vendor-overview-title">
+            <div className="mb-3 flex items-end justify-between gap-3">
               <div>
-                <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Vendor directory</p>
-                <h2 className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">Search and triage vendor records</h2>
+                <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                  Operational overview
+                </p>
+                <h2 id="vendor-overview-title" className="mt-1 text-lg font-semibold">
+                  What needs attention now
+                </h2>
               </div>
-              <div className="flex w-full flex-wrap gap-2 md:w-auto">
+              {loading ? (
+                <span className="text-xs text-[color:var(--theme-text-muted)]">Loading…</span>
+              ) : null}
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              <MetricCard
+                label="Vendors"
+                value={summary.totalVendors}
+                detail="Active and inactive supplier records"
+                onClick={() => setStateFilter("all")}
+              />
+              <MetricCard
+                label="Need setup"
+                value={summary.vendorsNeedingSetup}
+                detail="Missing contact or account information"
+                onClick={() => setStateFilter("needs_setup")}
+              />
+              <MetricCard
+                label="Open purchase orders"
+                value={summary.openPurchaseOrders}
+                detail="Orders still in progress"
+                href="/parts/po"
+              />
+              <MetricCard
+                label="Pending receiving"
+                value={summary.pendingReceiving}
+                detail="Approved quantity not fully received"
+                href="/parts/receiving"
+              />
+              <MetricCard
+                label="Catalog-linked parts"
+                value={summary.catalogLinkedParts}
+                detail="Direct vendor part-number or barcode links"
+              />
+              <MetricCard
+                label="Legacy vendor text"
+                value={summary.legacyUnlinkedParts}
+                detail="Inventory names not yet converted to catalog links"
+                href="/parts/inventory"
+              />
+            </div>
+          </section>
+
+          {(summary.duplicateVendorCandidates > 0 ||
+            summary.openPoWithoutVendorRecord > 0 ||
+            summary.requestRowsWithoutVendorRecord > 0 ||
+            summary.partsWithoutVendorReference > 0) &&
+          !loading ? (
+            <section className="desktop-panel-soft p-4">
+              <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Data cleanup
+              </p>
+              <div className="mt-3 grid gap-2 md:grid-cols-2">
+                {summary.duplicateVendorCandidates > 0 ? (
+                  <button
+                    type="button"
+                    className={`${ui.itemCard} flex items-center justify-between gap-3 px-3 py-3 text-left`}
+                    onClick={() => {
+                      setSearch("");
+                      setStateFilter("duplicates");
+                    }}
+                  >
+                    <span>Possible duplicate vendor records</span>
+                    <strong>{formatCount(summary.duplicateVendorCandidates)}</strong>
+                  </button>
+                ) : null}
+                {summary.partsWithoutVendorReference > 0 ? (
+                  <Link
+                    href="/parts/inventory"
+                    className={`${ui.itemCard} flex items-center justify-between gap-3 px-3 py-3`}
+                  >
+                    <span>Inventory parts with no vendor reference</span>
+                    <strong>{formatCount(summary.partsWithoutVendorReference)}</strong>
+                  </Link>
+                ) : null}
+                {summary.openPoWithoutVendorRecord > 0 ? (
+                  <Link
+                    href="/parts/po"
+                    className={`${ui.itemCard} flex items-center justify-between gap-3 px-3 py-3`}
+                  >
+                    <span>Open POs missing a valid vendor</span>
+                    <strong>{formatCount(summary.openPoWithoutVendorRecord)}</strong>
+                  </Link>
+                ) : null}
+                {summary.requestRowsWithoutVendorRecord > 0 ? (
+                  <Link
+                    href="/parts/requests"
+                    className={`${ui.itemCard} flex items-center justify-between gap-3 px-3 py-3`}
+                  >
+                    <span>Part requests using vendor text only</span>
+                    <strong>{formatCount(summary.requestRowsWithoutVendorRecord)}</strong>
+                  </Link>
+                ) : null}
+              </div>
+            </section>
+          ) : null}
+
+          <section className="desktop-panel-soft p-4" aria-labelledby="integrations-title">
+            <div className="max-w-3xl">
+              <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Connected services
+              </p>
+              <h2 id="integrations-title" className="mt-1 text-lg font-semibold">
+                Integration status
+              </h2>
+              <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+                Only QuickBooks is implemented today. Supplier catalog lookup and automatic
+                ordering are planned; no supplier credentials or live ordering are active.
+              </p>
+            </div>
+            <div className="mt-4 grid gap-3 lg:grid-cols-3">
+              <IntegrationCard
+                name="QuickBooks Online"
+                status="Available now"
+                description="Connect one company per shop and export finalized ProFixIQ invoices. It does not currently import vendors, inventory, or purchase orders."
+                action={
+                  canManageConnections ? (
+                    <Link
+                      href="/dashboard/owner/settings/integrations/quickbooks"
+                      className={ui.buttonSecondary}
+                    >
+                      Manage QuickBooks
+                    </Link>
+                  ) : (
+                    <p className="text-xs text-[color:var(--theme-text-muted)]">
+                      An owner or admin manages this connection.
+                    </p>
+                  )
+                }
+              />
+              <IntegrationCard
+                name="PartsTech"
+                status="Planned"
+                description="Future catalog search, availability, and ordering. The current parts workflow remains manual and fully usable."
+              />
+              <IntegrationCard
+                name="Direct supplier ordering"
+                status="Planned"
+                description="Future supplier-specific API connections for quotes and orders. No live supplier API calls are made today."
+              />
+            </div>
+          </section>
+
+          <section className="desktop-panel-soft p-4" aria-labelledby="directory-title">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                  Vendor directory
+                </p>
+                <h2 id="directory-title" className="mt-1 text-lg font-semibold">
+                  Supplier records and activity
+                </h2>
+                <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+                  Expand a vendor to review its setup, catalog links, purchase history, and receiving work.
+                </p>
+              </div>
+              <div className="grid w-full gap-2 sm:grid-cols-2 lg:w-auto">
                 <input
-                  className={`${ui.input} min-w-[220px] md:min-w-[280px]`}
-                  placeholder="Search by name, account, email, phone"
+                  className={`${ui.input} min-w-0 lg:min-w-[280px]`}
+                  placeholder="Search vendors"
                   value={search}
-                  onChange={(e) => setSearch(e.target.value)}
+                  onChange={(event) => setSearch(event.target.value)}
                 />
-                <select className={ui.input} value={readinessFilter} onChange={(e) => setReadinessFilter(e.target.value)}>
-                  <option value="all">All readiness states</option>
-                  <option value="Ready">Ready</option>
-                  <option value="Missing contact">Missing contact</option>
-                  <option value="Missing account/code">Missing account/code</option>
-                  <option value="No linked parts">No linked parts</option>
-                  <option value="Needs review">Needs review</option>
+                <select
+                  className={ui.input}
+                  value={stateFilter}
+                  onChange={(event) => setStateFilter(event.target.value)}
+                >
+                  <option value="all">All vendor states</option>
+                  <option value="needs_setup">Needs setup</option>
+                  <option value="duplicates">Possible duplicates</option>
+                  {DIRECTORY_STATES.filter((state) => state !== "Needs setup").map((state) => (
+                    <option key={state} value={state}>
+                      {state}
+                    </option>
+                  ))}
                 </select>
               </div>
             </div>
 
             {!loading && vendors.length === 0 ? (
-              <div className="mt-3 rounded-lg border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
-                <p className="font-medium text-[color:var(--theme-text-primary)]">No vendors found yet.</p>
-                <p className="mt-1 text-[color:var(--theme-text-secondary)]">Vendors can appear from Parts inventory usage, purchase orders, receiving flows, or import activation later.</p>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Link href="/parts/inventory" className={ui.buttonSecondary}>Go to Inventory</Link>
-                  <Link href="/parts/po" className={ui.buttonSecondary}>Go to Purchase Orders</Link>
-                </div>
+              <div className="mt-4 rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 text-sm">
+                <p className="font-medium">No vendors yet.</p>
+                <p className="mt-1 text-[color:var(--theme-text-secondary)]">
+                  Add the shops your parts department buys from. Those records become the
+                  supplier source for purchase orders and receiving.
+                </p>
+                <button type="button" className={`${ui.buttonPrimary} mt-3`} onClick={openCreate}>
+                  Add first vendor
+                </button>
               </div>
             ) : null}
 
-            {!loading && vendors.length > 0 ? (
-              <div className="mt-3 space-y-2">
-                {filteredDirectory.map((row) => (
-                  <details key={row.supplier.id} className="desktop-item-card overflow-hidden">
-                    <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 px-3 py-3">
+            {!loading && vendors.length > 0 && filteredDirectory.length === 0 ? (
+              <div className="mt-4 rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+                No vendors match this search and filter.
+              </div>
+            ) : null}
+
+            <div className="mt-4 space-y-2">
+              {filteredDirectory.map((row) => (
+                <details key={row.supplier.id} className="desktop-item-card overflow-hidden">
+                  <summary className="cursor-pointer list-none px-3 py-3 sm:px-4">
+                    <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
                       <div className="min-w-0">
-                        <p className="truncate text-sm font-semibold text-[color:var(--theme-text-primary)]">{row.supplier.name}</p>
-                        <p className="text-xs text-[color:var(--theme-text-secondary)]">
-                          Account: {hasValue(row.supplier.account_no) ? row.supplier.account_no : "Not tracked"} · Email: {hasValue(row.supplier.email) ? row.supplier.email : "Not tracked"} · Phone: {hasValue(row.supplier.phone) ? row.supplier.phone : "Not tracked"}
+                        <div className="flex flex-wrap items-center gap-2">
+                          <p className="truncate font-semibold text-[color:var(--theme-text-primary)]">
+                            {row.supplier.name}
+                          </p>
+                          <span
+                            className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${stateTone(row.state)}`}
+                          >
+                            {row.state}
+                          </span>
+                        </div>
+                        <p className="mt-1 break-words text-xs leading-5 text-[color:var(--theme-text-secondary)]">
+                          Account: {hasVendorValue(row.supplier.account_no) ? row.supplier.account_no : "Not set"}
+                          <span className="mx-1.5 text-[color:var(--theme-text-muted)]">·</span>
+                          {hasVendorValue(row.supplier.email) ? row.supplier.email : "No email"}
+                          <span className="mx-1.5 text-[color:var(--theme-text-muted)]">·</span>
+                          {hasVendorValue(row.supplier.phone) ? row.supplier.phone : "No phone"}
                         </p>
                       </div>
-                      <div className="flex flex-wrap items-center gap-2 text-xs">
-                        <span className={`rounded-md border px-2 py-1 ${readinessTone(row.readiness)}`}>{row.readiness}</span>
-                        <span className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1">Parts: {row.linkedPartsCount}</span>
-                        <span className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1">Open POs: {row.openPoCount}</span>
-                        <span className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1">Pending receive: {row.pendingReceivingCount}</span>
-                        <span className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1">Last activity: {formatDate(row.lastActivityAt)}</span>
-                      </div>
-                    </summary>
-
-                    <div className="border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm text-[color:var(--theme-text-secondary)]">
-                      <div className="grid gap-3 lg:grid-cols-2">
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.15em] text-[color:var(--theme-text-secondary)]">Overview</p>
-                          <ul className="mt-2 space-y-1 text-xs text-[color:var(--theme-text-secondary)]">
-                            <li>Vendor ID: {row.supplier.id}</li>
-                            <li>Linked parts (detected): {row.linkedPartsCount}</li>
-                            <li>Open purchase orders: {row.openPoCount}</li>
-                            <li>Pending receiving records: {row.pendingReceivingCount}</li>
-                          </ul>
-                        </div>
-                        <div>
-                          <p className="text-xs font-semibold uppercase tracking-[0.15em] text-[color:var(--theme-text-secondary)]">Detected issues</p>
-                          {row.issues.length === 0 ? (
-                            <p className="mt-2 text-xs text-emerald-200">No deterministic issues detected.</p>
-                          ) : (
-                            <ul className="mt-2 list-disc space-y-1 pl-5 text-xs text-amber-200">
-                              {row.issues.map((issue) => <li key={issue}>{issue}</li>)}
-                            </ul>
-                          )}
-                        </div>
-                      </div>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        <Link href="/parts/inventory" className={ui.buttonSecondary}>Linked parts in Inventory</Link>
-                        <Link href="/parts/po" className={ui.buttonSecondary}>Open POs</Link>
-                        <Link href="/parts/receiving" className={ui.buttonSecondary}>Receiving activity</Link>
+                      <div className="grid grid-cols-2 gap-2 text-xs sm:flex sm:flex-wrap">
+                        <span className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1.5">
+                          Catalog parts: {row.catalogPartCount}
+                        </span>
+                        <span className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1.5">
+                          Open POs: {row.openPoCount}
+                        </span>
+                        <span className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1.5">
+                          To receive: {row.pendingReceivingCount}
+                        </span>
+                        <span className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1.5">
+                          Last PO: {formatDate(row.lastActivityAt)}
+                        </span>
                       </div>
                     </div>
-                  </details>
-                ))}
-              </div>
-            ) : null}
+                  </summary>
+
+                  <div className="border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 sm:p-4">
+                    <div className="grid gap-4 lg:grid-cols-2">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                          Activity
+                        </p>
+                        <dl className="mt-2 grid grid-cols-2 gap-2 text-sm">
+                          <div className={`${ui.itemCard} px-3 py-2`}>
+                            <dt className="text-xs text-[color:var(--theme-text-muted)]">Catalog links</dt>
+                            <dd className="mt-1 font-semibold">{row.catalogPartCount}</dd>
+                          </div>
+                          <div className={`${ui.itemCard} px-3 py-2`}>
+                            <dt className="text-xs text-[color:var(--theme-text-muted)]">Parts bought before</dt>
+                            <dd className="mt-1 font-semibold">{row.purchasedPartCount}</dd>
+                          </div>
+                          <div className={`${ui.itemCard} px-3 py-2`}>
+                            <dt className="text-xs text-[color:var(--theme-text-muted)]">Open POs</dt>
+                            <dd className="mt-1 font-semibold">{row.openPoCount}</dd>
+                          </div>
+                          <div className={`${ui.itemCard} px-3 py-2`}>
+                            <dt className="text-xs text-[color:var(--theme-text-muted)]">Pending receiving</dt>
+                            <dd className="mt-1 font-semibold">{row.pendingReceivingCount}</dd>
+                          </div>
+                        </dl>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                          Setup review
+                        </p>
+                        {row.issues.length > 0 ? (
+                          <ul className="mt-2 space-y-2 text-sm">
+                            {row.issues.map((issue) => (
+                              <li
+                                key={issue}
+                                className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-amber-100"
+                              >
+                                {issue}
+                              </li>
+                            ))}
+                          </ul>
+                        ) : (
+                          <p className="mt-2 rounded-lg border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
+                            Vendor setup is complete.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    {row.supplier.notes ? (
+                      <div className="mt-4 rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-2 text-sm text-[color:var(--theme-text-secondary)]">
+                        <span className="font-medium text-[color:var(--theme-text-primary)]">Notes:</span>{" "}
+                        {row.supplier.notes}
+                      </div>
+                    ) : null}
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className={ui.buttonSecondary}
+                        onClick={() => openEdit(row.supplier as SupplierRow)}
+                      >
+                        <Pencil className="mr-1.5 inline h-3.5 w-3.5" />
+                        Edit vendor
+                      </button>
+                      <Link href="/parts/po" className={ui.buttonSecondary}>
+                        Purchase orders
+                      </Link>
+                      <Link href="/parts/inventory" className={ui.buttonSecondary}>
+                        Inventory
+                      </Link>
+                    </div>
+                  </div>
+                </details>
+              ))}
+            </div>
           </section>
 
-          <section className="desktop-panel-soft p-4">
-            <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">AI assistant preparation</p>
-            <h2 className="mt-2 text-base font-semibold text-[color:var(--theme-text-primary)]">Ready for assistant review · Future AI-assisted cleanup</h2>
-            <ul className="mt-3 grid gap-2 text-sm md:grid-cols-2">
-              <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Duplicate vendor candidates</span><strong>{loading ? "…" : formatCount(derived.duplicateVendorCandidates)}</strong></li>
-              <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Parts missing vendor link</span><strong>{loading ? "…" : formatCount(derived.partsMissingVendorLink)}</strong></li>
-              <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Vendors with no linked parts</span><strong>{loading ? "…" : directory.filter((d) => d.linkedPartsCount === 0).length.toLocaleString()}</strong></li>
-              <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>Incomplete vendor setup</span><strong>{loading ? "…" : formatCount(derived.vendorsMissingContactOrAccount)}</strong></li>
-              <li className="desktop-item-card flex items-center justify-between px-3 py-2"><span>PO/request records that appear unlinked</span><strong>{loading ? "…" : formatCount((derived.openPoWithoutVendorRecord ?? 0) + (derived.poItemsWithVendorTextNoVendorLink ?? 0))}</strong></li>
-            </ul>
-          </section>
-
-          {derived.warnings.length > 0 ? (
-            <section className="desktop-panel-soft border border-amber-500/30 bg-amber-950/25 p-4">
-              <p className="text-[10px] uppercase tracking-[0.18em] text-amber-300">Data availability notes</p>
+          {warnings.length > 0 ? (
+            <section className="rounded-xl border border-amber-500/25 bg-amber-500/10 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-200">
+                Some vendor data could not be loaded
+              </p>
               <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-amber-100">
-                {derived.warnings.map((warning) => <li key={warning}>{warning}</li>)}
+                {warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
               </ul>
             </section>
           ) : null}
-
-          <div className="text-xs text-[color:var(--theme-text-muted)]">Shop scope: {shopId || "Not resolved"}</div>
         </div>
       </PageShell>
+
+      <VendorModal
+        open={modalOpen}
+        draft={draft}
+        editing={Boolean(editingVendor)}
+        busy={saving}
+        error={saveError}
+        onChange={setDraft}
+        onClose={() => {
+          if (!saving) setModalOpen(false);
+        }}
+        onSubmit={() => void saveVendor()}
+      />
     </div>
   );
 }

--- a/features/parts/lib/vendorWorkspace.test.ts
+++ b/features/parts/lib/vendorWorkspace.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVendorWorkspace,
+  normalizeVendorName,
+  type VendorWorkspaceSupplier,
+} from "./vendorWorkspace";
+
+function supplier(
+  overrides: Partial<VendorWorkspaceSupplier> & Pick<VendorWorkspaceSupplier, "id" | "name">,
+): VendorWorkspaceSupplier {
+  return {
+    account_no: "ACCOUNT-1",
+    email: "parts@example.com",
+    phone: null,
+    notes: null,
+    is_active: true,
+    ...overrides,
+  };
+}
+
+describe("normalizeVendorName", () => {
+  it("normalizes punctuation and spacing for deterministic comparisons", () => {
+    expect(normalizeVendorName("  North-Star_Parts Ltd. ")).toBe(
+      "north star parts ltd",
+    );
+  });
+});
+
+describe("buildVendorWorkspace", () => {
+  it("counts canonical catalog links from vendor part numbers and barcodes", () => {
+    const result = buildVendorWorkspace({
+      suppliers: [supplier({ id: "vendor-1", name: "North Star Parts" })],
+      parts: [
+        { id: "part-1", supplier: null, part_number: "A1", sku: null },
+        { id: "part-2", supplier: null, part_number: "A2", sku: null },
+      ],
+      purchaseOrders: [],
+      purchaseOrderLines: [],
+      requestItems: [],
+      barcodeLinks: [{ supplier_id: "vendor-1", part_id: "part-2" }],
+      vendorPartNumberLinks: [{ supplier_id: "vendor-1", part_id: "part-1" }],
+    });
+
+    expect(result.summary.catalogLinkedParts).toBe(2);
+    expect(result.summary.partsWithoutVendorReference).toBe(0);
+    expect(result.directory[0]?.catalogPartCount).toBe(2);
+  });
+
+  it("keeps purchase history separate from catalog links", () => {
+    const result = buildVendorWorkspace({
+      suppliers: [supplier({ id: "vendor-1", name: "North Star Parts" })],
+      parts: [{ id: "part-1", supplier: null, part_number: "A1", sku: null }],
+      purchaseOrders: [
+        {
+          id: "po-1",
+          supplier_id: "vendor-1",
+          status: "ordered",
+          created_at: "2026-07-23T12:00:00.000Z",
+        },
+      ],
+      purchaseOrderLines: [{ po_id: "po-1", part_id: "part-1" }],
+      requestItems: [],
+      barcodeLinks: [],
+      vendorPartNumberLinks: [],
+    });
+
+    expect(result.directory[0]?.purchasedPartCount).toBe(1);
+    expect(result.directory[0]?.catalogPartCount).toBe(0);
+    expect(result.directory[0]?.state).toBe("On order");
+  });
+
+  it("assigns pending receiving directly from vendor_id when no PO is attached", () => {
+    const result = buildVendorWorkspace({
+      suppliers: [supplier({ id: "vendor-1", name: "North Star Parts" })],
+      parts: [],
+      purchaseOrders: [],
+      purchaseOrderLines: [],
+      requestItems: [
+        {
+          po_id: null,
+          qty_approved: 2,
+          qty_received: 1,
+          vendor: "North Star Parts",
+          vendor_id: "vendor-1",
+        },
+      ],
+      barcodeLinks: [],
+      vendorPartNumberLinks: [],
+    });
+
+    expect(result.summary.pendingReceiving).toBe(1);
+    expect(result.directory[0]?.pendingReceivingCount).toBe(1);
+    expect(result.directory[0]?.state).toBe("Receiving");
+  });
+
+  it("reports legacy vendor text without treating it as a canonical catalog link", () => {
+    const result = buildVendorWorkspace({
+      suppliers: [supplier({ id: "vendor-1", name: "North-Star Parts" })],
+      parts: [
+        {
+          id: "part-1",
+          supplier: "north star parts",
+          part_number: "A1",
+          sku: null,
+        },
+      ],
+      purchaseOrders: [],
+      purchaseOrderLines: [],
+      requestItems: [],
+      barcodeLinks: [],
+      vendorPartNumberLinks: [],
+    });
+
+    expect(result.summary.legacyUnlinkedParts).toBe(1);
+    expect(result.summary.catalogLinkedParts).toBe(0);
+    expect(result.directory[0]?.legacyMatchedPartCount).toBe(1);
+    expect(result.directory[0]?.issues[0]).toContain("without a catalog link");
+  });
+
+  it("does not guess a legacy match when duplicate normalized vendor names exist", () => {
+    const result = buildVendorWorkspace({
+      suppliers: [
+        supplier({ id: "vendor-1", name: "North Star Parts" }),
+        supplier({ id: "vendor-2", name: "North-Star Parts" }),
+      ],
+      parts: [
+        {
+          id: "part-1",
+          supplier: "North Star Parts",
+          part_number: "A1",
+          sku: null,
+        },
+      ],
+      purchaseOrders: [],
+      purchaseOrderLines: [],
+      requestItems: [],
+      barcodeLinks: [],
+      vendorPartNumberLinks: [],
+    });
+
+    expect(result.summary.duplicateVendorCandidates).toBe(2);
+    expect(result.directory.every((row) => row.legacyMatchedPartCount === 0)).toBe(true);
+  });
+});

--- a/features/parts/lib/vendorWorkspace.ts
+++ b/features/parts/lib/vendorWorkspace.ts
@@ -1,0 +1,279 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+
+export type VendorWorkspaceSupplier = Pick<
+  DB["public"]["Tables"]["suppliers"]["Row"],
+  "id" | "name" | "account_no" | "email" | "phone" | "notes" | "is_active"
+>;
+
+export type VendorWorkspacePart = Pick<
+  DB["public"]["Tables"]["parts"]["Row"],
+  "id" | "supplier" | "part_number" | "sku"
+>;
+
+export type VendorWorkspacePurchaseOrder = Pick<
+  DB["public"]["Tables"]["purchase_orders"]["Row"],
+  "id" | "supplier_id" | "status" | "created_at"
+>;
+
+export type VendorWorkspacePurchaseOrderLine = Pick<
+  DB["public"]["Tables"]["purchase_order_lines"]["Row"],
+  "po_id" | "part_id"
+>;
+
+export type VendorWorkspaceRequestItem = Pick<
+  DB["public"]["Tables"]["part_request_items"]["Row"],
+  "po_id" | "qty_approved" | "qty_received" | "vendor" | "vendor_id"
+>;
+
+export type VendorWorkspaceDirectLink = {
+  supplier_id: string | null;
+  part_id: string | null;
+};
+
+export type VendorOperationalState =
+  | "Receiving"
+  | "On order"
+  | "Needs setup"
+  | "Active"
+  | "No activity"
+  | "Inactive";
+
+export type VendorDirectoryItem = {
+  supplier: VendorWorkspaceSupplier;
+  catalogPartCount: number;
+  purchasedPartCount: number;
+  legacyMatchedPartCount: number;
+  openPoCount: number;
+  pendingReceivingCount: number;
+  lastActivityAt: string | null;
+  state: VendorOperationalState;
+  issues: string[];
+};
+
+export type VendorWorkspaceSummary = {
+  totalVendors: number;
+  vendorsNeedingSetup: number;
+  openPurchaseOrders: number;
+  pendingReceiving: number;
+  catalogLinkedParts: number;
+  legacyUnlinkedParts: number;
+  partsWithoutVendorReference: number;
+  duplicateVendorCandidates: number;
+  openPoWithoutVendorRecord: number;
+  requestRowsWithoutVendorRecord: number;
+};
+
+export const OPEN_PO_STATUSES = [
+  "draft",
+  "open",
+  "sent",
+  "ordered",
+  "partially_received",
+  "receiving",
+] as const;
+
+export function normalizeVendorName(value: string | null | undefined): string {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/[\s\-_.]+/g, " ")
+    .replace(/[^a-z0-9 ]/g, "")
+    .trim();
+}
+
+export function hasVendorValue(value: string | null | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function laterTimestamp(current: string | undefined, candidate: string | null): string | undefined {
+  if (!candidate) return current;
+  if (!current) return candidate;
+  return new Date(candidate).getTime() > new Date(current).getTime() ? candidate : current;
+}
+
+function isOpenPurchaseOrder(status: string | null): boolean {
+  return OPEN_PO_STATUSES.includes(
+    String(status ?? "").toLowerCase() as (typeof OPEN_PO_STATUSES)[number],
+  );
+}
+
+export function buildVendorWorkspace(input: {
+  suppliers: VendorWorkspaceSupplier[];
+  parts: VendorWorkspacePart[];
+  purchaseOrders: VendorWorkspacePurchaseOrder[];
+  purchaseOrderLines: VendorWorkspacePurchaseOrderLine[];
+  requestItems: VendorWorkspaceRequestItem[];
+  barcodeLinks: VendorWorkspaceDirectLink[];
+  vendorPartNumberLinks: VendorWorkspaceDirectLink[];
+}): {
+  directory: VendorDirectoryItem[];
+  summary: VendorWorkspaceSummary;
+} {
+  const supplierById = new Map(input.suppliers.map((supplier) => [supplier.id, supplier]));
+  const supplierIdsByNormalizedName = new Map<string, string[]>();
+  const duplicateBuckets = new Map<string, VendorWorkspaceSupplier[]>();
+
+  for (const supplier of input.suppliers) {
+    const key = normalizeVendorName(supplier.name);
+    if (!key) continue;
+    const supplierIds = supplierIdsByNormalizedName.get(key) ?? [];
+    supplierIds.push(supplier.id);
+    supplierIdsByNormalizedName.set(key, supplierIds);
+    const bucket = duplicateBuckets.get(key) ?? [];
+    bucket.push(supplier);
+    duplicateBuckets.set(key, bucket);
+  }
+
+  const catalogPartsBySupplier = new Map<string, Set<string>>();
+  const catalogLinkedPartIds = new Set<string>();
+  for (const link of [...input.vendorPartNumberLinks, ...input.barcodeLinks]) {
+    const supplierId = String(link.supplier_id ?? "");
+    const partId = String(link.part_id ?? "");
+    if (!supplierId || !partId || !supplierById.has(supplierId)) continue;
+    const linkedParts = catalogPartsBySupplier.get(supplierId) ?? new Set<string>();
+    linkedParts.add(partId);
+    catalogPartsBySupplier.set(supplierId, linkedParts);
+    catalogLinkedPartIds.add(partId);
+  }
+
+  const purchaseOrderById = new Map(input.purchaseOrders.map((po) => [po.id, po]));
+  const purchasedPartsBySupplier = new Map<string, Set<string>>();
+  const openPoCountBySupplier = new Map<string, number>();
+  const lastActivityBySupplier = new Map<string, string>();
+
+  for (const po of input.purchaseOrders) {
+    const supplierId = po.supplier_id;
+    if (!supplierId || !supplierById.has(supplierId)) continue;
+    if (isOpenPurchaseOrder(po.status)) {
+      openPoCountBySupplier.set(supplierId, (openPoCountBySupplier.get(supplierId) ?? 0) + 1);
+    }
+    const latest = laterTimestamp(lastActivityBySupplier.get(supplierId), po.created_at);
+    if (latest) lastActivityBySupplier.set(supplierId, latest);
+  }
+
+  for (const line of input.purchaseOrderLines) {
+    const po = purchaseOrderById.get(line.po_id);
+    const supplierId = po?.supplier_id ?? null;
+    if (!supplierId || !line.part_id || !supplierById.has(supplierId)) continue;
+    const linkedParts = purchasedPartsBySupplier.get(supplierId) ?? new Set<string>();
+    linkedParts.add(line.part_id);
+    purchasedPartsBySupplier.set(supplierId, linkedParts);
+  }
+
+  const pendingReceivingBySupplier = new Map<string, number>();
+  for (const item of input.requestItems) {
+    if (Number(item.qty_approved ?? 0) <= Number(item.qty_received ?? 0)) continue;
+    const poSupplierId = item.po_id
+      ? purchaseOrderById.get(item.po_id)?.supplier_id ?? null
+      : null;
+    const supplierId = item.vendor_id ?? poSupplierId;
+    if (!supplierId || !supplierById.has(supplierId)) continue;
+    pendingReceivingBySupplier.set(
+      supplierId,
+      (pendingReceivingBySupplier.get(supplierId) ?? 0) + 1,
+    );
+  }
+
+  const legacyPartsBySupplier = new Map<string, Set<string>>();
+  for (const part of input.parts) {
+    if (!hasVendorValue(part.supplier) || catalogLinkedPartIds.has(part.id)) continue;
+    const matchingSupplierIds =
+      supplierIdsByNormalizedName.get(normalizeVendorName(part.supplier)) ?? [];
+    if (matchingSupplierIds.length !== 1) continue;
+    const supplierId = matchingSupplierIds[0];
+    const linkedParts = legacyPartsBySupplier.get(supplierId) ?? new Set<string>();
+    linkedParts.add(part.id);
+    legacyPartsBySupplier.set(supplierId, linkedParts);
+  }
+
+  const directory = input.suppliers.map((supplier): VendorDirectoryItem => {
+    const catalogPartCount = catalogPartsBySupplier.get(supplier.id)?.size ?? 0;
+    const purchasedPartCount = purchasedPartsBySupplier.get(supplier.id)?.size ?? 0;
+    const legacyMatchedPartCount = legacyPartsBySupplier.get(supplier.id)?.size ?? 0;
+    const openPoCount = openPoCountBySupplier.get(supplier.id) ?? 0;
+    const pendingReceivingCount = pendingReceivingBySupplier.get(supplier.id) ?? 0;
+    const missingContact = !hasVendorValue(supplier.email) && !hasVendorValue(supplier.phone);
+    const missingAccount = !hasVendorValue(supplier.account_no);
+    const issues: string[] = [];
+
+    if (missingContact) issues.push("Add an email or phone number");
+    if (missingAccount) issues.push("Add an account number or vendor code");
+    if ((duplicateBuckets.get(normalizeVendorName(supplier.name))?.length ?? 0) > 1) {
+      issues.push("Possible duplicate vendor record");
+    }
+    if (legacyMatchedPartCount > 0) {
+      issues.push(
+        `${legacyMatchedPartCount.toLocaleString()} inventory ${
+          legacyMatchedPartCount === 1 ? "part uses" : "parts use"
+        } this vendor name without a catalog link`,
+      );
+    }
+
+    let state: VendorOperationalState;
+    if (!supplier.is_active) state = "Inactive";
+    else if (pendingReceivingCount > 0) state = "Receiving";
+    else if (openPoCount > 0) state = "On order";
+    else if (missingContact || missingAccount) state = "Needs setup";
+    else if (catalogPartCount > 0 || purchasedPartCount > 0 || legacyMatchedPartCount > 0) {
+      state = "Active";
+    } else state = "No activity";
+
+    return {
+      supplier,
+      catalogPartCount,
+      purchasedPartCount,
+      legacyMatchedPartCount,
+      openPoCount,
+      pendingReceivingCount,
+      lastActivityAt: lastActivityBySupplier.get(supplier.id) ?? null,
+      state,
+      issues,
+    };
+  });
+
+  const duplicateVendorCandidates = Array.from(duplicateBuckets.values()).reduce(
+    (total, bucket) => total + (bucket.length > 1 ? bucket.length : 0),
+    0,
+  );
+  const openPurchaseOrders = input.purchaseOrders.filter((po) =>
+    isOpenPurchaseOrder(po.status),
+  );
+
+  return {
+    directory,
+    summary: {
+      totalVendors: input.suppliers.length,
+      vendorsNeedingSetup: input.suppliers.filter(
+        (supplier) =>
+          (!hasVendorValue(supplier.email) && !hasVendorValue(supplier.phone)) ||
+          !hasVendorValue(supplier.account_no),
+      ).length,
+      openPurchaseOrders: openPurchaseOrders.length,
+      pendingReceiving: input.requestItems.filter(
+        (item) => Number(item.qty_approved ?? 0) > Number(item.qty_received ?? 0),
+      ).length,
+      catalogLinkedParts: catalogLinkedPartIds.size,
+      legacyUnlinkedParts: input.parts.filter(
+        (part) => hasVendorValue(part.supplier) && !catalogLinkedPartIds.has(part.id),
+      ).length,
+      partsWithoutVendorReference: input.parts.filter(
+        (part) => !hasVendorValue(part.supplier) && !catalogLinkedPartIds.has(part.id),
+      ).length,
+      duplicateVendorCandidates,
+      openPoWithoutVendorRecord: openPurchaseOrders.filter(
+        (po) => !po.supplier_id || !supplierById.has(po.supplier_id),
+      ).length,
+      requestRowsWithoutVendorRecord: input.requestItems.filter((item) => {
+        const poSupplierId = item.po_id
+          ? purchaseOrderById.get(item.po_id)?.supplier_id ?? null
+          : null;
+        return (
+          hasVendorValue(item.vendor) &&
+          !item.vendor_id &&
+          (!poSupplierId || !supplierById.has(poSupplierId))
+        );
+      }).length,
+    },
+  };
+}

--- a/features/shared/components/RoleHubTiles/tiles.ts
+++ b/features/shared/components/RoleHubTiles/tiles.ts
@@ -158,11 +158,10 @@ export const TILES: Tile[] = [
     roles: ["parts", "manager", "owner", "admin"],
     scopes: ["parts", "all"],
   },
-  // Optional: vendor API keys / integrations page
   {
     href: "/parts/vendors",
-    title: "Vendor Integrations",
-    subtitle: "API keys for suppliers",
+    title: "Vendors",
+    subtitle: "Supplier records & activity",
     roles: ["owner", "admin", "manager", "parts"],
     scopes: ["parts", "settings", "all"],
   },

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -307,8 +307,8 @@ export const TILES: Tile[] = [
 },
 {
   href: "/parts/vendors",
-  title: "Vendor Integrations",
-  subtitle: "API keys for suppliers",
+  title: "Vendors",
+  subtitle: "Supplier records & activity",
   roles: ["owner", "admin", "manager", "parts"],
   scopes: ["parts", "settings", "all"],
   section: "Parts",

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -244,8 +244,8 @@ export const ROUTE_META: Record<string, RouteMeta> = {
     roles: ["owner", "admin", "manager", "parts"],
   },
   "/parts/vendors": {
-    title: () => "Vendor Integrations",
-    icon: "🔑",
+    title: () => "Vendors",
+    icon: "🏪",
     roles: ["owner", "admin", "manager", "parts"],
   },
   "/parts/returns": {

--- a/tests/parts/vendor-management-route.test.ts
+++ b/tests/parts/vendor-management-route.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  requireShopScopedApiAccess: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireShopScopedApiAccess,
+}));
+
+const vendorId = "11111111-1111-4111-8111-111111111111";
+
+function createSupabase(existing: Array<{ id: string; name: string }> = []) {
+  const inserted: Array<Record<string, unknown>> = [];
+  const updated: Array<Record<string, unknown>> = [];
+  const filters: Array<[string, unknown]> = [];
+
+  const supplierTable = {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        limit: vi.fn(async () => ({ data: existing, error: null })),
+      })),
+    })),
+    insert: vi.fn((payload: Record<string, unknown>) => {
+      inserted.push(payload);
+      return {
+        select: vi.fn(() => ({
+          single: vi.fn(async () => ({
+            data: { id: vendorId, ...payload },
+            error: null,
+          })),
+        })),
+      };
+    }),
+    update: vi.fn((payload: Record<string, unknown>) => {
+      updated.push(payload);
+      const chain: {
+        eq: (field: string, value: unknown) => typeof chain;
+        select: () => {
+          maybeSingle: () => Promise<{
+            data: Record<string, unknown>;
+            error: null;
+          }>;
+        };
+      } = {
+        eq(field: string, value: unknown) {
+          filters.push([field, value]);
+          return chain;
+        },
+        select: () => ({
+          maybeSingle: async () => ({
+            data: { id: vendorId, shop_id: "shop-1", ...payload },
+            error: null,
+          }),
+        }),
+      };
+      return chain;
+    }),
+  };
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table !== "suppliers") throw new Error(`Unexpected table ${table}`);
+      return supplierTable;
+    }),
+    supplierTable,
+    inserted,
+    updated,
+    filters,
+  };
+}
+
+function authorize(supabase: ReturnType<typeof createSupabase>) {
+  mocks.requireShopScopedApiAccess.mockResolvedValue({
+    ok: true,
+    profile: { id: "actor-1", shop_id: "shop-1" },
+    supabase,
+  });
+}
+
+describe("parts vendor management route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a vendor only in the authorized shop scope", async () => {
+    const supabase = createSupabase();
+    authorize(supabase);
+    const { POST } = await import("../../app/api/parts/vendors/route");
+    const response = await POST(
+      new Request("http://localhost/api/parts/vendors", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "North Star Parts",
+          accountNo: "A-100",
+          email: "parts@northstar.example",
+          phone: "555-0100",
+          notes: "Main supplier",
+          isActive: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mocks.requireShopScopedApiAccess).toHaveBeenCalledWith({
+      requiredCapability: "canManageParts",
+    });
+    expect(supabase.inserted).toEqual([
+      expect.objectContaining({
+        shop_id: "shop-1",
+        created_by: "actor-1",
+        name: "North Star Parts",
+        account_no: "A-100",
+      }),
+    ]);
+  });
+
+  it("rejects normalized duplicate names before inserting", async () => {
+    const supabase = createSupabase([
+      { id: vendorId, name: "North-Star Parts" },
+    ]);
+    authorize(supabase);
+    const { POST } = await import("../../app/api/parts/vendors/route");
+    const response = await POST(
+      new Request("http://localhost/api/parts/vendors", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ name: "north star parts" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(supabase.supplierTable.insert).not.toHaveBeenCalled();
+  });
+
+  it("scopes an idempotent update by vendor id and authorized shop id", async () => {
+    const supabase = createSupabase();
+    authorize(supabase);
+    const { PATCH } = await import("../../app/api/parts/vendors/route");
+    const response = await PATCH(
+      new Request("http://localhost/api/parts/vendors", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          id: vendorId,
+          name: "North Star Parts",
+          accountNo: "",
+          email: "",
+          phone: "",
+          notes: "",
+          isActive: false,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(supabase.updated).toEqual([
+      expect.objectContaining({
+        name: "North Star Parts",
+        account_no: null,
+        is_active: false,
+      }),
+    ]);
+    expect(supabase.filters).toEqual([
+      ["id", vendorId],
+      ["shop_id", "shop-1"],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the unclear Vendor Integrations readiness report with an operational vendor workspace for parts staff, while keeping secured connection management in Owner Settings.

## Root cause

The page mixed three separate concerns: vendor data cleanup, current parts exceptions, and future integration marketing. It also calculated linked-part counts without the canonical `vendor_part_numbers` table, so valid catalog links could be reported as zero. Finally, it described all integrations as preparation-only even though QuickBooks is already implemented elsewhere in ProFixIQ.

## What changed

- rebuilt Parts → Vendors around vendor management and current purchasing/receiving exceptions
- added shop-scoped, role-authorized vendor create and edit actions
- corrected catalog-link counts using canonical vendor part numbers and barcode links
- separated catalog linkage, purchase history, and legacy vendor-text usage
- added search, setup and duplicate filters, cleanup indicators, and responsive vendor cards
- routed owners/admins to the existing secured QuickBooks settings flow
- marked PartsTech and direct supplier ordering accurately as planned
- removed speculative AI cleanup/readiness claims and the exposed shop UUID
- renamed navigation from Vendor Integrations to Vendors
- added focused authorization, validation, and count coverage

## User impact

Parts staff now have a clear place to maintain vendor records and identify operational cleanup work. Owners retain authority over accounting connections. The page no longer implies unavailable integrations are active or reports misleading vendor-to-part totals.

## Validation

Completed before publication:

- full test suite: 1,230 passed, 2 skipped
- focused vendor authorization/count coverage: 9 passed
- TypeScript: passed
- touched-file ESLint: passed
- production build: compiled and completed lint/type validation, then stopped during page-data collection because the checkout had no Supabase URL; the failure came from the existing `/api/agent/requests` route

The branch was cleanly rebased onto current `main` with no conflicts. A post-rebase focused rerun could not start because this publishing workspace's pnpm runtime attempted to purge/reinstall `node_modules` without an interactive TTY. GitHub CI should provide the final current-main verification.

## Production smoke test

1. Open Parts → Vendors on desktop, tablet, and mobile.
2. Confirm vendor, PO, and receiving totals match their source pages.
3. Add a vendor and verify duplicate names are rejected.
4. Edit contact/account information and confirm it persists.
5. Verify catalog-linked parts count vendor-part-number and barcode links.
6. Verify legacy vendor text is reported separately.
7. Test the Need setup and Possible duplicates filters.
8. Confirm owners/admins reach QuickBooks settings while parts staff see owner-managed messaging.
9. Confirm the vendor modal scrolls fully on mobile.

## Operational notes

- no migrations
- no new environment variables
- no production data changes
- no deployment included