### PR TITLE
Harden P0-005 AI route authorization and spend controls

### DIFF
--- a/.github/workflows/p0-005-ai-route-validation.yml
+++ b/.github/workflows/p0-005-ai-route-validation.yml
@@ -1,0 +1,48 @@
+name: P0-005 AI Route Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/ai/interpret/**"
+      - "app/api/dtc-suggest/**"
+      - "app/api/work-orders/dtc-suggest/**"
+      - "features/shared/lib/server/ai-ops-guard.ts"
+      - "features/shared/lib/server/ai-policy.ts"
+      - "features/shared/lib/server/bounded-json.ts"
+      - "features/shared/lib/server/durable-ai-guard.ts"
+      - "features/shared/lib/server/provider-timeout.ts"
+      - "features/shared/types/types/supabase.ts"
+      - "tests/p0-005-ai-route-security.test.ts"
+      - "tsconfig.p0-005.json"
+      - ".github/workflows/p0-005-ai-route-validation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec tsc --noEmit -p tsconfig.p0-005.json
+      - run: >-
+          pnpm exec eslint
+          app/api/ai/interpret/route.ts
+          app/api/dtc-suggest/route.ts
+          app/api/work-orders/dtc-suggest/route.ts
+          features/shared/lib/server/ai-ops-guard.ts
+          features/shared/lib/server/ai-policy.ts
+          features/shared/lib/server/bounded-json.ts
+          features/shared/lib/server/durable-ai-guard.ts
+          features/shared/lib/server/provider-timeout.ts
+          tests/p0-005-ai-route-security.test.ts
+      - run: pnpm exec vitest run tests/p0-005-ai-route-security.test.ts

--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -167,6 +167,20 @@ jobs:
             -f tests/security/p0-004-vehicle-recall-fetch.runtime.sql \
             2>&1 | tee p0-004-vehicle-recall-fetch-runtime.log
 
+      - name: Execute P0 AI route governance integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/p0-005-ai-route-governance.runtime.sql \
+            2>&1 | tee p0-005-ai-route-governance-runtime.log
+
       - name: Verify bootstrap and existing-database baseline paths
         shell: bash
         env:
@@ -232,6 +246,7 @@ jobs:
             p0-002-rpc-privileges-runtime.log
             p0-002-stock-move-signature-compat-runtime.log
             p0-004-vehicle-recall-fetch-runtime.log
+            p0-005-ai-route-governance-runtime.log
             supabase/config.toml
           if-no-files-found: warn
 

--- a/app/api/ai/interpret/route.ts
+++ b/app/api/ai/interpret/route.ts
@@ -1,11 +1,37 @@
-// /app/api/ai/interpret/route.ts (FULL FILE REPLACEMENT)
 import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { readBoundedJson } from "@/features/shared/lib/server/bounded-json";
+import {
+  claimDurableAIRouteQuota,
+  completeDurableAIRouteQuota,
+} from "@/features/shared/lib/server/durable-ai-guard";
+import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
+import { estimateAICostUsd, registerAIUsageEvent } from "@/features/shared/lib/server/ai-ops-guard";
+import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
 import { getOpenAIClient } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
+import { runWithProviderTimeout } from "@/features/shared/lib/server/provider-timeout";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
 export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
-const openai = getOpenAIClient();
+const FEATURE = "inspection_interpret" as const;
+const ENDPOINT = "/api/ai/interpret";
+const REQUEST_MAX_BYTES = 64 * 1024;
+
+const contextSchema = z.object({
+  sectionTitle: z.string().trim().max(160).optional(),
+  sectionTitles: z.array(z.string().trim().min(1).max(160)).max(64).optional(),
+  items: z.array(z.string().trim().min(1).max(200)).max(300).optional(),
+});
+
+const requestSchema = z.object({
+  transcript: z.string().trim().min(1).max(4000),
+  context: contextSchema.nullish(),
+  mode: z.enum(["open", "strict_context"]).optional().default("open"),
+});
 
 type CommandStatus = "ok" | "fail" | "na" | "recommend";
 type InterpretMode = "open" | "strict_context";
@@ -114,38 +140,17 @@ function isRecord(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null;
 }
 
-function getString(o: Record<string, unknown>, key: string): string | undefined {
-  const v = o[key];
-  return typeof v === "string" ? v : undefined;
-}
-
-function getStringArray(o: Record<string, unknown>, key: string): string[] | undefined {
-  const v = o[key];
-  if (!Array.isArray(v)) return undefined;
-  const out: string[] = [];
-  for (const it of v) {
-    if (typeof it === "string") out.push(it);
-  }
-  return out;
-}
-
 function safeJsonParseArray(input: string): VoiceCommand[] {
   try {
     const parsed: unknown = JSON.parse(input);
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter((x): x is VoiceCommand => {
+    return parsed.slice(0, 50).filter((x): x is VoiceCommand => {
       if (!isRecord(x)) return false;
       return typeof x.command === "string";
     });
   } catch {
     return [];
   }
-}
-
-function isBodyShape(
-  x: unknown,
-): x is { transcript?: unknown; context?: unknown; mode?: unknown } {
-  return isRecord(x);
 }
 
 function findExactAllowedItem(allowed: string[], candidate: string): string | null {
@@ -273,37 +278,34 @@ function findBestAllowedItem(allowed: string[], candidate: string): string | nul
 /* ------------------------------------------------------------------------------------------------- */
 
 export async function POST(req: Request) {
+  const startedAt = Date.now();
   try {
-    const rawBody: unknown = await req.json().catch(() => null);
-    const body = isBodyShape(rawBody)
-      ? (rawBody as { transcript?: unknown; context?: unknown; mode?: unknown })
-      : null;
+    const access = await requireShopScopedApiAccess({
+      requiredCapability: "canRunInspections",
+    });
+    if (!access.ok) return access.response;
 
-    const transcript = norm(body?.transcript);
-    if (!transcript) return NextResponse.json([]);
+    const boundedBody = await readBoundedJson(req, REQUEST_MAX_BYTES);
+    if (!boundedBody.ok) {
+      return NextResponse.json([], {
+        status: boundedBody.reason === "too_large" ? 413 : 400,
+        headers: { "Cache-Control": "no-store" },
+      });
+    }
 
-    const mode = parseInterpretMode(body?.mode);
+    const parsedBody = requestSchema.safeParse(boundedBody.value);
+    if (!parsedBody.success) {
+      return NextResponse.json([], {
+        status: 400,
+        headers: { "Cache-Control": "no-store" },
+      });
+    }
+
+    const transcript = norm(parsedBody.data.transcript);
+    const mode = parseInterpretMode(parsedBody.data.mode);
 
     // ✅ No "any": parse context safely
-    const ctxCandidate: unknown = body?.context ?? null;
-    let ctx: InterpretContext | null = null;
-
-    if (isRecord(ctxCandidate)) {
-      const sectionTitleRaw = getString(ctxCandidate, "sectionTitle");
-      const sectionTitlesRaw = getStringArray(ctxCandidate, "sectionTitles");
-      const itemsRaw = getStringArray(ctxCandidate, "items");
-
-      const sectionTitle = norm(sectionTitleRaw ?? "");
-      const sectionTitles = Array.isArray(sectionTitlesRaw)
-        ? sectionTitlesRaw.map((x) => norm(x)).filter(Boolean)
-        : undefined;
-
-      const items = Array.isArray(itemsRaw)
-        ? itemsRaw.map((x) => norm(x)).filter(Boolean)
-        : undefined;
-
-      ctx = { sectionTitle, sectionTitles, items };
-    }
+    const ctx: InterpretContext | null = parsedBody.data.context ?? null;
 
     const allowedItems = (ctx?.items ?? []).filter(Boolean);
     const hasContext = allowedItems.length > 0;
@@ -376,14 +378,111 @@ Optional section hint (may be empty): ${norm(ctx?.sectionTitle ?? "")}
       .filter(Boolean)
       .join("\n\n");
 
-    const completion = await openai.chat.completions.create({
-      model: getOpenAIModelForPurpose("extraction"),
-      ...openAITemperatureParam(getOpenAIModelForPurpose("extraction"), 0.2),
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: transcript },
-      ],
-    });
+    const admin = createAdminSupabase();
+    let claim: Awaited<ReturnType<typeof claimDurableAIRouteQuota>>;
+    try {
+      claim = await claimDurableAIRouteQuota({
+        admin,
+        actorId: access.profile.id,
+        feature: FEATURE,
+        shopId: access.profile.shop_id,
+      });
+    } catch (error) {
+      console.error("inspection_interpret_quota_failed", {
+        shopId: access.profile.shop_id,
+        error: error instanceof Error ? error.message : "unknown",
+      });
+      return NextResponse.json([], {
+        status: 503,
+        headers: { "Cache-Control": "no-store" },
+      });
+    }
+
+    if (!claim.allowed) {
+      return NextResponse.json([], {
+        status: 429,
+        headers: {
+          "Cache-Control": "no-store",
+          "Retry-After": String(claim.retryAfterSeconds),
+          "X-Profixiq-AI-Limit": claim.reason,
+        },
+      });
+    }
+
+    const policy = getAIPolicy(FEATURE);
+    const model = getOpenAIModelForPurpose(policy.modelPurpose);
+    let completion: Awaited<
+      ReturnType<ReturnType<typeof getOpenAIClient>["chat"]["completions"]["create"]>
+    >;
+    try {
+      const openai = getOpenAIClient();
+      completion = await runWithProviderTimeout(policy.timeoutMs, (signal) =>
+        openai.chat.completions.create(
+          {
+            model,
+            ...openAITemperatureParam(model, 0.2),
+            max_completion_tokens: policy.maxTokens,
+            messages: [
+              { role: "system", content: systemPrompt },
+              { role: "user", content: transcript },
+            ],
+          },
+          { signal },
+        ),
+      );
+    } catch (error) {
+      await completeDurableAIRouteQuota({
+        admin,
+        actorId: access.profile.id,
+        actualCostUsd: 0,
+        feature: FEATURE,
+        receiptId: claim.receiptId,
+        shopId: access.profile.shop_id,
+        succeeded: false,
+      });
+      recordAITelemetry({
+        feature: FEATURE,
+        endpoint: ENDPOINT,
+        shop_id: access.profile.shop_id,
+        user_id: access.profile.id,
+        model,
+        latency_ms: Date.now() - startedAt,
+        prompt_tokens: null,
+        completion_tokens: null,
+        total_tokens: null,
+        estimated_cost_usd: 0,
+        status: "error",
+        error_code: "inspection_interpret_failed",
+      error_message:
+        error instanceof Error && error.message.includes("timed out")
+          ? "provider_timeout"
+          : "provider_error",
+      });
+      registerAIUsageEvent({
+        feature: FEATURE,
+        endpoint: ENDPOINT,
+        shopId: access.profile.shop_id,
+        model,
+        totalTokens: null,
+        estimatedCostUsd: 0,
+        status: "error",
+        errorCode: "inspection_interpret_failed",
+      });
+      console.error("inspection_interpret_provider_failed", {
+        shopId: access.profile.shop_id,
+        kind:
+          error instanceof Error && error.message.includes("timed out")
+            ? "timeout"
+            : "provider",
+      });
+      return NextResponse.json([], {
+        status:
+          error instanceof Error && error.message.includes("timed out")
+            ? 504
+            : 502,
+        headers: { "Cache-Control": "no-store" },
+      });
+    }
 
     const raw = completion.choices[0]?.message?.content?.trim() ?? "[]";
     let commands = safeJsonParseArray(raw).map(normalizeNoteFields);
