### PR TITLE
Fix quote email portal approval flow

### DIFF
--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -458,6 +458,20 @@ export async function POST(req: Request) {
                 if (error) throw new Error(error.message);
               },
             },
+            {
+              step: "work_order_quote_approval_state_update",
+              run: async () => {
+                const { error } = await supabaseAdmin
+                  .from("work_orders")
+                  .update({
+                    approval_state: "pending",
+                    updated_at: new Date().toISOString(),
+                  })
+                  .eq("id", workOrderId)
+                  .eq("shop_id", wo.shop_id);
+                if (error) throw new Error(error.message);
+              },
+            },
           ]
         : []),
       ...(portalUserId

--- a/app/portal/approvals/page.tsx
+++ b/app/portal/approvals/page.tsx
@@ -60,6 +60,15 @@ type PartRequestHeader = {
 type ApprovalsPayload = {
   lines: ApprovalLine[];
   partRequestHeaders: PartRequestHeader[];
+  quoteApprovals: QuoteApprovalSummary[];
+};
+
+type QuoteApprovalSummary = {
+  workOrderId: string;
+  reference: string;
+  createdAt: string | null;
+  lineCount: number;
+  total: number;
 };
 
 function cx(...parts: Array<string | false | null | undefined>) {
@@ -97,17 +106,21 @@ async function readJson(res: Response): Promise<unknown> {
 }
 
 function safePayload(v: unknown): ApprovalsPayload {
-  if (!isRecord(v)) return { lines: [], partRequestHeaders: [] };
+  if (!isRecord(v)) return { lines: [], partRequestHeaders: [], quoteApprovals: [] };
 
   const linesRaw = v.lines;
   const headersRaw = v.partRequestHeaders;
+  const quoteApprovalsRaw = v.quoteApprovals;
 
   const lines = Array.isArray(linesRaw) ? (linesRaw as ApprovalLine[]) : [];
   const partRequestHeaders = Array.isArray(headersRaw)
     ? (headersRaw as PartRequestHeader[])
     : [];
+  const quoteApprovals = Array.isArray(quoteApprovalsRaw)
+    ? (quoteApprovalsRaw as QuoteApprovalSummary[])
+    : [];
 
-  return { lines, partRequestHeaders };
+  return { lines, partRequestHeaders, quoteApprovals };
 }
 
 export default function PortalApprovalsPage() {
@@ -115,6 +128,7 @@ export default function PortalApprovalsPage() {
 
   const [lines, setLines] = useState<ApprovalLine[]>([]);
   const [headers, setHeaders] = useState<PartRequestHeader[]>([]);
+  const [quoteApprovals, setQuoteApprovals] = useState<QuoteApprovalSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -139,16 +153,19 @@ export default function PortalApprovalsPage() {
         setError(msg);
         setLines([]);
         setHeaders([]);
+        setQuoteApprovals([]);
         return;
       }
 
       const payload = safePayload(parsed);
       setLines(payload.lines);
       setHeaders(payload.partRequestHeaders);
+      setQuoteApprovals(payload.quoteApprovals);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Failed to load approvals");
       setLines([]);
       setHeaders([]);
+      setQuoteApprovals([]);
     } finally {
       if (!silent) setLoading(false);
       else setRefreshing(false);
@@ -163,8 +180,18 @@ export default function PortalApprovalsPage() {
   const flattenedCount = useMemo(() => {
     let n = 0;
     lines.forEach((ln) => (n += Array.isArray(ln.part_request_items) ? ln.part_request_items.length : 0));
+    quoteApprovals.forEach((quote) => (n += quote.lineCount));
     return n;
-  }, [lines]);
+  }, [lines, quoteApprovals]);
+
+  const pendingJobCount = useMemo(
+    () =>
+      new Set([
+        ...lines.map((line) => line.work_order_id),
+        ...quoteApprovals.map((quote) => quote.workOrderId),
+      ]).size,
+    [lines, quoteApprovals],
+  );
 
   const runLineDecision = async (
     itemId: string,
@@ -237,7 +264,7 @@ export default function PortalApprovalsPage() {
                 APPROVALS
               </div>
               <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                Review and approve parts for jobs awaiting your confirmation.
+                Review estimates and approve work waiting for your confirmation.
               </div>
               <div className="mt-2 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
                 When all items on a job are approved, the job automatically moves forward.
@@ -247,7 +274,7 @@ export default function PortalApprovalsPage() {
             <div className="flex shrink-0 flex-col items-end gap-2">
               <div className="flex items-center gap-2">
                 <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[0.7rem] text-[color:var(--theme-text-primary)]">
-                  {lines.length} jobs
+                  {pendingJobCount} jobs
                 </span>
                 <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[0.7rem] text-[color:var(--theme-text-primary)]">
                   {flattenedCount} items
@@ -298,7 +325,40 @@ export default function PortalApprovalsPage() {
             </div>
           ) : null}
 
-          {!loading && !error && lines.length === 0 ? (
+          {!loading && !error && quoteApprovals.length > 0 ? (
+            <div className="mt-4 space-y-3">
+              {quoteApprovals.map((quote) => (
+                <div key={quote.workOrderId} className={glass}>
+                  <div className="flex flex-wrap items-center justify-between gap-4 px-4 py-4">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                          Estimate {quote.reference}
+                        </div>
+                        <StatusBadge variant="warning">Awaiting approval</StatusBadge>
+                      </div>
+                      <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
+                        {quote.lineCount} quote item{quote.lineCount === 1 ? "" : "s"} ready for your decision
+                        {quote.total > 0 ? ` · ${fmtMoney(quote.total)}` : ""}.
+                      </div>
+                      <div className="mt-1 text-[0.7rem] text-[color:var(--theme-text-muted)]">
+                        Sent {fmtDate(quote.createdAt)}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => router.push(`/portal/quotes/${quote.workOrderId}`)}
+                      className="inline-flex min-h-10 items-center rounded-full border border-[var(--accent-copper)] bg-[color:color-mix(in_srgb,var(--accent-copper)_14%,transparent)] px-4 py-2 text-xs font-semibold text-[var(--accent-copper-light)]"
+                    >
+                      Review estimate
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {!loading && !error && lines.length === 0 && quoteApprovals.length === 0 ? (
             <div className="mt-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6 text-center">
               <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Nothing to approve</div>
               <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">

--- a/app/portal/auth/sign-in/PortalSignInForm.tsx
+++ b/app/portal/auth/sign-in/PortalSignInForm.tsx
@@ -128,14 +128,14 @@ export default function PortalSignInForm() {
       <form className="mt-5 space-y-4" onSubmit={handleSubmit}>
         <div>
           <label htmlFor="portal-identifier" className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
-            {isFleet ? "Email or fleet username" : "Email"}
+            {isFleet ? "Email or fleet username" : "Email or username"}
           </label>
           <input
             id="portal-identifier"
             className={inputClass}
-            type={isFleet ? "text" : "email"}
+            type="text"
             autoComplete="username"
-            placeholder={isFleet ? "dispatch@fleet.com or username" : "you@example.com"}
+            placeholder={isFleet ? "dispatch@fleet.com or username" : "you@example.com or username"}
             value={identifier}
             onChange={(event) => setIdentifier(event.target.value)}
             required

--- a/features/portal/lib/quoteApprovalPresentation.ts
+++ b/features/portal/lib/quoteApprovalPresentation.ts
@@ -1,0 +1,44 @@
+function text(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function number(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function isPendingCustomerQuoteLine(row: Record<string, unknown>): boolean {
+  const status = (text(row.status) ?? "").trim().toLowerCase();
+  const stage = (text(row.stage) ?? "").trim().toLowerCase();
+  const terminalStatuses = new Set([
+    "approved",
+    "converted",
+    "declined",
+    "deferred",
+    "rejected",
+    "cancelled",
+  ]);
+
+  if (
+    terminalStatuses.has(status) ||
+    text(row.approved_at) ||
+    text(row.declined_at) ||
+    text(row.work_order_line_id)
+  ) {
+    return false;
+  }
+
+  return (
+    Boolean(text(row.sent_to_customer_at)) ||
+    status === "sent" ||
+    stage === "sent" ||
+    stage === "customer_review"
+  );
+}
+
+export function quoteLineTotal(row: Record<string, unknown>): number {
+  return (
+    number(row.grand_total) ??
+    number(row.subtotal) ??
+    (number(row.labor_total) ?? 0) + (number(row.parts_total) ?? 0)
+  );
+}

--- a/features/portal/server/listPortalApprovals.ts
+++ b/features/portal/server/listPortalApprovals.ts
@@ -1,6 +1,10 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import type { PortalCustomer } from "@/features/portal/server/portalAuth";
+import {
+  isPendingCustomerQuoteLine,
+  quoteLineTotal,
+} from "@/features/portal/lib/quoteApprovalPresentation";
 
 type DB = Database;
 
@@ -40,6 +44,19 @@ export type PortalApprovalLine = {
 export type PortalApprovalsPayload = {
   lines: PortalApprovalLine[];
   partRequestHeaders: PartRequestHeaderPick[];
+  quoteApprovals: PortalQuoteApprovalSummary[];
+};
+
+export type PortalQuoteApprovalSummary = {
+  workOrderId: string;
+  reference: string;
+  createdAt: string | null;
+  lineCount: number;
+  total: number;
+};
+
+type QuoteApprovalAccumulator = PortalQuoteApprovalSummary & {
+  seenLineIds: Set<string>;
 };
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -143,6 +160,34 @@ function normalizeLines(rowsUnknown: unknown): PortalApprovalLine[] {
   return out;
 }
 
+export function normalizeQuoteApprovals(rowsUnknown: unknown): PortalQuoteApprovalSummary[] {
+  const grouped = new Map<string, QuoteApprovalAccumulator>();
+
+  for (const raw of asArray(rowsUnknown)) {
+    if (!isRecord(raw) || !isPendingCustomerQuoteLine(raw)) continue;
+    const lineId = asString(raw.id);
+    const workOrderId = asString(raw.work_order_id);
+    const workOrder = pickWorkOrder(raw.work_orders);
+    if (!lineId || !workOrderId || workOrder?.id !== workOrderId) continue;
+
+    const current = grouped.get(workOrderId) ?? {
+      workOrderId,
+      reference: workOrder.custom_id?.trim() || `#${workOrderId.slice(0, 8).toUpperCase()}`,
+      createdAt: asString(raw.sent_to_customer_at) ?? workOrder.created_at,
+      lineCount: 0,
+      total: 0,
+      seenLineIds: new Set<string>(),
+    };
+    if (current.seenLineIds.has(lineId)) continue;
+    current.seenLineIds.add(lineId);
+    current.lineCount += 1;
+    current.total += quoteLineTotal(raw);
+    grouped.set(workOrderId, current);
+  }
+
+  return [...grouped.values()].map(({ seenLineIds: _seenLineIds, ...summary }) => summary);
+}
+
 export async function listPortalApprovalsForCustomer({
   supabase,
   customer,
@@ -150,9 +195,8 @@ export async function listPortalApprovalsForCustomer({
   supabase: SupabaseClient<DB>;
   customer: Pick<PortalCustomer, "id">;
 }): Promise<{ ok: true; data: PortalApprovalsPayload } | { ok: false; error: string; status: number }> {
-  const { data: rows, error } = await supabase
-    .from("work_order_lines")
-    .select(
+  const [lineResult, quoteResult] = await Promise.all([
+    supabase.from("work_order_lines").select(
       `
       id,
       description,
@@ -179,13 +223,42 @@ export async function listPortalApprovalsForCustomer({
       )
     `,
     )
-    .eq("work_orders.customer_id", customer.id)
-    .eq("approval_state", "pending")
-    .order("created_at", { ascending: false });
+      .eq("work_orders.customer_id", customer.id)
+      .eq("approval_state", "pending")
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("work_order_quote_lines")
+      .select(
+        `
+        id,
+        work_order_id,
+        status,
+        stage,
+        sent_to_customer_at,
+        approved_at,
+        declined_at,
+        work_order_line_id,
+        labor_total,
+        parts_total,
+        subtotal,
+        grand_total,
+        work_orders!inner (
+          id,
+          custom_id,
+          created_at
+        )
+      `,
+      )
+      .eq("work_orders.customer_id", customer.id)
+      .order("created_at", { ascending: false })
+      .limit(200),
+  ]);
 
-  if (error) return { ok: false, error: error.message, status: 400 };
+  if (lineResult.error) return { ok: false, error: lineResult.error.message, status: 400 };
+  if (quoteResult.error) return { ok: false, error: quoteResult.error.message, status: 400 };
 
-  const lines = normalizeLines(rows as unknown);
+  const lines = normalizeLines(lineResult.data as unknown);
+  const quoteApprovals = normalizeQuoteApprovals(quoteResult.data as unknown);
   const requestIds = uniqStrings(lines.flatMap((ln) => ln.part_request_items.map((it) => it.request_id)));
 
   let partRequestHeaders: PartRequestHeaderPick[] = [];
@@ -201,6 +274,7 @@ export async function listPortalApprovalsForCustomer({
     data: {
       lines,
       partRequestHeaders,
+      quoteApprovals,
     },
   };
 }

--- a/features/portal/server/portalWorkOrders.ts
+++ b/features/portal/server/portalWorkOrders.ts
@@ -4,12 +4,14 @@ import {
   toPortalWorkOrderStatus,
   type PortalWorkOrderStatus,
 } from "@/features/portal/lib/workOrderPresentation";
+import { isPendingCustomerQuoteLine } from "@/features/portal/lib/quoteApprovalPresentation";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
 type ProfileRow = DB["public"]["Tables"]["profiles"]["Row"];
 type WorkOrderLineRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 
 type WorkOrderSummaryRow = Pick<
   WorkOrderRow,
@@ -44,6 +46,20 @@ type AdvisorSummaryRow = Pick<ProfileRow, "id" | "full_name">;
 type LineSummaryRow = Pick<
   WorkOrderLineRow,
   "id" | "work_order_id" | "line_no" | "description" | "complaint"
+>;
+type QuoteLineSummaryRow = Pick<
+  QuoteLineRow,
+  | "id"
+  | "work_order_id"
+  | "description"
+  | "ai_complaint"
+  | "notes"
+  | "status"
+  | "stage"
+  | "sent_to_customer_at"
+  | "approved_at"
+  | "declined_at"
+  | "work_order_line_id"
 >;
 
 export type PortalWorkOrderSummary = {
@@ -160,7 +176,7 @@ export async function listPortalWorkOrdersForCustomer({
     ),
   );
 
-  const [vehicleResult, advisorResult, lineResult] = await Promise.all([
+  const [vehicleResult, advisorResult, lineResult, quoteLineResult] = await Promise.all([
     vehicleIds.length
       ? supabase
           .from("vehicles")
@@ -184,10 +200,21 @@ export async function listPortalWorkOrdersForCustomer({
       .in("work_order_id", workOrderIds)
       .order("line_no", { ascending: true })
       .returns<LineSummaryRow[]>(),
+    supabase
+      .from("work_order_quote_lines")
+      .select(
+        "id,work_order_id,description,ai_complaint,notes,status,stage,sent_to_customer_at,approved_at,declined_at,work_order_line_id",
+      )
+      .in("work_order_id", workOrderIds)
+      .order("created_at", { ascending: true })
+      .returns<QuoteLineSummaryRow[]>(),
   ]);
 
   const queryError =
-    vehicleResult.error ?? advisorResult.error ?? lineResult.error;
+    vehicleResult.error ??
+    advisorResult.error ??
+    lineResult.error ??
+    quoteLineResult.error;
   if (queryError) throw new Error(queryError.message);
 
   const vehiclesById = new Map(
@@ -197,6 +224,8 @@ export async function listPortalWorkOrdersForCustomer({
     (advisorResult.data ?? []).map((advisor) => [advisor.id, advisor]),
   );
   const linesByWorkOrder = new Map<string, string[]>();
+  const pendingQuoteWorkOrderIds = new Set<string>();
+  const quoteLinesByWorkOrder = new Map<string, string[]>();
 
   for (const line of lineResult.data ?? []) {
     const summary =
@@ -207,10 +236,27 @@ export async function listPortalWorkOrdersForCustomer({
     linesByWorkOrder.set(line.work_order_id, current);
   }
 
+  for (const line of quoteLineResult.data ?? []) {
+    if (!isPendingCustomerQuoteLine(line as unknown as Record<string, unknown>)) {
+      continue;
+    }
+    pendingQuoteWorkOrderIds.add(line.work_order_id);
+    const summary =
+      compactText(line.description) ??
+      compactText(line.ai_complaint) ??
+      compactText(line.notes);
+    if (!summary) continue;
+    const current = quoteLinesByWorkOrder.get(line.work_order_id) ?? [];
+    if (!current.includes(summary) && current.length < 3) current.push(summary);
+    quoteLinesByWorkOrder.set(line.work_order_id, current);
+  }
+
   return rows.map((workOrder) => {
     const status = toPortalWorkOrderStatus({
       status: workOrder.status,
-      approvalState: workOrder.approval_state,
+      approvalState: pendingQuoteWorkOrderIds.has(workOrder.id)
+        ? "pending"
+        : workOrder.approval_state,
       scheduledAt: workOrder.scheduled_at,
       invoiceSentAt: workOrder.invoice_sent_at,
     });
@@ -226,7 +272,10 @@ export async function listPortalWorkOrdersForCustomer({
         `#${workOrder.id.slice(0, 8).toUpperCase()}`,
       vehicleLabel: vehicle.label,
       vehicleDetail: vehicle.detail,
-      serviceSummary: linesByWorkOrder.get(workOrder.id) ?? ["Service visit"],
+      serviceSummary:
+        linesByWorkOrder.get(workOrder.id) ??
+        quoteLinesByWorkOrder.get(workOrder.id) ??
+        ["Service visit"],
       advisorName: workOrder.advisor_id
         ? compactText(advisorsById.get(workOrder.advisor_id)?.full_name)
         : null,

--- a/tests/quote-email-portal-alignment.test.ts
+++ b/tests/quote-email-portal-alignment.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { normalizeQuoteApprovals } from "@/features/portal/server/listPortalApprovals";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("quote email and customer portal alignment", () => {
+  it("surfaces sent canonical quote lines and excludes completed decisions", () => {
+    const summaries = normalizeQuoteApprovals([
+      {
+        id: "quote-1",
+        work_order_id: "work-order-1",
+        status: "sent",
+        stage: "sent",
+        sent_to_customer_at: "2026-07-26T22:34:14.939Z",
+        grand_total: 125,
+        work_orders: {
+          id: "work-order-1",
+          custom_id: "EL000006",
+          created_at: "2026-07-26T20:00:00.000Z",
+        },
+      },
+      {
+        id: "quote-2",
+        work_order_id: "work-order-1",
+        status: "converted",
+        stage: "customer_approved",
+        sent_to_customer_at: "2026-07-26T22:34:14.939Z",
+        approved_at: "2026-07-26T23:00:00.000Z",
+        grand_total: 75,
+        work_orders: {
+          id: "work-order-1",
+          custom_id: "EL000006",
+          created_at: "2026-07-26T20:00:00.000Z",
+        },
+      },
+    ]);
+
+    expect(summaries).toEqual([
+      {
+        workOrderId: "work-order-1",
+        reference: "EL000006",
+        createdAt: "2026-07-26T22:34:14.939Z",
+        lineCount: 1,
+        total: 125,
+      },
+    ]);
+  });
+
+  it("marks the work order pending when quote email persistence completes", () => {
+    const sendRoute = read("app/api/quotes/send/route.ts");
+    const newlySentQuotePersistence = sendRoute.indexOf(
+      "...(sendableQuoteLineIds.length > 0",
+    );
+    const approvalStatePersistence = sendRoute.indexOf(
+      "work_order_quote_approval_state_update",
+    );
+    expect(newlySentQuotePersistence).toBeGreaterThanOrEqual(0);
+    expect(approvalStatePersistence).toBeGreaterThan(newlySentQuotePersistence);
+    expect(sendRoute).toContain("work_order_quote_approval_state_update");
+    expect(sendRoute).toContain('approval_state: "pending"');
+  });
+
+  it("derives portal-home attention from unresolved canonical quote lines", () => {
+    const loader = read("features/portal/server/portalWorkOrders.ts");
+    expect(loader).toContain('from("work_order_quote_lines")');
+    expect(loader).toContain("pendingQuoteWorkOrderIds.has(workOrder.id)");
+    expect(loader).toContain("quoteLinesByWorkOrder.get(workOrder.id)");
+  });
+
+  it("keeps deep-link login compatible with the shared identifier strategy", () => {
+    const signIn = read("app/portal/auth/sign-in/PortalSignInForm.tsx");
+    expect(signIn).toContain('"Email or username"');
+    expect(signIn).toContain('type="text"');
+  });
+
+  it("sends the stable idempotency key required by quote decisions", () => {
+    const actions = read("features/portal/components/QuoteApprovalActions.tsx");
+    expect(actions).toContain('"Idempotency-Key": operationKey');
+    expect(actions).toContain("operationKeys.current.get(actionIdentity)");
+  });
+});


### PR DESCRIPTION
## Summary

- Allow customer portal deep-link sign-in with the same email-or-username identifier strategy as the shared authentication endpoint.
- Mark newly sent quote work orders as pending approval.
- Surface unresolved canonical `work_order_quote_lines` on the portal home and Approvals page, including historical sent quotes without requiring a resend.
- Link customers to the canonical quote review page and keep completed quote decisions out of the pending list.
- Add focused regression coverage for canonical quote visibility, send persistence, deep-link login, and decision idempotency.

## Root cause

The quote email sent customers to a protected portal route, but the customer sign-in form enforced browser email validation even though the server accepts email or username. Separately, quote sending persisted the customer-visible estimate in `work_order_quote_lines`, while the portal home and Approvals page still derived pending work from legacy `work_order_lines` and the work-order approval field. That source-of-truth split made successfully sent quotes disappear from the customer's approval surfaces.

## Impact and safety

Customers can use the same credentials from the emailed deep link that work during manual portal navigation. Newly sent and already-sent unresolved quotes appear as approval work and route to the canonical quote page. Reads remain scoped through the authenticated customer relationship and existing RLS; the send-side work-order update remains shop-scoped. Existing stable idempotency keys for approval decisions are preserved.

## Validation

- Focused Vitest: 3 files, 17 tests passed.
- Final quote-flow regression: 1 file, 5 tests passed.
- ESLint on all seven changed files passed.
- TypeScript `tsc --noEmit` passed.
- `git diff --check` passed.
- An additional four-file run passed 22 of 23 tests; the unrelated customer messaging source-string assertion fails on current `main` because that route now uses the canonical role helper instead of the older literal query.

## Database and configuration

No migration, backfill, or environment-variable changes are required.