### PR TITLE
Fix P0-008 payment amount migration contract

### DIFF
--- a/supabase/migrations/20260725190490_p0_008_reconcile_payment_amount_contract.sql
+++ b/supabase/migrations/20260725190490_p0_008_reconcile_payment_amount_contract.sql
@@ -1,0 +1,38 @@
+-- P0-008: reconcile the canonical decimal payment amount before the
+-- application schema migration backfills cent-denominated Stripe fields.
+--
+-- Some deployed projects were created from the Stripe-first payment shape and
+-- therefore have amount_cents but not the canonical amount column.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+SET LOCAL search_path = public, pg_temp;
+
+ALTER TABLE public.payments
+  ADD COLUMN IF NOT EXISTS amount numeric(14,2);
+
+UPDATE public.payments
+SET amount = round(amount_cents::numeric / 100, 2)
+WHERE amount IS NULL
+  AND amount_cents IS NOT NULL;
+
+DO $p0_008$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.payments
+    WHERE amount IS NULL
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = 'P0001',
+      MESSAGE = 'P0-008 cannot infer payments.amount for legacy payment rows';
+  END IF;
+END
+$p0_008$;
+
+ALTER TABLE public.payments
+  ALTER COLUMN amount SET DEFAULT 0,
+  ALTER COLUMN amount SET NOT NULL;
+
+COMMIT;

--- a/supabase/migrations/20260725190490_p0_008_reconcile_payment_amount_contract.sql
+++ b/supabase/migrations/20260725190490_p0_008_reconcile_payment_amount_contract.sql
@@ -12,10 +12,24 @@ SET LOCAL search_path = public, pg_temp;
 ALTER TABLE public.payments
   ADD COLUMN IF NOT EXISTS amount numeric(14,2);
 
-UPDATE public.payments
-SET amount = round(amount_cents::numeric / 100, 2)
-WHERE amount IS NULL
-  AND amount_cents IS NOT NULL;
+DO $p0_008_backfill$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'payments'
+      AND column_name = 'amount_cents'
+  ) THEN
+    EXECUTE $sql$
+      UPDATE public.payments
+      SET amount = round(amount_cents::numeric / 100, 2)
+      WHERE amount IS NULL
+        AND amount_cents IS NOT NULL
+    $sql$;
+  END IF;
+END
+$p0_008_backfill$;
 
 DO $p0_008$
 BEGIN

--- a/tests/p0-006-stripe-identity.test.ts
+++ b/tests/p0-006-stripe-identity.test.ts
@@ -74,6 +74,20 @@ describe("P0-006 Stripe identity boundary", () => {
     expect(linking).toContain("idempotencyKey: `profixiq:acquisition-subscription-link:");
   });
 
+  it("reconciles canonical payment amounts before the application contract", async () => {
+    const correctionPath =
+      "supabase/migrations/20260725190490_p0_008_reconcile_payment_amount_contract.sql";
+    const applicationPath =
+      "supabase/migrations/20260725190500_p0_008_reconcile_application_schema_contract.sql";
+    const correction = await source(correctionPath);
+
+    expect(correctionPath.localeCompare(applicationPath)).toBeLessThan(0);
+    expect(correction).toContain("ADD COLUMN IF NOT EXISTS amount numeric(14,2)");
+    expect(correction).toContain("amount_cents::numeric / 100");
+    expect(correction).toContain("ALTER COLUMN amount SET NOT NULL");
+    expect(correction).toContain("cannot infer payments.amount");
+  });
+
   it("does not expose acquisition email by bearer Checkout Session ID", async () => {
     const sessionRoute = await source("app/api/stripe/session/route.ts");
     const accessIndex = sessionRoute.indexOf("requireShopScopedApiAccess({");

--- a/tests/security/p0-008-schema-reconciliation.runtime.sql
+++ b/tests/security/p0-008-schema-reconciliation.runtime.sql
@@ -191,6 +191,19 @@ begin
     raise exception 'P0-008 work_orders.source_row_id must support namespaced text identities';
   end if;
 
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'payments'
+      and column_name = 'amount'
+      and data_type = 'numeric'
+      and is_nullable = 'NO'
+      and column_default is not null
+  ) then
+    raise exception 'P0-008 payments.amount must preserve the canonical decimal contract';
+  end if;
+
   select array_agg(
       expected.table_name || '.' || expected.column_name
       order by expected.table_name, expected.column_name


### PR DESCRIPTION
## What changed

- adds a forward migration after the last applied production version (`20260725190475`) and before the failing application-contract migration
- restores the canonical `payments.amount numeric(14,2) NOT NULL DEFAULT 0` column
- backfills decimal amounts from `amount_cents` when legacy rows exist
- fails safely when an amount cannot be inferred
- adds migration-order and final runtime-contract assertions

## Root cause

Production uses the Stripe-first payment shape and has `amount_cents`, but not the canonical decimal `amount` column. Migration `20260725190500` referenced `amount` while backfilling cents and failed transactionally.

## Production preflight

Read-only Supabase inspection confirmed:

- `payments` currently contains 0 rows
- `amount_cents` is present and non-null
- migration history still ends at `20260725190475`
- no assignment duplicates or payroll check violations block the remainder of `20260725190500`

## Verification required before merge

- Supabase Clean Replay Validation
- P0-006 Stripe Identity Validation
- P0-008 schema reconciliation runtime

## Deployment after merge

1. pull current `main`
2. run `supabase db push --dry-run`
3. confirm `20260725190490` appears before `20260725190500`
4. run `supabase db push`
5. verify migration history through `20260725190525`
