### PR TITLE
Fix desktop inbox thread refresh and unread badge

### DIFF
--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -197,6 +197,22 @@ export default function InboxModal({
     );
   }, [seedConversationId]);
 
+  const loadMessages = useCallback(async (conversationId: string) => {
+    const res = await fetch("/api/chat/get-messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationId }),
+    });
+    const data = await res.json().catch(() => null);
+    setMessages(Array.isArray(data) ? data : []);
+    await fetch("/api/chat/mark-read", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationId }),
+    }).catch(() => undefined);
+    window.dispatchEvent(new CustomEvent("profixiq:inbox-read"));
+  }, []);
+
   useEffect(() => {
     if (!open) return;
 
@@ -328,21 +344,27 @@ export default function InboxModal({
   useEffect(() => {
     if (!open || !activeConversationId) return;
 
-    void fetch("/api/chat/get-messages", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ conversationId: activeConversationId }),
-    })
-      .then((r) => r.json())
-      .then((data) => {
-        setMessages(Array.isArray(data) ? data : []);
-        void fetch("/api/chat/mark-read", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ conversationId: activeConversationId }),
-        });
-      });
-  }, [open, activeConversationId]);
+    void loadMessages(activeConversationId);
+  }, [open, activeConversationId, loadMessages]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const refresh = (event: Event) => {
+      const detail = (event as CustomEvent<{ conversationId?: string | null }>).detail;
+      const conversationId = detail?.conversationId ?? activeConversationId;
+      void loadConversations();
+      if (conversationId) {
+        setActiveConversationId(conversationId);
+        void loadMessages(conversationId);
+      }
+    };
+
+    window.addEventListener("profixiq:inbox-refresh", refresh);
+    return () => {
+      window.removeEventListener("profixiq:inbox-refresh", refresh);
+    };
+  }, [activeConversationId, loadConversations, loadMessages, open]);
 
   useEffect(() => {
     if (!open || !activeConversationId) return;
@@ -491,6 +513,10 @@ export default function InboxModal({
         conversationId = data.id;
       }
 
+      if (!conversationId) {
+        throw new Error("Could not resolve inbox thread");
+      }
+
       const res = await fetch("/api/chat/send-message", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -511,6 +537,14 @@ export default function InboxModal({
         const failure = (await res.json().catch(() => null)) as { error?: string } | null;
         throw new Error(failure?.error ?? "Could not send message");
       }
+      const sentMessage = (await res.json().catch(() => null)) as MessageRow | null;
+      if (sentMessage?.id) {
+        setMessages((prev) =>
+          prev.some((message) => message.id === sentMessage.id)
+            ? prev
+            : [...prev, sentMessage],
+        );
+      }
       if (draftScope) {
         await removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
       }
@@ -521,6 +555,12 @@ export default function InboxModal({
       }
       setActiveConversationId(conversationId);
       await loadConversations();
+      await loadMessages(conversationId);
+      window.dispatchEvent(
+        new CustomEvent("profixiq:inbox-refresh", {
+          detail: { conversationId },
+        }),
+      );
     } catch (cause) {
       setSendError(cause instanceof Error ? cause.message : "Could not send message");
     } finally {
@@ -537,6 +577,7 @@ export default function InboxModal({
     useContext,
     context,
     loadConversations,
+    loadMessages,
     messageDraft,
     draftScope,
     draftTargetId,

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
@@ -66,6 +66,10 @@ type AppShellInitialIdentity = {
   role: string | null;
 };
 
+type InboxConversationSummary = {
+  unread_count?: number | null;
+};
+
 function daysUntil(iso: string | null): number | null {
   if (!iso) return null;
   const t = new Date(iso).getTime();
@@ -108,6 +112,7 @@ export default function AppShell({
   const [chatOpen, setChatOpen] = useState(false);
   const [agentDialogOpen, setAgentDialogOpen] = useState(false);
   const [incomingConvoId, setIncomingConvoId] = useState<string | null>(null);
+  const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
   const punchRef = useRef<HTMLDivElement | null>(null);
@@ -124,6 +129,27 @@ export default function AppShell({
   const showBillingBadge = isBillingAttentionStatus(subStatus);
 
   const billingHref = "/dashboard/owner/settings#billing";
+
+  const loadInboxUnreadCount = useCallback(async () => {
+    if (!userId || !isAppRoute) {
+      setInboxUnreadCount(0);
+      return;
+    }
+
+    const response = await fetch("/api/chat/my-conversations", {
+      credentials: "include",
+    }).catch(() => null);
+    if (!response?.ok) return;
+
+    const conversations = (await response.json().catch(() => [])) as InboxConversationSummary[];
+    const count = Array.isArray(conversations)
+      ? conversations.reduce(
+          (sum, row) => sum + Math.max(0, Number(row.unread_count ?? 0)),
+          0,
+        )
+      : 0;
+    setInboxUnreadCount(count);
+  }, [isAppRoute, userId]);
 
   useEffect(() => {
     if (!isAppRoute) return;
@@ -199,6 +225,12 @@ export default function AppShell({
               return;
 
             setIncomingConvoId(msg.conversation_id);
+            setInboxUnreadCount((count) => Math.max(count + 1, 1));
+            window.dispatchEvent(
+              new CustomEvent("profixiq:inbox-refresh", {
+                detail: { conversationId: msg.conversation_id },
+              }),
+            );
             setChatOpen(true);
           },
         )
@@ -211,6 +243,26 @@ export default function AppShell({
 
     return () => cleanup?.();
   }, [supabase, isAppRoute]);
+
+  useEffect(() => {
+    if (!isAppRoute || !userId) {
+      setInboxUnreadCount(0);
+      return;
+    }
+
+    void loadInboxUnreadCount();
+    const refresh = () => {
+      void loadInboxUnreadCount();
+    };
+    const interval = window.setInterval(refresh, 60_000);
+    window.addEventListener("profixiq:inbox-refresh", refresh);
+    window.addEventListener("profixiq:inbox-read", refresh);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("profixiq:inbox-refresh", refresh);
+      window.removeEventListener("profixiq:inbox-read", refresh);
+    };
+  }, [isAppRoute, loadInboxUnreadCount, userId]);
 
   useEffect(() => {
     if (!userId) {
@@ -460,6 +512,11 @@ export default function AppShell({
 
               <ActionButton onClick={() => setChatOpen(true)} title="Inbox">
                 <span>Inbox</span>
+                {inboxUnreadCount > 0 ? (
+                  <span className="ml-0.5 rounded-full bg-[var(--accent-copper-soft)] px-1.5 py-0.5 text-[10px] font-bold leading-none text-[color:var(--theme-text-on-accent)]">
+                    {inboxUnreadCount > 99 ? "99+" : inboxUnreadCount}
+                  </span>
+                ) : null}
               </ActionButton>
 
               {userId ? (

--- a/tests/offline-message-drafts.test.ts
+++ b/tests/offline-message-drafts.test.ts
@@ -7,6 +7,7 @@ const scopeRoute = read("app/api/chat/offline-scope/route.ts");
 const staffInbox = read("features/chat/components/InboxModal.tsx");
 const portal = read("features/chat/components/PortalMessagesWorkspace.tsx");
 const chatWindow = read("features/ai/components/chat/ChatWindow.tsx");
+const appShell = read("features/shared/components/AppShell.tsx");
 const serviceWorker = read("app/sw.ts");
 
 describe("offline messaging drafts", () => {
@@ -80,5 +81,21 @@ describe("offline messaging drafts", () => {
     expect(serviceWorker).toContain('url.pathname === "/portal/messages"');
     expect(serviceWorker).toContain('cacheName: "profixiq-messaging-shell-v1"');
     expect(serviceWorker).toContain("new NetworkFirst");
+  });
+
+  it("keeps tablet desktop inbox replies and unread badges in sync", () => {
+    expect(staffInbox).toContain("const loadMessages = useCallback");
+    expect(staffInbox).toContain("setMessages((prev) =>");
+    expect(staffInbox).toContain("await loadMessages(conversationId)");
+    expect(staffInbox).toContain('new CustomEvent("profixiq:inbox-refresh"');
+    expect(staffInbox).toContain("detail: { conversationId }");
+    expect(staffInbox).toContain('new CustomEvent("profixiq:inbox-read")');
+
+    expect(appShell).toContain("inboxUnreadCount");
+    expect(appShell).toContain("loadInboxUnreadCount");
+    expect(appShell).toContain('"/api/chat/my-conversations"');
+    expect(appShell).toContain('window.addEventListener("profixiq:inbox-refresh"');
+    expect(appShell).toContain('window.addEventListener("profixiq:inbox-read"');
+    expect(appShell).toContain('{inboxUnreadCount > 99 ? "99+" : inboxUnreadCount}');
   });
 });

--- a/tests/phase-d3-dashboard-navigation.test.tsx
+++ b/tests/phase-d3-dashboard-navigation.test.tsx
@@ -40,7 +40,6 @@ function sectionTitles(role: string, section: string) {
 function duplicateCount<T>(values: T[], value: T) {
   return values.filter((item) => item === value).length;
 }
-const dashboardEntry = read("app/dashboard/page.tsx");
 
 describe("Phase D3 dashboard operational navigation", () => {
   it("groups canonical daily operational views under Dashboard", () => {
@@ -91,12 +90,12 @@ describe("Phase D3 dashboard operational navigation", () => {
     const mechanicHrefs = mechanicTiles.map((tile) => tile.href);
 
     expect(mechanicTitles).toEqual(expect.arrayContaining([
-      "Shop Overview",
       "Tech Job Queue",
       "Team Chat",
       "Tech Settings",
       "My Performance",
     ]));
+    expect(mechanicTitles).not.toContain("Shop Overview");
     expect(mechanicTitles).not.toContain("My Parts Requests");
     expect(mechanicTitles).not.toContain("History");
     expect(mechanicHrefs).not.toContain("/parts/requests?mine=1");


### PR DESCRIPTION
## Summary

- Reload the active inbox thread from `/api/chat/get-messages` when inbox refresh events arrive, so tablet/desktop panes do not show a stale message stream while the left preview updates.
- Append/reload sent messages after `send-message` and broadcast conversation-specific inbox refresh events.
- Add a desktop header unread count badge sourced from `/api/chat/my-conversations`, refreshed on incoming messages, reads, sends, and periodic polling.
- Align the dashboard navigation test with the current mechanic shop-dashboard removal on `main`.

## Validation

- `./node_modules/.bin/vitest run tests/offline-message-drafts.test.ts tests/phase-d3-dashboard-navigation.test.tsx`
- `./node_modules/.bin/tsc --noEmit`

Note: local `git push` was blocked by missing HTTPS credentials in the shell, so the branch files were updated through the GitHub connector.