### PR TITLE
Fix P1-012 Stripe webhook replay and ordering

### DIFF
--- a/.github/workflows/p1-012-stripe-webhook-validation.yml
+++ b/.github/workflows/p1-012-stripe-webhook-validation.yml
@@ -1,0 +1,52 @@
+name: P1-012 Stripe Webhook Validation
+
+on:
+  pull_request:
+    paths:
+      - "app/api/stripe/webhook/**"
+      - "app/api/stripe/checkout/webhook/**"
+      - "features/shared/types/types/supabase.ts"
+      - "features/stripe/api/stripe/webhook/**"
+      - "features/stripe/lib/server/canonical-shop-billing.ts"
+      - "features/stripe/lib/server/stripe-webhook-receipts.ts"
+      - "supabase/migrations/*p1_012_stripe_webhook_receipts.sql"
+      - "tests/p1-012-stripe-webhook-idempotency.test.ts"
+      - "tests/p1-012-stripe-subscription-ordering.test.ts"
+      - "tests/support/p1-012-next-server.ts"
+      - "tests/security/p1-012-stripe-webhook-*.runtime.sql"
+      - "tests/security/p1-012-stripe-webhook-*.sh"
+      - "tsconfig.p1-012.json"
+      - "vitest.p1-012.config.ts"
+      - ".github/workflows/p1-012-stripe-webhook-validation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec tsc --noEmit -p tsconfig.p1-012.json
+      - run: >-
+          pnpm exec eslint
+          app/api/stripe/webhook/route.ts
+          app/api/stripe/checkout/webhook/route.ts
+          features/stripe/api/stripe/webhook/route.ts
+          features/stripe/lib/server/canonical-shop-billing.ts
+          features/stripe/lib/server/stripe-webhook-receipts.ts
+          tests/p1-012-stripe-webhook-idempotency.test.ts
+          tests/p1-012-stripe-subscription-ordering.test.ts
+          tests/support/p1-012-next-server.ts
+          vitest.p1-012.config.ts
+      - run: pnpm exec vitest run --config vitest.p1-012.config.ts
+      - run: bash -n tests/security/p1-012-stripe-webhook-concurrency.sh

--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -221,6 +221,29 @@ jobs:
           bash tests/security/p0-007-financial-outbox-concurrency.sh \
             2>&1 | tee p0-007-financial-outbox-concurrency.log
 
+      - name: Execute P1 Stripe webhook receipt integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/p1-012-stripe-webhook-receipts.runtime.sql \
+            2>&1 | tee p1-012-stripe-webhook-receipts-runtime.log
+
+      - name: Execute P1 Stripe webhook concurrent-delivery integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          bash tests/security/p1-012-stripe-webhook-concurrency.sh \
+            2>&1 | tee p1-012-stripe-webhook-concurrency.log
+
       - name: Execute P0 schema reconciliation integration
         shell: bash
         env:
@@ -315,6 +338,8 @@ jobs:
             p0-006-stripe-identity-runtime.log
             p0-007-financial-outbox-runtime.log
             p0-007-financial-outbox-concurrency.log
+            p1-012-stripe-webhook-receipts-runtime.log
+            p1-012-stripe-webhook-concurrency.log
             p0-008-schema-reconciliation-runtime.log
             p0-008-generated-types.diff
             generated-supabase-types.ts

--- a/docs/stripe-webhook-operations.md
+++ b/docs/stripe-webhook-operations.md
@@ -1,0 +1,29 @@
+# Stripe webhook operations
+
+## Canonical endpoint
+
+Register exactly one production Stripe webhook destination for ProFixIQ:
+
+`https://<production-domain>/api/stripe/webhook`
+
+The older `/api/stripe/checkout/webhook` route is a temporary compatibility alias that delegates to the same canonical handler. Do not register both URLs in Stripe. Remove the legacy registration only after confirming Stripe delivery history no longer targets it; the application alias may remain during that controlled migration.
+
+## Delivery behavior
+
+- Stripe signatures are verified from the raw request body before persistence or side effects.
+- Every verified Stripe event ID is durably claimed before processing.
+- Completed event IDs return success on replay without repeating side effects.
+- Concurrent deliveries receive a retryable non-success response until the active claim completes, preventing an abandoned lease from being acknowledged as processed.
+- Failed claims are retryable, and abandoned processing claims become retryable after the lease expires.
+- Subscription events retrieve the current Stripe subscription and apply it through a monotonic database watermark, so an older delivery cannot replace a newer canonical billing state.
+
+## Dashboard verification
+
+In Stripe Workbench or Developers > Webhooks:
+
+1. Confirm the production destination URL ends in `/api/stripe/webhook`.
+2. Confirm `/api/stripe/checkout/webhook` is not also registered.
+3. Confirm the destination listens only for the event types handled by `features/stripe/api/stripe/webhook/route.ts`.
+4. Replay one recent test-mode event twice and confirm both deliveries receive HTTP 200 while only one receipt attempt is processed.
+
+Changing Stripe dashboard configuration is a manual production action and is not performed by repository migrations.

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -21910,6 +21910,17 @@ export type Database = {
           isSetofReturn: false
         }
       }
