### PR TITLE
Fix customer portal request start and advisor messaging

### DIFF
--- a/app/api/chat/context-options/route.ts
+++ b/app/api/chat/context-options/route.ts
@@ -3,7 +3,10 @@ import {
   createAdminSupabase,
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
-import { resolveMessagingActor } from "@/features/ai/lib/chat/authorization";
+import {
+  isCustomerMessagingRole,
+  resolveMessagingActor,
+} from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
@@ -49,7 +52,7 @@ export async function GET(req: Request): Promise<NextResponse> {
     { data: workOrders, error: workOrderError },
     { data: bookings, error: bookingError },
     { data: vehicles, error: vehicleError },
-    { data: advisors, error: advisorError },
+    { data: staffRows, error: staffError },
   ] =
     await Promise.all([
       admin
@@ -75,15 +78,14 @@ export async function GET(req: Request): Promise<NextResponse> {
         .limit(25),
       admin
         .from("profiles")
-        .select("id, user_id, full_name, email")
+        .select("id, user_id, full_name, email, role")
         .eq("shop_id", shopId)
-        .eq("role", "advisor")
         .order("full_name", { ascending: true })
-        .limit(50),
+        .limit(100),
     ]);
 
   const queryError =
-    workOrderError ?? bookingError ?? vehicleError ?? advisorError;
+    workOrderError ?? bookingError ?? vehicleError ?? staffError;
   if (queryError) {
     return NextResponse.json({ error: queryError.message }, { status: 500 });
   }
@@ -111,18 +113,19 @@ export async function GET(req: Request): Promise<NextResponse> {
     })),
   ];
 
