### PR TITLE
P0-003: require tokens before Shop Boost preview reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,8 @@ ONBOARDING_AGENT_MODEL=gpt-5.5
 ONBOARDING_AGENT_REQUIRE_AI=false
 
 # Do not add NEXT_PUBLIC_OPENAI_API_KEY.
+
+# Required server-only HMAC secret for Shop Boost preview and share links.
+# Use at least 32 random bytes and configure a separate value per environment.
+# Rotating this value immediately revokes every outstanding preview link.
+SHOP_BOOST_SHARE_SECRET=

--- a/.github/workflows/p0-003-shop-boost-preview-validation.yml
+++ b/.github/workflows/p0-003-shop-boost-preview-validation.yml
@@ -1,0 +1,50 @@
+name: P0-003 Shop Boost Preview Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/demo/shop-boost/**"
+      - "app/demo/instant-shop-analysis/**"
+      - "app/demo/preview/**"
+      - "app/demo/report/**"
+      - "features/integrations/shopBoost/**"
+      - "tests/shop-boost-preview-*.test.ts"
+      - ".github/workflows/p0-003-shop-boost-preview-validation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: >-
+          pnpm exec eslint
+          app/api/demo/shop-boost/claim/route.ts
+          app/api/demo/shop-boost/run/route.ts
+          app/api/demo/shop-boost/share/route.ts
+          app/demo/instant-shop-analysis/page.tsx
+          'app/demo/preview/[demoId]/page.tsx'
+          'app/demo/preview/[demoId]/not-found.tsx'
+          'app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx'
+          'app/demo/report/[demoId]/page.tsx'
+          'app/demo/report/[demoId]/not-found.tsx'
+          features/integrations/shopBoost/ShopBoostAnalysisUnavailable.tsx
+          features/integrations/shopBoost/shareAccess.ts
+          tests/shop-boost-preview-access.test.ts
+          tests/shop-boost-preview-route-guards.test.ts
+      - run: >-
+          pnpm exec vitest run
+          tests/shop-boost-preview-access.test.ts
+          tests/shop-boost-preview-route-guards.test.ts

--- a/.github/workflows/p0-003-shop-boost-preview-validation.yml
+++ b/.github/workflows/p0-003-shop-boost-preview-validation.yml
@@ -9,6 +9,7 @@ on:
       - "app/demo/report/**"
       - "features/integrations/shopBoost/**"
       - "tests/shop-boost-preview-*.test.ts"
+      - "tsconfig.p0-003.json"
       - ".github/workflows/p0-003-shop-boost-preview-validation.yml"
 
 permissions:
@@ -28,7 +29,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm typecheck
+      - run: pnpm exec tsc --noEmit -p tsconfig.p0-003.json
       - run: >-
           pnpm exec eslint
           app/api/demo/shop-boost/claim/route.ts

--- a/app/api/demo/shop-boost/claim/route.ts
+++ b/app/api/demo/shop-boost/claim/route.ts
@@ -2,12 +2,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { Database } from "@shared/types/types/supabase";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { verifyShopBoostPreviewToken } from "@/features/integrations/shopBoost/shareAccess";
 
 type DB = Database;
 
 type ClaimBody = {
-  demoId?: string;
-  intakeId?: string;
+  previewToken?: string;
   email?: string;
 };
 
@@ -35,13 +35,18 @@ export async function POST(
   try {
     const body = (await req.json().catch(() => null)) as ClaimBody | null;
 
-    const demoId = body?.demoId?.trim();
-    const intakeId = body?.intakeId?.trim() ?? null;
+    const access = verifyShopBoostPreviewToken(body?.previewToken?.trim() ?? "");
     const emailRaw = body?.email?.trim();
 
-    if (!demoId || !emailRaw) {
+    if (!access) {
       return NextResponse.json(
-        { ok: false, error: "demoId and email are required." },
+        { ok: false, error: "Analysis unavailable." },
+        { status: 404, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    if (!emailRaw) {
+      return NextResponse.json(
+        { ok: false, error: "Email is required." },
         { status: 400 },
       );
     }
@@ -70,7 +75,7 @@ export async function POST(
     const { data: demoRow, error: demoErr } = await supabase
       .from("demo_shop_boosts")
       .select("id, snapshot")
-      .eq("id", demoId)
+      .eq("id", access.demoId)
       .maybeSingle();
 
     if (demoErr || !demoRow || !demoRow.snapshot) {
@@ -82,14 +87,13 @@ export async function POST(
     }
 
     const rawPayload = asRecord(demoRow.snapshot);
-    if (intakeId) {
-      const snapshotIntakeId = typeof rawPayload.intakeId === "string" ? rawPayload.intakeId : null;
-      if (!snapshotIntakeId || snapshotIntakeId !== intakeId) {
-        return NextResponse.json(
-          { ok: false, error: "This preview link does not match the analysis intake." },
-          { status: 403 },
-        );
-      }
+    const snapshotIntakeId =
+      typeof rawPayload.intakeId === "string" ? rawPayload.intakeId : null;
+    if (snapshotIntakeId !== access.intakeId) {
+      return NextResponse.json(
+        { ok: false, error: "Analysis unavailable." },
+        { status: 404, headers: { "Cache-Control": "no-store" } },
+      );
     }
 
     const summary =
@@ -100,7 +104,7 @@ export async function POST(
     const { error: leadErr } = await supabase
       .from("demo_shop_boost_leads")
       .insert({
-        demo_id: demoId,
+        demo_id: access.demoId,
         email: emailNormalized,
         summary,
         lead_kind: "activation_claim",
@@ -117,7 +121,7 @@ export async function POST(
     const { error: updateErr } = await supabase
       .from("demo_shop_boosts")
       .update({ has_unlocked: true })
-      .eq("id", demoId);
+      .eq("id", access.demoId);
 
     if (updateErr) {
       console.error("[demo/shop-boost/claim] Failed to mark demo as unlocked", updateErr);
@@ -125,12 +129,13 @@ export async function POST(
 
     return NextResponse.json(
       { ok: true, analysis: demoRow.snapshot },
-      { status: 200 },
+      { status: 200, headers: { "Cache-Control": "no-store" } },
     );
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "Unexpected error while claiming demo.";
     console.error("[demo/shop-boost/claim] Demo claim error", err);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: "Unexpected error while claiming demo." },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/demo/shop-boost/run/route.ts
+++ b/app/api/demo/shop-boost/run/route.ts
@@ -15,6 +15,10 @@ import {
   validateDemoUploadFileDescriptors,
 } from "@/features/integrations/shopBoost/demoUploadContract";
 import type { ShopBoostUploadDatasetKey } from "@/features/integrations/shopBoost/uploadDatasets";
+import {
+  assertShopBoostPreviewTokenConfigured,
+  generateShopBoostPreviewToken,
+} from "@/features/integrations/shopBoost/shareAccess";
 
 type DB = Database;
 
@@ -31,6 +35,7 @@ type DemoRunSuccessResponse = {
   ok: true;
   demoId: string;
   intakeId: string;
+  previewToken: string;
   analysis: ShadowShopSnapshot;
 };
 
@@ -135,6 +140,10 @@ export async function POST(
       return NextResponse.json(manifest, { status: 400 });
     }
 
+    // Fail before any service-role read or write if preview access cannot be
+    // secured. This avoids persisting an analysis that the caller cannot open.
+    assertShopBoostPreviewTokenConfigured();
+
     const supabase = createAdminSupabase();
     const { data: existingDemo, error: existingError } = await supabase
       .from("demo_shop_boosts")
@@ -154,12 +163,16 @@ export async function POST(
         ? existingDemo.snapshot
         : {};
       if (existingSnapshot.intakeId === intakeId) {
-        return NextResponse.json({
-          ok: true,
-          demoId,
-          intakeId,
-          analysis: existingSnapshot as unknown as ShadowShopSnapshot,
-        });
+        return NextResponse.json(
+          {
+            ok: true,
+            demoId,
+            intakeId,
+            previewToken: generateShopBoostPreviewToken({ demoId, intakeId }),
+            analysis: existingSnapshot as unknown as ShadowShopSnapshot,
+          },
+          { headers: { "Cache-Control": "no-store" } },
+        );
       }
       return NextResponse.json(
         { ok: false, error: "This analysis intake is already in use. Please start again." },
@@ -264,6 +277,10 @@ export async function POST(
         ok: true,
         demoId: demoRow.id as string,
         intakeId,
+        previewToken: generateShopBoostPreviewToken({
+          demoId: demoRow.id as string,
+          intakeId,
+        }),
         analysis: snapshotWithActivation,
       },
       {

--- a/app/api/demo/shop-boost/share/route.ts
+++ b/app/api/demo/shop-boost/share/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import sgMail from "@sendgrid/mail";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import { buildShopBoostShareHref } from "@/features/integrations/shopBoost/shareAccess";
+import {
+  buildShopBoostShareHref,
+  verifyShopBoostPreviewToken,
+} from "@/features/integrations/shopBoost/shareAccess";
+import { loadShadowPreviewContext } from "@/features/integrations/shopBoost/shadowShop";
 
 function requiredEnv(name: string): string {
   const value = process.env[name]?.trim();
@@ -16,35 +20,42 @@ function isEmail(value: string): boolean {
 export async function POST(req: NextRequest) {
   try {
     const body = (await req.json()) as {
-      demoId?: string;
-      intakeId?: string;
+      previewToken?: string;
       recipientEmail?: string;
       senderName?: string;
     };
 
-    const demoId = body.demoId?.trim() ?? "";
-    const intakeId = body.intakeId?.trim() ?? "";
+    const access = verifyShopBoostPreviewToken(body.previewToken?.trim() ?? "");
     const recipientEmail = body.recipientEmail?.trim() ?? "";
-    const senderName = body.senderName?.trim() || "ProFixIQ Shop Boost";
+    const senderName =
+      body.senderName?.trim().slice(0, 80) || "ProFixIQ Shop Boost";
 
-    if (!demoId || !intakeId || !isEmail(recipientEmail)) {
+    if (!access) {
+      return NextResponse.json(
+        { ok: false, error: "Analysis unavailable." },
+        { status: 404, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    if (!isEmail(recipientEmail)) {
       return NextResponse.json({ ok: false, error: "Invalid payload." }, { status: 400 });
     }
 
-    const supabase = createAdminSupabase();
-    const { data: demo } = await supabase
-      .from("demo_shop_boosts")
-      .select("id, shop_name")
-      .eq("id", demoId)
-      .maybeSingle<{ id: string; shop_name: string }>();
-
-    if (!demo) return NextResponse.json({ ok: false, error: "Demo not found." }, { status: 404 });
+    const context = await loadShadowPreviewContext({
+      demoId: access.demoId,
+      intakeId: access.intakeId,
+    });
+    if (!context) {
+      return NextResponse.json(
+        { ok: false, error: "Analysis unavailable." },
+        { status: 404, headers: { "Cache-Control": "no-store" } },
+      );
+    }
 
     const origin = new URL(req.url).origin;
     const shareLink = buildShopBoostShareHref({
       origin,
-      demoId,
-      intakeId,
+      demoId: access.demoId,
+      intakeId: access.intakeId,
       senderName,
       expiresInDays: 7,
     });
@@ -53,18 +64,19 @@ export async function POST(req: NextRequest) {
     await sgMail.send({
       to: recipientEmail,
       from: requiredEnv("SENDGRID_FROM_EMAIL"),
-      subject: `${senderName} shared a Shop Boost analysis for ${demo.shop_name}`,
+      subject: `${senderName} shared a Shop Boost analysis for ${context.shopName}`,
       text: [
-        `This analysis was generated for ${demo.shop_name}.`,
+        `This analysis was generated for ${context.shopName}.`,
         `ROI highlights and blockers are included in this read-only view.`,
         `Open analysis: ${shareLink}`,
       ].join("\n"),
     });
 
+    const supabase = createAdminSupabase();
     const { data: existingLead } = await supabase
       .from("demo_shop_boost_leads")
       .select("id, share_count, emails_sent, lead_kind")
-      .eq("demo_id", demoId)
+      .eq("demo_id", access.demoId)
       .eq("email", recipientEmail)
       .maybeSingle<{ id: string; share_count: number | null; emails_sent: number | null; lead_kind: string | null }>();
 
@@ -81,7 +93,7 @@ export async function POST(req: NextRequest) {
         .eq("id", existingLead.id);
     } else {
       await supabase.from("demo_shop_boost_leads").insert({
-        demo_id: demoId,
+        demo_id: access.demoId,
         email: recipientEmail,
         summary: `Shared by ${senderName}`,
         share_count: 1,
@@ -91,9 +103,15 @@ export async function POST(req: NextRequest) {
       } as Record<string, unknown>);
     }
 
-    return NextResponse.json({ ok: true, shareLink });
+    return NextResponse.json(
+      { ok: true, shareLink },
+      { headers: { "Cache-Control": "no-store" } },
+    );
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unable to send share email.";
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    console.error("[demo/shop-boost/share] Unable to share analysis", error);
+    return NextResponse.json(
+      { ok: false, error: "Unable to send share email." },
+      { status: 500 },
+    );
   }
 }

--- a/app/demo/instant-shop-analysis/page.tsx
+++ b/app/demo/instant-shop-analysis/page.tsx
@@ -30,6 +30,7 @@ type RunResponse =
       ok: true;
       demoId: string;
       intakeId: string;
+      previewToken: string;
       analysis: InstantAnalysisPayload;
     }
   | {
@@ -50,13 +51,14 @@ type ClaimResponse =
 type ResumePreviewContext = {
   demoId: string;
   intakeId: string;
+  previewToken: string;
   shopName: string;
   blockers: number;
   reviewQueue: number;
   recoverableValue: number;
 };
 
-const PREVIEW_RESUME_STORAGE_KEY = "shop-boost-last-preview-v1";
+const PREVIEW_RESUME_STORAGE_KEY = "shop-boost-last-preview-v2";
 
 
 
@@ -109,6 +111,7 @@ export default function InstantShopAnalysisPage() {
   const [step, setStep] = useState<DemoStep>("form");
   const [demoId, setDemoId] = useState<string | null>(null);
   const [intakeId, setIntakeId] = useState<string | null>(null);
+  const [previewToken, setPreviewToken] = useState<string | null>(null);
   const [analysis, setAnalysis] = useState<InstantAnalysisPayload | null>(null);
 
   const [runError, setRunError] = useState<string | null>(null);
@@ -126,10 +129,16 @@ export default function InstantShopAnalysisPage() {
     if (!stored) return;
     try {
       const parsed = JSON.parse(stored) as Partial<ResumePreviewContext>;
-      if (!parsed.demoId || !parsed.intakeId || !parsed.shopName) return;
+      if (
+        !parsed.demoId ||
+        !parsed.intakeId ||
+        !parsed.previewToken ||
+        !parsed.shopName
+      ) return;
       setResumePreview({
         demoId: parsed.demoId,
         intakeId: parsed.intakeId,
+        previewToken: parsed.previewToken,
         shopName: parsed.shopName,
         blockers: Number(parsed.blockers) || 0,
         reviewQueue: Number(parsed.reviewQueue) || 0,
@@ -185,6 +194,7 @@ export default function InstantShopAnalysisPage() {
     setAnalysis(null);
     setDemoId(null);
     setIntakeId(null);
+    setPreviewToken(null);
 
     if (!shopName.trim()) {
       setRunError("Please enter your shop name.");
@@ -247,6 +257,7 @@ export default function InstantShopAnalysisPage() {
 
       setDemoId(json.demoId);
       setIntakeId(json.intakeId);
+      setPreviewToken(json.previewToken);
       const normalized = normalizeAnalysisPayload(json.analysis);
       if (!normalized) {
         setRunError("Received an invalid analysis payload. Please retry with a CSV export.");
@@ -272,7 +283,7 @@ export default function InstantShopAnalysisPage() {
   const handleClaim = async () => {
     setClaimError(null);
 
-    if (!demoId || !analysis) {
+    if (!demoId || !previewToken || !analysis) {
       setClaimError("Run the analysis first.");
       return;
     }
@@ -288,7 +299,7 @@ export default function InstantShopAnalysisPage() {
       const res = await fetch("/api/demo/shop-boost/claim", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ demoId, intakeId, email: email.trim() }),
+        body: JSON.stringify({ previewToken, email: email.trim() }),
       });
 
       const json = (await res.json()) as ClaimResponse;
@@ -357,7 +368,7 @@ export default function InstantShopAnalysisPage() {
                   <button
                     type="button"
                     onClick={() =>
-                      (window.location.href = `/demo/preview/${encodeURIComponent(resumePreview.demoId)}?intakeId=${encodeURIComponent(resumePreview.intakeId)}`)
+                      (window.location.href = `/demo/preview/${encodeURIComponent(resumePreview.demoId)}?token=${encodeURIComponent(resumePreview.previewToken)}`)
                     }
                     className="mt-2 inline-flex items-center rounded-full border border-cyan-400/30 bg-cyan-500/20 px-4 py-2 text-[11px] text-cyan-100 hover:bg-cyan-500/30"
                   >
@@ -578,7 +589,7 @@ export default function InstantShopAnalysisPage() {
 
                   {claimError ? <p className="mt-2 text-[11px] text-red-400">{claimError}</p> : null}
                   <a
-                    href={`/demo/preview/${encodeURIComponent(demoId ?? "")}?intakeId=${encodeURIComponent(intakeId ?? analysis.intakeId ?? "")}`}
+                    href={`/demo/preview/${encodeURIComponent(demoId ?? "")}?token=${encodeURIComponent(previewToken ?? "")}`}
                     className="mt-3 inline-flex items-center justify-center rounded-md border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-[11px] text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
                   >
                     Enter your system preview
@@ -607,7 +618,7 @@ export default function InstantShopAnalysisPage() {
 
                 <div className="flex flex-wrap gap-2">
                   <a
-                    href={`/demo/preview/${encodeURIComponent(demoId ?? "")}?intakeId=${encodeURIComponent(intakeId ?? analysis.intakeId)}`}
+                    href={`/demo/preview/${encodeURIComponent(demoId ?? "")}?token=${encodeURIComponent(previewToken ?? "")}`}
                     className={[
                       "inline-flex items-center justify-center rounded-md px-4 py-1.5 text-xs font-semibold shadow-sm transition",
                       THEME.cta,

--- a/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
+++ b/app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx
@@ -31,7 +31,7 @@ type Props = {
   shareMeta: {
     enabled: boolean;
     senderName: string | null;
-    token: string | null;
+    token: string;
   };
 };
 
@@ -94,7 +94,7 @@ const gateCopyByAction: Record<GateActionContext, GateCopy> = {
   },
 };
 
-const PREVIEW_RESUME_STORAGE_KEY = "shop-boost-last-preview-v1";
+const PREVIEW_RESUME_STORAGE_KEY = "shop-boost-last-preview-v2";
 
 function toActivationReadiness(readiness: string): ActivationReadiness {
   if (readiness === "READY_FOR_GO_LIVE" || readiness === "COMPLETED_CLEAN") return "READY";
@@ -161,9 +161,7 @@ export default function ShadowPreviewClient({ context, mode, shareMeta }: Props)
     const url = new URL(window.location.href);
     url.searchParams.set("share", "1");
     url.searchParams.set("mode", mode);
-    if (shareMeta.token) {
-      url.searchParams.set("token", shareMeta.token);
-    }
+    url.searchParams.set("token", shareMeta.token);
     return url.toString();
   }, [mode, shareMeta.token]);
 
@@ -174,6 +172,7 @@ export default function ShadowPreviewClient({ context, mode, shareMeta }: Props)
       JSON.stringify({
         demoId: context.demoId,
         intakeId: context.intakeId,
+        previewToken: shareMeta.token,
         shopName: context.shopName,
         blockers: context.snapshot.dashboard.blockerCount,
         reviewQueue: context.snapshot.dashboard.reviewQueueCount,
@@ -181,7 +180,7 @@ export default function ShadowPreviewClient({ context, mode, shareMeta }: Props)
         updatedAt: new Date().toISOString(),
       }),
     );
-  }, [context.demoId, context.intakeId, context.shopName, context.snapshot.dashboard.blockerCount, context.snapshot.dashboard.reviewQueueCount, context.snapshot.roi.estimated_monthly_impact]);
+  }, [context.demoId, context.intakeId, context.shopName, context.snapshot.dashboard.blockerCount, context.snapshot.dashboard.reviewQueueCount, context.snapshot.roi.estimated_monthly_impact, shareMeta.token]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -313,8 +312,7 @@ export default function ShadowPreviewClient({ context, mode, shareMeta }: Props)
                   method: "POST",
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify({
-                    demoId: context.demoId,
-                    intakeId: context.intakeId,
+                    previewToken: shareMeta.token,
                     recipientEmail: recipientEmail.trim(),
                     senderName: shareMeta.senderName ?? "Shop Boost user",
                   }),
@@ -326,10 +324,10 @@ export default function ShadowPreviewClient({ context, mode, shareMeta }: Props)
               Send via email
             </button>
             <Link
-              href={`/api/shop-boost/intakes/${context.intakeId}/report?download=1`}
+              href={`/demo/report/${context.demoId}?token=${encodeURIComponent(shareMeta.token)}`}
               className="block w-full rounded-md border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-center text-xs hover:bg-[color:var(--theme-surface-subtle)]"
             >
-              Download report
+              View report
             </Link>
             {shareStatus ? <p className="text-[11px] text-cyan-200">{shareStatus}</p> : null}
           </div>

--- a/app/demo/preview/[demoId]/not-found.tsx
+++ b/app/demo/preview/[demoId]/not-found.tsx
@@ -1,0 +1,3 @@
+import { ShopBoostAnalysisUnavailable } from "@/features/integrations/shopBoost/ShopBoostAnalysisUnavailable";
+
+export default ShopBoostAnalysisUnavailable;

--- a/app/demo/preview/[demoId]/page.tsx
+++ b/app/demo/preview/[demoId]/page.tsx
@@ -1,84 +1,49 @@
-import Link from "next/link";
+import type { Metadata } from "next";
+import { unstable_noStore as noStore } from "next/cache";
+import { notFound } from "next/navigation";
 import { loadShadowPreviewContext } from "@/features/integrations/shopBoost/shadowShop";
-import { verifyShopBoostShareToken } from "@/features/integrations/shopBoost/shareAccess";
+import { verifyShopBoostPreviewToken } from "@/features/integrations/shopBoost/shareAccess";
 import ShadowPreviewClient from "./_components/ShadowPreviewClient";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  referrer: "no-referrer",
+};
 
 type PageProps = {
   params: Promise<{ demoId: string }>;
-  searchParams: Promise<{ intakeId?: string; mode?: string; share?: string; token?: string }>;
+  searchParams: Promise<{ mode?: string; share?: string; token?: string }>;
 };
 
 export default async function DemoPreviewPage({ params, searchParams }: PageProps) {
-  const { demoId } = await params;
-  const sp = await searchParams;
+  noStore();
+
+  const [{ demoId: routeDemoId }, sp] = await Promise.all([params, searchParams]);
   const token = typeof sp.token === "string" ? sp.token : "";
+  const access = token ? verifyShopBoostPreviewToken(token) : null;
+
+  if (!access || access.demoId !== routeDemoId) notFound();
+
+  const context = await loadShadowPreviewContext({
+    demoId: access.demoId,
+    intakeId: access.intakeId,
+  });
+  if (!context) notFound();
+
   const shared = sp.share === "1";
-  const validatedToken = token ? verifyShopBoostShareToken(token) : null;
-  const intakeId = typeof sp.intakeId === "string" ? sp.intakeId : validatedToken?.intakeId ?? "";
   const mode = sp.mode === "sales" ? "sales" : "default";
-  const isUuid = (value: string) =>
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
-
-  if (!intakeId) {
-    return (
-      <div className="grid min-h-screen place-items-center bg-[color:var(--theme-surface-page)] px-4 text-[color:var(--theme-text-primary)]">
-        <div className="max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-center">
-          <p className="text-lg font-semibold">Missing preview intake</p>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">This preview link is incomplete. Return to Instant Shop Analysis and relaunch preview mode.</p>
-          <Link href="/demo/instant-shop-analysis" className="mt-4 inline-flex rounded-md border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs">Back to analysis</Link>
-        </div>
-      </div>
-    );
-  }
-  if (!isUuid(demoId) || !isUuid(intakeId)) {
-    return (
-      <div className="grid min-h-screen place-items-center bg-[color:var(--theme-surface-page)] px-4 text-[color:var(--theme-text-primary)]">
-        <div className="max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-center">
-          <p className="text-lg font-semibold">Preview expired</p>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">This preview link is invalid or expired. Start a new analysis to continue.</p>
-          <Link href="/demo/instant-shop-analysis" className="mt-4 inline-flex rounded-md border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs">Restart analysis</Link>
-        </div>
-      </div>
-    );
-  }
-
-  const context = await loadShadowPreviewContext({ demoId, intakeId });
-  if (!context) {
-    return (
-      <div className="grid min-h-screen place-items-center bg-[color:var(--theme-surface-page)] px-4 text-[color:var(--theme-text-primary)]">
-        <div className="max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-center">
-          <p className="text-lg font-semibold">Preview expired</p>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">The demo snapshot is missing or no longer matches this intake link. Please restart Instant Shop Analysis.</p>
-          <Link href="/demo/instant-shop-analysis" className="mt-4 inline-flex rounded-md border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs">Restart analysis</Link>
-        </div>
-      </div>
-    );
-  }
-
-  if (shared && token && (!validatedToken || validatedToken.demoId !== demoId || validatedToken.intakeId !== intakeId)) {
-    return (
-      <div className="grid min-h-screen place-items-center bg-[color:var(--theme-surface-page)] px-4 text-[color:var(--theme-text-primary)]">
-        <div className="max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-center">
-          <p className="text-lg font-semibold">Share link expired</p>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">This shared link is no longer valid. Ask the sender for a fresh link.</p>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <ShadowPreviewClient
       context={context}
       mode={mode}
-      shareMeta={
-        shared
-          ? {
-              enabled: true,
-              senderName: validatedToken?.senderName ?? null,
-              token: token || null,
-            }
-          : { enabled: false, senderName: null, token: null }
-      }
+      shareMeta={{
+        enabled: shared,
+        senderName: shared ? access.senderName ?? null : null,
+        token,
+      }}
     />
   );
 }

--- a/app/demo/report/[demoId]/not-found.tsx
+++ b/app/demo/report/[demoId]/not-found.tsx
@@ -1,0 +1,3 @@
+import { ShopBoostAnalysisUnavailable } from "@/features/integrations/shopBoost/ShopBoostAnalysisUnavailable";
+
+export default ShopBoostAnalysisUnavailable;

--- a/app/demo/report/[demoId]/page.tsx
+++ b/app/demo/report/[demoId]/page.tsx
@@ -1,5 +1,9 @@
+import type { Metadata } from "next";
+import { unstable_noStore as noStore } from "next/cache";
+import { notFound } from "next/navigation";
 import Link from "next/link";
 import { loadShadowPreviewContext } from "@/features/integrations/shopBoost/shadowShop";
+import { verifyShopBoostPreviewToken } from "@/features/integrations/shopBoost/shareAccess";
 import {
   buildConsequenceItems,
   buildDecisionSummary,
@@ -8,30 +12,34 @@ import {
   formatUsd,
 } from "@/features/integrations/shopBoost/conversionPolish";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  referrer: "no-referrer",
+};
+
 type PageProps = {
   params: Promise<{ demoId: string }>;
-  searchParams: Promise<{ intakeId?: string; sender?: string }>;
+  searchParams: Promise<{ token?: string }>;
 };
 
 export default async function DemoReportPage({ params, searchParams }: PageProps) {
-  const { demoId } = await params;
-  const sp = await searchParams;
-  const intakeId = typeof sp.intakeId === "string" ? sp.intakeId : "";
-  const sender = typeof sp.sender === "string" ? sp.sender : null;
+  noStore();
 
-  const context = intakeId ? await loadShadowPreviewContext({ demoId, intakeId }) : null;
-  if (!context) {
-    return (
-      <div className="grid min-h-screen place-items-center bg-[color:var(--theme-surface-page)] px-4 text-[color:var(--theme-text-primary)]">
-        <div className="max-w-xl rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-6 text-center">
-          <p className="text-lg font-semibold">Report unavailable</p>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">This report link is missing context or has expired.</p>
-        </div>
-      </div>
-    );
-  }
+  const [{ demoId: routeDemoId }, sp] = await Promise.all([params, searchParams]);
+  const token = typeof sp.token === "string" ? sp.token : "";
+  const access = token ? verifyShopBoostPreviewToken(token) : null;
+  if (!access || access.demoId !== routeDemoId) notFound();
+
+  const context = await loadShadowPreviewContext({
+    demoId: access.demoId,
+    intakeId: access.intakeId,
+  });
+  if (!context) notFound();
 
   const { snapshot } = context;
+  const sender = access.senderName ?? null;
   const decisionSummary = buildDecisionSummary(context);
   const consequences = buildConsequenceItems(snapshot).slice(0, 4);
   const objectionHandling = buildObjectionHandlingContent(snapshot);
@@ -114,7 +122,7 @@ export default async function DemoReportPage({ params, searchParams }: PageProps
           <p className="font-semibold text-[color:var(--theme-text-primary)]">Recommended next step</p>
           <p className="mt-1">{decisionSummary.primaryActionHelper}</p>
           <div className="mt-3">
-            <Link href={`/demo/preview/${context.demoId}?intakeId=${context.intakeId}&mode=sales`} className="inline-flex rounded-md bg-[var(--accent-copper)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-on-accent)]">
+            <Link href={`/demo/preview/${context.demoId}?${new URLSearchParams({ token, mode: "sales" }).toString()}`} className="inline-flex rounded-md bg-[var(--accent-copper)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-on-accent)]">
               {decisionSummary.primaryActionLabel}
             </Link>
           </div>

--- a/features/integrations/shopBoost/ShopBoostAnalysisUnavailable.tsx
+++ b/features/integrations/shopBoost/ShopBoostAnalysisUnavailable.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export function ShopBoostAnalysisUnavailable() {
+  return (
+    <div className="grid min-h-screen place-items-center bg-[color:var(--theme-surface-page)] px-4 text-[color:var(--theme-text-primary)]">
+      <div className="max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-5 text-center">
+        <p className="text-lg font-semibold">Analysis unavailable</p>
+        <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+          This analysis link is invalid or has expired. Start a new Instant Shop
+          Analysis or ask the sender for a fresh link.
+        </p>
+        <Link
+          href="/demo/instant-shop-analysis"
+          className="mt-4 inline-flex rounded-md border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs"
+        >
+          Start a new analysis
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/features/integrations/shopBoost/shareAccess.ts
+++ b/features/integrations/shopBoost/shareAccess.ts
@@ -1,63 +1,171 @@
-import crypto from "crypto";
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 const DEFAULT_EXPIRY_DAYS = 7;
+const MAX_EXPIRY_DAYS = 7;
+const MAX_TOKEN_LENGTH = 4096;
+const MAX_ENCODED_PAYLOAD_LENGTH = 2048;
+const MIN_SECRET_BYTES = 32;
+const PREVIEW_TOKEN_VERSION = 1;
+const PREVIEW_TOKEN_PURPOSE = "shop_boost_preview";
+const CLOCK_SKEW_MS = 5 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-export type ShareTokenPayload = {
+export type ShopBoostPreviewTokenPayload = {
+  version: typeof PREVIEW_TOKEN_VERSION;
+  purpose: typeof PREVIEW_TOKEN_PURPOSE;
   demoId: string;
   intakeId: string;
+  issuedAt: number;
   exp: number;
   senderName?: string;
-  issuedAt: string;
 };
 
-function getSecret(): string {
-  return process.env.SHOP_BOOST_SHARE_SECRET?.trim() || process.env.SUPABASE_SERVICE_ROLE_KEY?.trim() || "profixiq-shop-boost-share";
+function readSecret(): Buffer | null {
+  const value = process.env.SHOP_BOOST_SHARE_SECRET?.trim();
+  if (!value || Buffer.byteLength(value, "utf8") < MIN_SECRET_BYTES) return null;
+  return Buffer.from(value, "utf8");
+}
+
+function requireSecret(): Buffer {
+  const secret = readSecret();
+  if (!secret) {
+    throw new Error(
+      "SHOP_BOOST_SHARE_SECRET must be configured with at least 32 bytes.",
+    );
+  }
+  return secret;
+}
+
+export function assertShopBoostPreviewTokenConfigured(): void {
+  requireSecret();
 }
 
 function base64UrlEncode(value: string): string {
-  return Buffer.from(value).toString("base64url");
+  return Buffer.from(value, "utf8").toString("base64url");
 }
 
-function base64UrlDecode(value: string): string {
-  return Buffer.from(value, "base64url").toString("utf8");
+function base64UrlDecode(value: string): string | null {
+  try {
+    const decoded = Buffer.from(value, "base64url");
+    if (decoded.toString("base64url") !== value) return null;
+    return decoded.toString("utf8");
+  } catch {
+    return null;
+  }
 }
 
-function sign(value: string): string {
-  return crypto.createHmac("sha256", getSecret()).update(value).digest("base64url");
+function sign(value: string, secret: Buffer): Buffer {
+  return createHmac("sha256", secret).update(value).digest();
 }
 
-export function generateShopBoostShareToken(args: {
+function hasValidPayloadShape(
+  value: unknown,
+  now: number,
+): value is ShopBoostPreviewTokenPayload {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const payload = value as Record<string, unknown>;
+  const senderName = payload.senderName;
+
+  return (
+    payload.version === PREVIEW_TOKEN_VERSION &&
+    payload.purpose === PREVIEW_TOKEN_PURPOSE &&
+    typeof payload.demoId === "string" &&
+    UUID_PATTERN.test(payload.demoId) &&
+    typeof payload.intakeId === "string" &&
+    UUID_PATTERN.test(payload.intakeId) &&
+    Number.isSafeInteger(payload.issuedAt) &&
+    Number.isSafeInteger(payload.exp) &&
+    (payload.issuedAt as number) <= now + CLOCK_SKEW_MS &&
+    (payload.exp as number) > now &&
+    (payload.exp as number) > (payload.issuedAt as number) &&
+    (payload.exp as number) - (payload.issuedAt as number) <=
+      MAX_EXPIRY_DAYS * DAY_MS &&
+    (senderName === undefined ||
+      (typeof senderName === "string" && senderName.length <= 80))
+  );
+}
+
+export function generateShopBoostPreviewToken(args: {
   demoId: string;
   intakeId: string;
   senderName?: string;
   expiresInDays?: number;
 }): string {
+  if (!UUID_PATTERN.test(args.demoId) || !UUID_PATTERN.test(args.intakeId)) {
+    throw new Error("Shop Boost preview identifiers are invalid.");
+  }
+
+  const expiresInDays = args.expiresInDays ?? DEFAULT_EXPIRY_DAYS;
+  if (
+    !Number.isFinite(expiresInDays) ||
+    expiresInDays <= 0 ||
+    expiresInDays > MAX_EXPIRY_DAYS
+  ) {
+    throw new Error("Shop Boost preview expiry is invalid.");
+  }
+
   const now = Date.now();
-  const payload: ShareTokenPayload = {
+  const senderName = args.senderName?.trim().slice(0, 80) || undefined;
+  const payload: ShopBoostPreviewTokenPayload = {
+    version: PREVIEW_TOKEN_VERSION,
+    purpose: PREVIEW_TOKEN_PURPOSE,
     demoId: args.demoId,
     intakeId: args.intakeId,
-    senderName: args.senderName,
-    issuedAt: new Date(now).toISOString(),
-    exp: now + (args.expiresInDays ?? DEFAULT_EXPIRY_DAYS) * 24 * 60 * 60 * 1000,
+    senderName,
+    issuedAt: now,
+    exp: now + Math.floor(expiresInDays * DAY_MS),
   };
 
   const encodedPayload = base64UrlEncode(JSON.stringify(payload));
-  const signature = sign(encodedPayload);
+  const signature = sign(encodedPayload, requireSecret()).toString("base64url");
   return `${encodedPayload}.${signature}`;
 }
 
-export function verifyShopBoostShareToken(token: string): ShareTokenPayload | null {
-  const [encodedPayload, signature] = token.split(".");
-  if (!encodedPayload || !signature) return null;
+export function verifyShopBoostPreviewToken(
+  token: string,
+): ShopBoostPreviewTokenPayload | null {
+  if (!token || token.length > MAX_TOKEN_LENGTH) return null;
 
-  const expected = sign(encodedPayload);
-  if (expected !== signature) return null;
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [encodedPayload, encodedSignature] = parts;
+  if (
+    !encodedPayload ||
+    !encodedSignature ||
+    encodedPayload.length > MAX_ENCODED_PAYLOAD_LENGTH
+  ) {
+    return null;
+  }
+
+  const secret = readSecret();
+  if (!secret) return null;
+
+  let suppliedSignature: Buffer;
+  try {
+    suppliedSignature = Buffer.from(encodedSignature, "base64url");
+    if (suppliedSignature.toString("base64url") !== encodedSignature) return null;
+  } catch {
+    return null;
+  }
+
+  const expectedSignature = sign(encodedPayload, secret);
+  if (
+    suppliedSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(suppliedSignature, expectedSignature)
+  ) {
+    return null;
+  }
+
+  const decodedPayload = base64UrlDecode(encodedPayload);
+  if (!decodedPayload) return null;
 
   try {
-    const payload = JSON.parse(base64UrlDecode(encodedPayload)) as ShareTokenPayload;
-    if (!payload.demoId || !payload.intakeId || !payload.exp) return null;
-    if (Date.now() > payload.exp) return null;
-    return payload;
+    const payload: unknown = JSON.parse(decodedPayload);
+    return hasValidPayloadShape(payload, Date.now()) ? payload : null;
   } catch {
     return null;
   }
@@ -70,7 +178,7 @@ export function buildShopBoostShareHref(args: {
   senderName?: string;
   expiresInDays?: number;
 }): string {
-  const token = generateShopBoostShareToken({
+  const token = generateShopBoostPreviewToken({
     demoId: args.demoId,
     intakeId: args.intakeId,
     senderName: args.senderName,
@@ -78,7 +186,6 @@ export function buildShopBoostShareHref(args: {
   });
 
   const url = new URL(`/demo/preview/${args.demoId}`, args.origin);
-  url.searchParams.set("intakeId", args.intakeId);
   url.searchParams.set("share", "1");
   url.searchParams.set("token", token);
   return url.toString();

--- a/tests/shop-boost-preview-access.test.ts
+++ b/tests/shop-boost-preview-access.test.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import DemoPreviewPage from "@/app/demo/preview/[demoId]/page";
-import DemoReportPage from "@/app/demo/report/[demoId]/page";
+import DemoPreviewPage from "../app/demo/preview/[demoId]/page";
+import DemoReportPage from "../app/demo/report/[demoId]/page";
 import {
   generateShopBoostPreviewToken,
   verifyShopBoostPreviewToken,

--- a/tests/shop-boost-preview-access.test.ts
+++ b/tests/shop-boost-preview-access.test.ts
@@ -1,0 +1,164 @@
+import { createHmac } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DemoPreviewPage from "@/app/demo/preview/[demoId]/page";
+import DemoReportPage from "@/app/demo/report/[demoId]/page";
+import {
+  generateShopBoostPreviewToken,
+  verifyShopBoostPreviewToken,
+} from "@/features/integrations/shopBoost/shareAccess";
+
+const loadShadowPreviewContext = vi.hoisted(() => vi.fn());
+const notFound = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("TEST_NOT_FOUND");
+  }),
+);
+
+vi.mock("next/cache", () => ({ unstable_noStore: vi.fn() }));
+vi.mock("next/navigation", () => ({ notFound }));
+vi.mock("@/features/integrations/shopBoost/shadowShop", () => ({
+  loadShadowPreviewContext,
+}));
+
+const SECRET =
+  "shop-boost-preview-test-secret-with-more-than-thirty-two-bytes";
+const DEMO_A = "11111111-1111-4111-8111-111111111111";
+const DEMO_B = "22222222-2222-4222-8222-222222222222";
+const INTAKE_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const INTAKE_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function makeToken(overrides?: Partial<{ demoId: string; intakeId: string }>) {
+  return generateShopBoostPreviewToken({
+    demoId: overrides?.demoId ?? DEMO_A,
+    intakeId: overrides?.intakeId ?? INTAKE_A,
+  });
+}
+
+async function expectPreviewDenied(args: {
+  demoId?: string;
+  token?: string;
+  intakeId?: string;
+}) {
+  await expect(
+    DemoPreviewPage({
+      params: Promise.resolve({ demoId: args.demoId ?? DEMO_A }),
+      searchParams: Promise.resolve({
+        token: args.token,
+        intakeId: args.intakeId,
+      } as never),
+    }),
+  ).rejects.toThrow("TEST_NOT_FOUND");
+  expect(loadShadowPreviewContext).not.toHaveBeenCalled();
+}
+
+describe("Shop Boost preview access", () => {
+  beforeEach(() => {
+    vi.stubEnv("SHOP_BOOST_SHARE_SECRET", SECRET);
+    loadShadowPreviewContext.mockReset();
+    notFound.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("fails closed without the dedicated secret and never falls back to the service key", () => {
+    const token = makeToken();
+    vi.stubEnv("SHOP_BOOST_SHARE_SECRET", "");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", SECRET);
+
+    expect(verifyShopBoostPreviewToken(token)).toBeNull();
+    expect(() => makeToken()).toThrow("SHOP_BOOST_SHARE_SECRET");
+  });
+
+  it("rejects a correctly signed token for another purpose", () => {
+    const token = makeToken();
+    const [encodedPayload] = token.split(".");
+    const payload = JSON.parse(
+      Buffer.from(encodedPayload, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    payload.purpose = "shop_boost_share_email";
+    const wrongPurposePayload = Buffer.from(
+      JSON.stringify(payload),
+      "utf8",
+    ).toString("base64url");
+    const signature = createHmac("sha256", SECRET)
+      .update(wrongPurposePayload)
+      .digest("base64url");
+
+    expect(
+      verifyShopBoostPreviewToken(`${wrongPurposePayload}.${signature}`),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["malformed", "not-a-token"],
+    ["empty", ""],
+  ])("returns a generic 404 for a %s token before privileged loading", async (_label, token) => {
+    await expectPreviewDenied({ token });
+  });
+
+  it("protects the adjacent report page before privileged loading", async () => {
+    await expect(
+      DemoReportPage({
+        params: Promise.resolve({ demoId: DEMO_A }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow("TEST_NOT_FOUND");
+    expect(loadShadowPreviewContext).not.toHaveBeenCalled();
+  });
+
+  it("rejects a tampered token before privileged loading", async () => {
+    const token = makeToken();
+    const [payload, signature] = token.split(".");
+    const replacement = signature.startsWith("A") ? "B" : "A";
+
+    await expectPreviewDenied({
+      token: `${payload}.${replacement}${signature.slice(1)}`,
+    });
+  });
+
+  it("rejects an expired token before privileged loading", async () => {
+    vi.useFakeTimers();
+    const issuedAt = new Date("2026-07-25T12:00:00.000Z");
+    vi.setSystemTime(issuedAt);
+    const token = generateShopBoostPreviewToken({
+      demoId: DEMO_A,
+      intakeId: INTAKE_A,
+      expiresInDays: 1,
+    });
+    vi.setSystemTime(issuedAt.getTime() + 24 * 60 * 60 * 1000 + 1);
+
+    await expectPreviewDenied({ token });
+  });
+
+  it("rejects a valid token used on another demo route before privileged loading", async () => {
+    await expectPreviewDenied({ demoId: DEMO_B, token: makeToken() });
+  });
+
+  it("derives both privileged lookup identifiers only from the validated token", async () => {
+    const token = makeToken();
+    loadShadowPreviewContext.mockResolvedValue({
+      demoId: DEMO_A,
+      intakeId: INTAKE_A,
+      shopName: "Token Bound Auto",
+      country: "US",
+      snapshot: {},
+    });
+
+    const result = await DemoPreviewPage({
+      params: Promise.resolve({ demoId: DEMO_A }),
+      searchParams: Promise.resolve({ token, intakeId: INTAKE_B } as never),
+    });
+
+    expect(loadShadowPreviewContext).toHaveBeenCalledTimes(1);
+    expect(loadShadowPreviewContext).toHaveBeenCalledWith({
+      demoId: DEMO_A,
+      intakeId: INTAKE_A,
+    });
+    const props = result.props as { shareMeta: { token: string } };
+    expect(props.shareMeta.token).toBe(token);
+  });
+});

--- a/tests/shop-boost-preview-access.test.ts
+++ b/tests/shop-boost-preview-access.test.ts
@@ -1,4 +1,5 @@
 import { createHmac } from "node:crypto";
+import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DemoPreviewPage from "../app/demo/preview/[demoId]/page";
 import DemoReportPage from "../app/demo/report/[demoId]/page";
@@ -53,6 +54,7 @@ async function expectPreviewDenied(args: {
 
 describe("Shop Boost preview access", () => {
   beforeEach(() => {
+    vi.stubGlobal("React", React);
     vi.stubEnv("SHOP_BOOST_SHARE_SECRET", SECRET);
     loadShadowPreviewContext.mockReset();
     notFound.mockClear();
@@ -61,6 +63,7 @@ describe("Shop Boost preview access", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it("fails closed without the dedicated secret and never falls back to the service key", () => {

--- a/tests/shop-boost-preview-route-guards.test.ts
+++ b/tests/shop-boost-preview-route-guards.test.ts
@@ -1,8 +1,8 @@
 import type { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { POST as claimPreview } from "@/app/api/demo/shop-boost/claim/route";
-import { POST as runAnalysis } from "@/app/api/demo/shop-boost/run/route";
-import { POST as sharePreview } from "@/app/api/demo/shop-boost/share/route";
+import { POST as claimPreview } from "../app/api/demo/shop-boost/claim/route";
+import { POST as runAnalysis } from "../app/api/demo/shop-boost/run/route";
+import { POST as sharePreview } from "../app/api/demo/shop-boost/share/route";
 import {
   generateShopBoostPreviewToken,
   verifyShopBoostPreviewToken,

--- a/tests/shop-boost-preview-route-guards.test.ts
+++ b/tests/shop-boost-preview-route-guards.test.ts
@@ -1,0 +1,218 @@
+import type { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST as claimPreview } from "@/app/api/demo/shop-boost/claim/route";
+import { POST as runAnalysis } from "@/app/api/demo/shop-boost/run/route";
+import { POST as sharePreview } from "@/app/api/demo/shop-boost/share/route";
+import {
+  generateShopBoostPreviewToken,
+  verifyShopBoostPreviewToken,
+} from "@/features/integrations/shopBoost/shareAccess";
+
+const createAdminSupabase = vi.hoisted(() => vi.fn());
+const buildShadowShopSnapshot = vi.hoisted(() => vi.fn());
+const loadShadowPreviewContext = vi.hoisted(() => vi.fn());
+const setApiKey = vi.hoisted(() => vi.fn());
+const sendEmail = vi.hoisted(() => vi.fn());
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase,
+}));
+vi.mock("@/features/integrations/shopBoost/shadowShop", () => ({
+  buildShadowShopSnapshot,
+  loadShadowPreviewContext,
+}));
+vi.mock("@sendgrid/mail", () => ({
+  default: { setApiKey, send: sendEmail },
+}));
+
+const SECRET =
+  "shop-boost-preview-route-test-secret-with-more-than-thirty-two-bytes";
+const DEMO_A = "11111111-1111-4111-8111-111111111111";
+const DEMO_B = "22222222-2222-4222-8222-222222222222";
+const INTAKE_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const INTAKE_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function request(path: string, body: Record<string, unknown>): NextRequest {
+  return new Request(`https://www.profixiq.com${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+describe("Shop Boost preview route guards", () => {
+  beforeEach(() => {
+    vi.stubEnv("SHOP_BOOST_SHARE_SECRET", SECRET);
+    vi.stubEnv("SENDGRID_API_KEY", "sendgrid-test-key");
+    vi.stubEnv("SENDGRID_FROM_EMAIL", "no-reply@profixiq.test");
+    createAdminSupabase.mockReset();
+    buildShadowShopSnapshot.mockReset();
+    loadShadowPreviewContext.mockReset();
+    setApiKey.mockReset();
+    sendEmail.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects claim requests without a token before creating an admin client", async () => {
+    const response = await claimPreview(
+      request("/api/demo/shop-boost/claim", {
+        demoId: DEMO_A,
+        intakeId: INTAKE_A,
+        email: "owner@example.com",
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(createAdminSupabase).not.toHaveBeenCalled();
+  });
+
+  it("fails the analysis before privileged access when the token secret is missing", async () => {
+    vi.stubEnv("SHOP_BOOST_SHARE_SECRET", "");
+
+    const response = await runAnalysis(
+      request("/api/demo/shop-boost/run", {
+        demoId: DEMO_A,
+        intakeId: INTAKE_A,
+        shopName: "Token Bound Auto",
+        uploads: [
+          {
+            dataset: "customers",
+            fileName: "customers.csv",
+            sizeBytes: 10,
+            contentType: "text/csv",
+            path: `demos/${DEMO_A}/${INTAKE_A}/customers.csv`,
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(createAdminSupabase).not.toHaveBeenCalled();
+  });
+
+  it("rejects share requests with a tampered token before any privileged read", async () => {
+    const token = generateShopBoostPreviewToken({
+      demoId: DEMO_A,
+      intakeId: INTAKE_A,
+    });
+    const tampered = `${token.slice(0, -1)}${token.endsWith("A") ? "B" : "A"}`;
+
+    const response = await sharePreview(
+      request("/api/demo/shop-boost/share", {
+        previewToken: tampered,
+        recipientEmail: "owner@example.com",
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(loadShadowPreviewContext).not.toHaveBeenCalled();
+    expect(createAdminSupabase).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("uses only token-bound identifiers when claiming an analysis", async () => {
+    const token = generateShopBoostPreviewToken({
+      demoId: DEMO_A,
+      intakeId: INTAKE_A,
+    });
+    const leadLookup: Record<string, ReturnType<typeof vi.fn>> = {};
+    leadLookup.select = vi.fn(() => leadLookup);
+    leadLookup.eq = vi.fn(() => leadLookup);
+    leadLookup.maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+
+    const demoLookup: Record<string, ReturnType<typeof vi.fn>> = {};
+    demoLookup.select = vi.fn(() => demoLookup);
+    demoLookup.eq = vi.fn(() => demoLookup);
+    demoLookup.maybeSingle = vi.fn(async () => ({
+      data: { id: DEMO_A, snapshot: { intakeId: INTAKE_A } },
+      error: null,
+    }));
+
+    const insert = vi.fn(async () => ({ error: null }));
+    const updateQuery: Record<string, ReturnType<typeof vi.fn>> = {};
+    updateQuery.update = vi.fn(() => updateQuery);
+    updateQuery.eq = vi.fn(async () => ({ error: null }));
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(leadLookup)
+      .mockReturnValueOnce(demoLookup)
+      .mockReturnValueOnce({ insert })
+      .mockReturnValueOnce(updateQuery);
+    createAdminSupabase.mockReturnValue({ from });
+
+    const response = await claimPreview(
+      request("/api/demo/shop-boost/claim", {
+        previewToken: token,
+        demoId: DEMO_B,
+        intakeId: INTAKE_B,
+        email: "OWNER@EXAMPLE.COM",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(demoLookup.eq).toHaveBeenCalledWith("id", DEMO_A);
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ demo_id: DEMO_A, email: "owner@example.com" }),
+    );
+    expect(updateQuery.eq).toHaveBeenCalledWith("id", DEMO_A);
+  });
+
+  it("uses only token-bound identifiers when issuing a new share link", async () => {
+    const token = generateShopBoostPreviewToken({
+      demoId: DEMO_A,
+      intakeId: INTAKE_A,
+    });
+    loadShadowPreviewContext.mockResolvedValue({
+      demoId: DEMO_A,
+      intakeId: INTAKE_A,
+      shopName: "Token Bound Auto",
+      country: "US",
+      snapshot: {},
+    });
+
+    const existingLeadQuery: Record<string, ReturnType<typeof vi.fn>> = {};
+    existingLeadQuery.select = vi.fn(() => existingLeadQuery);
+    existingLeadQuery.eq = vi.fn(() => existingLeadQuery);
+    existingLeadQuery.maybeSingle = vi.fn(async () => ({ data: null }));
+    const insert = vi.fn(async () => ({ error: null }));
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(existingLeadQuery)
+      .mockReturnValueOnce({ insert });
+    createAdminSupabase.mockReturnValue({ from });
+    sendEmail.mockResolvedValue([{}]);
+
+    const response = await sharePreview(
+      request("/api/demo/shop-boost/share", {
+        previewToken: token,
+        demoId: DEMO_B,
+        intakeId: INTAKE_B,
+        recipientEmail: "owner@example.com",
+        senderName: "Advisor",
+      }),
+    );
+    const body = (await response.json()) as {
+      ok: boolean;
+      shareLink: string;
+    };
+    const shareUrl = new URL(body.shareLink);
+    const sharedAccess = verifyShopBoostPreviewToken(
+      shareUrl.searchParams.get("token") ?? "",
+    );
+
+    expect(response.status).toBe(200);
+    expect(loadShadowPreviewContext).toHaveBeenCalledWith({
+      demoId: DEMO_A,
+      intakeId: INTAKE_A,
+    });
+    expect(sharedAccess?.demoId).toBe(DEMO_A);
+    expect(sharedAccess?.intakeId).toBe(INTAKE_A);
+    expect(sharedAccess?.senderName).toBe("Advisor");
+    expect(shareUrl.searchParams.has("intakeId")).toBe(false);
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tsconfig.p0-003.json
+++ b/tsconfig.p0-003.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "include": [
+    "next-env.d.ts",
+    "app/api/demo/shop-boost/claim/route.ts",
+    "app/api/demo/shop-boost/run/route.ts",
+    "app/api/demo/shop-boost/share/route.ts",
+    "app/demo/instant-shop-analysis/page.tsx",
+    "app/demo/preview/[demoId]/_components/ShadowPreviewClient.tsx",
+    "app/demo/preview/[demoId]/not-found.tsx",
+    "app/demo/preview/[demoId]/page.tsx",
+    "app/demo/report/[demoId]/not-found.tsx",
+    "app/demo/report/[demoId]/page.tsx",
+    "features/integrations/shopBoost/ShopBoostAnalysisUnavailable.tsx",
+    "features/integrations/shopBoost/shareAccess.ts",
+    "tests/shop-boost-preview-access.test.ts",
+    "tests/shop-boost-preview-route-guards.test.ts"
+  ]
+}


### PR DESCRIPTION
## P0-003

Closes the release-blocking Shop Boost preview exposure identified in the production-readiness audit.

### Root cause

The preview accepted `demoId` and `intakeId` from the URL and called a service-role-backed loader before optional share-token validation. Token signing also fell back to the Supabase service-role key or a hard-coded secret.

### What changed

- makes a signed preview token mandatory before every privileged preview/report/share/claim read
- derives both `demoId` and `intakeId` exclusively from the validated token
- replaces secret fallbacks with required server-only `SHOP_BOOST_SHARE_SECRET` configuration
- adds purpose, version, issuance, expiry, UUID, size, canonical-encoding, and timing-safe HMAC validation
- disables caching and returns the same generic unavailable state for missing, malformed, expired, tampered, and cross-demo tokens
- migrates new and resumed analysis links to token-only access
- protects the adjacent report, share-email, and claim routes
- adds focused route and token regression tests plus a path-scoped GitHub Actions gate

### Verification

Passed on commit `282fd4b`:

- clean `pnpm install --frozen-lockfile` in GitHub Actions
- scoped TypeScript validation
- scoped ESLint
- 15/15 focused Vitest security and route tests
- Vercel Next.js preview build
- `git diff --check`
- API route boundary inventory audit (381 routes; generated inventory changes discarded)
- Node runtime smoke of the actual token module
- static privileged-loader and legacy-link searches

### Required environment setup

Before manually testing the preview deployment, configure a unique server-only `SHOP_BOOST_SHARE_SECRET` of at least 32 random bytes in Vercel Preview. Before production promotion, configure a separate value in Vercel Production. Do not reuse the Supabase service-role key.

Existing v1 browser resume links intentionally expire and users must rerun Instant Shop Analysis to receive a token-bound link.

No database migration is included or required.