### PR TITLE
Fix owner report release gate regressions

### DIFF
--- a/app/api/stats/summarize/route.ts
+++ b/app/api/stats/summarize/route.ts
@@ -1,7 +1,46 @@
 import { POST as canonicalPost } from "../../ai/summarize-stats/route";
 
+const LEGACY_RANGE_ALIASES = new Map<string, string>([
+  ["week", "weekly"],
+  ["weekly", "weekly"],
+  ["7d", "weekly"],
+  ["last_7_days", "weekly"],
+  ["month", "monthly"],
+  ["monthly", "monthly"],
+  ["30d", "monthly"],
+  ["last_30_days", "monthly"],
+  ["quarter", "quarterly"],
+  ["quarterly", "quarterly"],
+  ["90d", "quarterly"],
+  ["year", "yearly"],
+  ["yearly", "yearly"],
+  ["12m", "yearly"],
+]);
+
+function normalizeRange(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return LEGACY_RANGE_ALIASES.get(normalized) ?? null;
+}
+
 // Legacy compatibility route. The canonical handler enforces
 // requireShopScopedApiAccess, usage controls, caching, and evidence building.
 export async function POST(request: Request) {
-  return canonicalPost(request);
+  const body = (await request.json().catch(() => null)) as {
+    range?: unknown;
+    timeRange?: unknown;
+    force?: unknown;
+  } | null;
+
+  const range = normalizeRange(body?.range) ?? normalizeRange(body?.timeRange);
+  const canonicalRequest = new Request(request.url, {
+    method: "POST",
+    headers: request.headers,
+    body: JSON.stringify({
+      range: range ?? body?.range ?? body?.timeRange ?? null,
+      force: body?.force === true,
+    }),
+  });
+
+  return canonicalPost(canonicalRequest);
 }

--- a/features/shared/lib/workboard/filters.ts
+++ b/features/shared/lib/workboard/filters.ts
@@ -5,6 +5,7 @@ export const WORK_ORDER_BOARD_FILTER_KEYS = [
   "awaiting_approval",
   "waiting_parts",
   "on_hold",
+  "ready_to_invoice",
   "completed",
 ] as const;
 

--- a/tests/owner-report-release-gates.test.ts
+++ b/tests/owner-report-release-gates.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+describe("owner report release gates", () => {
+  it("keeps owner reports behind the shop-scoped financial access helper", () => {
+    const route = source("app/api/reports/owner/route.ts");
+
+    expect(route).toContain("requireShopScopedApiAccess");
+    expect(route).toContain('requiredCapability: "canViewFinancials"');
+    expect(route).toContain('allowRoles: ["owner", "admin", "manager"]');
+    expect(route).toContain("supabase: access.supabase");
+    expect(route).toContain("shopId: access.profile.shop_id");
+    expect(route).not.toContain("searchParams.get(\"shopId\")");
+  });
+
+  it("translates legacy stats-summary timeRange bodies into the canonical report range", () => {
+    const route = source("app/api/stats/summarize/route.ts");
+
+    expect(route).toContain("LEGACY_RANGE_ALIASES");
+    expect(route).toContain('["week", "weekly"]');
+    expect(route).toContain('["month", "monthly"]');
+    expect(route).toContain("body?.range) ?? normalizeRange(body?.timeRange)");
+    expect(route).toContain("canonicalPost(canonicalRequest)");
+    expect(route).not.toContain("chat.completions");
+  });
+
+  it("allows owner-report ready-to-invoice focus links to open the matching board filter", () => {
+    const reportBuilder = source(
+      "features/owner/reports/server/buildOwnerIntelligenceReport.ts",
+    );
+    const filters = source("features/shared/lib/workboard/filters.ts");
+
+    expect(reportBuilder).toContain('/work-orders/board?stage=ready_to_invoice');
+    expect(filters).toContain('"ready_to_invoice"');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the owner-report release gate issues found during the current-main audit before the tech mobile / tech web / owner web cohesion pass.

## What changed

- Restored legacy `/api/stats/summarize` compatibility by translating old `timeRange` bodies into the canonical owner-report `range` contract before delegating to `/api/ai/summarize-stats`.
- Added `ready_to_invoice` to the work-order board stage filter so Owner Intelligence drilldowns no longer fall back to the full board.
- Added focused release-gate regression coverage for:
  - shop-scoped financial access on the owner report route;
  - legacy summary route compatibility;
  - ready-to-invoice report drilldowns.

## Why

The report route itself already uses `requireShopScopedApiAccess`, `access.supabase`, and `access.profile.shop_id`; the active code did not accept a caller-supplied shop id. The two concrete current-main defects were the legacy summary body mismatch and the missing board filter key.

## Validation

- Connector diff check: branch is 3 commits ahead of `main`.
- Changed files confirmed by fetch/spot-check.
- CI/Vercel should run on this draft PR.

No production changes, deploys, or migrations were performed.