### PR TITLE
Fix P0-008 work-order source identity migration

### DIFF
--- a/supabase/migrations/20260725190225_p0_008_reconcile_work_order_source_identity.sql
+++ b/supabase/migrations/20260725190225_p0_008_reconcile_work_order_source_identity.sql
@@ -1,0 +1,40 @@
+-- P0-008: reconcile the deployed work-order source identity before the
+-- portal request migration begins storing namespaced idempotency keys.
+--
+-- Some existing projects created source_row_id as uuid. The portal contract
+-- stores values such as "portal_start:<customer>:<operation>", so text is the
+-- canonical type. UUID values cast to text losslessly.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+SET LOCAL search_path = public, pg_temp;
+
+DO $p0_008$
+DECLARE
+  source_row_id_type regtype;
+BEGIN
+  SELECT a.atttypid::regtype
+  INTO source_row_id_type
+  FROM pg_attribute a
+  WHERE a.attrelid = 'public.work_orders'::regclass
+    AND a.attname = 'source_row_id'
+    AND NOT a.attisdropped;
+
+  IF source_row_id_type IS NULL THEN
+    ALTER TABLE public.work_orders
+      ADD COLUMN source_row_id text;
+  ELSIF source_row_id_type = 'uuid'::regtype THEN
+    ALTER TABLE public.work_orders
+      ALTER COLUMN source_row_id TYPE text
+      USING source_row_id::text;
+  ELSIF source_row_id_type <> 'text'::regtype THEN
+    RAISE EXCEPTION
+      'work_orders.source_row_id has unsupported type %, expected uuid or text',
+      source_row_id_type;
+  END IF;
+END
+$p0_008$;
+
+COMMIT;
+

--- a/tests/portal-service-quote-requests.test.ts
+++ b/tests/portal-service-quote-requests.test.ts
@@ -66,6 +66,21 @@ describe("customer portal service and quote requests", () => {
     expect(startRoute).toContain("quoteBooking: true");
   });
 
+  it("reconciles legacy UUID work-order source identities before portal starts", () => {
+    const correctionPath =
+      "supabase/migrations/20260725190225_p0_008_reconcile_work_order_source_identity.sql";
+    const portalPath =
+      "supabase/migrations/20260725190250_p0_008_restore_portal_request_atomicity.sql";
+    const correction = source(correctionPath);
+
+    expect(correctionPath.localeCompare(portalPath)).toBeLessThan(0);
+    expect(correction).toContain("source_row_id_type = 'uuid'::regtype");
+    expect(correction).toMatch(
+      /alter column source_row_id type text\s+using source_row_id::text/i,
+    );
+    expect(correction).toContain("source_row_id_type <> 'text'::regtype");
+  });
+
   it("uses the canonical quote approval and invoice payment paths", () => {
     const approval = source("features/portal/components/QuoteApprovalActions.tsx");
     const quotePage = source("features/portal/app/quotes/[id]/QuotePageClient.tsx");

--- a/tests/security/p0-008-schema-reconciliation.runtime.sql
+++ b/tests/security/p0-008-schema-reconciliation.runtime.sql
@@ -180,6 +180,17 @@ begin
     raise exception 'P0-008 work_orders.shop_id must be required';
   end if;
 
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'work_orders'
+      and column_name = 'source_row_id'
+      and data_type = 'text'
+  ) then
+    raise exception 'P0-008 work_orders.source_row_id must support namespaced text identities';
+  end if;
+
   select array_agg(
       expected.table_name || '.' || expected.column_name
       order by expected.table_name, expected.column_name


### PR DESCRIPTION
## What changed

- adds a forward migration between the last applied P0-008 migration and the failed portal migration
- converts legacy `public.work_orders.source_row_id uuid` columns to the canonical `text` contract
- preserves any existing UUID identities through a lossless text cast
- no-ops when the column is already text and rejects unexpected types
- asserts the final database type and migration ordering in regression coverage

## Root cause

Production still had `work_orders.source_row_id` as `uuid`, while the portal request contract stores namespaced text keys such as `portal_start:...`. Migration `20260725190250` therefore failed while creating its filtered index with `LIKE`.

The failed migration was transactional and was not recorded in `supabase_migrations.schema_migrations`.

## Production preflight

Read-only inspection found:

- 8 work-order rows
- 0 non-null `source_row_id` values
- one ordinary btree index on the column
- no constraints or other dependent objects
- remote migration history still ends at `20260725190200`

## Verification

- Git diff/static contract checks pass
- focused local Vitest could not run because dependencies are not linked in the local desktop checkout
- required before merge: Supabase Clean Replay and existing P0 validation workflows must pass

## Deployment

After this PR is green and merged:

1. pull current `main`
2. run `supabase db push --dry-run`
3. confirm `20260725190225` appears before `20260725190250`
4. run `supabase db push`
5. verify `supabase migration list` aligns through `20260725190525`
