### PR TITLE
Add Work Order filters, board colors, and evidence previews

### DIFF
--- a/features/shared/components/workboard/WorkOrderBoard.tsx
+++ b/features/shared/components/workboard/WorkOrderBoard.tsx
@@ -25,6 +25,7 @@ import type {
   WorkOrderBoardStage,
   WorkOrderBoardVariant,
 } from "../../lib/workboard/types";
+import { getWorkOrderBoardStageSurface } from "../../lib/workboard/presentation";
 import { buildBlockers, timeAgoLabel } from "../../lib/workboard/utils";
 
 type FilterKey = WorkOrderBoardFilterKey;
@@ -100,8 +101,11 @@ function BoardCard({
     row.first_tech_name ||
     row.assigned_summary ||
     "Unassigned";
+  const stageSurface = getWorkOrderBoardStageSurface(row.overall_stage);
   const card = (
-    <article className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 shadow-sm transition hover:border-[var(--brand-accent,#E39A6E)]/60 hover:shadow-md">
+    <article
+      className={`rounded-xl border p-3 shadow-sm transition hover:border-[var(--brand-accent,#E39A6E)]/60 hover:shadow-md ${stageSurface.card}`}
+    >
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <div className="font-extrabold text-[color:var(--theme-text-primary)]">
@@ -478,6 +482,7 @@ export default function WorkOrderBoard(props: {
           >
             {visibleStages.map((stage) => {
               const Icon = stage.icon;
+              const stageSurface = getWorkOrderBoardStageSurface(stage.key);
               const stageRows = filteredRows.filter((row) =>
                 stageFilter === "on_hold"
                   ? row.overall_stage === "on_hold"
@@ -489,12 +494,14 @@ export default function WorkOrderBoard(props: {
               return (
                 <section
                   key={stage.key}
-                  className="min-h-[560px] rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3"
+                  className={`min-h-[560px] rounded-xl border p-3 ${stageSurface.column}`}
                 >
                   <header className="mb-3 flex items-center gap-2">
                     <Icon className={`h-4 w-4 ${stage.tone}`} />
                     <h2 className="text-sm font-bold">{stage.label}</h2>
-                    <span className="rounded-full bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-xs font-bold">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-bold ${stageSurface.count}`}
+                    >
                       {stageRows.length}
                     </span>
                   </header>

--- a/features/shared/lib/workboard/presentation.ts
+++ b/features/shared/lib/workboard/presentation.ts
@@ -1,0 +1,56 @@
+import type { WorkOrderBoardStage } from "./types";
+
+export type WorkOrderBoardStageSurface = {
+  column: string;
+  card: string;
+  count: string;
+};
+
+export const WORK_ORDER_BOARD_STAGE_SURFACES: Record<
+  WorkOrderBoardStage,
+  WorkOrderBoardStageSurface
+> = {
+  awaiting: {
+    column: "border-blue-500/25 bg-blue-500/[0.055]",
+    card: "border-blue-500/30 bg-blue-500/[0.075]",
+    count: "bg-blue-500/15 text-blue-700 dark:text-blue-200",
+  },
+  in_progress: {
+    column: "border-violet-500/25 bg-violet-500/[0.055]",
+    card: "border-violet-500/30 bg-violet-500/[0.075]",
+    count: "bg-violet-500/15 text-violet-700 dark:text-violet-200",
+  },
+  awaiting_approval: {
+    column: "border-amber-500/25 bg-amber-500/[0.055]",
+    card: "border-amber-500/30 bg-amber-500/[0.075]",
+    count: "bg-amber-500/15 text-amber-800 dark:text-amber-200",
+  },
+  waiting_parts: {
+    column: "border-orange-500/25 bg-orange-500/[0.055]",
+    card: "border-orange-500/30 bg-orange-500/[0.075]",
+    count: "bg-orange-500/15 text-orange-800 dark:text-orange-200",
+  },
+  on_hold: {
+    column: "border-rose-500/25 bg-rose-500/[0.055]",
+    card: "border-rose-500/30 bg-rose-500/[0.075]",
+    count: "bg-rose-500/15 text-rose-700 dark:text-rose-200",
+  },
+  completed: {
+    column: "border-emerald-500/25 bg-emerald-500/[0.055]",
+    card: "border-emerald-500/30 bg-emerald-500/[0.075]",
+    count: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-200",
+  },
+  empty: {
+    column:
+      "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]",
+    card: "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]",
+    count:
+      "bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-secondary)]",
+  },
+};
+
+export function getWorkOrderBoardStageSurface(
+  stage: WorkOrderBoardStage | null | undefined,
+): WorkOrderBoardStageSurface {
+  return WORK_ORDER_BOARD_STAGE_SURFACES[stage ?? "empty"];
+}

--- a/features/work-orders/app/work-orders/view/page.tsx
+++ b/features/work-orders/app/work-orders/view/page.tsx
@@ -19,6 +19,12 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
+import {
+  countWorkOrdersBySummary,
+  filterWorkOrdersBySummary,
+  toggleWorkOrderSummaryFilter,
+  type WorkOrderSummaryFilter,
+} from "@/features/work-orders/lib/workOrderListFilters";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 
 import { WorkOrderAssignedSummary } from "@/features/work-orders/components/WorkOrderAssignedSummary";
@@ -300,6 +306,8 @@ export default function WorkOrdersView(): JSX.Element {
   const [loading, setLoading] = useState(true);
   const [q, setQ] = useState("");
   const [status, setStatus] = useState<string>("");
+  const [summaryFilter, setSummaryFilter] =
+    useState<WorkOrderSummaryFilter | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [isSeededShop, setIsSeededShop] = useState(false);
 
@@ -879,6 +887,7 @@ export default function WorkOrdersView(): JSX.Element {
   );
 
   const total = rows.length;
+  const summaryNow = useMemo(() => Date.now(), [rows]);
 
   const activeCount = useMemo(
     () =>
@@ -893,48 +902,23 @@ export default function WorkOrdersView(): JSX.Element {
   );
 
   const readyToWorkCount = useMemo(
-    () =>
-      rows.filter((row) =>
-        [
-          "new",
-          "awaiting",
-          "awaiting_inspection",
-          "recommended",
-          "approved",
-          "queued",
-          "planned",
-        ].includes(normalizeStatusKey(row.status)),
-      ).length,
-    [rows],
+    () => countWorkOrdersBySummary(rows, "ready_to_work", summaryNow),
+    [rows, summaryNow],
   );
 
   const waitingPartsCount = useMemo(
-    () =>
-      rows.filter((row) => normalizeStatusKey(row.status) === "waiting_parts")
-        .length,
-    [rows],
+    () => countWorkOrdersBySummary(rows, "waiting_parts", summaryNow),
+    [rows, summaryNow],
   );
 
   const readyToInvoiceCount = useMemo(
-    () =>
-      rows.filter((row) =>
-        ["completed", "ready_to_invoice"].includes(
-          normalizeStatusKey(row.status),
-        ),
-      ).length,
-    [rows],
+    () => countWorkOrdersBySummary(rows, "ready_to_invoice", summaryNow),
+    [rows, summaryNow],
   );
 
   const atRiskCount = useMemo(
-    () =>
-      rows.filter((row) => {
-        if (Number(row.priority ?? 3) === 1) return true;
-        const updatedAt = new Date(
-          row.updated_at ?? row.created_at ?? Date.now(),
-        ).getTime();
-        return Date.now() - updatedAt >= 3 * 86400000;
-      }).length,
-    [rows],
+    () => countWorkOrdersBySummary(rows, "at_risk", summaryNow),
+    [rows, summaryNow],
   );
 
   const needsAttentionCount = useMemo(
@@ -942,17 +926,53 @@ export default function WorkOrdersView(): JSX.Element {
       rows.filter((row) => {
         const statusKey = normalizeStatusKey(row.status);
         const updatedAt = new Date(
-          row.updated_at ?? row.created_at ?? Date.now(),
+          row.updated_at ?? row.created_at ?? summaryNow,
         ).getTime();
         return (
           Number(row.priority ?? 3) === 1 ||
           statusKey === "awaiting_approval" ||
           statusKey === "waiting_parts" ||
-          Date.now() - updatedAt >= 3 * 86400000
+          summaryNow - updatedAt >= 3 * 86400000
         );
       }).length,
-    [rows],
+    [rows, summaryNow],
   );
+
+  const visibleRows = useMemo(
+    () => filterWorkOrdersBySummary(rows, summaryFilter, summaryNow),
+    [rows, summaryFilter, summaryNow],
+  );
+
+  const summaryCards = [
+    {
+      label: "At risk",
+      value: atRiskCount,
+      icon: AlertTriangle,
+      tone: "text-orange-600 dark:text-orange-300",
+      filter: "at_risk",
+    },
+    {
+      label: "Ready to work",
+      value: readyToWorkCount,
+      icon: CheckCircle2,
+      tone: "text-blue-600 dark:text-blue-300",
+      filter: "ready_to_work",
+    },
+    {
+      label: "Waiting parts",
+      value: waitingPartsCount,
+      icon: Clock3,
+      tone: "text-amber-600 dark:text-amber-300",
+      filter: "waiting_parts",
+    },
+    {
+      label: "Ready to invoice",
+      value: readyToInvoiceCount,
+      icon: ClipboardCheck,
+      tone: "text-emerald-600 dark:text-emerald-300",
+      filter: "ready_to_invoice",
+    },
+  ] as const;
 
   return (
     <div
@@ -1027,7 +1047,10 @@ export default function WorkOrdersView(): JSX.Element {
 
             <select
               value={status}
-              onChange={(event) => setStatus(event.target.value)}
+              onChange={(event) => {
+                setStatus(event.target.value);
+                setSummaryFilter(null);
+              }}
               className={`${SELECT_DARK} h-11`}
               aria-label="Filter by status"
             >
@@ -1065,43 +1088,32 @@ export default function WorkOrdersView(): JSX.Element {
 
         {!loading && !err ? (
           <section className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-            {[
-              {
-                label: "At risk",
-                value: atRiskCount,
-                icon: AlertTriangle,
-                tone: "text-orange-600 dark:text-orange-300",
-              },
-              {
-                label: "Ready to work",
-                value: readyToWorkCount,
-                icon: CheckCircle2,
-                tone: "text-blue-600 dark:text-blue-300",
-              },
-              {
-                label: "Waiting parts",
-                value: waitingPartsCount,
-                icon: Clock3,
-                tone: "text-amber-600 dark:text-amber-300",
-              },
-              {
-                label: "Ready to invoice",
-                value: readyToInvoiceCount,
-                icon: ClipboardCheck,
-                tone: "text-emerald-600 dark:text-emerald-300",
-              },
-            ].map(({ label, value, icon: Icon, tone }) => (
-              <div
-                key={label}
-                className="flex items-center gap-3 rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-4 py-3 shadow-sm"
-              >
-                <Icon className={`h-5 w-5 ${tone}`} />
-                <span className="flex-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                  {label}
-                </span>
-                <strong className={`text-xl ${tone}`}>{value}</strong>
-              </div>
-            ))}
+            {summaryCards.map(({ label, value, icon: Icon, tone, filter }) => {
+              const selected = summaryFilter === filter;
+              return (
+                <button
+                  key={label}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() =>
+                    setSummaryFilter((current) =>
+                      toggleWorkOrderSummaryFilter(current, filter),
+                    )
+                  }
+                  className={`flex items-center gap-3 rounded-xl border bg-[color:var(--desktop-item-bg)] px-4 py-3 text-left shadow-sm transition hover:border-[color:var(--brand-primary,#1747FF)]/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-primary,#1747FF)]/50 ${
+                    selected
+                      ? "border-[color:var(--brand-primary,#1747FF)] shadow-[0_0_0_1px_color-mix(in_srgb,var(--brand-primary,#1747FF)_30%,transparent)]"
+                      : "border-[color:var(--desktop-border)]"
+                  }`}
+                >
+                  <Icon className={`h-5 w-5 ${tone}`} />
+                  <span className="flex-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                    {label}
+                  </span>
+                  <strong className={`text-xl ${tone}`}>{value}</strong>
+                </button>
+              );
+            })}
           </section>
         ) : null}
 
@@ -1120,11 +1132,13 @@ export default function WorkOrdersView(): JSX.Element {
               />
             ))}
           </section>
-        ) : rows.length === 0 ? (
+        ) : visibleRows.length === 0 ? (
           <div className="rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] p-6 text-sm text-[color:var(--theme-text-secondary)]">
             {workforceDrilldownActive
               ? "No unassigned active jobs right now."
-              : "No work orders match your current filters."}
+              : summaryFilter
+                ? "No work orders match the selected summary filter."
+                : "No work orders match your current filters."}
           </div>
         ) : (
           <section className="overflow-hidden rounded-2xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-panel-bg-soft)] shadow-[var(--desktop-shadow-card)]">
@@ -1137,7 +1151,7 @@ export default function WorkOrdersView(): JSX.Element {
             </div>
 
             <div className="space-y-2 p-2">
-              {rows.map((row) => {
+              {visibleRows.map((row) => {
                 const displayId = workOrderDisplayId(row);
                 const href = `/work-orders/${row.custom_id ?? row.id}?mode=view`;
                 const isAssigning = assigningFor === row.id;

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -2,19 +2,28 @@
 
 import { useEffect, useMemo, useState, type JSX, type MouseEvent } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { ChevronDown, ChevronUp, CircleAlert, CircleCheck, Images, PackagePlus, Play, UserRound, Wrench } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  CircleAlert,
+  CircleCheck,
+  PackagePlus,
+  UserRound,
+  Wrench,
+} from "lucide-react";
 
 import type { Database } from "@shared/types/types/supabase";
 import { Button } from "@shared/components/ui/Button";
 import Card from "@shared/components/ui/Card";
 import { cn } from "@shared/lib/utils";
 import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
-import { formatLaborSummary, formatPartsSummary, resolvePrimaryTechDisplay } from "@/features/work-orders/lib/display/linePresentation";
-import EvidenceImage from "@/features/work-orders/components/evidence/EvidenceImage";
 import {
-  isVideoEvidence,
-  type WorkOrderEvidenceItem,
-} from "@/features/work-orders/lib/evidence/workOrderEvidence";
+  formatLaborSummary,
+  formatPartsSummary,
+  resolvePrimaryTechDisplay,
+} from "@/features/work-orders/lib/display/linePresentation";
+import JobEvidenceStrip from "@/features/work-orders/components/evidence/JobEvidenceStrip";
+import type { WorkOrderEvidenceItem } from "@/features/work-orders/lib/evidence/workOrderEvidence";
 
 type WorkOrderLine = Database["public"]["Tables"]["work_order_lines"]["Row"];
 type WorkOrderPartAllocation =
@@ -80,11 +89,12 @@ type StatusVisual = {
   muted: boolean;
 };
 
-const METALLIC_CARD_SURFACE =
-  "bg-[var(--theme-gradient-panel)]";
+const METALLIC_CARD_SURFACE = "bg-[var(--theme-gradient-panel)]";
 
 function norm(s: unknown): string {
-  return String(s ?? "").trim().toLowerCase();
+  return String(s ?? "")
+    .trim()
+    .toLowerCase();
 }
 
 function formatCurrency(value: number | null | undefined): string {
@@ -108,18 +118,24 @@ function resolveStatusVisual(status: string | null | undefined): StatusVisual {
     return {
       label: null,
       railClass: "bg-[color:var(--theme-surface-subtle)]",
-      chipClass: "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]",
+      chipClass:
+        "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]",
       borderClass: "border-[color:var(--theme-border-soft)]",
       glowClass: "",
       muted: false,
     };
   }
 
-  if (normalized === "completed" || normalized === "ready_to_invoice" || normalized === "invoiced") {
+  if (
+    normalized === "completed" ||
+    normalized === "ready_to_invoice" ||
+    normalized === "invoiced"
+  ) {
     return {
       label: statusLabelFromKey(normalized),
       railClass: "bg-[color:var(--theme-surface-subtle)]",
-      chipClass: "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]",
+      chipClass:
+        "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]",
       borderClass: "border-[color:var(--theme-border-soft)]",
       glowClass: "",
       muted: true,
@@ -159,9 +175,19 @@ function resolveStatusVisual(status: string | null | undefined): StatusVisual {
     };
   }
 
-  if (raw === "blocked" || raw === "critical" || normalized === "declined" || normalized === "deferred") {
+  if (
+    raw === "blocked" ||
+    raw === "critical" ||
+    normalized === "declined" ||
+    normalized === "deferred"
+  ) {
     return {
-      label: normalized === "deferred" ? "Deferred" : normalized === "declined" ? "Declined" : "Blocked",
+      label:
+        normalized === "deferred"
+          ? "Deferred"
+          : normalized === "declined"
+            ? "Declined"
+            : "Blocked",
       railClass: "bg-red-400/90",
       chipClass: "border-red-300/60 bg-red-500/12 text-red-100",
       borderClass: "border-red-400/45",
@@ -182,7 +208,12 @@ function resolveStatusVisual(status: string | null | undefined): StatusVisual {
   }
 
   return {
-    label: normalized === "pending" ? "Awaiting" : raw ? statusLabelFromKey(raw) : "Awaiting",
+    label:
+      normalized === "pending"
+        ? "Awaiting"
+        : raw
+          ? statusLabelFromKey(raw)
+          : "Awaiting",
     railClass: "bg-sky-500/80",
     chipClass: "border-sky-400/55 bg-sky-500/10 text-sky-100",
     borderClass: "border-sky-500/40",
@@ -198,7 +229,8 @@ function computeReviewFlags(args: {
 }): ReviewFlags {
   const localMissingCause = !norm(args.line.cause);
   const localMissingCorrection = !norm(args.line.correction);
-  const localMissingComplaint = !norm(args.line.complaint) && !norm(args.line.description);
+  const localMissingComplaint =
+    !norm(args.line.complaint) && !norm(args.line.description);
   const localNoParts = args.partsCount === 0;
 
   const issues = Array.isArray(args.reviewIssues) ? args.reviewIssues : [];
@@ -270,17 +302,15 @@ function ReviewPill({
   );
 }
 
-function MetaTile({
-  label,
-  value,
-}: {
-  label: string;
-  value: string;
-}) {
+function MetaTile({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3">
-      <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">{label}</div>
-      <div className="mt-1 text-sm text-[color:var(--theme-text-primary)]">{value}</div>
+      <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+        {label}
+      </div>
+      <div className="mt-1 text-sm text-[color:var(--theme-text-primary)]">
+        {value}
+      </div>
     </div>
   );
 }
@@ -343,7 +373,10 @@ export function JobCard({
   const assignedTech = useMemo(() => {
     const techId = line.assigned_tech_id;
     const profile = technicians.find((tech) => tech.id === techId) ?? null;
-    return resolvePrimaryTechDisplay(line, profile ? { ...profile, role: "tech" } : null);
+    return resolvePrimaryTechDisplay(
+      line,
+      profile ? { ...profile, role: "tech" } : null,
+    );
   }, [line, technicians]);
 
   const effectivePartsCount = Math.max(
@@ -367,9 +400,11 @@ export function JobCard({
     : "—";
 
   const lineTotal =
-    pricing?.lineTotal ?? (Number(pricing?.laborTotal ?? 0) + Number(pricing?.partsTotal ?? 0));
+    pricing?.lineTotal ??
+    Number(pricing?.laborTotal ?? 0) + Number(pricing?.partsTotal ?? 0);
 
-  const isBlocked = norm(line.status) === "on_hold" || norm(line.status) === "blocked";
+  const isBlocked =
+    norm(line.status) === "on_hold" || norm(line.status) === "blocked";
   const waitingApproval = norm(line.approval_state) === "pending";
 
   const showDeleteAction = canDelete === true && typeof onDelete === "function";
@@ -408,17 +443,31 @@ export function JobCard({
         className={cn(
           "relative overflow-hidden border p-0 transition",
           METALLIC_CARD_SURFACE,
-          isPunchedIn ? "border-cyan-300/70 shadow-[0_0_28px_rgba(34,211,238,0.24)]" : statusVisual.borderClass,
+          isPunchedIn
+            ? "border-cyan-300/70 shadow-[0_0_28px_rgba(34,211,238,0.24)]"
+            : statusVisual.borderClass,
           !isPunchedIn && statusVisual.glowClass,
           isPunchedIn && "[animation:pulse_3.2s_ease-in-out_infinite]",
-          statusVisual.muted && "border-[color:var(--theme-border-soft)] opacity-[0.74] saturate-[0.56] contrast-[0.9]",
+          statusVisual.muted &&
+            "border-[color:var(--theme-border-soft)] opacity-[0.74] saturate-[0.56] contrast-[0.9]",
           "hover:-translate-y-[1px] hover:border-[color:var(--theme-border-soft)]",
           "focus-within:border-[color:var(--theme-border-soft)]",
-          isSelected && !isPunchedIn && "border-[color:var(--theme-border-soft)] shadow-[0_0_0_1px_rgba(148,163,184,0.45)]",
-          isSelected && isPunchedIn && "shadow-[0_0_0_1px_rgba(226,232,240,0.38),0_0_28px_rgba(34,211,238,0.24)]",
+          isSelected &&
+            !isPunchedIn &&
+            "border-[color:var(--theme-border-soft)] shadow-[0_0_0_1px_rgba(148,163,184,0.45)]",
+          isSelected &&
+            isPunchedIn &&
+            "shadow-[0_0_0_1px_rgba(226,232,240,0.38),0_0_28px_rgba(34,211,238,0.24)]",
         )}
       >
-        <div className={cn("absolute inset-y-0 left-0", isPunchedIn ? "w-2 bg-cyan-300" : "w-1.5", !isPunchedIn && statusVisual.railClass, statusVisual.muted && "opacity-75")} />
+        <div
+          className={cn(
+            "absolute inset-y-0 left-0",
+            isPunchedIn ? "w-2 bg-cyan-300" : "w-1.5",
+            !isPunchedIn && statusVisual.railClass,
+            statusVisual.muted && "opacity-75",
+          )}
+        />
 
         <div className={cn("relative pl-5", compact ? "p-3" : "p-4")}>
           <div className={cn("flex flex-col", compact ? "gap-2" : "gap-3")}>
@@ -428,7 +477,14 @@ export function JobCard({
                   <span className="inline-flex h-7 min-w-7 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 text-xs font-semibold text-[color:var(--theme-text-primary)]">
                     {index + 1}
                   </span>
-                  <h3 className={cn("truncate font-semibold text-[color:var(--theme-text-primary)]", compact ? "text-sm sm:text-[15px]" : "text-[15px] sm:text-base")}>
+                  <h3
+                    className={cn(
+                      "truncate font-semibold text-[color:var(--theme-text-primary)]",
+                      compact
+                        ? "text-sm sm:text-[15px]"
+                        : "text-[15px] sm:text-base",
+                    )}
+                  >
                     {jobLabel}
                   </h3>
                   {statusVisual.label ? (
@@ -436,7 +492,8 @@ export function JobCard({
                       className={cn(
                         "inline-flex items-center rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em]",
                         statusVisual.chipClass,
-                        statusVisual.muted && "text-[color:var(--theme-text-secondary)]",
+                        statusVisual.muted &&
+                          "text-[color:var(--theme-text-secondary)]",
                       )}
                     >
                       {statusVisual.label}
@@ -457,7 +514,13 @@ export function JobCard({
                 </p>
               </div>
 
-              <div className={cn("flex max-w-full flex-wrap items-center justify-end", compact ? "gap-1" : "gap-1.5", statusVisual.muted && "opacity-80")}>
+              <div
+                className={cn(
+                  "flex max-w-full flex-wrap items-center justify-end",
+                  compact ? "gap-1" : "gap-1.5",
+                  statusVisual.muted && "opacity-80",
+                )}
+              >
                 {canAssign && onAssign ? (
                   <label
                     className="relative inline-flex items-center"
@@ -471,7 +534,9 @@ export function JobCard({
                       onChange={(event) => onAssign(event.target.value)}
                       className="h-8 max-w-44 appearance-none truncate rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] py-1 pl-7 pr-3 text-[10px] font-semibold text-[color:var(--theme-text-primary)]"
                     >
-                      <option value="" disabled>Unassigned</option>
+                      <option value="" disabled>
+                        Unassigned
+                      </option>
                       {technicians.map((tech) => (
                         <option key={tech.id} value={tech.id}>
                           {tech.full_name || "Unnamed tech"}
@@ -487,13 +552,23 @@ export function JobCard({
                 )}
 
                 {onOpenInspection ? (
-                  <Button type="button" variant="secondary" size="sm" onClick={onOpenInspection}>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={onOpenInspection}
+                  >
                     Inspection
                   </Button>
                 ) : null}
 
                 {onAddPart ? (
-                  <Button type="button" variant="secondary" size="sm" onClick={handleAddPartClick}>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleAddPartClick}
+                  >
                     Add Part
                   </Button>
                 ) : null}
@@ -528,7 +603,10 @@ export function JobCard({
                   variant="ghost"
                   size="sm"
                   onClick={() => setCollapsed((v) => !v)}
-                  className={cn("border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]", compact && "px-2")}
+                  className={cn(
+                    "border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]",
+                    compact && "px-2",
+                  )}
                 >
                   {collapsed ? (
                     <>
@@ -543,27 +621,71 @@ export function JobCard({
               </div>
             </div>
 
-            <div className={cn("flex flex-wrap", compact ? "gap-1" : "gap-1.5", statusVisual.muted && "opacity-85")}>
-              {!hideExecutionStageCompletenessPills && reviewFlags.missingCause ? (
-                <ReviewPill tone="warn" label="Cause Missing" title="Cause completeness" />
+            <div
+              className={cn(
+                "flex flex-wrap",
+                compact ? "gap-1" : "gap-1.5",
+                statusVisual.muted && "opacity-85",
+              )}
+            >
+              {!hideExecutionStageCompletenessPills &&
+              reviewFlags.missingCause ? (
+                <ReviewPill
+                  tone="warn"
+                  label="Cause Missing"
+                  title="Cause completeness"
+                />
               ) : null}
-              {!hideExecutionStageCompletenessPills && reviewFlags.missingCorrection ? (
-                <ReviewPill tone="warn" label="Correction Missing" title="Correction completeness" />
+              {!hideExecutionStageCompletenessPills &&
+              reviewFlags.missingCorrection ? (
+                <ReviewPill
+                  tone="warn"
+                  label="Correction Missing"
+                  title="Correction completeness"
+                />
               ) : null}
               {!hideExecutionStageCompletenessPills && reviewFlags.noParts ? (
-                <ReviewPill tone="warn" label="No Parts" title="Parts completeness" />
+                <ReviewPill
+                  tone="warn"
+                  label="No Parts"
+                  title="Parts completeness"
+                />
               ) : null}
-              {isBlocked ? <ReviewPill tone="warn" label="Blocked" title="Line currently blocked or on hold" /> : null}
+              {isBlocked ? (
+                <ReviewPill
+                  tone="warn"
+                  label="Blocked"
+                  title="Line currently blocked or on hold"
+                />
+              ) : null}
               {waitingApproval ? (
-                <ReviewPill tone="info" label="Awaiting Approval" title="Waiting for approval decision" />
+                <ReviewPill
+                  tone="info"
+                  label="Awaiting Approval"
+                  title="Waiting for approval decision"
+                />
               ) : null}
               {reviewFlags.missingComplaint ? (
-                <ReviewPill tone="info" label="Complaint Missing" title="Complaint / description completeness" />
+                <ReviewPill
+                  tone="info"
+                  label="Complaint Missing"
+                  title="Complaint / description completeness"
+                />
               ) : null}
               {reviewFlags.otherIssues > 0 ? (
-                <ReviewPill tone="info" label={`${reviewFlags.otherIssues} Other`} title="Additional review issues" />
+                <ReviewPill
+                  tone="info"
+                  label={`${reviewFlags.otherIssues} Other`}
+                  title="Additional review issues"
+                />
               ) : null}
-              {reviewOk ? <ReviewPill tone="ok" label="Review Ready" title="Review checks are clear" /> : null}
+              {reviewOk ? (
+                <ReviewPill
+                  tone="ok"
+                  label="Review Ready"
+                  title="Review checks are clear"
+                />
+              ) : null}
             </div>
 
             {!collapsed ? (
@@ -586,67 +708,44 @@ export function JobCard({
                         partsTotal: Number(pricing?.partsTotal ?? 0),
                       }),
                       partsStatusLabel,
-                    ].filter(Boolean).join(" · ")}
+                    ]
+                      .filter(Boolean)
+                      .join(" · ")}
                   />
-                  <MetaTile label="Line Total" value={lineTotal > 0 ? formatCurrency(lineTotal) : "Estimate pending"} />
+                  <MetaTile
+                    label="Line Total"
+                    value={
+                      lineTotal > 0
+                        ? formatCurrency(lineTotal)
+                        : "Estimate pending"
+                    }
+                  />
                 </div>
 
                 {evidence.length > 0 ? (
-                  <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2.5">
-                    <div className="mb-2 flex items-center justify-between gap-2">
-                      <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
-                        <Images className="h-3.5 w-3.5" />
-                        Evidence
-                      </span>
-                      <span className="text-[10px] text-[color:var(--theme-text-muted)]">
-                        {evidence.filter((item) => !isVideoEvidence(item)).length} photo
-                        {evidence.filter((item) => !isVideoEvidence(item)).length === 1 ? "" : "s"}
-                        {evidence.some(isVideoEvidence)
-                          ? ` · ${evidence.filter(isVideoEvidence).length} video${evidence.filter(isVideoEvidence).length === 1 ? "" : "s"}`
-                          : ""}
-                      </span>
-                    </div>
-                    <div className="flex gap-2 overflow-x-auto">
-                      {evidence.slice(0, 3).map((item) => (
-                        <div
-                          key={item.id}
-                          className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg border border-[color:var(--theme-border-soft)] bg-black"
-                        >
-                          {isVideoEvidence(item) ? (
-                            <>
-                              {item.displayUrl ? (
-                                <video src={item.displayUrl} muted preload="metadata" className="h-full w-full object-cover" />
-                              ) : null}
-                              <Play className="absolute left-1/2 top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 text-white" />
-                            </>
-                          ) : (
-                            <EvidenceImage
-                              item={item}
-                              alt={item.fileName ?? "Job evidence"}
-                              className="h-full [&_img]:h-full [&_img]:object-cover"
-                            />
-                          )}
-                        </div>
-                      ))}
-                      {evidence.length > 3 ? (
-                        <div className="grid h-16 w-16 shrink-0 place-items-center rounded-lg border border-[color:var(--theme-border-soft)] text-xs font-semibold text-[color:var(--theme-text-secondary)]">
-                          +{evidence.length - 3}
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
+                  <JobEvidenceStrip evidence={evidence} />
                 ) : null}
 
-                {(line.complaint || line.cause || line.correction || line.hold_reason) ? (
+                {line.complaint ||
+                line.cause ||
+                line.correction ||
+                line.hold_reason ? (
                   <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-xs text-[color:var(--theme-text-secondary)]">
-                    {line.complaint ? <div>Complaint: {line.complaint}</div> : null}
+                    {line.complaint ? (
+                      <div>Complaint: {line.complaint}</div>
+                    ) : null}
                     {line.cause ? <div>Cause: {line.cause}</div> : null}
-                    {line.correction ? <div>Correction: {line.correction}</div> : null}
-                    {line.hold_reason ? <div>Blocker: {line.hold_reason}</div> : null}
-                    <div className="mt-2 text-[11px] text-[color:var(--theme-text-muted)]">Updated {updatedLabel}</div>
+                    {line.correction ? (
+                      <div>Correction: {line.correction}</div>
+                    ) : null}
+                    {line.hold_reason ? (
+                      <div>Blocker: {line.hold_reason}</div>
+                    ) : null}
+                    <div className="mt-2 text-[11px] text-[color:var(--theme-text-muted)]">
+                      Updated {updatedLabel}
+                    </div>
                   </div>
                 ) : null}
-
               </>
             ) : null}
           </div>

--- a/features/work-orders/components/WorkOrderAssignedSummary.tsx
+++ b/features/work-orders/components/WorkOrderAssignedSummary.tsx
@@ -4,7 +4,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 
-
 type Props = {
   workOrderId: string;
 };
@@ -65,10 +64,7 @@ export function WorkOrderAssignedSummary({ workOrderId }: Props) {
 
   // ---------- derived values ----------
 
-  const hasActive = useMemo(
-    () => rows.some((r) => !!r.has_active),
-    [rows],
-  );
+  const hasActive = useMemo(() => rows.some((r) => !!r.has_active), [rows]);
 
   const firstTechLabel = useMemo(() => {
     if (!rows.length) return null;
@@ -101,9 +97,9 @@ export function WorkOrderAssignedSummary({ workOrderId }: Props) {
   const base =
     "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-[0.7rem] font-medium";
   const activeCls =
-    "border-emerald-400/80 bg-emerald-500/15 text-emerald-100 shadow-[0_0_18px_rgba(16,185,129,0.8)]";
+    "border-emerald-500/55 bg-emerald-500/15 text-emerald-800 shadow-[0_0_12px_rgba(16,185,129,0.12)] dark:border-emerald-400/80 dark:text-emerald-100 dark:shadow-[0_0_18px_rgba(16,185,129,0.45)]";
   const assignedCls =
-    "border-amber-400/80 bg-amber-500/15 text-amber-50";
+    "border-amber-500/55 bg-amber-500/15 text-amber-900 dark:border-amber-400/80 dark:text-amber-100";
 
   return (
     <span
@@ -122,7 +118,7 @@ export function WorkOrderAssignedSummary({ workOrderId }: Props) {
       )}
       <span>{firstTechLabel}</span>
       {extraCount > 0 && (
-        <span className="text-[0.65rem] text-[color:var(--theme-text-secondary)]">
+        <span className="text-[0.65rem] text-current opacity-75">
           +{extraCount} collaborators
         </span>
       )}

--- a/features/work-orders/components/evidence/JobEvidenceStrip.tsx
+++ b/features/work-orders/components/evidence/JobEvidenceStrip.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useMemo, useState, type KeyboardEvent, type MouseEvent } from "react";
+import { ChevronLeft, ChevronRight, Images, Play, X } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/features/shared/components/ui/dialog";
+import {
+  isVideoEvidence,
+  type WorkOrderEvidenceItem,
+} from "@/features/work-orders/lib/evidence/workOrderEvidence";
+
+import EvidenceImage from "./EvidenceImage";
+
+type Props = {
+  evidence: WorkOrderEvidenceItem[];
+};
+
+export function nextEvidenceIndex(
+  current: number,
+  itemCount: number,
+  direction: -1 | 1,
+): number {
+  if (itemCount <= 0) return 0;
+  return (current + direction + itemCount) % itemCount;
+}
+
+function evidenceLabel(item: WorkOrderEvidenceItem, index: number): string {
+  return item.fileName?.trim() || `Evidence ${index + 1}`;
+}
+
+export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const photos = useMemo(
+    () => evidence.filter((item) => !isVideoEvidence(item)).length,
+    [evidence],
+  );
+  const videos = evidence.length - photos;
+  const selected =
+    selectedIndex === null ? null : (evidence[selectedIndex] ?? null);
+
+  const stopCardClick = (event: MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
+
+  const stopCardKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
+
+  const moveSelection = (direction: -1 | 1) => {
+    setSelectedIndex((current) =>
+      current === null
+        ? null
+        : nextEvidenceIndex(current, evidence.length, direction),
+    );
+  };
+
+  return (
+    <div onClick={stopCardClick} onKeyDown={stopCardKeyDown}>
+      <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2.5">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+            <Images className="h-3.5 w-3.5" />
+            Evidence
+          </span>
+          <span className="text-[10px] text-[color:var(--theme-text-muted)]">
+            {photos} photo{photos === 1 ? "" : "s"}
+            {videos > 0 ? ` · ${videos} video${videos === 1 ? "" : "s"}` : ""}
+          </span>
+        </div>
+
+        <div className="flex gap-2 overflow-x-auto">
+          {evidence.slice(0, 3).map((item, index) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => setSelectedIndex(index)}
+              aria-label={`Open ${evidenceLabel(item, index)}`}
+              className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg border border-[color:var(--theme-border-soft)] bg-black text-left transition hover:border-[color:var(--brand-primary,#1747FF)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-primary,#1747FF)]"
+            >
+              {isVideoEvidence(item) ? (
+                <>
+                  {item.displayUrl ? (
+                    <video
+                      src={item.displayUrl}
+                      muted
+                      preload="metadata"
+                      className="h-full w-full object-cover"
+                    />
+                  ) : null}
+                  <Play className="absolute left-1/2 top-1/2 h-5 w-5 -translate-x-1/2 -translate-y-1/2 text-white drop-shadow" />
+                </>
+              ) : (
+                <EvidenceImage
+                  item={item}
+                  alt={evidenceLabel(item, index)}
+                  className="h-full [&_img]:h-full [&_img]:object-cover"
+                />
+              )}
+            </button>
+          ))}
+
+          {evidence.length > 3 ? (
+            <button
+              type="button"
+              onClick={() => setSelectedIndex(3)}
+              aria-label={`Open ${evidence.length - 3} more evidence item${evidence.length - 3 === 1 ? "" : "s"}`}
+              className="grid h-16 w-16 shrink-0 place-items-center rounded-lg border border-[color:var(--theme-border-soft)] text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[color:var(--brand-primary,#1747FF)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-primary,#1747FF)]"
+            >
+              +{evidence.length - 3}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <Dialog
+        open={selected !== null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedIndex(null);
+        }}
+      >
+        {selected && selectedIndex !== null ? (
+          <DialogContent
+            className="overflow-hidden"
+            style={{
+              width: "min(92vw, 48rem)",
+              maxWidth: "48rem",
+              padding: 0,
+            }}
+            onClick={stopCardClick}
+            onKeyDown={stopCardKeyDown}
+          >
+            <DialogHeader className="flex-row items-start justify-between gap-3 px-4 py-3">
+              <div className="min-w-0">
+                <DialogTitle className="truncate text-sm normal-case tracking-normal">
+                  {evidenceLabel(selected, selectedIndex)}
+                </DialogTitle>
+                <DialogDescription className="mt-0.5 text-xs">
+                  Evidence {selectedIndex + 1} of {evidence.length}
+                </DialogDescription>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelectedIndex(null)}
+                aria-label="Close evidence preview"
+                className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-[color:var(--theme-border-soft)] text-[color:var(--theme-text-secondary)] transition hover:text-[color:var(--theme-text-primary)]"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </DialogHeader>
+
+            <div className="grid min-h-64 place-items-center bg-black/90 p-3">
+              {selected.displayUrl ? (
+                isVideoEvidence(selected) ? (
+                  <video
+                    key={selected.id}
+                    src={selected.displayUrl}
+                    controls
+                    preload="metadata"
+                    className="max-h-[65vh] w-full object-contain"
+                  />
+                ) : (
+                  <EvidenceImage
+                    item={selected}
+                    alt={evidenceLabel(selected, selectedIndex)}
+                    className="flex max-h-[65vh] w-full items-center justify-center [&_img]:max-h-[65vh] [&_img]:w-auto [&_img]:max-w-full [&_img]:object-contain"
+                  />
+                )
+              ) : (
+                <div className="text-sm text-white/70">Preview unavailable</div>
+              )}
+            </div>
+
+            {evidence.length > 1 ? (
+              <div className="flex items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] px-4 py-3">
+                <button
+                  type="button"
+                  onClick={() => moveSelection(-1)}
+                  aria-label="Previous evidence"
+                  className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--brand-primary,#1747FF)]"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </button>
+                <span className="text-xs text-[color:var(--theme-text-muted)]">
+                  {selectedIndex + 1} / {evidence.length}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => moveSelection(1)}
+                  aria-label="Next evidence"
+                  className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--brand-primary,#1747FF)]"
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            ) : null}
+          </DialogContent>
+        ) : null}
+      </Dialog>
+    </div>
+  );
+}

--- a/features/work-orders/lib/workOrderListFilters.ts
+++ b/features/work-orders/lib/workOrderListFilters.ts
@@ -1,0 +1,125 @@
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
+
+export const WORK_ORDER_SUMMARY_FILTERS = [
+  "at_risk",
+  "ready_to_work",
+  "waiting_parts",
+  "ready_to_invoice",
+] as const;
+
+export type WorkOrderSummaryFilter =
+  (typeof WORK_ORDER_SUMMARY_FILTERS)[number];
+
+export type WorkOrderSummaryRow = {
+  status?: unknown;
+  priority?: number | null;
+  updated_at?: string | null;
+  created_at?: string | null;
+};
+
+const READY_TO_WORK_STATUSES = new Set([
+  "new",
+  "awaiting",
+  "awaiting_inspection",
+  "recommended",
+  "approved",
+  "queued",
+  "planned",
+]);
+
+const READY_TO_INVOICE_STATUSES = new Set(["completed", "ready_to_invoice"]);
+
+const PRESERVED_LIST_STATUSES = new Set([
+  "new",
+  "awaiting",
+  "awaiting_inspection",
+  "recommended",
+  "awaiting_approval",
+  "waiting_parts",
+  "approved",
+  "in_progress",
+  "on_hold",
+  "queued",
+  "planned",
+  "completed",
+  "ready_to_invoice",
+  "invoiced",
+]);
+
+const AT_RISK_AGE_MS = 3 * 86_400_000;
+
+export function normalizeWorkOrderListStatus(value: unknown): string {
+  const normalized = String(value ?? "new")
+    .trim()
+    .toLowerCase()
+    .replaceAll(" ", "_");
+
+  return PRESERVED_LIST_STATUSES.has(normalized)
+    ? normalized
+    : normalizeWorkOrderStatus(normalized);
+}
+
+function updatedAtMs(row: WorkOrderSummaryRow): number | null {
+  const raw = row.updated_at ?? row.created_at;
+  if (!raw) return null;
+
+  const timestamp = new Date(raw).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function matchesWorkOrderSummaryFilter(
+  row: WorkOrderSummaryRow,
+  filter: WorkOrderSummaryFilter,
+  nowMs = Date.now(),
+): boolean {
+  const status = normalizeWorkOrderListStatus(row.status);
+
+  if (filter === "ready_to_work") {
+    return READY_TO_WORK_STATUSES.has(status);
+  }
+
+  if (filter === "waiting_parts") {
+    return status === "waiting_parts";
+  }
+
+  if (filter === "ready_to_invoice") {
+    return READY_TO_INVOICE_STATUSES.has(status);
+  }
+
+  if (Number(row.priority ?? 3) === 1) {
+    return true;
+  }
+
+  const updatedAt = updatedAtMs(row);
+  return updatedAt !== null && nowMs - updatedAt >= AT_RISK_AGE_MS;
+}
+
+export function filterWorkOrdersBySummary<T extends WorkOrderSummaryRow>(
+  rows: T[],
+  filter: WorkOrderSummaryFilter | null,
+  nowMs = Date.now(),
+): T[] {
+  if (!filter) return rows;
+  return rows.filter((row) =>
+    matchesWorkOrderSummaryFilter(row, filter, nowMs),
+  );
+}
+
+export function countWorkOrdersBySummary(
+  rows: WorkOrderSummaryRow[],
+  filter: WorkOrderSummaryFilter,
+  nowMs = Date.now(),
+): number {
+  return rows.reduce(
+    (count, row) =>
+      count + (matchesWorkOrderSummaryFilter(row, filter, nowMs) ? 1 : 0),
+    0,
+  );
+}
+
+export function toggleWorkOrderSummaryFilter(
+  current: WorkOrderSummaryFilter | null,
+  next: WorkOrderSummaryFilter,
+): WorkOrderSummaryFilter | null {
+  return current === next ? null : next;
+}

--- a/tests/job-evidence-strip.test.tsx
+++ b/tests/job-evidence-strip.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import JobEvidenceStrip, {
+  nextEvidenceIndex,
+} from "@/features/work-orders/components/evidence/JobEvidenceStrip";
+import type { WorkOrderEvidenceItem } from "@/features/work-orders/lib/evidence/workOrderEvidence";
+
+function evidence(
+  id: string,
+  fileName: string,
+  kind: "photo" | "video" = "photo",
+): WorkOrderEvidenceItem {
+  return {
+    id,
+    workOrderId: "work-order-1",
+    workOrderLineId: "line-1",
+    quoteLineId: null,
+    kind,
+    source: "inspection",
+    visibility: "customer",
+    fileName,
+    contentType: kind === "video" ? "video/mp4" : "image/jpeg",
+    fileSize: 100,
+    createdAt: "2026-07-30T12:00:00.000Z",
+    displayUrl:
+      kind === "video"
+        ? "https://example.test/evidence.mp4"
+        : `https://example.test/${id}.jpg`,
+    annotation: null,
+  };
+}
+
+const items = [
+  evidence("one", "Front brake.jpg"),
+  evidence("two", "Rear brake.jpg"),
+  evidence("three", "Road test.mp4", "video"),
+  evidence("four", "Tire.jpg"),
+];
+
+describe("job evidence strip", () => {
+  it("wraps previous and next navigation", () => {
+    expect(nextEvidenceIndex(0, 4, -1)).toBe(3);
+    expect(nextEvidenceIndex(3, 4, 1)).toBe(0);
+    expect(nextEvidenceIndex(0, 0, 1)).toBe(0);
+  });
+
+  it("opens a medium preview without activating the parent job card", async () => {
+    const user = userEvent.setup();
+    const parentClick = vi.fn();
+
+    render(
+      <div onClick={parentClick}>
+        <JobEvidenceStrip evidence={items} />
+      </div>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Open Front brake.jpg" }),
+    );
+
+    expect(parentClick).not.toHaveBeenCalled();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveStyle({ width: "min(92vw, 48rem)" });
+    expect(dialog).toHaveStyle({ maxWidth: "48rem" });
+    expect(
+      screen.getByRole("heading", { name: "Front brake.jpg" }),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates through photos and video evidence", async () => {
+    const user = userEvent.setup();
+    render(<JobEvidenceStrip evidence={items} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Open Front brake.jpg" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Next evidence" }));
+    expect(
+      screen.getByRole("heading", { name: "Rear brake.jpg" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next evidence" }));
+    expect(
+      screen.getByRole("heading", { name: "Road test.mp4" }),
+    ).toBeInTheDocument();
+    expect(document.querySelector("video[controls]")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Previous evidence" }));
+    expect(
+      screen.getByRole("heading", { name: "Rear brake.jpg" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens hidden evidence from the overflow control and closes cleanly", async () => {
+    const user = userEvent.setup();
+    render(<JobEvidenceStrip evidence={items} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Open 1 more evidence item" }),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Tire.jpg" }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Close evidence preview" }),
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/tests/work-order-board-presentation.test.ts
+++ b/tests/work-order-board-presentation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getWorkOrderBoardStageSurface,
+  WORK_ORDER_BOARD_STAGE_SURFACES,
+} from "@/features/shared/lib/workboard/presentation";
+import type { WorkOrderBoardStage } from "@/features/shared/lib/workboard/types";
+
+describe("work-order board stage presentation", () => {
+  it("gives every operational stage a color-coded column, card, and count", () => {
+    const stages: WorkOrderBoardStage[] = [
+      "awaiting",
+      "in_progress",
+      "awaiting_approval",
+      "waiting_parts",
+      "on_hold",
+      "completed",
+    ];
+
+    for (const stage of stages) {
+      const surface = getWorkOrderBoardStageSurface(stage);
+      expect(surface.column).toMatch(
+        /border-(blue|violet|amber|orange|rose|emerald)-500/,
+      );
+      expect(surface.card).toMatch(
+        /bg-(blue|violet|amber|orange|rose|emerald)-500/,
+      );
+      expect(surface.count).toMatch(
+        /text-(blue|violet|amber|orange|rose|emerald)-/,
+      );
+    }
+  });
+
+  it("keeps stage color contracts distinct", () => {
+    const operational = Object.entries(WORK_ORDER_BOARD_STAGE_SURFACES)
+      .filter(([stage]) => stage !== "empty")
+      .map(([, surface]) => surface.column);
+
+    expect(new Set(operational).size).toBe(operational.length);
+  });
+
+  it("falls back to the neutral empty surface when a stage is unavailable", () => {
+    expect(getWorkOrderBoardStageSurface(undefined)).toBe(
+      WORK_ORDER_BOARD_STAGE_SURFACES.empty,
+    );
+  });
+});

--- a/tests/work-order-line-evidence.test.ts
+++ b/tests/work-order-line-evidence.test.ts
@@ -325,7 +325,9 @@ describe("evidence URL safety", () => {
       "https://cdn.example/photo.jpg",
     );
     expect(
-      sanitizeEvidenceFallbackUrl("/storage/v1/object/public/job-photos/photo.jpg"),
+      sanitizeEvidenceFallbackUrl(
+        "/storage/v1/object/public/job-photos/photo.jpg",
+      ),
     ).toBe("/storage/v1/object/public/job-photos/photo.jpg");
     expect(sanitizeEvidenceFallbackUrl("javascript:alert(1)")).toBeNull();
     expect(sanitizeEvidenceFallbackUrl("not-a-url")).toBeNull();
@@ -339,7 +341,9 @@ describe("canonical line evidence migration contract", () => {
   );
 
   it("registers quote evidence and relinks it when approval materializes a job", () => {
-    expect(migration).toContain("quote_line_id uuid references public.work_order_quote_lines");
+    expect(migration).toContain(
+      "quote_line_id uuid references public.work_order_quote_lines",
+    );
     expect(migration).toContain("trg_sync_quote_line_media_evidence");
     expect(migration).toContain("update of metadata, work_order_line_id");
     expect(migration).toContain("work_order_line_id = new.work_order_line_id");
@@ -349,7 +353,9 @@ describe("canonical line evidence migration contract", () => {
   it("backfills evidence directly without replaying quote-line update triggers", () => {
     const backfill = migration.slice(
       migration.indexOf("-- Register existing inspection evidence"),
-      migration.indexOf("alter table public.work_order_media_annotations enable row level security"),
+      migration.indexOf(
+        "alter table public.work_order_media_annotations enable row level security",
+      ),
     );
 
     expect(backfill).toContain("insert into public.work_order_media");
@@ -361,7 +367,9 @@ describe("canonical line evidence migration contract", () => {
     expect(migration).toContain(
       `drop policy if exists "Users can view their shop's media"`,
     );
-    expect(migration).toContain('drop policy if exists "Users can insert their own WO media"');
+    expect(migration).toContain(
+      'drop policy if exists "Users can insert their own WO media"',
+    );
     expect(migration).toContain("c.shop_id = work_order_media.shop_id");
     expect(migration).toContain("fm.shop_id = work_order_media.shop_id");
     expect(migration).toContain("fm.shop_id = wom.shop_id");
@@ -370,8 +378,12 @@ describe("canonical line evidence migration contract", () => {
 
   it("keeps annotation writes atomic, tenant-scoped, bounded, and replay-safe", () => {
     const writer = migration.slice(
-      migration.indexOf("create or replace function public.save_work_order_media_annotation_atomic"),
-      migration.indexOf("revoke all on function public.save_work_order_media_annotation_atomic"),
+      migration.indexOf(
+        "create or replace function public.save_work_order_media_annotation_atomic",
+      ),
+      migration.indexOf(
+        "revoke all on function public.save_work_order_media_annotation_atomic",
+      ),
     );
 
     expect(writer.indexOf("where id = p_media_id")).toBeLessThan(
@@ -382,13 +394,19 @@ describe("canonical line evidence migration contract", () => {
     expect(writer).toContain("pg_advisory_xact_lock");
     expect(writer).toContain("v_media.visibility <> 'customer'");
     expect(migration).toContain("jsonb_array_length(overlay) <= 100");
-    expect(migration).toContain("revoke all on table public.work_order_media_annotations");
-    expect(migration).toContain("grant select on table public.work_order_media_annotations to authenticated");
+    expect(migration).toContain(
+      "revoke all on table public.work_order_media_annotations",
+    );
+    expect(migration).toContain(
+      "grant select on table public.work_order_media_annotations to authenticated",
+    );
   });
 
   it("publishes canonical media and annotations for cross-device refresh", () => {
     expect(migration).toContain("c.relname = 'work_order_media_annotations'");
-    expect(migration).toContain("add table public.work_order_media_annotations");
+    expect(migration).toContain(
+      "add table public.work_order_media_annotations",
+    );
     expect(migration).toContain("c.relname = 'work_order_media'");
     expect(migration).toContain("add table public.work_order_media");
   });
@@ -401,6 +419,10 @@ describe("premium work-order evidence UI contract", () => {
   );
   const jobCard = readFileSync(
     "features/work-orders/components/JobCard.tsx",
+    "utf8",
+  );
+  const jobEvidenceStrip = readFileSync(
+    "features/work-orders/components/evidence/JobEvidenceStrip.tsx",
     "utf8",
   );
   const workOrder = readFileSync("app/work-orders/[id]/Client.tsx", "utf8");
@@ -417,18 +439,21 @@ describe("premium work-order evidence UI contract", () => {
     "utf8",
   );
 
-  it("uses a compact premium work-order list instead of priority cards", () => {
-    expect(board).toContain("function BoardRow");
-    expect(board).toContain("Operational state");
-    expect(board).toContain("jobs complete");
-    expect(board).not.toContain("priorityLabel");
+  it("keeps the dashboard work-order board on its color-coded stage cards", () => {
+    expect(board).toContain("function BoardCard");
+    expect(board).toContain("visibleStages.map");
+    expect(board).toContain("getWorkOrderBoardStageSurface");
+    expect(board).not.toContain("function BoardRow");
+    expect(board).not.toContain("<span>Operational state</span>");
   });
 
   it("removes job priority and moves line evidence and technician identity into the card", () => {
     expect(jobCard).not.toContain("onPriorityChange");
     expect(workOrder).not.toContain("updateLinePriority");
     expect(jobCard).toContain("Assigned technician");
-    expect(jobCard).toContain("evidence.slice(0, 3)");
+    expect(jobCard).toContain("<JobEvidenceStrip evidence={evidence} />");
+    expect(jobEvidenceStrip).toContain("evidence.slice(0, 3)");
+    expect(jobEvidenceStrip).toContain("Open ${evidenceLabel(item, index)}");
     expect(workOrder).toContain("item.workOrderLineId === ln.id");
   });
 
@@ -440,9 +465,7 @@ describe("premium work-order evidence UI contract", () => {
   });
 
   it("shows canonical line evidence in customer and fleet portal experiences", () => {
-    expect(quote).toContain(
-      "/api/work-orders/${workOrderId}/media?scope=all",
-    );
+    expect(quote).toContain("/api/work-orders/${workOrderId}/media?scope=all");
     expect(quote).toContain("item.quoteLineId === line.id");
     expect(quote).toContain("EvidenceImage");
     expect(

--- a/tests/work-order-list-filters.test.ts
+++ b/tests/work-order-list-filters.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  countWorkOrdersBySummary,
+  filterWorkOrdersBySummary,
+  matchesWorkOrderSummaryFilter,
+  normalizeWorkOrderListStatus,
+  toggleWorkOrderSummaryFilter,
+} from "@/features/work-orders/lib/workOrderListFilters";
+
+const NOW = Date.parse("2026-07-30T12:00:00.000Z");
+const DAY = 86_400_000;
+
+describe("work-order summary filters", () => {
+  it("preserves list-only statuses instead of folding on hold into waiting parts", () => {
+    expect(normalizeWorkOrderListStatus("on hold")).toBe("on_hold");
+    expect(normalizeWorkOrderListStatus("waiting parts")).toBe("waiting_parts");
+    expect(normalizeWorkOrderListStatus("queued")).toBe("queued");
+  });
+
+  it.each([
+    "new",
+    "awaiting",
+    "awaiting_inspection",
+    "recommended",
+    "approved",
+    "queued",
+    "planned",
+  ])("treats %s as ready to work", (status) => {
+    expect(
+      matchesWorkOrderSummaryFilter({ status }, "ready_to_work", NOW),
+    ).toBe(true);
+  });
+
+  it.each(["awaiting_approval", "in_progress", "on_hold", "waiting_parts"])(
+    "does not treat %s as ready to work",
+    (status) => {
+      expect(
+        matchesWorkOrderSummaryFilter({ status }, "ready_to_work", NOW),
+      ).toBe(false);
+    },
+  );
+
+  it("counts only the canonical waiting-parts state", () => {
+    expect(
+      matchesWorkOrderSummaryFilter(
+        { status: "waiting_parts" },
+        "waiting_parts",
+        NOW,
+      ),
+    ).toBe(true);
+    expect(
+      matchesWorkOrderSummaryFilter(
+        { status: "on_hold" },
+        "waiting_parts",
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it.each(["completed", "ready_to_invoice"])(
+    "treats %s as ready to invoice",
+    (status) => {
+      expect(
+        matchesWorkOrderSummaryFilter({ status }, "ready_to_invoice", NOW),
+      ).toBe(true);
+    },
+  );
+
+  it("marks urgent work as at risk regardless of age", () => {
+    expect(
+      matchesWorkOrderSummaryFilter(
+        {
+          status: "new",
+          priority: 1,
+          updated_at: new Date(NOW).toISOString(),
+        },
+        "at_risk",
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("marks work stale at three days as at risk", () => {
+    expect(
+      matchesWorkOrderSummaryFilter(
+        {
+          status: "new",
+          priority: 3,
+          updated_at: new Date(NOW - 3 * DAY).toISOString(),
+        },
+        "at_risk",
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps fresh and invalidly dated work out of at risk", () => {
+    expect(
+      matchesWorkOrderSummaryFilter(
+        {
+          status: "new",
+          priority: 3,
+          updated_at: new Date(NOW - DAY).toISOString(),
+        },
+        "at_risk",
+        NOW,
+      ),
+    ).toBe(false);
+    expect(
+      matchesWorkOrderSummaryFilter(
+        { status: "new", priority: 3, updated_at: "not-a-date" },
+        "at_risk",
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("filters and counts with the same predicate", () => {
+    const rows = [
+      { id: "parts", status: "waiting_parts" },
+      { id: "hold", status: "on_hold" },
+      { id: "ready", status: "approved" },
+    ];
+
+    expect(
+      filterWorkOrdersBySummary(rows, "waiting_parts", NOW).map(
+        (row) => row.id,
+      ),
+    ).toEqual(["parts"]);
+    expect(countWorkOrdersBySummary(rows, "waiting_parts", NOW)).toBe(1);
+  });
+
+  it("returns the original list when no summary filter is selected", () => {
+    const rows = [{ status: "approved" }];
+    expect(filterWorkOrdersBySummary(rows, null, NOW)).toBe(rows);
+  });
+
+  it("toggles a selected card off and switches directly to another card", () => {
+    expect(toggleWorkOrderSummaryFilter(null, "at_risk")).toBe("at_risk");
+    expect(toggleWorkOrderSummaryFilter("at_risk", "at_risk")).toBeNull();
+    expect(toggleWorkOrderSummaryFilter("at_risk", "waiting_parts")).toBe(
+      "waiting_parts",
+    );
+  });
+});

--- a/tests/work-order-surface-routing.test.ts
+++ b/tests/work-order-surface-routing.test.ts
@@ -64,10 +64,19 @@ describe("work-order surface ownership", () => {
 
   it("does not count a generic on-hold job as waiting for parts", () => {
     expect(workOrdersPageSource).toContain(
-      'normalizeStatusKey(row.status) === "waiting_parts"',
+      'countWorkOrdersBySummary(rows, "waiting_parts", summaryNow)',
     );
-    expect(workOrdersPageSource).not.toContain(
-      'normalizeStatusKey(row.status) === "waiting_parts" ||',
+    expect(workOrdersPageSource).toContain(
+      "filterWorkOrdersBySummary(rows, summaryFilter, summaryNow)",
     );
+  });
+
+  it("uses the operational summary cards as accessible toggle filters", () => {
+    expect(workOrdersPageSource).toContain("type WorkOrderSummaryFilter");
+    expect(workOrdersPageSource).toContain("aria-pressed={selected}");
+    expect(workOrdersPageSource).toContain(
+      "toggleWorkOrderSummaryFilter(current, filter)",
+    );
+    expect(workOrdersPageSource).toContain("visibleRows.map((row)");
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import { resolve } from "node:path";
 
 export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
   resolve: {
     alias: {
       "@": resolve(__dirname, "."),


### PR DESCRIPTION
## Root cause

The four operational Work Orders summary cards were display-only, the assigned-technician badge used dark-mode-only text colors, the dashboard board retained colored icons but lost its stage-colored surfaces, and job evidence thumbnails had no preview interaction inside the parent job card.

## What changed

- Turned At risk, Ready to work, Waiting parts, and Ready to invoice into accessible toggle filters.
- Centralized summary predicates so each card count and its filtered work-order list use the same rule.
- Preserved On hold as distinct from Waiting parts.
- Improved assigned-technician contrast in light and dark themes.
- Restored stage-specific column, card, and count colors on the dashboard Work Order Board.
- Added a medium photo/video evidence modal with previous/next navigation and a close action.
- Isolated evidence events so clicking a thumbnail never opens the parent focused-job panel.
- Updated stale Work Order Board/evidence source contracts and added focused filter, presentation, and modal tests.

## Why this is safe

This is a presentation and client-side filtering change over already-authorized records. Existing work-order queries, realtime refresh, role capabilities, assignment, stage transitions, invoice review, invoice opening, and draft deletion handlers are unchanged. No stored status, evidence relationship, tenant scope, or authorization policy changes.

## Validation

- Prettier check: passed for all 13 changed files.
- `git diff --check`: passed.
- Remote branch tree matches the local committed tree byte-for-byte.
- New focused unit, interaction, and source-contract tests are included.
- Full local execution was blocked by transient npm registry timeouts in the recycled workspace; GitHub CI and Vercel preview are the authoritative clean-checkout validation for this PR.

## Database

No migration required.

## Environment variables

None required.

## Manual actions

None. Authenticated preview smoke testing should cover iPad sizing, light/dark contrast, summary-filter toggling, board colors, and real signed photo/video URLs.