### PR TITLE
Address portal request start fallback review

### DIFF
--- a/app/api/portal/request/start/route.ts
+++ b/app/api/portal/request/start/route.ts
@@ -39,15 +39,18 @@ type DbError = {
   hint?: string | null;
 };
 
-type AdminSupabase = ReturnType<typeof createAdminSupabase>;
-
-type PortalCustomer = {
-  id: string;
-  shop_id: string;
-};
-
 function bad(msg: string, status = 400) {
   return NextResponse.json({ error: msg }, { status });
+}
+
+function portalSetupUnavailable() {
+  return NextResponse.json(
+    {
+      error:
+        "Portal appointment requests are being updated. Please try again shortly.",
+    },
+    { status: 503, headers: { "Retry-After": "120" } },
+  );
 }
 
 function isIsoDateString(s: string) {
@@ -107,94 +110,14 @@ function isDuplicateKeyError(
   );
 }
 
-function statusForCreateError(err: DbError | null | undefined): number {
-  const text = dbErrorText(err);
-  if (err?.code === "P0001" || err?.code === "23P01" || text.includes("overlap")) {
-    return 409;
-  }
-  return 500;
-}
-
-async function createPortalRequestDirect({
-  supabase,
-  customer,
-  vehicleId,
-  startsAt,
-  endsAt,
-  visitType,
-  notes,
-  sourceRowId,
-}: {
-  supabase: AdminSupabase;
-  customer: PortalCustomer;
-  vehicleId: string | null;
-  startsAt: string;
-  endsAt: string;
-  visitType: "waiter" | "drop_off";
-  notes: string | null;
-  sourceRowId: string | null;
-}): Promise<{ row: StartRpcRow | null; error: DbError | null }> {
-  const notesValue = notes?.trim() || null;
-  const workOrderInsert = {
-    shop_id: customer.shop_id,
-    customer_id: customer.id,
-    vehicle_id: vehicleId,
-    status: "awaiting_approval",
-    approval_state: "pending",
-    is_waiter: visitType === "waiter",
-    notes: notesValue,
-    portal_submitted_at: new Date().toISOString(),
-    ...(sourceRowId ? { source_row_id: sourceRowId } : {}),
-  };
-
-  const { data: workOrder, error: workOrderErr } = await supabase
-    .from("work_orders")
-    .insert(workOrderInsert)
-    .select("id")
-    .single();
-
-  if (workOrderErr || !workOrder?.id) {
-    return { row: null, error: workOrderErr ?? { message: "Work order was not created" } };
-  }
-
-  const { data: booking, error: bookingErr } = await supabase
-    .from("bookings")
-    .insert({
-      shop_id: customer.shop_id,
-      customer_id: customer.id,
-      vehicle_id: vehicleId,
-      work_order_id: workOrder.id,
-      starts_at: startsAt,
-      ends_at: endsAt,
-      status: "pending",
-      notes: notesValue,
-    })
-    .select("id")
-    .single();
-
-  if (bookingErr || !booking?.id) {
-    await supabase.from("work_orders").delete().eq("id", workOrder.id);
-    return { row: null, error: bookingErr ?? { message: "Booking was not created" } };
-  }
-
-  return {
-    row: {
-      work_order_id: workOrder.id,
-      booking_id: booking.id,
-      deduped: false,
-    },
-    error: null,
-  };
-}
-
-function portalStartResponse(row: StartRpcRow, statusOverride?: number) {
+function portalStartResponse(row: StartRpcRow) {
   return NextResponse.json(
     {
       workOrderId: row.work_order_id,
       bookingId: row.booking_id,
       replayed: Boolean(row.deduped),
     },
-    { status: statusOverride ?? (row.deduped ? 200 : 201) },
+    { status: row.deduped ? 200 : 201 },
   );
 }
 
@@ -310,7 +233,6 @@ export async function POST(req: Request) {
     }
 
     const sourceRowId = `portal_start:${customer.id}:${normalizedKey}`;
-    const notes = (body.notes ?? "").trim() || null;
 
     const { data: existingWo, error: existingWoErr } = await admin
       .from("work_orders")
@@ -325,26 +247,7 @@ export async function POST(req: Request) {
         error: serializeDbError(existingWoErr),
       });
       if (isPortalStartCompatibilityError(existingWoErr)) {
-        const fallback = await createPortalRequestDirect({
-          supabase: admin,
-          customer,
-          vehicleId,
-          startsAt,
-          endsAt,
-          visitType,
-          notes,
-          sourceRowId: null,
-        });
-        if (fallback.error || !fallback.row) {
-          console.error("[portal/request/start] direct fallback failed", {
-            error: serializeDbError(fallback.error),
-          });
-          return bad(
-            fallback.error?.message || "Failed to start request",
-            statusForCreateError(fallback.error),
-          );
-        }
-        return portalStartResponse(fallback.row, 201);
+        return portalSetupUnavailable();
       }
       return bad("Failed to verify request replay", 500);
     }
