### PR TITLE
Fix mobile Open Work provider boundary

### DIFF
--- a/app/mobile/layout.tsx
+++ b/app/mobile/layout.tsx
@@ -1,13 +1,23 @@
 // app/mobile/layout.tsx
 "use client";
 
+import { usePathname } from "next/navigation";
 
 import { MobileShell } from "components/layout/MobileShell";
+import TabsBridge from "@/features/shared/components/tabs/TabsBridge";
+import { isStandalonePublicRoute } from "@/features/shared/lib/routes/shellBoundaries";
 
 export default function MobileLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return <MobileShell>{children}</MobileShell>;
+  const pathname = usePathname() || "/mobile";
+  const shell = <MobileShell>{children}</MobileShell>;
+
+  if (isStandalonePublicRoute(pathname)) {
+    return shell;
+  }
+
+  return <TabsBridge>{shell}</TabsBridge>;
 }

--- a/tests/open-work-tray.test.ts
+++ b/tests/open-work-tray.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,6 +10,7 @@ import {
   visibleOpenWorkItems,
 } from "@/features/shared/components/tabs/openWork";
 import { metaFor } from "@/features/shared/lib/routeMeta";
+import { isStandalonePublicRoute } from "@/features/shared/lib/routes/shellBoundaries";
 
 const WORK_ORDER_ID = "4b2ab5f1-2e74-45f1-8c71-2b12fcd32e95";
 
@@ -151,6 +153,28 @@ describe("Open Work persistence and presentation", () => {
     );
     expect(metaFor(`/work-orders/${WORK_ORDER_ID}`).title).toContain(
       WORK_ORDER_ID.slice(0, 8),
+    );
+  });
+});
+
+
+describe("Open Work provider boundaries", () => {
+  it("provides Open Work to authenticated mobile routes without wrapping sign-in", () => {
+    const mobileLayout = readFileSync("app/mobile/layout.tsx", "utf8");
+
+    expect(isStandalonePublicRoute("/mobile/sign-in")).toBe(true);
+    expect(isStandalonePublicRoute("/mobile/sign-in/help")).toBe(true);
+    expect(isStandalonePublicRoute("/mobile")).toBe(false);
+    expect(isStandalonePublicRoute("/mobile/work-orders/EL000001")).toBe(false);
+
+    expect(mobileLayout).toContain(
+      'import TabsBridge from "@/features/shared/components/tabs/TabsBridge";',
+    );
+    expect(mobileLayout).toContain(
+      "if (isStandalonePublicRoute(pathname))",
+    );
+    expect(mobileLayout).toContain(
+      "return <TabsBridge>{shell}</TabsBridge>;",
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes the mobile login crash introduced by the Open Work redesign.

## Root cause

`MobileBottomNav` now consumes `useTabs()`, but mobile routes are deliberately rendered outside the desktop `AppShell`. The only `TabsProvider` lived inside the desktop `TabsBridge`, so the authenticated mobile shell rendered the menu without its required context and threw:

`useTabs must be used inside <TabsProvider>`

## What changed

- Wraps the shared authenticated `/mobile` layout in `TabsBridge`.
- Keeps `/mobile/sign-in` standalone so public authentication does not depend on session-scoped Open Work context.
- Covers every mobile role route, immersive job/inspection route, and the menu from one boundary.
- Adds regression coverage for authenticated mobile routes and the standalone sign-in exception.

## Impact

Mobile users can sign in and load their role dashboard again. Open Work remains available in the mobile menu and uses the same user-scoped persistence as desktop.

## Safety

This is a client-side provider-boundary fix. It does not change authentication, authorization, tenant data, workflow state, database schema, or production data.

## Validation

- Remote diff: 2 files only, 38 changed lines.
- Branch is 2 commits ahead and 0 behind `main`.
- Focused regression coverage added to `tests/open-work-tray.test.ts`.
- Vercel preview deployment: ready.
- Local execution is unavailable because workspace maintenance removed the repository checkout; validation is therefore limited to the regression guard, remote diff inspection, and successful Vercel production compilation.

## Smoke test

- Sign in through `/mobile/sign-in`.
- Confirm the role dashboard loads without the provider error.
- Open the hamburger menu and confirm Open Work renders.
- Open a work order and confirm it appears once in Open Work.
- Navigate to an immersive job and inspection route and confirm neither crashes.
- Sign out and confirm the standalone mobile sign-in screen still loads.
