### PR TITLE
Harden P0-002 RPC privileges

### DIFF
--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -125,6 +125,20 @@ jobs:
             -f tests/security/p0-001-relation-boundaries.runtime.sql \
             2>&1 | tee p0-001-relation-boundaries-runtime.log
 
+      - name: Execute P0 RPC privilege runtime integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/p0-002-rpc-privileges.runtime.sql \
+            2>&1 | tee p0-002-rpc-privileges-runtime.log
+
       - name: Verify bootstrap and existing-database baseline paths
         shell: bash
         env:
@@ -187,6 +201,7 @@ jobs:
             supabase-existing-baseline.log
             parts-use-handoff-runtime.log
             p0-001-relation-boundaries-runtime.log
+            p0-002-rpc-privileges-runtime.log
             supabase/config.toml
           if-no-files-found: warn
 

--- a/app/api/receive-scan/route.ts
+++ b/app/api/receive-scan/route.ts
@@ -16,6 +16,7 @@ export async function POST(req: Request) {
       location_id: string;
       qty: number;
       po_id?: string | null;
+      operation_id?: string | null;
     }>;
 
     const partId = typeof body.part_id === "string" ? body.part_id : "";
@@ -24,6 +25,13 @@ export async function POST(req: Request) {
       typeof body.qty === "number" && Number.isFinite(body.qty) ? body.qty : 0;
     const poId =
       typeof body.po_id === "string" && body.po_id.length > 0 ? body.po_id : null;
+    const operationId =
+      typeof body.operation_id === "string" &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+          body.operation_id,
+        )
+        ? body.operation_id
+        : null;
 
     if (!partId || !locationId || qty <= 0) {
       return NextResponse.json(
@@ -94,7 +102,9 @@ export async function POST(req: Request) {
         p_qty: qty,
         p_reason: "receive",
         p_ref_kind: "manual_receive",
-        p_ref_id: partId, // non-null placeholder for strict RPC args
+        // New callers send a per-action UUID. The part-id fallback preserves
+        // rolling compatibility and is deliberately non-idempotent in SQL.
+        p_ref_id: operationId ?? partId,
       } as unknown as DB["public"]["Functions"]["apply_stock_move"]["Args"],
     );
 

--- a/app/parts/inventory/page.tsx
+++ b/app/parts/inventory/page.tsx
@@ -483,6 +483,9 @@ export default function InventoryPage(): JSX.Element {
   const [recvPart, setRecvPart] = useState<Part | null>(null);
   const [recvLoc, setRecvLoc] = useState<string>("");
   const [recvQty, setRecvQty] = useState<number | "">("");
+  const [recvOperationId, setRecvOperationId] = useState<string>("");
+  const [recvSaving, setRecvSaving] = useState<boolean>(false);
+  const recvSubmittingRef = useRef(false);
 
   // Import CSV
   const [csvRows, setCsvRows] = useState<ParsedPartCsvRow[]>([]);
@@ -745,8 +748,8 @@ export default function InventoryPage(): JSX.Element {
           p_loc: initLoc,
           p_qty: initQty,
           p_reason: "receive",
-          p_ref_kind: "manual_receive",
-          p_ref_id: null,
+          p_ref_kind: "parts_inventory_initial_stock",
+          p_ref_id: id,
         });
       } catch (err: unknown) {
         alert(`Part created, but stock receive failed: ${errMsg(err)}`);
@@ -797,12 +800,23 @@ export default function InventoryPage(): JSX.Element {
   const openReceive = (p: Part) => {
     setRecvPart(p);
     setRecvQty("");
+    setRecvOperationId(crypto.randomUUID());
     setRecvOpen(true);
   };
 
   const applyReceive = async () => {
-    if (!recvPart?.id || !recvLoc || typeof recvQty !== "number" || recvQty <= 0) return;
+    if (
+      recvSubmittingRef.current ||
+      !recvPart?.id ||
+      !recvLoc ||
+      typeof recvQty !== "number" ||
+      recvQty <= 0
+    ) return;
 
+    recvSubmittingRef.current = true;
+    setRecvSaving(true);
+    const operationId = recvOperationId || crypto.randomUUID();
+    if (!recvOperationId) setRecvOperationId(operationId);
     try {
       await applyStockMoveRPC(supabase, {
         p_part: recvPart.id,
@@ -810,12 +824,15 @@ export default function InventoryPage(): JSX.Element {
         p_qty: recvQty,
         p_reason: "receive",
         p_ref_kind: "manual_receive",
-        p_ref_id: null,
+        p_ref_id: operationId,
       });
       setRecvOpen(false);
       await load(shopId);
     } catch (err: unknown) {
       alert(errMsg(err));
+    } finally {
+      recvSubmittingRef.current = false;
+      setRecvSaving(false);
     }
   };
 
@@ -966,7 +983,7 @@ export default function InventoryPage(): JSX.Element {
           continue;
         }
         const delta = (row.quantity_on_hand as number) - (currentByPartLoc.get(`${partId}:${locId}`) ?? 0);
-        if (delta !== 0) await applyStockMoveRPC(supabase, { p_part: partId, p_loc: locId, p_qty: delta, p_reason: "adjust", p_ref_kind: "parts_inventory_csv_import", p_ref_id: null });
+        if (delta !== 0) await applyStockMoveRPC(supabase, { p_part: partId, p_loc: locId, p_qty: delta, p_reason: "adjust", p_ref_kind: "parts_inventory_csv_import", p_ref_id: crypto.randomUUID() });
         adjusted++;
         if (adjusted % 25 === 0 || adjusted === stockRows.length) setCsvProgress({ phase: "Applying stock adjustments", phaseKey: "importing", processed: adjusted, total: stockRows.length, percent: 84 + Math.round((adjusted / Math.max(1, stockRows.length)) * 10), imported: counts.created + counts.updated, skipped: counts.skipped, failed: counts.failed });
       }
@@ -1419,9 +1436,9 @@ export default function InventoryPage(): JSX.Element {
             <button
               className={btnBlue}
               onClick={applyReceive}
-              disabled={!recvPart?.id || !recvLoc || typeof recvQty !== "number" || recvQty <= 0}
+              disabled={recvSaving || !recvPart?.id || !recvLoc || typeof recvQty !== "number" || recvQty <= 0}
             >
-              Apply Receive
+              {recvSaving ? "Receiving..." : "Apply Receive"}
             </button>
           </div>
         }

--- a/app/parts/receive/page.tsx
+++ b/app/parts/receive/page.tsx
@@ -82,6 +82,9 @@ export default function ReceivePage(): JSX.Element {
   const [busy, setBusy] = useState(false);
 
   const onDetectedRef = useRef<QuaggaDetectedHandler | null>(null);
+  const lastScanRef = useRef("");
+  const receiveBusyRef = useRef(false);
+  const scanOperationRef = useRef<{ code: string; id: string } | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -174,29 +177,57 @@ export default function ReceivePage(): JSX.Element {
 
     const handler: QuaggaDetectedHandler = async (res) => {
       const code = res.codeResult?.code ?? "";
-      if (!code || code === lastScan) return;
+      if (
+        !code ||
+        code === lastScanRef.current ||
+        receiveBusyRef.current
+      ) return;
 
+      lastScanRef.current = code;
+      receiveBusyRef.current = true;
       setLastScan(code);
       setLastResult(null);
 
       if (!selectedLoc) {
         setLastResult({ error: "Select a location first." });
-        window.setTimeout(() => setLastScan(""), 800);
+        receiveBusyRef.current = false;
+        window.setTimeout(() => {
+          lastScanRef.current = "";
+          setLastScan("");
+        }, 800);
         return;
       }
 
       const supplierId = pos.find((p) => p.id === selectedPo)?.supplier_id ?? null;
 
-      const { part_id } = await resolveScannedCode({
-        code,
-        supplier_id: supplierId,
-      });
+      let part_id: string | null = null;
+      try {
+        ({ part_id } = await resolveScannedCode({
+          code,
+          supplier_id: supplierId,
+        }));
+      } catch (error) {
+        receiveBusyRef.current = false;
+        setLastResult({
+          error: error instanceof Error ? error.message : "Part lookup failed",
+        });
+        window.setTimeout(() => {
+          lastScanRef.current = "";
+          setLastScan("");
+        }, 900);
+        return;
+      }
 
       if (!part_id) {
         setLastResult({
           error: `No part found for "${code}". Map it in Parts → Inventory → Edit → Barcodes.`,
         });
-        window.setTimeout(() => setLastScan(""), 1200);
+        receiveBusyRef.current = false;
+        scanOperationRef.current = null;
+        window.setTimeout(() => {
+          lastScanRef.current = "";
+          setLastScan("");
+        }, 1200);
         return;
       }
       const { data: partRow } = await supabase
@@ -215,6 +246,11 @@ export default function ReceivePage(): JSX.Element {
         }),
       );
 
+      const operationId =
+        scanOperationRef.current?.code === code
+          ? scanOperationRef.current.id
+          : crypto.randomUUID();
+      scanOperationRef.current = { code, id: operationId };
       setBusy(true);
       try {
         const resp = await fetch("/api/receive-scan", {
@@ -225,6 +261,7 @@ export default function ReceivePage(): JSX.Element {
             location_id: selectedLoc,
             qty,
             po_id: selectedPo || null,
+            operation_id: operationId,
           }),
         });
 
@@ -247,10 +284,19 @@ export default function ReceivePage(): JSX.Element {
           result: (json as { result?: unknown }).result,
         });
 
+        scanOperationRef.current = null;
         window.dispatchEvent(new CustomEvent("parts:received"));
+      } catch (error) {
+        setLastResult({
+          error: error instanceof Error ? error.message : "Receive failed",
+        });
       } finally {
+        receiveBusyRef.current = false;
         setBusy(false);
-        window.setTimeout(() => setLastScan(""), 900);
+        window.setTimeout(() => {
+          lastScanRef.current = "";
+          setLastScan("");
+        }, 900);
       }
     };
 

