### PR TITLE
Unify work-order source of truth across devices

### DIFF
--- a/app/api/offline/technician-work-orders/route.ts
+++ b/app/api/offline/technician-work-orders/route.ts
@@ -11,6 +11,10 @@ import type {
   TechnicianOfflineBundle,
   TechnicianOfflineWorkOrder,
 } from "@/features/work-orders/mobile/technicianOfflineTypes";
+import {
+  emptyCanonicalWorkOrderLineContext,
+  loadCanonicalWorkOrderLineContexts,
+} from "@/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -173,7 +177,7 @@ export async function GET() {
   const customerIds = [
     ...new Set(workOrders.map((row) => row.customer_id).filter(Boolean)),
   ] as string[];
-  const [linesResult, quotesResult, vehiclesResult, customersResult] =
+  const [linesResult, quotesResult, vehiclesResult, customersResult, shopResult] =
     await Promise.all([
       authClient
         .from("work_order_lines")
@@ -200,12 +204,18 @@ export async function GET() {
             .eq("shop_id", profile.shop_id)
             .in("id", customerIds)
         : Promise.resolve({ data: [], error: null }),
+      authClient
+        .from("shops")
+        .select("labor_rate")
+        .eq("id", profile.shop_id)
+        .maybeSingle<{ labor_rate: number | null }>(),
     ]);
   const supportingReadError =
     linesResult.error ??
     quotesResult.error ??
     vehiclesResult.error ??
-    customersResult.error;
+    customersResult.error ??
+    shopResult.error;
   if (supportingReadError) {
     return NextResponse.json(
       { error: supportingReadError.message },
@@ -240,6 +250,38 @@ export async function GET() {
     ]),
   );
 
+  let lineContextsByWorkOrder = new Map<
+    string,
+    ReturnType<typeof emptyCanonicalWorkOrderLineContext>
+  >();
+  try {
+    lineContextsByWorkOrder = await loadCanonicalWorkOrderLineContexts({
+      supabase: authClient,
+      shopId: profile.shop_id,
+      workOrders: workOrders.map((workOrder) => ({
+        workOrderId: workOrder.id,
+        lineIds: lines
+          .filter((line) => line.work_order_id === workOrder.id)
+          .map((line) => line.id),
+      })),
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Canonical work-order context could not be loaded.",
+      },
+      { status: 500 },
+    );
+  }
+
+  const shopLaborRate =
+    typeof shopResult.data?.labor_rate === "number"
+      ? shopResult.data.labor_rate
+      : null;
+
   const bundle: TechnicianOfflineBundle = {
     scope: { userId: user.id, shopId: profile.shop_id },
     downloadedAt: new Date().toISOString(),
@@ -255,6 +297,10 @@ export async function GET() {
         customers.find((customer) => customer.id === workOrder.customer_id) ??
         null,
       techNamesById,
+      lineContext:
+        lineContextsByWorkOrder.get(workOrder.id) ??
+        emptyCanonicalWorkOrderLineContext(),
+      shopLaborRate,
       assignedLineIds: lines
         .filter(
           (line) =>

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -34,6 +34,13 @@ import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/l
 import { deriveEventsFromWorkOrder } from "@/features/shared/lib/decisionEvents";
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
+import {
+  getPartsRequestStatusLabel,
+  loadCanonicalWorkOrderLineContext,
+  type CanonicalWorkOrderPartRow as WorkOrderPartRow,
+  type WorkOrderAllocationRow as AllocationRow,
+  type WorkOrderPartRequestRow as PartRequestRow,
+} from "@/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext";
 import { isReviewableQuoteLine } from "@/features/work-orders/lib/quotes/reviewableQuoteLines";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
@@ -57,25 +64,6 @@ type WorkOrderShopRateRow = Pick<DB["public"]["Tables"]["shops"]["Row"], "labor_
 type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
 type Profile = DB["public"]["Tables"]["profiles"]["Row"];
-type AllocationRow =
-  DB["public"]["Tables"]["work_order_part_allocations"]["Row"] & {
-    parts?: { name: string | null } | null;
-  };
-type WorkOrderPartRow = DB["public"]["Tables"]["work_order_parts"]["Row"] & {
-  description_snapshot?: string | null;
-  manufacturer_snapshot?: string | null;
-  part_number_snapshot?: string | null;
-  unit_sell_price_snapshot?: number | null;
-  lifecycle_status?: string | null;
-  is_active?: boolean | null;
-  source_parts_request_item_id?: string | null;
-  parts?: { name: string | null; sku?: string | null; part_number?: string | null; manufacturer?: string | null } | null;
-};
-type LineTechRow = DB["public"]["Tables"]["work_order_line_technicians"]["Row"];
-type PartRequestRow = Pick<
-  DB["public"]["Tables"]["part_requests"]["Row"],
-  "id" | "quote_line_id" | "job_id" | "status"
->;
 
 type WorkOrderLineWithInspectionMeta = WorkOrderLine & {
   // real DB column
@@ -695,88 +683,17 @@ export default function WorkOrderIdClient(): JSX.Element {
 
         // allocations + line techs
         if (lineRows.length) {
-          const [allocsQuery, stagedQuery, lineTechsQuery, partRequestsQuery] = await Promise.all([
-            supabase
-              .from("work_order_part_allocations")
-              .select("*, parts(name)")
-              .in(
-                "work_order_line_id",
-                lineRows.map((l) => l.id),
-              ),
-
-            // ✅ staged/quoted parts from menu quick add (NOT allocated inventory)
-            supabase
-              .from("work_order_parts")
-              .select("*, parts(name, sku, part_number, manufacturer, supplier)")
-              .eq("work_order_id", woRow.id)
-              .eq("shop_id", woRow.shop_id)
-              .eq("is_active", true)
-              .in(
-                "work_order_line_id",
-                lineRows.map((l) => l.id),
-              ),
-
-            supabase
-              .from("work_order_line_technicians")
-              .select("work_order_line_id, technician_id")
-              .in(
-                "work_order_line_id",
-                lineRows.map((l) => l.id),
-              ),
-
-            supabase
-              .from("part_requests")
-              .select("id, quote_line_id, job_id, status")
-              .eq("work_order_id", woRow.id)
-              .eq("shop_id", woRow.shop_id),
-          ]);
-
-          const byLine: Record<string, AllocationRow[]> = {};
-          (allocsQuery.data ?? []).forEach((a) => {
-            const row = a as AllocationRow;
-            const key = row.work_order_line_id;
-            if (!byLine[key]) byLine[key] = [];
-            byLine[key].push(row);
+          const lineContext = await loadCanonicalWorkOrderLineContext({
+            supabase,
+            workOrderId: woRow.id,
+            shopId: woRow.shop_id,
+            lineIds: lineRows.map((line) => line.id),
           });
-          setAllocsByLine(byLine);
-
-          const stagedByLine: Record<string, WorkOrderPartRow[]> = {};
-          (stagedQuery.data ?? []).forEach((p) => {
-            const row = p as WorkOrderPartRow;
-            const key = row.work_order_line_id;
-            if (!key) return;
-            if (!stagedByLine[key]) stagedByLine[key] = [];
-            stagedByLine[key].push(row);
-          });
-          setStagedPartsByLine(stagedByLine);
-
-          const techMap: Record<string, string[]> = {};
-          (lineTechsQuery.data as LineTechRow[] | null)?.forEach((lt) => {
-            const lnId = lt.work_order_line_id;
-            const techId = lt.technician_id;
-            if (!techMap[lnId]) techMap[lnId] = [];
-            if (!techMap[lnId].includes(techId)) {
-              techMap[lnId].push(techId);
-            }
-          });
-          setLineTechsByLine(techMap);
-
-          const requestsByQuote: Record<string, PartRequestRow[]> = {};
-          const requestsByLine: Record<string, PartRequestRow[]> = {};
-          (partRequestsQuery.data as PartRequestRow[] | null)?.forEach((request) => {
-            const quoteLineId = request.quote_line_id;
-            if (quoteLineId) {
-              if (!requestsByQuote[quoteLineId]) requestsByQuote[quoteLineId] = [];
-              requestsByQuote[quoteLineId].push(request);
-            }
-            const lineId = request.job_id;
-            if (lineId) {
-              if (!requestsByLine[lineId]) requestsByLine[lineId] = [];
-              requestsByLine[lineId].push(request);
-            }
-          });
-          setPartRequestsByQuoteLine(requestsByQuote);
-          setPartRequestsByLine(requestsByLine);
+          setAllocsByLine(lineContext.allocationsByLine);
+          setStagedPartsByLine(lineContext.canonicalPartsByLine);
+          setLineTechsByLine(lineContext.technicianIdsByLine);
+          setPartRequestsByQuoteLine(lineContext.partRequestsByQuoteLine);
+          setPartRequestsByLine(lineContext.partRequestsByLine);
         } else {
           setAllocsByLine({});
           setStagedPartsByLine({});
@@ -868,6 +785,16 @@ export default function WorkOrderIdClient(): JSX.Element {
           event: "*",
           schema: "public",
           table: "work_order_line_technicians",
+        },
+        () => fetchAll(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "part_requests",
+          filter: `work_order_id=eq.${wo.id}`,
         },
         () => fetchAll(),
       )
@@ -987,7 +914,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   }, [quoteLines]);
 
   const pricingByLine = useMemo(() => {
-    const byLine: Record<string, { laborTotal: number; partsTotal: number; lineTotal: number }> = {};
+    const byLine: Record<string, { laborTotal: number; partsTotal: number; lineTotal: number; partsCount: number }> = {};
     for (const line of lines) {
       const quoteCandidates = activeQuotesByLine[line.id] ?? [];
       const quote = quoteCandidates[quoteCandidates.length - 1];
@@ -1002,6 +929,7 @@ export default function WorkOrderIdClient(): JSX.Element {
         laborTotal: resolved.laborTotal,
         partsTotal: resolved.partsTotal,
         lineTotal: resolved.lineTotal,
+        partsCount: resolved.partsCount,
       };
     }
     return byLine;
@@ -2052,6 +1980,8 @@ export default function WorkOrderIdClient(): JSX.Element {
                         index={idx}
                         line={ln}
                         parts={partsForLine}
+                        partsCount={pricingByLine[ln.id]?.partsCount ?? 0}
+                        partsStatusLabel={getPartsRequestStatusLabel(linePartRequests)}
                         technicians={assignables}
                         canAssign={canAssign}
                         isPunchedIn={isPunchedIn}

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -40,6 +40,8 @@ type JobCardProps = {
   index: number;
   line: WorkOrderLine;
   parts: WorkOrderPartAllocation[];
+  partsCount?: number;
+  partsStatusLabel?: string | null;
   technicians: Pick<ProfileRow, "id" | "full_name">[];
   canAssign: boolean;
   canDelete?: boolean;
@@ -299,6 +301,8 @@ export function JobCard({
   index,
   line,
   parts,
+  partsCount,
+  partsStatusLabel,
   technicians,
   canAssign,
   canDelete,
@@ -356,10 +360,15 @@ export function JobCard({
 
   const linePriority = toLinePriority(line);
   const quietPriority = linePriority === "urgent" || linePriority === "high" ? linePriority : null;
+  const effectivePartsCount = Math.max(
+    parts.length,
+    partsCount ?? 0,
+    Number(pricing?.partsTotal ?? 0) > 0 ? 1 : 0,
+  );
 
   const reviewFlags = computeReviewFlags({
     line,
-    partsCount: parts.length,
+    partsCount: effectivePartsCount,
     reviewIssues,
   });
 
@@ -572,10 +581,13 @@ export function JobCard({
                   />
                   <MetaTile
                     label="Parts"
-                    value={formatPartsSummary({
-                      partsCount: Math.max(parts.length, Number(pricing?.partsTotal ?? 0) > 0 ? 1 : 0),
-                      partsTotal: Number(pricing?.partsTotal ?? 0),
-                    })}
+                    value={[
+                      formatPartsSummary({
+                        partsCount: effectivePartsCount,
+                        partsTotal: Number(pricing?.partsTotal ?? 0),
+                      }),
+                      partsStatusLabel,
+                    ].filter(Boolean).join(" · ")}
                   />
                   <MetaTile label="Line Total" value={lineTotal > 0 ? formatCurrency(lineTotal) : "Estimate pending"} />
                 </div>

--- a/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.test.ts
+++ b/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCanonicalWorkOrderLineContext,
+  getPartsRequestStatusLabel,
+  type CanonicalWorkOrderPartRow,
+  type WorkOrderAllocationRow,
+  type WorkOrderLineTechnicianRow,
+  type WorkOrderPartRequestRow,
+} from "./loadCanonicalWorkOrderLineContext";
+
+describe("canonical work-order line context", () => {
+  it("projects EL000007-shaped parts, requests, and assignments into one line context", () => {
+    const allocation = {
+      id: "allocation-1",
+      work_order_line_id: "brake-fluid-line",
+    } as unknown as WorkOrderAllocationRow;
+    const activePart = {
+      id: "bosch-brake-fluid",
+      is_active: true,
+      lifecycle_status: "consumed",
+      quantity: 1,
+      total_price: 255,
+      work_order_line_id: "brake-fluid-line",
+    } as unknown as CanonicalWorkOrderPartRow;
+    const inactivePart = {
+      id: "retired-part",
+      is_active: false,
+      work_order_line_id: "brake-fluid-line",
+    } as unknown as CanonicalWorkOrderPartRow;
+    const technicians = [
+      {
+        technician_id: "tech-1",
+        work_order_line_id: "brake-fluid-line",
+      },
+      {
+        technician_id: "tech-1",
+        work_order_line_id: "brake-fluid-line",
+      },
+    ] as WorkOrderLineTechnicianRow[];
+    const requests = [
+      {
+        id: "request-fulfilled",
+        work_order_id: "EL000007",
+        job_id: "brake-fluid-line",
+        quote_line_id: "quote-1",
+        status: "fulfilled",
+      },
+      {
+        id: "request-cancelled",
+        work_order_id: "EL000007",
+        job_id: "brake-fluid-line",
+        quote_line_id: null,
+        status: "cancelled",
+      },
+    ] as WorkOrderPartRequestRow[];
+
+    const context = buildCanonicalWorkOrderLineContext({
+      lineIds: ["brake-fluid-line", "inspection-line"],
+      allocations: [allocation],
+      canonicalParts: [activePart, inactivePart],
+      technicians,
+      partRequests: requests,
+    });
+
+    expect(context.allocationsByLine["brake-fluid-line"]).toEqual([allocation]);
+    expect(context.canonicalPartsByLine["brake-fluid-line"]).toEqual([
+      activePart,
+    ]);
+    expect(context.technicianIdsByLine["brake-fluid-line"]).toEqual(["tech-1"]);
+    expect(context.partRequestsByLine["brake-fluid-line"]).toEqual(requests);
+    expect(context.partRequestsByQuoteLine["quote-1"]).toEqual([requests[0]]);
+    expect(
+      getPartsRequestStatusLabel(
+        context.partRequestsByLine["brake-fluid-line"],
+      ),
+    ).toBe("Parts handed off");
+  });
+
+  it("does not attach rows from another work-order line", () => {
+    const context = buildCanonicalWorkOrderLineContext({
+      lineIds: ["visible-line"],
+      allocations: [
+        {
+          work_order_line_id: "other-line",
+        } as unknown as WorkOrderAllocationRow,
+      ],
+      canonicalParts: [
+        {
+          is_active: true,
+          work_order_line_id: "other-line",
+        } as unknown as CanonicalWorkOrderPartRow,
+      ],
+      technicians: [
+        {
+          technician_id: "other-tech",
+          work_order_line_id: "other-line",
+        },
+      ],
+      partRequests: [
+        {
+          id: "other-request",
+          work_order_id: "other-work-order",
+          job_id: "other-line",
+          quote_line_id: null,
+          status: "requested",
+        },
+      ],
+    });
+
+    expect(context.allocationsByLine).toEqual({});
+    expect(context.canonicalPartsByLine).toEqual({});
+    expect(context.technicianIdsByLine).toEqual({});
+    expect(context.partRequestsByLine).toEqual({});
+  });
+});

--- a/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts
+++ b/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts
@@ -1,0 +1,227 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@shared/types/types/supabase";
+
+type DB = Database;
+
+export type WorkOrderAllocationRow =
+  DB["public"]["Tables"]["work_order_part_allocations"]["Row"] & {
+    parts?: { name: string | null } | null;
+  };
+
+export type CanonicalWorkOrderPartRow =
+  DB["public"]["Tables"]["work_order_parts"]["Row"] & {
+    parts?: {
+      name: string | null;
+      sku?: string | null;
+      part_number?: string | null;
+      manufacturer?: string | null;
+      supplier?: string | null;
+    } | null;
+  };
+
+export type WorkOrderPartRequestRow = Pick<
+  DB["public"]["Tables"]["part_requests"]["Row"],
+  "id" | "work_order_id" | "quote_line_id" | "job_id" | "status"
+>;
+
+export type WorkOrderLineTechnicianRow = Pick<
+  DB["public"]["Tables"]["work_order_line_technicians"]["Row"],
+  "work_order_line_id" | "technician_id"
+>;
+
+export type CanonicalWorkOrderLineContext = {
+  allocationsByLine: Record<string, WorkOrderAllocationRow[]>;
+  canonicalPartsByLine: Record<string, CanonicalWorkOrderPartRow[]>;
+  technicianIdsByLine: Record<string, string[]>;
+  partRequestsByLine: Record<string, WorkOrderPartRequestRow[]>;
+  partRequestsByQuoteLine: Record<string, WorkOrderPartRequestRow[]>;
+};
+
+export function emptyCanonicalWorkOrderLineContext(): CanonicalWorkOrderLineContext {
+  return {
+    allocationsByLine: {},
+    canonicalPartsByLine: {},
+    technicianIdsByLine: {},
+    partRequestsByLine: {},
+    partRequestsByQuoteLine: {},
+  };
+}
+
+export function buildCanonicalWorkOrderLineContext(input: {
+  lineIds: string[];
+  allocations: WorkOrderAllocationRow[];
+  canonicalParts: CanonicalWorkOrderPartRow[];
+  technicians: WorkOrderLineTechnicianRow[];
+  partRequests: WorkOrderPartRequestRow[];
+}): CanonicalWorkOrderLineContext {
+  const lineIds = new Set(input.lineIds);
+  const result = emptyCanonicalWorkOrderLineContext();
+
+  for (const allocation of input.allocations) {
+    const lineId = allocation.work_order_line_id;
+    if (!lineId || !lineIds.has(lineId)) continue;
+    (result.allocationsByLine[lineId] ??= []).push(allocation);
+  }
+
+  for (const part of input.canonicalParts) {
+    const lineId = part.work_order_line_id;
+    if (!lineId || !lineIds.has(lineId) || part.is_active === false) continue;
+    (result.canonicalPartsByLine[lineId] ??= []).push(part);
+  }
+
+  for (const assignment of input.technicians) {
+    const lineId = assignment.work_order_line_id;
+    if (!lineIds.has(lineId)) continue;
+    const ids = (result.technicianIdsByLine[lineId] ??= []);
+    if (!ids.includes(assignment.technician_id)) {
+      ids.push(assignment.technician_id);
+    }
+  }
+
+  for (const request of input.partRequests) {
+    if (request.job_id && lineIds.has(request.job_id)) {
+      (result.partRequestsByLine[request.job_id] ??= []).push(request);
+    }
+    if (request.quote_line_id) {
+      (result.partRequestsByQuoteLine[request.quote_line_id] ??= []).push(
+        request,
+      );
+    }
+  }
+
+  return result;
+}
+
+export function getPartsRequestStatusLabel(
+  requests: WorkOrderPartRequestRow[],
+): string | null {
+  if (requests.length === 0) return null;
+  const statuses = new Set(
+    requests.map((request) =>
+      String(request.status ?? "requested").toLowerCase(),
+    ),
+  );
+  if (statuses.has("fulfilled")) return "Parts handed off";
+  if (
+    statuses.has("approved") ||
+    statuses.has("partially_ordered") ||
+    statuses.has("partially_consumed") ||
+    statuses.has("partially_returned")
+  ) {
+    return "Pick / order active";
+  }
+  if (statuses.has("quoted")) return "Awaiting approval";
+  if (statuses.has("rejected") || statuses.has("cancelled")) {
+    return "Parts history recorded";
+  }
+  return "Parts requested";
+}
+
+export async function loadCanonicalWorkOrderLineContexts(input: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  workOrders: Array<{ workOrderId: string; lineIds: string[] }>;
+}): Promise<Map<string, CanonicalWorkOrderLineContext>> {
+  const workOrders = input.workOrders.map((workOrder) => ({
+    workOrderId: workOrder.workOrderId,
+    lineIds: [...new Set(workOrder.lineIds.filter(Boolean))],
+  }));
+  const workOrderIds = [...new Set(workOrders.map((item) => item.workOrderId))];
+  const lineIds = [...new Set(workOrders.flatMap((item) => item.lineIds))];
+  if (workOrderIds.length === 0 || lineIds.length === 0) {
+    return new Map(
+      workOrders.map((item) => [
+        item.workOrderId,
+        emptyCanonicalWorkOrderLineContext(),
+      ]),
+    );
+  }
+
+  const [allocationsResult, partsResult, techniciansResult, requestsResult] =
+    await Promise.all([
+      input.supabase
+        .from("work_order_part_allocations")
+        .select("*, parts(name)")
+        .eq("shop_id", input.shopId)
+        .in("work_order_id", workOrderIds)
+        .in("work_order_line_id", lineIds)
+        .order("created_at", { ascending: true }),
+      input.supabase
+        .from("work_order_parts")
+        .select("*, parts(name, sku, part_number, manufacturer, supplier)")
+        .eq("shop_id", input.shopId)
+        .eq("is_active", true)
+        .in("work_order_id", workOrderIds)
+        .in("work_order_line_id", lineIds)
+        .order("created_at", { ascending: true }),
+      input.supabase
+        .from("work_order_line_technicians")
+        .select("work_order_line_id, technician_id")
+        .in("work_order_line_id", lineIds),
+      input.supabase
+        .from("part_requests")
+        .select("id, work_order_id, quote_line_id, job_id, status")
+        .eq("shop_id", input.shopId)
+        .in("work_order_id", workOrderIds)
+        .order("created_at", { ascending: true }),
+    ]);
+
+  const error =
+    allocationsResult.error ??
+    partsResult.error ??
+    techniciansResult.error ??
+    requestsResult.error;
+  if (error) throw new Error(error.message);
+
+  const allocations =
+    (allocationsResult.data as WorkOrderAllocationRow[] | null) ?? [];
+  const canonicalParts =
+    (partsResult.data as CanonicalWorkOrderPartRow[] | null) ?? [];
+  const technicians =
+    (techniciansResult.data as WorkOrderLineTechnicianRow[] | null) ?? [];
+  const partRequests =
+    (requestsResult.data as WorkOrderPartRequestRow[] | null) ?? [];
+
+  return new Map(
+    workOrders.map((workOrder) => {
+      const scopedLineIds = new Set(workOrder.lineIds);
+      return [
+        workOrder.workOrderId,
+        buildCanonicalWorkOrderLineContext({
+          lineIds: workOrder.lineIds,
+          allocations: allocations.filter(
+            (row) => row.work_order_id === workOrder.workOrderId,
+          ),
+          canonicalParts: canonicalParts.filter(
+            (row) => row.work_order_id === workOrder.workOrderId,
+          ),
+          technicians: technicians.filter((row) =>
+            scopedLineIds.has(row.work_order_line_id),
+          ),
+          partRequests: partRequests.filter(
+            (row) => row.work_order_id === workOrder.workOrderId,
+          ),
+        }),
+      ];
+    }),
+  );
+}
+
+export async function loadCanonicalWorkOrderLineContext(input: {
+  supabase: SupabaseClient<DB>;
+  workOrderId: string;
+  shopId: string;
+  lineIds: string[];
+}): Promise<CanonicalWorkOrderLineContext> {
+  const contexts = await loadCanonicalWorkOrderLineContexts({
+    supabase: input.supabase,
+    shopId: input.shopId,
+    workOrders: [
+      { workOrderId: input.workOrderId, lineIds: input.lineIds },
+    ],
+  });
+  return (
+    contexts.get(input.workOrderId) ?? emptyCanonicalWorkOrderLineContext()
+  );
+}

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -322,6 +322,12 @@ export default function MobileFocusedJob(props: {
       setWorkOrder(cached.snapshot.workOrder);
       setVehicle(cached.snapshot.vehicle);
       setCustomer(cached.snapshot.customer);
+      setAllocs(
+        (cached.snapshot.lineContext?.allocationsByLine[id] ?? []) as AllocationRow[],
+      );
+      setRequiredParts(
+        (cached.snapshot.lineContext?.canonicalPartsByLine[id] ?? []) as RequiredPartRow[],
+      );
       const editorDraft = await getTechnicianJobEditorDraft({
         scope,
         lineId: id,
@@ -375,8 +381,16 @@ export default function MobileFocusedJob(props: {
   const loadAllocations = useCallback(async () => {
     if (!workOrderLineId) return;
     if (!navigator.onLine) {
-      setAllocs([]);
-      setRequiredParts([]);
+      const scope = getOfflineMutationScope();
+      const cached = scope
+        ? await findProjectedTechnicianJob({ scope, lineId: workOrderLineId })
+        : null;
+      setAllocs(
+        (cached?.snapshot.lineContext?.allocationsByLine[workOrderLineId] ?? []) as AllocationRow[],
+      );
+      setRequiredParts(
+        (cached?.snapshot.lineContext?.canonicalPartsByLine[workOrderLineId] ?? []) as RequiredPartRow[],
+      );
       return;
     }
     setAllocsLoading(true);

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -29,6 +29,14 @@ import MobileFocusedJob from "@/features/work-orders/mobile/MobileFocusedJob";
 import AskAssistantEntry from "@/features/assistant/components/AskAssistantEntry";
 import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
 import { isReviewableQuoteLine } from "@/features/work-orders/lib/quotes/reviewableQuoteLines";
+import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
+import {
+  emptyCanonicalWorkOrderLineContext,
+  getPartsRequestStatusLabel,
+  loadCanonicalWorkOrderLineContext,
+  type CanonicalWorkOrderLineContext,
+} from "@/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext";
 import {
   applyFetchedMobileDetailSnapshot,
   deriveMobileDetailOperationalState,
@@ -202,6 +210,15 @@ export default function MobileWorkOrderClient({
     `${keyBase}:cust`,
     null,
   );
+  const [lineContext, setLineContext] =
+    useTabState<CanonicalWorkOrderLineContext>(
+      `${keyBase}:lineContext`,
+      emptyCanonicalWorkOrderLineContext(),
+    );
+  const [shopLaborRate, setShopLaborRate] = useTabState<number | null>(
+    `${keyBase}:shopLaborRate`,
+    null,
+  );
 
   const [loading, setLoading] = useState<boolean>(false);
   const [viewError, setViewError] = useState<string | null>(null);
@@ -339,6 +356,10 @@ export default function MobileWorkOrderClient({
         setVehicle(cached.vehicle);
         setCustomer(cached.customer);
         setTechNamesById(cached.techNamesById);
+        setLineContext(
+          cached.lineContext ?? emptyCanonicalWorkOrderLineContext(),
+        );
+        setShopLaborRate(cached.shopLaborRate ?? null);
         setViewError("Offline copy · changes may be newer on the server.");
         return true;
       };
@@ -427,6 +448,8 @@ export default function MobileWorkOrderClient({
           setQuoteLines([]);
           setVehicle(null);
           setCustomer(null);
+          setLineContext(emptyCanonicalWorkOrderLineContext());
+          setShopLaborRate(null);
           setLoading(false);
           return;
         }
@@ -438,7 +461,7 @@ export default function MobileWorkOrderClient({
           setWarnedMissing(true);
         }
 
-        const [linesRes, vehRes, custRes, quotesRes] = await Promise.all([
+        const [linesRes, vehRes, custRes, quotesRes, shopRes] = await Promise.all([
           supabase
             .from("work_order_lines")
             .select("*")
@@ -463,6 +486,11 @@ export default function MobileWorkOrderClient({
             .select("*")
             .eq("work_order_id", woRow.id)
             .order("created_at", { ascending: true }),
+          supabase
+            .from("shops")
+            .select("labor_rate")
+            .eq("id", woRow.shop_id)
+            .maybeSingle<{ labor_rate: number | null }>(),
         ]);
 
         if (linesRes.error) throw linesRes.error;
@@ -476,12 +504,27 @@ export default function MobileWorkOrderClient({
         setWo(freshCore.workOrder);
         setLines(freshCore.lines);
 
-        // 🔹 populate tech names from assigned_tech_id
+        const freshLineContext = await loadCanonicalWorkOrderLineContext({
+          supabase,
+          workOrderId: woRow.id,
+          shopId: woRow.shop_id,
+          lineIds: lineRows.map((line) => line.id),
+        });
+        setLineContext(freshLineContext);
+        if (shopRes.error) throw shopRes.error;
+        const freshShopLaborRate =
+          typeof shopRes.data?.labor_rate === "number"
+            ? shopRes.data.labor_rate
+            : null;
+        setShopLaborRate(freshShopLaborRate);
+
+        // Populate names for every visible primary or shared assignment.
         const techIds = Array.from(
           new Set(
-            lineRows
-              .map((ln) => ln.assigned_tech_id)
-              .filter((id): id is string => Boolean(id)),
+            [
+              ...lineRows.map((line) => line.assigned_tech_id),
+              ...Object.values(freshLineContext.technicianIdsByLine).flat(),
+            ].filter((id): id is string => Boolean(id)),
           ),
         );
 
@@ -538,6 +581,8 @@ export default function MobileWorkOrderClient({
             vehicle: freshVehicle,
             customer: freshCustomer,
             techNamesById: techMap,
+            lineContext: freshLineContext,
+            shopLaborRate: freshShopLaborRate,
           };
           await Promise.all([
             saveOfflineSnapshot({ scope, kind: "mobile-work-order-detail", entityId: routeId, data: snapshot }),
@@ -565,6 +610,8 @@ export default function MobileWorkOrderClient({
       setQuoteLines,
       setVehicle,
       setCustomer,
+      setLineContext,
+      setShopLaborRate,
     ],
   );
 
@@ -611,6 +658,45 @@ export default function MobileWorkOrderClient({
           schema: "public",
           table: "work_order_quote_lines",
           filter: `work_order_id=eq.${wo.id}`,
+        },
+        () => fetchAll(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "work_order_parts",
+          filter: `work_order_id=eq.${wo.id}`,
+        },
+        () => fetchAll(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "work_order_part_allocations",
+          filter: `work_order_id=eq.${wo.id}`,
+        },
+        () => fetchAll(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "part_requests",
+          filter: `work_order_id=eq.${wo.id}`,
+        },
+        () => fetchAll(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "work_order_line_technicians",
         },
         () => fetchAll(),
       )
@@ -690,6 +776,30 @@ export default function MobileWorkOrderClient({
 
     return m;
   }, [quoteLines]);
+
+  const pricingByLine = useMemo(() => {
+    const result: Record<
+      string,
+      ReturnType<typeof resolveWorkOrderLinePricing>
+    > = {};
+    for (const line of lines) {
+      const canonicalParts =
+        lineContext.canonicalPartsByLine[line.id] ?? [];
+      const allocations = filterAllocationsNotBackedByCanonicalParts(
+        lineContext.allocationsByLine[line.id] ?? [],
+        canonicalParts,
+      );
+      const quotes = activeQuotesByLine[line.id] ?? [];
+      result[line.id] = resolveWorkOrderLinePricing({
+        line,
+        quote: quotes[quotes.length - 1],
+        shopLaborRate,
+        stagedParts: canonicalParts,
+        allocatedParts: allocations,
+      });
+    }
+    return result;
+  }, [activeQuotesByLine, lineContext, lines, shopLaborRate]);
 
   const mobileOperationalState = useMemo(
     () => deriveMobileDetailOperationalState(wo, lines),
@@ -793,6 +903,9 @@ export default function MobileWorkOrderClient({
     createdAt && !Number.isNaN(createdAt.getTime())
       ? format(createdAt, "PPpp")
       : "—";
+  const expectedCompletionText = wo?.expected_completion_at
+    ? format(new Date(wo.expected_completion_at), "PPpp")
+    : "—";
 
   const canAssign = false; // assignments handled in focused view / desktop
   const canApprove = currentUserRole
@@ -1159,6 +1272,7 @@ export default function MobileWorkOrderClient({
                   ) : null}
                 </div>
                 <p className="text-[11px] text-[color:var(--theme-text-secondary)]">Created {createdAtText}</p>
+                <p className="text-[11px] text-[color:var(--theme-text-secondary)]">Expected {expectedCompletionText}</p>
               </div>
             </div>
             <div className="mt-2 flex gap-1.5 overflow-x-auto pb-1">
@@ -1233,9 +1347,12 @@ export default function MobileWorkOrderClient({
                         )}
                         <br />
                         Mileage:{" "}
-                        {vehicle.mileage ?? (
-                          <span className="text-[color:var(--theme-text-muted)]">—</span>
-                        )}
+                        {vehicle.mileage ??
+                          (wo.odometer_km != null ? (
+                            `${wo.odometer_km} km`
+                          ) : (
+                            <span className="text-[color:var(--theme-text-muted)]">—</span>
+                          ))}
                       </p>
                     </>
                   ) : (
@@ -1520,13 +1637,24 @@ export default function MobileWorkOrderClient({
                     setFocusedOpen(true);
                   };
 
-                  const lineTechnicians = ln.assigned_tech_id
-                    ? [
-                        {
-                          id: ln.assigned_tech_id,
-                          full_name: techNamesById[ln.assigned_tech_id] ?? "Assigned tech",
-                        },
-                      ]
+                  const technicianIds = [
+                    ln.assigned_tech_id,
+                    ...(lineContext.technicianIdsByLine[ln.id] ?? []),
+                  ].filter(
+                    (id, index, ids): id is string =>
+                      Boolean(id) && ids.indexOf(id) === index,
+                  );
+                  const lineTechnicians = technicianIds.map((id) => ({
+                    id,
+                    full_name: techNamesById[id] ?? "Assigned tech",
+                  }));
+                  const pricing = pricingByLine[ln.id];
+                  const partRequests =
+                    lineContext.partRequestsByLine[ln.id] ?? [];
+                  const activeTechnicianNames = punchedIn
+                    ? technicianIds
+                        .map((id) => techNamesById[id])
+                        .filter((name): name is string => Boolean(name))
                     : [];
 
                   return (
@@ -1538,10 +1666,19 @@ export default function MobileWorkOrderClient({
                       <JobCard
                         index={idx}
                         line={ln}
-                        parts={[]} // stripped-down: no parts list on main mobile view
+                        parts={lineContext.allocationsByLine[ln.id] ?? []}
+                        partsCount={pricing?.partsCount ?? 0}
+                        partsStatusLabel={getPartsRequestStatusLabel(partRequests)}
+                        pricing={pricing}
                         technicians={lineTechnicians}
                         canAssign={canAssign}
                         isPunchedIn={punchedIn}
+                        isCurrentUserWorkingThisLine={Boolean(
+                          punchedIn &&
+                            currentUserId &&
+                            technicianIds.includes(currentUserId),
+                        )}
+                        activeTechnicianNames={activeTechnicianNames}
                         onOpen={openFocused}
                         onAssign={undefined}
                         onOpenInspection={() => openInspection(ln)}

--- a/features/work-orders/mobile/technicianOfflineDownload.ts
+++ b/features/work-orders/mobile/technicianOfflineDownload.ts
@@ -71,6 +71,8 @@ export async function cacheTechnicianOfflineBundle(
           vehicle: item.vehicle,
           customer: item.customer,
           techNamesById: item.techNamesById,
+          lineContext: item.lineContext,
+          shopLaborRate: item.shopLaborRate,
         },
       }),
     );

--- a/features/work-orders/mobile/technicianOfflineExecution.ts
+++ b/features/work-orders/mobile/technicianOfflineExecution.ts
@@ -13,6 +13,7 @@ import {
   type PendingMutation,
 } from "@/features/shared/lib/offline/mutations";
 import type { Database } from "@shared/types/types/supabase";
+import type { CanonicalWorkOrderLineContext } from "@/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -28,6 +29,8 @@ export type MobileWorkOrderSnapshot = {
   vehicle: Vehicle | null;
   customer: Customer | null;
   techNamesById: Record<string, string>;
+  lineContext?: CanonicalWorkOrderLineContext;
+  shopLaborRate?: number | null;
 };
 
 export type TechnicianJobEditorDraft = {

--- a/features/work-orders/mobile/technicianOfflineTypes.ts
+++ b/features/work-orders/mobile/technicianOfflineTypes.ts
@@ -1,4 +1,5 @@
 import type { Database } from "@shared/types/types/supabase";
+import type { CanonicalWorkOrderLineContext } from "@/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext";
 
 type DB = Database;
 
@@ -9,6 +10,8 @@ export type TechnicianOfflineWorkOrder = {
   vehicle: DB["public"]["Tables"]["vehicles"]["Row"] | null;
   customer: DB["public"]["Tables"]["customers"]["Row"] | null;
   techNamesById: Record<string, string>;
+  lineContext: CanonicalWorkOrderLineContext;
+  shopLaborRate: number | null;
   assignedLineIds: string[];
 };
 

--- a/supabase/migrations/20260726231759_work_order_detail_source_of_truth.sql
+++ b/supabase/migrations/20260726231759_work_order_detail_source_of_truth.sql
@@ -1,0 +1,69 @@
+begin;
+
+alter table public.work_order_parts enable row level security;
+
+-- Reconcile drift from older broad same-shop policies. Keep write policies intact,
+-- but make every read path follow the same role/assignment rules as work orders.
+do $$
+declare
+  policy_row record;
+begin
+  for policy_row in
+    select policyname
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'work_order_parts'
+      and cmd = 'SELECT'
+  loop
+    execute format(
+      'drop policy if exists %I on public.work_order_parts',
+      policy_row.policyname
+    );
+  end loop;
+end $$;
+
+create policy work_order_parts_role_select
+on public.work_order_parts
+for select
+to authenticated
+using (
+  shop_id = (select public.current_shop_id())
+  and (
+    (select public.profixiq_current_role()) in (
+      'owner', 'admin', 'manager', 'advisor', 'service', 'parts', 'lead_hand', 'foreman'
+    )
+    or (
+      (select public.profixiq_current_role()) = 'mechanic'
+      and (
+        (
+          work_order_line_id is not null
+          and public.profixiq_is_assigned_to_line(work_order_line_id)
+        )
+        or public.profixiq_is_assigned_to_work_order(work_order_id)
+      )
+    )
+  )
+);
+
+-- Customer portal reads are intentionally independent from shop-role access.
+create policy work_order_parts_customer_portal_select
+on public.work_order_parts
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.work_orders wo
+    join public.customers c
+      on c.id = wo.customer_id
+    where wo.id = work_order_parts.work_order_id
+      and wo.shop_id = work_order_parts.shop_id
+      and c.user_id = (select auth.uid())
+  )
+);
+
+grant select on table public.work_order_parts to authenticated;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/parts/parts-package-handoffs-source.test.ts
+++ b/tests/parts/parts-package-handoffs-source.test.ts
@@ -7,6 +7,10 @@ describe("parts package handoff source contracts", () => {
   const mapper = readFileSync("features/parts/components/request-workbench/mapToWorkbenchModel.ts", "utf8");
   const row = readFileSync("features/parts/components/request-workbench/PartsRequestWorkbenchRow.tsx", "utf8");
   const workOrderClient = readFileSync("app/work-orders/[id]/Client.tsx", "utf8");
+  const workOrderContext = readFileSync(
+    "features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts",
+    "utf8",
+  );
   const focusedJob = readFileSync("features/work-orders/components/workorders/FocusedJobModal.tsx", "utf8");
   const appShell = readFileSync("features/shared/components/AppShell.tsx", "utf8");
 
@@ -33,9 +37,10 @@ describe("parts package handoff source contracts", () => {
   });
 
   it("uses active canonical work_order_parts for work-order display before allocation", () => {
-    expect(workOrderClient).toContain('.from("work_order_parts")');
-    expect(workOrderClient).toContain('.eq("work_order_id", woRow.id)');
-    expect(workOrderClient).toContain('.eq("is_active", true)');
+    expect(workOrderClient).toContain("loadCanonicalWorkOrderLineContext");
+    expect(workOrderContext).toContain('.from("work_order_parts")');
+    expect(workOrderContext).toContain('.in("work_order_id", workOrderIds)');
+    expect(workOrderContext).toContain('.eq("is_active", true)');
     expect(focusedJob).toContain("requiredParts");
     expect(focusedJob).toContain('.from("work_order_parts")');
     expect(focusedJob).toContain('.eq("is_active", true)');

--- a/tests/work-order-cross-device-source-of-truth.test.ts
+++ b/tests/work-order-cross-device-source-of-truth.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const desktop = read("app/work-orders/[id]/Client.tsx");
+const mobile = read("features/work-orders/mobile/MobileWorkOrderClient.tsx");
+const focusedJob = read("features/work-orders/mobile/MobileFocusedJob.tsx");
+const offlineRoute = read("app/api/offline/technician-work-orders/route.ts");
+const offlineTypes = read(
+  "features/work-orders/mobile/technicianOfflineTypes.ts",
+);
+const contextLoader = read(
+  "features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts",
+);
+const migration = read(
+  "supabase/migrations/20260726231759_work_order_detail_source_of_truth.sql",
+);
+
+describe("cross-device work-order source of truth", () => {
+  it("makes desktop and mobile use the same tenant-scoped line-context loader", () => {
+    expect(desktop).toContain("loadCanonicalWorkOrderLineContext");
+    expect(mobile).toContain("loadCanonicalWorkOrderLineContext");
+    expect(contextLoader).toContain('.from("work_order_parts")');
+    expect(contextLoader).toContain('.from("work_order_part_allocations")');
+    expect(contextLoader).toContain('.from("part_requests")');
+    expect(contextLoader).toContain('.from("work_order_line_technicians")');
+    expect(contextLoader).toContain('.in("work_order_id", workOrderIds)');
+    expect(contextLoader).toContain('.eq("shop_id", input.shopId)');
+    expect(contextLoader).toContain('.eq("is_active", true)');
+  });
+
+  it("renders canonical parts and pricing on mobile instead of an empty placeholder", () => {
+    expect(mobile).not.toContain("parts={[]}");
+    expect(mobile).toContain("lineContext.allocationsByLine[ln.id]");
+    expect(mobile).toContain("lineContext.canonicalPartsByLine[line.id]");
+    expect(mobile).toContain("resolveWorkOrderLinePricing");
+    expect(mobile).toContain("partsCount={pricing?.partsCount ?? 0}");
+  });
+
+  it("refreshes mobile when any canonical line-context table changes", () => {
+    for (const table of [
+      "work_order_parts",
+      "work_order_part_allocations",
+      "part_requests",
+      "work_order_line_technicians",
+    ]) {
+      expect(mobile).toContain(`table: "${table}"`);
+    }
+  });
+
+  it("carries the same context and labor rate into downloaded work orders", () => {
+    expect(offlineRoute).toContain("loadCanonicalWorkOrderLineContext");
+    expect(offlineRoute).toContain("lineContext:");
+    expect(offlineRoute).toContain("shopLaborRate");
+    expect(offlineTypes).toContain(
+      "lineContext: CanonicalWorkOrderLineContext",
+    );
+    expect(offlineTypes).toContain("shopLaborRate: number | null");
+    expect(focusedJob).toContain(
+      "cached.snapshot.lineContext?.allocationsByLine[id]",
+    );
+    expect(focusedJob).toContain(
+      "cached.snapshot.lineContext?.canonicalPartsByLine[id]",
+    );
+  });
+
+  it("allows only role-authorized staff or assigned mechanics to read parts", () => {
+    expect(migration).toContain("create policy work_order_parts_role_select");
+    expect(migration).toContain("shop_id = (select public.current_shop_id())");
+    expect(migration).toContain(
+      "(select public.profixiq_current_role()) = 'mechanic'",
+    );
+    expect(migration).toContain("public.profixiq_is_assigned_to_line");
+    expect(migration).toContain("public.profixiq_is_assigned_to_work_order");
+    expect(migration).toContain(
+      "create policy work_order_parts_customer_portal_select",
+    );
+    expect(migration).not.toContain("for update\nto authenticated");
+  });
+});


### PR DESCRIPTION
## Root cause

Mobile explicitly passed an empty parts array and omitted canonical work-order related records from its load, realtime, and offline paths. Assigned mechanics also lacked SELECT access to `work_order_parts`, so desktop and mobile could show different versions of the same work order.

## What changed

- Added one tenant-scoped loader for canonical active parts, allocations, part requests, and technician assignment links.
- Made desktop, mobile web, focused-job, and offline downloads use the same line context and pricing.
- Added realtime subscriptions for parts, allocations, part requests, and assignments.
- Restored parts and allocation state from offline snapshots.
- Added mechanic-safe, least-privilege SELECT access to canonical work-order parts while preserving customer portal access.
- Added regression coverage, including an EL000007-shaped consumed $255 part.

## Validation

- `tsc --noEmit`
- Changed-file ESLint: 0 errors; 2 pre-existing warnings in `MobileFocusedJob.tsx`
- 50 directly impacted tests passed
- Full suite: 1,371 passed; 20 unrelated existing failures; 2 skipped
- `git diff --check`

## Database

Apply `20260726231759_work_order_detail_source_of_truth.sql`.

## Deployment

Apply the migration before deploying the application. Mobile technicians should refresh or re-download assigned offline work after deployment.