### PR TITLE
Fix payroll punch pipeline and period generation

### DIFF
--- a/app/api/payroll-time/periods/route.ts
+++ b/app/api/payroll-time/periods/route.ts
@@ -7,9 +7,7 @@ import {
   splitIntervalByShopDay,
 } from "@/features/payroll-time/server/payrollTime";
 import { requirePayrollReviewer } from "../_lib/auth";
-import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 import { composeActiveWorkforceRoster } from "@/features/workforce/lib/roster";
-import { isValidPayrollDateKey } from "@/features/payroll-time/lib/payPeriodBounds";
 type AdminClient = ReturnType<typeof createAdminSupabase>;
 type PayrollProfile = {
   id?: string;
@@ -67,7 +65,19 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const periodId = url.searchParams.get("period_id");
 
-  const current = await getOrCreateCurrentPeriod(me.shop_id!);
+  let current: Awaited<ReturnType<typeof getOrCreateCurrentPeriod>>;
+  try {
+    current = await getOrCreateCurrentPeriod(me.shop_id!);
+  } catch (error) {
+    console.error("payroll period initialization failed", error);
+    return NextResponse.json(
+      {
+        error:
+          "Payroll is temporarily unavailable. Recorded punches are safe; retry the payroll load.",
+      },
+      { status: 503 },
+    );
+  }
   const { data: shop, error: shopError } = await admin
     .from("shops")
     .select("timezone")
@@ -99,7 +109,23 @@ export async function GET(req: NextRequest) {
     requestedPeriod?.id ?? current.period?.id ?? periods?.[0]?.id ?? null;
   if (!activePeriodId) return NextResponse.json({ periods: [], entries: [], exceptions: [] });
 
-  const refreshState = await refreshOpenPeriodIfStale({ shopId: me.shop_id!, actorId: me.id, periodId: activePeriodId });
+  let refreshState: Awaited<ReturnType<typeof refreshOpenPeriodIfStale>>;
+  try {
+    refreshState = await refreshOpenPeriodIfStale({
+      shopId: me.shop_id!,
+      actorId: me.id,
+      periodId: activePeriodId,
+    });
+  } catch (error) {
+    console.error("payroll period source refresh failed", error);
+    return NextResponse.json(
+      {
+        error:
+          "Payroll totals could not be assembled from recorded time. The source punches remain safe; retry the payroll load.",
+      },
+      { status: 503 },
+    );
+  }
 
   const [
     { data: entries, error: entriesErr },
@@ -385,81 +411,7 @@ export async function GET(req: NextRequest) {
 }
 
 
-type PayrollCadence = "weekly" | "biweekly" | "semimonthly" | "monthly";
-
-type SettingsBody = {
-  cadence?: PayrollCadence;
-  week_starts_on?: number;
-  period_anchor_date?: string | null;
-};
-
-export async function PUT(req: NextRequest) {
-  const auth = await requirePayrollReviewer();
-  if (!auth.ok) return auth.response;
-  if (!["owner", "admin"].includes(String(auth.me.role ?? ""))) {
-    return NextResponse.json({ error: "Only an owner or admin can change payroll period settings." }, { status: 403 });
-  }
-  const pin = await requireOwnerPinVerified(req, auth.supabase as never, {
-    shopId: auth.me.shop_id!,
-    userId: auth.authUserId,
-    allowedPurposes: [OWNER_PIN_PURPOSES.SETTINGS, OWNER_PIN_PURPOSES.PRIVILEGED],
-  });
-  if (!pin.ok) return pin.response;
-
-  const body = (await req.json().catch(() => null)) as SettingsBody | null;
-  const allowedCadences: PayrollCadence[] = ["weekly", "biweekly", "semimonthly", "monthly"];
-  if (!body?.cadence || !allowedCadences.includes(body.cadence)) {
-    return NextResponse.json({ error: "Choose weekly, bi-weekly, semi-monthly, or monthly." }, { status: 400 });
-  }
-
-  const weekStartsOn = Number(body.week_starts_on);
-  if (!Number.isInteger(weekStartsOn) || weekStartsOn < 0 || weekStartsOn > 6) {
-    return NextResponse.json({ error: "Week start must be a day from Sunday through Saturday." }, { status: 400 });
-  }
-
-  const anchorDate = body.period_anchor_date?.trim() || null;
-  if (anchorDate && !isValidPayrollDateKey(anchorDate)) {
-    return NextResponse.json({ error: "Anchor date must be a valid calendar date." }, { status: 400 });
-  }
-  if (body.cadence === "biweekly" && !anchorDate) {
-    return NextResponse.json({ error: "Bi-weekly payroll requires an anchor period start date." }, { status: 400 });
-  }
-
-  const admin: AdminClient = createAdminSupabase();
-  const now = new Date().toISOString();
-  const { data: settings, error } = await (admin as any)
-    .from("shop_payroll_settings")
-    .upsert({
-      shop_id: auth.me.shop_id,
-      cadence: body.cadence,
-      week_starts_on: weekStartsOn,
-      period_anchor_date: anchorDate,
-      updated_at: now,
-    }, { onConflict: "shop_id" })
-    .select("*")
-    .single();
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-
-  const { error: auditError } = await (admin as any).from("audit_logs").insert({
-    actor_id: auth.me.id,
-    action: "payroll.settings.updated",
-    target: settings.id,
-    metadata: {
-      shop_id: auth.me.shop_id,
-      target_type: "shop_payroll_settings",
-      cadence: body.cadence,
-      week_starts_on: weekStartsOn,
-      period_anchor_date: anchorDate,
-    },
-  });
-  const current = await getOrCreateCurrentPeriod(auth.me.shop_id!);
-  return NextResponse.json({
-    ok: true,
-    settings,
-    currentPeriod: current.period,
-    warning: auditError
-      ? "Payroll settings were saved, but the Activity entry could not be recorded. No retry is needed."
-      : null,
-  });
-}
+// Compatibility for older clients. All payroll settings writes are owned by
+// the canonical settings route so validation, Owner PIN, and audit behavior
+// cannot drift between surfaces.
+export { PUT } from "../settings/route";

--- a/app/api/payroll-time/settings/route.ts
+++ b/app/api/payroll-time/settings/route.ts
@@ -2,8 +2,28 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { OWNER_PIN_PURPOSES, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
 import { requirePayrollReviewer } from "../_lib/auth";
+import { getOrCreateCurrentPeriod } from "@/features/payroll-time/server/payrollTime";
+import {
+  isValidPayrollDateKey,
+  type PayrollCadence,
+} from "@/features/payroll-time/lib/payPeriodBounds";
 
 const CADENCES = new Set(["weekly", "biweekly", "semimonthly", "monthly"]);
+
+type SettingsBody = Partial<{
+  cadence: PayrollCadence;
+  week_starts_on: number;
+  daily_overtime_after_minutes: number;
+  weekly_overtime_after_minutes: number;
+  period_anchor_date: string | null;
+  suspicious_shift_minutes: number;
+  paid_breaks_per_day: number;
+  paid_break_duration_minutes: number;
+  breaks_are_paid: boolean;
+  lunch_is_paid: boolean;
+  default_lunch_duration_minutes: number;
+  lunch_required_after_minutes: number;
+}>;
 
 function intIn(value: unknown, fallback: number, min: number, max: number) {
   const n = Number(value ?? fallback);
@@ -14,7 +34,7 @@ function intIn(value: unknown, fallback: number, min: number, max: number) {
 export async function GET() {
   const auth = await requirePayrollReviewer();
   if (!auth.ok) return auth.response;
-  const admin = createAdminSupabase() as any;
+  const admin = createAdminSupabase();
   const { data, error } = await admin.from("shop_payroll_settings").select("*").eq("shop_id", auth.me.shop_id).maybeSingle();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ settings: data });
@@ -32,29 +52,87 @@ export async function PUT(req: NextRequest) {
   });
   if (!pin.ok) return pin.response;
 
-  const body = await req.json().catch(() => ({}));
+  const body = (await req.json().catch(() => null)) as SettingsBody | null;
+  if (!body) {
+    return NextResponse.json(
+      { error: "Payroll settings payload is required." },
+      { status: 400 },
+    );
+  }
   try {
-    const cadence = String(body.cadence ?? "biweekly");
+    const admin = createAdminSupabase();
+    const { data: existing, error: existingError } = await admin
+      .from("shop_payroll_settings")
+      .select("*")
+      .eq("shop_id", auth.me.shop_id)
+      .maybeSingle();
+    if (existingError) throw new Error(existingError.message);
+
+    const cadence = String(body.cadence ?? existing?.cadence ?? "biweekly");
     if (!CADENCES.has(cadence)) throw new Error("Invalid pay cadence");
+    const rawAnchorDate =
+      body.period_anchor_date !== undefined
+        ? body.period_anchor_date
+        : existing?.period_anchor_date ?? null;
+    const periodAnchorDate = rawAnchorDate?.trim() || null;
+    if (periodAnchorDate && !isValidPayrollDateKey(periodAnchorDate)) {
+      throw new Error("Anchor date must be a valid calendar date");
+    }
+    if (cadence === "biweekly" && !periodAnchorDate) {
+      throw new Error("Bi-weekly payroll requires an anchor period start date");
+    }
+
     const payload = {
       shop_id: auth.me.shop_id,
       cadence,
-      week_starts_on: intIn(body.week_starts_on, 1, 0, 6),
-      daily_overtime_after_minutes: intIn(body.daily_overtime_after_minutes, 480, 0, 1440),
-      weekly_overtime_after_minutes: intIn(body.weekly_overtime_after_minutes, 2400, 0, 10080),
-      period_anchor_date: typeof body.period_anchor_date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(body.period_anchor_date)
-        ? body.period_anchor_date
-        : null,
-      suspicious_shift_minutes: intIn(body.suspicious_shift_minutes, 960, 60, 2880),
-      paid_breaks_per_day: intIn(body.paid_breaks_per_day, 2, 0, 2),
-      paid_break_duration_minutes: intIn(body.paid_break_duration_minutes, 15, 0, 120),
-      breaks_are_paid: body.breaks_are_paid !== false,
-      lunch_is_paid: body.lunch_is_paid === true,
-      default_lunch_duration_minutes: intIn(body.default_lunch_duration_minutes, 30, 0, 240),
-      lunch_required_after_minutes: intIn(body.lunch_required_after_minutes, 300, 0, 1440),
+      week_starts_on: intIn(body.week_starts_on, existing?.week_starts_on ?? 1, 0, 6),
+      daily_overtime_after_minutes: intIn(
+        body.daily_overtime_after_minutes,
+        existing?.daily_overtime_after_minutes ?? 480,
+        0,
+        1440,
+      ),
+      weekly_overtime_after_minutes: intIn(
+        body.weekly_overtime_after_minutes,
+        existing?.weekly_overtime_after_minutes ?? 2400,
+        0,
+        10080,
+      ),
+      period_anchor_date: periodAnchorDate,
+      suspicious_shift_minutes: intIn(
+        body.suspicious_shift_minutes,
+        existing?.suspicious_shift_minutes ?? 960,
+        60,
+        2880,
+      ),
+      paid_breaks_per_day: intIn(
+        body.paid_breaks_per_day,
+        existing?.paid_breaks_per_day ?? 2,
+        0,
+        2,
+      ),
+      paid_break_duration_minutes: intIn(
+        body.paid_break_duration_minutes,
+        existing?.paid_break_duration_minutes ?? 15,
+        0,
+        120,
+      ),
+      breaks_are_paid: body.breaks_are_paid ?? existing?.breaks_are_paid ?? true,
+      lunch_is_paid: body.lunch_is_paid ?? existing?.lunch_is_paid ?? false,
+      default_lunch_duration_minutes: intIn(
+        body.default_lunch_duration_minutes,
+        existing?.default_lunch_duration_minutes ?? 30,
+        0,
+        240,
+      ),
+      lunch_required_after_minutes: intIn(
+        body.lunch_required_after_minutes,
+        existing?.lunch_required_after_minutes ?? 300,
+        0,
+        1440,
+      ),
       updated_at: new Date().toISOString(),
     };
-    const admin = createAdminSupabase() as any;
     const { data, error } = await admin.from("shop_payroll_settings").upsert(payload, { onConflict: "shop_id" }).select("*").single();
     if (error) throw new Error(error.message);
     const { error: auditError } = await admin.from("audit_logs").insert({
@@ -63,9 +141,11 @@ export async function PUT(req: NextRequest) {
       target: data.id,
       metadata: { ...payload, shop_id: auth.me.shop_id },
     });
+    const current = await getOrCreateCurrentPeriod(auth.me.shop_id!);
     return NextResponse.json({
       ok: true,
       settings: data,
+      currentPeriod: current.period,
       warning: auditError
         ? "Payroll settings were saved, but the Activity entry could not be recorded. No retry is needed."
         : null,

--- a/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
+++ b/features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx
@@ -188,6 +188,7 @@ export default function PayrollTimeClient({
   const [entries, setEntries] = useState<Entry[]>([]);
   const [exceptions, setExceptions] = useState<Exception[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<string | null>(null);
@@ -327,49 +328,69 @@ export default function PayrollTimeClient({
 
   const load = useCallback(async (periodId?: string | null) => {
     setLoading(true);
+    setLoadError(null);
     setError(null);
-    const url = periodId ? `/api/payroll-time/periods?period_id=${periodId}` : "/api/payroll-time/periods";
-    const res = await fetch(url, { cache: "no-store" });
-    const body = await res.json().catch(() => null);
+    try {
+      const url = periodId ? `/api/payroll-time/periods?period_id=${periodId}` : "/api/payroll-time/periods";
+      const res = await fetch(url, { cache: "no-store" });
+      const body = await res.json().catch(() => null);
 
-    if (!res.ok) {
-      setError(body?.error ?? "Failed to load payroll time data");
-      setLoading(false);
-      return;
-    }
+      if (!res.ok) {
+        setPeriods([]);
+        setActivePeriodId(null);
+        setEntries([]);
+        setExceptions([]);
+        setCanConfigurePeriods(false);
+        setLoadError(
+          body?.error ??
+            "Payroll is temporarily unavailable. Recorded punches are safe; retry the payroll load.",
+        );
+        return;
+      }
 
-    const nextSettings = (body?.settings ?? null) as PayrollSettings | null;
-    setShopId(typeof body?.shopId === "string" ? body.shopId : null);
-    setTimezone(
-      typeof body?.timezone === "string" && body.timezone
-        ? body.timezone
-        : "UTC",
-    );
-    setPayrollSettings(nextSettings);
-    setCanConfigurePeriods(Boolean(body?.canConfigure));
-    if (nextSettings) {
-      setSettingsForm({
-        cadence: nextSettings.cadence,
-        week_starts_on: Number(nextSettings.week_starts_on ?? 1),
-        period_anchor_date:
-          nextSettings.period_anchor_date ?? DEFAULT_BIWEEKLY_ANCHOR_DATE,
+      const nextSettings = (body?.settings ?? null) as PayrollSettings | null;
+      setShopId(typeof body?.shopId === "string" ? body.shopId : null);
+      setTimezone(
+        typeof body?.timezone === "string" && body.timezone
+          ? body.timezone
+          : "UTC",
+      );
+      setPayrollSettings(nextSettings);
+      setCanConfigurePeriods(Boolean(body?.canConfigure));
+      if (nextSettings) {
+        setSettingsForm({
+          cadence: nextSettings.cadence,
+          week_starts_on: Number(nextSettings.week_starts_on ?? 1),
+          period_anchor_date:
+            nextSettings.period_anchor_date ?? DEFAULT_BIWEEKLY_ANCHOR_DATE,
+        });
+      }
+      setPeriods((body?.periods ?? []) as Period[]);
+      setActivePeriodId((body?.activePeriodId as string | null) ?? null);
+      setEntries((body?.entries ?? []) as Entry[]);
+      setExceptions((body?.exceptions ?? []) as Exception[]);
+      setZeroState(body?.zeroState ?? null);
+      setRosterSummary({
+        activeWorkforce: Number(body?.rosterSummary?.activeWorkforce ?? 0),
+        payrollEligible: Number(body?.rosterSummary?.payrollEligible ?? 0),
+        payrollSetupIncomplete: Number(
+          body?.rosterSummary?.payrollSetupIncomplete ?? 0,
+        ),
+        recordedEmployees: Number(body?.rosterSummary?.recordedEmployees ?? 0),
       });
+      setRefreshState(body?.refresh ?? null);
+    } catch {
+      setPeriods([]);
+      setActivePeriodId(null);
+      setEntries([]);
+      setExceptions([]);
+      setCanConfigurePeriods(false);
+      setLoadError(
+        "Payroll is temporarily unavailable. Recorded punches are safe; retry the payroll load.",
+      );
+    } finally {
+      setLoading(false);
     }
-    setPeriods((body?.periods ?? []) as Period[]);
-    setActivePeriodId((body?.activePeriodId as string | null) ?? null);
-    setEntries((body?.entries ?? []) as Entry[]);
-    setExceptions((body?.exceptions ?? []) as Exception[]);
-    setZeroState(body?.zeroState ?? null);
-    setRosterSummary({
-      activeWorkforce: Number(body?.rosterSummary?.activeWorkforce ?? 0),
-      payrollEligible: Number(body?.rosterSummary?.payrollEligible ?? 0),
-      payrollSetupIncomplete: Number(
-        body?.rosterSummary?.payrollSetupIncomplete ?? 0,
-      ),
-      recordedEmployees: Number(body?.rosterSummary?.recordedEmployees ?? 0),
-    });
-    setRefreshState(body?.refresh ?? null);
-    setLoading(false);
   }, []);
 
   const loadExportHistory = useCallback(async (periodId?: string | null) => {
@@ -434,7 +455,7 @@ export default function PayrollTimeClient({
     setBusyAction("settings");
     setError(null);
     setNotice(null);
-    const response = await fetch("/api/payroll-time/periods", {
+    const response = await fetch("/api/payroll-time/settings", {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(settingsForm),
@@ -507,6 +528,53 @@ export default function PayrollTimeClient({
     window.open(String(body.signedUrl), "_blank", "noopener,noreferrer");
     setDownloadingBatchId(null);
     await loadExportHistory(activePeriodId);
+  }
+
+  if (loading && periods.length === 0) {
+    return (
+      <div className="space-y-4">
+        <AdminPageHeader
+          eyebrow="Pay-period review"
+          title="Payroll Review"
+          subtitle="Review attendance, job time, flat-rate credit, exceptions, approvals, and export readiness."
+        />
+        <AdminPanel>
+          <AdminEmptyState
+            title="Loading payroll from recorded time"
+            body="Connecting shift punches, job punches, and pay-period settings."
+          />
+        </AdminPanel>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="space-y-4">
+        <AdminPageHeader
+          eyebrow="Pay-period review"
+          title="Payroll Review"
+          subtitle="Review attendance, job time, flat-rate credit, exceptions, approvals, and export readiness."
+        />
+        <AdminPanel>
+          <AdminPanelTitle
+            title="Payroll is unavailable"
+            description="This is a payroll assembly failure, not a zero-time result. Recorded shift and job punches have not been removed."
+          />
+          <div className="space-y-3 p-4">
+            <p className="text-sm text-[color:var(--theme-danger-text)]">
+              {loadError}
+            </p>
+            <button
+              className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs uppercase tracking-[0.12em] text-[color:var(--theme-text-primary)]"
+              onClick={() => void load()}
+            >
+              Retry payroll load
+            </button>
+          </div>
+        </AdminPanel>
+      </div>
+    );
   }
 
   return (

--- a/features/payroll-time/lib/payPeriodBounds.ts
+++ b/features/payroll-time/lib/payPeriodBounds.ts
@@ -79,3 +79,53 @@ export function calculatePayPeriodBounds(params: {
     end: new Date(Date.UTC(year, month + 1, 0)),
   };
 }
+
+export type PayrollPeriodRange = {
+  periodStart: string;
+  periodEnd: string;
+};
+
+export function buildPayrollPeriodRanges(params: {
+  firstWorkDate: string;
+  currentWorkDate: string;
+  cadence: PayrollCadence;
+  weekStartsOn: number;
+  anchorDate?: string | null;
+}): PayrollPeriodRange[] {
+  const firstWorkDate = atUtcDay(params.firstWorkDate);
+  const currentWorkDate = atUtcDay(params.currentWorkDate);
+  if (firstWorkDate > currentWorkDate) return [];
+
+  const ranges: PayrollPeriodRange[] = [];
+  const seen = new Set<string>();
+  let cursor = firstWorkDate;
+  let iterationCount = 0;
+
+  while (cursor <= currentWorkDate) {
+    const bounds = calculatePayPeriodBounds({
+      shopDate: cursor,
+      cadence: params.cadence,
+      weekStartsOn: params.weekStartsOn,
+      anchorDate: params.anchorDate,
+    });
+    const periodStart = bounds.start.toISOString().slice(0, 10);
+    const periodEnd = bounds.end.toISOString().slice(0, 10);
+    const key = `${periodStart}:${periodEnd}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      ranges.push({ periodStart, periodEnd });
+    }
+
+    const nextCursor = addUtcDays(bounds.end, 1);
+    if (nextCursor <= cursor) {
+      throw new Error("Payroll period calculation did not advance");
+    }
+    cursor = nextCursor;
+    iterationCount += 1;
+    if (iterationCount > 1200) {
+      throw new Error("Payroll period history exceeds the supported range");
+    }
+  }
+
+  return ranges;
+}

--- a/features/payroll-time/server/payrollTime.ts
+++ b/features/payroll-time/server/payrollTime.ts
@@ -2,6 +2,7 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { createHash } from "crypto";
 import { shopLocalDateTimeToUtc } from "@/features/shared/lib/utils/shopDayWindow";
 import {
+  buildPayrollPeriodRanges,
   calculatePayPeriodBounds,
   DEFAULT_BIWEEKLY_ANCHOR_DATE,
   type PayrollCadence,
@@ -269,6 +270,62 @@ function clampIso(iso: string, minIso: string, maxIso: string): string {
   return iso;
 }
 
+async function getEarliestPayrollSourceDate(
+  admin: any,
+  shopId: string,
+  timezone: string,
+): Promise<string | null> {
+  const [shiftResult, jobResult, creditResult] = await Promise.all([
+    admin
+      .from("tech_shifts")
+      .select("start_time")
+      .eq("shop_id", shopId)
+      .neq("excluded_from_payroll", true)
+      .order("start_time", { ascending: true })
+      .limit(1)
+      .maybeSingle(),
+    admin
+      .from("work_order_line_labor_segments")
+      .select("started_at")
+      .eq("shop_id", shopId)
+      .order("started_at", { ascending: true })
+      .limit(1)
+      .maybeSingle(),
+    admin
+      .from("work_order_line_flat_rate_credits")
+      .select("credited_at")
+      .eq("shop_id", shopId)
+      .order("credited_at", { ascending: true })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+  const sourceError =
+    shiftResult.error ?? jobResult.error ?? creditResult.error;
+  if (sourceError) throw new Error(sourceError.message);
+
+  const timestamps = [
+    shiftResult.data?.start_time,
+    jobResult.data?.started_at,
+    creditResult.data?.credited_at,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => ({ value, timestamp: new Date(value).getTime() }))
+    .filter((value) => Number.isFinite(value.timestamp))
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  return timestamps[0] ? toShopDate(timestamps[0].value, timezone) : null;
+}
+
+function periodsOverlap(
+  left: { periodStart: string; periodEnd: string },
+  right: { period_start: string; period_end: string },
+) {
+  return (
+    left.periodStart <= right.period_end &&
+    left.periodEnd >= right.period_start
+  );
+}
+
 export async function getOrCreateCurrentPeriod(shopId: string) {
   const admin = createAdminSupabase() as any;
   const today = new Date();
@@ -332,7 +389,8 @@ export async function getOrCreateCurrentPeriod(shopId: string) {
 
   const cadence = (payrollSettings?.cadence ?? "biweekly") as PayrollCadence;
   const weekStartsOn = Number(payrollSettings?.week_starts_on ?? 1);
-  const todayUtc = startOfUtcDay(`${toShopDate(today.toISOString(), timezone)}T00:00:00.000Z`);
+  const currentWorkDate = toShopDate(today.toISOString(), timezone);
+  const todayUtc = startOfUtcDay(`${currentWorkDate}T00:00:00.000Z`);
   const { start: periodStart, end: periodEnd } = calculatePayPeriodBounds({
     shopDate: todayUtc,
     cadence,
@@ -343,46 +401,75 @@ export async function getOrCreateCurrentPeriod(shopId: string) {
   const periodStartIso = toIsoDate(periodStart);
   const periodEndIso = toIsoDate(periodEnd);
 
-  const existing = await admin
+  const { data: existingPeriods, error: existingPeriodsError } = await admin
+    .from("payroll_pay_periods")
+    .select("id, period_start, period_end, status")
+    .eq("shop_id", shopId)
+    .order("period_start", { ascending: true });
+  if (existingPeriodsError) throw new Error(existingPeriodsError.message);
+
+  const earliestSourceDate = await getEarliestPayrollSourceDate(
+    admin,
+    shopId,
+    timezone,
+  );
+  const calculatedRanges = buildPayrollPeriodRanges({
+    firstWorkDate: earliestSourceDate ?? currentWorkDate,
+    currentWorkDate,
+    cadence,
+    weekStartsOn,
+    anchorDate: payrollSettings?.period_anchor_date ?? null,
+  });
+  const rangesToCreate = calculatedRanges.filter((range) => {
+    const isCurrent =
+      range.periodStart === periodStartIso && range.periodEnd === periodEndIso;
+    const exactPeriodExists = (existingPeriods ?? []).some(
+      (period: { period_start: string; period_end: string }) =>
+        period.period_start === range.periodStart &&
+        period.period_end === range.periodEnd,
+    );
+    if (exactPeriodExists) return false;
+    if (isCurrent) return true;
+    return !(existingPeriods ?? []).some(
+      (period: { period_start: string; period_end: string }) =>
+        periodsOverlap(range, period),
+    );
+  });
+
+  const periodRows = rangesToCreate.map((range) => ({
+    shop_id: shopId,
+    period_start: range.periodStart,
+    period_end: range.periodEnd,
+    start_date: range.periodStart,
+    end_date: range.periodEnd,
+    processed: false,
+    status: "open",
+    notes:
+      range.periodStart === periodStartIso && range.periodEnd === periodEndIso
+        ? "Automatically created by Workforce Payroll."
+        : "Automatically created from recorded Workforce time.",
+  }));
+  if (periodRows.length > 0) {
+    const created = await admin
+      .from("payroll_pay_periods")
+      .upsert(periodRows, {
+        onConflict: "shop_id,period_start,period_end",
+        ignoreDuplicates: true,
+      });
+    if (created.error) throw new Error(created.error.message);
+  }
+
+  const currentPeriod = await admin
     .from("payroll_pay_periods")
     .select("*")
     .eq("shop_id", shopId)
     .eq("period_start", periodStartIso)
     .eq("period_end", periodEndIso)
     .maybeSingle();
+  if (currentPeriod.error) throw new Error(currentPeriod.error.message);
+  if (!currentPeriod.data) throw new Error("Current payroll period was not created");
 
-  if (existing.error) throw new Error(existing.error.message);
-  if (existing.data) return { settings: payrollSettings, period: existing.data };
-
-  const created = await admin
-    .from("payroll_pay_periods")
-    .insert({
-      shop_id: shopId,
-      period_start: periodStartIso,
-      period_end: periodEndIso,
-      status: "open",
-      notes: "Automatically created by Workforce Payroll.",
-    })
-    .select("*")
-    .single();
-
-  if (created.error) {
-    // A concurrent request can win the unique
-    // (shop_id, period_start, period_end) insert. Resolve that exact row rather
-    // than rendering an empty payroll screen.
-    const concurrent = await admin
-      .from("payroll_pay_periods")
-      .select("*")
-      .eq("shop_id", shopId)
-      .eq("period_start", periodStartIso)
-      .eq("period_end", periodEndIso)
-      .maybeSingle();
-    if (concurrent.error || !concurrent.data) {
-      throw new Error(created.error.message);
-    }
-    return { settings: payrollSettings, period: concurrent.data };
-  }
-  return { settings: payrollSettings, period: created.data };
+  return { settings: payrollSettings, period: currentPeriod.data };
 }
 
 async function getPeriodSourceState(admin: any, shopId: string, period: any, timezone: string) {

--- a/supabase/migrations/20260801051252_fix_payroll_period_pipeline.sql
+++ b/supabase/migrations/20260801051252_fix_payroll_period_pipeline.sql
@@ -1,0 +1,551 @@
+-- Repair the payroll period contract without rewriting earlier migrations.
+--
+-- Production carries legacy start_date/end_date columns alongside the
+-- canonical period_start/period_end columns. The application writes the
+-- canonical pair, while the legacy pair was later made NOT NULL. Keep both
+-- pairs synchronized during the rolling deployment, restore the canonical
+-- uniqueness invariant, materialize periods that cover recorded source time,
+-- and remove direct database mutation paths that bypass the payroll APIs.
+
+update public.payroll_pay_periods
+set
+  start_date = period_start,
+  end_date = period_end
+where start_date is distinct from period_start
+   or end_date is distinct from period_end;
+
+do $payroll_period_date_precheck$
+begin
+  if exists (
+    select 1
+    from public.payroll_pay_periods period
+    where period.period_start is null
+       or period.period_end is null
+       or period.start_date is null
+       or period.end_date is null
+       or period.period_end < period.period_start
+  ) then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Payroll period dates must be complete and ordered before synchronization can be enabled';
+  end if;
+end
+$payroll_period_date_precheck$;
+
+create or replace function public.sync_payroll_period_date_aliases()
+returns trigger
+language plpgsql
+set search_path = ''
+as $function$
+declare
+  v_canonical_changed boolean;
+  v_legacy_changed boolean;
+begin
+  if tg_op = 'INSERT' then
+    if new.period_start is not null
+       and new.start_date is not null
+       and new.period_start <> new.start_date then
+      raise exception 'Payroll period start dates disagree';
+    end if;
+    if new.period_end is not null
+       and new.end_date is not null
+       and new.period_end <> new.end_date then
+      raise exception 'Payroll period end dates disagree';
+    end if;
+
+    new.period_start := coalesce(new.period_start, new.start_date);
+    new.period_end := coalesce(new.period_end, new.end_date);
+    new.start_date := new.period_start;
+    new.end_date := new.period_end;
+  else
+    v_canonical_changed :=
+      new.period_start is distinct from old.period_start
+      or new.period_end is distinct from old.period_end;
+    v_legacy_changed :=
+      new.start_date is distinct from old.start_date
+      or new.end_date is distinct from old.end_date;
+
+    if v_canonical_changed and v_legacy_changed then
+      if new.period_start is distinct from new.start_date
+         or new.period_end is distinct from new.end_date then
+        raise exception 'Payroll period date aliases cannot be changed to different values';
+      end if;
+    elsif v_canonical_changed then
+      new.start_date := new.period_start;
+      new.end_date := new.period_end;
+    elsif v_legacy_changed then
+      new.period_start := new.start_date;
+      new.period_end := new.end_date;
+    end if;
+  end if;
+
+  if new.period_start is null
+     or new.period_end is null
+     or new.start_date is null
+     or new.end_date is null then
+    raise exception 'Payroll period start and end dates are required';
+  end if;
+  if new.period_end < new.period_start then
+    raise exception 'Payroll period end date cannot precede its start date';
+  end if;
+
+  return new;
+end;
+$function$;
+
+drop trigger if exists payroll_pay_periods_sync_date_aliases
+  on public.payroll_pay_periods;
+create trigger payroll_pay_periods_sync_date_aliases
+before insert or update of period_start, period_end, start_date, end_date
+on public.payroll_pay_periods
+for each row
+execute function public.sync_payroll_period_date_aliases();
+
+revoke all on function public.sync_payroll_period_date_aliases()
+  from public, anon, authenticated;
+
+alter table public.payroll_pay_periods
+  drop constraint if exists payroll_pay_periods_date_aliases_chk;
+alter table public.payroll_pay_periods
+  add constraint payroll_pay_periods_date_aliases_chk
+  check (
+    start_date = period_start
+    and end_date = period_end
+  ) not valid;
+alter table public.payroll_pay_periods
+  validate constraint payroll_pay_periods_date_aliases_chk;
+
+create unique index if not exists payroll_pay_periods_shop_period_key
+  on public.payroll_pay_periods (shop_id, period_start, period_end);
+
+-- Backfill open period shells for every shop-local source date. This never
+-- updates an existing period, so approved/exported history remains immutable.
+with source_dates as (
+  select
+    shift.shop_id,
+    (shift.start_time at time zone coalesce(shop.timezone, 'UTC'))::date as work_date
+  from public.tech_shifts shift
+  join public.shops shop on shop.id = shift.shop_id
+  where shift.start_time is not null
+    and coalesce(shift.excluded_from_payroll, false) = false
+
+  union all
+
+  select
+    segment.shop_id,
+    (segment.started_at at time zone coalesce(shop.timezone, 'UTC'))::date as work_date
+  from public.work_order_line_labor_segments segment
+  join public.shops shop on shop.id = segment.shop_id
+  where segment.started_at is not null
+
+  union all
+
+  select
+    credit.shop_id,
+    (credit.credited_at at time zone coalesce(shop.timezone, 'UTC'))::date as work_date
+  from public.work_order_line_flat_rate_credits credit
+  join public.shops shop on shop.id = credit.shop_id
+  where credit.credited_at is not null
+),
+source_bounds as (
+  select shop_id, min(work_date) as first_work_date
+  from source_dates
+  group by shop_id
+),
+payroll_rules as (
+  select
+    bounds.shop_id,
+    bounds.first_work_date,
+    (now() at time zone coalesce(shop.timezone, 'UTC'))::date as current_work_date,
+    coalesce(settings.cadence, 'biweekly') as cadence,
+    coalesce(settings.week_starts_on, 1)::integer as week_starts_on,
+    coalesce(settings.period_anchor_date, date '2024-01-01') as anchor_date
+  from source_bounds bounds
+  join public.shops shop on shop.id = bounds.shop_id
+  left join public.shop_payroll_settings settings
+    on settings.shop_id = bounds.shop_id
+),
+source_calendar as (
+  select
+    rule.*,
+    generated.work_date::date
+  from payroll_rules rule
+  cross join lateral generate_series(
+    rule.first_work_date,
+    greatest(rule.first_work_date, rule.current_work_date),
+    interval '1 day'
+  ) as generated(work_date)
+),
+period_starts as (
+  select
+    calendar.shop_id,
+    calendar.cadence,
+    calendar.work_date,
+    case calendar.cadence
+      when 'weekly' then
+        calendar.work_date
+          - ((extract(dow from calendar.work_date)::integer - calendar.week_starts_on + 7) % 7)
+      when 'biweekly' then
+        calendar.anchor_date
+          + (floor((calendar.work_date - calendar.anchor_date) / 14.0)::integer * 14)
+      when 'semimonthly' then
+        case
+          when extract(day from calendar.work_date) <= 15
+            then date_trunc('month', calendar.work_date)::date
+          else (date_trunc('month', calendar.work_date)::date + 15)
+        end
+      else date_trunc('month', calendar.work_date)::date
+    end as period_start
+  from source_calendar calendar
+),
+period_ranges as (
+  select distinct
+    period.shop_id,
+    period.period_start,
+    case period.cadence
+      when 'weekly' then period.period_start + 6
+      when 'biweekly' then period.period_start + 13
+      when 'semimonthly' then
+        case
+          when extract(day from period.period_start) = 1
+            then period.period_start + 14
+          else (date_trunc('month', period.period_start)::date + interval '1 month - 1 day')::date
+        end
+      else (date_trunc('month', period.period_start)::date + interval '1 month - 1 day')::date
+    end as period_end
+  from period_starts period
+)
+insert into public.payroll_pay_periods (
+  shop_id,
+  period_start,
+  period_end,
+  start_date,
+  end_date,
+  processed,
+  status,
+  notes
+)
+select
+  period.shop_id,
+  period.period_start,
+  period.period_end,
+  period.period_start,
+  period.period_end,
+  false,
+  'open',
+  'Automatically created from recorded Workforce time.'
+from period_ranges period
+on conflict (shop_id, period_start, period_end) do nothing;
+
+-- Payroll period/settings mutations are server-only because the API enforces
+-- reviewer capabilities and Owner PIN requirements. Retain scoped reads.
+drop policy if exists payroll_pay_periods_shop_all
+  on public.payroll_pay_periods;
+drop policy if exists payroll_pay_periods__shop_insert
+  on public.payroll_pay_periods;
+drop policy if exists payroll_pay_periods__shop_update
+  on public.payroll_pay_periods;
+drop policy if exists payroll_pay_periods__shop_delete
+  on public.payroll_pay_periods;
+drop policy if exists payroll_pay_periods__shop_select
+  on public.payroll_pay_periods;
+drop policy if exists payroll_pay_periods_manager_select
+  on public.payroll_pay_periods;
+
+create policy payroll_pay_periods_manager_select
+  on public.payroll_pay_periods
+  for select to authenticated
+  using (
+    shop_id = (select public.profixiq_workforce_shop_id())
+    and (select public.profixiq_can_manage_workforce())
+  );
+
+drop policy if exists shop_payroll_settings_shop_crud
+  on public.shop_payroll_settings;
+drop policy if exists shop_payroll_settings_shop_insert
+  on public.shop_payroll_settings;
+drop policy if exists shop_payroll_settings_shop_update
+  on public.shop_payroll_settings;
+drop policy if exists shop_payroll_settings_shop_delete
+  on public.shop_payroll_settings;
+drop policy if exists shop_payroll_settings_shop_select
+  on public.shop_payroll_settings;
+drop policy if exists shop_payroll_settings_owner_write
+  on public.shop_payroll_settings;
+drop policy if exists shop_payroll_settings_manager_select
+  on public.shop_payroll_settings;
+
+create policy shop_payroll_settings_manager_select
+  on public.shop_payroll_settings
+  for select to authenticated
+  using (
+    shop_id = (select public.profixiq_workforce_shop_id())
+    and (select public.profixiq_can_manage_workforce())
+  );
+
+revoke insert, update, delete on table public.payroll_pay_periods
+  from anon, authenticated;
+revoke insert, update, delete on table public.shop_payroll_settings
+  from anon, authenticated;
+
+-- Snapshot replacement remains privileged because it replaces the entire open
+-- period atomically. Only the server's service role may call it, and the actor,
+-- shop, period, employee identities, dates, and non-negative values are checked
+-- again inside the transaction.
+create or replace function public.replace_payroll_period_snapshot(
+  p_shop_id uuid,
+  p_actor_profile_id uuid,
+  p_period_id uuid,
+  p_entries jsonb,
+  p_exceptions jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_actor_role text;
+  v_period public.payroll_pay_periods%rowtype;
+  v_entry_count integer := 0;
+  v_exception_count integer := 0;
+begin
+  if coalesce(auth.jwt() ->> 'role', '') <> 'service_role' then
+    raise exception 'Forbidden';
+  end if;
+  if p_shop_id is null
+     or p_actor_profile_id is null
+     or p_period_id is null then
+    raise exception 'Shop, actor, and pay period are required';
+  end if;
+  if jsonb_typeof(coalesce(p_entries, '[]'::jsonb)) <> 'array'
+     or jsonb_typeof(coalesce(p_exceptions, '[]'::jsonb)) <> 'array' then
+    raise exception 'Payroll entries and exceptions must be arrays';
+  end if;
+
+  select lower(coalesce(profile.role::text, ''))
+  into v_actor_role
+  from public.profiles profile
+  where profile.id = p_actor_profile_id
+    and profile.shop_id = p_shop_id;
+  if not found then
+    raise exception 'Actor is not a member of this shop';
+  end if;
+  if v_actor_role not in ('owner', 'admin', 'manager') then
+    raise exception 'Forbidden';
+  end if;
+
+  select *
+  into v_period
+  from public.payroll_pay_periods period
+  where period.id = p_period_id
+    and period.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception 'Pay period not found';
+  end if;
+  if v_period.status in ('approved', 'exported') then
+    raise exception 'Approved/exported periods are locked';
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_to_recordset(coalesce(p_entries, '[]'::jsonb)) as entry(
+      user_id uuid,
+      work_date date,
+      worked_minutes integer,
+      attendance_minutes integer,
+      unpaid_break_minutes integer,
+      paid_break_minutes integer,
+      regular_minutes integer,
+      overtime_minutes integer,
+      job_minutes integer,
+      flagged_minutes integer,
+      adjustment_minutes integer,
+      has_exceptions boolean,
+      warning_exception_count integer,
+      blocking_exception_count integer,
+      source_snapshot jsonb
+    )
+    left join public.profiles profile
+      on profile.id = entry.user_id
+     and profile.shop_id = p_shop_id
+    where profile.id is null
+       or entry.work_date is null
+       or entry.work_date < v_period.period_start
+       or entry.work_date > v_period.period_end
+       or entry.worked_minutes < 0
+       or entry.attendance_minutes < 0
+       or entry.unpaid_break_minutes < 0
+       or entry.paid_break_minutes < 0
+       or entry.regular_minutes < 0
+       or entry.overtime_minutes < 0
+       or entry.job_minutes < 0
+       or entry.flagged_minutes < 0
+       or entry.warning_exception_count < 0
+       or entry.blocking_exception_count < 0
+  ) then
+    raise exception 'Payroll snapshot contains an invalid employee, date, or minute value';
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_to_recordset(coalesce(p_exceptions, '[]'::jsonb)) as exception(
+      user_id uuid,
+      work_date date,
+      severity text,
+      code text,
+      message text,
+      source_type text,
+      source_ref jsonb
+    )
+    left join public.profiles profile
+      on profile.id = exception.user_id
+     and profile.shop_id = p_shop_id
+    where profile.id is null
+       or (
+         exception.work_date is not null
+         and (
+           exception.work_date < v_period.period_start
+           or exception.work_date > v_period.period_end
+         )
+       )
+       or exception.severity not in ('warning', 'blocking')
+       or exception.source_type not in ('attendance', 'job_time', 'manual_adjustment', 'system')
+       or nullif(trim(exception.code), '') is null
+       or nullif(trim(exception.message), '') is null
+  ) then
+    raise exception 'Payroll snapshot contains an invalid exception';
+  end if;
+
+  delete from public.payroll_time_exceptions exception
+  where exception.shop_id = p_shop_id
+    and exception.period_id = p_period_id;
+  delete from public.payroll_time_entries entry
+  where entry.shop_id = p_shop_id
+    and entry.period_id = p_period_id;
+
+  insert into public.payroll_time_entries (
+    shop_id,
+    period_id,
+    user_id,
+    work_date,
+    worked_minutes,
+    attendance_minutes,
+    unpaid_break_minutes,
+    paid_break_minutes,
+    regular_minutes,
+    overtime_minutes,
+    job_minutes,
+    flagged_minutes,
+    adjustment_minutes,
+    has_exceptions,
+    warning_exception_count,
+    blocking_exception_count,
+    approval_state,
+    source_snapshot
+  )
+  select
+    p_shop_id,
+    p_period_id,
+    entry.user_id,
+    entry.work_date,
+    entry.worked_minutes,
+    entry.attendance_minutes,
+    entry.unpaid_break_minutes,
+    entry.paid_break_minutes,
+    entry.regular_minutes,
+    entry.overtime_minutes,
+    entry.job_minutes,
+    entry.flagged_minutes,
+    entry.adjustment_minutes,
+    entry.has_exceptions,
+    entry.warning_exception_count,
+    entry.blocking_exception_count,
+    'draft',
+    entry.source_snapshot
+  from jsonb_to_recordset(coalesce(p_entries, '[]'::jsonb)) as entry(
+    user_id uuid,
+    work_date date,
+    worked_minutes integer,
+    attendance_minutes integer,
+    unpaid_break_minutes integer,
+    paid_break_minutes integer,
+    regular_minutes integer,
+    overtime_minutes integer,
+    job_minutes integer,
+    flagged_minutes integer,
+    adjustment_minutes integer,
+    has_exceptions boolean,
+    warning_exception_count integer,
+    blocking_exception_count integer,
+    source_snapshot jsonb
+  );
+  get diagnostics v_entry_count = row_count;
+
+  insert into public.payroll_time_exceptions (
+    shop_id,
+    period_id,
+    user_id,
+    work_date,
+    severity,
+    code,
+    message,
+    source_type,
+    source_ref
+  )
+  select
+    p_shop_id,
+    p_period_id,
+    exception.user_id,
+    exception.work_date,
+    exception.severity,
+    exception.code,
+    exception.message,
+    exception.source_type,
+    exception.source_ref
+  from jsonb_to_recordset(coalesce(p_exceptions, '[]'::jsonb)) as exception(
+    user_id uuid,
+    work_date date,
+    severity text,
+    code text,
+    message text,
+    source_type text,
+    source_ref jsonb
+  );
+  get diagnostics v_exception_count = row_count;
+
+  update public.payroll_pay_periods period
+  set status = 'open', updated_at = now()
+  where period.id = p_period_id
+    and period.shop_id = p_shop_id;
+
+  return jsonb_build_object(
+    'rows', v_entry_count,
+    'exceptions', v_exception_count
+  );
+end;
+$function$;
+
+revoke all on function public.replace_payroll_period_snapshot(
+  uuid,
+  uuid,
+  uuid,
+  jsonb,
+  jsonb
+) from public, anon, authenticated;
+grant execute on function public.replace_payroll_period_snapshot(
+  uuid,
+  uuid,
+  uuid,
+  jsonb,
+  jsonb
+) to service_role;
+
+comment on function public.replace_payroll_period_snapshot(
+  uuid,
+  uuid,
+  uuid,
+  jsonb,
+  jsonb
+) is
+  'Atomically replaces an open payroll snapshot through the authorized server API only.';

--- a/supabase/migrations/20260801053356_deduplicate_payroll_period_index.sql
+++ b/supabase/migrations/20260801053356_deduplicate_payroll_period_index.sql
@@ -1,0 +1,12 @@
+-- The live schema already carries the canonical unique index under the
+-- ux_payroll_pay_periods_shop_period name. The repair migration created the
+-- same index defensively for environments that lacked it. Keep whichever
+-- canonical index predates the repair and remove only the redundant one.
+
+do $deduplicate_payroll_period_index$
+begin
+  if to_regclass('public.ux_payroll_pay_periods_shop_period') is not null then
+    drop index if exists public.payroll_pay_periods_shop_period_key;
+  end if;
+end
+$deduplicate_payroll_period_index$;

--- a/tests/payroll-period-pipeline.test.ts
+++ b/tests/payroll-period-pipeline.test.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { buildPayrollPeriodRanges } from "@/features/payroll-time/lib/payPeriodBounds";
+
+const migrationSource = readFileSync(
+  "supabase/migrations/20260801051252_fix_payroll_period_pipeline.sql",
+  "utf8",
+);
+const cleanupMigrationSource = readFileSync(
+  "supabase/migrations/20260801053356_deduplicate_payroll_period_index.sql",
+  "utf8",
+);
+const payrollSource = readFileSync(
+  "features/payroll-time/server/payrollTime.ts",
+  "utf8",
+);
+const periodsRouteSource = readFileSync(
+  "app/api/payroll-time/periods/route.ts",
+  "utf8",
+);
+const settingsRouteSource = readFileSync(
+  "app/api/payroll-time/settings/route.ts",
+  "utf8",
+);
+const payrollUiSource = readFileSync(
+  "features/dashboard/app/dashboard/admin/payroll-time/PayrollTimeClient.tsx",
+  "utf8",
+);
+
+describe("payroll period history generation", () => {
+  it("materializes every bi-weekly period covering existing source time", () => {
+    expect(
+      buildPayrollPeriodRanges({
+        firstWorkDate: "2026-07-10",
+        currentWorkDate: "2026-07-31",
+        cadence: "biweekly",
+        weekStartsOn: 1,
+        anchorDate: "2024-01-01",
+      }),
+    ).toEqual([
+      { periodStart: "2026-06-29", periodEnd: "2026-07-12" },
+      { periodStart: "2026-07-13", periodEnd: "2026-07-26" },
+      { periodStart: "2026-07-27", periodEnd: "2026-08-09" },
+    ]);
+  });
+
+  it("handles semi-monthly and monthly boundaries without gaps", () => {
+    expect(
+      buildPayrollPeriodRanges({
+        firstWorkDate: "2026-01-14",
+        currentWorkDate: "2026-02-02",
+        cadence: "semimonthly",
+        weekStartsOn: 1,
+      }),
+    ).toEqual([
+      { periodStart: "2026-01-01", periodEnd: "2026-01-15" },
+      { periodStart: "2026-01-16", periodEnd: "2026-01-31" },
+      { periodStart: "2026-02-01", periodEnd: "2026-02-15" },
+    ]);
+    expect(
+      buildPayrollPeriodRanges({
+        firstWorkDate: "2026-01-31",
+        currentWorkDate: "2026-03-01",
+        cadence: "monthly",
+        weekStartsOn: 1,
+      }),
+    ).toEqual([
+      { periodStart: "2026-01-01", periodEnd: "2026-01-31" },
+      { periodStart: "2026-02-01", periodEnd: "2026-02-28" },
+      { periodStart: "2026-03-01", periodEnd: "2026-03-31" },
+    ]);
+  });
+});
+
+describe("payroll period persistence and authorization contract", () => {
+  it("writes both live date-column pairs and resolves concurrent creation idempotently", () => {
+    expect(payrollSource).toContain("start_date: range.periodStart");
+    expect(payrollSource).toContain("end_date: range.periodEnd");
+    expect(payrollSource).toContain(
+      'onConflict: "shop_id,period_start,period_end"',
+    );
+    expect(payrollSource).toContain("ignoreDuplicates: true");
+    expect(migrationSource).toContain(
+      "create trigger payroll_pay_periods_sync_date_aliases",
+    );
+    expect(migrationSource).toContain("payroll_pay_periods_shop_period_key");
+    expect(cleanupMigrationSource).toContain(
+      "ux_payroll_pay_periods_shop_period",
+    );
+    expect(cleanupMigrationSource).toContain(
+      "drop index if exists public.payroll_pay_periods_shop_period_key",
+    );
+  });
+
+  it("makes payroll mutations server-only and keeps scoped reviewer reads", () => {
+    expect(migrationSource).toContain(
+      "revoke insert, update, delete on table public.payroll_pay_periods",
+    );
+    expect(migrationSource).toContain(
+      "revoke insert, update, delete on table public.shop_payroll_settings",
+    );
+    expect(migrationSource).toContain("from public, anon, authenticated");
+    expect(migrationSource).toContain("to service_role");
+    expect(migrationSource).toContain(
+      "shop_id = (select public.profixiq_workforce_shop_id())",
+    );
+    expect(migrationSource).toContain(
+      "and (select public.profixiq_can_manage_workforce())",
+    );
+  });
+
+  it("uses one settings implementation and preserves omitted policy fields", () => {
+    expect(periodsRouteSource).toContain(
+      'export { PUT } from "../settings/route"',
+    );
+    expect(payrollUiSource).toContain('fetch("/api/payroll-time/settings"');
+    expect(settingsRouteSource).toContain(
+      "existing?.daily_overtime_after_minutes ?? 480",
+    );
+    expect(settingsRouteSource).toContain(
+      "existing?.weekly_overtime_after_minutes ?? 2400",
+    );
+    expect(settingsRouteSource).toContain("getOrCreateCurrentPeriod");
+  });
+
+  it("does not represent an API failure as zero payroll", () => {
+    expect(payrollUiSource).toContain("Payroll is unavailable");
+    expect(payrollUiSource).toContain(
+      "This is a payroll assembly failure, not a zero-time result.",
+    );
+    expect(periodsRouteSource).toContain(
+      "Payroll is temporarily unavailable. Recorded punches are safe",
+    );
+  });
+});

--- a/tests/security/payroll-period-pipeline.runtime.sql
+++ b/tests/security/payroll-period-pipeline.runtime.sql
@@ -1,0 +1,159 @@
+begin;
+
+do $payroll_period_pipeline$
+declare
+  v_shop_id uuid;
+  v_period_id uuid;
+  v_period public.payroll_pay_periods%rowtype;
+begin
+  if not exists (
+    select 1
+    from pg_trigger trigger
+    join pg_class relation on relation.oid = trigger.tgrelid
+    join pg_namespace namespace on namespace.oid = relation.relnamespace
+    where namespace.nspname = 'public'
+      and relation.relname = 'payroll_pay_periods'
+      and trigger.tgname = 'payroll_pay_periods_sync_date_aliases'
+      and not trigger.tgisinternal
+  ) then
+    raise exception 'Payroll period date synchronization trigger is missing';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint constraint_row
+    join pg_class relation on relation.oid = constraint_row.conrelid
+    join pg_namespace namespace on namespace.oid = relation.relnamespace
+    where namespace.nspname = 'public'
+      and relation.relname = 'payroll_pay_periods'
+      and constraint_row.conname = 'payroll_pay_periods_date_aliases_chk'
+      and constraint_row.convalidated
+  ) then
+    raise exception 'Payroll period alias equality constraint is missing or unvalidated';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_indexes index_row
+    where index_row.schemaname = 'public'
+      and index_row.tablename = 'payroll_pay_periods'
+      and index_row.indexname in (
+        'ux_payroll_pay_periods_shop_period',
+        'payroll_pay_periods_shop_period_key'
+      )
+      and index_row.indexdef ilike 'create unique index%'
+  ) then
+    raise exception 'Canonical payroll period uniqueness index is missing';
+  end if;
+
+  if exists (
+    select 1
+    from pg_policies policy
+    where policy.schemaname = 'public'
+      and policy.tablename in ('payroll_pay_periods', 'shop_payroll_settings')
+      and policy.cmd in ('INSERT', 'UPDATE', 'DELETE', 'ALL')
+      and 'authenticated' = any(policy.roles)
+  ) then
+    raise exception 'Direct authenticated payroll period/settings mutation policy remains';
+  end if;
+
+  if has_table_privilege('authenticated', 'public.payroll_pay_periods', 'INSERT')
+     or has_table_privilege('authenticated', 'public.payroll_pay_periods', 'UPDATE')
+     or has_table_privilege('authenticated', 'public.payroll_pay_periods', 'DELETE')
+     or has_table_privilege('authenticated', 'public.shop_payroll_settings', 'INSERT')
+     or has_table_privilege('authenticated', 'public.shop_payroll_settings', 'UPDATE')
+     or has_table_privilege('authenticated', 'public.shop_payroll_settings', 'DELETE') then
+    raise exception 'Authenticated payroll period/settings table grants remain';
+  end if;
+
+  if has_function_privilege(
+       'anon',
+       'public.replace_payroll_period_snapshot(uuid,uuid,uuid,jsonb,jsonb)',
+       'EXECUTE'
+     )
+     or has_function_privilege(
+       'authenticated',
+       'public.replace_payroll_period_snapshot(uuid,uuid,uuid,jsonb,jsonb)',
+       'EXECUTE'
+     )
+     or not has_function_privilege(
+       'service_role',
+       'public.replace_payroll_period_snapshot(uuid,uuid,uuid,jsonb,jsonb)',
+       'EXECUTE'
+     ) then
+    raise exception 'Payroll snapshot RPC grants are unsafe';
+  end if;
+
+  select shop.id
+  into v_shop_id
+  from public.shops shop
+  order by shop.created_at
+  limit 1;
+  if v_shop_id is null then
+    raise exception 'A shop is required for the payroll period trigger runtime test';
+  end if;
+
+  insert into public.payroll_pay_periods (
+    shop_id,
+    period_start,
+    period_end,
+    status
+  ) values (
+    v_shop_id,
+    date '2099-01-01',
+    date '2099-01-14',
+    'open'
+  )
+  returning id into v_period_id;
+
+  select *
+  into v_period
+  from public.payroll_pay_periods period
+  where period.id = v_period_id;
+  if v_period.start_date <> v_period.period_start
+     or v_period.end_date <> v_period.period_end then
+    raise exception 'Canonical-only payroll insert did not synchronize legacy aliases';
+  end if;
+
+  update public.payroll_pay_periods period
+  set
+    start_date = date '2099-02-01',
+    end_date = date '2099-02-14'
+  where period.id = v_period_id;
+
+  select *
+  into v_period
+  from public.payroll_pay_periods period
+  where period.id = v_period_id;
+  if v_period.period_start <> date '2099-02-01'
+     or v_period.period_end <> date '2099-02-14' then
+    raise exception 'Legacy payroll date update did not synchronize canonical dates';
+  end if;
+
+  begin
+    insert into public.payroll_pay_periods (
+      shop_id,
+      period_start,
+      period_end,
+      start_date,
+      end_date,
+      status
+    ) values (
+      v_shop_id,
+      date '2099-03-01',
+      date '2099-03-14',
+      date '2099-04-01',
+      date '2099-04-14',
+      'open'
+    );
+    raise exception 'Mismatched payroll date aliases were accepted';
+  exception
+    when others then
+      if sqlerrm = 'Mismatched payroll date aliases were accepted' then
+        raise;
+      end if;
+  end;
+end
+$payroll_period_pipeline$;
+
+rollback;


### PR DESCRIPTION
## Summary

Repairs the Workforce-to-Payroll pipeline so recorded shift punches, job labor, pay-period settings, and payroll review resolve through one path.

- synchronizes canonical and legacy payroll-period date columns during rolling deploys
- creates historical period shells covering existing Workforce time
- makes period creation idempotent and concurrency-safe
- consolidates settings writes through the canonical settings route
- shows a truthful unavailable state instead of false zero totals
- restricts direct period/settings mutations and the snapshot RPC to server-authorized paths

## Root cause

Production requires both `period_start/period_end` and legacy `start_date/end_date`, but the application inserted only the canonical pair. PostgreSQL rejected every current-period insert, aborting payroll assembly before entries, settings, or periods reached the UI.

## Database

Applied to Supabase project `scjjkmuwadwkaaqjoigx`:

- `fix_payroll_period_pipeline`
- `deduplicate_payroll_period_index`

Live verification confirms:

- three synchronized biweekly periods: Jun 29–Jul 12, Jul 13–26, and Jul 27–Aug 9
- all 13 stored shifts and 11 stored job segments are covered
- only reviewer-scoped SELECT policies remain on periods/settings
- authenticated direct mutation grants are revoked
- snapshot RPC execution is denied to anon/authenticated and retained for service_role
- transactional insert/update/conflict assertions pass and roll back cleanly

## Validation

- `vitest` payroll scope: 5 files, 29 tests passed
- `tsc --noEmit`: passed
- focused ESLint: passed with existing `no-explicit-any` warnings only
- API route boundary audit: passed
- migration runtime assertions: passed against live production schema
- full Vitest baseline: 1,557 passed; 17 unrelated failures plus one unrelated import-resolution suite failure
- full ESLint baseline: existing unrelated errors outside this change
- Next production build compiled and passed type/lint phases; page-data collection then stopped because the local environment does not provide `NEXT_PUBLIC_SUPABASE_URL` for the pre-existing agent route

## Rollout

The migrations are rolling-compatible with the currently deployed application. After this branch deploys, the Payroll Review UI will also gain historical generation on demand, consolidated settings behavior, and explicit load-failure handling.
