### PR TITLE
Fix P0-002 production signature compatibility

### DIFF
--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -139,6 +139,20 @@ jobs:
             -f tests/security/p0-002-rpc-privileges.runtime.sql \
             2>&1 | tee p0-002-rpc-privileges-runtime.log
 
+      - name: Execute P0 production-signature compatibility integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/p0-002-stock-move-signature-compat.runtime.sql \
+            2>&1 | tee p0-002-stock-move-signature-compat-runtime.log
+
       - name: Verify bootstrap and existing-database baseline paths
         shell: bash
         env:
@@ -202,6 +216,7 @@ jobs:
             parts-use-handoff-runtime.log
             p0-001-relation-boundaries-runtime.log
             p0-002-rpc-privileges-runtime.log
+            p0-002-stock-move-signature-compat-runtime.log
             supabase/config.toml
           if-no-files-found: warn
 

--- a/supabase/migrations/20260725100000_p0_002_stock_move_signature_compat.sql
+++ b/supabase/migrations/20260725100000_p0_002_stock_move_signature_compat.sql
@@ -1,0 +1,46 @@
+-- P0-002 production compatibility preflight.
+--
+-- Clean replay includes the historical enum overload below, but at least one
+-- deployed schema never created it. The following P0-002 hardening migration
+-- revokes this exact signature and must be able to do so on both histories.
+-- Create a locked, fail-closed placeholder only when the overload is absent.
+-- Do not replace an existing implementation or expose this legacy contract.
+do $migration$
+begin
+  if pg_catalog.to_regprocedure(
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)'
+  ) is null then
+    execute $function$
+      create function public.apply_stock_move(
+        p_part uuid,
+        p_loc uuid,
+        p_qty numeric,
+        p_reason public.stock_move_reason,
+        p_ref_kind text default null,
+        p_ref_id uuid default null
+      ) returns uuid
+      language plpgsql
+      security invoker
+      set search_path = pg_catalog, public
+      as $body$
+      begin
+        raise exception using
+          errcode = '42501',
+          message = 'LEGACY_STOCK_MOVE_OVERLOAD_DISABLED';
+      end;
+      $body$
+    $function$;
+  end if;
+
+  execute $revoke$
+    revoke all privileges on function public.apply_stock_move(
+      uuid,
+      uuid,
+      numeric,
+      public.stock_move_reason,
+      text,
+      uuid
+    ) from public, anon, authenticated, service_role
+  $revoke$;
+end
+$migration$;

