### PR TITLE
Fix portal message start stale draft IDs

### DIFF
--- a/app/api/chat/start-conversation/route.ts
+++ b/app/api/chat/start-conversation/route.ts
@@ -12,6 +12,12 @@ import { authorizeConversationContext } from "@/features/chat/server/conversatio
 
 export const dynamic = "force-dynamic";
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
 export async function POST(req: Request): Promise<NextResponse> {
   const userClient = createServerSupabaseRoute();
   const {
@@ -47,6 +53,13 @@ export async function POST(req: Request): Promise<NextResponse> {
   });
 
   if (!createAccess.ok) {
+    console.warn("[chat/start-conversation] create access denied", {
+      status: createAccess.status,
+      error: createAccess.error,
+      channel: body?.channel ?? "internal",
+      actorKind: body?.actor_kind ?? null,
+      participantCount: requestedParticipantIds.length,
+    });
     return NextResponse.json(
       { error: createAccess.error },
       { status: createAccess.status },
@@ -73,6 +86,12 @@ export async function POST(req: Request): Promise<NextResponse> {
   });
 
   if (!context.ok) {
+    console.warn("[chat/start-conversation] context denied", {
+      status: context.status,
+      error: context.error,
+      contextType: body?.context_type ?? null,
+      hasContextId: Boolean(body?.context_id),
+    });
     return NextResponse.json(
       { error: context.error },
       { status: context.status },
@@ -144,17 +163,14 @@ export async function POST(req: Request): Promise<NextResponse> {
     }
   }
 
-  const requestedId = body?.request_id?.trim();
-  if (
-    requestedId &&
-    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-      requestedId,
-    )
-  ) {
-    return NextResponse.json(
-      { error: "request_id must be a UUID" },
-      { status: 400 },
-    );
+  const requestedIdRaw = body?.request_id?.trim() ?? "";
+  const requestedId = requestedIdRaw && isUuid(requestedIdRaw) ? requestedIdRaw : undefined;
+  if (requestedIdRaw && !requestedId) {
+    console.warn("[chat/start-conversation] ignored invalid request_id", {
+      actorKind: createAccess.actor.kind,
+      channel: createAccess.channel,
+      requestIdLength: requestedIdRaw.length,
+    });
   }
 
   const conversationId = requestedId ?? randomUUID();
@@ -211,6 +227,12 @@ export async function POST(req: Request): Promise<NextResponse> {
   );
 
   if (createError) {
+    console.error("[chat/start-conversation] create rpc failed", {
+      code: createError.code ?? null,
+      message: createError.message ?? null,
+      details: createError.details ?? null,
+      hint: createError.hint ?? null,
+    });
     return NextResponse.json({ error: createError.message }, { status: 500 });
   }
 

--- a/features/chat/components/PortalMessagesWorkspace.tsx
+++ b/features/chat/components/PortalMessagesWorkspace.tsx
@@ -52,6 +52,24 @@ type RecipientOption = {
   label: string;
 };
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function ensureUuid(value: string | null | undefined): string {
+  return value && UUID_RE.test(value) ? value : crypto.randomUUID();
+}
+
+function normalizeMessageDraft(draft: OfflineMessageDraft): OfflineMessageDraft {
+  const conversationRequestId = ensureUuid(draft.conversationRequestId);
+  const clientMessageId = ensureUuid(draft.clientMessageId);
+  if (
+    conversationRequestId === draft.conversationRequestId &&
+    clientMessageId === draft.clientMessageId
+  ) {
+    return draft;
+  }
+  return { ...draft, conversationRequestId, clientMessageId };
+}
+
 export default function PortalMessagesWorkspace(): JSX.Element {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const searchParams = useSearchParams();
@@ -110,10 +128,18 @@ export default function PortalMessagesWorkspace(): JSX.Element {
         };
         const options = payload.options;
         const safeOptions = Array.isArray(options) ? options : [];
+        const safeRecipients = Array.isArray(payload.recipients)
+          ? payload.recipients
+          : [];
         setContextOptions(safeOptions);
-        setRecipientOptions(
-          Array.isArray(payload.recipients) ? payload.recipients : [],
-        );
+        setRecipientOptions(safeRecipients);
+        if (safeRecipients.length > 0) {
+          setError((current) =>
+            current === "No customer-facing shop staff are available"
+              ? null
+              : current,
+          );
+        }
         if (
           requestedContextKey &&
           safeOptions.some(
@@ -145,8 +171,12 @@ export default function PortalMessagesWorkspace(): JSX.Element {
         targetId: draftTargetId,
       });
       if (cancelled) return;
-      const next =
+      const rawNext =
         stored ?? createMessageDraft({ scope, targetId: draftTargetId });
+      const next = normalizeMessageDraft(rawNext);
+      if (stored && next !== rawNext) {
+        void saveOfflineMessageDraft(next);
+      }
       setDraftScope(scope);
       setNewThreadDraft(next);
       setMessage(next.content);
@@ -210,8 +240,21 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     const selectedContext = contextOptions.find(
       (option) => `${option.type}:${option.id}` === contextKey,
     );
-    const requestId =
-      newThreadDraft?.conversationRequestId ?? crypto.randomUUID();
+    const requestId = ensureUuid(newThreadDraft?.conversationRequestId);
+    const clientMessageId = ensureUuid(newThreadDraft?.clientMessageId);
+    if (
+      newThreadDraft &&
+      (requestId !== newThreadDraft.conversationRequestId ||
+        clientMessageId !== newThreadDraft.clientMessageId)
+    ) {
+      const refreshed = {
+        ...newThreadDraft,
+        conversationRequestId: requestId,
+        clientMessageId,
+      };
+      setNewThreadDraft(refreshed);
+      if (draftScope) void saveOfflineMessageDraft(refreshed);
+    }
 
     try {
       const createResponse = await fetch("/api/chat/start-conversation", {
@@ -242,8 +285,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
         body: JSON.stringify({
           conversationId: created.id,
           content,
-          clientMessageId:
-            newThreadDraft?.clientMessageId ?? crypto.randomUUID(),
+          clientMessageId,
         }),
       });
       if (!messageResponse.ok) {
@@ -295,6 +337,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
         <button
           type="button"
           onClick={() => {
+            setError(null);
             setNewThread(true);
             setActiveId(null);
           }}
@@ -410,7 +453,10 @@ export default function PortalMessagesWorkspace(): JSX.Element {
               />
               <select
                 value={recipientUserId}
-                onChange={(event) => setRecipientUserId(event.target.value)}
+                onChange={(event) => {
+                  setRecipientUserId(event.target.value);
+                  setError(null);
+                }}
                 aria-label="Message recipient"
                 className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm"
               >

--- a/tests/portal-messaging-navigation.test.ts
+++ b/tests/portal-messaging-navigation.test.ts
@@ -28,6 +28,9 @@ describe("portal work-order navigation and messaging", () => {
     expect(contextRoute).toContain("isCustomerMessagingRole(staff.role)");
     expect(contextRoute).toContain("recipients");
     expect(workspace).toContain('aria-label="Message recipient"');
+    expect(workspace).toContain("normalizeMessageDraft");
+    expect(workspace).toContain("ensureUuid(newThreadDraft?.conversationRequestId)");
+    expect(workspace).toContain("setError(null)");
     expect(workspace).toContain(
       "/api/chat/my-conversations?actor=customer",
     );
@@ -42,6 +45,8 @@ describe("portal work-order navigation and messaging", () => {
       "requestedParticipantIds.length === 0",
     );
     expect(startRoute).toContain("isCustomerMessagingRole(profile.role)");
+    expect(startRoute).toContain("ignored invalid request_id");
+    expect(startRoute).not.toContain("request_id must be a UUID");
   });
 
   it("keeps portal request start server-owned after customer auth", () => {


### PR DESCRIPTION
## Summary

Fixes the production 400 on `POST /api/chat/start-conversation` from the customer portal messages screen.

## Root cause

The route still rejected any non-UUID `request_id`. Portal messages saves offline drafts locally, so an older/stale draft can send an invalid `conversationRequestId`. In the Vercel trace, auth, customer lookup, and staff lookup all completed, then the route returned 400 before creating the conversation, which matches that request-id guard.

## Changes

- Ignore invalid `request_id` values server-side and generate a fresh conversation UUID instead of returning 400.
- Log invalid request IDs plus create/context denials so future Vercel traces show the real reason.
- Normalize saved portal message draft IDs on the client before sending.
- Reuse the normalized client message ID for the follow-up send-message call.
- Clear the stale `No customer-facing shop staff are available` banner once recipient options load or the recipient is changed.
- Add static regression coverage for the stale draft ID behavior.

## Validation

- Compared branch against `main`; only portal messaging start/component/test files changed.
- Vercel will run on this PR preview.