### PR TITLE
Fix technician menu, dictation, and parts picker

### DIFF
--- a/app/api/parts/picker/route.ts
+++ b/app/api/parts/picker/route.ts
@@ -1,0 +1,169 @@
+import { NextResponse } from "next/server";
+
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type WorkOrderLineTechnician =
+  DB["public"]["Tables"]["work_order_line_technicians"]["Row"];
+
+const ALLOWED_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "parts",
+  "mechanic",
+  "lead_hand",
+  "foreman",
+] as const;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function cleanSearch(value: string | null): string {
+  return (value ?? "")
+    .replace(/[,%_().]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 80);
+}
+
+async function mechanicCanUseLine(input: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  lineId: string | null;
+  shopId: string;
+  technicianId: string;
+}): Promise<boolean> {
+  if (!input.lineId || !UUID_PATTERN.test(input.lineId)) return false;
+
+  const { data: line, error } = await input.admin
+    .from("work_order_lines")
+    .select("id,assigned_tech_id,assigned_to")
+    .eq("id", input.lineId)
+    .eq("shop_id", input.shopId)
+    .maybeSingle<
+      Pick<WorkOrderLine, "id" | "assigned_tech_id" | "assigned_to">
+    >();
+
+  if (error || !line) return false;
+  if (
+    line.assigned_tech_id === input.technicianId ||
+    line.assigned_to === input.technicianId
+  ) {
+    return true;
+  }
+
+  const { data: sharedAssignment, error: sharedError } = await input.admin
+    .from("work_order_line_technicians")
+    .select("id")
+    .eq("work_order_line_id", line.id)
+    .eq("technician_id", input.technicianId)
+    .maybeSingle<Pick<WorkOrderLineTechnician, "id">>();
+
+  return !sharedError && Boolean(sharedAssignment);
+}
+
+export async function GET(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ALLOWED_ROLES,
+  });
+  if (!access.ok) return access.response;
+
+  const url = new URL(request.url);
+  const lineId = url.searchParams.get("workOrderLineId")?.trim() || null;
+  const search = cleanSearch(url.searchParams.get("q"));
+  const admin = createAdminSupabase();
+
+  if (
+    access.canonicalRole === "mechanic" &&
+    !(await mechanicCanUseLine({
+      admin,
+      lineId,
+      shopId: access.profile.shop_id,
+      technicianId: access.profile.id,
+    }))
+  ) {
+    return NextResponse.json(
+      { error: "This inventory picker is limited to your assigned jobs." },
+      { status: 403 },
+    );
+  }
+
+  let partsQuery = admin
+    .from("parts")
+    .select(
+      "id,shop_id,name,sku,part_number,category,default_cost,cost,price",
+    )
+    .eq("shop_id", access.profile.shop_id)
+    .order("name")
+    .limit(50);
+
+  if (search) {
+    const pattern = `%${search}%`;
+    partsQuery = partsQuery.or(
+      `name.ilike.${pattern},sku.ilike.${pattern},part_number.ilike.${pattern},category.ilike.${pattern}`,
+    );
+  }
+
+  const [partsResult, locationsResult] = await Promise.all([
+    partsQuery,
+    admin
+      .from("stock_locations")
+      .select("id,code,name,shop_id")
+      .eq("shop_id", access.profile.shop_id)
+      .order("code"),
+  ]);
+
+  if (partsResult.error) {
+    return NextResponse.json(
+      { error: partsResult.error.message || "Unable to load parts inventory." },
+      { status: 500 },
+    );
+  }
+  if (locationsResult.error) {
+    return NextResponse.json(
+      {
+        error:
+          locationsResult.error.message ||
+          "Unable to load inventory locations.",
+      },
+      { status: 500 },
+    );
+  }
+
+  const parts = partsResult.data ?? [];
+  const partIds = parts.map((part) => part.id);
+  const stockResult = partIds.length
+    ? await admin
+        .from("v_part_stock")
+        .select(
+          "part_id,location_id,qty_available,qty_on_hand,qty_reserved",
+        )
+        .in("part_id", partIds)
+    : { data: [], error: null };
+
+  if (stockResult.error) {
+    return NextResponse.json(
+      { error: stockResult.error.message || "Unable to load inventory stock." },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      shopId: access.profile.shop_id,
+      parts,
+      locations: locationsResult.data ?? [],
+      stock: stockResult.data ?? [],
+    },
+    {
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    },
+  );
+}

