### PR TITLE
Harden P0-004 tenant-scoped vehicle recall fetches

### DIFF
--- a/.github/workflows/p0-004-vehicle-recall-validation.yml
+++ b/.github/workflows/p0-004-vehicle-recall-validation.yml
@@ -1,0 +1,45 @@
+name: P0-004 Vehicle Recall Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/recalls/fetch/**"
+      - "app/vehicle/VinCaptureModal.tsx"
+      - "app/agent/planner/page.tsx"
+      - "app/mobile/work-orders/create/page.tsx"
+      - "features/vehicles/**"
+      - "features/work-orders/app/work-orders/create/page.tsx"
+      - "features/shared/types/types/supabase.ts"
+      - "tests/vehicle-recall-fetch-security.test.ts"
+      - "tsconfig.p0-004.json"
+      - ".github/workflows/p0-004-vehicle-recall-validation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec tsc --noEmit -p tsconfig.p0-004.json
+      - run: >-
+          pnpm exec eslint
+          app/api/recalls/fetch/route.ts
+          app/vehicle/VinCaptureModal.tsx
+          app/agent/planner/page.tsx
+          app/mobile/work-orders/create/page.tsx
+          features/vehicles/lib/requestRecallEnrichment.ts
+          features/vehicles/server/recallFetch.ts
+          features/work-orders/app/work-orders/create/page.tsx
+          tests/vehicle-recall-fetch-security.test.ts
+      - run: pnpm exec vitest run tests/vehicle-recall-fetch-security.test.ts

--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -153,6 +153,20 @@ jobs:
             -f tests/security/p0-002-stock-move-signature-compat.runtime.sql \
             2>&1 | tee p0-002-stock-move-signature-compat-runtime.log
 
+      - name: Execute P0 vehicle recall tenant-boundary integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/p0-004-vehicle-recall-fetch.runtime.sql \
+            2>&1 | tee p0-004-vehicle-recall-fetch-runtime.log
+
       - name: Verify bootstrap and existing-database baseline paths
         shell: bash
         env:
@@ -217,6 +231,7 @@ jobs:
             p0-001-relation-boundaries-runtime.log
             p0-002-rpc-privileges-runtime.log
             p0-002-stock-move-signature-compat-runtime.log
+            p0-004-vehicle-recall-fetch-runtime.log
             supabase/config.toml
           if-no-files-found: warn
 

--- a/app/agent/planner/page.tsx
+++ b/app/agent/planner/page.tsx
@@ -1521,7 +1521,7 @@ export default function PlannerPage() {
               engine: d.engine ?? null,
             });
             setPlateOrVin(d.vin);
-            setToast("VIN decoded and recalls queued ✅");
+            setToast("VIN decoded and added to the work-order draft.");
             window.setTimeout(() => setToast(null), 4000);
 
             setCustomerDraft({

--- a/app/api/recalls/fetch/route.ts
+++ b/app/api/recalls/fetch/route.ts
@@ -1,104 +1,181 @@
-// app/api/recalls/fetch/route.ts
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 
-/** Run on Node so env vars are available (not Edge) */
+import { ROLE_GROUPS } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
+import {
+  fetchNhtsaRecalls,
+  NhtsaRecallFetchError,
+  toVehicleRecallRows,
+} from "@/features/vehicles/server/recallFetch";
+
 export const runtime = "nodejs";
-/** Ensure it isn't statically rendered */
 export const dynamic = "force-dynamic";
 
