### PR TITLE
P0-007: make financial outbox delivery safely idempotent

### DIFF
--- a/.github/workflows/p0-007-financial-outbox-validation.yml
+++ b/.github/workflows/p0-007-financial-outbox-validation.yml
@@ -1,0 +1,51 @@
+name: P0-007 Financial Outbox Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/internal/financial-outbox/**"
+      - "app/api/webhooks/sendgrid/**"
+      - "features/email/server/sendFinancialEventEmail.ts"
+      - "features/email/server/sendgridWebhook.ts"
+      - "features/invoices/server/processFinancialOutbox.ts"
+      - "features/shared/types/types/supabase.ts"
+      - "supabase/migrations/**"
+      - "tests/p0-007-financial-outbox.test.ts"
+      - "tests/phase1-financial-foundation.test.ts"
+      - "tests/security/p0-007-financial-outbox.runtime.sql"
+      - "tests/security/p0-007-financial-outbox-concurrency.sh"
+      - "tsconfig.p0-007.json"
+      - ".github/workflows/p0-007-financial-outbox-validation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec tsc --noEmit -p tsconfig.p0-007.json
+      - run: >-
+          pnpm exec eslint
+          app/api/internal/financial-outbox/tick/route.ts
+          app/api/webhooks/sendgrid/events/route.ts
+          features/email/server/sendFinancialEventEmail.ts
+          features/email/server/sendgridWebhook.ts
+          features/invoices/server/processFinancialOutbox.ts
+          tests/p0-007-financial-outbox.test.ts
+          tests/phase1-financial-foundation.test.ts
+      - run: >-
+          pnpm exec vitest run
+          tests/p0-007-financial-outbox.test.ts
+          tests/phase1-financial-foundation.test.ts
+          tests/sendgrid-webhook-security.test.ts

--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -195,6 +195,29 @@ jobs:
             -f tests/security/p0-006-stripe-identity.runtime.sql \
             2>&1 | tee p0-006-stripe-identity-runtime.log
 
+      - name: Execute P0 financial outbox idempotency integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/p0-007-financial-outbox.runtime.sql \
+            2>&1 | tee p0-007-financial-outbox-runtime.log
+
+      - name: Execute P0 financial outbox concurrent-worker integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          bash tests/security/p0-007-financial-outbox-concurrency.sh \
+            2>&1 | tee p0-007-financial-outbox-concurrency.log
+
       - name: Verify bootstrap and existing-database baseline paths
         shell: bash
         env:
@@ -262,6 +285,8 @@ jobs:
             p0-004-vehicle-recall-fetch-runtime.log
             p0-005-ai-route-governance-runtime.log
             p0-006-stripe-identity-runtime.log
+            p0-007-financial-outbox-runtime.log
+            p0-007-financial-outbox-concurrency.log
             supabase/config.toml
           if-no-files-found: warn
 

--- a/features/email/server/sendFinancialEventEmail.ts
+++ b/features/email/server/sendFinancialEventEmail.ts
@@ -14,6 +14,11 @@ function configure() {
   configured = true;
 }
 
+export function assertFinancialEventEmailConfigured() {
+  requiredEnv("SENDGRID_API_KEY");
+  requiredEnv("SENDGRID_FROM_EMAIL");
+}
+
 function escapeHtml(value: string) {
   return value
     .replaceAll("&", "&amp;")
@@ -30,8 +35,12 @@ export async function sendFinancialEventEmail(input: {
   heading: string;
   body: string;
   portalUrl?: string | null;
+  deliveryKey: string;
+  outboxId: string;
+  recipientKind: "customer" | "staff";
   metadata?: Record<string, unknown>;
-}) {
+}): Promise<{ providerMessageId: string | null }> {
+  assertFinancialEventEmailConfigured();
   configure();
   const heading = escapeHtml(input.heading);
   const body = escapeHtml(input.body);
@@ -40,16 +49,26 @@ export async function sendFinancialEventEmail(input: {
     ? `<p style="margin-top:24px"><a href="${escapeHtml(portalUrl)}" style="display:inline-block;padding:12px 18px;border-radius:8px;background:#c57a4a;color:#fff;text-decoration:none">View in portal</a></p>`
     : "";
 
-  await sgMail.send({
-    to: input.to,
+  const [response] = await sgMail.send({
+    to: input.to.trim().toLowerCase(),
     from: requiredEnv("SENDGRID_FROM_EMAIL"),
     subject: input.subject,
     text: `${input.heading}\n\n${input.body}${portalUrl ? `\n\n${portalUrl}` : ""}`,
     html: `<div style="font-family:Arial,sans-serif;max-width:620px;margin:auto;padding:24px;color:#111827"><h1 style="font-size:22px">${heading}</h1><p style="font-size:15px;line-height:1.6">${body}</p>${action}<p style="margin-top:28px;color:#6b7280;font-size:12px">Sent by ProFixIQ</p></div>`,
     customArgs: {
-      shop_id: input.shopId,
+      financial_delivery_key: input.deliveryKey,
+      financial_outbox_id: input.outboxId,
+      financial_recipient_kind: input.recipientKind,
       event_type: String(input.metadata?.event_type ?? "financial_event"),
-      dedupe_key: String(input.metadata?.dedupe_key ?? ""),
     },
   });
+
+  const headerValue =
+    response.headers["x-message-id"] ?? response.headers["X-Message-Id"] ?? null;
+
+  return {
+    providerMessageId: Array.isArray(headerValue)
+      ? (headerValue[0] ?? null)
+      : headerValue,
+  };
 }

--- a/features/email/server/sendgridWebhook.ts
+++ b/features/email/server/sendgridWebhook.ts
@@ -7,6 +7,7 @@ export type SendGridEvent = {
   sg_event_id?: unknown;
   sg_message_id?: unknown;
   email_log_id?: unknown;
+  financial_delivery_key?: unknown;
   reason?: unknown;
   response?: unknown;
   status?: unknown;
@@ -16,6 +17,7 @@ export type SendGridEvent = {
 
 const MAX_WEBHOOK_BYTES = 1_000_000;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const FINANCIAL_DELIVERY_KEY_RE = /^fin_[0-9a-f]{32}_(customer|staff)$/;
 
 function cleanString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
@@ -61,6 +63,10 @@ export function normalizeSendGridEvent(event: SendGridEvent) {
   const eventAt = Number.isFinite(timestamp) && timestamp > 0
     ? new Date(timestamp * 1000).toISOString()
     : new Date().toISOString();
+  const financialDeliveryKey = cleanString(event.financial_delivery_key);
+  const safeFinancialDeliveryKey = FINANCIAL_DELIVERY_KEY_RE.test(financialDeliveryKey ?? "")
+    ? financialDeliveryKey
+    : null;
 
   return {
     eventType,
@@ -71,6 +77,7 @@ export function normalizeSendGridEvent(event: SendGridEvent) {
       ? cleanString(event.email_log_id)
       : null,
     email: cleanString(event.email)?.toLowerCase() ?? null,
+    financialDeliveryKey: safeFinancialDeliveryKey,
     errorText:
       cleanString(event.reason) ??
       cleanString(event.response) ??
@@ -81,6 +88,7 @@ export function normalizeSendGridEvent(event: SendGridEvent) {
       status: cleanString(event.status),
       attempt: typeof event.attempt === "number" ? event.attempt : null,
       type: cleanString(event.type),
+      financial_delivery_key: safeFinancialDeliveryKey,
     },
   };
 }

--- a/features/invoices/server/processFinancialOutbox.ts
+++ b/features/invoices/server/processFinancialOutbox.ts
@@ -1,10 +1,14 @@
+import { randomUUID } from "node:crypto";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { sendFinancialEventEmail } from "@/features/email/server/sendFinancialEventEmail";
+import {
+  assertFinancialEventEmailConfigured,
+  sendFinancialEventEmail,
+} from "@/features/email/server/sendFinancialEventEmail";
 
 type DB = Database;
 type OutboxRow = {
-  id: string;
+  outbox_id: string;
   shop_id: string;
   aggregate_id: string;
   event_type: string;
@@ -13,24 +17,68 @@ type OutboxRow = {
   attempts: number;
 };
 
-type DynamicQuery = {
-  is(column: string, value: null): DynamicQuery;
-  lte(column: string, value: string): DynamicQuery;
-  order(column: string, options: { ascending: boolean }): DynamicQuery;
-  limit(value: number): DynamicQuery;
-  returns<T>(): Promise<{ data: T | null; error: { message: string } | null }>;
+type DeliveryClaim = {
+  delivery_id: string;
+  delivery_key: string;
+  delivery_status: string;
+  should_send: boolean;
+  delivery_attempts: number;
 };
 
-type DynamicMutation = {
-  eq(column: string, value: string): Promise<{ error: { message: string } | null }>;
+type CustomerRow = {
+  id: string;
+  user_id: string | null;
+  email: string | null;
+  name: string | null;
+  first_name: string | null;
+  last_name: string | null;
 };
 
-type DynamicClient = {
-  from(table: string): {
-    select(columns: string): DynamicQuery;
-    update(values: Record<string, unknown>): DynamicMutation;
-  };
+type RpcError = { message: string };
+type FinancialOutboxRpcClient = {
+  rpc(
+    name: string,
+    args: Record<string, unknown>,
+  ): PromiseLike<{ data: unknown; error: RpcError | null }>;
 };
+
+type FinancialEmailInput = Parameters<typeof sendFinancialEventEmail>[0];
+type ProcessFinancialOutboxOptions = {
+  workerId?: string;
+  sendEmail?: (input: FinancialEmailInput) => Promise<{ providerMessageId: string | null }>;
+  now?: () => Date;
+};
+
+const TERMINAL_DELIVERY_STATUSES = new Set([
+  "accepted",
+  "delivered",
+  "bounced",
+  "dropped",
+]);
+
+async function rpc<T>(
+  admin: SupabaseClient<DB>,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const client = admin as unknown as FinancialOutboxRpcClient;
+  const { data, error } = await client.rpc(name, args);
+  if (error) throw new Error(error.message);
+  return data as T;
+}
+
+function firstRpcRow<T>(value: T[] | T | null): T | null {
+  return Array.isArray(value) ? (value[0] ?? null) : value;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Financial outbox delivery failed";
+}
+
+function retryAt(now: Date, attempts: number): string {
+  const delayMinutes = Math.min(60, Math.max(1, 2 ** Math.min(Math.max(attempts - 1, 0), 5)));
+  return new Date(now.getTime() + delayMinutes * 60_000).toISOString();
+}
 
 function formatMoney(value: unknown, currency: unknown) {
   const normalized = String(currency ?? "USD").toUpperCase() === "CAD" ? "CAD" : "USD";
@@ -81,40 +129,108 @@ function eventCopy(eventType: string, payload: Record<string, unknown>) {
   }
 }
 
+async function deliverRecipient(input: {
+  admin: SupabaseClient<DB>;
+  workerId: string;
+  row: OutboxRow;
+  recipientKind: "customer" | "staff";
+  recipientEmail: string;
+  message: Omit<FinancialEmailInput, "deliveryKey" | "outboxId" | "recipientKind" | "to">;
+  sendEmail: NonNullable<ProcessFinancialOutboxOptions["sendEmail"]>;
+}) {
+  // Fail before reserving a provider-send boundary when configuration is missing.
+  assertFinancialEventEmailConfigured();
+
+  const claimData = await rpc<DeliveryClaim[] | DeliveryClaim | null>(
+    input.admin,
+    "claim_financial_outbox_delivery",
+    {
+      p_outbox_id: input.row.outbox_id,
+      p_worker_id: input.workerId,
+      p_recipient_kind: input.recipientKind,
+      p_recipient_email: input.recipientEmail,
+      p_lease_seconds: 120,
+    },
+  );
+  const claim = firstRpcRow(claimData);
+  if (!claim) throw new Error("Financial delivery claim returned no row");
+
+  if (TERMINAL_DELIVERY_STATUSES.has(claim.delivery_status)) return;
+  if (claim.delivery_status === "ambiguous") {
+    throw new Error(`Financial ${input.recipientKind} delivery requires provider reconciliation`);
+  }
+  if (!claim.should_send || claim.delivery_status !== "claimed") {
+    throw new Error(`Financial ${input.recipientKind} delivery is not available for this worker`);
+  }
+
+  const began = await rpc<boolean>(input.admin, "begin_financial_outbox_delivery", {
+    p_delivery_id: claim.delivery_id,
+    p_worker_id: input.workerId,
+    p_lease_seconds: 120,
+  });
+  if (!began) throw new Error("Financial delivery send boundary could not be started");
+
+  try {
+    const result = await input.sendEmail({
+      ...input.message,
+      to: input.recipientEmail,
+      deliveryKey: claim.delivery_key,
+      outboxId: input.row.outbox_id,
+      recipientKind: input.recipientKind,
+    });
+
+    const accepted = await rpc<boolean>(input.admin, "accept_financial_outbox_delivery", {
+      p_delivery_id: claim.delivery_id,
+      p_worker_id: input.workerId,
+      p_provider_message_id: result.providerMessageId,
+    });
+    if (!accepted) throw new Error("Financial delivery acceptance was not recorded");
+  } catch (error) {
+    // SendGrid has no Mail Send idempotency key. Any failure after the request
+    // boundary is therefore ambiguous and must not be retried automatically.
+    try {
+      await rpc<boolean>(input.admin, "mark_financial_outbox_delivery_ambiguous", {
+        p_delivery_id: claim.delivery_id,
+        p_worker_id: input.workerId,
+        p_error: errorMessage(error),
+      });
+    } catch {
+      // If this acknowledgement also fails, the delivery lease expiry performs
+      // the same safe transition to ambiguous for webhook reconciliation.
+    }
+    throw error;
+  }
+}
+
 export async function processFinancialOutbox(
   admin: SupabaseClient<DB>,
   limit = 25,
+  options: ProcessFinancialOutboxOptions = {},
 ): Promise<{ processed: number; failed: number }> {
-  const client = admin as unknown as DynamicClient;
-  const { data, error } = await client
-    .from("financial_domain_outbox")
-    .select("id,shop_id,aggregate_id,event_type,dedupe_key,payload,attempts")
-    .is("delivered_at", null)
-    .lte("next_attempt_at", new Date().toISOString())
-    .order("occurred_at", { ascending: true })
-    .limit(limit)
-    .returns<OutboxRow[]>();
-  if (error) throw new Error(error.message);
+  const workerId = options.workerId ?? randomUUID();
+  const now = options.now ?? (() => new Date());
+  const sendEmail = options.sendEmail ?? sendFinancialEventEmail;
+  const data = await rpc<OutboxRow[] | null>(admin, "claim_financial_outbox_batch", {
+    p_worker_id: workerId,
+    p_limit: Math.max(1, Math.min(limit, 100)),
+    p_lease_seconds: 120,
+  });
 
   let processed = 0;
   let failed = 0;
 
   for (const row of data ?? []) {
-    const copy = eventCopy(row.event_type, row.payload ?? {});
-    if (!copy) {
-      await client
-        .from("financial_domain_outbox")
-        .update({ delivered_at: new Date().toISOString(), attempts: row.attempts + 1 })
-        .eq("id", row.id);
-      processed += 1;
-      continue;
-    }
-
     try {
-      await client
-        .from("financial_domain_outbox")
-        .update({ processing_at: new Date().toISOString(), attempts: row.attempts + 1 })
-        .eq("id", row.id);
+      const copy = eventCopy(row.event_type, row.payload ?? {});
+      if (!copy) {
+        const completed = await rpc<boolean>(admin, "complete_financial_outbox_claim", {
+          p_outbox_id: row.outbox_id,
+          p_worker_id: workerId,
+        });
+        if (!completed) throw new Error("Unsupported financial event could not be completed");
+        processed += 1;
+        continue;
+      }
 
       const workOrderId = String(row.payload.work_order_id ?? "").trim();
       if (!workOrderId) throw new Error("Outbox event is missing work_order_id");
@@ -129,32 +245,29 @@ export async function processFinancialOutbox(
         throw new Error(workOrderError?.message ?? "Work order not found");
       }
 
-      const [{ data: customer }, { data: shop }] = await Promise.all([
-        workOrder.customer_id
-          ? admin
-              .from("customers")
-              .select("id,user_id,email,name,first_name,last_name")
-              .eq("id", workOrder.customer_id)
-              .maybeSingle<{
-                id: string;
-                user_id: string | null;
-                email: string | null;
-                name: string | null;
-                first_name: string | null;
-                last_name: string | null;
-              }>()
-          : Promise.resolve({ data: null, error: null }),
-        admin
-          .from("shops")
-          .select("email,business_name,shop_name,name")
-          .eq("id", row.shop_id)
-          .maybeSingle<{
-            email: string | null;
-            business_name: string | null;
-            shop_name: string | null;
-            name: string | null;
-          }>(),
-      ]);
+      let customer: CustomerRow | null = null;
+      if (workOrder.customer_id) {
+        const customerResult = await admin
+          .from("customers")
+          .select("id,user_id,email,name,first_name,last_name")
+          .eq("id", workOrder.customer_id)
+          .eq("shop_id", row.shop_id)
+          .maybeSingle<CustomerRow>();
+        if (customerResult.error) throw new Error(customerResult.error.message);
+        customer = customerResult.data;
+      }
+
+      const { data: shop, error: shopError } = await admin
+        .from("shops")
+        .select("email,business_name,shop_name,name")
+        .eq("id", row.shop_id)
+        .maybeSingle<{
+          email: string | null;
+          business_name: string | null;
+          shop_name: string | null;
+          name: string | null;
+        }>();
+      if (shopError || !shop) throw new Error(shopError?.message ?? "Shop not found");
 
       const portalUrl = `${process.env.NEXT_PUBLIC_SITE_URL ?? "https://profixiq.com"}/portal/invoices/${workOrderId}`;
       if (customer?.user_id) {
@@ -174,56 +287,60 @@ export async function processFinancialOutbox(
       }
 
       if (customer?.email) {
-        await sendFinancialEventEmail({
-          shopId: row.shop_id,
-          to: customer.email,
-          subject: copy.customerTitle,
-          heading: copy.customerTitle,
-          body: copy.customerBody,
-          portalUrl,
-          metadata: {
-            outbox_id: row.id,
-            event_type: row.event_type,
-            dedupe_key: row.dedupe_key,
+        await deliverRecipient({
+          admin,
+          workerId,
+          row,
+          recipientKind: "customer",
+          recipientEmail: customer.email,
+          sendEmail,
+          message: {
+            shopId: row.shop_id,
+            subject: copy.customerTitle,
+            heading: copy.customerTitle,
+            body: copy.customerBody,
+            portalUrl,
+            metadata: { event_type: row.event_type },
           },
         });
       }
 
-      if (shop?.email && row.event_type !== "payment.succeeded" && row.event_type !== "manual.payment") {
-        await sendFinancialEventEmail({
-          shopId: row.shop_id,
-          to: shop.email,
-          subject: copy.staffSubject,
-          heading: copy.staffSubject,
-          body: copy.staffBody,
-          metadata: {
-            outbox_id: row.id,
-            event_type: row.event_type,
-            dedupe_key: `${row.dedupe_key}:staff`,
+      if (shop.email && row.event_type !== "payment.succeeded" && row.event_type !== "manual.payment") {
+        await deliverRecipient({
+          admin,
+          workerId,
+          row,
+          recipientKind: "staff",
+          recipientEmail: shop.email,
+          sendEmail,
+          message: {
+            shopId: row.shop_id,
+            subject: copy.staffSubject,
+            heading: copy.staffSubject,
+            body: copy.staffBody,
+            metadata: { event_type: row.event_type },
           },
         });
       }
 
-      await client
-        .from("financial_domain_outbox")
-        .update({
-          delivered_at: new Date().toISOString(),
-          processing_at: null,
-          last_error: null,
-        })
-        .eq("id", row.id);
+      const completed = await rpc<boolean>(admin, "complete_financial_outbox_claim", {
+        p_outbox_id: row.outbox_id,
+        p_worker_id: workerId,
+      });
+      if (!completed) throw new Error("Financial outbox has unresolved recipient deliveries");
       processed += 1;
     } catch (deliveryError) {
-      const message = deliveryError instanceof Error ? deliveryError.message : "Delivery failed";
-      const delayMinutes = Math.min(60, Math.max(1, 2 ** Math.min(row.attempts, 5)));
-      await client
-        .from("financial_domain_outbox")
-        .update({
-          processing_at: null,
-          last_error: message,
-          next_attempt_at: new Date(Date.now() + delayMinutes * 60_000).toISOString(),
-        })
-        .eq("id", row.id);
+      const message = errorMessage(deliveryError);
+      try {
+        await rpc<boolean>(admin, "release_financial_outbox_claim", {
+          p_outbox_id: row.outbox_id,
+          p_worker_id: workerId,
+          p_error: message,
+          p_next_attempt_at: retryAt(now(), row.attempts),
+        });
+      } catch {
+        // The row lease safely expires if the release acknowledgement fails.
+      }
       failed += 1;
     }
   }

--- a/supabase/migrations/20260725181500_harden_p0_007_financial_outbox_delivery.sql
+++ b/supabase/migrations/20260725181500_harden_p0_007_financial_outbox_delivery.sql
@@ -1,0 +1,692 @@
+begin;
+
+create schema if not exists private;
+
+alter table public.financial_domain_outbox
+  add column if not exists lease_owner uuid,
+  add column if not exists lease_expires_at timestamptz;
+
+create index if not exists financial_domain_outbox_claim_idx
+  on public.financial_domain_outbox (next_attempt_at, occurred_at)
+  where delivered_at is null;
+
+create table if not exists private.financial_outbox_deliveries (
+  id uuid primary key default gen_random_uuid(),
+  outbox_id uuid not null references public.financial_domain_outbox(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  recipient_kind text not null,
+  recipient_email text not null,
+  delivery_key text not null,
+  status text not null default 'pending',
+  provider text not null default 'sendgrid',
+  provider_message_id text,
+  attempts integer not null default 0,
+  lease_owner uuid,
+  lease_expires_at timestamptz,
+  next_attempt_at timestamptz not null default now(),
+  send_started_at timestamptz,
+  accepted_at timestamptz,
+  delivered_at timestamptz,
+  ambiguous_at timestamptz,
+  last_provider_event_at timestamptz,
+  last_provider_event_type text,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint financial_outbox_deliveries_recipient_kind_check
+    check (recipient_kind in ('customer', 'staff')),
+  constraint financial_outbox_deliveries_recipient_email_check
+    check (
+      char_length(recipient_email) between 3 and 320
+      and recipient_email = lower(btrim(recipient_email))
+      and recipient_email !~ '[\r\n]'
+    ),
+  constraint financial_outbox_deliveries_delivery_key_check
+    check (delivery_key ~ '^fin_[0-9a-f]{32}_(customer|staff)$'),
+  constraint financial_outbox_deliveries_status_check
+    check (status in (
+      'pending',
+      'claimed',
+      'sending',
+      'accepted',
+      'delivered',
+      'bounced',
+      'dropped',
+      'failed',
+      'ambiguous'
+    )),
+  constraint financial_outbox_deliveries_attempts_check
+    check (attempts >= 0),
+  unique (outbox_id, recipient_kind),
+  unique (delivery_key)
+);
+
+create index if not exists financial_outbox_deliveries_reconcile_idx
+  on private.financial_outbox_deliveries (status, lease_expires_at, next_attempt_at);
+
+create index if not exists financial_outbox_deliveries_outbox_idx
+  on private.financial_outbox_deliveries (outbox_id, status);
+
+alter table private.financial_outbox_deliveries enable row level security;
+alter table private.financial_outbox_deliveries force row level security;
+
+revoke all on table private.financial_outbox_deliveries
+  from public, anon, authenticated, service_role;
+
+create or replace function public.claim_financial_outbox_batch(
+  p_worker_id uuid,
+  p_limit integer default 25,
+  p_lease_seconds integer default 120
+)
+returns table (
+  outbox_id uuid,
+  shop_id uuid,
+  aggregate_id uuid,
+  event_type text,
+  dedupe_key text,
+  payload jsonb,
+  attempts integer
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_limit integer := greatest(1, least(coalesce(p_limit, 25), 100));
+  v_lease_seconds integer := greatest(30, least(coalesce(p_lease_seconds, 120), 900));
+begin
+  if p_worker_id is null then
+    raise exception using errcode = '22023', message = 'financial outbox worker id is required';
+  end if;
+
+  -- An expired pre-send claim is safe to reclaim. Once a provider request has
+  -- started, however, a missing acknowledgement is ambiguous and must be
+  -- reconciled from the provider webhook instead of sent again.
+  update private.financial_outbox_deliveries delivery
+  set status = case
+        when delivery.status = 'claimed' then 'pending'
+        else 'ambiguous'
+      end,
+      ambiguous_at = case
+        when delivery.status = 'sending' then coalesce(delivery.ambiguous_at, now())
+        else delivery.ambiguous_at
+      end,
+      last_error = case
+        when delivery.status = 'sending' then coalesce(
+          delivery.last_error,
+          'provider acknowledgement missing after delivery lease expired'
+        )
+        else delivery.last_error
+      end,
+      lease_owner = null,
+      lease_expires_at = null,
+      updated_at = now()
+  where delivery.status in ('claimed', 'sending')
+    and delivery.lease_expires_at <= now();
+
+  return query
+  with candidates as (
+    select outbox.id
+    from public.financial_domain_outbox outbox
+    where outbox.delivered_at is null
+      and outbox.next_attempt_at <= now()
+      and (outbox.lease_expires_at is null or outbox.lease_expires_at <= now())
+      and not exists (
+        select 1
+        from private.financial_outbox_deliveries delivery
+        where delivery.outbox_id = outbox.id
+          and delivery.status in ('claimed', 'sending', 'ambiguous')
+      )
+    order by outbox.occurred_at, outbox.id
+    for update skip locked
+    limit v_limit
+  ), claimed_rows as (
+    update public.financial_domain_outbox outbox
+    set lease_owner = p_worker_id,
+        lease_expires_at = now() + make_interval(secs => v_lease_seconds),
+        processing_at = now(),
+        attempts = outbox.attempts + 1,
+        last_error = null
+    from candidates
+    where outbox.id = candidates.id
+    returning outbox.*
+  )
+  select
+    claimed_rows.id,
+    claimed_rows.shop_id,
+    claimed_rows.aggregate_id,
+    claimed_rows.event_type,
+    claimed_rows.dedupe_key,
+    claimed_rows.payload,
+    claimed_rows.attempts
+  from claimed_rows
+  order by claimed_rows.occurred_at, claimed_rows.id;
+end;
+$$;
+
+create or replace function public.claim_financial_outbox_delivery(
+  p_outbox_id uuid,
+  p_worker_id uuid,
+  p_recipient_kind text,
+  p_recipient_email text,
+  p_lease_seconds integer default 120
+)
+returns table (
+  delivery_id uuid,
+  delivery_key text,
+  delivery_status text,
+  should_send boolean,
+  delivery_attempts integer
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_outbox public.financial_domain_outbox%rowtype;
+  v_delivery private.financial_outbox_deliveries%rowtype;
+  v_email text := lower(btrim(coalesce(p_recipient_email, '')));
+  v_delivery_key text;
+  v_lease_seconds integer := greatest(30, least(coalesce(p_lease_seconds, 120), 900));
+begin
+  if p_worker_id is null
+     or p_recipient_kind not in ('customer', 'staff')
+     or char_length(v_email) not between 3 and 320
+     or v_email ~ '[\r\n]' then
+    raise exception using errcode = '22023', message = 'invalid financial delivery claim';
+  end if;
+
+  select outbox.*
+  into v_outbox
+  from public.financial_domain_outbox outbox
+  where outbox.id = p_outbox_id
+    and outbox.delivered_at is null
+    and outbox.lease_owner = p_worker_id
+    and outbox.lease_expires_at > now()
+  for update;
+
+  if not found then
+    raise exception using errcode = '42501', message = 'financial outbox lease is not owned by worker';
+  end if;
+
+  v_delivery_key := 'fin_'
+    || replace(p_outbox_id::text, '-', '')
+    || '_'
+    || p_recipient_kind;
+
+  select delivery.*
+  into v_delivery
+  from private.financial_outbox_deliveries delivery
+  where delivery.outbox_id = p_outbox_id
+    and delivery.recipient_kind = p_recipient_kind
+  for update;
+
+  if not found then
+    insert into private.financial_outbox_deliveries (
+      outbox_id,
+      shop_id,
+      recipient_kind,
+      recipient_email,
+      delivery_key,
+      status,
+      attempts,
+      lease_owner,
+      lease_expires_at
+    )
+    values (
+      p_outbox_id,
+      v_outbox.shop_id,
+      p_recipient_kind,
+      v_email,
+      v_delivery_key,
+      'claimed',
+      1,
+      p_worker_id,
+      now() + make_interval(secs => v_lease_seconds)
+    )
+    returning * into v_delivery;
+  else
+    if v_delivery.delivery_key <> v_delivery_key
+       or v_delivery.shop_id <> v_outbox.shop_id then
+      raise exception using errcode = '23505', message = 'financial delivery identity conflict';
+    end if;
+
+    if v_delivery.recipient_email <> v_email then
+      if v_delivery.status not in ('pending', 'failed') then
+        raise exception using errcode = '23505', message = 'financial delivery recipient is immutable after claim';
+      end if;
+      update private.financial_outbox_deliveries
+      set recipient_email = v_email,
+          updated_at = now()
+      where id = v_delivery.id
+      returning * into v_delivery;
+    end if;
+
+    if v_delivery.status = 'claimed'
+       and v_delivery.lease_owner = p_worker_id
+       and v_delivery.lease_expires_at > now() then
+      return query
+      select v_delivery.id, v_delivery.delivery_key, v_delivery.status, true, v_delivery.attempts;
+      return;
+    end if;
+
+    if v_delivery.status = 'claimed'
+       and v_delivery.lease_expires_at <= now() then
+      update private.financial_outbox_deliveries
+      set status = 'pending',
+          lease_owner = null,
+          lease_expires_at = null,
+          updated_at = now()
+      where id = v_delivery.id
+      returning * into v_delivery;
+    elsif v_delivery.status = 'sending'
+       and v_delivery.lease_expires_at <= now() then
+      update private.financial_outbox_deliveries
+      set status = 'ambiguous',
+          ambiguous_at = coalesce(ambiguous_at, now()),
+          last_error = coalesce(
+            last_error,
+            'provider acknowledgement missing after delivery lease expired'
+          ),
+          lease_owner = null,
+          lease_expires_at = null,
+          updated_at = now()
+      where id = v_delivery.id
+      returning * into v_delivery;
+    end if;
+
+    if v_delivery.status in ('pending', 'failed')
+       and v_delivery.next_attempt_at <= now() then
+      update private.financial_outbox_deliveries
+      set status = 'claimed',
+          attempts = attempts + 1,
+          lease_owner = p_worker_id,
+          lease_expires_at = now() + make_interval(secs => v_lease_seconds),
+          last_error = null,
+          updated_at = now()
+      where id = v_delivery.id
+      returning * into v_delivery;
+    end if;
+  end if;
+
+  return query
+  select
+    v_delivery.id,
+    v_delivery.delivery_key,
+    v_delivery.status,
+    v_delivery.status = 'claimed'
+      and v_delivery.lease_owner = p_worker_id
+      and v_delivery.lease_expires_at > now(),
+    v_delivery.attempts;
+end;
+$$;
+
+create or replace function public.begin_financial_outbox_delivery(
+  p_delivery_id uuid,
+  p_worker_id uuid,
+  p_lease_seconds integer default 120
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_started boolean;
+  v_lease_seconds integer := greatest(30, least(coalesce(p_lease_seconds, 120), 900));
+begin
+  update private.financial_outbox_deliveries delivery
+  set status = 'sending',
+      send_started_at = coalesce(delivery.send_started_at, now()),
+      lease_expires_at = now() + make_interval(secs => v_lease_seconds),
+      updated_at = now()
+  where delivery.id = p_delivery_id
+    and delivery.status = 'claimed'
+    and delivery.lease_owner = p_worker_id
+    and delivery.lease_expires_at > now()
+  returning true into v_started;
+
+  if coalesce(v_started, false) then
+    return true;
+  end if;
+
+  return exists (
+    select 1
+    from private.financial_outbox_deliveries delivery
+    where delivery.id = p_delivery_id
+      and delivery.status = 'sending'
+      and delivery.lease_owner = p_worker_id
+      and delivery.lease_expires_at > now()
+  );
+end;
+$$;
+
+create or replace function public.accept_financial_outbox_delivery(
+  p_delivery_id uuid,
+  p_worker_id uuid,
+  p_provider_message_id text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_accepted boolean;
+begin
+  update private.financial_outbox_deliveries delivery
+  set status = 'accepted',
+      provider_message_id = coalesce(nullif(btrim(p_provider_message_id), ''), delivery.provider_message_id),
+      accepted_at = coalesce(delivery.accepted_at, now()),
+      lease_owner = null,
+      lease_expires_at = null,
+      last_error = null,
+      updated_at = now()
+  where delivery.id = p_delivery_id
+    and delivery.status = 'sending'
+    and delivery.lease_owner = p_worker_id
+  returning true into v_accepted;
+
+  if coalesce(v_accepted, false) then
+    return true;
+  end if;
+
+  return exists (
+    select 1
+    from private.financial_outbox_deliveries delivery
+    where delivery.id = p_delivery_id
+      and delivery.status in ('accepted', 'delivered', 'bounced', 'dropped')
+  );
+end;
+$$;
+
+create or replace function public.mark_financial_outbox_delivery_ambiguous(
+  p_delivery_id uuid,
+  p_worker_id uuid,
+  p_error text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_marked boolean;
+begin
+  update private.financial_outbox_deliveries delivery
+  set status = 'ambiguous',
+      ambiguous_at = coalesce(delivery.ambiguous_at, now()),
+      lease_owner = null,
+      lease_expires_at = null,
+      last_error = left(coalesce(nullif(btrim(p_error), ''), 'provider result is ambiguous'), 2000),
+      updated_at = now()
+  where delivery.id = p_delivery_id
+    and delivery.status = 'sending'
+    and delivery.lease_owner = p_worker_id
+  returning true into v_marked;
+
+  if coalesce(v_marked, false) then
+    return true;
+  end if;
+
+  return exists (
+    select 1
+    from private.financial_outbox_deliveries delivery
+    where delivery.id = p_delivery_id
+      and delivery.status in ('ambiguous', 'accepted', 'delivered', 'bounced', 'dropped')
+  );
+end;
+$$;
+
+create or replace function public.release_financial_outbox_claim(
+  p_outbox_id uuid,
+  p_worker_id uuid,
+  p_error text,
+  p_next_attempt_at timestamptz
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_released boolean;
+begin
+  update public.financial_domain_outbox outbox
+  set lease_owner = null,
+      lease_expires_at = null,
+      processing_at = null,
+      last_error = left(coalesce(nullif(btrim(p_error), ''), 'financial outbox delivery failed'), 2000),
+      next_attempt_at = greatest(coalesce(p_next_attempt_at, now()), now())
+  where outbox.id = p_outbox_id
+    and outbox.delivered_at is null
+    and outbox.lease_owner = p_worker_id
+  returning true into v_released;
+
+  return coalesce(v_released, false);
+end;
+$$;
+
+create or replace function public.complete_financial_outbox_claim(
+  p_outbox_id uuid,
+  p_worker_id uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_completed boolean;
+begin
+  update public.financial_domain_outbox outbox
+  set delivered_at = coalesce(outbox.delivered_at, now()),
+      lease_owner = null,
+      lease_expires_at = null,
+      processing_at = null,
+      last_error = null
+  where outbox.id = p_outbox_id
+    and outbox.delivered_at is null
+    and outbox.lease_owner = p_worker_id
+    and not exists (
+      select 1
+      from private.financial_outbox_deliveries delivery
+      where delivery.outbox_id = outbox.id
+        and delivery.status in ('pending', 'claimed', 'sending', 'failed', 'ambiguous')
+    )
+  returning true into v_completed;
+
+  return coalesce(v_completed, false);
+end;
+$$;
+
+create or replace function public.process_sendgrid_delivery_event(
+  p_email_log_id uuid,
+  p_provider_event_id text,
+  p_provider_message_id text,
+  p_event_type text,
+  p_event_at timestamptz,
+  p_error_text text,
+  p_payload jsonb,
+  p_suppression_email text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_event_id uuid;
+  v_email_log_id uuid;
+  v_delivery_key text := nullif(btrim(coalesce(p_payload ->> 'financial_delivery_key', '')), '');
+  v_outbox_id uuid;
+begin
+  select email_log.id
+  into v_email_log_id
+  from public.email_logs email_log
+  where email_log.id = p_email_log_id;
+
+  insert into public.email_delivery_events (
+    email_log_id,
+    provider,
+    provider_event_id,
+    provider_message_id,
+    event_type,
+    event_at,
+    payload
+  )
+  values (
+    v_email_log_id,
+    'sendgrid',
+    p_provider_event_id,
+    p_provider_message_id,
+    p_event_type,
+    p_event_at,
+    coalesce(p_payload, '{}'::jsonb)
+  )
+  on conflict (provider, provider_event_id) do nothing
+  returning id into v_event_id;
+
+  if v_event_id is null then
+    return false;
+  end if;
+
+  if v_email_log_id is not null then
+    update public.email_logs
+    set status = p_event_type,
+        error_text = p_error_text,
+        provider_message_id = coalesce(p_provider_message_id, provider_message_id),
+        last_event_at = p_event_at,
+        last_event_type = p_event_type,
+        delivered_at = case
+          when p_event_type = 'delivered' then p_event_at
+          else delivered_at
+        end
+    where id = v_email_log_id
+      and (last_event_at is null or last_event_at <= p_event_at);
+  end if;
+
+  if v_delivery_key is not null then
+    update private.financial_outbox_deliveries delivery
+    set status = case
+          when p_event_type = 'delivered' then 'delivered'
+          when p_event_type = 'bounce' then 'bounced'
+          when p_event_type = 'dropped' then 'dropped'
+          when p_event_type in ('processed', 'deferred')
+               and delivery.status not in ('delivered', 'bounced', 'dropped') then 'accepted'
+          else delivery.status
+        end,
+        provider_message_id = coalesce(p_provider_message_id, delivery.provider_message_id),
+        accepted_at = case
+          when p_event_type in ('processed', 'deferred', 'delivered', 'bounce', 'dropped')
+            then coalesce(delivery.accepted_at, p_event_at)
+          else delivery.accepted_at
+        end,
+        delivered_at = case
+          when p_event_type = 'delivered' then coalesce(delivery.delivered_at, p_event_at)
+          else delivery.delivered_at
+        end,
+        last_provider_event_at = p_event_at,
+        last_provider_event_type = p_event_type,
+        last_error = case
+          when p_event_type in ('bounce', 'dropped') then left(coalesce(p_error_text, p_event_type), 2000)
+          when p_event_type in ('processed', 'delivered') then null
+          else delivery.last_error
+        end,
+        lease_owner = case
+          when p_event_type in ('processed', 'deferred', 'delivered', 'bounce', 'dropped') then null
+          else delivery.lease_owner
+        end,
+        lease_expires_at = case
+          when p_event_type in ('processed', 'deferred', 'delivered', 'bounce', 'dropped') then null
+          else delivery.lease_expires_at
+        end,
+        updated_at = now()
+    where delivery.delivery_key = v_delivery_key
+      and (
+        delivery.last_provider_event_at is null
+        or delivery.last_provider_event_at <= p_event_at
+      )
+    returning delivery.outbox_id into v_outbox_id;
+
+    if v_outbox_id is not null then
+      update public.financial_domain_outbox outbox
+      set delivered_at = coalesce(outbox.delivered_at, now()),
+          lease_owner = null,
+          lease_expires_at = null,
+          processing_at = null,
+          last_error = null
+      where outbox.id = v_outbox_id
+        and not exists (
+          select 1
+          from private.financial_outbox_deliveries delivery
+          where delivery.outbox_id = outbox.id
+            and delivery.status in ('pending', 'claimed', 'sending', 'failed', 'ambiguous')
+        );
+    end if;
+  end if;
+
+  if nullif(lower(btrim(p_suppression_email)), '') is not null then
+    insert into public.email_suppressions (email, suppressed, reason, updated_at)
+    values (
+      lower(btrim(p_suppression_email)),
+      true,
+      'sendgrid:' || p_event_type || coalesce(':' || nullif(p_error_text, ''), ''),
+      p_event_at
+    )
+    on conflict (email) do update
+      set suppressed = true,
+          reason = excluded.reason,
+          updated_at = excluded.updated_at;
+  end if;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.claim_financial_outbox_batch(uuid, integer, integer)
+  from public, anon, authenticated;
+revoke all on function public.claim_financial_outbox_delivery(uuid, uuid, text, text, integer)
+  from public, anon, authenticated;
+revoke all on function public.begin_financial_outbox_delivery(uuid, uuid, integer)
+  from public, anon, authenticated;
+revoke all on function public.accept_financial_outbox_delivery(uuid, uuid, text)
+  from public, anon, authenticated;
+revoke all on function public.mark_financial_outbox_delivery_ambiguous(uuid, uuid, text)
+  from public, anon, authenticated;
+revoke all on function public.release_financial_outbox_claim(uuid, uuid, text, timestamptz)
+  from public, anon, authenticated;
+revoke all on function public.complete_financial_outbox_claim(uuid, uuid)
+  from public, anon, authenticated;
+revoke all on function public.process_sendgrid_delivery_event(
+  uuid, text, text, text, timestamptz, text, jsonb, text
+) from public, anon, authenticated;
+
+grant execute on function public.claim_financial_outbox_batch(uuid, integer, integer)
+  to service_role;
+grant execute on function public.claim_financial_outbox_delivery(uuid, uuid, text, text, integer)
+  to service_role;
+grant execute on function public.begin_financial_outbox_delivery(uuid, uuid, integer)
+  to service_role;
+grant execute on function public.accept_financial_outbox_delivery(uuid, uuid, text)
+  to service_role;
+grant execute on function public.mark_financial_outbox_delivery_ambiguous(uuid, uuid, text)
+  to service_role;
+grant execute on function public.release_financial_outbox_claim(uuid, uuid, text, timestamptz)
+  to service_role;
+grant execute on function public.complete_financial_outbox_claim(uuid, uuid)
+  to service_role;
+grant execute on function public.process_sendgrid_delivery_event(
+  uuid, text, text, text, timestamptz, text, jsonb, text
+) to service_role;
+
+comment on table private.financial_outbox_deliveries is
+  'P0-007 server-only per-recipient financial email delivery ledger.';
+
+comment on function public.claim_financial_outbox_batch(uuid, integer, integer) is
+  'Atomically leases eligible financial outbox rows using FOR UPDATE SKIP LOCKED.';
+
+comment on function public.claim_financial_outbox_delivery(uuid, uuid, text, text, integer) is
+  'Creates or leases one deterministic delivery identity per outbox recipient.';
+
+commit;

--- a/tests/p0-007-financial-outbox.test.ts
+++ b/tests/p0-007-financial-outbox.test.ts
@@ -1,0 +1,89 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+import { normalizeSendGridEvent } from "../features/email/server/sendgridWebhook";
+
+async function source(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}
+
+describe("P0-007 financial outbox delivery", () => {
+  it("atomically leases outbox rows and keeps the delivery ledger private", async () => {
+    const migration = await source(
+      "supabase/migrations/20260725181500_harden_p0_007_financial_outbox_delivery.sql",
+    );
+
+    expect(migration).toContain("for update skip locked");
+    expect(migration).toContain("unique (outbox_id, recipient_kind)");
+    expect(migration).toContain("unique (delivery_key)");
+    expect(migration).toContain("force row level security");
+    expect(migration).toContain("from public, anon, authenticated, service_role");
+    expect(migration).toContain("to service_role");
+  });
+
+  it("distinguishes safe pre-send reclaim from ambiguous post-send recovery", async () => {
+    const migration = await source(
+      "supabase/migrations/20260725181500_harden_p0_007_financial_outbox_delivery.sql",
+    );
+
+    expect(migration).toContain("when delivery.status = 'claimed' then 'pending'");
+    expect(migration).toContain("else 'ambiguous'");
+    expect(migration).toContain("delivery.status in ('claimed', 'sending', 'ambiguous')");
+    expect(migration).toContain("provider acknowledgement missing after delivery lease expired");
+  });
+
+  it("uses only database claim/complete RPCs for outbox lifecycle changes", async () => {
+    const worker = await source("features/invoices/server/processFinancialOutbox.ts");
+
+    expect(worker).toContain('"claim_financial_outbox_batch"');
+    expect(worker).toContain('"claim_financial_outbox_delivery"');
+    expect(worker).toContain('"begin_financial_outbox_delivery"');
+    expect(worker).toContain('"accept_financial_outbox_delivery"');
+    expect(worker).toContain('"complete_financial_outbox_claim"');
+    expect(worker).not.toContain('.from("financial_domain_outbox")');
+    expect(worker).not.toContain("delivered_at: new Date");
+  });
+
+  it("does not automatically retry an ambiguous SendGrid request", async () => {
+    const worker = await source("features/invoices/server/processFinancialOutbox.ts");
+
+    expect(worker).toContain('claim.delivery_status === "ambiguous"');
+    expect(worker).toContain('"mark_financial_outbox_delivery_ambiguous"');
+    expect(worker).toContain("SendGrid has no Mail Send idempotency key");
+  });
+
+  it("correlates provider events with a non-PII deterministic delivery key", async () => {
+    const sender = await source("features/email/server/sendFinancialEventEmail.ts");
+    const validKey = "fin_a7000000000040008000000000000002_staff";
+    const normalized = normalizeSendGridEvent({
+      event: "processed",
+      timestamp: 1770000000,
+      sg_event_id: "event-p0-007",
+      sg_message_id: "message-p0-007",
+      financial_delivery_key: validKey,
+    });
+    const invalid = normalizeSendGridEvent({
+      event: "processed",
+      financial_delivery_key: "customer@example.com",
+    });
+
+    expect(sender).toContain("financial_delivery_key: input.deliveryKey");
+    expect(sender).toContain("financial_outbox_id: input.outboxId");
+    expect(sender).not.toContain("dedupe_key: String");
+    expect(sender).not.toContain("shop_id: input.shopId");
+    expect(normalized.financialDeliveryKey).toBe(validKey);
+    expect(normalized.safePayload.financial_delivery_key).toBe(validKey);
+    expect(invalid.financialDeliveryKey).toBeNull();
+    expect(invalid.safePayload.financial_delivery_key).toBeNull();
+  });
+
+  it("ships runtime coverage for worker overlap and both crash boundaries", async () => {
+    const runtime = await source("tests/security/p0-007-financial-outbox.runtime.sql");
+
+    expect(runtime).toContain("overlapping workers claimed the same row");
+    expect(runtime).toContain("crash-after-send delivery was retried");
+    expect(runtime).toContain("safe pre-send reclaim did not occur");
+    expect(runtime).toContain("completed customer delivery was duplicated");
+    expect(runtime).toContain("pending staff delivery was not claimable");
+  });
+});

--- a/tests/phase1-financial-foundation.test.ts
+++ b/tests/phase1-financial-foundation.test.ts
@@ -67,6 +67,8 @@ describe("phase 1 financial foundation", () => {
     expect(source("app/api/payments/manual/reverse/route.ts")).toContain('eventKind: "manual_reversal"');
     expect(source("app/api/invoices/versions/[id]/void/route.ts")).toContain("void_invoice_version");
     expect(source("app/api/portal/payments/session/[id]/route.ts")).toContain("payment_receipts");
-    expect(source("features/invoices/server/processFinancialOutbox.ts")).toContain("financial_domain_outbox");
+    const outboxWorker = source("features/invoices/server/processFinancialOutbox.ts");
+    expect(outboxWorker).toContain('"claim_financial_outbox_batch"');
+    expect(outboxWorker).not.toContain('.from("financial_domain_outbox")');
   });
 });

--- a/tests/security/p0-007-financial-outbox-concurrency.sh
+++ b/tests/security/p0-007-financial-outbox-concurrency.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DB_URL:?DB_URL is required}"
+
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  psql "$DB_URL" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' || true
+delete from public.financial_domain_outbox
+where id in (
+  'a7000000-0000-4000-8000-000000000011',
+  'a7000000-0000-4000-8000-000000000012'
+);
+update public.profiles
+set shop_id = null
+where id = '77000000-0000-4000-8000-000000000011';
+delete from public.shops where id = 'e7100000-0000-4000-8000-000000000011';
+delete from public.profiles where id = '77000000-0000-4000-8000-000000000011';
+delete from auth.users where id = '77000000-0000-4000-8000-000000000011';
+SQL
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+psql "$DB_URL" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+insert into auth.users (id, email, raw_user_meta_data)
+values (
+  '77000000-0000-4000-8000-000000000011',
+  'p0-007-concurrency@example.com',
+  '{"full_name":"P0-007 Concurrency"}'::jsonb
+)
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name, shop_id)
+values (
+  '77000000-0000-4000-8000-000000000011',
+  '77000000-0000-4000-8000-000000000011',
+  'owner',
+  'P0-007 Concurrency',
+  null
+)
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name,
+    shop_id = excluded.shop_id;
+
+insert into public.shops (id, owner_id, business_name, name, user_limit)
+values (
+  'e7100000-0000-4000-8000-000000000011',
+  '77000000-0000-4000-8000-000000000011',
+  'P0-007 Concurrency Shop',
+  'P0-007 Concurrency Shop',
+  3
+)
+on conflict (id) do nothing;
+
+insert into public.financial_domain_outbox (
+  id,
+  shop_id,
+  aggregate_type,
+  aggregate_id,
+  event_type,
+  dedupe_key,
+  payload,
+  occurred_at
+)
+values
+  (
+    'a7000000-0000-4000-8000-000000000011',
+    'e7100000-0000-4000-8000-000000000011',
+    'payment_event',
+    'b7000000-0000-4000-8000-000000000011',
+    'payment.failed',
+    'p0-007:concurrent-a',
+    '{}'::jsonb,
+    now() - interval '2 minutes'
+  ),
+  (
+    'a7000000-0000-4000-8000-000000000012',
+    'e7100000-0000-4000-8000-000000000011',
+    'payment_event',
+    'b7000000-0000-4000-8000-000000000012',
+    'payment.failed',
+    'p0-007:concurrent-b',
+    '{}'::jsonb,
+    now() - interval '1 minute'
+  )
+on conflict (id) do nothing;
+SQL
+
+psql "$DB_URL" -X -qAt -v ON_ERROR_STOP=1 >"$tmp_dir/worker-a.txt" <<'SQL' &
+begin;
+set local role service_role;
+select outbox_id
+from public.claim_financial_outbox_batch(
+  '71000000-0000-4000-8000-000000000011',
+  1,
+  120
+);
+select pg_sleep(3);
+commit;
+SQL
+worker_a_pid=$!
+
+sleep 1
+
+psql "$DB_URL" -X -qAt -v ON_ERROR_STOP=1 >"$tmp_dir/worker-b.txt" <<'SQL'
+begin;
+set local role service_role;
+select outbox_id
+from public.claim_financial_outbox_batch(
+  '72000000-0000-4000-8000-000000000012',
+  1,
+  120
+);
+commit;
+SQL
+
+wait "$worker_a_pid"
+
+worker_a_row="$(grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$tmp_dir/worker-a.txt" | head -n 1)"
+worker_b_row="$(grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' "$tmp_dir/worker-b.txt" | head -n 1)"
+
+test -n "$worker_a_row"
+test -n "$worker_b_row"
+test "$worker_a_row" != "$worker_b_row"
+test "$worker_a_row" = "a7000000-0000-4000-8000-000000000011"
+test "$worker_b_row" = "a7000000-0000-4000-8000-000000000012"
+
+echo "P0-007 concurrent claims were disjoint: $worker_a_row / $worker_b_row"

--- a/tests/security/p0-007-financial-outbox.runtime.sql
+++ b/tests/security/p0-007-financial-outbox.runtime.sql
@@ -1,0 +1,472 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+do $$
+declare
+  v_signature text;
+begin
+  foreach v_signature in array array[
+    'public.claim_financial_outbox_batch(uuid,integer,integer)',
+    'public.claim_financial_outbox_delivery(uuid,uuid,text,text,integer)',
+    'public.begin_financial_outbox_delivery(uuid,uuid,integer)',
+    'public.accept_financial_outbox_delivery(uuid,uuid,text)',
+    'public.mark_financial_outbox_delivery_ambiguous(uuid,uuid,text)',
+    'public.release_financial_outbox_claim(uuid,uuid,text,timestamptz)',
+    'public.complete_financial_outbox_claim(uuid,uuid)'
+  ]
+  loop
+    if has_function_privilege('anon', v_signature, 'EXECUTE')
+       or has_function_privilege('authenticated', v_signature, 'EXECUTE')
+       or not has_function_privilege('service_role', v_signature, 'EXECUTE') then
+      raise exception 'P0-007 runtime assertion failed: unsafe function ACL for %', v_signature;
+    end if;
+  end loop;
+
+  if has_table_privilege('anon', 'private.financial_outbox_deliveries', 'SELECT')
+     or has_table_privilege('authenticated', 'private.financial_outbox_deliveries', 'SELECT')
+     or has_table_privilege('service_role', 'private.financial_outbox_deliveries', 'SELECT') then
+    raise exception 'P0-007 runtime assertion failed: delivery ledger is directly exposed';
+  end if;
+end
+$$;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values (
+  '77000000-0000-4000-8000-000000000001',
+  'p0-007-owner@example.com',
+  '{"full_name":"P0-007 Owner"}'::jsonb
+)
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name, shop_id)
+values (
+  '77000000-0000-4000-8000-000000000001',
+  '77000000-0000-4000-8000-000000000001',
+  'owner',
+  'P0-007 Owner',
+  null
+)
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name,
+    shop_id = excluded.shop_id;
+
+insert into public.shops (id, owner_id, business_name, name, user_limit)
+values (
+  'e7100000-0000-4000-8000-000000000001',
+  '77000000-0000-4000-8000-000000000001',
+  'P0-007 Shop',
+  'P0-007 Shop',
+  3
+)
+on conflict (id) do nothing;
+
+insert into public.financial_domain_outbox (
+  id,
+  shop_id,
+  aggregate_type,
+  aggregate_id,
+  event_type,
+  dedupe_key,
+  payload,
+  occurred_at
+)
+values
+  (
+    'a7000000-0000-4000-8000-000000000001',
+    'e7100000-0000-4000-8000-000000000001',
+    'payment_event',
+    'b7000000-0000-4000-8000-000000000001',
+    'payment.failed',
+    'p0-007:accepted-retry',
+    '{}'::jsonb,
+    now() - interval '5 minutes'
+  ),
+  (
+    'a7000000-0000-4000-8000-000000000002',
+    'e7100000-0000-4000-8000-000000000001',
+    'payment_event',
+    'b7000000-0000-4000-8000-000000000002',
+    'payment.failed',
+    'p0-007:crash-after-send',
+    '{}'::jsonb,
+    now() - interval '4 minutes'
+  ),
+  (
+    'a7000000-0000-4000-8000-000000000003',
+    'e7100000-0000-4000-8000-000000000001',
+    'payment_event',
+    'b7000000-0000-4000-8000-000000000003',
+    'payment.failed',
+    'p0-007:crash-before-send',
+    '{}'::jsonb,
+    now() - interval '3 minutes'
+  ),
+  (
+    'a7000000-0000-4000-8000-000000000004',
+    'e7100000-0000-4000-8000-000000000001',
+    'payment_event',
+    'b7000000-0000-4000-8000-000000000004',
+    'payment.failed',
+    'p0-007:partial-recipient',
+    '{}'::jsonb,
+    now() - interval '2 minutes'
+  )
+on conflict (id) do nothing;
+
+set local role service_role;
+
+do $$
+declare
+  v_worker_a uuid := '71000000-0000-4000-8000-000000000001';
+  v_worker_b uuid := '72000000-0000-4000-8000-000000000002';
+  v_row_a uuid;
+  v_row_b uuid;
+  v_delivery_id uuid;
+  v_delivery_key text;
+  v_delivery_status text;
+  v_should_send boolean;
+  v_attempts integer;
+  v_ok boolean;
+begin
+  select outbox_id into v_row_a
+  from public.claim_financial_outbox_batch(v_worker_a, 1, 120);
+  select outbox_id into v_row_b
+  from public.claim_financial_outbox_batch(v_worker_b, 1, 120);
+
+  if v_row_a <> 'a7000000-0000-4000-8000-000000000001'::uuid
+     or v_row_b <> 'a7000000-0000-4000-8000-000000000002'::uuid
+     or v_row_a = v_row_b then
+    raise exception 'P0-007 runtime assertion failed: overlapping workers claimed the same row';
+  end if;
+
+  select delivery_id, delivery_key, delivery_status, should_send, delivery_attempts
+  into v_delivery_id, v_delivery_key, v_delivery_status, v_should_send, v_attempts
+  from public.claim_financial_outbox_delivery(
+    v_row_a,
+    v_worker_a,
+    'customer',
+    'customer@example.com',
+    120
+  );
+  if not v_should_send or v_delivery_status <> 'claimed' or v_attempts <> 1 then
+    raise exception 'P0-007 runtime assertion failed: first recipient claim was invalid';
+  end if;
+
+  select public.begin_financial_outbox_delivery(v_delivery_id, v_worker_a, 120) into v_ok;
+  if not v_ok then
+    raise exception 'P0-007 runtime assertion failed: send boundary did not start';
+  end if;
+  select public.accept_financial_outbox_delivery(v_delivery_id, v_worker_a, 'sg-p0-007-a') into v_ok;
+  if not v_ok then
+    raise exception 'P0-007 runtime assertion failed: accepted delivery was not recorded';
+  end if;
+
+  select delivery_status, should_send, delivery_attempts
+  into v_delivery_status, v_should_send, v_attempts
+  from public.claim_financial_outbox_delivery(
+    v_row_a,
+    v_worker_a,
+    'customer',
+    'customer@example.com',
+    120
+  );
+  if v_should_send or v_delivery_status <> 'accepted' or v_attempts <> 1 then
+    raise exception 'P0-007 runtime assertion failed: accepted recipient was claimable twice';
+  end if;
+
+  select public.complete_financial_outbox_claim(v_row_a, v_worker_a) into v_ok;
+  if not v_ok then
+    raise exception 'P0-007 runtime assertion failed: terminal outbox row did not complete';
+  end if;
+
+  select delivery_id, delivery_key, should_send
+  into v_delivery_id, v_delivery_key, v_should_send
+  from public.claim_financial_outbox_delivery(
+    v_row_b,
+    v_worker_b,
+    'staff',
+    'staff@example.com',
+    120
+  );
+  if not v_should_send then
+    raise exception 'P0-007 runtime assertion failed: crash fixture delivery was not claimed';
+  end if;
+  select public.begin_financial_outbox_delivery(v_delivery_id, v_worker_b, 120) into v_ok;
+  if not v_ok then
+    raise exception 'P0-007 runtime assertion failed: crash fixture send boundary did not start';
+  end if;
+end
+$$;
+
+reset role;
+
+-- Simulate a worker disappearing after the provider request began but before
+-- its acceptance acknowledgement was stored.
+update private.financial_outbox_deliveries
+set lease_expires_at = now() - interval '1 second'
+where outbox_id = 'a7000000-0000-4000-8000-000000000002';
+update public.financial_domain_outbox
+set lease_expires_at = now() - interval '1 second'
+where id = 'a7000000-0000-4000-8000-000000000002';
+
+set local role service_role;
+
+do $$
+declare
+  v_worker_c uuid := '73000000-0000-4000-8000-000000000003';
+  v_claimed_row uuid;
+begin
+  select outbox_id into v_claimed_row
+  from public.claim_financial_outbox_batch(v_worker_c, 1, 120);
+  if v_claimed_row = 'a7000000-0000-4000-8000-000000000002'::uuid then
+    raise exception 'P0-007 runtime assertion failed: crash-after-send delivery was retried';
+  end if;
+
+  -- Release the unrelated row claimed while proving the ambiguous row was
+  -- skipped so the next crash-boundary case can exercise it.
+  if v_claimed_row is not null then
+    perform public.release_financial_outbox_claim(
+      v_claimed_row,
+      v_worker_c,
+      'released after ambiguity isolation check',
+      now()
+    );
+  end if;
+end
+$$;
+
+reset role;
+
+do $$
+declare
+  v_status text;
+begin
+  select status
+  into v_status
+  from private.financial_outbox_deliveries
+  where outbox_id = 'a7000000-0000-4000-8000-000000000002';
+  if v_status <> 'ambiguous' then
+    raise exception 'P0-007 runtime assertion failed: expired send was not made ambiguous';
+  end if;
+end
+$$;
+
+set local role service_role;
+
+do $$
+declare
+  v_delivery_key text := 'fin_a7000000000040008000000000000002_staff';
+  v_processed boolean;
+begin
+  select public.process_sendgrid_delivery_event(
+    null,
+    'sg-event-p0-007-crash',
+    'sg-message-p0-007-crash',
+    'processed',
+    now(),
+    null,
+    jsonb_build_object('financial_delivery_key', v_delivery_key),
+    null
+  ) into v_processed;
+  if not v_processed then
+    raise exception 'P0-007 runtime assertion failed: provider reconciliation was not recorded';
+  end if;
+end
+$$;
+
+reset role;
+
+do $$
+declare
+  v_status text;
+begin
+  select status into v_status
+  from private.financial_outbox_deliveries
+  where outbox_id = 'a7000000-0000-4000-8000-000000000002';
+  if v_status <> 'accepted' then
+    raise exception 'P0-007 runtime assertion failed: provider event did not resolve ambiguity';
+  end if;
+
+  if not exists (
+    select 1 from public.financial_domain_outbox
+    where id = 'a7000000-0000-4000-8000-000000000002'
+      and delivered_at is not null
+  ) then
+    raise exception 'P0-007 runtime assertion failed: reconciled outbox row did not complete';
+  end if;
+end
+$$;
+
+set local role service_role;
+
+-- Claim the third row and reserve its recipient without crossing the provider
+-- send boundary. That expired lease is safe for a different worker to reclaim.
+do $$
+declare
+  v_worker uuid := '74000000-0000-4000-8000-000000000004';
+  v_row uuid;
+  v_should_send boolean;
+begin
+  select outbox_id into v_row
+  from public.claim_financial_outbox_batch(v_worker, 1, 120);
+  if v_row <> 'a7000000-0000-4000-8000-000000000003'::uuid then
+    raise exception 'P0-007 runtime assertion failed: pre-send crash fixture was not claimed';
+  end if;
+
+  select should_send into v_should_send
+  from public.claim_financial_outbox_delivery(
+    v_row,
+    v_worker,
+    'customer',
+    'customer@example.com',
+    120
+  );
+  if not v_should_send then
+    raise exception 'P0-007 runtime assertion failed: pre-send delivery was not reserved';
+  end if;
+end
+$$;
+
+reset role;
+
+update private.financial_outbox_deliveries
+set lease_expires_at = now() - interval '1 second'
+where outbox_id = 'a7000000-0000-4000-8000-000000000003';
+update public.financial_domain_outbox
+set lease_expires_at = now() - interval '1 second'
+where id = 'a7000000-0000-4000-8000-000000000003';
+
+set local role service_role;
+
+do $$
+declare
+  v_worker uuid := '75000000-0000-4000-8000-000000000005';
+  v_row uuid;
+  v_delivery_id uuid;
+  v_status text;
+  v_should_send boolean;
+  v_attempts integer;
+  v_ok boolean;
+begin
+  select outbox_id into v_row
+  from public.claim_financial_outbox_batch(v_worker, 1, 120);
+  if v_row <> 'a7000000-0000-4000-8000-000000000003'::uuid then
+    raise exception 'P0-007 runtime assertion failed: expired pre-send row was not reclaimed';
+  end if;
+
+  select delivery_id, delivery_status, should_send, delivery_attempts
+  into v_delivery_id, v_status, v_should_send, v_attempts
+  from public.claim_financial_outbox_delivery(
+    v_row,
+    v_worker,
+    'customer',
+    'customer@example.com',
+    120
+  );
+  if not v_should_send or v_status <> 'claimed' or v_attempts <> 2 then
+    raise exception 'P0-007 runtime assertion failed: safe pre-send reclaim did not occur';
+  end if;
+  perform public.begin_financial_outbox_delivery(v_delivery_id, v_worker, 120);
+  perform public.accept_financial_outbox_delivery(v_delivery_id, v_worker, 'sg-p0-007-c');
+  select public.complete_financial_outbox_claim(v_row, v_worker) into v_ok;
+  if not v_ok then
+    raise exception 'P0-007 runtime assertion failed: reclaimed delivery did not complete';
+  end if;
+end
+$$;
+
+-- A retry after only the customer delivery completed must not resend the
+-- customer while the staff recipient is still pending.
+do $$
+declare
+  v_worker_a uuid := '76000000-0000-4000-8000-000000000006';
+  v_worker_b uuid := '76000000-0000-4000-8000-000000000007';
+  v_row uuid;
+  v_delivery_id uuid;
+  v_status text;
+  v_should_send boolean;
+  v_ok boolean;
+begin
+  select outbox_id into v_row
+  from public.claim_financial_outbox_batch(v_worker_a, 1, 120);
+  if v_row <> 'a7000000-0000-4000-8000-000000000004'::uuid then
+    raise exception 'P0-007 runtime assertion failed: partial-recipient row was not claimed';
+  end if;
+
+  select delivery_id into v_delivery_id
+  from public.claim_financial_outbox_delivery(
+    v_row,
+    v_worker_a,
+    'customer',
+    'customer@example.com',
+    120
+  );
+  perform public.begin_financial_outbox_delivery(v_delivery_id, v_worker_a, 120);
+  perform public.accept_financial_outbox_delivery(v_delivery_id, v_worker_a, 'sg-p0-007-d-customer');
+  perform public.release_financial_outbox_claim(v_row, v_worker_a, 'worker stopped before staff delivery', now());
+
+  select outbox_id into v_row
+  from public.claim_financial_outbox_batch(v_worker_b, 1, 120);
+
+  select delivery_status, should_send
+  into v_status, v_should_send
+  from public.claim_financial_outbox_delivery(
+    v_row,
+    v_worker_b,
+    'customer',
+    'customer@example.com',
+    120
+  );
+  if v_should_send or v_status <> 'accepted' then
+    raise exception 'P0-007 runtime assertion failed: completed customer delivery was duplicated';
+  end if;
+
+  select delivery_id, should_send
+  into v_delivery_id, v_should_send
+  from public.claim_financial_outbox_delivery(
+    v_row,
+    v_worker_b,
+    'staff',
+    'staff@example.com',
+    120
+  );
+  if not v_should_send then
+    raise exception 'P0-007 runtime assertion failed: pending staff delivery was not claimable';
+  end if;
+  perform public.begin_financial_outbox_delivery(v_delivery_id, v_worker_b, 120);
+  perform public.accept_financial_outbox_delivery(v_delivery_id, v_worker_b, 'sg-p0-007-d-staff');
+  select public.complete_financial_outbox_claim(v_row, v_worker_b) into v_ok;
+  if not v_ok then
+    raise exception 'P0-007 runtime assertion failed: customer/staff delivery pair did not complete';
+  end if;
+end
+$$;
+
+reset role;
+
+do $$
+begin
+  if exists (
+    select outbox_id, recipient_kind
+    from private.financial_outbox_deliveries
+    group by outbox_id, recipient_kind
+    having count(*) > 1
+  ) then
+    raise exception 'P0-007 runtime assertion failed: duplicate per-recipient delivery identities exist';
+  end if;
+
+  if exists (
+    select 1
+    from public.financial_domain_outbox
+    where id::text like 'a7000000-%'
+      and delivered_at is null
+  ) then
+    raise exception 'P0-007 runtime assertion failed: verified outbox fixtures remain incomplete';
+  end if;
+end
+$$;
+
+rollback;

--- a/tsconfig.p0-007.json
+++ b/tsconfig.p0-007.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "include": [
+    "next-env.d.ts",
+    "app/api/internal/financial-outbox/tick/route.ts",
+    "app/api/webhooks/sendgrid/events/route.ts",
+    "features/email/server/sendFinancialEventEmail.ts",
+    "features/email/server/sendgridWebhook.ts",
+    "features/invoices/server/processFinancialOutbox.ts",
+    "features/shared/types/types/supabase.ts",
+    "tests/p0-007-financial-outbox.test.ts",
+    "tests/phase1-financial-foundation.test.ts"
+  ]
+}


### PR DESCRIPTION
## Release-readiness item

Closes P0-007: overlapping cron workers and crash recovery could resend payment, refund, dispute, or failure emails.

## What changed

- atomically lease eligible outbox rows with `FOR UPDATE SKIP LOCKED`
- keep a private, forced-RLS per-recipient delivery ledger with deterministic delivery keys
- expose outbox lifecycle changes only through service-role RPCs with fixed search paths and explicit grants
- distinguish safe pre-send lease recovery from ambiguous post-SendGrid-request recovery
- attach a non-PII delivery key to SendGrid custom args and reconcile it through the existing signed Event Webhook
- prevent a retry of one failed recipient from resending a recipient already accepted by SendGrid
- add focused TypeScript/lint/Vitest validation plus clean-replay runtime tests for ACLs, worker overlap, both crash boundaries, partial recipient retry, and true concurrent claims

## Important provider boundary

SendGrid Mail Send does not provide a request idempotency key. A lost acknowledgement after the provider request starts is therefore marked `ambiguous` and is not automatically resent. A signed SendGrid Event Webhook event carrying `financial_delivery_key` resolves that state. This prioritizes preventing duplicate financial communications over guessing after an uncertain network outcome.

## Verification

All required PR checks passed on commit `7cf157f`:

- ✅ focused TypeScript check
- ✅ focused ESLint
- ✅ P0-007, financial-foundation, and existing SendGrid security Vitest suites
- ✅ unique migration versions and deterministic generated baseline
- ✅ fresh Supabase startup and full 136-migration replay
- ✅ all existing P0 database runtime integrations
- ✅ P0-007 ACL, crash-before-send, crash-after-send reconciliation, and partial-recipient runtime integration
- ✅ true two-process concurrent `FOR UPDATE SKIP LOCKED` claim integration
- ✅ bootstrap and existing-database baseline compatibility

Local static verification also passed: `git diff --check`, API route boundary audit (381 routes with no inventory change), JSON/SQL delimiter checks, and credential-pattern scan.

## Deployment

This PR does not apply migrations, deploy, or mutate production data. Migration `20260725181500_harden_p0_007_financial_outbox_delivery.sql` must be applied before the new worker code receives traffic. If merging `main` automatically deploys production, apply the forward-compatible migration first and then merge. Otherwise, merge, apply the migration, and only then promote/deploy. Finally, confirm the signed SendGrid Event Webhook is enabled and includes custom arguments.