--- a/features/mobile/config/mobile-tiles.ts
+++ b/features/mobile/config/mobile-tiles.ts
@@ -110,7 +110,6 @@ export const MOBILE_TILES: MobileTile[] = [
     title: "Inspections",
     subtitle: "Run checklists on vehicles",
     roles: [
-      "mechanic",
       "owner",
       "admin",
       "advisor",

--- a/features/parts/components/PartPicker.tsx
+++ b/features/parts/components/PartPicker.tsx
@@ -13,7 +13,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 import {
   useAiPartSuggestions,
@@ -33,6 +32,13 @@ type VStock = {
   qty_available: number;
   qty_on_hand: number;
   qty_reserved: number;
+};
+
+type PartPickerResponse = {
+  parts?: PartRow[];
+  locations?: StockLoc[];
+  stock?: VStock[];
+  error?: string;
 };
 
 export type AvailabilityFlag =
@@ -122,9 +128,6 @@ export function PartPicker({
   requireLocation = false,
   variant = "modal",
 }: Props) {
-  const supabase = useMemo(() => createBrowserSupabase(), []);
-
-  const [shopId, setShopId] = useState<UUID>("");
   const [search, setSearch] = useState(initialSearch);
 
   const [parts, setParts] = useState<PartRow[]>([]);
@@ -178,48 +181,6 @@ export function PartPicker({
   };
 
   useEffect(() => {
-    if (!open) return;
-
-    (async () => {
-      setErr(null);
-
-      const { data: auth } = await supabase.auth.getUser();
-      const userId = auth.user?.id;
-      if (!userId) return;
-
-      // profiles keyed by id = auth.uid()
-      const { data: prof, error: pe } = await supabase
-        .from("profiles")
-        .select("shop_id")
-        .eq("id", userId)
-        .maybeSingle();
-
-      if (pe) {
-        setErr(pe.message);
-        return;
-      }
-
-      const sid = (prof?.shop_id as UUID | null) ?? "";
-      setShopId(sid);
-
-      if (!sid) return;
-
-      const { data: locsData, error: le } = await supabase
-        .from("stock_locations")
-        .select("id, code, name, shop_id")
-        .eq("shop_id", sid)
-        .order("code");
-
-      if (le) {
-        setErr(le.message);
-        return;
-      }
-
-      setLocs((locsData ?? []) as StockLoc[]);
-    })();
-  }, [open, supabase]);
-
-  useEffect(() => {
     if (!open || !workOrderId) return;
 
     void suggest({
@@ -241,7 +202,7 @@ export function PartPicker({
   ]);
 
   useEffect(() => {
-    if (!open || !shopId) return;
+    if (!open) return;
 
     let cancelled = false;
 
@@ -250,55 +211,48 @@ export function PartPicker({
       setErr(null);
 
       try {
-        let q = supabase
-          .from("parts")
-          .select("*")
-          .eq("shop_id", shopId)
-          .order("name")
-          .limit(50);
-
+        const params = new URLSearchParams();
         const term = search.trim();
-        if (term) {
-          q = q.or(
-            `name.ilike.%${term}%,sku.ilike.%${term}%,part_number.ilike.%${term}%,category.ilike.%${term}%`,
-          );
+        if (term) params.set("q", term);
+        if (workOrderLineId) {
+          params.set("workOrderLineId", workOrderLineId);
         }
 
-        const { data: rows, error } = await q;
-        if (error) throw error;
+        const response = await fetch(`/api/parts/picker?${params.toString()}`, {
+          method: "GET",
+          cache: "no-store",
+          credentials: "same-origin",
+        });
+        const body = (await response.json().catch(() => null)) as
+          | PartPickerResponse
+          | null;
+        if (!response.ok) {
+          throw new Error(body?.error || "Unable to load parts inventory.");
+        }
         if (cancelled) return;
 
-        const rowsSafe = (rows ?? []) as PartRow[];
+        const rowsSafe = Array.isArray(body?.parts) ? body.parts : [];
+        const locationsSafe = Array.isArray(body?.locations)
+          ? body.locations
+          : [];
+        const stockSafe = Array.isArray(body?.stock) ? body.stock : [];
+
         setParts(rowsSafe);
+        setLocs(locationsSafe);
 
-        const ids = rowsSafe.map((r) => r.id as UUID);
-        if (ids.length) {
-          const { data: vs, error: ve } = await supabase
-            .from("v_part_stock")
-            .select(
-              "part_id, location_id, qty_available, qty_on_hand, qty_reserved",
-            )
-            .in("part_id", ids);
-
-          if (ve) throw ve;
-
-          const grouped: Record<UUID, VStock[]> = {};
-          (vs ?? []).forEach((s) => {
-            const key = s.part_id as UUID;
-            if (!grouped[key]) grouped[key] = [];
-            grouped[key].push({
-              part_id: s.part_id as UUID,
-              location_id: s.location_id as UUID,
-              qty_available: Number(s.qty_available),
-              qty_on_hand: Number(s.qty_on_hand),
-              qty_reserved: Number(s.qty_reserved),
-            });
+        const grouped: Record<UUID, VStock[]> = {};
+        stockSafe.forEach((entry) => {
+          const key = entry.part_id as UUID;
+          if (!grouped[key]) grouped[key] = [];
+          grouped[key].push({
+            part_id: key,
+            location_id: entry.location_id as UUID,
+            qty_available: Number(entry.qty_available),
+            qty_on_hand: Number(entry.qty_on_hand),
+            qty_reserved: Number(entry.qty_reserved),
           });
-
-          if (!cancelled) setStock(grouped);
-        } else {
-          setStock({});
-        }
+        });
+        setStock(grouped);
       } catch (e: unknown) {
         if (!cancelled)
           setErr(e instanceof Error ? e.message : "Search failed");
@@ -310,7 +264,7 @@ export function PartPicker({
     return () => {
       cancelled = true;
     };
-  }, [open, shopId, search, supabase]);
+  }, [open, search, workOrderLineId]);
 
   useEffect(() => {
     if (!open) return;
@@ -452,29 +406,13 @@ export function PartPicker({
   async function resolveSuggestionToPartId(
     s: AiPartSuggestion,
   ): Promise<string | null> {
-    if (!shopId) return null;
-
-    if (s.sku) {
-      const { data } = await supabase
-        .from("parts")
-        .select("id")
-        .eq("shop_id", shopId)
-        .eq("sku", s.sku)
-        .maybeSingle();
-      if (data?.id) return data.id as string;
-    }
-
-    if (s.title) {
-      const { data } = await supabase
-        .from("parts")
-        .select("id")
-        .eq("shop_id", shopId)
-        .ilike("name", s.title)
-        .maybeSingle();
-      if (data?.id) return data.id as string;
-    }
-
-    return null;
+    const sku = s.sku?.trim().toLowerCase();
+    const title = s.title?.trim().toLowerCase();
+    const matched = parts.find((part) => {
+      if (sku && part.sku?.trim().toLowerCase() === sku) return true;
+      return Boolean(title && part.name?.trim().toLowerCase() === title);
+    });
+    return matched?.id ?? null;
   }
 
   if (!open) return null;

--- a/features/shared/voice/VoiceDictationButton.tsx
+++ b/features/shared/voice/VoiceDictationButton.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Mic, Square } from "lucide-react";
-import { Button } from "@shared/components/ui/Button";
+import { Button } from "@/features/shared/components/ui/Button";
 import {
   useRealtimeVoice,
   type VoiceState,
-} from "@inspections/lib/inspection/useRealtimeVoice";
+} from "@/features/inspections/lib/inspection/useRealtimeVoice";
 
 type VoiceDictationButtonProps = {
   onTranscript: (text: string) => void;
@@ -15,6 +15,30 @@ type VoiceDictationButtonProps = {
   listeningLabel?: string;
   className?: string;
 };
+
+type SpeechRecognitionConstructor = new () => SpeechRecognition;
+type DictationSource = "native" | "realtime" | null;
+
+function getNativeSpeechRecognition(): SpeechRecognitionConstructor | null {
+  if (typeof window === "undefined") return null;
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null;
+}
+
+function nativeSpeechErrorMessage(error: string | undefined): string {
+  switch (error) {
+    case "not-allowed":
+    case "service-not-allowed":
+      return "Microphone access is blocked. Allow microphone access and try again.";
+    case "audio-capture":
+      return "No microphone is available.";
+    case "network":
+      return "Dictation could not reach the speech service.";
+    case "no-speech":
+      return "No speech was detected. Try again.";
+    default:
+      return "Voice dictation stopped unexpectedly. Try again.";
+  }
+}
 
 export default function VoiceDictationButton({
   onTranscript,
@@ -25,6 +49,13 @@ export default function VoiceDictationButton({
 }: VoiceDictationButtonProps): JSX.Element {
   const [state, setState] = useState<VoiceState>("idle");
   const [error, setError] = useState<string | null>(null);
+  const sourceRef = useRef<DictationSource>(null);
+  const nativeRecognitionRef = useRef<SpeechRecognition | null>(null);
+  const onTranscriptRef = useRef(onTranscript);
+
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  }, [onTranscript]);
 
   const voice = useRealtimeVoice(
     (text) => onTranscript(text.trim()),
@@ -37,21 +68,86 @@ export default function VoiceDictationButton({
 
   const active = state === "connecting" || state === "listening";
 
+  const startNativeDictation = (
+    Constructor: SpeechRecognitionConstructor,
+  ): void => {
+    const recognition = new Constructor();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
+
+    recognition.onstart = () => setState("listening");
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const completed: string[] = [];
+      for (let index = event.resultIndex; index < event.results.length; index += 1) {
+        const result = event.results[index];
+        if (!result?.isFinal) continue;
+        const transcript = result[0]?.transcript?.trim();
+        if (transcript) completed.push(transcript);
+      }
+      const transcript = completed.join(" ").trim();
+      if (transcript) onTranscriptRef.current(transcript);
+    };
+    recognition.onerror = (event: Event & { error?: string }) => {
+      setError(nativeSpeechErrorMessage(event.error));
+      setState("error");
+    };
+    recognition.onend = () => {
+      nativeRecognitionRef.current = null;
+      sourceRef.current = null;
+      setState("idle");
+    };
+
+    nativeRecognitionRef.current = recognition;
+    sourceRef.current = "native";
+    setState("connecting");
+    recognition.start();
+  };
+
   const toggle = async (): Promise<void> => {
     setError(null);
     if (active) {
-      voice.stop();
+      if (sourceRef.current === "native") {
+        nativeRecognitionRef.current?.stop();
+      } else {
+        voice.stop();
+        sourceRef.current = null;
+      }
       return;
     }
 
+    const NativeSpeechRecognition = getNativeSpeechRecognition();
+    if (NativeSpeechRecognition) {
+      try {
+        startNativeDictation(NativeSpeechRecognition);
+        return;
+      } catch {
+        nativeRecognitionRef.current = null;
+        sourceRef.current = null;
+      }
+    }
+
     try {
+      sourceRef.current = "realtime";
       await voice.start();
     } catch (caught) {
+      sourceRef.current = null;
+      setState("error");
       setError(
         caught instanceof Error ? caught.message : "Voice dictation unavailable.",
       );
     }
   };
+
+  useEffect(() => {
+    return () => {
+      try {
+        nativeRecognitionRef.current?.abort();
+      } catch {}
+      nativeRecognitionRef.current = null;
+      sourceRef.current = null;
+    };
+  }, []);
 
   return (
     <div className={className}>

--- a/features/work-orders/components/UsePartButton.tsx
+++ b/features/work-orders/components/UsePartButton.tsx
@@ -85,6 +85,7 @@ export function UsePartButton({
 
       <PartPicker
         open={open}
+        workOrderLineId={workOrderLineId}
         onClose={() => setOpen(false)}
         onPick={handlePick}
         requireLocation

--- a/tests/mobile-technician-first-ux.test.ts
+++ b/tests/mobile-technician-first-ux.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it, test } from "vitest";
+import { getMobileTilesForRole } from "@/features/mobile/config/mobile-tiles";
 
 const mobileHome = readFileSync("app/mobile/page.tsx", "utf8");
 const techHome = readFileSync(
@@ -69,6 +70,14 @@ describe("technician-first mobile UX", () => {
     expect(techHome).not.toContain("next action");
   });
 
+  it("keeps inspections out of the mechanic menu while preserving job access", () => {
+    const mechanicRoutes = getMobileTilesForRole("mechanic", ["all"]).map(
+      (tile) => tile.href,
+    );
+    expect(mechanicRoutes).not.toContain("/mobile/inspections");
+    expect(mechanicRoutes).toContain("/mobile/tech/queue");
+  });
+
   it("uses a factual job queue without AI or prescribed next steps", () => {
     expect(queuePage).toContain("MobileTechnicianQueue");
     expect(queue).toContain('href={`/mobile/jobs/${line.id}`}');
@@ -112,12 +121,12 @@ describe("technician-first mobile UX", () => {
     expect(photoModal).toContain("Take photo");
     expect(photoModal).toContain("Choose existing");
     expect(photoModal).toContain("Open camera");
-    expect(photoModal).toContain("Choose photo");
+    expect(photoModal).toContain("Choose media");
     expect(photoModal).toContain('capture="environment"');
     expect(photoModal).toContain("void upload(selected);");
     expect(photoModal).toContain("hideFooter");
-    expect(photoModal).toContain('title="Attach Photo"');
-    expect(photoModal).toContain('submitText={busy ? "Uploading…" : "Upload"}');
+    expect(photoModal).toContain('title="Attach photo / video"');
+    expect(photoModal).toContain('{busy ? "Uploading..." : "Upload"}');
   });
 
   it("keeps the assistant contextual, question-driven, and non-automatic", () => {

--- a/tests/part-picker-async-submit.test.tsx
+++ b/tests/part-picker-async-submit.test.tsx
@@ -157,6 +157,69 @@ describe("PartPicker async submission", () => {
         return `00000000-0000-4000-8000-${String(keySequence).padStart(12, "0")}`;
       }),
     });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          shopId: "00000000-0000-4000-8000-000000000002",
+          parts: [
+            {
+              id: PART_A,
+              shop_id: "00000000-0000-4000-8000-000000000002",
+              name: "Brake Pad",
+              sku: "PAD-1",
+              part_number: "BP-1",
+              category: "Brakes",
+              default_cost: 12,
+              cost: 10,
+              price: 24,
+            },
+            {
+              id: PART_B,
+              shop_id: "00000000-0000-4000-8000-000000000002",
+              name: "Brake Rotor",
+              sku: "ROTOR-1",
+              part_number: "BR-1",
+              category: "Brakes",
+              default_cost: 30,
+              cost: 28,
+              price: 60,
+            },
+          ],
+          locations: [
+            {
+              id: LOCATION_A,
+              shop_id: "00000000-0000-4000-8000-000000000002",
+              code: "A",
+              name: "Shelf A",
+            },
+            {
+              id: LOCATION_B,
+              shop_id: "00000000-0000-4000-8000-000000000002",
+              code: "B",
+              name: "Shelf B",
+            },
+          ],
+          stock: [
+            {
+              part_id: PART_A,
+              location_id: LOCATION_A,
+              qty_available: 5,
+              qty_on_hand: 5,
+              qty_reserved: 0,
+            },
+            {
+              part_id: PART_B,
+              location_id: LOCATION_B,
+              qty_available: 5,
+              qty_on_hand: 5,
+              qty_reserved: 0,
+            },
+          ],
+        }),
+      })),
+    );
   });
 
   afterEach(() => {

--- a/tests/technician-part-picker-access.test.ts
+++ b/tests/technician-part-picker-access.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const picker = readFileSync(
+  "features/parts/components/PartPicker.tsx",
+  "utf8",
+);
+const usePartButton = readFileSync(
+  "features/work-orders/components/UsePartButton.tsx",
+  "utf8",
+);
+const pickerRoute = readFileSync("app/api/parts/picker/route.ts", "utf8");
+
+describe("technician part picker access", () => {
+  it("loads inventory through a server-scoped route", () => {
+    expect(picker).toContain("fetch(`/api/parts/picker?");
+    expect(picker).toContain('params.set("workOrderLineId", workOrderLineId)');
+    expect(picker).not.toContain('.from("parts")');
+    expect(usePartButton).toContain(
+      "workOrderLineId={workOrderLineId}",
+    );
+  });
+
+  it("limits mechanic inventory to an assigned work-order line", () => {
+    expect(pickerRoute).toContain('"mechanic"');
+    expect(pickerRoute).toContain(
+      'access.canonicalRole === "mechanic"',
+    );
+    expect(pickerRoute).toContain("line.assigned_tech_id");
+    expect(pickerRoute).toContain("line.assigned_to");
+    expect(pickerRoute).toContain(
+      '.from("work_order_line_technicians")',
+    );
+    expect(pickerRoute).toContain(
+      '.eq("technician_id", input.technicianId)',
+    );
+    expect(pickerRoute).toContain(
+      "This inventory picker is limited to your assigned jobs.",
+    );
+  });
+
+  it("keeps every inventory query scoped to the authenticated shop", () => {
+    expect(pickerRoute).toContain("createAdminSupabase()");
+    expect(pickerRoute).toContain(
+      '.eq("shop_id", access.profile.shop_id)',
+    );
+    expect(pickerRoute).toContain('"Cache-Control": "private, no-store"');
+  });
+});

--- a/tests/voice-dictation-button.test.tsx
+++ b/tests/voice-dictation-button.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import VoiceDictationButton from "@/features/shared/voice/VoiceDictationButton";
+
+const realtime = vi.hoisted(() => ({
+  start: vi.fn(async () => undefined),
+  stop: vi.fn(),
+}));
+
+vi.mock("@/features/inspections/lib/inspection/useRealtimeVoice", () => ({
+  useRealtimeVoice: () => realtime,
+}));
+
+class FakeSpeechRecognition {
+  static latest: FakeSpeechRecognition | null = null;
+
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  onstart: (() => void) | null = null;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null = null;
+  onerror: ((event: Event & { error?: string }) => void) | null = null;
+  onend: (() => void) | null = null;
+  start = vi.fn(() => this.onstart?.());
+  stop = vi.fn(() => this.onend?.());
+  abort = vi.fn();
+
+  constructor() {
+    FakeSpeechRecognition.latest = this;
+  }
+}
+
+describe("VoiceDictationButton", () => {
+  beforeEach(() => {
+    FakeSpeechRecognition.latest = null;
+    realtime.start.mockClear();
+    realtime.stop.mockClear();
+    Object.defineProperty(window, "SpeechRecognition", {
+      configurable: true,
+      value: FakeSpeechRecognition,
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, "SpeechRecognition");
+  });
+
+  it("uses native browser dictation and emits final transcript text", async () => {
+    const onTranscript = vi.fn();
+    render(
+      <VoiceDictationButton
+        idleLabel="Dictate note"
+        listeningLabel="Stop"
+        onTranscript={onTranscript}
+      />,
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Dictate note" }),
+    );
+
+    const recognition = FakeSpeechRecognition.latest;
+    expect(recognition?.start).toHaveBeenCalledTimes(1);
+    expect(realtime.start).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+
+    recognition?.onresult?.({
+      resultIndex: 0,
+      results: {
+        0: {
+          0: { transcript: "Checked front brakes", confidence: 0.98 },
+          isFinal: true,
+          length: 1,
+        },
+        length: 1,
+      },
+    } as unknown as SpeechRecognitionEvent);
+
+    expect(onTranscript).toHaveBeenCalledWith("Checked front brakes");
+
+    await userEvent.click(screen.getByRole("button", { name: "Stop" }));
+    expect(recognition?.stop).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Remove the standalone Inspections entry from the mechanic mobile/browser menu while keeping inspections available from assigned work.
- Use Safari/Chrome native speech recognition for focused-job note dictation when available, with the existing Realtime transcription path as fallback.
- Load part-picker inventory through a shop-scoped server endpoint instead of browser RLS queries.
- Require mechanics to be directly or jointly assigned to the selected work-order line before inventory is returned.

## Root causes

- The shared mobile tile allowed the mechanic role on the standalone inspections route.
- Focused-job dictation always used the Realtime WebSocket/audio-worklet path, even when mobile Safari exposed a native speech recognizer.
- The web part picker queried `parts` and stock views directly from the browser, so missing `current_shop_id` session context could produce an empty result for mechanics.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- Focused ESLint on all changed source and test files
- `./node_modules/.bin/vitest run tests/mobile-technician-first-ux.test.ts tests/part-picker-async-submit.test.tsx tests/voice-dictation-button.test.tsx tests/technician-part-picker-access.test.ts tests/offline-message-drafts.test.ts tests/phase-d3-dashboard-navigation.test.tsx`
- 6 test files passed, 36 tests passed

## Notes

PR #1202 was already merged before these additional technician fixes were ready, so this follow-up starts from current `main`.