### PR TITLE
Route mechanics directly to tech queue

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -43,6 +43,11 @@ export default function DashboardEntryPage() {
         return;
       }
 
+      if (role === "mechanic") {
+        router.replace("/tech/queue");
+        return;
+      }
+
       if (role === "lead_hand" || role === "foreman") {
         router.replace("/dashboard/operations");
         return;

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -53,7 +53,7 @@ export const TILES: Tile[] = [
     href: "/dashboard",
     title: "Shop Overview",
     subtitle: "Today at a glance",
-    roles: ["mechanic", "manager", "owner", "admin", "advisor", "parts", "fleet_manager", "dispatcher", "driver", "lead_hand", "foreman"],
+    roles: ["manager", "owner", "admin", "advisor", "parts", "fleet_manager", "dispatcher", "driver", "lead_hand", "foreman"],
     scopes: ["all"],
     section: "Dashboard",
   },

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -38,7 +38,11 @@ const PERSIST_DEFAULTS: PersistMeta = { scroll: true, inputs: true };
 const ALL_ROLES: UserRole[] | undefined = undefined;
 
 export const ROUTE_META: Record<string, RouteMeta> = {
-  "/dashboard": { title: () => "Shop Overview", icon: "🏠", roles: ALL_ROLES },
+  "/dashboard": {
+    title: () => "Shop Overview",
+    icon: "🏠",
+    roles: ["owner", "admin", "manager", "advisor", "parts", "dispatcher", "driver", "fleet_manager", "lead_hand", "foreman"],
+  },
   // ----------------------------------------------------------------
   // Work Orders
   // ----------------------------------------------------------------

--- a/tests/phase-d3-dashboard-navigation.test.tsx
+++ b/tests/phase-d3-dashboard-navigation.test.tsx
@@ -40,6 +40,7 @@ function sectionTitles(role: string, section: string) {
 function duplicateCount<T>(values: T[], value: T) {
   return values.filter((item) => item === value).length;
 }
+const dashboardEntry = read("app/dashboard/page.tsx");
 
 describe("Phase D3 dashboard operational navigation", () => {
   it("groups canonical daily operational views under Dashboard", () => {

--- a/tests/phase-d3-dashboard-navigation.test.tsx
+++ b/tests/phase-d3-dashboard-navigation.test.tsx
@@ -173,3 +173,16 @@ describe("Phase D3 dashboard operational navigation", () => {
     expect(read("app/dashboard/manager/dispatch/page.tsx")).toContain('redirect("/work-orders/board")');
   });
 });
+
+
+test("mechanic dashboard entry redirects to the tech queue instead of shop overview", () => {
+  expect(dashboardEntry).toContain('if (role === "mechanic")');
+  expect(dashboardEntry).toContain('router.replace("/tech/queue")');
+  expect(navTiles).toContain('title: "Shop Overview"');
+  expect(navTiles).toContain('title: "Tech Job Queue"');
+  expect(navTiles).toContain('title: "Team Chat"');
+  expect(navTiles).toContain('title: "My Performance"');
+  expect(navTiles).toContain('roles: ["manager", "owner", "admin", "advisor", "parts", "fleet_manager", "dispatcher", "driver", "lead_hand", "foreman"]');
+  expect(routeMeta).toContain('"/dashboard":');
+  expect(routeMeta).not.toContain('roles: ALL_ROLES },');
+});

--- a/tests/phase-d3-dashboard-navigation.test.tsx
+++ b/tests/phase-d3-dashboard-navigation.test.tsx
@@ -176,14 +176,20 @@ describe("Phase D3 dashboard operational navigation", () => {
 });
 
 
-test("mechanic dashboard entry redirects to the tech queue instead of shop overview", () => {
-  expect(dashboardEntry).toContain('if (role === "mechanic")');
-  expect(dashboardEntry).toContain('router.replace("/tech/queue")');
-  expect(navTiles).toContain('title: "Shop Overview"');
-  expect(navTiles).toContain('title: "Tech Job Queue"');
-  expect(navTiles).toContain('title: "Team Chat"');
-  expect(navTiles).toContain('title: "My Performance"');
-  expect(navTiles).toContain('roles: ["manager", "owner", "admin", "advisor", "parts", "fleet_manager", "dispatcher", "driver", "lead_hand", "foreman"]');
-  expect(routeMeta).toContain('"/dashboard":');
-  expect(routeMeta).not.toContain('roles: ALL_ROLES },');
+describe("mechanic shop dashboard removal", () => {
+  it("routes dashboard entry to the tech queue and keeps the rest of tech navigation", () => {
+    const dashboardEntry = read("app/dashboard/page.tsx");
+    const navTiles = read("features/shared/config/tiles.ts");
+    const routeMeta = read("features/shared/lib/routeMeta.ts");
+
+    expect(dashboardEntry).toContain('if (role === "mechanic")');
+    expect(dashboardEntry).toContain('router.replace("/tech/queue")');
+    expect(navTiles).toContain('title: "Shop Overview"');
+    expect(navTiles).toContain('title: "Tech Job Queue"');
+    expect(navTiles).toContain('title: "Team Chat"');
+    expect(navTiles).toContain('title: "My Performance"');
+    expect(navTiles).toContain('roles: ["manager", "owner", "admin", "advisor", "parts", "fleet_manager", "dispatcher", "driver", "lead_hand", "foreman"]');
+    expect(routeMeta).toContain('"/dashboard":');
+    expect(routeMeta).not.toContain('roles: ALL_ROLES },');
+  });
 });


### PR DESCRIPTION
## Summary

- Removes the mechanic role from the sidebar/tab Shop Overview dashboard tile.
- Redirects mechanics who hit `/dashboard` straight to `/tech/queue`.
- Keeps the rest of mechanic navigation intact: Tech Job Queue, Team Chat, Tech Settings, and My Performance.
- Leaves owner/admin/manager/advisor/parts/dispatcher/driver/fleet/lead hand/foreman shop dashboard access unchanged.

## Validation

- Added static coverage in `tests/phase-d3-dashboard-navigation.test.tsx` for mechanic dashboard routing and retained tech navigation.

## Notes

PR #1199 was already merged, so this is a small follow-up branch off current `main`.