### PR TITLE
Restore ProFixIQ blue modal top bar

### DIFF
--- a/features/shared/components/ModalShell.tsx
+++ b/features/shared/components/ModalShell.tsx
@@ -52,8 +52,8 @@ export default function ModalShell({
 
       <div className={`relative z-[510] w-full ${width}`}>
         <Dialog.Panel className="relative w-full overflow-hidden rounded-[26px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] text-[color:var(--theme-text-primary)] shadow-[var(--theme-shadow-medium)]">
-          <div className="absolute inset-x-0 top-0 h-[3px] bg-[linear-gradient(90deg,rgba(184,115,51,0),rgba(184,115,51,0.95),rgba(253,186,116,0.95),rgba(184,115,51,0))]" />
-          <div className="pointer-events-none absolute inset-x-10 top-0 h-24 bg-[radial-gradient(circle_at_top,rgba(184,115,51,0.14),transparent_72%)]" />
+          <div className="absolute inset-x-0 top-0 z-20 h-[3px] bg-[linear-gradient(90deg,transparent,var(--brand-primary),var(--brand-accent),transparent)]" />
+          <div className="pointer-events-none absolute inset-x-10 top-0 z-10 h-24 bg-[radial-gradient(circle_at_top,color-mix(in_srgb,var(--brand-primary)_18%,transparent),transparent_72%)]" />
 
           <div className="relative flex items-center justify-between border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 sm:px-5">
             <div className="min-w-0">
@@ -97,7 +97,12 @@ export default function ModalShell({
               </div>
 
               <div className="flex gap-2">
-                <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={onClose}
+                >
                   Cancel
                 </Button>
 

--- a/tests/work-order-modal-history.test.ts
+++ b/tests/work-order-modal-history.test.ts
@@ -25,6 +25,10 @@ const mobileFocusedJob = readFileSync(
   "features/work-orders/mobile/MobileFocusedJob.tsx",
   "utf8",
 );
+const modalShell = readFileSync(
+  "features/shared/components/ModalShell.tsx",
+  "utf8",
+);
 
 describe("work-order modal sizing, theme, and vehicle history", () => {
   it("gives cause and correction a large responsive shell without nested scrolling", () => {
@@ -43,6 +47,13 @@ describe("work-order modal sizing, theme, and vehicle history", () => {
     expect(assistantModal).not.toContain(
       'className="var(--theme-gradient-panel)"',
     );
+  });
+
+  it("uses the ProFixIQ brand blue treatment for shared modal top bars", () => {
+    expect(modalShell).toContain("var(--brand-primary)");
+    expect(modalShell).toContain("var(--brand-accent)");
+    expect(modalShell).not.toContain("rgba(184,115,51");
+    expect(modalShell).not.toContain("rgba(253,186,116");
   });
 
   it("loads canonical prior work orders through a shop-authorized server route", () => {


### PR DESCRIPTION
## Summary

Restores the shared ProFixIQ modal top rail and ambient glow to the canonical blue brand treatment.

## Root cause

The shared `ModalShell` still hard-coded the previous burnt-copper RGB values for its top rail and glow. Because the Hold modal and many other operational modals consume that shell, the old accent returned across every shared-shell modal regardless of the current ProFixIQ theme.

## What changed

- Replaced hard-coded copper values with `--brand-primary` and `--brand-accent`.
- Raised the 3px rail above the header surface so it remains visibly blue.
- Kept legitimate shop branding compatible through the existing brand token system.
- Added regression coverage preventing the hard-coded copper values from returning.

## Scope and safety

Presentation-only. No modal behavior, hold lifecycle, work-order state, authorization, database access, or data mutations changed.

Shared-shell consumers include Hold, Cause/Correction, AI Assistant, vehicle history, add job, parts request, photo capture, VIN capture, and inbox.

## Validation

- Focused modal regression suite: 5/5 passed
- TypeScript: passed
- Changed-file ESLint: passed
- Prettier: passed
- `git diff --check`: passed
- Production build: application compiled successfully; repository-wide page-data collection then stopped because this local checkout has no Supabase URL configured

## Database

No migration required.

## Environment variables

None required by this change.

## Manual smoke test

- Open Place / Update Hold on iPad and confirm the top rail/glow is ProFixIQ blue.
- Open Cause/Correction and one additional shared-shell modal to confirm the same treatment.
- Confirm close, cancel, submit, and body scrolling behavior are unchanged.