### PR TITLE
Unify generic inspection sync across mobile and desktop

### DIFF
--- a/features/inspections/app/inspection/fill/page.tsx
+++ b/features/inspections/app/inspection/fill/page.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import GenericInspectionScreen from "@/features/inspections/screens/GenericInspectionScreen";
+import { mergeInspectionRuntimeParams } from "@inspections/lib/inspection/runtimeParams";
 
 type Dict = Record<string, string>;
 
@@ -34,30 +35,13 @@ export default function InspectionFillPage() {
         ? (JSON.parse(stagedParamsRaw) as Dict)
         : {};
 
-      /**
-       * IMPORTANT:
-       * - When coming from work order embed, staged params should be authoritative.
-       * - URL params are allowed to add context (workOrderId, customerId, etc),
-       *   but should NOT be able to force us back into "draft/builder" mode.
-       *
-       * So: URL first, staged second (staged wins).
-       */
-      const merged: Dict = { ...urlParams, ...stagedParams };
-
-// allow URL to override for grid specifically
-if (urlParams.grid) merged.grid = urlParams.grid;
-
-      // Hard safety: if we have staged mode, keep it.
-      if (stagedParams.mode) merged.mode = stagedParams.mode;
-
-      // Same for screen template if staged already set it
-      if (stagedParams.template) merged.template = stagedParams.template;
-
-      // Also preserve template identity helpers if staged has them
-      if (stagedParams.templateId) merged.templateId = stagedParams.templateId;
-      if (stagedParams.template_id) merged.template_id = stagedParams.template_id;
-      if (stagedParams.templateName) merged.templateName = stagedParams.templateName;
-      if (stagedParams.template_name) merged.template_name = stagedParams.template_name;
+      // Staged data carries the prepared template, while the current URL owns
+      // the work-order/line identity. This prevents a prior tab's staged params
+      // from reopening or saving a different inspection line.
+      const merged = mergeInspectionRuntimeParams({
+        staged: stagedParams,
+        route: urlParams,
+      });
 
       sessionStorage.setItem("inspection:params", JSON.stringify(merged));
 

--- a/features/inspections/hooks/useInspectionAutosave.ts
+++ b/features/inspections/hooks/useInspectionAutosave.ts
@@ -14,6 +14,12 @@ import {
   saveInspectionOfflineDraft,
   type InspectionDraftRecoveryState,
 } from "@inspections/lib/inspection/offlineDrafts";
+import {
+  inspectionFingerprint,
+  inspectionRevision,
+  remoteInspectionShouldReplace,
+  shouldForceCanonicalBootstrap,
+} from "@inspections/lib/inspection/reconciliation";
 
 export type InspectionSyncState =
   | "hydrating"
@@ -39,6 +45,7 @@ type UseInspectionAutosaveArgs = {
   draftKey?: string;
   debounceMs?: number;
   recoveryOperationKey?: string;
+  hasRecoveredLocalDraft?: boolean;
   onRemoteSession: (session: InspectionSession) => void;
   onRemoteMeta?: (meta: InspectionRemoteMeta) => void;
   onRecoveryState?: (
@@ -78,22 +85,6 @@ function timestamp(value: unknown): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function revision(session: InspectionSession | null): number {
-  const value = session?.syncRevision;
-  return typeof value === "number" && Number.isFinite(value)
-    ? Math.max(0, Math.trunc(value))
-    : 0;
-}
-
-function fingerprint(session: InspectionSession | null): string {
-  if (!session) return "";
-  return [
-    session.id ?? "",
-    revision(session),
-    session.lastUpdated ?? "",
-  ].join(":");
-}
-
 function hasDurableSession(value: unknown): value is InspectionSession {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Partial<InspectionSession>;
@@ -107,59 +98,6 @@ function sessionMatchesWorkOrderLine(
   const embeddedLineId = session?.workOrderLineId?.trim() ?? "";
   const activeLineId = workOrderLineId?.trim() ?? "";
   return !embeddedLineId || !activeLineId || embeddedLineId === activeLineId;
-}
-
-function hasMeaningfulLocalChanges(session: InspectionSession): boolean {
-  if (session.transcript?.trim()) return true;
-  if ((session.quote?.length ?? 0) > 0) return true;
-
-  return (session.sections ?? []).some((section) =>
-    (section.items ?? []).some((item) => {
-      const value = item as unknown as {
-        status?: unknown;
-        notes?: unknown;
-        value?: unknown;
-        photoUrls?: unknown;
-      };
-      const status = String(value.status ?? "").trim().toLowerCase();
-      const hasStatus =
-        status.length > 0 &&
-        !["pending", "not_started", "not started"].includes(status);
-      const hasNotes =
-        typeof value.notes === "string" && value.notes.trim().length > 0;
-      const hasValue =
-        value.value !== null &&
-        value.value !== undefined &&
-        String(value.value).trim().length > 0;
-      const hasPhotos =
-        Array.isArray(value.photoUrls) && value.photoUrls.length > 0;
-      return hasStatus || hasNotes || hasValue || hasPhotos;
-    }),
-  );
-}
-
-function remoteShouldReplace(
-  remote: InspectionSession,
-  local: InspectionSession | null,
-  lastPersistedFingerprint: string,
-): boolean {
-  if (!local) return true;
-
-  const remoteRevision = revision(remote);
-  const localRevision = revision(local);
-  const localFingerprint = fingerprint(local);
-  const localIsDirty = lastPersistedFingerprint
-    ? Boolean(localFingerprint) &&
-      localFingerprint !== lastPersistedFingerprint
-    : hasMeaningfulLocalChanges(local);
-
-  // Never erase an unsaved edit (including a field the user intentionally
-  // cleared). The following save will surface a revision conflict if another
-  // device advanced while this client was dirty.
-  if (localIsDirty) return false;
-  if (remoteRevision > localRevision) return true;
-  if (remoteRevision < localRevision) return false;
-  return timestamp(remote.lastUpdated) >= timestamp(local.lastUpdated);
 }
 
 function errorStatus(error: unknown): number | null {
@@ -207,6 +145,7 @@ export function useInspectionAutosave({
   draftKey,
   debounceMs = 700,
   recoveryOperationKey,
+  hasRecoveredLocalDraft = false,
   onRemoteSession,
   onRemoteMeta,
   onRecoveryState,
@@ -263,7 +202,7 @@ export function useInspectionAutosave({
     const recoveredKey = recoveryOperationKey?.trim();
     if (recoveredKey && !pendingOperationKeyRef.current) {
       pendingOperationKeyRef.current = recoveredKey;
-      pendingOperationFingerprintRef.current = fingerprint(
+      pendingOperationFingerprintRef.current = inspectionFingerprint(
         latestSessionRef.current,
       );
     }
@@ -314,19 +253,19 @@ export function useInspectionAutosave({
         ? latestSessionRef.current
         : null;
       const metaAccepted = meta ? applyRemoteMeta(meta) : true;
-      const remoteFingerprint = fingerprint(remote);
-      const remoteRevision = revision(remote);
+      const remoteFingerprint = inspectionFingerprint(remote);
+      const remoteRevision = inspectionRevision(remote);
       const remoteUpdatedAt = timestamp(
         remote.serverUpdatedAt ?? meta?.updatedAt ?? remote.lastUpdated,
       );
       const shouldReplace =
         force ||
         (metaAccepted && Boolean(meta?.locked)) ||
-        remoteShouldReplace(
+        remoteInspectionShouldReplace({
           remote,
-          current,
-          previousServerFingerprint,
-        );
+          local: current,
+          lastPersistedFingerprint: previousServerFingerprint,
+        });
 
       if (
         remoteRevision > lastServerRevisionRef.current ||
@@ -397,13 +336,7 @@ export function useInspectionAutosave({
     const remote = json?.session;
     if (hasDurableSession(remote)) {
       const local = latestSessionRef.current;
-      const localRevision = revision(local);
-      const serverIsAhead = revision(remote) > localRevision;
       const hasPendingLocalSave = Boolean(pendingOperationKeyRef.current);
-      const hasUnversionedRecovery =
-        localRevision === 0 &&
-        Boolean(local) &&
-        hasMeaningfulLocalChanges(local as InspectionSession);
 
       // On first hydration, the durable server revision is canonical across
       // devices. Queued offline work and older unversioned recovery drafts stay
@@ -411,10 +344,13 @@ export function useInspectionAutosave({
       applyRemote(
         remote,
         meta,
-        preferCanonicalServer &&
-          serverIsAhead &&
-          !hasPendingLocalSave &&
-          !hasUnversionedRecovery,
+        shouldForceCanonicalBootstrap({
+          remote,
+          local,
+          preferCanonicalServer,
+          hasPendingLocalSave,
+          hasRecoveredLocalDraft,
+        }),
       );
     } else {
       applyRemoteMeta(meta);
@@ -425,6 +361,7 @@ export function useInspectionAutosave({
     enabled,
     identityKey,
     inspectionId,
+    hasRecoveredLocalDraft,
     workOrderLineId,
   ]);
 
@@ -582,7 +519,7 @@ export function useInspectionAutosave({
         };
       }
 
-      const nextFingerprint = fingerprint(snapshot);
+      const nextFingerprint = inspectionFingerprint(snapshot);
       if (
         nextFingerprint &&
         nextFingerprint === lastServerFingerprintRef.current
@@ -683,13 +620,14 @@ export function useInspectionAutosave({
               result.savedAt ?? snapshot.serverUpdatedAt ?? null,
           };
           const current = latestSessionRef.current;
-          const acknowledgementRevision = revision(acknowledgedSnapshot);
+          const acknowledgementRevision =
+            inspectionRevision(acknowledgedSnapshot);
 
-          if (!current || fingerprint(current) === nextFingerprint) {
+          if (!current || inspectionFingerprint(current) === nextFingerprint) {
             persistedSnapshot = acknowledgedSnapshot;
             latestSessionRef.current = acknowledgedSnapshot;
             onRemoteSessionRef.current(acknowledgedSnapshot);
-          } else if (acknowledgementRevision >= revision(current)) {
+          } else if (acknowledgementRevision >= inspectionRevision(current)) {
             // Preserve edits made while the request was in flight, but advance
             // their concurrency token so the follow-up save is accepted.
             persistedSnapshot = {
@@ -713,7 +651,7 @@ export function useInspectionAutosave({
             // Record only the snapshot the server acknowledged. A newer local
             // edit must remain dirty and receive its own operation key.
             lastServerFingerprintRef.current =
-              fingerprint(acknowledgedSnapshot);
+              inspectionFingerprint(acknowledgedSnapshot);
           }
           lastQueuedFingerprintRef.current = "";
         } else {
@@ -808,7 +746,7 @@ export function useInspectionAutosave({
             const latest = latestSessionRef.current ?? result.session;
             if (
               !requireServer ||
-              fingerprint(latest) === lastServerFingerprintRef.current
+              inspectionFingerprint(latest) === lastServerFingerprintRef.current
             ) {
               return latest;
             }
@@ -850,7 +788,7 @@ export function useInspectionAutosave({
       return;
     }
 
-    const nextFingerprint = fingerprint(session);
+    const nextFingerprint = inspectionFingerprint(session);
     const offline =
       typeof navigator !== "undefined" && !navigator.onLine;
     if (

--- a/features/inspections/lib/inspection/findings/page.tsx
+++ b/features/inspections/lib/inspection/findings/page.tsx
@@ -213,6 +213,14 @@ export default function InspectionFindingsPage(): JSX.Element {
   );
 
   const [session, setSession] = useState<InspectionSession | null>(null);
+  const [draftBootstrappedKey, setDraftBootstrappedKey] = useState<
+    string | null
+  >(null);
+  const draftBootLoaded = draftBootstrappedKey === draftKey;
+  const [hasRecoveredLocalDraft, setHasRecoveredLocalDraft] = useState(false);
+  const [recoveryOperationKey, setRecoveryOperationKey] = useState<
+    string | undefined
+  >(undefined);
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
   const latestSessionRef = useRef<InspectionSession | null>(session);
@@ -254,9 +262,13 @@ export default function InspectionFindingsPage(): JSX.Element {
     session,
     inspectionId: resolvedInspectionId,
     workOrderLineId: resolvedWorkOrderLineId,
-    enabled: Boolean(resolvedInspectionId || resolvedWorkOrderLineId),
+    enabled:
+      draftBootLoaded &&
+      Boolean(resolvedInspectionId || resolvedWorkOrderLineId),
     locked: isLocked,
     draftKey,
+    recoveryOperationKey,
+    hasRecoveredLocalDraft,
     onRemoteSession: (remote) => {
       latestSessionRef.current = remote;
       setSession(remote);
@@ -266,22 +278,46 @@ export default function InspectionFindingsPage(): JSX.Element {
       isLockedRef.current = meta.locked;
       setIsLocked(meta.locked);
     },
+    onRecoveryState: (_state, operationKey) => {
+      setRecoveryOperationKey(operationKey);
+    },
   });
 
   const syncFromDraft = useCallback(async () => {
-    if (isLockedRef.current || busyRef.current) return;
-    const recovered = await getInspectionOfflineDraft({
-      draftKey,
-      sessionHint: {
-        id: inspectionId,
-        workOrderId: workOrderId || null,
-        workOrderLineId: workOrderLineId || null,
-        templateitem: templateName,
-      },
-    });
-    if (recovered) {
-      latestSessionRef.current = recovered.session;
-      setSession(recovered.session);
+    setHasRecoveredLocalDraft(false);
+    setRecoveryOperationKey(undefined);
+    try {
+      const recovered = await getInspectionOfflineDraft({
+        draftKey,
+        sessionHint: {
+          id: inspectionId,
+          workOrderId: workOrderId || null,
+          workOrderLineId: workOrderLineId || null,
+          templateitem: templateName,
+        },
+      });
+      if (activeDraftKeyRef.current !== draftKey) return;
+      if (recovered) {
+        latestSessionRef.current = recovered.session;
+        setSession(recovered.session);
+        setHasRecoveredLocalDraft(true);
+        setRecoveryOperationKey(recovered.operationKey);
+      } else {
+        latestSessionRef.current = null;
+        setSession(null);
+      }
+    } catch (error) {
+      // IndexedDB recovery is a safety net. If it is unavailable, continue to
+      // the canonical HTTP load instead of leaving this screen unbootstrapped.
+      console.warn("[inspection findings] offline recovery unavailable", error);
+      if (activeDraftKeyRef.current === draftKey) {
+        latestSessionRef.current = null;
+        setSession(null);
+      }
+    } finally {
+      if (activeDraftKeyRef.current === draftKey) {
+        setDraftBootstrappedKey(draftKey);
+      }
     }
   }, [draftKey, inspectionId, templateName, workOrderId, workOrderLineId]);
 

--- a/features/inspections/lib/inspection/reconciliation.ts
+++ b/features/inspections/lib/inspection/reconciliation.ts
@@ -1,0 +1,115 @@
+import type { InspectionSession } from "@inspections/lib/inspection/types";
+
+function timestamp(value: unknown): number {
+  if (typeof value !== "string" || !value.trim()) return 0;
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function inspectionRevision(
+  session: InspectionSession | null | undefined,
+): number {
+  const value = session?.syncRevision;
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : 0;
+}
+
+export function inspectionFingerprint(
+  session: InspectionSession | null | undefined,
+): string {
+  if (!session) return "";
+  return [
+    session.id ?? "",
+    inspectionRevision(session),
+    session.lastUpdated ?? "",
+  ].join(":");
+}
+
+export function hasMeaningfulInspectionProgress(
+  session: InspectionSession,
+): boolean {
+  if (session.transcript?.trim()) return true;
+  if ((session.quote?.length ?? 0) > 0) return true;
+
+  return (session.sections ?? []).some((section) =>
+    (section.items ?? []).some((item) => {
+      const value = item as unknown as {
+        status?: unknown;
+        notes?: unknown;
+        value?: unknown;
+        photoUrls?: unknown;
+      };
+      const status = String(value.status ?? "").trim().toLowerCase();
+      const hasStatus =
+        status.length > 0 &&
+        !["pending", "not_started", "not started"].includes(status);
+      const hasNotes =
+        typeof value.notes === "string" && value.notes.trim().length > 0;
+      const hasValue =
+        value.value !== null &&
+        value.value !== undefined &&
+        String(value.value).trim().length > 0;
+      const hasPhotos =
+        Array.isArray(value.photoUrls) && value.photoUrls.length > 0;
+      return hasStatus || hasNotes || hasValue || hasPhotos;
+    }),
+  );
+}
+
+export function remoteInspectionShouldReplace(args: {
+  remote: InspectionSession;
+  local: InspectionSession | null;
+  lastPersistedFingerprint: string;
+}): boolean {
+  const { remote, local, lastPersistedFingerprint } = args;
+  if (!local) return true;
+
+  const remoteRevision = inspectionRevision(remote);
+  const localRevision = inspectionRevision(local);
+  const localFingerprint = inspectionFingerprint(local);
+  const localIsDirty = lastPersistedFingerprint
+    ? Boolean(localFingerprint) &&
+      localFingerprint !== lastPersistedFingerprint
+    : hasMeaningfulInspectionProgress(local);
+
+  // A normal refresh must not erase an edit made after the last server
+  // acknowledgement. A revision conflict will preserve that device copy.
+  if (localIsDirty) return false;
+  if (remoteRevision > localRevision) return true;
+  if (remoteRevision < localRevision) return false;
+  return timestamp(remote.lastUpdated) >= timestamp(local.lastUpdated);
+}
+
+export function shouldForceCanonicalBootstrap(args: {
+  remote: InspectionSession;
+  local: InspectionSession | null;
+  preferCanonicalServer: boolean;
+  hasPendingLocalSave: boolean;
+  hasRecoveredLocalDraft: boolean;
+}): boolean {
+  const {
+    remote,
+    local,
+    preferCanonicalServer,
+    hasPendingLocalSave,
+    hasRecoveredLocalDraft,
+  } = args;
+  const serverIsAhead =
+    inspectionRevision(remote) > inspectionRevision(local);
+  const hasUnversionedRecovery =
+    hasRecoveredLocalDraft &&
+    inspectionRevision(local) === 0 &&
+    Boolean(local) &&
+    hasMeaningfulInspectionProgress(local as InspectionSession);
+
+  // A freshly initialized template is never a source of truth. Only a real
+  // recovered device draft (or an operation already queued for the server)
+  // can block the first canonical hydration.
+  return (
+    preferCanonicalServer &&
+    !hasPendingLocalSave &&
+    !hasUnversionedRecovery &&
+    (!hasRecoveredLocalDraft || serverIsAhead)
+  );
+}

--- a/features/inspections/lib/inspection/runtimeParams.ts
+++ b/features/inspections/lib/inspection/runtimeParams.ts
@@ -1,0 +1,18 @@
+export type InspectionRuntimeParams = Record<string, string>;
+
+export function mergeInspectionRuntimeParams(args: {
+  staged?: InspectionRuntimeParams | null;
+  route?: InspectionRuntimeParams | null;
+  props?: Record<string, string | number | boolean | null | undefined> | null;
+}): InspectionRuntimeParams {
+  const merged: InspectionRuntimeParams = {
+    ...(args.staged ?? {}),
+    ...(args.route ?? {}),
+  };
+
+  Object.entries(args.props ?? {}).forEach(([key, value]) => {
+    if (value != null) merged[key] = String(value);
+  });
+
+  return merged;
+}

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -57,6 +57,7 @@ import {
   saveInspectionOfflineDraft,
   type InspectionDraftRecoveryState,
 } from "@inspections/lib/inspection/offlineDrafts";
+import { mergeInspectionRuntimeParams } from "@inspections/lib/inspection/runtimeParams";
 
 /* -------------------------- helpers -------------------------- */
 
@@ -628,21 +629,18 @@ type SmartMatchRow = {
 };
 
   const sp = useMemo(() => {
-    const merged = new URLSearchParams();
     const staged = readStaged<Record<string, string>>("inspection:params");
-
-    // Direct-route params form the base. The mobile runner stages its context
-    // because it prepares the template client-side. A desktop modal passes the
-    // exact inspection source as props and must win over any stale staged run.
-    routeSp.forEach((value, key) => merged.set(key, value));
-    Object.entries(staged ?? {}).forEach(([key, value]) => {
-      if (value != null) merged.set(key, String(value));
-    });
-    Object.entries(props.params ?? {}).forEach(([key, value]) => {
-      if (value != null) merged.set(key, String(value));
+    const route: Record<string, string> = {};
+    routeSp.forEach((value, key) => {
+      route[key] = value;
     });
 
-    return merged;
+    // Session storage carries the template payload, but it must never redirect
+    // a newly opened work-order line back to an older line. Route identity wins,
+    // and explicit host props remain the strongest source.
+    return new URLSearchParams(
+      mergeInspectionRuntimeParams({ staged, route, props: props.params }),
+    );
   }, [props.params, routeSp]);
 
   const isEmbed = useMemo(
@@ -654,18 +652,23 @@ type SmartMatchRow = {
     [props.embed, sp],
   );
 
-  const workOrderId = sp.get("workOrderId") || null;
-  const workOrderLineId = sp.get("workOrderLineId") || "";
+  const workOrderId =
+    sp.get("workOrderId") || sp.get("work_order_id") || null;
+  const workOrderLineId =
+    sp.get("workOrderLineId") ||
+    sp.get("work_order_line_id") ||
+    sp.get("lineId") ||
+    "";
 
   const showMissingLineWarning = isEmbed && !workOrderLineId;
 
 
   const templateName =
+    sp.get("templateName") ||
+    sp.get("template_name") ||
     (typeof window !== "undefined"
       ? sessionStorage.getItem("inspection:title")
       : null) ||
-    sp.get("templateName") ||
-    sp.get("template_name") ||
     props.template ||
     sp.get("template") ||
     "Inspection";
@@ -814,7 +817,11 @@ type SmartMatchRow = {
 
   const [voicePulse, setVoicePulse] = useState(false);
   const pulseTimerRef = useRef<number | null>(null);
-  const [draftBootLoaded, setDraftBootLoaded] = useState(false);
+  const [draftBootstrappedKey, setDraftBootstrappedKey] = useState<
+    string | null
+  >(null);
+  const draftBootLoaded = draftBootstrappedKey === draftKey;
+  const [hasRecoveredLocalDraft, setHasRecoveredLocalDraft] = useState(false);
   const [recoveryState, setRecoveryState] =
     useState<InspectionDraftRecoveryState>("editing");
   const [recoveryMessage, setRecoveryMessage] = useState<string | null>(null);
@@ -848,13 +855,21 @@ type SmartMatchRow = {
       quote: [],
       customer,
       vehicle,
-      sections: [],
+      sections: bootSections,
       currentSectionIndex: 0,
       currentItemIndex: 0,
       started: false,
       completed: false,
     }),
-    [inspectionId, templateName, workOrderId, workOrderLineId, customer, vehicle],
+    [
+      bootSections,
+      inspectionId,
+      templateName,
+      workOrderId,
+      workOrderLineId,
+      customer,
+      vehicle,
+    ],
   );
 
   const {
@@ -921,6 +936,7 @@ type SmartMatchRow = {
     locked: isLocked,
     draftKey,
     recoveryOperationKey: recoveryOperationKeyRef.current,
+    hasRecoveredLocalDraft,
     onRemoteSession: (remote) => {
       replaceSession(remote);
     },
@@ -949,6 +965,12 @@ type SmartMatchRow = {
   useEffect(() => {
     let cancelled = false;
     inspectionCompletedRef.current = false;
+    setHasRecoveredLocalDraft(false);
+    setRecoveryState("editing");
+    recoveryOperationKeyRef.current = undefined;
+    queuedSessionRef.current = null;
+    skipNextQueuedEditCheckRef.current = false;
+    setRecoveryMessage(null);
     const recoverDraft = async () => {
       try {
         const recovered = await getInspectionOfflineDraft({
@@ -957,6 +979,7 @@ type SmartMatchRow = {
         });
         if (cancelled) return;
         if (recovered) {
+          setHasRecoveredLocalDraft(true);
           replaceSession(recovered.session);
           setRecoveryState(recovered.state);
           recoveryOperationKeyRef.current = recovered.operationKey;
@@ -972,12 +995,13 @@ type SmartMatchRow = {
                 : `Recovered inspection saved ${new Date(recovered.savedAt).toLocaleString()}.`,
           );
         } else {
+          setHasRecoveredLocalDraft(false);
           replaceSession(initialSession);
         }
       } catch (error) {
         console.warn("[inspection] offline recovery unavailable", error);
       } finally {
-        if (!cancelled) setDraftBootLoaded(true);
+        if (!cancelled) setDraftBootstrappedKey(draftKey);
       }
     };
     void recoverDraft();
@@ -1413,12 +1437,6 @@ type SmartMatchRow = {
     toast.error("This inspection is signed and locked. Editing is disabled.");
     return true;
   };
-
-  useEffect(() => {
-    if (session && (session.sections?.length ?? 0) === 0) {
-      updateInspection({ sections: bootSections });
-    }
-  }, [session, bootSections, updateInspection]);
 
   useEffect(() => {
     if (

--- a/supabase/migrations/20260726010000_reassert_canonical_inspection_realtime.sql
+++ b/supabase/migrations/20260726010000_reassert_canonical_inspection_realtime.sql
@@ -1,0 +1,38 @@
+begin;
+
+-- The canonical inspections row is the only live progress stream. Reassert
+-- publication membership for environments whose Realtime publication drifted
+-- during the legacy inspection_sessions cutover.
+alter table public.inspections replica identity full;
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_publication p
+    where p.pubname = 'supabase_realtime'
+  ) and not exists (
+    select 1
+    from pg_publication p
+    join pg_publication_rel pr on pr.prpubid = p.oid
+    where p.pubname = 'supabase_realtime'
+      and pr.prrelid = 'public.inspections'::regclass
+  ) then
+    alter publication supabase_realtime add table public.inspections;
+  end if;
+
+  if exists (
+    select 1
+    from pg_publication p
+    join pg_publication_rel pr on pr.prpubid = p.oid
+    where p.pubname = 'supabase_realtime'
+      and pr.prrelid = to_regclass('public.inspection_sessions')
+  ) then
+    alter publication supabase_realtime drop table public.inspection_sessions;
+  end if;
+end;
+$$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/inspection-autosave-realtime-signatures.test.ts
+++ b/tests/inspection-autosave-realtime-signatures.test.ts
@@ -92,7 +92,8 @@ describe("inspection autosave, realtime, and signatures", () => {
   });
 
   it("uses the work-order line as the shared mobile and desktop identity", () => {
-    expect(genericScreen).toContain("Object.entries(props.params ?? {})");
+    expect(genericScreen).toContain("mergeInspectionRuntimeParams");
+    expect(genericScreen).toContain("staged, route, props: props.params");
     expect(genericScreen).toContain("props.embed === true");
     expect(mobileRunner).toContain('.from("work_orders")');
     expect(mobileRunner).toContain("Object.assign(runtimeParams, workOrderContext)");

--- a/tests/inspection-canonical-sync-identity.test.ts
+++ b/tests/inspection-canonical-sync-identity.test.ts
@@ -10,6 +10,22 @@ const migration = readFileSync(
   "utf8",
 );
 const saveRoute = readFileSync("app/api/inspections/save/route.ts", "utf8");
+const reconciliation = readFileSync(
+  "features/inspections/lib/inspection/reconciliation.ts",
+  "utf8",
+);
+const genericScreen = readFileSync(
+  "features/inspections/screens/GenericInspectionScreen.tsx",
+  "utf8",
+);
+const findings = readFileSync(
+  "features/inspections/lib/inspection/findings/page.tsx",
+  "utf8",
+);
+const realtimeMigration = readFileSync(
+  "supabase/migrations/20260726010000_reassert_canonical_inspection_realtime.sql",
+  "utf8",
+);
 
 describe("inspection canonical cross-device synchronization", () => {
   it("authorizes both supported profile identity layouts end to end", () => {
@@ -24,10 +40,8 @@ describe("inspection canonical cross-device synchronization", () => {
 
   it("uses a newer server revision for initial cross-device hydration", () => {
     expect(autosave).toContain("preferCanonicalServer = false");
-    expect(autosave).toContain("const serverIsAhead = revision(remote) > localRevision");
-    expect(autosave).toContain(
-      "preferCanonicalServer &&",
-    );
+    expect(reconciliation).toContain("const serverIsAhead =");
+    expect(reconciliation).toContain("preferCanonicalServer &&");
     expect(autosave).toContain("await pullLatest(true)");
   });
 
@@ -36,7 +50,31 @@ describe("inspection canonical cross-device synchronization", () => {
       "const hasPendingLocalSave = Boolean(pendingOperationKeyRef.current)",
     );
     expect(autosave).toContain("pendingOperationKeyRef.current = recoveredKey");
-    expect(autosave).toContain("const hasUnversionedRecovery =");
-    expect(autosave).toContain("!hasUnversionedRecovery");
+    expect(reconciliation).toContain("const hasUnversionedRecovery =");
+    expect(reconciliation).toContain("hasRecoveredLocalDraft &&");
+    expect(reconciliation).toContain("!hasUnversionedRecovery");
+  });
+
+  it("finishes device recovery before either editable screen hydrates", () => {
+    expect(genericScreen).toContain(
+      "const draftBootLoaded = draftBootstrappedKey === draftKey",
+    );
+    expect(genericScreen).toContain("hasRecoveredLocalDraft,");
+    expect(findings).toContain(
+      "const draftBootLoaded = draftBootstrappedKey === draftKey",
+    );
+    expect(findings).toContain("hasRecoveredLocalDraft,");
+  });
+
+  it("publishes only the canonical progress row for realtime", () => {
+    expect(realtimeMigration).toContain(
+      "alter publication supabase_realtime add table public.inspections",
+    );
+    expect(realtimeMigration).toContain(
+      "alter publication supabase_realtime drop table public.inspection_sessions",
+    );
+    expect(realtimeMigration).toContain(
+      "alter table public.inspections replica identity full",
+    );
   });
 });

--- a/tests/inspection-reconciliation.test.ts
+++ b/tests/inspection-reconciliation.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  inspectionFingerprint,
+  remoteInspectionShouldReplace,
+  shouldForceCanonicalBootstrap,
+} from "../features/inspections/lib/inspection/reconciliation";
+import { mergeInspectionRuntimeParams } from "../features/inspections/lib/inspection/runtimeParams";
+import type { InspectionSession } from "../features/inspections/lib/inspection/types";
+
+function session(args: {
+  id: string;
+  revision: number;
+  updatedAt: string;
+  status?: string;
+}): InspectionSession {
+  return {
+    id: args.id,
+    syncRevision: args.revision,
+    lastUpdated: args.updatedAt,
+    sections: [
+      {
+        title: "General",
+        items: [
+          {
+            item: "Visual walkaround",
+            status: args.status ?? "na",
+          },
+        ],
+      },
+    ],
+    transcript: "",
+    quote: [],
+  } as unknown as InspectionSession;
+}
+
+describe("inspection canonical reconciliation", () => {
+  it("uses a newer canonical phone revision over a fresh desktop template", () => {
+    const remote = session({
+      id: "canonical",
+      revision: 7,
+      updatedAt: "2026-07-26T15:00:00.000Z",
+      status: "ok",
+    });
+    const freshDesktop = session({
+      id: "temporary-desktop-id",
+      revision: 0,
+      updatedAt: "2026-07-26T15:01:00.000Z",
+    });
+
+    expect(
+      shouldForceCanonicalBootstrap({
+        remote,
+        local: freshDesktop,
+        preferCanonicalServer: true,
+        hasPendingLocalSave: false,
+        hasRecoveredLocalDraft: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("uses a legacy canonical revision zero over a fresh desktop template", () => {
+    const legacyCanonical = session({
+      id: "legacy-canonical",
+      revision: 0,
+      updatedAt: "2026-07-20T15:00:00.000Z",
+      status: "fail",
+    });
+    const freshDesktop = session({
+      id: "temporary-desktop-id",
+      revision: 0,
+      updatedAt: "2026-07-26T15:01:00.000Z",
+    });
+
+    expect(
+      shouldForceCanonicalBootstrap({
+        remote: legacyCanonical,
+        local: freshDesktop,
+        preferCanonicalServer: true,
+        hasPendingLocalSave: false,
+        hasRecoveredLocalDraft: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not erase a real unversioned device recovery draft", () => {
+    const remote = session({
+      id: "canonical",
+      revision: 7,
+      updatedAt: "2026-07-26T15:00:00.000Z",
+      status: "ok",
+    });
+    const recovered = session({
+      id: "device-copy",
+      revision: 0,
+      updatedAt: "2026-07-26T15:01:00.000Z",
+      status: "fail",
+    });
+
+    expect(
+      shouldForceCanonicalBootstrap({
+        remote,
+        local: recovered,
+        preferCanonicalServer: true,
+        hasPendingLocalSave: false,
+        hasRecoveredLocalDraft: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a later server revision once the local snapshot is clean", () => {
+    const local = session({
+      id: "canonical",
+      revision: 7,
+      updatedAt: "2026-07-26T15:00:00.000Z",
+      status: "ok",
+    });
+    const remote = session({
+      id: "canonical",
+      revision: 8,
+      updatedAt: "2026-07-26T15:02:00.000Z",
+      status: "fail",
+    });
+
+    expect(
+      remoteInspectionShouldReplace({
+        remote,
+        local,
+        lastPersistedFingerprint: inspectionFingerprint(local),
+      }),
+    ).toBe(true);
+  });
+
+  it("lets current route identity override stale staged browser context", () => {
+    expect(
+      mergeInspectionRuntimeParams({
+        staged: {
+          workOrderId: "old-order",
+          workOrderLineId: "old-line",
+          templateId: "old-template",
+          vehicleType: "truck",
+        },
+        route: {
+          workOrderId: "current-order",
+          workOrderLineId: "current-line",
+          templateId: "current-template",
+        },
+      }),
+    ).toEqual({
+      workOrderId: "current-order",
+      workOrderLineId: "current-line",
+      templateId: "current-template",
+      vehicleType: "truck",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- make the canonical `inspections` row keyed by `work_order_line_id` win fresh mobile, desktop, and findings hydration
- distinguish real recovered device drafts from newly initialized template state
- make current route identity override stale staged browser parameters
- sequence IndexedDB recovery before canonical server hydration on both editable screens
- reassert canonical-only Supabase Realtime publication membership
- add cross-device, revision-zero legacy, route identity, and offline recovery coverage

## Root cause

Fresh template state could be classified as meaningful local work before the first server load. A desktop screen could therefore reject a newer canonical revision completed on mobile and then attempt a revision-zero save. Stale `sessionStorage` parameters could also override the current work-order-line route, while the findings screen raced local draft recovery against canonical hydration.

## Impact

A technician can start or update a generic inspection on mobile, open the same assigned work-order line on desktop, and continue from the canonical server revision. Real queued or conflicted offline work remains protected, and signed/locked inspections remain server-authoritative.

All authenticated shop roles continue through the same canonical load/save API and same-shop RLS boundary; no role-specific inspection writer was added.

## Database

Apply:

`supabase/migrations/20260726010000_reassert_canonical_inspection_realtime.sql`

The migration is idempotent. It ensures `public.inspections` is published with full replica identity and removes the legacy `inspection_sessions` table from Realtime if present. It does not delete historical inspection data.

## Validation

- TypeScript: passed
- changed-file ESLint: passed
- focused inspection suites: 30/30 passed
- full suite: 1,351 passed; 21 unrelated existing Windows git-path/CRLF assertion failures
- production bundle: compiled successfully; page-data collection then stopped because the clean worktree did not contain the existing Supabase URL configuration
- `git diff --check`: passed