+      apply_stripe_subscription_webhook_snapshot: {
+        Args: {
+          p_customer_id: string
+          p_event_created_at: string
+          p_event_id: string
+          p_shop_id: string
+          p_snapshot: Json
+          p_subscription_id: string
+        }
+        Returns: boolean
+      }
       apply_approval_compatibility_bundle_atomic: {
         Args: {
           p_actor_user_id: string
@@ -22233,6 +22244,24 @@ export type Database = {
           shop_id: string
         }[]
       }
+      claim_stripe_webhook_event: {
+        Args: {
+          p_event_created_at: string
+          p_event_id: string
+          p_event_type: string
+          p_lease_seconds: number
+          p_livemode: boolean
+          p_object_id: string
+          p_stripe_account_id: string
+        }
+        Returns: {
+          already_processed: boolean
+          attempt_count: number
+          claim_token: string
+          claimed: boolean
+          in_progress: boolean
+        }[]
+      }
       clear_auth: { Args: never; Returns: undefined }
       close_work_order_correction_session: {
         Args: {
@@ -22295,6 +22324,10 @@ export type Database = {
       }
       complete_financial_outbox_claim: {
         Args: { p_outbox_id: string; p_worker_id: string }
+        Returns: boolean
+      }
+      complete_stripe_webhook_event: {
+        Args: { p_claim_token: string; p_event_id: string }
         Returns: boolean
       }
       consume_ai_route_quota: {
@@ -22471,6 +22504,10 @@ export type Database = {
         }
       }
       current_shop_id: { Args: never; Returns: string }
+      fail_stripe_webhook_event: {
+        Args: { p_claim_token: string; p_error: string; p_event_id: string }
+        Returns: boolean
+      }
       finalize_inspection_pdf_atomic: {
         Args: {
           p_actor_user_id: string

--- a/features/stripe/api/stripe/webhook/route.ts
+++ b/features/stripe/api/stripe/webhook/route.ts
@@ -20,6 +20,11 @@ import {
   postPaymentEvent,
   type PaymentEventKind,
 } from "@/features/invoices/server/financialLifecycle";
+import {
+  claimStripeWebhookEvent,
+  completeStripeWebhookEvent,
+  failStripeWebhookEvent,
+} from "@/features/stripe/lib/server/stripe-webhook-receipts";
 
 type DB = Database;
 type AdminClient = ReturnType<typeof createAdminSupabase>;
@@ -470,6 +475,7 @@ async function processStripeWebhookEvent(ctx: WebhookContext): Promise<void> {
     case "customer.subscription.deleted": {
       const subscription = event.data.object as Stripe.Subscription;
       const customerId = toStripeId(subscription.customer, "cus_");
+      if (!customerId) return;
       const shopId = await resolveShopIdForSubscription({
         stripe,
         supabase,
@@ -483,6 +489,10 @@ async function processStripeWebhookEvent(ctx: WebhookContext): Promise<void> {
         shopId,
         customerId,
         subscriptionId: subscription.id,
+        webhookEvent: {
+          id: event.id,
+          createdAt: new Date(event.created * 1000).toISOString(),
+        },
       });
       return;
     }
@@ -515,12 +525,54 @@ export async function handleStripeWebhook(req: Request): Promise<Response> {
     return NextResponse.json({ error: `Webhook Error: ${message}` }, { status: 400 });
   }
 
+  let claimToken: string | null = null;
   try {
+    const claim = await claimStripeWebhookEvent({ supabase, event });
+    if (!claim.claimed) {
+      if (claim.inProgress) {
+        return NextResponse.json(
+          { received: false, retry: true },
+          { status: 409, headers: { "Retry-After": "300" } },
+        );
+      }
+      return NextResponse.json(
+        {
+          received: true,
+          duplicate: claim.alreadyProcessed,
+        },
+        { status: 200 },
+      );
+    }
+    if (!claim.claimToken) {
+      throw new Error("Stripe webhook claim token missing");
+    }
+
+    claimToken = claim.claimToken;
     await processStripeWebhookEvent({ event, stripe, supabase });
+    await completeStripeWebhookEvent({
+      supabase,
+      eventId: event.id,
+      claimToken,
+    });
     return NextResponse.json({ received: true }, { status: 200 });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Unknown error";
     console.error("[stripe/webhook] processing error:", message);
+    if (claimToken) {
+      try {
+        await failStripeWebhookEvent({
+          supabase,
+          eventId: event.id,
+          claimToken,
+          error,
+        });
+      } catch (receiptError) {
+        console.error(
+          "[stripe/webhook] failure receipt error:",
+          receiptError instanceof Error ? receiptError.message : "Unknown error",
+        );
+      }
+    }
     return NextResponse.json({ error: "Webhook handler failure" }, { status: 500 });
   }
 }

--- a/features/stripe/lib/server/canonical-shop-billing.ts
+++ b/features/stripe/lib/server/canonical-shop-billing.ts
@@ -111,24 +111,63 @@ export async function syncCanonicalShopBilling(params: {
   customerId: string | null;
   subscriptionId: string;
   checkoutSessionId?: string | null;
-}): Promise<void> {
-  const { stripe, supabase, shopId, customerId, subscriptionId, checkoutSessionId } = params;
+  webhookEvent?: {
+    id: string;
+    createdAt: string;
+  };
+}): Promise<{ applied: boolean }> {
+  const {
+    stripe,
+    supabase,
+    shopId,
+    customerId,
+    subscriptionId,
+    checkoutSessionId,
+    webhookEvent,
+  } = params;
   const sub = await stripe.subscriptions.retrieve(subscriptionId);
+  const update = toCanonicalShopBillingUpdate({
+    customerId,
+    subscription: sub,
+    checkoutSessionId,
+  });
+
+  if (webhookEvent) {
+    if (!customerId) {
+      throw new Error("Stripe subscription webhook is missing its customer identity");
+    }
+    const { data, error } = await supabase.rpc("apply_stripe_subscription_webhook_snapshot", {
+      p_shop_id: shopId,
+      p_customer_id: customerId,
+      p_subscription_id: sub.id,
+      p_event_id: webhookEvent.id,
+      p_event_created_at: webhookEvent.createdAt,
+      p_snapshot: {
+        stripe_subscription_status: update.stripe_subscription_status ?? null,
+        stripe_trial_end: update.stripe_trial_end ?? null,
+        stripe_current_period_end: update.stripe_current_period_end ?? null,
+        plan: update.plan ?? null,
+        stripe_checkout_session_id: checkoutSessionId ?? null,
+      },
+    });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return { applied: data === true };
+  }
 
   const { error } = await supabase
     .from("shops")
-    .update(
-      toCanonicalShopBillingUpdate({
-        customerId,
-        subscription: sub,
-        checkoutSessionId,
-      }),
-    )
+    .update(update)
     .eq("id", shopId);
 
   if (error) {
     throw new Error(error.message);
   }
+
+  return { applied: true };
 }
 
 export async function reconcileShopBillingFromUser(params: {

--- a/features/stripe/lib/server/stripe-webhook-receipts.ts
+++ b/features/stripe/lib/server/stripe-webhook-receipts.ts
@@ -1,0 +1,130 @@
+import type Stripe from "stripe";
+
+import type { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type AdminClient = ReturnType<typeof createAdminSupabase>;
+
+export type StripeWebhookClaim = {
+  claimed: boolean;
+  alreadyProcessed: boolean;
+  inProgress: boolean;
+  claimToken: string | null;
+  attemptCount: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function eventObjectId(event: Stripe.Event): string | null {
+  const object = event.data.object as { id?: unknown };
+  return typeof object.id === "string" && object.id.trim()
+    ? object.id.trim()
+    : null;
+}
+
+function eventCreatedAt(event: Stripe.Event): string {
+  return new Date(event.created * 1000).toISOString();
+}
+
+export async function claimStripeWebhookEvent(args: {
+  supabase: AdminClient;
+  event: Stripe.Event;
+}): Promise<StripeWebhookClaim> {
+  const { data, error } = await args.supabase.rpc(
+    "claim_stripe_webhook_event",
+    {
+      p_event_id: args.event.id,
+      p_event_type: args.event.type,
+      p_livemode: args.event.livemode,
+      p_stripe_account_id: args.event.account ?? "",
+      p_object_id: eventObjectId(args.event) ?? "",
+      p_event_created_at: eventCreatedAt(args.event),
+      p_lease_seconds: 300,
+    },
+  );
+
+  if (error) {
+    throw new Error(`Stripe webhook claim failed (${error.code ?? "unknown"})`);
+  }
+
+  const row: unknown = Array.isArray(data) ? data[0] : null;
+  if (!isRecord(row)) {
+    throw new Error("Stripe webhook claim returned no receipt");
+  }
+
+  const claimed = row.claimed;
+  const alreadyProcessed = row.already_processed;
+  const inProgress = row.in_progress;
+  const claimToken =
+    typeof row.claim_token === "string" ? row.claim_token : null;
+  const attemptCount = row.attempt_count;
+  const dispositionCount = [claimed, alreadyProcessed, inProgress].filter(
+    (value) => value === true,
+  ).length;
+
+  if (
+    typeof claimed !== "boolean" ||
+    typeof alreadyProcessed !== "boolean" ||
+    typeof inProgress !== "boolean" ||
+    typeof attemptCount !== "number" ||
+    !Number.isInteger(attemptCount) ||
+    attemptCount < 1 ||
+    dispositionCount !== 1 ||
+    (claimed && !claimToken) ||
+    (!claimed && claimToken !== null)
+  ) {
+    throw new Error("Stripe webhook claim returned an invalid receipt");
+  }
+
+  return {
+    claimed,
+    alreadyProcessed,
+    inProgress,
+    claimToken,
+    attemptCount,
+  };
+}
+
+export async function completeStripeWebhookEvent(args: {
+  supabase: AdminClient;
+  eventId: string;
+  claimToken: string;
+}): Promise<void> {
+  const { data, error } = await args.supabase.rpc(
+    "complete_stripe_webhook_event",
+    {
+      p_event_id: args.eventId,
+      p_claim_token: args.claimToken,
+    },
+  );
+
+  if (error || data !== true) {
+    throw new Error(
+      `Stripe webhook completion failed (${error?.code ?? "claim_mismatch"})`,
+    );
+  }
+}
+
+export async function failStripeWebhookEvent(args: {
+  supabase: AdminClient;
+  eventId: string;
+  claimToken: string;
+  error: unknown;
+}): Promise<void> {
+  const detail =
+    args.error instanceof Error
+      ? `${args.error.name}: ${args.error.message}`
+      : `Unknown failure: ${String(args.error)}`;
+  const { error } = await args.supabase.rpc("fail_stripe_webhook_event", {
+    p_event_id: args.eventId,
+    p_claim_token: args.claimToken,
+    p_error: detail.slice(0, 1000),
+  });
+
+  if (error) {
+    throw new Error(
+      `Stripe webhook failure receipt failed (${error.code ?? "unknown"})`,
+    );
+  }
+}

--- a/supabase/migrations/20260727020644_p1_012_stripe_webhook_receipts.sql
+++ b/supabase/migrations/20260727020644_p1_012_stripe_webhook_receipts.sql
@@ -1,0 +1,418 @@
+-- P1-012: make Stripe webhook delivery replay-safe and prevent stale
+-- subscription events from overwriting newer canonical billing state.
+
+begin;
+
+create schema if not exists private;
+
+create table if not exists private.stripe_webhook_event_receipts (
+  event_id text primary key,
+  event_type text not null,
+  livemode boolean not null,
+  stripe_account_id text,
+  object_id text,
+  event_created_at timestamptz not null,
+  status text not null default 'processing',
+  claim_token uuid,
+  attempt_count integer not null default 1,
+  delivery_count integer not null default 1,
+  first_received_at timestamptz not null default now(),
+  last_received_at timestamptz not null default now(),
+  claimed_at timestamptz,
+  processed_at timestamptz,
+  failed_at timestamptz,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint stripe_webhook_event_receipts_event_id_check
+    check (event_id ~ '^evt_[A-Za-z0-9_]+$'),
+  constraint stripe_webhook_event_receipts_event_type_check
+    check (char_length(event_type) between 3 and 200),
+  constraint stripe_webhook_event_receipts_status_check
+    check (status in ('processing', 'processed', 'failed')),
+  constraint stripe_webhook_event_receipts_attempt_count_check
+    check (attempt_count > 0),
+  constraint stripe_webhook_event_receipts_delivery_count_check
+    check (delivery_count > 0)
+);
+
+alter table private.stripe_webhook_event_receipts enable row level security;
+alter table private.stripe_webhook_event_receipts force row level security;
+
+create index if not exists stripe_webhook_event_receipts_status_claimed_idx
+  on private.stripe_webhook_event_receipts (status, claimed_at);
+
+create table if not exists private.stripe_subscription_event_watermarks (
+  subscription_id text primary key,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  stripe_customer_id text,
+  event_id text not null unique,
+  event_created_at timestamptz not null,
+  applied_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint stripe_subscription_event_watermarks_subscription_check
+    check (subscription_id ~ '^sub_[A-Za-z0-9]+$'),
+  constraint stripe_subscription_event_watermarks_customer_check
+    check (stripe_customer_id is null or stripe_customer_id ~ '^cus_[A-Za-z0-9]+$'),
+  constraint stripe_subscription_event_watermarks_event_check
+    check (event_id ~ '^evt_[A-Za-z0-9_]+$')
+);
+
+alter table private.stripe_subscription_event_watermarks enable row level security;
+alter table private.stripe_subscription_event_watermarks force row level security;
+
+create index if not exists stripe_subscription_event_watermarks_shop_idx
+  on private.stripe_subscription_event_watermarks (shop_id, event_created_at desc);
+
+revoke all on table private.stripe_webhook_event_receipts
+  from public, anon, authenticated, service_role;
+revoke all on table private.stripe_subscription_event_watermarks
+  from public, anon, authenticated, service_role;
+
+create or replace function public.claim_stripe_webhook_event(
+  p_event_id text,
+  p_event_type text,
+  p_livemode boolean,
+  p_stripe_account_id text,
+  p_object_id text,
+  p_event_created_at timestamptz,
+  p_lease_seconds integer
+)
+returns table (
+  claimed boolean,
+  already_processed boolean,
+  in_progress boolean,
+  claim_token uuid,
+  attempt_count integer
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_receipt private.stripe_webhook_event_receipts%rowtype;
+  v_claim_token uuid := gen_random_uuid();
+begin
+  if p_event_id is null or p_event_id !~ '^evt_[A-Za-z0-9_]+$' then
+    raise exception using errcode = '22023', message = 'invalid Stripe event id';
+  end if;
+  if p_event_type is null or char_length(trim(p_event_type)) not between 3 and 200 then
+    raise exception using errcode = '22023', message = 'invalid Stripe event type';
+  end if;
+  if p_event_created_at is null then
+    raise exception using errcode = '22023', message = 'Stripe event creation time is required';
+  end if;
+  if p_lease_seconds is null or p_lease_seconds not between 30 and 3600 then
+    raise exception using errcode = '22023', message = 'Stripe event lease must be between 30 and 3600 seconds';
+  end if;
+
+  insert into private.stripe_webhook_event_receipts (
+    event_id,
+    event_type,
+    livemode,
+    stripe_account_id,
+    object_id,
+    event_created_at,
+    status,
+    claim_token,
+    claimed_at
+  )
+  values (
+    p_event_id,
+    trim(p_event_type),
+    p_livemode,
+    nullif(trim(coalesce(p_stripe_account_id, '')), ''),
+    nullif(trim(coalesce(p_object_id, '')), ''),
+    p_event_created_at,
+    'processing',
+    v_claim_token,
+    now()
+  )
+  on conflict (event_id) do nothing
+  returning * into v_receipt;
+
+  if found then
+    return query
+    select true, false, false, v_receipt.claim_token, v_receipt.attempt_count;
+    return;
+  end if;
+
+  select receipt.*
+  into v_receipt
+  from private.stripe_webhook_event_receipts receipt
+  where receipt.event_id = p_event_id
+  for update;
+
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Stripe event receipt disappeared during claim';
+  end if;
+
+  if v_receipt.event_type <> trim(p_event_type)
+     or v_receipt.livemode is distinct from p_livemode
+     or v_receipt.stripe_account_id is distinct from nullif(trim(coalesce(p_stripe_account_id, '')), '')
+     or v_receipt.object_id is distinct from nullif(trim(coalesce(p_object_id, '')), '')
+     or v_receipt.event_created_at is distinct from p_event_created_at then
+    raise exception using errcode = '22023', message = 'Stripe event receipt metadata conflict';
+  end if;
+
+  update private.stripe_webhook_event_receipts
+  set delivery_count = delivery_count + 1,
+      last_received_at = now(),
+      updated_at = now()
+  where event_id = p_event_id
+  returning * into v_receipt;
+
+  if v_receipt.status = 'processed' then
+    return query
+    select false, true, false, null::uuid, v_receipt.attempt_count;
+    return;
+  end if;
+
+  if v_receipt.status = 'processing'
+     and v_receipt.claimed_at is not null
+     and v_receipt.claimed_at > now() - make_interval(secs => p_lease_seconds) then
+    return query
+    select false, false, true, null::uuid, v_receipt.attempt_count;
+    return;
+  end if;
+
+  v_claim_token := gen_random_uuid();
+  update private.stripe_webhook_event_receipts
+  set status = 'processing',
+      claim_token = v_claim_token,
+      attempt_count = attempt_count + 1,
+      claimed_at = now(),
+      processed_at = null,
+      failed_at = null,
+      last_error = null,
+      updated_at = now()
+  where event_id = p_event_id
+  returning * into v_receipt;
+
+  return query
+  select true, false, false, v_receipt.claim_token, v_receipt.attempt_count;
+end;
+$$;
+
+create or replace function public.complete_stripe_webhook_event(
+  p_event_id text,
+  p_claim_token uuid
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+begin
+  update private.stripe_webhook_event_receipts
+  set status = 'processed',
+      processed_at = now(),
+      failed_at = null,
+      last_error = null,
+      updated_at = now()
+  where event_id = p_event_id
+    and claim_token = p_claim_token
+    and status = 'processing';
+
+  if found then
+    return true;
+  end if;
+
+  return exists (
+    select 1
+    from private.stripe_webhook_event_receipts
+    where event_id = p_event_id
+      and claim_token = p_claim_token
+      and status = 'processed'
+  );
+end;
+$$;
+
+create or replace function public.fail_stripe_webhook_event(
+  p_event_id text,
+  p_claim_token uuid,
+  p_error text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+begin
+  update private.stripe_webhook_event_receipts
+  set status = 'failed',
+      failed_at = now(),
+      last_error = left(nullif(trim(coalesce(p_error, '')), ''), 1000),
+      updated_at = now()
+  where event_id = p_event_id
+    and claim_token = p_claim_token
+    and status = 'processing';
+
+  return found;
+end;
+$$;
+
+create or replace function public.apply_stripe_subscription_webhook_snapshot(
+  p_shop_id uuid,
+  p_customer_id text,
+  p_subscription_id text,
+  p_event_id text,
+  p_event_created_at timestamptz,
+  p_snapshot jsonb
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v_shop public.shops%rowtype;
+  v_watermark private.stripe_subscription_event_watermarks%rowtype;
+  v_subscription_status text;
+  v_trial_end timestamptz;
+  v_current_period_end timestamptz;
+  v_plan text;
+  v_checkout_session_id text;
+begin
+  if p_shop_id is null then
+    raise exception using errcode = '22023', message = 'shop id is required';
+  end if;
+  if p_subscription_id is null or p_subscription_id !~ '^sub_[A-Za-z0-9]+$' then
+    raise exception using errcode = '22023', message = 'invalid Stripe subscription id';
+  end if;
+  if p_customer_id is not null and p_customer_id !~ '^cus_[A-Za-z0-9]+$' then
+    raise exception using errcode = '22023', message = 'invalid Stripe customer id';
+  end if;
+  if p_event_id is null or p_event_id !~ '^evt_[A-Za-z0-9_]+$' or p_event_created_at is null then
+    raise exception using errcode = '22023', message = 'invalid Stripe subscription event';
+  end if;
+  if p_snapshot is null or jsonb_typeof(p_snapshot) <> 'object' then
+    raise exception using errcode = '22023', message = 'invalid Stripe subscription snapshot';
+  end if;
+
+  v_subscription_status := nullif(trim(p_snapshot ->> 'stripe_subscription_status'), '');
+  v_plan := nullif(trim(p_snapshot ->> 'plan'), '');
+  v_checkout_session_id := nullif(trim(p_snapshot ->> 'stripe_checkout_session_id'), '');
+
+  begin
+    v_trial_end := nullif(trim(p_snapshot ->> 'stripe_trial_end'), '')::timestamptz;
+    v_current_period_end := nullif(trim(p_snapshot ->> 'stripe_current_period_end'), '')::timestamptz;
+  exception
+    when invalid_datetime_format then
+      raise exception using errcode = '22023', message = 'invalid Stripe subscription timestamp';
+  end;
+
+  if v_subscription_status is not null and v_subscription_status not in (
+    'incomplete',
+    'incomplete_expired',
+    'trialing',
+    'active',
+    'past_due',
+    'canceled',
+    'unpaid',
+    'paused'
+  ) then
+    raise exception using errcode = '22023', message = 'invalid Stripe subscription status';
+  end if;
+  if v_plan is not null and v_plan not in ('starter', 'pro', 'unlimited') then
+    raise exception using errcode = '22023', message = 'invalid canonical billing plan';
+  end if;
+
+  select shop.*
+  into v_shop
+  from public.shops shop
+  where shop.id = p_shop_id
+  for update;
+
+  if not found then
+    raise exception using errcode = '23503', message = 'billing shop not found';
+  end if;
+
+  if (v_shop.stripe_customer_id is not null and v_shop.stripe_customer_id is distinct from p_customer_id)
+     or (v_shop.stripe_subscription_id is not null and v_shop.stripe_subscription_id <> p_subscription_id) then
+    return false;
+  end if;
+
+  insert into private.stripe_subscription_event_watermarks (
+    subscription_id,
+    shop_id,
+    stripe_customer_id,
+    event_id,
+    event_created_at
+  )
+  values (
+    p_subscription_id,
+    p_shop_id,
+    p_customer_id,
+    p_event_id,
+    p_event_created_at
+  )
+  on conflict (subscription_id) do nothing;
+
+  select watermark.*
+  into v_watermark
+  from private.stripe_subscription_event_watermarks watermark
+  where watermark.subscription_id = p_subscription_id
+  for update;
+
+  if not found or v_watermark.shop_id <> p_shop_id then
+    return false;
+  end if;
+
+  if v_watermark.event_created_at > p_event_created_at
+     or (
+       v_watermark.event_created_at = p_event_created_at
+       and v_watermark.event_id > p_event_id
+     ) then
+    return false;
+  end if;
+
+  update public.shops
+  set stripe_customer_id = p_customer_id,
+      stripe_subscription_id = p_subscription_id,
+      stripe_subscription_status = v_subscription_status,
+      stripe_trial_end = v_trial_end,
+      stripe_current_period_end = v_current_period_end,
+      plan = v_plan,
+      stripe_checkout_session_id = coalesce(
+        v_checkout_session_id,
+        stripe_checkout_session_id
+      )
+  where id = p_shop_id;
+
+  update private.stripe_subscription_event_watermarks
+  set stripe_customer_id = p_customer_id,
+      event_id = p_event_id,
+      event_created_at = p_event_created_at,
+      applied_at = now(),
+      updated_at = now()
+  where subscription_id = p_subscription_id;
+
+  return true;
+end;
+$$;
+
+revoke all on function public.claim_stripe_webhook_event(text, text, boolean, text, text, timestamptz, integer)
+  from public, anon, authenticated;
+revoke all on function public.complete_stripe_webhook_event(text, uuid)
+  from public, anon, authenticated;
+revoke all on function public.fail_stripe_webhook_event(text, uuid, text)
+  from public, anon, authenticated;
+revoke all on function public.apply_stripe_subscription_webhook_snapshot(uuid, text, text, text, timestamptz, jsonb)
+  from public, anon, authenticated;
+
+grant execute on function public.claim_stripe_webhook_event(text, text, boolean, text, text, timestamptz, integer)
+  to service_role;
+grant execute on function public.complete_stripe_webhook_event(text, uuid)
+  to service_role;
+grant execute on function public.fail_stripe_webhook_event(text, uuid, text)
+  to service_role;
+grant execute on function public.apply_stripe_subscription_webhook_snapshot(uuid, text, text, text, timestamptz, jsonb)
+  to service_role;
+
+comment on table private.stripe_webhook_event_receipts is
+  'Service-only Stripe webhook receipt ledger used for atomic delivery claims and replay protection.';
+comment on table private.stripe_subscription_event_watermarks is
+  'Service-only monotonic watermark for canonical Stripe subscription billing updates.';
+
+commit;

--- a/tests/p1-012-stripe-subscription-ordering.test.ts
+++ b/tests/p1-012-stripe-subscription-ordering.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  claimStripeWebhookEvent,
+  completeStripeWebhookEvent,
+} from "../features/stripe/lib/server/stripe-webhook-receipts";
+
+vi.mock("@/features/stripe/lib/server/subscription-discovery", () => ({
+  collectCustomerSubscriptionDiagnostics: vi.fn(),
+}));
+
+const SHOP_ID = "8b100000-0000-4000-8000-000000000001";
+const EVENT_ID = "evt_p1012_ordered";
+const EVENT_CREATED_AT = "2026-07-27T02:00:00.000Z";
+
+function subscription() {
+  return {
+    id: "sub_p1012shop",
+    customer: "cus_p1012shop",
+    status: "active",
+    trial_end: null,
+    current_period_end: 1_787_788_800,
+    items: {
+      data: [
+        {
+          price: {
+            id: "price_p1012pro",
+            lookup_key: "profixiq_pro50_monthly",
+            nickname: "Complete 50",
+          },
+        },
+      ],
+    },
+  };
+}
+
+describe("P1-012 Stripe subscription ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends the retrieved canonical subscription through the monotonic snapshot RPC", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: true, error: null });
+    const from = vi.fn(() => {
+      throw new Error("ordered webhook sync must not update shops directly");
+    });
+    const retrieve = vi.fn().mockResolvedValue(subscription());
+    const { syncCanonicalShopBilling } =
+      await import("../features/stripe/lib/server/canonical-shop-billing");
+
+    const result = await syncCanonicalShopBilling({
+      stripe: { subscriptions: { retrieve } } as never,
+      supabase: { rpc, from } as never,
+      shopId: SHOP_ID,
+      customerId: "cus_p1012shop",
+      subscriptionId: "sub_p1012shop",
+      webhookEvent: { id: EVENT_ID, createdAt: EVENT_CREATED_AT },
+    });
+
+    expect(result).toEqual({ applied: true });
+    expect(retrieve).toHaveBeenCalledWith("sub_p1012shop");
+    expect(rpc).toHaveBeenCalledWith(
+      "apply_stripe_subscription_webhook_snapshot",
+      {
+        p_shop_id: SHOP_ID,
+        p_customer_id: "cus_p1012shop",
+        p_subscription_id: "sub_p1012shop",
+        p_event_id: EVENT_ID,
+        p_event_created_at: EVENT_CREATED_AT,
+        p_snapshot: {
+          stripe_subscription_status: "active",
+          stripe_trial_end: null,
+          stripe_current_period_end: new Date(
+            1_787_788_800 * 1000,
+          ).toISOString(),
+          plan: "pro",
+          stripe_checkout_session_id: null,
+        },
+      },
+    );
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("maps receipt claims and completes only with the durable claim token", async () => {
+    const rpc = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [
+          {
+            claimed: true,
+            already_processed: false,
+            in_progress: false,
+            claim_token: "7a100000-0000-4000-8000-000000000001",
+            attempt_count: 2,
+          },
+        ],
+        error: null,
+      })
+      .mockResolvedValueOnce({ data: true, error: null });
+    const event = {
+      id: EVENT_ID,
+      type: "customer.subscription.updated",
+      livemode: true,
+      account: undefined,
+      created: 1_785_109_200,
+      data: { object: { id: "sub_p1012shop" } },
+    };
+
+    const claim = await claimStripeWebhookEvent({
+      supabase: { rpc } as never,
+      event: event as never,
+    });
+    expect(claim).toEqual({
+      claimed: true,
+      alreadyProcessed: false,
+      inProgress: false,
+      claimToken: "7a100000-0000-4000-8000-000000000001",
+      attemptCount: 2,
+    });
+
+    await completeStripeWebhookEvent({
+      supabase: { rpc } as never,
+      eventId: EVENT_ID,
+      claimToken: claim.claimToken ?? "",
+    });
+
+    expect(rpc).toHaveBeenNthCalledWith(1, "claim_stripe_webhook_event", {
+      p_event_id: EVENT_ID,
+      p_event_type: "customer.subscription.updated",
+      p_livemode: true,
+      p_stripe_account_id: "",
+      p_object_id: "sub_p1012shop",
+      p_event_created_at: new Date(1_785_109_200 * 1000).toISOString(),
+      p_lease_seconds: 300,
+    });
+    expect(rpc).toHaveBeenNthCalledWith(2, "complete_stripe_webhook_event", {
+      p_event_id: EVENT_ID,
+      p_claim_token: "7a100000-0000-4000-8000-000000000001",
+    });
+  });
+
+  it("rejects a malformed claim response instead of acknowledging an unclaimed event", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: [
+        {
+          claimed: false,
+          already_processed: false,
+          in_progress: false,
+          claim_token: null,
+          attempt_count: 1,
+        },
+      ],
+      error: null,
+    });
+
+    await expect(
+      claimStripeWebhookEvent({
+        supabase: { rpc } as never,
+        event: {
+          id: EVENT_ID,
+          type: "customer.subscription.updated",
+          livemode: true,
+          created: 1_785_109_200,
+          data: { object: { id: "sub_p1012shop" } },
+        } as never,
+      }),
+    ).rejects.toThrow("invalid receipt");
+  });
+});

--- a/tests/p1-012-stripe-webhook-idempotency.test.ts
+++ b/tests/p1-012-stripe-webhook-idempotency.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const SHOP_ID = "8a100000-0000-4000-8000-000000000001";
+const EVENT_CREATED = 1_785_109_200;
+
+const mocks = vi.hoisted(() => ({
+  claim: vi.fn(),
+  complete: vi.fn(),
+  fail: vi.fn(),
+  constructEvent: vi.fn(),
+  syncCanonicalShopBilling: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: () => ({ rpc: vi.fn(), from: vi.fn() }),
+}));
+
+vi.mock("@/features/stripe/lib/stripe/client", () => ({
+  createStripeClient: () => ({
+    webhooks: { constructEvent: mocks.constructEvent },
+  }),
+}));
+
+vi.mock("@/features/stripe/lib/server/canonical-shop-billing", () => ({
+  syncCanonicalShopBilling: mocks.syncCanonicalShopBilling,
+}));
+
+vi.mock("@/features/stripe/lib/server/stripe-webhook-receipts", () => ({
+  claimStripeWebhookEvent: mocks.claim,
+  completeStripeWebhookEvent: mocks.complete,
+  failStripeWebhookEvent: mocks.fail,
+}));
+
+vi.mock("@/features/stripe/lib/server/stripe-acquisition-intent", () => ({
+  STRIPE_ACQUISITION_PURPOSE: "profixiq_acquisition",
+  getStripeCheckoutEmail: vi.fn(),
+  getStripeCheckoutPriceId: vi.fn(),
+  isCompletedStripeAcquisitionSession: vi.fn(),
+  readStripeAcquisitionMetadata: vi.fn(),
+  recordStripeAcquisitionCompletion: vi.fn(),
+  toStripeId: (value: unknown, prefix: string) =>
+    typeof value === "string" && value.startsWith(prefix) ? value : null,
+}));
+
+vi.mock("@/features/invoices/server/financialLifecycle", () => ({
+  getActiveInvoiceVersion: vi.fn(),
+  postPaymentEvent: vi.fn(),
+}));
+
+function subscriptionEvent(id: string) {
+  return {
+    id,
+    object: "event",
+    api_version: "2025-02-24.acacia",
+    created: EVENT_CREATED,
+    data: {
+      object: {
+        id: "sub_p1012",
+        object: "subscription",
+        customer: "cus_p1012",
+        metadata: { shop_id: SHOP_ID },
+      },
+    },
+    livemode: true,
+    pending_webhooks: 1,
+    request: null,
+    type: "customer.subscription.updated",
+  };
+}
+
+function request(): Request {
+  return new Request("https://profixiq.test/api/stripe/webhook", {
+    method: "POST",
+    headers: { "stripe-signature": "signed" },
+    body: "raw-stripe-body",
+  });
+}
+
+describe("P1-012 Stripe webhook delivery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_p1012");
+    vi.stubEnv("STRIPE_WEBHOOK_SECRET", "whsec_p1012");
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://p1012.supabase.co");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-p1012");
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.complete.mockResolvedValue(undefined);
+    mocks.fail.mockResolvedValue(undefined);
+    mocks.syncCanonicalShopBilling.mockResolvedValue({ applied: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("acknowledges a durable duplicate without repeating subscription side effects", async () => {
+    const event = subscriptionEvent("evt_p1012_duplicate");
+    mocks.constructEvent.mockReturnValue(event);
+    mocks.claim.mockResolvedValue({
+      claimed: false,
+      alreadyProcessed: true,
+      inProgress: false,
+      claimToken: null,
+      attemptCount: 1,
+    });
+
+    const { handleStripeWebhook } =
+      await import("../features/stripe/api/stripe/webhook/route");
+    const response = await handleStripeWebhook(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      received: true,
+      duplicate: true,
+    });
+    expect(mocks.syncCanonicalShopBilling).not.toHaveBeenCalled();
+    expect(mocks.complete).not.toHaveBeenCalled();
+  });
+
+  it("asks Stripe to retry a concurrent delivery until the active claim completes", async () => {
+    const event = subscriptionEvent("evt_p1012_in_progress");
+    mocks.constructEvent.mockReturnValue(event);
+    mocks.claim.mockResolvedValue({
+      claimed: false,
+      alreadyProcessed: false,
+      inProgress: true,
+      claimToken: null,
+      attemptCount: 1,
+    });
+
+    const { handleStripeWebhook } =
+      await import("../features/stripe/api/stripe/webhook/route");
+    const response = await handleStripeWebhook(request());
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get("Retry-After")).toBe("300");
+    await expect(response.json()).resolves.toEqual({
+      received: false,
+      retry: true,
+    });
+    expect(mocks.syncCanonicalShopBilling).not.toHaveBeenCalled();
+    expect(mocks.complete).not.toHaveBeenCalled();
+    expect(mocks.fail).not.toHaveBeenCalled();
+  });
+
+  it("completes a claimed event after applying a timestamped subscription snapshot", async () => {
+    const event = subscriptionEvent("evt_p1012_claimed");
+    mocks.constructEvent.mockReturnValue(event);
+    mocks.claim.mockResolvedValue({
+      claimed: true,
+      alreadyProcessed: false,
+      inProgress: false,
+      claimToken: "7a100000-0000-4000-8000-000000000001",
+      attemptCount: 1,
+    });
+
+    const { handleStripeWebhook } =
+      await import("../features/stripe/api/stripe/webhook/route");
+    const response = await handleStripeWebhook(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.syncCanonicalShopBilling).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shopId: SHOP_ID,
+        customerId: "cus_p1012",
+        subscriptionId: "sub_p1012",
+        webhookEvent: {
+          id: event.id,
+          createdAt: new Date(EVENT_CREATED * 1000).toISOString(),
+        },
+      }),
+    );
+    expect(mocks.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: event.id,
+        claimToken: "7a100000-0000-4000-8000-000000000001",
+      }),
+    );
+    expect(mocks.fail).not.toHaveBeenCalled();
+  });
+
+  it("marks a claimed event failed so Stripe can retry it", async () => {
+    const event = subscriptionEvent("evt_p1012_retry");
+    const processingError = new Error("subscription persistence unavailable");
+    mocks.constructEvent.mockReturnValue(event);
+    mocks.claim.mockResolvedValue({
+      claimed: true,
+      alreadyProcessed: false,
+      inProgress: false,
+      claimToken: "7a100000-0000-4000-8000-000000000002",
+      attemptCount: 1,
+    });
+    mocks.syncCanonicalShopBilling.mockRejectedValue(processingError);
+
+    const { handleStripeWebhook } =
+      await import("../features/stripe/api/stripe/webhook/route");
+    const response = await handleStripeWebhook(request());
+
+    expect(response.status).toBe(500);
+    expect(mocks.complete).not.toHaveBeenCalled();
+    expect(mocks.fail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: event.id,
+        claimToken: "7a100000-0000-4000-8000-000000000002",
+        error: processingError,
+      }),
+    );
+  });
+});

