### PR TITLE
Round and separate create work order fields

### DIFF
--- a/features/inspections/components/inspection/CustomerVehicleForm.tsx
+++ b/features/inspections/components/inspection/CustomerVehicleForm.tsx
@@ -13,6 +13,9 @@ import {
   type VehicleDuplicateMatch,
 } from "@/features/shared/lib/vehicles/duplicateCheck";
 import { CarFront, CheckCircle2, ChevronDown, UserRound } from "lucide-react";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
+
+const intakeFieldClass = `${ui.input} min-h-11 rounded-xl`;
 
 type VehicleInfo = SessionVehicle & {
   submodel?: string | null;
@@ -796,7 +799,7 @@ export default function CustomerVehicleForm({
                 </span>
               </label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Business name"
                 value={customer.business_name ?? ""}
                 onChange={(e) => {
@@ -821,7 +824,7 @@ export default function CustomerVehicleForm({
             <div className="space-y-1">
               <label className={labelClass}>First name</label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="First name"
                 value={customer.first_name ?? ""}
                 onChange={(e) => {
@@ -846,7 +849,7 @@ export default function CustomerVehicleForm({
             <div className="space-y-1">
               <label className={labelClass}>Last name</label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Last name"
                 value={customer.last_name ?? ""}
                 onChange={(e) => {
@@ -871,7 +874,7 @@ export default function CustomerVehicleForm({
             <div className="space-y-1">
               <label className={labelClass}>Phone</label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Phone"
                 value={customer.phone ?? ""}
                 onChange={(e) => {
@@ -897,7 +900,7 @@ export default function CustomerVehicleForm({
               <label className={labelClass}>Email</label>
               <input
                 type="email"
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Email"
                 value={customer.email ?? ""}
                 onChange={(e) => {
@@ -931,7 +934,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1 sm:col-span-2">
                 <label className={labelClass}>Address</label>
                 <input
-                  className="input"
+                  className={intakeFieldClass}
                   placeholder="Street address"
                   value={customer.address ?? ""}
                   onChange={(e) =>
@@ -942,7 +945,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1">
                 <label className={labelClass}>City</label>
                 <input
-                  className="input"
+                  className={intakeFieldClass}
                   placeholder="City"
                   value={customer.city ?? ""}
                   onChange={(e) =>
@@ -953,7 +956,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1">
                 <label className={labelClass}>Province</label>
                 <input
-                  className="input"
+                  className={intakeFieldClass}
                   placeholder="Province / State"
                   value={customer.province ?? ""}
                   onChange={(e) =>
@@ -964,7 +967,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1">
                 <label className={labelClass}>Postal code</label>
                 <input
-                  className="input"
+                  className={intakeFieldClass}
                   placeholder="Postal code"
                   value={customer.postal_code ?? ""}
                   onChange={(e) =>
@@ -1040,7 +1043,7 @@ export default function CustomerVehicleForm({
             <div className="space-y-1">
               <label className={labelClass}>Unit #</label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Unit #"
                 value={vehicle.unit_number ?? ""}
                 onChange={(e) =>
@@ -1061,7 +1064,7 @@ export default function CustomerVehicleForm({
               <label className={labelClass}>Year</label>
               <input
                 inputMode="numeric"
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Year"
                 value={vehicle.year ?? ""}
                 onChange={(e) => safeSetVehicle("year", e.target.value || null)}
@@ -1072,7 +1075,7 @@ export default function CustomerVehicleForm({
             <div className="space-y-1">
               <label className={labelClass}>Make</label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Make"
                 value={vehicle.make ?? ""}
                 onChange={(e) => safeSetVehicle("make", e.target.value || null)}
@@ -1083,7 +1086,7 @@ export default function CustomerVehicleForm({
             <div className="space-y-1">
               <label className={labelClass}>Model</label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Model"
                 value={vehicle.model ?? ""}
                 onChange={(e) =>
@@ -1096,7 +1099,7 @@ export default function CustomerVehicleForm({
             <div className="space-y-1">
               <label className={labelClass}>VIN</label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="VIN"
                 value={vehicle.vin ?? ""}
                 onChange={(e) => safeSetVehicle("vin", e.target.value || null)}
@@ -1107,7 +1110,7 @@ export default function CustomerVehicleForm({
             <div className="space-y-1">
               <label className={labelClass}>License plate</label>
               <input
-                className="input"
+                className={intakeFieldClass}
                 placeholder="License plate"
                 value={vehicle.license_plate ?? ""}
                 onChange={(e) =>
@@ -1128,7 +1131,7 @@ export default function CustomerVehicleForm({
               <label className={labelClass}>Mileage</label>
               <input
                 inputMode="numeric"
-                className="input"
+                className={intakeFieldClass}
                 placeholder="Mileage"
                 value={vehicle.mileage ?? ""}
                 onChange={(e) =>
@@ -1150,7 +1153,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1">
                 <label className={labelClass}>Color</label>
                 <input
-                  className="input"
+                  className={intakeFieldClass}
                   placeholder="Color"
                   value={vehicle.color ?? ""}
                   onChange={(e) =>
@@ -1162,7 +1165,7 @@ export default function CustomerVehicleForm({
                 <label className={labelClass}>Engine hours</label>
                 <input
                   inputMode="numeric"
-                  className="input"
+                  className={intakeFieldClass}
                   placeholder="Engine hours"
                   value={vehicle.engine_hours ?? ""}
                   onChange={(e) =>
@@ -1173,7 +1176,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1">
                 <label className={labelClass}>Engine / Trim</label>
                 <input
-                  className="input"
+                  className={intakeFieldClass}
                   placeholder="e.g. 3.5L EcoBoost"
                   value={vehicle.engine ?? ""}
                   onChange={(e) =>
@@ -1184,7 +1187,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1">
                 <label className={labelClass}>Transmission</label>
                 <select
-                  className="input"
+                  className={intakeFieldClass}
                   value={vehicle.transmission ?? ""}
                   onChange={(e) =>
                     safeSetVehicle("transmission", e.target.value || null)
@@ -1201,7 +1204,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1">
                 <label className={labelClass}>Fuel type</label>
                 <select
-                  className="input"
+                  className={intakeFieldClass}
                   value={vehicle.fuel_type ?? ""}
                   onChange={(e) =>
                     safeSetVehicle("fuel_type", e.target.value || null)
@@ -1220,7 +1223,7 @@ export default function CustomerVehicleForm({
               <div className="space-y-1">
                 <label className={labelClass}>Drivetrain</label>
                 <select
-                  className="input"
+                  className={intakeFieldClass}
                   value={vehicle.drivetrain ?? ""}
                   onChange={(e) =>
                     safeSetVehicle("drivetrain", e.target.value || null)

--- a/features/work-orders/app/work-orders/create/page.tsx
+++ b/features/work-orders/app/work-orders/create/page.tsx
@@ -37,6 +37,7 @@ import { normalizeCustomerForIntake } from "@/features/inspections/lib/customerN
 import { normalizeVinInput } from "@/features/shared/lib/vin/normalizeVin";
 import { checkVehicleDuplicates } from "@/features/shared/lib/vehicles/duplicateCheck";
 import { requestVehicleRecallEnrichment } from "@/features/vehicles/lib/requestRecallEnrichment";
+import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 // 👇 inspection modal, client-only
 const InspectionModal = dynamic(
@@ -62,6 +63,7 @@ const subtlePanel =
   "rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)]";
 const softButton =
   "rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-overlay)]";
+const formControlClass = `${ui.input} min-h-11 rounded-xl`;
 
 /* =============================================================================
    Types & helpers
@@ -2367,7 +2369,7 @@ export default function CreateWorkOrderPage() {
                   <select
                     value={priority}
                     onChange={(e) => setPriority(Number(e.target.value))}
-                    className="input"
+                    className={formControlClass}
                     disabled={loading}
                   >
                     <option value={1}>Urgent</option>
@@ -2387,7 +2389,7 @@ export default function CreateWorkOrderPage() {
                   <select
                     value={type}
                     onChange={(e) => setType(e.target.value as WOType)}
-                    className="input"
+                    className={formControlClass}
                     disabled={loading}
                   >
                     <option value="maintenance">Maintenance</option>
@@ -2407,7 +2409,7 @@ export default function CreateWorkOrderPage() {
                     type="datetime-local"
                     value={expectedCompletionInput}
                     onChange={(e) => setExpectedCompletionInput(e.target.value)}
-                    className="input"
+                    className={formControlClass}
                     disabled={loading}
                   />
                   <p className="mt-1 text-[11px] text-[color:var(--theme-text-muted)]">
@@ -2636,7 +2638,7 @@ export default function CreateWorkOrderPage() {
                       onChange={(e) =>
                         setPhotoFiles(Array.from(e.target.files ?? []))
                       }
-                      className="input"
+                      className={formControlClass}
                       disabled={loading}
                     />
                   </div>
@@ -2651,7 +2653,7 @@ export default function CreateWorkOrderPage() {
                       onChange={(e) =>
                         setDocFiles(Array.from(e.target.files ?? []))
                       }
-                      className="input"
+                      className={formControlClass}
                       disabled={loading}
                     />
                   </div>
@@ -2663,7 +2665,7 @@ export default function CreateWorkOrderPage() {
                   <textarea
                     value={notes}
                     onChange={(e) => setNotes(e.target.value)}
-                    className="input min-h-32"
+                    className={`${formControlClass} min-h-32`}
                     rows={4}
                     placeholder="Optional note for the technician"
                     disabled={loading}
@@ -2958,7 +2960,7 @@ export default function CreateWorkOrderPage() {
                     <input
                       value={intakeConcern}
                       onChange={(e) => setIntakeConcern(e.target.value)}
-                      className="input"
+                      className={formControlClass}
                       placeholder="e.g. No start / rough idle / brake noise…"
                       disabled={intakeSaving}
                     />
@@ -2971,7 +2973,7 @@ export default function CreateWorkOrderPage() {
                     <textarea
                       value={intakeDetails}
                       onChange={(e) => setIntakeDetails(e.target.value)}
-                      className="input"
+                      className={formControlClass}
                       rows={3}
                       placeholder="Anything else they said?"
                       disabled={intakeSaving}
@@ -2986,7 +2988,7 @@ export default function CreateWorkOrderPage() {
                       <select
                         value={intakeContactPref}
                         onChange={(e) => setIntakeContactPref(e.target.value)}
-                        className="input"
+                        className={formControlClass}
                         disabled={intakeSaving}
                       >
                         <option>Text or call</option>
@@ -3003,7 +3005,7 @@ export default function CreateWorkOrderPage() {
                       <input
                         value={intakeMileage}
                         onChange={(e) => setIntakeMileage(e.target.value)}
-                        className="input"
+                        className={formControlClass}
                         placeholder="e.g. 245,000"
                         disabled={intakeSaving}
                       />

--- a/tests/work-orders/create-work-order-fast-intake-redesign.test.ts
+++ b/tests/work-orders/create-work-order-fast-intake-redesign.test.ts
@@ -54,4 +54,18 @@ describe("create work order fast-intake redesign", () => {
     expect(createPage).toContain("min-h-11 w-full");
     expect(createPage).toContain("min-h-10 items-center");
   });
+
+  it("renders every intake control as a separate rounded themed field", () => {
+    expect(customerVehicleForm).toContain(
+      "const intakeFieldClass = `${ui.input} min-h-11 rounded-xl`",
+    );
+    expect(createPage).toContain(
+      "const formControlClass = `${ui.input} min-h-11 rounded-xl`",
+    );
+    expect(customerVehicleForm).not.toContain('className="input"');
+    expect(createPage).not.toContain('className="input"');
+    expect(customerVehicleForm).toContain(
+      'className="grid grid-cols-1 gap-3 sm:grid-cols-2"',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the square, joined-looking inputs on Create Work Order after the fast-intake redesign was merged.

### What changed

- Replaces the inactive legacy `input` class with ProFixIQ's canonical themed desktop input primitive.
- Gives every customer, vehicle, address, advanced vehicle, visit-setting, attachment, notes, and quick-intake control its own rounded shell.
- Preserves the existing responsive grid gaps so paired fields remain visibly separate on iPad and desktop and stack cleanly on mobile.
- Keeps a minimum 44px control height for touch use.
- Adds regression coverage preventing the legacy unstyled class from returning.

## Root cause

The redesign retained a legacy `input` class that has no active component definition. Tailwind's form reset therefore rendered the controls with square corners, making adjacent paired fields appear joined despite their semantic grid grouping.

## Safety

This is presentation-only. Field values, autocomplete, selection callbacks, VIN handling, validation, draft persistence, work-order creation, uploads, and submit behavior are unchanged. No database, authorization, API, or lifecycle changes.

## Validation

- Focused fast-intake suite: 6/6 passed
- TypeScript: passed
- Changed-file ESLint: passed
- Prettier: passed
- `git diff --check`: passed

## Database

No migration required.

## Environment variables

None required.

## Manual smoke test

- Confirm customer and vehicle fields have independent rounded borders on iPad landscape.
- Confirm paired fields retain visible spacing on desktop.
- Confirm fields stack without overflow on mobile.
- Expand Address details, More vehicle details, Visit settings, and Attachments & internal notes.
- Confirm autocomplete dropdowns still anchor below their corresponding fields.