--- a/app/parts/receive/page.tsx
+++ b/app/parts/receive/page.tsx
@@ -71,8 +71,6 @@ export default function ReceivePage(): JSX.Element {
   const [selectedPo, setSelectedPo] = useState<string>("");
   const [selectedLoc, setSelectedLoc] = useState<string>("");
   const [locs, setLocs] = useState<StockLoc[]>([]);
-  const [lastScan, setLastScan] = useState<string>("");
-
   const videoRef = useRef<HTMLDivElement | null>(null);
   const [scanning, setScanning] = useState<boolean>(false);
   const [qty, setQty] = useState<number>(1);
@@ -185,7 +183,6 @@ export default function ReceivePage(): JSX.Element {
 
       lastScanRef.current = code;
       receiveBusyRef.current = true;
-      setLastScan(code);
       setLastResult(null);
 
       if (!selectedLoc) {
@@ -193,7 +190,6 @@ export default function ReceivePage(): JSX.Element {
         receiveBusyRef.current = false;
         window.setTimeout(() => {
           lastScanRef.current = "";
-          setLastScan("");
         }, 800);
         return;
       }
@@ -213,7 +209,6 @@ export default function ReceivePage(): JSX.Element {
         });
         window.setTimeout(() => {
           lastScanRef.current = "";
-          setLastScan("");
         }, 900);
         return;
       }
@@ -226,7 +221,6 @@ export default function ReceivePage(): JSX.Element {
         scanOperationRef.current = null;
         window.setTimeout(() => {
           lastScanRef.current = "";
-          setLastScan("");
         }, 1200);
         return;
       }
@@ -295,7 +289,6 @@ export default function ReceivePage(): JSX.Element {
         setBusy(false);
         window.setTimeout(() => {
           lastScanRef.current = "";
-          setLastScan("");
         }, 900);
       }
     };

