### PR TITLE
Fix light-mode desktop surfaces and quote review borders

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -112,6 +112,110 @@ html {
   -moz-osx-font-smoothing: grayscale;
 }
 
+@layer components {
+  .desktop-backdrop {
+    background: var(--app-shell-wash);
+  }
+
+  .desktop-panel {
+    border: 1px solid var(--desktop-border);
+    border-radius: var(--theme-radius-xl, 1rem);
+    background: var(--desktop-panel-bg);
+    box-shadow: var(--desktop-shadow-panel);
+    backdrop-filter: blur(18px);
+  }
+
+  .desktop-panel-soft {
+    border: 1px solid var(--desktop-border);
+    border-radius: var(--theme-radius-lg, 0.75rem);
+    background: var(--desktop-panel-bg-soft);
+  }
+
+  .desktop-item-card {
+    border: 1px solid var(--desktop-border);
+    border-radius: var(--theme-radius-xl, 1rem);
+    background: var(--desktop-item-bg);
+    box-shadow: var(--desktop-shadow-card);
+    backdrop-filter: blur(14px);
+  }
+
+  .desktop-toolbar-row {
+    border: 1px solid var(--desktop-border);
+    border-radius: var(--theme-radius-lg, 0.75rem);
+    background: var(--desktop-panel-bg-soft);
+    padding: 0.75rem;
+  }
+
+  .desktop-title {
+    color: var(--theme-text-primary);
+  }
+
+  .desktop-input {
+    border: 1px solid var(--theme-input-border);
+    border-radius: var(--theme-radius-md, 0.5rem);
+    background: var(--theme-input-bg);
+    color: var(--theme-input-text);
+    outline: none;
+    transition: border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+  }
+
+  .desktop-input::placeholder {
+    color: var(--theme-text-muted);
+    opacity: 1;
+  }
+
+  .desktop-input:focus {
+    border-color: color-mix(in srgb, var(--brand-primary) 72%, var(--brand-accent));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-primary) 18%, transparent);
+  }
+
+  .desktop-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    border: 1px solid var(--desktop-border);
+    border-radius: 999px;
+    background: var(--desktop-item-bg);
+    padding: 0.3rem 0.65rem;
+    color: var(--theme-text-secondary);
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+
+  .desktop-pill-active {
+    border-color: var(--desktop-border-strong);
+    background: color-mix(in srgb, var(--brand-primary) 14%, var(--desktop-item-bg));
+    color: var(--theme-text-primary);
+  }
+
+  .desktop-btn-primary,
+  .desktop-btn-secondary {
+    border-radius: var(--theme-radius-md, 0.5rem);
+    transition: border-color 150ms ease, background-color 150ms ease, filter 150ms ease;
+  }
+
+  .desktop-btn-primary {
+    border: 1px solid color-mix(in srgb, var(--brand-primary) 76%, var(--brand-accent));
+    background: var(--theme-button-primary-bg);
+    color: var(--theme-button-primary-text);
+  }
+
+  .desktop-btn-primary:hover {
+    filter: brightness(1.06);
+  }
+
+  .desktop-btn-secondary {
+    border: 1px solid var(--desktop-border);
+    background: var(--desktop-item-bg);
+    color: var(--theme-text-primary);
+  }
+
+  .desktop-btn-secondary:hover {
+    border-color: var(--desktop-border-strong);
+    background: color-mix(in srgb, var(--desktop-item-bg) 82%, var(--theme-surface-hover));
+  }
+}
+
 /* The public marketing site has a deliberate light presentation independent
    of the signed-in application's saved theme preference. */
 .pfq-marketing {
@@ -176,7 +280,7 @@ html[data-theme-mode="light"] {
   /* BrandThemeBoot writes brand values inline, so mode tokens intentionally
      use !important to remain authoritative when the mode changes. */
   --theme-surface-page: #f8fafc !important;
-  --theme-surface-panel: rgba(255, 255, 255, 0.92) !important;
+  --theme-surface-panel: rgba(255, 255, 255, 0.94) !important;
   --theme-surface-panel-strong: #ffffff !important;
   --theme-surface-inset: rgba(226, 232, 240, 0.72) !important;
   --theme-surface-subtle: rgba(37, 99, 235, 0.08) !important;
@@ -192,7 +296,7 @@ html[data-theme-mode="light"] {
     linear-gradient(180deg, #f8fafc, #e2e8f0) !important;
   --theme-gradient-panel:
     radial-gradient(circle at top left, color-mix(in srgb, var(--brand-primary) 7%, transparent), transparent 60%),
-    linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(241, 245, 249, 0.94)) !important;
+    linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(241, 245, 249, 0.96)) !important;
   --theme-gradient-header:
     linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(241, 245, 249, 0.96)) !important;
 
@@ -205,20 +309,51 @@ html[data-theme-mode="light"] {
 
   --theme-sidebar-bg: #e8eef7 !important;
   --theme-sidebar-text: #0f172a !important;
-  --theme-sidebar-active-text: #ffffff;
+  --theme-sidebar-active-bg: var(--brand-primary) !important;
+  --theme-sidebar-active-text: #ffffff !important;
 
-  --theme-header-bg: rgba(255, 255, 255, 0.92) !important;
+  --theme-header-bg: rgba(255, 255, 255, 0.94) !important;
   --theme-header-text: #0f172a !important;
 
-  --theme-card-bg: rgba(255, 255, 255, 0.9) !important;
+  --theme-card-bg: rgba(255, 255, 255, 0.96) !important;
   --theme-card-border: rgba(59, 99, 140, 0.28) !important;
-  --theme-surface-2: rgba(239, 246, 255, 0.8) !important;
+  --theme-surface-2: rgba(239, 246, 255, 0.84) !important;
 
+  --theme-button-primary-bg: var(--brand-primary) !important;
+  --theme-button-primary-text: #ffffff !important;
   --theme-button-secondary-bg: #e2e8f0 !important;
   --theme-button-secondary-text: #0f172a !important;
 
-  --theme-input-bg: rgba(255, 255, 255, 0.94) !important;
-  --theme-input-border: rgba(59, 99, 140, 0.38) !important;
+  --theme-input-bg: rgba(255, 255, 255, 0.98) !important;
+  --theme-input-border: rgba(59, 99, 140, 0.42) !important;
+  --theme-input-text: #0f172a !important;
+
+  --metal-bg: #f8fafc !important;
+  --metal-panel: #ffffff !important;
+  --metal-border-soft: rgba(59, 99, 140, 0.22) !important;
+  --metal-border-strong: rgba(37, 99, 235, 0.34) !important;
+  --glass-bg: rgba(255, 255, 255, 0.82) !important;
+  --glass-bg-soft: rgba(248, 250, 252, 0.74) !important;
+
+  --desktop-bg-base: #f8fafc !important;
+  --desktop-bg-secondary: #eef3f9 !important;
+  --desktop-bg-tint: rgba(23, 71, 255, 0.08) !important;
+  --desktop-panel-bg: linear-gradient(160deg, rgba(255, 255, 255, 0.98), rgba(241, 245, 249, 0.96)) !important;
+  --desktop-panel-bg-soft: rgba(255, 255, 255, 0.9) !important;
+  --desktop-item-bg: rgba(255, 255, 255, 0.96) !important;
+  --desktop-border: rgba(71, 85, 105, 0.24) !important;
+  --desktop-border-strong: rgba(37, 99, 235, 0.38) !important;
+  --desktop-shadow-panel: 0 20px 55px rgba(15, 23, 42, 0.1) !important;
+  --desktop-shadow-card: 0 12px 32px rgba(15, 23, 42, 0.08) !important;
+  --desktop-focus-ring: color-mix(in srgb, #2563eb 72%, #60a5fa) !important;
+  --app-shell-bg:
+    radial-gradient(circle at top, rgba(23, 71, 255, 0.07), transparent 52%),
+    linear-gradient(180deg, #f8fafc, #eef3f9) !important;
+  --app-shell-wash:
+    radial-gradient(1200px 680px at 50% -8%, rgba(23, 71, 255, 0.08), transparent 62%),
+    radial-gradient(950px 620px at 100% 100%, rgba(11, 183, 255, 0.05), transparent 64%) !important;
+
+  color-scheme: light;
 }
 
 /* Some older routes still carry hard-coded white form classes. Normalize all

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import "./light-mode-contrast.css";
 import { Inter, Black_Ops_One } from "next/font/google";
 import Script from "next/script";
 import Providers from "./providers";

--- a/app/light-mode-contrast.css
+++ b/app/light-mode-contrast.css
@@ -1,0 +1,58 @@
+/*
+ * Several operational surfaces use translucent semantic badges that were
+ * originally authored for the dark shell. In light mode, the pastel 100/200
+ * text utilities become nearly invisible. These overrides keep the same badge
+ * meaning while providing readable contrast without changing dark mode.
+ */
+html[data-theme-mode="light"] body .text-sky-100,
+html[data-theme-mode="light"] body .text-sky-200 {
+  color: #075985 !important;
+}
+
+html[data-theme-mode="light"] body .text-blue-100,
+html[data-theme-mode="light"] body .text-blue-200 {
+  color: #1d4ed8 !important;
+}
+
+html[data-theme-mode="light"] body .text-cyan-100,
+html[data-theme-mode="light"] body .text-cyan-200 {
+  color: #0e7490 !important;
+}
+
+html[data-theme-mode="light"] body .text-emerald-100,
+html[data-theme-mode="light"] body .text-emerald-200 {
+  color: #047857 !important;
+}
+
+html[data-theme-mode="light"] body .text-teal-100,
+html[data-theme-mode="light"] body .text-teal-200 {
+  color: #0f766e !important;
+}
+
+html[data-theme-mode="light"] body .text-amber-100,
+html[data-theme-mode="light"] body .text-amber-200 {
+  color: #92400e !important;
+}
+
+html[data-theme-mode="light"] body .text-orange-100,
+html[data-theme-mode="light"] body .text-orange-200,
+html[data-theme-mode="light"] body .text-orange-300 {
+  color: #c2410c !important;
+}
+
+html[data-theme-mode="light"] body .text-red-100,
+html[data-theme-mode="light"] body .text-red-200,
+html[data-theme-mode="light"] body .text-rose-100,
+html[data-theme-mode="light"] body .text-rose-200 {
+  color: #b91c1c !important;
+}
+
+html[data-theme-mode="light"] body .text-purple-100,
+html[data-theme-mode="light"] body .text-purple-200 {
+  color: #6b21a8 !important;
+}
+
+html[data-theme-mode="light"] body .text-indigo-100,
+html[data-theme-mode="light"] body .text-indigo-200 {
+  color: #4338ca !important;
+}

--- a/features/shared/components/ui/StatusBadge.tsx
+++ b/features/shared/components/ui/StatusBadge.tsx
@@ -23,12 +23,15 @@ type StatusBadgeProps = {
 const variantClasses: Record<StatusBadgeVariant, string> = {
   neutral:
     "border-[var(--theme-card-border,var(--theme-border-soft))] bg-[color:color-mix(in_srgb,var(--theme-surface-2,var(--theme-surface-page))_84%,transparent)] text-[var(--theme-text-secondary,var(--theme-text-muted))]",
-  info: "border-sky-500/40 bg-sky-500/10 text-sky-200",
+  info: "border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-200",
   active:
-    "border-sky-400/60 bg-sky-500/10 text-sky-100",
-  warning: "border-amber-500/60 bg-amber-500/10 text-amber-200",
-  success: "border-emerald-500/60 bg-emerald-500/10 text-emerald-200",
-  danger: "border-rose-500/60 bg-rose-500/10 text-rose-200",
+    "border-sky-400/60 bg-sky-500/10 text-sky-700 dark:text-sky-100",
+  warning:
+    "border-amber-500/60 bg-amber-500/10 text-amber-800 dark:text-amber-200",
+  success:
+    "border-emerald-500/60 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
+  danger:
+    "border-rose-500/60 bg-rose-500/10 text-rose-700 dark:text-rose-200",
 };
 
 const sizeClasses: Record<StatusBadgeSize, string> = {


### PR DESCRIPTION
## Root cause

The ProFixIQ Blue theme changed the signed-in semantic tokens, but the older desktop workspace tokens (`--desktop-panel-bg`, `--desktop-panel-bg-soft`, `--desktop-item-bg`, metal/glass tokens, and desktop shadows) remained dark even when the user selected Light mode. Work Orders, Create Work Order, Customers, Vehicles, and other desktop workspaces still consume those tokens, which produced dark cards with dark light-mode text.

Quote Review also relies on shared `desktop-panel`, `desktop-item-card`, `desktop-pill`, and button class names, but those classes did not provide a complete border/background shell on their own. This made the queue appear borderless compared with the other operational pages.

## What changed

- Adds authoritative light-mode overrides for all desktop, metal, glass, input-text, and app-shell surface tokens.
- Defines the shared desktop panel, soft panel, item card, toolbar, input, pill, and button primitives in one place.
- Restores visible borders, radii, backgrounds, and shadows to PageShell and Quote Review surfaces.
- Keeps dark mode on the existing ProFixIQ navy treatment.
- Adds light-mode semantic contrast safeguards for existing translucent status badges.
- Makes the shared StatusBadge variants explicitly readable in both light and dark modes.

## Important boundary

This does **not** restore the broad light-mode native form override that was reverted in PR #1245. The fix is limited to theme tokens and the existing shared desktop primitives, so it does not force unrelated surfaces into a different mode.

## Validation recommended

- Verify Work Orders list and loading cards in Light and Dark modes.
- Verify Create Work Order nested panels and fields in Light and Dark modes.
- Verify Customers and Vehicles list cards in Light mode.
- Verify Quote Review has bordered header, filter panel, cards, pills, and readable statuses.
- Verify Parts desktop pages remain unchanged in Dark mode and use light surfaces in Light mode.
- Run `pnpm typecheck` and focused lint on the four changed files.