--- a/tests/security/p1-012-stripe-webhook-concurrency.sh
+++ b/tests/security/p1-012-stripe-webhook-concurrency.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DB_URL:?DB_URL is required}"
+
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  psql "$DB_URL" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL' || true
+delete from private.stripe_webhook_event_receipts
+where event_id = 'evt_p1012_concurrent';
+SQL
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+psql "$DB_URL" -X -v ON_ERROR_STOP=1 >/dev/null <<'SQL'
+delete from private.stripe_webhook_event_receipts
+where event_id = 'evt_p1012_concurrent';
+SQL
+
+psql "$DB_URL" -X -qAt -F '|' -v ON_ERROR_STOP=1 >"$tmp_dir/worker-a.txt" <<'SQL' &
+begin;
+set local role service_role;
+select claimed, already_processed, in_progress, attempt_count
+from public.claim_stripe_webhook_event(
+  'evt_p1012_concurrent',
+  'customer.subscription.updated',
+  true,
+  '',
+  'sub_p1012concurrent',
+  '2026-07-27T02:00:00Z'::timestamptz,
+  300
+);
+select pg_sleep(3);
+commit;
+SQL
+worker_a_pid=$!
+
+sleep 1
+
+psql "$DB_URL" -X -qAt -F '|' -v ON_ERROR_STOP=1 >"$tmp_dir/worker-b.txt" <<'SQL'
+begin;
+set local role service_role;
+select claimed, already_processed, in_progress, attempt_count
+from public.claim_stripe_webhook_event(
+  'evt_p1012_concurrent',
+  'customer.subscription.updated',
+  true,
+  '',
+  'sub_p1012concurrent',
+  '2026-07-27T02:00:00Z'::timestamptz,
+  300
+);
+commit;
+SQL
+
+wait "$worker_a_pid"
+
+worker_a_result="$(grep -E '^[tf]\|[tf]\|[tf]\|[0-9]+$' "$tmp_dir/worker-a.txt" | head -n 1)"
+worker_b_result="$(grep -E '^[tf]\|[tf]\|[tf]\|[0-9]+$' "$tmp_dir/worker-b.txt" | head -n 1)"
+
+test "$worker_a_result" = "t|f|f|1"
+test "$worker_b_result" = "f|f|t|1"
+
+echo "P1-012 concurrent webhook delivery produced one claim: $worker_a_result / $worker_b_result"