--- a/features/parts/actions.ts
+++ b/features/parts/actions.ts
@@ -74,8 +74,8 @@ export async function adjustStock(input: {
     p_loc: input.location_id,
     p_qty: input.qty_change,
     p_reason: input.reason,
-    p_ref_kind: input.reference_kind ?? null,
-    p_ref_id: input.reference_id ?? null,
+    p_ref_kind: input.reference_kind ?? "manual_adjustment",
+    p_ref_id: input.reference_id ?? crypto.randomUUID(),
   };
 
   const { data, error } = await supabase.rpc(

--- a/features/parts/components/AdjustStockForm.tsx
+++ b/features/parts/components/AdjustStockForm.tsx
@@ -1,11 +1,12 @@
 "use client";
-import { useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import { adjustStock } from "@/features/parts/actions";
 
 export function AdjustStockForm({ partId }: { partId: string }) {
   const [locationId, setLocationId] = useState("");
   const [qty, setQty] = useState<number>(0);
   const [pending, start] = useTransition();
+  const operationIdRef = useRef(crypto.randomUUID());
 
   return (
     <form
@@ -17,7 +18,10 @@ export function AdjustStockForm({ partId }: { partId: string }) {
             location_id: locationId,
             qty_change: qty,
             reason: qty >= 0 ? "receive" : "adjust",
+            reference_kind: "manual_adjustment",
+            reference_id: operationIdRef.current,
           });
+          operationIdRef.current = crypto.randomUUID();
         });
       }}
       className="space-y-2"

--- a/features/parts/server/poActions.ts
+++ b/features/parts/server/poActions.ts
@@ -148,18 +148,18 @@ export async function receivePo(po_id: string) {
       );
     }
 
+    const lineId = typeof rec.id === "string" ? rec.id : null;
+    if (!lineId) throw new Error("Missing purchase_order_lines.id");
+
     const { error: se } = await supabase.rpc("apply_stock_move", {
       p_part: partId,
       p_loc: loc,
       p_qty: delta,
       p_reason: "receive",
-      p_ref_kind: "purchase_order",
-      p_ref_id: po_id,
+      p_ref_kind: "purchase_order_line",
+      p_ref_id: lineId,
     });
     if (se) throw se;
-
-    const lineId = typeof rec.id === "string" ? rec.id : null;
-    if (!lineId) throw new Error("Missing purchase_order_lines.id");
 
     const { error: ue } = await supabase
       .from("purchase_order_lines")

--- a/supabase/migrations/20260725103000_harden_p0_002_rpc_privileges.sql
+++ b/supabase/migrations/20260725103000_harden_p0_002_rpc_privileges.sql
@@ -4,12 +4,17 @@
 -- PostgreSQL grants EXECUTE on new functions to PUBLIC by default. The
 -- baseline also granted broad table, sequence, and function privileges to the
 -- client roles. Future migrations must grant client access intentionally.
+-- Function EXECUTE is granted to PUBLIC by PostgreSQL's global default, so
+-- that revoke must be global; a schema-scoped revoke cannot remove it.
+alter default privileges for role postgres
+  revoke execute on functions from public;
+
 alter default privileges for role postgres in schema public
-  revoke all privileges on tables from public, anon, authenticated;
+  revoke all privileges on tables from anon, authenticated;
 alter default privileges for role postgres in schema public
-  revoke all privileges on sequences from public, anon, authenticated;
+  revoke all privileges on sequences from anon, authenticated;
 alter default privileges for role postgres in schema public
-  revoke all privileges on functions from public, anon, authenticated;
+  revoke all privileges on functions from anon, authenticated;
 
 alter default privileges for role postgres in schema public
   grant all privileges on tables to service_role;

