### PR TITLE
Address tech performance review findings

### DIFF
--- a/app/api/ai/summarize-tech-performance/route.ts
+++ b/app/api/ai/summarize-tech-performance/route.ts
@@ -66,10 +66,6 @@ export async function POST(req: Request) {
 
     // Build a compact numeric context for the model
     const peerCount = peers.length;
-    const totalPeerRevenue = peers.reduce((acc, p) => acc + safeNumber(p.revenue), 0);
-    const avgPeerRevenue =
-      peerCount > 0 ? totalPeerRevenue / peerCount : 0;
-
     const totalPeerEff = peers.reduce(
       (acc, p) => acc + safeNumber(p.efficiencyPct),
       0,
@@ -77,15 +73,10 @@ export async function POST(req: Request) {
     const avgPeerEff =
       peerCount > 0 ? totalPeerEff / peerCount : 0;
 
-    const revenue = safeNumber(tech.revenue);
-    const laborCost = safeNumber(tech.laborCost);
-    const profit = safeNumber(tech.profit);
     const clockedHours = safeNumber(tech.clockedHours ?? tech.attendanceHours);
     const attendanceHours = safeNumber(tech.attendanceHours ?? tech.clockedHours);
     const actualJobHours = safeNumber(tech.actualJobHours);
     const flaggedHours = safeNumber(tech.flaggedHours ?? tech.billedHours);
-    const billedHours = safeNumber(tech.billedHours ?? tech.flaggedHours);
-    const revenuePerHour = safeNumber(tech.revenuePerHour);
     const efficiencyPct = safeNumber(tech.efficiencyPct);
     const productivityPct = safeNumber(tech.productivityPct);
     const overallPerformancePct = safeNumber(tech.overallPerformancePct);
@@ -95,27 +86,25 @@ export async function POST(req: Request) {
       "",
       `Technician: ${tech.name || "Unnamed tech"}`,
       `Jobs: ${tech.jobs}`,
-      `Revenue: ${revenue.toFixed(2)}`,
-      `Labor cost: ${laborCost.toFixed(2)}`,
-      `Profit: ${profit.toFixed(2)}`,
       `Clocked attendance hours: ${clockedHours.toFixed(2)}`,
       `Attendance hours: ${attendanceHours.toFixed(2)}`,
       `Actual job hours: ${actualJobHours.toFixed(2)}`,
       `Flagged hours: ${flaggedHours.toFixed(2)}`,
-      `Billed hours: ${billedHours.toFixed(2)}`,
-      `Revenue per hour: ${revenuePerHour.toFixed(2)}`,
       `Efficiency (% flagged / actual job): ${efficiencyPct.toFixed(1)}`,
       `Productivity (% actual job / attendance): ${productivityPct.toFixed(1)}`,
       `Overall performance (% flagged / attendance): ${overallPerformancePct.toFixed(1)}`,
       "",
-      `Peer techs in same shop for ${timeLabel}: ${peerCount}`,
-      `Average peer revenue: ${avgPeerRevenue.toFixed(2)}`,
-      `Average peer efficiency: ${avgPeerEff.toFixed(1)}%`,
+      peerCount > 0
+        ? `Peer techs in same shop for ${timeLabel}: ${peerCount}`
+        : "No authorized peer comparison is available.",
+      peerCount > 0 ? `Average peer efficiency: ${avgPeerEff.toFixed(1)}%` : "",
       "",
       "Write a short, plain-language summary (3–5 sentences) for the technician themselves.",
       "Focus on:",
       "- how they are doing overall,",
-      "- where they appear above or below the peer average, and",
+      peerCount > 0
+        ? "- where they appear above or below the peer average, and"
+        : "- what their own time metrics indicate, and",
       "- one or two simple, actionable suggestions.",
       "Do NOT use bullet points. Keep it under 120 words. No greetings or sign-offs.",
     ].join("\n");

--- a/app/mobile/tech/performance/page.tsx
+++ b/app/mobile/tech/performance/page.tsx
@@ -124,8 +124,17 @@ export default function MobileTechPerformancePage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             timeRange: range,
-            tech: myRow,
-            peers: rows,
+            tech: {
+              name: myRow.name,
+              jobs: myRow.jobs,
+              flaggedHours: myRow.flaggedHours,
+              actualJobHours: myRow.actualJobHours,
+              attendanceHours: myRow.attendanceHours,
+              efficiencyPct: myRow.efficiencyPct,
+              productivityPct: myRow.productivityPct,
+              overallPerformancePct: myRow.overallPerformancePct,
+            },
+            peers: [],
           }),
         });
 