-type NhtsaRecall = {
-  NHTSACampaignNumber?: string;
-  campaignNumber?: string;
-  ReportReceivedDate?: string;
-  ReportDate?: string;
-  Component?: string;
-  Summary?: string;
-  Conequence?: string;
-  Consequence?: string;
-  Remedy?: string;
-  Notes?: string;
-  Manufacturer?: string;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type RecallRequest = { vehicleId?: unknown };
+type VehicleScope = {
+  id: string;
+  shop_id: string | null;
+  vin: string | null;
+  year: number | null;
+  make: string | null;
+  model: string | null;
 };
 
-export async function POST(req: Request) {
+function json(body: Record<string, unknown>, status = 200, headers?: HeadersInit) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+      ...headers,
+    },
+  });
+}
+
+function safeVehicleText(value: string | null, maxLength: number): string | null {
+  const normalized = value?.trim() ?? "";
+  return normalized && normalized.length <= maxLength ? normalized : null;
+}
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ROLE_GROUPS.workOrderCreators,
+  });
+
+  if (!access.ok) {
+    access.response.headers.set("Cache-Control", "no-store");
+    return access.response;
+  }
+
+  const body = (await request.json().catch(() => null)) as RecallRequest | null;
+  const vehicleId =
+    typeof body?.vehicleId === "string" ? body.vehicleId.trim() : "";
+
+  if (!UUID_PATTERN.test(vehicleId)) {
+    return json({ ok: false, error: "A valid vehicleId is required." }, 400);
+  }
+
+  const shopId = access.profile.shop_id;
+  const { data: vehicle, error: vehicleError } = await access.supabase
+    .from("vehicles")
+    .select("id, shop_id, vin, year, make, model")
+    .eq("id", vehicleId)
+    .eq("shop_id", shopId)
+    .maybeSingle<VehicleScope>();
+
+  if (vehicleError) {
+    console.error("recall_fetch_vehicle_lookup_failed", {
+      vehicleId,
+      shopId,
+      code: vehicleError.code,
+    });
+    return json({ ok: false, error: "Recall lookup is temporarily unavailable." }, 503);
+  }
+
+  if (!vehicle) {
+    return json({ ok: false, error: "Vehicle not found." }, 404);
+  }
+
+  const normalizedVin = normalizeVinInput(vehicle.vin);
+  const make = safeVehicleText(vehicle.make, 80);
+  const model = safeVehicleText(vehicle.model, 120);
+  const currentYear = new Date().getUTCFullYear();
+  const year = vehicle.year;
+
+  if (
+    !normalizedVin.isValid ||
+    !make ||
+    !model ||
+    !Number.isInteger(year) ||
+    (year as number) < 1900 ||
+    (year as number) > currentYear + 2
+  ) {
+    return json(
+      {
+        ok: false,
+        error: "The saved vehicle needs a valid VIN, year, make, and model before recalls can be checked.",
+      },
+      422,
+    );
+  }
+
+  const admin = createAdminSupabase();
+  const { data: quotaRows, error: quotaError } = await admin.rpc(
+    "consume_vehicle_recall_fetch_quota",
+    {
+      p_actor_id: access.profile.id,
+      p_shop_id: shopId,
+      p_vehicle_id: vehicle.id,
+    },
+  );
+
+  if (quotaError) {
+    console.error("recall_fetch_quota_failed", {
+      vehicleId,
+      shopId,
+      code: quotaError.code,
+    });
+    return json({ ok: false, error: "Recall lookup is temporarily unavailable." }, 503);
+  }
+
+  const quota = quotaRows?.[0];
+  if (!quota?.allowed) {
+    const retryAfter = Math.max(1, quota?.retry_after_seconds ?? 60);
+    return json(
+      { ok: false, error: "Recall lookup limit reached. Please try again later." },
+      429,
+      { "Retry-After": String(retryAfter) },
+    );
+  }
+
   try {
-    // Resolve env at runtime (Node), prefer non-public URL if present
-    const SUPABASE_URL =
-      process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-    if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
-      return NextResponse.json(
-        { error: "Server is missing Supabase environment variables." },
-        { status: 500 }
-      );
-    }
-
-    // Create a server-side Supabase client using the service role (never on the client!)
-    const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
-
-    const body = (await req.json()) as {
-      vin?: string;
-      year?: string;
-      make?: string;
-      model?: string;
-      user_id?: string;
-    };
-
-    const { vin, year, make, model, user_id } = body;
-
-    if (!vin) {
-      return NextResponse.json({ error: "VIN required" }, { status: 400 });
-    }
-
-    // Fetch from NHTSA Recall API
-    const params = new URLSearchParams({
-      make: make ?? "",
-      model: model ?? "",
-      modelYear: year ?? "",
+    const recalls = await fetchNhtsaRecalls({
+      year: year as number,
+      make,
+      model,
+    });
+    const rows = toVehicleRecallRows(recalls, {
+      actorId: access.profile.id,
+      make,
+      model,
+      shopId,
+      vehicleId: vehicle.id,
+      vin: normalizedVin.vin,
+      year: year as number,
     });
 
-    const res = await fetch(
-      `https://api.nhtsa.gov/recalls/recallsByVehicle?${params.toString()}`,
-      { headers: { "Content-Type": "application/json" }, cache: "no-store" }
-    );
+    if (rows.length > 0) {
+      const { error: upsertError } = await admin.from("vehicle_recalls").upsert(rows, {
+        onConflict: "shop_id,vehicle_id,campaign_number",
+      });
 
-    if (!res.ok) throw new Error(`NHTSA error ${res.status}`);
-    const data = (await res.json()) as { results?: NhtsaRecall[] };
-    const results = data.results ?? [];
-
-    // Prepare upserts for vehicle_recalls
-    const now = new Date().toISOString();
-    const records = results.map((r) => ({
-      vin,
-      campaign_number: r.NHTSACampaignNumber ?? r.campaignNumber ?? "UNKNOWN",
-      report_date: r.ReportReceivedDate ?? r.ReportDate ?? null,
-      component: r.Component ?? null,
-      summary: r.Summary ?? null,
-      consequence: r.Conequence ?? r.Consequence ?? null,
-      remedy: r.Remedy ?? null,
-      notes: r.Notes ?? null,
-      manufacturer: r.Manufacturer ?? null,
-      make: make ?? null,
-      model: model ?? null,
-      model_year: year ?? null,
-      user_id: user_id ?? null,
-      created_at: now,
-    }));
-
-    if (records.length > 0) {
-      const { error } = await supabase
-        .from("vehicle_recalls")
-        .upsert(records, { onConflict: "vin,campaign_number" });
-
-      if (error) throw error;
+      if (upsertError) {
+        console.error("recall_fetch_upsert_failed", {
+          vehicleId,
+          shopId,
+          code: upsertError.code,
+        });
+        return json({ ok: false, error: "Recall data could not be saved." }, 503);
+      }
     }
 
-    return NextResponse.json({ count: records.length, status: "ok" });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error("Recall fetch error:", msg);
-    return NextResponse.json({ error: msg }, { status: 500 });
+    return json({ ok: true, vehicleId: vehicle.id, count: rows.length });
+  } catch (error) {
+    const isTimeout =
+      error instanceof NhtsaRecallFetchError && error.kind === "timeout";
+    console.error("recall_fetch_upstream_failed", {
+      vehicleId,
+      shopId,
+      kind:
+        error instanceof NhtsaRecallFetchError ? error.kind : "unexpected",
+    });
+    return json(
+      { ok: false, error: "The recall provider is temporarily unavailable." },
+      isTimeout ? 504 : 502,
+    );
   }
 }

--- a/app/api/recalls/fetch/route.ts
+++ b/app/api/recalls/fetch/route.ts
@@ -25,6 +25,10 @@ type VehicleScope = {
   make: string | null;
   model: string | null;
 };
+type RecallQuota = {
+  allowed: boolean;
+  retry_after_seconds: number;
+};
 
 function json(body: Record<string, unknown>, status = 200, headers?: HeadersInit) {
   return NextResponse.json(body, {
@@ -122,7 +126,9 @@ export async function POST(request: Request) {
     return json({ ok: false, error: "Recall lookup is temporarily unavailable." }, 503);
   }
 
-  const quota = quotaRows?.[0];
+  const quota = Array.isArray(quotaRows)
+    ? (quotaRows[0] as RecallQuota | undefined)
+    : undefined;
   if (!quota?.allowed) {
     const retryAfter = Math.max(1, quota?.retry_after_seconds ?? 60);
     return json(

--- a/app/mobile/work-orders/create/page.tsx
+++ b/app/mobile/work-orders/create/page.tsx
@@ -56,6 +56,7 @@ import {
   pruneDependentPartsRequestDrafts,
   resolveAndSubmitDependentPartsDrafts,
 } from "@/features/parts/offline/partsRequestDrafts";
+import { requestVehicleRecallEnrichment } from "@/features/vehicles/lib/requestRecallEnrichment";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -1061,6 +1062,7 @@ export default function MobileCreateWorkOrderPage() {
 
       const cust = await ensureCustomer();
       const veh = await ensureVehicle(cust);
+      void requestVehicleRecallEnrichment(veh.id);
 
       if (draftLines.length > 0) {
         const prepared = buildAdvisorDraft();

--- a/app/vehicle/VinCaptureModal.tsx
+++ b/app/vehicle/VinCaptureModal.tsx
@@ -168,28 +168,6 @@ export default function VinCaptureModal({
       window.removeEventListener("vin:decoded", handler as EventListener);
   }, [setOpen]);
 
-  const fetchRecallData = useCallback(
-    (vin: string, decoded: DecodeVinResponseExtended) => {
-      if (!decoded.year || !decoded.make || !decoded.model) return;
-
-      void fetch("/api/recalls/fetch", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          vin,
-          year: decoded.year,
-          make: decoded.make,
-          model: decoded.model,
-          user_id: userId,
-        }),
-        keepalive: true,
-      }).catch(() => {
-        // Recall enrichment must never block vehicle intake.
-      });
-    },
-    [userId],
-  );
-
   const handleManualVin = useCallback(
     async (rawVin: string) => {
       const normalized = normalizeVinInput(rawVin);
@@ -212,7 +190,6 @@ export default function VinCaptureModal({
 
         const enriched = decoded as DecodeVinResponseExtended;
         applyDecodedVehicle(normalized.vin, enriched);
-        fetchRecallData(normalized.vin, enriched);
         setOpen(false);
       } catch {
         setCaptureError(
@@ -223,7 +200,7 @@ export default function VinCaptureModal({
         setIsDecoding(false);
       }
     },
-    [applyDecodedVehicle, fetchRecallData, setOpen, userId],
+    [applyDecodedVehicle, setOpen, userId],
   );
 
   const handleScannedVin = useCallback(
@@ -255,13 +232,12 @@ export default function VinCaptureModal({
           if (decoded.error) return;
           const enriched = decoded as DecodeVinResponseExtended;
           applyDecodedVehicle(normalized.vin, enriched);
-          fetchRecallData(normalized.vin, enriched);
         })
         .catch(() => {
           // Local intake is already complete.
         });
     },
-    [applyDecodedVehicle, fetchRecallData, setOpen, userId],
+    [applyDecodedVehicle, setOpen, userId],
   );
 
   return (

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -18810,6 +18810,48 @@ export type Database = {
           },
         ]
       }
+      vehicle_recall_fetch_limits: {
+        Row: {
+          request_count: number
+          scope: string
+          shop_id: string
+          subject_id: string
+          updated_at: string
+          window_started_at: string
+        }
+        Insert: {
+          request_count?: number
+          scope: string
+          shop_id: string
+          subject_id: string
+          updated_at?: string
+          window_started_at?: string
+        }
+        Update: {
+          request_count?: number
+          scope?: string
+          shop_id?: string
+          subject_id?: string
+          updated_at?: string
+          window_started_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "vehicle_recall_fetch_limits_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "vehicle_recall_fetch_limits_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       vehicle_recalls: {
         Row: {
           campaign_number: string
@@ -23541,6 +23583,17 @@ export type Database = {
             Args: { p_location_id: string; p_request_item_id: string }
             Returns: undefined
           }
+      consume_vehicle_recall_fetch_quota: {
+        Args: {
+          p_actor_id: string
+          p_shop_id: string
+          p_vehicle_id: string
+        }
+        Returns: {
+          allowed: boolean
+          retry_after_seconds: number
+        }[]
+      }
       create_fleet_form_upload: {
         Args: { _filename: string; _path: string }
         Returns: string

--- a/features/vehicles/lib/requestRecallEnrichment.ts
+++ b/features/vehicles/lib/requestRecallEnrichment.ts
@@ -1,0 +1,21 @@
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function requestVehicleRecallEnrichment(
+  vehicleId: string,
+  fetcher: typeof fetch = fetch,
+): Promise<boolean> {
+  if (!UUID_PATTERN.test(vehicleId)) return false;
+
+  try {
+    const response = await fetcher("/api/recalls/fetch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vehicleId }),
+      keepalive: true,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/features/vehicles/server/recallFetch.ts
+++ b/features/vehicles/server/recallFetch.ts
@@ -1,0 +1,205 @@
+import "server-only";
+
+import type { Database } from "@shared/types/types/supabase";
+
+const NHTSA_RECALLS_ENDPOINT = "https://api.nhtsa.gov/recalls/recallsByVehicle";
+const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const MAX_ATTEMPTS = 2;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_RESPONSE_BYTES = 2_000_000;
+const MAX_RESULTS = 500;
+
+type RecallInsert = Database["public"]["Tables"]["vehicle_recalls"]["Insert"];
+
+export type RecallVehicleQuery = {
+  year: number;
+  make: string;
+  model: string;
+};
+
+export type VehicleRecallScope = RecallVehicleQuery & {
+  actorId: string;
+  shopId: string;
+  vehicleId: string;
+  vin: string;
+};
+
+export type NhtsaRecall = Record<string, unknown>;
+
+type RecallFetchOptions = {
+  fetcher?: typeof fetch;
+  sleep?: (milliseconds: number) => Promise<void>;
+  timeoutMs?: number;
+};
+
+export class NhtsaRecallFetchError extends Error {
+  constructor(
+    readonly kind: "timeout" | "upstream" | "invalid_response",
+    message: string,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = "NhtsaRecallFetchError";
+  }
+}
+
+function delay(milliseconds: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function text(value: unknown, maxLength = 10_000): string | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const normalized = String(value).trim();
+  return normalized ? normalized.slice(0, maxLength) : null;
+}
+
+function campaignNumber(recall: NhtsaRecall): string | null {
+  return text(
+    recall.NHTSACampaignNumber ??
+      recall.NHTSACampaign ??
+      recall.CampaignNumber ??
+      recall.campaignNumber,
+    64,
+  )?.toUpperCase() ?? null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+export function buildNhtsaRecallUrl(vehicle: RecallVehicleQuery): string {
+  const params = new URLSearchParams({
+    make: vehicle.make,
+    model: vehicle.model,
+    modelYear: String(vehicle.year),
+  });
+  return `${NHTSA_RECALLS_ENDPOINT}?${params.toString()}`;
+}
+
+export async function fetchNhtsaRecalls(
+  vehicle: RecallVehicleQuery,
+  options: RecallFetchOptions = {},
+): Promise<NhtsaRecall[]> {
+  const fetcher = options.fetcher ?? fetch;
+  const sleep = options.sleep ?? delay;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const url = buildNhtsaRecallUrl(vehicle);
+  let lastError: NhtsaRecallFetchError | null = null;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetcher(url, {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+        signal: controller.signal,
+      });
+      const contentLength = Number(response.headers.get("content-length") ?? "0");
+
+      if (contentLength > MAX_RESPONSE_BYTES) {
+        throw new NhtsaRecallFetchError(
+          "invalid_response",
+          "NHTSA response exceeded the permitted size.",
+          false,
+        );
+      }
+
+      if (!response.ok) {
+        lastError = new NhtsaRecallFetchError(
+          "upstream",
+          `NHTSA returned HTTP ${response.status}.`,
+          RETRYABLE_STATUS_CODES.has(response.status),
+        );
+        throw lastError;
+      }
+
+      const payload = (await response.json()) as unknown;
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        throw new NhtsaRecallFetchError(
+          "invalid_response",
+          "NHTSA returned an invalid response.",
+          true,
+        );
+      }
+
+      const results = (payload as { results?: unknown }).results;
+      if (!Array.isArray(results)) {
+        throw new NhtsaRecallFetchError(
+          "invalid_response",
+          "NHTSA response did not include recall results.",
+          true,
+        );
+      }
+
+      return results
+        .filter(
+          (item): item is NhtsaRecall =>
+            Boolean(item) && typeof item === "object" && !Array.isArray(item),
+        )
+        .slice(0, MAX_RESULTS);
+    } catch (error) {
+      if (isAbortError(error)) {
+        lastError = new NhtsaRecallFetchError(
+          "timeout",
+          "NHTSA recall lookup timed out.",
+          true,
+        );
+      } else if (error instanceof NhtsaRecallFetchError) {
+        lastError = error;
+      } else {
+        lastError = new NhtsaRecallFetchError(
+          "upstream",
+          "NHTSA recall lookup failed.",
+          true,
+        );
+      }
+
+      if (attempt < MAX_ATTEMPTS && lastError.retryable) {
+        await sleep(150 * attempt);
+        continue;
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  throw (
+    lastError ??
+    new NhtsaRecallFetchError("upstream", "NHTSA recall lookup failed.", false)
+  );
+}
+
+export function toVehicleRecallRows(
+  recalls: NhtsaRecall[],
+  vehicle: VehicleRecallScope,
+): RecallInsert[] {
+  const unique = new Map<string, RecallInsert>();
+
+  for (const recall of recalls) {
+    const campaign = campaignNumber(recall);
+    if (!campaign) continue;
+
+    unique.set(campaign, {
+      campaign_number: campaign,
+      component: text(recall.Component),
+      consequence: text(recall.Consequence ?? recall.Conequence),
+      make: vehicle.make,
+      manufacturer: text(recall.Manufacturer, 255),
+      model: vehicle.model,
+      model_year: String(vehicle.year),
+      nhtsa_campaign: campaign,
+      notes: text(recall.Notes),
+      remedy: text(recall.Remedy),
+      report_date: text(recall.ReportReceivedDate ?? recall.ReportDate, 64),
+      shop_id: vehicle.shopId,
+      summary: text(recall.Summary),
+      user_id: vehicle.actorId,
+      vehicle_id: vehicle.vehicleId,
+      vin: vehicle.vin,
+    });
+  }
+
+  return [...unique.values()];
+}

--- a/features/vehicles/server/recallFetch.ts
+++ b/features/vehicles/server/recallFetch.ts
@@ -160,6 +160,8 @@ export async function fetchNhtsaRecalls(
         await sleep(150 * attempt);
         continue;
       }
+
+      throw lastError;
     } finally {
       clearTimeout(timeout);
     }

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -29,6 +29,7 @@ import type {
 import { normalizeCustomerForIntake } from "@/features/inspections/lib/customerNormalization";
 import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
+import { requestVehicleRecallEnrichment } from "@/features/vehicles/lib/requestRecallEnrichment";
 
 // 👇 inspection modal, client-only
 const InspectionModal = dynamic(
@@ -1414,6 +1415,7 @@ useEffect(() => {
       const hadExplicitVehicleId = Boolean(vehicleId);
       const cust = await ensureCustomer(shopId);
       const veh = await ensureVehicleRow(cust, shopId);
+      void requestVehicleRecallEnrichment(veh.id);
       const persistedCustomer = hydrateCustomerFromRow(cust);
       const persistedVehicle = hydrateVehicleFromRow(veh);
 

--- a/supabase/migrations/20260725155117_harden_p0_004_vehicle_recall_fetch.sql
+++ b/supabase/migrations/20260725155117_harden_p0_004_vehicle_recall_fetch.sql
@@ -1,0 +1,202 @@
+begin;
+
+-- A VIN may legitimately exist in more than one tenant (for example after an
+-- ownership transfer). Canonical recall identity is the tenant vehicle plus
+-- the NHTSA campaign, never a globally shared VIN.
+do $migration$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.vehicles'::regclass
+      and conname = 'vehicles_id_shop_id_key'
+  ) then
+    alter table public.vehicles
+      add constraint vehicles_id_shop_id_key unique (id, shop_id);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.vehicle_recalls'::regclass
+      and conname = 'vehicle_recalls_shop_vehicle_campaign_key'
+  ) then
+    alter table public.vehicle_recalls
+      add constraint vehicle_recalls_shop_vehicle_campaign_key
+      unique (shop_id, vehicle_id, campaign_number);
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.vehicle_recalls'::regclass
+      and conname = 'vehicle_recalls_vehicle_shop_fkey'
+  ) then
+    alter table public.vehicle_recalls
+      add constraint vehicle_recalls_vehicle_shop_fkey
+      foreign key (vehicle_id, shop_id)
+      references public.vehicles (id, shop_id)
+      on delete cascade
+      not valid;
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.vehicle_recalls'::regclass
+      and conname = 'vehicle_recalls_vin_format_check'
+  ) then
+    alter table public.vehicle_recalls
+      add constraint vehicle_recalls_vin_format_check
+      check (vin ~ '^[A-HJ-NPR-Z0-9]{17}$')
+      not valid;
+  end if;
+end
+$migration$;
+
+drop index if exists public.vehicle_recalls_vin_campaign_idx;
+
+create table if not exists public.vehicle_recall_fetch_limits (
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  scope text not null check (scope in ('actor', 'vehicle')),
+  subject_id uuid not null,
+  window_started_at timestamptz not null default clock_timestamp(),
+  request_count integer not null default 0 check (request_count >= 0),
+  updated_at timestamptz not null default clock_timestamp(),
+  primary key (shop_id, scope, subject_id)
+);
+
+alter table public.vehicle_recall_fetch_limits enable row level security;
+alter table public.vehicle_recall_fetch_limits force row level security;
+
+revoke all on table public.vehicle_recall_fetch_limits from public, anon, authenticated;
+grant all on table public.vehicle_recall_fetch_limits to service_role;
+
+create or replace function public.consume_vehicle_recall_fetch_quota(
+  p_shop_id uuid,
+  p_actor_id uuid,
+  p_vehicle_id uuid
+)
+returns table (
+  allowed boolean,
+  retry_after_seconds integer
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $function$
+declare
+  v_now timestamptz := clock_timestamp();
+  v_actor_started timestamptz;
+  v_actor_count integer;
+  v_vehicle_started timestamptz;
+  v_vehicle_count integer;
+  v_retry integer;
+begin
+  if p_shop_id is null or p_actor_id is null or p_vehicle_id is null then
+    raise exception 'recall quota scope is required' using errcode = '22023';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles p
+    where p.id = p_actor_id
+      and p.shop_id = p_shop_id
+  ) then
+    raise exception 'recall quota actor is outside shop scope' using errcode = '42501';
+  end if;
+
+  if not exists (
+    select 1
+    from public.vehicles v
+    where v.id = p_vehicle_id
+      and v.shop_id = p_shop_id
+  ) then
+    raise exception 'recall quota vehicle is outside shop scope' using errcode = '42501';
+  end if;
+
+  insert into public.vehicle_recall_fetch_limits (shop_id, scope, subject_id)
+  values
+    (p_shop_id, 'actor', p_actor_id),
+    (p_shop_id, 'vehicle', p_vehicle_id)
+  on conflict (shop_id, scope, subject_id) do nothing;
+
+  select window_started_at, request_count
+  into v_actor_started, v_actor_count
+  from public.vehicle_recall_fetch_limits
+  where shop_id = p_shop_id
+    and scope = 'actor'
+    and subject_id = p_actor_id
+  for update;
+
+  select window_started_at, request_count
+  into v_vehicle_started, v_vehicle_count
+  from public.vehicle_recall_fetch_limits
+  where shop_id = p_shop_id
+    and scope = 'vehicle'
+    and subject_id = p_vehicle_id
+  for update;
+
+  if v_actor_started + interval '1 hour' <= v_now then
+    v_actor_started := v_now;
+    v_actor_count := 0;
+    update public.vehicle_recall_fetch_limits
+    set window_started_at = v_now,
+        request_count = 0,
+        updated_at = v_now
+    where shop_id = p_shop_id
+      and scope = 'actor'
+      and subject_id = p_actor_id;
+  end if;
+
+  if v_vehicle_started + interval '1 hour' <= v_now then
+    v_vehicle_started := v_now;
+    v_vehicle_count := 0;
+    update public.vehicle_recall_fetch_limits
+    set window_started_at = v_now,
+        request_count = 0,
+        updated_at = v_now
+    where shop_id = p_shop_id
+      and scope = 'vehicle'
+      and subject_id = p_vehicle_id;
+  end if;
+
+  if v_actor_count >= 120 or v_vehicle_count >= 12 then
+    v_retry := greatest(
+      case
+        when v_actor_count >= 120 then
+          ceil(extract(epoch from (v_actor_started + interval '1 hour' - v_now)))::integer
+        else 0
+      end,
+      case
+        when v_vehicle_count >= 12 then
+          ceil(extract(epoch from (v_vehicle_started + interval '1 hour' - v_now)))::integer
+        else 0
+      end,
+      1
+    );
+    return query select false, v_retry;
+    return;
+  end if;
+
+  update public.vehicle_recall_fetch_limits
+  set request_count = request_count + 1,
+      updated_at = v_now
+  where shop_id = p_shop_id
+    and (
+      (scope = 'actor' and subject_id = p_actor_id)
+      or (scope = 'vehicle' and subject_id = p_vehicle_id)
+    );
+
+  return query select true, 0;
+end
+$function$;
+
+alter function public.consume_vehicle_recall_fetch_quota(uuid, uuid, uuid)
+  owner to postgres;
+revoke all on function public.consume_vehicle_recall_fetch_quota(uuid, uuid, uuid)
+  from public, anon, authenticated;
+grant execute on function public.consume_vehicle_recall_fetch_quota(uuid, uuid, uuid)
+  to service_role;
+
+commit;

--- a/tests/security/p0-004-vehicle-recall-fetch.runtime.sql
+++ b/tests/security/p0-004-vehicle-recall-fetch.runtime.sql
@@ -1,0 +1,212 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+do $$
+begin
+  if has_function_privilege(
+    'anon',
+    'public.consume_vehicle_recall_fetch_quota(uuid,uuid,uuid)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'public.consume_vehicle_recall_fetch_quota(uuid,uuid,uuid)',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'service_role',
+    'public.consume_vehicle_recall_fetch_quota(uuid,uuid,uuid)',
+    'EXECUTE'
+  ) then
+    raise exception 'P0-004 runtime assertion failed: recall quota ACL is unsafe';
+  end if;
+
+  if has_table_privilege(
+    'anon',
+    'public.vehicle_recall_fetch_limits',
+    'SELECT'
+  )
+  or has_table_privilege(
+    'authenticated',
+    'public.vehicle_recall_fetch_limits',
+    'SELECT'
+  ) then
+    raise exception 'P0-004 runtime assertion failed: recall quota table is exposed';
+  end if;
+end
+$$;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  (
+    '44000000-0000-4000-8000-000000000001',
+    'p0-004-owner-a@example.com',
+    '{"full_name":"P0-004 Owner A"}'::jsonb
+  ),
+  (
+    '45000000-0000-4000-8000-000000000002',
+    'p0-004-owner-b@example.com',
+    '{"full_name":"P0-004 Owner B"}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values
+  (
+    '44000000-0000-4000-8000-000000000001',
+    '44000000-0000-4000-8000-000000000001',
+    'owner',
+    'P0-004 Owner A'
+  ),
+  (
+    '45000000-0000-4000-8000-000000000002',
+    '45000000-0000-4000-8000-000000000002',
+    'owner',
+    'P0-004 Owner B'
+  )
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+insert into public.shops (id, owner_id, business_name, name, user_limit)
+values
+  (
+    'a4100000-0000-4000-8000-000000000001',
+    '44000000-0000-4000-8000-000000000001',
+    'P0-004 Shop A',
+    'P0-004 Shop A',
+    3
+  ),
+  (
+    'b4200000-0000-4000-8000-000000000002',
+    '45000000-0000-4000-8000-000000000002',
+    'P0-004 Shop B',
+    'P0-004 Shop B',
+    3
+  )
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = case id
+  when '44000000-0000-4000-8000-000000000001'::uuid
+    then 'a4100000-0000-4000-8000-000000000001'::uuid
+  else 'b4200000-0000-4000-8000-000000000002'::uuid
+end
+where id in (
+  '44000000-0000-4000-8000-000000000001',
+  '45000000-0000-4000-8000-000000000002'
+);
+
+insert into public.vehicles (id, shop_id, user_id, vin, year, make, model)
+values
+  (
+    'a4300000-0000-4000-8000-000000000001',
+    'a4100000-0000-4000-8000-000000000001',
+    '44000000-0000-4000-8000-000000000001',
+    '1HGCM82633A004352',
+    2003,
+    'Honda',
+    'Accord'
+  ),
+  (
+    'b4400000-0000-4000-8000-000000000002',
+    'b4200000-0000-4000-8000-000000000002',
+    '45000000-0000-4000-8000-000000000002',
+    '1HGCM82633A004352',
+    2003,
+    'Honda',
+    'Accord'
+  );
+
+-- The same VIN/campaign may exist in separate tenant vehicle records.
+insert into public.vehicle_recalls (
+  shop_id,
+  vehicle_id,
+  user_id,
+  vin,
+  campaign_number
+)
+values
+  (
+    'a4100000-0000-4000-8000-000000000001',
+    'a4300000-0000-4000-8000-000000000001',
+    '44000000-0000-4000-8000-000000000001',
+    '1HGCM82633A004352',
+    '24V001000'
+  ),
+  (
+    'b4200000-0000-4000-8000-000000000002',
+    'b4400000-0000-4000-8000-000000000002',
+    '45000000-0000-4000-8000-000000000002',
+    '1HGCM82633A004352',
+    '24V001000'
+  );
+
+do $$
+begin
+  begin
+    insert into public.vehicle_recalls (
+      shop_id,
+      vehicle_id,
+      user_id,
+      vin,
+      campaign_number
+    ) values (
+      'b4200000-0000-4000-8000-000000000002',
+      'a4300000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000002',
+      '1HGCM82633A004352',
+      '24V002000'
+    );
+    raise exception 'P0-004 runtime assertion failed: mismatched vehicle/shop was accepted';
+  exception
+    when foreign_key_violation then null;
+  end;
+end
+$$;
+
+set local role service_role;
+
+do $$
+declare
+  v_attempt integer;
+  v_allowed_count integer;
+  v_allowed boolean;
+  v_retry integer;
+begin
+  v_allowed_count := 0;
+  for v_attempt in 1..12 loop
+    select allowed
+    into v_allowed
+    from public.consume_vehicle_recall_fetch_quota(
+      'a4100000-0000-4000-8000-000000000001',
+      '44000000-0000-4000-8000-000000000001',
+      'a4300000-0000-4000-8000-000000000001'
+    );
+    if v_allowed then
+      v_allowed_count := v_allowed_count + 1;
+    end if;
+  end loop;
+
+  if v_allowed_count <> 12 then
+    raise exception 'P0-004 runtime assertion failed: valid quota calls were denied';
+  end if;
+
+  select allowed, retry_after_seconds
+  into v_allowed, v_retry
+  from public.consume_vehicle_recall_fetch_quota(
+    'a4100000-0000-4000-8000-000000000001',
+    '44000000-0000-4000-8000-000000000001',
+    'a4300000-0000-4000-8000-000000000001'
+  );
+
+  if v_allowed or v_retry < 1 then
+    raise exception 'P0-004 runtime assertion failed: vehicle quota was not enforced';
+  end if;
+end
+$$;
+
+reset role;
+rollback;

--- a/tests/vehicle-recall-fetch-security.test.ts
+++ b/tests/vehicle-recall-fetch-security.test.ts
@@ -111,7 +111,7 @@ describe("POST /api/recalls/fetch tenant boundary", () => {
       ok: false,
       response: Response.json({ error: "Not authenticated" }, { status: 401 }),
     });
-    const { POST } = await import("@/app/api/recalls/fetch/route");
+    const { POST } = await import("../app/api/recalls/fetch/route");
 
     const response = await POST(request({ vehicleId: VEHICLE_ID }));
 
@@ -122,7 +122,7 @@ describe("POST /api/recalls/fetch tenant boundary", () => {
 
   it("returns not found for a vehicle outside the actor shop", async () => {
     mocks.vehicleMaybeSingle.mockResolvedValue({ data: null, error: null });
-    const { POST } = await import("@/app/api/recalls/fetch/route");
+    const { POST } = await import("../app/api/recalls/fetch/route");
 
     const response = await POST(request({ vehicleId: VEHICLE_ID }));
 
@@ -134,7 +134,7 @@ describe("POST /api/recalls/fetch tenant boundary", () => {
   });
 
   it("rejects a malformed vehicle id", async () => {
-    const { POST } = await import("@/app/api/recalls/fetch/route");
+    const { POST } = await import("../app/api/recalls/fetch/route");
 
     const response = await POST(request({ vehicleId: "not-a-uuid" }));
 
@@ -155,7 +155,7 @@ describe("POST /api/recalls/fetch tenant boundary", () => {
       },
       error: null,
     });
-    const { POST } = await import("@/app/api/recalls/fetch/route");
+    const { POST } = await import("../app/api/recalls/fetch/route");
 
     const response = await POST(request({ vehicleId: VEHICLE_ID }));
 
@@ -165,7 +165,7 @@ describe("POST /api/recalls/fetch tenant boundary", () => {
   });
 
   it("ignores forged identity and vehicle fields and writes only server-derived scope", async () => {
-    const { POST } = await import("@/app/api/recalls/fetch/route");
+    const { POST } = await import("../app/api/recalls/fetch/route");
 
     const response = await POST(
       request({
@@ -204,7 +204,7 @@ describe("POST /api/recalls/fetch tenant boundary", () => {
       data: [{ allowed: false, retry_after_seconds: 37 }],
       error: null,
     });
-    const { POST } = await import("@/app/api/recalls/fetch/route");
+    const { POST } = await import("../app/api/recalls/fetch/route");
 
     const response = await POST(request({ vehicleId: VEHICLE_ID }));
 
@@ -215,7 +215,7 @@ describe("POST /api/recalls/fetch tenant boundary", () => {
   });
 
   it("uses a stable tenant-safe conflict key on repeated requests", async () => {
-    const { POST } = await import("@/app/api/recalls/fetch/route");
+    const { POST } = await import("../app/api/recalls/fetch/route");
 
     const first = await POST(request({ vehicleId: VEHICLE_ID }));
     const second = await POST(request({ vehicleId: VEHICLE_ID }));

--- a/tests/vehicle-recall-fetch-security.test.ts
+++ b/tests/vehicle-recall-fetch-security.test.ts
@@ -1,0 +1,333 @@
+import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchNhtsaRecalls,
+  toVehicleRecallRows,
+} from "@/features/vehicles/server/recallFetch";
+import { requestVehicleRecallEnrichment } from "@/features/vehicles/lib/requestRecallEnrichment";
+
+const ACTOR_ID = "44000000-0000-4000-8000-000000000001";
+const SHOP_ID = "a4100000-0000-4000-8000-000000000001";
+const VEHICLE_ID = "a4300000-0000-4000-8000-000000000001";
+
+const mocks = vi.hoisted(() => ({
+  requireAccess: vi.fn(),
+  createAdmin: vi.fn(),
+  vehicleEq: vi.fn(),
+  vehicleMaybeSingle: vi.fn(),
+  rpc: vi.fn(),
+  upsert: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireAccess,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: mocks.createAdmin,
+}));
+
+function vehicleQuery() {
+  const query = {
+    select: vi.fn(),
+    eq: mocks.vehicleEq,
+    maybeSingle: mocks.vehicleMaybeSingle,
+  };
+  query.select.mockReturnValue(query);
+  query.eq.mockReturnValue(query);
+  return query;
+}
+
+function request(body: Record<string, unknown>): Request {
+  return new Request("https://profixiq.test/api/recalls/fetch", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function nhtsaResponse(status = 200): Response {
+  return new Response(
+    JSON.stringify({
+      results: [
+        {
+          NHTSACampaignNumber: "24V001000",
+          Component: "AIR BAGS",
+          Summary: "A test recall summary",
+          Consequence: "A test consequence",
+          Remedy: "A test remedy",
+          Manufacturer: "Honda",
+          ReportReceivedDate: "01/10/2024",
+        },
+      ],
+    }),
+    { status, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+describe("POST /api/recalls/fetch tenant boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const scopedVehicleQuery = vehicleQuery();
+    mocks.requireAccess.mockResolvedValue({
+      ok: true,
+      profile: { id: ACTOR_ID, shop_id: SHOP_ID, role: "owner" },
+      canonicalRole: "owner",
+      supabase: { from: vi.fn(() => scopedVehicleQuery) },
+    });
+    mocks.vehicleMaybeSingle.mockResolvedValue({
+      data: {
+        id: VEHICLE_ID,
+        shop_id: SHOP_ID,
+        vin: "1HGCM82633A004352",
+        year: 2003,
+        make: "Honda",
+        model: "Accord",
+      },
+      error: null,
+    });
+    mocks.rpc.mockResolvedValue({
+      data: [{ allowed: true, retry_after_seconds: 0 }],
+      error: null,
+    });
+    mocks.upsert.mockResolvedValue({ error: null });
+    mocks.createAdmin.mockReturnValue({
+      rpc: mocks.rpc,
+      from: vi.fn(() => ({ upsert: mocks.upsert })),
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => nhtsaResponse()));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects an anonymous caller before privileged access", async () => {
+    mocks.requireAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Not authenticated" }, { status: 401 }),
+    });
+    const { POST } = await import("@/app/api/recalls/fetch/route");
+
+    const response = await POST(request({ vehicleId: VEHICLE_ID }));
+
+    expect(response.status).toBe(401);
+    expect(mocks.createAdmin).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns not found for a vehicle outside the actor shop", async () => {
+    mocks.vehicleMaybeSingle.mockResolvedValue({ data: null, error: null });
+    const { POST } = await import("@/app/api/recalls/fetch/route");
+
+    const response = await POST(request({ vehicleId: VEHICLE_ID }));
+
+    expect(response.status).toBe(404);
+    expect(mocks.vehicleEq).toHaveBeenCalledWith("id", VEHICLE_ID);
+    expect(mocks.vehicleEq).toHaveBeenCalledWith("shop_id", SHOP_ID);
+    expect(mocks.createAdmin).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed vehicle id", async () => {
+    const { POST } = await import("@/app/api/recalls/fetch/route");
+
+    const response = await POST(request({ vehicleId: "not-a-uuid" }));
+
+    expect(response.status).toBe(400);
+    expect(mocks.vehicleMaybeSingle).not.toHaveBeenCalled();
+    expect(mocks.createAdmin).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid saved VIN before privileged access", async () => {
+    mocks.vehicleMaybeSingle.mockResolvedValue({
+      data: {
+        id: VEHICLE_ID,
+        shop_id: SHOP_ID,
+        vin: "INVALID",
+        year: 2003,
+        make: "Honda",
+        model: "Accord",
+      },
+      error: null,
+    });
+    const { POST } = await import("@/app/api/recalls/fetch/route");
+
+    const response = await POST(request({ vehicleId: VEHICLE_ID }));
+
+    expect(response.status).toBe(422);
+    expect(mocks.createAdmin).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores forged identity and vehicle fields and writes only server-derived scope", async () => {
+    const { POST } = await import("@/app/api/recalls/fetch/route");
+
+    const response = await POST(
+      request({
+        vehicleId: VEHICLE_ID,
+        user_id: "45000000-0000-4000-8000-000000000002",
+        shop_id: "b4200000-0000-4000-8000-000000000002",
+        vin: "1FD0W5HT4FED33898",
+        year: 2024,
+        make: "Forged",
+        model: "Vehicle",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.rpc).toHaveBeenCalledWith("consume_vehicle_recall_fetch_quota", {
+      p_actor_id: ACTOR_ID,
+      p_shop_id: SHOP_ID,
+      p_vehicle_id: VEHICLE_ID,
+    });
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          campaign_number: "24V001000",
+          shop_id: SHOP_ID,
+          user_id: ACTOR_ID,
+          vehicle_id: VEHICLE_ID,
+          vin: "1HGCM82633A004352",
+        }),
+      ],
+      { onConflict: "shop_id,vehicle_id,campaign_number" },
+    );
+  });
+
+  it("enforces the distributed quota before calling NHTSA", async () => {
+    mocks.rpc.mockResolvedValue({
+      data: [{ allowed: false, retry_after_seconds: 37 }],
+      error: null,
+    });
+    const { POST } = await import("@/app/api/recalls/fetch/route");
+
+    const response = await POST(request({ vehicleId: VEHICLE_ID }));
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("37");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it("uses a stable tenant-safe conflict key on repeated requests", async () => {
+    const { POST } = await import("@/app/api/recalls/fetch/route");
+
+    const first = await POST(request({ vehicleId: VEHICLE_ID }));
+    const second = await POST(request({ vehicleId: VEHICLE_ID }));
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(mocks.upsert).toHaveBeenCalledTimes(2);
+    expect(mocks.upsert.mock.calls[0]).toEqual(mocks.upsert.mock.calls[1]);
+  });
+});
+
+describe("NHTSA recall fetch resilience", () => {
+  it("retries a retryable response once and then succeeds", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+      .mockResolvedValueOnce(nhtsaResponse());
+    const sleep = vi.fn(async () => undefined);
+
+    const recalls = await fetchNhtsaRecalls(
+      { year: 2003, make: "Honda", model: "Accord" },
+      { fetcher, sleep },
+    );
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(recalls).toHaveLength(1);
+  });
+
+  it("does not retry a non-retryable provider error", async () => {
+    const fetcher = vi.fn(async () => new Response("bad request", { status: 400 }));
+
+    await expect(
+      fetchNhtsaRecalls(
+        { year: 2003, make: "Honda", model: "Accord" },
+        { fetcher, sleep: vi.fn(async () => undefined) },
+      ),
+    ).rejects.toMatchObject({ kind: "upstream" });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds timeout retries to two attempts", async () => {
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+    const fetcher = vi.fn(async () => {
+      throw abortError;
+    });
+
+    await expect(
+      fetchNhtsaRecalls(
+        { year: 2003, make: "Honda", model: "Accord" },
+        { fetcher, sleep: vi.fn(async () => undefined), timeoutMs: 1 },
+      ),
+    ).rejects.toMatchObject({ kind: "timeout" });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates campaign rows and skips records without a campaign number", () => {
+    const rows = toVehicleRecallRows(
+      [
+        { NHTSACampaignNumber: "24V001000", Summary: "old" },
+        { NHTSACampaignNumber: "24v001000", Summary: "new" },
+        { Summary: "missing campaign" },
+      ],
+      {
+        actorId: ACTOR_ID,
+        shopId: SHOP_ID,
+        vehicleId: VEHICLE_ID,
+        vin: "1HGCM82633A004352",
+        year: 2003,
+        make: "Honda",
+        model: "Accord",
+      },
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      campaign_number: "24V001000",
+      summary: "new",
+      shop_id: SHOP_ID,
+      vehicle_id: VEHICLE_ID,
+    });
+  });
+});
+
+describe("saved vehicle recall trigger", () => {
+  it("sends only the saved vehicle id", async () => {
+    const fetcher = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await expect(requestVehicleRecallEnrichment(VEHICLE_ID, fetcher)).resolves.toBe(true);
+
+    expect(fetcher).toHaveBeenCalledWith("/api/recalls/fetch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ vehicleId: VEHICLE_ID }),
+      keepalive: true,
+    });
+  });
+
+  it("queues enrichment only after desktop or mobile persistence", () => {
+    const modalSource = readFileSync("app/vehicle/VinCaptureModal.tsx", "utf8");
+    const desktopSource = readFileSync(
+      "features/work-orders/app/work-orders/create/page.tsx",
+      "utf8",
+    );
+    const mobileSource = readFileSync(
+      "app/mobile/work-orders/create/page.tsx",
+      "utf8",
+    );
+
+    expect(modalSource).not.toContain('/api/recalls/fetch');
+    expect(desktopSource).toContain("requestVehicleRecallEnrichment(veh.id)");
+    expect(mobileSource).toContain("requestVehicleRecallEnrichment(veh.id)");
+  });
+});

--- a/tsconfig.p0-004.json
+++ b/tsconfig.p0-004.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "include": [
+    "next-env.d.ts",
+    "app/api/recalls/fetch/route.ts",
+    "app/vehicle/VinCaptureModal.tsx",
+    "features/vehicles/lib/requestRecallEnrichment.ts",
+    "features/vehicles/server/recallFetch.ts",
+    "features/work-orders/app/work-orders/create/page.tsx",
+    "app/mobile/work-orders/create/page.tsx",
+    "app/agent/planner/page.tsx",
+    "tests/vehicle-recall-fetch-security.test.ts"
+  ]
+}


### PR DESCRIPTION
## What changed

- require an authenticated work-order-capable shop actor before recall fetching
- accept only a persisted `vehicleId`, then derive VIN, year, make, model, actor, and shop server-side
- move recall enrichment from VIN decoding to the post-save desktop/mobile vehicle flow
- replace global VIN/campaign identity with tenant vehicle/campaign identity
- add a composite vehicle/shop database boundary and strict VIN constraint for new recall writes
- add an atomic service-role-only Postgres quota for actor and vehicle recall lookups
- add bounded NHTSA timeouts/retries, response limits, generic failure responses, and structured diagnostics
- add focused route/unit tests plus a clean Supabase runtime integration and CI gate

## Why

P0-004 allowed anonymous callers to invoke a service-role route, forge `user_id`, and overwrite a recall row owned by another tenant through the global `(vin, campaign_number)` conflict key. The request also ran before a vehicle record existed, so tenant ownership could not be proven.

## Impact

Vehicle intake remains non-blocking. Recall enrichment now begins only after the vehicle is persisted. Repeated requests are idempotent within `(shop_id, vehicle_id, campaign_number)` and NHTSA calls are rate-limited across serverless instances.

## Validation

Local:
- `git diff --check`
- unique migration-version inspection
- Node 24 TypeScript syntax checks for the changed non-TSX files
- focused React hooks/performance regression review

CI added:
- scoped TypeScript and ESLint validation
- `tests/vehicle-recall-fetch-security.test.ts`
- full Supabase migration replay
- `tests/security/p0-004-vehicle-recall-fetch.runtime.sql`

Local dependency-backed type/lint/Vitest and Postgres execution were unavailable because the interrupted local package install did not link executables; the PR checks are the authoritative clean validation.