### PR TITLE
Fix work-order source-of-truth review regressions

### DIFF
--- a/.github/workflows/phase-6-technician-mobile-reliability.yml
+++ b/.github/workflows/phase-6-technician-mobile-reliability.yml
@@ -5,10 +5,19 @@ on:
     paths:
       - "features/shared/lib/offline/**"
       - "features/work-orders/lib/jobPunchTransitionsClient.ts"
+      - "features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts"
+      - "features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.test.ts"
+      - "features/work-orders/lib/display/workOrderParts.ts"
+      - "features/work-orders/lib/display/linePresentation.test.ts"
+      - "features/work-orders/mobile/MobileWorkOrderClient.tsx"
+      - "app/api/offline/technician-work-orders/route.ts"
+      - "app/work-orders/[id]/Client.tsx"
       - "features/inspections/lib/inspection/save.ts"
       - "app/api/inspections/save/route.ts"
       - "supabase/migrations/20260715070*.sql"
       - "tests/phase6-*.test.ts"
+      - "tests/technician-offline-download.test.ts"
+      - "tests/work-order-cross-device-source-of-truth.test.ts"
       - ".github/workflows/phase-6-technician-mobile-reliability.yml"
   workflow_dispatch:
 
@@ -31,6 +40,13 @@ jobs:
           pnpm exec eslint
           features/shared/lib/offline/mutations.ts
           features/work-orders/lib/jobPunchTransitionsClient.ts
+          features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts
+          features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.test.ts
+          features/work-orders/lib/display/workOrderParts.ts
+          features/work-orders/lib/display/linePresentation.test.ts
+          features/work-orders/mobile/MobileWorkOrderClient.tsx
+          app/api/offline/technician-work-orders/route.ts
+          app/work-orders/[id]/Client.tsx
           features/inspections/lib/inspection/save.ts
           app/api/inspections/save/route.ts
           tests/phase6-job-punch-client.test.ts
@@ -38,6 +54,8 @@ jobs:
           tests/phase6-inspection-progress-route.test.ts
           tests/phase6-inspection-progress-sql-contract.test.ts
           tests/phase6-job-photo-evidence-sql-contract.test.ts
+          tests/technician-offline-download.test.ts
+          tests/work-order-cross-device-source-of-truth.test.ts
       - run: >-
           pnpm exec vitest run
           tests/phase6-job-punch-client.test.ts
@@ -45,3 +63,7 @@ jobs:
           tests/phase6-inspection-progress-route.test.ts
           tests/phase6-inspection-progress-sql-contract.test.ts
           tests/phase6-job-photo-evidence-sql-contract.test.ts
+          features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.test.ts
+          features/work-orders/lib/display/linePresentation.test.ts
+          tests/technician-offline-download.test.ts
+          tests/work-order-cross-device-source-of-truth.test.ts

--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -244,6 +244,20 @@ jobs:
           bash tests/security/p1-012-stripe-webhook-concurrency.sh \
             2>&1 | tee p1-012-stripe-webhook-concurrency.log
 
+      - name: Execute customer portal work-order parts policy integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/work-order-parts-portal-policy.runtime.sql \
+            2>&1 | tee work-order-parts-portal-policy-runtime.log
+
       - name: Execute P0 schema reconciliation integration
         shell: bash
         env:
@@ -340,6 +354,7 @@ jobs:
             p0-007-financial-outbox-concurrency.log
             p1-012-stripe-webhook-receipts-runtime.log
             p1-012-stripe-webhook-concurrency.log
+            work-order-parts-portal-policy-runtime.log
             p0-008-schema-reconciliation-runtime.log
             p0-008-generated-types.diff
             generated-supabase-types.ts

--- a/app/api/offline/technician-work-orders/route.ts
+++ b/app/api/offline/technician-work-orders/route.ts
@@ -12,8 +12,10 @@ import type {
   TechnicianOfflineWorkOrder,
 } from "@/features/work-orders/mobile/technicianOfflineTypes";
 import {
+  collectTechnicianIdsForLineContexts,
   emptyCanonicalWorkOrderLineContext,
   loadCanonicalWorkOrderLineContexts,
+  loadRowsForIdChunks,
 } from "@/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext";
 
 type DB = Database;
@@ -68,30 +70,42 @@ export async function GET() {
   }
 
   const admin = createAdminSupabase();
