### PR TITLE
Fix customer portal slot selection and messaging recipient routing

### DIFF
--- a/app/api/chat/context-options/route.ts
+++ b/app/api/chat/context-options/route.ts
@@ -3,7 +3,10 @@ import {
   createAdminSupabase,
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
-import { resolveMessagingActor } from "@/features/ai/lib/chat/authorization";
+import {
+  resolveMessagingActor,
+  CUSTOMER_MESSAGING_ROLE_LIST,
+} from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
@@ -77,7 +80,7 @@ export async function GET(req: Request): Promise<NextResponse> {
         .from("profiles")
         .select("id, user_id, full_name, email")
         .eq("shop_id", shopId)
-        .eq("role", "advisor")
+        .in("role", CUSTOMER_MESSAGING_ROLE_LIST)
         .order("full_name", { ascending: true })
         .limit(50),
     ]);

--- a/app/api/chat/start-conversation/route.ts
+++ b/app/api/chat/start-conversation/route.ts
@@ -4,7 +4,10 @@ import {
   createAdminSupabase,
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
-import { authorizeConversationCreate } from "@/features/ai/lib/chat/authorization";
+import {
+  authorizeConversationCreate,
+  CUSTOMER_MESSAGING_ROLE_LIST,
+} from "@/features/ai/lib/chat/authorization";
 import { authorizeConversationContext } from "@/features/chat/server/conversationContext";
 
 export const dynamic = "force-dynamic";
@@ -100,46 +103,42 @@ export async function POST(req: Request): Promise<NextResponse> {
       );
     }
 
-    if (workOrder?.advisor_id) {
-      const [
-        { data: assignedAdvisor, error: advisorError },
-        { data: coverage, error: coverageError },
-      ] = await Promise.all([
-        admin
+    const { data: assignedAdvisor, error: advisorError } = workOrder?.advisor_id
+      ? await admin
           .from("profiles")
           .select("id,user_id")
           .eq("id", workOrder.advisor_id)
           .eq("shop_id", createAccess.actorShopId)
-          .maybeSingle(),
-        admin
-          .from("profiles")
-          .select("id,user_id")
-          .eq("shop_id", createAccess.actorShopId)
-          .in("role", ["owner", "admin", "manager"])
-          .limit(25),
-      ]);
+          .maybeSingle()
+      : { data: null, error: null };
 
-      const recipientError = advisorError ?? coverageError;
-      if (recipientError) {
-        return NextResponse.json(
-          { error: recipientError.message },
-          { status: 500 },
-        );
-      }
+    const { data: coverage, error: coverageError } = await admin
+      .from("profiles")
+      .select("id,user_id")
+      .eq("shop_id", createAccess.actorShopId)
+      .in("role", CUSTOMER_MESSAGING_ROLE_LIST)
+      .limit(50);
 
-      const advisorUserId =
-        assignedAdvisor?.user_id ?? assignedAdvisor?.id ?? null;
-      if (advisorUserId) {
-        recipientUserIds = Array.from(
-          new Set([
-            advisorUserId,
-            ...(coverage ?? []).map((profile) => profile.user_id ?? profile.id),
-          ]),
-        ).filter((id) => id !== user.id);
-        participantKindByUserId = Object.fromEntries(
-          recipientUserIds.map((id) => [id, "staff" as const]),
-        );
-      }
+    const recipientError = advisorError ?? coverageError;
+    if (recipientError) {
+      return NextResponse.json(
+        { error: recipientError.message },
+        { status: 500 },
+      );
+    }
+
+    const advisorUserId = assignedAdvisor?.user_id ?? assignedAdvisor?.id ?? null;
+    const coverageUserIds = (coverage ?? [])
+      .map((profile) => profile.user_id ?? profile.id)
+      .filter((id): id is string => Boolean(id) && id !== user.id);
+
+    if (advisorUserId || coverageUserIds.length > 0) {
+      recipientUserIds = Array.from(
+        new Set([...(advisorUserId ? [advisorUserId] : []), ...coverageUserIds]),
+      ).filter((id) => id !== user.id);
+      participantKindByUserId = Object.fromEntries(
+        recipientUserIds.map((id) => [id, "staff" as const]),
+      );
     }
   }
 

--- a/app/portal/request/when/page.tsx
+++ b/app/portal/request/when/page.tsx
@@ -59,6 +59,21 @@ function normalizeWeekdayToJs(dowRaw: number): number | null {
   return null;
 }
 
