### PR TITLE
Address portal messaging replay review

### DIFF
--- a/app/api/chat/start-conversation/route.ts
+++ b/app/api/chat/start-conversation/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import {
   createAdminSupabase,
   createServerSupabaseRoute,
@@ -16,6 +16,14 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 
 function isUuid(value: string): boolean {
   return UUID_RE.test(value);
+}
+
+function deterministicUuidFromRequestId(requestId: string, actorUserId: string): string {
+  const hex = createHash("sha256")
+    .update(`chat:start-conversation:${actorUserId}:${requestId}`)
+    .digest("hex");
+  const variant = ((parseInt(hex[16] ?? "0", 16) & 0x3) | 0x8).toString(16);
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-${variant}${hex.slice(17, 20)}-${hex.slice(20, 32)}`;
 }
 
 export async function POST(req: Request): Promise<NextResponse> {
@@ -164,9 +172,13 @@ export async function POST(req: Request): Promise<NextResponse> {
   }
 
   const requestedIdRaw = body?.request_id?.trim() ?? "";
-  const requestedId = requestedIdRaw && isUuid(requestedIdRaw) ? requestedIdRaw : undefined;
-  if (requestedIdRaw && !requestedId) {
-    console.warn("[chat/start-conversation] ignored invalid request_id", {
+  const requestedId = requestedIdRaw
+    ? isUuid(requestedIdRaw)
+      ? requestedIdRaw
+      : deterministicUuidFromRequestId(requestedIdRaw, user.id)
+    : undefined;
+  if (requestedIdRaw && requestedId !== requestedIdRaw) {
+    console.warn("[chat/start-conversation] normalized invalid request_id", {
       actorKind: createAccess.actor.kind,
       channel: createAccess.channel,
       requestIdLength: requestedIdRaw.length,

--- a/tests/chat-start-conversation-route.test.ts
+++ b/tests/chat-start-conversation-route.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const mocks = vi.hoisted(() => {
+  const conversations = new Map<string, { id: string; created_by: string }>();
+  const getUser = vi.fn();
+  const rpc = vi.fn();
+  const from = vi.fn((table: string) => {
+    if (table === "conversations") {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn((_column: string, id: string) => ({
+            maybeSingle: vi.fn(async () => ({
+              data: conversations.get(id) ?? null,
+              error: null,
+            })),
+          })),
+        })),
+      };
+    }
+    return {};
+  });
+  return {
+    conversations,
+    getUser,
+    rpc,
+    from,
+    authorizeConversationCreate: vi.fn(),
+    authorizeConversationContext: vi.fn(),
+  };
+});
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createServerSupabaseRoute: () => ({
+    auth: { getUser: mocks.getUser },
+  }),
+  createAdminSupabase: () => ({
+    from: mocks.from,
+    rpc: mocks.rpc,
+  }),
+}));
+
+vi.mock("@/features/ai/lib/chat/authorization", () => ({
+  authorizeConversationCreate: mocks.authorizeConversationCreate,
+  isCustomerMessagingRole: vi.fn(() => true),
+}));
+
+vi.mock("@/features/chat/server/conversationContext", () => ({
+  authorizeConversationContext: mocks.authorizeConversationContext,
+}));
+
+function startRequest(body: Record<string, unknown>): Request {
+  return new Request("https://profixiq.test/api/chat/start-conversation", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/chat/start-conversation", () => {
+  beforeEach(() => {
+    mocks.conversations.clear();
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    mocks.getUser.mockResolvedValue({
+      data: { user: { id: "customer-user-1" } },
+    });
+    mocks.authorizeConversationCreate.mockResolvedValue({
+      ok: true,
+      actor: {
+        kind: "customer",
+        userId: "customer-user-1",
+        customerId: "customer-1",
+        shopId: "shop-1",
+        role: null,
+        profileId: null,
+      },
+      actorShopId: "shop-1",
+      channel: "customer",
+      customerId: "customer-1",
+      recipientUserIds: ["advisor-user-1"],
+      participantKinds: { "advisor-user-1": "staff" },
+    });
+    mocks.authorizeConversationContext.mockResolvedValue({
+      ok: true,
+      anchors: {
+        context_type: null,
+        context_id: null,
+        customer_id: "customer-1",
+        work_order_id: null,
+        vehicle_id: null,
+        booking_id: null,
+      },
+    });
+    mocks.rpc.mockImplementation(async (_fn: string, args: Record<string, string>) => {
+      mocks.conversations.set(args._conversation_id, {
+        id: args._conversation_id,
+        created_by: args._created_by,
+      });
+      return { data: args._conversation_id, error: null };
+    });
+  });
+
+  it("normalizes a stale non-UUID request ID into a replayable conversation ID", async () => {
+    const { POST } = await import("@/app/api/chat/start-conversation/route");
+    const body = {
+      request_id: "legacy-offline-draft-id",
+      actor_kind: "customer",
+      channel: "customer",
+      participant_ids: ["advisor-user-1"],
+      context_type: null,
+      context_id: null,
+      title: "Message from customer",
+    };
+
+    const firstResponse = await POST(startRequest(body));
+    const firstPayload = await firstResponse.json();
+
+    expect(firstResponse.status).toBe(201);
+    expect(firstPayload.id).toMatch(UUID_RE);
+    expect(mocks.rpc).toHaveBeenCalledTimes(1);
+
+    const secondResponse = await POST(startRequest(body));
+    const secondPayload = await secondResponse.json();
+
+    expect(secondResponse.status).toBe(200);
+    expect(secondPayload).toEqual({ id: firstPayload.id, reused: true });
+    expect(mocks.rpc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/portal-messaging-navigation.test.ts
+++ b/tests/portal-messaging-navigation.test.ts
@@ -45,7 +45,8 @@ describe("portal work-order navigation and messaging", () => {
       "requestedParticipantIds.length === 0",
     );
     expect(startRoute).toContain("isCustomerMessagingRole(profile.role)");
-    expect(startRoute).toContain("ignored invalid request_id");
+    expect(startRoute).toContain("deterministicUuidFromRequestId");
+    expect(startRoute).toContain("normalized invalid request_id");
     expect(startRoute).not.toContain("request_id must be a UUID");
   });
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1210 addressing the automated review feedback on stale portal message request IDs.

## Root cause

PR #1210 stopped stale non-UUID draft IDs from returning 400, but it generated a new random UUID on each retry. If an old/cached portal client retried after an ambiguous network failure, that could create multiple conversations for the same customer message.

## Changes

- Normalize malformed `request_id` values into deterministic UUIDs scoped by authenticated user + stale request value.
- Preserve the existing replay lookup for normalized IDs, so retries reuse the same conversation.
- Add a route-level Vitest test that invokes `POST /api/chat/start-conversation` twice with the same stale ID and asserts first create, second reuse.
- Update the existing portal messaging guard to expect `normalized invalid request_id` instead of `ignored invalid request_id`.

## Validation

- Compared branch against current `main`; only the chat start route and tests changed.
- Vercel will run on this PR preview.