@@ -379,7 +282,7 @@ export async function POST(req: Request) {
       p_starts_at: startsAt,
       p_ends_at: endsAt,
       p_visit_type: visitType,
-      p_notes: notes,
+      p_notes: (body.notes ?? "").trim() || null,
       p_source_row_id: sourceRowId,
     };
 
@@ -400,26 +303,7 @@ export async function POST(req: Request) {
         error: serializeDbError(createErr),
       });
       if (isPortalStartCompatibilityError(createErr)) {
-        const fallback = await createPortalRequestDirect({
-          supabase: admin,
-          customer,
-          vehicleId,
-          startsAt,
-          endsAt,
-          visitType,
-          notes,
-          sourceRowId,
-        });
-        if (fallback.error || !fallback.row) {
-          console.error("[portal/request/start] direct fallback failed", {
-            error: serializeDbError(fallback.error),
-          });
-          return bad(
-            fallback.error?.message || "Failed to start request",
-            statusForCreateError(fallback.error),
-          );
-        }
-        return portalStartResponse(fallback.row, 201);
+        return portalSetupUnavailable();
       }
 
       if (isDuplicateKeyError(createErr)) {

--- a/tests/portal-messaging-navigation.test.ts
+++ b/tests/portal-messaging-navigation.test.ts
@@ -56,11 +56,14 @@ describe("portal work-order navigation and messaging", () => {
     expect(startRoute).toContain("const admin = createAdminSupabase()");
     expect(startRoute).toContain("admin.rpc(");
     expect(startRoute).toContain("isPortalStartCompatibilityError");
-    expect(startRoute).toContain("createPortalRequestDirect");
+    expect(startRoute).toContain("portalSetupUnavailable");
     expect(startRoute).toContain(
       'console.error("[portal/request/start] replay lookup failed"',
     );
-    expect(startRoute).toContain("sourceRowId: null");
+    expect(startRoute).toContain("Retry-After");
+    expect(startRoute).not.toContain("createPortalRequestDirect");
+    expect(startRoute).not.toContain("portal_submitted_at");
+    expect(startRoute).not.toContain("sourceRowId: null");
     expect(submitRoute).toContain("const admin = createAdminSupabase()");
     expect(migration).toContain("work_orders_customer_portal_select");
     expect(migration).toContain("profixiq_is_portal_customer_work_order");


### PR DESCRIPTION
## Summary

Addresses the automated review feedback on merged PR #1209 by removing the unsafe degraded-schema write fallback from `/api/portal/request/start`.

## Root cause

The compatibility fallback created a work order and booking through separate PostgREST calls when the idempotency/RPC schema was missing. That path could:

- set `portal_submitted_at` before the customer finished Review & Sign
- drop replay protection when `source_row_id` was unavailable
- bypass the atomic overlap protection from `portal_request_start_atomic`
- leave a work order without a booking on partial failure

## Changes

- Remove `createPortalRequestDirect` entirely.
- Keep structured logging for replay lookup and atomic create failures.
- Return a safe 503 with `Retry-After` when the database schema/RPC compatibility requirements are not present.
- Preserve the normal idempotent `portal_request_start_atomic` path when the database is correctly migrated.
- Update the regression test to assert no direct fallback, no early `portal_submitted_at`, and no discarded `sourceRowId` path.

## Validation

- Compared branch against `main`; only the portal request start route and portal messaging/navigation test changed.
- Vercel will run on this PR preview.