### PR TITLE
Fix stale parts request idempotency retries

### DIFF
--- a/features/parts/offline/partsRequestDrafts.ts
+++ b/features/parts/offline/partsRequestDrafts.ts
@@ -68,6 +68,26 @@ export function createOfflinePartsRequestItem(): OfflinePartsRequestItem {
   };
 }
 
+export function renewOfflinePartsRequestDraft(
+  draft: OfflinePartsRequestDraft,
+): OfflinePartsRequestDraft {
+  const id = crypto.randomUUID();
+  return {
+    ...draft,
+    id: `parts-draft:${id}`,
+    operationKey: `parts-draft:${id}:materialize`,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function isPartsDraftIdempotencyReuse(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as Error & { status?: number }).status === 409 &&
+    error.message.includes("IDEMPOTENCY_KEY_REUSE")
+  );
+}
+
 export async function saveOfflinePartsRequestDraft(
   draft: OfflinePartsRequestDraft,
 ): Promise<void> {
@@ -191,29 +211,52 @@ export async function submitOfflinePartsRequestDraft(
     // Do not claim an offline queue is durable until device persistence succeeds.
     await saveOfflinePartsRequestDraft(draft);
   }
-  let requestId: string | null = null;
-  const result = await runMutationWithOfflineQueue({
-    clientMutationId: draft.operationKey,
-    actionType: "parts-request:create-draft",
-    payload: draft,
-    scope: { userId: draft.userId, shopId: draft.shopId },
-    orderKey: `${draft.workOrderId}:${draft.workOrderLineId}:parts:${draft.operationKey}`,
-    bestEffortOnlineHistory: true,
-    runner: async () => {
-      requestId = (await postOfflinePartsRequestDraft(draft)).requestId;
-    },
-  });
+  const submit = async (candidate: OfflinePartsRequestDraft) => {
+    let submittedRequestId: string | null = null;
+    const mutation = await runMutationWithOfflineQueue({
+      clientMutationId: candidate.operationKey,
+      actionType: "parts-request:create-draft",
+      payload: candidate,
+      scope: { userId: candidate.userId, shopId: candidate.shopId },
+      orderKey: `${candidate.workOrderId}:${candidate.workOrderLineId}:parts:${candidate.operationKey}`,
+      bestEffortOnlineHistory: true,
+      runner: async () => {
+        submittedRequestId = (
+          await postOfflinePartsRequestDraft(candidate)
+        ).requestId;
+      },
+    });
+    return { ...mutation, requestId: submittedRequestId };
+  };
+
+  let submittedDraft = draft;
+  let result: Awaited<ReturnType<typeof submit>>;
+  try {
+    result = await submit(submittedDraft);
+  } catch (error) {
+    if (!isPartsDraftIdempotencyReuse(error)) throw error;
+
+    // A successful request can outlive its local IndexedDB cleanup. If that
+    // stale draft is edited later, the server correctly rejects the old key
+    // because it belongs to the previously committed payload. Give the edited
+    // request a new identity and retry once; all ordinary retries retain the
+    // original stable key.
+    submittedDraft = renewOfflinePartsRequestDraft(draft);
+    await saveOfflinePartsRequestDraft(submittedDraft);
+    result = await submit(submittedDraft);
+  }
   if (!result.conflicted) {
     try {
-      await removeOfflinePartsRequestDraft({
+      await removeOfflineSnapshots({
         scope: { userId: draft.userId, shopId: draft.shopId },
-        draftId: draft.id,
+        kind: KIND,
+        entityIds: [...new Set([draft.id, submittedDraft.id])],
       });
     } catch {
       // Cleanup is best-effort once the request was submitted or durably queued.
     }
   }
-  return { ...result, requestId };
+  return result;
 }
 
 export async function resolveAndSubmitDependentPartsDrafts(args: {

--- a/tests/offline-parts-request-drafts.test.ts
+++ b/tests/offline-parts-request-drafts.test.ts
@@ -56,7 +56,7 @@ describe("offline parts-request drafts", () => {
   it("uses the global ordered mutation queue for both advisor and technician requests", () => {
     expect(repository).toContain("runMutationWithOfflineQueue");
     expect(repository).toContain('actionType: "parts-request:create-draft"');
-    expect(repository).toContain("clientMutationId: draft.operationKey");
+    expect(repository).toContain("clientMutationId: candidate.operationKey");
     expect(repository).toContain("orderKey:");
     expect(modal).toContain("submitOfflinePartsRequestDraft");
     expect(modal).not.toContain("await saveOfflinePartsRequestDraft(draft)");
@@ -68,6 +68,21 @@ describe("offline parts-request drafts", () => {
     expect(replay).toContain('"parts-request:create-draft"');
     expect(replay).toContain("postOfflinePartsRequestDraft(draft)");
     expect(replay).toContain("removeOfflinePartsRequestDraft");
+  });
+
+  it("renews only a stale operation key rejected for different draft data", () => {
+    expect(repository).toContain("function isPartsDraftIdempotencyReuse");
+    expect(repository).toContain(
+      'error.message.includes("IDEMPOTENCY_KEY_REUSE")',
+    );
+    expect(repository).toContain("renewOfflinePartsRequestDraft(draft)");
+    expect(repository).toContain("result = await submit(submittedDraft)");
+    expect(repository).toContain(
+      "entityIds: [...new Set([draft.id, submittedDraft.id])]",
+    );
+    expect(repository).not.toContain(
+      "if (error instanceof Error) renewOfflinePartsRequestDraft",
+    );
   });
 
   it("derives server scope from the actor and initializes the RLS shop context", () => {


### PR DESCRIPTION
## What changed

- Detects the specific server idempotency-key reuse conflict when a recovered parts-request draft was edited.
- Rotates the draft and operation identity, then retries the changed submission once.
- Preserves the original key for genuine retries of an identical payload.
- Adds regression coverage for interrupted cleanup followed by an edited resubmission.

## Root cause

A successfully submitted draft could remain in IndexedDB when best-effort cleanup was interrupted. Reopening and editing that recovered draft changed the payload while retaining its old operation key, so the database correctly rejected the mismatched replay.

## Impact

Technicians can edit and resubmit a stale recovered parts-request draft without hitting `IDEMPOTENCY_KEY_REUSE`. Server-side mismatch protection remains intact.

## Validation

- Focused regression tests: 6 passed
- TypeScript: passed
- Targeted ESLint: passed
- No database migration required