### PR TITLE
Align fleet management UI

### DIFF
--- a/app/fleet/programs/page.tsx
+++ b/app/fleet/programs/page.tsx
@@ -51,7 +51,7 @@ export default function FleetProgramsPage(): JSX.Element {
       } = await supabase.auth.getUser();
 
       if (userError || !user) {
-        setError("You must be signed in to manage fleet programs.");
+        setError("You must be signed in to manage fleets.");
         setLoading(false);
         return;
       }
@@ -146,11 +146,18 @@ export default function FleetProgramsPage(): JSX.Element {
           .single();
 
         if (insertError || !inserted) {
-          throw new Error("Failed to create fleet program.");
+          throw new Error("Failed to create fleet.");
         }
 
         setFleets((prev) => [...prev, inserted]);
-        setSuccess("Fleet program created.");
+        const returnTo = new URLSearchParams(window.location.search).get(
+          "returnTo",
+        );
+        if (returnTo === "/fleet/portal-access") {
+          router.push(`${returnTo}?fleetId=${encodeURIComponent(inserted.id)}`);
+          return;
+        }
+        setSuccess("Fleet created.");
         resetForm();
       } else {
         if (!form.id) {
@@ -171,13 +178,13 @@ export default function FleetProgramsPage(): JSX.Element {
           .single();
 
         if (updateError || !updated) {
-          throw new Error("Failed to update fleet program.");
+          throw new Error("Failed to update fleet.");
         }
 
         setFleets((prev) =>
           prev.map((f) => (f.id === updated.id ? updated : f)),
         );
-        setSuccess("Fleet program updated.");
+        setSuccess("Fleet updated.");
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Unexpected error");
@@ -188,18 +195,18 @@ export default function FleetProgramsPage(): JSX.Element {
 
   return (
     <PageShell
-      title="Fleet programs"
-      description="Organize your units into fleets like Linehaul, Local P&D, and Trailers."
+      title="Manage fleets"
+      description="Create and manage the fleets used for units, service requests, and portal access."
     >
       <div className="space-y-6 text-[color:var(--theme-text-primary)]">
         {/* Top header card */}
         <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card backdrop-blur-xl sm:p-6">
           <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold">Programs / groups</h2>
+              <h2 className="text-lg font-semibold">Fleet details</h2>
               <p className="text-xs text-[color:var(--theme-text-secondary)]">
-                Create fleets to group tractors, trailers, buses, or other units.
-                These fleets power the{" "}
+                Group tractors, trailers, buses, or other units into the fleets
+                your team already recognizes. Fleets power the{" "}
                 <span style={{ color: COPPER }}>Fleet Control Tower</span> and
                 unit list.
               </p>
@@ -210,7 +217,7 @@ export default function FleetProgramsPage(): JSX.Element {
               className="inline-flex items-center gap-2 rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-inset)]"
             >
               <span aria-hidden>←</span>
-              Back to fleet
+              Back to Fleet Control Tower
             </button>
           </div>
 
@@ -233,10 +240,14 @@ export default function FleetProgramsPage(): JSX.Element {
           <div className="grid gap-4 sm:grid-cols-[1.1fr_0.9fr]">
             <div className="space-y-3 text-sm">
               <div className="space-y-1">
-                <label className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                <label
+                  htmlFor="fleet-name"
+                  className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]"
+                >
                   Fleet name
                 </label>
                 <input
+                  id="fleet-name"
                   className="w-full rounded-lg border border-[color:var(--theme-border-soft)] bg-[var(--glass-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-sky-400/40 focus:border-sky-400/40"
                   placeholder="e.g. Linehaul, Local P&D, Trailers"
                   value={form.name}
@@ -248,10 +259,14 @@ export default function FleetProgramsPage(): JSX.Element {
 
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <div className="space-y-1">
-                  <label className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                  <label
+                    htmlFor="fleet-contact-name"
+                    className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]"
+                  >
                     Contact name
                   </label>
                   <input
+                    id="fleet-contact-name"
                     className="w-full rounded-lg border border-[color:var(--theme-border-soft)] bg-[var(--glass-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-sky-400/40 focus:border-sky-400/40"
                     placeholder="Dispatcher / supervisor"
                     value={form.contact_name}
@@ -264,10 +279,14 @@ export default function FleetProgramsPage(): JSX.Element {
                   />
                 </div>
                 <div className="space-y-1">
-                  <label className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                  <label
+                    htmlFor="fleet-contact-email"
+                    className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]"
+                  >
                     Contact email
                   </label>
                   <input
+                    id="fleet-contact-email"
                     type="email"
                     className="w-full rounded-lg border border-[color:var(--theme-border-soft)] bg-[var(--glass-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-sky-400/40 focus:border-sky-400/40"
                     placeholder="contact@example.com"
@@ -283,13 +302,17 @@ export default function FleetProgramsPage(): JSX.Element {
               </div>
 
               <div className="space-y-1">
-                <label className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
+                <label
+                  htmlFor="fleet-notes"
+                  className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]"
+                >
                   Notes
                 </label>
                 <textarea
+                  id="fleet-notes"
                   rows={3}
                   className="w-full rounded-lg border border-[color:var(--theme-border-soft)] bg-[var(--glass-bg)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:outline-none focus:ring-2 focus:ring-sky-400/40 focus:border-sky-400/40"
-                  placeholder="Optional: program notes, maintenance rules, or contract details."
+                  placeholder="Optional: fleet notes, service expectations, or contract details."
                   value={form.notes}
                   onChange={(e) =>
                     setForm((prev) => ({ ...prev, notes: e.target.value }))
@@ -309,7 +332,7 @@ export default function FleetProgramsPage(): JSX.Element {
                       ? "Creating…"
                       : "Saving…"
                     : mode === "create"
-                      ? "Create program"
+                      ? "Create fleet"
                       : "Save changes"}
                 </button>
                 {mode === "edit" && (
@@ -328,20 +351,19 @@ export default function FleetProgramsPage(): JSX.Element {
             <div className="space-y-2 text-xs text-[color:var(--theme-text-secondary)]">
               <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3">
                 <h3 className="mb-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                  How programs are used
+                  How fleets are used
                 </h3>
                 <ul className="list-disc space-y-1 pl-4">
                   <li>
-                    Each fleet groups a set of units via{" "}
-                    <span style={{ color: COPPER }}>fleet_vehicles</span>.
+                    Each fleet keeps its vehicles and contacts together.
                   </li>
                   <li>
                     Units enrolled here show up in the Fleet Control Tower and
                     the fleet units list.
                   </li>
                   <li>
-                    You can have multiple fleets per shop: Linehaul, Local P&D,
-                    Trailers, etc.
+                    Create separate fleets when units have different contacts,
+                    operations, or portal access.
                   </li>
                 </ul>
               </div>
@@ -352,13 +374,13 @@ export default function FleetProgramsPage(): JSX.Element {
         {/* Existing fleets list */}
         <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 backdrop-blur-md shadow-[var(--theme-shadow-medium)] sm:p-6">
           <h2 className="mb-3 text-sm font-semibold text-[color:var(--theme-text-primary)]">
-            Existing programs
+            Existing fleets
           </h2>
           {loading ? (
             <p className="text-sm text-[color:var(--theme-text-secondary)]">Loading…</p>
           ) : fleets.length === 0 ? (
             <p className="text-sm text-[color:var(--theme-text-muted)]">
-              No fleet programs yet. Create your first one above.
+              No fleets yet. Create your first fleet above.
             </p>
           ) : (
             <div className="space-y-2 text-sm">
@@ -366,6 +388,7 @@ export default function FleetProgramsPage(): JSX.Element {
                 <button
                   key={f.id}
                   type="button"
+                  aria-label={`Edit ${f.name || "unnamed fleet"}`}
                   onClick={() => startEdit(f)}
                   className="flex w-full items-start justify-between gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-left hover:border-[color:var(--accent-copper-soft)] hover:bg-[color:var(--theme-surface-overlay)]"
                 >
@@ -375,7 +398,7 @@ export default function FleetProgramsPage(): JSX.Element {
                         {f.name || "Unnamed fleet"}
                       </span>
                       <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
-                        Tap to edit
+                        Select to edit
                       </span>
                     </div>
                     {f.notes && (

--- a/app/fleet/units/new/page.tsx
+++ b/app/fleet/units/new/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import PageShell from "@/features/shared/components/PageShell";
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
@@ -106,7 +107,7 @@ export default function FleetUnitNewPage(): JSX.Element {
       }
 
       if (!fleetId) {
-        throw new Error("Select a fleet program before adding a unit.");
+        throw new Error("Select a fleet before adding a unit.");
       }
 
       let vehicleId: string | null = null;
@@ -237,7 +238,7 @@ export default function FleetUnitNewPage(): JSX.Element {
   return (
     <PageShell
       title="Add fleet unit"
-      description="Enroll a vehicle into a fleet program so it appears in the tower, pre-trips, and service requests."
+      description="Assign a vehicle to a fleet so it appears in the tower, pre-trips, and service requests."
     >
       <div className="space-y-6 text-[color:var(--theme-text-primary)]">
         <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card backdrop-blur-xl sm:p-6">
@@ -245,8 +246,8 @@ export default function FleetUnitNewPage(): JSX.Element {
             <div>
               <h2 className="text-lg font-semibold">Fleet & vehicle</h2>
               <p className="text-xs text-[color:var(--theme-text-secondary)]">
-                Choose the fleet program and either link an existing vehicle or
-                create a new asset.
+                Choose a fleet, then link an existing vehicle or create a new
+                one.
               </p>
             </div>
             <button
@@ -262,9 +263,17 @@ export default function FleetUnitNewPage(): JSX.Element {
           {loading ? (
             <p className="text-sm text-[color:var(--theme-text-secondary)]">Loading fleet data…</p>
           ) : fleets.length === 0 ? (
-            <div className="rounded-xl border border-amber-500/30 bg-amber-950/20 px-3 py-3 text-xs text-amber-100">
-              No fleet programs found for this shop. Create a fleet in the
-              database (or future Fleet Programs screen) before adding units.
+            <div className="rounded-xl border border-amber-500/30 bg-amber-950/20 px-4 py-4 text-sm text-amber-100">
+              <p className="font-semibold">Create a fleet before adding units.</p>
+              <p className="mt-1 text-xs text-amber-100/80">
+                Every fleet unit must belong to a fleet.
+              </p>
+              <Link
+                href="/fleet/programs"
+                className="mt-3 inline-flex rounded-lg bg-amber-100 px-3 py-2 text-xs font-semibold text-amber-950 transition hover:bg-white"
+              >
+                Create fleet
+              </Link>
             </div>
           ) : null}
 
@@ -282,10 +291,14 @@ export default function FleetUnitNewPage(): JSX.Element {
           <div className="mt-4 space-y-5 opacity-100">
             {/* Fleet selection */}
             <div className="space-y-1 text-sm">
-              <label className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]">
-                Fleet program
+              <label
+                htmlFor="fleet-unit-fleet"
+                className="text-xs font-medium uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)]"
+              >
+                Fleet
               </label>
               <select
+                id="fleet-unit-fleet"
                 disabled={disabled}
                 className="w-full rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] focus:outline-none focus:ring-2 focus:ring-sky-400/40 focus:border-sky-400/40 disabled:cursor-not-allowed disabled:opacity-50"
                 value={fleetId}

--- a/features/fleet/components/FleetPortalAccessManager.tsx
+++ b/features/fleet/components/FleetPortalAccessManager.tsx
@@ -1,11 +1,34 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
 import { Building2, Loader2, MailPlus, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 
-type Fleet = { id: string; name: string };
-type Invite = { id: string; fleet_id: string; email: string; role: string; expires_at: string; accepted_at: string | null; revoked_at: string | null; created_at: string };
+type Fleet = {
+  id: string;
+  name: string;
+};
+
+type Invite = {
+  id: string;
+  fleet_id: string;
+  email: string;
+  role: string;
+  expires_at: string;
+  accepted_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+};
+
+type InvitePayload = {
+  fleets?: Fleet[];
+  invites?: Invite[];
+  error?: string;
+};
+
+const CREATE_FLEET_HREF =
+  "/fleet/programs?returnTo=%2Ffleet%2Fportal-access";
 
 export default function FleetPortalAccessManager() {
   const [fleets, setFleets] = useState<Fleet[]>([]);
@@ -15,32 +38,79 @@ export default function FleetPortalAccessManager() {
   const [role, setRole] = useState("viewer");
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
-  async function load() {
-    const response = await fetch("/api/portal/fleet/invites", { cache: "no-store" });
-    const payload = (await response.json().catch(() => null)) as { fleets?: Fleet[]; invites?: Invite[] } | null;
-    if (response.ok) {
-      setFleets(payload?.fleets ?? []);
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+
+    try {
+      const response = await fetch("/api/portal/fleet/invites", {
+        cache: "no-store",
+      });
+      const payload = (await response
+        .json()
+        .catch(() => null)) as InvitePayload | null;
+
+      if (!response.ok) {
+        throw new Error(
+          payload?.error || "Fleet portal access could not be loaded.",
+        );
+      }
+
+      const nextFleets = payload?.fleets ?? [];
+      setFleets(nextFleets);
       setInvites(payload?.invites ?? []);
-      setFleetId((current) => current || payload?.fleets?.[0]?.id || "");
-    } else toast.error("Fleet portal access could not be loaded.");
-    setLoading(false);
-  }
 
-  useEffect(() => { void load(); }, []);
+      const requestedFleetId = new URLSearchParams(
+        window.location.search,
+      ).get("fleetId");
+      setFleetId((current) => {
+        const preferred = current || requestedFleetId || "";
+        return nextFleets.some((fleet) => fleet.id === preferred)
+          ? preferred
+          : (nextFleets[0]?.id ?? "");
+      });
+    } catch (value) {
+      setLoadError(
+        value instanceof Error
+          ? value.message
+          : "Fleet portal access could not be loaded.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   async function send(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setSending(true);
+
     try {
-      const response = await fetch("/api/portal/fleet/invites", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ fleetId, email, role }) });
-      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
-      if (!response.ok) throw new Error(payload?.error || "Invitation could not be sent.");
+      const response = await fetch("/api/portal/fleet/invites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fleetId, email, role }),
+      });
+      const payload = (await response
+        .json()
+        .catch(() => null)) as InvitePayload | null;
+
+      if (!response.ok) {
+        throw new Error(payload?.error || "Invitation could not be sent.");
+      }
+
       toast.success("Fleet portal invitation sent.");
       setEmail("");
       await load();
     } catch (value) {
-      toast.error(value instanceof Error ? value.message : "Invitation could not be sent.");
+      toast.error(
+        value instanceof Error ? value.message : "Invitation could not be sent.",
+      );
     } finally {
       setSending(false);
     }
@@ -48,19 +118,205 @@ export default function FleetPortalAccessManager() {
 
   return (
     <div className="mx-auto w-full max-w-6xl space-y-6 px-4 py-6 text-[color:var(--theme-text-primary)] xl:px-6">
-      <div><div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">Fleet portal</div><h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">Invite & access</h1><p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">Invite fleet managers, approvers, and drivers into the correct fleet-scoped portal.</p></div>
+      <header>
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Fleet portal
+        </div>
+        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">
+          Invite & access
+        </h1>
+        <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+          Invite fleet managers, approvers, and drivers into the correct
+          fleet-scoped portal.
+        </p>
+      </header>
+
       <div className="grid gap-5 lg:grid-cols-[360px_1fr]">
-        <form onSubmit={send} className="space-y-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5 shadow-[var(--theme-shadow-soft)]">
-          <div className="flex items-center gap-2 font-semibold"><MailPlus className="h-4 w-4 text-[var(--accent-copper)]" /> Send fleet invitation</div>
-          <label className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]">Fleet<select required value={fleetId} onChange={(event) => setFleetId(event.target.value)} className="mt-1.5 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 py-2.5 text-sm text-[color:var(--theme-input-text)]"><option value="">Select fleet</option>{fleets.map((fleet) => <option key={fleet.id} value={fleet.id}>{fleet.name}</option>)}</select></label>
-          <label className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]">Invitee email<input required type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="manager@fleet.com" className="mt-1.5 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 py-2.5 text-sm text-[color:var(--theme-input-text)]" /></label>
-          <label className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]">Portal role<select value={role} onChange={(event) => setRole(event.target.value)} className="mt-1.5 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 py-2.5 text-sm text-[color:var(--theme-input-text)]"><option value="viewer">Viewer / driver</option><option value="approver">Approver / dispatcher</option><option value="manager">Fleet manager</option></select></label>
-          <button type="submit" disabled={sending || loading || !fleetId} className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60">{sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}{sending ? "Sending…" : "Send secure invitation"}</button>
+        <form
+          onSubmit={send}
+          aria-busy={loading || sending}
+          className="space-y-4 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5 shadow-[var(--theme-shadow-soft)]"
+        >
+          <div className="flex items-center gap-2 font-semibold">
+            <MailPlus className="h-4 w-4 text-[var(--accent-copper)]" />
+            Send fleet invitation
+          </div>
+
+          {loading ? (
+            <div
+              role="status"
+              className="rounded-xl border border-[color:var(--theme-border-soft)] px-4 py-8 text-center text-sm text-[color:var(--theme-text-secondary)]"
+            >
+              <Loader2 className="mx-auto mb-2 h-5 w-5 animate-spin" />
+              Loading fleets…
+            </div>
+          ) : loadError ? (
+            <div
+              role="alert"
+              className="rounded-xl border border-red-500/40 bg-red-950/20 p-4 text-sm text-red-100"
+            >
+              <p>{loadError}</p>
+              <button
+                type="button"
+                onClick={() => void load()}
+                className="mt-3 rounded-lg border border-red-200/30 px-3 py-2 text-xs font-semibold transition hover:bg-red-100/10"
+              >
+                Retry loading fleet access
+              </button>
+            </div>
+          ) : fleets.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-5 text-center">
+              <p className="font-semibold">Create a fleet before inviting members.</p>
+              <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                Invitations are scoped to one fleet so members only see the
+                correct units and service records.
+              </p>
+              <Link
+                href={CREATE_FLEET_HREF}
+                className="mt-4 inline-flex rounded-xl bg-[var(--accent-copper)] px-4 py-2.5 text-sm font-bold text-[color:var(--theme-text-on-accent)]"
+              >
+                Create fleet
+              </Link>
+            </div>
+          ) : (
+            <>
+              <div>
+                <div className="flex items-center justify-between gap-3">
+                  <label
+                    htmlFor="fleet-portal-fleet"
+                    className="text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+                  >
+                    Fleet
+                  </label>
+                  <Link
+                    href="/fleet/programs"
+                    className="text-xs font-semibold text-[var(--accent-copper)] hover:underline"
+                  >
+                    Manage fleets
+                  </Link>
+                </div>
+                <select
+                  id="fleet-portal-fleet"
+                  required
+                  value={fleetId}
+                  onChange={(event) => setFleetId(event.target.value)}
+                  className="mt-1.5 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 py-2.5 text-sm text-[color:var(--theme-input-text)]"
+                >
+                  <option value="">Select fleet</option>
+                  {fleets.map((fleet) => (
+                    <option key={fleet.id} value={fleet.id}>
+                      {fleet.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="fleet-invite-email"
+                  className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+                >
+                  Invitee email
+                </label>
+                <input
+                  id="fleet-invite-email"
+                  required
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  placeholder="manager@fleet.com"
+                  className="mt-1.5 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 py-2.5 text-sm text-[color:var(--theme-input-text)]"
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="fleet-invite-role"
+                  className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+                >
+                  Portal permissions
+                </label>
+                <select
+                  id="fleet-invite-role"
+                  value={role}
+                  onChange={(event) => setRole(event.target.value)}
+                  className="mt-1.5 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 py-2.5 text-sm text-[color:var(--theme-input-text)]"
+                >
+                  <option value="viewer">Viewer / driver</option>
+                  <option value="approver">Approver / dispatcher</option>
+                  <option value="manager">Fleet manager</option>
+                </select>
+              </div>
+
+              <button
+                type="submit"
+                disabled={sending || !fleetId}
+                className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60"
+              >
+                {sending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ShieldCheck className="h-4 w-4" />
+                )}
+                {sending ? "Sending…" : "Send secure invitation"}
+              </button>
+            </>
+          )}
         </form>
 
         <section className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5 shadow-[var(--theme-shadow-soft)]">
-          <div className="flex items-center gap-2 font-semibold"><Building2 className="h-4 w-4 text-[var(--accent-copper)]" /> Recent invitations</div>
-          {loading ? <div className="py-10 text-center"><Loader2 className="mx-auto h-5 w-5 animate-spin" /></div> : invites.length ? <div className="mt-4 divide-y divide-[color:var(--theme-border-soft)]">{invites.map((invite) => { const fleet = fleets.find((item) => item.id === invite.fleet_id); const status = invite.accepted_at ? "Accepted" : invite.revoked_at ? "Revoked" : new Date(invite.expires_at) <= new Date() ? "Expired" : "Pending"; return <div key={invite.id} className="grid gap-1 py-3 text-sm sm:grid-cols-[1fr_auto]"><div><div className="font-semibold">{invite.email}</div><div className="text-xs text-[color:var(--theme-text-muted)]">{fleet?.name || "Fleet"} · <span className="capitalize">{invite.role}</span></div></div><div className="self-center rounded-full border border-[color:var(--theme-border-soft)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--theme-text-secondary)]">{status}</div></div>; })}</div> : <div className="mt-4 rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-muted)]">No fleet portal invitations yet.</div>}
+          <div className="flex items-center gap-2 font-semibold">
+            <Building2 className="h-4 w-4 text-[var(--accent-copper)]" />
+            Recent invitations
+          </div>
+
+          {loading ? (
+            <div role="status" className="py-10 text-center">
+              <Loader2 className="mx-auto h-5 w-5 animate-spin" />
+              <span className="sr-only">Loading invitations</span>
+            </div>
+          ) : loadError ? (
+            <div className="mt-4 rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-muted)]">
+              Invitations will appear after fleet access reloads.
+            </div>
+          ) : invites.length ? (
+            <div className="mt-4 divide-y divide-[color:var(--theme-border-soft)]">
+              {invites.map((invite) => {
+                const fleet = fleets.find(
+                  (item) => item.id === invite.fleet_id,
+                );
+                const status = invite.accepted_at
+                  ? "Accepted"
+                  : invite.revoked_at
+                    ? "Revoked"
+                    : new Date(invite.expires_at) <= new Date()
+                      ? "Expired"
+                      : "Pending";
+
+                return (
+                  <div
+                    key={invite.id}
+                    className="grid gap-1 py-3 text-sm sm:grid-cols-[1fr_auto]"
+                  >
+                    <div>
+                      <div className="font-semibold">{invite.email}</div>
+                      <div className="text-xs text-[color:var(--theme-text-muted)]">
+                        {fleet?.name || "Fleet"} ·{" "}
+                        <span className="capitalize">{invite.role}</span>
+                      </div>
+                    </div>
+                    <div className="self-center rounded-full border border-[color:var(--theme-border-soft)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--theme-text-secondary)]">
+                      {status}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="mt-4 rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-8 text-center text-sm text-[color:var(--theme-text-muted)]">
+              No fleet portal invitations yet.
+            </div>
+          )}
         </section>
       </div>
     </div>

--- a/features/fleet/components/FleetUnitsPage.tsx
+++ b/features/fleet/components/FleetUnitsPage.tsx
@@ -115,7 +115,7 @@ export default function FleetUnitsPage({
               <h1 className={ui.title}>Fleet Units</h1>
               <p className={ui.subtitle}>
                 Master list of tractors, trailers, buses and other HD assets
-                enrolled in fleet programs.
+                assigned to fleets.
               </p>
               <p className={ui.note}>Actor surface: {uiContext.actorLabel}</p>
             </div>
@@ -151,7 +151,7 @@ export default function FleetUnitsPage({
             </div>
 
             <div className="text-[11px] text-[color:var(--theme-text-muted)] md:pl-3">
-              Units shown are linked from your fleet programs and vehicle list.
+              Units shown are linked from your fleets and vehicle list.
             </div>
           </div>
         </div>
@@ -176,7 +176,7 @@ export default function FleetUnitsPage({
                 No fleet units found
               </div>
               <p className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
-                Add vehicles to a fleet program to see them here.
+                Add vehicles to a fleet to see them here.
               </p>
             </div>
           )}

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -335,15 +335,15 @@ export const TILES: Tile[] = [
   {
     href: "/fleet/units/new",
     title: "Add Fleet Unit",
-    subtitle: "Enroll units into programs",
+    subtitle: "Assign vehicles to fleets",
     roles: ["owner", "admin", "manager", "fleet_manager"],
     scopes: ["management", "inspections", "all"],
     section: "Fleet",
   },
   {
     href: "/fleet/programs",
-    title: "Fleet Programs",
-    subtitle: "Groups, contacts & notes",
+    title: "Manage Fleets",
+    subtitle: "Create fleets and contacts",
     roles: ["owner", "admin", "manager", "fleet_manager"],
     scopes: ["management", "settings", "all"],
     section: "Fleet",

--- a/tests/fleet-management-ui-cohesion.test.ts
+++ b/tests/fleet-management-ui-cohesion.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("fleet management UI cohesion", () => {
+  it("names fleet records consistently across navigation and unit surfaces", () => {
+    const tiles = read("features/shared/config/tiles.ts");
+    const manageFleets = read("app/fleet/programs/page.tsx");
+    const addUnit = read("app/fleet/units/new/page.tsx");
+    const units = read("features/fleet/components/FleetUnitsPage.tsx");
+
+    expect(tiles).toContain('title: "Manage Fleets"');
+    expect(tiles).toContain('subtitle: "Create fleets and contacts"');
+    expect(tiles).toContain('subtitle: "Assign vehicles to fleets"');
+    expect(tiles).not.toContain('title: "Fleet Programs"');
+
+    expect(manageFleets).toContain('title="Manage fleets"');
+    expect(manageFleets).toContain('"Create fleet"');
+    expect(manageFleets).toContain("Existing fleets");
+    expect(manageFleets).not.toContain('title="Fleet programs"');
+    expect(manageFleets).not.toContain('"Create program"');
+
+    expect(addUnit).toContain("Select a fleet before adding a unit.");
+    expect(addUnit).toContain("Create a fleet before adding units.");
+    expect(addUnit).not.toContain("Select a fleet program");
+    expect(units).toContain("assigned to fleets.");
+    expect(units).not.toContain("enrolled in fleet programs.");
+  });
+
+  it("provides a complete no-fleet path from portal access to creation and back", () => {
+    const portalAccess = read(
+      "features/fleet/components/FleetPortalAccessManager.tsx",
+    );
+    const manageFleets = read("app/fleet/programs/page.tsx");
+
+    expect(portalAccess).toContain(
+      '"/fleet/programs?returnTo=%2Ffleet%2Fportal-access"',
+    );
+    expect(portalAccess).toContain(
+      "Create a fleet before inviting members.",
+    );
+    expect(portalAccess).toContain("Manage fleets");
+    expect(portalAccess).toContain("Retry loading fleet access");
+    expect(portalAccess).toContain('htmlFor="fleet-portal-fleet"');
+
+    expect(manageFleets).toContain(
+      'if (returnTo === "/fleet/portal-access")',
+    );
+    expect(manageFleets).toContain(
+      "fleetId=${encodeURIComponent(inserted.id)}",
+    );
+  });
+});


### PR DESCRIPTION
### Root cause

The shop UI used “fleet program” for records stored in `fleets`, even though ProFixIQ also has a separate maintenance-program concept. Fleet Portal Access depended on an existing fleet but presented only an empty dropdown and disabled action when none existed.

### What changed

- Rename the navigation surface to **Manage Fleets** and replace fleet-program wording across fleet management and unit screens.
- Rename creation, edit, success, error, and empty-state copy around the actual fleet entity.
- Add an explicit **Create fleet** path from Fleet Portal Access and Add Fleet Unit.
- Return users from fleet creation to Portal Access with the new fleet preselected.
- Add a persistent **Manage fleets** link beside the invitation dropdown.
- Separate loading, request failure, no-fleet, and ready states on the invitation screen.
- Add retry handling and keep the selected fleet valid after refresh.
- Associate fleet form controls with explicit accessible labels.
- Add regression coverage for terminology and the create-to-invite path.

### Why this is safe

The existing `/fleet/programs` route remains intact for bookmarks and navigation compatibility. No database tables, APIs, permissions, or fleet relationships changed. The return path is allowlisted to `/fleet/portal-access`, so the new redirect cannot become an open redirect.

### Files changed

- Fleet management page
- Add Fleet Unit page
- Fleet Units copy
- Fleet Portal Access manager
- Fleet dashboard tile configuration
- Focused fleet UI cohesion tests

### Validation

- Focused fleet/portal tests: 18 passed across 4 files
- TypeScript: passed
- ESLint on all changed TypeScript/TSX files: passed
- React quality review: passed for hooks, accessibility, loading states, and rendering
- `git diff --check`: passed

### Database

No database changes.

### Environment variables

None.

### Manual/deployment actions

None.

### Remaining risks or unverified assumptions

Authenticated browser visual QA was not run in this local environment. The legacy URL remains `/fleet/programs` intentionally, while all visible terminology now says fleets.