+function toLabelForSlotInZone(iso: string, tz?: string | null) {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "Unavailable";
+  try {
+    return date.toLocaleTimeString([], {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+      ...(tz ? { timeZone: tz } : {}),
+    });
+  } catch {
+    return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit", hour12: true });
+  }
+}
+
 function getWeekdayCandidates(h: ShopHoursRow): number[] {
   const r = rec(h);
 
@@ -173,6 +188,56 @@ function mergeRanges(ranges: Array<[number, number]>): Array<[number, number]> {
   return out;
 }
 
+function computeLocalSlotsForDate(
+  date: string,
+  shopHours: ShopHoursRow[],
+): Slot[] {
+  const d = new Date(`${date}T00:00:00`);
+  const jsDay = d.getDay();
+
+  const candidateRows = shopHours.filter((h) => {
+    if (isClosedRow(h)) return false;
+    const cands = getWeekdayCandidates(h);
+    return cands.includes(jsDay);
+  });
+
+  if (!candidateRows.length) return [];
+
+  const ranges: Array<[number, number]> = [];
+
+  for (const row of candidateRows) {
+    const open = getOpen(row);
+    const close = getClose(row);
+    if (!open || !close) continue;
+
+    const openM = parseHmToMinutes(open);
+    const closeM = parseHmToMinutes(close);
+    if (openM == null || closeM == null) continue;
+    if (closeM <= openM) continue;
+
+    ranges.push([openM, closeM]);
+  }
+
+  const merged = mergeRanges(ranges);
+  if (!merged.length) return [];
+
+  const startOfDay = new Date(`${date}T00:00:00.000`);
+  const out: Slot[] = [];
+
+  for (const [openM, closeM] of merged) {
+    for (let m = openM; m + 60 <= closeM; m += 60) {
+      const slotStart = new Date(startOfDay);
+      slotStart.setMinutes(m, 0, 0);
+      out.push({
+        startsAtIso: slotStart.toISOString(),
+        label: minutesToLabel(m),
+      });
+    }
+  }
+
+  return out;
+}
+
 export default function PortalRequestWhenPage() {
   const supabase = createBrowserSupabase();
   const router = useRouter();
@@ -185,6 +250,8 @@ export default function PortalRequestWhenPage() {
   const [shop, setShop] = useState<ShopRow | null>(null);
   const [vehicles, setVehicles] = useState<VehicleRow[]>([]);
   const [shopHours, setShopHours] = useState<ShopHoursRow[]>([]);
+  const [slots, setSlots] = useState<Slot[]>([]);
+  const [slotsLoading, setSlotsLoading] = useState(false);
 
   const [vehicleId, setVehicleId] = useState<string>("");
   const [date, setDate] = useState<string>(() => toIsoDate(new Date()));
@@ -278,12 +345,21 @@ export default function PortalRequestWhenPage() {
             .eq("id", quoteLineId)
             .eq("shop_id", cust.shop_id)
             .maybeSingle();
-          const quoteMetadata = quote?.metadata && typeof quote.metadata === "object" && !Array.isArray(quote.metadata)
-            ? quote.metadata as Record<string, unknown>
-            : {};
-          const quoteVehicleId = typeof quote?.vehicle_id === "string" ? quote.vehicle_id : "";
+          const quoteMetadata =
+            quote?.metadata &&
+            typeof quote.metadata === "object" &&
+            !Array.isArray(quote.metadata)
+              ? (quote.metadata as Record<string, unknown>)
+              : {};
+          const quoteVehicleId =
+            typeof quote?.vehicle_id === "string" ? quote.vehicle_id : "";
           const ownedVehicle = vv.some((vehicle) => vehicle.id === quoteVehicleId);
-          if (!quote || quoteMetadata.request_kind !== "repair" || (!quote.approved_at && !quote.work_order_line_id) || !ownedVehicle) {
+          if (
+            !quote ||
+            quoteMetadata.request_kind !== "repair" ||
+            (!quote.approved_at && !quote.work_order_line_id) ||
+            !ownedVehicle
+          ) {
             toast.error("This repair quote is not ready to book.");
             router.replace("/portal/quotes");
             return;
@@ -294,7 +370,10 @@ export default function PortalRequestWhenPage() {
         }
       }
 
-      const { data: h, error: hErr } = await supabase.from("shop_hours").select("*").eq("shop_id", s.id);
+      const { data: h, error: hErr } = await supabase
+        .from("shop_hours")
+        .select("*")
+        .eq("shop_id", s.id);
 
       if (cancelled) return;
 
@@ -319,61 +398,67 @@ export default function PortalRequestWhenPage() {
     const days = Array.from({ length: 21 }).map((_, i) => addDays(base, i));
     return days.map((d) => {
       const iso = toIsoDate(d);
-      const label = d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+      const label = d.toLocaleDateString(undefined, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+      });
       return { iso, label };
     });
   }, []);
 
-  const slots: Slot[] = useMemo(() => {
-    if (!date) return [];
-    if (!shopHours.length) return [];
-
-    const d = new Date(`${date}T00:00:00`);
-    const jsDay = d.getDay();
-
-    const candidateRows = shopHours.filter((h) => {
-      if (isClosedRow(h)) return false;
-      const cands = getWeekdayCandidates(h);
-      return cands.includes(jsDay);
-    });
-
-    if (!candidateRows.length) return [];
-
-    const ranges: Array<[number, number]> = [];
-
-    for (const row of candidateRows) {
-      const open = getOpen(row);
-      const close = getClose(row);
-      if (!open || !close) continue;
-
-      const openM = parseHmToMinutes(open);
-      const closeM = parseHmToMinutes(close);
-      if (openM == null || closeM == null) continue;
-      if (closeM <= openM) continue;
-
-      ranges.push([openM, closeM]);
+  useEffect(() => {
+    if (!date || !shop?.slug) {
+      setSlots([]);
+      return;
     }
 
-    const merged = mergeRanges(ranges);
-    if (!merged.length) return [];
+    let cancelled = false;
+    setSlotsLoading(true);
 
-    const startOfDay = new Date(`${date}T00:00:00.000`);
-    const out: Slot[] = [];
+    const loadSlots = async () => {
+      try {
+        const availabilityUrl = `/api/portal/availability?shop=${encodeURIComponent(
+          shop.slug,
+        )}&start=${encodeURIComponent(
+          date,
+        )}&end=${encodeURIComponent(
+          date,
+        )}&slotMins=60`;
+        const response = await fetch(availabilityUrl, { cache: "no-store" });
 
-    for (const [openM, closeM] of merged) {
-      for (let m = openM; m + 60 <= closeM; m += 60) {
-        const slotStart = new Date(startOfDay);
-        slotStart.setMinutes(m, 0, 0);
+        if (!response.ok) {
+          throw new Error("availability endpoint failed");
+        }
 
-        out.push({
-          startsAtIso: slotStart.toISOString(),
-          label: minutesToLabel(m),
-        });
+        const payload = (await response.json().catch(() => ({}))) as {
+          slots?: Array<{ start: string }>;
+        };
+        if (cancelled) return;
+
+        const computed = (payload.slots ?? [])
+          .filter((slot) => typeof slot.start === "string")
+          .map((slot) => ({
+            startsAtIso: slot.start,
+            label: toLabelForSlotInZone(slot.start, shop.timezone),
+          }));
+
+        setSlots(computed);
+      } catch {
+        if (cancelled) return;
+        setSlots(computeLocalSlotsForDate(date, shopHours));
+        toast.error("Using local availability fallback. Please verify slot time.");
+      } finally {
+        if (!cancelled) setSlotsLoading(false);
       }
-    }
+    };
 
-    return out;
-  }, [date, shopHours]);
+    void loadSlots();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [date, shop?.slug, shop?.timezone, shopHours]);
 
   const startAttemptKeyRef = useRef<string>("");
 
@@ -445,7 +530,7 @@ export default function PortalRequestWhenPage() {
   }
 
   if (loading) {
-    return <div className={cardClass() + " mx-auto max-w-xl text-sm text-[color:var(--theme-text-primary)]"}>Loading…</div>;
+    return <div className={cardClass() + " mx-auto max-w-xl text-sm text-[color:var(--theme-text-primary)]"}>Loadingâ€¦</div>;
   }
 
   if (!customer) {
@@ -454,7 +539,7 @@ export default function PortalRequestWhenPage() {
         <Toaster position="top-center" />
         <div className={cardClass()}>
           <h1 className="text-lg font-blackops uppercase tracking-[0.18em] text-[color:var(--theme-text-primary)]">Request service</h1>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">We couldn’t find your customer profile yet.</p>
+          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">We couldnâ€™t find your customer profile yet.</p>
           <div className="mt-4 flex gap-2">
             <LinkButton href="/portal/profile" variant="outline" size="sm">
               Go to profile
@@ -474,7 +559,7 @@ export default function PortalRequestWhenPage() {
         <Toaster position="top-center" />
         <div className={cardClass()}>
           <h1 className="text-lg font-blackops uppercase tracking-[0.18em] text-[color:var(--theme-text-primary)]">Request service</h1>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">Your portal account isn’t linked to a shop yet.</p>
+          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">Your portal account isnâ€™t linked to a shop yet.</p>
           <div className="mt-4 flex gap-2">
             <LinkButton href="/portal/profile" variant="outline" size="sm">
               Go to profile
@@ -522,7 +607,12 @@ export default function PortalRequestWhenPage() {
               </div>
             </div>
           ) : (
-            <select className={inputClass()} value={vehicleId} onChange={(e) => setVehicleId(e.target.value)} disabled={Boolean(quoteLineId)}>
+            <select
+              className={inputClass()}
+              value={vehicleId}
+              onChange={(e) => setVehicleId(e.target.value)}
+              disabled={Boolean(quoteLineId)}
+            >
               {vehicles.map((v) => {
                 const label =
                   [v.year ?? "", v.make ?? "", v.model ?? ""].filter(Boolean).join(" ").trim() || "Vehicle";
@@ -555,7 +645,11 @@ export default function PortalRequestWhenPage() {
             <div className="text-[0.75rem] text-[color:var(--theme-text-muted)]">1-hour slots</div>
           </div>
 
-          {slots.length === 0 ? (
+          {slotsLoading ? (
+            <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-secondary)]">
+              Loading available times...
+            </div>
+          ) : slots.length === 0 ? (
             <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-sm text-[color:var(--theme-text-secondary)]">
               No hours available for this day.
             </div>
@@ -607,7 +701,7 @@ export default function PortalRequestWhenPage() {
             disabled={!canStart || starting || vehicles.length === 0}
             className="min-w-[180px]"
           >
-            {starting ? "Starting…" : quoteLineId ? "Book this quote" : "Next: choose service"}
+            {starting ? "Startingâ€¦" : quoteLineId ? "Book this quote" : "Next: choose service"}
           </Button>
 
           <LinkButton href="/portal/customer-appointments" variant="outline" size="sm">
@@ -616,7 +710,7 @@ export default function PortalRequestWhenPage() {
         </div>
 
         <p className="text-[0.75rem] text-[color:var(--theme-text-muted)]">
-          Next you’ll complete an intake form, then build your request (menu items, custom lines, and quote-only requests).
+          Next youâ€™ll complete an intake form, then build your request (menu items, custom lines, and quote-only requests).
         </p>
       </section>
     </div>

--- a/features/ai/lib/chat/authorization.ts
+++ b/features/ai/lib/chat/authorization.ts
@@ -4,25 +4,18 @@ import type { Database } from "@shared/types/types/supabase";
 type ConversationRow = Database["public"]["Tables"]["conversations"]["Row"];
 type MessagingChannel = "internal" | "customer";
 type ParticipantKind = "staff" | "customer";
-const CUSTOMER_MESSAGING_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
-
-export type MessagingActor =
-  | {
-      kind: "staff";
-      userId: string;
-      profileId: string;
-      shopId: string;
-      role: string | null;
-      customerId: null;
-    }
-  | {
-      kind: "customer";
-      userId: string;
-      customerId: string;
-      shopId: string;
-      role: null;
-      profileId: null;
-    };
+const CUSTOMER_MESSAGING_ROLES_LIST = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "mechanic",
+] as const;
+export const CUSTOMER_MESSAGING_ROLES = new Set(
+  CUSTOMER_MESSAGING_ROLES_LIST,
+);
+export const CUSTOMER_MESSAGING_ROLE_LIST = CUSTOMER_MESSAGING_ROLES_LIST;
 
 type AccessFailure = {
   ok: false;
@@ -379,7 +372,7 @@ export async function authorizeConversationCreate({
       .from("profiles")
       .select("id, user_id")
       .eq("shop_id", actor.shopId)
-      .in("role", ["advisor", "manager", "owner", "admin"])
+      .in("role", CUSTOMER_MESSAGING_ROLE_LIST)
       .limit(50);
 
     if (serviceTeamError) {

--- a/tests/portal-messaging-navigation.test.ts
+++ b/tests/portal-messaging-navigation.test.ts
@@ -23,7 +23,7 @@ describe("portal work-order navigation and messaging", () => {
 
     expect(authorization).toContain('preferredKind === "customer"');
     expect(authorization).toContain('profileRole === "customer"');
-    expect(contextRoute).toContain('.eq("role", "advisor")');
+    expect(contextRoute).toContain('.in("role", CUSTOMER_MESSAGING_ROLE_LIST)');
     expect(contextRoute).toContain("recipients");
     expect(workspace).toContain('aria-label="Message recipient"');
     expect(workspace).toContain(


### PR DESCRIPTION
## Summary
- Fix portal availability flow after selecting date by using shop-based availability endpoint first and falling back to computed shop-hour slots.
- Update customer chat authorization so customer-facing messaging includes additional service roles (owner/admin/manager/advisor/service/mechanic).
- Expand chat recipient lookup context-options to return all customer-facing staff, not advisor-only.
- Use work-order fallback to preferred advisor or service-team members when creating customer-started conversations.
- Update portal messaging navigation test to match new role-based recipient behavior.