--- a/supabase/migrations/20260725103000_harden_p0_002_rpc_privileges.sql
+++ b/supabase/migrations/20260725103000_harden_p0_002_rpc_privileges.sql
@@ -1,0 +1,441 @@
+-- P0-002: close unsafe SECURITY DEFINER RPCs and fail closed for objects
+-- created by future migrations.
+
+-- PostgreSQL grants EXECUTE on new functions to PUBLIC by default. The
+-- baseline also granted broad table, sequence, and function privileges to the
+-- client roles. Future migrations must grant client access intentionally.
+alter default privileges for role postgres in schema public
+  revoke all privileges on tables from public, anon, authenticated;
+alter default privileges for role postgres in schema public
+  revoke all privileges on sequences from public, anon, authenticated;
+alter default privileges for role postgres in schema public
+  revoke all privileges on functions from public, anon, authenticated;
+
+alter default privileges for role postgres in schema public
+  grant all privileges on tables to service_role;
+alter default privileges for role postgres in schema public
+  grant all privileges on sequences to service_role;
+alter default privileges for role postgres in schema public
+  grant all privileges on functions to service_role;
+
+create schema if not exists private authorization postgres;
+revoke all privileges on schema private
+  from public, anon, authenticated, service_role;
+
+-- Keep the client-facing signature stable while moving the implementation to
+-- a private core. The core returns only the durable ledger id so wrappers can
+-- preserve either historical return contract (uuid or stock_moves row).
+create or replace function private.profixiq_apply_stock_move_core(
+  p_part uuid,
+  p_loc uuid,
+  p_qty numeric,
+  p_reason text,
+  p_ref_kind text,
+  p_ref_id uuid
+) returns uuid
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+declare
+  v_part public.parts%rowtype;
+  v_location_id uuid;
+  v_reason public.stock_move_reason;
+  v_effect numeric;
+  v_ref_kind text := nullif(trim(p_ref_kind), '');
+  v_idempotency_key text;
+  v_move public.stock_moves%rowtype;
+  v_summary_relkind "char";
+begin
+  if p_qty is null
+     or p_qty = 0
+     or p_qty::text in ('NaN', 'Infinity', '-Infinity') then
+    raise exception using
+      errcode = '22023',
+      message = 'STOCK_MOVE_QUANTITY_INVALID';
+  end if;
+
+  if v_ref_kind is not null and length(v_ref_kind) > 80 then
+    raise exception using
+      errcode = '22023',
+      message = 'STOCK_MOVE_REFERENCE_KIND_TOO_LONG';
+  end if;
+
+  begin
+    v_reason := lower(trim(coalesce(p_reason, '')))
+      ::public.stock_move_reason;
+  exception
+    when invalid_text_representation then
+      raise exception using
+        errcode = '22023',
+        message = 'STOCK_MOVE_REASON_INVALID';
+  end;
+
+  if v_reason::text = 'adjust' then
+    v_effect := p_qty;
+  elsif v_reason::text in ('receive', 'return', 'transfer_in', 'seed') then
+    if p_qty < 0 then
+      raise exception using
+        errcode = '22023',
+        message = 'STOCK_MOVE_DIRECTION_INVALID';
+    end if;
+    v_effect := p_qty;
+  elsif v_reason::text in ('consume', 'transfer_out') then
+    if p_qty < 0 then
+      raise exception using
+        errcode = '22023',
+        message = 'STOCK_MOVE_DIRECTION_INVALID';
+    end if;
+    v_effect := -p_qty;
+  else
+    raise exception using
+      errcode = '22023',
+      message = 'STOCK_MOVE_LIFECYCLE_RPC_REQUIRED';
+  end if;
+
+  select part.*
+    into v_part
+  from public.parts part
+  where part.id = p_part
+  for update;
+
+  if not found or v_part.shop_id is null then
+    raise exception using
+      errcode = '42501',
+      message = 'STOCK_MOVE_SCOPE_DENIED';
+  end if;
+
+  perform public.parts_lifecycle_assert_shop_access(v_part.shop_id);
+
+  select location.id
+    into v_location_id
+  from public.stock_locations location
+  where location.id = p_loc
+    and location.shop_id = v_part.shop_id
+  for update;
+
+  if v_location_id is null then
+    raise exception using
+      errcode = '42501',
+      message = 'STOCK_MOVE_SCOPE_DENIED';
+  end if;
+
+  -- Old receive-scan clients used the part id as a non-unique placeholder for
+  -- manual receipts. Do not collapse those legitimate repeated receipts.
+  if p_ref_id is not null
+     and v_ref_kind is not null
+     and not (
+       v_ref_kind = 'manual_receive'
+       and p_ref_id = p_part
+     ) then
+    v_idempotency_key :=
+      v_part.shop_id::text
+      || ':apply-stock-move:'
+      || v_reason::text
+      || ':'
+      || v_ref_kind
+      || ':'
+      || p_ref_id::text
+      || ':'
+      || p_part::text
+      || ':'
+      || p_loc::text;
+
+    select move.*
+      into v_move
+    from public.stock_moves move
+    where move.shop_id = v_part.shop_id
+      and move.idempotency_key = v_idempotency_key
+    for update;
+
+    if found then
+      if v_move.part_id is distinct from p_part
+         or v_move.location_id is distinct from p_loc
+         or v_move.qty_change is distinct from v_effect
+         or v_move.reason is distinct from v_reason
+         or v_move.reference_kind is distinct from v_ref_kind
+         or v_move.reference_id is distinct from p_ref_id then
+        raise exception using
+          errcode = '22023',
+          message = 'STOCK_MOVE_IDEMPOTENCY_CONFLICT';
+      end if;
+      return v_move.id;
+    end if;
+  end if;
+
+  insert into public.stock_moves (
+    shop_id,
+    part_id,
+    location_id,
+    qty_change,
+    reason,
+    reference_kind,
+    reference_id,
+    created_by,
+    idempotency_key,
+    metadata,
+    lifecycle_quantity
+  ) values (
+    v_part.shop_id,
+    p_part,
+    p_loc,
+    v_effect,
+    v_reason,
+    v_ref_kind,
+    p_ref_id,
+    auth.uid(),
+    v_idempotency_key,
+    jsonb_build_object(
+      'operation', 'apply_stock_move',
+      'requested_qty', p_qty,
+      'effective_qty', v_effect
+    ),
+    abs(v_effect)
+  )
+  on conflict (shop_id, idempotency_key)
+    where idempotency_key is not null
+  do nothing
+  returning * into v_move;
+
+  if not found then
+    select move.*
+      into v_move
+    from public.stock_moves move
+    where move.shop_id = v_part.shop_id
+      and move.idempotency_key = v_idempotency_key
+    for update;
+
+    if not found
+       or v_move.part_id is distinct from p_part
+       or v_move.location_id is distinct from p_loc
+       or v_move.qty_change is distinct from v_effect
+       or v_move.reason is distinct from v_reason
+       or v_move.reference_kind is distinct from v_ref_kind
+       or v_move.reference_id is distinct from p_ref_id then
+      raise exception using
+        errcode = '22023',
+        message = 'STOCK_MOVE_IDEMPOTENCY_CONFLICT';
+    end if;
+
+    return v_move.id;
+  end if;
+
+  -- Maintain the legacy caches only for the new ledger row. Current inventory
+  -- reads remain ledger-backed; these writes preserve older consumers.
+  insert into public.part_stock (
+    part_id,
+    location_id,
+    qty_on_hand,
+    qty_reserved
+  ) values (
+    p_part,
+    p_loc,
+    v_effect,
+    0
+  )
+  on conflict (part_id, location_id) do update
+  set qty_on_hand = public.part_stock.qty_on_hand + excluded.qty_on_hand;
+
+  select relation.relkind
+    into v_summary_relkind
+  from pg_catalog.pg_class relation
+  join pg_catalog.pg_namespace namespace
+    on namespace.oid = relation.relnamespace
+  where namespace.nspname = 'public'
+    and relation.relname = 'part_stock_summary';
+
+  if v_summary_relkind in ('r', 'p') then
+    insert into public.part_stock_summary (
+      part_id,
+      location_id,
+      shop_id,
+      qty_on_hand,
+      qty_reserved
+    ) values (
+      p_part,
+      p_loc,
+      v_part.shop_id,
+      v_effect,
+      0
+    )
+    on conflict (part_id, location_id) do update
+    set qty_on_hand =
+      public.part_stock_summary.qty_on_hand + excluded.qty_on_hand;
+  end if;
+
+  return v_move.id;
+end;
+$$;
+
+-- The ordered migration chain returns uuid. Generated types from at least one
+-- deployed schema describe a stock_moves row. Preserve whichever contract is
+-- already installed rather than dropping the function or its dependencies.
+do $migration$
+declare
+  v_return_type regtype;
+  v_returns_set boolean;
+begin
+  select procedure.prorettype::regtype, procedure.proretset
+    into v_return_type, v_returns_set
+  from pg_catalog.pg_proc procedure
+  where procedure.oid = pg_catalog.to_regprocedure(
+    'public.apply_stock_move(uuid,uuid,numeric,text,text,uuid)'
+  );
+
+  if v_return_type is null then
+    raise exception
+      'P0-002 requires public.apply_stock_move(uuid,uuid,numeric,text,text,uuid)';
+  end if;
+  if v_returns_set then
+    raise exception
+      'P0-002 cannot preserve a set-returning apply_stock_move contract';
+  end if;
+
+  if v_return_type = 'uuid'::regtype then
+    execute $wrapper$
+      create or replace function public.apply_stock_move(
+        p_part uuid,
+        p_loc uuid,
+        p_qty numeric,
+        p_reason text,
+        p_ref_kind text,
+        p_ref_id uuid
+      ) returns uuid
+      language plpgsql
+      security definer
+      set search_path = pg_catalog, public
+      as $body$
+      begin
+        return private.profixiq_apply_stock_move_core(
+          p_part,
+          p_loc,
+          p_qty,
+          p_reason,
+          p_ref_kind,
+          p_ref_id
+        );
+      end;
+      $body$
+    $wrapper$;
+  elsif v_return_type = 'public.stock_moves'::regtype then
+    execute $wrapper$
+      create or replace function public.apply_stock_move(
+        p_part uuid,
+        p_loc uuid,
+        p_qty numeric,
+        p_reason text,
+        p_ref_kind text,
+        p_ref_id uuid
+      ) returns public.stock_moves
+      language plpgsql
+      security definer
+      set search_path = pg_catalog, public
+      as $body$
+      declare
+        v_move_id uuid;
+        v_move public.stock_moves%rowtype;
+      begin
+        v_move_id := private.profixiq_apply_stock_move_core(
+          p_part,
+          p_loc,
+          p_qty,
+          p_reason,
+          p_ref_kind,
+          p_ref_id
+        );
+
+        select move.*
+          into strict v_move
+        from public.stock_moves move
+        where move.id = v_move_id;
+
+        return v_move;
+      end;
+      $body$
+    $wrapper$;
+  else
+    raise exception
+      'P0-002 cannot preserve apply_stock_move return type %',
+      v_return_type;
+  end if;
+end
+$migration$;
+
+-- This legacy RPC has no repository caller. Keep the server-only capability
+-- available without allowing client roles to alter arbitrary seat limits.
+create or replace function public.increment_user_limit(
+  input_shop_id uuid,
+  increment_by integer default 5
+) returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $$
+begin
+  if coalesce(
+    nullif(current_setting('request.jwt.claim.role', true), ''),
+    auth.jwt() ->> 'role',
+    ''
+  ) <> 'service_role' then
+    raise exception using
+      errcode = '42501',
+      message = 'USER_LIMIT_SERVICE_ROLE_REQUIRED';
+  end if;
+
+  if input_shop_id is null or increment_by is null or increment_by = 0 then
+    raise exception using
+      errcode = '22023',
+      message = 'USER_LIMIT_INPUT_INVALID';
+  end if;
+
+  update public.shops
+  set user_limit = coalesce(user_limit, 0) + increment_by
+  where id = input_shop_id;
+end;
+$$;
+
+revoke all privileges on function private.profixiq_apply_stock_move_core(
+  uuid,
+  uuid,
+  numeric,
+  text,
+  text,
+  uuid
+) from public, anon, authenticated, service_role;
+
+revoke all privileges on function public.apply_stock_move(
+  uuid,
+  uuid,
+  numeric,
+  text,
+  text,
+  uuid
+) from public, anon, authenticated, service_role;
+grant execute on function public.apply_stock_move(
+  uuid,
+  uuid,
+  numeric,
+  text,
+  text,
+  uuid
+) to authenticated, service_role;
+
+-- Disable the ambiguous legacy enum overload. Repository callers all use the
+-- hardened six-argument text contract above.
+revoke all privileges on function public.apply_stock_move(
+  uuid,
+  uuid,
+  numeric,
+  public.stock_move_reason,
+  text,
+  uuid
+) from public, anon, authenticated, service_role;
+
+revoke all privileges on function public.increment_user_limit(
+  uuid,
+  integer
+) from public, anon, authenticated, service_role;
+grant execute on function public.increment_user_limit(
+  uuid,
+  integer
+) to service_role;

