### PR TITLE
Harden workforce policy replay and RPC access

### DIFF
--- a/supabase/migrations/20260724021500_harden_workforce_policy_replay.sql
+++ b/supabase/migrations/20260724021500_harden_workforce_policy_replay.sql
@@ -1,0 +1,147 @@
+-- Forward hardening for the workforce rollout.
+--
+-- The initial workforce migration can be applied cleanly once, but PostgreSQL
+-- does not support CREATE POLICY IF NOT EXISTS. Replacing the policies here
+-- makes the final schema deterministic after a recovered/partial rollout
+-- without rewriting the original migration.
+
+drop policy if exists shop_payroll_settings_manager_select
+  on public.shop_payroll_settings;
+drop policy if exists shop_payroll_settings_owner_write
+  on public.shop_payroll_settings;
+drop policy if exists payroll_pay_periods_manager_select
+  on public.payroll_pay_periods;
+drop policy if exists payroll_time_entries_scoped_select
+  on public.payroll_time_entries;
+drop policy if exists payroll_time_exceptions_scoped_select
+  on public.payroll_time_exceptions;
+drop policy if exists payroll_export_batches_owner_select
+  on public.payroll_export_batches;
+drop policy if exists payroll_export_rows_owner_select
+  on public.payroll_export_rows;
+drop policy if exists payroll_employee_mappings_owner_all
+  on public.payroll_employee_mappings;
+
+create policy shop_payroll_settings_manager_select
+  on public.shop_payroll_settings
+  for select to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_manage_workforce()
+  );
+
+create policy shop_payroll_settings_owner_write
+  on public.shop_payroll_settings
+  for all to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_finalize_workforce()
+  )
+  with check (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_finalize_workforce()
+  );
+
+create policy payroll_pay_periods_manager_select
+  on public.payroll_pay_periods
+  for select to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_manage_workforce()
+  );
+
+create policy payroll_time_entries_scoped_select
+  on public.payroll_time_entries
+  for select to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and (
+      user_id = auth.uid()
+      or public.profixiq_can_manage_workforce()
+    )
+  );
+
+create policy payroll_time_exceptions_scoped_select
+  on public.payroll_time_exceptions
+  for select to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and (
+      user_id = auth.uid()
+      or public.profixiq_can_manage_workforce()
+    )
+  );
+
+create policy payroll_export_batches_owner_select
+  on public.payroll_export_batches
+  for select to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_finalize_workforce()
+  );
+
+create policy payroll_export_rows_owner_select
+  on public.payroll_export_rows
+  for select to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_finalize_workforce()
+  );
+
+create policy payroll_employee_mappings_owner_all
+  on public.payroll_employee_mappings
+  for all to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_finalize_workforce()
+  )
+  with check (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_finalize_workforce()
+  );
+
+drop policy if exists flat_rate_credits_scoped_select
+  on public.work_order_line_flat_rate_credits;
+create policy flat_rate_credits_scoped_select
+  on public.work_order_line_flat_rate_credits
+  for select to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and (
+      technician_id = auth.uid()
+      or public.profixiq_can_manage_workforce()
+    )
+  );
+
+drop policy if exists labor_segment_corrections_scoped_select
+  on public.work_order_line_labor_segment_corrections;
+create policy labor_segment_corrections_scoped_select
+  on public.work_order_line_labor_segment_corrections
+  for select to authenticated
+  using (
+    shop_id = public.current_shop_id()
+    and public.profixiq_can_manage_workforce()
+  );
+
+-- All mutations use authenticated API routes or the audited SECURITY DEFINER
+-- functions. Removing direct table writes prevents callers from bypassing the
+-- atomic transition, availability-block, and schedule-replacement behavior.
+drop policy if exists staff_schedule_templates_shop_write
+  on public.staff_schedule_templates;
+drop policy if exists staff_schedule_overrides_shop_write
+  on public.staff_schedule_overrides;
+drop policy if exists staff_time_off_requests_manager_update
+  on public.staff_time_off_requests;
+drop policy if exists staff_availability_blocks_shop_write
+  on public.staff_availability_blocks;
+
+-- This is an internal trigger/backfill helper. It has no caller authorization
+-- of its own, so it must never inherit PostgreSQL's default PUBLIC execute grant.
+revoke all on function public.sync_work_order_line_flat_rate_credits(uuid)
+  from public;
+revoke all on function public.sync_work_order_line_flat_rate_credits(uuid)
+  from authenticated;
+revoke all on function public.sync_work_order_line_flat_rate_credits(uuid)
+  from anon;
+grant execute on function public.sync_work_order_line_flat_rate_credits(uuid)
+  to service_role;