--- a/tests/security/p1-012-stripe-webhook-receipts.runtime.sql
+++ b/tests/security/p1-012-stripe-webhook-receipts.runtime.sql
@@ -1,0 +1,348 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+do $$
+declare
+  v_signature text;
+begin
+  foreach v_signature in array array[
+    'public.claim_stripe_webhook_event(text,text,boolean,text,text,timestamptz,integer)',
+    'public.complete_stripe_webhook_event(text,uuid)',
+    'public.fail_stripe_webhook_event(text,uuid,text)',
+    'public.apply_stripe_subscription_webhook_snapshot(uuid,text,text,text,timestamptz,jsonb)'
+  ]
+  loop
+    if has_function_privilege('anon', v_signature, 'EXECUTE')
+       or has_function_privilege('authenticated', v_signature, 'EXECUTE')
+       or not has_function_privilege('service_role', v_signature, 'EXECUTE') then
+      raise exception 'P1-012 runtime assertion failed: unsafe function ACL for %', v_signature;
+    end if;
+  end loop;
+
+  if has_table_privilege('anon', 'private.stripe_webhook_event_receipts', 'SELECT')
+     or has_table_privilege('authenticated', 'private.stripe_webhook_event_receipts', 'SELECT')
+     or has_table_privilege('service_role', 'private.stripe_webhook_event_receipts', 'SELECT')
+     or has_table_privilege('anon', 'private.stripe_subscription_event_watermarks', 'SELECT')
+     or has_table_privilege('authenticated', 'private.stripe_subscription_event_watermarks', 'SELECT')
+     or has_table_privilege('service_role', 'private.stripe_subscription_event_watermarks', 'SELECT') then
+    raise exception 'P1-012 runtime assertion failed: private Stripe ledgers are directly exposed';
+  end if;
+end
+$$;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values (
+  '8a100000-0000-4000-8000-000000000001',
+  'p1-012-owner@example.com',
+  '{"full_name":"P1-012 Owner"}'::jsonb
+)
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name, shop_id)
+values (
+  '8a100000-0000-4000-8000-000000000001',
+  '8a100000-0000-4000-8000-000000000001',
+  'owner',
+  'P1-012 Owner',
+  null
+)
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name,
+    shop_id = excluded.shop_id;
+
+insert into public.shops (id, owner_id, business_name, name, user_limit)
+values (
+  '8b100000-0000-4000-8000-000000000001',
+  '8a100000-0000-4000-8000-000000000001',
+  'P1-012 Shop',
+  'P1-012 Shop',
+  3
+)
+on conflict (id) do nothing;
+
+set local role service_role;
+
+do $$
+declare
+  v_claimed boolean;
+  v_processed boolean;
+  v_in_progress boolean;
+  v_token_a uuid;
+  v_token_b uuid;
+  v_attempts integer;
+  v_ok boolean;
+begin
+  select claimed, already_processed, in_progress, claim_token, attempt_count
+  into v_claimed, v_processed, v_in_progress, v_token_a, v_attempts
+  from public.claim_stripe_webhook_event(
+    'evt_p1012_receipt',
+    'customer.subscription.updated',
+    true,
+    '',
+    'sub_p1012receipt',
+    '2026-07-27T02:00:00Z'::timestamptz,
+    300
+  );
+  if not v_claimed or v_processed or v_in_progress or v_token_a is null or v_attempts <> 1 then
+    raise exception 'P1-012 runtime assertion failed: first Stripe event claim was invalid';
+  end if;
+
+  select claimed, already_processed, in_progress, claim_token, attempt_count
+  into v_claimed, v_processed, v_in_progress, v_token_b, v_attempts
+  from public.claim_stripe_webhook_event(
+    'evt_p1012_receipt',
+    'customer.subscription.updated',
+    true,
+    '',
+    'sub_p1012receipt',
+    '2026-07-27T02:00:00Z'::timestamptz,
+    300
+  );
+  if v_claimed or v_processed or not v_in_progress or v_token_b is not null or v_attempts <> 1 then
+    raise exception 'P1-012 runtime assertion failed: concurrent delivery was claimable twice';
+  end if;
+
+  select public.fail_stripe_webhook_event(
+    'evt_p1012_receipt',
+    v_token_a,
+    'simulated transient failure'
+  ) into v_ok;
+  if not v_ok then
+    raise exception 'P1-012 runtime assertion failed: claimed event could not be failed';
+  end if;
+
+  select claimed, already_processed, in_progress, claim_token, attempt_count
+  into v_claimed, v_processed, v_in_progress, v_token_b, v_attempts
+  from public.claim_stripe_webhook_event(
+    'evt_p1012_receipt',
+    'customer.subscription.updated',
+    true,
+    '',
+    'sub_p1012receipt',
+    '2026-07-27T02:00:00Z'::timestamptz,
+    300
+  );
+  if not v_claimed or v_processed or v_in_progress or v_token_b is null
+     or v_token_b = v_token_a or v_attempts <> 2 then
+    raise exception 'P1-012 runtime assertion failed: failed Stripe event was not safely reclaimable';
+  end if;
+
+  select public.complete_stripe_webhook_event(
+    'evt_p1012_receipt',
+    v_token_b
+  ) into v_ok;
+  if not v_ok then
+    raise exception 'P1-012 runtime assertion failed: claimed Stripe event could not complete';
+  end if;
+
+  select claimed, already_processed, in_progress, claim_token, attempt_count
+  into v_claimed, v_processed, v_in_progress, v_token_a, v_attempts
+  from public.claim_stripe_webhook_event(
+    'evt_p1012_receipt',
+    'customer.subscription.updated',
+    true,
+    '',
+    'sub_p1012receipt',
+    '2026-07-27T02:00:00Z'::timestamptz,
+    300
+  );
+  if v_claimed or not v_processed or v_in_progress or v_token_a is not null or v_attempts <> 2 then
+    raise exception 'P1-012 runtime assertion failed: processed Stripe event was replayed';
+  end if;
+
+  begin
+    perform public.claim_stripe_webhook_event(
+      'evt_p1012_receipt',
+      'customer.subscription.deleted',
+      true,
+      '',
+      'sub_p1012receipt',
+      '2026-07-27T02:00:00Z'::timestamptz,
+      300
+    );
+    raise exception 'P1-012 runtime assertion failed: conflicting event metadata was accepted';
+  exception
+    when invalid_parameter_value then null;
+  end;
+end
+$$;
+
+do $$
+declare
+  v_applied boolean;
+  v_shop public.shops%rowtype;
+begin
+  select public.apply_stripe_subscription_webhook_snapshot(
+    '8b100000-0000-4000-8000-000000000001',
+    'cus_p1012shop',
+    'sub_p1012shop',
+    'evt_p1012_subscription_new',
+    '2026-07-27T02:00:00Z'::timestamptz,
+    '{
+      "stripe_subscription_status":"active",
+      "stripe_trial_end":null,
+      "stripe_current_period_end":"2026-08-27T02:00:00Z",
+      "plan":"pro",
+      "stripe_checkout_session_id":"cs_p1012shop"
+    }'::jsonb
+  ) into v_applied;
+  if not v_applied then
+    raise exception 'P1-012 runtime assertion failed: first subscription snapshot was rejected';
+  end if;
+
+  select public.apply_stripe_subscription_webhook_snapshot(
+    '8b100000-0000-4000-8000-000000000001',
+    'cus_p1012shop',
+    'sub_p1012shop',
+    'evt_p1012_subscription_old',
+    '2026-07-27T01:00:00Z'::timestamptz,
+    '{
+      "stripe_subscription_status":"canceled",
+      "stripe_trial_end":null,
+      "stripe_current_period_end":"2026-07-27T01:00:00Z",
+      "plan":"starter",
+      "stripe_checkout_session_id":null
+    }'::jsonb
+  ) into v_applied;
+  if v_applied then
+    raise exception 'P1-012 runtime assertion failed: stale subscription snapshot was applied';
+  end if;
+
+  select * into v_shop
+  from public.shops
+  where id = '8b100000-0000-4000-8000-000000000001';
+  if v_shop.stripe_subscription_status <> 'active'
+     or v_shop.plan <> 'pro'
+     or v_shop.stripe_subscription_id <> 'sub_p1012shop' then
+    raise exception 'P1-012 runtime assertion failed: stale event changed canonical billing';
+  end if;
+
+  select public.apply_stripe_subscription_webhook_snapshot(
+    '8b100000-0000-4000-8000-000000000001',
+    'cus_p1012shop',
+    'sub_p1012shop',
+    'evt_p1012_subscription_new',
+    '2026-07-27T02:00:00Z'::timestamptz,
+    '{
+      "stripe_subscription_status":"active",
+      "stripe_trial_end":null,
+      "stripe_current_period_end":"2026-08-27T02:00:00Z",
+      "plan":"pro",
+      "stripe_checkout_session_id":"cs_p1012shop"
+    }'::jsonb
+  ) into v_applied;
+  if not v_applied then
+    raise exception 'P1-012 runtime assertion failed: same-event retry was not idempotent';
+  end if;
+
+  select public.apply_stripe_subscription_webhook_snapshot(
+    '8b100000-0000-4000-8000-000000000001',
+    'cus_p1012shop',
+    'sub_p1012shop',
+    'evt_p1012_subscription_latest',
+    '2026-07-27T03:00:00Z'::timestamptz,
+    '{
+      "stripe_subscription_status":"canceled",
+      "stripe_trial_end":null,
+      "stripe_current_period_end":"2026-07-27T03:00:00Z",
+      "plan":"starter",
+      "stripe_checkout_session_id":null
+    }'::jsonb
+  ) into v_applied;
+  if not v_applied then
+    raise exception 'P1-012 runtime assertion failed: newer subscription snapshot was rejected';
+  end if;
+
+  select * into v_shop
+  from public.shops
+  where id = '8b100000-0000-4000-8000-000000000001';
+  if v_shop.stripe_subscription_status <> 'canceled'
+     or v_shop.plan <> 'starter' then
+    raise exception 'P1-012 runtime assertion failed: newest billing state was not canonical';
+  end if;
+
+  select public.apply_stripe_subscription_webhook_snapshot(
+    '8b100000-0000-4000-8000-000000000001',
+    'cus_p1012shop',
+    'sub_p1012other',
+    'evt_p1012_wrong_subscription',
+    '2026-07-27T04:00:00Z'::timestamptz,
+    '{"stripe_subscription_status":"active","plan":"unlimited"}'::jsonb
+  ) into v_applied;
+  if v_applied then
+    raise exception 'P1-012 runtime assertion failed: different subscription replaced shop billing identity';
+  end if;
+end
+$$;
+
+reset role;
+
+do $$
+declare
+  v_claimed boolean;
+  v_processed boolean;
+  v_in_progress boolean;
+  v_token_a uuid;
+  v_token_b uuid;
+  v_attempts integer;
+  v_status text;
+  v_deliveries integer;
+  v_watermark_event text;
+begin
+  select claimed, already_processed, in_progress, claim_token, attempt_count
+  into v_claimed, v_processed, v_in_progress, v_token_a, v_attempts
+  from public.claim_stripe_webhook_event(
+    'evt_p1012_abandoned',
+    'customer.subscription.updated',
+    true,
+    '',
+    'sub_p1012abandoned',
+    '2026-07-27T02:30:00Z'::timestamptz,
+    30
+  );
+  if not v_claimed or v_processed or v_in_progress
+     or v_token_a is null or v_attempts <> 1 then
+    raise exception 'P1-012 runtime assertion failed: abandoned-lease fixture was not claimed';
+  end if;
+
+  update private.stripe_webhook_event_receipts
+  set claimed_at = now() - interval '31 seconds'
+  where event_id = 'evt_p1012_abandoned';
+
+  select claimed, already_processed, in_progress, claim_token, attempt_count
+  into v_claimed, v_processed, v_in_progress, v_token_b, v_attempts
+  from public.claim_stripe_webhook_event(
+    'evt_p1012_abandoned',
+    'customer.subscription.updated',
+    true,
+    '',
+    'sub_p1012abandoned',
+    '2026-07-27T02:30:00Z'::timestamptz,
+    30
+  );
+  if not v_claimed or v_processed or v_in_progress or v_token_b is null
+     or v_token_b = v_token_a or v_attempts <> 2 then
+    raise exception 'P1-012 runtime assertion failed: abandoned Stripe claim was not safely reclaimed';
+  end if;
+
+  select status, attempt_count, delivery_count
+  into v_status, v_attempts, v_deliveries
+  from private.stripe_webhook_event_receipts
+  where event_id = 'evt_p1012_receipt';
+  if v_status <> 'processed' or v_attempts <> 2 or v_deliveries <> 4 then
+    raise exception 'P1-012 runtime assertion failed: durable receipt history is inconsistent';
+  end if;
+
+  select event_id into v_watermark_event
+  from private.stripe_subscription_event_watermarks
+  where subscription_id = 'sub_p1012shop';
+  if v_watermark_event <> 'evt_p1012_subscription_latest' then
+    raise exception 'P1-012 runtime assertion failed: subscription watermark is not monotonic';
+  end if;
+end
+$$;
+
+rollback;