@@ -414,10 +513,53 @@ Optional section hint (may be empty): ${norm(ctx?.sectionTitle ?? "")}
       commands = filtered;
     }
 
-    return NextResponse.json(commands);
+    const totalTokens = completion.usage?.total_tokens ?? null;
+    const estimatedCostUsd = estimateAICostUsd(FEATURE, totalTokens);
+    await completeDurableAIRouteQuota({
+      admin,
+      actorId: access.profile.id,
+      actualCostUsd: estimatedCostUsd,
+      feature: FEATURE,
+      receiptId: claim.receiptId,
+      shopId: access.profile.shop_id,
+      succeeded: true,
+    });
+    recordAITelemetry({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shop_id: access.profile.shop_id,
+      user_id: access.profile.id,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: completion.usage?.prompt_tokens ?? null,
+      completion_tokens: completion.usage?.completion_tokens ?? null,
+      total_tokens: totalTokens,
+      estimated_cost_usd: estimatedCostUsd,
+      status: "success",
+      error_code: null,
+      error_message: null,
+    });
+    registerAIUsageEvent({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shopId: access.profile.shop_id,
+      model,
+      totalTokens,
+      estimatedCostUsd,
+      status: "success",
+      errorCode: null,
+    });
+
+    return NextResponse.json(commands, {
+      headers: { "Cache-Control": "no-store" },
+    });
   } catch (err: unknown) {
-    // eslint-disable-next-line no-console
-    console.error("[api/ai/interpret] error:", err);
-    return NextResponse.json([]);
+    console.error("inspection_interpret_unexpected", {
+      kind: err instanceof Error ? err.name : "unknown",
+    });
+    return NextResponse.json([], {
+      status: 500,
+      headers: { "Cache-Control": "no-store" },
+    });
   }
 }

--- a/app/api/dtc-suggest/route.ts
+++ b/app/api/dtc-suggest/route.ts
@@ -1,159 +1,274 @@
-// app/api/work-orders/dtc-suggest/route.ts
 import { NextResponse } from "next/server";