--- a/tests/workforce-operations-flat-rate.test.ts
+++ b/tests/workforce-operations-flat-rate.test.ts
@@ -6,6 +6,10 @@ const migration = readFileSync(
   "supabase/migrations/20260724020000_workforce_operations_flat_rate.sql",
   "utf8",
 );
+const policyHardeningMigration = readFileSync(
+  "supabase/migrations/20260724021500_harden_workforce_policy_replay.sql",
+  "utf8",
+);
 const legacyCollectionRoute = readFileSync(
   "app/api/scheduling/sessions/route.ts",
   "utf8",
@@ -59,6 +63,39 @@ describe("workforce operations security and integrity contract", () => {
     );
     expect(migration).toContain(
       "create or replace function public.replace_payroll_period_snapshot",
+    );
+  });
+
+  it("makes policy recovery replay-safe and keeps atomic tables RPC-only", () => {
+    expect(policyHardeningMigration).toContain(
+      "drop policy if exists shop_payroll_settings_manager_select",
+    );
+    expect(policyHardeningMigration).toContain(
+      "drop policy if exists flat_rate_credits_scoped_select",
+    );
+    expect(policyHardeningMigration).toContain(
+      "drop policy if exists labor_segment_corrections_scoped_select",
+    );
+    expect(policyHardeningMigration).toContain(
+      "drop policy if exists staff_schedule_templates_shop_write",
+    );
+    expect(policyHardeningMigration).toContain(
+      "drop policy if exists staff_time_off_requests_manager_update",
+    );
+    expect(policyHardeningMigration).toContain(
+      "drop policy if exists staff_availability_blocks_shop_write",
+    );
+  });
+
+  it("restricts the internal flat-rate sync helper to service role", () => {
+    expect(policyHardeningMigration).toContain(
+      "revoke all on function public.sync_work_order_line_flat_rate_credits(uuid)\n  from public",
+    );
+    expect(policyHardeningMigration).toContain(
+      "revoke all on function public.sync_work_order_line_flat_rate_credits(uuid)\n  from authenticated",
+    );
+    expect(policyHardeningMigration).toContain(
+      "grant execute on function public.sync_work_order_line_flat_rate_credits(uuid)\n  to service_role",
     );
   });
 


### PR DESCRIPTION
## Root cause

The workforce migration creates several replacement RLS policies without first dropping those new policy names. A partially applied manual run therefore fails on retry with PostgreSQL error `42710` as soon as it reaches the first policy that already exists.

The same review found that the internal `SECURITY DEFINER` flat-rate synchronization helper inherited PostgreSQL's default public execute permission, and direct write policies could bypass the audited atomic workforce mutations.

## What changed

- Adds a new forward migration; the merged workforce migration remains unchanged.
- Replaces all workforce payroll, flat-rate, and labor-correction policies with drop/create pairs.
- Removes direct authenticated writes to the canonical schedule, time-away, and availability tables so mutations stay behind authorized APIs/RPCs.
- Revokes public, authenticated, and anonymous execution of the internal flat-rate sync helper; only `service_role` retains direct execute permission.
- Adds regression coverage for policy replay and RPC permission hardening.

## Production recovery order

Production is currently partially applied from a manual SQL Editor run.

1. Run the one-time policy cleanup block documented in the handoff.
2. Rerun `20260724020000_workforce_operations_flat_rate.sql` from the beginning.
3. Apply `20260724021500_harden_workforce_policy_replay.sql`.
4. Do not deploy application changes until both SQL steps complete successfully.

No production changes are performed by this PR.

## Validation

- Focused workforce/payroll suite: 103 passed across 11 files.
- New contract test: 8 passed.
- `git diff --check`: passed.
- Remote branch files were verified byte-for-byte against the tested local files.

## Database

Adds `supabase/migrations/20260724021500_harden_workforce_policy_replay.sql`.

## Environment variables

None required.
