### PR TITLE
Redesign Vendors as an operational supplier directory

### DIFF
--- a/app/parts/vendors/page.tsx
+++ b/app/parts/vendors/page.tsx
@@ -2,14 +2,29 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Pencil, Plus, PlugZap } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Building2,
+  CheckCircle2,
+  ChevronRight,
+  ClipboardList,
+  Mail,
+  PackageCheck,
+  Pencil,
+  Phone,
+  PlugZap,
+  Plus,
+  Search,
+  Truck,
+  X,
+} from "lucide-react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import PageShell from "@/features/shared/components/PageShell";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 import {
   buildVendorWorkspace,
-  hasVendorValue,
   type VendorDirectoryItem,
   type VendorOperationalState,
   type VendorWorkspaceSummary,
@@ -19,7 +34,8 @@ type DB = Database;
 type SupplierRow = DB["public"]["Tables"]["suppliers"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type PurchaseOrderRow = DB["public"]["Tables"]["purchase_orders"]["Row"];
-type PurchaseOrderLineRow = DB["public"]["Tables"]["purchase_order_lines"]["Row"];
+type PurchaseOrderLineRow =
+  DB["public"]["Tables"]["purchase_order_lines"]["Row"];
 type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
 
 type VendorDraft = {
@@ -30,6 +46,16 @@ type VendorDraft = {
   notes: string;
   isActive: boolean;
 };
+
+type DirectoryFilter =
+  | "all"
+  | "attention"
+  | "receiving"
+  | "on_order"
+  | "inactive"
+  | "duplicates";
+
+type PanelMode = "profile" | "edit" | "create" | null;
 
 const EMPTY_SUMMARY: VendorWorkspaceSummary = {
   totalVendors: 0,
@@ -53,23 +79,34 @@ const EMPTY_DRAFT: VendorDraft = {
   isActive: true,
 };
 
-const DIRECTORY_STATES: VendorOperationalState[] = [
-  "Receiving",
-  "On order",
-  "Needs setup",
-  "Active",
-  "No activity",
-  "Inactive",
-];
+const STATE_PRIORITY: Record<VendorOperationalState, number> = {
+  Receiving: 0,
+  "On order": 1,
+  "Needs setup": 2,
+  Active: 3,
+  "No activity": 4,
+  Inactive: 5,
+};
 
 function formatCount(value: number): string {
   return value.toLocaleString();
 }
 
 function formatDate(value: string | null): string {
-  if (!value) return "No purchase activity";
+  if (!value) return "No orders yet";
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "No purchase activity" : date.toLocaleDateString();
+  return Number.isNaN(date.getTime())
+    ? "No orders yet"
+    : date.toLocaleDateString();
+}
+
+function getInitials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
 }
 
 function stateTone(state: VendorOperationalState): string {
@@ -89,6 +126,26 @@ function stateTone(state: VendorOperationalState): string {
   }
 }
 
+function matchesFilter(
+  row: VendorDirectoryItem,
+  filter: DirectoryFilter,
+): boolean {
+  switch (filter) {
+    case "attention":
+      return row.issues.length > 0;
+    case "receiving":
+      return row.pendingReceivingCount > 0;
+    case "on_order":
+      return row.openPoCount > 0;
+    case "inactive":
+      return !row.supplier.is_active;
+    case "duplicates":
+      return row.setup.possibleDuplicate;
+    default:
+      return true;
+  }
+}
+
 async function resolveShopContext(
   supabase: ReturnType<typeof createBrowserSupabase>,
 ): Promise<{ shopId: string; role: string }> {
@@ -102,7 +159,10 @@ async function resolveShopContext(
     .eq("user_id", userId)
     .maybeSingle();
   if (byUserId?.shop_id) {
-    return { shopId: String(byUserId.shop_id), role: String(byUserId.role ?? "") };
+    return {
+      shopId: String(byUserId.shop_id),
+      role: String(byUserId.role ?? ""),
+    };
   }
 
   const { data: byId } = await supabase
@@ -132,215 +192,761 @@ async function fetchAllRows<T>(
   return rows;
 }
 
-function MetricCard({
-  label,
-  value,
-  detail,
-  onClick,
-  href,
+function SummaryStrip({
+  summary,
+  onFilter,
 }: {
-  label: string;
-  value: number;
-  detail: string;
-  onClick?: () => void;
-  href?: string;
+  summary: VendorWorkspaceSummary;
+  onFilter: (filter: DirectoryFilter) => void;
 }) {
-  const content = (
-    <div className={`${ui.itemCard} h-full px-4 py-3 text-left transition hover:border-[color:var(--desktop-border-strong)]`}>
-      <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-        {label}
-      </p>
-      <p className="mt-2 text-2xl font-semibold tabular-nums text-[color:var(--theme-text-primary)]">
-        {formatCount(value)}
-      </p>
-      <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">{detail}</p>
-    </div>
-  );
+  const stats = [
+    {
+      label: "Vendors",
+      value: summary.totalVendors,
+      detail: "supplier records",
+      action: () => onFilter("all"),
+    },
+    {
+      label: "Open POs",
+      value: summary.openPurchaseOrders,
+      detail: "orders in progress",
+      href: "/parts/po",
+    },
+    {
+      label: "To receive",
+      value: summary.pendingReceiving,
+      detail: "approved line items",
+      href: "/parts/receiving",
+    },
+    {
+      label: "Catalog linked",
+      value: summary.catalogLinkedParts,
+      detail: "inventory parts",
+    },
+  ];
 
-  if (href) {
-    return (
-      <Link href={href} className="block min-w-0">
-        {content}
-      </Link>
-    );
-  }
-  if (onClick) {
-    return (
-      <button type="button" onClick={onClick} className="min-w-0">
-        {content}
-      </button>
-    );
-  }
-  return content;
-}
-
-function IntegrationCard({
-  name,
-  status,
-  description,
-  action,
-}: {
-  name: string;
-  status: "Available now" | "Planned";
-  description: string;
-  action?: React.ReactNode;
-}) {
-  const live = status === "Available now";
   return (
-    <div className={`${ui.itemCard} flex h-full flex-col justify-between gap-4 p-4`}>
-      <div>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <PlugZap className="h-4 w-4 text-[color:var(--theme-text-secondary)]" />
-            <h3 className="font-semibold text-[color:var(--theme-text-primary)]">{name}</h3>
-          </div>
-          <span
-            className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] ${
-              live
-                ? "border-emerald-500/35 bg-emerald-500/10 text-emerald-200"
-                : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-muted)]"
-            }`}
+    <section
+      className="grid overflow-hidden rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg)] sm:grid-cols-2 xl:grid-cols-4"
+      aria-label="Vendor activity summary"
+    >
+      {stats.map((stat, index) => {
+        const content = (
+          <div
+            className={`flex min-h-24 items-center gap-3 px-4 py-3 text-left transition hover:bg-[color:var(--theme-surface-subtle)] ${
+              index > 0
+                ? "border-t border-[color:var(--theme-border-soft)] sm:border-l"
+                : ""
+            } ${index === 1 ? "sm:border-t-0" : ""} ${
+              index === 2
+                ? "sm:border-l-0 sm:border-t xl:border-l xl:border-t-0"
+                : ""
+            } ${index === 3 ? "sm:border-t xl:border-t-0" : ""}`}
           >
-            {status}
-          </span>
-        </div>
-        <p className="mt-2 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-          {description}
-        </p>
-      </div>
-      {action ? <div>{action}</div> : null}
-    </div>
+            <span className="text-3xl font-semibold tabular-nums text-[color:var(--theme-text-primary)]">
+              {formatCount(stat.value)}
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                {stat.label}
+              </span>
+              <span className="block text-xs text-[color:var(--theme-text-muted)]">
+                {stat.detail}
+              </span>
+            </span>
+          </div>
+        );
+
+        if (stat.href) {
+          return (
+            <Link key={stat.label} href={stat.href}>
+              {content}
+            </Link>
+          );
+        }
+        if (stat.action) {
+          return (
+            <button key={stat.label} type="button" onClick={stat.action}>
+              {content}
+            </button>
+          );
+        }
+        return <div key={stat.label}>{content}</div>;
+      })}
+    </section>
   );
 }
 
-function VendorModal({
-  open,
+function AttentionQueue({
+  summary,
+  loading,
+  onFilter,
+}: {
+  summary: VendorWorkspaceSummary;
+  loading: boolean;
+  onFilter: (filter: DirectoryFilter) => void;
+}) {
+  const actions = [
+    {
+      key: "setup",
+      count: summary.vendorsNeedingSetup,
+      label: "Vendor profiles need setup",
+      detail: "Add account or contact details",
+      action: () => onFilter("attention"),
+    },
+    {
+      key: "duplicates",
+      count: summary.duplicateVendorCandidates,
+      label: "Possible duplicate vendors",
+      detail: "Review matching supplier names",
+      action: () => onFilter("duplicates"),
+    },
+    {
+      key: "legacy",
+      count: summary.legacyUnlinkedParts,
+      label: "Legacy vendor references",
+      detail: "Convert text into catalog links",
+      href: "/parts/inventory",
+    },
+    {
+      key: "missing-po",
+      count: summary.openPoWithoutVendorRecord,
+      label: "Open POs missing a vendor",
+      detail: "Repair the purchasing link",
+      href: "/parts/po",
+    },
+    {
+      key: "requests",
+      count: summary.requestRowsWithoutVendorRecord,
+      label: "Requests using vendor text",
+      detail: "Connect them to a vendor record",
+      href: "/parts/requests",
+    },
+    {
+      key: "inventory",
+      count: summary.partsWithoutVendorReference,
+      label: "Parts without a vendor",
+      detail: "Add a vendor source",
+      href: "/parts/inventory",
+    },
+  ].filter((item) => item.count > 0);
+
+  return (
+    <section className="overflow-hidden rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg)]">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-4 py-3">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+            Work queue
+          </p>
+          <h2 className="mt-0.5 text-base font-semibold">Needs attention</h2>
+        </div>
+        {loading ? (
+          <span className="text-xs text-[color:var(--theme-text-muted)]">
+            Loading…
+          </span>
+        ) : actions.length > 0 ? (
+          <span className="rounded-full border border-amber-500/25 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold text-amber-200">
+            {formatCount(
+              actions.reduce((total, item) => total + item.count, 0),
+            )}{" "}
+            items
+          </span>
+        ) : null}
+      </div>
+
+      {!loading && actions.length === 0 ? (
+        <div className="flex items-center gap-3 px-4 py-4 text-sm">
+          <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-300" />
+          <div>
+            <p className="font-medium text-[color:var(--theme-text-primary)]">
+              Vendor records are in good shape
+            </p>
+            <p className="text-xs text-[color:var(--theme-text-muted)]">
+              There are no vendor-link or profile exceptions to review.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="divide-y divide-[color:var(--theme-border-soft)]">
+          {actions.map((item) => {
+            const content = (
+              <div className="flex min-h-16 items-center gap-3 px-4 py-3 text-left transition hover:bg-[color:var(--theme-surface-subtle)]">
+                <span className="flex h-9 min-w-9 items-center justify-center rounded-xl border border-amber-500/25 bg-amber-500/10 px-2 text-sm font-semibold tabular-nums text-amber-100">
+                  {formatCount(item.count)}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium text-[color:var(--theme-text-primary)]">
+                    {item.label}
+                  </span>
+                  <span className="block text-xs text-[color:var(--theme-text-muted)]">
+                    {item.detail}
+                  </span>
+                </span>
+                <ChevronRight className="h-4 w-4 shrink-0 text-[color:var(--theme-text-muted)]" />
+              </div>
+            );
+
+            if (item.href) {
+              return (
+                <Link key={item.key} href={item.href}>
+                  {content}
+                </Link>
+              );
+            }
+            return (
+              <button
+                key={item.key}
+                type="button"
+                className="block w-full"
+                onClick={item.action}
+              >
+                {content}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function VendorDirectoryRow({
+  row,
+  selected,
+  onSelect,
+}: {
+  row: VendorDirectoryItem;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const contact =
+    row.supplier.email ?? row.supplier.phone ?? "No contact information";
+  const orderText =
+    row.pendingReceivingCount > 0
+      ? `${row.pendingReceivingCount} to receive`
+      : row.openPoCount > 0
+        ? `${row.openPoCount} open ${row.openPoCount === 1 ? "PO" : "POs"}`
+        : "No open orders";
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={selected}
+      className={`group grid w-full gap-3 border-t border-[color:var(--theme-border-soft)] px-4 py-4 text-left transition first:border-t-0 hover:bg-[color:var(--theme-surface-subtle)] md:grid-cols-[minmax(180px,1.4fr)_minmax(160px,1fr)_150px_120px_20px] md:items-center ${
+        selected
+          ? "bg-[color:var(--theme-surface-subtle)] shadow-[inset_3px_0_0_var(--accent-copper)]"
+          : ""
+      }`}
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-xs font-bold tracking-[0.08em] text-[color:var(--theme-text-secondary)]">
+          {getInitials(row.supplier.name) || "V"}
+        </span>
+        <span className="min-w-0">
+          <span className="block truncate font-semibold text-[color:var(--theme-text-primary)]">
+            {row.supplier.name}
+          </span>
+          <span className="mt-1 flex flex-wrap items-center gap-1.5">
+            <span
+              className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${stateTone(row.state)}`}
+            >
+              {row.state}
+            </span>
+            {row.issues.length > 0 ? (
+              <span className="inline-flex items-center gap-1 text-[10px] font-medium text-amber-200">
+                <AlertTriangle className="h-3 w-3" />
+                {row.issues.length} {row.issues.length === 1 ? "item" : "items"}
+              </span>
+            ) : null}
+          </span>
+        </span>
+      </div>
+
+      <div className="min-w-0 pl-[52px] md:pl-0">
+        <span className="block truncate text-sm text-[color:var(--theme-text-secondary)]">
+          {contact}
+        </span>
+        <span className="block truncate text-xs text-[color:var(--theme-text-muted)]">
+          {row.supplier.account_no
+            ? `Account ${row.supplier.account_no}`
+            : "No account number"}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between pl-[52px] md:block md:pl-0">
+        <span className="text-xs text-[color:var(--theme-text-muted)] md:hidden">
+          Purchasing
+        </span>
+        <span className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+          {orderText}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between pl-[52px] md:block md:pl-0">
+        <span className="text-xs text-[color:var(--theme-text-muted)] md:hidden">
+          Catalog
+        </span>
+        <span className="text-sm font-medium tabular-nums text-[color:var(--theme-text-primary)]">
+          {row.catalogPartCount} linked
+        </span>
+      </div>
+
+      <ChevronRight className="hidden h-4 w-4 text-[color:var(--theme-text-muted)] transition group-hover:translate-x-0.5 md:block" />
+    </button>
+  );
+}
+
+function VendorForm({
   draft,
-  editing,
   busy,
   error,
+  submitLabel,
   onChange,
-  onClose,
+  onCancel,
   onSubmit,
 }: {
-  open: boolean;
   draft: VendorDraft;
-  editing: boolean;
   busy: boolean;
   error: string | null;
+  submitLabel: string;
   onChange: (draft: VendorDraft) => void;
-  onClose: () => void;
+  onCancel: () => void;
   onSubmit: () => void;
 }) {
-  if (!open) return null;
   const inputClass = `${ui.input} w-full`;
 
   return (
-    <div
-      className="fixed inset-0 z-[80] flex items-end justify-center bg-[color:var(--theme-surface-overlay)] p-0 sm:items-center sm:p-4"
-      onMouseDown={onClose}
-    >
-      <div
-        className="max-h-[92dvh] w-full overflow-y-auto rounded-t-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg)] p-5 shadow-2xl sm:max-w-2xl sm:rounded-2xl"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="vendor-form-title"
-        onMouseDown={(event) => event.stopPropagation()}
-      >
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-              Vendor record
-            </p>
-            <h2 id="vendor-form-title" className="mt-1 text-xl font-semibold">
-              {editing ? "Edit vendor" : "Add vendor"}
-            </h2>
-          </div>
-          <button type="button" className={ui.buttonSecondary} onClick={onClose} disabled={busy}>
-            Close
-          </button>
-        </div>
-
-        <div className="mt-5 grid gap-4 sm:grid-cols-2">
-          <label className="sm:col-span-2">
-            <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
-              Vendor name
-            </span>
-            <input
-              className={inputClass}
-              value={draft.name}
-              onChange={(event) => onChange({ ...draft, name: event.target.value })}
-              autoFocus
-            />
-          </label>
-          <label>
-            <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
-              Account number / vendor code
-            </span>
-            <input
-              className={inputClass}
-              value={draft.accountNo}
-              onChange={(event) => onChange({ ...draft, accountNo: event.target.value })}
-            />
-          </label>
-          <label>
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-5">
+        <label className="block">
+          <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+            Vendor name
+          </span>
+          <input
+            className={inputClass}
+            value={draft.name}
+            onChange={(event) =>
+              onChange({ ...draft, name: event.target.value })
+            }
+            autoFocus
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+            Account number / vendor code
+          </span>
+          <input
+            className={inputClass}
+            value={draft.accountNo}
+            onChange={(event) =>
+              onChange({ ...draft, accountNo: event.target.value })
+            }
+          />
+        </label>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-1">
+          <label className="block">
             <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
               Phone
             </span>
             <input
               className={inputClass}
               value={draft.phone}
-              onChange={(event) => onChange({ ...draft, phone: event.target.value })}
+              onChange={(event) =>
+                onChange({ ...draft, phone: event.target.value })
+              }
               inputMode="tel"
             />
           </label>
-          <label className="sm:col-span-2">
+          <label className="block">
             <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
               Email
             </span>
             <input
               className={inputClass}
               value={draft.email}
-              onChange={(event) => onChange({ ...draft, email: event.target.value })}
+              onChange={(event) =>
+                onChange({ ...draft, email: event.target.value })
+              }
               type="email"
               inputMode="email"
             />
           </label>
-          <label className="sm:col-span-2">
-            <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
-              Notes
-            </span>
-            <textarea
-              className={`${inputClass} min-h-24 resize-y`}
-              value={draft.notes}
-              onChange={(event) => onChange({ ...draft, notes: event.target.value })}
-            />
-          </label>
-          <label className="flex items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-3 text-sm sm:col-span-2">
-            <input
-              type="checkbox"
-              checked={draft.isActive}
-              onChange={(event) => onChange({ ...draft, isActive: event.target.checked })}
-            />
-            Active vendor
-          </label>
         </div>
+        <label className="block">
+          <span className="mb-1.5 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+            Internal notes
+          </span>
+          <textarea
+            className={`${inputClass} min-h-28 resize-y`}
+            value={draft.notes}
+            onChange={(event) =>
+              onChange({ ...draft, notes: event.target.value })
+            }
+          />
+        </label>
+        <label className="flex items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-3 text-sm">
+          <input
+            type="checkbox"
+            checked={draft.isActive}
+            onChange={(event) =>
+              onChange({ ...draft, isActive: event.target.checked })
+            }
+          />
+          <span>
+            <span className="block font-medium">Active vendor</span>
+            <span className="block text-xs text-[color:var(--theme-text-muted)]">
+              Available for current purchasing work
+            </span>
+          </span>
+        </label>
 
         {error ? (
-          <div className="mt-4 rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+          <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
             {error}
           </div>
         ) : null}
-
-        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <button type="button" className={ui.buttonSecondary} onClick={onClose} disabled={busy}>
-            Cancel
-          </button>
-          <button type="button" className={ui.buttonPrimary} onClick={onSubmit} disabled={busy}>
-            {busy ? "Saving…" : editing ? "Save changes" : "Add vendor"}
-          </button>
-        </div>
       </div>
+
+      <div className="flex flex-col-reverse gap-2 border-t border-[color:var(--theme-border-soft)] px-5 py-4 sm:flex-row sm:justify-end lg:flex-col-reverse">
+        <button
+          type="button"
+          className={ui.buttonSecondary}
+          onClick={onCancel}
+          disabled={busy}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className={ui.buttonPrimary}
+          onClick={onSubmit}
+          disabled={busy || !draft.name.trim()}
+        >
+          {busy ? "Saving…" : submitLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function VendorProfile({
+  row,
+  onEdit,
+  onShowDuplicates,
+}: {
+  row: VendorDirectoryItem;
+  onEdit: () => void;
+  onShowDuplicates: () => void;
+}) {
+  const setupComplete = row.issues.length === 0;
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="border-b border-[color:var(--theme-border-soft)] px-5 py-5">
+        <div className="flex items-start gap-3">
+          <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-sm font-bold tracking-[0.08em]">
+            {getInitials(row.supplier.name) || "V"}
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 className="break-words text-xl font-semibold">
+              {row.supplier.name}
+            </h2>
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <span
+                className={`rounded-full border px-2.5 py-1 text-[10px] font-semibold ${stateTone(row.state)}`}
+              >
+                {row.state}
+              </span>
+              <span className="text-xs text-[color:var(--theme-text-muted)]">
+                Last PO: {formatDate(row.lastActivityAt)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          className={`${ui.buttonPrimary} mt-4 w-full`}
+          onClick={onEdit}
+        >
+          <Pencil className="mr-1.5 h-3.5 w-3.5" />
+          Edit vendor profile
+        </button>
+      </div>
+
+      <div className="space-y-5 px-5 py-5">
+        <section>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+            Contact & account
+          </p>
+          <div className="mt-2 overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)]">
+            {row.supplier.account_no ? (
+              <div className="flex items-center gap-3 border-b border-[color:var(--theme-border-soft)] px-3 py-3">
+                <Building2 className="h-4 w-4 shrink-0 text-[color:var(--theme-text-muted)]" />
+                <div className="min-w-0">
+                  <p className="text-[10px] uppercase tracking-[0.12em] text-[color:var(--theme-text-muted)]">
+                    Account
+                  </p>
+                  <p className="break-words text-sm font-medium">
+                    {row.supplier.account_no}
+                  </p>
+                </div>
+              </div>
+            ) : null}
+            {row.supplier.phone ? (
+              <a
+                href={`tel:${row.supplier.phone}`}
+                className="flex items-center gap-3 border-b border-[color:var(--theme-border-soft)] px-3 py-3 transition hover:bg-[color:var(--theme-surface-subtle)]"
+              >
+                <Phone className="h-4 w-4 shrink-0 text-[color:var(--theme-text-muted)]" />
+                <span className="break-all text-sm">{row.supplier.phone}</span>
+              </a>
+            ) : null}
+            {row.supplier.email ? (
+              <a
+                href={`mailto:${row.supplier.email}`}
+                className="flex items-center gap-3 px-3 py-3 transition hover:bg-[color:var(--theme-surface-subtle)]"
+              >
+                <Mail className="h-4 w-4 shrink-0 text-[color:var(--theme-text-muted)]" />
+                <span className="break-all text-sm">{row.supplier.email}</span>
+              </a>
+            ) : null}
+            {!row.supplier.account_no &&
+            !row.supplier.phone &&
+            !row.supplier.email ? (
+              <button
+                type="button"
+                onClick={onEdit}
+                className="flex w-full items-center gap-3 px-3 py-3 text-left text-sm text-amber-100"
+              >
+                <AlertTriangle className="h-4 w-4 shrink-0" />
+                Add account and contact details
+              </button>
+            ) : null}
+          </div>
+        </section>
+
+        <section>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+            Current activity
+          </p>
+          <dl className="mt-2 grid grid-cols-2 gap-2">
+            <div className={`${ui.itemCard} p-3`}>
+              <dt className="text-xs text-[color:var(--theme-text-muted)]">
+                Open POs
+              </dt>
+              <dd className="mt-1 text-xl font-semibold tabular-nums">
+                {row.openPoCount}
+              </dd>
+            </div>
+            <div className={`${ui.itemCard} p-3`}>
+              <dt className="text-xs text-[color:var(--theme-text-muted)]">
+                To receive
+              </dt>
+              <dd className="mt-1 text-xl font-semibold tabular-nums">
+                {row.pendingReceivingCount}
+              </dd>
+            </div>
+            <div className={`${ui.itemCard} p-3`}>
+              <dt className="text-xs text-[color:var(--theme-text-muted)]">
+                Catalog links
+              </dt>
+              <dd className="mt-1 text-xl font-semibold tabular-nums">
+                {row.catalogPartCount}
+              </dd>
+            </div>
+            <div className={`${ui.itemCard} p-3`}>
+              <dt className="text-xs text-[color:var(--theme-text-muted)]">
+                Parts purchased
+              </dt>
+              <dd className="mt-1 text-xl font-semibold tabular-nums">
+                {row.purchasedPartCount}
+              </dd>
+            </div>
+          </dl>
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            <Link href="/parts/po" className={ui.buttonSecondary}>
+              Purchase orders
+            </Link>
+            <Link href="/parts/receiving" className={ui.buttonSecondary}>
+              Receiving
+            </Link>
+          </div>
+        </section>
+
+        <section>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+            Record health
+          </p>
+          {setupComplete ? (
+            <div className="mt-2 flex items-start gap-3 rounded-xl border border-emerald-500/25 bg-emerald-500/10 px-3 py-3 text-sm text-emerald-100">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+              <div>
+                <p className="font-medium">Profile is ready</p>
+                <p className="mt-0.5 text-xs text-emerald-100/75">
+                  No vendor setup exceptions were found.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-2 space-y-2">
+              {row.setup.missingContact || row.setup.missingAccount ? (
+                <button
+                  type="button"
+                  onClick={onEdit}
+                  className="flex w-full items-center gap-3 rounded-xl border border-amber-500/25 bg-amber-500/10 px-3 py-3 text-left text-sm text-amber-100"
+                >
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    Complete the missing profile details
+                  </span>
+                  <ChevronRight className="h-4 w-4 shrink-0" />
+                </button>
+              ) : null}
+              {row.setup.possibleDuplicate ? (
+                <button
+                  type="button"
+                  onClick={onShowDuplicates}
+                  className="flex w-full items-center gap-3 rounded-xl border border-amber-500/25 bg-amber-500/10 px-3 py-3 text-left text-sm text-amber-100"
+                >
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    Review the matching vendor records
+                  </span>
+                  <ChevronRight className="h-4 w-4 shrink-0" />
+                </button>
+              ) : null}
+              {row.setup.hasLegacyVendorText ? (
+                <Link
+                  href="/parts/inventory"
+                  className="flex items-center gap-3 rounded-xl border border-amber-500/25 bg-amber-500/10 px-3 py-3 text-sm text-amber-100"
+                >
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    Link {row.legacyMatchedPartCount} legacy inventory{" "}
+                    {row.legacyMatchedPartCount === 1 ? "part" : "parts"}
+                  </span>
+                  <ChevronRight className="h-4 w-4 shrink-0" />
+                </Link>
+              ) : null}
+            </div>
+          )}
+        </section>
+
+        {row.supplier.notes ? (
+          <section>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+              Internal notes
+            </p>
+            <p className="mt-2 whitespace-pre-wrap rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
+              {row.supplier.notes}
+            </p>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function VendorPanel({
+  mode,
+  row,
+  draft,
+  busy,
+  error,
+  onDraftChange,
+  onClose,
+  onEdit,
+  onCancelForm,
+  onSubmit,
+  onShowDuplicates,
+}: {
+  mode: PanelMode;
+  row: VendorDirectoryItem | null;
+  draft: VendorDraft;
+  busy: boolean;
+  error: string | null;
+  onDraftChange: (draft: VendorDraft) => void;
+  onClose: () => void;
+  onEdit: () => void;
+  onCancelForm: () => void;
+  onSubmit: () => void;
+  onShowDuplicates: () => void;
+}) {
+  const mobileOpen = mode !== null;
+  const heading =
+    mode === "create"
+      ? "Add vendor"
+      : mode === "edit"
+        ? "Edit vendor"
+        : "Vendor profile";
+
+  return (
+    <div
+      className={`inset-0 z-[80] bg-[color:var(--theme-surface-overlay)] ${
+        mobileOpen ? "fixed" : "hidden"
+      } lg:sticky lg:inset-auto lg:top-4 lg:z-auto lg:block lg:self-start lg:bg-transparent`}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <aside
+        className="ml-auto flex h-full w-full max-w-[480px] flex-col overflow-hidden border-l border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg)] shadow-2xl lg:h-[calc(100vh-8rem)] lg:max-h-[820px] lg:max-w-none lg:rounded-2xl lg:border lg:shadow-[var(--theme-shadow-soft)]"
+        role={mobileOpen ? "dialog" : "complementary"}
+        aria-label={heading}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-5 py-4">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+              Vendor workspace
+            </p>
+            <p className="mt-0.5 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+              {heading}
+            </p>
+          </div>
+          {mobileOpen ? (
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-[color:var(--theme-border-soft)] p-2 text-[color:var(--theme-text-secondary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+              aria-label="Close vendor panel"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          ) : null}
+        </div>
+
+        {mode === "create" || mode === "edit" ? (
+          <VendorForm
+            draft={draft}
+            busy={busy}
+            error={error}
+            submitLabel={mode === "create" ? "Add vendor" : "Save changes"}
+            onChange={onDraftChange}
+            onCancel={onCancelForm}
+            onSubmit={onSubmit}
+          />
+        ) : row ? (
+          <VendorProfile
+            row={row}
+            onEdit={onEdit}
+            onShowDuplicates={onShowDuplicates}
+          />
+        ) : (
+          <div className="flex flex-1 flex-col items-center justify-center px-8 py-12 text-center">
+            <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]">
+              <Building2 className="h-6 w-6 text-[color:var(--theme-text-muted)]" />
+            </div>
+            <h2 className="mt-4 text-base font-semibold">Select a vendor</h2>
+            <p className="mt-1 max-w-xs text-sm leading-6 text-[color:var(--theme-text-muted)]">
+              Open a vendor to see contact details, purchasing activity, catalog
+              links, notes, and setup work in one profile.
+            </p>
+          </div>
+        )}
+      </aside>
     </div>
   );
 }
@@ -355,9 +961,11 @@ export default function PartsVendorsPage(): JSX.Element {
   const [directory, setDirectory] = useState<VendorDirectoryItem[]>([]);
   const [summary, setSummary] = useState<VendorWorkspaceSummary>(EMPTY_SUMMARY);
   const [search, setSearch] = useState("");
-  const [stateFilter, setStateFilter] = useState<string>("all");
+  const [directoryFilter, setDirectoryFilter] =
+    useState<DirectoryFilter>("all");
   const [refreshToken, setRefreshToken] = useState(0);
-  const [modalOpen, setModalOpen] = useState(false);
+  const [panelMode, setPanelMode] = useState<PanelMode>(null);
+  const [selectedVendorId, setSelectedVendorId] = useState<string | null>(null);
   const [editingVendor, setEditingVendor] = useState<SupplierRow | null>(null);
   const [draft, setDraft] = useState<VendorDraft>(EMPTY_DRAFT);
   const [saving, setSaving] = useState(false);
@@ -384,7 +992,9 @@ export default function PartsVendorsPage(): JSX.Element {
       const suppliers = await fetchAllRows<SupplierRow>(async (from, to) => {
         const result = await supabase
           .from("suppliers")
-          .select("id, name, account_no, email, phone, notes, is_active, created_at, created_by, shop_id")
+          .select(
+            "id, name, account_no, email, phone, notes, is_active, created_at, created_by, shop_id",
+          )
           .eq("shop_id", context.shopId)
           .order("name", { ascending: true })
           .range(from, to);
@@ -412,7 +1022,9 @@ export default function PartsVendorsPage(): JSX.Element {
               .order("id", { ascending: true })
               .range(from, to);
             if (result.error) {
-              loadWarnings.push(`Inventory vendor references: ${result.error.message}`);
+              loadWarnings.push(
+                `Inventory vendor references: ${result.error.message}`,
+              );
               return [];
             }
             return result.data ?? [];
@@ -440,7 +1052,9 @@ export default function PartsVendorsPage(): JSX.Element {
               .select("po_id, part_id")
               .range(from, to);
             if (result.error) {
-              loadWarnings.push(`Purchase-order part history: ${result.error.message}`);
+              loadWarnings.push(
+                `Purchase-order part history: ${result.error.message}`,
+              );
               return [];
             }
             return result.data ?? [];
@@ -471,7 +1085,9 @@ export default function PartsVendorsPage(): JSX.Element {
               .eq("shop_id", context.shopId)
               .range(from, to);
             if (result.error) {
-              loadWarnings.push(`Barcode vendor links: ${result.error.message}`);
+              loadWarnings.push(
+                `Barcode vendor links: ${result.error.message}`,
+              );
               return [];
             }
             return result.data ?? [];
@@ -485,7 +1101,9 @@ export default function PartsVendorsPage(): JSX.Element {
               .eq("shop_id", context.shopId)
               .range(from, to);
             if (result.error) {
-              loadWarnings.push(`Vendor catalog links: ${result.error.message}`);
+              loadWarnings.push(
+                `Vendor catalog links: ${result.error.message}`,
+              );
               return [];
             }
             return result.data ?? [];
@@ -523,55 +1141,65 @@ export default function PartsVendorsPage(): JSX.Element {
     };
   }, [refreshToken, supabase]);
 
+  useEffect(() => {
+    if (!panelMode) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !saving) setPanelMode(null);
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [panelMode, saving]);
+
   const filteredDirectory = useMemo(() => {
     const query = search.trim().toLowerCase();
-    return directory.filter((row) => {
-      if (
-        stateFilter === "needs_setup" &&
-        !(
-          (!hasVendorValue(row.supplier.email) && !hasVendorValue(row.supplier.phone)) ||
-          !hasVendorValue(row.supplier.account_no)
-        )
-      ) {
-        return false;
-      }
-      if (
-        stateFilter === "duplicates" &&
-        !row.issues.includes("Possible duplicate vendor record")
-      ) {
-        return false;
-      }
-      if (
-        stateFilter !== "all" &&
-        stateFilter !== "needs_setup" &&
-        stateFilter !== "duplicates" &&
-        row.state !== stateFilter
-      ) {
-        return false;
-      }
-      if (!query) return true;
-      return [
-        row.supplier.name,
-        row.supplier.account_no,
-        row.supplier.email,
-        row.supplier.phone,
-      ]
-        .map((value) => String(value ?? "").toLowerCase())
-        .join(" ")
-        .includes(query);
-    });
-  }, [directory, search, stateFilter]);
+    return directory
+      .filter((row) => {
+        if (!matchesFilter(row, directoryFilter)) return false;
+        if (!query) return true;
+        return [
+          row.supplier.name,
+          row.supplier.account_no,
+          row.supplier.email,
+          row.supplier.phone,
+        ]
+          .map((value) => String(value ?? "").toLowerCase())
+          .join(" ")
+          .includes(query);
+      })
+      .sort(
+        (left, right) =>
+          STATE_PRIORITY[left.state] - STATE_PRIORITY[right.state] ||
+          left.supplier.name.localeCompare(right.supplier.name),
+      );
+  }, [directory, directoryFilter, search]);
 
+  const selectedRow =
+    directory.find((row) => row.supplier.id === selectedVendorId) ?? null;
   const canManageConnections = role === "owner" || role === "admin";
 
+  const applyFilter = useCallback((filter: DirectoryFilter) => {
+    setSearch("");
+    setDirectoryFilter(filter);
+  }, []);
+
   const openCreate = useCallback(() => {
+    setSelectedVendorId(null);
     setEditingVendor(null);
     setDraft(EMPTY_DRAFT);
     setSaveError(null);
-    setModalOpen(true);
+    setPanelMode("create");
   }, []);
 
-  const openEdit = useCallback((vendor: SupplierRow) => {
+  const openProfile = useCallback((row: VendorDirectoryItem) => {
+    setSelectedVendorId(row.supplier.id);
+    setEditingVendor(null);
+    setSaveError(null);
+    setPanelMode("profile");
+  }, []);
+
+  const openEdit = useCallback((row: VendorDirectoryItem) => {
+    const vendor = row.supplier as SupplierRow;
+    setSelectedVendorId(vendor.id);
     setEditingVendor(vendor);
     setDraft({
       name: vendor.name,
@@ -582,8 +1210,20 @@ export default function PartsVendorsPage(): JSX.Element {
       isActive: vendor.is_active,
     });
     setSaveError(null);
-    setModalOpen(true);
+    setPanelMode("edit");
   }, []);
+
+  const cancelForm = useCallback(() => {
+    if (editingVendor && selectedVendorId) {
+      setPanelMode("profile");
+      setSaveError(null);
+      return;
+    }
+    setPanelMode(null);
+    setEditingVendor(null);
+    setDraft(EMPTY_DRAFT);
+    setSaveError(null);
+  }, [editingVendor, selectedVendorId]);
 
   const saveVendor = useCallback(async () => {
     setSaving(true);
@@ -599,42 +1239,83 @@ export default function PartsVendorsPage(): JSX.Element {
       });
       const result = (await response.json().catch(() => ({}))) as {
         error?: string;
+        vendor?: { id?: string };
       };
       if (!response.ok) {
         throw new Error(result.error || "Unable to save vendor.");
       }
-      setModalOpen(false);
+      const savedId = result.vendor?.id ?? editingVendor?.id ?? null;
+      setSelectedVendorId(savedId);
       setEditingVendor(null);
       setDraft(EMPTY_DRAFT);
+      setPanelMode(savedId ? "profile" : null);
       setRefreshToken((value) => value + 1);
     } catch (saveFailure) {
       setSaveError(
-        saveFailure instanceof Error ? saveFailure.message : "Unable to save vendor.",
+        saveFailure instanceof Error
+          ? saveFailure.message
+          : "Unable to save vendor.",
       );
     } finally {
       setSaving(false);
     }
   }, [draft, editingVendor]);
 
+  const filterButtons: Array<{
+    id: DirectoryFilter;
+    label: string;
+    count?: number;
+  }> = [
+    { id: "all", label: "All", count: summary.totalVendors },
+    {
+      id: "attention",
+      label: "Needs attention",
+      count: directory.filter((row) => row.issues.length > 0).length,
+    },
+    { id: "receiving", label: "Receiving" },
+    { id: "on_order", label: "On order" },
+    { id: "inactive", label: "Inactive" },
+    ...(summary.duplicateVendorCandidates > 0
+      ? [
+          {
+            id: "duplicates" as const,
+            label: "Duplicates",
+            count: summary.duplicateVendorCandidates,
+          },
+        ]
+      : []),
+  ];
+
   return (
     <div className="relative p-4 text-[color:var(--theme-text-primary)] fade-in sm:p-5 md:p-6">
       <PageShell
         eyebrow="Parts · Purchasing"
         title="Vendors"
-        description="Manage the supplier records used by parts requests, purchase orders, receiving, and vendor catalog matching."
+        description="The working directory for supplier contacts, purchasing activity, receiving, and catalog links."
         actions={
-          <div className="flex flex-wrap gap-2">
-            <button type="button" className={ui.buttonPrimary} onClick={openCreate}>
-              <Plus className="mr-1.5 inline h-4 w-4" />
-              Add vendor
-            </button>
+          <>
+            {canManageConnections ? (
+              <Link
+                href="/dashboard/owner/settings#settings-integrations"
+                className={ui.buttonSecondary}
+              >
+                <PlugZap className="mr-1.5 h-4 w-4" />
+                Integrations
+              </Link>
+            ) : null}
             <Link href="/parts/po" className={ui.buttonSecondary}>
+              <ClipboardList className="mr-1.5 h-4 w-4" />
               Purchase orders
             </Link>
-            <Link href="/parts/receiving" className={ui.buttonSecondary}>
-              Receiving
-            </Link>
-          </div>
+            <button
+              type="button"
+              className={ui.buttonPrimary}
+              onClick={openCreate}
+            >
+              <Plus className="mr-1.5 h-4 w-4" />
+              Add vendor
+            </button>
+          </>
         }
       >
         <div className="space-y-4">
@@ -644,330 +1325,144 @@ export default function PartsVendorsPage(): JSX.Element {
             </div>
           ) : null}
 
-          <section aria-labelledby="vendor-overview-title">
-            <div className="mb-3 flex items-end justify-between gap-3">
-              <div>
-                <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-                  Operational overview
-                </p>
-                <h2 id="vendor-overview-title" className="mt-1 text-lg font-semibold">
-                  What needs attention now
-                </h2>
-              </div>
-              {loading ? (
-                <span className="text-xs text-[color:var(--theme-text-muted)]">Loading…</span>
-              ) : null}
-            </div>
-            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-              <MetricCard
-                label="Vendors"
-                value={summary.totalVendors}
-                detail="Active and inactive supplier records"
-                onClick={() => setStateFilter("all")}
-              />
-              <MetricCard
-                label="Need setup"
-                value={summary.vendorsNeedingSetup}
-                detail="Missing contact or account information"
-                onClick={() => setStateFilter("needs_setup")}
-              />
-              <MetricCard
-                label="Open purchase orders"
-                value={summary.openPurchaseOrders}
-                detail="Orders still in progress"
-                href="/parts/po"
-              />
-              <MetricCard
-                label="Pending receiving"
-                value={summary.pendingReceiving}
-                detail="Approved quantity not fully received"
-                href="/parts/receiving"
-              />
-              <MetricCard
-                label="Catalog-linked parts"
-                value={summary.catalogLinkedParts}
-                detail="Direct vendor part-number or barcode links"
-              />
-              <MetricCard
-                label="Legacy vendor text"
-                value={summary.legacyUnlinkedParts}
-                detail="Inventory names not yet converted to catalog links"
-                href="/parts/inventory"
-              />
-            </div>
-          </section>
+          <SummaryStrip summary={summary} onFilter={applyFilter} />
 
-          {(summary.duplicateVendorCandidates > 0 ||
-            summary.openPoWithoutVendorRecord > 0 ||
-            summary.requestRowsWithoutVendorRecord > 0 ||
-            summary.partsWithoutVendorReference > 0) &&
-          !loading ? (
-            <section className="desktop-panel-soft p-4">
-              <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-                Data cleanup
-              </p>
-              <div className="mt-3 grid gap-2 md:grid-cols-2">
-                {summary.duplicateVendorCandidates > 0 ? (
-                  <button
-                    type="button"
-                    className={`${ui.itemCard} flex items-center justify-between gap-3 px-3 py-3 text-left`}
-                    onClick={() => {
-                      setSearch("");
-                      setStateFilter("duplicates");
-                    }}
-                  >
-                    <span>Possible duplicate vendor records</span>
-                    <strong>{formatCount(summary.duplicateVendorCandidates)}</strong>
-                  </button>
-                ) : null}
-                {summary.partsWithoutVendorReference > 0 ? (
-                  <Link
-                    href="/parts/inventory"
-                    className={`${ui.itemCard} flex items-center justify-between gap-3 px-3 py-3`}
-                  >
-                    <span>Inventory parts with no vendor reference</span>
-                    <strong>{formatCount(summary.partsWithoutVendorReference)}</strong>
-                  </Link>
-                ) : null}
-                {summary.openPoWithoutVendorRecord > 0 ? (
-                  <Link
-                    href="/parts/po"
-                    className={`${ui.itemCard} flex items-center justify-between gap-3 px-3 py-3`}
-                  >
-                    <span>Open POs missing a valid vendor</span>
-                    <strong>{formatCount(summary.openPoWithoutVendorRecord)}</strong>
-                  </Link>
-                ) : null}
-                {summary.requestRowsWithoutVendorRecord > 0 ? (
-                  <Link
-                    href="/parts/requests"
-                    className={`${ui.itemCard} flex items-center justify-between gap-3 px-3 py-3`}
-                  >
-                    <span>Part requests using vendor text only</span>
-                    <strong>{formatCount(summary.requestRowsWithoutVendorRecord)}</strong>
-                  </Link>
-                ) : null}
-              </div>
-            </section>
-          ) : null}
-
-          <section className="desktop-panel-soft p-4" aria-labelledby="integrations-title">
-            <div className="max-w-3xl">
-              <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-                Connected services
-              </p>
-              <h2 id="integrations-title" className="mt-1 text-lg font-semibold">
-                Integration status
-              </h2>
-              <p className="mt-1 text-sm leading-6 text-[color:var(--theme-text-secondary)]">
-                Only QuickBooks is implemented today. Supplier catalog lookup and automatic
-                ordering are planned; no supplier credentials or live ordering are active.
-              </p>
-            </div>
-            <div className="mt-4 grid gap-3 lg:grid-cols-3">
-              <IntegrationCard
-                name="QuickBooks Online"
-                status="Available now"
-                description="Connect one company per shop and export finalized ProFixIQ invoices. It does not currently import vendors, inventory, or purchase orders."
-                action={
-                  canManageConnections ? (
-                    <Link
-                      href="/dashboard/owner/settings/integrations/quickbooks"
-                      className={ui.buttonSecondary}
-                    >
-                      Manage QuickBooks
-                    </Link>
-                  ) : (
-                    <p className="text-xs text-[color:var(--theme-text-muted)]">
-                      An owner or admin manages this connection.
-                    </p>
-                  )
-                }
+          <div className="grid items-start gap-4 lg:grid-cols-[minmax(0,1fr)_360px] xl:grid-cols-[minmax(0,1fr)_390px]">
+            <div className="min-w-0 space-y-4">
+              <AttentionQueue
+                summary={summary}
+                loading={loading}
+                onFilter={applyFilter}
               />
-              <IntegrationCard
-                name="PartsTech"
-                status="Planned"
-                description="Future catalog search, availability, and ordering. The current parts workflow remains manual and fully usable."
-              />
-              <IntegrationCard
-                name="Direct supplier ordering"
-                status="Planned"
-                description="Future supplier-specific API connections for quotes and orders. No live supplier API calls are made today."
-              />
-            </div>
-          </section>
 
-          <section className="desktop-panel-soft p-4" aria-labelledby="directory-title">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-              <div>
-                <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-                  Vendor directory
-                </p>
-                <h2 id="directory-title" className="mt-1 text-lg font-semibold">
-                  Supplier records and activity
-                </h2>
-                <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-                  Expand a vendor to review its setup, catalog links, purchase history, and receiving work.
-                </p>
-              </div>
-              <div className="grid w-full gap-2 sm:grid-cols-2 lg:w-auto">
-                <input
-                  className={`${ui.input} min-w-0 lg:min-w-[280px]`}
-                  placeholder="Search vendors"
-                  value={search}
-                  onChange={(event) => setSearch(event.target.value)}
-                />
-                <select
-                  className={ui.input}
-                  value={stateFilter}
-                  onChange={(event) => setStateFilter(event.target.value)}
-                >
-                  <option value="all">All vendor states</option>
-                  <option value="needs_setup">Needs setup</option>
-                  <option value="duplicates">Possible duplicates</option>
-                  {DIRECTORY_STATES.filter((state) => state !== "Needs setup").map((state) => (
-                    <option key={state} value={state}>
-                      {state}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            </div>
-
-            {!loading && vendors.length === 0 ? (
-              <div className="mt-4 rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 text-sm">
-                <p className="font-medium">No vendors yet.</p>
-                <p className="mt-1 text-[color:var(--theme-text-secondary)]">
-                  Add the shops your parts department buys from. Those records become the
-                  supplier source for purchase orders and receiving.
-                </p>
-                <button type="button" className={`${ui.buttonPrimary} mt-3`} onClick={openCreate}>
-                  Add first vendor
-                </button>
-              </div>
-            ) : null}
-
-            {!loading && vendors.length > 0 && filteredDirectory.length === 0 ? (
-              <div className="mt-4 rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-4 text-sm text-[color:var(--theme-text-secondary)]">
-                No vendors match this search and filter.
-              </div>
-            ) : null}
-
-            <div className="mt-4 space-y-2">
-              {filteredDirectory.map((row) => (
-                <details key={row.supplier.id} className="desktop-item-card overflow-hidden">
-                  <summary className="cursor-pointer list-none px-3 py-3 sm:px-4">
-                    <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-                      <div className="min-w-0">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <p className="truncate font-semibold text-[color:var(--theme-text-primary)]">
-                            {row.supplier.name}
-                          </p>
-                          <span
-                            className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold ${stateTone(row.state)}`}
-                          >
-                            {row.state}
-                          </span>
-                        </div>
-                        <p className="mt-1 break-words text-xs leading-5 text-[color:var(--theme-text-secondary)]">
-                          Account: {hasVendorValue(row.supplier.account_no) ? row.supplier.account_no : "Not set"}
-                          <span className="mx-1.5 text-[color:var(--theme-text-muted)]">·</span>
-                          {hasVendorValue(row.supplier.email) ? row.supplier.email : "No email"}
-                          <span className="mx-1.5 text-[color:var(--theme-text-muted)]">·</span>
-                          {hasVendorValue(row.supplier.phone) ? row.supplier.phone : "No phone"}
-                        </p>
-                      </div>
-                      <div className="grid grid-cols-2 gap-2 text-xs sm:flex sm:flex-wrap">
-                        <span className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1.5">
-                          Catalog parts: {row.catalogPartCount}
-                        </span>
-                        <span className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1.5">
-                          Open POs: {row.openPoCount}
-                        </span>
-                        <span className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1.5">
-                          To receive: {row.pendingReceivingCount}
-                        </span>
-                        <span className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-2 py-1.5">
-                          Last PO: {formatDate(row.lastActivityAt)}
-                        </span>
-                      </div>
+              <section className="overflow-hidden rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg)]">
+                <div className="border-b border-[color:var(--theme-border-soft)] px-4 py-4">
+                  <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                    <div>
+                      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+                        Directory
+                      </p>
+                      <h2 className="mt-0.5 text-base font-semibold">
+                        Supplier records
+                      </h2>
                     </div>
-                  </summary>
-
-                  <div className="border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 sm:p-4">
-                    <div className="grid gap-4 lg:grid-cols-2">
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
-                          Activity
-                        </p>
-                        <dl className="mt-2 grid grid-cols-2 gap-2 text-sm">
-                          <div className={`${ui.itemCard} px-3 py-2`}>
-                            <dt className="text-xs text-[color:var(--theme-text-muted)]">Catalog links</dt>
-                            <dd className="mt-1 font-semibold">{row.catalogPartCount}</dd>
-                          </div>
-                          <div className={`${ui.itemCard} px-3 py-2`}>
-                            <dt className="text-xs text-[color:var(--theme-text-muted)]">Parts bought before</dt>
-                            <dd className="mt-1 font-semibold">{row.purchasedPartCount}</dd>
-                          </div>
-                          <div className={`${ui.itemCard} px-3 py-2`}>
-                            <dt className="text-xs text-[color:var(--theme-text-muted)]">Open POs</dt>
-                            <dd className="mt-1 font-semibold">{row.openPoCount}</dd>
-                          </div>
-                          <div className={`${ui.itemCard} px-3 py-2`}>
-                            <dt className="text-xs text-[color:var(--theme-text-muted)]">Pending receiving</dt>
-                            <dd className="mt-1 font-semibold">{row.pendingReceivingCount}</dd>
-                          </div>
-                        </dl>
-                      </div>
-                      <div>
-                        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
-                          Setup review
-                        </p>
-                        {row.issues.length > 0 ? (
-                          <ul className="mt-2 space-y-2 text-sm">
-                            {row.issues.map((issue) => (
-                              <li
-                                key={issue}
-                                className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-amber-100"
-                              >
-                                {issue}
-                              </li>
-                            ))}
-                          </ul>
-                        ) : (
-                          <p className="mt-2 rounded-lg border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
-                            Vendor setup is complete.
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                    {row.supplier.notes ? (
-                      <div className="mt-4 rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-2 text-sm text-[color:var(--theme-text-secondary)]">
-                        <span className="font-medium text-[color:var(--theme-text-primary)]">Notes:</span>{" "}
-                        {row.supplier.notes}
-                      </div>
-                    ) : null}
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      <button
-                        type="button"
-                        className={ui.buttonSecondary}
-                        onClick={() => openEdit(row.supplier as SupplierRow)}
-                      >
-                        <Pencil className="mr-1.5 inline h-3.5 w-3.5" />
-                        Edit vendor
-                      </button>
-                      <Link href="/parts/po" className={ui.buttonSecondary}>
-                        Purchase orders
-                      </Link>
-                      <Link href="/parts/inventory" className={ui.buttonSecondary}>
-                        Inventory
-                      </Link>
-                    </div>
+                    <label className="relative block w-full xl:max-w-xs">
+                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--theme-text-muted)]" />
+                      <input
+                        className={`${ui.input} pl-9`}
+                        placeholder="Search name, contact, or account"
+                        value={search}
+                        onChange={(event) => setSearch(event.target.value)}
+                      />
+                    </label>
                   </div>
-                </details>
-              ))}
+
+                  <div className="mt-3 flex gap-2 overflow-x-auto pb-1">
+                    {filterButtons.map((filter) => (
+                      <button
+                        key={filter.id}
+                        type="button"
+                        onClick={() => setDirectoryFilter(filter.id)}
+                        className={
+                          directoryFilter === filter.id
+                            ? ui.pillActive
+                            : ui.pill
+                        }
+                      >
+                        {filter.label}
+                        {filter.count !== undefined ? (
+                          <span className="ml-1.5 tabular-nums opacity-70">
+                            {formatCount(filter.count)}
+                          </span>
+                        ) : null}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="hidden grid-cols-[minmax(180px,1.4fr)_minmax(160px,1fr)_150px_120px_20px] gap-3 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)] md:grid">
+                  <span>Vendor</span>
+                  <span>Contact</span>
+                  <span>Purchasing</span>
+                  <span>Catalog</span>
+                  <span />
+                </div>
+
+                {loading ? (
+                  <div className="space-y-0">
+                    {[0, 1, 2, 3].map((index) => (
+                      <div
+                        key={index}
+                        className="flex animate-pulse items-center gap-3 border-t border-[color:var(--theme-border-soft)] px-4 py-4 first:border-t-0"
+                      >
+                        <div className="h-10 w-10 rounded-xl bg-[color:var(--theme-surface-subtle)]" />
+                        <div className="flex-1">
+                          <div className="h-3 w-40 rounded bg-[color:var(--theme-surface-subtle)]" />
+                          <div className="mt-2 h-2.5 w-28 rounded bg-[color:var(--theme-surface-subtle)]" />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : vendors.length === 0 ? (
+                  <div className="px-5 py-10 text-center">
+                    <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]">
+                      <Truck className="h-5 w-5 text-[color:var(--theme-text-muted)]" />
+                    </div>
+                    <h3 className="mt-3 font-semibold">
+                      Build your vendor directory
+                    </h3>
+                    <p className="mx-auto mt-1 max-w-sm text-sm leading-6 text-[color:var(--theme-text-muted)]">
+                      Add the suppliers your parts department buys from so
+                      purchase orders and receiving share one vendor record.
+                    </p>
+                    <button
+                      type="button"
+                      className={`${ui.buttonPrimary} mt-4`}
+                      onClick={openCreate}
+                    >
+                      Add first vendor
+                    </button>
+                  </div>
+                ) : filteredDirectory.length === 0 ? (
+                  <div className="px-5 py-10 text-center text-sm text-[color:var(--theme-text-muted)]">
+                    No vendors match this search and filter.
+                  </div>
+                ) : (
+                  <div>
+                    {filteredDirectory.map((row) => (
+                      <VendorDirectoryRow
+                        key={row.supplier.id}
+                        row={row}
+                        selected={selectedVendorId === row.supplier.id}
+                        onSelect={() => openProfile(row)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
             </div>
-          </section>
+
+            <VendorPanel
+              mode={panelMode}
+              row={selectedRow}
+              draft={draft}
+              busy={saving}
+              error={saveError}
+              onDraftChange={setDraft}
+              onClose={() => {
+                if (!saving) setPanelMode(null);
+              }}
+              onEdit={() => {
+                if (selectedRow) openEdit(selectedRow);
+              }}
+              onCancelForm={cancelForm}
+              onSubmit={() => void saveVendor()}
+              onShowDuplicates={() => {
+                applyFilter("duplicates");
+                setPanelMode(null);
+              }}
+            />
+          </div>
 
           {warnings.length > 0 ? (
             <section className="rounded-xl border border-amber-500/25 bg-amber-500/10 p-4">
@@ -981,21 +1476,32 @@ export default function PartsVendorsPage(): JSX.Element {
               </ul>
             </section>
           ) : null}
+
+          <section className="flex flex-col gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <PackageCheck className="mt-0.5 h-5 w-5 shrink-0 text-[color:var(--theme-text-muted)]" />
+              <div>
+                <p className="text-sm font-medium">
+                  Looking for integration setup?
+                </p>
+                <p className="mt-0.5 text-xs leading-5 text-[color:var(--theme-text-muted)]">
+                  Vendor records stay here. Accounting and future supplier
+                  connections are managed separately by an owner or admin.
+                </p>
+              </div>
+            </div>
+            {canManageConnections ? (
+              <Link
+                href="/dashboard/owner/settings#settings-integrations"
+                className={`${ui.buttonSecondary} shrink-0`}
+              >
+                Open integrations
+                <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+              </Link>
+            ) : null}
+          </section>
         </div>
       </PageShell>
-
-      <VendorModal
-        open={modalOpen}
-        draft={draft}
-        editing={Boolean(editingVendor)}
-        busy={saving}
-        error={saveError}
-        onChange={setDraft}
-        onClose={() => {
-          if (!saving) setModalOpen(false);
-        }}
-        onSubmit={() => void saveVendor()}
-      />
     </div>
   );
 }

--- a/features/parts/lib/vendorWorkspace.test.ts
+++ b/features/parts/lib/vendorWorkspace.test.ts
@@ -6,7 +6,8 @@ import {
 } from "./vendorWorkspace";
 
 function supplier(
-  overrides: Partial<VendorWorkspaceSupplier> & Pick<VendorWorkspaceSupplier, "id" | "name">,
+  overrides: Partial<VendorWorkspaceSupplier> &
+    Pick<VendorWorkspaceSupplier, "id" | "name">,
 ): VendorWorkspaceSupplier {
   return {
     account_no: "ACCOUNT-1",
@@ -139,6 +140,45 @@ describe("buildVendorWorkspace", () => {
     });
 
     expect(result.summary.duplicateVendorCandidates).toBe(2);
-    expect(result.directory.every((row) => row.legacyMatchedPartCount === 0)).toBe(true);
+    expect(
+      result.directory.every((row) => row.legacyMatchedPartCount === 0),
+    ).toBe(true);
+    expect(result.directory.every((row) => row.setup.possibleDuplicate)).toBe(
+      true,
+    );
+  });
+
+  it("exposes structured profile flags for directory filtering and actions", () => {
+    const result = buildVendorWorkspace({
+      suppliers: [
+        supplier({
+          id: "vendor-1",
+          name: "North Star Parts",
+          account_no: null,
+          email: null,
+          phone: null,
+        }),
+      ],
+      parts: [
+        {
+          id: "part-1",
+          supplier: "North Star Parts",
+          part_number: "A1",
+          sku: null,
+        },
+      ],
+      purchaseOrders: [],
+      purchaseOrderLines: [],
+      requestItems: [],
+      barcodeLinks: [],
+      vendorPartNumberLinks: [],
+    });
+
+    expect(result.directory[0]?.setup).toEqual({
+      missingContact: true,
+      missingAccount: true,
+      possibleDuplicate: false,
+      hasLegacyVendorText: true,
+    });
   });
 });

--- a/features/parts/lib/vendorWorkspace.ts
+++ b/features/parts/lib/vendorWorkspace.ts
@@ -50,6 +50,12 @@ export type VendorDirectoryItem = {
   lastActivityAt: string | null;
   state: VendorOperationalState;
   issues: string[];
+  setup: {
+    missingContact: boolean;
+    missingAccount: boolean;
+    possibleDuplicate: boolean;
+    hasLegacyVendorText: boolean;
+  };
 };
 
 export type VendorWorkspaceSummary = {
@@ -86,10 +92,15 @@ export function hasVendorValue(value: string | null | undefined): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function laterTimestamp(current: string | undefined, candidate: string | null): string | undefined {
+function laterTimestamp(
+  current: string | undefined,
+  candidate: string | null,
+): string | undefined {
   if (!candidate) return current;
   if (!current) return candidate;
-  return new Date(candidate).getTime() > new Date(current).getTime() ? candidate : current;
+  return new Date(candidate).getTime() > new Date(current).getTime()
+    ? candidate
+    : current;
 }
 
 function isOpenPurchaseOrder(status: string | null): boolean {
@@ -110,7 +121,9 @@ export function buildVendorWorkspace(input: {
   directory: VendorDirectoryItem[];
   summary: VendorWorkspaceSummary;
 } {
-  const supplierById = new Map(input.suppliers.map((supplier) => [supplier.id, supplier]));
+  const supplierById = new Map(
+    input.suppliers.map((supplier) => [supplier.id, supplier]),
+  );
   const supplierIdsByNormalizedName = new Map<string, string[]>();
   const duplicateBuckets = new Map<string, VendorWorkspaceSupplier[]>();
 
@@ -131,13 +144,16 @@ export function buildVendorWorkspace(input: {
     const supplierId = String(link.supplier_id ?? "");
     const partId = String(link.part_id ?? "");
     if (!supplierId || !partId || !supplierById.has(supplierId)) continue;
-    const linkedParts = catalogPartsBySupplier.get(supplierId) ?? new Set<string>();
+    const linkedParts =
+      catalogPartsBySupplier.get(supplierId) ?? new Set<string>();
     linkedParts.add(partId);
     catalogPartsBySupplier.set(supplierId, linkedParts);
     catalogLinkedPartIds.add(partId);
   }
 
-  const purchaseOrderById = new Map(input.purchaseOrders.map((po) => [po.id, po]));
+  const purchaseOrderById = new Map(
+    input.purchaseOrders.map((po) => [po.id, po]),
+  );
   const purchasedPartsBySupplier = new Map<string, Set<string>>();
   const openPoCountBySupplier = new Map<string, number>();
   const lastActivityBySupplier = new Map<string, string>();
@@ -146,9 +162,15 @@ export function buildVendorWorkspace(input: {
     const supplierId = po.supplier_id;
     if (!supplierId || !supplierById.has(supplierId)) continue;
     if (isOpenPurchaseOrder(po.status)) {
-      openPoCountBySupplier.set(supplierId, (openPoCountBySupplier.get(supplierId) ?? 0) + 1);
+      openPoCountBySupplier.set(
+        supplierId,
+        (openPoCountBySupplier.get(supplierId) ?? 0) + 1,
+      );
     }
-    const latest = laterTimestamp(lastActivityBySupplier.get(supplierId), po.created_at);
+    const latest = laterTimestamp(
+      lastActivityBySupplier.get(supplierId),
+      po.created_at,
+    );
     if (latest) lastActivityBySupplier.set(supplierId, latest);
   }
 
@@ -156,16 +178,18 @@ export function buildVendorWorkspace(input: {
     const po = purchaseOrderById.get(line.po_id);
     const supplierId = po?.supplier_id ?? null;
     if (!supplierId || !line.part_id || !supplierById.has(supplierId)) continue;
-    const linkedParts = purchasedPartsBySupplier.get(supplierId) ?? new Set<string>();
+    const linkedParts =
+      purchasedPartsBySupplier.get(supplierId) ?? new Set<string>();
     linkedParts.add(line.part_id);
     purchasedPartsBySupplier.set(supplierId, linkedParts);
   }
 
   const pendingReceivingBySupplier = new Map<string, number>();
   for (const item of input.requestItems) {
-    if (Number(item.qty_approved ?? 0) <= Number(item.qty_received ?? 0)) continue;
+    if (Number(item.qty_approved ?? 0) <= Number(item.qty_received ?? 0))
+      continue;
     const poSupplierId = item.po_id
-      ? purchaseOrderById.get(item.po_id)?.supplier_id ?? null
+      ? (purchaseOrderById.get(item.po_id)?.supplier_id ?? null)
       : null;
     const supplierId = item.vendor_id ?? poSupplierId;
     if (!supplierId || !supplierById.has(supplierId)) continue;
@@ -177,29 +201,38 @@ export function buildVendorWorkspace(input: {
 
   const legacyPartsBySupplier = new Map<string, Set<string>>();
   for (const part of input.parts) {
-    if (!hasVendorValue(part.supplier) || catalogLinkedPartIds.has(part.id)) continue;
+    if (!hasVendorValue(part.supplier) || catalogLinkedPartIds.has(part.id))
+      continue;
     const matchingSupplierIds =
       supplierIdsByNormalizedName.get(normalizeVendorName(part.supplier)) ?? [];
     if (matchingSupplierIds.length !== 1) continue;
     const supplierId = matchingSupplierIds[0];
-    const linkedParts = legacyPartsBySupplier.get(supplierId) ?? new Set<string>();
+    const linkedParts =
+      legacyPartsBySupplier.get(supplierId) ?? new Set<string>();
     linkedParts.add(part.id);
     legacyPartsBySupplier.set(supplierId, linkedParts);
   }
 
   const directory = input.suppliers.map((supplier): VendorDirectoryItem => {
     const catalogPartCount = catalogPartsBySupplier.get(supplier.id)?.size ?? 0;
-    const purchasedPartCount = purchasedPartsBySupplier.get(supplier.id)?.size ?? 0;
-    const legacyMatchedPartCount = legacyPartsBySupplier.get(supplier.id)?.size ?? 0;
+    const purchasedPartCount =
+      purchasedPartsBySupplier.get(supplier.id)?.size ?? 0;
+    const legacyMatchedPartCount =
+      legacyPartsBySupplier.get(supplier.id)?.size ?? 0;
     const openPoCount = openPoCountBySupplier.get(supplier.id) ?? 0;
-    const pendingReceivingCount = pendingReceivingBySupplier.get(supplier.id) ?? 0;
-    const missingContact = !hasVendorValue(supplier.email) && !hasVendorValue(supplier.phone);
+    const pendingReceivingCount =
+      pendingReceivingBySupplier.get(supplier.id) ?? 0;
+    const missingContact =
+      !hasVendorValue(supplier.email) && !hasVendorValue(supplier.phone);
     const missingAccount = !hasVendorValue(supplier.account_no);
+    const possibleDuplicate =
+      (duplicateBuckets.get(normalizeVendorName(supplier.name))?.length ?? 0) >
+      1;
     const issues: string[] = [];
 
     if (missingContact) issues.push("Add an email or phone number");
     if (missingAccount) issues.push("Add an account number or vendor code");
-    if ((duplicateBuckets.get(normalizeVendorName(supplier.name))?.length ?? 0) > 1) {
+    if (possibleDuplicate) {
       issues.push("Possible duplicate vendor record");
     }
     if (legacyMatchedPartCount > 0) {
@@ -215,7 +248,11 @@ export function buildVendorWorkspace(input: {
     else if (pendingReceivingCount > 0) state = "Receiving";
     else if (openPoCount > 0) state = "On order";
     else if (missingContact || missingAccount) state = "Needs setup";
-    else if (catalogPartCount > 0 || purchasedPartCount > 0 || legacyMatchedPartCount > 0) {
+    else if (
+      catalogPartCount > 0 ||
+      purchasedPartCount > 0 ||
+      legacyMatchedPartCount > 0
+    ) {
       state = "Active";
     } else state = "No activity";
 
@@ -229,10 +266,18 @@ export function buildVendorWorkspace(input: {
       lastActivityAt: lastActivityBySupplier.get(supplier.id) ?? null,
       state,
       issues,
+      setup: {
+        missingContact,
+        missingAccount,
+        possibleDuplicate,
+        hasLegacyVendorText: legacyMatchedPartCount > 0,
+      },
     };
   });
 
-  const duplicateVendorCandidates = Array.from(duplicateBuckets.values()).reduce(
+  const duplicateVendorCandidates = Array.from(
+    duplicateBuckets.values(),
+  ).reduce(
     (total, bucket) => total + (bucket.length > 1 ? bucket.length : 0),
     0,
   );
@@ -246,19 +291,23 @@ export function buildVendorWorkspace(input: {
       totalVendors: input.suppliers.length,
       vendorsNeedingSetup: input.suppliers.filter(
         (supplier) =>
-          (!hasVendorValue(supplier.email) && !hasVendorValue(supplier.phone)) ||
+          (!hasVendorValue(supplier.email) &&
+            !hasVendorValue(supplier.phone)) ||
           !hasVendorValue(supplier.account_no),
       ).length,
       openPurchaseOrders: openPurchaseOrders.length,
       pendingReceiving: input.requestItems.filter(
-        (item) => Number(item.qty_approved ?? 0) > Number(item.qty_received ?? 0),
+        (item) =>
+          Number(item.qty_approved ?? 0) > Number(item.qty_received ?? 0),
       ).length,
       catalogLinkedParts: catalogLinkedPartIds.size,
       legacyUnlinkedParts: input.parts.filter(
-        (part) => hasVendorValue(part.supplier) && !catalogLinkedPartIds.has(part.id),
+        (part) =>
+          hasVendorValue(part.supplier) && !catalogLinkedPartIds.has(part.id),
       ).length,
       partsWithoutVendorReference: input.parts.filter(
-        (part) => !hasVendorValue(part.supplier) && !catalogLinkedPartIds.has(part.id),
+        (part) =>
+          !hasVendorValue(part.supplier) && !catalogLinkedPartIds.has(part.id),
       ).length,
       duplicateVendorCandidates,
       openPoWithoutVendorRecord: openPurchaseOrders.filter(
@@ -266,7 +315,7 @@ export function buildVendorWorkspace(input: {
       ).length,
       requestRowsWithoutVendorRecord: input.requestItems.filter((item) => {
         const poSupplierId = item.po_id
-          ? purchaseOrderById.get(item.po_id)?.supplier_id ?? null
+          ? (purchaseOrderById.get(item.po_id)?.supplier_id ?? null)
           : null;
         return (
           hasVendorValue(item.vendor) &&

--- a/tests/parts/vendor-directory-redesign.test.ts
+++ b/tests/parts/vendor-directory-redesign.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PAGE_PATH = resolve(process.cwd(), "app/parts/vendors/page.tsx");
+
+describe("vendor directory redesign", () => {
+  it("keeps operational vendor work on the page and routes integrations to owner settings", async () => {
+    const source = await readFile(PAGE_PATH, "utf8");
+
+    expect(source).toContain("Needs attention");
+    expect(source).toContain("Supplier records");
+    expect(source).toContain("Vendor profile");
+    expect(source).toContain("/dashboard/owner/settings#settings-integrations");
+    expect(source).not.toContain("PartsTech");
+    expect(source).not.toContain("Direct supplier ordering");
+  });
+
+  it("uses structured vendor flags for actionable filters and profile health", async () => {
+    const source = await readFile(PAGE_PATH, "utf8");
+
+    expect(source).toContain("row.setup.possibleDuplicate");
+    expect(source).toContain("row.setup.missingContact");
+    expect(source).toContain("row.setup.hasLegacyVendorText");
+  });
+
+  it("provides a sticky desktop profile and a fixed mobile drawer", async () => {
+    const source = await readFile(PAGE_PATH, "utf8");
+
+    expect(source).toContain('mobileOpen ? "fixed" : "hidden"');
+    expect(source).toContain("lg:sticky");
+    expect(source).toContain("h-[calc(100vh-8rem)]");
+  });
+});


### PR DESCRIPTION
## Root cause

The first Vendors redesign corrected the underlying data and actions but retained the old report-card information architecture. The page therefore still looked and behaved like the previous readiness report instead of a first-class supplier workspace.

## What changed

- rebuilt Vendors as an operational supplier directory
- added a compact exception work queue
- added searchable, prioritized vendor rows
- added vendor profiles with contacts, account details, purchasing activity, catalog links, notes, and actionable issues
- added a sticky desktop profile panel and full-height mobile/tablet drawer
- moved vendor creation and editing into the profile experience
- removed QuickBooks, PartsTech, and supplier integration cards from Vendors
- routed owners/admins to the separate Integrations settings
- added structured vendor setup flags for actionable filtering and profile health

## User impact

Parts staff now land on the work they need to resolve and can manage supplier records without moving through oversized report cards or unrelated integration marketing. Owners and admins retain a clear route to secured integration management.

## Safety and compatibility

Existing shop-scoped queries and the authorized vendor API remain intact. This change does not alter vendor authorization, parts lifecycle, purchasing, receiving, database schema, RLS, or production data.

## Files changed

- `app/parts/vendors/page.tsx`
- `features/parts/lib/vendorWorkspace.ts`
- `features/parts/lib/vendorWorkspace.test.ts`
- `tests/parts/vendor-directory-redesign.test.ts`

## Validation

- full ESLint: passed
- TypeScript: passed
- full test suite: 1,237 passed, 2 skipped
- final focused suite: 13 passed
- formatting and diff checks: passed
- remote tree matches the validated local tree exactly
- remote branch is one commit ahead and zero behind `main`

The production build compiled and passed lint/type validation, then stopped during page-data collection because this checkout lacks the Supabase URL required by the existing `/api/agent/requests` route. No page compile or type error was reported.

## Database and environment

- no migration required
- no new environment variables
- no manual deployment action required
- no production changes included

## Post-deployment smoke test

1. Open Parts → Vendors with authenticated shop data on desktop.
2. Confirm the attention queue counts and links match vendor, PO, receiving, request, and inventory sources.
3. Search and filter vendor rows, including attention, receiving, on-order, inactive, and duplicate states.
4. Open a vendor profile and verify contact, account, purchasing, catalog, notes, and issues.
5. Create and edit a vendor and confirm the existing authorized API persists the changes.
6. Confirm owners/admins can open Integrations settings and other roles do not receive connection-management actions.
7. Repeat profile open/close, create/edit, filtering, and scrolling on iPad portrait, iPad landscape, and mobile.

## Remaining risk

The authenticated page still requires visual smoke testing with representative real shop data across desktop, iPad portrait/landscape, and mobile.