### PR TITLE
Complete inspection report lifecycle

### DIFF
--- a/app/api/inspections/[id]/report/pdf/route.ts
+++ b/app/api/inspections/[id]/report/pdf/route.ts
@@ -1,0 +1,68 @@
+import "server-only";
+
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
+import { getInspectionReportForActor } from "@/features/inspections/server/inspectionReportAccess";
+
+export const runtime = "nodejs";
+
+function isExpectedStoragePath(args: {
+  path: string;
+  shopId: string;
+  workOrderId: string;
+  inspectionId: string;
+}): boolean {
+  const prefix = `shops/${args.shopId}/work_orders/${args.workOrderId}/inspections/${args.inspectionId}/`;
+  return (
+    args.path.startsWith(prefix) &&
+    args.path.endsWith(".pdf") &&
+    !args.path.includes("..") &&
+    !args.path.includes("//")
+  );
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const record = await getInspectionReportForActor({
+    actorUserId: user.id,
+    inspectionId: id,
+    includeEvidencePhotos: false,
+  });
+  if (
+    !record ||
+    !isExpectedStoragePath({
+      path: record.storagePath,
+      shopId: record.shopId,
+      workOrderId: record.workOrderId,
+      inspectionId: record.inspectionId,
+    })
+  ) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const admin = createAdminClient();
+  const { data, error: signedError } = await admin.storage
+    .from(record.storageBucket)
+    .createSignedUrl(record.storagePath, 60 * 10);
+  if (signedError || !data?.signedUrl) {
+    return NextResponse.json(
+      { error: signedError?.message ?? "Unable to open report" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.redirect(data.signedUrl);
+}

--- a/app/api/inspections/finalize/pdf/route.ts
+++ b/app/api/inspections/finalize/pdf/route.ts
@@ -3,14 +3,12 @@ import "server-only";
 
 export const runtime = "nodejs";
 
-import { createHash } from "node:crypto";
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
 import type { Database } from "@shared/types/types/supabase";
-import { generateInspectionPDF } from "@/features/inspections/lib/inspection/pdf";
-import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
 import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
+import { publishInspectionPdf } from "@/features/inspections/server/publishInspectionPdf";
 
 type DB = Database;
 
@@ -45,21 +43,8 @@ function isRecord(x: unknown): x is Record<string, unknown> {
   return typeof x === "object" && x !== null;
 }
 
-function isStorageAlreadyExistsError(error: unknown): boolean {
-  if (!isRecord(error)) return false;
-  const status = Number(error.statusCode ?? error.status);
-  const message = [error.message, error.error]
-    .filter((value): value is string => typeof value === "string")
-    .join(" ");
-  return status === 409 || /already exists|duplicate/i.test(message);
-}
-
 function asString(x: unknown): string | null {
   return typeof x === "string" && x.trim().length ? x.trim() : null;
-}
-
-function safeFilePart(x: string): string {
-  return x.replace(/[^a-zA-Z0-9._-]/g, "_");
 }
 
 export async function POST(req: NextRequest) {
@@ -226,69 +211,34 @@ export async function POST(req: NextRequest) {
   }
 
   const inspectionId = insp.id;
-  const brand = await getActiveBrandForRender(shopId);
-
-  // 5) Generate PDF
-  const pdfBytes = await generateInspectionPDF(summary, {
-    logoUrl: brand.logoUrl,
-    shopName: null,
-    colors: brand.colors,
-  });
-  const pdfBuffer = Buffer.from(pdfBytes);
-  const pdfHash = createHash("sha256").update(pdfBuffer).digest("hex");
-
-  // 6) Upload to storage (Policy-based: path includes shop id)
-  const bucket = "inspection_pdfs";
-  const shopPart = safeFilePart(shopId);
-  const woPart = safeFilePart(workOrderId);
-  const inspPart = safeFilePart(String(inspectionId));
-  const linePart = safeFilePart(workOrderLineId);
-
-  const path = `shops/${shopPart}/work_orders/${woPart}/inspections/${inspPart}/line_${linePart}_r${summaryRevision}_${pdfHash}.pdf`;
-
-  const { error: uploadErr } = await storageSupabase.storage
-    .from(bucket)
-    .upload(path, pdfBuffer, { contentType: "application/pdf", upsert: false });
-
-  if (uploadErr && !isStorageAlreadyExistsError(uploadErr)) {
-    // eslint-disable-next-line no-console
-    console.error("[inspections/finalize/pdf] upload failed", {
-      message: uploadErr.message,
-      name: uploadErr.name,
-      cause: (uploadErr as unknown as { cause?: unknown })?.cause,
-      path,
-      bucket,
+  let published;
+  try {
+    published = await publishInspectionPdf({
+      admin: storageSupabase,
       shopId,
       workOrderId,
       workOrderLineId,
+      inspectionId,
+      summary,
+      syncRevision: summaryRevision,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Inspection PDF upload failed.";
+    console.error("[inspections/finalize/pdf] publish failed", {
+      message,
+      shopId,
+      workOrderId,
+      workOrderLineId,
+      inspectionId,
     });
     return NextResponse.json(
-      {
-        error: uploadErr.message,
-        detail: {
-          bucket,
-          path,
-          hint: "Storage RLS likely blocked upload. Confirm policy matches shops/<shop_id>/... and current_shop_id() is set.",
-        },
-      },
+      { error: message },
       { status: 500 },
     );
   }
 
-  // Optional: signed URL for quick-open in UI
-  const { data: signed, error: signedErr } = await storageSupabase.storage
-    .from(bucket)
-    .createSignedUrl(path, 60 * 60 * 24 * 30);
-
-  if (signedErr) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      "[inspections/finalize/pdf] createSignedUrl failed",
-      signedErr,
-    );
-  }
-
-  // 7) Publish the immutable object only if the persisted summary revision is
+  // Publish the immutable object only if the persisted summary revision is
   // still the one used to generate it. The RPC locks and rechecks the row.
   const finalizeRpc = storageSupabase as unknown as FinalizeRpcClient;
   const { error: finalizeErr } = await finalizeRpc.rpc(
@@ -298,9 +248,9 @@ export async function POST(req: NextRequest) {
       p_work_order_line_id: workOrderLineId,
       p_actor_user_id: user.id,
       p_expected_sync_revision: expectedSyncRevision,
-      p_pdf_storage_path: path,
-      p_pdf_sha256: pdfHash,
-      p_pdf_url: signed?.signedUrl ?? null,
+      p_pdf_storage_path: published.path,
+      p_pdf_sha256: published.sha256,
+      p_pdf_url: published.reportUrl,
     },
   );
 
@@ -330,8 +280,8 @@ export async function POST(req: NextRequest) {
     inspectionId,
     workOrderId,
     workOrderLineId,
-    bucket,
-    pdf_storage_path: path,
-    pdf_url: signed?.signedUrl ?? null,
+    bucket: published.bucket,
+    pdf_storage_path: published.path,
+    pdf_url: published.reportUrl,
   });
 }

--- a/app/api/inspections/reports/route.ts
+++ b/app/api/inspections/reports/route.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+import { NextResponse, type NextRequest } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { listInspectionReportsForActor } from "@/features/inspections/server/inspectionReportAccess";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const workOrderId = req.nextUrl.searchParams.get("workOrderId");
+  const vehicleId = req.nextUrl.searchParams.get("vehicleId");
+  if (Boolean(workOrderId) === Boolean(vehicleId)) {
+    return NextResponse.json(
+      { error: "Provide exactly one workOrderId or vehicleId." },
+      { status: 400 },
+    );
+  }
+
+  const reports = await listInspectionReportsForActor({
+    actorUserId: user.id,
+    workOrderId,
+    vehicleId,
+  });
+  if (!reports) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    reports: reports.map((record) => ({
+      inspectionId: record.inspectionId,
+      workOrderId: record.workOrderId,
+      workOrderReference: record.workOrderReference,
+      vehicleId: record.vehicleId,
+      title: record.report.title,
+      finalizedAt: record.finalizedAt,
+      technicianName: record.technicianName,
+      totals: record.report.totals,
+      viewUrl: `/inspection-reports/${record.inspectionId}`,
+      pdfUrl: `/api/inspections/${record.inspectionId}/report/pdf`,
+    })),
+  });
+}

--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -3,6 +3,9 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
+import { publishInspectionPdf } from "@/features/inspections/server/publishInspectionPdf";
+import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
 
 type Role = "technician" | "customer" | "advisor";
 
@@ -92,6 +95,15 @@ function isSignRequestBody(value: unknown): value is SignRequestBody {
 
 type Supabase = ReturnType<typeof createServerSupabaseRoute>;
 type RpcReturn = { data: unknown; error: { message: string } | null };
+type AttachSignedPdfArgs = {
+  p_inspection_id: string;
+  p_work_order_line_id: string;
+  p_actor_user_id: string;
+  p_expected_sync_revision: number;
+  p_pdf_storage_path: string;
+  p_pdf_sha256: string;
+  p_pdf_url: string;
+};
 type ResolveInspectionResult =
   | { ok: true; inspectionId: string }
   | { ok: false; error: string; status: number };
@@ -105,6 +117,20 @@ async function callSignInspectionRpc(
       rpc: (fn: string, args: SignInspectionArgs) => Promise<RpcReturn>;
     }
   ).rpc("sign_inspection", args);
+}
+
+async function callAttachSignedPdfRpc(
+  args: AttachSignedPdfArgs,
+): Promise<RpcReturn> {
+  const admin = createAdminClient();
+  return (
+    admin as unknown as {
+      rpc: (
+        fn: "attach_signed_inspection_pdf_atomic",
+        values: AttachSignedPdfArgs,
+      ) => Promise<RpcReturn>;
+    }
+  ).rpc("attach_signed_inspection_pdf_atomic", args);
 }
 
 async function resolveInspectionForSigning(args: {
@@ -337,7 +363,7 @@ export async function POST(req: NextRequest) {
     p_expected_sync_revision: bodyUnknown.expectedSyncRevision,
   });
 
-  if (error) {
+  if (error && !error.message.toLowerCase().includes("already signed")) {
     const lower = error.message.toLowerCase();
     const status =
       lower.includes("not found") ||
@@ -354,11 +380,89 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: error.message }, { status });
   }
 
+  // Signing is a completion path, so it must not leave a locked inspection
+  // without its immutable report. An idempotent retry of sign_inspection is
+  // allowed to repair a prior upload/attachment interruption.
+  const admin = createAdminClient();
+  const { data: inspection, error: inspectionError } = await admin
+    .from("inspections")
+    .select(
+      "id,shop_id,work_order_id,work_order_line_id,summary,sync_revision,pdf_storage_path",
+    )
+    .eq("id", resolved.inspectionId)
+    .eq("shop_id", profile.shop_id)
+    .eq("is_canonical", true)
+    .maybeSingle<{
+      id: string;
+      shop_id: string;
+      work_order_id: string | null;
+      work_order_line_id: string | null;
+      summary: unknown;
+      sync_revision: number | null;
+      pdf_storage_path: string | null;
+    }>();
+  if (
+    inspectionError ||
+    !inspection?.work_order_id ||
+    !inspection.work_order_line_id ||
+    !inspection.summary ||
+    typeof inspection.summary !== "object"
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          inspectionError?.message ??
+          "Inspection was signed, but its report context could not be loaded. Sign again to retry report publication.",
+      },
+      { status: 500 },
+    );
+  }
+
+  let reportUrl = `/api/inspections/${inspection.id}/report/pdf`;
+  if (!inspection.pdf_storage_path) {
+    const syncRevision = Math.max(
+      0,
+      Math.trunc(inspection.sync_revision ?? 0),
+    );
+    try {
+      const published = await publishInspectionPdf({
+        admin,
+        shopId: inspection.shop_id,
+        workOrderId: inspection.work_order_id,
+        workOrderLineId: inspection.work_order_line_id,
+        inspectionId: inspection.id,
+        summary: inspection.summary as InspectionSession,
+        syncRevision,
+      });
+      const attached = await callAttachSignedPdfRpc({
+        p_inspection_id: inspection.id,
+        p_work_order_line_id: inspection.work_order_line_id,
+        p_actor_user_id: user.id,
+        p_expected_sync_revision: syncRevision,
+        p_pdf_storage_path: published.path,
+        p_pdf_sha256: published.sha256,
+        p_pdf_url: published.reportUrl,
+      });
+      if (attached.error) throw new Error(attached.error.message);
+      reportUrl = published.reportUrl;
+    } catch (publishError) {
+      return NextResponse.json(
+        {
+          error:
+            publishError instanceof Error
+              ? `Inspection was signed, but the report could not be published: ${publishError.message}. Sign again to retry.`
+              : "Inspection was signed, but the report could not be published. Sign again to retry.",
+        },
+        { status: 500 },
+      );
+    }
+  }
+
   return NextResponse.json({
     success: true,
     data,
     inspectionId: resolved.inspectionId,
     signedName: effectiveSignedName,
+    reportUrl,
   });
 }
