### PR TITLE
Redesign dashboard tabs as record-based Open Work

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -36,6 +36,7 @@ import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/
 import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
 import { isReviewableQuoteLine } from "@/features/work-orders/lib/quotes/reviewableQuoteLines";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
+import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
 import { prepareSectionsWithCornerGrid } from "@inspections/lib/inspection/prepareSectionsWithCornerGrid";
 
@@ -218,6 +219,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   const params = useParams();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { updateActiveTab } = useTabs();
 
   const routeId = (params?.id as string) || "";
 
@@ -294,6 +296,33 @@ export default function WorkOrderIdClient(): JSX.Element {
 
   // ✅ read job from query (desktop panel)
   const jobFromQuery = searchParams?.get("job") || null;
+
+  useEffect(() => {
+    if (!wo) return;
+    const customerName =
+      customer?.business_name?.trim() ||
+      customer?.name?.trim() ||
+      [customer?.first_name ?? "", customer?.last_name ?? ""]
+        .filter(Boolean)
+        .join(" ")
+        .trim() ||
+      wo.customer_name?.trim() ||
+      "";
+    const vehicleLabel = vehicle
+      ? [vehicle.year, vehicle.make, vehicle.model]
+          .filter((value) => value != null && String(value).trim())
+          .join(" ")
+      : "";
+    const workOrderLabel = wo.custom_id?.trim() || `WO-${wo.id.slice(0, 8)}`;
+
+    updateActiveTab({
+      title: customerName
+        ? `${workOrderLabel} · ${customerName}`
+        : workOrderLabel,
+      subtitle: vehicleLabel || undefined,
+      status: formatDecisionStatus({ workStatus: wo.status }).label,
+    });
+  }, [customer, updateActiveTab, vehicle, wo]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -14,6 +14,7 @@ import {
   getActorCapabilities,
 } from "@/features/shared/lib/rbac";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
 type NavItem = {
   href: string;
@@ -102,6 +103,7 @@ export function MobileBottomNav({ open, onClose }: Props) {
   const pathname = usePathname();
   const router = useRouter();
   const supabase = useMemo(() => createBrowserSupabase(), []);
+  const { tabs, activateTab, closeTab } = useTabs();
   const [userId, setUserId] = useState<string | null>(null);
   const [role, setRole] = useState<MobileRole | null>(null);
   const [signingOut, setSigningOut] = useState(false);
@@ -206,6 +208,15 @@ export function MobileBottomNav({ open, onClose }: Props) {
     ];
   }, [role]);
 
+  const openWorkItems = useMemo(
+    () =>
+      tabs
+        .filter((item) => !item.pinned)
+        .sort((a, b) => b.lastOpenedAt - a.lastOpenedAt)
+        .slice(0, 6),
+    [tabs],
+  );
+
   const handleSignOut = async () => {
     if (signingOut) return;
     setSigningOut(true);
@@ -259,6 +270,73 @@ export function MobileBottomNav({ open, onClose }: Props) {
 
         <div className="flex-1 space-y-5 overflow-y-auto px-3 py-3">
           {userId ? <MobileShiftTracker userId={userId} /> : null}
+
+          <section className="space-y-2">
+            <div className="flex items-end justify-between gap-3 px-1">
+              <div>
+                <h2 className="text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">
+                  Open work
+                </h2>
+                <p className="mt-0.5 text-[0.66rem] text-[color:var(--theme-text-muted)]">
+                  Continue a working record
+                </p>
+              </div>
+              <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-0.5 text-[0.65rem] text-[color:var(--theme-text-secondary)]">
+                {tabs.filter((item) => !item.pinned).length}
+              </span>
+            </div>
+
+            {openWorkItems.length ? (
+              <div className="space-y-1.5">
+                {openWorkItems.map((item) => (
+                  <div
+                    key={item.key}
+                    className="flex items-center gap-1 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-1"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        activateTab(
+                          item.key,
+                          item.mobileHref ?? item.href,
+                        );
+                        onClose();
+                      }}
+                      className="min-w-0 flex-1 rounded-lg px-2 py-2 text-left active:bg-[color:var(--theme-surface-overlay)]"
+                    >
+                      <span className="flex items-center gap-2">
+                        <span className="truncate text-sm font-medium text-[color:var(--theme-text-primary)]">
+                          {item.title}
+                        </span>
+                        {item.dirty ? (
+                          <span
+                            aria-label="Unsaved changes"
+                            className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400"
+                          />
+                        ) : null}
+                      </span>
+                      <span className="mt-0.5 block truncate text-[0.68rem] text-[color:var(--theme-text-muted)]">
+                        {item.status || item.subtitle || "Ready to resume"}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => closeTab(item.key)}
+                      aria-label={`Close ${item.title}`}
+                      className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-lg text-[color:var(--theme-text-muted)] active:bg-[color:var(--theme-surface-overlay)]"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] px-3 py-3 text-[0.7rem] leading-4 text-[color:var(--theme-text-muted)]">
+                Work orders, inspections, invoices, and customer files you open
+                will stay here.
+              </div>
+            )}
+          </section>
 
           <MenuSection
             title="Navigation"

--- a/features/customers/app/customers/[id]/page.tsx
+++ b/features/customers/app/customers/[id]/page.tsx
@@ -17,6 +17,7 @@ import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageS
 import { CustomerCsvImportCard } from "@/features/customers/components/CustomerCsvImportCard";
 import { ImportedHistoryRecordCard } from "@/features/work-orders/components/ImportedHistoryRecordCard";
 import { usePersistentGuidedOnboardingQuery } from "@/features/onboarding-v2/guided/persistence";
+import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
 type DB = Database;
 
@@ -647,6 +648,29 @@ export default function CustomerProfilePage(): JSX.Element {
   ] = useState(false);
   const [newCustomer, setNewCustomer] =
     useState<NewCustomerDraft>(EMPTY_NEW_CUSTOMER);
+  const { updateActiveTab } = useTabs();
+
+  useEffect(() => {
+    if (!effectiveCustomerId || !customer) return;
+    const name = bestCustomerDisplayName(customer);
+    updateActiveTab({
+      title: `Customer · ${name}`,
+      subtitle:
+        vehicles.length > 0
+          ? `${vehicles.length} vehicle${vehicles.length === 1 ? "" : "s"}`
+          : undefined,
+      status:
+        workOrders.length > 0
+          ? `${workOrders.length} work order${workOrders.length === 1 ? "" : "s"}`
+          : "Customer file",
+    });
+  }, [
+    customer,
+    effectiveCustomerId,
+    updateActiveTab,
+    vehicles.length,
+    workOrders.length,
+  ]);
 
   const selectedVehicle = useMemo(() => {
     if (!selectedVehicleId) return null;

--- a/features/dashboard/components/DashboardTabs.tsx
+++ b/features/dashboard/components/DashboardTabs.tsx
@@ -6,13 +6,13 @@ import { motion, AnimatePresence } from "framer-motion";
 import { useMemo } from "react";
 
 export default function DashboardTabs() {
-  const { tabs, activeHref, activateTab, closeTab, closeOthers, closeAll } =
+  const { tabs, activeKey, activateTab, closeTab, closeOthers, closeAll } =
     useTabs();
 
   const hasTabs = tabs.length > 0;
   const canCloseOthers = useMemo(
-    () => hasTabs && tabs.some((t) => t.href !== activeHref),
-    [hasTabs, tabs, activeHref],
+    () => hasTabs && tabs.some((t) => t.key !== activeKey && !t.pinned),
+    [hasTabs, tabs, activeKey],
   );
 
   return (
@@ -27,7 +27,7 @@ export default function DashboardTabs() {
                   key={t.href}
                   className={[
                     "flex items-center gap-2 rounded px-3 py-1 whitespace-nowrap",
-                    t.href === activeHref
+                    t.key === activeKey
                       ? "bg-orange-700 text-[color:var(--theme-text-primary)] border border-orange-400"
                       : "bg-[color:var(--theme-surface-panel-strong)] text-[color:var(--theme-text-primary)] border border-[color:var(--theme-border-soft)] hover:border-orange-400/60",
                   ].join(" ")}
@@ -38,22 +38,17 @@ export default function DashboardTabs() {
                 >
                   <button
                     type="button"
-                    onClick={() => activateTab(t.href)}
+                    onClick={() => activateTab(t.key)}
                     className="flex items-center gap-2"
                     title={t.title}
-                    aria-current={t.href === activeHref ? "page" : undefined}
+                    aria-current={t.key === activeKey ? "page" : undefined}
                   >
-                    {t.icon ? (
-                      <span aria-hidden className="text-lg leading-none">
-                        {t.icon}
-                      </span>
-                    ) : null}
                     <span className="truncate max-w-[160px]">{t.title}</span>
                   </button>
 
                   <button
                     type="button"
-                    onClick={() => closeTab(t.href)}
+                    onClick={() => closeTab(t.key)}
                     className="ml-1 rounded px-1 text-xs leading-none text-red-300 hover:bg-red-900/30"
                     aria-label={`Close ${t.title}`}
                     title="Close"
@@ -72,7 +67,7 @@ export default function DashboardTabs() {
             {canCloseOthers && (
               <button
                 type="button"
-                onClick={() => closeOthers(activeHref)}
+                onClick={() => closeOthers(activeKey)}
                 className="rounded border border-orange-400 px-2 py-1 text-xs font-medium text-orange-300 hover:bg-orange-500/10"
               >
                 Close Others

--- a/features/inspections/app/inspection/[id]/page.tsx
+++ b/features/inspections/app/inspection/[id]/page.tsx
@@ -7,6 +7,7 @@ import PreviousPageButton from "@shared/components/ui/PreviousPageButton";
 import PageShell from "@/features/shared/components/PageShell";
 import Card from "@/features/shared/components/ui/Card";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
+import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
 // --- Types ---
 interface InspectionItem {
@@ -51,6 +52,7 @@ export default function InspectionDetailPage() {
   const [inspection, setInspection] = useState<CanonicalInspection | null>(null);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
+  const { updateActiveTab } = useTabs();
 
   useEffect(() => {
     const fetchInspection = async () => {
@@ -83,6 +85,17 @@ export default function InspectionDetailPage() {
       fetchInspection();
     }
   }, [id, router]);
+
+  useEffect(() => {
+    if (!inspection) return;
+    updateActiveTab({
+      title: `Inspection · ${inspection.templateName || inspection.id.slice(0, 8)}`,
+      status: inspection.status.replaceAll("_", " "),
+      subtitle: inspection.updatedAt
+        ? `Updated ${format(new Date(inspection.updatedAt), "PP")}`
+        : undefined,
+    });
+  }, [inspection, updateActiveTab]);
 
   const statusVariant = (status: string) => {
     const s = status.toLowerCase();

--- a/features/shared/components/tabs/TabsBar.tsx
+++ b/features/shared/components/tabs/TabsBar.tsx
@@ -1,9 +1,27 @@
 "use client";
 
-import { motion, AnimatePresence } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  CalendarDays,
+  ClipboardCheck,
+  LayoutDashboard,
+  MoreHorizontal,
+  ReceiptText,
+  Search,
+  UserRound,
+  WifiOff,
+  Wrench,
+  X,
+} from "lucide-react";
 import { usePathname } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/features/shared/utils/cn";
 import { useTabs } from "./TabsProvider";
+import {
+  visibleOpenWorkItems,
+  type OpenWorkItem,
+  type OpenWorkKind,
+} from "./openWork";
 
 const AUTH_ROUTES = new Set([
   "/sign-in",
@@ -16,104 +34,315 @@ type TabsBarProps = {
   subdued?: boolean;
 };
 
-export default function TabsBar({ subdued = false }: TabsBarProps) {
-  const { tabs, activeHref, activateTab, closeTab, closeOthers, closeAll } =
-    useTabs();
+function KindIcon({
+  kind,
+  className,
+}: {
+  kind: OpenWorkKind;
+  className?: string;
+}) {
+  const props = { className: cn("h-3.5 w-3.5", className), "aria-hidden": true };
+  if (kind === "dashboard") return <LayoutDashboard {...props} />;
+  if (kind === "inspection") return <ClipboardCheck {...props} />;
+  if (kind === "invoice") return <ReceiptText {...props} />;
+  if (kind === "customer") return <UserRound {...props} />;
+  if (kind === "appointment") return <CalendarDays {...props} />;
+  return <Wrench {...props} />;
+}
 
+function WorkSignals({ item }: { item: OpenWorkItem }) {
+  if (!item.dirty && !item.offline && !item.status) return null;
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      {item.dirty ? (
+        <span
+          aria-label="Unsaved changes"
+          title="Unsaved changes"
+          className="h-1.5 w-1.5 rounded-full bg-amber-400"
+        />
+      ) : null}
+      {item.offline ? (
+        <WifiOff
+          aria-label="Offline changes"
+          className="h-3 w-3 text-amber-400"
+        />
+      ) : null}
+      {item.status ? (
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-full bg-[var(--accent-copper)]"
+        />
+      ) : null}
+    </span>
+  );
+}
+
+export default function TabsBar({ subdued = false }: TabsBarProps) {
+  const {
+    tabs,
+    activeKey,
+    activateTab,
+    closeTab,
+    closeOthers,
+    closeAll,
+  } = useTabs();
   const pathname = usePathname() || "/";
+  const [openWorkOpen, setOpenWorkOpen] = useState(false);
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement | null>(null);
   const isDashboardRoute =
     pathname === "/dashboard" || pathname.startsWith("/dashboard/");
 
-  // ❌ Never show tabs on auth routes or polished dashboard surfaces
-  if (AUTH_ROUTES.has(pathname) || isDashboardRoute) {
-    return null;
-  }
+  const visibleTabs = useMemo(
+    () => visibleOpenWorkItems(tabs, activeKey, 5),
+    [activeKey, tabs],
+  );
+  const workItems = useMemo(
+    () =>
+      tabs
+        .filter((item) => !item.pinned)
+        .sort((a, b) => b.lastOpenedAt - a.lastOpenedAt),
+    [tabs],
+  );
+  const filteredWorkItems = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return workItems;
+    return workItems.filter((item) =>
+      [item.title, item.subtitle, item.status, item.kind]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(normalized),
+    );
+  }, [query, workItems]);
 
-  const safeTabs = Array.isArray(tabs) ? tabs : [];
+  useEffect(() => {
+    const onPointerDown = (event: PointerEvent) => {
+      if (
+        rootRef.current &&
+        event.target instanceof Node &&
+        !rootRef.current.contains(event.target)
+      ) {
+        setOpenWorkOpen(false);
+        setActionsOpen(false);
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpenWorkOpen(false);
+        setActionsOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, []);
+
+  if (AUTH_ROUTES.has(pathname) || isDashboardRoute) return null;
 
   return (
     <div
+      ref={rootRef}
       aria-hidden={subdued}
       className={cn(
-        "sticky top-0 z-20 -mt-1 w-full min-w-0 border-b px-2 transition-all duration-200",
+        "sticky top-0 z-20 -mt-1 hidden w-full min-w-0 border-b px-2 transition-all duration-200 md:block",
         "border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] backdrop-blur-lg",
         subdued && "pointer-events-none opacity-25 saturate-50",
       )}
     >
-      <div className="flex min-w-0 items-center gap-1.5 py-1">
-        <div className="min-w-0 flex-1 overflow-x-auto overflow-y-hidden [&::-webkit-scrollbar]:hidden">
-          <div className="flex w-max items-center gap-1">
+      <div className="flex min-w-0 items-center gap-1.5 py-1.5">
+        <div className="min-w-0 flex-1 overflow-hidden">
+          <div className="flex min-w-0 items-center gap-1.5">
             <AnimatePresence initial={false}>
-              {safeTabs.map((t) => {
-                const active = t.href === activeHref;
-                const pinned = !!t.pinned;
-
+              {visibleTabs.map((item) => {
+                const active = item.key === activeKey;
                 return (
                   <motion.div
-                    key={t.href}
+                    key={item.key}
                     layout
                     initial={{ opacity: 0, scale: 0.97 }}
                     animate={{ opacity: 1, scale: 1 }}
                     exit={{ opacity: 0, scale: 0.97 }}
                     className={cn(
-                      "group inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors",
+                      "group inline-flex h-9 min-w-0 max-w-[17rem] items-center gap-1 rounded-lg border pl-2.5 pr-1.5 text-xs transition",
                       active
-                        ? "border-[var(--brand-accent,#E39A6E)]/45 bg-[var(--theme-gradient-panel)] text-[color:var(--theme-text-primary)] shadow-[inset_0_1px_0_rgba(148,163,184,0.16)]"
-                        : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-secondary)] hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-panel)] hover:text-[color:var(--theme-text-primary)]",
+                        ? "border-[var(--accent-copper)]/60 bg-[color:var(--theme-surface-overlay)] text-[color:var(--theme-text-primary)] shadow-[0_0_0_1px_rgba(197,122,74,0.12),inset_0_1px_0_rgba(255,255,255,0.08)]"
+                        : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-panel)] hover:text-[color:var(--theme-text-primary)]",
+                      item.pinned && "shrink-0",
                     )}
                   >
                     <button
                       type="button"
-                      onClick={() => activateTab(t.href)}
-                      className="flex max-w-[200px] items-center gap-1"
+                      onClick={() => activateTab(item.key)}
+                      title={item.subtitle || item.title}
+                      aria-current={active ? "page" : undefined}
+                      className="flex min-w-0 flex-1 items-center gap-2 py-2 text-left"
                     >
-                      <span className="truncate leading-none">{t.title}</span>
-                      {pinned && (
-                        <span
-                          aria-label="Default dashboard tab"
-                          className="rounded-sm border border-[color:var(--theme-border-soft)] px-1 py-px text-[8px] uppercase tracking-[0.1em] text-[color:var(--theme-text-secondary)]"
-                        >
-                          Base
-                        </span>
-                      )}
+                      <KindIcon
+                        kind={item.kind}
+                        className={active ? "text-[var(--accent-copper)]" : ""}
+                      />
+                      <span className="truncate font-medium">{item.title}</span>
+                      <WorkSignals item={item} />
                     </button>
-
-                    {!pinned && (
+                    {!item.pinned ? (
                       <button
                         type="button"
-                        onClick={() => closeTab(t.href)}
-                        className="inline-flex h-3.5 w-3.5 items-center justify-center rounded text-[10px] leading-none text-[color:var(--theme-text-muted)] transition hover:bg-[color:var(--theme-surface-hover)] hover:text-[color:var(--theme-text-primary)]"
-                        aria-label="Close tab"
+                        onClick={() => closeTab(item.key)}
+                        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[color:var(--theme-text-muted)] transition hover:bg-[color:var(--theme-surface-hover)] hover:text-[color:var(--theme-text-primary)]"
+                        aria-label={`Close ${item.title}`}
                       >
-                        ✕
+                        <X className="h-3.5 w-3.5" aria-hidden />
                       </button>
-                    )}
+                    ) : null}
                   </motion.div>
                 );
               })}
             </AnimatePresence>
-
-            {safeTabs.length === 0 && (
-              <div className="px-2 py-1 text-xs text-[color:var(--theme-text-muted)]">No tabs yet</div>
-            )}
           </div>
         </div>
 
-        <div className="ml-1.5 flex shrink-0 items-center gap-1.5">
+        <div className="relative ml-auto flex shrink-0 items-center gap-1.5">
           <button
             type="button"
-            onClick={() => closeOthers(activeHref)}
-            className="inline-flex h-6 items-center rounded border border-[color:var(--theme-border-soft)] px-1.5 text-[10px] text-[color:var(--theme-text-secondary)] transition hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-panel)] hover:text-[color:var(--theme-text-primary)]"
+            onClick={() => {
+              setOpenWorkOpen((current) => !current);
+              setActionsOpen(false);
+            }}
+            aria-expanded={openWorkOpen}
+            className={cn(
+              "inline-flex h-9 items-center gap-2 rounded-lg border px-3 text-xs font-medium transition",
+              openWorkOpen
+                ? "border-[var(--accent-copper)]/60 bg-[color:var(--theme-surface-overlay)] text-[color:var(--theme-text-primary)]"
+                : "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]",
+            )}
           >
-            Close others
+            <Wrench className="h-3.5 w-3.5" aria-hidden />
+            Open work ({workItems.length})
           </button>
           <button
             type="button"
-            onClick={closeAll}
-            className="inline-flex h-6 items-center rounded border border-[color:var(--theme-border-soft)] px-1.5 text-[10px] text-[color:var(--theme-text-secondary)] transition hover:border-[color:var(--theme-border-soft)] hover:bg-[color:var(--theme-surface-panel)] hover:text-[color:var(--theme-text-primary)]"
+            onClick={() => {
+              setActionsOpen((current) => !current);
+              setOpenWorkOpen(false);
+            }}
+            aria-label="Open work actions"
+            aria-expanded={actionsOpen}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-secondary)] transition hover:text-[color:var(--theme-text-primary)]"
           >
-            Close all
+            <MoreHorizontal className="h-4 w-4" aria-hidden />
           </button>
+
+          {openWorkOpen ? (
+            <section className="absolute right-10 top-[calc(100%+0.5rem)] z-50 w-[min(25rem,calc(100vw-2rem))] overflow-hidden rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] shadow-[var(--theme-shadow-medium)]">
+              <div className="border-b border-[color:var(--theme-border-soft)] p-3">
+                <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  Open work
+                </div>
+                <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">
+                  Working records saved on this device
+                </div>
+                <label className="mt-3 flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2">
+                  <Search
+                    className="h-3.5 w-3.5 text-[color:var(--theme-text-muted)]"
+                    aria-hidden
+                  />
+                  <span className="sr-only">Search open work</span>
+                  <input
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Search work orders, customers…"
+                    className="min-w-0 flex-1 bg-transparent text-xs text-[color:var(--theme-text-primary)] outline-none placeholder:text-[color:var(--theme-text-muted)]"
+                  />
+                </label>
+              </div>
+
+              <div className="max-h-[24rem] overflow-y-auto p-2">
+                {filteredWorkItems.length ? (
+                  filteredWorkItems.map((item) => (
+                    <div
+                      key={item.key}
+                      className={cn(
+                        "group flex items-center gap-2 rounded-xl px-2 py-1.5",
+                        item.key === activeKey
+                          ? "bg-[color:var(--theme-surface-overlay)]"
+                          : "hover:bg-[color:var(--theme-surface-subtle)]",
+                      )}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => {
+                          activateTab(item.key);
+                          setOpenWorkOpen(false);
+                        }}
+                        className="flex min-w-0 flex-1 items-center gap-3 px-1 py-1.5 text-left"
+                      >
+                        <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[var(--accent-copper)]">
+                          <KindIcon kind={item.kind} />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center gap-2">
+                            <span className="truncate text-xs font-medium text-[color:var(--theme-text-primary)]">
+                              {item.title}
+                            </span>
+                            <WorkSignals item={item} />
+                          </span>
+                          <span className="mt-0.5 block truncate text-[10px] text-[color:var(--theme-text-muted)]">
+                            {item.status || item.subtitle || "Ready to resume"}
+                          </span>
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => closeTab(item.key)}
+                        aria-label={`Close ${item.title}`}
+                        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[color:var(--theme-text-muted)] hover:bg-[color:var(--theme-surface-hover)] hover:text-[color:var(--theme-text-primary)]"
+                      >
+                        <X className="h-3.5 w-3.5" aria-hidden />
+                      </button>
+                    </div>
+                  ))
+                ) : (
+                  <div className="px-3 py-8 text-center text-xs text-[color:var(--theme-text-muted)]">
+                    {workItems.length
+                      ? "No open work matches that search."
+                      : "Open a work order, inspection, invoice, or customer file to keep it here."}
+                  </div>
+                )}
+              </div>
+            </section>
+          ) : null}
+
+          {actionsOpen ? (
+            <div className="absolute right-0 top-[calc(100%+0.5rem)] z-50 w-44 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-1.5 shadow-[var(--theme-shadow-medium)]">
+              <button
+                type="button"
+                onClick={() => {
+                  closeOthers(activeKey);
+                  setActionsOpen(false);
+                }}
+                disabled={!activeKey || activeKey === "dashboard"}
+                className="w-full rounded-lg px-3 py-2 text-left text-xs text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Close other work
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  closeAll();
+                  setActionsOpen(false);
+                }}
+                disabled={workItems.length === 0}
+                className="w-full rounded-lg px-3 py-2 text-left text-xs text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Close all work
+              </button>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/features/shared/components/tabs/TabsProvider.tsx
+++ b/features/shared/components/tabs/TabsProvider.tsx
@@ -2,6 +2,7 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -9,18 +10,27 @@ import {
   useState,
 } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { metaFor } from "@/features/shared/lib/routeMeta";
-
-type Tab = { href: string; title: string; icon?: string; pinned?: boolean };
+import {
+  DASHBOARD_OPEN_WORK_ITEM,
+  migrateLegacyTabs,
+  resolveOpenWork,
+  sanitizePersistedOpenWork,
+  updateOpenWorkItem,
+  upsertOpenWork,
+  type OpenWorkItem,
+  type OpenWorkUpdate,
+} from "./openWork";
 
 type TabsContextValue = {
-  tabs: Tab[];
+  tabs: OpenWorkItem[];
+  activeKey: string;
   activeHref: string;
   openTab: (href: string) => void;
-  activateTab: (href: string) => void;
-  closeTab: (href: string) => void;
-  closeOthers: (href: string) => void;
+  activateTab: (key: string, navigationHref?: string) => void;
+  closeTab: (key: string) => void;
+  closeOthers: (key: string) => void;
   closeAll: () => void;
+  updateActiveTab: (update: OpenWorkUpdate) => void;
 };
 
 const TabsCtx = createContext<TabsContextValue | null>(null);
@@ -32,19 +42,23 @@ export const useTabs = (): TabsContextValue => {
 };
 
 function storageKey(userId?: string) {
+  return `open-work:v2:${userId ?? "anon"}`;
+}
+
+function legacyStorageKey(userId?: string) {
   return `dash-tabs:${userId ?? "anon"}`;
 }
 
-type PersistShape = { tabs: Tab[]; activeHref: string };
+type PersistShape = {
+  version: 2;
+  tabs: OpenWorkItem[];
+  activeKey: string;
+};
 
-const DASH_TAB: Tab = { href: "/dashboard", title: "Dashboard", pinned: true };
-
-function ensurePinnedDashboard(list: Tab[]): Tab[] {
-  const withoutDash = (Array.isArray(list) ? list : []).filter(
-    (t) => t?.href && t.href !== "/dashboard",
-  );
-  return [DASH_TAB, ...withoutDash];
-}
+type LegacyPersistShape = {
+  tabs?: Array<{ href?: unknown; title?: unknown }>;
+  activeHref?: unknown;
+};
 
 export function TabsProvider({
   children,
@@ -55,143 +69,224 @@ export function TabsProvider({
 }) {
   const router = useRouter();
   const pathname = usePathname() || "/";
+  const [tabs, setTabs] = useState<OpenWorkItem[]>([
+    DASHBOARD_OPEN_WORK_ITEM,
+  ]);
+  const [activeKey, setActiveKey] = useState("dashboard");
+  const [hydrated, setHydrated] = useState(false);
+  const lastPath = useRef<string>("");
+  const initialPath = useRef(pathname);
+  const hydratedStorageKey = useRef<string | null>(null);
+  const dashboardHref =
+    pathname === "/mobile" || pathname.startsWith("/mobile/")
+      ? "/mobile"
+      : "/dashboard";
 
-  // ✅ Synchronous initial state: dashboard tab exists immediately
-  const [tabs, setTabs] = useState<Tab[]>(() => [DASH_TAB]);
-  const [activeHref, setActiveHref] = useState<string>(() => "/dashboard");
-
-  // Load persisted (but always ensure dashboard pinned)
   useEffect(() => {
+    hydratedStorageKey.current = null;
     try {
       const raw = localStorage.getItem(storageKey(userId));
-      if (!raw) return;
-      const parsed = JSON.parse(raw) as Partial<PersistShape>;
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<PersistShape>;
+        const loaded = sanitizePersistedOpenWork(parsed.tabs);
+        const currentRouteKey =
+          resolveOpenWork(initialPath.current)?.key ?? "";
+        setTabs(loaded);
+        setActiveKey(
+          loaded.some((item) => item.key === currentRouteKey)
+            ? currentRouteKey
+            : "",
+        );
+        setHydrated(true);
+        return;
+      }
 
-      const loaded = Array.isArray(parsed.tabs) ? parsed.tabs : [];
-      setTabs(ensurePinnedDashboard(loaded));
-
-      if (typeof parsed.activeHref === "string" && parsed.activeHref.trim()) {
-        setActiveHref(parsed.activeHref);
-      } else {
-        setActiveHref("/dashboard");
+      const legacyRaw = localStorage.getItem(legacyStorageKey(userId));
+      if (legacyRaw) {
+        const legacy = JSON.parse(legacyRaw) as LegacyPersistShape;
+        const migrated = migrateLegacyTabs(
+          Array.isArray(legacy.tabs) ? legacy.tabs : [],
+        );
+        const legacyActive =
+          typeof legacy.activeHref === "string"
+            ? resolveOpenWork(legacy.activeHref)
+            : null;
+        const currentRouteKey =
+          resolveOpenWork(initialPath.current)?.key ?? "";
+        setTabs(migrated);
+        setActiveKey(
+          migrated.some((item) => item.key === currentRouteKey)
+            ? currentRouteKey
+            : legacyActive &&
+                migrated.some((item) => item.key === legacyActive.key) &&
+                initialPath.current === legacyActive.href
+              ? legacyActive.key
+              : "",
+        );
       }
     } catch {
-      // noop
+      setTabs([DASHBOARD_OPEN_WORK_ITEM]);
+      setActiveKey("dashboard");
+    } finally {
+      hydratedStorageKey.current = storageKey(userId);
+      setHydrated(true);
     }
   }, [userId]);
 
-  // Persist
   useEffect(() => {
-    try {
-      localStorage.setItem(
-        storageKey(userId),
-        JSON.stringify({ tabs, activeHref }),
-      );
-    } catch {
-      // noop
+    if (
+      !hydrated ||
+      hydratedStorageKey.current !== storageKey(userId)
+    ) {
+      return;
     }
-  }, [tabs, activeHref, userId]);
+    try {
+      const payload: PersistShape = { version: 2, tabs, activeKey };
+      localStorage.setItem(storageKey(userId), JSON.stringify(payload));
+    } catch {
+      // Local storage can be unavailable in private browsing or managed devices.
+    }
+  }, [tabs, activeKey, hydrated, userId]);
 
-  // Sync across browser tabs/windows
   useEffect(() => {
-    const onStorage = (e: StorageEvent) => {
-      if (e.key !== storageKey(userId) || !e.newValue) return;
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== storageKey(userId) || !event.newValue) return;
       try {
-        const parsed = JSON.parse(e.newValue) as PersistShape;
-        const loaded = Array.isArray(parsed.tabs) ? parsed.tabs : [];
-        setTabs(ensurePinnedDashboard(loaded));
-        setActiveHref(parsed.activeHref || "/dashboard");
+        const parsed = JSON.parse(event.newValue) as Partial<PersistShape>;
+        const loaded = sanitizePersistedOpenWork(parsed.tabs);
+        const currentRouteKey = resolveOpenWork(pathname)?.key ?? "";
+        setTabs(loaded);
+        setActiveKey(
+          loaded.some((item) => item.key === currentRouteKey)
+            ? currentRouteKey
+            : "",
+        );
       } catch {
-        // noop
+        // Ignore malformed writes from stale browser sessions.
       }
     };
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
-  }, [userId]);
+  }, [pathname, userId]);
 
-  // Auto-open a tab if route wants to appear
-  const lastPath = useRef<string>("");
   useEffect(() => {
     if (!pathname || pathname === lastPath.current) return;
     lastPath.current = pathname;
 
-    const { title, icon, show } = metaFor(pathname);
+    const next = resolveOpenWork(pathname);
+    if (!next) {
+      setActiveKey("");
+      return;
+    }
 
-    // Always keep activeHref in sync with navigation
-    setActiveHref(pathname);
-
-    if (!show) return;
-
-    setTabs((prev) => {
-      const next = ensurePinnedDashboard(prev);
-      if (next.some((t) => t.href === pathname)) return next;
-      return [...next, { href: pathname, title, icon }];
-    });
+    setActiveKey(next.key);
+    if (next.key !== DASHBOARD_OPEN_WORK_ITEM.key) {
+      setTabs((current) => upsertOpenWork(current, next));
+    }
   }, [pathname]);
+
+  const openTab = useCallback(
+    (href: string) => {
+      const next = resolveOpenWork(href);
+      if (next) {
+        setActiveKey(next.key);
+        if (next.key !== DASHBOARD_OPEN_WORK_ITEM.key) {
+          setTabs((current) => upsertOpenWork(current, next));
+        }
+      }
+      router.push(href);
+    },
+    [router],
+  );
+
+  const activateTab = useCallback(
+    (key: string, navigationHref?: string) => {
+      const item = tabs.find((candidate) => candidate.key === key);
+      if (!item) return;
+      setActiveKey(key);
+      setTabs((current) =>
+        current.map((candidate) =>
+          candidate.key === key && !candidate.pinned
+            ? { ...candidate, lastOpenedAt: Date.now() }
+            : candidate,
+        ),
+      );
+      router.push(navigationHref ?? item.href);
+    },
+    [router, tabs],
+  );
+
+  const closeTab = useCallback(
+    (key: string) => {
+      if (key === DASHBOARD_OPEN_WORK_ITEM.key) return;
+      const closingActive = activeKey === key;
+      setTabs((current) =>
+        current.filter((item) => item.key !== key || item.pinned),
+      );
+      if (closingActive) {
+        setActiveKey("dashboard");
+        router.push(dashboardHref);
+      }
+    },
+    [activeKey, dashboardHref, router],
+  );
+
+  const closeOthers = useCallback(
+    (key: string) => {
+      const item = tabs.find((candidate) => candidate.key === key);
+      if (!item || key === DASHBOARD_OPEN_WORK_ITEM.key) {
+        setTabs([DASHBOARD_OPEN_WORK_ITEM]);
+        setActiveKey("dashboard");
+        router.push(dashboardHref);
+        return;
+      }
+      setTabs([DASHBOARD_OPEN_WORK_ITEM, item]);
+      setActiveKey(key);
+      router.push(item.href);
+    },
+    [dashboardHref, router, tabs],
+  );
+
+  const closeAll = useCallback(() => {
+    setTabs([DASHBOARD_OPEN_WORK_ITEM]);
+    setActiveKey("dashboard");
+    router.push(dashboardHref);
+  }, [dashboardHref, router]);
+
+  const updateActiveTab = useCallback(
+    (update: OpenWorkUpdate) => {
+      if (!activeKey || activeKey === DASHBOARD_OPEN_WORK_ITEM.key) return;
+      setTabs((current) => updateOpenWorkItem(current, activeKey, update));
+    },
+    [activeKey],
+  );
+
+  const activeHref =
+    tabs.find((item) => item.key === activeKey)?.href ?? pathname;
 
   const api = useMemo<TabsContextValue>(
     () => ({
       tabs,
+      activeKey,
       activeHref,
-
-      openTab: (href) => {
-        const { title, icon, show } = metaFor(href);
-
-        setActiveHref(href);
-        router.push(href);
-
-        if (!show) return;
-
-        setTabs((prev) => {
-          const next = ensurePinnedDashboard(prev);
-          if (next.some((t) => t.href === href)) return next;
-          return [...next, { href, title, icon }];
-        });
-      },
-
-      activateTab: (href) => {
-        setActiveHref(href);
-        router.push(href);
-      },
-
-      closeTab: (href) => {
-        if (href === "/dashboard") return; // pinned
-
-        setTabs((prev) => {
-          const nextTabs = ensurePinnedDashboard(
-            prev.filter((t) => t.href !== href),
-          );
-
-          // If closing active tab, pick a new active tab based on nextTabs
-          if (activeHref === href) {
-            const last = nextTabs[nextTabs.length - 1]?.href ?? "/dashboard";
-            setActiveHref(last);
-            router.push(last);
-          }
-
-          return nextTabs;
-        });
-      },
-
-      closeOthers: (href) => {
-        setTabs((prev) => {
-          const keep =
-            href === "/dashboard"
-              ? [DASH_TAB]
-              : [DASH_TAB, ...prev.filter((t) => t.href === href)];
-          return ensurePinnedDashboard(keep);
-        });
-        setActiveHref(href);
-        router.push(href);
-      },
-
-      closeAll: () => {
-        setTabs([DASH_TAB]);
-        setActiveHref("/dashboard");
-        router.push("/dashboard");
-      },
+      openTab,
+      activateTab,
+      closeTab,
+      closeOthers,
+      closeAll,
+      updateActiveTab,
     }),
-    [tabs, activeHref, router],
+    [
+      tabs,
+      activeKey,
+      activeHref,
+      openTab,
+      activateTab,
+      closeTab,
+      closeOthers,
+      closeAll,
+      updateActiveTab,
+    ],
   );
 
   return <TabsCtx.Provider value={api}>{children}</TabsCtx.Provider>;

--- a/features/shared/components/tabs/openWork.ts
+++ b/features/shared/components/tabs/openWork.ts
@@ -1,0 +1,366 @@
+export type OpenWorkKind =
+  | "dashboard"
+  | "work-order"
+  | "inspection"
+  | "invoice"
+  | "customer"
+  | "appointment";
+
+export type OpenWorkItem = {
+  key: string;
+  href: string;
+  mobileHref?: string;
+  title: string;
+  subtitle?: string;
+  kind: OpenWorkKind;
+  status?: string;
+  dirty?: boolean;
+  offline?: boolean;
+  pinned?: boolean;
+  lastOpenedAt: number;
+};
+
+export type OpenWorkUpdate = Partial<
+  Pick<
+    OpenWorkItem,
+    "title" | "subtitle" | "status" | "dirty" | "offline"
+  >
+>;
+
+export const DASHBOARD_OPEN_WORK_ITEM: OpenWorkItem = {
+  key: "dashboard",
+  href: "/dashboard",
+  mobileHref: "/mobile",
+  title: "Dashboard",
+  kind: "dashboard",
+  pinned: true,
+  lastOpenedAt: 0,
+};
+
+const WORK_ORDER_STATIC_SEGMENTS = new Set([
+  "board",
+  "confirm",
+  "create",
+  "editor",
+  "history",
+  "invoice",
+  "queue",
+  "quote-review",
+  "view",
+]);
+
+const INSPECTION_STATIC_SEGMENTS = new Set([
+  "created",
+  "custom-draft",
+  "custom-inspection",
+  "customer-vehicle",
+  "fill",
+  "findings",
+  "fleet-import",
+  "fleet-review",
+  "genericInspection",
+  "run",
+  "saved",
+  "summary",
+  "summaries",
+  "templates",
+]);
+
+const CUSTOMER_STATIC_SEGMENTS = new Set(["all", "directory", "search"]);
+
+function cleanPath(href: string): string {
+  const path = String(href || "/").split(/[?#]/, 1)[0] || "/";
+  return path.length > 1 ? path.replace(/\/+$/, "") : path;
+}
+
+function pathSegments(href: string): string[] {
+  return cleanPath(href).split("/").filter(Boolean);
+}
+
+function shortId(id: string): string {
+  const decoded = decodeURIComponent(id);
+  return decoded.includes("-") && decoded.length >= 24
+    ? decoded.slice(0, 8)
+    : decoded;
+}
+
+function workOrderItem(
+  id: string,
+  href: string,
+  now: number,
+): OpenWorkItem {
+  const label = shortId(id);
+  return {
+    key: `work-order:${id}`,
+    href,
+    mobileHref: `/mobile/work-orders/${encodeURIComponent(id)}`,
+    title: `WO · ${label}`,
+    kind: "work-order",
+    lastOpenedAt: now,
+  };
+}
+
+function invoiceItem(id: string, href: string, now: number): OpenWorkItem {
+  return {
+    key: `invoice:${id}`,
+    href,
+    mobileHref: `/mobile/work-orders/${encodeURIComponent(id)}`,
+    title: `Invoice · ${shortId(id)}`,
+    kind: "invoice",
+    lastOpenedAt: now,
+  };
+}
+
+export function resolveOpenWork(
+  href: string,
+  now = Date.now(),
+): OpenWorkItem | null {
+  const path = cleanPath(href);
+  const segments = pathSegments(path);
+
+  if (path === "/dashboard" || path === "/mobile") {
+    return DASHBOARD_OPEN_WORK_ITEM;
+  }
+
+  if (
+    segments[0] === "work-orders" &&
+    segments[1] === "invoice" &&
+    segments[2]
+  ) {
+    return invoiceItem(segments[2], path, now);
+  }
+
+  if (
+    segments[0] === "work-orders" &&
+    segments[1] === "view" &&
+    segments[2]
+  ) {
+    return workOrderItem(segments[2], `/work-orders/${segments[2]}`, now);
+  }
+
+  if (
+    segments[0] === "work-orders" &&
+    segments[1] &&
+    !WORK_ORDER_STATIC_SEGMENTS.has(segments[1])
+  ) {
+    if (segments[2] === "invoice") {
+      return invoiceItem(
+        segments[1],
+        `/work-orders/invoice/${segments[1]}`,
+        now,
+      );
+    }
+    return workOrderItem(segments[1], path, now);
+  }
+
+  if (segments[0] === "quote-review" && segments[1]) {
+    return workOrderItem(segments[1], path, now);
+  }
+
+  if (
+    segments[0] === "mobile" &&
+    segments[1] === "work-orders" &&
+    segments[2] &&
+    segments[2] !== "create" &&
+    segments[2] !== "view"
+  ) {
+    return workOrderItem(
+      segments[2],
+      `/work-orders/${segments[2]}`,
+      now,
+    );
+  }
+
+  if (
+    segments[0] === "inspections" &&
+    segments[1] &&
+    !INSPECTION_STATIC_SEGMENTS.has(segments[1])
+  ) {
+    return {
+      key: `inspection:${segments[1]}`,
+      href: path,
+      mobileHref: `/mobile/inspections/${encodeURIComponent(segments[1])}`,
+      title: `Inspection · ${shortId(segments[1])}`,
+      kind: "inspection",
+      lastOpenedAt: now,
+    };
+  }
+
+  if (
+    segments[0] === "mobile" &&
+    segments[1] === "inspections" &&
+    segments[2] &&
+    segments[2] !== "import"
+  ) {
+    return {
+      key: `inspection:${segments[2]}`,
+      href: `/inspections/${segments[2]}`,
+      mobileHref: `/mobile/inspections/${encodeURIComponent(segments[2])}`,
+      title: `Inspection · ${shortId(segments[2])}`,
+      kind: "inspection",
+      lastOpenedAt: now,
+    };
+  }
+
+  if (
+    segments[0] === "customers" &&
+    segments[1] &&
+    !CUSTOMER_STATIC_SEGMENTS.has(segments[1])
+  ) {
+    return {
+      key: `customer:${segments[1]}`,
+      href: path,
+      mobileHref: `/mobile/customers/${encodeURIComponent(segments[1])}`,
+      title: `Customer · ${shortId(segments[1])}`,
+      kind: "customer",
+      lastOpenedAt: now,
+    };
+  }
+
+  if (
+    segments[0] === "mobile" &&
+    segments[1] === "customers" &&
+    segments[2]
+  ) {
+    return {
+      key: `customer:${segments[2]}`,
+      href: `/customers/${segments[2]}`,
+      mobileHref: `/mobile/customers/${encodeURIComponent(segments[2])}`,
+      title: `Customer · ${shortId(segments[2])}`,
+      kind: "customer",
+      lastOpenedAt: now,
+    };
+  }
+
+  return null;
+}
+
+export function ensureOpenWorkDashboard(
+  items: OpenWorkItem[],
+): OpenWorkItem[] {
+  const withoutDashboard = items.filter(
+    (item) => item?.key && item.key !== DASHBOARD_OPEN_WORK_ITEM.key,
+  );
+  return [DASHBOARD_OPEN_WORK_ITEM, ...withoutDashboard];
+}
+
+export function upsertOpenWork(
+  items: OpenWorkItem[],
+  incoming: OpenWorkItem,
+  maxItems = 24,
+): OpenWorkItem[] {
+  if (incoming.key === DASHBOARD_OPEN_WORK_ITEM.key) {
+    return ensureOpenWorkDashboard(items);
+  }
+
+  const current = items.find((item) => item.key === incoming.key);
+  const merged = current
+    ? {
+        ...current,
+        ...incoming,
+        title:
+          current.title !== resolveOpenWork(current.href, 0)?.title
+            ? current.title
+            : incoming.title,
+        subtitle: current.subtitle,
+        status: current.status,
+        dirty: current.dirty,
+        offline: current.offline,
+      }
+    : incoming;
+
+  const work = items
+    .filter(
+      (item) =>
+        item.key !== DASHBOARD_OPEN_WORK_ITEM.key && item.key !== incoming.key,
+    )
+    .concat(merged)
+    .sort((a, b) => b.lastOpenedAt - a.lastOpenedAt)
+    .slice(0, Math.max(1, maxItems - 1));
+
+  return [DASHBOARD_OPEN_WORK_ITEM, ...work];
+}
+
+export function updateOpenWorkItem(
+  items: OpenWorkItem[],
+  key: string,
+  update: OpenWorkUpdate,
+): OpenWorkItem[] {
+  return items.map((item) =>
+    item.key === key ? { ...item, ...update } : item,
+  );
+}
+
+export function visibleOpenWorkItems(
+  items: OpenWorkItem[],
+  activeKey: string,
+  maxVisible = 5,
+): OpenWorkItem[] {
+  const dashboard =
+    items.find((item) => item.key === DASHBOARD_OPEN_WORK_ITEM.key) ??
+    DASHBOARD_OPEN_WORK_ITEM;
+  const work = items
+    .filter((item) => item.key !== DASHBOARD_OPEN_WORK_ITEM.key)
+    .sort((a, b) => b.lastOpenedAt - a.lastOpenedAt);
+  const active = work.find((item) => item.key === activeKey);
+  const remaining = work.filter((item) => item.key !== activeKey);
+  return [dashboard, ...(active ? [active] : []), ...remaining].slice(
+    0,
+    Math.max(1, maxVisible),
+  );
+}
+
+type LegacyTab = {
+  href?: unknown;
+  title?: unknown;
+  icon?: unknown;
+  pinned?: unknown;
+};
+
+export function migrateLegacyTabs(
+  legacyTabs: LegacyTab[],
+  now = Date.now(),
+): OpenWorkItem[] {
+  let next: OpenWorkItem[] = [DASHBOARD_OPEN_WORK_ITEM];
+  for (const [index, legacy] of legacyTabs.entries()) {
+    if (typeof legacy?.href !== "string") continue;
+    const resolved = resolveOpenWork(legacy.href, now + index);
+    if (!resolved || resolved.key === DASHBOARD_OPEN_WORK_ITEM.key) continue;
+    next = upsertOpenWork(next, resolved);
+  }
+  return next;
+}
+
+export function sanitizePersistedOpenWork(
+  value: unknown,
+): OpenWorkItem[] {
+  if (!Array.isArray(value)) return [DASHBOARD_OPEN_WORK_ITEM];
+
+  let next: OpenWorkItem[] = [DASHBOARD_OPEN_WORK_ITEM];
+  for (const candidate of value) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const item = candidate as Partial<OpenWorkItem>;
+    if (
+      typeof item.key !== "string" ||
+      typeof item.href !== "string" ||
+      typeof item.title !== "string" ||
+      typeof item.kind !== "string"
+    ) {
+      continue;
+    }
+    const resolved = resolveOpenWork(item.href);
+    if (!resolved || resolved.key !== item.key) continue;
+    next = upsertOpenWork(next, {
+      ...resolved,
+      ...item,
+      kind: resolved.kind,
+      pinned: false,
+      lastOpenedAt:
+        typeof item.lastOpenedAt === "number" &&
+        Number.isFinite(item.lastOpenedAt)
+          ? item.lastOpenedAt
+          : resolved.lastOpenedAt,
+    });
+  }
+  return next;
+}

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -512,6 +512,20 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   },
 };
 
+function routeMetaMatches(pattern: string, href: string): boolean {
+  const path = href.split(/[?#]/, 1)[0] || "/";
+  const patternSegments = pattern.split("/").filter(Boolean);
+  const pathSegments = path.split("/").filter(Boolean);
+  if (patternSegments.length !== pathSegments.length) return false;
+
+  return patternSegments.every((segment, index) => {
+    if (segment.startsWith("[") && segment.endsWith("]")) {
+      return pathSegments[index].length > 0;
+    }
+    return segment === pathSegments[index];
+  });
+}
+
 export function metaFor(
   href: string,
   _params?: Record<string, string>,
@@ -520,9 +534,7 @@ export function metaFor(
   const keys = Object.keys(ROUTE_META).sort((a, b) => b.length - a.length);
 
   for (const key of keys) {
-    const isDyn = key.includes("[");
-    const keyPrefix = key.replace(/\[.*?\]/g, "");
-    if ((isDyn && href.startsWith(keyPrefix)) || (!isDyn && href === key)) {
+    if (routeMetaMatches(key, href)) {
       const m = ROUTE_META[key];
 
       const allowed =

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -13,6 +13,7 @@ import CustomerPaymentButton from "@/features/stripe/components/CustomerPaymentB
 import { WorkOrderInvoiceDownloadButton } from "@work-orders/components/WorkOrderInvoiceDownloadButton";
 import SyncInvoiceToQuickBooksButton from "@/features/integrations/quickbooks/components/SyncInvoiceToQuickBooksButton";
 import RecordManualPayment from "@/features/invoices/components/RecordManualPayment";
+import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
 type DB = Database;
 
@@ -270,6 +271,7 @@ export default function InvoicePreviewPageClient({
 }: Props) {
   const router = useRouter();
   const supabase = useMemo(() => createBrowserSupabase(), []);
+  const { updateActiveTab } = useTabs();
 
   const [loading, setLoading] = useState(false);
   const [shopId, setShopId] = useState<string | null>(null);
@@ -278,6 +280,7 @@ export default function InvoicePreviewPageClient({
 
   const [shopInfo, setShopInfo] = useState<ShopInfo | undefined>(undefined);
   const [invoiceId, setInvoiceId] = useState<string | null>(null);
+  const [workOrderLabel, setWorkOrderLabel] = useState<string | null>(null);
   const [canonicalSnapshot, setCanonicalSnapshot] =
     useState<InvoiceSnapshotView | null>(null);
   const [activeInvoiceVersion, setActiveInvoiceVersion] =
@@ -311,6 +314,29 @@ export default function InvoicePreviewPageClient({
 
   const effectiveVehicleInfo = vehicleInfo ?? fVehicleInfo;
   const effectiveCustomerInfo = customerInfo ?? fCustomerInfo;
+
+  useEffect(() => {
+    const label = workOrderLabel || workOrderId.slice(0, 8);
+    updateActiveTab({
+      title: `Invoice · ${label}`,
+      subtitle:
+        effectiveCustomerInfo?.name?.trim() ||
+        effectiveCustomerInfo?.business_name?.trim() ||
+        undefined,
+      status:
+        activeInvoiceVersion?.lifecycle_status?.replaceAll("_", " ") ||
+        (reviewLoading ? "Reviewing" : reviewOk ? "Ready" : "Draft"),
+    });
+  }, [
+    activeInvoiceVersion?.lifecycle_status,
+    effectiveCustomerInfo?.business_name,
+    effectiveCustomerInfo?.name,
+    reviewLoading,
+    reviewOk,
+    updateActiveTab,
+    workOrderId,
+    workOrderLabel,
+  ]);
 
   const effectiveLines = useMemo(() => {
     const provided = Array.isArray(lines) ? lines : undefined;
@@ -424,13 +450,14 @@ export default function InvoicePreviewPageClient({
       const { data: woRow, error: woErr } = await supabase
         .from("work_orders")
         .select(
-          "id, shop_id, customer_id, vehicle_id, labor_total, parts_total, invoice_total, customer_name",
+          "id, custom_id, shop_id, customer_id, vehicle_id, labor_total, parts_total, invoice_total, customer_name",
         )
         .eq("id", workOrderId)
         .maybeSingle<
           Pick<
             WorkOrderRow,
             | "id"
+            | "custom_id"
             | "shop_id"
             | "customer_id"
             | "vehicle_id"
@@ -453,6 +480,7 @@ export default function InvoicePreviewPageClient({
       }
 
       setShopId(woRow.shop_id);
+      setWorkOrderLabel(woRow.custom_id?.trim() || null);
 
       const { data: invoiceRow } = await supabase
         .from("invoices")

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -44,6 +44,7 @@ import {
   loadProjectedWorkOrderSnapshot,
   type MobileWorkOrderSnapshot,
 } from "@/features/work-orders/mobile/technicianOfflineExecution";
+import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -175,6 +176,7 @@ export default function MobileWorkOrderClient({
 }): JSX.Element {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { updateActiveTab } = useTabs();
 
   // ✅ handle ?focus=<workOrderLineId>
   const focusParam = searchParams?.get("focus") ?? null;
@@ -693,6 +695,40 @@ export default function MobileWorkOrderClient({
     () => deriveMobileDetailOperationalState(wo, lines),
     [wo, lines],
   );
+
+  useEffect(() => {
+    if (!wo) return;
+    const customerName =
+      customer?.business_name?.trim() ||
+      customer?.name?.trim() ||
+      [customer?.first_name ?? "", customer?.last_name ?? ""]
+        .filter(Boolean)
+        .join(" ")
+        .trim() ||
+      wo.customer_name?.trim() ||
+      "";
+    const vehicleLabel = vehicle
+      ? [vehicle.year, vehicle.make, vehicle.model]
+          .filter((value) => value != null && String(value).trim())
+          .join(" ")
+      : "";
+    const workOrderLabel = wo.custom_id?.trim() || `WO-${wo.id.slice(0, 8)}`;
+    const pendingOfflineChanges =
+      offlineSummary.queued +
+        offlineSummary.syncing +
+        offlineSummary.failed +
+        offlineSummary.conflicted >
+      0;
+
+    updateActiveTab({
+      title: customerName
+        ? `${workOrderLabel} · ${customerName}`
+        : workOrderLabel,
+      subtitle: vehicleLabel || undefined,
+      status: String(wo.status ?? "awaiting").replaceAll("_", " "),
+      offline: !navigator.onLine || pendingOfflineChanges,
+    });
+  }, [customer, offlineSummary, updateActiveTab, vehicle, wo]);
 
   const visibleLineState = useCallback(
     (line: WorkOrderLine) => mobileOperationalState.lineStates.get(line) ?? "awaiting",

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -17,6 +17,7 @@ import {
   shopSuppliesSummaryText,
 } from "@/features/work-orders/lib/shopSupplies";
 import { quoteLineTotalResolved, resolveQuoteLineParts, type CatalogPart, type PartRequest, type PartRequestItem, type ResolvedQuotePart } from "./partsModel";
+import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
 const COPPER = "#C57A4A";
 const SEND_READY_STAGES = new Set(["advisor_pending", "ready_to_send"]);
@@ -361,6 +362,7 @@ export default function QuoteReviewView(props: {
   const woId = String(props.workOrderId ?? "").trim();
   const embedded = Boolean(props.embedded);
   const supabase = useMemo(() => createBrowserSupabase(), []);
+  const { updateActiveTab } = useTabs();
 
   const [loading, setLoading] = useState(true);
   const [loadedOnce, setLoadedOnce] = useState(false);
@@ -390,6 +392,22 @@ export default function QuoteReviewView(props: {
   const [suppliesEnabledDraft, setSuppliesEnabledDraft] = useState<boolean | null>(null);
   const [suppliesAmountDraft, setSuppliesAmountDraft] = useState("");
   const [savingSuppliesOverride, setSavingSuppliesOverride] = useState(false);
+
+  useEffect(() => {
+    if (embedded || !wo) return;
+    const customerName = customerDisplayName(customer);
+    const workOrderLabel =
+      safeTrim(wo.custom_id) || `WO-${wo.id.slice(0, 8)}`;
+    updateActiveTab({
+      title:
+        customerName && customerName !== "—"
+          ? `${workOrderLabel} · ${customerName}`
+          : workOrderLabel,
+      subtitle: "Quote review",
+      status: "Quote review",
+      dirty: quoteLines.some((line) => line._dirty),
+    });
+  }, [customer, embedded, quoteLines, updateActiveTab, wo]);
 
   const laborRate = useMemo(() => asNumber((shop as unknown as { labor_rate?: unknown } | null)?.labor_rate) ?? 120, [shop]);
 

--- a/tests/open-work-tray.test.ts
+++ b/tests/open-work-tray.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DASHBOARD_OPEN_WORK_ITEM,
+  migrateLegacyTabs,
+  resolveOpenWork,
+  updateOpenWorkItem,
+  upsertOpenWork,
+  visibleOpenWorkItems,
+} from "@/features/shared/components/tabs/openWork";
+import { metaFor } from "@/features/shared/lib/routeMeta";
+
+const WORK_ORDER_ID = "4b2ab5f1-2e74-45f1-8c71-2b12fcd32e95";
+
+describe("Open Work route identity", () => {
+  it("does not turn navigation destinations into working records", () => {
+    expect(resolveOpenWork("/work-orders")).toBeNull();
+    expect(resolveOpenWork("/work-orders/view")).toBeNull();
+    expect(resolveOpenWork("/work-orders/quote-review")).toBeNull();
+    expect(resolveOpenWork("/parts/requests")).toBeNull();
+    expect(resolveOpenWork("/dashboard/owner/reports")).toBeNull();
+  });
+
+  it("deduplicates work-order actions under one canonical record", () => {
+    const detail = resolveOpenWork(`/work-orders/${WORK_ORDER_ID}`, 10);
+    const approval = resolveOpenWork(
+      `/work-orders/${WORK_ORDER_ID}/approve`,
+      20,
+    );
+    const quote = resolveOpenWork(`/quote-review/${WORK_ORDER_ID}`, 30);
+    const focused = resolveOpenWork(
+      `/work-orders/${WORK_ORDER_ID}/focused-job/line-1`,
+      40,
+    );
+
+    expect(detail?.key).toBe(`work-order:${WORK_ORDER_ID}`);
+    expect(approval?.key).toBe(detail?.key);
+    expect(quote?.key).toBe(detail?.key);
+    expect(focused?.key).toBe(detail?.key);
+
+    let items = [DASHBOARD_OPEN_WORK_ITEM];
+    for (const item of [detail, approval, quote, focused]) {
+      if (item) items = upsertOpenWork(items, item);
+    }
+    expect(items).toHaveLength(2);
+    expect(items[1].href).toBe(
+      `/work-orders/${WORK_ORDER_ID}/focused-job/line-1`,
+    );
+  });
+
+  it("keeps an invoice as a distinct working record with a mobile handoff", () => {
+    const invoice = resolveOpenWork(
+      `/work-orders/invoice/${WORK_ORDER_ID}`,
+      10,
+    );
+    expect(invoice).toMatchObject({
+      key: `invoice:${WORK_ORDER_ID}`,
+      kind: "invoice",
+      mobileHref: `/mobile/work-orders/${WORK_ORDER_ID}`,
+    });
+  });
+
+  it("uses the same record identity on mobile without replacing the desktop resume route", () => {
+    expect(
+      resolveOpenWork(`/mobile/work-orders/${WORK_ORDER_ID}`, 10),
+    ).toMatchObject({
+      key: `work-order:${WORK_ORDER_ID}`,
+      href: `/work-orders/${WORK_ORDER_ID}`,
+      mobileHref: `/mobile/work-orders/${WORK_ORDER_ID}`,
+    });
+  });
+
+  it("tracks inspections and customer files but excludes their directory pages", () => {
+    expect(resolveOpenWork("/inspections/saved")).toBeNull();
+    expect(resolveOpenWork("/customers/directory")).toBeNull();
+    expect(resolveOpenWork("/inspections/inspection-123")).toMatchObject({
+      key: "inspection:inspection-123",
+      kind: "inspection",
+    });
+    expect(resolveOpenWork("/customers/customer-123")).toMatchObject({
+      key: "customer:customer-123",
+      kind: "customer",
+    });
+  });
+});
+
+describe("Open Work persistence and presentation", () => {
+  it("migrates legacy action tabs into one record and drops page tabs", () => {
+    const migrated = migrateLegacyTabs(
+      [
+        { href: "/parts/requests", title: "Parts Requests" },
+        {
+          href: `/work-orders/${WORK_ORDER_ID}/approve`,
+          title: "WO #approve",
+        },
+        {
+          href: `/work-orders/${WORK_ORDER_ID}/quote-review`,
+          title: "WO #quote-review",
+        },
+      ],
+      100,
+    );
+
+    expect(migrated.map((item) => item.key)).toEqual([
+      "dashboard",
+      `work-order:${WORK_ORDER_ID}`,
+    ]);
+    expect(migrated[1].title).not.toContain("approve");
+  });
+
+  it("preserves an enriched label while updating the last resume route", () => {
+    const initial = resolveOpenWork(`/work-orders/${WORK_ORDER_ID}`, 10);
+    expect(initial).not.toBeNull();
+    let items = upsertOpenWork(
+      [DASHBOARD_OPEN_WORK_ITEM],
+      initial!,
+    );
+    items = updateOpenWorkItem(items, initial!.key, {
+      title: "EL000001 · Anderson",
+      status: "In progress",
+    });
+
+    const quote = resolveOpenWork(`/quote-review/${WORK_ORDER_ID}`, 20);
+    items = upsertOpenWork(items, quote!);
+
+    expect(items[1]).toMatchObject({
+      title: "EL000001 · Anderson",
+      status: "In progress",
+      href: `/quote-review/${WORK_ORDER_ID}`,
+    });
+  });
+
+  it("keeps the active record visible inside the five-item desktop limit", () => {
+    const records = Array.from({ length: 7 }, (_, index) =>
+      resolveOpenWork(`/work-orders/EL${index + 1}`, index + 1),
+    ).filter((item): item is NonNullable<typeof item> => Boolean(item));
+    const visible = visibleOpenWorkItems(
+      [DASHBOARD_OPEN_WORK_ITEM, ...records],
+      "work-order:EL1",
+      5,
+    );
+
+    expect(visible).toHaveLength(5);
+    expect(visible[0].key).toBe("dashboard");
+    expect(visible.some((item) => item.key === "work-order:EL1")).toBe(true);
+  });
+
+  it("does not mislabel a nested action as the dynamic work-order id", () => {
+    expect(metaFor(`/work-orders/${WORK_ORDER_ID}/approve`).title).toBe(
+      "Approve",
+    );
+    expect(metaFor(`/work-orders/${WORK_ORDER_ID}`).title).toContain(
+      WORK_ORDER_ID.slice(0, 8),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Redesigns the old URL-based dashboard tab strip as a record-based **Open Work** tray for desktop and mobile.

## Root cause

The previous tabs were keyed by raw URLs. Nested work-order actions therefore became separate tabs named `approve`, `confirm`, or `view`, and ordinary navigation destinations were treated like active records.

## What changed

- Canonicalizes work orders, inspections, invoices, and customer files into record identities.
- Deduplicates nested approval, quote, focused-job, and detail routes into one work-order workspace.
- Adds meaningful labels such as `EL000001 · Anderson`.
- Limits desktop display to five prioritized records with searchable overflow.
- Moves close/manage actions into a compact menu.
- Adds status, unsaved-change, and offline indicators.
- Persists useful work across refreshes and migrates compatible legacy tabs.
- Exposes the same Open Work records from the mobile hamburger menu.
- Stops dashboard destinations such as Parts, Reports, Billing, and Quote Review lists from opening tabs.

## Impact

Users can reliably resume the records they are actively working on without accumulating duplicate action-route tabs. Desktop stays compact, while mobile gets the capability without a horizontal tab strip.

## Safety

This is a client-side navigation and browser-persistence change only. It does not change authorization, tenant isolation, workflow statuses, database writes, or production data.

## Validation

- Focused Open Work regression suite: 9 passed.
- Full test suite: passed.
- TypeScript: passed.
- Changed-file ESLint: zero errors; one pre-existing inspection image warning remains.
- Full-repository ESLint: blocked by 12 unrelated pre-existing errors.
- Production bundle compiled and passed its type check; page-data collection requires the repository's Supabase and OpenAI build variables.
- Final diff and whitespace validation: passed.
- Remote comparison: one commit ahead of `main`, zero commits behind, 13 intended files only.

## Database and configuration

- Database migration: none.
- New environment variables: none.
- Production or deployment actions: none.

## Smoke test

- Open several work orders and confirm each appears once with its work-order/customer label.
- Visit approve, confirm, quote, and focused-job routes for the same work order and confirm no duplicate appears.
- Open an inspection, invoice, and customer file and confirm their labels and icons.
- Confirm only five records display in the desktop tray and additional records appear in searchable overflow.
- Refresh and confirm Open Work persists.
- Verify close, close others, and close all from the management menu.
- On mobile, open the hamburger menu and verify Open Work records navigate correctly.
- Confirm navigation pages such as Reports, Parts, Billing, and Quote Review lists do not create records.
- Verify unsaved and offline indicators when those states are present.

## Remaining verification

The responsive interface still needs a visual smoke test against live shop data.