### PR TITLE
Connect Workforce status and readiness wiring

### DIFF
--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -5,6 +5,23 @@ import { requirePayrollReviewer } from "../_lib/auth";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 type AdminClient = ReturnType<typeof createAdminSupabase>;
+type PayrollProfile = {
+  id?: string;
+  full_name: string | null;
+  email: string | null;
+};
+type PayrollRosterRow = {
+  user_id: string;
+  payroll_ready: boolean | null;
+  employment_status: string | null;
+  profiles: PayrollProfile | null;
+};
+type PayrollEntryRow = {
+  user_id: string;
+  work_date: string;
+  profiles: PayrollProfile | null;
+  [key: string]: unknown;
+};
 
 export async function GET(req: NextRequest) {
   const auth = await requirePayrollReviewer();
@@ -47,9 +64,7 @@ export async function GET(req: NextRequest) {
     admin
       .from("people_workforce_profiles")
       .select("user_id, payroll_ready, employment_status, profiles:user_id(full_name, email)")
-      .eq("shop_id", me.shop_id)
-      .eq("payroll_ready", true)
-      .eq("employment_status", "active"),
+      .eq("shop_id", me.shop_id),
   ]);
 
   if (entriesErr) return NextResponse.json({ error: entriesErr.message }, { status: 500 });
@@ -86,9 +101,15 @@ export async function GET(req: NextRequest) {
     awayMap.set(row.user_id, (awayMap.get(row.user_id) ?? 0) + minutes);
   }
 
-  const entryRows = (entries ?? []) as any[];
+  const activeRoster = ((roster ?? []) as unknown as PayrollRosterRow[]).filter(
+    (person) => person.employment_status === "active",
+  );
+  const eligibleRoster = activeRoster.filter(
+    (person) => person.payroll_ready === true,
+  );
+  const entryRows = (entries ?? []) as unknown as PayrollEntryRow[];
   const entryUsers = new Set(entryRows.map((entry) => entry.user_id));