-import { openai } from "lib/server/openai";
-import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models"; // adjust path if needed
+import { z } from "zod";
+
+import { ROLE_GROUPS } from "@/features/shared/lib/rbac";
+import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
+import {
+  estimateAICostUsd,
+  registerAIUsageEvent,
+} from "@/features/shared/lib/server/ai-ops-guard";
+import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { readBoundedJson } from "@/features/shared/lib/server/bounded-json";
+import {
+  claimDurableAIRouteQuota,
+  completeDurableAIRouteQuota,
+} from "@/features/shared/lib/server/durable-ai-guard";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
+import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { runWithProviderTimeout } from "@/features/shared/lib/server/provider-timeout";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 
-type DtcSuggestion = {
-  cause?: string;
-  correction?: string;
-  laborTime?: number;
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const FEATURE = "dtc_suggest" as const;
+const ENDPOINT = "/api/dtc-suggest";
+const REQUEST_MAX_BYTES = 8 * 1024;
+const DTC_ALLOWED_ROLES = [...ROLE_GROUPS.workOrderManagers, "mechanic"] as const;
+
+const requestSchema = z.object({
+  jobId: z.string().uuid(),
+});
+
+const suggestionSchema = z.object({
+  cause: z.string().trim().min(1).max(6000),
+  correction: z.string().trim().min(1).max(6000),
+  laborTime: z.number().finite().min(0).max(1000).nullable().optional(),
+});
+
+type VehicleContext = {
+  year: number | null;
+  make: string | null;
+  model: string | null;
 };
 
-export async function POST(req: Request) {
-  try {
-    const { jobId } = (await req.json()) as { jobId?: string };
-    if (!jobId) {
-      return NextResponse.json(
-        { error: "jobId is required" },
-        { status: 400 },
-      );
-    }
+function json(body: Record<string, unknown>, status = 200, headers?: HeadersInit) {
+  return NextResponse.json(body, {
+    status,
+    headers: { "Cache-Control": "no-store", ...headers },
+  });
+}
 
-    const supabase = await createAdminSupabase();
+export async function POST(request: Request): Promise<NextResponse> {
+  const startedAt = Date.now();
+  const access = await requireShopScopedApiAccess({
+    allowRoles: DTC_ALLOWED_ROLES,
+  });
+  if (!access.ok) return access.response;
 
-    // Load job + minimal context
-    const { data: job, error: jobErr } = await supabase
-      .from("work_order_lines")
-      .select("id, complaint, cause, correction, labor_time, work_order_id")
-      .eq("id", jobId)
+  const boundedBody = await readBoundedJson(request, REQUEST_MAX_BYTES);
+  if (!boundedBody.ok) {
+    return json(
+      { error: boundedBody.reason === "too_large" ? "Request is too large." : "A valid jobId is required." },
+      boundedBody.reason === "too_large" ? 413 : 400,
+    );
+  }
+
+  const parsedBody = requestSchema.safeParse(boundedBody.value);
+  if (!parsedBody.success) {
+    return json({ error: "A valid jobId is required." }, 400);
+  }
+
+  const admin = createAdminSupabase();
+  const { data: job, error: jobError } = await admin
+    .from("work_order_lines")
+    .select("id, complaint, cause, correction, labor_time, work_order_id")
+    .eq("id", parsedBody.data.jobId)
+    .maybeSingle();
+
+  if (jobError) {
+    console.error("dtc_suggest_job_lookup_failed", { code: jobError.code });
+    return json({ error: "Unable to load this job." }, 503);
+  }
+  if (!job?.work_order_id) return json({ error: "Job not found." }, 404);
+
+  const { data: workOrder, error: workOrderError } = await admin
+    .from("work_orders")
+    .select("id, vehicle_id")
+    .eq("id", job.work_order_id)
+    .eq("shop_id", access.profile.shop_id)
+    .maybeSingle();
+
+  if (workOrderError) {
+    console.error("dtc_suggest_work_order_lookup_failed", {
+      code: workOrderError.code,
+      shopId: access.profile.shop_id,
+    });
+    return json({ error: "Unable to load this job." }, 503);
+  }
+  if (!workOrder) return json({ error: "Job not found." }, 404);
+
+  let vehicle: VehicleContext | null = null;
+  if (workOrder.vehicle_id) {
+    const { data: vehicleRow, error: vehicleError } = await admin
+      .from("vehicles")
+      .select("year, make, model")
+      .eq("id", workOrder.vehicle_id)
+      .eq("shop_id", access.profile.shop_id)
       .maybeSingle();
 
-    if (jobErr || !job) {
-      return NextResponse.json(
-        { error: "Job not found" },
-        { status: 404 },
-      );
-    }
-
-    let vehicle:
-      | {
-          year?: number | null;
-          make?: string | null;
-          model?: string | null;
-        }
-      | null = null;
-
-    if (job.work_order_id) {
-      const { data: wo } = await supabase
-        .from("work_orders")
-        .select("vehicle_id")
-        .eq("id", job.work_order_id)
-        .maybeSingle();
-
-      if (wo?.vehicle_id) {
-        const { data: v } = await supabase
-          .from("vehicles")
-          .select("year, make, model")
-          .eq("id", wo.vehicle_id)
-          .maybeSingle();
-
-        if (v) {
-          vehicle = {
-            year: v.year ?? null,
-            make: v.make ?? null,
-            model: v.model ?? null,
-          };
-        }
-      }
-    }
-
-    const complaint =
-      job.complaint ||
-      "No explicit complaint recorded – infer from job description and DTC context.";
-
-    // --- OpenAI call with friendly error handling --------------------------
-    let completion;
-    try {
-      completion = await openai.chat.completions.create({
-        model: getOpenAIModelForPurpose("reasoning"),
-        response_format: { type: "json_object" },
-        messages: [
-          {
-            role: "system",
-            content: [
-              "You are an expert automotive diagnostician writing clear, shop-friendly job notes.",
-              "Given a vehicle and complaint, generate:",
-              "- cause: 1–3 sentences describing root cause using DTC-style language when appropriate.",
-              "- correction: 2–6 sentences describing what was/will be done, including key checks and specs (but no torque numbers).",
-              "- laborTime: a reasonable flat-rate style estimate in hours.",
-              "Respond ONLY as JSON with keys: cause, correction, laborTime.",
-            ].join(" "),
-          },
-          {
-            role: "user",
-            content: JSON.stringify({
-              vehicle,
-              complaint,
-              existingCause: job.cause,
-              existingCorrection: job.correction,
-              existingLaborTime: job.labor_time,
-            }),
-          },
-        ],
+    if (vehicleError) {
+      console.error("dtc_suggest_vehicle_lookup_failed", {
+        code: vehicleError.code,
+        shopId: access.profile.shop_id,
       });
-    } catch (err) {
-      console.error("[dtc-suggest] OpenAI error", err);
-      return NextResponse.json(
-        {
-          error:
-            "AI engine error while generating DTC suggestions. Try again or edit manually.",
-        },
-        { status: 500 },
-      );
+      return json({ error: "Unable to load this job." }, 503);
     }
+    vehicle = vehicleRow ?? null;
+  }
 
-    const raw = completion.choices[0]?.message?.content ?? "{}";
-
-    let parsed: DtcSuggestion = {};
-    try {
-      parsed = JSON.parse(raw) as DtcSuggestion;
-    } catch (err) {
-      console.error("[dtc-suggest] JSON parse error", err, "raw:", raw);
-      return NextResponse.json(
-        {
-          error:
-            "AI returned an unexpected format while generating DTC suggestions. Try again or edit manually.",
-        },
-        { status: 500 },
-      );
-    }
-
-    if (!parsed.cause || !parsed.correction) {
-      return NextResponse.json(
-        { error: "Model did not return a valid suggestion." },
-        { status: 500 },
-      );
-    }
-
-    // ✅ This is what the modal uses to auto-populate cause/correction/laborTime
-    return NextResponse.json({
-      suggestion: {
-        cause: parsed.cause,
-        correction: parsed.correction,
-        laborTime:
-          typeof parsed.laborTime === "number" ? parsed.laborTime : null,
-      },
+  let claim: Awaited<ReturnType<typeof claimDurableAIRouteQuota>>;
+  try {
+    claim = await claimDurableAIRouteQuota({
+      admin,
+      actorId: access.profile.id,
+      feature: FEATURE,
+      shopId: access.profile.shop_id,
     });
-  } catch (err) {
-    const error = err instanceof Error ? err : new Error("Unexpected error");
-    console.error("[dtc-suggest] error", error);
-    return NextResponse.json(
+  } catch (error) {
+    console.error("dtc_suggest_quota_failed", {
+      shopId: access.profile.shop_id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return json({ error: "AI suggestions are temporarily unavailable." }, 503);
+  }
+
+  if (!claim.allowed) {
+    return json(
       {
-        error:
-          "Unexpected error while preparing DTC suggestions. Check server logs for details.",
+        error: "AI suggestions are temporarily limited. Please try again later.",
+        code: claim.reason === "hard_budget_exceeded" ? "ai_budget_limit" : "ai_rate_limit",
       },
-      { status: 500 },
+      429,
+      { "Retry-After": String(claim.retryAfterSeconds) },
+    );
+  }
+
+  const policy = getAIPolicy(FEATURE);
+  const model = getOpenAIModelForPurpose(policy.modelPurpose);
+
+  try {
+    const openai = getOpenAIClient();
+    const completion = await runWithProviderTimeout(policy.timeoutMs, (signal) =>
+      openai.chat.completions.create(
+        {
+          model,
+          response_format: { type: "json_object" },
+          max_completion_tokens: policy.maxTokens,
+          messages: [
+            {
+              role: "system",
+              content: [
+                "You are an expert automotive diagnostician writing clear, shop-friendly job notes.",
+                "Generate a concise cause, correction, and reasonable flat-rate labor estimate from only the supplied vehicle and job facts.",
+                "Never invent a completed test, measurement, repair, or verification result.",
+                "Respond only as JSON with keys cause, correction, and laborTime.",
+              ].join(" "),
+            },
+            {
+              role: "user",
+              content: JSON.stringify({
+                vehicle,
+                complaint: job.complaint ?? "No explicit complaint recorded.",
+                existingCause: job.cause,
+                existingCorrection: job.correction,
+                existingLaborTime: job.labor_time,
+              }),
+            },
+          ],
+        },
+        { signal },
+      ),
+    );
+
+    const suggestion = suggestionSchema.parse(
+      JSON.parse(completion.choices[0]?.message?.content ?? "{}") as unknown,
+    );
+    const totalTokens = completion.usage?.total_tokens ?? null;
+    const estimatedCostUsd = estimateAICostUsd(FEATURE, totalTokens);
+
+    await completeDurableAIRouteQuota({
+      admin,
+      actorId: access.profile.id,
+      actualCostUsd: estimatedCostUsd,
+      feature: FEATURE,
+      receiptId: claim.receiptId,
+      shopId: access.profile.shop_id,
+      succeeded: true,
+    });
+    recordAITelemetry({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shop_id: access.profile.shop_id,
+      user_id: access.profile.id,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: completion.usage?.prompt_tokens ?? null,
+      completion_tokens: completion.usage?.completion_tokens ?? null,
+      total_tokens: totalTokens,
+      estimated_cost_usd: estimatedCostUsd,
+      status: "success",
+      error_code: null,
+      error_message: null,
+    });
+    registerAIUsageEvent({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shopId: access.profile.shop_id,
+      model,
+      totalTokens,
+      estimatedCostUsd,
+      status: "success",
+      errorCode: null,
+    });
+
+    return json({ suggestion: { ...suggestion, laborTime: suggestion.laborTime ?? null } });
+  } catch (error) {
+    await completeDurableAIRouteQuota({
+      admin,
+      actorId: access.profile.id,
+      actualCostUsd: 0,
+      feature: FEATURE,
+      receiptId: claim.receiptId,
+      shopId: access.profile.shop_id,
+      succeeded: false,
+    });
+    recordAITelemetry({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shop_id: access.profile.shop_id,
+      user_id: access.profile.id,
+      model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: null,
+      completion_tokens: null,
+      total_tokens: null,
+      estimated_cost_usd: 0,
+      status: "error",
+      error_code: "dtc_suggest_failed",
+      error_message:
+        error instanceof Error && error.message.includes("timed out")
+          ? "provider_timeout"
+          : "provider_error",
+    });
+    registerAIUsageEvent({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shopId: access.profile.shop_id,
+      model,
+      totalTokens: null,
+      estimatedCostUsd: 0,
+      status: "error",
+      errorCode: "dtc_suggest_failed",
+    });
+    console.error("dtc_suggest_provider_failed", {
+      shopId: access.profile.shop_id,
+      kind: error instanceof Error && error.message.includes("timed out") ? "timeout" : "provider",
+    });
+    return json(
+      { error: "AI could not prepare a suggestion. Try again or edit manually." },
+      error instanceof Error && error.message.includes("timed out") ? 504 : 502,
     );
   }
 }

--- a/app/api/work-orders/dtc-suggest/route.ts
+++ b/app/api/work-orders/dtc-suggest/route.ts
@@ -1,11 +1,37 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { openai } from "lib/server/openai";
+import { z } from "zod";
+import { ROLE_GROUPS } from "@/features/shared/lib/rbac";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { readBoundedJson } from "@/features/shared/lib/server/bounded-json";
+import {
+  claimDurableAIRouteQuota,
+  completeDurableAIRouteQuota,
+} from "@/features/shared/lib/server/durable-ai-guard";
+import { getAIPolicy } from "@/features/shared/lib/server/ai-policy";
+import { estimateAICostUsd, registerAIUsageEvent } from "@/features/shared/lib/server/ai-ops-guard";
+import { recordAITelemetry } from "@/features/shared/lib/server/ai-telemetry";
+import { getOpenAIClient } from "@/features/shared/lib/server/openai";
 import { getOpenAIModelForPurpose } from "@/features/shared/lib/server/openai-models";
+import { runWithProviderTimeout } from "@/features/shared/lib/server/provider-timeout";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import type { Database, Json } from "@shared/types/types/supabase";
 
 type DB = Database;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const FEATURE = "dtc_suggest" as const;
+const ENDPOINT = "/api/work-orders/dtc-suggest";
+const REQUEST_MAX_BYTES = 32 * 1024;
+const DTC_ALLOWED_ROLES = [...ROLE_GROUPS.workOrderManagers, "mechanic"] as const;
+
+const jobIdSchema = z.string().uuid();
+const postBodySchema = z.object({
+  jobId: jobIdSchema,
+  code: z.string().trim().max(32).nullable().optional(),
+  userMessage: z.string().trim().min(1).max(4000),
+});
 
 type ChatRole = "user" | "assistant";
 
@@ -74,12 +100,6 @@ type RouteContext = {
   vehicle: VehicleContext | null;
 };
 
-type PostBody = {
-  jobId?: string;
-  code?: string | null;
-  userMessage?: string;
-};
-
 function asNonEmptyString(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
@@ -119,11 +139,12 @@ function parseMessages(value: unknown): PersistedMessage[] {
 
       return {
         role,
-        content,
+        content: content.slice(0, 4000),
         createdAt,
       } satisfies PersistedMessage;
     })
-    .filter((item): item is PersistedMessage => item !== null);
+    .filter((item): item is PersistedMessage => item !== null)
+    .slice(-40);
 }
 
 function parseSummary(value: unknown): DtcAnalysisSummary | null {
@@ -163,25 +184,13 @@ function parseSummary(value: unknown): DtcAnalysisSummary | null {
   };
 }
 
-async function loadRouteContext(jobId: string): Promise<RouteContext | null> {
-  const routeSupabase = createServerSupabaseRoute();
-  const admin = await createAdminSupabase();
-
-  const {
-    data: { user },
-    error: authErr,
-  } = await routeSupabase.auth.getUser();
-
-  if (authErr || !user) return null;
-
-  const { data: profile, error: profileErr } = await admin
-    .from("profiles")
-    .select("id, shop_id")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (profileErr || !profile?.shop_id) return null;
-
+async function loadRouteContext(input: {
+  admin: ReturnType<typeof createAdminSupabase>;
+  jobId: string;
+  shopId: string;
+  userId: string;
+}): Promise<RouteContext | null> {
+  const { admin, jobId, shopId, userId } = input;
   const { data: line, error: lineErr } = await admin
     .from("work_order_lines")
     .select(
@@ -196,9 +205,10 @@ async function loadRouteContext(jobId: string): Promise<RouteContext | null> {
     .from("work_orders")
     .select("id, custom_id, shop_id, vehicle_id, notes")
     .eq("id", line.work_order_id)
+    .eq("shop_id", shopId)
     .maybeSingle();
 
-  if (workOrderErr || !workOrder || workOrder.shop_id !== profile.shop_id) {
+  if (workOrderErr || !workOrder) {
     return null;
   }
 
@@ -207,14 +217,15 @@ async function loadRouteContext(jobId: string): Promise<RouteContext | null> {
         .from("vehicles")
         .select(
           "year, make, model, engine, fuel_type, drivetrain, transmission, vin, unit_number, license_plate",
-        )
+         )
         .eq("id", workOrder.vehicle_id)
+        .eq("shop_id", shopId)
         .maybeSingle()
     : { data: null };
 
   return {
-    userId: user.id,
-    shopId: profile.shop_id,
+    userId,
+    shopId,
     line,
     workOrder,
     vehicle: vehicle
@@ -235,13 +246,12 @@ async function loadRouteContext(jobId: string): Promise<RouteContext | null> {
 }
 
 async function upsertThread(args: {
+  admin: ReturnType<typeof createAdminSupabase>;
   context: RouteContext;
   dtcCode: string | null;
   messages: PersistedMessage[];
   summary: DtcAnalysisSummary | null;
 }) {
-  const admin = await createAdminSupabase();
-
   const payload: DB["public"]["Tables"]["work_order_line_dtc_threads"]["Insert"] = {
     shop_id: args.context.shopId,
     work_order_id: args.context.workOrder.id,
@@ -255,7 +265,7 @@ async function upsertThread(args: {
     updated_at: new Date().toISOString(),
   };
 
-  const { error } = await admin
+  const { error } = await args.admin
     .from("work_order_line_dtc_threads")
     .upsert(payload, { onConflict: "work_order_line_id" });
 
@@ -316,7 +326,7 @@ function buildUserPrompt(args: {
       notes: args.context.line.notes ?? null,
     },
     dtcCode: args.dtcCode,
-    conversation: args.messages.map((message) => ({
+    conversation: args.messages.slice(-20).map((message) => ({
       role: message.role,
       content: message.content,
       createdAt: message.createdAt,
@@ -328,21 +338,30 @@ async function generateDtcResponse(args: {
   context: RouteContext;
   dtcCode: string | null;
   messages: PersistedMessage[];
-}): Promise<DtcSuggestResponse> {
-  const completion = await openai.chat.completions.create({
-    model: getOpenAIModelForPurpose("reasoning"),
-    response_format: { type: "json_object" },
-    messages: [
+}) {
+  const policy = getAIPolicy(FEATURE);
+  const model = getOpenAIModelForPurpose(policy.modelPurpose);
+  const openai = getOpenAIClient();
+  const completion = await runWithProviderTimeout(policy.timeoutMs, (signal) =>
+    openai.chat.completions.create(
       {
-        role: "system",
-        content: buildSystemPrompt(),
+        model,
+        response_format: { type: "json_object" },
+        max_completion_tokens: policy.maxTokens,
+        messages: [
+          {
+            role: "system",
+            content: buildSystemPrompt(),
+          },
+          {
+            role: "user",
+            content: buildUserPrompt(args),
+          },
+        ],
       },
-      {
-        role: "user",
-        content: buildUserPrompt(args),
-      },
-    ],
-  });
+      { signal },
+    ),
+  );
 
   const raw = completion.choices[0]?.message?.content ?? "{}";
 
@@ -370,41 +389,52 @@ async function generateDtcResponse(args: {
       laborHours: null,
     } satisfies DtcAnalysisSummary);
 
-  return { reply, summary };
+  return { reply, summary, usage: completion.usage, model };
 }
 
 export async function GET(req: Request) {
   try {
-    const url = new URL(req.url);
-    const jobId = asNonEmptyString(url.searchParams.get("jobId"));
+    const access = await requireShopScopedApiAccess({
+      allowRoles: DTC_ALLOWED_ROLES,
+    });
+    if (!access.ok) return access.response;
 
-    if (!jobId) {
+    const url = new URL(req.url);
+    const parsedJobId = jobIdSchema.safeParse(url.searchParams.get("jobId"));
+
+    if (!parsedJobId.success) {
       return NextResponse.json(
-        { error: "jobId is required" },
-        { status: 400 },
+        { error: "A valid jobId is required." },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
       );
     }
 
-    const context = await loadRouteContext(jobId);
+    const admin = createAdminSupabase();
+    const context = await loadRouteContext({
+      admin,
+      jobId: parsedJobId.data,
+      shopId: access.profile.shop_id,
+      userId: access.profile.id,
+    });
     if (!context) {
       return NextResponse.json(
-        { error: "Unauthorized or job not found" },
-        { status: 401 },
+        { error: "Job not found." },
+        { status: 404, headers: { "Cache-Control": "no-store" } },
       );
     }
-
-    const admin = await createAdminSupabase();
 
     const { data: thread, error } = await admin
       .from("work_order_line_dtc_threads")
       .select("dtc_code, messages, summary")
-      .eq("work_order_line_id", jobId)
+      .eq("work_order_line_id", parsedJobId.data)
+      .eq("shop_id", access.profile.shop_id)
       .maybeSingle();
 
     if (error) {
+      console.error("dtc_suggest_thread_lookup_failed", { code: error.code });
       return NextResponse.json(
-        { error: error.message },
-        { status: 500 },
+        { error: "Failed to load DTC thread." },
+        { status: 503, headers: { "Cache-Control": "no-store" } },
       );
     }
 
@@ -413,11 +443,14 @@ export async function GET(req: Request) {
       "dtc_code" | "messages" | "summary"
     > | null;
 
-    return NextResponse.json({
-      dtcCode: typedThread?.dtc_code ?? null,
-      messages: parseMessages(typedThread?.messages ?? []),
-      summary: parseSummary(typedThread?.summary ?? null),
-    });
+    return NextResponse.json(
+      {
+        dtcCode: typedThread?.dtc_code ?? null,
+        messages: parseMessages(typedThread?.messages ?? []),
+        summary: parseSummary(typedThread?.summary ?? null),
+      },
+      { headers: { "Cache-Control": "no-store" } },
+    );
   } catch (error) {
     console.error("[dtc-suggest][GET]", error);
     return NextResponse.json(
@@ -428,35 +461,68 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
+  const startedAt = Date.now();
   try {
-    const body = (await req.json()) as PostBody;
+    const access = await requireShopScopedApiAccess({
+      allowRoles: DTC_ALLOWED_ROLES,
+    });
+    if (!access.ok) return access.response;
 
-    const jobId = asNonEmptyString(body.jobId);
-    const userMessage = asNonEmptyString(body.userMessage);
-    const dtcCode = asNullableString(body.code)?.toUpperCase() ?? null;
-
-    if (!jobId || !userMessage) {
+    const boundedBody = await readBoundedJson(req, REQUEST_MAX_BYTES);
+    if (!boundedBody.ok) {
       return NextResponse.json(
-        { error: "jobId and userMessage are required" },
-        { status: 400 },
+        {
+          error:
+            boundedBody.reason === "too_large"
+              ? "Request is too large."
+              : "A valid job and message are required.",
+        },
+        {
+          status: boundedBody.reason === "too_large" ? 413 : 400,
+          headers: { "Cache-Control": "no-store" },
+        },
       );
     }
 
-    const context = await loadRouteContext(jobId);
+    const parsedBody = postBodySchema.safeParse(boundedBody.value);
+    if (!parsedBody.success) {
+      return NextResponse.json(
+        { error: "A valid job and message are required." },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    const jobId = parsedBody.data.jobId;
+    const userMessage = parsedBody.data.userMessage;
+    const dtcCode = asNullableString(parsedBody.data.code)?.toUpperCase() ?? null;
+    const admin = createAdminSupabase();
+    const context = await loadRouteContext({
+      admin,
+      jobId,
+      shopId: access.profile.shop_id,
+      userId: access.profile.id,
+    });
     if (!context) {
       return NextResponse.json(
-        { error: "Unauthorized or job not found" },
-        { status: 401 },
+        { error: "Job not found." },
+        { status: 404, headers: { "Cache-Control": "no-store" } },
       );
     }
 
-    const admin = await createAdminSupabase();
-
-    const { data: existingThread } = await admin
+    const { data: existingThread, error: threadError } = await admin
       .from("work_order_line_dtc_threads")
       .select("dtc_code, messages, summary")
       .eq("work_order_line_id", jobId)
+      .eq("shop_id", access.profile.shop_id)
       .maybeSingle();
+
+    if (threadError) {
+      console.error("dtc_suggest_thread_lookup_failed", { code: threadError.code });
+      return NextResponse.json(
+        { error: "Failed to load DTC thread." },
+        { status: 503, headers: { "Cache-Control": "no-store" } },
+      );
+    }
 
     const persistedMessages = parseMessages(existingThread?.messages ?? []);
     const persistedSummary = parseSummary(existingThread?.summary ?? null);
@@ -470,10 +536,144 @@ export async function POST(req: Request) {
       },
     ];
 
-    const ai = await generateDtcResponse({
-      context,
-      dtcCode: dtcCode ?? existingThread?.dtc_code ?? null,
-      messages: nextMessages,
+    let claim: Awaited<ReturnType<typeof claimDurableAIRouteQuota>>;
+    try {
+      claim = await claimDurableAIRouteQuota({
+        admin,
+        actorId: access.profile.id,
+        feature: FEATURE,
+        shopId: access.profile.shop_id,
+      });
+    } catch (error) {
+      console.error("dtc_suggest_quota_failed", {
+        shopId: access.profile.shop_id,
+        error: error instanceof Error ? error.message : "unknown",
+      });
+      return NextResponse.json(
+        { error: "AI diagnosis is temporarily unavailable." },
+        { status: 503, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    if (!claim.allowed) {
+      return NextResponse.json(
+        {
+          error: "AI diagnosis is temporarily limited. Please try again later.",
+          code:
+            claim.reason === "hard_budget_exceeded"
+              ? "ai_budget_limit"
+              : "ai_rate_limit",
+        },
+        {
+          status: 429,
+          headers: {
+            "Cache-Control": "no-store",
+            "Retry-After": String(claim.retryAfterSeconds),
+          },
+        },
+      );
+    }
+
+    let ai: Awaited<ReturnType<typeof generateDtcResponse>>;
+    try {
+      ai = await generateDtcResponse({
+        context,
+        dtcCode: dtcCode ?? existingThread?.dtc_code ?? null,
+        messages: nextMessages,
+      });
+    } catch (error) {
+      await completeDurableAIRouteQuota({
+        admin,
+        actorId: access.profile.id,
+        actualCostUsd: 0,
+        feature: FEATURE,
+        receiptId: claim.receiptId,
+        shopId: access.profile.shop_id,
+        succeeded: false,
+      });
+      const model = getOpenAIModelForPurpose(getAIPolicy(FEATURE).modelPurpose);
+      recordAITelemetry({
+        feature: FEATURE,
+        endpoint: ENDPOINT,
+        shop_id: access.profile.shop_id,
+        user_id: access.profile.id,
+        model,
+        latency_ms: Date.now() - startedAt,
+        prompt_tokens: null,
+        completion_tokens: null,
+        total_tokens: null,
+        estimated_cost_usd: 0,
+        status: "error",
+        error_code: "dtc_suggest_failed",
+        error_message:
+          error instanceof Error && error.message.includes("timed out")
+            ? "provider_timeout"
+            : "provider_error",
+      });
+      registerAIUsageEvent({
+        feature: FEATURE,
+        endpoint: ENDPOINT,
+        shopId: access.profile.shop_id,
+        model,
+        totalTokens: null,
+        estimatedCostUsd: 0,
+        status: "error",
+        errorCode: "dtc_suggest_failed",
+      });
+      console.error("dtc_suggest_provider_failed", {
+        shopId: access.profile.shop_id,
+        kind:
+          error instanceof Error && error.message.includes("timed out")
+            ? "timeout"
+            : "provider",
+      });
+      return NextResponse.json(
+        { error: "Failed to continue DTC diagnosis. Try again or continue manually." },
+        {
+          status:
+            error instanceof Error && error.message.includes("timed out")
+              ? 504
+              : 502,
+          headers: { "Cache-Control": "no-store" },
+        },
+      );
+    }
+
+    const totalTokens = ai.usage?.total_tokens ?? null;
+    const estimatedCostUsd = estimateAICostUsd(FEATURE, totalTokens);
+    await completeDurableAIRouteQuota({
+      admin,
+      actorId: access.profile.id,
+      actualCostUsd: estimatedCostUsd,
+      feature: FEATURE,
+      receiptId: claim.receiptId,
+      shopId: access.profile.shop_id,
+      succeeded: true,
+    });
+    recordAITelemetry({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shop_id: access.profile.shop_id,
+      user_id: access.profile.id,
+      model: ai.model,
+      latency_ms: Date.now() - startedAt,
+      prompt_tokens: ai.usage?.prompt_tokens ?? null,
+      completion_tokens: ai.usage?.completion_tokens ?? null,
+      total_tokens: totalTokens,
+      estimated_cost_usd: estimatedCostUsd,
+      status: "success",
+      error_code: null,
+      error_message: null,
+    });
+    registerAIUsageEvent({
+      feature: FEATURE,
+      endpoint: ENDPOINT,
+      shopId: access.profile.shop_id,
+      model: ai.model,
+      totalTokens,
+      estimatedCostUsd,
+      status: "success",
+      errorCode: null,
     });
 
     const finalMessages: PersistedMessage[] = [
@@ -483,21 +683,25 @@ export async function POST(req: Request) {
         content: ai.reply,
         createdAt: new Date().toISOString(),
       },
-    ];
+    ].slice(-40);
 
     const finalSummary = ai.summary ?? persistedSummary;
 
     await upsertThread({
+      admin,
       context,
       dtcCode: dtcCode ?? existingThread?.dtc_code ?? null,
       messages: finalMessages,
       summary: finalSummary,
     });
 
-    return NextResponse.json({
-      reply: ai.reply,
-      summary: finalSummary,
-    } satisfies DtcSuggestResponse);
+    return NextResponse.json(
+      {
+        reply: ai.reply,
+        summary: finalSummary,
+      } satisfies DtcSuggestResponse,
+      { headers: { "Cache-Control": "no-store" } },
+    );
   } catch (error) {
     console.error("[dtc-suggest][POST]", error);
     return NextResponse.json(

--- a/app/api/work-orders/dtc-suggest/route.ts
+++ b/app/api/work-orders/dtc-suggest/route.ts
@@ -676,14 +676,12 @@ export async function POST(req: Request) {
       errorCode: null,
     });
 
-    const finalMessages: PersistedMessage[] = [
-      ...nextMessages,
-      {
-        role: "assistant",
-        content: ai.reply,
-        createdAt: new Date().toISOString(),
-      },
-    ].slice(-40);
+    const assistantMessage: PersistedMessage = {
+      role: "assistant",
+      content: ai.reply,
+      createdAt: new Date().toISOString(),
+    };
+    const finalMessages = [...nextMessages, assistantMessage].slice(-40);
 
     const finalSummary = ai.summary ?? persistedSummary;
 

--- a/docs/audits/api-route-boundary-inventory.json
+++ b/docs/audits/api-route-boundary-inventory.json
@@ -200,6 +200,24 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/admin/users/[id]/resend-invite/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "public_or_token",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/admin/users/[id]/route.ts",
     "methods": [
       "PUT",
@@ -412,17 +430,17 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [
-      "mutating_without_obvious_auth_marker"
+      "has_stronger_boundary_signal"
     ],
-    "riskLevel": "high"
+    "riskLevel": "low"
   },
   {
     "path": "app/api/ai/parts/suggest/route.ts",
@@ -1294,12 +1312,15 @@
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
-    "hasServiceRolePattern": false,
+    "hasServiceRolePattern": true,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "public_or_token",
-    "riskFlags": [],
-    "riskLevel": "low"
+    "riskFlags": [
+      "mutating_with_service_role_without_obvious_auth_or_boundary",
+      "service_role_with_shop_identifier_input_or_reference"
+    ],
+    "riskLevel": "high"
   },
   {
     "path": "app/api/demo/shop-boost/share/route.ts",
@@ -1361,17 +1382,17 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [
-      "mutating_without_obvious_auth_marker"
+      "has_stronger_boundary_signal"
     ],
-    "riskLevel": "high"
+    "riskLevel": "low"
   },
   {
     "path": "app/api/email/logs/route.ts",
@@ -2906,6 +2927,24 @@
     "riskLevel": "high"
   },
   {
+    "path": "app/api/parts/picker/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "public_or_token",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/parts/receiving/receive-item/route.ts",
     "methods": [
       "POST"
@@ -4118,17 +4157,17 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
-    "hasRouteHandlerSupabaseAuthClient": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
-    "hasServiceRolePattern": true,
-    "hasShopReference": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "public_or_token",
+    "routeClassGuess": "staff_or_admin",
     "riskFlags": [
-      "mutating_with_service_role_without_obvious_auth_or_boundary"
+      "has_stronger_boundary_signal"
     ],
-    "riskLevel": "high"
+    "riskLevel": "low"
   },
   {
     "path": "app/api/receive-scan/route.ts",
@@ -4258,7 +4297,7 @@
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "public_or_token",
+    "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
     "riskLevel": "low"
   },
@@ -5820,14 +5859,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "public_or_token",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -6417,6 +6458,61 @@
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/flat-rate/credits/route.ts",
+    "methods": [
+      "GET",
+      "PUT"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/job-time/corrections/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/workforce/me/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [
       "has_stronger_boundary_signal"

--- a/docs/audits/api-route-boundary-inventory.md
+++ b/docs/audits/api-route-boundary-inventory.md
@@ -1,20 +1,19 @@
 # API Route Boundary Inventory (Static Heuristic)
 
-Generated: 2026-07-24T02:48:34.215Z
+Generated: 2026-07-25T22:46:58.427Z
 
 ## Summary
-- Total route count: **376**
-- Routes exporting GET: **119**
-- Routes exporting POST: **267**
-- Routes exporting PUT: **9**
+- Total route count: **381**
+- Routes exporting GET: **122**
+- Routes exporting POST: **269**
+- Routes exporting PUT: **10**
 - Routes exporting PATCH: **22**
 - Routes exporting DELETE: **12**
 - Routes with service-role pattern: **24**
-- Routes using requireShopScopedApiAccess: **114**
-- Routes with auth.getUser references: **146**
+- Routes using requireShopScopedApiAccess: **123**
+- Routes with auth.getUser references: **145**
 
 ## High-Risk Routes
-- `app/api/ai/interpret/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/auth/resolve-login/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/activate/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/assets/[id]/archive/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -24,10 +23,10 @@ Generated: 2026-07-24T02:48:34.215Z
 - `app/api/branding/user-preferences/reset/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/branding/user-preferences/route.ts` | methods: GET, POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/dashboard/layout/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/demo/shop-boost/run/route.ts` | methods: POST | riskFlags: mutating_with_service_role_without_obvious_auth_or_boundary, service_role_with_shop_identifier_input_or_reference
 - `app/api/demo/shop-boost/share/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/demo/shop-boost/uploads/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/diag/log/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/dtc-suggest/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/fleet/service-requests/convert-to-work-order/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/inspections/build/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/connect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -57,7 +56,6 @@ Generated: 2026-07-24T02:48:34.215Z
 - `app/api/payroll-time/periods/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/rebuild/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/settings/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/recalls/fetch/route.ts` | methods: POST | riskFlags: mutating_with_service_role_without_obvious_auth_or_boundary
 - `app/api/scheduling/shifts/[id]/route.ts` | methods: PATCH, DELETE | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop-assistant/actions/[actionId]/cancel/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/shop-assistant/actions/[actionId]/confirm/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -104,6 +102,7 @@ Generated: 2026-07-24T02:48:34.215Z
 - `app/api/agent/requests/[id]/notify-discord/route.ts` | methods: POST | riskFlags: none
 - `app/api/agent/requests/route.ts` | methods: GET, POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/assignables/route.ts` | methods: GET | riskFlags: service_role_with_shop_identifier_input_or_reference
+- `app/api/demo/shop-boost/run/route.ts` | methods: POST | riskFlags: mutating_with_service_role_without_obvious_auth_or_boundary, service_role_with_shop_identifier_input_or_reference
 - `app/api/integrations/quickbooks/callback/route.ts` | methods: GET | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/invoice-versions/[id]/pdf/route.ts` | methods: GET | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/invoices/send/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
@@ -114,7 +113,6 @@ Generated: 2026-07-24T02:48:34.215Z
 - `app/api/portal/payments/session/[id]/route.ts` | methods: GET | riskFlags: none
 - `app/api/quotes/apply-ai/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/quotes/send/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
-- `app/api/recalls/fetch/route.ts` | methods: POST | riskFlags: mutating_with_service_role_without_obvious_auth_or_boundary
 - `app/api/time/labor-segments/backfill/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/[id]/corrections/[sessionId]/close/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
 - `app/api/work-orders/[id]/corrections/open/route.ts` | methods: POST | riskFlags: service_role_with_shop_identifier_input_or_reference
@@ -127,7 +125,6 @@ Generated: 2026-07-24T02:48:34.215Z
 
 ## Routes Missing Obvious Auth Markers (staff/admin guess)
 - `app/api/agent/events/route.ts` | methods: GET | riskFlags: none
-- `app/api/ai/interpret/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/ai/suggest/route.ts` | methods: none | riskFlags: none
 - `app/api/auth/resolve-login/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/auth/send-reset-email/route.ts` | methods: none | riskFlags: none
@@ -144,7 +141,6 @@ Generated: 2026-07-24T02:48:34.215Z
 - `app/api/demo/shop-boost/share/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/demo/shop-boost/uploads/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/diag/log/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/dtc-suggest/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/fleet/service-requests/convert-to-work-order/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/inspections/build/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/integrations/quickbooks/connect/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker

--- a/features/shared/lib/server/ai-ops-guard.ts
+++ b/features/shared/lib/server/ai-ops-guard.ts
@@ -106,6 +106,26 @@ const FEATURE_POLICY: Record<AIFeature, AIOpsPolicy> = {
     anomalyHighCostUsd: envNum("AI_ANOMALY_COST_BRANDING", 1.5),
     anomalyHardDenialThreshold: envNum("AI_ANOMALY_DENIAL_BRANDING", 3),
   },
+  dtc_suggest: {
+    budgetSoftUsd: 50,
+    budgetHardUsd: 75,
+    rateLimitMax: 20,
+    rateLimitWindowMs: 5 * 60 * 1000,
+    anomalySpikeThreshold: 15,
+    anomalyFailureThreshold: 6,
+    anomalyHighCostUsd: 0.2,
+    anomalyHardDenialThreshold: 4,
+  },
+  inspection_interpret: {
+    budgetSoftUsd: 35,
+    budgetHardUsd: 50,
+    rateLimitMax: 60,
+    rateLimitWindowMs: 5 * 60 * 1000,
+    anomalySpikeThreshold: 45,
+    anomalyFailureThreshold: 8,
+    anomalyHighCostUsd: 0.08,
+    anomalyHardDenialThreshold: 8,
+  },
 };
 
 export function estimateAICostUsd(feature: AIFeature, totalTokens: number | null): number {

--- a/features/shared/lib/server/ai-policy.ts
+++ b/features/shared/lib/server/ai-policy.ts
@@ -15,7 +15,9 @@ export type AIFeature =
   | "ai_summarize_stats"
   | "openai_realtime_token"
   | "work_order_documentation_rewrite"
-  | "branding_generate_logo";
+  | "branding_generate_logo"
+  | "dtc_suggest"
+  | "inspection_interpret";
 
 const AI_POLICIES: Record<AIFeature, AIPolicy> = {
   work_orders_suggest_lines: {
@@ -52,6 +54,20 @@ const AI_POLICIES: Record<AIFeature, AIPolicy> = {
     timeoutMs: 30000,
     maxTokens: 0,
     fallbackMode: "hard_fail",
+  },
+  dtc_suggest: {
+    feature: "dtc_suggest",
+    modelPurpose: "reasoning",
+    timeoutMs: 20000,
+    maxTokens: 900,
+    fallbackMode: "graceful_empty",
+  },
+  inspection_interpret: {
+    feature: "inspection_interpret",
+    modelPurpose: "extraction",
+    timeoutMs: 12000,
+    maxTokens: 700,
+    fallbackMode: "graceful_empty",
   },
 };
 

--- a/features/shared/lib/server/bounded-json.ts
+++ b/features/shared/lib/server/bounded-json.ts
@@ -1,0 +1,46 @@
+import "server-only";
+
+type BoundedJsonResult =
+  | { ok: true; value: unknown }
+  | { ok: false; reason: "invalid_json" | "too_large" };
+
+export async function readBoundedJson(
+  request: Request,
+  maxBytes: number,
+): Promise<BoundedJsonResult> {
+  const contentLength = Number(request.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    return { ok: false, reason: "too_large" };
+  }
+
+  if (!request.body) {
+    return { ok: false, reason: "invalid_json" };
+  }
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let received = 0;
+  let text = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      received += value.byteLength;
+      if (received > maxBytes) {
+        await reader.cancel("request body too large");
+        return { ok: false, reason: "too_large" };
+      }
+
+      text += decoder.decode(value, { stream: true });
+    }
+
+    text += decoder.decode();
+    return { ok: true, value: JSON.parse(text) as unknown };
+  } catch {
+    return { ok: false, reason: "invalid_json" };
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/features/shared/lib/server/durable-ai-guard.ts
+++ b/features/shared/lib/server/durable-ai-guard.ts
@@ -1,0 +1,112 @@
+import "server-only";
+
+import type { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+export type DurableAIFeature = "dtc_suggest" | "inspection_interpret";
+
+type AdminClient = ReturnType<typeof createAdminSupabase>;
+
+type DurablePolicy = {
+  actorMax: number;
+  shopMax: number;
+  windowSeconds: number;
+  hardBudgetUsd: number;
+  reservationCostUsd: number;
+};
+
+const DURABLE_POLICIES: Record<DurableAIFeature, DurablePolicy> = {
+  dtc_suggest: {
+    actorMax: 20,
+    shopMax: 80,
+    windowSeconds: 5 * 60,
+    hardBudgetUsd: 75,
+    reservationCostUsd: 0.1,
+  },
+  inspection_interpret: {
+    actorMax: 60,
+    shopMax: 240,
+    windowSeconds: 5 * 60,
+    hardBudgetUsd: 50,
+    reservationCostUsd: 0.03,
+  },
+};
+
+type QuotaRow = {
+  allowed: boolean;
+  denial_reason: string | null;
+  retry_after_seconds: number;
+  receipt_id: string | null;
+};
+
+export type DurableAIClaim =
+  | { allowed: true; receiptId: string }
+  | {
+      allowed: false;
+      reason: "rate_limited" | "hard_budget_exceeded";
+      retryAfterSeconds: number;
+    };
+
+export async function claimDurableAIRouteQuota(input: {
+  admin: AdminClient;
+  feature: DurableAIFeature;
+  shopId: string;
+  actorId: string;
+}): Promise<DurableAIClaim> {
+  const policy = DURABLE_POLICIES[input.feature];
+  const { data, error } = await input.admin.rpc("consume_ai_route_quota", {
+    p_actor_id: input.actorId,
+    p_actor_max: policy.actorMax,
+    p_feature: input.feature,
+    p_hard_budget_usd: policy.hardBudgetUsd,
+    p_reservation_cost_usd: policy.reservationCostUsd,
+    p_shop_id: input.shopId,
+    p_shop_max: policy.shopMax,
+    p_window_seconds: policy.windowSeconds,
+  });
+
+  if (error) {
+    throw new Error(`AI route quota unavailable (${error.code ?? "unknown"})`);
+  }
+
+  const row = Array.isArray(data) ? (data[0] as QuotaRow | undefined) : undefined;
+  if (row?.allowed && row.receipt_id) {
+    return { allowed: true, receiptId: row.receipt_id };
+  }
+
+  return {
+    allowed: false,
+    reason:
+      row?.denial_reason === "hard_budget_exceeded"
+        ? "hard_budget_exceeded"
+        : "rate_limited",
+    retryAfterSeconds: Math.max(1, row?.retry_after_seconds ?? 60),
+  };
+}
+
+export async function completeDurableAIRouteQuota(input: {
+  admin: AdminClient;
+  feature: DurableAIFeature;
+  shopId: string;
+  actorId: string;
+  receiptId: string;
+  actualCostUsd: number;
+  succeeded: boolean;
+}): Promise<void> {
+  const { data, error } = await input.admin.rpc("complete_ai_route_quota", {
+    p_actor_id: input.actorId,
+    p_actual_cost_usd: Math.max(0, input.actualCostUsd),
+    p_feature: input.feature,
+    p_receipt_id: input.receiptId,
+    p_shop_id: input.shopId,
+    p_succeeded: input.succeeded,
+  });
+
+  if (error || data !== true) {
+    console.error("ai_route_quota_completion_failed", {
+      actorId: input.actorId,
+      feature: input.feature,
+      shopId: input.shopId,
+      code: error?.code ?? "receipt_not_reserved",
+    });
+  }
+}

--- a/features/shared/lib/server/provider-timeout.ts
+++ b/features/shared/lib/server/provider-timeout.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+export async function runWithProviderTimeout<T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await operation(controller.signal);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error("AI provider timed out", { cause: error });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -23583,6 +23583,35 @@ export type Database = {
             Args: { p_location_id: string; p_request_item_id: string }
             Returns: undefined
           }
+      complete_ai_route_quota: {
+        Args: {
+          p_actor_id: string
+          p_actual_cost_usd: number
+          p_feature: string
+          p_receipt_id: string
+          p_shop_id: string
+          p_succeeded: boolean
+        }
+        Returns: boolean
+      }
+      consume_ai_route_quota: {
+        Args: {
+          p_actor_id: string
+          p_actor_max: number
+          p_feature: string
+          p_hard_budget_usd: number
+          p_reservation_cost_usd: number
+          p_shop_id: string
+          p_shop_max: number
+          p_window_seconds: number
+        }
+        Returns: {
+          allowed: boolean
+          denial_reason: string | null
+          receipt_id: string | null
+          retry_after_seconds: number
+        }[]
+      }
       consume_vehicle_recall_fetch_quota: {
         Args: {
           p_actor_id: string

--- a/supabase/migrations/20260725162838_harden_p0_005_ai_route_governance.sql
+++ b/supabase/migrations/20260725162838_harden_p0_005_ai_route_governance.sql
@@ -1,0 +1,270 @@
+begin;
+
+create schema if not exists private authorization postgres;
+revoke all privileges on schema private
+  from public, anon, authenticated, service_role;
+
+create table if not exists private.ai_route_usage_receipts (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  actor_id uuid not null references public.profiles(id) on delete cascade,
+  feature text not null check (feature in ('dtc_suggest', 'inspection_interpret')),
+  status text not null default 'reserved'
+    check (status in ('reserved', 'success', 'error')),
+  reserved_cost_usd numeric(12, 6) not null
+    check (reserved_cost_usd >= 0),
+  actual_cost_usd numeric(12, 6)
+    check (actual_cost_usd is null or actual_cost_usd >= 0),
+  created_at timestamptz not null default clock_timestamp(),
+  completed_at timestamptz
+);
+
+create index if not exists ai_route_usage_receipts_actor_window_idx
+  on private.ai_route_usage_receipts (shop_id, actor_id, feature, created_at desc);
+
+create index if not exists ai_route_usage_receipts_shop_budget_idx
+  on private.ai_route_usage_receipts (shop_id, feature, created_at desc);
+
+create index if not exists ai_route_usage_receipts_actor_fk_idx
+  on private.ai_route_usage_receipts (actor_id);
+
+create index if not exists ai_route_usage_receipts_reserved_idx
+  on private.ai_route_usage_receipts (shop_id, feature, created_at)
+  where status = 'reserved';
+
+revoke all privileges on table private.ai_route_usage_receipts
+  from public, anon, authenticated, service_role;
+
+create or replace function public.consume_ai_route_quota(
+  p_shop_id uuid,
+  p_actor_id uuid,
+  p_feature text,
+  p_actor_max integer,
+  p_shop_max integer,
+  p_window_seconds integer,
+  p_hard_budget_usd numeric,
+  p_reservation_cost_usd numeric
+)
+returns table (
+  allowed boolean,
+  denial_reason text,
+  retry_after_seconds integer,
+  receipt_id uuid
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $function$
+declare
+  v_now timestamptz := clock_timestamp();
+  v_window interval;
+  v_month_started_at timestamptz;
+  v_actor_count integer;
+  v_shop_count integer;
+  v_oldest timestamptz;
+  v_monthly_cost numeric(12, 6);
+  v_receipt_id uuid;
+begin
+  if p_shop_id is null
+     or p_actor_id is null
+     or p_feature not in ('dtc_suggest', 'inspection_interpret')
+     or p_actor_max is null or p_actor_max < 1
+     or p_shop_max is null or p_shop_max < p_actor_max
+     or p_window_seconds is null or p_window_seconds < 1 or p_window_seconds > 86400
+     or p_hard_budget_usd is null or p_hard_budget_usd <= 0
+     or p_reservation_cost_usd is null or p_reservation_cost_usd < 0 then
+    raise exception using
+      errcode = '22023',
+      message = 'AI_ROUTE_QUOTA_INPUT_INVALID';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles profile
+    where profile.id = p_actor_id
+      and profile.shop_id = p_shop_id
+  ) then
+    raise exception using
+      errcode = '42501',
+      message = 'AI_ROUTE_QUOTA_SCOPE_DENIED';
+  end if;
+
+  v_window := make_interval(secs => p_window_seconds);
+  v_month_started_at := date_trunc('month', v_now, 'UTC');
+
+  -- Serialize a shop/feature quota decision so parallel serverless instances
+  -- cannot all pass the same count or monthly budget check.
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(p_shop_id::text || ':' || p_feature, 0)
+  );
+
+  -- A crashed provider call must not reserve monthly budget forever.
+  update private.ai_route_usage_receipts receipt
+  set status = 'error',
+      actual_cost_usd = 0,
+      completed_at = v_now
+  where receipt.shop_id = p_shop_id
+    and receipt.feature = p_feature
+    and receipt.status = 'reserved'
+    and receipt.created_at <= v_now - interval '30 minutes';
+
+  select count(*)::integer
+  into v_actor_count
+  from private.ai_route_usage_receipts receipt
+  where receipt.shop_id = p_shop_id
+    and receipt.actor_id = p_actor_id
+    and receipt.feature = p_feature
+    and receipt.created_at > v_now - v_window;
+
+  if v_actor_count >= p_actor_max then
+    select min(receipt.created_at)
+    into v_oldest
+    from private.ai_route_usage_receipts receipt
+    where receipt.shop_id = p_shop_id
+      and receipt.actor_id = p_actor_id
+      and receipt.feature = p_feature
+      and receipt.created_at > v_now - v_window;
+
+    return query select
+      false,
+      'rate_limited'::text,
+      greatest(1, ceil(extract(epoch from (v_oldest + v_window - v_now)))::integer),
+      null::uuid;
+    return;
+  end if;
+
+  select count(*)::integer
+  into v_shop_count
+  from private.ai_route_usage_receipts receipt
+  where receipt.shop_id = p_shop_id
+    and receipt.feature = p_feature
+    and receipt.created_at > v_now - v_window;
+
+  if v_shop_count >= p_shop_max then
+    select min(receipt.created_at)
+    into v_oldest
+    from private.ai_route_usage_receipts receipt
+    where receipt.shop_id = p_shop_id
+      and receipt.feature = p_feature
+      and receipt.created_at > v_now - v_window;
+
+    return query select
+      false,
+      'rate_limited'::text,
+      greatest(1, ceil(extract(epoch from (v_oldest + v_window - v_now)))::integer),
+      null::uuid;
+    return;
+  end if;
+
+  select coalesce(
+    sum(
+      case
+        when receipt.status = 'reserved' then receipt.reserved_cost_usd
+        else coalesce(receipt.actual_cost_usd, 0)
+      end
+    ),
+    0
+  )::numeric(12, 6)
+  into v_monthly_cost
+  from private.ai_route_usage_receipts receipt
+  where receipt.shop_id = p_shop_id
+    and receipt.feature = p_feature
+    and receipt.created_at >= v_month_started_at;
+
+  if v_monthly_cost + p_reservation_cost_usd > p_hard_budget_usd then
+    return query select
+      false,
+      'hard_budget_exceeded'::text,
+      greatest(
+        1,
+        ceil(
+          extract(
+            epoch from (
+              v_month_started_at + interval '1 month' - v_now
+            )
+          )
+        )::integer
+      ),
+      null::uuid;
+    return;
+  end if;
+
+  insert into private.ai_route_usage_receipts (
+    shop_id,
+    actor_id,
+    feature,
+    reserved_cost_usd
+  ) values (
+    p_shop_id,
+    p_actor_id,
+    p_feature,
+    p_reservation_cost_usd
+  )
+  returning id into v_receipt_id;
+
+  return query select true, null::text, 0, v_receipt_id;
+end
+$function$;
+
+create or replace function public.complete_ai_route_quota(
+  p_receipt_id uuid,
+  p_shop_id uuid,
+  p_actor_id uuid,
+  p_feature text,
+  p_actual_cost_usd numeric,
+  p_succeeded boolean
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $function$
+begin
+  if p_receipt_id is null
+     or p_shop_id is null
+     or p_actor_id is null
+     or p_feature not in ('dtc_suggest', 'inspection_interpret')
+     or p_actual_cost_usd is null
+     or p_actual_cost_usd < 0
+     or p_succeeded is null then
+    raise exception using
+      errcode = '22023',
+      message = 'AI_ROUTE_COMPLETION_INPUT_INVALID';
+  end if;
+
+  update private.ai_route_usage_receipts receipt
+  set status = case when p_succeeded then 'success' else 'error' end,
+      actual_cost_usd = p_actual_cost_usd,
+      completed_at = clock_timestamp()
+  where receipt.id = p_receipt_id
+    and receipt.shop_id = p_shop_id
+    and receipt.actor_id = p_actor_id
+    and receipt.feature = p_feature
+    and receipt.status = 'reserved';
+
+  return found;
+end
+$function$;
+
+alter function public.consume_ai_route_quota(
+  uuid, uuid, text, integer, integer, integer, numeric, numeric
+) owner to postgres;
+alter function public.complete_ai_route_quota(
+  uuid, uuid, uuid, text, numeric, boolean
+) owner to postgres;
+
+revoke all privileges on function public.consume_ai_route_quota(
+  uuid, uuid, text, integer, integer, integer, numeric, numeric
+) from public, anon, authenticated, service_role;
+revoke all privileges on function public.complete_ai_route_quota(
+  uuid, uuid, uuid, text, numeric, boolean
+) from public, anon, authenticated, service_role;
+
+grant execute on function public.consume_ai_route_quota(
+  uuid, uuid, text, integer, integer, integer, numeric, numeric
+) to service_role;
+grant execute on function public.complete_ai_route_quota(
+  uuid, uuid, uuid, text, numeric, boolean
+) to service_role;
+
+commit;

--- a/tests/chat-start-conversation-route.test.ts
+++ b/tests/chat-start-conversation-route.test.ts
@@ -103,7 +103,7 @@ describe("POST /api/chat/start-conversation", () => {
   });
 
   it("normalizes a stale non-UUID request ID into a replayable conversation ID", async () => {
-    const { POST } = await import("@/app/api/chat/start-conversation/route");
+    const { POST } = await import("../app/api/chat/start-conversation/route");
     const body = {
       request_id: "legacy-offline-draft-id",
       actor_kind: "customer",

--- a/tests/p0-005-ai-route-security.test.ts
+++ b/tests/p0-005-ai-route-security.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ACTOR_ID = "55000000-0000-4000-8000-000000000001";
+const SHOP_ID = "a5100000-0000-4000-8000-000000000001";
+const JOB_ID = "a5300000-0000-4000-8000-000000000001";
+const WORK_ORDER_ID = "a5400000-0000-4000-8000-000000000001";
+const VEHICLE_ID = "a5500000-0000-4000-8000-000000000001";
+
+const mocks = vi.hoisted(() => ({
+  requireAccess: vi.fn(),
+  createAdmin: vi.fn(),
+  claimQuota: vi.fn(),
+  completeQuota: vi.fn(),
+  openAICreate: vi.fn(),
+  from: vi.fn(),
+  threadUpsert: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireAccess,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: mocks.createAdmin,
+}));
+
+vi.mock("@/features/shared/lib/server/durable-ai-guard", () => ({
+  claimDurableAIRouteQuota: mocks.claimQuota,
+  completeDurableAIRouteQuota: mocks.completeQuota,
+}));
+
+vi.mock("@/features/shared/lib/server/openai", () => ({
+  getOpenAIClient: () => ({
+    chat: { completions: { create: mocks.openAICreate } },
+  }),
+}));
+
+function query(result: unknown, error: unknown = null) {
+  const builder = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn(async () => ({ data: result, error })),
+    upsert: mocks.threadUpsert,
+  };
+  builder.select.mockReturnValue(builder);
+  builder.eq.mockReturnValue(builder);
+  return builder;
+}
+
+function postRequest(path: string, body: unknown, headers?: HeadersInit): Request {
+  return new Request(`https://profixiq.test${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function completion(content: string) {
+  return {
+    choices: [{ message: { content } }],
+    usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+  };
+}
+
+describe("P0-005 AI route boundaries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    mocks.requireAccess.mockResolvedValue({
+      ok: true,
+      profile: { id: ACTOR_ID, shop_id: SHOP_ID, role: "mechanic" },
+      canonicalRole: "mechanic",
+      supabase: {},
+    });
+    mocks.claimQuota.mockResolvedValue({ allowed: true, receiptId: "quota-receipt" });
+    mocks.completeQuota.mockResolvedValue(undefined);
+    mocks.threadUpsert.mockResolvedValue({ error: null });
+    mocks.from.mockImplementation((table: string) => {
+      if (table === "work_order_lines") {
+        return query({
+          id: JOB_ID,
+          work_order_id: WORK_ORDER_ID,
+          job_type: "diagnosis",
+          complaint: "Check engine light",
+          description: "Diagnose P0420",
+          cause: null,
+          correction: null,
+          labor_time: null,
+          notes: null,
+        });
+      }
+      if (table === "work_orders") {
+        return query({
+          id: WORK_ORDER_ID,
+          custom_id: "WO-005",
+          shop_id: SHOP_ID,
+          vehicle_id: VEHICLE_ID,
+          notes: null,
+        });
+      }
+      if (table === "vehicles") {
+        return query({
+          year: 2020,
+          make: "Honda",
+          model: "Accord",
+          engine: "2.0L",
+          fuel_type: "gas",
+          drivetrain: "FWD",
+          transmission: "automatic",
+          vin: "1HGCM82633A004352",
+          unit_number: null,
+          license_plate: null,
+        });
+      }
+      if (table === "work_order_line_dtc_threads") return query(null);
+      throw new Error(`Unexpected table ${table}`);
+    });
+    mocks.createAdmin.mockReturnValue({ from: mocks.from });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("denies anonymous DTC access before privileged or provider work", async () => {
+    mocks.requireAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Not authenticated" }, { status: 401 }),
+    });
+    const { POST } = await import("../app/api/dtc-suggest/route");
+
+    const response = await POST(postRequest("/api/dtc-suggest", { jobId: JOB_ID }));
+
+    expect(response.status).toBe(401);
+    expect(mocks.createAdmin).not.toHaveBeenCalled();
+    expect(mocks.claimQuota).not.toHaveBeenCalled();
+    expect(mocks.openAICreate).not.toHaveBeenCalled();
+  });
+
+  it("denies a role without inspection capability before provider work", async () => {
+    mocks.requireAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
+    const { POST } = await import("../app/api/ai/interpret/route");
+
+    const response = await POST(
+      postRequest("/api/ai/interpret", { transcript: "brakes pass" }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mocks.requireAccess).toHaveBeenCalledWith({
+      requiredCapability: "canRunInspections",
+    });
+    expect(mocks.createAdmin).not.toHaveBeenCalled();
+    expect(mocks.claimQuota).not.toHaveBeenCalled();
+    expect(mocks.openAICreate).not.toHaveBeenCalled();
+  });
+
+  it("denies anonymous access to the canonical technician DTC route", async () => {
+    mocks.requireAccess.mockResolvedValue({
+      ok: false,
+      response: Response.json({ error: "Not authenticated" }, { status: 401 }),
+    });
+    const { POST } = await import("../app/api/work-orders/dtc-suggest/route");
+
+    const response = await POST(
+      postRequest("/api/work-orders/dtc-suggest", {
+        jobId: JOB_ID,
+        userMessage: "P0420 stored",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.createAdmin).not.toHaveBeenCalled();
+    expect(mocks.claimQuota).not.toHaveBeenCalled();
+    expect(mocks.openAICreate).not.toHaveBeenCalled();
+  });
+
+  it("returns not found without calling AI for a cross-shop DTC job", async () => {
+    mocks.from.mockImplementation((table: string) => {
+      if (table === "work_order_lines") {
+        return query({ id: JOB_ID, work_order_id: WORK_ORDER_ID });
+      }
+      if (table === "work_orders") return query(null);
+      throw new Error(`Unexpected table ${table}`);
+    });
+    const { POST } = await import("../app/api/dtc-suggest/route");
+
+    const response = await POST(postRequest("/api/dtc-suggest", { jobId: JOB_ID }));
+
+    expect(response.status).toBe(404);
+    expect(mocks.claimQuota).not.toHaveBeenCalled();
+    expect(mocks.openAICreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized inspection input before quota or provider use", async () => {
+    const { POST } = await import("../app/api/ai/interpret/route");
+
+    const response = await POST(
+      postRequest("/api/ai/interpret", { transcript: "x".repeat(4001) }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.claimQuota).not.toHaveBeenCalled();
+    expect(mocks.openAICreate).not.toHaveBeenCalled();
+  });
+
+  it("enforces a distributed rate denial before provider use", async () => {
+    mocks.claimQuota.mockResolvedValue({
+      allowed: false,
+      reason: "rate_limited",
+      retryAfterSeconds: 42,
+    });
+    const { POST } = await import("../app/api/ai/interpret/route");
+
+    const response = await POST(
+      postRequest("/api/ai/interpret", { transcript: "left front tread 8 mm" }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("42");
+    expect(mocks.openAICreate).not.toHaveBeenCalled();
+  });
+
+  it("returns a bounded failure and releases quota on provider timeout", async () => {
+    mocks.openAICreate.mockRejectedValue(new Error("Inspection interpretation timed out"));
+    const { POST } = await import("../app/api/ai/interpret/route");
+
+    const response = await POST(
+      postRequest("/api/ai/interpret", { transcript: "left front tread 8 mm" }),
+    );
+
+    expect(response.status).toBe(504);
+    expect(await response.json()).toEqual([]);
+    expect(mocks.completeQuota).toHaveBeenCalledWith(
+      expect.objectContaining({ succeeded: false, actualCostUsd: 0 }),
+    );
+  });
+
+  it("preserves same-shop DTC suggestion output and records usage", async () => {
+    mocks.openAICreate.mockResolvedValue(
+      completion(JSON.stringify({ cause: "Catalyst efficiency low", correction: "Continue testing", laborTime: 1 })),
+    );
+    const { POST } = await import("../app/api/dtc-suggest/route");
+
+    const response = await POST(postRequest("/api/dtc-suggest", { jobId: JOB_ID }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      suggestion: {
+        cause: "Catalyst efficiency low",
+        correction: "Continue testing",
+        laborTime: 1,
+      },
+    });
+    expect(mocks.completeQuota).toHaveBeenCalledWith(
+      expect.objectContaining({ succeeded: true, receiptId: "quota-receipt" }),
+    );
+  });
+
+  it("secures the canonical technician DTC conversation flow", async () => {
+    mocks.openAICreate.mockResolvedValue(
+      completion(
+        JSON.stringify({
+          reply: "Test the downstream oxygen sensor next.",
+          summary: { dtc: "P0420", commonRepairs: [], recommendedTests: ["Check O2 response"] },
+        }),
+      ),
+    );
+    const { POST } = await import("../app/api/work-orders/dtc-suggest/route");
+
+    const response = await POST(
+      postRequest("/api/work-orders/dtc-suggest", {
+        jobId: JOB_ID,
+        code: "P0420",
+        userMessage: "Rear O2 stays near 0.72V",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.claimQuota).toHaveBeenCalledWith(
+      expect.objectContaining({ actorId: ACTOR_ID, shopId: SHOP_ID }),
+    );
+    expect(mocks.threadUpsert).toHaveBeenCalled();
+  });
+});

--- a/tests/security/p0-005-ai-route-governance.runtime.sql
+++ b/tests/security/p0-005-ai-route-governance.runtime.sql
@@ -1,0 +1,271 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+do $$
+begin
+  if has_function_privilege(
+    'anon',
+    'public.consume_ai_route_quota(uuid,uuid,text,integer,integer,integer,numeric,numeric)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'public.consume_ai_route_quota(uuid,uuid,text,integer,integer,integer,numeric,numeric)',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'service_role',
+    'public.consume_ai_route_quota(uuid,uuid,text,integer,integer,integer,numeric,numeric)',
+    'EXECUTE'
+  ) then
+    raise exception 'P0-005 runtime assertion failed: claim RPC ACL is unsafe';
+  end if;
+
+  if has_function_privilege(
+    'anon',
+    'public.complete_ai_route_quota(uuid,uuid,uuid,text,numeric,boolean)',
+    'EXECUTE'
+  )
+  or has_function_privilege(
+    'authenticated',
+    'public.complete_ai_route_quota(uuid,uuid,uuid,text,numeric,boolean)',
+    'EXECUTE'
+  )
+  or not has_function_privilege(
+    'service_role',
+    'public.complete_ai_route_quota(uuid,uuid,uuid,text,numeric,boolean)',
+    'EXECUTE'
+  ) then
+    raise exception 'P0-005 runtime assertion failed: completion RPC ACL is unsafe';
+  end if;
+
+  if has_table_privilege('anon', 'private.ai_route_usage_receipts', 'SELECT')
+     or has_table_privilege('authenticated', 'private.ai_route_usage_receipts', 'SELECT')
+     or has_table_privilege('service_role', 'private.ai_route_usage_receipts', 'SELECT') then
+    raise exception 'P0-005 runtime assertion failed: private usage receipts are exposed';
+  end if;
+end
+$$;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  (
+    '55000000-0000-4000-8000-000000000001',
+    'p0-005-owner-a@example.com',
+    '{"full_name":"P0-005 Owner A"}'::jsonb
+  ),
+  (
+    '56000000-0000-4000-8000-000000000002',
+    'p0-005-owner-b@example.com',
+    '{"full_name":"P0-005 Owner B"}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values
+  (
+    '55000000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'owner',
+    'P0-005 Owner A'
+  ),
+  (
+    '56000000-0000-4000-8000-000000000002',
+    '56000000-0000-4000-8000-000000000002',
+    'owner',
+    'P0-005 Owner B'
+  )
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+insert into public.shops (id, owner_id, business_name, name, user_limit)
+values
+  (
+    'a5100000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'P0-005 Shop A',
+    'P0-005 Shop A',
+    3
+  ),
+  (
+    'b5200000-0000-4000-8000-000000000002',
+    '56000000-0000-4000-8000-000000000002',
+    'P0-005 Shop B',
+    'P0-005 Shop B',
+    3
+  )
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = case id
+  when '55000000-0000-4000-8000-000000000001'::uuid
+    then 'a5100000-0000-4000-8000-000000000001'::uuid
+  else 'b5200000-0000-4000-8000-000000000002'::uuid
+end
+where id in (
+  '55000000-0000-4000-8000-000000000001',
+  '56000000-0000-4000-8000-000000000002'
+);
+
+set local role service_role;
+
+do $$
+declare
+  v_allowed boolean;
+begin
+  begin
+    select allowed
+    into v_allowed
+    from public.consume_ai_route_quota(
+      'b5200000-0000-4000-8000-000000000002',
+      '55000000-0000-4000-8000-000000000001',
+      'dtc_suggest',
+      2,
+      4,
+      300,
+      10,
+      0.1
+    );
+    raise exception 'P0-005 runtime assertion failed: cross-shop actor was accepted';
+  exception
+    when insufficient_privilege then null;
+  end;
+end
+$$;
+
+do $$
+declare
+  v_attempt integer;
+  v_allowed boolean;
+  v_reason text;
+  v_receipt uuid;
+begin
+  for v_attempt in 1..2 loop
+    select allowed, receipt_id
+    into v_allowed, v_receipt
+    from public.consume_ai_route_quota(
+      'a5100000-0000-4000-8000-000000000001',
+      '55000000-0000-4000-8000-000000000001',
+      'dtc_suggest',
+      2,
+      4,
+      300,
+      10,
+      0.1
+    );
+    if not v_allowed or v_receipt is null then
+      raise exception 'P0-005 runtime assertion failed: valid rate claim was denied';
+    end if;
+  end loop;
+
+  select allowed, denial_reason
+  into v_allowed, v_reason
+  from public.consume_ai_route_quota(
+    'a5100000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'dtc_suggest',
+    2,
+    4,
+    300,
+    10,
+    0.1
+  );
+
+  if v_allowed or v_reason <> 'rate_limited' then
+    raise exception 'P0-005 runtime assertion failed: actor rate limit was bypassed';
+  end if;
+end
+$$;
+
+do $$
+declare
+  v_allowed boolean;
+  v_reason text;
+  v_receipt_one uuid;
+  v_receipt_two uuid;
+  v_completed boolean;
+begin
+  select allowed, receipt_id
+  into v_allowed, v_receipt_one
+  from public.consume_ai_route_quota(
+    'a5100000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'inspection_interpret',
+    10,
+    20,
+    300,
+    0.05,
+    0.04
+  );
+
+  if not v_allowed or v_receipt_one is null then
+    raise exception 'P0-005 runtime assertion failed: budget claim was denied';
+  end if;
+
+  select public.complete_ai_route_quota(
+    v_receipt_one,
+    'a5100000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'inspection_interpret',
+    0.01,
+    true
+  ) into v_completed;
+
+  if not v_completed then
+    raise exception 'P0-005 runtime assertion failed: valid receipt was not completed';
+  end if;
+
+  select public.complete_ai_route_quota(
+    v_receipt_one,
+    'a5100000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'inspection_interpret',
+    0.01,
+    true
+  ) into v_completed;
+
+  if v_completed then
+    raise exception 'P0-005 runtime assertion failed: receipt completion was replayable';
+  end if;
+
+  select allowed, receipt_id
+  into v_allowed, v_receipt_two
+  from public.consume_ai_route_quota(
+    'a5100000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'inspection_interpret',
+    10,
+    20,
+    300,
+    0.05,
+    0.04
+  );
+
+  if not v_allowed or v_receipt_two is null then
+    raise exception 'P0-005 runtime assertion failed: reconciled budget was not reusable';
+  end if;
+
+  select allowed, denial_reason
+  into v_allowed, v_reason
+  from public.consume_ai_route_quota(
+    'a5100000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'inspection_interpret',
+    10,
+    20,
+    300,
+    0.05,
+    0.04
+  );
+
+  if v_allowed or v_reason <> 'hard_budget_exceeded' then
+    raise exception 'P0-005 runtime assertion failed: hard budget was bypassed';
+  end if;
+end
+$$;
+
+reset role;
+rollback;

--- a/tsconfig.p0-005.json
+++ b/tsconfig.p0-005.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "include": [
+    "next-env.d.ts",
+    "app/api/ai/interpret/route.ts",
+    "app/api/dtc-suggest/route.ts",
+    "app/api/work-orders/dtc-suggest/route.ts",
+    "features/shared/lib/server/ai-ops-guard.ts",
+    "features/shared/lib/server/ai-policy.ts",
+    "features/shared/lib/server/bounded-json.ts",
+    "features/shared/lib/server/durable-ai-guard.ts",
+    "features/shared/lib/server/provider-timeout.ts",
+    "tests/p0-005-ai-route-security.test.ts"
+  ]
+}


### PR DESCRIPTION
## What changed

- require authenticated, shop-scoped, role-capable access for the legacy DTC suggestion route, the canonical technician DTC conversation route, and inspection voice interpretation
- bind DTC job, work order, vehicle, and persisted thread reads to the authenticated shop before service-role data is used
- add byte and schema limits for AI request bodies, bounded conversation history, bounded model output, no-store responses, generic public errors, and aborting provider timeouts
- add a private AI usage receipt ledger plus service-role-only RPCs for atomic actor/shop rate claims and monthly hard-budget reservations across serverless instances
- reconcile actual usage after provider success/failure and preserve existing technician-facing response shapes
- add focused route behavior tests, direct SQL ACL/quota tests, a scoped validation workflow, and clean-replay coverage
- refresh the API boundary inventory; the two audited anonymous routes are no longer flagged as missing auth

## Why

P0-005 allowed anonymous OpenAI calls. The legacy DTC route also loaded work-order and vehicle data through the service role from an arbitrary job ID, which could disclose another shop's repair context. In-memory rate controls do not hold across Vercel instances.

## Safety and deployment

The new RPCs are executable only by `service_role`; their table lives in the unexposed `private` schema with no direct client or service-role table grants. Each claim verifies actor/shop membership and serializes quota decisions with a short transaction-scoped advisory lock. Provider calls happen after the database transaction finishes.

The migration is additive. Deploy the migration before or with the code. If code reaches production first, affected AI routes fail closed with a generic 503 until the RPC exists.

## Validation

Local:
- Node 24 strip-types syntax checks for all changed TypeScript files
- `node scripts/audit-api-routes.mjs` (381 routes; audited routes no longer flagged)
- `git diff --check`
- unique migration-version and migration transaction static checks

CI added:
- clean frozen install
- scoped TypeScript and ESLint
- `tests/p0-005-ai-route-security.test.ts`
- full Supabase migration replay
- `tests/security/p0-005-ai-route-governance.runtime.sql`

Local dependency-backed typecheck/lint/Vitest and Postgres execution remain pending because this checkout has an incomplete node_modules link and the pnpm wrapper stalled before starting; CI is authoritative.