-  const recipients: RecipientOption[] = (advisors ?? [])
-    .map((advisor) => ({
-      id: advisor.user_id ?? advisor.id,
+  const recipients: RecipientOption[] = (staffRows ?? [])
+    .filter((staff) => isCustomerMessagingRole(staff.role))
+    .map((staff) => ({
+      id: staff.user_id ?? staff.id,
       label:
-        advisor.full_name?.trim() ||
-        advisor.email?.trim() ||
+        staff.full_name?.trim() ||
+        staff.email?.trim() ||
         "Service advisor",
     }))
     .filter(
-      (advisor, index, rows) =>
-        Boolean(advisor.id) &&
-        rows.findIndex((candidate) => candidate.id === advisor.id) === index,
+      (staff, index, rows) =>
+        Boolean(staff.id) &&
+        rows.findIndex((candidate) => candidate.id === staff.id) === index,
     );
 
   return NextResponse.json({ options, recipients });

--- a/app/api/chat/start-conversation/route.ts
+++ b/app/api/chat/start-conversation/route.ts
@@ -4,7 +4,10 @@ import {
   createAdminSupabase,
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
-import { authorizeConversationCreate } from "@/features/ai/lib/chat/authorization";
+import {
+  authorizeConversationCreate,
+  isCustomerMessagingRole,
+} from "@/features/ai/lib/chat/authorization";
 import { authorizeConversationContext } from "@/features/chat/server/conversationContext";
 
 export const dynamic = "force-dynamic";
@@ -100,46 +103,44 @@ export async function POST(req: Request): Promise<NextResponse> {
       );
     }
 
-    if (workOrder?.advisor_id) {
-      const [
-        { data: assignedAdvisor, error: advisorError },
-        { data: coverage, error: coverageError },
-      ] = await Promise.all([
-        admin
+    const { data: assignedAdvisor, error: advisorError } = workOrder?.advisor_id
+      ? await admin
           .from("profiles")
-          .select("id,user_id")
+          .select("id,user_id,role")
           .eq("id", workOrder.advisor_id)
           .eq("shop_id", createAccess.actorShopId)
-          .maybeSingle(),
-        admin
-          .from("profiles")
-          .select("id,user_id")
-          .eq("shop_id", createAccess.actorShopId)
-          .in("role", ["owner", "admin", "manager"])
-          .limit(25),
-      ]);
+          .maybeSingle()
+      : { data: null, error: null };
 
-      const recipientError = advisorError ?? coverageError;
-      if (recipientError) {
-        return NextResponse.json(
-          { error: recipientError.message },
-          { status: 500 },
-        );
-      }
+    const { data: coverage, error: coverageError } = await admin
+      .from("profiles")
+      .select("id,user_id,role")
+      .eq("shop_id", createAccess.actorShopId)
+      .limit(100);
 
-      const advisorUserId =
-        assignedAdvisor?.user_id ?? assignedAdvisor?.id ?? null;
-      if (advisorUserId) {
-        recipientUserIds = Array.from(
-          new Set([
-            advisorUserId,
-            ...(coverage ?? []).map((profile) => profile.user_id ?? profile.id),
-          ]),
-        ).filter((id) => id !== user.id);
-        participantKindByUserId = Object.fromEntries(
-          recipientUserIds.map((id) => [id, "staff" as const]),
-        );
-      }
+    const recipientError = advisorError ?? coverageError;
+    if (recipientError) {
+      return NextResponse.json(
+        { error: recipientError.message },
+        { status: 500 },
+      );
+    }
+
+    const advisorUserId = assignedAdvisor && isCustomerMessagingRole(assignedAdvisor.role)
+      ? assignedAdvisor.user_id ?? assignedAdvisor.id
+      : null;
+    const coverageUserIds = (coverage ?? [])
+      .filter((profile) => isCustomerMessagingRole(profile.role))
+      .map((profile) => profile.user_id ?? profile.id)
+      .filter((id): id is string => Boolean(id) && id !== user.id);
+
+    if (advisorUserId || coverageUserIds.length > 0) {
+      recipientUserIds = Array.from(
+        new Set([...(advisorUserId ? [advisorUserId] : []), ...coverageUserIds]),
+      ).filter((id) => id !== user.id);
+      participantKindByUserId = Object.fromEntries(
+        recipientUserIds.map((id) => [id, "staff" as const]),
+      );
     }
   }
 

--- a/app/api/portal/request/add-quote-only/route.ts
+++ b/app/api/portal/request/add-quote-only/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 import {
@@ -28,10 +31,11 @@ function bad(message: string, status = 400) {
 }
 
 export async function POST(req: Request) {
-  const supabase = createServerSupabaseRoute();
+  const userClient = createServerSupabaseRoute();
 
   try {
-    const actor = await requirePortalCustomerActor(supabase);
+    const actor = await requirePortalCustomerActor(userClient);
+    const admin = createAdminSupabase();
     const body = (await req.json().catch(() => null)) as Body | null;
     const description = clean(body?.description);
     const workOrderId = clean(body?.workOrderId) || null;
@@ -47,7 +51,7 @@ export async function POST(req: Request) {
 
     let vehicleId = clean(body?.vehicleId);
     if (workOrderId) {
-      const { data: workOrder, error } = await supabase
+      const { data: workOrder, error } = await admin
         .from("work_orders")
         .select("id, vehicle_id")
         .eq("id", workOrderId)
@@ -61,7 +65,7 @@ export async function POST(req: Request) {
     if (!vehicleId) return bad("A vehicle is required for a quote request.");
 
     const result = await createPortalQuoteRequest({
-      supabase,
+      supabase: userClient,
       shopId: actor.customer.shop_id,
       customerId: actor.customer.id,
       vehicleId,

--- a/app/api/portal/request/start/route.ts
+++ b/app/api/portal/request/start/route.ts
@@ -1,6 +1,9 @@
 // app/api/portal/request/start/route.ts
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 
@@ -59,8 +62,9 @@ function isDuplicateKeyError(
 
 export async function POST(req: Request) {
   try {
-    const supabase = createServerSupabaseRoute();
-    const actor = await requirePortalCustomerActor(supabase);
+    const userClient = createServerSupabaseRoute();
+    const actor = await requirePortalCustomerActor(userClient);
+    const admin = createAdminSupabase();
 
     let body: Body;
     try {
@@ -95,7 +99,7 @@ export async function POST(req: Request) {
     const startsAt = startsAtDate.toISOString();
     const endsAt = addMinsIso(startsAt, duration);
 
-    const { data: customer, error: custErr } = await supabase
+    const { data: customer, error: custErr } = await admin
       .from("customers")
       .select("id, shop_id")
       .eq("id", actor.customer.id)
@@ -117,7 +121,7 @@ export async function POST(req: Request) {
         ? body.vehicleId.trim()
         : null;
     if (vehicleId) {
-      const { data: vehicle, error: vehicleErr } = await supabase
+      const { data: vehicle, error: vehicleErr } = await admin
         .from("vehicles")
         .select("id")
         .eq("id", vehicleId)
@@ -144,7 +148,7 @@ export async function POST(req: Request) {
         p_at: new Date().toISOString(),
       };
       const { data, error } = await (
-        supabase as never as {
+        userClient as never as {
           rpc: (
             fn: "book_portal_repair_quote_atomic",
             args: typeof quotePayload,
@@ -169,7 +173,7 @@ export async function POST(req: Request) {
 
     const sourceRowId = `portal_start:${customer.id}:${normalizedKey}`;
 
-    const { data: existingWo, error: existingWoErr } = await supabase
+    const { data: existingWo, error: existingWoErr } = await admin
       .from("work_orders")
       .select("id")
       .eq("shop_id", customer.shop_id)
@@ -179,7 +183,7 @@ export async function POST(req: Request) {
 
     if (existingWoErr) return bad("Failed to verify request replay", 500);
     if (existingWo?.id) {
-      const { data: existingBooking, error: existingBookingErr } = await supabase
+      const { data: existingBooking, error: existingBookingErr } = await admin
         .from("bookings")
         .select("id")
         .eq("work_order_id", existingWo.id)
@@ -209,7 +213,7 @@ export async function POST(req: Request) {
     };
 
     const { data: created, error: createErr } = await (
-      supabase as never as {
+      admin as never as {
         rpc: (
           fn: "portal_request_start_atomic",
           args: typeof rpcPayload,
@@ -222,7 +226,7 @@ export async function POST(req: Request) {
 
     if (createErr) {
       if (isDuplicateKeyError(createErr)) {
-        const { data: fallbackWo } = await supabase
+        const { data: fallbackWo } = await admin
           .from("work_orders")
           .select("id")
           .eq("shop_id", customer.shop_id)
@@ -231,7 +235,7 @@ export async function POST(req: Request) {
           .maybeSingle();
 
         if (fallbackWo?.id) {
-          const { data: fallbackBooking } = await supabase
+          const { data: fallbackBooking } = await admin
             .from("bookings")
             .select("id")
             .eq("work_order_id", fallbackWo.id)

--- a/app/api/portal/request/submit/route.ts
+++ b/app/api/portal/request/submit/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
@@ -29,10 +32,11 @@ function bad(message: string, status = 400) {
 }
 
 export async function POST(req: Request) {
-  const supabase = createServerSupabaseRoute();
+  const userClient = createServerSupabaseRoute();
 
   try {
-    const actor = await requirePortalCustomerActor(supabase);
+    const actor = await requirePortalCustomerActor(userClient);
+    const admin = createAdminSupabase();
     const body = (await req.json().catch(() => null)) as Body | null;
     const workOrderId = clean(body?.workOrderId);
     const bookingId = clean(body?.bookingId);
@@ -43,7 +47,7 @@ export async function POST(req: Request) {
     if (!customerAgreedAt) return bad("You must agree to the terms before submitting.");
     if (!actor.customer.shop_id) return bad("Customer is not linked to a shop", 409);
 
-    const { data: workOrder, error: workOrderError } = await supabase
+    const { data: workOrder, error: workOrderError } = await admin
       .from("work_orders")
       .select("id,shop_id,customer_id,portal_submitted_at")
       .eq("id", workOrderId)
@@ -53,7 +57,7 @@ export async function POST(req: Request) {
     if (workOrderError) return bad("Failed to load work order", 500);
     if (!workOrder) return bad("Work order not found", 404);
 
-    const { data: booking, error: bookingError } = await supabase
+    const { data: booking, error: bookingError } = await admin
       .from("bookings")
       .select("id,shop_id,customer_id,work_order_id,starts_at,status")
       .eq("id", bookingId)
@@ -72,12 +76,12 @@ export async function POST(req: Request) {
       return bad("This booking time is in the past. Please start again.", 409);
     }
 
-    const { count: lineCount, error: lineError } = await supabase
+    const { count: lineCount, error: lineError } = await admin
       .from("work_order_lines")
       .select("id", { count: "exact", head: true })
       .eq("shop_id", workOrder.shop_id)
       .eq("work_order_id", workOrder.id);
-    const { count: quoteCount, error: quoteError } = await supabase
+    const { count: quoteCount, error: quoteError } = await admin
       .from("work_order_quote_lines")
       .select("id", { count: "exact", head: true })
       .eq("shop_id", workOrder.shop_id)
@@ -91,7 +95,7 @@ export async function POST(req: Request) {
       customer_approval_signature_url: customerSignatureUrl,
       portal_submitted_at: workOrder.portal_submitted_at ?? submittedAt,
     };
-    const { error: updateWorkOrderError } = await supabase
+    const { error: updateWorkOrderError } = await admin
       .from("work_orders")
       .update(workOrderUpdate)
       .eq("id", workOrder.id)
@@ -103,7 +107,7 @@ export async function POST(req: Request) {
       status: "pending",
       work_order_id: workOrder.id,
     };
-    const { error: updateBookingError } = await supabase
+    const { error: updateBookingError } = await admin
       .from("bookings")
       .update(bookingUpdate)
       .eq("id", booking.id)

--- a/features/ai/lib/chat/authorization.ts
+++ b/features/ai/lib/chat/authorization.ts
@@ -1,10 +1,28 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { canonicalizeRole, type CanonicalRole } from "@/features/shared/lib/rbac";
 
 type ConversationRow = Database["public"]["Tables"]["conversations"]["Row"];
 type MessagingChannel = "internal" | "customer";
 type ParticipantKind = "staff" | "customer";
-const CUSTOMER_MESSAGING_ROLES = new Set(["owner", "admin", "manager", "advisor"]);
+
+export const CUSTOMER_MESSAGING_ROLE_LIST = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "lead_hand",
+  "foreman",
+] as const satisfies readonly CanonicalRole[];
+
+export const CUSTOMER_MESSAGING_ROLES = new Set<CanonicalRole>(
+  CUSTOMER_MESSAGING_ROLE_LIST,
+);
+
+export function isCustomerMessagingRole(role: string | null | undefined): boolean {
+  return CUSTOMER_MESSAGING_ROLES.has(canonicalizeRole(role));
+}
 
 export type MessagingActor =
   | {
@@ -337,10 +355,7 @@ export async function authorizeConversationCreate({
     };
   }
 
-  if (
-    actor.kind === "staff" &&
-    !CUSTOMER_MESSAGING_ROLES.has((actor.role ?? "").toLowerCase())
-  ) {
+  if (actor.kind === "staff" && !isCustomerMessagingRole(actor.role)) {
     return {
       ok: false,
       status: 403,
@@ -377,10 +392,9 @@ export async function authorizeConversationCreate({
   if (actor.kind === "customer" && staffUserIds.length === 0) {
     const { data: serviceTeam, error: serviceTeamError } = await supabase
       .from("profiles")
-      .select("id, user_id")
+      .select("id, user_id, role")
       .eq("shop_id", actor.shopId)
-      .in("role", ["advisor", "manager", "owner", "admin"])
-      .limit(50);
+      .limit(100);
 
     if (serviceTeamError) {
       return { ok: false, status: 500, error: serviceTeamError.message };
@@ -388,6 +402,7 @@ export async function authorizeConversationCreate({
     staffUserIds = Array.from(
       new Set(
         (serviceTeam ?? [])
+          .filter((row) => isCustomerMessagingRole(row.role))
           .map((row) => row.user_id ?? row.id)
           .filter((id): id is string => Boolean(id) && id !== actorUserId),
       ),

--- a/supabase/migrations/20260725024500_restore_customer_portal_request_read_access.sql
+++ b/supabase/migrations/20260725024500_restore_customer_portal_request_read_access.sql
@@ -1,0 +1,113 @@
+begin;
+
+create or replace function public.profixiq_has_portal_customer_shop(p_shop_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.customers c
+    join public.customer_portal_invites i on i.customer_id = c.id
+    where c.shop_id = p_shop_id
+      and c.user_id = auth.uid()
+      and i.accepted_by_user_id = auth.uid()
+      and i.accepted_at is not null
+      and i.revoked_at is null
+  )
+$$;
+
+create or replace function public.profixiq_is_portal_customer_for(
+  p_customer_id uuid,
+  p_shop_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.customers c
+    join public.customer_portal_invites i on i.customer_id = c.id
+    where c.id = p_customer_id
+      and c.shop_id = p_shop_id
+      and c.user_id = auth.uid()
+      and i.accepted_by_user_id = auth.uid()
+      and i.accepted_at is not null
+      and i.revoked_at is null
+  )
+$$;
+
+create or replace function public.profixiq_is_portal_customer_work_order(
+  p_work_order_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.work_orders wo
+    where wo.id = p_work_order_id
+      and public.profixiq_is_portal_customer_for(wo.customer_id, wo.shop_id)
+  )
+$$;
+
+revoke all on function public.profixiq_has_portal_customer_shop(uuid) from public;
+revoke all on function public.profixiq_is_portal_customer_for(uuid, uuid) from public;
+revoke all on function public.profixiq_is_portal_customer_work_order(uuid) from public;
+grant execute on function public.profixiq_has_portal_customer_shop(uuid) to authenticated;
+grant execute on function public.profixiq_is_portal_customer_for(uuid, uuid) to authenticated;
+grant execute on function public.profixiq_is_portal_customer_work_order(uuid) to authenticated;
+
+alter table public.work_orders enable row level security;
+alter table public.bookings enable row level security;
+alter table public.work_order_lines enable row level security;
+alter table public.work_order_quote_lines enable row level security;
+alter table public.menu_items enable row level security;
+
+drop policy if exists work_orders_customer_portal_select on public.work_orders;
+create policy work_orders_customer_portal_select
+on public.work_orders
+for select
+to authenticated
+using (public.profixiq_is_portal_customer_for(customer_id, shop_id));
+
+drop policy if exists bookings_customer_portal_select on public.bookings;
+create policy bookings_customer_portal_select
+on public.bookings
+for select
+to authenticated
+using (public.profixiq_is_portal_customer_for(customer_id, shop_id));
+
+drop policy if exists work_order_lines_customer_portal_select on public.work_order_lines;
+create policy work_order_lines_customer_portal_select
+on public.work_order_lines
+for select
+to authenticated
+using (public.profixiq_is_portal_customer_work_order(work_order_id));
+
+drop policy if exists work_order_quote_lines_customer_portal_select on public.work_order_quote_lines;
+create policy work_order_quote_lines_customer_portal_select
+on public.work_order_quote_lines
+for select
+to authenticated
+using (public.profixiq_is_portal_customer_work_order(work_order_id));
+
+drop policy if exists menu_items_customer_portal_select on public.menu_items;
+create policy menu_items_customer_portal_select
+on public.menu_items
+for select
+to authenticated
+using (
+  is_active = true
+  and public.profixiq_has_portal_customer_shop(shop_id)
+);
+
+commit;

--- a/tests/portal-messaging-navigation.test.ts
+++ b/tests/portal-messaging-navigation.test.ts
@@ -21,9 +21,11 @@ describe("portal work-order navigation and messaging", () => {
       "features/chat/components/PortalMessagesWorkspace.tsx",
     );
 
+    expect(authorization).toContain('export type MessagingActor');
     expect(authorization).toContain('preferredKind === "customer"');
     expect(authorization).toContain('profileRole === "customer"');
-    expect(contextRoute).toContain('.eq("role", "advisor")');
+    expect(authorization).toContain("isCustomerMessagingRole");
+    expect(contextRoute).toContain("isCustomerMessagingRole(staff.role)");
     expect(contextRoute).toContain("recipients");
     expect(workspace).toContain('aria-label="Message recipient"');
     expect(workspace).toContain(
@@ -39,5 +41,22 @@ describe("portal work-order navigation and messaging", () => {
     expect(startRoute).toContain(
       "requestedParticipantIds.length === 0",
     );
+    expect(startRoute).toContain("isCustomerMessagingRole(profile.role)");
+  });
+
+  it("keeps portal request start server-owned after customer auth", () => {
+    const startRoute = source("app/api/portal/request/start/route.ts");
+    const submitRoute = source("app/api/portal/request/submit/route.ts");
+    const migration = source(
+      "supabase/migrations/20260725024500_restore_customer_portal_request_read_access.sql",
+    );
+
+    expect(startRoute).toContain("const userClient = createServerSupabaseRoute()");
+    expect(startRoute).toContain("const actor = await requirePortalCustomerActor(userClient)");
+    expect(startRoute).toContain("const admin = createAdminSupabase()");
+    expect(startRoute).toContain("admin.rpc(");
+    expect(submitRoute).toContain("const admin = createAdminSupabase()");
+    expect(migration).toContain("work_orders_customer_portal_select");
+    expect(migration).toContain("profixiq_is_portal_customer_work_order");
   });
 });


### PR DESCRIPTION
## Summary
- Keep customer messaging authorization compile-safe while resolving customer-facing staff via canonical roles instead of advisor-only exact role matches.
- Route customer-started messages to the assigned advisor when available, with owner/admin/manager/advisor/service/lead hand/foreman coverage as fallback.
- Move portal request start, submit, and quote pre-check database work behind server-owned Supabase access after authenticating the portal customer.
- Restore narrow customer-owned read policies so the portal build-service page can load the newly-created work order, booking, request lines, quote lines, and active menu items.
- Add static regression coverage for the messaging export, recipient routing, and server-owned portal request start boundary.

## Notes
- This avoids reapplying the failed PR #1206 changes to `app/portal/request/when/page.tsx`, including the accidental text encoding churn.
- Vercel is pending on the branch at PR creation time.
