### PR TITLE
Unify tech performance time metrics

### DIFF
--- a/app/api/ai/summarize-tech-performance/route.ts
+++ b/app/api/ai/summarize-tech-performance/route.ts
@@ -9,13 +9,18 @@ type Range = "weekly" | "monthly" | "quarterly" | "yearly";
 type TechRow = {
   name: string;
   jobs: number;
-  revenue: number;
-  laborCost: number;
-  profit: number;
-  billedHours: number;
-  clockedHours: number;
-  revenuePerHour: number;
-  efficiencyPct: number;
+  revenue?: number;
+  laborCost?: number;
+  profit?: number;
+  billedHours?: number;
+  clockedHours?: number;
+  flaggedHours?: number;
+  actualJobHours?: number;
+  attendanceHours?: number;
+  revenuePerHour?: number;
+  efficiencyPct?: number;
+  productivityPct?: number;
+  overallPerformancePct?: number;
 };
 
 type Payload = {
@@ -23,6 +28,11 @@ type Payload = {
   tech: TechRow | null;
   peers: TechRow[]; // all rows for this shop/range (including tech)
 };
+
+function safeNumber(value: unknown): number {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
 
 export async function POST(req: Request) {
   try {
@@ -56,29 +66,47 @@ export async function POST(req: Request) {
 
     // Build a compact numeric context for the model
     const peerCount = peers.length;
-    const totalPeerRevenue = peers.reduce((acc, p) => acc + p.revenue, 0);
+    const totalPeerRevenue = peers.reduce((acc, p) => acc + safeNumber(p.revenue), 0);
     const avgPeerRevenue =
       peerCount > 0 ? totalPeerRevenue / peerCount : 0;
 
     const totalPeerEff = peers.reduce(
-      (acc, p) => acc + (Number.isFinite(p.efficiencyPct) ? p.efficiencyPct : 0),
+      (acc, p) => acc + safeNumber(p.efficiencyPct),
       0,
     );
     const avgPeerEff =
       peerCount > 0 ? totalPeerEff / peerCount : 0;
+
+    const revenue = safeNumber(tech.revenue);
+    const laborCost = safeNumber(tech.laborCost);
+    const profit = safeNumber(tech.profit);
+    const clockedHours = safeNumber(tech.clockedHours ?? tech.attendanceHours);
+    const attendanceHours = safeNumber(tech.attendanceHours ?? tech.clockedHours);
+    const actualJobHours = safeNumber(tech.actualJobHours);
+    const flaggedHours = safeNumber(tech.flaggedHours ?? tech.billedHours);
+    const billedHours = safeNumber(tech.billedHours ?? tech.flaggedHours);
+    const revenuePerHour = safeNumber(tech.revenuePerHour);
+    const efficiencyPct = safeNumber(tech.efficiencyPct);
+    const productivityPct = safeNumber(tech.productivityPct);
+    const overallPerformancePct = safeNumber(tech.overallPerformancePct);
 
     const userPrompt = [
       `You are helping an auto repair shop summarize one technician's performance ${timeLabel}.`,
       "",
       `Technician: ${tech.name || "Unnamed tech"}`,
       `Jobs: ${tech.jobs}`,
-      `Revenue: ${tech.revenue.toFixed(2)}`,
-      `Labor cost: ${tech.laborCost.toFixed(2)}`,
-      `Profit: ${tech.profit.toFixed(2)}`,
-      `Clocked hours: ${tech.clockedHours.toFixed(2)}`,
-      `Billed hours: ${tech.billedHours.toFixed(2)}`,
-      `Revenue per hour: ${tech.revenuePerHour.toFixed(2)}`,
-      `Efficiency (%): ${tech.efficiencyPct.toFixed(1)}`,
+      `Revenue: ${revenue.toFixed(2)}`,
+      `Labor cost: ${laborCost.toFixed(2)}`,
+      `Profit: ${profit.toFixed(2)}`,
+      `Clocked attendance hours: ${clockedHours.toFixed(2)}`,
+      `Attendance hours: ${attendanceHours.toFixed(2)}`,
+      `Actual job hours: ${actualJobHours.toFixed(2)}`,
+      `Flagged hours: ${flaggedHours.toFixed(2)}`,
+      `Billed hours: ${billedHours.toFixed(2)}`,
+      `Revenue per hour: ${revenuePerHour.toFixed(2)}`,
+      `Efficiency (% flagged / actual job): ${efficiencyPct.toFixed(1)}`,
+      `Productivity (% actual job / attendance): ${productivityPct.toFixed(1)}`,
+      `Overall performance (% flagged / attendance): ${overallPerformancePct.toFixed(1)}`,
       "",
       `Peer techs in same shop for ${timeLabel}: ${peerCount}`,
       `Average peer revenue: ${avgPeerRevenue.toFixed(2)}`,

--- a/app/mobile/tech/performance/page.tsx
+++ b/app/mobile/tech/performance/page.tsx
@@ -31,7 +31,7 @@ export default function MobileTechPerformancePage() {
   const [shopId, setShopId] = useState<string | null>(null);
   const [, setRole] = useState<ProfileRole | null>(null);
 
-  const [range, setRange] = useState<Range>("monthly");
+  const [range, setRange] = useState<Range>("weekly");
   const [rows, setRows] = useState<TechLeaderboardRow[]>([]);
   const [myRow, setMyRow] = useState<TechLeaderboardRow | null>(null);
 
@@ -124,17 +124,8 @@ export default function MobileTechPerformancePage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             timeRange: range,
-            tech: {
-              name: myRow.name,
-              jobs: myRow.jobs,
-              flaggedHours: myRow.flaggedHours,
-              actualJobHours: myRow.actualJobHours,
-              attendanceHours: myRow.attendanceHours,
-              efficiencyPct: myRow.efficiencyPct,
-              productivityPct: myRow.productivityPct,
-              overallPerformancePct: myRow.overallPerformancePct,
-            },
-            peers: [],
+            tech: myRow,
+            peers: rows,
           }),
         });
 
@@ -166,7 +157,7 @@ export default function MobileTechPerformancePage() {
           <h1 className="font-blackops text-lg uppercase tracking-[0.16em] text-sky-300">My Performance</h1>
           <p className="text-[0.8rem] text-[color:var(--theme-text-secondary)]">Jobs, hours and efficiency for your chosen time range.</p>
           <p className="text-[0.68rem] text-[color:var(--theme-text-muted)]">
-            Actual job time, attendance, and durable flagged-hour credits.
+            Clocked shift time, actual job time, and durable flagged-hour credits.
           </p>
         </header>
 
@@ -205,7 +196,7 @@ export default function MobileTechPerformancePage() {
         {!loading && !error && myRow && (
           <section className="grid grid-cols-2 gap-2.5">
             <StatTile label="Jobs" value={String(myRow.jobs)} accent="text-sky-300" />
-            <StatTile label="Attendance" value={`${myRow.attendanceHours.toFixed(1)} h`} />
+            <StatTile label="Clocked" value={`${myRow.attendanceHours.toFixed(1)} h`} />
             <StatTile label="Actual job" value={`${myRow.actualJobHours.toFixed(1)} h`} />
             <StatTile label="Flagged hours" value={`${myRow.flaggedHours.toFixed(1)} h`} />
             <StatTile label="Efficiency" value={`${myRow.efficiencyPct.toFixed(1)}%`} accent="text-sky-300" />

--- a/app/tech/performance/page.tsx
+++ b/app/tech/performance/page.tsx
@@ -173,17 +173,8 @@ export default function TechPerformancePage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             timeRange: range,
-            tech: {
-              name: myRow.name,
-              jobs: myRow.jobs,
-              flaggedHours: myRow.flaggedHours,
-              actualJobHours: myRow.actualJobHours,
-              attendanceHours: myRow.attendanceHours,
-              efficiencyPct: myRow.efficiencyPct,
-              productivityPct: myRow.productivityPct,
-              overallPerformancePct: myRow.overallPerformancePct,
-            },
-            peers: [],
+            tech: myRow,
+            peers: rows,
           }),
         });
 
@@ -279,7 +270,7 @@ export default function TechPerformancePage() {
             </div>
           </div>
           <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
-            Actual job time comes from canonical labor segments. Attendance comes from approved workforce time.
+            Clocked hours come from canonical shift punches. Actual job time comes from canonical labor segments.
           </p>
 
           {/* Quick compare row */}
@@ -329,7 +320,7 @@ export default function TechPerformancePage() {
             <div className="grid gap-3 md:grid-cols-3">
               <SummaryCard label="Jobs" value={String(myRow.jobs)} />
               <SummaryCard
-                label="Attendance hours"
+                label="Clocked hours"
                 value={`${myRow.attendanceHours.toFixed(1)} h`}
               />
               <SummaryCard

--- a/features/shared/lib/stats/getTechLeaderboard.ts
+++ b/features/shared/lib/stats/getTechLeaderboard.ts
@@ -1,62 +1,4 @@
-// /features/shared/lib/stats/getTechLeaderboard.ts (FULL FILE REPLACEMENT)
-
-import {
-  startOfMonth,
-  endOfMonth,
-  startOfWeek,
-  endOfWeek,
-  startOfQuarter,
-  endOfQuarter,
-  startOfYear,
-  endOfYear,
-} from "date-fns";
-import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-
 import type { TimeRange } from "./getShopStats";
-
-type SlimProfile = {
-  id: string;
-  full_name: string | null;
-  role: string | null;
-  shop_id: string | null;
-};
-
-type InvoiceSlim = {
-  id: string;
-  tech_id: string | null;
-  shop_id: string | null;
-  work_order_id: string | null;
-  total: number | null;
-  labor_cost: number | null;
-  created_at: string | null;
-};
-
-type TimecardSlim = {
-  id: string;
-  user_id: string | null;
-  shop_id: string | null;
-  clock_in: string | null;
-  clock_out: string | null;
-  hours_worked: number | null;
-  created_at: string | null;
-};
-
-type LaborSegmentSlim = {
-  technician_id: string | null;
-  started_at: string;
-  ended_at: string | null;
-};
-
-type FlatRateCreditSlim = {
-  technician_id: string;
-  work_order_line_id: string;
-  credit_hours: number | null;
-};
-
-type AttendanceEntrySlim = {
-  user_id: string;
-  attendance_minutes: number | null;
-};
 
 export type TechLeaderboardRow = {
   techId: string;
@@ -86,10 +28,6 @@ export type TechLeaderboardResult = {
   rows: TechLeaderboardRow[];
 };
 
-function toIso(d: Date): string {
-  return d.toISOString();
-}
-
 /**
  * Normalize role strings so "Technician", "tech", "Lead Tech", etc all match.
  */
@@ -104,264 +42,30 @@ export function isTechRole(role: string | null): boolean {
   return false;
 }
 
-function safeNum(v: number | null | undefined): number {
-  const n = Number(v ?? 0);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function getOverlapHours(
-  startedAt: string | null | undefined,
-  endedAt: string | null | undefined,
-  rangeStartIso: string,
-  rangeEndIso: string,
-): number {
-  if (!startedAt) return 0;
-  const startMs = new Date(startedAt).getTime();
-  if (!Number.isFinite(startMs)) return 0;
-  const endMs = endedAt ? new Date(endedAt).getTime() : new Date().getTime();
-  if (!Number.isFinite(endMs)) return 0;
-  const windowStart = new Date(rangeStartIso).getTime();
-  const windowEnd = new Date(rangeEndIso).getTime();
-  const overlapMs = Math.min(endMs, windowEnd) - Math.max(startMs, windowStart);
-  if (overlapMs <= 0) return 0;
-  return overlapMs / (1000 * 60 * 60);
-}
-
 export async function getTechLeaderboard(
   shopId: string,
   timeRange: TimeRange,
   technicianId?: string,
 ): Promise<TechLeaderboardResult> {
-  const supabase = createBrowserSupabase();
-  const workforceDb = supabase as any;
+  const res = await fetch("/api/stats/tech-leaderboard", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    cache: "no-store",
+    body: JSON.stringify({ shopId, timeRange, technicianId }),
+  });
 
-  const now = new Date();
-  let start: Date;
-  let end: Date;
+  const json = (await res.json().catch(() => null)) as
+    | (Partial<TechLeaderboardResult> & { error?: string })
+    | null;
 
-  switch (timeRange) {
-    case "weekly":
-      start = startOfWeek(now, { weekStartsOn: 1 });
-      end = endOfWeek(now, { weekStartsOn: 1 });
-      break;
-    case "quarterly":
-      start = startOfQuarter(now);
-      end = endOfQuarter(now);
-      break;
-    case "yearly":
-      start = startOfYear(now);
-      end = endOfYear(now);
-      break;
-    case "monthly":
-    default:
-      start = startOfMonth(now);
-      end = endOfMonth(now);
-      break;
+  if (!res.ok) {
+    throw new Error(json?.error ?? `Failed to load tech leaderboard (${res.status})`);
   }
-
-  // exclusive end bound
-  const endExclusive = new Date(end.getTime() + 1);
-
-  const startIso = toIso(start);
-  const endIso = toIso(end);
-  const endExclusiveIso = toIso(endExclusive);
-
-  // 1) Pull ALL profiles in shop, then filter in JS
-  let profilesQuery = supabase
-    .from("profiles")
-    .select("id, full_name, role, shop_id")
-    .eq("shop_id", shopId);
-  if (technicianId) profilesQuery = profilesQuery.eq("id", technicianId);
-  const { data: profiles, error: profErr } = await profilesQuery;
-
-  if (profErr) throw profErr;
-
-  const techProfiles: SlimProfile[] = (profiles ?? [])
-    .map((p) => ({
-      id: p.id,
-      full_name: p.full_name ?? null,
-      role: p.role ?? null,
-      shop_id: p.shop_id ?? null,
-    }))
-    .filter((p) => isTechRole(p.role));
-
-  const techIds = techProfiles.map((p) => p.id).filter(Boolean);
-
-  if (techIds.length === 0) {
-    return { shop_id: shopId, start: startIso, end: endIso, rows: [] };
-  }
-
-  // 2) Pull accounting + live labor/completion sources for this range
-  const [invoicesRes, timecardsRes, segmentsRes, creditsRes, attendanceRes] = await Promise.all([
-    supabase
-      .from("invoices")
-      .select("id, tech_id, shop_id, work_order_id, total, labor_cost, created_at")
-      .eq("shop_id", shopId)
-      .in("tech_id", techIds)
-      .gte("created_at", startIso)
-      .lt("created_at", endExclusiveIso),
-
-    supabase
-      .from("payroll_timecards")
-      .select("id, user_id, shop_id, clock_in, clock_out, hours_worked, created_at")
-      .eq("shop_id", shopId)
-      .in("user_id", techIds)
-      .gte("clock_in", startIso)
-      .lt("clock_in", endExclusiveIso),
-
-    supabase
-      .from("work_order_line_labor_segments")
-      .select("technician_id, started_at, ended_at")
-      .eq("shop_id", shopId)
-      .in("technician_id", techIds)
-      .lt("started_at", endExclusiveIso)
-      .or(`ended_at.gte.${startIso},ended_at.is.null`),
-
-    workforceDb
-      .from("work_order_line_flat_rate_credits")
-      .select("technician_id, work_order_line_id, credit_hours")
-      .eq("shop_id", shopId)
-      .in("technician_id", techIds)
-      .gte("credited_at", startIso)
-      .lt("credited_at", endExclusiveIso),
-
-    workforceDb
-      .from("payroll_time_entries")
-      .select("user_id, attendance_minutes")
-      .eq("shop_id", shopId)
-      .in("user_id", techIds)
-      .gte("work_date", startIso.slice(0, 10))
-      .lte("work_date", endIso.slice(0, 10)),
-  ]);
-
-  if (invoicesRes.error) throw invoicesRes.error;
-  if (timecardsRes.error) throw timecardsRes.error;
-  if (segmentsRes.error) throw segmentsRes.error;
-  if (creditsRes.error) throw creditsRes.error;
-  if (attendanceRes.error) throw attendanceRes.error;
-
-  const invoices: InvoiceSlim[] = (invoicesRes.data as InvoiceSlim[]) ?? [];
-  const timecards: TimecardSlim[] = (timecardsRes.data as TimecardSlim[]) ?? [];
-  const segments: LaborSegmentSlim[] = (segmentsRes.data as LaborSegmentSlim[]) ?? [];
-  const credits: FlatRateCreditSlim[] =
-    (creditsRes.data as FlatRateCreditSlim[]) ?? [];
-  const attendance: AttendanceEntrySlim[] =
-    (attendanceRes.data as AttendanceEntrySlim[]) ?? [];
-
-  // 3) Seed rows so techs show even with 0 activity
-  const byTech = new Map<string, TechLeaderboardRow>();
-
-  for (const prof of techProfiles) {
-    if (!prof.id) continue;
-    byTech.set(prof.id, {
-      techId: prof.id,
-      name: prof.full_name || "Unnamed tech",
-      role: prof.role,
-      jobs: 0,
-      revenue: 0,
-      laborCost: 0,
-      profit: 0,
-      billedHours: 0,
-      clockedHours: 0,
-      flaggedHours: 0,
-      actualJobHours: 0,
-      attendanceHours: 0,
-      revenuePerHour: 0,
-      efficiencyPct: 0,
-      productivityPct: 0,
-      overallPerformancePct: 0,
-    });
-  }
-
-  // 4) Aggregate accounting metrics from invoices only
-  for (const inv of invoices) {
-    const techId = inv.tech_id;
-    if (!techId) continue;
-
-    const row = byTech.get(techId);
-    if (!row) continue;
-
-    row.revenue += safeNum(inv.total);
-    row.laborCost += safeNum(inv.labor_cost);
-  }
-
-  // 4b) Durable technician credits are the source for flagged hours.
-  const creditedLines = new Map<string, Set<string>>();
-  for (const credit of credits) {
-    const row = byTech.get(credit.technician_id);
-    if (!row) continue;
-    const hours = safeNum(credit.credit_hours);
-    row.flaggedHours += hours;
-    row.billedHours += hours;
-    const lines = creditedLines.get(credit.technician_id) ?? new Set<string>();
-    lines.add(credit.work_order_line_id);
-    creditedLines.set(credit.technician_id, lines);
-  }
-  for (const [techId, lines] of creditedLines) {
-    const row = byTech.get(techId);
-    if (row) row.jobs = lines.size;
-  }
-
-  // 5) Aggregate clocked hours from labor segments (source of truth)
-  for (const seg of segments) {
-    const techId = seg.technician_id;
-    if (!techId) continue;
-    const row = byTech.get(techId);
-    if (!row) continue;
-    const hours = getOverlapHours(seg.started_at, seg.ended_at, startIso, endExclusiveIso);
-    row.actualJobHours += hours;
-    row.clockedHours += hours;
-  }
-
-  // Compatibility fallback for historical windows where no segments were created yet.
-  for (const tc of timecards) {
-    const techId = tc.user_id;
-    if (!techId) continue;
-
-    const row = byTech.get(techId);
-    if (!row) continue;
-    if (row.clockedHours <= 0) {
-      row.clockedHours += safeNum(tc.hours_worked);
-    }
-  }
-
-  // Attendance is distinct from actual job time. Historical rows fall back to
-  // timecards when the canonical pay-period snapshot is not available.
-  for (const entry of attendance) {
-    const row = byTech.get(entry.user_id);
-    if (!row) continue;
-    row.attendanceHours += safeNum(entry.attendance_minutes) / 60;
-  }
-  for (const row of byTech.values()) {
-    if (row.attendanceHours <= 0) {
-      row.attendanceHours = timecards
-        .filter((timecard) => timecard.user_id === row.techId)
-        .reduce((total, timecard) => total + safeNum(timecard.hours_worked), 0);
-    }
-  }
-
-  // 7) Final derived metrics
-  for (const row of byTech.values()) {
-    row.profit = row.revenue - row.laborCost;
-
-    // ✅ Tech efficiency = billed ÷ worked
-    row.efficiencyPct =
-      row.actualJobHours > 0 ? (row.flaggedHours / row.actualJobHours) * 100 : 0;
-    row.productivityPct =
-      row.attendanceHours > 0 ? (row.actualJobHours / row.attendanceHours) * 100 : 0;
-    row.overallPerformancePct =
-      row.attendanceHours > 0 ? (row.flaggedHours / row.attendanceHours) * 100 : 0;
-
-    row.revenuePerHour =
-      row.clockedHours > 0 ? row.revenue / row.clockedHours : 0;
-  }
-
-  const rows = Array.from(byTech.values()).sort((a, b) => b.revenue - a.revenue);
 
   return {
-    shop_id: shopId,
-    start: startIso,
-    end: endIso,
-    rows,
+    shop_id: String(json?.shop_id ?? shopId),
+    start: String(json?.start ?? ""),
+    end: String(json?.end ?? ""),
+    rows: Array.isArray(json?.rows) ? json.rows : [],
   };
 }

--- a/features/stats/api/tech-leaderboard/route.ts
+++ b/features/stats/api/tech-leaderboard/route.ts
@@ -1,138 +1,220 @@
-// features/stats/api/tech-leaderboard/route.ts
 import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import {
-  startOfMonth,
   endOfMonth,
-  startOfWeek,
-  endOfWeek,
-  startOfQuarter,
   endOfQuarter,
-  startOfYear,
+  endOfWeek,
   endOfYear,
+  startOfMonth,
+  startOfQuarter,
+  startOfWeek,
+  startOfYear,
 } from "date-fns";
 
-import type { Database } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import type { TimeRange } from "@shared/lib/stats/getShopStats";
-import type {
-  TechLeaderboardResult,
-  TechLeaderboardRow,
+import {
+  isTechRole,
+  type TechLeaderboardResult,
+  type TechLeaderboardRow,
 } from "@shared/lib/stats/getTechLeaderboard";
-
-const supabaseAdmin = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-);
 
 type Body = {
   shopId?: string;
   timeRange?: TimeRange;
+  technicianId?: string;
+};
+
+type SlimProfile = {
+  id: string;
+  full_name: string | null;
+  role: string | null;
+  shop_id: string | null;
+};
+
+type InvoiceSlim = {
+  id: string;
+  tech_id: string | null;
+  total: number | null;
+  labor_cost: number | null;
+};
+
+type ShiftSlim = {
+  user_id: string | null;
+  start_time: string | null;
+  end_time: string | null;
+};
+
+type LaborSegmentSlim = {
+  technician_id: string | null;
+  started_at: string;
+  ended_at: string | null;
+};
+
+type FlatRateCreditSlim = {
+  technician_id: string;
+  work_order_line_id: string;
+  credit_hours: number | null;
+};
+
+type TimecardSlim = {
+  user_id: string | null;
+  hours_worked: number | null;
 };
 
 function toIso(d: Date): string {
   return d.toISOString();
 }
 
+function safeNum(value: number | null | undefined): number {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function getRange(timeRange: TimeRange) {
+  const now = new Date();
+
+  switch (timeRange) {
+    case "weekly":
+      return {
+        start: startOfWeek(now, { weekStartsOn: 1 }),
+        end: endOfWeek(now, { weekStartsOn: 1 }),
+      };
+    case "quarterly":
+      return { start: startOfQuarter(now), end: endOfQuarter(now) };
+    case "yearly":
+      return { start: startOfYear(now), end: endOfYear(now) };
+    case "monthly":
+    default:
+      return { start: startOfMonth(now), end: endOfMonth(now) };
+  }
+}
+
+function getOverlapHours(
+  startedAt: string | null | undefined,
+  endedAt: string | null | undefined,
+  rangeStartIso: string,
+  rangeEndIso: string,
+): number {
+  if (!startedAt) return 0;
+  const startMs = new Date(startedAt).getTime();
+  if (!Number.isFinite(startMs)) return 0;
+
+  const endMs = endedAt ? new Date(endedAt).getTime() : Date.now();
+  if (!Number.isFinite(endMs)) return 0;
+
+  const windowStart = new Date(rangeStartIso).getTime();
+  const windowEnd = new Date(rangeEndIso).getTime();
+  const overlapMs = Math.min(endMs, windowEnd) - Math.max(startMs, windowStart);
+  return overlapMs > 0 ? overlapMs / (1000 * 60 * 60) : 0;
+}
+
 export async function POST(req: Request) {
+  const access = await requireShopScopedApiAccess();
+  if (!access.ok) return access.response;
+
   try {
     const body = (await req.json().catch(() => null)) as Body | null;
-    const shopId = body?.shopId;
-    const timeRange = body?.timeRange ?? "monthly";
+    const requestedShopId = body?.shopId ?? access.profile.shop_id;
+    const timeRange = body?.timeRange ?? "weekly";
+    const technicianId = body?.technicianId?.trim() || undefined;
 
-    if (!shopId) {
-      return NextResponse.json({ error: "Missing shopId" }, { status: 400 });
+    if (requestedShopId !== access.profile.shop_id) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const now = new Date();
-    let start: Date;
-    let end: Date;
-
-    switch (timeRange) {
-      case "weekly":
-        start = startOfWeek(now, { weekStartsOn: 1 });
-        end = endOfWeek(now, { weekStartsOn: 1 });
-        break;
-      case "quarterly":
-        start = startOfQuarter(now);
-        end = endOfQuarter(now);
-        break;
-      case "yearly":
-        start = startOfYear(now);
-        end = endOfYear(now);
-        break;
-      case "monthly":
-      default:
-        start = startOfMonth(now);
-        end = endOfMonth(now);
-        break;
-    }
-
-    // exclusive end bound
+    const { start, end } = getRange(timeRange);
     const endExclusive = new Date(end.getTime() + 1);
     const startIso = toIso(start);
     const endIso = toIso(end);
     const endExclusiveIso = toIso(endExclusive);
 
-    // 1) tech profiles (don’t over-filter; roles can be messy)
-    const { data: profiles, error: profErr } = await supabaseAdmin
+    const admin = createAdminSupabase();
+
+    let profilesQuery = admin
       .from("profiles")
       .select("id, full_name, role, shop_id")
-      .eq("shop_id", shopId);
+      .eq("shop_id", requestedShopId);
+    if (technicianId) profilesQuery = profilesQuery.eq("id", technicianId);
 
-    if (profErr) throw profErr;
+    const { data: profiles, error: profilesError } = await profilesQuery;
+    if (profilesError) throw profilesError;
 
-    // Filter to “tech-ish” roles but tolerate casing/variants
-    const techProfiles =
-      (profiles ?? []).filter((p) => {
-        const role = (p.role ?? "").toLowerCase();
-        return role === "tech" || role === "technician" || role === "mechanic";
-      }) ?? [];
+    const techProfiles: SlimProfile[] = ((profiles ?? []) as SlimProfile[])
+      .filter((profile) => profile.shop_id === requestedShopId)
+      .filter((profile) => isTechRole(profile.role));
 
-    const techIds = techProfiles.map((p) => p.id).filter(Boolean);
-
+    const techIds = techProfiles.map((profile) => profile.id).filter(Boolean);
     if (techIds.length === 0) {
-      const empty: TechLeaderboardResult = {
-        shop_id: shopId,
+      return NextResponse.json({
+        shop_id: requestedShopId,
         start: startIso,
         end: endIso,
         rows: [],
-      };
-      return NextResponse.json(empty);
+      } satisfies TechLeaderboardResult);
     }
 
-    // 2) invoices + timecards
-    const [invoicesRes, timecardsRes] = await Promise.all([
-      supabaseAdmin
+    const [
+      invoicesRes,
+      shiftsRes,
+      segmentsRes,
+      creditsRes,
+      timecardsRes,
+    ] = await Promise.all([
+      admin
         .from("invoices")
-        .select("id, tech_id, shop_id, total, labor_cost, created_at")
-        .eq("shop_id", shopId)
+        .select("id, tech_id, total, labor_cost")
+        .eq("shop_id", requestedShopId)
         .in("tech_id", techIds)
         .gte("created_at", startIso)
         .lt("created_at", endExclusiveIso),
 
-      supabaseAdmin
+      admin
+        .from("tech_shifts")
+        .select("user_id, start_time, end_time")
+        .eq("shop_id", requestedShopId)
+        .in("user_id", techIds)
+        .neq("excluded_from_payroll", true)
+        .lt("start_time", endExclusiveIso)
+        .or(`end_time.is.null,end_time.gt.${startIso}`),
+
+      admin
+        .from("work_order_line_labor_segments")
+        .select("technician_id, started_at, ended_at")
+        .eq("shop_id", requestedShopId)
+        .in("technician_id", techIds)
+        .lt("started_at", endExclusiveIso)
+        .or(`ended_at.is.null,ended_at.gt.${startIso}`),
+
+      admin
+        .from("work_order_line_flat_rate_credits")
+        .select("technician_id, work_order_line_id, credit_hours")
+        .eq("shop_id", requestedShopId)
+        .in("technician_id", techIds)
+        .gte("credited_at", startIso)
+        .lt("credited_at", endExclusiveIso),
+
+      admin
         .from("payroll_timecards")
-        .select("id, user_id, shop_id, clock_in, clock_out, hours_worked, created_at")
-        .eq("shop_id", shopId)
+        .select("user_id, hours_worked")
+        .eq("shop_id", requestedShopId)
         .in("user_id", techIds)
         .gte("clock_in", startIso)
         .lt("clock_in", endExclusiveIso),
     ]);
 
     if (invoicesRes.error) throw invoicesRes.error;
+    if (shiftsRes.error) throw shiftsRes.error;
+    if (segmentsRes.error) throw segmentsRes.error;
+    if (creditsRes.error) throw creditsRes.error;
     if (timecardsRes.error) throw timecardsRes.error;
 
-    const invoices = invoicesRes.data ?? [];
-    const timecards = timecardsRes.data ?? [];
-
-    // 3) aggregate
     const byTech = new Map<string, TechLeaderboardRow>();
-
-    for (const prof of techProfiles) {
-      byTech.set(prof.id, {
-        techId: prof.id,
-        name: prof.full_name || "Unnamed tech",
-        role: prof.role ?? null,
+    for (const profile of techProfiles) {
+      byTech.set(profile.id, {
+        techId: profile.id,
+        name: profile.full_name || "Unnamed tech",
+        role: profile.role,
         jobs: 0,
         revenue: 0,
         laborCost: 0,
@@ -149,38 +231,76 @@ export async function POST(req: Request) {
       });
     }
 
-    for (const inv of invoices) {
-      const techId = inv.tech_id;
-      if (!techId) continue;
-      const row = byTech.get(techId);
+    for (const invoice of ((invoicesRes.data ?? []) as InvoiceSlim[])) {
+      if (!invoice.tech_id) continue;
+      const row = byTech.get(invoice.tech_id);
       if (!row) continue;
-
-      const total = Number(inv.total ?? 0);
-      const laborCost = Number(inv.labor_cost ?? 0);
-
-      row.jobs += 1;
-      row.revenue += Number.isFinite(total) ? total : 0;
-      row.laborCost += Number.isFinite(laborCost) ? laborCost : 0;
+      row.revenue += safeNum(invoice.total);
+      row.laborCost += safeNum(invoice.labor_cost);
     }
 
-    for (const tc of timecards) {
-      const techId = tc.user_id;
-      if (!techId) continue;
-      const row = byTech.get(techId);
+    for (const shift of ((shiftsRes.data ?? []) as ShiftSlim[])) {
+      if (!shift.user_id) continue;
+      const row = byTech.get(shift.user_id);
       if (!row) continue;
+      row.attendanceHours += getOverlapHours(
+        shift.start_time,
+        shift.end_time,
+        startIso,
+        endExclusiveIso,
+      );
+    }
 
-      const hours = Number(tc.hours_worked ?? 0);
-      row.clockedHours += Number.isFinite(hours) ? hours : 0;
+    for (const segment of ((segmentsRes.data ?? []) as LaborSegmentSlim[])) {
+      if (!segment.technician_id) continue;
+      const row = byTech.get(segment.technician_id);
+      if (!row) continue;
+      row.actualJobHours += getOverlapHours(
+        segment.started_at,
+        segment.ended_at,
+        startIso,
+        endExclusiveIso,
+      );
+    }
+
+    const creditedLines = new Map<string, Set<string>>();
+    for (const credit of ((creditsRes.data ?? []) as FlatRateCreditSlim[])) {
+      const row = byTech.get(credit.technician_id);
+      if (!row) continue;
+      const hours = safeNum(credit.credit_hours);
+      row.flaggedHours += hours;
+      row.billedHours += hours;
+      const lines = creditedLines.get(credit.technician_id) ?? new Set<string>();
+      lines.add(credit.work_order_line_id);
+      creditedLines.set(credit.technician_id, lines);
+    }
+
+    for (const [techId, lines] of creditedLines) {
+      const row = byTech.get(techId);
+      if (row) row.jobs = lines.size;
     }
 
     for (const row of byTech.values()) {
+      if (row.attendanceHours <= 0) {
+        row.attendanceHours = ((timecardsRes.data ?? []) as TimecardSlim[])
+          .filter((timecard) => timecard.user_id === row.techId)
+          .reduce((total, timecard) => total + safeNum(timecard.hours_worked), 0);
+      }
+
+      row.clockedHours = row.attendanceHours;
       row.profit = row.revenue - row.laborCost;
-      row.efficiencyPct = row.laborCost > 0 ? (row.revenue / row.laborCost) * 100 : 0;
-      row.revenuePerHour = row.clockedHours > 0 ? row.revenue / row.clockedHours : 0;
+      row.efficiencyPct =
+        row.actualJobHours > 0 ? (row.flaggedHours / row.actualJobHours) * 100 : 0;
+      row.productivityPct =
+        row.attendanceHours > 0 ? (row.actualJobHours / row.attendanceHours) * 100 : 0;
+      row.overallPerformancePct =
+        row.attendanceHours > 0 ? (row.flaggedHours / row.attendanceHours) * 100 : 0;
+      row.revenuePerHour =
+        row.clockedHours > 0 ? row.revenue / row.clockedHours : 0;
     }
 
     const result: TechLeaderboardResult = {
-      shop_id: shopId,
+      shop_id: requestedShopId,
       start: startIso,
       end: endIso,
       rows: Array.from(byTech.values()).sort((a, b) => b.revenue - a.revenue),
@@ -189,7 +309,6 @@ export async function POST(req: Request) {
     return NextResponse.json(result);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Unknown error";
-    // eslint-disable-next-line no-console
     console.error("[tech-leaderboard] error:", message);
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/features/tech/components/TechPerformanceTiles.tsx
+++ b/features/tech/components/TechPerformanceTiles.tsx
@@ -148,7 +148,7 @@ export default function TechPerformanceTiles({
       </div>
 
       <Link href="/tech/performance" className={`${T.card} ${T.link} px-4 py-3`}>
-        <div className={T.label}>Hours worked</div>
+        <div className={T.label}>Clocked hours</div>
         <div className={`${T.value} ${T.copper}`}>{loading ? "…" : fmtHours(clocked)}</div>
         <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-muted)]">
           Based on clocked hours ({range})

--- a/tests/tech-performance-canonical-time.test.ts
+++ b/tests/tech-performance-canonical-time.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("technician performance canonical time contract", () => {
+  const leaderboardHelper = readFileSync(
+    "features/shared/lib/stats/getTechLeaderboard.ts",
+    "utf8",
+  );
+  const leaderboardRoute = readFileSync(
+    "features/stats/api/tech-leaderboard/route.ts",
+    "utf8",
+  );
+  const mobilePerformance = readFileSync(
+    "app/mobile/tech/performance/page.tsx",
+    "utf8",
+  );
+  const desktopPerformance = readFileSync("app/tech/performance/page.tsx", "utf8");
+  const aiRoute = readFileSync(
+    "app/api/ai/summarize-tech-performance/route.ts",
+    "utf8",
+  );
+
+  it("routes all leaderboard consumers through the same API route", () => {
+    expect(leaderboardHelper).toContain('fetch("/api/stats/tech-leaderboard"');
+    expect(leaderboardHelper).not.toContain(".from(");
+  });
+
+  it("uses live shift punches for clocked hours and job labor segments for actual job hours", () => {
+    expect(leaderboardRoute).toContain("requireShopScopedApiAccess");
+    expect(leaderboardRoute).toContain('.from("tech_shifts")');
+    expect(leaderboardRoute).toContain('.from("work_order_line_labor_segments")');
+    expect(leaderboardRoute).toContain("row.clockedHours = row.attendanceHours");
+    expect(leaderboardRoute).not.toContain('.from("payroll_time_entries")');
+  });
+
+  it("keeps the stats route tenant-scoped even though it uses admin reads", () => {
+    expect(leaderboardRoute).toContain("requestedShopId !== access.profile.shop_id");
+    expect(leaderboardRoute).toContain('return NextResponse.json({ error: "Forbidden" }, { status: 403 })');
+  });
+
+  it("sends the full current metric row to the AI summary route on mobile and desktop", () => {
+    expect(mobilePerformance).toContain("tech: myRow");
+    expect(mobilePerformance).toContain("peers: rows");
+    expect(desktopPerformance).toContain("tech: myRow");
+    expect(desktopPerformance).toContain("peers: rows");
+  });
+
+  it("does not crash AI summaries when legacy revenue fields are missing", () => {
+    expect(aiRoute).toContain("function safeNumber");
+    expect(aiRoute).toContain("tech.clockedHours ?? tech.attendanceHours");
+    expect(aiRoute).toContain("tech.flaggedHours ?? tech.billedHours");
+  });
+});


### PR DESCRIPTION
## Summary

Unifies tech performance time reporting so mobile tech performance, desktop tech performance, and dashboard tiles read the same canonical route instead of splitting between browser table reads and an older leaderboard path.

## Root cause

The performance UI was showing "clocked" time from mixed sources. Real shift attendance came from shift/payroll-style records, while job labor came from line labor segments. Mobile performance could show actual job time while daily clocked hours stayed at zero, and the AI summary could fail because it expected legacy revenue/billed-hour fields that the current page payload no longer sent.

## What changed

- Makes `/api/stats/tech-leaderboard` the shared read path for tech performance metrics.
- Computes clocked/attendance hours from live `tech_shifts` overlap.
- Keeps actual job time sourced from `work_order_line_labor_segments`.
- Keeps flagged hours sourced from `work_order_line_flat_rate_credits`.
- Adds same-shop authorization before service-role reads in the stats route.
- Updates mobile and desktop tech performance pages to send the current metric shape to AI summary.
- Updates wording so shift time is labeled as clocked hours and job-punch time remains separate.
- Adds a source-level regression test to guard the canonical route and table split.

## Validation

- `pnpm typecheck` passed
- `pnpm vitest run tests/tech-performance-canonical-time.test.ts` passed, 5 tests
- `git diff --check` passed

## Notes

No migration, production data change, or deployment is included.