-  const rosterEntries = ((roster ?? []) as any[])
+  const rosterEntries = eligibleRoster
     .filter((person) => person.user_id && !entryUsers.has(person.user_id))
     .map((person) => ({
       id: `roster-${activePeriodId}-${person.user_id}`,
@@ -121,7 +142,11 @@ export async function GET(req: NextRequest) {
   const { data: fallbackProfiles } = missingProfileUserIds.length
     ? await admin.from("profiles").select("id, full_name, email").eq("shop_id", me.shop_id).in("id", missingProfileUserIds)
     : { data: [] };
-  const fallbackProfileById = new Map((fallbackProfiles ?? []).map((profile: any) => [profile.id, profile]));
+  const fallbackProfileById = new Map(
+    ((fallbackProfiles ?? []) as PayrollProfile[])
+      .filter((profile): profile is PayrollProfile & { id: string } => Boolean(profile.id))
+      .map((profile) => [profile.id, profile]),
+  );
 
   const enrichedEntries = [...entryRows, ...rosterEntries].map((entry) => ({
     ...entry,
@@ -139,10 +164,17 @@ export async function GET(req: NextRequest) {
     entries: enrichedEntries,
     exceptions: exceptions ?? [],
     refresh: refreshState,
+    rosterSummary: {
+      activeWorkforce: activeRoster.length,
+      payrollEligible: eligibleRoster.length,
+      excludedFromPayroll: Math.max(activeRoster.length - eligibleRoster.length, 0),
+    },
     zeroState: {
       trueZero,
       message: trueZero
-        ? "No employee time has been recorded for this pay period."
+        ? eligibleRoster.length === 0
+          ? "No active people are marked payroll-ready."
+          : "No employee time has been recorded for this pay period."
         : refreshState.refreshError
           ? "Time records exist, but payroll totals could not be refreshed."
           : null,

--- a/app/api/scheduling/staff/route.ts
+++ b/app/api/scheduling/staff/route.ts
@@ -3,6 +3,11 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { getShopDayRange } from "@/features/shared/lib/utils/shopDayWindow";
+import { buildWorkforceActivity } from "@/features/workforce/server/buildWorkforceActivity";
+import {
+  getShopScheduleDateContext,
+  resolveWorkforceSchedulePosture,
+} from "@/features/workforce/lib/schedulePosture";
 type AdminClient = ReturnType<typeof createAdminSupabase>;
 
 export async function GET(req: NextRequest) {
@@ -12,18 +17,30 @@ export async function GET(req: NextRequest) {
   if (!actor.canManageScheduling) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
   const admin: AdminClient = createAdminSupabase();
+  const now = new Date();
   const url = new URL(req.url);
-  const from = url.searchParams.get("from") ?? new Date().toISOString();
-  const to = url.searchParams.get("to") ?? new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString();
+  const from = url.searchParams.get("from") ?? now.toISOString();
+  const to = url.searchParams.get("to") ?? new Date(now.getTime() + 1000 * 60 * 60 * 24 * 7).toISOString();
+  const fromDate = new Date(from);
+  const toDate = new Date(to);
+  if (
+    !Number.isFinite(fromDate.getTime()) ||
+    !Number.isFinite(toDate.getTime()) ||
+    toDate <= fromDate
+  ) {
+    return NextResponse.json({ error: "Invalid scheduling date range" }, { status: 400 });
+  }
   const shopRes = await admin.from("shops").select("timezone").eq("id", access.profile.shop_id).maybeSingle();
   if (shopRes.error) return NextResponse.json({ error: shopRes.error.message }, { status: 500 });
-  const todayBounds = getShopDayRange(shopRes.data?.timezone, new Date());
+  const todayBounds = getShopDayRange(shopRes.data?.timezone, now);
+  const fromDateKey = getShopScheduleDateContext(fromDate, shopRes.data?.timezone).dateKey;
+  const toDateKey = getShopScheduleDateContext(toDate, shopRes.data?.timezone).dateKey;
 
   const [profilesRes, workforceRes, templatesRes, overridesRes, blocksRes, requestsRes, activeLinesRes] = await Promise.all([
     admin.from("profiles").select("id, full_name, email, role").eq("shop_id", access.profile.shop_id).order("full_name", { ascending: true }),
     admin.from("people_workforce_profiles").select("user_id, employment_status").eq("shop_id", access.profile.shop_id),
     admin.from("staff_schedule_templates").select("*").eq("shop_id", access.profile.shop_id),
-    admin.from("staff_schedule_overrides").select("*").eq("shop_id", access.profile.shop_id).gte("schedule_date", from.slice(0, 10)).lte("schedule_date", to.slice(0, 10)),
+    admin.from("staff_schedule_overrides").select("*").eq("shop_id", access.profile.shop_id).gte("schedule_date", fromDateKey).lte("schedule_date", toDateKey),
     admin.from("staff_availability_blocks").select("*").eq("shop_id", access.profile.shop_id).lte("starts_at", to).gte("ends_at", from),
     admin.from("staff_time_off_requests").select("*").eq("shop_id", access.profile.shop_id).eq("status", "pending").order("created_at", { ascending: true }).limit(50),
     admin.from("work_order_lines").select("id, assigned_tech_id, status").eq("shop_id", access.profile.shop_id).not("assigned_tech_id", "is", null).not("status", "in", '("completed","invoiced","cancelled","declined")'),
@@ -35,6 +52,14 @@ export async function GET(req: NextRequest) {
   if (overridesRes.error) return NextResponse.json({ error: overridesRes.error.message }, { status: 500 });
   if (blocksRes.error) return NextResponse.json({ error: blocksRes.error.message }, { status: 500 });
   if (requestsRes.error) return NextResponse.json({ error: requestsRes.error.message }, { status: 500 });
+  if (activeLinesRes.error) return NextResponse.json({ error: activeLinesRes.error.message }, { status: 500 });
+
+  const activity = await buildWorkforceActivity({
+    shopId: access.profile.shop_id!,
+    timezone: shopRes.data?.timezone ?? null,
+    now,
+  });
+  const activityByUser = new Map(activity.activities.map((row) => [row.userId, row]));
 
   const templates = templatesRes.data ?? [];
   const overrides = overridesRes.data ?? [];
@@ -68,6 +93,21 @@ export async function GET(req: NextRequest) {
     const tomorrowStart = new Date(todayBounds.end);
     const tomorrowEnd = new Date(tomorrowStart.getTime() + 24 * 60 * 60 * 1000);
     const isAwayTomorrow = personBlocks.some((b) => new Date(b.starts_at) < tomorrowEnd && new Date(b.ends_at) > tomorrowStart);
+    const todaySchedule = resolveWorkforceSchedulePosture({
+      userId: p.id,
+      at: now,
+      timezone: shopRes.data?.timezone,
+      templates,
+      overrides,
+    });
+    const tomorrowSchedule = resolveWorkforceSchedulePosture({
+      userId: p.id,
+      at: new Date(new Date(todayBounds.end).getTime() + 12 * 60 * 60 * 1000),
+      timezone: shopRes.data?.timezone,
+      templates,
+      overrides,
+    });
+    const liveActivity = activityByUser.get(p.id);
 
     return {
       ...p,
@@ -77,6 +117,21 @@ export async function GET(req: NextRequest) {
       approved_away_blocks_in_range: personBlocks.length,
       is_away_today: isAwayToday,
       is_away_tomorrow: isAwayTomorrow,
+      is_scheduled_today: todaySchedule.scheduled,
+      is_scheduled_tomorrow: tomorrowSchedule.scheduled,
+      schedule_source_today: todaySchedule.source,
+      live_state: liveActivity?.operationalState ?? "off_shift",
+      is_clocked_in: Boolean(
+        liveActivity &&
+          liveActivity.operationalState !== "off_shift" &&
+          liveActivity.operationalState !== "shift_ended",
+      ),
+      current_job: liveActivity?.currentJob
+        ? {
+            work_order_number: liveActivity.currentJob.workOrderNumber,
+            line_description: liveActivity.currentJob.lineDescription,
+          }
+        : null,
       active_assigned_work_count: activeWorkByUser.get(p.id) ?? 0,
       next_override: personOverrides
         .slice()

--- a/app/api/workforce/overview/route.ts
+++ b/app/api/workforce/overview/route.ts
@@ -3,6 +3,7 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { getShopTodayTomorrowRanges } from "@/features/shared/lib/utils/shopDayWindow";
 import { buildWorkforceActivity } from "@/features/workforce/server/buildWorkforceActivity";
+import { resolveWorkforceSchedulePosture } from "@/features/workforce/lib/schedulePosture";
 
 type AdminClient = ReturnType<typeof createAdminSupabase>;
 type Severity = "blocking" | "warning" | "info";
@@ -10,6 +11,8 @@ type WorkforceInboxItem = { id: string; type: string; severity: Severity; title:
 type WorkforceOverviewResponse = {
   summary: {
     workingToday: number;
+    scheduledToday: number;
+    activeStaff: number;
     awayToday: number;
     awayTomorrow: number;
     pendingTimeOff: number;
@@ -67,18 +70,19 @@ export async function GET() {
   const todayEndIso = dayRanges.today.end;
   const tomorrowEndIso = dayRanges.tomorrow.end;
 
-  const [activity, profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, blocksRes, linesRes] = await Promise.all([
+  const [activity, profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, overridesRes, blocksRes, linesRes] = await Promise.all([
     buildWorkforceActivity({ shopId, timezone: shopRes.data?.timezone ?? null }),
     admin.from("profiles").select("id, full_name").eq("shop_id", shopId),
     admin.from("people_workforce_profiles").select("user_id, employment_status").eq("shop_id", shopId),
     admin.from("staff_time_off_requests").select("id, created_at").eq("shop_id", shopId).eq("status", "pending").order("created_at", { ascending: true }),
     admin.from("payroll_pay_periods").select("id, period_start").eq("shop_id", shopId).order("period_start", { ascending: false }).limit(1),
     admin.from("staff_certifications").select("expiry_date, status").eq("shop_id", shopId),
-    admin.from("staff_schedule_templates").select("user_id").eq("shop_id", shopId),
+    admin.from("staff_schedule_templates").select("user_id, day_of_week, is_working_day, start_time, end_time, effective_from, effective_to").eq("shop_id", shopId),
+    admin.from("staff_schedule_overrides").select("user_id, schedule_date, start_time, end_time, status").eq("shop_id", shopId).gte("schedule_date", todayStartIso.slice(0, 10)).lte("schedule_date", todayEndIso.slice(0, 10)),
     admin.from("staff_availability_blocks").select("user_id, starts_at, ends_at").eq("shop_id", shopId).lte("starts_at", tomorrowEndIso).gte("ends_at", todayStartIso),
     admin.from("work_order_lines").select("id, assigned_tech_id, line_status, status, voided_at").eq("shop_id", shopId).is("voided_at", null),
   ]);
-  const firstError = [profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, blocksRes, linesRes].find((r) => r.error);
+  const firstError = [profilesRes, workforceRes, timeOffRes, periodsRes, certsRes, templatesRes, overridesRes, blocksRes, linesRes].find((r) => r.error);
   if (firstError?.error) return NextResponse.json({ error: firstError.error.message }, { status: 500 });
   const activeLineIds = (linesRes.data ?? [])
     .filter((l) => !ACTIVE_LINE_EXCLUDED.includes((l.line_status || l.status || "").toLowerCase()))
@@ -92,6 +96,15 @@ export async function GET() {
   const profileName = new Map((profilesRes.data ?? []).map((p) => [p.id, p.full_name || "Unknown"]));
   const activeStaff = new Set((workforceRes.data ?? []).filter((w) => w.employment_status === "active").map((w) => w.user_id));
   const templateUsers = new Set((templatesRes.data ?? []).map((t) => t.user_id));
+  const scheduledToday = [...activeStaff].filter((userId) =>
+    resolveWorkforceSchedulePosture({
+      userId,
+      at: now,
+      timezone: shopRes.data?.timezone,
+      templates: templatesRes.data ?? [],
+      overrides: overridesRes.data ?? [],
+    }).scheduled,
+  ).length;
   const blocks = blocksRes.data ?? [];
   const overlap = (start: string, end: string, from: Date, to: Date) => new Date(start) < to && new Date(end) > from;
   const awayTodayUsers = new Set(blocks.filter((b) => overlap(b.starts_at, b.ends_at, new Date(todayStartIso), new Date(todayEndIso))).map((b) => b.user_id));
@@ -165,6 +178,8 @@ export async function GET() {
   const response: WorkforceOverviewResponse = {
     summary: {
       workingToday: activity.summary.activeTechnicians,
+      scheduledToday,
+      activeStaff: activeStaff.size,
       awayToday: awayTodayUsers.size,
       awayTomorrow: awayTomorrowUsers.size,
       pendingTimeOff,

--- a/app/dashboard/workforce/insights/page.tsx
+++ b/app/dashboard/workforce/insights/page.tsx
@@ -1,34 +1,7 @@
-import Link from "next/link";
+import { redirect } from "next/navigation";
 import { requireAdminPageAccess } from "@/features/shared/lib/server/admin-access";
-
-const insightTopics = [
-  "Tech availability and shift coverage",
-  "Payroll exceptions and correction trends",
-  "Certification expiration risk",
-  "Absent technicians with active jobs",
-  "Workload imbalance across teams",
-  "Unassigned work orders impacting throughput",
-];
 
 export default async function WorkforceInsightsPage() {
   await requireAdminPageAccess({ allow: ["owner", "admin", "manager"] });
-
-  return (
-    <div className="space-y-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5 shadow-[var(--theme-shadow-soft)]">
-      <h1 className="text-2xl font-semibold text-[color:var(--theme-text-primary)]">Workforce Insights</h1>
-      <p className="text-sm text-[color:var(--theme-text-secondary)]">Use trusted workforce signals to spot coverage, time, readiness, and throughput risks.</p>
-      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
-        <p className="text-sm text-[color:var(--theme-text-primary)]">Use Scheduling, Attendance, and Payroll Review today for immediate decisions and exception handling.</p>
-        <div className="mt-3 flex flex-wrap gap-2 text-xs">
-          <Link href="/dashboard/workforce/scheduling" className="rounded border border-[color:var(--theme-border-soft)] px-2 py-1 text-[color:var(--theme-accent-text)]">Scheduling Command</Link>
-          <Link href="/dashboard/workforce/attendance" className="rounded border border-[color:var(--theme-border-soft)] px-2 py-1 text-[color:var(--theme-accent-text)]">Attendance & Activity</Link>
-          <Link href="/dashboard/workforce/payroll-review" className="rounded border border-[color:var(--theme-border-soft)] px-2 py-1 text-[color:var(--theme-accent-text)]">Payroll Review</Link>
-        </div>
-      </div>
-      <ul className="list-disc space-y-1 pl-5 text-sm text-[color:var(--theme-text-primary)]">
-        {insightTopics.map((topic) => <li key={topic}>{topic}</li>)}
-      </ul>
-      <p className="text-xs text-[color:var(--theme-text-secondary)]">Trend visualizations and historical comparisons will use the same trusted Workforce data sources.</p>
-    </div>
-  );
+  redirect("/dashboard/workforce/overview");
 }

--- a/features/dashboard/app/dashboard/admin/PeoplePageClient.tsx
+++ b/features/dashboard/app/dashboard/admin/PeoplePageClient.tsx
@@ -69,13 +69,17 @@ export default function PeoplePageClient() {
 
   useEffect(() => {
     const view = searchParams.get("view");
+    const filter = searchParams.get("filter");
     if (view === "workforce") {
       setActionFilter("needs_action");
+    }
+    if (filter === "payroll") {
+      setActionFilter("payroll_issues");
     }
     if (workforceAction === "cert_expired" || workforceAction === "cert_expiring") {
       setActionFilter("cert_expiry");
     }
-  }, [searchParams]);
+  }, [searchParams, workforceAction]);
 
   useEffect(() => {
     (async () => {

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -111,6 +111,11 @@ export default function PayrollTimeClient() {
   const [csvPreview, setCsvPreview] = useState<string | null>(null);
   const [exportHistory, setExportHistory] = useState<ExportBatch[]>([]);
   const [zeroState, setZeroState] = useState<{ trueZero?: boolean; message?: string | null } | null>(null);
+  const [rosterSummary, setRosterSummary] = useState({
+    activeWorkforce: 0,
+    payrollEligible: 0,
+    excludedFromPayroll: 0,
+  });
   const [refreshState, setRefreshState] = useState<{ reason?: string; refreshError?: string | null; hasSourceTime?: boolean } | null>(null);
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [downloadingBatchId, setDownloadingBatchId] = useState<string | null>(null);
@@ -210,6 +215,11 @@ export default function PayrollTimeClient() {
     setEntries((body?.entries ?? []) as Entry[]);
     setExceptions((body?.exceptions ?? []) as Exception[]);
     setZeroState(body?.zeroState ?? null);
+    setRosterSummary({
+      activeWorkforce: Number(body?.rosterSummary?.activeWorkforce ?? 0),
+      payrollEligible: Number(body?.rosterSummary?.payrollEligible ?? 0),
+      excludedFromPayroll: Number(body?.rosterSummary?.excludedFromPayroll ?? 0),
+    });
     setRefreshState(body?.refresh ?? null);
     setLoading(false);
   }, []);
@@ -331,7 +341,7 @@ export default function PayrollTimeClient() {
           description="Recorded attendance is refreshed automatically for open periods. Overtime and warnings are advisory unless a blocking integrity issue remains."
         />
         <AdminStatGrid>
-          <AdminStatCard label="Employees" value={summary.employees} />
+          <AdminStatCard label="Payroll eligible" value={rosterSummary.payrollEligible} hint={`${rosterSummary.activeWorkforce} active workforce`} />
           <AdminStatCard label="Payroll hours" value={summary.totalHours} />
           <AdminStatCard label="Regular hours" value={fmtHours(entries.reduce((acc, entry) => acc + Number(entry.regular_minutes ?? 0), 0))} />
           <AdminStatCard label="Overtime" value={summary.overtimeHours} />
@@ -348,7 +358,15 @@ export default function PayrollTimeClient() {
           {summary.blocking > 0 ? <p>{summary.blocking} blocking integrity issue{summary.blocking === 1 ? "" : "s"} must be resolved before payroll can be finalized.</p> : null}
           {Number(summary.overtimeHours) > 0 ? <p>{entries.filter((entry) => entry.overtime_minutes > 0).length} employee day{entries.filter((entry) => entry.overtime_minutes > 0).length === 1 ? "" : "s"} recorded overtime this period.</p> : null}
           {summary.warnings > 0 ? <p>{summary.warnings} advisory warning{summary.warnings === 1 ? "" : "s"} may need owner review, but do not remove recorded payable hours.</p> : null}
-          {summary.blocking === 0 && summary.warnings === 0 ? <p>Payroll totals are ready for review.</p> : null}
+          {rosterSummary.payrollEligible === 0 ? (
+            <p>
+              No active people are included in payroll.{" "}
+              <Link href="/dashboard/workforce/people?filter=payroll" className="font-medium text-[color:var(--theme-accent-text)]">
+                Review payroll readiness in People →
+              </Link>
+            </p>
+          ) : summary.blocking === 0 && summary.warnings === 0 ? <p>Payroll totals are ready for review.</p> : null}
+          {rosterSummary.excludedFromPayroll > 0 ? <p>{rosterSummary.excludedFromPayroll} active person{rosterSummary.excludedFromPayroll === 1 ? " is" : " are"} excluded because payroll readiness is off.</p> : null}
           <p className="text-xs text-[color:var(--theme-text-muted)]">Overtime, long shifts, missing lunch, and job-time ratio flags are advisory. Valid recorded attendance remains visible and payable for owner/admin decisions.</p>
         </div>
       </AdminPanel>
@@ -437,7 +455,7 @@ export default function PayrollTimeClient() {
           <button
             className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs uppercase tracking-[0.12em] text-[color:var(--theme-success-text)] disabled:opacity-50"
             onClick={() => void handleApprove()}
-            disabled={!activePeriodId || busyAction !== null || summary.blocking > 0 || Boolean(refreshState?.refreshError) || activePeriod?.status === "approved" || activePeriod?.status === "exported"}
+            disabled={!activePeriodId || summary.employees === 0 || busyAction !== null || summary.blocking > 0 || Boolean(refreshState?.refreshError) || activePeriod?.status === "approved" || activePeriod?.status === "exported"}
           >
             {busyAction === "approve" ? "Approving…" : "Approve Payroll"}
           </button>
@@ -485,7 +503,14 @@ export default function PayrollTimeClient() {
         {loading ? (
           <AdminEmptyState title="Loading payroll period" body="Refreshing employee time records." />
         ) : filteredEntries.length === 0 ? (
-          <AdminEmptyState title={zeroState?.message ?? "No employee time has been recorded for this pay period."} body={activePeriod ? `${activePeriod.period_start} → ${activePeriod.period_end}` : "Open Attendance or Scheduling to record employee time."} />
+          <AdminEmptyState
+            title={zeroState?.message ?? "No employee time has been recorded for this pay period."}
+            body={rosterSummary.payrollEligible === 0
+              ? "Open People and mark each employee who belongs in payroll as payroll-ready."
+              : activePeriod
+                ? `${activePeriod.period_start} → ${activePeriod.period_end}. Attendance—not the schedule template—creates payable hours.`
+                : "Open Attendance to review recorded employee time."}
+          />
         ) : (
           <div className="space-y-3 p-4">
             {groupedEntries.map((group) => (

--- a/features/dashboard/app/dashboard/admin/scheduling/WorkforceSchedulingClient.tsx
+++ b/features/dashboard/app/dashboard/admin/scheduling/WorkforceSchedulingClient.tsx
@@ -15,6 +15,15 @@ type Staff = {
   approved_away_blocks_in_range: number;
   is_away_today: boolean;
   is_away_tomorrow: boolean;
+  is_scheduled_today: boolean;
+  is_scheduled_tomorrow: boolean;
+  schedule_source_today: "override" | "template" | "none";
+  live_state: string;
+  is_clocked_in: boolean;
+  current_job: {
+    work_order_number: string | null;
+    line_description: string | null;
+  } | null;
   active_assigned_work_count: number;
 };
 
@@ -103,12 +112,22 @@ export default function WorkforceSchedulingClient() {
   const coverage = useMemo(() => {
     const awayToday = staff.filter((s) => s.is_away_today).length;
     const activeCount = staff.length;
-    const availableCount = Math.max(activeCount - awayToday, 0);
-    const missingTemplates = staff.filter((s) => s.recurring_template_rows === 0).length;
+    const scheduledToday = staff.filter((s) => s.is_scheduled_today && !s.is_away_today).length;
+    const clockedIn = staff.filter((s) => s.is_clocked_in).length;
     const overrideCount = staff.reduce((sum, s) => sum + s.override_count_in_range, 0);
 
-    return { awayToday, activeCount, availableCount, missingTemplates, overrideCount };
+    return { awayToday, activeCount, scheduledToday, clockedIn, overrideCount };
   }, [staff]);
+
+  function todayPosture(person: Staff) {
+    if (person.is_away_today) return { label: "Away today", tone: "text-[color:var(--theme-warning-text)]" };
+    if (person.live_state === "working_on_job") return { label: "Clocked in · On job", tone: "text-[color:var(--theme-success-text)]" };
+    if (person.live_state === "on_break") return { label: "Clocked in · Break", tone: "text-[color:var(--theme-warning-text)]" };
+    if (person.live_state === "on_lunch") return { label: "Clocked in · Lunch", tone: "text-[color:var(--theme-warning-text)]" };
+    if (person.is_clocked_in) return { label: "Clocked in · No active job", tone: "text-[color:var(--theme-info-text)]" };
+    if (person.is_scheduled_today) return { label: "Scheduled · Not clocked in", tone: "text-[color:var(--theme-text-secondary)]" };
+    return { label: "Off today", tone: "text-[color:var(--theme-text-muted)]" };
+  }
 
   const focus = searchParams.get("focus");
   const status = searchParams.get("status");
@@ -224,20 +243,20 @@ export default function WorkforceSchedulingClient() {
 
       <section className="mb-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
         <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
-          <p className="text-xs text-[color:var(--theme-text-secondary)]">Available / Working</p>
-          <p className="text-xl font-semibold text-[color:var(--theme-success-text)]">{coverage.availableCount} / {coverage.activeCount}</p>
+          <p className="text-xs text-[color:var(--theme-text-secondary)]">Scheduled Today</p>
+          <p className="text-xl font-semibold text-[color:var(--theme-success-text)]">{coverage.scheduledToday} / {coverage.activeCount}</p>
         </div>
         <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
-          <p className="text-xs text-[color:var(--theme-text-secondary)]">Away Today</p>
-          <p className="text-xl font-semibold text-[color:var(--theme-warning-text)]">{coverage.awayToday}</p>
+          <p className="text-xs text-[color:var(--theme-text-secondary)]">Clocked In Now</p>
+          <p className="text-xl font-semibold text-[color:var(--theme-info-text)]">{coverage.clockedIn}</p>
         </div>
         <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
           <p className="text-xs text-[color:var(--theme-text-secondary)]">Pending Time-Off</p>
           <p className="text-xl font-semibold text-[color:var(--theme-accent-text)]">{pending.length}</p>
         </div>
         <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
-          <p className="text-xs text-[color:var(--theme-text-secondary)]">Missing Templates</p>
-          <p className="text-xl font-semibold text-[color:var(--theme-danger-text)]">{coverage.missingTemplates}</p>
+          <p className="text-xs text-[color:var(--theme-text-secondary)]">Away Today</p>
+          <p className="text-xl font-semibold text-[color:var(--theme-warning-text)]">{coverage.awayToday}</p>
         </div>
         <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
           <p className="text-xs text-[color:var(--theme-text-secondary)]">Overrides (Range)</p>
@@ -249,11 +268,14 @@ export default function WorkforceSchedulingClient() {
         <AdminPanel>
           <AdminPanelTitle title="Today Roster" description="Real-time posture for today's assigned workforce." />
           <div className="space-y-2 p-4 text-sm">
-            <p className="text-xs text-[color:var(--theme-text-secondary)]">Available: {coverage.availableCount} · Away: {coverage.awayToday}</p>
+            <p className="text-xs text-[color:var(--theme-text-secondary)]">Scheduled: {coverage.scheduledToday} · Clocked in: {coverage.clockedIn} · Away: {coverage.awayToday}</p>
             {staff.length === 0 ? <p className="text-[color:var(--theme-text-secondary)]">No staff in current range.</p> : staff.map((s) => (
               <div key={`today-${s.id}`} className="flex items-center justify-between rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2">
-                <span>{s.full_name ?? "Unnamed"}</span>
-                <span className={s.is_away_today ? "text-[color:var(--theme-warning-text)]" : "text-[color:var(--theme-success-text)]"}>{s.is_away_today ? "Away today" : "Available"}</span>
+                <span>
+                  <span className="block">{s.full_name ?? "Unnamed"}</span>
+                  {s.current_job ? <span className="block text-xs text-[color:var(--theme-text-secondary)]">{s.current_job.work_order_number ?? "Work order"} · {s.current_job.line_description ?? "Active job"}</span> : null}
+                </span>
+                <span className={todayPosture(s).tone}>{todayPosture(s).label}</span>
               </div>
             ))}
           </div>
@@ -265,7 +287,7 @@ export default function WorkforceSchedulingClient() {
             {staff.map((s) => (
               <div key={`tomorrow-${s.id}`} className="flex items-center justify-between rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2">
                 <span>{s.full_name ?? "Unnamed"}</span>
-                <span className={s.is_away_tomorrow ? "text-[color:var(--theme-warning-text)]" : "text-[color:var(--theme-success-text)]"}>{s.is_away_tomorrow ? "Away tomorrow" : "Available"}</span>
+                <span className={s.is_away_tomorrow ? "text-[color:var(--theme-warning-text)]" : s.is_scheduled_tomorrow ? "text-[color:var(--theme-success-text)]" : "text-[color:var(--theme-text-muted)]"}>{s.is_away_tomorrow ? "Away tomorrow" : s.is_scheduled_tomorrow ? "Scheduled" : "Off tomorrow"}</span>
               </div>
             ))}
           </div>

--- a/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceDocumentsClient.tsx
@@ -57,7 +57,7 @@ type RequirementsPayload = {
 };
 
 type MatrixPayload = {
-  requirements: Array<{ key: string; workforceRole: string | null; workforceCategory: string | null; docType: string; label: string; required: true; expiresRequired: boolean; warningDays: number }>;
+  requirements: Array<{ key: string; workforceRole: string | null; workforceCategory: string | null; docType: string; label: string; required: boolean; expiresRequired: boolean; warningDays: number }>;
   readinessItems: Array<{ personId: string; personName: string; personEmail: string | null; workforceRole: string | null; workforceCategory: string | null; readiness: string; missingDocTypes: string[]; expiredDocTypes: string[]; expiringDocTypes: string[]; needsReviewDocTypes: string[]; href: string }>;
   missingByPerson: Array<{ personId: string; personName: string; missingDocTypes: string[]; href: string }>;
   missingByDocType: Array<{ docType: string; label: string; count: number }>;
@@ -153,7 +153,7 @@ const normalizeMatrixPayload = (value: unknown): { matrix: MatrixPayload | null;
         workforceCategory: safeString(row.workforceCategory) || null,
         docType: safeString(row.docType),
         label: safeString(row.label) || safeString(row.docType) || "Document",
-        required: true,
+        required: row.required === false ? false : true,
         expiresRequired: Boolean(row.expiresRequired),
         warningDays: num(row.warningDays),
       };

--- a/features/dashboard/app/dashboard/workforce/WorkforceOverviewClient.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceOverviewClient.tsx
@@ -252,11 +252,11 @@ export default function WorkforceOverviewClient() {
       title: "Coverage",
       accent: "text-[color:var(--theme-info-text)]",
       items: [
-        { label: "Working today", value: data.summary.workingToday, tone: "border-sky-400/30" },
+        { label: "Scheduled today", value: data.summary.scheduledToday, tone: "border-sky-400/30" },
+        { label: "Clocked in", value: data.summary.workingToday, tone: "border-sky-400/30" },
         { label: "Working on jobs", value: data.summary.workingOnJobs ?? 0, tone: "border-emerald-400/30" },
-        { label: "No active job", value: data.summary.idleTechnicians ?? 0, tone: "border-orange-400/30" },
+        { label: "Clocked in, no job", value: data.summary.idleTechnicians ?? 0, tone: "border-orange-400/30" },
         { label: "Away today", value: data.summary.awayToday, tone: "border-sky-500/20" },
-        { label: "Away tomorrow", value: data.summary.awayTomorrow, tone: "border-sky-500/20" },
       ],
     },
     {

--- a/features/dashboard/app/dashboard/workforce/WorkforceShell.tsx
+++ b/features/dashboard/app/dashboard/workforce/WorkforceShell.tsx
@@ -3,7 +3,6 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
-  BarChart3,
   CalendarDays,
   ClipboardCheck,
   Clock3,
@@ -28,7 +27,6 @@ const ICONS: Record<WorkforceNavigationItem["icon"], LucideIcon> = {
   payroll: FileClock,
   documents: Files,
   certifications: ShieldCheck,
-  insights: BarChart3,
   activity: ClipboardCheck,
 };
 
@@ -87,7 +85,7 @@ export default function WorkforceShell({
             aria-label="Workforce sections"
             className="border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]"
           >
-            <div className="flex gap-1.5 overflow-x-auto px-3 py-2.5 sm:px-4">
+            <div className="grid grid-cols-2 gap-1.5 px-3 py-2.5 sm:grid-cols-3 sm:px-4 lg:grid-cols-4 xl:grid-cols-8">
               {navigation.map((item) => {
                 const active = isWorkforceNavigationItemActive(pathname, item);
                 const Icon = ICONS[item.icon];
@@ -97,7 +95,7 @@ export default function WorkforceShell({
                     key={item.href}
                     href={item.href}
                     aria-current={active ? "page" : undefined}
-                    className="group flex min-w-max items-center gap-2 rounded-xl border px-3 py-2.5 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-accent)]"
+                    className="group flex min-w-0 items-center gap-2 rounded-xl border px-3 py-2.5 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-accent)]"
                     style={{
                       borderColor: active
                         ? "color-mix(in srgb, var(--brand-primary) 64%, var(--theme-border-strong))"
@@ -118,7 +116,7 @@ export default function WorkforceShell({
                       <span className="block text-sm font-semibold leading-none">
                         {item.label}
                       </span>
-                      <span className="mt-1 hidden text-[0.67rem] leading-none text-[color:var(--theme-text-muted)] xl:block">
+                      <span className="mt-1 hidden text-[0.67rem] leading-tight text-[color:var(--theme-text-muted)] 2xl:block">
                         {item.description}
                       </span>
                     </span>

--- a/features/dashboard/app/dashboard/workforce/workforceNavigation.ts
+++ b/features/dashboard/app/dashboard/workforce/workforceNavigation.ts
@@ -12,7 +12,6 @@ export type WorkforceNavigationItem = {
     | "payroll"
     | "documents"
     | "certifications"
-    | "insights"
     | "activity";
   roles: readonly WorkforceNavigationRole[];
   matchPrefixes?: readonly string[];
@@ -72,13 +71,6 @@ export const WORKFORCE_NAVIGATION: readonly WorkforceNavigationItem[] = [
     description: "Expiry readiness",
     icon: "certifications",
     roles: OWNER_ADMIN,
-  },
-  {
-    href: "/dashboard/workforce/insights",
-    label: "Insights",
-    description: "Trends and capacity",
-    icon: "insights",
-    roles: ALL_WORKFORCE_MANAGERS,
   },
   {
     href: "/dashboard/workforce/activity",

--- a/features/shared/lib/workforce/documentReadiness.ts
+++ b/features/shared/lib/workforce/documentReadiness.ts
@@ -38,6 +38,7 @@ function getRequirementsForPerson(person: WorkforcePerson, requirements: Require
   const category = normalize(person.workforce_category);
 
   const matched = requirements.filter((requirement) => {
+    if (!requirement.required) return false;
     const reqRole = normalize(requirement.workforceRole);
     const reqCategory = normalize(requirement.workforceCategory);
 

--- a/features/shared/lib/workforce/documentRequirementsDefaults.ts
+++ b/features/shared/lib/workforce/documentRequirementsDefaults.ts
@@ -6,7 +6,7 @@ export type RequirementRule = {
   workforceCategory: string | null;
   docType: RequiredDocType;
   label: string;
-  required: true;
+  required: boolean;
   expiresRequired: boolean;
   warningDays: number;
 };
@@ -97,16 +97,6 @@ export const DEFAULT_DOCUMENT_REQUIREMENTS: RequirementRule[] = [
     expiresRequired: false,
     warningDays: DEFAULT_WARNING_DAYS,
   },
-  {
-    key: "default:active:tax_form",
-    workforceRole: null,
-    workforceCategory: null,
-    docType: "tax_form",
-    label: "Tax Form",
-    required: true,
-    expiresRequired: false,
-    warningDays: DEFAULT_WARNING_DAYS,
-  },
 ];
 
 const REQUIRED_DOC_TYPES = new Set<RequiredDocType>(["drivers_license", "certification", "tax_form", "other"]);
@@ -148,7 +138,7 @@ export function buildEffectiveDocumentRequirements(
           workforceCategory,
           docType,
           label,
-          required: true as const,
+          required: row.is_required,
           expiresRequired: row.expires_required,
           warningDays: row.expires_warning_days ?? DEFAULT_WARNING_DAYS,
         },

--- a/features/workforce/lib/schedulePosture.ts
+++ b/features/workforce/lib/schedulePosture.ts
@@ -1,0 +1,118 @@
+export type WorkforceScheduleTemplate = {
+  user_id: string;
+  day_of_week: number;
+  is_working_day: boolean;
+  start_time: string | null;
+  end_time: string | null;
+  effective_from?: string | null;
+  effective_to?: string | null;
+};
+
+export type WorkforceScheduleOverride = {
+  user_id: string;
+  schedule_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  status: string | null;
+};
+
+export type WorkforceSchedulePosture = {
+  dateKey: string;
+  dayOfWeek: number;
+  scheduled: boolean;
+  source: "override" | "template" | "none";
+};
+
+export function getShopScheduleDateContext(
+  at: Date,
+  timezone: string | null | undefined,
+) {
+  const fallback = "UTC";
+  let formatter: Intl.DateTimeFormat;
+  try {
+    formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone || fallback,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      weekday: "short",
+    });
+  } catch {
+    formatter = new Intl.DateTimeFormat("en-CA", {
+      timeZone: fallback,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      weekday: "short",
+    });
+  }
+
+  const parts = Object.fromEntries(
+    formatter
+      .formatToParts(at)
+      .filter((part) => part.type !== "literal")
+      .map((part) => [part.type, part.value]),
+  );
+  const weekday = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].indexOf(
+    parts.weekday ?? "",
+  );
+
+  return {
+    dateKey: `${parts.year}-${parts.month}-${parts.day}`,
+    dayOfWeek: weekday >= 0 ? weekday : at.getUTCDay(),
+  };
+}
+
+function appliesOnDate(
+  row: WorkforceScheduleTemplate,
+  dateKey: string,
+): boolean {
+  return (
+    (!row.effective_from || row.effective_from <= dateKey) &&
+    (!row.effective_to || row.effective_to >= dateKey)
+  );
+}
+
+export function resolveWorkforceSchedulePosture(params: {
+  userId: string;
+  at: Date;
+  timezone?: string | null;
+  templates: WorkforceScheduleTemplate[];
+  overrides: WorkforceScheduleOverride[];
+}): WorkforceSchedulePosture {
+  const { dateKey, dayOfWeek } = getShopScheduleDateContext(
+    params.at,
+    params.timezone,
+  );
+  const override = params.overrides.find(
+    (row) =>
+      row.user_id === params.userId &&
+      row.schedule_date === dateKey &&
+      String(row.status ?? "").toLowerCase() !== "cancelled",
+  );
+
+  if (override) {
+    return {
+      dateKey,
+      dayOfWeek,
+      scheduled: Boolean(override.start_time && override.end_time),
+      source: "override",
+    };
+  }
+
+  const template = params.templates.find(
+    (row) =>
+      row.user_id === params.userId &&
+      row.day_of_week === dayOfWeek &&
+      appliesOnDate(row, dateKey),
+  );
+
+  return {
+    dateKey,
+    dayOfWeek,
+    scheduled: Boolean(
+      template?.is_working_day && template.start_time && template.end_time,
+    ),
+    source: template ? "template" : "none",
+  };
+}

--- a/tests/workforce-cleanup.test.ts
+++ b/tests/workforce-cleanup.test.ts
@@ -62,7 +62,6 @@ describe("workforce cleanup consolidation", () => {
       "Payroll",
       "Documents",
       "Certifications",
-      "Insights",
       "Activity",
     ]);
     expect(getWorkforceNavigation("manager").map((item) => item.label)).toEqual([
@@ -70,7 +69,6 @@ describe("workforce cleanup consolidation", () => {
       "Attendance",
       "Schedule",
       "Payroll",
-      "Insights",
     ]);
   });
 

--- a/tests/workforce-command-shell.test.ts
+++ b/tests/workforce-command-shell.test.ts
@@ -73,6 +73,21 @@ describe("workforce command shell", () => {
     expect(layout).toContain('allow: ["owner", "admin", "manager"]');
     expect(shell).toContain('aria-label="Workforce sections"');
     expect(shell).toContain("Workforce Command");
+    expect(shell).toContain("xl:grid-cols-8");
+    expect(shell).not.toContain("overflow-x-auto");
+  });
+
+  it("does not advertise an unwired Insights placeholder", () => {
+    expect(
+      WORKFORCE_NAVIGATION.some(
+        (item) => item.href === "/dashboard/workforce/insights",
+      ),
+    ).toBe(false);
+    const legacyPage = readFileSync(
+      "app/dashboard/workforce/insights/page.tsx",
+      "utf8",
+    );
+    expect(legacyPage).toContain('redirect("/dashboard/workforce/overview")');
   });
 
   it("removes duplicate in-page quick-link navigation", () => {

--- a/tests/workforce-document-readiness.test.ts
+++ b/tests/workforce-document-readiness.test.ts
@@ -72,6 +72,22 @@ describe("buildDocumentRequirementsReadiness", () => {
     expect(result.readinessItems[0].missingDocTypes).toContain("tax_form");
   });
 
+  it("does not invent a tax-form requirement for an unclassified active owner", () => {
+    const result = buildDocumentRequirementsReadiness({
+      people: [{
+        id: "owner-1",
+        full_name: "Owner",
+        workforce_role: "owner",
+        workforce_category: null,
+        employment_status: "active",
+      }],
+      documents: [],
+    });
+
+    expect(result.readinessItems[0].readiness).toBe("ready");
+    expect(result.readinessItems[0].missingDocTypes).toEqual([]);
+  });
+
   it.each(["active", "approved", "accepted"])("treats accepted status '%s' as satisfying required documents", (status) => {
     const future = new Date(Date.now() + 1000 * 60 * 60 * 24 * 180).toISOString();
     const result = buildDocumentRequirementsReadiness({
@@ -121,6 +137,10 @@ describe("buildDocumentRequirementsReadiness", () => {
     const result = buildDocumentRequirementsReadiness({
       people: [makePerson({ workforce_category: "technician" })],
       documents: [{ id: "cert", user_id: "1", doc_type: "certification", status: "pending", expires_at: null, uploaded_at: "2024-01-01" }],
+      requirements: [
+        { key: "custom:certification", docType: "certification", label: "Certification", workforceCategory: "technician", workforceRole: null, required: true, expiresRequired: false, warningDays: 30 },
+        { key: "custom:license", docType: "drivers_license", label: "Driver's License", workforceCategory: "technician", workforceRole: null, required: true, expiresRequired: true, warningDays: 30 },
+      ],
     });
 
     expect(result.readinessItems[0].readiness).toBe("missing_required");
@@ -131,6 +151,10 @@ describe("buildDocumentRequirementsReadiness", () => {
       people: [makePerson({ workforce_category: "driver" })],
       documents: [
         { id: "license", user_id: "1", doc_type: "drivers_license", status: "accepted", expires_at: "2020-01-01", uploaded_at: "2019-01-01" },
+      ],
+      requirements: [
+        { key: "custom:license", docType: "drivers_license", label: "Driver's License", workforceCategory: "driver", workforceRole: null, required: true, expiresRequired: true, warningDays: 30 },
+        { key: "custom:certification", docType: "certification", label: "Certification", workforceCategory: "driver", workforceRole: null, required: true, expiresRequired: false, warningDays: 30 },
       ],
     });
 
@@ -215,6 +239,44 @@ describe("buildDocumentRequirementsReadiness", () => {
     expect(globalOther?.label).toBe("Custom Shop Doc");
   });
 
+  it("lets an active shop override disable a matching default requirement", () => {
+    const effective = applyOverrides([
+      {
+        id: "disable-tech-license",
+        workforce_role: "technician",
+        workforce_category: null,
+        doc_type: "drivers_license",
+        label: "Driver's License",
+        is_required: false,
+        expires_required: true,
+        expires_warning_days: 30,
+        priority: 10,
+        is_active: true,
+      },
+    ]);
+    const result = buildDocumentRequirementsReadiness({
+      people: [{
+        id: "1",
+        full_name: "Tech",
+        workforce_role: "technician",
+        workforce_category: null,
+        employment_status: "active",
+      }],
+      documents: [{
+        id: "cert",
+        user_id: "1",
+        doc_type: "certification",
+        status: "accepted",
+        expires_at: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString(),
+        uploaded_at: "2026-01-01",
+      }],
+      requirements: effective,
+    });
+
+    expect(result.readinessItems[0].missingDocTypes).not.toContain("drivers_license");
+    expect(result.readinessItems[0].readiness).toBe("ready");
+  });
+
   it("prefers category override over global override/default", () => {
     const effective = applyOverrides([
       {
@@ -281,7 +343,7 @@ describe("buildDocumentRequirementsReadiness", () => {
     expect(picked?.expiresRequired).toBe(false);
   });
 
-  it("ignores inactive overrides and keeps defaults", () => {
+  it("ignores inactive global overrides without inventing a global default", () => {
     const effective = applyOverrides([
       {
         id: "inactive-global-tax",
@@ -297,7 +359,7 @@ describe("buildDocumentRequirementsReadiness", () => {
       },
     ]);
     const globalTax = effective.find((rule) => rule.key === "default:active:tax_form");
-    expect(globalTax?.expiresRequired).toBe(false);
+    expect(globalTax).toBeUndefined();
   });
 
   it("ignores override rows with unsupported doc_type", () => {

--- a/tests/workforce-schedule-posture.test.ts
+++ b/tests/workforce-schedule-posture.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { resolveWorkforceSchedulePosture } from "@/features/workforce/lib/schedulePosture";
+
+const thursdayTemplate = {
+  user_id: "person-1",
+  day_of_week: 4,
+  is_working_day: true,
+  start_time: "08:00",
+  end_time: "17:00",
+  effective_from: null,
+  effective_to: null,
+};
+
+describe("workforce schedule posture", () => {
+  it("resolves the shop-local weekday rather than the server weekday", () => {
+    const result = resolveWorkforceSchedulePosture({
+      userId: "person-1",
+      at: new Date("2026-07-24T05:30:00.000Z"),
+      timezone: "America/Edmonton",
+      templates: [thursdayTemplate],
+      overrides: [],
+    });
+
+    expect(result).toMatchObject({
+      dateKey: "2026-07-23",
+      dayOfWeek: 4,
+      scheduled: true,
+      source: "template",
+    });
+  });
+
+  it("lets a dated day-off override replace the recurring template", () => {
+    const result = resolveWorkforceSchedulePosture({
+      userId: "person-1",
+      at: new Date("2026-07-23T18:00:00.000Z"),
+      timezone: "America/Edmonton",
+      templates: [thursdayTemplate],
+      overrides: [
+        {
+          user_id: "person-1",
+          schedule_date: "2026-07-23",
+          start_time: null,
+          end_time: null,
+          status: "scheduled",
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({ scheduled: false, source: "override" });
+  });
+
+  it("ignores templates outside their effective date range", () => {
+    const result = resolveWorkforceSchedulePosture({
+      userId: "person-1",
+      at: new Date("2026-07-23T18:00:00.000Z"),
+      timezone: "America/Edmonton",
+      templates: [
+        {
+          ...thursdayTemplate,
+          effective_to: "2026-07-22",
+        },
+      ],
+      overrides: [],
+    });
+
+    expect(result).toMatchObject({ scheduled: false, source: "none" });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1190. The shell was unified, but the pages still used conflicting definitions for employee status. This connects the Workforce pages to explicit, canonical posture/readiness signals so Schedule, Command, Attendance, Payroll, and Documents stop contradicting each other.

## What changed

- Separated scheduled, clocked-in, on-job, away, off, and payroll-recorded states.
- Connected Schedule to live attendance/job activity instead of showing active/not-away as “available/working.”
- Added shop-timezone-aware schedule posture resolution.
- Updated Workforce Command coverage counts to show scheduled today, clocked in, and working on jobs separately.
- Made Payroll distinguish active workforce, payroll-eligible people, excluded people, and recorded payable time.
- Prevented approval of an empty payroll period.
- Removed the incorrect fallback tax-form requirement for every active person.
- Honored disabled document requirements instead of still applying defaults.
- Removed the unwired Insights placeholder from primary navigation and redirects the old route to Command.
- Made Workforce tabs visible on tablet without horizontal discovery.

## Validation

- Full suite: 1,277 passed; 2 skipped.
- Focused Workforce tests: 43 passed.
- TypeScript: passed.
- Production compilation: passed.
- Page-data collection stopped only because local `supabaseUrl` is unavailable in the isolated worktree.
- Remote compare: 1 commit ahead of `main`, 0 behind, 18 files changed.

## Database

No migration required.

## Environment variables

No new variables required.

## Manual QA

- Owner/Admin/Manager Workforce Command: scheduled/clocked-in/on-job counts are distinct.
- Schedule: today roster labels show scheduled, clocked in, on job, away, or off clearly.
- Attendance: actual punches remain the source of clocked-in state.
- Payroll: payroll-ready roster and recorded time are not collapsed into one count.
- Documents: owner/unclassified users are not marked non-compliant by generic tax-form fallback.

Nothing has been merged or deployed.