-  const [
-    { data: directlyAssigned, error: directError },
-    { data: sharedAssigned, error: sharedError },
-  ] = await Promise.all([
-    admin
-      .from("work_order_lines")
-      .select("id, work_order_id")
-      .eq("shop_id", profile.shop_id)
-      .eq("line_type", "job")
-      .or(
-        `assigned_tech_id.eq.${user.id},assigned_to.eq.${user.id},user_id.eq.${user.id}`,
+  let directlyAssigned: Array<{ id: string; work_order_id: string }>;
+  let sharedAssigned: Array<{ work_order_line_id: string }>;
+  try {
+    [directlyAssigned, sharedAssigned] = await Promise.all([
+      loadRowsForIdChunks<{ id: string; work_order_id: string }>(
+        [user.id],
+        ([technicianId], from, to) =>
+          admin
+            .from("work_order_lines")
+            .select("id, work_order_id")
+            .eq("shop_id", profile.shop_id)
+            .eq("line_type", "job")
+            .or(
+              `assigned_tech_id.eq.${technicianId},assigned_to.eq.${technicianId},user_id.eq.${technicianId}`,
+            )
+            .order("id", { ascending: true })
+            .range(from, to),
       ),
-    admin
-      .from("work_order_line_technicians")
-      .select("work_order_line_id")
-      .eq("technician_id", user.id),
-  ]);
-  if (directError || sharedError) {
+      loadRowsForIdChunks<{ work_order_line_id: string }>(
+        [user.id],
+        (technicianIds, from, to) =>
+          admin
+            .from("work_order_line_technicians")
+            .select("work_order_line_id")
+            .in("technician_id", technicianIds)
+            .order("work_order_line_id", { ascending: true })
+            .range(from, to),
+      ),
+    ]);
+  } catch (error) {
     return NextResponse.json(
       {
         error:
-          directError?.message ??
-          sharedError?.message ??
-          "Assignments could not be loaded.",
+          error instanceof Error
+            ? error.message
+            : "Assignments could not be loaded.",
       },
       { status: 500 },
     );
@@ -100,22 +114,31 @@ export async function GET() {
   const sharedLineIds = (sharedAssigned ?? []).map(
     (row) => row.work_order_line_id,
   );
-  const { data: sharedLines, error: sharedLinesError } = sharedLineIds.length
-    ? await admin
+  let sharedLines: Array<{ id: string; work_order_id: string }>;
+  try {
+    sharedLines = await loadRowsForIdChunks(sharedLineIds, (ids, from, to) =>
+      admin
         .from("work_order_lines")
         .select("id, work_order_id")
         .eq("shop_id", profile.shop_id)
         .eq("line_type", "job")
-        .in("id", sharedLineIds)
-    : { data: [], error: null };
-  if (sharedLinesError) {
+        .in("id", ids)
+        .order("id", { ascending: true })
+        .range(from, to),
+    );
+  } catch (error) {
     return NextResponse.json(
-      { error: sharedLinesError.message },
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Shared assignments could not be loaded.",
+      },
       { status: 500 },
     );
   }
 
-  const assignedRows = [...(directlyAssigned ?? []), ...(sharedLines ?? [])];
+  const assignedRows = [...directlyAssigned, ...sharedLines];
   const assignedLineIds = new Set(assignedRows.map((row) => row.id));
   const workOrderIds = [
     ...new Set(assignedRows.map((row) => row.work_order_id).filter(Boolean)),
@@ -177,78 +200,74 @@ export async function GET() {
   const customerIds = [
     ...new Set(workOrders.map((row) => row.customer_id).filter(Boolean)),
   ] as string[];
-  const [linesResult, quotesResult, vehiclesResult, customersResult, shopResult] =
-    await Promise.all([
-      authClient
-        .from("work_order_lines")
-        .select("*")
-        .eq("shop_id", profile.shop_id)
-        .in("work_order_id", allowedWorkOrderIds)
-        .order("created_at"),
-      authClient
-        .from("work_order_quote_lines")
-        .select("*")
-        .in("work_order_id", allowedWorkOrderIds)
-        .order("created_at"),
-      vehicleIds.length
-        ? authClient
-            .from("vehicles")
-            .select("*")
-            .eq("shop_id", profile.shop_id)
-            .in("id", vehicleIds)
-        : Promise.resolve({ data: [], error: null }),
-      customerIds.length
-        ? authClient
-            .from("customers")
-            .select("*")
-            .eq("shop_id", profile.shop_id)
-            .in("id", customerIds)
-        : Promise.resolve({ data: [], error: null }),
-      authClient
-        .from("shops")
-        .select("labor_rate")
-        .eq("id", profile.shop_id)
-        .maybeSingle<{ labor_rate: number | null }>(),
+  const shopResultPromise = authClient
+    .from("shops")
+    .select("labor_rate")
+    .eq("id", profile.shop_id)
+    .maybeSingle<{ labor_rate: number | null }>();
+  let lines: WorkOrderLine[];
+  let quoteLines: QuoteLine[];
+  let vehicles: Vehicle[];
+  let customers: Customer[];
+  try {
+    [lines, quoteLines, vehicles, customers] = await Promise.all([
+      loadRowsForIdChunks<WorkOrderLine>(allowedWorkOrderIds, (ids, from, to) =>
+        authClient
+          .from("work_order_lines")
+          .select("*")
+          .eq("shop_id", profile.shop_id)
+          .in("work_order_id", ids)
+          .order("created_at", { ascending: true })
+          .order("id", { ascending: true })
+          .range(from, to),
+      ),
+      loadRowsForIdChunks<QuoteLine>(allowedWorkOrderIds, (ids, from, to) =>
+        authClient
+          .from("work_order_quote_lines")
+          .select("*")
+          .in("work_order_id", ids)
+          .order("created_at", { ascending: true })
+          .order("id", { ascending: true })
+          .range(from, to),
+      ),
+      loadRowsForIdChunks<Vehicle>(vehicleIds, (ids, from, to) =>
+        authClient
+          .from("vehicles")
+          .select("*")
+          .eq("shop_id", profile.shop_id)
+          .in("id", ids)
+          .order("id", { ascending: true })
+          .range(from, to),
+      ),
+      loadRowsForIdChunks<Customer>(customerIds, (ids, from, to) =>
+        authClient
+          .from("customers")
+          .select("*")
+          .eq("shop_id", profile.shop_id)
+          .in("id", ids)
+          .order("id", { ascending: true })
+          .range(from, to),
+      ),
     ]);
-  const supportingReadError =
-    linesResult.error ??
-    quotesResult.error ??
-    vehiclesResult.error ??
-    customersResult.error ??
-    shopResult.error;
-  if (supportingReadError) {
+  } catch (error) {
     return NextResponse.json(
-      { error: supportingReadError.message },
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Offline supporting records could not be loaded.",
+      },
       { status: 500 },
     );
   }
 
-  const lines = (linesResult.data ?? []) as WorkOrderLine[];
-  const quoteLines = (quotesResult.data ?? []) as QuoteLine[];
-  const vehicles = (vehiclesResult.data ?? []) as Vehicle[];
-  const customers = (customersResult.data ?? []) as Customer[];
-  const techIds = [
-    ...new Set(lines.map((line) => line.assigned_tech_id).filter(Boolean)),
-  ] as string[];
-  const { data: technicians, error: techniciansError } = techIds.length
-    ? await authClient
-        .from("profiles")
-        .select("id, full_name")
-        .eq("shop_id", profile.shop_id)
-        .in("id", techIds)
-    : { data: [], error: null };
-  if (techniciansError) {
+  const shopResult = await shopResultPromise;
+  if (shopResult.error) {
     return NextResponse.json(
-      { error: techniciansError.message },
+      { error: shopResult.error.message },
       { status: 500 },
     );
   }
-  const techNamesById = Object.fromEntries(
-    (technicians ?? []).map((technician) => [
-      technician.id,
-      technician.full_name ?? "Technician",
-    ]),
-  );
 
   let lineContextsByWorkOrder = new Map<
     string,
@@ -276,6 +295,39 @@ export async function GET() {
       { status: 500 },
     );
   }
+
+  const techIds = collectTechnicianIdsForLineContexts(
+    lineContextsByWorkOrder.values(),
+    lines.map((line) => line.assigned_tech_id),
+  );
+  let technicians: Array<{ id: string; full_name: string | null }>;
+  try {
+    technicians = await loadRowsForIdChunks(techIds, (ids, from, to) =>
+      authClient
+        .from("profiles")
+        .select("id, full_name")
+        .eq("shop_id", profile.shop_id)
+        .in("id", ids)
+        .order("id", { ascending: true })
+        .range(from, to),
+    );
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Technician names could not be loaded.",
+      },
+      { status: 500 },
+    );
+  }
+  const techNamesById = Object.fromEntries(
+    technicians.map((technician) => [
+      technician.id,
+      technician.full_name ?? "Technician",
+    ]),
+  );
 
   const shopLaborRate =
     typeof shopResult.data?.labor_rate === "number"

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -35,6 +35,7 @@ import { deriveEventsFromWorkOrder } from "@/features/shared/lib/decisionEvents"
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
 import {
+  getPartsRequestDisplayState,
   getPartsRequestStatusLabel,
   loadCanonicalWorkOrderLineContext,
   type CanonicalWorkOrderPartRow as WorkOrderPartRow,
@@ -115,22 +116,14 @@ function isCompletedLineStatus(status: string | null | undefined): boolean {
 }
 
 function partsRequestActionLabel(requests: PartRequestRow[]): string {
-  if (requests.length === 0) return "Request all parts";
-  const statuses = new Set(
-    requests.map((request) => String(request.status ?? "requested").toLowerCase()),
-  );
-  if (statuses.has("fulfilled")) return "Parts handed off";
-  if (
-    statuses.has("approved") ||
-    statuses.has("partially_ordered") ||
-    statuses.has("partially_consumed") ||
-    statuses.has("partially_returned")
-  ) {
-    return "Open Pick / Order";
+  switch (getPartsRequestDisplayState(requests)) {
+    case "none": return "Request all parts";
+    case "pick_order": return "Open Pick / Order";
+    case "awaiting_approval": return "Awaiting approval";
+    case "requested": return "Parts requested";
+    case "handoff": return "Parts handed off";
+    case "history": return "View parts history";
   }
-  if (statuses.has("quoted")) return "Awaiting approval";
-  if (statuses.has("rejected") || statuses.has("cancelled")) return "View parts history";
-  return "Parts requested";
 }
 
 /** Normalize “where is the inspection template id stored for this line?” */
@@ -270,8 +263,7 @@ export default function WorkOrderIdClient(): JSX.Element {
     Array<Pick<Profile, "id" | "full_name" | "role">>
   >([]);
 
-  // per-line technicians
-  const [lineTechsByLine, setLineTechsByLine] = useState<Record<string, string[]>>({});
+  const [activeTechsByLine, setActiveTechsByLine] = useState<Record<string, string[]>>({});
 
   // ✅ AI review state for status icons
   const [, setReviewChecked] = useState<boolean>(false);
@@ -537,7 +529,7 @@ export default function WorkOrderIdClient(): JSX.Element {
             setAllocsByLine({});
             setStagedPartsByLine({});
             setPartRequestsByQuoteLine({});
-            setLineTechsByLine({});
+            setActiveTechsByLine({});
           }
 
           // ✅ reset review state
@@ -691,7 +683,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           });
           setAllocsByLine(lineContext.allocationsByLine);
           setStagedPartsByLine(lineContext.canonicalPartsByLine);
-          setLineTechsByLine(lineContext.technicianIdsByLine);
+          setActiveTechsByLine(lineContext.activeTechnicianIdsByLine);
           setPartRequestsByQuoteLine(lineContext.partRequestsByQuoteLine);
           setPartRequestsByLine(lineContext.partRequestsByLine);
         } else {
@@ -699,7 +691,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           setStagedPartsByLine({});
           setPartRequestsByQuoteLine({});
           setPartRequestsByLine({});
-          setLineTechsByLine({});
+          setActiveTechsByLine({});
         }
 
         // ✅ load latest AI invoice review (drives status icons in JobCard)
@@ -785,6 +777,16 @@ export default function WorkOrderIdClient(): JSX.Element {
           event: "*",
           schema: "public",
           table: "work_order_line_technicians",
+        },
+        () => fetchAll(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "work_order_line_labor_segments",
+          filter: `work_order_id=eq.${wo.id}`,
         },
         () => fetchAll(),
       )
@@ -1042,17 +1044,14 @@ export default function WorkOrderIdClient(): JSX.Element {
     });
 
     const activeForCurrentTech = baseSorted.find((line) => {
-      const punchedIn = Boolean(line.punched_in_at) && !line.punched_out_at;
+      const activeTechnicianIds = activeTechsByLine[line.id] ?? [];
+      const punchedIn =
+        activeTechnicianIds.length > 0 ||
+        (Boolean(line.punched_in_at) && !line.punched_out_at);
       if (!punchedIn || isCompletedLineStatus(line.status)) return false;
 
       if (!currentUserId) return true;
-
-      const assignedTechId =
-        typeof (line as { assigned_tech_id?: string | null }).assigned_tech_id === "string"
-          ? (line as { assigned_tech_id?: string | null }).assigned_tech_id
-          : null;
-      const linkedTechIds = lineTechsByLine[line.id] ?? [];
-      return assignedTechId === currentUserId || linkedTechIds.includes(currentUserId);
+      return activeTechnicianIds.includes(currentUserId);
     });
 
     const pinnedActiveId = activeForCurrentTech?.id ?? null;
@@ -1067,7 +1066,7 @@ export default function WorkOrderIdClient(): JSX.Element {
       return [activeForCurrentTech, ...nonCompleted, ...completed];
     }
     return [...nonCompleted, ...completed];
-  }, [activeJobLines, currentUserId, lineTechsByLine]);
+  }, [activeJobLines, activeTechsByLine, currentUserId]);
 
   useEffect(() => {
     if (!prefersPanel) return;
@@ -1918,7 +1917,10 @@ export default function WorkOrderIdClient(): JSX.Element {
               ) : (
                 <div className="space-y-2.5">
                   {sortedLines.map((ln, idx) => {
-                    const punchedIn = !!ln.punched_in_at && !ln.punched_out_at;
+                    const activeTechnicianIds = activeTechsByLine[ln.id] ?? [];
+                    const punchedIn =
+                      activeTechnicianIds.length > 0 ||
+                      (!!ln.punched_in_at && !ln.punched_out_at);
 
                     const allocPartsForLine = allocsByLine[ln.id] ?? [];
                     const stagedForLine = stagedPartsByLine[ln.id] ?? [];
@@ -1942,33 +1944,19 @@ export default function WorkOrderIdClient(): JSX.Element {
 
                     const partsForLine = [...allocPartsForLine, ...stagedAsAllocShape];
 
-                    const lineTechIds = lineTechsByLine[ln.id] ?? [];
-                    const primaryId =
-                      typeof (ln as unknown as { assigned_tech_id?: string | null }).assigned_tech_id === "string"
-                        ? (ln as unknown as { assigned_tech_id?: string | null }).assigned_tech_id
-                        : null;
-
-                    const orderedTechIds: string[] = [];
-                    if (primaryId) orderedTechIds.push(primaryId);
-                    lineTechIds.forEach((tid) => {
-                      if (!orderedTechIds.includes(tid)) orderedTechIds.push(tid);
-                    });
-
                     const isPunchedIn = punchedIn;
                     const isCurrentUserWorkingThisLine = Boolean(
                       isPunchedIn &&
                         currentUserId &&
-                        (primaryId === currentUserId || lineTechIds.includes(currentUserId)),
+                        activeTechnicianIds.includes(currentUserId),
                     );
-                    const activeTechnicianNames = isPunchedIn
-                      ? orderedTechIds
-                          .map(
-                            (techId) =>
-                              assignables.find((tech) => tech.id === techId)?.full_name?.trim() ??
-                              null,
-                          )
-                          .filter((name): name is string => Boolean(name))
-                      : [];
+                    const activeTechnicianNames = activeTechnicianIds
+                      .map(
+                        (techId) =>
+                          assignables.find((tech) => tech.id === techId)?.full_name?.trim() ??
+                          null,
+                      )
+                      .filter((name): name is string => Boolean(name));
                     const isSelectedForPanel = panelLineId === ln.id;
                     const linePartRequests = partRequestsByLine[ln.id] ?? [];
                     const hasRequestableParts =

--- a/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.test.ts
+++ b/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildCanonicalWorkOrderLineContext,
+  collectTechnicianIdsForLineContexts,
+  getPartsRequestDisplayState,
   getPartsRequestStatusLabel,
+  loadRowsForIdChunks,
   type CanonicalWorkOrderPartRow,
   type WorkOrderAllocationRow,
+  type WorkOrderLineLaborSegmentRow,
   type WorkOrderLineTechnicianRow,
   type WorkOrderPartRequestRow,
 } from "./loadCanonicalWorkOrderLineContext";
@@ -60,6 +64,18 @@ describe("canonical work-order line context", () => {
       allocations: [allocation],
       canonicalParts: [activePart, inactivePart],
       technicians,
+      activeLaborSegments: [
+        {
+          technician_id: "tech-1",
+          work_order_line_id: "brake-fluid-line",
+          ended_at: null,
+        },
+        {
+          technician_id: "inactive-tech",
+          work_order_line_id: "brake-fluid-line",
+          ended_at: "2026-07-26T20:00:00.000Z",
+        },
+      ] as WorkOrderLineLaborSegmentRow[],
       partRequests: requests,
     });
 
@@ -68,6 +84,9 @@ describe("canonical work-order line context", () => {
       activePart,
     ]);
     expect(context.technicianIdsByLine["brake-fluid-line"]).toEqual(["tech-1"]);
+    expect(context.activeTechnicianIdsByLine["brake-fluid-line"]).toEqual([
+      "tech-1",
+    ]);
     expect(context.partRequestsByLine["brake-fluid-line"]).toEqual(requests);
     expect(context.partRequestsByQuoteLine["quote-1"]).toEqual([requests[0]]);
     expect(
@@ -97,6 +116,13 @@ describe("canonical work-order line context", () => {
           work_order_line_id: "other-line",
         },
       ],
+      activeLaborSegments: [
+        {
+          technician_id: "other-tech",
+          work_order_line_id: "other-line",
+          ended_at: null,
+        },
+      ],
       partRequests: [
         {
           id: "other-request",
@@ -111,6 +137,93 @@ describe("canonical work-order line context", () => {
     expect(context.allocationsByLine).toEqual({});
     expect(context.canonicalPartsByLine).toEqual({});
     expect(context.technicianIdsByLine).toEqual({});
+    expect(context.activeTechnicianIdsByLine).toEqual({});
     expect(context.partRequestsByLine).toEqual({});
   });
+
+  it.each([
+    ["requested", "requested", "Parts requested"],
+    ["quoted", "awaiting_approval", "Awaiting approval"],
+    ["approved", "pick_order", "Pick / order active"],
+  ] as const)(
+    "prefers an outstanding %s request over fulfilled history",
+    (activeStatus, displayState, label) => {
+      const requests = [
+        {
+          id: "fulfilled",
+          work_order_id: "wo",
+          job_id: "line",
+          quote_line_id: null,
+          status: "fulfilled",
+        },
+        {
+          id: "active",
+          work_order_id: "wo",
+          job_id: "line",
+          quote_line_id: null,
+          status: activeStatus,
+        },
+      ] as WorkOrderPartRequestRow[];
+
+      expect(getPartsRequestDisplayState(requests)).toBe(displayState);
+      expect(getPartsRequestStatusLabel(requests)).toBe(label);
+    },
+  );
+
+  it("collects primary, shared, and actively working technician IDs", () => {
+    const context = emptyContextWithTechnicians({
+      shared: ["shared-tech"],
+      active: ["active-tech"],
+    });
+
+    expect(
+      collectTechnicianIdsForLineContexts(
+        [context],
+        ["primary-tech", "shared-tech", null],
+      ),
+    ).toEqual(["primary-tech", "shared-tech", "active-tech"]);
+  });
+
+  it("paginates every ID chunk until all rows are loaded", async () => {
+    const rowsById: Record<string, Array<{ id: string }>> = {
+      a: Array.from({ length: 5 }, (_, index) => ({ id: `a-${index}` })),
+      b: Array.from({ length: 4 }, (_, index) => ({ id: `b-${index}` })),
+      c: Array.from({ length: 3 }, (_, index) => ({ id: `c-${index}` })),
+    };
+    const calls: Array<{ ids: string[]; from: number; to: number }> = [];
+
+    const rows = await loadRowsForIdChunks(
+      ["a", "b", "c", "a"],
+      async (ids, from, to) => {
+        calls.push({ ids, from, to });
+        const chunkRows = ids.flatMap((id) => rowsById[id] ?? []);
+        return { data: chunkRows.slice(from, to + 1), error: null };
+      },
+      { idChunkSize: 2, pageSize: 3 },
+    );
+
+    expect(rows).toHaveLength(12);
+    expect(calls).toEqual([
+      { ids: ["a", "b"], from: 0, to: 2 },
+      { ids: ["a", "b"], from: 3, to: 5 },
+      { ids: ["a", "b"], from: 6, to: 8 },
+      { ids: ["a", "b"], from: 9, to: 11 },
+      { ids: ["c"], from: 0, to: 2 },
+      { ids: ["c"], from: 3, to: 5 },
+    ]);
+  });
 });
+
+function emptyContextWithTechnicians(input: {
+  shared: string[];
+  active: string[];
+}) {
+  return {
+    allocationsByLine: {},
+    canonicalPartsByLine: {},
+    technicianIdsByLine: { line: input.shared },
+    activeTechnicianIdsByLine: { line: input.active },
+    partRequestsByLine: {},
+    partRequestsByQuoteLine: {},
+  };
+}

--- a/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts
+++ b/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts
@@ -30,10 +30,16 @@ export type WorkOrderLineTechnicianRow = Pick<
   "work_order_line_id" | "technician_id"
 >;
 
+export type WorkOrderLineLaborSegmentRow = Pick<
+  DB["public"]["Tables"]["work_order_line_labor_segments"]["Row"],
+  "work_order_line_id" | "technician_id" | "ended_at"
+>;
+
 export type CanonicalWorkOrderLineContext = {
   allocationsByLine: Record<string, WorkOrderAllocationRow[]>;
   canonicalPartsByLine: Record<string, CanonicalWorkOrderPartRow[]>;
   technicianIdsByLine: Record<string, string[]>;
+  activeTechnicianIdsByLine: Record<string, string[]>;
   partRequestsByLine: Record<string, WorkOrderPartRequestRow[]>;
   partRequestsByQuoteLine: Record<string, WorkOrderPartRequestRow[]>;
 };
@@ -43,6 +49,7 @@ export function emptyCanonicalWorkOrderLineContext(): CanonicalWorkOrderLineCont
     allocationsByLine: {},
     canonicalPartsByLine: {},
     technicianIdsByLine: {},
+    activeTechnicianIdsByLine: {},
     partRequestsByLine: {},
     partRequestsByQuoteLine: {},
   };
@@ -53,6 +60,7 @@ export function buildCanonicalWorkOrderLineContext(input: {
   allocations: WorkOrderAllocationRow[];
   canonicalParts: CanonicalWorkOrderPartRow[];
   technicians: WorkOrderLineTechnicianRow[];
+  activeLaborSegments: WorkOrderLineLaborSegmentRow[];
   partRequests: WorkOrderPartRequestRow[];
 }): CanonicalWorkOrderLineContext {
   const lineIds = new Set(input.lineIds);
@@ -79,6 +87,15 @@ export function buildCanonicalWorkOrderLineContext(input: {
     }
   }
 
+  for (const segment of input.activeLaborSegments) {
+    const lineId = segment.work_order_line_id;
+    if (!lineIds.has(lineId) || segment.ended_at) continue;
+    const ids = (result.activeTechnicianIdsByLine[lineId] ??= []);
+    if (!ids.includes(segment.technician_id)) {
+      ids.push(segment.technician_id);
+    }
+  }
+
   for (const request of input.partRequests) {
     if (request.job_id && lineIds.has(request.job_id)) {
       (result.partRequestsByLine[request.job_id] ??= []).push(request);
@@ -93,29 +110,116 @@ export function buildCanonicalWorkOrderLineContext(input: {
   return result;
 }
 
-export function getPartsRequestStatusLabel(
+export type PartsRequestDisplayState =
+  | "none"
+  | "pick_order"
+  | "awaiting_approval"
+  | "requested"
+  | "handoff"
+  | "history";
+
+export function getPartsRequestDisplayState(
   requests: WorkOrderPartRequestRow[],
-): string | null {
-  if (requests.length === 0) return null;
+): PartsRequestDisplayState {
+  if (requests.length === 0) return "none";
   const statuses = new Set(
     requests.map((request) =>
       String(request.status ?? "requested").toLowerCase(),
     ),
   );
-  if (statuses.has("fulfilled")) return "Parts handed off";
   if (
     statuses.has("approved") ||
     statuses.has("partially_ordered") ||
     statuses.has("partially_consumed") ||
     statuses.has("partially_returned")
   ) {
-    return "Pick / order active";
+    return "pick_order";
   }
-  if (statuses.has("quoted")) return "Awaiting approval";
-  if (statuses.has("rejected") || statuses.has("cancelled")) {
-    return "Parts history recorded";
+  if (statuses.has("quoted")) return "awaiting_approval";
+  if (statuses.has("requested")) return "requested";
+  if (statuses.has("fulfilled")) return "handoff";
+  return statuses.size > 0 ? "history" : "requested";
+}
+
+export function getPartsRequestStatusLabel(
+  requests: WorkOrderPartRequestRow[],
+): string | null {
+  switch (getPartsRequestDisplayState(requests)) {
+    case "none":
+      return null;
+    case "pick_order":
+      return "Pick / order active";
+    case "awaiting_approval":
+      return "Awaiting approval";
+    case "requested":
+      return "Parts requested";
+    case "handoff":
+      return "Parts handed off";
+    case "history":
+      return "Parts history recorded";
   }
-  return "Parts requested";
+}
+
+export function collectTechnicianIdsForLineContexts(
+  contexts: Iterable<CanonicalWorkOrderLineContext>,
+  primaryTechnicianIds: Iterable<string | null | undefined> = [],
+): string[] {
+  const technicianIds = new Set<string>();
+  for (const technicianId of primaryTechnicianIds) {
+    if (technicianId) technicianIds.add(technicianId);
+  }
+  for (const context of contexts) {
+    for (const technicianId of Object.values(
+      context.technicianIdsByLine,
+    ).flat()) {
+      technicianIds.add(technicianId);
+    }
+    for (const technicianId of Object.values(
+      context.activeTechnicianIdsByLine ?? {},
+    ).flat()) {
+      technicianIds.add(technicianId);
+    }
+  }
+  return [...technicianIds];
+}
+
+type PaginatedReadResult<T> = {
+  data: T[] | null;
+  error: { message: string } | null;
+};
+
+export async function loadRowsForIdChunks<T>(
+  ids: string[],
+  fetchPage: (
+    chunkIds: string[],
+    from: number,
+    to: number,
+  ) => PromiseLike<PaginatedReadResult<T>>,
+  options: { idChunkSize?: number; pageSize?: number } = {},
+): Promise<T[]> {
+  const uniqueIds = [...new Set(ids.filter(Boolean))];
+  if (uniqueIds.length === 0) return [];
+
+  const idChunkSize = Math.max(1, options.idChunkSize ?? 100);
+  const pageSize = Math.max(1, options.pageSize ?? 500);
+  const rows: T[] = [];
+
+  for (
+    let chunkStart = 0;
+    chunkStart < uniqueIds.length;
+    chunkStart += idChunkSize
+  ) {
+    const chunkIds = uniqueIds.slice(chunkStart, chunkStart + idChunkSize);
+    for (let from = 0; ; from += pageSize) {
+      const result = await fetchPage(chunkIds, from, from + pageSize - 1);
+      if (result.error) throw new Error(result.error.message);
+      const page = result.data ?? [];
+      rows.push(...page);
+      if (page.length < pageSize) break;
+    }
+  }
+
+  return rows;
 }
 
 export async function loadCanonicalWorkOrderLineContexts(input: {
@@ -138,50 +242,77 @@ export async function loadCanonicalWorkOrderLineContexts(input: {
     );
   }
 
-  const [allocationsResult, partsResult, techniciansResult, requestsResult] =
-    await Promise.all([
-      input.supabase
-        .from("work_order_part_allocations")
-        .select("*, parts(name)")
-        .eq("shop_id", input.shopId)
-        .in("work_order_id", workOrderIds)
-        .in("work_order_line_id", lineIds)
-        .order("created_at", { ascending: true }),
-      input.supabase
-        .from("work_order_parts")
-        .select("*, parts(name, sku, part_number, manufacturer, supplier)")
-        .eq("shop_id", input.shopId)
-        .eq("is_active", true)
-        .in("work_order_id", workOrderIds)
-        .in("work_order_line_id", lineIds)
-        .order("created_at", { ascending: true }),
+  const [
+    allocations,
+    canonicalParts,
+    technicians,
+    activeLaborSegments,
+    partRequests,
+  ] = await Promise.all([
+    loadRowsForIdChunks<WorkOrderAllocationRow>(
+      lineIds,
+      (ids, from, to) =>
+        input.supabase
+          .from("work_order_part_allocations")
+          .select("*, parts(name)")
+          .eq("shop_id", input.shopId)
+          .in("work_order_line_id", ids)
+          .order("created_at", { ascending: true })
+          .order("id", { ascending: true })
+          .range(from, to) as unknown as PromiseLike<
+          PaginatedReadResult<WorkOrderAllocationRow>
+        >,
+    ),
+    loadRowsForIdChunks<CanonicalWorkOrderPartRow>(
+      lineIds,
+      (ids, from, to) =>
+        input.supabase
+          .from("work_order_parts")
+          .select("*, parts(name, sku, part_number, manufacturer, supplier)")
+          .eq("shop_id", input.shopId)
+          .eq("is_active", true)
+          .in("work_order_line_id", ids)
+          .order("created_at", { ascending: true })
+          .order("id", { ascending: true })
+          .range(from, to) as unknown as PromiseLike<
+          PaginatedReadResult<CanonicalWorkOrderPartRow>
+        >,
+    ),
+    loadRowsForIdChunks<WorkOrderLineTechnicianRow>(lineIds, (ids, from, to) =>
       input.supabase
         .from("work_order_line_technicians")
         .select("work_order_line_id, technician_id")
-        .in("work_order_line_id", lineIds),
-      input.supabase
-        .from("part_requests")
-        .select("id, work_order_id, quote_line_id, job_id, status")
-        .eq("shop_id", input.shopId)
-        .in("work_order_id", workOrderIds)
-        .order("created_at", { ascending: true }),
-    ]);
-
-  const error =
-    allocationsResult.error ??
-    partsResult.error ??
-    techniciansResult.error ??
-    requestsResult.error;
-  if (error) throw new Error(error.message);
-
-  const allocations =
-    (allocationsResult.data as WorkOrderAllocationRow[] | null) ?? [];
-  const canonicalParts =
-    (partsResult.data as CanonicalWorkOrderPartRow[] | null) ?? [];
-  const technicians =
-    (techniciansResult.data as WorkOrderLineTechnicianRow[] | null) ?? [];
-  const partRequests =
-    (requestsResult.data as WorkOrderPartRequestRow[] | null) ?? [];
+        .in("work_order_line_id", ids)
+        .order("work_order_line_id", { ascending: true })
+        .order("technician_id", { ascending: true })
+        .range(from, to),
+    ),
+    loadRowsForIdChunks<WorkOrderLineLaborSegmentRow>(
+      lineIds,
+      (ids, from, to) =>
+        input.supabase
+          .from("work_order_line_labor_segments")
+          .select("work_order_line_id, technician_id, ended_at")
+          .eq("shop_id", input.shopId)
+          .is("ended_at", null)
+          .in("work_order_line_id", ids)
+          .order("started_at", { ascending: true })
+          .order("id", { ascending: true })
+          .range(from, to),
+    ),
+    loadRowsForIdChunks<WorkOrderPartRequestRow>(
+      workOrderIds,
+      (ids, from, to) =>
+        input.supabase
+          .from("part_requests")
+          .select("id, work_order_id, quote_line_id, job_id, status")
+          .eq("shop_id", input.shopId)
+          .in("work_order_id", ids)
+          .order("created_at", { ascending: true })
+          .order("id", { ascending: true })
+          .range(from, to),
+    ),
+  ]);
 
   return new Map(
     workOrders.map((workOrder) => {
@@ -197,6 +328,9 @@ export async function loadCanonicalWorkOrderLineContexts(input: {
             (row) => row.work_order_id === workOrder.workOrderId,
           ),
           technicians: technicians.filter((row) =>
+            scopedLineIds.has(row.work_order_line_id),
+          ),
+          activeLaborSegments: activeLaborSegments.filter((row) =>
             scopedLineIds.has(row.work_order_line_id),
           ),
           partRequests: partRequests.filter(
@@ -217,9 +351,7 @@ export async function loadCanonicalWorkOrderLineContext(input: {
   const contexts = await loadCanonicalWorkOrderLineContexts({
     supabase: input.supabase,
     shopId: input.shopId,
-    workOrders: [
-      { workOrderId: input.workOrderId, lineIds: input.lineIds },
-    ],
+    workOrders: [{ workOrderId: input.workOrderId, lineIds: input.lineIds }],
   });
   return (
     contexts.get(input.workOrderId) ?? emptyCanonicalWorkOrderLineContext()

--- a/features/work-orders/lib/display/linePresentation.test.ts
+++ b/features/work-orders/lib/display/linePresentation.test.ts
@@ -132,18 +132,19 @@ describe("linePresentation", () => {
     expect(activeParts.reduce((sum, part) => sum + getCanonicalPartTotal(part), 0)).toBeCloseTo(1636.81, 2);
   });
 
-  it("does not double-count allocations backed by canonical request items and does not require allocation for display", () => {
+  it("does not double-count allocations linked to canonical parts or request items", () => {
     const canonicalParts = [
-      { source_parts_request_item_id: "request-item-1" },
-      { source_parts_request_item_id: "request-item-2" },
+      { id: "canonical-direct", source_parts_request_item_id: null },
+      { id: "canonical-request", source_parts_request_item_id: "request-item-1" },
     ];
     const allocations = [
-      { source_request_item_id: "request-item-1", qty: 1, unit_cost: 260.47 },
-      { source_request_item_id: null, qty: 1, unit_cost: 20 },
+      { work_order_part_id: null, source_request_item_id: "request-item-1", qty: 1, unit_cost: 260.47 },
+      { work_order_part_id: "canonical-direct", source_request_item_id: null, qty: 1, unit_cost: 50 },
+      { work_order_part_id: null, source_request_item_id: null, qty: 1, unit_cost: 20 },
     ];
 
     expect(filterAllocationsNotBackedByCanonicalParts(allocations, canonicalParts)).toEqual([
-      { source_request_item_id: null, qty: 1, unit_cost: 20 },
+      { work_order_part_id: null, source_request_item_id: null, qty: 1, unit_cost: 20 },
     ]);
   });
 });

--- a/features/work-orders/lib/display/workOrderParts.ts
+++ b/features/work-orders/lib/display/workOrderParts.ts
@@ -2,7 +2,6 @@ import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type WorkOrderPart = DB["public"]["Tables"]["work_order_parts"]["Row"];
-type WorkOrderPartAllocation = DB["public"]["Tables"]["work_order_part_allocations"]["Row"];
 
 export type CanonicalWorkOrderPart = WorkOrderPart & {
   id: string;
@@ -61,18 +60,30 @@ export function activeCanonicalWorkOrderParts(parts: CanonicalWorkOrderPart[]): 
   return parts.filter((part) => part.is_active !== false);
 }
 
-export function filterAllocationsNotBackedByCanonicalParts<T extends Pick<WorkOrderPartAllocation, "source_request_item_id">>(
+export function filterAllocationsNotBackedByCanonicalParts<T extends {
+  source_request_item_id?: string | null;
+  work_order_part_id?: string | null;
+}>(
   allocations: T[],
-  canonicalParts: Array<{ source_parts_request_item_id?: string | null }>,
+  canonicalParts: Array<{ id?: string | null; source_parts_request_item_id?: string | null }>,
 ): T[] {
+  const canonicalPartIds = new Set(
+    canonicalParts
+      .map((part) => part.id ?? null)
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
+  );
   const canonicalSourceItemIds = new Set(
     canonicalParts
       .map((part) => part.source_parts_request_item_id ?? null)
       .filter((id): id is string => typeof id === "string" && id.length > 0),
   );
-  if (canonicalSourceItemIds.size === 0) return allocations;
+  if (canonicalPartIds.size === 0 && canonicalSourceItemIds.size === 0) return allocations;
   return allocations.filter((allocation) => {
+    const workOrderPartId = allocation.work_order_part_id ?? null;
     const sourceItemId = allocation.source_request_item_id ?? null;
-    return !sourceItemId || !canonicalSourceItemIds.has(sourceItemId);
+    return !(
+      (workOrderPartId && canonicalPartIds.has(workOrderPartId)) ||
+      (sourceItemId && canonicalSourceItemIds.has(sourceItemId))
+    );
   });
 }

--- a/features/work-orders/mobile/MobileWorkOrderClient.tsx
+++ b/features/work-orders/mobile/MobileWorkOrderClient.tsx
@@ -32,6 +32,7 @@ import { isReviewableQuoteLine } from "@/features/work-orders/lib/quotes/reviewa
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
 import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
 import {
+  collectTechnicianIdsForLineContexts,
   emptyCanonicalWorkOrderLineContext,
   getPartsRequestStatusLabel,
   loadCanonicalWorkOrderLineContext,
@@ -519,13 +520,9 @@ export default function MobileWorkOrderClient({
         setShopLaborRate(freshShopLaborRate);
 
         // Populate names for every visible primary or shared assignment.
-        const techIds = Array.from(
-          new Set(
-            [
-              ...lineRows.map((line) => line.assigned_tech_id),
-              ...Object.values(freshLineContext.technicianIdsByLine).flat(),
-            ].filter((id): id is string => Boolean(id)),
-          ),
+        const techIds = collectTechnicianIdsForLineContexts(
+          [freshLineContext],
+          lineRows.map((line) => line.assigned_tech_id),
         );
 
         const techMap: Record<string, string> = {};
@@ -697,6 +694,16 @@ export default function MobileWorkOrderClient({
           event: "*",
           schema: "public",
           table: "work_order_line_technicians",
+        },
+        () => fetchAll(),
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "work_order_line_labor_segments",
+          filter: `work_order_id=eq.${wo.id}`,
         },
         () => fetchAll(),
       )
@@ -1630,7 +1637,11 @@ export default function MobileWorkOrderClient({
             ) : (
               <div className="space-y-2">
                 {displayLines.map((ln, idx) => {
-                  const punchedIn = !!ln.punched_in_at && !ln.punched_out_at;
+                  const activeTechnicianIds =
+                    lineContext.activeTechnicianIdsByLine?.[ln.id] ?? [];
+                  const punchedIn =
+                    activeTechnicianIds.length > 0 ||
+                    (!!ln.punched_in_at && !ln.punched_out_at);
 
                   const openFocused = () => {
                     setFocusedJobId(ln.id);
@@ -1651,11 +1662,9 @@ export default function MobileWorkOrderClient({
                   const pricing = pricingByLine[ln.id];
                   const partRequests =
                     lineContext.partRequestsByLine[ln.id] ?? [];
-                  const activeTechnicianNames = punchedIn
-                    ? technicianIds
-                        .map((id) => techNamesById[id])
-                        .filter((name): name is string => Boolean(name))
-                    : [];
+                  const activeTechnicianNames = activeTechnicianIds
+                    .map((id) => techNamesById[id])
+                    .filter((name): name is string => Boolean(name));
 
                   return (
                     <div
@@ -1676,7 +1685,7 @@ export default function MobileWorkOrderClient({
                         isCurrentUserWorkingThisLine={Boolean(
                           punchedIn &&
                             currentUserId &&
-                            technicianIds.includes(currentUserId),
+                            activeTechnicianIds.includes(currentUserId),
                         )}
                         activeTechnicianNames={activeTechnicianNames}
                         onOpen={openFocused}

--- a/supabase/migrations/20260727030911_restore_work_order_parts_portal_policy.sql
+++ b/supabase/migrations/20260727030911_restore_work_order_parts_portal_policy.sql
@@ -1,0 +1,18 @@
+begin;
+
+alter table public.work_order_parts enable row level security;
+
+drop policy if exists work_order_parts_customer_portal_select
+  on public.work_order_parts;
+
+create policy work_order_parts_customer_portal_select
+  on public.work_order_parts
+  for select
+  to authenticated
+  using (
+    public.profixiq_is_portal_customer_work_order(work_order_id)
+  );
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/security/work-order-parts-portal-policy.runtime.sql
+++ b/tests/security/work-order-parts-portal-policy.runtime.sql
@@ -1,0 +1,234 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values
+  (
+    '91000000-0000-4000-8000-000000000001',
+    'portal-policy-owner-a@example.com',
+    '{"full_name":"Portal Policy Owner A"}'::jsonb
+  ),
+  (
+    '92000000-0000-4000-8000-000000000002',
+    'portal-policy-owner-b@example.com',
+    '{"full_name":"Portal Policy Owner B"}'::jsonb
+  ),
+  (
+    '93000000-0000-4000-8000-000000000003',
+    'portal-policy-customer-a@example.com',
+    '{}'::jsonb
+  ),
+  (
+    '94000000-0000-4000-8000-000000000004',
+    'portal-policy-customer-b@example.com',
+    '{}'::jsonb
+  )
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values
+  (
+    '91000000-0000-4000-8000-000000000001',
+    '91000000-0000-4000-8000-000000000001',
+    'owner',
+    'Portal Policy Owner A'
+  ),
+  (
+    '92000000-0000-4000-8000-000000000002',
+    '92000000-0000-4000-8000-000000000002',
+    'owner',
+    'Portal Policy Owner B'
+  )
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+delete from public.profiles
+where id in (
+  '93000000-0000-4000-8000-000000000003',
+  '94000000-0000-4000-8000-000000000004'
+);
+
+insert into public.shops (id, owner_id, business_name, name, plan, user_limit)
+values
+  (
+    'a9100000-0000-4000-8000-000000000001',
+    '91000000-0000-4000-8000-000000000001',
+    'Portal Policy Shop A',
+    'Portal Policy Shop A',
+    'complete_10',
+    1
+  ),
+  (
+    'b9200000-0000-4000-8000-000000000002',
+    '92000000-0000-4000-8000-000000000002',
+    'Portal Policy Shop B',
+    'Portal Policy Shop B',
+    'complete_10',
+    1
+  )
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = case id
+  when '91000000-0000-4000-8000-000000000001'::uuid
+    then 'a9100000-0000-4000-8000-000000000001'::uuid
+  else 'b9200000-0000-4000-8000-000000000002'::uuid
+end
+where id in (
+  '91000000-0000-4000-8000-000000000001',
+  '92000000-0000-4000-8000-000000000002'
+);
+
+insert into public.customers (id, shop_id, user_id, name, email)
+values
+  (
+    'ca100000-0000-4000-8000-000000000001',
+    'a9100000-0000-4000-8000-000000000001',
+    '93000000-0000-4000-8000-000000000003',
+    'Portal Customer A',
+    'portal-policy-customer-a@example.com'
+  ),
+  (
+    'cb200000-0000-4000-8000-000000000002',
+    'b9200000-0000-4000-8000-000000000002',
+    '94000000-0000-4000-8000-000000000004',
+    'Portal Customer B',
+    'portal-policy-customer-b@example.com'
+  )
+on conflict (id) do update
+set shop_id = excluded.shop_id,
+    user_id = excluded.user_id,
+    name = excluded.name,
+    email = excluded.email;
+
+insert into public.work_orders (id, shop_id, customer_id, status)
+values
+  (
+    'ea100000-0000-4000-8000-000000000001',
+    'a9100000-0000-4000-8000-000000000001',
+    'ca100000-0000-4000-8000-000000000001',
+    'open'
+  ),
+  (
+    'eb200000-0000-4000-8000-000000000002',
+    'b9200000-0000-4000-8000-000000000002',
+    'cb200000-0000-4000-8000-000000000002',
+    'open'
+  )
+on conflict (id) do update
+set shop_id = excluded.shop_id,
+    customer_id = excluded.customer_id,
+    status = excluded.status;
+
+insert into public.work_order_parts (id, shop_id, work_order_id, description_snapshot)
+values
+  (
+    'fa100000-0000-4000-8000-000000000001',
+    'a9100000-0000-4000-8000-000000000001',
+    'ea100000-0000-4000-8000-000000000001',
+    'Portal-visible part A'
+  ),
+  (
+    'fb200000-0000-4000-8000-000000000002',
+    'b9200000-0000-4000-8000-000000000002',
+    'eb200000-0000-4000-8000-000000000002',
+    'Other-shop part B'
+  )
+on conflict (id) do update
+set shop_id = excluded.shop_id,
+    work_order_id = excluded.work_order_id,
+    description_snapshot = excluded.description_snapshot;
+
+insert into public.customer_portal_invites (
+  id,
+  shop_id,
+  customer_id,
+  email,
+  token,
+  accepted_at,
+  accepted_by_user_id,
+  revoked_at
+)
+values
+  (
+    'da100000-0000-4000-8000-000000000001',
+    'a9100000-0000-4000-8000-000000000001',
+    'ca100000-0000-4000-8000-000000000001',
+    'portal-policy-customer-a@example.com',
+    'portal-policy-token-a',
+    now(),
+    '93000000-0000-4000-8000-000000000003',
+    null
+  ),
+  (
+    'db200000-0000-4000-8000-000000000002',
+    'b9200000-0000-4000-8000-000000000002',
+    'cb200000-0000-4000-8000-000000000002',
+    'portal-policy-customer-b@example.com',
+    'portal-policy-token-b',
+    now(),
+    '94000000-0000-4000-8000-000000000004',
+    null
+  )
+on conflict (id) do update
+set accepted_at = excluded.accepted_at,
+    accepted_by_user_id = excluded.accepted_by_user_id,
+    revoked_at = excluded.revoked_at;
+
+do $portal_policy$
+begin
+  if exists (
+    select 1
+    from public.profiles
+    where id in (
+      '93000000-0000-4000-8000-000000000003',
+      '94000000-0000-4000-8000-000000000004'
+    )
+  ) then
+    raise exception 'Portal policy fixture must not have staff profiles';
+  end if;
+end
+$portal_policy$;
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"93000000-0000-4000-8000-000000000003","role":"authenticated"}',
+  true
+);
+
+do $portal_policy$
+declare
+  visible_ids uuid[];
+begin
+  select array_agg(id order by id)
+  into visible_ids
+  from public.work_order_parts;
+
+  if visible_ids is distinct from array[
+    'fa100000-0000-4000-8000-000000000001'::uuid
+  ] then
+    raise exception 'Portal-only customer saw the wrong work-order parts: %', visible_ids;
+  end if;
+end
+$portal_policy$;
+
+reset role;
+update public.customer_portal_invites
+set revoked_at = now()
+where id = 'da100000-0000-4000-8000-000000000001';
+
+set local role authenticated;
+do $portal_policy$
+begin
+  if exists (select 1 from public.work_order_parts) then
+    raise exception 'Revoked portal invite still grants work-order part access';
+  end if;
+end
+$portal_policy$;
+
+reset role;
+rollback;

--- a/tests/technician-offline-download.test.ts
+++ b/tests/technician-offline-download.test.ts
@@ -13,10 +13,10 @@ describe("technician assigned-work offline download", () => {
   it("authenticates the actor and resolves only their shop assignments", () => {
     expect(route).toContain("auth.getUser()");
     expect(route).toContain("canPerformAssignedWork");
-    expect(route).toContain("assigned_tech_id.eq.${user.id}");
-    expect(route).toContain("assigned_to.eq.${user.id}");
+    expect(route).toContain("assigned_tech_id.eq.${technicianId}");
+    expect(route).toContain("assigned_to.eq.${technicianId}");
     expect(route).toContain('from("work_order_line_technicians")');
-    expect(route).toContain('.eq("technician_id", user.id)');
+    expect(route).toContain('.in("technician_id", technicianIds)');
     expect(route).toContain('.eq("shop_id", profile.shop_id)');
   });
 
@@ -30,10 +30,12 @@ describe("technician assigned-work offline download", () => {
     );
     expect(route).toContain("chunks(workOrderIds)");
     expect(route).not.toContain(".limit(50)");
-    expect(route).toContain("await authClient");
+    expect(route).toContain("loadRowsForIdChunks");
+    expect(route).toContain(".range(from, to)");
     expect(route).toMatch(/authClient\s*\.from\("work_order_lines"\)/);
     expect(route).toMatch(/authClient\s*\.from\("work_order_quote_lines"\)/);
-    expect(route).toContain("quotesResult.error");
+    expect(route).toContain("collectTechnicianIdsForLineContexts");
+    expect(route).toContain("lineContextsByWorkOrder.values()");
     expect(route).toContain('"Cache-Control": "private, no-store"');
   });
 

--- a/tests/work-order-cross-device-source-of-truth.test.ts
+++ b/tests/work-order-cross-device-source-of-truth.test.ts
@@ -14,7 +14,7 @@ const contextLoader = read(
   "features/work-orders/lib/data/loadCanonicalWorkOrderLineContext.ts",
 );
 const migration = read(
-  "supabase/migrations/20260726231759_work_order_detail_source_of_truth.sql",
+  "supabase/migrations/20260727030911_restore_work_order_parts_portal_policy.sql",
 );
 
 describe("cross-device work-order source of truth", () => {
@@ -25,7 +25,10 @@ describe("cross-device work-order source of truth", () => {
     expect(contextLoader).toContain('.from("work_order_part_allocations")');
     expect(contextLoader).toContain('.from("part_requests")');
     expect(contextLoader).toContain('.from("work_order_line_technicians")');
-    expect(contextLoader).toContain('.in("work_order_id", workOrderIds)');
+    expect(contextLoader).toContain('.from("work_order_line_labor_segments")');
+    expect(contextLoader).toContain('.in("work_order_id", ids)');
+    expect(contextLoader).toContain("loadRowsForIdChunks");
+    expect(contextLoader).toContain(".range(from, to)");
     expect(contextLoader).toContain('.eq("shop_id", input.shopId)');
     expect(contextLoader).toContain('.eq("is_active", true)');
   });
@@ -44,6 +47,7 @@ describe("cross-device work-order source of truth", () => {
       "work_order_part_allocations",
       "part_requests",
       "work_order_line_technicians",
+      "work_order_line_labor_segments",
     ]) {
       expect(mobile).toContain(`table: "${table}"`);
     }
@@ -65,17 +69,13 @@ describe("cross-device work-order source of truth", () => {
     );
   });
 
-  it("allows only role-authorized staff or assigned mechanics to read parts", () => {
-    expect(migration).toContain("create policy work_order_parts_role_select");
-    expect(migration).toContain("shop_id = (select public.current_shop_id())");
-    expect(migration).toContain(
-      "(select public.profixiq_current_role()) = 'mechanic'",
-    );
-    expect(migration).toContain("public.profixiq_is_assigned_to_line");
-    expect(migration).toContain("public.profixiq_is_assigned_to_work_order");
+  it("uses the canonical security-definer helper for portal part reads", () => {
     expect(migration).toContain(
       "create policy work_order_parts_customer_portal_select",
     );
-    expect(migration).not.toContain("for update\nto authenticated");
+    expect(migration).toContain(
+      "public.profixiq_is_portal_customer_work_order(work_order_id)",
+    );
+    expect(migration).not.toContain("join public.customers");
   });
 });


### PR DESCRIPTION
## What changed

- deduplicate mobile and desktop pricing for allocations linked directly to canonical work-order parts
- derive active technician labels from open labor segments rather than every assigned technician
- prioritize outstanding parts requests over fulfilled history
- include shared-only technicians in offline name hydration
- paginate assignment discovery and all aggregate offline line-context reads
- restore portal-only `work_order_parts` access through the canonical security-definer authorization helper
- add focused unit/source-contract coverage and clean-database RLS runtime coverage

## Root cause

The work-order detail source-of-truth change handled request-item links but not direct canonical-part links, inferred activity from line-level punch state, ranked fulfilled history above active requests, and performed several aggregate reads without paging. The portal policy also joined through `customers` under nested RLS, which blocks accepted portal customers who do not have staff profiles.

## Impact

This prevents doubled parts totals, misleading active-technician labels, stale handoff statuses, incomplete offline bundles, generic shared-assignee names, and denied portal part reads for legitimate portal-only customers.

## Validation

- focused Vitest: 25/25 passed
- changed-file ESLint: passed
- changed-file TypeScript filtering: no errors
- `git diff --check`: passed
- duplicate migration versions: none

Repository-wide typecheck still reports pre-existing unrelated React/PDF/dashboard errors. The new database runtime test is wired into Supabase Clean Replay and was not run locally because Docker/Supabase Local was unavailable.

## Database

Adds forward migration `20260727030911_restore_work_order_parts_portal_policy.sql`. No existing migration was modified. Do not apply to production until the PR checks are green and the PR is merged.