### PR TITLE
Fix Work Orders production build

### DIFF
--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -270,19 +270,6 @@ function stageAccent(status: string | null | undefined): {
   };
 }
 
-function techRollupChip(rollup: TechRollup): string {
-  if (rollup === "in_progress") {
-    return "border-sky-500/45 bg-sky-500/10 text-sky-700 dark:text-sky-100";
-  }
-  if (rollup === "on_hold") {
-    return "border-amber-500/45 bg-amber-500/10 text-amber-700 dark:text-amber-100";
-  }
-  if (rollup === "completed") {
-    return "border-emerald-500/45 bg-emerald-500/10 text-emerald-700 dark:text-emerald-100";
-  }
-  return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]";
-}
-
 function priorityLabel(priority: number | null | undefined): string | null {
   if (priority === 1) return "Urgent";
   if (priority === 2) return "High";

--- a/tests/work-order-surface-routing.test.ts
+++ b/tests/work-order-surface-routing.test.ts
@@ -33,6 +33,7 @@ describe("work-order surface ownership", () => {
     expect(workOrdersPageSource).not.toContain(
       'className="grid gap-4 md:grid-cols-2 xl:grid-cols-3"',
     );
+    expect(workOrdersPageSource).not.toContain("function techRollupChip");
   });
 
   it("preserves every existing operational action and authorization gate", () => {


### PR DESCRIPTION
### Root cause

PR #1253 removed the UI that used `techRollupChip`, but left the helper declared in `features/work-orders/app/work-orders/view/page.tsx`. The repository treats unused declarations as TypeScript build errors, so the merged deployment failed during `pnpm build`.

### Fix

- Remove only the orphaned `techRollupChip` helper.
- Keep the `TechRollup` domain type, rollup calculation, operational progress, filters, actions, permissions, and redesigned Work Orders presentation unchanged.
- Add a focused regression assertion preventing the dead helper from being reintroduced.

### Scope

- `features/work-orders/app/work-orders/view/page.tsx`: 13 deletions.
- `tests/work-order-surface-routing.test.ts`: 1 assertion.

### Validation

- Focused Work Orders regression suite: 4/4 passed.
- Prettier check: passed.
- Isolated TSX transpilation: passed.
- Remote diff verified against current `main`: exactly two files, zero commits behind.
- Full repository CI and Vercel build will provide complete-checkout verification.

### Database

No migration required.

### Environment variables

None required.