### PR TITLE
Enable markup in job evidence previews

### DIFF
--- a/features/work-orders/components/evidence/JobEvidenceStrip.tsx
+++ b/features/work-orders/components/evidence/JobEvidenceStrip.tsx
@@ -1,7 +1,22 @@
 "use client";
 
-import { useMemo, useState, type KeyboardEvent, type MouseEvent } from "react";
-import { ChevronLeft, ChevronRight, Images, Play, X } from "lucide-react";
+import dynamic from "next/dynamic";
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Images,
+  Loader2,
+  Pencil,
+  Play,
+  X,
+} from "lucide-react";
 
 import {
   Dialog,
@@ -17,8 +32,17 @@ import {
 
 import EvidenceImage from "./EvidenceImage";
 
+const ImageMarkupEditor = dynamic(() => import("./ImageMarkupEditor"), {
+  ssr: false,
+});
+
 type Props = {
   evidence: WorkOrderEvidenceItem[];
+};
+
+type MediaResponse = {
+  items?: WorkOrderEvidenceItem[];
+  canEdit?: boolean;
 };
 
 export function nextEvidenceIndex(
@@ -36,13 +60,23 @@ function evidenceLabel(item: WorkOrderEvidenceItem, index: number): string {
 
 export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [mediaItems, setMediaItems] = useState<WorkOrderEvidenceItem[]>([]);
+  const [canEdit, setCanEdit] = useState(false);
+  const [loadingMedia, setLoadingMedia] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [showMarkup, setShowMarkup] = useState(true);
   const photos = useMemo(
     () => evidence.filter((item) => !isVideoEvidence(item)).length,
     [evidence],
   );
   const videos = evidence.length - photos;
-  const selected =
+  const selectedBase =
     selectedIndex === null ? null : (evidence[selectedIndex] ?? null);
+  const selected = selectedBase
+    ? (mediaItems.find((item) => item.id === selectedBase.id) ?? selectedBase)
+    : null;
+  const selectedIsVideo = selected ? isVideoEvidence(selected) : false;
+  const hasMarkup = Boolean(selected?.annotation);
 
   const stopCardClick = (event: MouseEvent<HTMLElement>) => {
     event.stopPropagation();
@@ -52,7 +86,50 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
     event.stopPropagation();
   };
 
+  const loadMedia = useCallback(async (item: WorkOrderEvidenceItem) => {
+    if (!item.workOrderId || !item.workOrderLineId) {
+      setMediaItems([]);
+      setCanEdit(false);
+      return;
+    }
+
+    setLoadingMedia(true);
+    try {
+      const response = await fetch(
+        `/api/work-orders/${encodeURIComponent(item.workOrderId)}/media?scope=line&lineId=${encodeURIComponent(item.workOrderLineId)}`,
+        { credentials: "include", cache: "no-store" },
+      );
+      if (!response.ok) throw new Error("Unable to load evidence permissions");
+      const payload = (await response.json()) as MediaResponse;
+      setMediaItems(Array.isArray(payload.items) ? payload.items : []);
+      setCanEdit(payload.canEdit === true);
+    } catch (error) {
+      console.error("[job-evidence-strip] media load failed", error);
+      setMediaItems([]);
+      setCanEdit(false);
+    } finally {
+      setLoadingMedia(false);
+    }
+  }, []);
+
+  const openEvidence = (index: number) => {
+    const item = evidence[index];
+    if (!item) return;
+    setSelectedIndex(index);
+    setEditing(false);
+    setShowMarkup(true);
+    void loadMedia(item);
+  };
+
+  const closePreview = () => {
+    setSelectedIndex(null);
+    setEditing(false);
+    setShowMarkup(true);
+  };
+
   const moveSelection = (direction: -1 | 1) => {
+    setEditing(false);
+    setShowMarkup(true);
     setSelectedIndex((current) =>
       current === null
         ? null
@@ -79,7 +156,7 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
             <button
               key={item.id}
               type="button"
-              onClick={() => setSelectedIndex(index)}
+              onClick={() => openEvidence(index)}
               aria-label={`Open ${evidenceLabel(item, index)}`}
               className="relative h-16 w-24 shrink-0 overflow-hidden rounded-lg border border-[color:var(--theme-border-soft)] bg-black text-left transition hover:border-[color:var(--brand-primary,#1747FF)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-primary,#1747FF)]"
             >
@@ -108,7 +185,7 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
           {evidence.length > 3 ? (
             <button
               type="button"
-              onClick={() => setSelectedIndex(3)}
+              onClick={() => openEvidence(3)}
               aria-label={`Open ${evidence.length - 3} more evidence item${evidence.length - 3 === 1 ? "" : "s"}`}
               className="grid h-16 w-16 shrink-0 place-items-center rounded-lg border border-[color:var(--theme-border-soft)] text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[color:var(--brand-primary,#1747FF)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--brand-primary,#1747FF)]"
             >
@@ -121,7 +198,7 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
       <Dialog
         open={selected !== null}
         onOpenChange={(open) => {
-          if (!open) setSelectedIndex(null);
+          if (!open) closePreview();
         }}
       >
         {selected && selectedIndex !== null ? (
@@ -135,72 +212,127 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
             onClick={stopCardClick}
             onKeyDown={stopCardKeyDown}
           >
-            <DialogHeader className="flex-row items-start justify-between gap-3 px-4 py-3">
-              <div className="min-w-0">
-                <DialogTitle className="truncate text-sm normal-case tracking-normal">
-                  {evidenceLabel(selected, selectedIndex)}
-                </DialogTitle>
-                <DialogDescription className="mt-0.5 text-xs">
-                  Evidence {selectedIndex + 1} of {evidence.length}
-                </DialogDescription>
-              </div>
-              <button
-                type="button"
-                onClick={() => setSelectedIndex(null)}
-                aria-label="Close evidence preview"
-                className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-[color:var(--theme-border-soft)] text-[color:var(--theme-text-secondary)] transition hover:text-[color:var(--theme-text-primary)]"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </DialogHeader>
+            {editing && !selectedIsVideo ? (
+              <ImageMarkupEditor
+                item={selected}
+                onClose={() => setEditing(false)}
+                onSaved={async () => {
+                  await loadMedia(selected);
+                  setShowMarkup(true);
+                }}
+              />
+            ) : (
+              <>
+                <DialogHeader className="flex-row items-start justify-between gap-3 px-4 py-3">
+                  <div className="min-w-0">
+                    <DialogTitle className="truncate text-sm normal-case tracking-normal">
+                      {evidenceLabel(selected, selectedIndex)}
+                    </DialogTitle>
+                    <DialogDescription className="mt-0.5 text-xs">
+                      Evidence {selectedIndex + 1} of {evidence.length}
+                    </DialogDescription>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={closePreview}
+                    aria-label="Close evidence preview"
+                    className="grid h-9 w-9 shrink-0 place-items-center rounded-lg border border-[color:var(--theme-border-soft)] text-[color:var(--theme-text-secondary)] transition hover:text-[color:var(--theme-text-primary)]"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </DialogHeader>
 
-            <div className="grid min-h-64 place-items-center bg-black/90 p-3">
-              {selected.displayUrl ? (
-                isVideoEvidence(selected) ? (
-                  <video
-                    key={selected.id}
-                    src={selected.displayUrl}
-                    controls
-                    preload="metadata"
-                    className="max-h-[65vh] w-full object-contain"
-                  />
-                ) : (
-                  <EvidenceImage
-                    item={selected}
-                    alt={evidenceLabel(selected, selectedIndex)}
-                    className="flex max-h-[65vh] w-full items-center justify-center [&_img]:max-h-[65vh] [&_img]:w-auto [&_img]:max-w-full [&_img]:object-contain"
-                  />
-                )
-              ) : (
-                <div className="text-sm text-white/70">Preview unavailable</div>
-              )}
-            </div>
+                <div className="grid min-h-64 place-items-center bg-black/90 p-3">
+                  {selected.displayUrl ? (
+                    selectedIsVideo ? (
+                      <video
+                        key={selected.id}
+                        src={selected.displayUrl}
+                        controls
+                        preload="metadata"
+                        className="max-h-[65vh] w-full object-contain"
+                      />
+                    ) : (
+                      <EvidenceImage
+                        item={selected}
+                        showMarkup={showMarkup}
+                        alt={evidenceLabel(selected, selectedIndex)}
+                        className="flex max-h-[65vh] w-full items-center justify-center [&_img]:max-h-[65vh] [&_img]:w-auto [&_img]:max-w-full [&_img]:object-contain"
+                      />
+                    )
+                  ) : (
+                    <div className="text-sm text-white/70">
+                      Preview unavailable
+                    </div>
+                  )}
+                </div>
 
-            {evidence.length > 1 ? (
-              <div className="flex items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] px-4 py-3">
-                <button
-                  type="button"
-                  onClick={() => moveSelection(-1)}
-                  aria-label="Previous evidence"
-                  className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--brand-primary,#1747FF)]"
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                  Previous
-                </button>
-                <span className="text-xs text-[color:var(--theme-text-muted)]">
-                  {selectedIndex + 1} / {evidence.length}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => moveSelection(1)}
-                  aria-label="Next evidence"
-                  className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--brand-primary,#1747FF)]"
-                >
-                  Next
-                  <ChevronRight className="h-4 w-4" />
-                </button>
-              </div>
-            ) : null}
+                <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] px-4 py-3">
+                  <div className="text-xs text-[color:var(--theme-text-muted)]">
+                    {loadingMedia ? (
+                      <span className="inline-flex items-center gap-2">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        Checking markup access…
+                      </span>
+                    ) : selectedIsVideo ? (
+                      "Video evidence is view-only"
+                    ) : hasMarkup ? (
+                      `Markup version ${selected.annotation?.version}`
+                    ) : (
+                      "Original photo"
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    {!selectedIsVideo && hasMarkup ? (
+                      <button
+                        type="button"
+                        onClick={() => setShowMarkup((current) => !current)}
+                        className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs font-semibold"
+                      >
+                        {showMarkup ? "Show original" : "Show marked up"}
+                      </button>
+                    ) : null}
+                    {!selectedIsVideo && canEdit && selected.displayUrl ? (
+                      <button
+                        type="button"
+                        onClick={() => setEditing(true)}
+                        className="inline-flex items-center gap-2 rounded-full bg-orange-700 px-3 py-1.5 text-xs font-semibold text-white hover:bg-orange-600"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                        Mark up
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+
+                {evidence.length > 1 ? (
+                  <div className="flex items-center justify-between gap-3 border-t border-[color:var(--theme-border-soft)] px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={() => moveSelection(-1)}
+                      aria-label="Previous evidence"
+                      className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--brand-primary,#1747FF)]"
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                      Previous
+                    </button>
+                    <span className="text-xs text-[color:var(--theme-text-muted)]">
+                      {selectedIndex + 1} / {evidence.length}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => moveSelection(1)}
+                      aria-label="Next evidence"
+                      className="inline-flex h-9 items-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:border-[color:var(--brand-primary,#1747FF)]"
+                    >
+                      Next
+                      <ChevronRight className="h-4 w-4" />
+                    </button>
+                  </div>
+                ) : null}
+              </>
+            )}
           </DialogContent>
         ) : null}
       </Dialog>

--- a/tests/job-evidence-strip.test.tsx
+++ b/tests/job-evidence-strip.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import JobEvidenceStrip, {
   nextEvidenceIndex,
@@ -39,7 +39,22 @@ const items = [
   evidence("four", "Tire.jpg"),
 ];
 
+function mockMediaResponse(canEdit = true) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ items, canEdit }),
+    })),
+  );
+}
+
 describe("job evidence strip", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockMediaResponse();
+  });
+
   it("wraps previous and next navigation", () => {
     expect(nextEvidenceIndex(0, 4, -1)).toBe(3);
     expect(nextEvidenceIndex(3, 4, 1)).toBe(0);
@@ -67,6 +82,46 @@ describe("job evidence strip", () => {
     expect(
       screen.getByRole("heading", { name: "Front brake.jpg" }),
     ).toBeInTheDocument();
+  });
+
+  it("offers markup only for authorized photo evidence", async () => {
+    const user = userEvent.setup();
+    render(<JobEvidenceStrip evidence={items} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Open Front brake.jpg" }),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Mark up" }),
+    ).toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/work-orders/work-order-1/media?scope=line&lineId=line-1",
+      { credentials: "include", cache: "no-store" },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Next evidence" }));
+    await user.click(screen.getByRole("button", { name: "Next evidence" }));
+    expect(
+      screen.getByRole("heading", { name: "Road test.mp4" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Mark up" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Video evidence is view-only")).toBeInTheDocument();
+  });
+
+  it("keeps markup hidden for read-only viewers", async () => {
+    mockMediaResponse(false);
+    const user = userEvent.setup();
+    render(<JobEvidenceStrip evidence={items} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Open Front brake.jpg" }),
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(
+      screen.queryByRole("button", { name: "Mark up" }),
+    ).not.toBeInTheDocument();
   });
 
   it("navigates through photos and video evidence", async () => {


### PR DESCRIPTION
## Root cause

The job-card evidence modal rendered canonical media as a viewer only. Unlike the inspection and work-order galleries, it never requested the media API's server-authorized `canEdit` result and never mounted the existing image markup editor.

## What changed

- refresh the selected job line's canonical media when evidence opens
- show **Mark up** only for authorized photo evidence
- keep video evidence explicitly view-only
- reuse the existing `ImageMarkupEditor` and atomic annotation save route
- reload canonical media after save so the new markup appears immediately
- support switching between original and marked-up versions
- preserve previous/next navigation and parent-card click isolation
- add interaction coverage for editable photos, read-only viewers, and video evidence

## Safety

The client does not infer edit access. The button is gated by `canEdit` returned from the existing authorized media API, and the existing PATCH route/RPC remains the final authorization boundary.

## Validation

- Vercel production-equivalent preview/build passed
- Prettier passed for both changed files
- remote comparison is exactly two intended files with zero branch drift
- GitHub Actions have not registered runs for this draft PR

## Database

No migration required. Existing canonical media and annotation contracts are reused unchanged.