### PR TITLE
Restore menu library loading

### DIFF
--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -153,6 +153,7 @@ export default function MenuItemsPage() {
   const [templates, setTemplates] = useState<TemplateRow[]>([]);
   const [shopDefaults, setShopDefaults] = useState<ShopDefaults | null>(null);
   const [loadingLibrary, setLoadingLibrary] = useState(true);
+  const [shopServicesLoadFailed, setShopServicesLoadFailed] = useState(false);
   const [saving, setSaving] = useState(false);
   const [editorOpen, setEditorOpen] = useState(false);
   const [libraryTab, setLibraryTab] = useState<LibraryTab>("shop");
@@ -222,17 +223,24 @@ export default function MenuItemsPage() {
   }, [shopId, supabase]);
 
   const fetchMenuItems = useCallback(async () => {
-    if (!shopId) return setMenuItems([]);
+    if (!shopId) {
+      setMenuItems([]);
+      setShopServicesLoadFailed(false);
+      return;
+    }
     const { data, error } = await supabase
       .from("menu_items")
       .select("*, inspection_template:inspection_templates(template_name)")
       .eq("shop_id", shopId)
-      .order("updated_at", { ascending: false })
-      .limit(200);
+      .order("created_at", { ascending: false })
+      .limit(1000);
     if (error) {
+      console.error("[menu] shop services load failed", error);
+      setShopServicesLoadFailed(true);
       toast.error("Could not load shop services.");
       return;
     }
+    setShopServicesLoadFailed(false);
     setMenuItems((data ?? []) as MenuItemRow[]);
   }, [shopId, supabase]);
 
@@ -496,6 +504,17 @@ export default function MenuItemsPage() {
       }),
     [learnedRepairs, query, statusFilter],
   );
