### PR TITLE
Fix portal work order quote flow

### DIFF
--- a/app/api/chat/start-conversation/route.ts
+++ b/app/api/chat/start-conversation/route.ts
@@ -126,16 +126,20 @@ export async function POST(req: Request): Promise<NextResponse> {
   let recipientUserIds = createAccess.recipientUserIds;
   let participantKindByUserId = createAccess.participantKinds;
 
+  const requestedWorkOrderId =
+    body?.context_type === "work_order" && body?.context_id ? body.context_id : null;
+  const routedWorkOrderId = context.anchors.work_order_id ?? requestedWorkOrderId;
+
   if (
     createAccess.actor.kind === "customer" &&
     createAccess.customerId &&
-    context.anchors.work_order_id &&
+    routedWorkOrderId &&
     requestedParticipantIds.length === 0
   ) {
     const { data: workOrder, error: workOrderError } = await admin
       .from("work_orders")
       .select("advisor_id")
-      .eq("id", context.anchors.work_order_id)
+      .eq("id", routedWorkOrderId)
       .eq("shop_id", createAccess.actorShopId)
       .eq("customer_id", createAccess.customerId)
       .maybeSingle();
@@ -160,6 +164,7 @@ export async function POST(req: Request): Promise<NextResponse> {
       .from("profiles")
       .select("id,user_id,role")
       .eq("shop_id", createAccess.actorShopId)
+      .in("role", ["owner", "admin", "manager"])
       .limit(100);
 
     const recipientError = advisorError ?? coverageError;
@@ -174,7 +179,6 @@ export async function POST(req: Request): Promise<NextResponse> {
       ? assignedAdvisor.user_id ?? assignedAdvisor.id
       : null;
     const coverageUserIds = (coverage ?? [])
-      .filter((profile) => isCustomerMessagingRole(profile.role))
       .map((profile) => profile.user_id ?? profile.id)
       .filter((id): id is string => Boolean(id) && id !== user.id);
 
@@ -242,7 +246,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     _shop_id: createAccess.actorShopId,
     _channel: createAccess.channel,
     _customer_id: context.anchors.customer_id,
-    _work_order_id: context.anchors.work_order_id,
+    _work_order_id: routedWorkOrderId,
     _vehicle_id: context.anchors.vehicle_id,
     _booking_id: context.anchors.booking_id,
     _context_type: context.anchors.context_type,

--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -142,6 +142,11 @@ function isSendableQuoteLine(line: Pick<QuoteLineRow, "status" | "stage" | "sent
   return SEND_READY_STATUSES.has(status) || SEND_READY_STAGES.has(stage);
 }
 
+function isResendableQuoteLine(line: Pick<QuoteLineRow, "status" | "sent_to_customer_at" | "approved_at" | "declined_at" | "work_order_line_id">): boolean {
+  const status = safeStr(line.status).trim().toLowerCase();
+  return Boolean(line.sent_to_customer_at) && !line.approved_at && !line.declined_at && !line.work_order_line_id && status === "sent";
+}
+
 export async function POST(req: Request) {
   const trace = `quotes-send:${Date.now()}:${Math.random().toString(16).slice(2)}`;
 
@@ -350,7 +355,10 @@ export async function POST(req: Request) {
       >
     >;
 
-    const sendableQuoteLines = quoteLineRows.filter(isSendableQuoteLine);
+    const requestAllowsResend = req.headers.get("x-profix-resend") === "1";
+    const sendableQuoteLines = quoteLineRows.filter((line) =>
+      isSendableQuoteLine(line) || (requestAllowsResend && isResendableQuoteLine(line)),
+    );
 
     if (sendableQuoteLines.length === 0) {
       return NextResponse.json(
@@ -402,7 +410,6 @@ export async function POST(req: Request) {
       ? `${normalizedAppUrl}/portal/quotes/${workOrderId}`
       : null;
 
-    const requestAllowsResend = req.headers.get("x-profix-resend") === "1";
     const quoteUrlForSend = portalQuoteUrl ?? pdfUrl ?? wo.quote_url ?? "";
     const shouldSkipAsDuplicate = Boolean(wo.quote_url) && wo.quote_url === quoteUrlForSend && !requestAllowsResend;
 

--- a/app/portal/work-orders/view/[id]/page.tsx
+++ b/app/portal/work-orders/view/[id]/page.tsx
@@ -12,6 +12,11 @@ import {
 } from "@/features/portal/server/portalAuth";
 
 import PortalInvoicePayButton from "@/features/stripe/components/PortalInvoicePayButton";
+import {
+  calculateShopSupplies,
+  resolveShopSuppliesOverride,
+  resolveShopSuppliesSettings,
+} from "@/features/work-orders/lib/shopSupplies";
 
 import WorkOrderViewer, {
   type WorkOrderViewerLine,
@@ -28,6 +33,7 @@ type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
 type PartRow = DB["public"]["Tables"]["parts"]["Row"];
 type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
+type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 
 type WorkOrderLite = Pick<
   WorkOrderRow,
@@ -45,6 +51,8 @@ type WorkOrderLite = Pick<
   | "invoice_pdf_url"
   | "intake_status"
   | "intake_submitted_at"
+  | "shop_supplies_enabled_override"
+  | "shop_supplies_amount_override"
 >;
 
 type VehicleLite = Pick<
@@ -85,6 +93,29 @@ type ShopLite = Pick<
   | "province"
   | "postal_code"
   | "country"
+  | "labor_rate"
+  | "shop_supplies_enabled"
+  | "shop_supplies_type"
+  | "shop_supplies_percent"
+  | "shop_supplies_flat_amount"
+  | "shop_supplies_cap_amount"
+  | "supplies_percent"
+>;
+type QuoteLineLite = Pick<
+  QuoteLineRow,
+  | "labor_hours"
+  | "est_labor_hours"
+  | "labor_total"
+  | "parts_total"
+  | "subtotal"
+  | "grand_total"
+  | "status"
+  | "stage"
+  | "sent_to_customer_at"
+  | "approved_at"
+  | "declined_at"
+  | "work_order_line_id"
+  | "metadata"
 >;
 
 type PartLookupRow = Pick<PartRow, "id" | "name" | "sku" | "part_number" | "unit">;
@@ -97,6 +128,47 @@ function normalizeCurrencyFromCountry(country: unknown): "CAD" | "USD" {
 function safeNumber(v: unknown): number {
   const n = typeof v === "number" ? v : Number(v);
   return Number.isFinite(n) ? n : 0;
+}
+
+function nullableNumber(v: unknown): number | null {
+  if (v == null) return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function quoteMetadata(line: Pick<QuoteLineLite, "metadata">): Record<string, unknown> {
+  if (!line.metadata || typeof line.metadata !== "object" || Array.isArray(line.metadata)) {
+    return {};
+  }
+  return line.metadata as Record<string, unknown>;
+}
+
+function quoteLaborHours(line: Pick<QuoteLineLite, "labor_hours" | "est_labor_hours">): number {
+  return nullableNumber(line.labor_hours) ?? nullableNumber(line.est_labor_hours) ?? 0;
+}
+
+function quoteLaborRate(line: Pick<QuoteLineLite, "metadata">, shopLaborRate: number): number {
+  return nullableNumber(quoteMetadata(line).labor_rate) ?? shopLaborRate;
+}
+
+function quoteLaborTotal(line: Pick<QuoteLineLite, "labor_total" | "labor_hours" | "est_labor_hours" | "metadata">, shopLaborRate: number): number {
+  return nullableNumber(line.labor_total) ?? quoteLaborHours(line) * quoteLaborRate(line, shopLaborRate);
+}
+
+function quotePartsTotal(line: Pick<QuoteLineLite, "parts_total">): number {
+  return nullableNumber(line.parts_total) ?? 0;
+}
+
+function quoteGrandTotal(line: Pick<QuoteLineLite, "grand_total" | "subtotal" | "labor_total" | "labor_hours" | "est_labor_hours" | "metadata" | "parts_total">, shopLaborRate: number): number {
+  return nullableNumber(line.grand_total) ?? nullableNumber(line.subtotal) ?? quoteLaborTotal(line, shopLaborRate) + quotePartsTotal(line);
+}
+
+function isCustomerVisibleQuoteLine(line: QuoteLineLite): boolean {
+  const status = String(line.status ?? "").trim().toLowerCase();
+  const stage = String(line.stage ?? "").trim().toLowerCase();
+  if (line.declined_at || status === "declined" || stage === "customer_declined") return false;
+  if (status === "pending_parts" || stage === "advisor_pending") return false;
+  return Boolean(line.sent_to_customer_at || line.approved_at || line.work_order_line_id || ["sent", "approved", "converted"].includes(status));
 }
 
 function dollarsToCents(n: number | null): number {
@@ -140,7 +212,7 @@ export default async function PortalWorkOrderViewerPage({
     const { data: wo, error: woErr } = await supabase
       .from("work_orders")
       .select(
-        "id, custom_id, status, created_at, updated_at, invoice_total, labor_total, parts_total, shop_id, customer_id, vehicle_id, invoice_pdf_url, intake_status, intake_submitted_at",
+        "id, custom_id, status, created_at, updated_at, invoice_total, labor_total, parts_total, shop_id, customer_id, vehicle_id, invoice_pdf_url, intake_status, intake_submitted_at, shop_supplies_enabled_override, shop_supplies_amount_override",
       )
       .eq("id", workOrderId)
       .eq("customer_id", portalCustomer.id)
@@ -155,7 +227,7 @@ export default async function PortalWorkOrderViewerPage({
       const { data: s, error: sErr } = await supabase
         .from("shops")
         .select(
-          "business_name, shop_name, name, phone_number, email, street, city, province, postal_code, country",
+          "business_name, shop_name, name, phone_number, email, street, city, province, postal_code, country, labor_rate, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount, supplies_percent",
         )
         .eq("id", wo.shop_id)
         .maybeSingle<ShopLite>();
@@ -204,6 +276,24 @@ export default async function PortalWorkOrderViewerPage({
     if (wolErr) throw wolErr;
 
     const lines = (Array.isArray(wol) ? wol : []) as WorkOrderViewerLine[];
+
+    const { data: quoteLineRaw, error: quoteLineErr } = await supabase
+      .from("work_order_quote_lines")
+      .select("labor_hours, est_labor_hours, labor_total, parts_total, subtotal, grand_total, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id, metadata")
+      .eq("work_order_id", workOrderId);
+
+    if (quoteLineErr) throw quoteLineErr;
+
+    const quoteLines = ((Array.isArray(quoteLineRaw) ? quoteLineRaw : []) as QuoteLineLite[]).filter(isCustomerVisibleQuoteLine);
+    const shopLaborRate = nullableNumber(shop?.labor_rate) ?? 140;
+    const quoteLineTotal = quoteLines.reduce((sum, line) => sum + quoteGrandTotal(line, shopLaborRate), 0);
+    const quoteLaborPartsBase = quoteLines.reduce((sum, line) => sum + quoteLaborTotal(line, shopLaborRate) + quotePartsTotal(line), 0);
+    const quoteSupplies = calculateShopSupplies({
+      baseAmount: quoteLaborPartsBase,
+      settings: resolveShopSuppliesSettings(shop as Parameters<typeof resolveShopSuppliesSettings>[0]),
+      override: resolveShopSuppliesOverride(wo as Parameters<typeof resolveShopSuppliesOverride>[0]),
+    });
+    const visibleQuoteTotal = quoteLines.length > 0 ? quoteLineTotal + quoteSupplies.amount : null;
 
     // Allocations (truth for parts)
     const { data: allocRaw, error: allocErr } = await supabase
@@ -276,6 +366,9 @@ export default async function PortalWorkOrderViewerPage({
     });
 
     const woInvoiceTotal = safeNumber(wo.invoice_total);
+    const displayWorkOrder = visibleQuoteTotal != null && woInvoiceTotal <= 0
+      ? { ...wo, invoice_total: visibleQuoteTotal }
+      : wo;
     const payAmountCents = dollarsToCents(woInvoiceTotal > 0 ? woInvoiceTotal : null);
 
     // Intake CTA (portal)
@@ -313,7 +406,7 @@ export default async function PortalWorkOrderViewerPage({
 
         <WorkOrderViewer
           kind="portal"
-          workOrder={wo}
+          workOrder={displayWorkOrder}
           currency={currency}
           vehicle={vehicle ?? undefined}
           customer={

--- a/features/chat/components/PortalMessagesWorkspace.tsx
+++ b/features/chat/components/PortalMessagesWorkspace.tsx
@@ -86,7 +86,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
   );
   const [message, setMessage] = useState("");
   const [subject, setSubject] = useState("");
-  const [contextKey, setContextKey] = useState("");
+  const [contextKey, setContextKey] = useState(requestedContextKey);
   const [contextOptions, setContextOptions] = useState<ContextOption[]>([]);
   const [recipientUserId, setRecipientUserId] = useState("");
   const [recipientOptions, setRecipientOptions] = useState<RecipientOption[]>(
@@ -237,9 +237,16 @@ export default function PortalMessagesWorkspace(): JSX.Element {
       return;
     }
 
-    const selectedContext = contextOptions.find(
-      (option) => `${option.type}:${option.id}` === contextKey,
-    );
+    const selectedContext =
+      contextOptions.find((option) => `${option.type}:${option.id}` === contextKey) ??
+      (requestedWorkOrderId && contextKey === requestedContextKey
+        ? {
+            type: "work_order" as const,
+            id: requestedWorkOrderId,
+            label: `Work Order ${requestedWorkOrderId.slice(0, 8)}`,
+            secondary: null,
+          }
+        : null);
     const requestId = ensureUuid(newThreadDraft?.conversationRequestId);
     const clientMessageId = ensureUuid(newThreadDraft?.clientMessageId);
     if (
@@ -295,7 +302,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
 
       setMessage("");
       setSubject("");
-      setContextKey("");
+      setContextKey(requestedContextKey);
       setRecipientUserId("");
       setNewThread(false);
       setActiveId(created.id);

--- a/features/portal/components/PortalWorkOrderCard.tsx
+++ b/features/portal/components/PortalWorkOrderCard.tsx
@@ -8,16 +8,16 @@ import {
 import type { PortalWorkOrderSummary } from "@/features/portal/server/portalWorkOrders";
 
 const STATUS_STYLE: Record<PortalWorkOrderSummary["status"]["key"], string> = {
-  appointment_confirmed: "border-sky-400/35 bg-sky-500/10 text-sky-100",
-  vehicle_received: "border-blue-400/35 bg-blue-500/10 text-blue-100",
-  inspection_underway: "border-violet-400/35 bg-violet-500/10 text-violet-100",
-  approval_needed: "border-amber-400/45 bg-amber-500/15 text-amber-100",
-  work_underway: "border-cyan-400/35 bg-cyan-500/10 text-cyan-100",
-  waiting_for_parts: "border-orange-400/40 bg-orange-500/10 text-orange-100",
-  final_checks: "border-indigo-400/35 bg-indigo-500/10 text-indigo-100",
-  ready_for_pickup: "border-emerald-400/40 bg-emerald-500/12 text-emerald-100",
+  appointment_confirmed: "border-sky-500 bg-sky-200 text-sky-950 shadow-sm shadow-sky-900/10",
+  vehicle_received: "border-blue-600 bg-blue-200 text-blue-950 shadow-sm shadow-blue-900/10",
+  inspection_underway: "border-violet-600 bg-violet-200 text-violet-950 shadow-sm shadow-violet-900/10",
+  approval_needed: "border-amber-600 bg-amber-200 text-amber-950 shadow-sm shadow-amber-900/10",
+  work_underway: "border-cyan-600 bg-cyan-200 text-cyan-950 shadow-sm shadow-cyan-900/10",
+  waiting_for_parts: "border-orange-600 bg-orange-200 text-orange-950 shadow-sm shadow-orange-900/10",
+  final_checks: "border-indigo-600 bg-indigo-200 text-indigo-950 shadow-sm shadow-indigo-900/10",
+  ready_for_pickup: "border-emerald-600 bg-emerald-200 text-emerald-950 shadow-sm shadow-emerald-900/10",
   completed:
-    "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-secondary)]",
+    "border-slate-500 bg-slate-200 text-slate-900 shadow-sm shadow-slate-900/10",
 };
 
 function dateLabel(value: string | null): string | null {

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -770,7 +770,7 @@ export default function QuoteReviewView(props: {
     }
   }
 
-  async function sendQuoteToCustomer() {
+  async function sendQuoteToCustomer(resend = false) {
     if (!woId || sending) return;
     setSending(true);
     try {
@@ -779,7 +779,10 @@ export default function QuoteReviewView(props: {
 
       const res = await fetch(`/api/work-orders/${woId}/send-quote`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...(resend ? { "x-profix-resend": "1" } : {}),
+        },
         body: JSON.stringify({}),
       });
       const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string; detail?: string } | null;
@@ -792,7 +795,7 @@ export default function QuoteReviewView(props: {
       }
 
       setSendBlocker(null);
-      toast.success("Quote sent to customer using canonical quote lines.");
+      toast.success(resend ? "Quote resent to customer." : "Quote sent to customer using canonical quote lines.");
       await reload();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to send quote.");
@@ -839,9 +842,14 @@ export default function QuoteReviewView(props: {
             </button>
           )}
           <div className="flex flex-wrap items-center gap-2">
-            <button onClick={() => void sendQuoteToCustomer()} disabled={sending || quoteTotals.sendable === 0} className={actionBtnCls} title="Email the ready canonical quote lines to the customer">
+            <button onClick={() => void sendQuoteToCustomer(false)} disabled={sending || quoteTotals.sendable === 0} className={actionBtnCls} title="Email the ready canonical quote lines to the customer">
               {sending ? "Sending…" : "Send Quote"}
             </button>
+            {quoteTotals.sent > 0 ? (
+              <button onClick={() => void sendQuoteToCustomer(true)} disabled={sending || missingCustomerEmail} className={actionBtnCls} title="Resend the current customer portal quote email">
+                {sending ? "Sending…" : "Resend Quote"}
+              </button>
+            ) : null}
             <button onClick={() => void saveAllDirty()} disabled={saving} className={saveBtnCls} title="Save canonical quote line changes">
               {saving ? "Saving…" : "Save"}
             </button>
@@ -1180,9 +1188,14 @@ export default function QuoteReviewView(props: {
                     </div>
                   </div>
                 ) : null}
-                <button onClick={() => void sendQuoteToCustomer()} disabled={sending || savingCustomerEmail || quoteTotals.sendable === 0} className="desktop-btn-secondary mt-3 w-full rounded-xl px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-60">
+                <button onClick={() => void sendQuoteToCustomer(false)} disabled={sending || savingCustomerEmail || quoteTotals.sendable === 0} className="desktop-btn-secondary mt-3 w-full rounded-xl px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-60">
                   {sending ? "Sending…" : "Send ready quote lines"}
                 </button>
+                {quoteTotals.sent > 0 ? (
+                  <button onClick={() => void sendQuoteToCustomer(true)} disabled={sending || savingCustomerEmail || missingCustomerEmail} className="desktop-btn-secondary mt-2 w-full rounded-xl px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-primary)] disabled:opacity-60">
+                    {sending ? "Sending…" : "Resend quote"}
+                  </button>
+                ) : null}
                 <div className="mt-3 text-xs text-[color:var(--theme-text-muted)]">Portal link will be: <span className="text-[color:var(--theme-text-secondary)]">/portal/quotes/{woId}</span></div>
                 <div className="mt-2 text-xs text-[color:var(--theme-text-muted)]">Customer portal decisions and shop-recorded phone decisions use the same canonical approval lifecycle.</div>
               </div>


### PR DESCRIPTION
## Summary

- Adds an explicit quote resend path for advisor quote review, including API support for resending already-sent canonical quote lines.
- Aligns portal work order detail totals with customer-visible quote totals when an invoice total is not available yet.
- Hardens portal customer messaging so work-order deep links preserve advisor routing and management coverage.
- Strengthens customer portal work order status pill colors so statuses are easier to distinguish.

## Why

The customer portal could show a blank/mismatched total before invoicing, advisors had no clear way to resend a quote, work-order message compose could lose its work-order routing context, and portal status pills were too visually similar.

## Validation

- Patch reviewed locally with `git diff --stat` and scoped to the six files in this fix.
- Focused `pnpm` tests/typecheck were attempted earlier, but `pnpm` first stopped on an interactive node_modules purge prompt and the follow-up CI-mode runs were interrupted before completion, so automated validation is not reported as passing.