--- a/app/tech/performance/page.tsx
+++ b/app/tech/performance/page.tsx
@@ -173,8 +173,17 @@ export default function TechPerformancePage() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             timeRange: range,
-            tech: myRow,
-            peers: rows,
+            tech: {
+              name: myRow.name,
+              jobs: myRow.jobs,
+              flaggedHours: myRow.flaggedHours,
+              actualJobHours: myRow.actualJobHours,
+              attendanceHours: myRow.attendanceHours,
+              efficiencyPct: myRow.efficiencyPct,
+              productivityPct: myRow.productivityPct,
+              overallPerformancePct: myRow.overallPerformancePct,
+            },
+            peers: [],
           }),
         });
 

--- a/features/stats/api/tech-leaderboard/route.ts
+++ b/features/stats/api/tech-leaderboard/route.ts
@@ -1,17 +1,11 @@
 import { NextResponse } from "next/server";
-import {
-  endOfMonth,
-  endOfQuarter,
-  endOfWeek,
-  endOfYear,
-  startOfMonth,
-  startOfQuarter,
-  startOfWeek,
-  startOfYear,
-} from "date-fns";
-
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+import {
+  derivePerformanceMetrics,
+  getShopPerformanceRange,
+  mergedIntervalHours,
+} from "@/features/stats/lib/techPerformanceMetrics";
 import type { TimeRange } from "@shared/lib/stats/getShopStats";
 import {
   isTechRole,
@@ -59,35 +53,14 @@ type FlatRateCreditSlim = {
 
 type TimecardSlim = {
   user_id: string | null;
+  clock_in: string;
+  clock_out: string | null;
   hours_worked: number | null;
 };
-
-function toIso(d: Date): string {
-  return d.toISOString();
-}
 
 function safeNum(value: number | null | undefined): number {
   const n = Number(value ?? 0);
   return Number.isFinite(n) ? n : 0;
-}
-
-function getRange(timeRange: TimeRange) {
-  const now = new Date();
-
-  switch (timeRange) {
-    case "weekly":
-      return {
-        start: startOfWeek(now, { weekStartsOn: 1 }),
-        end: endOfWeek(now, { weekStartsOn: 1 }),
-      };
-    case "quarterly":
-      return { start: startOfQuarter(now), end: endOfQuarter(now) };
-    case "yearly":
-      return { start: startOfYear(now), end: endOfYear(now) };
-    case "monthly":
-    default:
-      return { start: startOfMonth(now), end: endOfMonth(now) };
-  }
 }
 
 function getOverlapHours(
@@ -123,13 +96,16 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const { start, end } = getRange(timeRange);
-    const endExclusive = new Date(end.getTime() + 1);
-    const startIso = toIso(start);
-    const endIso = toIso(end);
-    const endExclusiveIso = toIso(endExclusive);
-
     const admin = createAdminSupabase();
+    const { data: shop, error: shopError } = await admin
+      .from("shops")
+      .select("timezone")
+      .eq("id", requestedShopId)
+      .maybeSingle();
+    if (shopError) throw shopError;
+    const { start: startIso, endExclusive: endExclusiveIso } =
+      getShopPerformanceRange(timeRange, shop?.timezone?.trim() || "UTC");
+    const endIso = endExclusiveIso;
 
     let profilesQuery = admin
       .from("profiles")
@@ -174,6 +150,7 @@ export async function POST(req: Request) {
         .select("user_id, start_time, end_time")
         .eq("shop_id", requestedShopId)
         .in("user_id", techIds)
+        .eq("type", "shift")
         .neq("excluded_from_payroll", true)
         .lt("start_time", endExclusiveIso)
         .or(`end_time.is.null,end_time.gt.${startIso}`),
@@ -196,11 +173,11 @@ export async function POST(req: Request) {
 
       admin
         .from("payroll_timecards")
-        .select("user_id, hours_worked")
+        .select("user_id, clock_in, clock_out, hours_worked")
         .eq("shop_id", requestedShopId)
         .in("user_id", techIds)
-        .gte("clock_in", startIso)
-        .lt("clock_in", endExclusiveIso),
+        .lt("clock_in", endExclusiveIso)
+        .or(`clock_out.is.null,clock_out.gt.${startIso}`),
     ]);
 
     if (invoicesRes.error) throw invoicesRes.error;
@@ -239,18 +216,6 @@ export async function POST(req: Request) {
       row.laborCost += safeNum(invoice.labor_cost);
     }
 
-    for (const shift of ((shiftsRes.data ?? []) as ShiftSlim[])) {
-      if (!shift.user_id) continue;
-      const row = byTech.get(shift.user_id);
-      if (!row) continue;
-      row.attendanceHours += getOverlapHours(
-        shift.start_time,
-        shift.end_time,
-        startIso,
-        endExclusiveIso,
-      );
-    }
-
     for (const segment of ((segmentsRes.data ?? []) as LaborSegmentSlim[])) {
       if (!segment.technician_id) continue;
       const row = byTech.get(segment.technician_id);
@@ -281,22 +246,22 @@ export async function POST(req: Request) {
     }
 
     for (const row of byTech.values()) {
-      if (row.attendanceHours <= 0) {
-        row.attendanceHours = ((timecardsRes.data ?? []) as TimecardSlim[])
-          .filter((timecard) => timecard.user_id === row.techId)
-          .reduce((total, timecard) => total + safeNum(timecard.hours_worked), 0);
-      }
-
-      row.clockedHours = row.attendanceHours;
-      row.profit = row.revenue - row.laborCost;
-      row.efficiencyPct =
-        row.actualJobHours > 0 ? (row.flaggedHours / row.actualJobHours) * 100 : 0;
-      row.productivityPct =
-        row.attendanceHours > 0 ? (row.actualJobHours / row.attendanceHours) * 100 : 0;
-      row.overallPerformancePct =
-        row.attendanceHours > 0 ? (row.flaggedHours / row.attendanceHours) * 100 : 0;
-      row.revenuePerHour =
-        row.clockedHours > 0 ? row.revenue / row.clockedHours : 0;
+      const shifts = ((shiftsRes.data ?? []) as ShiftSlim[])
+        .filter((shift) => shift.user_id === row.techId)
+        .map((shift) => ({ start: shift.start_time, end: shift.end_time }));
+      const timecards = ((timecardsRes.data ?? []) as TimecardSlim[])
+        .filter((timecard) => timecard.user_id === row.techId)
+        .map((timecard) => ({
+          start: timecard.clock_in,
+          end: timecard.clock_out,
+          fallbackHours: timecard.hours_worked,
+        }));
+      row.attendanceHours = mergedIntervalHours(
+        [...shifts, ...timecards],
+        startIso,
+        endExclusiveIso,
+      );
+      derivePerformanceMetrics(row);
     }
 
     const result: TechLeaderboardResult = {

--- a/features/stats/lib/techPerformanceMetrics.ts
+++ b/features/stats/lib/techPerformanceMetrics.ts
@@ -1,0 +1,135 @@
+import type { TimeRange } from "@shared/lib/stats/getShopStats";
+import type { TechLeaderboardRow } from "@shared/lib/stats/getTechLeaderboard";
+import { shopLocalDateTimeToUtc } from "@/features/shared/lib/utils/shopDayWindow";
+
+type Interval = {
+  start: string | null;
+  end: string | null;
+  fallbackHours?: number | null;
+};
+
+function localDateKey(value: Date, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(value);
+  const part = (type: string) => parts.find((entry) => entry.type === type)?.value;
+  return `${part("year")}-${part("month")}-${part("day")}`;
+}
+
+function utcDateFromKey(key: string): Date {
+  const [year, month, day] = key.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day, 12));
+}
+
+function dateKey(date: Date): string {
+  return [
+    String(date.getUTCFullYear()).padStart(4, "0"),
+    String(date.getUTCMonth() + 1).padStart(2, "0"),
+    String(date.getUTCDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function addToKey(key: string, amount: number, unit: "day" | "month"): string {
+  const date = utcDateFromKey(key);
+  if (unit === "day") date.setUTCDate(date.getUTCDate() + amount);
+  else {
+    date.setUTCDate(1);
+    date.setUTCMonth(date.getUTCMonth() + amount);
+  }
+  return dateKey(date);
+}
+
+export function getShopPerformanceRange(
+  timeRange: TimeRange,
+  timezone: string,
+  now = new Date(),
+): { start: string; endExclusive: string } {
+  const todayKey = localDateKey(now, timezone);
+  const startDate = utcDateFromKey(todayKey);
+
+  if (timeRange === "weekly") {
+    const weekday = startDate.getUTCDay();
+    startDate.setUTCDate(startDate.getUTCDate() + (weekday === 0 ? -6 : 1 - weekday));
+  } else if (timeRange === "monthly") {
+    startDate.setUTCDate(1);
+  } else if (timeRange === "quarterly") {
+    startDate.setUTCDate(1);
+    startDate.setUTCMonth(Math.floor(startDate.getUTCMonth() / 3) * 3);
+  } else {
+    startDate.setUTCMonth(0, 1);
+  }
+
+  const startKey = dateKey(startDate);
+  const endKey =
+    timeRange === "weekly"
+      ? addToKey(startKey, 7, "day")
+      : addToKey(
+          startKey,
+          timeRange === "monthly" ? 1 : timeRange === "quarterly" ? 3 : 12,
+          "month",
+        );
+
+  return {
+    start: shopLocalDateTimeToUtc(startKey, "00:00:00", timezone),
+    endExclusive: shopLocalDateTimeToUtc(endKey, "00:00:00", timezone),
+  };
+}
+
+export function mergedIntervalHours(
+  intervals: Interval[],
+  rangeStartIso: string,
+  rangeEndIso: string,
+  now = new Date(),
+): number {
+  const rangeStart = new Date(rangeStartIso).getTime();
+  const rangeEnd = new Date(rangeEndIso).getTime();
+  const normalized = intervals
+    .flatMap((interval) => {
+      if (!interval.start) return [];
+      const start = new Date(interval.start).getTime();
+      if (!Number.isFinite(start)) return [];
+      const explicitEnd = interval.end ? new Date(interval.end).getTime() : Number.NaN;
+      const fallbackEnd =
+        start + Math.max(0, Number(interval.fallbackHours ?? 0)) * 60 * 60 * 1000;
+      const end = Number.isFinite(explicitEnd)
+        ? explicitEnd
+        : fallbackEnd > start
+          ? fallbackEnd
+          : now.getTime();
+      const clippedStart = Math.max(start, rangeStart);
+      const clippedEnd = Math.min(end, rangeEnd);
+      return clippedEnd > clippedStart ? [{ start: clippedStart, end: clippedEnd }] : [];
+    })
+    .sort((a, b) => a.start - b.start);
+
+  let totalMs = 0;
+  let currentStart = 0;
+  let currentEnd = 0;
+  for (const interval of normalized) {
+    if (interval.start > currentEnd) {
+      totalMs += Math.max(0, currentEnd - currentStart);
+      currentStart = interval.start;
+      currentEnd = interval.end;
+    } else {
+      currentEnd = Math.max(currentEnd, interval.end);
+    }
+  }
+  totalMs += Math.max(0, currentEnd - currentStart);
+  return totalMs / (60 * 60 * 1000);
+}
+
+export function derivePerformanceMetrics(row: TechLeaderboardRow): TechLeaderboardRow {
+  row.clockedHours = row.attendanceHours;
+  row.profit = row.revenue - row.laborCost;
+  row.efficiencyPct =
+    row.actualJobHours > 0 ? (row.flaggedHours / row.actualJobHours) * 100 : 0;
+  row.productivityPct =
+    row.attendanceHours > 0 ? (row.actualJobHours / row.attendanceHours) * 100 : 0;
+  row.overallPerformancePct =
+    row.attendanceHours > 0 ? (row.flaggedHours / row.attendanceHours) * 100 : 0;
+  row.revenuePerHour = row.clockedHours > 0 ? row.revenue / row.clockedHours : 0;
+  return row;
+}

--- a/tests/tech-performance-canonical-time.test.ts
+++ b/tests/tech-performance-canonical-time.test.ts
@@ -1,53 +1,114 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
+import {
+  derivePerformanceMetrics,
+  getShopPerformanceRange,
+  mergedIntervalHours,
+} from "../features/stats/lib/techPerformanceMetrics";
+import type { TechLeaderboardRow } from "../features/shared/lib/stats/getTechLeaderboard";
+
 describe("technician performance canonical time contract", () => {
-  const leaderboardHelper = readFileSync(
-    "features/shared/lib/stats/getTechLeaderboard.ts",
-    "utf8",
-  );
-  const leaderboardRoute = readFileSync(
-    "features/stats/api/tech-leaderboard/route.ts",
-    "utf8",
-  );
-  const mobilePerformance = readFileSync(
-    "app/mobile/tech/performance/page.tsx",
-    "utf8",
-  );
-  const desktopPerformance = readFileSync("app/tech/performance/page.tsx", "utf8");
-  const aiRoute = readFileSync(
-    "app/api/ai/summarize-tech-performance/route.ts",
-    "utf8",
-  );
+  it("builds calendar boundaries in the shop timezone", () => {
+    const range = getShopPerformanceRange(
+      "weekly",
+      "America/Los_Angeles",
+      new Date("2026-07-27T00:30:00.000Z"),
+    );
 
-  it("routes all leaderboard consumers through the same API route", () => {
-    expect(leaderboardHelper).toContain('fetch("/api/stats/tech-leaderboard"');
-    expect(leaderboardHelper).not.toContain(".from(");
+    expect(range).toEqual({
+      start: "2026-07-20T07:00:00.000Z",
+      endExclusive: "2026-07-27T07:00:00.000Z",
+    });
   });
 
-  it("uses live shift punches for clocked hours and job labor segments for actual job hours", () => {
-    expect(leaderboardRoute).toContain("requireShopScopedApiAccess");
-    expect(leaderboardRoute).toContain('.from("tech_shifts")');
-    expect(leaderboardRoute).toContain('.from("work_order_line_labor_segments")');
-    expect(leaderboardRoute).toContain("row.clockedHours = row.attendanceHours");
-    expect(leaderboardRoute).not.toContain('.from("payroll_time_entries")');
+  it("merges overlapping canonical shifts and legacy timecards without dropping history", () => {
+    const hours = mergedIntervalHours(
+      [
+        {
+          start: "2026-07-20T15:00:00.000Z",
+          end: "2026-07-20T17:00:00.000Z",
+        },
+        {
+          start: "2026-07-20T16:00:00.000Z",
+          end: "2026-07-20T19:00:00.000Z",
+          fallbackHours: 3,
+        },
+        {
+          start: "2026-07-21T15:00:00.000Z",
+          end: null,
+          fallbackHours: 8,
+        },
+      ],
+      "2026-07-20T00:00:00.000Z",
+      "2026-07-22T00:00:00.000Z",
+    );
+
+    expect(hours).toBe(12);
   });
 
-  it("keeps the stats route tenant-scoped even though it uses admin reads", () => {
-    expect(leaderboardRoute).toContain("requestedShopId !== access.profile.shop_id");
-    expect(leaderboardRoute).toContain('return NextResponse.json({ error: "Forbidden" }, { status: 403 })');
+  it("clips intervals to the requested range and derives concrete percentages", () => {
+    const attendanceHours = mergedIntervalHours(
+      [
+        {
+          start: "2026-07-19T23:00:00.000Z",
+          end: "2026-07-20T03:00:00.000Z",
+        },
+      ],
+      "2026-07-20T00:00:00.000Z",
+      "2026-07-21T00:00:00.000Z",
+    );
+    const row = derivePerformanceMetrics({
+      techId: "tech-1",
+      name: "Test Tech",
+      role: "mechanic",
+      jobs: 1,
+      revenue: 600,
+      laborCost: 100,
+      profit: 0,
+      billedHours: 3,
+      clockedHours: 0,
+      flaggedHours: 3,
+      actualJobHours: 2,
+      attendanceHours,
+      revenuePerHour: 0,
+      efficiencyPct: 0,
+      productivityPct: 0,
+      overallPerformancePct: 0,
+    } satisfies TechLeaderboardRow);
+
+    expect(row.attendanceHours).toBe(3);
+    expect(row.clockedHours).toBe(3);
+    expect(row.efficiencyPct).toBe(150);
+    expect(row.productivityPct).toBeCloseTo(66.67, 2);
+    expect(row.overallPerformancePct).toBe(100);
+    expect(row.profit).toBe(500);
   });
 
-  it("sends the full current metric row to the AI summary route on mobile and desktop", () => {
-    expect(mobilePerformance).toContain("tech: myRow");
-    expect(mobilePerformance).toContain("peers: rows");
-    expect(desktopPerformance).toContain("tech: myRow");
-    expect(desktopPerformance).toContain("peers: rows");
+  it("keeps the route shop-scoped and filters attendance rows to shifts", () => {
+    const route = readFileSync(
+      "features/stats/api/tech-leaderboard/route.ts",
+      "utf8",
+    );
+    expect(route).toContain("requireShopScopedApiAccess");
+    expect(route).toContain("requestedShopId !== access.profile.shop_id");
+    expect(route).toContain('.eq("type", "shift")');
   });
 
-  it("does not crash AI summaries when legacy revenue fields are missing", () => {
-    expect(aiRoute).toContain("function safeNumber");
-    expect(aiRoute).toContain("tech.clockedHours ?? tech.attendanceHours");
-    expect(aiRoute).toContain("tech.flaggedHours ?? tech.billedHours");
+  it("redacts financial metrics and omits fake peer comparisons on tech pages", () => {
+    for (const path of [
+      "app/tech/performance/page.tsx",
+      "app/mobile/tech/performance/page.tsx",
+    ]) {
+      const page = readFileSync(path, "utf8");
+      const payload = page.slice(
+        page.indexOf("body: JSON.stringify"),
+        page.indexOf("if (!res.ok", page.indexOf("body: JSON.stringify")),
+      );
+      expect(payload).toContain("peers: []");
+      expect(payload).not.toContain("revenue:");
+      expect(payload).not.toContain("laborCost:");
+      expect(payload).not.toContain("profit:");
+    }
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1224 addressing all six Codex review findings.

## Changes

- Computes weekly/monthly/quarterly/yearly boundaries in the shop timezone and converts them to UTC for querying.
- Filters `tech_shifts` attendance to `type = shift`.
- Reconciles canonical shifts with historical `payroll_timecards` using interval union, preserving non-overlapping history without double-counting duplicate overlap.
- Restores a nonfinancial allowlist for technician AI-summary payloads on mobile and desktop.
- Omits peer comparison when the route only returns the requesting technician.
- Removes financial figures from the technician summary prompt.
- Replaces source-string-only checks with executable range, overlap, fallback, and derived-metric tests while retaining authorization/filter guards.

## Validation

- `vitest run tests/tech-performance-canonical-time.test.ts` — 5 passed
- `tsc --noEmit` — passed
- `git diff --check` — passed

No migration, production data change, or deployment is included.