### PR TITLE
Fix focused job Add Job schema mismatch

### DIFF
--- a/features/work-orders/components/workorders/AddJobModal.tsx
+++ b/features/work-orders/components/workorders/AddJobModal.tsx
@@ -9,10 +9,10 @@ import { toast } from "sonner";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ModalShell from "@/features/shared/components/ModalShell";
 import type { Database } from "@shared/types/types/supabase";
+import { buildAddJobLinePayload } from "@/features/work-orders/lib/addJobLinePayload";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
-type WorkOrderLineInsert = DB["public"]["Tables"]["work_order_lines"]["Insert"];
 
 type Props = {
   isOpen: boolean;
@@ -229,47 +229,21 @@ export default function AddJobModal(props: Props) {
 
       const hasParts = validItems.length > 0;
 
-      // ✅ IMPORTANT CHANGE:
-      // This modal creates advisor/tech-added jobs that require customer authorization.
-      // Parts requests do NOT imply "on hold" (that's operational hold like waiting for parts delivery).
-      // So always start in the approval bucket.
-      const initialStatus: WorkOrderLineInsert["status"] = "awaiting_approval";
-
       const newLineId = uuidv4();
 
-      const payloadBase: WorkOrderLineInsert = {
+      const payload = buildAddJobLinePayload({
         id: newLineId,
-        work_order_id: workOrderId,
-        vehicle_id: vehicleId,
-        complaint: jobName.trim(),
-        cause: null,
-        correction: notes.trim() || null,
-        labor_time: laborHours > 0 ? laborHours : null,
-
-        // keep legacy text column filled for now (useful for quick scanning)
-        parts: hasParts
-          ? validItems.map((p) => `${p.qty}x ${p.description}`).join(", ")
-          : null,
-
-        status: initialStatus,
-        job_type: "repair",
-        shop_id: useShopId,
-
-        ...(user?.id ? { user_id: user.id } : {}),
-        ...(techId && techId !== "system" ? { assigned_tech_id: techId } : {}),
-        ...(urgency ? { urgency } : {}),
-      };
-
-      // If your DB has approval columns, we want them consistent with the UI bucket.
-      // We apply them in a TS-safe way (won't break compile if not present in generated types).
-      const payload = {
-        ...payloadBase,
-        ...( {
-          approval_state: "pending",
-          approval_decision: "pending",
-          approval_requested_at: new Date().toISOString(),
-        } as unknown as Partial<WorkOrderLineInsert>),
-      } satisfies WorkOrderLineInsert;
+        workOrderId,
+        vehicleId,
+        jobName,
+        notes,
+        laborHours,
+        parts: validItems,
+        shopId: useShopId,
+        userId: user?.id ?? null,
+        assignedTechId: techId && techId !== "system" ? techId : null,
+        urgency,
+      });
 
       // 1) Create the line
       const { error: insErr } = await supabase.from("work_order_lines").insert(payload);

--- a/features/work-orders/lib/addJobLinePayload.ts
+++ b/features/work-orders/lib/addJobLinePayload.ts
@@ -1,0 +1,50 @@
+import type { Database } from "@shared/types/types/supabase";
+
+type WorkOrderLineInsert =
+  Database["public"]["Tables"]["work_order_lines"]["Insert"];
+
+export type AddJobLinePart = {
+  description: string;
+  qty: number;
+};
+
+export type AddJobLinePayloadInput = {
+  id: string;
+  workOrderId: string;
+  vehicleId: string | null;
+  jobName: string;
+  notes: string;
+  laborHours: number;
+  parts: AddJobLinePart[];
+  shopId: string;
+  userId: string | null;
+  assignedTechId: string | null;
+  urgency: "low" | "medium" | "high";
+};
+
+export function buildAddJobLinePayload(
+  input: AddJobLinePayloadInput,
+): WorkOrderLineInsert {
+  return {
+    id: input.id,
+    work_order_id: input.workOrderId,
+    vehicle_id: input.vehicleId,
+    complaint: input.jobName.trim(),
+    cause: null,
+    correction: input.notes.trim() || null,
+    labor_time: input.laborHours > 0 ? input.laborHours : null,
+    parts:
+      input.parts.length > 0
+        ? input.parts.map((part) => `${part.qty}x ${part.description}`).join(", ")
+        : null,
+    status: "awaiting_approval",
+    approval_state: "pending",
+    job_type: "repair",
+    shop_id: input.shopId,
+    urgency: input.urgency,
+    ...(input.userId ? { user_id: input.userId } : {}),
+    ...(input.assignedTechId
+      ? { assigned_tech_id: input.assignedTechId }
+      : {}),
+  };
+}

--- a/tests/focused-job-add-job-payload.test.ts
+++ b/tests/focused-job-add-job-payload.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAddJobLinePayload } from "@/features/work-orders/lib/addJobLinePayload";
+
+describe("focused-job add-job payload", () => {
+  it("uses only the canonical work-order-line approval fields", () => {
+    const payload = buildAddJobLinePayload({
+      id: "line-1",
+      workOrderId: "work-order-1",
+      vehicleId: "vehicle-1",
+      jobName: " Replace left rear wheel speed sensor ",
+      notes: " Verify wiring first ",
+      laborHours: 1,
+      parts: [{ description: "left rear wheel speed sensor", qty: 1 }],
+      shopId: "shop-1",
+      userId: "user-1",
+      assignedTechId: "tech-1",
+      urgency: "medium",
+    });
+
+    expect(payload).toMatchObject({
+      id: "line-1",
+      work_order_id: "work-order-1",
+      vehicle_id: "vehicle-1",
+      complaint: "Replace left rear wheel speed sensor",
+      correction: "Verify wiring first",
+      labor_time: 1,
+      parts: "1x left rear wheel speed sensor",
+      status: "awaiting_approval",
+      approval_state: "pending",
+      job_type: "repair",
+      shop_id: "shop-1",
+      user_id: "user-1",
+      assigned_tech_id: "tech-1",
+      urgency: "medium",
+    });
+    expect(payload).not.toHaveProperty("approval_decision");
+    expect(payload).not.toHaveProperty("approval_requested_at");
+  });
+
+  it("omits optional actor fields and normalizes empty values", () => {
+    const payload = buildAddJobLinePayload({
+      id: "line-2",
+      workOrderId: "work-order-2",
+      vehicleId: null,
+      jobName: "Diagnosis",
+      notes: "   ",
+      laborHours: 0,
+      parts: [],
+      shopId: "shop-2",
+      userId: null,
+      assignedTechId: null,
+      urgency: "low",
+    });
+
+    expect(payload.correction).toBeNull();
+    expect(payload.labor_time).toBeNull();
+    expect(payload.parts).toBeNull();
+    expect(payload).not.toHaveProperty("user_id");
+    expect(payload).not.toHaveProperty("assigned_tech_id");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the focused-job **Add Job** failure caused by inserting fields that do not exist on `work_order_lines`.

## Root cause

`AddJobModal` force-added `approval_decision` and `approval_requested_at` behind an `unknown` cast. Neither column exists in the repository schema or generated Supabase types, so the runtime insert failed even though TypeScript did not catch it.

## What changed

- Removed the invalid approval fields and unsafe cast boundary.
- Added a schema-typed payload builder.
- Preserved the canonical approval state:
  - `status: "awaiting_approval"`
  - `approval_state: "pending"`
- Preserved shop scoping, technician assignment, labor, urgency, legacy parts text, and linked parts-request behavior.
- Added regression coverage for the exact insert payload.

## Impact

Technicians and advisors can add a job from the focused-job modal again. New job lines enter the existing customer-approval workflow without introducing a duplicate approval model.

## Validation

- 13 focused approval/status/mobile-flow tests passed.
- Changed-file ESLint passed.
- Strict focused TypeScript check passed.
- Remote diff confirmed as exactly three intended files.
- Full repository build was not run because the local checkout is sparse.

## Database and environment

- No migration required.
- No environment-variable changes required.

## Deployment smoke test

1. Open a focused job as a technician.
2. Add a job without parts and confirm it appears as awaiting approval.
3. Add a job with parts and confirm the parts request is linked to the new line.
4. Confirm there is no missing-column error for `approval_decision` or `approval_requested_at`.