+  const statusCounts = useMemo(() => {
+    const items = libraryTab === "shop" ? menuItems : learnedRepairs;
+    return items.reduce(
+      (counts, item) => {
+        if (item.is_active) counts.active += 1;
+        else counts.inactive += 1;
+        return counts;
+      },
+      { active: 0, inactive: 0 },
+    );
+  }, [learnedRepairs, libraryTab, menuItems]);
 
   const flatMaster = useMemo(
     () => masterServicesList.flatMap((category) => category.items.map((item) => item.item)),
@@ -560,7 +579,7 @@ export default function MenuItemsPage() {
                   <span className="sm:hidden">Shop</span>
                   <span className="hidden sm:inline">Shop services</span>
                   <span className="rounded-full bg-blue-500/10 px-2 py-0.5 text-[11px] text-blue-500">
-                    {menuItems.length}
+                    {shopServicesLoadFailed ? "—" : menuItems.length}
                   </span>
                 </button>
                 <button
@@ -589,13 +608,18 @@ export default function MenuItemsPage() {
                     key={status}
                     type="button"
                     onClick={() => setStatusFilter(status)}
-                    className={`min-h-9 rounded-lg border px-3 text-xs font-semibold capitalize transition ${
+                    className={`inline-flex min-h-9 items-center gap-2 rounded-lg border px-3 text-xs font-semibold capitalize transition ${
                       statusFilter === status
                         ? "border-blue-500/40 bg-blue-500/10 text-blue-500"
                         : "border-[color:var(--theme-border-soft)] text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]"
                     }`}
                   >
-                    {status}
+                    <span>{status}</span>
+                    <span className="rounded-full bg-[color:var(--theme-surface-subtle)] px-1.5 py-0.5 text-[10px] tabular-nums">
+                      {libraryTab === "shop" && shopServicesLoadFailed
+                        ? "—"
+                        : statusCounts[status]}
+                    </span>
                   </button>
                 ))}
               </div>
@@ -619,7 +643,11 @@ export default function MenuItemsPage() {
 
           <div className="p-3 sm:p-4">
             <div className="mb-3 flex items-center justify-between px-1 text-xs text-[color:var(--theme-text-muted)]">
-              <span>{currentCount} {currentCount === 1 ? "result" : "results"}</span>
+              <span>
+                {libraryTab === "shop" && shopServicesLoadFailed
+                  ? "Services unavailable"
+                  : `${currentCount} ${currentCount === 1 ? "result" : "results"}`}
+              </span>
               {libraryTab === "learned" ? (
                 <span className="hidden sm:inline">Exact YMM suggestions only</span>
               ) : null}
@@ -628,6 +656,26 @@ export default function MenuItemsPage() {
             {loadingLibrary ? (
               <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] px-4 py-12 text-center text-sm text-[color:var(--theme-text-secondary)]">
                 Loading services…
+              </div>
+            ) : libraryTab === "shop" && shopServicesLoadFailed ? (
+              <div
+                role="alert"
+                className="rounded-xl border border-red-500/35 bg-red-500/5 px-5 py-10 text-center"
+              >
+                <p className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  Shop services could not be loaded.
+                </p>
+                <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  Your saved services have not been removed. Retry the request
+                  to load them.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => void fetchMenuItems()}
+                  className={`${QUIET_BUTTON} mt-4`}
+                >
+                  Retry loading services
+                </button>
               </div>
             ) : libraryTab === "shop" ? (
               <div className="space-y-2">
@@ -731,7 +779,9 @@ export default function MenuItemsPage() {
               </div>
             )}
 
-            {!loadingLibrary && currentCount === 0 ? (
+            {!loadingLibrary &&
+            !(libraryTab === "shop" && shopServicesLoadFailed) &&
+            currentCount === 0 ? (
               <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] px-5 py-12 text-center">
                 <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-xl bg-blue-500/10 text-blue-500">
                   {libraryTab === "shop" ? <Sparkles className="h-5 w-5" /> : <History className="h-5 w-5" />}

--- a/tests/menu-repair-completed-lifecycle.test.ts
+++ b/tests/menu-repair-completed-lifecycle.test.ts
@@ -152,6 +152,19 @@ describe("completed repair memory", () => {
     expect(menuPage).toContain("Learned from completed work");
     expect(menuPage).toContain("Exact YMM suggestions only");
     expect(menuPage).toContain("Create service");
+    expect(menuPage).toMatch(
+      /\.from\("menu_items"\)[\s\S]{0,500}\.order\("created_at", \{ ascending: false \}\)/,
+    );
+    expect(menuPage).not.toMatch(
+      /\.from\("menu_items"\)[\s\S]{0,500}\.order\("updated_at"/,
+    );
+    expect(menuPage).toMatch(
+      /\.from\("menu_items"\)[\s\S]{0,700}\.limit\(1000\)/,
+    );
+    expect(menuPage).toContain("shopServicesLoadFailed");
+    expect(menuPage).toContain("Your saved services have not been removed.");
+    expect(menuPage).toContain("Retry loading services");
+    expect(menuPage).toContain("statusCounts[status]");
     expect(inspectionBuilder).toContain('buildMethod === "template"');
     expect(inspectionBuilder).toContain('buildMethod === "prompt"');
     expect(inspectionBuilder).toContain('buildMethod === "manual"');


### PR DESCRIPTION
### Root cause

The menu redesign changed the `menu_items` query from `created_at` ordering to `updated_at`, but `menu_items` has no `updated_at` column. Supabase returned HTTP 400, and the UI then misleadingly rendered the empty-library state. The query also limited results to the newest 200 rows before applying the Active filter, which could exclude the shop's older active services.

### What changed

- Restore `menu_items` ordering by `created_at`.
- Raise the bounded library fetch from 200 to 1,000 so the current 435 saved services are included before client-side status filtering.
- Show Active and Inactive counts directly on the status controls.
- Represent failed counts as unavailable rather than zero.
- Render a dedicated error state explaining that saved services were not removed.
- Add an explicit retry action.
- Prevent a failed request from falling through to “No shop services yet.”
- Add regression coverage for the valid column, fetch bound, status counts, and error state.

### Why this is safe

No menu item or inspection-template records are mutated. Production verification found 435 menu items (3 active, 432 inactive) and 4 inspection templates. Inspection-template requests returned HTTP 200; only the invalid menu query returned HTTP 400. The corrected read-only query returns all 435 current records.

### Files changed

- `app/menu/page.tsx`
- `tests/menu-repair-completed-lifecycle.test.ts`

### Validation

- Focused menu lifecycle suite: 8 passed
- TypeScript: passed
- ESLint on changed files: passed
- `git diff --check`: passed
- Production read-only verification: 435 of 435 menu records returned, including all 3 active records

### Database

No database changes. The branch contains no migration files, and no migration was required or applied.

### Environment variables

None.

### Manual/deployment actions

Deploy the application change through the normal merge/release path.

### Remaining risks or unverified assumptions

The 1,000-row bound safely covers the current 435-row library. Server-side pagination should replace the bounded client fetch before any shop approaches 1,000 menu items.