--- a/tests/support/p1-012-next-server.ts
+++ b/tests/support/p1-012-next-server.ts
@@ -1,0 +1,5 @@
+export const NextResponse = {
+  json(body: unknown, init?: ResponseInit): Response {
+    return Response.json(body, init);
+  },
+};

--- a/tsconfig.p1-012.json
+++ b/tsconfig.p1-012.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "include": [
+    "next-env.d.ts",
+    "app/api/stripe/webhook/route.ts",
+    "app/api/stripe/checkout/webhook/route.ts",
+    "features/shared/types/types/supabase.ts",
+    "features/stripe/api/stripe/webhook/route.ts",
+    "features/stripe/lib/server/canonical-shop-billing.ts",
+    "features/stripe/lib/server/stripe-webhook-receipts.ts",
+    "tests/p1-012-stripe-webhook-idempotency.test.ts",
+    "tests/p1-012-stripe-subscription-ordering.test.ts",
+    "tests/support/p1-012-next-server.ts",
+    "vitest.p1-012.config.ts"
+  ]
+}

--- a/vitest.p1-012.config.ts
+++ b/vitest.p1-012.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL(".", import.meta.url));
+
+const config = {
+  resolve: {
+    alias: [
+      {
+        find: "next/server",
+        replacement: fileURLToPath(
+          new URL("./tests/support/p1-012-next-server.ts", import.meta.url),
+        ),
+      },
+      { find: "@", replacement: repositoryRoot },
+    ],
+  },
+  test: {
+    environment: "node",
+    include: [
+      "tests/p0-006-stripe-identity.test.ts",
+      "tests/p1-012-stripe-*.test.ts",
+    ],
+    setupFiles: [],
+  },
+};
+
+export default config;