--- a/tests/security/p0-002-stock-move-signature-compat.runtime.sql
+++ b/tests/security/p0-002-stock-move-signature-compat.runtime.sql
@@ -1,0 +1,164 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+-- The clean-replay path already has the enum overload. The preflight must not
+-- replace its implementation; it may only keep the legacy signature locked.
+create temp table p0_002_existing_enum_overload as
+select pg_catalog.pg_get_functiondef(procedure.oid) as definition
+from pg_catalog.pg_proc procedure
+where procedure.oid = pg_catalog.to_regprocedure(
+  'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)'
+);
+
+\ir ../../supabase/migrations/20260725100000_p0_002_stock_move_signature_compat.sql
+
+do $$
+declare
+  v_definition text;
+begin
+  select pg_catalog.pg_get_functiondef(procedure.oid)
+    into v_definition
+  from pg_catalog.pg_proc procedure
+  where procedure.oid = pg_catalog.to_regprocedure(
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)'
+  );
+
+  if v_definition is distinct from (
+    select snapshot.definition
+    from p0_002_existing_enum_overload snapshot
+  ) then
+    raise exception
+      'P0-002 compatibility assertion failed: existing overload was replaced';
+  end if;
+
+  if has_function_privilege(
+    'anon',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'service_role',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  ) then
+    raise exception
+      'P0-002 compatibility assertion failed: existing overload is exposed';
+  end if;
+end
+$$;
+
+-- Reproduce the deployed schema shape that caused the production migration to
+-- fail, then prove the preflight creates only a locked placeholder.
+drop function public.apply_stock_move(
+  uuid,
+  uuid,
+  numeric,
+  public.stock_move_reason,
+  text,
+  uuid
+);
+
+\ir ../../supabase/migrations/20260725100000_p0_002_stock_move_signature_compat.sql
+
+do $$
+declare
+  v_oid regprocedure := pg_catalog.to_regprocedure(
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)'
+  );
+  v_definition text;
+  v_security_definer boolean;
+  v_return_type regtype;
+begin
+  if v_oid is null then
+    raise exception
+      'P0-002 compatibility assertion failed: absent overload was not created';
+  end if;
+
+  select
+    pg_catalog.pg_get_functiondef(procedure.oid),
+    procedure.prosecdef,
+    procedure.prorettype::regtype
+  into v_definition, v_security_definer, v_return_type
+  from pg_catalog.pg_proc procedure
+  where procedure.oid = v_oid;
+
+  if v_security_definer then
+    raise exception
+      'P0-002 compatibility assertion failed: placeholder is SECURITY DEFINER';
+  end if;
+
+  if v_return_type <> 'uuid'::regtype then
+    raise exception
+      'P0-002 compatibility assertion failed: placeholder return type is %',
+      v_return_type;
+  end if;
+
+  if pg_catalog.strpos(
+    v_definition,
+    'LEGACY_STOCK_MOVE_OVERLOAD_DISABLED'
+  ) = 0 then
+    raise exception
+      'P0-002 compatibility assertion failed: placeholder does not fail closed';
+  end if;
+
+  if has_function_privilege('anon', v_oid, 'EXECUTE')
+  or has_function_privilege('authenticated', v_oid, 'EXECUTE')
+  or has_function_privilege('service_role', v_oid, 'EXECUTE') then
+    raise exception
+      'P0-002 compatibility assertion failed: placeholder is exposed';
+  end if;
+end
+$$;
+
+-- This is the exact step that failed against production. Reaching the final
+-- assertion proves the existing P0-002 migration can follow the compatibility
+-- preflight without changing the already-merged migration.
+\ir ../../supabase/migrations/20260725103000_harden_p0_002_rpc_privileges.sql
+
+do $$
+begin
+  if has_function_privilege(
+    'anon',
+    'public.apply_stock_move(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'authenticated',
+    'public.apply_stock_move(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'service_role',
+    'public.apply_stock_move(uuid,uuid,numeric,text,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'anon',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'service_role',
+    'public.apply_stock_move(uuid,uuid,numeric,public.stock_move_reason,text,uuid)',
+    'EXECUTE'
+  ) then
+    raise exception
+      'P0-002 compatibility assertion failed: final RPC ACLs are wrong';
+  end if;
+end
+$$;
+
+select 'p0_002_stock_move_signature_compat_runtime_ok' as result;
+
+rollback;


### PR DESCRIPTION
## What changed

- add a compatibility migration at `20260725100000`, immediately before the merged P0-002 hardening migration
- preserve an existing enum-based `apply_stock_move` overload when present
- create a fail-closed, non-`SECURITY DEFINER` placeholder only when that overload is absent
- revoke all client and service execution from the legacy overload
- add runtime coverage for both clean-replay and production-missing-signature histories
- rerun the exact merged P0-002 migration in the production-shaped regression test
- collect the new runtime log in clean-replay CI

## Root cause

Clean replay contains `public.apply_stock_move(uuid, uuid, numeric, stock_move_reason, text, uuid)`, but production does not. The merged P0-002 migration used an unconditional `REVOKE` against that signature, so production failed with PostgreSQL error `42883` before the migration could be recorded.

A read-only production inspection confirmed the failed SQL was fully rolled back: `20260725103000` is not in migration history, the private helper was not created, and the pre-existing function ACLs remain unchanged.

## Safety

- does not edit or reorder the merged P0-002 migration
- does not replace an existing legacy overload
- leaves a newly created compatibility overload fail-closed and uncallable by `PUBLIC`, `anon`, `authenticated`, and `service_role`
- requires no migration-history repair
- makes no production changes in this PR

## Validation

- `git diff --check`
- migration version uniqueness check
- read-only production schema and migration-history inspection
- clean-replay and production-shape SQL runtime checks are delegated to GitHub Actions because this workstation has no usable local Supabase/Postgres runtime

## Deployment after merge

1. Update to the merged `main`.
2. Run `supabase db push --dry-run` against the linked production project and confirm the only pending versions are `20260725100000` and `20260725103000`, in that order.
3. Run `supabase db push` once.
4. Verify both versions are recorded and rerun the P0-002 privilege postcheck.
