### PR TITLE
Harden technician performance date and legacy time handling

### DIFF
--- a/features/stats/api/tech-leaderboard/route.ts
+++ b/features/stats/api/tech-leaderboard/route.ts
@@ -103,9 +103,11 @@ export async function POST(req: Request) {
       .eq("id", requestedShopId)
       .maybeSingle();
     if (shopError) throw shopError;
-    const { start: startIso, endExclusive: endExclusiveIso } =
-      getShopPerformanceRange(timeRange, shop?.timezone?.trim() || "UTC");
-    const endIso = endExclusiveIso;
+    const {
+      start: startIso,
+      endInclusive: endIso,
+      endExclusive: endExclusiveIso,
+    } = getShopPerformanceRange(timeRange, shop?.timezone);
 
     let profilesQuery = admin
       .from("profiles")
@@ -248,7 +250,11 @@ export async function POST(req: Request) {
     for (const row of byTech.values()) {
       const shifts = ((shiftsRes.data ?? []) as ShiftSlim[])
         .filter((shift) => shift.user_id === row.techId)
-        .map((shift) => ({ start: shift.start_time, end: shift.end_time }));
+        .map((shift) => ({
+          start: shift.start_time,
+          end: shift.end_time,
+          useNowWhenOpen: true,
+        }));
       const timecards = ((timecardsRes.data ?? []) as TimecardSlim[])
         .filter((timecard) => timecard.user_id === row.techId)
         .map((timecard) => ({

--- a/features/stats/lib/techPerformanceMetrics.ts
+++ b/features/stats/lib/techPerformanceMetrics.ts
@@ -6,7 +6,19 @@ type Interval = {
   start: string | null;
   end: string | null;
   fallbackHours?: number | null;
+  useNowWhenOpen?: boolean;
 };
+
+function normalizeTimezone(timezone?: string | null): string {
+  const candidate = timezone?.trim();
+  if (!candidate) return "UTC";
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: candidate });
+    return candidate;
+  } catch {
+    return "UTC";
+  }
+}
 
 function localDateKey(value: Date, timezone: string): string {
   const parts = new Intl.DateTimeFormat("en-CA", {
@@ -46,8 +58,9 @@ export function getShopPerformanceRange(
   timeRange: TimeRange,
   timezone: string,
   now = new Date(),
-): { start: string; endExclusive: string } {
-  const todayKey = localDateKey(now, timezone);
+): { start: string; endInclusive: string; endExclusive: string } {
+  const safeTimezone = normalizeTimezone(timezone);
+  const todayKey = localDateKey(now, safeTimezone);
   const startDate = utcDateFromKey(todayKey);
 
   if (timeRange === "weekly") {
@@ -73,8 +86,11 @@ export function getShopPerformanceRange(
         );
 
   return {
-    start: shopLocalDateTimeToUtc(startKey, "00:00:00", timezone),
-    endExclusive: shopLocalDateTimeToUtc(endKey, "00:00:00", timezone),
+    start: shopLocalDateTimeToUtc(startKey, "00:00:00", safeTimezone),
+    endInclusive: new Date(
+      new Date(shopLocalDateTimeToUtc(endKey, "00:00:00", safeTimezone)).getTime() - 1,
+    ).toISOString(),
+    endExclusive: shopLocalDateTimeToUtc(endKey, "00:00:00", safeTimezone),
   };
 }
 
@@ -98,7 +114,9 @@ export function mergedIntervalHours(
         ? explicitEnd
         : fallbackEnd > start
           ? fallbackEnd
-          : now.getTime();
+          : interval.useNowWhenOpen
+            ? now.getTime()
+            : Number.NaN;
       const clippedStart = Math.max(start, rangeStart);
       const clippedEnd = Math.min(end, rangeEnd);
       return clippedEnd > clippedStart ? [{ start: clippedStart, end: clippedEnd }] : [];

--- a/tests/tech-performance-canonical-time.test.ts
+++ b/tests/tech-performance-canonical-time.test.ts
@@ -18,8 +18,53 @@ describe("technician performance canonical time contract", () => {
 
     expect(range).toEqual({
       start: "2026-07-20T07:00:00.000Z",
+      endInclusive: "2026-07-27T06:59:59.999Z",
       endExclusive: "2026-07-27T07:00:00.000Z",
     });
+  });
+
+  it("falls back to UTC when the saved shop timezone is invalid", () => {
+    const range = getShopPerformanceRange(
+      "monthly",
+      "not/a-timezone",
+      new Date("2026-07-26T18:00:00.000Z"),
+    );
+
+    expect(range).toEqual({
+      start: "2026-07-01T00:00:00.000Z",
+      endInclusive: "2026-07-31T23:59:59.999Z",
+      endExclusive: "2026-08-01T00:00:00.000Z",
+    });
+  });
+
+  it("excludes unbounded legacy cards but lets canonical open shifts run to now", () => {
+    const rangeStart = "2026-07-20T00:00:00.000Z";
+    const rangeEnd = "2026-07-27T00:00:00.000Z";
+    const now = new Date("2026-07-22T20:00:00.000Z");
+
+    expect(
+      mergedIntervalHours(
+        [{ start: "2026-01-01T00:00:00.000Z", end: null }],
+        rangeStart,
+        rangeEnd,
+        now,
+      ),
+    ).toBe(0);
+
+    expect(
+      mergedIntervalHours(
+        [
+          {
+            start: "2026-07-22T16:00:00.000Z",
+            end: null,
+            useNowWhenOpen: true,
+          },
+        ],
+        rangeStart,
+        rangeEnd,
+        now,
+      ),
+    ).toBe(4);
   });
 
   it("merges overlapping canonical shifts and legacy timecards without dropping history", () => {


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1226 addressing the three Codex findings on commit `c1336f1172`.

## Changes

- Validates the saved shop timezone once and falls back to UTC before both local-date formatting and UTC boundary conversion.
- Distinguishes canonical open shifts from incomplete legacy timecards: only canonical shifts may run to the current time; an unclosed legacy card without a positive `hours_worked` bound is excluded.
- Keeps database queries on `endExclusive` while returning an inclusive display `end`, so weekly/monthly/quarterly/yearly labels stop on the last included day.
- Adds behavioral coverage for invalid timezone fallback, inclusive range ends, stale unbounded legacy cards, and open canonical shifts.

## Scope

Three files only. No migration, production data change, or deployment.

## Verification

- Branch is based on current `main` and is 3 commits ahead / 0 behind.
- GitHub compare confirms only the intended three files changed.
- Full CI is pending on this draft PR because workspace maintenance removed the prior local checkout.