### PR TITLE
Add schedule-driven auto punch-out guard

### DIFF
--- a/app/api/internal/workforce/auto-punch-out/route.ts
+++ b/app/api/internal/workforce/auto-punch-out/route.ts
@@ -1,0 +1,191 @@
+import { NextResponse } from "next/server";
+import { requireInternalApiSecret } from "@/features/shared/lib/server/api-route-guard";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import { closeAllActiveTechnicianJobLabor } from "@/features/work-orders/server/technicianJobLabor";
+import { resolveScheduledShiftEnd } from "@/features/workforce/server/autoPunchOut";
+import type {
+  AutoPunchScheduleOverride,
+  AutoPunchScheduleTemplate,
+} from "@/features/workforce/server/autoPunchOut";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type ActiveShift = {
+  id: string;
+  shop_id: string;
+  user_id: string;
+  start_time: string;
+};
+
+type ShopRow = { id: string; timezone: string | null };
+
+function authorize(req: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (
+    cronSecret &&
+    req.headers.get("authorization") === `Bearer ${cronSecret}`
+  ) {
+    return { ok: true } as const;
+  }
+  return requireInternalApiSecret({
+    request: req,
+    envSecretName: "INTERNAL_WORKFORCE_GUARD_SECRET",
+    headerName: "x-internal-workforce-guard-secret",
+    routeLabel: "internal/workforce/auto-punch-out",
+  });
+}
+
+async function run(req: Request) {
+  const gate = authorize(req);
+  if (!gate.ok) return gate.response;
+
+  const admin = createAdminSupabase();
+  const now = new Date();
+  const { data: shifts, error: shiftError } = await admin
+    .from("tech_shifts")
+    .select("id, shop_id, user_id, start_time")
+    .eq("status", "active")
+    .is("end_time", null)
+    .not("shop_id", "is", null)
+    .not("user_id", "is", null)
+    .not("start_time", "is", null)
+    .order("start_time", { ascending: true })
+    .limit(500);
+  if (shiftError) throw shiftError;
+
+  const activeShifts = (shifts ?? []) as ActiveShift[];
+  if (activeShifts.length === 0) {
+    return NextResponse.json({ ok: true, inspected: 0, punchedOut: 0, failures: [] });
+  }
+
+  const shopIds = [...new Set(activeShifts.map((shift) => shift.shop_id))];
+  const userIds = [...new Set(activeShifts.map((shift) => shift.user_id))];
+  const [shopsResult, templatesResult, overridesResult] = await Promise.all([
+    admin.from("shops").select("id, timezone").in("id", shopIds),
+    admin
+      .from("staff_schedule_templates")
+      .select("user_id, day_of_week, is_working_day, start_time, end_time, effective_from, effective_to")
+      .in("shop_id", shopIds)
+      .in("user_id", userIds),
+    admin
+      .from("staff_schedule_overrides")
+      .select("user_id, schedule_date, start_time, end_time, status")
+      .in("shop_id", shopIds)
+      .in("user_id", userIds),
+  ]);
+  if (shopsResult.error) throw shopsResult.error;
+  if (templatesResult.error) throw templatesResult.error;
+  if (overridesResult.error) throw overridesResult.error;
+
+  const timezoneByShop = new Map(
+    ((shopsResult.data ?? []) as ShopRow[]).map((shop) => [
+      shop.id,
+      shop.timezone,
+    ]),
+  );
+  const templates = (templatesResult.data ?? []) as AutoPunchScheduleTemplate[];
+  const overrides = (overridesResult.data ?? []) as AutoPunchScheduleOverride[];
+  const failures: Array<{ shiftId: string; error: string }> = [];
+  let punchedOut = 0;
+
+  for (const shift of activeShifts) {
+    const schedule = resolveScheduledShiftEnd({
+      userId: shift.user_id,
+      shiftStartedAt: shift.start_time,
+      timezone: timezoneByShop.get(shift.shop_id),
+      templates,
+      overrides,
+    });
+    if (!schedule) continue;
+
+    const scheduledEnd = new Date(schedule.scheduledEndIso);
+    if (scheduledEnd.getTime() > now.getTime()) continue;
+
+    try {
+      const operationKey = `auto-end-day:${shift.id}:${schedule.scheduledEndIso}`;
+      const closed = await closeAllActiveTechnicianJobLabor({
+        supabase: admin,
+        shopId: shift.shop_id,
+        technicianId: shift.user_id,
+        operationKey,
+        endedAtIso: schedule.scheduledEndIso,
+        reason: "scheduled_shift_end",
+        event: "job_stopped_at_scheduled_end_day",
+        details: {
+          shift_id: shift.id,
+          schedule_source: schedule.source,
+          schedule_date: schedule.dateKey,
+          automatic: true,
+        },
+      });
+      if (!closed.ok) throw new Error(closed.error);
+
+      await admin
+        .from("workforce_job_resume_contexts")
+        .update({
+          status: "cancelled",
+          cancelled_at: schedule.scheduledEndIso,
+          cancel_reason: "scheduled_shift_ended",
+          updated_at: now.toISOString(),
+        })
+        .eq("shop_id", shift.shop_id)
+        .eq("user_id", shift.user_id)
+        .eq("status", "pending");
+
+      const { data, error } = await (admin as unknown as {
+        rpc: (
+          name: string,
+          args: Record<string, unknown>,
+        ) => PromiseLike<{ data: unknown[] | null; error: { message: string } | null }>;
+      }).rpc("complete_canonical_shift", {
+        p_shift_id: shift.id,
+        p_shop_id: shift.shop_id,
+        p_user_id: shift.user_id,
+        p_profile_id: shift.user_id,
+        p_timestamp: schedule.scheduledEndIso,
+      });
+
+      if (error) {
+        // A concurrent manual punch-out is a successful no-op for this guard.
+        if (error.message.toLowerCase().includes("no matching active shift")) continue;
+        throw new Error(error.message);
+      }
+      if (!data?.length) throw new Error("Canonical shift close returned no row");
+      punchedOut += 1;
+    } catch (error) {
+      failures.push({
+        shiftId: shift.id,
+        error: error instanceof Error ? error.message : "Unknown auto punch-out failure",
+      });
+    }
+  }
+
+  return NextResponse.json({
+    ok: failures.length === 0,
+    inspected: activeShifts.length,
+    punchedOut,
+    failures,
+  });
+}
+
+export async function GET(req: Request) {
+  try {
+    return await run(req);
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "Workforce auto punch-out guard failed",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(req: Request) {
+  return GET(req);
+}

--- a/features/workforce/server/autoPunchOut.ts
+++ b/features/workforce/server/autoPunchOut.ts
@@ -1,0 +1,100 @@
+import { shopLocalDateTimeToUtc } from "@/features/shared/lib/utils/shopDayWindow";
+import { getShopScheduleDateContext } from "@/features/workforce/lib/schedulePosture";
+
+export type AutoPunchScheduleTemplate = {
+  user_id: string;
+  day_of_week: number;
+  is_working_day: boolean;
+  start_time: string | null;
+  end_time: string | null;
+  effective_from?: string | null;
+  effective_to?: string | null;
+};
+
+export type AutoPunchScheduleOverride = {
+  user_id: string;
+  schedule_date: string;
+  start_time: string | null;
+  end_time: string | null;
+  status: string | null;
+};
+
+function templateApplies(
+  row: AutoPunchScheduleTemplate,
+  dateKey: string,
+  dayOfWeek: number,
+) {
+  return (
+    row.day_of_week === dayOfWeek &&
+    row.is_working_day &&
+    Boolean(row.start_time && row.end_time) &&
+    (!row.effective_from || row.effective_from <= dateKey) &&
+    (!row.effective_to || row.effective_to >= dateKey)
+  );
+}
+
+function timeOnly(value: string | null | undefined) {
+  if (!value) return null;
+  const match = /^(\d{2}:\d{2})(?::\d{2})?$/.exec(value);
+  return match?.[1] ?? null;
+}
+
+function nextDateKey(dateKey: string) {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  const next = new Date(Date.UTC(year, month - 1, day + 1));
+  return next.toISOString().slice(0, 10);
+}
+
+export function resolveScheduledShiftEnd(params: {
+  userId: string;
+  shiftStartedAt: string;
+  timezone?: string | null;
+  templates: AutoPunchScheduleTemplate[];
+  overrides: AutoPunchScheduleOverride[];
+}): { scheduledEndIso: string; source: "override" | "template"; dateKey: string } | null {
+  const startedAt = new Date(params.shiftStartedAt);
+  if (!Number.isFinite(startedAt.getTime())) return null;
+
+  const { dateKey, dayOfWeek } = getShopScheduleDateContext(
+    startedAt,
+    params.timezone,
+  );
+  const override = params.overrides.find(
+    (row) =>
+      row.user_id === params.userId &&
+      row.schedule_date === dateKey &&
+      String(row.status ?? "").toLowerCase() !== "cancelled",
+  );
+
+  // A same-day override is authoritative, including an explicit unscheduled day.
+  if (override) {
+    if (!override.start_time || !override.end_time) return null;
+    const end = new Date(override.end_time);
+    if (!Number.isFinite(end.getTime())) return null;
+    return {
+      scheduledEndIso: end.toISOString(),
+      source: "override",
+      dateKey,
+    };
+  }
+
+  const template = params.templates.find(
+    (row) =>
+      row.user_id === params.userId &&
+      templateApplies(row, dateKey, dayOfWeek),
+  );
+  const startTime = timeOnly(template?.start_time);
+  const endTime = timeOnly(template?.end_time);
+  if (!template || !startTime || !endTime) return null;
+
+  const endDateKey = endTime <= startTime ? nextDateKey(dateKey) : dateKey;
+  return {
+    scheduledEndIso: shopLocalDateTimeToUtc(
+      endDateKey,
+      endTime,
+      params.timezone,
+    ),
+    source: "template",
+    dateKey,
+  };
+}

--- a/tests/workforce-auto-punch-out.test.ts
+++ b/tests/workforce-auto-punch-out.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { resolveScheduledShiftEnd } from "@/features/workforce/server/autoPunchOut";
+
+describe("workforce auto punch-out schedule resolution", () => {
+  const template = {
+    user_id: "tech-1",
+    day_of_week: 1,
+    is_working_day: true,
+    start_time: "08:00",
+    end_time: "17:00",
+  };
+
+  it("resolves recurring end time in the shop timezone", () => {
+    expect(
+      resolveScheduledShiftEnd({
+        userId: "tech-1",
+        shiftStartedAt: "2026-07-27T14:00:00.000Z",
+        timezone: "America/Edmonton",
+        templates: [template],
+        overrides: [],
+      }),
+    ).toMatchObject({
+      scheduledEndIso: "2026-07-27T23:00:00.000Z",
+      source: "template",
+      dateKey: "2026-07-27",
+    });
+  });
+
+  it("uses the dated override instead of the recurring template", () => {
+    expect(
+      resolveScheduledShiftEnd({
+        userId: "tech-1",
+        shiftStartedAt: "2026-07-27T14:00:00.000Z",
+        timezone: "America/Edmonton",
+        templates: [template],
+        overrides: [{
+          user_id: "tech-1",
+          schedule_date: "2026-07-27",
+          start_time: "2026-07-27T15:00:00.000Z",
+          end_time: "2026-07-27T21:30:00.000Z",
+          status: "scheduled",
+        }],
+      }),
+    ).toMatchObject({
+      scheduledEndIso: "2026-07-27T21:30:00.000Z",
+      source: "override",
+    });
+  });
+
+  it("does not fall back to a template when an override marks the day off", () => {
+    expect(
+      resolveScheduledShiftEnd({
+        userId: "tech-1",
+        shiftStartedAt: "2026-07-27T14:00:00.000Z",
+        timezone: "America/Edmonton",
+        templates: [template],
+        overrides: [{
+          user_id: "tech-1",
+          schedule_date: "2026-07-27",
+          start_time: null,
+          end_time: null,
+          status: "scheduled",
+        }],
+      }),
+    ).toBeNull();
+  });
+
+  it("supports recurring overnight shifts", () => {
+    expect(
+      resolveScheduledShiftEnd({
+        userId: "tech-1",
+        shiftStartedAt: "2026-07-28T04:00:00.000Z",
+        timezone: "America/Edmonton",
+        templates: [{ ...template, start_time: "22:00", end_time: "06:00" }],
+        overrides: [],
+      }),
+    ).toMatchObject({
+      scheduledEndIso: "2026-07-28T12:00:00.000Z",
+      dateKey: "2026-07-27",
+    });
+  });
+});
+
+describe("workforce auto punch-out route contract", () => {
+  const route = readFileSync(
+    "app/api/internal/workforce/auto-punch-out/route.ts",
+    "utf8",
+  );
+  const vercel = readFileSync("vercel.json", "utf8");
+
+  it("closes job labor before the canonical shift at the scheduled timestamp", () => {
+    expect(route).toContain("closeAllActiveTechnicianJobLabor");
+    expect(route).toContain('reason: "scheduled_shift_end"');
+    expect(route).toContain('event: "job_stopped_at_scheduled_end_day"');
+    expect(route).toContain("p_timestamp: schedule.scheduledEndIso");
+    expect(route.indexOf("closeAllActiveTechnicianJobLabor")).toBeLessThan(
+      route.indexOf('rpc("complete_canonical_shift"'),
+    );
+  });
+
+  it("cancels break/lunch resume context instead of leaving a resumable job", () => {
+    expect(route).toContain('"workforce_job_resume_contexts"');
+    expect(route).toContain('cancel_reason: "scheduled_shift_ended"');
+  });
+
+  it("runs every minute behind an internal secret", () => {
+    expect(route).toContain("CRON_SECRET");
+    expect(vercel).toContain("/api/internal/workforce/auto-punch-out");
+    expect(vercel).toContain('"schedule": "* * * * *"');
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/internal/financial-outbox/tick",
       "schedule": "*/2 * * * *"
+    },
+    {
+      "path": "/api/internal/workforce/auto-punch-out",
+      "schedule": "* * * * *"
     }
   ],
   "git": {


### PR DESCRIPTION
## Summary

Adds a schedule-driven guard that automatically ends an active employee shift at the employee's configured daily schedule end time.

- Resolves schedules in the shop timezone.
- Gives same-day schedule overrides precedence over recurring templates.
- Supports effective-dated templates and overnight schedules.
- Records the shift and active job-labor end at the scheduled end time rather than the later cron execution time.
- Ends the active job punch without completing or changing the work-order line.
- Clears break/lunch resume context at end of day so yesterday's job cannot resume on the next shift.
- Leaves active shifts unchanged when no valid schedule end can be resolved.
- Uses the canonical end-day transition, shift locking, and deterministic operation keys so retries cannot duplicate labor or punch-out effects.

## Intended behavior

- **Break or lunch:** pause the active job punch and retain resumable context; punching back in resumes the job.
- **Manual End Day:** end the active job punch permanently while leaving the job line unfinished.
- **Automatic scheduled end:** perform the same permanent end-day transition at the configured schedule end time.

## Root cause

The existing manual lifecycle distinguished resumable break/lunch punches from end-of-day punches, but there was no reliable server-side schedule guard. An employee could therefore remain clocked in indefinitely, and any separately implemented cleanup risked diverging from the canonical end-day behavior.

## Validation

Added focused coverage for:

- recurring schedule resolution
- same-day override precedence
- overnight schedules
- effective-dated templates
- protected guard-route behavior
- canonical end-day delegation
- deterministic retry behavior

The focused tests were authored on the branch but were not executed in the original implementation workspace because that workspace did not contain a local repository checkout. CI should run the repository checks on this PR.

## Deployment notes

No database migration is included. This PR does not deploy, merge, run migrations, or modify production data.