--- a/tests/parts/use-part-handoff.runtime.sql
+++ b/tests/parts/use-part-handoff.runtime.sql
@@ -253,6 +253,8 @@ begin
   raise exception 'Runtime assertion failed: conflicting retry succeeded.';
 end;
 $$;
+grant execute on function pg_temp.expect_idempotency_conflict()
+  to authenticated;
 
 set local role authenticated;
 select pg_temp.expect_idempotency_conflict();
@@ -498,6 +500,8 @@ begin
   raise exception 'Runtime assertion failed: insufficient stock succeeded.';
 end;
 $$;
+grant execute on function pg_temp.expect_insufficient_stock()
+  to authenticated;
 
 set local role authenticated;
 select pg_temp.expect_insufficient_stock();
@@ -563,6 +567,8 @@ begin
   raise exception 'Runtime assertion failed: cross-shop direct RPC succeeded.';
 end;
 $$;
+grant execute on function pg_temp.expect_cross_shop_denied(uuid)
+  to authenticated;
 
 create function pg_temp.expect_cross_shop_canonical_denied()
 returns void
@@ -585,6 +591,8 @@ begin
     'Runtime assertion failed: cross-shop canonical RPC succeeded.';
 end;
 $$;
+grant execute on function pg_temp.expect_cross_shop_canonical_denied()
+  to authenticated;
 
 select set_config(
   'request.jwt.claim.sub',
@@ -675,6 +683,8 @@ begin
     'Runtime assertion failed: cross-shop request-item attach succeeded.';
 end;
 $$;
+grant execute on function pg_temp.expect_cross_shop_attach_denied()
+  to authenticated;
 
 select set_config(
   'request.jwt.claim.sub',
@@ -1005,6 +1015,8 @@ begin
   raise exception 'Runtime assertion failed: inconsistent handoff succeeded.';
 end;
 $$;
+grant execute on function pg_temp.expect_handoff_rollback()
+  to authenticated;
 
 set local role authenticated;
 select pg_temp.expect_handoff_rollback();

--- a/tests/security/p0-001-relation-boundaries.runtime.sql
+++ b/tests/security/p0-001-relation-boundaries.runtime.sql
@@ -441,6 +441,8 @@ begin
     p_relation;
 end;
 $$;
+grant execute on function pg_temp.expect_anon_select_denied(regclass)
+  to anon;
 
 set local role anon;
 insert into p0_001_public_view_result
@@ -684,6 +686,8 @@ begin
     p_target;
 end;
 $$;
+grant execute on function pg_temp.expect_protected_insert_denied(text)
+  to authenticated;
 
 create function pg_temp.expect_disallowed_updates_hidden()
 returns void
@@ -711,6 +715,8 @@ begin
   end if;
 end;
 $$;
+grant execute on function pg_temp.expect_disallowed_updates_hidden()
+  to authenticated;
 
 -- Same-shop technicians may read operational records but cannot mutate
 -- inventory, warranty, or private shop-profile configuration.

--- a/tests/security/p0-002-rpc-privileges.runtime.sql
+++ b/tests/security/p0-002-rpc-privileges.runtime.sql
@@ -291,6 +291,8 @@ begin
     'P0-002 runtime assertion failed: denied stock move succeeded';
 end;
 $$;
+grant execute on function pg_temp.expect_stock_move_denied(uuid, uuid, uuid)
+  to anon, authenticated;
 
 create function pg_temp.expect_user_limit_denied()
 returns void
@@ -310,6 +312,8 @@ begin
     'P0-002 runtime assertion failed: denied user-limit mutation succeeded';
 end;
 $$;
+grant execute on function pg_temp.expect_user_limit_denied()
+  to anon, authenticated;
 
 set local role anon;
 select pg_temp.expect_stock_move_denied(
@@ -410,6 +414,8 @@ begin
     'P0-002 runtime assertion failed: conflicting retry succeeded';
 end;
 $$;
+grant execute on function pg_temp.expect_idempotency_conflict()
+  to authenticated;
 
 set local role authenticated;
 select pg_temp.expect_idempotency_conflict();

--- a/tests/security/p0-002-rpc-privileges.runtime.sql
+++ b/tests/security/p0-002-rpc-privileges.runtime.sql
@@ -1,0 +1,573 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+-- Prove the repaired default ACLs on objects created after the migration.
+create table public.p0_002_default_table_probe (
+  id integer primary key
+);
+create sequence public.p0_002_default_sequence_probe;
+create function public.p0_002_default_function_probe()
+returns integer
+language sql
+as $$
+  select 1;
+$$;
+
+do $$
+begin
+  if has_table_privilege(
+    'anon',
+    'public.p0_002_default_table_probe',
+    'SELECT'
+  )
+  or has_table_privilege(
+    'authenticated',
+    'public.p0_002_default_table_probe',
+    'SELECT'
+  )
+  or not has_table_privilege(
+    'service_role',
+    'public.p0_002_default_table_probe',
+    'SELECT'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: future table ACL is unsafe';
+  end if;
+
+  if has_sequence_privilege(
+    'anon',
+    'public.p0_002_default_sequence_probe',
+    'USAGE'
+  )
+  or has_sequence_privilege(
+    'authenticated',
+    'public.p0_002_default_sequence_probe',
+    'USAGE'
+  )
+  or not has_sequence_privilege(
+    'service_role',
+    'public.p0_002_default_sequence_probe',
+    'USAGE'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: future sequence ACL is unsafe';
+  end if;
+
+  if has_function_privilege(
+    'anon',
+    'public.p0_002_default_function_probe()',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'public.p0_002_default_function_probe()',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'service_role',
+    'public.p0_002_default_function_probe()',
+    'EXECUTE'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: future function ACL is unsafe';
+  end if;
+end
+$$;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  (
+    '41000000-0000-4000-8000-000000000001',
+    'p0-002-owner-a@example.com',
+    '{"full_name":"P0-002 Owner A"}'::jsonb
+  ),
+  (
+    '42000000-0000-4000-8000-000000000002',
+    'p0-002-owner-b@example.com',
+    '{"full_name":"P0-002 Owner B"}'::jsonb
+  ),
+  (
+    '43000000-0000-4000-8000-000000000003',
+    'p0-002-tech-a@example.com',
+    '{"full_name":"P0-002 Tech A"}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values
+  (
+    '41000000-0000-4000-8000-000000000001',
+    '41000000-0000-4000-8000-000000000001',
+    'owner',
+    'P0-002 Owner A'
+  ),
+  (
+    '42000000-0000-4000-8000-000000000002',
+    '42000000-0000-4000-8000-000000000002',
+    'owner',
+    'P0-002 Owner B'
+  ),
+  (
+    '43000000-0000-4000-8000-000000000003',
+    '43000000-0000-4000-8000-000000000003',
+    'tech',
+    'P0-002 Tech A'
+  )
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+insert into public.shops (
+  id,
+  owner_id,
+  business_name,
+  name,
+  user_limit
+) values
+  (
+    'a2100000-0000-4000-8000-000000000001',
+    '41000000-0000-4000-8000-000000000001',
+    'P0-002 Shop A',
+    'P0-002 Shop A',
+    3
+  ),
+  (
+    'b2200000-0000-4000-8000-000000000002',
+    '42000000-0000-4000-8000-000000000002',
+    'P0-002 Shop B',
+    'P0-002 Shop B',
+    3
+  )
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = case id
+  when '42000000-0000-4000-8000-000000000002'::uuid
+    then 'b2200000-0000-4000-8000-000000000002'::uuid
+  else 'a2100000-0000-4000-8000-000000000001'::uuid
+end
+where id in (
+  '41000000-0000-4000-8000-000000000001',
+  '42000000-0000-4000-8000-000000000002',
+  '43000000-0000-4000-8000-000000000003'
+);
+
+insert into public.parts (id, shop_id, name, part_number, sku)
+values
+  (
+    'a2300000-0000-4000-8000-000000000001',
+    'a2100000-0000-4000-8000-000000000001',
+    'P0-002 Part A',
+    'P0-002-A',
+    'P0-002-A'
+  ),
+  (
+    'b2400000-0000-4000-8000-000000000002',
+    'b2200000-0000-4000-8000-000000000002',
+    'P0-002 Part B',
+    'P0-002-B',
+    'P0-002-B'
+  );
+
+insert into public.stock_locations (id, shop_id, code, name)
+values
+  (
+    'a2500000-0000-4000-8000-000000000001',
+    'a2100000-0000-4000-8000-000000000001',
+    'P02A',
+    'P0-002 Location A'
+  ),
+  (
+    'b2600000-0000-4000-8000-000000000002',
+    'b2200000-0000-4000-8000-000000000002',
+    'P02B',
+    'P0-002 Location B'
+  );
+
+do $$
+begin
+  if has_function_privilege(
+    'anon',
+    'public.apply_stock_move(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'authenticated',
+    'public.apply_stock_move(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'service_role',
+    'public.apply_stock_move(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: hardened stock RPC ACL is wrong';
+  end if;
+
+  if has_function_privilege(
+    'anon',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'service_role',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: unsafe enum overload remains exposed';
+  end if;
+
+  if has_function_privilege(
+    'anon',
+    'private.profixiq_apply_stock_move_core(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'private.profixiq_apply_stock_move_core(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'service_role',
+    'private.profixiq_apply_stock_move_core(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: private stock core is exposed';
+  end if;
+
+  if has_function_privilege(
+    'anon',
+    'public.increment_user_limit(uuid,integer)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'public.increment_user_limit(uuid,integer)',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'service_role',
+    'public.increment_user_limit(uuid,integer)',
+    'EXECUTE'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: user-limit RPC ACL is wrong';
+  end if;
+end
+$$;
+
+create function pg_temp.expect_stock_move_denied(
+  p_part uuid,
+  p_location uuid,
+  p_reference uuid
+) returns void
+language plpgsql
+as $$
+begin
+  begin
+    perform public.apply_stock_move(
+      p_part,
+      p_location,
+      1,
+      'receive',
+      'p0_002_denied',
+      p_reference
+    );
+  exception when insufficient_privilege then
+    return;
+  end;
+
+  raise exception
+    'P0-002 runtime assertion failed: denied stock move succeeded';
+end;
+$$;
+
+create function pg_temp.expect_user_limit_denied()
+returns void
+language plpgsql
+as $$
+begin
+  begin
+    perform public.increment_user_limit(
+      'a2100000-0000-4000-8000-000000000001',
+      1
+    );
+  exception when insufficient_privilege then
+    return;
+  end;
+
+  raise exception
+    'P0-002 runtime assertion failed: denied user-limit mutation succeeded';
+end;
+$$;
+
+set local role anon;
+select pg_temp.expect_stock_move_denied(
+  'a2300000-0000-4000-8000-000000000001',
+  'a2500000-0000-4000-8000-000000000001',
+  'a2700000-0000-4000-8000-000000000001'
+);
+select pg_temp.expect_user_limit_denied();
+reset role;
+
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config(
+  'request.jwt.claim.sub',
+  '41000000-0000-4000-8000-000000000001',
+  true
+);
+
+create temp table p0_002_move_results (
+  attempt text primary key,
+  move_id uuid not null
+);
+grant select, insert on table p0_002_move_results to authenticated;
+
+set local role authenticated;
+insert into p0_002_move_results (attempt, move_id)
+select
+  'first',
+  public.apply_stock_move(
+    'a2300000-0000-4000-8000-000000000001',
+    'a2500000-0000-4000-8000-000000000001',
+    5,
+    'receive',
+    'parts_request_initial_stock',
+    'a2300000-0000-4000-8000-000000000001'
+  );
+
+insert into p0_002_move_results (attempt, move_id)
+select
+  'replay',
+  public.apply_stock_move(
+    'a2300000-0000-4000-8000-000000000001',
+    'a2500000-0000-4000-8000-000000000001',
+    5,
+    'receive',
+    'parts_request_initial_stock',
+    'a2300000-0000-4000-8000-000000000001'
+  );
+reset role;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from p0_002_move_results first_attempt
+    join p0_002_move_results replay
+      on replay.attempt = 'replay'
+     and replay.move_id = first_attempt.move_id
+    where first_attempt.attempt = 'first'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: stable retry returned another move';
+  end if;
+
+  if (
+    select count(*)
+    from public.stock_moves
+    where shop_id = 'a2100000-0000-4000-8000-000000000001'
+      and reference_kind = 'parts_request_initial_stock'
+  ) <> 1 then
+    raise exception
+      'P0-002 runtime assertion failed: stable retry duplicated stock';
+  end if;
+end
+$$;
+
+create function pg_temp.expect_idempotency_conflict()
+returns void
+language plpgsql
+as $$
+begin
+  begin
+    perform public.apply_stock_move(
+      'a2300000-0000-4000-8000-000000000001',
+      'a2500000-0000-4000-8000-000000000001',
+      6,
+      'receive',
+      'parts_request_initial_stock',
+      'a2300000-0000-4000-8000-000000000001'
+    );
+  exception when invalid_parameter_value then
+    if sqlerrm = 'STOCK_MOVE_IDEMPOTENCY_CONFLICT' then
+      return;
+    end if;
+    raise;
+  end;
+
+  raise exception
+    'P0-002 runtime assertion failed: conflicting retry succeeded';
+end;
+$$;
+
+set local role authenticated;
+select pg_temp.expect_idempotency_conflict();
+
+-- A rolling-deployment placeholder remains intentionally non-idempotent.
+select public.apply_stock_move(
+  'a2300000-0000-4000-8000-000000000001',
+  'a2500000-0000-4000-8000-000000000001',
+  1,
+  'receive',
+  'manual_receive',
+  'a2300000-0000-4000-8000-000000000001'
+);
+select public.apply_stock_move(
+  'a2300000-0000-4000-8000-000000000001',
+  'a2500000-0000-4000-8000-000000000001',
+  1,
+  'receive',
+  'manual_receive',
+  'a2300000-0000-4000-8000-000000000001'
+);
+
+select public.apply_stock_move(
+  'a2300000-0000-4000-8000-000000000001',
+  'a2500000-0000-4000-8000-000000000001',
+  2,
+  'consume',
+  'p0_002_consumption',
+  'a2800000-0000-4000-8000-000000000001'
+);
+
+select pg_temp.expect_user_limit_denied();
+reset role;
+
+-- Shop B cannot mutate Shop A.
+select set_config(
+  'request.jwt.claim.sub',
+  '42000000-0000-4000-8000-000000000002',
+  true
+);
+set local role authenticated;
+select pg_temp.expect_stock_move_denied(
+  'a2300000-0000-4000-8000-000000000001',
+  'a2500000-0000-4000-8000-000000000001',
+  'b2900000-0000-4000-8000-000000000002'
+);
+reset role;
+
+-- Same-shop technicians cannot mutate inventory.
+select set_config(
+  'request.jwt.claim.sub',
+  '43000000-0000-4000-8000-000000000003',
+  true
+);
+set local role authenticated;
+select pg_temp.expect_stock_move_denied(
+  'a2300000-0000-4000-8000-000000000001',
+  'a2500000-0000-4000-8000-000000000001',
+  'a3000000-0000-4000-8000-000000000003'
+);
+reset role;
+
+-- An allowed Shop A actor still cannot bind a Shop B location.
+select set_config(
+  'request.jwt.claim.sub',
+  '41000000-0000-4000-8000-000000000001',
+  true
+);
+set local role authenticated;
+select pg_temp.expect_stock_move_denied(
+  'a2300000-0000-4000-8000-000000000001',
+  'b2600000-0000-4000-8000-000000000002',
+  'a3100000-0000-4000-8000-000000000001'
+);
+reset role;
+
+-- Server-only flows retain their intended capability.
+select set_config('request.jwt.claim.role', 'service_role', true);
+select set_config('request.jwt.claim.sub', '', true);
+set local role service_role;
+select public.apply_stock_move(
+  'b2400000-0000-4000-8000-000000000002',
+  'b2600000-0000-4000-8000-000000000002',
+  3,
+  'receive',
+  'p0_002_service_receive',
+  'b3200000-0000-4000-8000-000000000002'
+);
+select public.increment_user_limit(
+  'a2100000-0000-4000-8000-000000000001',
+  2
+);
+reset role;
+
+do $$
+begin
+  if public.parts_on_hand(
+    'a2100000-0000-4000-8000-000000000001',
+    'a2300000-0000-4000-8000-000000000001',
+    'a2500000-0000-4000-8000-000000000001'
+  ) <> 5 then
+    raise exception
+      'P0-002 runtime assertion failed: Shop A ledger total is wrong';
+  end if;
+
+  if not exists (
+    select 1
+    from public.part_stock
+    where part_id = 'a2300000-0000-4000-8000-000000000001'
+      and location_id = 'a2500000-0000-4000-8000-000000000001'
+      and qty_on_hand = 5
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: legacy stock cache is wrong';
+  end if;
+
+  if not exists (
+    select 1
+    from public.part_stock_summary
+    where part_id = 'a2300000-0000-4000-8000-000000000001'
+      and location_id = 'a2500000-0000-4000-8000-000000000001'
+      and shop_id = 'a2100000-0000-4000-8000-000000000001'
+      and qty_on_hand = 5
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: baseline stock summary cache is wrong';
+  end if;
+
+  if public.parts_on_hand(
+    'b2200000-0000-4000-8000-000000000002',
+    'b2400000-0000-4000-8000-000000000002',
+    'b2600000-0000-4000-8000-000000000002'
+  ) <> 3 then
+    raise exception
+      'P0-002 runtime assertion failed: service-role receipt failed';
+  end if;
+
+  if not exists (
+    select 1
+    from public.shops
+    where id = 'a2100000-0000-4000-8000-000000000001'
+      and user_limit = 5
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: service user-limit mutation failed';
+  end if;
+
+  if exists (
+    select 1
+    from public.stock_moves
+    where reference_kind = 'p0_002_denied'
+  ) then
+    raise exception
+      'P0-002 runtime assertion failed: a denied stock move persisted';
+  end if;
+end
+$$;
+
+select 'p0_002_rpc_privileges_runtime_ok' as result;
+
+rollback;


### PR DESCRIPTION
## What changed

- revokes anonymous/public execution from the unsafe stock-move and seat-limit RPCs
- moves the privileged stock-move implementation into a non-exposed `private` schema with a fixed search path
- preserves the deployed `apply_stock_move` return contract while adding shop/role/location authorization
- adds atomic, conflict-detecting idempotency for stock ledger writes
- makes `increment_user_limit` service-role only
- opts future public objects out of broad client default privileges
- updates receive, inventory adjustment, CSV import, and PO callers to use stable operation references
- adds a direct-role SQL runtime suite and wires it into clean-replay CI

## Why

P0-002 found that anonymous callers could execute privileged stock and account-limit functions, cross-shop writes were not rejected inside the RPC, and future functions/tables inherited broad client grants. Those paths could corrupt inventory, change account limits, or expose future objects over the Data API.

## Impact

Authenticated shop roles keep the existing stock workflows. Anonymous, cross-shop, unauthorized same-shop roles, and browser-side seat-limit calls now fail closed. Retries return the original stock-move ID instead of double-applying inventory, while conflicting reuse of an operation key is rejected.

## Validation

Passed locally:
- migration version uniqueness
- `git diff --check`
- static SQL contract checks for ACLs, role paths, idempotency conflict handling, and direct-role coverage
- caller/diff review

Pending in GitHub Actions:
- clean Supabase migration replay
- P0-002 direct RPC runtime integration
- repository typecheck/lint/test/build checks

Local typecheck was not run because the package installation repeatedly hung in this desktop environment; no dependency or lockfile changes are included.