### PR DESCRIPTION
## What changed

- adds a private, durable Stripe webhook receipt ledger with atomic claim, completion, failure, retry, and abandoned-lease handling
- acknowledges completed duplicate deliveries without repeating side effects
- returns a retryable non-success response while another delivery still owns the active claim
- applies subscription billing snapshots through a monotonic event watermark so older events cannot replace newer canonical state
- restricts all new database functions to the service role and keeps receipt/watermark tables private
- documents the single intended Stripe dashboard endpoint: `/api/stripe/webhook`
- adds focused route, ordering, authorization, clean-database, and concurrent-delivery verification

## Root cause

The canonical webhook handler processed verified Stripe events without first recording a durable event receipt. Stripe retries and out-of-order subscription delivery could therefore repeat side effects or overwrite newer billing state.

## Impact

Webhook replays are now idempotent at the event boundary, abandoned work can be retried safely, and subscription state changes are ordered before they update a shop's canonical billing record. Existing checkout and billing behavior is preserved outside the webhook-specific path.

## Validation

- focused TypeScript check passed: `tsc --noEmit -p tsconfig.p1-012.json`
- focused ESLint passed
- focused Vitest suite passed: 3 files, 14 tests
- `git diff --check` passed
- clean Supabase replay, SQL authorization assertions, abandoned-lease recovery, and concurrent claim tests are wired into GitHub Actions

## Before merge

- require the Supabase Clean Replay and P1-012 Stripe Webhook Validation checks to pass
- verify the Stripe dashboard registers exactly one production webhook URL ending in `/api/stripe/webhook`
- do not run the production migration until this PR is merged and all required checks are green

## Known unrelated baseline

The repository-wide TypeScript check still reports existing React/PDF/dashboard errors outside this change; the P1-012 focused typecheck is clean.