### PR TITLE
Fix blank evidence markup editor on iPad

### DIFF
--- a/features/inspections/components/inspection/InspectionPhotoGallery.tsx
+++ b/features/inspections/components/inspection/InspectionPhotoGallery.tsx
@@ -174,7 +174,7 @@ export default function InspectionPhotoGallery({
       </div>
 
       <Dialog
-        open={selectedPhoto !== null}
+        open={selectedPhoto !== null && !editing}
         onOpenChange={(open) => {
           if (!open) {
             setSelectedIndex(null);
@@ -187,17 +187,7 @@ export default function InspectionPhotoGallery({
           style={{ maxWidth: "48rem" }}
         >
           {selectedPhoto ? (
-            editing && selectedMedia ? (
-              <ImageMarkupEditor
-                item={selectedMedia}
-                onClose={() => setEditing(false)}
-                onSaved={async () => {
-                  setEditing(false);
-                  await loadMedia();
-                }}
-              />
-            ) : (
-              <>
+            <>
                 <DialogHeader className="border-b border-[color:var(--theme-border-soft)] px-5 py-4 text-left">
                   <DialogTitle>
                     {photoLabel(selectedPhoto, selectedIndex ?? 0)}
@@ -305,10 +295,20 @@ export default function InspectionPhotoGallery({
                   </div>
                 </div>
               </>
-            )
           ) : null}
         </DialogContent>
       </Dialog>
+
+      {editing && selectedMedia ? (
+        <ImageMarkupEditor
+          item={selectedMedia}
+          onClose={() => setEditing(false)}
+          onSaved={async () => {
+            setEditing(false);
+            await loadMedia();
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/features/work-orders/components/evidence/JobEvidenceStrip.tsx
+++ b/features/work-orders/components/evidence/JobEvidenceStrip.tsx
@@ -196,7 +196,7 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
       </div>
 
       <Dialog
-        open={selected !== null}
+        open={selected !== null && !editing}
         onOpenChange={(open) => {
           if (!open) closePreview();
         }}
@@ -212,17 +212,7 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
             onClick={stopCardClick}
             onKeyDown={stopCardKeyDown}
           >
-            {editing && !selectedIsVideo ? (
-              <ImageMarkupEditor
-                item={selected}
-                onClose={() => setEditing(false)}
-                onSaved={async () => {
-                  await loadMedia(selected);
-                  setShowMarkup(true);
-                }}
-              />
-            ) : (
-              <>
+            <>
                 <DialogHeader className="flex-row items-start justify-between gap-3 px-4 py-3">
                   <div className="min-w-0">
                     <DialogTitle className="truncate text-sm normal-case tracking-normal">
@@ -332,10 +322,20 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
                   </div>
                 ) : null}
               </>
-            )}
           </DialogContent>
         ) : null}
       </Dialog>
+
+      {editing && selected && !selectedIsVideo ? (
+        <ImageMarkupEditor
+          item={selected}
+          onClose={() => setEditing(false)}
+          onSaved={async () => {
+            await loadMedia(selected);
+            setShowMarkup(true);
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/features/work-orders/components/evidence/JobEvidenceStrip.tsx
+++ b/features/work-orders/components/evidence/JobEvidenceStrip.tsx
@@ -212,8 +212,7 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
             onClick={stopCardClick}
             onKeyDown={stopCardKeyDown}
           >
-            <>
-                <DialogHeader className="flex-row items-start justify-between gap-3 px-4 py-3">
+            <DialogHeader className="flex-row items-start justify-between gap-3 px-4 py-3">
                   <div className="min-w-0">
                     <DialogTitle className="truncate text-sm normal-case tracking-normal">
                       {evidenceLabel(selected, selectedIndex)}
@@ -321,7 +320,6 @@ export default function JobEvidenceStrip({ evidence }: Props): JSX.Element {
                     </button>
                   </div>
                 ) : null}
-              </>
           </DialogContent>
         ) : null}
       </Dialog>

--- a/tests/job-evidence-strip.test.tsx
+++ b/tests/job-evidence-strip.test.tsx
@@ -110,6 +110,29 @@ describe("job evidence strip", () => {
     expect(screen.getByText("Video evidence is view-only")).toBeInTheDocument();
   });
 
+  it("mounts markup as a viewport editor instead of clipping it inside the preview dialog", async () => {
+    const user = userEvent.setup();
+    render(<JobEvidenceStrip evidence={items} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Open Front brake.jpg" }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: "Mark up" }),
+    );
+
+    expect(await screen.findByText("Mark up evidence")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Save markup" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      await screen.findByRole("heading", { name: "Front brake.jpg" }),
+    ).toBeInTheDocument();
+  });
+
   it("keeps markup hidden for read-only viewers", async () => {
     mockMediaResponse(false);
     const user = userEvent.setup();


### PR DESCRIPTION
## Root cause

The shared markup editor is a fixed viewport surface, but both evidence launchers mounted it inside Radix DialogContent. The transformed, overflow-hidden dialog became the fixed element's containing block on iPad Safari; because the fixed child contributes no normal-flow height, the dialog collapsed and clipped the editor to a near-empty screen.

## What changed

- close the medium preview while markup mode is active
- mount the full-screen editor outside DialogContent
- return to the same selected photo after Cancel or Save
- apply the same correction to job-card and inspection evidence
- add regression coverage for the exact viewer-to-editor-to-viewer transition

## Safety

Authorization, canonical media lookup, save API, annotation RPC, visibility selection, original media, and video behavior are unchanged. This is presentation/state wiring only.

## Validation

- branch is based directly on current main with zero drift
- diff is limited to two UI components and one interaction test
- full GitHub/Vercel checks pending

## Database

No migration required. No migration files changed.