-

--- a/app/api/invoices/[id]/documents/[kind]/signed/route.ts
+++ b/app/api/invoices/[id]/documents/[kind]/signed/route.ts
@@ -3,10 +3,15 @@ export const runtime = "nodejs";
 
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
 
 
-type SupportedInvoiceDocumentKind = "invoice_pdf";
-const SUPPORTED_KINDS: ReadonlySet<SupportedInvoiceDocumentKind> = new Set(["invoice_pdf"]);
+type SupportedInvoiceDocumentKind = "invoice_pdf" | "inspection_report";
+const SUPPORTED_KINDS: ReadonlySet<SupportedInvoiceDocumentKind> = new Set([
+  "invoice_pdf",
+  "inspection_report",
+]);
 
 function extract(req: NextRequest): { invoiceId: string | null; kind: string | null } {
   const m = req.nextUrl.pathname.match(/\/api\/invoices\/([^/]+)\/documents\/([^/]+)\/signed$/);
@@ -48,24 +53,38 @@ export async function GET(req: NextRequest) {
     .maybeSingle();
 
   if (invErr) return NextResponse.json({ ok: false, error: invErr.message }, { status: 400 });
-  if (!invoice?.id || !invoice.customer_id) {
+  if (!invoice?.id) {
     return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
   }
 
-  const { data: customer, error: customerErr } = await supabase
-    .from("customers")
-    .select("id, shop_id")
-    .eq("id", invoice.customer_id)
-    .eq("user_id", user.id)
-    .maybeSingle();
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("shop_id,role")
+    .eq("id", user.id)
+    .maybeSingle<{ shop_id: string | null; role: string | null }>();
+  const staffRole = canonicalizeRole(profile?.role);
+  const isStaff =
+    profile?.shop_id === invoice.shop_id &&
+    !["fleet_manager", "driver", "customer", "unknown"].includes(staffRole);
 
-  if (customerErr) return NextResponse.json({ ok: false, error: customerErr.message }, { status: 400 });
-  if (!customer?.id) {
-    return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
-  }
-
-  if (invoice.shop_id !== customer.shop_id) {
-    return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
+  let customer: { id: string; shop_id: string } | null = null;
+  if (!isStaff) {
+    if (!invoice.customer_id) {
+      return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
+    }
+    const { data, error: customerErr } = await supabase
+      .from("customers")
+      .select("id, shop_id")
+      .eq("id", invoice.customer_id)
+      .eq("user_id", user.id)
+      .maybeSingle<{ id: string; shop_id: string }>();
+    if (customerErr) {
+      return NextResponse.json({ ok: false, error: customerErr.message }, { status: 400 });
+    }
+    customer = data ?? null;
+    if (!customer?.id || invoice.shop_id !== customer.shop_id) {
+      return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
+    }
   }
 
   if (invoice.work_order_id) {
@@ -82,15 +101,20 @@ export async function GET(req: NextRequest) {
 
     if (
       workOrder.customer_id !== invoice.customer_id ||
-      workOrder.customer_id !== customer.id ||
       workOrder.shop_id !== invoice.shop_id ||
-      workOrder.shop_id !== customer.shop_id
+      (!isStaff &&
+        (workOrder.customer_id !== customer?.id ||
+          workOrder.shop_id !== customer?.shop_id))
     ) {
       return NextResponse.json({ ok: false, error: "Invoice not found" }, { status: 404 });
     }
   }
 
-  const { data: doc, error } = await supabase
+  // invoice_documents is intentionally staff-RLS-only. Portal access is
+  // authorized above, then the admin client is limited to the exact verified
+  // invoice/shop/document tuple.
+  const admin = createAdminClient();
+  const { data: doc, error } = await admin
     .from("invoice_documents")
     .select("storage_bucket, storage_path, shop_id, invoice_id")
     .eq("invoice_id", invoiceId)
@@ -99,14 +123,26 @@ export async function GET(req: NextRequest) {
 
   if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
   if (!doc?.storage_bucket || !doc?.storage_path) return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
-  if (doc.invoice_id !== invoice.id || doc.shop_id !== invoice.shop_id || doc.shop_id !== customer.shop_id) {
+  if (
+    doc.invoice_id !== invoice.id ||
+    doc.shop_id !== invoice.shop_id ||
+    (!isStaff && doc.shop_id !== customer?.shop_id)
+  ) {
     return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
   }
   if (!isSafeStoragePath(doc.storage_path)) {
     return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
   }
+  if (
+    kind === "inspection_report" &&
+    !doc.storage_path.startsWith(
+      `shops/${invoice.shop_id}/invoices/${invoice.id}/`,
+    )
+  ) {
+    return NextResponse.json({ ok: false, error: "Not found" }, { status: 404 });
+  }
 
-  const { data: signed, error: sErr } = await supabase.storage
+  const { data: signed, error: sErr } = await admin.storage
     .from(doc.storage_bucket)
     .createSignedUrl(doc.storage_path, 60 * 10); // 10 minutes
 
@@ -114,5 +150,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ ok: false, error: sErr?.message ?? "Signed URL failed" }, { status: 500 });
   }
 
+  if (req.nextUrl.searchParams.get("redirect") === "1") {
+    return NextResponse.redirect(signed.signedUrl);
+  }
   return NextResponse.json({ ok: true, url: signed.signedUrl });
 }

--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -9,6 +9,7 @@ import { getActiveBrandForRender } from "@/features/branding/server/getActiveBra
 import { getIssuableInvoiceSnapshot } from "@/features/invoices/server/getIssuableInvoiceSnapshot";
 import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
 import { finalizeInvoiceVersion } from "@/features/invoices/server/financialLifecycle";
+import { attachInspectionReportToInvoice } from "@/features/invoices/server/attachInspectionReportToInvoice";
 import { reviewWorkOrder } from "../../work-orders/[id]/_lib/reviewWorkOrder";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
@@ -246,6 +247,13 @@ export async function POST(req: Request) {
     // configuration is stored in the immutable version snapshot so historical
     // invoices never change when the shop updates its logo or template later.
     const brand = await getActiveBrandForRender(workOrder.shop_id);
+    const inspectionAttachment = await attachInspectionReportToInvoice({
+      supabase: admin,
+      invoiceId,
+      workOrderId,
+      shopId: workOrder.shop_id,
+      actorUserId: access.profile.id,
+    });
     const issuedSnapshot = {
       ...snapshot,
       documentConfiguration: brand.document,
@@ -362,6 +370,7 @@ export async function POST(req: Request) {
       invoiceId,
       invoiceVersionId: version.id,
       invoiceVersion: version,
+      inspectionAttachment,
       sentWithWarnings: warnings.length > 0 || undefined,
       warnings: warnings.length ? warnings : undefined,
     });

--- a/app/inspection-reports/[id]/page.tsx
+++ b/app/inspection-reports/[id]/page.tsx
@@ -1,0 +1,44 @@
+import { notFound, redirect } from "next/navigation";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { getInspectionReportForActor } from "@/features/inspections/server/inspectionReportAccess";
+import { InspectionReportView } from "@/features/inspections/components/InspectionReportView";
+
+export const dynamic = "force-dynamic";
+
+export default async function InspectionReportPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = createServerSupabaseRSC();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect(`/sign-in?redirect=${encodeURIComponent(`/inspection-reports/${id}`)}`);
+  const record = await getInspectionReportForActor({
+    actorUserId: user.id,
+    inspectionId: id,
+    includeEvidencePhotos: true,
+  });
+  if (!record) notFound();
+  return (
+    <main className="mx-auto max-w-5xl space-y-5 px-4 py-8">
+      <div className="flex justify-end">
+        <a
+          href={`/api/inspections/${id}/report/pdf`}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded-full border border-[color:var(--theme-border-soft)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em]"
+        >
+          Open PDF
+        </a>
+      </div>
+      <InspectionReportView
+        report={record.report}
+        technicianName={record.technicianName}
+        finalizedAt={record.finalizedAt}
+      />
+    </main>
+  );
+}

--- a/app/portal/fleet/units/[unitId]/page.tsx
+++ b/app/portal/fleet/units/[unitId]/page.tsx
@@ -1,6 +1,7 @@
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import AssetDetailScreen from "@/features/fleet/components/AssetDetailScreen";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
+import { InspectionReportAttachments } from "@/features/inspections/components/InspectionReportAttachments";
 
 type Props = {
   params: Promise<{ unitId: string }>;
@@ -12,10 +13,16 @@ export default async function PortalFleetUnitPage({ params }: Props) {
   const uiContext = await resolveFleetUiContext(supabase);
 
   return (
-    <AssetDetailScreen
-      unitId={unitId}
-      uiContext={uiContext}
-      routePrefix="/portal/fleet"
-    />
+    <div className="space-y-5">
+      <AssetDetailScreen
+        unitId={unitId}
+        uiContext={uiContext}
+        routePrefix="/portal/fleet"
+      />
+      <InspectionReportAttachments
+        vehicleId={unitId}
+        title="Completed inspections"
+      />
+    </div>
   );
 }

--- a/app/portal/invoices/[id]/layout.tsx
+++ b/app/portal/invoices/[id]/layout.tsx
@@ -1,0 +1,22 @@
+import { InspectionReportAttachments } from "@/features/inspections/components/InspectionReportAttachments";
+
+export default async function PortalInvoiceLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <>
+      {children}
+      <div className="mx-auto max-w-4xl px-4 pb-10">
+        <InspectionReportAttachments
+          workOrderId={id}
+          title="Inspection reports attached to this invoice"
+        />
+      </div>
+    </>
+  );
+}

--- a/app/portal/work-orders/view/[id]/layout.tsx
+++ b/app/portal/work-orders/view/[id]/layout.tsx
@@ -1,0 +1,19 @@
+import { InspectionReportAttachments } from "@/features/inspections/components/InspectionReportAttachments";
+
+export default async function PortalWorkOrderLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <>
+      {children}
+      <div className="mx-auto max-w-5xl px-4 pb-8">
+        <InspectionReportAttachments workOrderId={id} />
+      </div>
+    </>
+  );
+}

