### PR TITLE
Fix Compare Plans pricing contrast

### DIFF
--- a/app/compare-plans/page.tsx
+++ b/app/compare-plans/page.tsx
@@ -115,6 +115,7 @@ export default function ComparePlansPage() {
             </div>
           ) : null}
           <PricingSection
+            surface="dark"
             onCheckout={handleCheckout}
             onStartFree={() => {
               toast.message("Choose a plan to continue", {

--- a/features/shared/components/ProFixIQLanding.tsx
+++ b/features/shared/components/ProFixIQLanding.tsx
@@ -130,7 +130,6 @@ function ProductVisual({ type }: { type: (typeof stories)[number]["visual"] }) {
     </div>
   );
 }
-
 export default function ProFixIQLanding() {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [sessionExists, setSessionExists] = useState(false);
@@ -227,7 +226,7 @@ export default function ProFixIQLanding() {
           <div className="mx-auto max-w-[1400px] px-5 sm:px-8"><div className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between"><div><div className="marketing-eyebrow">Complete platform</div><h2 className="marketing-heading mt-4 max-w-2xl">Everything included. No feature tax.</h2></div><p className="max-w-lg text-base leading-7 text-[color:var(--marketing-muted)]">Choose a plan by team size. The operating system stays complete at every level.</p></div><div className="mt-12 grid gap-4 md:grid-cols-2 xl:grid-cols-4">{modules.map(({ title, items, icon: Icon }) => <div key={title} className="rounded-2xl border border-[color:var(--marketing-border)] bg-white p-6 shadow-sm"><Icon size={21} className="text-[color:var(--marketing-copper-dark)]" /><h3 className="mt-8 text-lg font-bold">{title}</h3><p className="mt-3 text-sm leading-6 text-[color:var(--marketing-muted)]">{items}</p></div>)}</div></div>
         </section>
 
-        <section id="pricing" className="scroll-mt-24 bg-white py-20 sm:py-28"><div className="mx-auto max-w-[1400px] px-5 sm:px-8"><div className="mx-auto max-w-3xl text-center"><div className="marketing-eyebrow">Simple pricing</div><h2 className="marketing-heading mt-4">One complete product. Sized for your shop.</h2><p className="mt-5 text-lg leading-8 text-[color:var(--marketing-muted)]">All core features are included. Plans scale by the number of active users at each location.</p></div><div className="mt-12"><PricingSection onCheckout={startCheckout} onStartFree={() => { window.location.href = "/compare-plans"; }} /></div></div></section>
+        <section id="pricing" className="scroll-mt-24 bg-white py-20 sm:py-28"><div className="mx-auto max-w-[1400px] px-5 sm:px-8"><div className="mx-auto max-w-3xl text-center"><div className="marketing-eyebrow">Simple pricing</div><h2 className="marketing-heading mt-4">One complete product. Sized for your shop.</h2><p className="mt-5 text-lg leading-8 text-[color:var(--marketing-muted)]">All core features are included. Plans scale by the number of active users at each location.</p></div><div className="mt-12"><PricingSection surface="light" onCheckout={startCheckout} onStartFree={() => { window.location.href = "/compare-plans"; }} /></div></div></section>
       </main>
 
       <LandingChatbot />

--- a/features/shared/components/ui/PricingSection.module.css
+++ b/features/shared/components/ui/PricingSection.module.css
@@ -1,0 +1,134 @@
+.root {
+  --pricing-badge-bg: var(--brand-primary);
+  --pricing-badge-text: #ffffff;
+  --pricing-button-primary-bg: var(--brand-primary);
+  --pricing-button-primary-hover-bg: #1235c7;
+  --pricing-button-primary-text: #ffffff;
+  --pricing-focus-ring: var(--brand-accent);
+}
+
+.root[data-surface="light"] {
+  --pricing-card-bg: #ffffff;
+  --pricing-card-border: #dbe4ef;
+  --pricing-card-featured-border: var(--brand-primary);
+  --pricing-card-shadow: 0 4px 12px rgba(7, 17, 31, 0.08);
+  --pricing-card-featured-shadow: 0 22px 55px rgba(23, 71, 255, 0.14);
+  --pricing-primary-text: #07111f;
+  --pricing-muted-text: #5d6b7b;
+  --pricing-accent-text: #1235c7;
+  --pricing-divider: #dbe4ef;
+  --pricing-secondary-bg: #eef3f9;
+  --pricing-secondary-border: #bdcad9;
+  --pricing-secondary-hover-bg: #e8efff;
+  --pricing-secondary-hover-border: #2563eb;
+  --pricing-feature-icon-bg: #e8efff;
+  --pricing-feature-icon-text: #1235c7;
+  --pricing-notice-bg: #eef3f9;
+  --pricing-notice-border: #dbe4ef;
+  --pricing-notice-text: #5d6b7b;
+  color-scheme: light;
+}
+
+.root[data-surface="dark"] {
+  --pricing-card-bg: #0d172a;
+  --pricing-card-border: #243b61;
+  --pricing-card-featured-border: var(--brand-accent);
+  --pricing-card-shadow: 0 16px 36px rgba(0, 0, 0, 0.34);
+  --pricing-card-featured-shadow: 0 22px 55px rgba(11, 183, 255, 0.16);
+  --pricing-primary-text: #f8fbff;
+  --pricing-muted-text: #c3d2e8;
+  --pricing-accent-text: #7dd3fc;
+  --pricing-divider: #243b61;
+  --pricing-secondary-bg: #14243d;
+  --pricing-secondary-border: #36557f;
+  --pricing-secondary-hover-bg: #1b3152;
+  --pricing-secondary-hover-border: #60a5fa;
+  --pricing-feature-icon-bg: rgba(11, 183, 255, 0.14);
+  --pricing-feature-icon-text: #7dd3fc;
+  --pricing-notice-bg: #091426;
+  --pricing-notice-border: #243b61;
+  --pricing-notice-text: #c3d2e8;
+  color-scheme: dark;
+}
+
+.card {
+  border-color: var(--pricing-card-border);
+  background: var(--pricing-card-bg);
+  color: var(--pricing-primary-text);
+  box-shadow: var(--pricing-card-shadow);
+}
+
+.featuredCard {
+  border-color: var(--pricing-card-featured-border);
+  box-shadow: var(--pricing-card-featured-shadow);
+}
+
+.badge {
+  background: var(--pricing-badge-bg);
+  color: var(--pricing-badge-text);
+}
+
+.primaryText {
+  color: var(--pricing-primary-text);
+}
+
+.mutedText {
+  color: var(--pricing-muted-text);
+}
+
+.accentText {
+  color: var(--pricing-accent-text);
+}
+
+.button {
+  min-height: 44px;
+}
+
+.button:focus-visible {
+  outline: 3px solid var(--pricing-focus-ring);
+  outline-offset: 3px;
+}
+
+.button:disabled {
+  cursor: wait;
+  filter: saturate(0.7);
+  opacity: 0.6;
+}
+
+.primaryButton {
+  border-color: var(--pricing-button-primary-bg);
+  background: var(--pricing-button-primary-bg);
+  color: var(--pricing-button-primary-text);
+}
+
+.secondaryButton {
+  border-color: var(--pricing-secondary-border);
+  background: var(--pricing-secondary-bg);
+  color: var(--pricing-primary-text);
+}
+
+@media (hover: hover) {
+  .primaryButton:hover:not(:disabled) {
+    background: var(--pricing-button-primary-hover-bg);
+  }
+
+  .secondaryButton:hover:not(:disabled) {
+    border-color: var(--pricing-secondary-hover-border);
+    background: var(--pricing-secondary-hover-bg);
+  }
+}
+
+.divider {
+  background: var(--pricing-divider);
+}
+
+.featureIcon {
+  background: var(--pricing-feature-icon-bg);
+  color: var(--pricing-feature-icon-text);
+}
+
+.notice {
+  border-color: var(--pricing-notice-border);
+  background: var(--pricing-notice-bg);
+  color: var(--pricing-notice-text);
+}

--- a/features/shared/components/ui/PricingSection.tsx
+++ b/features/shared/components/ui/PricingSection.tsx
@@ -2,7 +2,11 @@
 
 import { useRef, useState } from "react";
 import { Check } from "lucide-react";
-import { PLAN_PRICING, type PlanKey } from "@/features/stripe/lib/stripe/constants";
+import {
+  PLAN_PRICING,
+  type PlanKey,
+} from "@/features/stripe/lib/stripe/constants";
+import styles from "./PricingSection.module.css";
 
 export type BillingInterval = "monthly" | "yearly";
 
@@ -15,6 +19,7 @@ export type CheckoutPayload = {
 export type PricingSectionProps = {
   onCheckout: (payload: CheckoutPayload) => void | Promise<void>;
   onStartFree: () => void;
+  surface: "light" | "dark";
 };
 
 const sharedFeatures = [
@@ -38,14 +43,16 @@ const plans: Array<{
     name: "Complete 10",
     price: `$${PLAN_PRICING.starter}`,
     users: "Up to 10 active users",
-    description: "A complete operating system for independent and smaller repair teams.",
+    description:
+      "A complete operating system for independent and smaller repair teams.",
   },
   {
     key: "pro",
     name: "Complete 50",
     price: `$${PLAN_PRICING.pro}`,
     users: "Up to 50 active users",
-    description: "Full platform access for growing shops with larger operational teams.",
+    description:
+      "Full platform access for growing shops with larger operational teams.",
     featured: true,
   },
   {
@@ -53,11 +60,15 @@ const plans: Array<{
     name: "Complete Unlimited",
     price: `$${PLAN_PRICING.unlimited}`,
     users: "Unlimited active users",
-    description: "Unlimited users per location for high-volume and multi-team operations.",
+    description:
+      "Unlimited users per location for high-volume and multi-team operations.",
   },
 ];
 
-export default function PricingSection({ onCheckout }: PricingSectionProps) {
+export default function PricingSection({
+  onCheckout,
+  surface,
+}: PricingSectionProps) {
   const [busyKey, setBusyKey] = useState<PlanKey | null>(null);
   const attemptIds = useRef<Partial<Record<PlanKey, string>>>({});
 
@@ -66,7 +77,8 @@ export default function PricingSection({ onCheckout }: PricingSectionProps) {
     setBusyKey(planKey);
     try {
       const checkoutAttemptId =
-        attemptIds.current[planKey] ?? (attemptIds.current[planKey] = crypto.randomUUID());
+        attemptIds.current[planKey] ??
+        (attemptIds.current[planKey] = crypto.randomUUID());
       await onCheckout({ planKey, interval: "monthly", checkoutAttemptId });
     } catch (error) {
       console.error("[PricingSection] checkout failed", error);
@@ -77,53 +89,79 @@ export default function PricingSection({ onCheckout }: PricingSectionProps) {
   };
 
   return (
-    <div>
+    <section
+      aria-label="Pricing plans"
+      className={styles.root}
+      data-surface={surface}
+    >
       <div className="grid gap-5 lg:grid-cols-3">
         {plans.map((plan) => {
           const isBusy = busyKey === plan.key;
           return (
             <article
               key={plan.key}
-              className={`relative flex flex-col rounded-[1.5rem] border bg-white p-7 transition sm:p-8 ${
-                plan.featured
-                  ? "border-[color:var(--marketing-copper)] shadow-[0_22px_55px_rgba(143,69,40,0.13)]"
-                  : "border-[color:var(--marketing-border)] shadow-sm"
-              }`}
+              className={`${styles.card} ${
+                plan.featured ? styles.featuredCard : ""
+              } relative flex flex-col rounded-[1.5rem] border p-7 transition sm:p-8`}
             >
               {plan.featured ? (
-                <div className="absolute right-6 top-0 -translate-y-1/2 rounded-full bg-[color:var(--marketing-copper)] px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.15em] text-white">
+                <div
+                  className={`${styles.badge} absolute right-6 top-0 -translate-y-1/2 rounded-full px-3 py-1.5 text-[10px] font-bold uppercase tracking-[0.15em]`}
+                >
                   Most popular
                 </div>
               ) : null}
 
-              <div className="text-sm font-bold text-[color:var(--marketing-copper-dark)]">{plan.name}</div>
-              <div className="mt-5 flex items-end gap-2">
-                <span className="text-5xl font-semibold tracking-[-0.05em] text-[color:var(--marketing-ink)]">{plan.price}</span>
-                <span className="pb-1.5 text-sm text-[color:var(--marketing-muted)]">/ month / location</span>
+              <div className={`${styles.accentText} text-sm font-bold`}>
+                {plan.name}
               </div>
-              <div className="mt-3 text-sm font-bold text-[color:var(--marketing-ink)]">{plan.users}</div>
-              <p className="mt-3 min-h-[48px] text-sm leading-6 text-[color:var(--marketing-muted)]">{plan.description}</p>
+              <div className="mt-5 flex items-end gap-2">
+                <span
+                  className={`${styles.primaryText} text-5xl font-semibold tracking-[-0.05em]`}
+                >
+                  {plan.price}
+                </span>
+                <span className={`${styles.mutedText} pb-1.5 text-sm`}>
+                  / month / location
+                </span>
+              </div>
+              <div className={`${styles.primaryText} mt-3 text-sm font-bold`}>
+                {plan.users}
+              </div>
+              <p
+                className={`${styles.mutedText} mt-3 min-h-[48px] text-sm leading-6`}
+              >
+                {plan.description}
+              </p>
 
               <button
                 type="button"
                 onClick={() => void startCheckout(plan.key)}
                 disabled={Boolean(busyKey)}
-                className={`mt-7 rounded-xl px-4 py-3 text-sm font-bold transition disabled:cursor-wait disabled:opacity-60 ${
-                  plan.featured
-                    ? "bg-[color:var(--marketing-copper)] text-white hover:bg-[color:var(--marketing-copper-dark)]"
-                    : "border border-[color:var(--marketing-border-strong)] bg-[color:var(--marketing-stone)] text-[color:var(--marketing-ink)] hover:border-[color:var(--marketing-steel)]"
-                }`}
+                aria-busy={isBusy}
+                className={`${styles.button} ${
+                  plan.featured ? styles.primaryButton : styles.secondaryButton
+                } mt-7 rounded-xl border px-4 py-3 text-sm font-bold transition`}
               >
                 {isBusy ? "Starting…" : "Start 14-day free trial"}
               </button>
 
-              <div className="my-7 h-px bg-[color:var(--marketing-border)]" />
-              <div className="text-xs font-bold uppercase tracking-[0.15em] text-[color:var(--marketing-muted)]">Everything included</div>
+              <div className={`${styles.divider} my-7 h-px`} />
+              <div
+                className={`${styles.mutedText} text-xs font-bold uppercase tracking-[0.15em]`}
+              >
+                Everything included
+              </div>
               <ul className="mt-4 space-y-3">
                 {sharedFeatures.map((feature) => (
-                  <li key={feature} className="flex items-start gap-3 text-sm leading-6 text-[color:var(--marketing-ink)]">
-                    <span className="mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full bg-[color:var(--marketing-copper-soft)] text-[color:var(--marketing-copper-dark)]">
-                      <Check size={12} />
+                  <li
+                    key={feature}
+                    className={`${styles.primaryText} flex items-start gap-3 text-sm leading-6`}
+                  >
+                    <span
+                      className={`${styles.featureIcon} mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full`}
+                    >
+                      <Check aria-hidden="true" size={12} />
                     </span>
                     {feature}
                   </li>
@@ -134,10 +172,17 @@ export default function PricingSection({ onCheckout }: PricingSectionProps) {
         })}
       </div>
 
-      <div className="mt-6 flex flex-col gap-2 rounded-2xl border border-[color:var(--marketing-border)] bg-[color:var(--marketing-stone)] px-5 py-4 text-xs leading-5 text-[color:var(--marketing-muted)] sm:flex-row sm:items-center sm:justify-between">
-        <span>All plans include the complete core platform. Cancel anytime.</span>
-        <span>Payment processing, SMS, storage overages, and unusually heavy AI usage may be billed separately.</span>
+      <div
+        className={`${styles.notice} mt-6 flex flex-col gap-2 rounded-2xl border px-5 py-4 text-xs leading-5 sm:flex-row sm:items-center sm:justify-between`}
+      >
+        <span>
+          All plans include the complete core platform. Cancel anytime.
+        </span>
+        <span>
+          Payment processing, SMS, storage overages, and unusually heavy AI
+          usage may be billed separately.
+        </span>
       </div>
-    </div>
+    </section>
   );
 }

--- a/tests/pricing-section-theme-contract.test.tsx
+++ b/tests/pricing-section-theme-contract.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { readFileSync } from "node:fs";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import PricingSection from "@/features/shared/components/ui/PricingSection";
+
+const pricingSource = readFileSync(
+  "features/shared/components/ui/PricingSection.tsx",
+  "utf8",
+);
+const pricingStyles = readFileSync(
+  "features/shared/components/ui/PricingSection.module.css",
+  "utf8",
+);
+const comparePlansSource = readFileSync("app/compare-plans/page.tsx", "utf8");
+const landingSource = readFileSync(
+  "features/shared/components/ProFixIQLanding.tsx",
+  "utf8",
+);
+
+const themeBlock = (surface: "light" | "dark") => {
+  const match = pricingStyles.match(
+    new RegExp(`\\.root\\[data-surface="${surface}"\\] \\{([\\s\\S]*?)\\n\\}`),
+  );
+  expect(match, `missing ${surface} pricing theme`).not.toBeNull();
+  return match?.[1] ?? "";
+};
+
+const tokenHex = (block: string, token: string) => {
+  const match = block.match(new RegExp(`${token}:\\s*(#[0-9a-f]{6})`, "i"));
+  expect(match, `missing hex value for ${token}`).not.toBeNull();
+  return match?.[1] ?? "#000000";
+};
+
+const relativeLuminance = (hex: string) => {
+  const channels =
+    hex
+      .slice(1)
+      .match(/.{2}/g)
+      ?.map((channel) => Number.parseInt(channel, 16) / 255) ?? [];
+  const [red, green, blue] = channels.map((channel) =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+  );
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+};
+
+const contrastRatio = (foreground: string, background: string) => {
+  const lighter = Math.max(
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  );
+  const darker = Math.min(
+    relativeLuminance(foreground),
+    relativeLuminance(background),
+  );
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+describe("PricingSection theme contract", () => {
+  it("requires callers to choose a surface and exposes it to styling", () => {
+    const onCheckout = vi.fn();
+    const { rerender } = render(
+      <PricingSection
+        surface="dark"
+        onCheckout={onCheckout}
+        onStartFree={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("region", { name: "Pricing plans" }),
+    ).toHaveAttribute("data-surface", "dark");
+
+    rerender(
+      <PricingSection
+        surface="light"
+        onCheckout={onCheckout}
+        onStartFree={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("region", { name: "Pricing plans" }),
+    ).toHaveAttribute("data-surface", "light");
+    expect(
+      screen.getAllByRole("button", { name: "Start 14-day free trial" }),
+    ).toHaveLength(3);
+  });
+
+  it("keeps text readable on both explicit card surfaces", () => {
+    for (const surface of ["light", "dark"] as const) {
+      const block = themeBlock(surface);
+      const cardBackground = tokenHex(block, "--pricing-card-bg");
+
+      for (const textToken of [
+        "--pricing-primary-text",
+        "--pricing-muted-text",
+        "--pricing-accent-text",
+      ]) {
+        expect(
+          contrastRatio(tokenHex(block, textToken), cardBackground),
+          `${surface} ${textToken} contrast`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+
+  it("themes the complete pricing interaction instead of overriding text alone", () => {
+    expect(pricingStyles).toContain('.root[data-surface="light"]');
+    expect(pricingStyles).toContain('.root[data-surface="dark"]');
+    expect(pricingStyles).toContain(".button:focus-visible");
+    expect(pricingStyles).toContain(".button:disabled");
+    expect(pricingStyles).toContain(".primaryButton:hover:not(:disabled)");
+    expect(pricingStyles).toContain(".secondaryButton:hover:not(:disabled)");
+    expect(pricingStyles).toContain(".badge");
+    expect(pricingStyles).toContain(".divider");
+    expect(pricingStyles).toContain(".featureIcon");
+    expect(pricingStyles).toContain(".notice");
+    expect(pricingSource).not.toContain("var(--marketing-");
+    expect(pricingSource).not.toContain("bg-white");
+  });
+
+  it("pins the landing and compare-plans callers to their intended themes", () => {
+    expect(landingSource).toMatch(/<PricingSection surface="light"/);
+    expect(comparePlansSource).toMatch(/<PricingSection\s+surface="dark"/);
+  });
+});


### PR DESCRIPTION
## Summary

- make `PricingSection` require an explicit `surface="light" | "dark"` contract
- scope card, text, badge, divider, feature icon, notice, button, focus, hover, and disabled-state tokens together
- pin the marketing landing page to the light pricing theme and `/compare-plans` to the dark theme
- add focused rendering, caller-contract, and WCAG AA contrast regression coverage

## Root cause

`PricingSection` forced white plan cards while resolving text and supporting UI colors from context-dependent marketing variables. On the dark Compare Plans route, that produced a white card with near-white text.

The new component-level theme contract makes the complete pricing surface explicit instead of applying isolated text-color overrides.

## User impact

Compare Plans is readable at desktop and mobile widths, retains a clear featured-plan hierarchy, and keeps focus and disabled states visible. The existing checkout behavior and idempotent checkout-attempt IDs are unchanged.

## Validation

Passed:

- `tsc --noEmit`
- targeted ESLint for the changed TS/TSX files
- `vitest run tests/pricing-section-theme-contract.test.tsx` — 4 tests passed
- `git diff --check`
- local browser verification at 1440 px and 390 px
  - three plan cards rendered
  - no error overlay
  - no horizontal overflow
  - card background: `rgb(13, 23, 42)`
  - card text: `rgb(248, 251, 255)`

Repository baseline issues outside this diff:

- full ESLint: 12 errors and 161 warnings in unrelated files
- full Vitest: 34 unrelated existing failures
- isolated browser QA logged the existing missing `NEXT_PUBLIC_SUPABASE_URL` PWA bootstrap error; the pricing route still rendered without an error overlay

## Database and configuration

- no migration or backfill
- no new environment variables
- no external service configuration changes