--- a/features/inspections/components/InspectionReportAttachments.tsx
+++ b/features/inspections/components/InspectionReportAttachments.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type ReportLink = {
+  inspectionId: string;
+  title: string;
+  finalizedAt: string | null;
+  technicianName: string | null;
+  viewUrl: string;
+  pdfUrl: string;
+};
+
+export function InspectionReportAttachments({
+  workOrderId,
+  vehicleId,
+  title = "Inspection reports",
+}: {
+  workOrderId?: string;
+  vehicleId?: string;
+  title?: string;
+}) {
+  const [reports, setReports] = useState<ReportLink[]>([]);
+  useEffect(() => {
+    const query = workOrderId
+      ? `workOrderId=${encodeURIComponent(workOrderId)}`
+      : vehicleId
+        ? `vehicleId=${encodeURIComponent(vehicleId)}`
+        : "";
+    if (!query) return;
+    void fetch(`/api/inspections/reports?${query}`, { cache: "no-store" })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((payload) => setReports(payload?.reports ?? []))
+      .catch(() => setReports([]));
+  }, [vehicleId, workOrderId]);
+  if (!reports.length) return null;
+  return (
+    <section className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.18em]">
+        {title}
+      </h2>
+      <div className="mt-3 space-y-2">
+        {reports.map((report) => (
+          <div
+            key={report.inspectionId}
+            className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] p-4"
+          >
+            <div>
+              <div className="font-semibold">{report.title}</div>
+              <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                {report.finalizedAt
+                  ? new Date(report.finalizedAt).toLocaleString()
+                  : "Finalized"}
+                {report.technicianName ? ` · ${report.technicianName}` : ""}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <a className="rounded-full border px-3 py-2 text-xs" href={report.viewUrl}>
+                View report
+              </a>
+              <a
+                className="rounded-full border px-3 py-2 text-xs"
+                href={report.pdfUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                PDF
+              </a>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/features/inspections/components/InspectionReportView.tsx
+++ b/features/inspections/components/InspectionReportView.tsx
@@ -1,0 +1,112 @@
+import type { InspectionReport } from "@/features/inspections/lib/inspection/report";
+
+const labels = {
+  ok: "Pass",
+  fail: "Needs attention",
+  recommend: "Recommended",
+  na: "Not applicable",
+  not_checked: "Not checked",
+} as const;
+
+export function InspectionReportView({
+  report,
+  technicianName,
+  finalizedAt,
+}: {
+  report: InspectionReport;
+  technicianName: string | null;
+  finalizedAt: string | null;
+}) {
+  return (
+    <article className="space-y-6">
+      <header className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6">
+        <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--accent-copper-light)]">
+          Professional inspection report
+        </div>
+        <h1 className="mt-2 text-2xl font-semibold">{report.title}</h1>
+        <div className="mt-3 grid gap-2 text-sm text-[color:var(--theme-text-secondary)] sm:grid-cols-2">
+          <div>Customer: {report.customerName ?? "—"}</div>
+          <div>Vehicle: {report.vehicleLabel ?? "—"}</div>
+          <div>VIN: {report.vin ?? "—"}</div>
+          <div>Mileage: {report.mileage ?? "—"}</div>
+          <div>Technician: {technicianName ?? "—"}</div>
+          <div>
+            Finalized:{" "}
+            {finalizedAt ? new Date(finalizedAt).toLocaleString() : "—"}
+          </div>
+        </div>
+      </header>
+
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+        {[
+          ["Checked", report.totals.checked],
+          ["Passed", report.totals.ok],
+          ["Attention", report.totals.failed],
+          ["Recommended", report.totals.recommended],
+          ["N/A", report.totals.notApplicable],
+        ].map(([label, value]) => (
+          <div
+            key={String(label)}
+            className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4"
+          >
+            <div className="text-xs uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
+              {label}
+            </div>
+            <div className="mt-1 text-2xl font-semibold">{value}</div>
+          </div>
+        ))}
+      </section>
+
+      {report.sections.map((section) => (
+        <section
+          key={section.title}
+          className="overflow-hidden rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]"
+        >
+          <h2 className="border-b border-[color:var(--theme-border-soft)] px-5 py-4 text-lg font-semibold">
+            {section.title}
+          </h2>
+          <div className="divide-y divide-[color:var(--theme-border-soft)]">
+            {section.items.map((item, index) => (
+              <div key={`${item.label}-${index}`} className="p-5">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <h3 className="font-semibold">{item.label}</h3>
+                  <span className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1 text-xs font-semibold">
+                    {labels[item.status]}
+                  </span>
+                </div>
+                {item.value ? (
+                  <div className="mt-2 text-sm">Measurement: {item.value}</div>
+                ) : null}
+                {item.note ? (
+                  <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+                    {item.note}
+                  </p>
+                ) : null}
+                {item.recommendations.length ? (
+                  <ul className="mt-2 list-disc pl-5 text-sm text-[color:var(--theme-text-secondary)]">
+                    {item.recommendations.map((recommendation) => (
+                      <li key={recommendation}>{recommendation}</li>
+                    ))}
+                  </ul>
+                ) : null}
+                {item.photoUrls.length ? (
+                  <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
+                    {item.photoUrls.map((url) => (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        key={url}
+                        src={url}
+                        alt={`${item.label} evidence`}
+                        className="aspect-[4/3] w-full rounded-xl object-cover"
+                      />
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </article>
+  );
+}

--- a/features/inspections/lib/inspection/report.test.ts
+++ b/features/inspections/lib/inspection/report.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { assembleInspectionReport } from "./report";
+import type { InspectionSession } from "./types";
+
+function session(): InspectionSession {
+  return {
+    templateName: "Annual vehicle inspection",
+    currentSectionIndex: 0,
+    currentItemIndex: 0,
+    isListening: false,
+    status: "completed",
+    started: true,
+    completed: true,
+    isPaused: false,
+    customer: {
+      business_name: "Example Fleet",
+      first_name: null,
+      last_name: null,
+      phone: null,
+      email: null,
+      address: null,
+      city: null,
+      province: null,
+      postal_code: null,
+    },
+    vehicle: {
+      year: "2024",
+      make: "Ford",
+      model: "F-550",
+      vin: "TESTVIN",
+      license_plate: null,
+      mileage: "42,000 km",
+      color: null,
+    },
+    sections: [
+      {
+        title: "Brakes",
+        items: [
+          { item: "Front pads", status: "ok", value: "8 mm" },
+          {
+            item: "Rear pads",
+            status: "fail",
+            notes: "Below service limit",
+            recommend: ["Replace rear pads"],
+            photoUrls: ["https://example.test/evidence.jpg"],
+          },
+          { item: "Parking brake", status: "na" },
+          { item: "Brake fluid", status: "recommend" },
+          { item: "Lines" },
+        ],
+      },
+    ],
+  };
+}
+
+describe("assembleInspectionReport", () => {
+  it("preserves technician evidence and recommendations", () => {
+    const report = assembleInspectionReport(session());
+    expect(report.sections[0].items[1]).toMatchObject({
+      label: "Rear pads",
+      status: "fail",
+      note: "Below service limit",
+      recommendations: ["Replace rear pads"],
+      photoUrls: ["https://example.test/evidence.jpg"],
+    });
+  });
+
+  it("calculates status totals without inventing unchecked results", () => {
+    expect(assembleInspectionReport(session()).totals).toEqual({
+      checked: 4,
+      ok: 1,
+      failed: 1,
+      recommended: 1,
+      notApplicable: 1,
+    });
+  });
+
+  it("assembles customer and vehicle headings", () => {
+    const report = assembleInspectionReport(session());
+    expect(report.customerName).toBe("Example Fleet");
+    expect(report.vehicleLabel).toBe("2024 Ford F-550");
+    expect(report.vin).toBe("TESTVIN");
+  });
+});

--- a/features/inspections/lib/inspection/report.ts
+++ b/features/inspections/lib/inspection/report.ts
@@ -1,0 +1,95 @@
+import type {
+  InspectionItemStatus,
+  InspectionSession,
+} from "./types";
+
+export type InspectionReportItem = {
+  label: string;
+  status: InspectionItemStatus | "not_checked";
+  value: string | null;
+  note: string | null;
+  recommendations: string[];
+  photoUrls: string[];
+};
+
+export type InspectionReport = {
+  title: string;
+  completedAt: string | null;
+  customerName: string | null;
+  vehicleLabel: string | null;
+  vin: string | null;
+  mileage: string | null;
+  sections: Array<{ title: string; items: InspectionReportItem[] }>;
+  totals: {
+    checked: number;
+    ok: number;
+    failed: number;
+    recommended: number;
+    notApplicable: number;
+  };
+};
+
+function text(value: unknown): string | null {
+  if (value == null) return null;
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+export function assembleInspectionReport(
+  session: InspectionSession,
+): InspectionReport {
+  const totals = {
+    checked: 0,
+    ok: 0,
+    failed: 0,
+    recommended: 0,
+    notApplicable: 0,
+  };
+  const sections = (session.sections ?? []).map((section, sectionIndex) => ({
+    title: text(section.title) ?? `Section ${sectionIndex + 1}`,
+    items: (section.items ?? []).map((item) => {
+      const status = item.status ?? "not_checked";
+      if (status !== "not_checked") totals.checked += 1;
+      if (status === "ok") totals.ok += 1;
+      if (status === "fail") totals.failed += 1;
+      if (status === "recommend") totals.recommended += 1;
+      if (status === "na") totals.notApplicable += 1;
+      return {
+        label: text(item.item ?? item.name) ?? "Inspection item",
+        status,
+        value: text(item.value),
+        note: text(item.notes ?? item.note),
+        recommendations: Array.isArray(item.recommend)
+          ? item.recommend.map(text).filter((value): value is string => !!value)
+          : [],
+        photoUrls: Array.isArray(item.photoUrls)
+          ? item.photoUrls.map(text).filter((value): value is string => !!value)
+          : [],
+      };
+    }),
+  }));
+  const customerName =
+    text(session.customer?.business_name) ??
+    text(session.customer?.name) ??
+    text(
+      [session.customer?.first_name, session.customer?.last_name]
+        .filter(Boolean)
+        .join(" "),
+    );
+  const vehicleLabel = text(
+    [session.vehicle?.year, session.vehicle?.make, session.vehicle?.model]
+      .filter(Boolean)
+      .join(" "),
+  );
+
+  return {
+    title: text(session.templateName ?? session.templateitem) ?? "Vehicle inspection report",
+    completedAt: text(session.lastUpdated),
+    customerName,
+    vehicleLabel,
+    vin: text(session.vehicle?.vin),
+    mileage: text(session.vehicle?.mileage),
+    sections,
+    totals,
+  };
+}

--- a/features/inspections/lib/inspection/report.ts
+++ b/features/inspections/lib/inspection/report.ts
@@ -48,7 +48,8 @@ export function assembleInspectionReport(
   const sections = (session.sections ?? []).map((section, sectionIndex) => ({
     title: text(section.title) ?? `Section ${sectionIndex + 1}`,
     items: (section.items ?? []).map((item) => {
-      const status = item.status ?? "not_checked";
+      const status: InspectionReportItem["status"] =
+        item.status ?? "not_checked";
       if (status !== "not_checked") totals.checked += 1;
       if (status === "ok") totals.ok += 1;
       if (status === "fail") totals.failed += 1;

--- a/features/inspections/server/inspectionReportAccess.ts
+++ b/features/inspections/server/inspectionReportAccess.ts
@@ -1,0 +1,243 @@
+import "server-only";
+
+import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
+import {
+  assembleInspectionReport,
+  type InspectionReport,
+} from "@/features/inspections/lib/inspection/report";
+import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
+import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
+
+export type InspectionReportRecord = {
+  inspectionId: string;
+  workOrderId: string;
+  workOrderReference: string | null;
+  vehicleId: string | null;
+  shopId: string;
+  storageBucket: string;
+  storagePath: string;
+  finalizedAt: string | null;
+  technicianName: string | null;
+  report: InspectionReport;
+};
+
+type RawInspection = {
+  id: string;
+  shop_id: string;
+  work_order_id: string | null;
+  summary: unknown;
+  pdf_storage_path: string | null;
+  finalized_at: string | null;
+  finalized_by: string | null;
+};
+
+async function actorCanRead(args: {
+  actorUserId: string;
+  shopId: string;
+  customerId: string | null;
+  vehicleId: string | null;
+}): Promise<boolean> {
+  const admin = createAdminClient();
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("shop_id,role")
+    .or(`id.eq.${args.actorUserId},user_id.eq.${args.actorUserId}`)
+    .eq("shop_id", args.shopId)
+    .limit(1)
+    .maybeSingle<{ shop_id: string | null; role: string | null }>();
+  const role = canonicalizeRole(profile?.role);
+  if (
+    profile?.shop_id === args.shopId &&
+    !["customer", "fleet_manager", "driver", "unknown"].includes(role)
+  ) {
+    return true;
+  }
+
+  if (args.customerId) {
+    const { data: customer } = await admin
+      .from("customers")
+      .select("id")
+      .eq("id", args.customerId)
+      .eq("shop_id", args.shopId)
+      .eq("user_id", args.actorUserId)
+      .maybeSingle<{ id: string }>();
+    if (customer?.id) return true;
+  }
+
+  if (!args.vehicleId) return false;
+  const actor = await resolveFleetActorContext(admin, {
+    userId: args.actorUserId,
+  });
+  if (!actor.isFleetActor || actor.shopId !== args.shopId) return false;
+  const { data: vehicle } = await admin
+    .from("vehicles")
+    .select("fleet_id")
+    .eq("id", args.vehicleId)
+    .eq("shop_id", args.shopId)
+    .maybeSingle<{ fleet_id: string | null }>();
+  return !!vehicle?.fleet_id && actor.fleetIds.includes(vehicle.fleet_id);
+}
+
+function storageObject(url: string): { bucket: string; path: string } | null {
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(
+      /\/storage\/v1\/object\/(?:sign|public)\/([^/]+)\/(.+)$/,
+    );
+    return match
+      ? { bucket: decodeURIComponent(match[1]), path: decodeURIComponent(match[2]) }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function refreshEvidence(report: InspectionReport): Promise<InspectionReport> {
+  const admin = createAdminClient();
+  const refreshed = await Promise.all(
+    report.sections.map(async (section) => ({
+      ...section,
+      items: await Promise.all(
+        section.items.map(async (item) => ({
+          ...item,
+          photoUrls: await Promise.all(
+            item.photoUrls.map(async (url) => {
+              const object = storageObject(url);
+              if (!object) return url;
+              const signed = await admin.storage
+                .from(object.bucket)
+                .createSignedUrl(object.path, 60 * 10);
+              return signed.data?.signedUrl ?? url;
+            }),
+          ),
+        })),
+      ),
+    })),
+  );
+  return { ...report, sections: refreshed };
+}
+
+async function hydrate(
+  inspection: RawInspection,
+  actorUserId: string,
+  includeEvidencePhotos: boolean,
+): Promise<InspectionReportRecord | null> {
+  if (
+    !inspection.work_order_id ||
+    !inspection.pdf_storage_path ||
+    !inspection.summary ||
+    typeof inspection.summary !== "object"
+  ) {
+    return null;
+  }
+  const admin = createAdminClient();
+  const { data: workOrder } = await admin
+    .from("work_orders")
+    .select("id,custom_id,vehicle_id,customer_id,shop_id")
+    .eq("id", inspection.work_order_id)
+    .eq("shop_id", inspection.shop_id)
+    .maybeSingle<{
+      id: string;
+      custom_id: string | null;
+      vehicle_id: string | null;
+      customer_id: string | null;
+      shop_id: string;
+    }>();
+  if (
+    !workOrder ||
+    !(await actorCanRead({
+      actorUserId,
+      shopId: inspection.shop_id,
+      customerId: workOrder.customer_id,
+      vehicleId: workOrder.vehicle_id,
+    }))
+  ) {
+    return null;
+  }
+  let technicianName: string | null = null;
+  if (inspection.finalized_by) {
+    const { data: technician } = await admin
+      .from("profiles")
+      .select("full_name")
+      .or(
+        `id.eq.${inspection.finalized_by},user_id.eq.${inspection.finalized_by}`,
+      )
+      .limit(1)
+      .maybeSingle<{ full_name: string | null }>();
+    technicianName = technician?.full_name ?? null;
+  }
+  let report = assembleInspectionReport(
+    inspection.summary as InspectionSession,
+  );
+  if (includeEvidencePhotos) report = await refreshEvidence(report);
+  return {
+    inspectionId: inspection.id,
+    workOrderId: workOrder.id,
+    workOrderReference: workOrder.custom_id,
+    vehicleId: workOrder.vehicle_id,
+    shopId: inspection.shop_id,
+    storageBucket: "inspection_pdfs",
+    storagePath: inspection.pdf_storage_path,
+    finalizedAt: inspection.finalized_at,
+    technicianName,
+    report,
+  };
+}
+
+export async function getInspectionReportForActor(args: {
+  actorUserId: string;
+  inspectionId: string;
+  includeEvidencePhotos?: boolean;
+}) {
+  const admin = createAdminClient();
+  const { data } = await admin
+    .from("inspections")
+    .select(
+      "id,shop_id,work_order_id,summary,pdf_storage_path,finalized_at,finalized_by",
+    )
+    .eq("id", args.inspectionId)
+    .eq("is_canonical", true)
+    .not("pdf_storage_path", "is", null)
+    .maybeSingle<RawInspection>();
+  return data
+    ? hydrate(data, args.actorUserId, args.includeEvidencePhotos ?? true)
+    : null;
+}
+
+export async function listInspectionReportsForActor(args: {
+  actorUserId: string;
+  workOrderId?: string | null;
+  vehicleId?: string | null;
+}) {
+  const admin = createAdminClient();
+  let workOrderIds: string[] | null = args.workOrderId
+    ? [args.workOrderId]
+    : null;
+  if (args.vehicleId) {
+    const { data } = await admin
+      .from("work_orders")
+      .select("id")
+      .eq("vehicle_id", args.vehicleId);
+    workOrderIds = (data ?? []).map((row) => row.id);
+  }
+  if (!workOrderIds?.length) return [];
+  const { data, error } = await admin
+    .from("inspections")
+    .select(
+      "id,shop_id,work_order_id,summary,pdf_storage_path,finalized_at,finalized_by",
+    )
+    .in("work_order_id", workOrderIds)
+    .eq("is_canonical", true)
+    .not("pdf_storage_path", "is", null)
+    .order("finalized_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  const records = await Promise.all(
+    ((data ?? []) as RawInspection[]).map((inspection) =>
+      hydrate(inspection, args.actorUserId, false),
+    ),
+  );
+  return records.filter(
+    (record): record is InspectionReportRecord => !!record,
+  );
+}

--- a/features/inspections/server/publishInspectionPdf.ts
+++ b/features/inspections/server/publishInspectionPdf.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
+import { generateInspectionPDF } from "@/features/inspections/lib/inspection/pdf";
+import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
+
+const BUCKET = "inspection_pdfs";
+
+function alreadyExists(error: unknown): boolean {
+  const candidate = error as { status?: number; statusCode?: number; message?: string };
+  return (
+    Number(candidate?.status ?? candidate?.statusCode) === 409 ||
+    /already exists|duplicate/i.test(candidate?.message ?? "")
+  );
+}
+
+export async function publishInspectionPdf(args: {
+  admin: SupabaseClient<Database>;
+  shopId: string;
+  workOrderId: string;
+  workOrderLineId: string;
+  inspectionId: string;
+  summary: InspectionSession;
+  syncRevision: number;
+}) {
+  const brand = await getActiveBrandForRender(args.shopId);
+  const bytes = await generateInspectionPDF(args.summary, {
+    logoUrl: brand.logoUrl,
+    shopName: null,
+    colors: brand.colors,
+  });
+  const body = Buffer.from(bytes);
+  const sha256 = createHash("sha256").update(body).digest("hex");
+  const path =
+    `shops/${args.shopId}/work_orders/${args.workOrderId}/inspections/` +
+    `${args.inspectionId}/line_${args.workOrderLineId}_r${args.syncRevision}_${sha256}.pdf`;
+  const { error } = await args.admin.storage.from(BUCKET).upload(path, body, {
+    contentType: "application/pdf",
+    upsert: false,
+  });
+  if (error && !alreadyExists(error)) throw new Error(error.message);
+  return {
+    bucket: BUCKET,
+    path,
+    sha256,
+    reportUrl: `/api/inspections/${args.inspectionId}/report/pdf`,
+  };
+}

--- a/features/invoices/server/attachInspectionReportToInvoice.ts
+++ b/features/invoices/server/attachInspectionReportToInvoice.ts
@@ -1,0 +1,65 @@
+import "server-only";
+
+import { PDFDocument } from "pdf-lib";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@shared/types/types/supabase";
+
+export async function attachInspectionReportToInvoice(args: {
+  supabase: SupabaseClient<Database>;
+  invoiceId: string;
+  workOrderId: string;
+  shopId: string;
+  actorUserId: string;
+}) {
+  const { data, error } = await args.supabase
+    .from("inspections")
+    .select("id,pdf_storage_path,finalized_at")
+    .eq("shop_id", args.shopId)
+    .eq("work_order_id", args.workOrderId)
+    .eq("is_canonical", true)
+    .not("pdf_storage_path", "is", null)
+    .order("finalized_at", { ascending: true });
+  if (error) throw new Error(error.message);
+  const inspections = (data ?? []).filter(
+    (row): row is typeof row & { pdf_storage_path: string } =>
+      typeof row.pdf_storage_path === "string" && !!row.pdf_storage_path,
+  );
+  if (!inspections.length) return { attached: false, count: 0 };
+
+  const combined = await PDFDocument.create();
+  for (const inspection of inspections) {
+    const downloaded = await args.supabase.storage
+      .from("inspection_pdfs")
+      .download(inspection.pdf_storage_path);
+    if (downloaded.error || !downloaded.data) {
+      throw new Error(
+        downloaded.error?.message ?? `Unable to load inspection ${inspection.id}`,
+      );
+    }
+    const source = await PDFDocument.load(await downloaded.data.arrayBuffer());
+    const pages = await combined.copyPages(source, source.getPageIndices());
+    pages.forEach((page) => combined.addPage(page));
+  }
+  const body = Buffer.from(await combined.save());
+  const path =
+    `shops/${args.shopId}/invoices/${args.invoiceId}/inspection-report.pdf`;
+  const upload = await args.supabase.storage
+    .from("inspection_pdfs")
+    .upload(path, body, { contentType: "application/pdf", upsert: true });
+  if (upload.error) throw new Error(upload.error.message);
+
+  const persisted = await args.supabase.from("invoice_documents").upsert(
+    {
+      invoice_id: args.invoiceId,
+      shop_id: args.shopId,
+      kind: "inspection_report",
+      storage_bucket: "inspection_pdfs",
+      storage_path: path,
+      mime_type: "application/pdf",
+      created_by: args.actorUserId,
+    },
+    { onConflict: "invoice_id,kind" },
+  );
+  if (persisted.error) throw new Error(persisted.error.message);
+  return { attached: true, count: inspections.length, path };
+}

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -22746,6 +22746,18 @@ export type Database = {
         }
         Returns: Json
       }
+      attach_signed_inspection_pdf_atomic: {
+        Args: {
+          p_actor_user_id: string
+          p_expected_sync_revision: number
+          p_inspection_id: string
+          p_pdf_sha256: string
+          p_pdf_storage_path: string
+          p_pdf_url: string
+          p_work_order_line_id: string
+        }
+        Returns: Json
+      }
       attach_stripe_acquisition_checkout: {
         Args: {
           p_checkout_session_id: string

--- a/supabase/migrations/20260729130000_publish_inspection_reports.sql
+++ b/supabase/migrations/20260729130000_publish_inspection_reports.sql
@@ -1,0 +1,121 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.sync_finalized_inspection_to_work_order()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF NEW.is_canonical
+     AND NEW.work_order_id IS NOT NULL
+     AND NEW.pdf_storage_path IS NOT NULL
+     AND (OLD.pdf_storage_path IS DISTINCT FROM NEW.pdf_storage_path
+          OR OLD.work_order_id IS DISTINCT FROM NEW.work_order_id) THEN
+    UPDATE public.work_orders
+       SET inspection_id = NEW.id,
+           inspection_pdf_url = '/api/inspections/' || NEW.id || '/report/pdf'
+     WHERE id = NEW.work_order_id
+       AND shop_id = NEW.shop_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sync_finalized_inspection_to_work_order
+  ON public.inspections;
+CREATE TRIGGER sync_finalized_inspection_to_work_order
+AFTER INSERT OR UPDATE OF pdf_storage_path, work_order_id, is_canonical
+ON public.inspections
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_finalized_inspection_to_work_order();
+
+WITH selected AS (
+  SELECT DISTINCT ON (i.work_order_id, i.shop_id)
+    i.work_order_id,
+    i.shop_id,
+    i.id
+  FROM public.inspections i
+  WHERE i.work_order_id IS NOT NULL
+    AND i.is_canonical
+    AND i.pdf_storage_path IS NOT NULL
+  ORDER BY
+    i.work_order_id,
+    i.shop_id,
+    i.finalized_at DESC NULLS LAST,
+    i.updated_at DESC,
+    i.id DESC
+)
+UPDATE public.work_orders wo
+SET inspection_id = selected.id,
+    inspection_pdf_url = '/api/inspections/' || selected.id || '/report/pdf'
+FROM selected
+WHERE selected.work_order_id = wo.id
+  AND selected.shop_id = wo.shop_id
+  AND (wo.inspection_id IS NULL OR wo.inspection_pdf_url IS NULL);
+
+CREATE OR REPLACE FUNCTION public.attach_signed_inspection_pdf_atomic(
+  p_inspection_id uuid,
+  p_work_order_line_id uuid,
+  p_actor_user_id uuid,
+  p_expected_sync_revision bigint,
+  p_pdf_storage_path text,
+  p_pdf_sha256 text,
+  p_pdf_url text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  target public.inspections%ROWTYPE;
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> p_actor_user_id THEN
+    RAISE EXCEPTION 'Actor identity mismatch';
+  END IF;
+  SELECT * INTO target
+  FROM public.inspections
+  WHERE id = p_inspection_id
+    AND work_order_line_id = p_work_order_line_id
+    AND is_canonical
+  FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Inspection not found'; END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE (p.id = p_actor_user_id OR p.user_id = p_actor_user_id)
+      AND p.shop_id = target.shop_id
+  ) THEN
+    RAISE EXCEPTION 'Forbidden';
+  END IF;
+  IF target.sync_revision <> p_expected_sync_revision THEN
+    RAISE EXCEPTION 'Saved inspection revision changed';
+  END IF;
+  IF NOT target.completed OR NOT target.locked OR target.is_draft THEN
+    RAISE EXCEPTION 'Inspection must be signed and complete';
+  END IF;
+  IF target.pdf_storage_path IS NOT NULL THEN
+    IF target.pdf_storage_path <> p_pdf_storage_path THEN
+      RAISE EXCEPTION 'Inspection already has a different immutable report';
+    END IF;
+    RETURN jsonb_build_object('inspection_id', target.id, 'reused', true);
+  END IF;
+  UPDATE public.inspections
+  SET pdf_storage_path = p_pdf_storage_path,
+      pdf_sha256 = p_pdf_sha256,
+      pdf_url = p_pdf_url,
+      finalized_at = COALESCE(finalized_at, now()),
+      finalized_by = COALESCE(finalized_by, p_actor_user_id)
+  WHERE id = target.id;
+  RETURN jsonb_build_object('inspection_id', target.id, 'reused', false);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.attach_signed_inspection_pdf_atomic(
+  uuid, uuid, uuid, bigint, text, text, text
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.attach_signed_inspection_pdf_atomic(
+  uuid, uuid, uuid, bigint, text, text, text
+) TO authenticated, service_role;
+
+COMMIT;

--- a/tests/inspection-report-delivery.test.ts
+++ b/tests/inspection-report-delivery.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string) {
+  return readFileSync(path, "utf8");
+}
+
+describe("inspection report delivery contracts", () => {
+  it("uses stable application URLs rather than persisted signed URLs", () => {
+    expect(
+      source("features/inspections/server/publishInspectionPdf.ts"),
+    ).toContain("/api/inspections/${args.inspectionId}/report/pdf");
+  });
+
+  it("authorizes report reads before service-role storage access", () => {
+    const route = source("app/api/inspections/[id]/report/pdf/route.ts");
+    expect(route).toContain("auth.getUser()");
+    expect(route.indexOf("getInspectionReportForActor")).toBeLessThan(
+      route.indexOf("createSignedUrl"),
+    );
+  });
+
+  it("attaches every finalized inspection when an invoice is issued", () => {
+    const route = source("app/api/invoices/send/route.ts");
+    expect(route).toContain("attachInspectionReportToInvoice");
+    expect(
+      source(
+        "features/invoices/server/attachInspectionReportToInvoice.ts",
+      ),
+    ).toContain('kind: "inspection_report"');
+  });
+
+  it("publishes the report from both completion entry points", () => {
+    expect(source("app/api/inspections/finalize/pdf/route.ts")).toContain(
+      "publishInspectionPdf",
+    );
+    expect(source("app/api/inspections/sign/route.ts")).toContain(
+      "publishInspectionPdf",
+    );
+  });
+
+  it("exposes reports in customer and fleet portal routes", () => {
+    expect(
+      source("app/portal/work-orders/view/[id]/layout.tsx"),
+    ).toContain("InspectionReportAttachments");
+    expect(
+      source("app/portal/fleet/units/[unitId]/page.tsx"),
+    ).toContain("InspectionReportAttachments");
+  });
+});


### PR DESCRIPTION
## Summary

Completes the inspection lifecycle from technician completion through durable report delivery:

- publishes one immutable, content-addressed inspection PDF from the signed snapshot
- makes technician signing retry-safe when PDF publication is interrupted
- assembles a professional evidence-first HTML/PDF report from one shared report model
- exposes authorized report views/downloads to staff, customer portal users, and fleet portal users
- attaches every finalized inspection as one consolidated `inspection_report` invoice document when an invoice is issued
- keeps `work_orders.inspection_id` and `inspection_pdf_url` synchronized and backfills historical finalized inspections

## Root cause

The existing finalizer could create a PDF, but completion had a split path where signing could finish before the PDF was published. Invoice UI queried only one latest inspection with an expiring URL, while customer and fleet portal surfaces did not expose finalized reports.

## Security and tenancy

- storage remains private
- downloads mint short-lived signed URLs only after actor authorization
- staff access is shop-bound
- customer access requires the matching work-order customer
- fleet access requires membership in the vehicle's fleet
- evidence photos are re-signed only after report authorization

## Validation

- Vercel production-equivalent preview build passed on head `415314f`
- Supabase clean replay passed, including the complete migration chain, runtime authorization/security integrations, schema reconciliation, generated-type parity, and bootstrap/existing-database paths
- full Next.js compile/typecheck passed and generated 403 static pages
- 8 focused inspection assembly/delivery tests passed
- ESLint passed for all changed TypeScript/TSX files
- `git diff --check` passed
- remote comparison is 3 commits / 20 intended files, based directly on `main`

## Deployment notes

- Includes additive migration `20260729130000_publish_inspection_reports.sql`
- No environment variables required
- Migration has not been applied to production
- Production has not been deployed