### PR TITLE
Add advisor estimate builder flow

### DIFF
--- a/app/api/estimates/[id]/parts-complete/route.ts
+++ b/app/api/estimates/[id]/parts-complete/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { ESTIMATE_PARTS_ROLES } from "@/features/estimates/lib/access";
+import { estimateRevisionSchema } from "@/features/estimates/server/schemas";
+import {
+  estimateMutationError,
+  requireIdempotencyKey,
+} from "@/features/estimates/server/http";
+
+const idSchema = z.string().uuid();
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ESTIMATE_PARTS_ROLES,
+    requiredCapability: "canManageParts",
+  });
+  if (!access.ok) return access.response;
+
+  const parsedId = idSchema.safeParse((await context.params).id);
+  const parsedBody = estimateRevisionSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsedId.success || !parsedBody.success) {
+    return NextResponse.json(
+      { error: "Invalid estimate completion." },
+      { status: 400 },
+    );
+  }
+  const idempotency = requireIdempotencyKey(request);
+  if (!idempotency.ok) return idempotency.response;
+
+  const { data, error } = await access.supabase.rpc(
+    "complete_estimate_parts_quote_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_work_order_id: parsedId.data,
+      p_expected_revision: parsedBody.data.expectedRevision,
+      p_idempotency_key: idempotency.key,
+    },
+  );
+  if (error) return estimateMutationError(error);
+  return NextResponse.json(data);
+}

--- a/app/api/estimates/[id]/return-to-parts/route.ts
+++ b/app/api/estimates/[id]/return-to-parts/route.ts
@@ -5,6 +5,7 @@ import { ESTIMATE_ADVISOR_ROLES } from "@/features/estimates/lib/access";
 import { returnEstimateSchema } from "@/features/estimates/server/schemas";
 import {
   estimateMutationError,
+  nullableRpcString,
   requireIdempotencyKey,
 } from "@/features/estimates/server/http";
 
@@ -41,7 +42,7 @@ export async function POST(
       p_quote_line_ids: parsedBody.data.quoteLineIds,
       p_expected_revision: parsedBody.data.expectedRevision,
       p_reason_code: parsedBody.data.reasonCode,
-      p_note: parsedBody.data.note ?? null,
+      p_note: nullableRpcString(parsedBody.data.note),
       p_idempotency_key: idempotency.key,
     },
   );

--- a/app/api/estimates/[id]/return-to-parts/route.ts
+++ b/app/api/estimates/[id]/return-to-parts/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { ESTIMATE_ADVISOR_ROLES } from "@/features/estimates/lib/access";
+import { returnEstimateSchema } from "@/features/estimates/server/schemas";
+import {
+  estimateMutationError,
+  requireIdempotencyKey,
+} from "@/features/estimates/server/http";
+
+const idSchema = z.string().uuid();
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ESTIMATE_ADVISOR_ROLES,
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  if (!access.ok) return access.response;
+
+  const parsedId = idSchema.safeParse((await context.params).id);
+  const parsedBody = returnEstimateSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsedId.success || !parsedBody.success) {
+    return NextResponse.json(
+      { error: "Invalid return-to-Parts request." },
+      { status: 400 },
+    );
+  }
+  const idempotency = requireIdempotencyKey(request);
+  if (!idempotency.ok) return idempotency.response;
+
+  const { data, error } = await access.supabase.rpc(
+    "return_estimate_to_parts_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_work_order_id: parsedId.data,
+      p_quote_line_ids: parsedBody.data.quoteLineIds,
+      p_expected_revision: parsedBody.data.expectedRevision,
+      p_reason_code: parsedBody.data.reasonCode,
+      p_note: parsedBody.data.note ?? null,
+      p_idempotency_key: idempotency.key,
+    },
+  );
+  if (error) return estimateMutationError(error);
+  return NextResponse.json(data);
+}

--- a/app/api/estimates/[id]/route.ts
+++ b/app/api/estimates/[id]/route.ts
@@ -10,6 +10,7 @@ import { loadEstimateDetail } from "@/features/estimates/server/data";
 import { saveEstimateSchema } from "@/features/estimates/server/schemas";
 import {
   estimateMutationError,
+  nullableRpcString,
   requireIdempotencyKey,
 } from "@/features/estimates/server/http";
 
@@ -115,8 +116,8 @@ export async function PATCH(
       p_work_order_id: parsedId.data,
       p_expected_revision: parsed.data.expectedRevision,
       p_lines: lines,
-      p_notes: parsed.data.notes ?? null,
-      p_expires_at: parsed.data.expiresAt ?? null,
+      p_notes: nullableRpcString(parsed.data.notes),
+      p_expires_at: nullableRpcString(parsed.data.expiresAt),
       p_idempotency_key: idempotency.key,
     },
   );

--- a/app/api/estimates/[id]/route.ts
+++ b/app/api/estimates/[id]/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import type { Json } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  ESTIMATE_ADVISOR_ROLES,
+  ESTIMATE_VIEW_ROLES,
+} from "@/features/estimates/lib/access";
+import { loadEstimateDetail } from "@/features/estimates/server/data";
+import { saveEstimateSchema } from "@/features/estimates/server/schemas";
+import {
+  estimateMutationError,
+  requireIdempotencyKey,
+} from "@/features/estimates/server/http";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const idSchema = z.string().uuid();
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ESTIMATE_VIEW_ROLES,
+  });
+  if (!access.ok) return access.response;
+
+  const parsedId = idSchema.safeParse((await context.params).id);
+  if (!parsedId.success) {
+    return NextResponse.json(
+      { error: "Invalid estimate id." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const payload = await loadEstimateDetail({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      role: access.canonicalRole,
+      workOrderId: parsedId.data,
+    });
+    if (!payload) {
+      return NextResponse.json(
+        { error: "Estimate not found." },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(payload, {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to load estimate.",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ESTIMATE_ADVISOR_ROLES,
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  if (!access.ok) return access.response;
+
+  const parsedId = idSchema.safeParse((await context.params).id);
+  if (!parsedId.success) {
+    return NextResponse.json(
+      { error: "Invalid estimate id." },
+      { status: 400 },
+    );
+  }
+  const idempotency = requireIdempotencyKey(request);
+  if (!idempotency.ok) return idempotency.response;
+
+  const parsed = saveEstimateSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid estimate draft.", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const lines: Json = parsed.data.lines.map((line) => ({
+    clientKey: line.clientKey,
+    title: line.title,
+    customerDescription: line.customerDescription,
+    advisorNotes: line.advisorNotes,
+    laborHours: line.laborHours,
+    laborRate: line.laborRate,
+    parts: line.parts.map((part) => ({
+      clientKey: part.clientKey,
+      description: part.description,
+      quantity: part.quantity,
+      partNumber: part.partNumber,
+      manufacturer: part.manufacturer,
+    })),
+  }));
+
+  const { data, error } = await access.supabase.rpc(
+    "save_estimate_draft_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_work_order_id: parsedId.data,
+      p_expected_revision: parsed.data.expectedRevision,
+      p_lines: lines,
+      p_notes: parsed.data.notes ?? null,
+      p_expires_at: parsed.data.expiresAt ?? null,
+      p_idempotency_key: idempotency.key,
+    },
+  );
+
+  if (error) return estimateMutationError(error);
+  return NextResponse.json(data);
+}

--- a/app/api/estimates/[id]/submit-parts/route.ts
+++ b/app/api/estimates/[id]/submit-parts/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { ESTIMATE_ADVISOR_ROLES } from "@/features/estimates/lib/access";
+import { estimateRevisionSchema } from "@/features/estimates/server/schemas";
+import {
+  estimateMutationError,
+  requireIdempotencyKey,
+} from "@/features/estimates/server/http";
+
+const idSchema = z.string().uuid();
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ESTIMATE_ADVISOR_ROLES,
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  if (!access.ok) return access.response;
+
+  const parsedId = idSchema.safeParse((await context.params).id);
+  const parsedBody = estimateRevisionSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsedId.success || !parsedBody.success) {
+    return NextResponse.json(
+      { error: "Invalid estimate submission." },
+      { status: 400 },
+    );
+  }
+  const idempotency = requireIdempotencyKey(request);
+  if (!idempotency.ok) return idempotency.response;
+
+  const { data, error } = await access.supabase.rpc(
+    "submit_estimate_to_parts_atomic",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_work_order_id: parsedId.data,
+      p_expected_revision: parsedBody.data.expectedRevision,
+      p_idempotency_key: idempotency.key,
+    },
+  );
+  if (error) return estimateMutationError(error);
+  return NextResponse.json(data);
+}

--- a/app/api/estimates/route.ts
+++ b/app/api/estimates/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import type { Json } from "@shared/types/types/supabase";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import {
+  ESTIMATE_ADVISOR_ROLES,
+  ESTIMATE_VIEW_ROLES,
+} from "@/features/estimates/lib/access";
+import { loadEstimateList } from "@/features/estimates/server/data";
+import { createEstimateSchema } from "@/features/estimates/server/schemas";
+import {
+  estimateMutationError,
+  requireIdempotencyKey,
+} from "@/features/estimates/server/http";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET() {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ESTIMATE_VIEW_ROLES,
+  });
+  if (!access.ok) return access.response;
+
+  try {
+    const payload = await loadEstimateList({
+      supabase: access.supabase,
+      shopId: access.profile.shop_id,
+      role: access.canonicalRole,
+    });
+    return NextResponse.json(payload, {
+      headers: { "Cache-Control": "private, no-store" },
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to load estimates.",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ESTIMATE_ADVISOR_ROLES,
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  if (!access.ok) return access.response;
+
+  const idempotency = requireIdempotencyKey(request);
+  if (!idempotency.ok) return idempotency.response;
+
+  const parsed = createEstimateSchema.safeParse(
+    await request.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid estimate.", issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
+
+  const input = parsed.data;
+  const customer: Json = {
+    id: input.customer.id ?? null,
+    businessName: input.customer.business_name ?? null,
+    name: input.customer.name ?? null,
+    firstName: input.customer.first_name ?? null,
+    lastName: input.customer.last_name ?? null,
+    email: input.customer.email || null,
+    phone: input.customer.phone ?? null,
+    address: input.customer.address ?? null,
+    city: input.customer.city ?? null,
+    province: input.customer.province ?? null,
+    postalCode: input.customer.postal_code ?? null,
+  };
+  const vehicle: Json = {
+    id: input.vehicle.id ?? null,
+    year: input.vehicle.year ?? null,
+    make: input.vehicle.make ?? null,
+    model: input.vehicle.model ?? null,
+    vin: input.vehicle.vin ?? null,
+    licensePlate: input.vehicle.license_plate ?? null,
+    mileage: input.vehicle.mileage ?? null,
+    unitNumber: input.vehicle.unit_number ?? null,
+    color: input.vehicle.color ?? null,
+    engine: input.vehicle.engine ?? null,
+    transmission: input.vehicle.transmission ?? null,
+    fuelType: input.vehicle.fuel_type ?? null,
+    drivetrain: input.vehicle.drivetrain ?? null,
+  };
+  const lines: Json = input.lines.map((line) => ({
+    clientKey: line.clientKey,
+    title: line.title,
+    customerDescription: line.customerDescription,
+    advisorNotes: line.advisorNotes,
+    laborHours: line.laborHours,
+    laborRate: line.laborRate,
+    parts: line.parts.map((part) => ({
+      clientKey: part.clientKey,
+      description: part.description,
+      quantity: part.quantity,
+      partNumber: part.partNumber,
+      manufacturer: part.manufacturer,
+    })),
+  }));
+
+  const { data, error } = await access.supabase.rpc("create_estimate_atomic", {
+    p_shop_id: access.profile.shop_id,
+    p_customer: customer,
+    p_vehicle: vehicle,
+    p_lines: lines,
+    p_notes: input.notes ?? null,
+    p_expires_at: input.expiresAt ?? null,
+    p_idempotency_key: idempotency.key,
+  });
+
+  if (error) return estimateMutationError(error);
+  return NextResponse.json(data, { status: 201 });
+}

--- a/app/api/estimates/route.ts
+++ b/app/api/estimates/route.ts
@@ -9,6 +9,7 @@ import { loadEstimateList } from "@/features/estimates/server/data";
 import { createEstimateSchema } from "@/features/estimates/server/schemas";
 import {
   estimateMutationError,
+  nullableRpcString,
   requireIdempotencyKey,
 } from "@/features/estimates/server/http";
 
@@ -111,8 +112,8 @@ export async function POST(request: Request) {
     p_customer: customer,
     p_vehicle: vehicle,
     p_lines: lines,
-    p_notes: input.notes ?? null,
-    p_expires_at: input.expiresAt ?? null,
+    p_notes: nullableRpcString(input.notes),
+    p_expires_at: nullableRpcString(input.expiresAt),
     p_idempotency_key: idempotency.key,
   });
 

--- a/app/api/parts/requests/items/[itemId]/quote-save/route.ts
+++ b/app/api/parts/requests/items/[itemId]/quote-save/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { syncQuoteLinePartsStatus } from "@/features/parts/server/syncQuoteLinePartsStatus";
 import { isPartsRequestItemPriced } from "@/features/parts/lib/status-display";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { ESTIMATE_PARTS_ROLES } from "@/features/estimates/lib/access";
 
 type DB = Database;
-type PartRequestItemUpdate = DB["public"]["Tables"]["part_request_items"]["Update"];
+type PartRequestItemUpdate =
+  DB["public"]["Tables"]["part_request_items"]["Update"];
 
 type Body = {
   quoteLineId?: string | null;
@@ -24,11 +26,15 @@ const BLOCKED_ITEM_STATUSES = new Set(["cancelled", "rejected", "declined"]);
 
 function isUuid(v: unknown): v is string {
   if (typeof v !== "string") return false;
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v.trim());
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    v.trim(),
+  );
 }
 
 function cleanString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
 }
 
 function nullableUuid(value: unknown, label: string): string | null {
@@ -58,60 +64,67 @@ export async function POST(
   const itemId = cleanString(rawItemId);
 
   if (!itemId || !isUuid(itemId)) {
-    return NextResponse.json({ ok: false, error: "Invalid itemId" }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: "Invalid itemId" },
+      { status: 400 },
+    );
   }
 
-  const supabase = createServerSupabaseRoute();
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabase.auth.getUser();
+  const access = await requireShopScopedApiAccess({
+    allowRoles: ["owner", "admin", "manager", "parts", "lead_hand", "foreman"],
+    requiredCapability: "canManageParts",
+  });
+  if (!access.ok) return access.response;
 
-  if (userErr) return NextResponse.json({ ok: false, error: userErr.message }, { status: 401 });
-  if (!user) return NextResponse.json({ ok: false, error: "Not authenticated" }, { status: 401 });
+  const supabase = access.supabase;
+  const shopId = access.profile.shop_id;
 
   const body = (await req.json().catch(() => null)) as Body | null;
   if (!body) {
-    return NextResponse.json({ ok: false, error: "Invalid JSON body" }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: "Invalid JSON body" },
+      { status: 400 },
+    );
   }
 
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("shop_id")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (profileError) {
-    return NextResponse.json({ ok: false, error: profileError.message }, { status: 500 });
-  }
-
-  const shopId = cleanString(profile?.shop_id);
-  if (!shopId) {
-    return NextResponse.json({ ok: false, error: "Missing shop context" }, { status: 403 });
-  }
-
-  const { error: contextError } = await supabase.rpc("set_current_shop_id", { p_shop_id: shopId });
+  const { error: contextError } = await supabase.rpc("set_current_shop_id", {
+    p_shop_id: shopId,
+  });
   if (contextError) {
-    return NextResponse.json({ ok: false, error: contextError.message }, { status: 403 });
+    return NextResponse.json(
+      { ok: false, error: contextError.message },
+      { status: 403 },
+    );
   }
 
   const { data: item, error: itemError } = await supabase
     .from("part_request_items")
-    .select("id, request_id, shop_id, work_order_id, quote_line_id, work_order_line_id, status, description, part_id, requested_part_number, requested_manufacturer, qty, qty_requested, quoted_price, unit_price, qty_received, qty_consumed, qty_reserved, qty_picked")
+    .select(
+      "id, request_id, shop_id, work_order_id, quote_line_id, work_order_line_id, status, description, part_id, requested_part_number, requested_manufacturer, qty, qty_requested, quoted_price, unit_price, qty_received, qty_consumed, qty_reserved, qty_picked",
+    )
     .eq("id", itemId)
     .eq("shop_id", shopId)
     .maybeSingle();
 
   if (itemError) {
-    return NextResponse.json({ ok: false, error: itemError.message }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: itemError.message },
+      { status: 500 },
+    );
   }
   if (!item) {
-    return NextResponse.json({ ok: false, error: "Request item not found" }, { status: 404 });
+    return NextResponse.json(
+      { ok: false, error: "Request item not found" },
+      { status: 404 },
+    );
   }
 
   const itemQuoteLineId = cleanString(item.quote_line_id);
   if (!itemQuoteLineId) {
-    return NextResponse.json({ ok: false, error: "This item is not linked to a quote line" }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: "This item is not linked to a quote line" },
+      { status: 400 },
+    );
   }
 
   let bodyQuoteLineId: string | null;
@@ -127,18 +140,28 @@ export async function POST(
     quotedPrice = numberOrNull(body.quotedPrice, "quotedPrice");
   } catch (error) {
     return NextResponse.json(
-      { ok: false, error: error instanceof Error ? error.message : "Invalid body" },
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : "Invalid body",
+      },
       { status: 400 },
     );
   }
 
   if (bodyQuoteLineId && bodyQuoteLineId !== itemQuoteLineId) {
-    return NextResponse.json({ ok: false, error: "Quote line mismatch" }, { status: 403 });
+    return NextResponse.json(
+      { ok: false, error: "Quote line mismatch" },
+      { status: 403 },
+    );
   }
 
   if (cleanString(item.work_order_line_id)) {
     return NextResponse.json(
-      { ok: false, error: "This item is already materialized to a work order line; use the normal allocation flow." },
+      {
+        ok: false,
+        error:
+          "This item is already materialized to a work order line; use the normal allocation flow.",
+      },
       { status: 409 },
     );
   }
@@ -146,7 +169,10 @@ export async function POST(
   const normalizedStatus = cleanString(item.status)?.toLowerCase() ?? "";
   if (BLOCKED_ITEM_STATUSES.has(normalizedStatus)) {
     return NextResponse.json(
-      { ok: false, error: "Cancelled or rejected request items cannot be quoted." },
+      {
+        ok: false,
+        error: "Cancelled or rejected request items cannot be quoted.",
+      },
       { status: 409 },
     );
   }
@@ -158,52 +184,142 @@ export async function POST(
     nonNegativeCounter(item.qty_picked) > 0
   ) {
     return NextResponse.json(
-      { ok: false, error: "Cannot change quote-only pricing after inventory activity exists." },
+      {
+        ok: false,
+        error:
+          "Cannot change quote-only pricing after inventory activity exists.",
+      },
       { status: 409 },
     );
   }
 
   const { data: parentRequest, error: requestError } = await supabase
     .from("part_requests")
-    .select("id, shop_id, work_order_id, quote_line_id, status")
+    .select(
+      "id, shop_id, work_order_id, quote_line_id, status, source_context, source_revision",
+    )
     .eq("id", item.request_id)
     .eq("shop_id", shopId)
     .maybeSingle();
 
   if (requestError) {
-    return NextResponse.json({ ok: false, error: requestError.message }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: requestError.message },
+      { status: 500 },
+    );
   }
   if (!parentRequest) {
-    return NextResponse.json({ ok: false, error: "Parent request not found" }, { status: 404 });
+    return NextResponse.json(
+      { ok: false, error: "Parent request not found" },
+      { status: 404 },
+    );
   }
-  if (cleanString(parentRequest.quote_line_id) && cleanString(parentRequest.quote_line_id) !== itemQuoteLineId) {
-    return NextResponse.json({ ok: false, error: "Parent request quote line mismatch" }, { status: 403 });
+  if (
+    cleanString(parentRequest.quote_line_id) &&
+    cleanString(parentRequest.quote_line_id) !== itemQuoteLineId
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Parent request quote line mismatch" },
+      { status: 403 },
+    );
+  }
+  if (
+    cleanString(parentRequest.work_order_id) !== cleanString(item.work_order_id)
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Parent request work order mismatch" },
+      { status: 403 },
+    );
+  }
+
+  if (parentRequest.source_context === "estimate") {
+    if (!ESTIMATE_PARTS_ROLES.some((role) => role === access.canonicalRole)) {
+      return NextResponse.json(
+        { ok: false, error: "This role cannot price advisor estimates." },
+        { status: 403 },
+      );
+    }
+    const { data: estimate, error: estimateError } = await supabase
+      .from("work_orders")
+      .select("id, estimate_status, estimate_revision")
+      .eq("id", parentRequest.work_order_id)
+      .eq("shop_id", shopId)
+      .maybeSingle();
+
+    if (estimateError) {
+      return NextResponse.json(
+        { ok: false, error: estimateError.message },
+        { status: 500 },
+      );
+    }
+    if (
+      !estimate ||
+      estimate.estimate_status !== "waiting_for_parts" ||
+      estimate.estimate_revision !== parentRequest.source_revision
+    ) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error:
+            "Estimate pricing is locked. The advisor must return the current revision to Parts before it can be changed.",
+        },
+        { status: 409 },
+      );
+    }
   }
 
   const { data: quoteLine, error: quoteLineError } = await supabase
     .from("work_order_quote_lines")
-    .select("id, shop_id, work_order_id, work_order_line_id, approved_at, declined_at, status, stage")
+    .select(
+      "id, shop_id, work_order_id, work_order_line_id, approved_at, declined_at, status, stage",
+    )
     .eq("id", itemQuoteLineId)
     .eq("shop_id", shopId)
     .maybeSingle();
 
   if (quoteLineError) {
-    return NextResponse.json({ ok: false, error: quoteLineError.message }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: quoteLineError.message },
+      { status: 500 },
+    );
   }
   if (!quoteLine) {
-    return NextResponse.json({ ok: false, error: "Quote line not found" }, { status: 404 });
+    return NextResponse.json(
+      { ok: false, error: "Quote line not found" },
+      { status: 404 },
+    );
   }
-  if (cleanString(quoteLine.work_order_id) !== cleanString(item.work_order_id)) {
-    return NextResponse.json({ ok: false, error: "Quote line work order mismatch" }, { status: 403 });
+  if (
+    cleanString(quoteLine.work_order_id) !== cleanString(item.work_order_id)
+  ) {
+    return NextResponse.json(
+      { ok: false, error: "Quote line work order mismatch" },
+      { status: 403 },
+    );
   }
   if (cleanString(quoteLine.work_order_line_id) || quoteLine.approved_at) {
     return NextResponse.json(
-      { ok: false, error: "Quote line is already approved/materialized; use the normal allocation flow." },
+      {
+        ok: false,
+        error:
+          "Quote line is already approved/materialized; use the normal allocation flow.",
+      },
       { status: 409 },
     );
   }
-  if (quoteLine.declined_at || ["cancelled", "rejected", "declined"].includes((cleanString(quoteLine.status) ?? "").toLowerCase())) {
-    return NextResponse.json({ ok: false, error: "Declined or cancelled quote lines cannot be quoted." }, { status: 409 });
+  if (
+    quoteLine.declined_at ||
+    ["cancelled", "rejected", "declined"].includes(
+      (cleanString(quoteLine.status) ?? "").toLowerCase(),
+    )
+  ) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Declined or cancelled quote lines cannot be quoted.",
+      },
+      { status: 409 },
+    );
   }
 
   if (partId) {
@@ -214,10 +330,16 @@ export async function POST(
       .eq("shop_id", shopId)
       .maybeSingle();
     if (partError) {
-      return NextResponse.json({ ok: false, error: partError.message }, { status: 500 });
+      return NextResponse.json(
+        { ok: false, error: partError.message },
+        { status: 500 },
+      );
     }
     if (!part) {
-      return NextResponse.json({ ok: false, error: "Selected part is not available in this shop" }, { status: 403 });
+      return NextResponse.json(
+        { ok: false, error: "Selected part is not available in this shop" },
+        { status: 403 },
+      );
     }
   }
 
@@ -229,19 +351,31 @@ export async function POST(
       .eq("shop_id", shopId)
       .maybeSingle();
     if (supplierError) {
-      return NextResponse.json({ ok: false, error: supplierError.message }, { status: 500 });
+      return NextResponse.json(
+        { ok: false, error: supplierError.message },
+        { status: 500 },
+      );
     }
     if (!supplier) {
-      return NextResponse.json({ ok: false, error: "Selected supplier is not available in this shop" }, { status: 403 });
+      return NextResponse.json(
+        { ok: false, error: "Selected supplier is not available in this shop" },
+        { status: 403 },
+      );
     }
   }
 
   const nextQty = qty == null ? null : Math.max(1, Math.floor(qty));
   if (quotedPrice != null && quotedPrice < 0) {
-    return NextResponse.json({ ok: false, error: "quotedPrice must be zero or greater" }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: "quotedPrice must be zero or greater" },
+      { status: 400 },
+    );
   }
   if (nextQty != null && nextQty <= 0) {
-    return NextResponse.json({ ok: false, error: "qty must be greater than zero" }, { status: 400 });
+    return NextResponse.json(
+      { ok: false, error: "qty must be greater than zero" },
+      { status: 400 },
+    );
   }
 
   const description = cleanString(body.description) ?? cleanString(body.notes);
@@ -251,10 +385,8 @@ export async function POST(
   const quoteComplete = isPartsRequestItemPriced({
     description: description ?? item.description,
     partId: partId ?? item.part_id,
-    requestedPartNumber:
-      requestedPartNumber ?? item.requested_part_number,
-    requestedManufacturer:
-      requestedManufacturer ?? item.requested_manufacturer,
+    requestedPartNumber: requestedPartNumber ?? item.requested_part_number,
+    requestedManufacturer: requestedManufacturer ?? item.requested_manufacturer,
     qty: nextQty ?? item.qty,
     qtyRequested: nextQty ?? item.qty_requested,
     quotedPrice: quotedPrice ?? item.quoted_price,
@@ -266,13 +398,17 @@ export async function POST(
     work_order_line_id: null,
     ...(description ? { description } : {}),
     ...(nextQty != null ? { qty: nextQty, qty_requested: nextQty } : {}),
-    ...(quotedPrice != null ? { quoted_price: quotedPrice, unit_price: quotedPrice } : {}),
+    ...(quotedPrice != null
+      ? { quoted_price: quotedPrice, unit_price: quotedPrice }
+      : {}),
     ...(vendorId !== null ? { vendor_id: vendorId } : {}),
     ...(vendor !== null ? { vendor } : {}),
     ...(partId !== null ? { part_id: partId } : {}),
     requested_part_number: requestedPartNumber,
     requested_manufacturer: requestedManufacturer,
-    status: (quoteComplete ? "quoted" : "requested") as PartRequestItemUpdate["status"],
+    status: (quoteComplete
+      ? "quoted"
+      : "requested") as PartRequestItemUpdate["status"],
   };
 
   const { data: updatedItem, error: updateError } = await supabase
@@ -287,10 +423,16 @@ export async function POST(
     .maybeSingle();
 
   if (updateError) {
-    return NextResponse.json({ ok: false, error: updateError.message }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: updateError.message },
+      { status: 500 },
+    );
   }
   if (!updatedItem) {
-    return NextResponse.json({ ok: false, error: "Quote save did not apply" }, { status: 409 });
+    return NextResponse.json(
+      { ok: false, error: "Quote save did not apply" },
+      { status: 409 },
+    );
   }
 
   const sync = await syncQuoteLinePartsStatus(supabase, {

--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -1,27 +1,61 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
-import { runPostSendPersistence, sendQuoteReadyEmail } from "@/features/email/server";
+import type { Database, Json } from "@shared/types/types/supabase";
+import {
+  runPostSendPersistence,
+  sendQuoteReadyEmail,
+} from "@/features/email/server";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
+import {
+  calculateTax,
+  getTaxAmount,
+  isProvinceCode,
+} from "@/features/integrations/tax";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import {
   calculateShopSupplies,
   resolveShopSuppliesOverride,
   resolveShopSuppliesSettings,
+  shopSuppliesTaxableSubtotal,
 } from "@/features/work-orders/lib/shopSupplies";
 
 type DB = Database;
 
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type WorkOrderUpdate = DB["public"]["Tables"]["work_orders"]["Update"];
 type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
 type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
 type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type EstimateEventRow = DB["public"]["Tables"]["estimate_events"]["Row"];
+type EmailLogRow = DB["public"]["Tables"]["email_logs"]["Row"];
+
+type EstimateSendEvent = Pick<
+  EstimateEventRow,
+  | "id"
+  | "work_order_id"
+  | "revision"
+  | "event_type"
+  | "idempotency_key"
+  | "actor_profile_id"
+  | "result"
+  | "snapshot"
+  | "created_at"
+  | "updated_at"
+>;
 
 type QuoteLine = { description: string; amount: number };
 
+class QuoteDeliveryBlockedError extends Error {
+  readonly status = 409;
+}
+
 const SEND_READY_STAGES = new Set(["advisor_pending", "ready_to_send"]);
-const SEND_READY_STATUSES = new Set(["advisor_pending", "ready_to_send", "quoted"]);
+const SEND_READY_STATUSES = new Set([
+  "advisor_pending",
+  "ready_to_send",
+  "quoted",
+]);
 const NON_SENDABLE_STATUSES = new Set([
   "pending_parts",
   "sent",
@@ -74,11 +108,13 @@ function asNumber(v: unknown): number | null {
   return null;
 }
 
-function buildCustomerName(customer: {
-  first_name?: string | null;
-  last_name?: string | null;
-  business_name?: string | null;
-} | null): string {
+function buildCustomerName(
+  customer: {
+    first_name?: string | null;
+    last_name?: string | null;
+    business_name?: string | null;
+  } | null,
+): string {
   if (!customer) return "";
   if (customer.business_name) return customer.business_name;
   const first = customer.first_name ?? "";
@@ -94,26 +130,43 @@ function buildVehicleLabel(vehicleInfo?: VehicleInfo): string {
   return [year, make, model].filter(Boolean).join(" ");
 }
 
-function quoteMetadata(line: Pick<QuoteLineRow, "metadata">): Record<string, unknown> {
-  if (!line.metadata || typeof line.metadata !== "object" || Array.isArray(line.metadata)) {
+function quoteMetadata(
+  line: Pick<QuoteLineRow, "metadata">,
+): Record<string, unknown> {
+  if (
+    !line.metadata ||
+    typeof line.metadata !== "object" ||
+    Array.isArray(line.metadata)
+  ) {
     return {};
   }
   return line.metadata as Record<string, unknown>;
 }
 
-function quoteLaborHours(line: Pick<QuoteLineRow, "labor_hours" | "est_labor_hours">): number {
+function quoteLaborHours(
+  line: Pick<QuoteLineRow, "labor_hours" | "est_labor_hours">,
+): number {
   return asNumber(line.labor_hours) ?? asNumber(line.est_labor_hours) ?? 0;
 }
 
-function quoteLaborRate(line: Pick<QuoteLineRow, "metadata">, shopLaborRate: number): number {
+function quoteLaborRate(
+  line: Pick<QuoteLineRow, "metadata">,
+  shopLaborRate: number,
+): number {
   return asNumber(quoteMetadata(line).labor_rate) ?? shopLaborRate;
 }
 
 function quoteLaborTotal(
-  line: Pick<QuoteLineRow, "labor_total" | "labor_hours" | "est_labor_hours" | "metadata">,
+  line: Pick<
+    QuoteLineRow,
+    "labor_total" | "labor_hours" | "est_labor_hours" | "metadata"
+  >,
   shopLaborRate: number,
 ): number {
-  return asNumber(line.labor_total) ?? quoteLaborHours(line) * quoteLaborRate(line, shopLaborRate);
+  return (
+    asNumber(line.labor_total) ??
+    quoteLaborHours(line) * quoteLaborRate(line, shopLaborRate)
+  );
 }
 
 function quotePartsTotal(line: Pick<QuoteLineRow, "parts_total">): number {
@@ -123,7 +176,13 @@ function quotePartsTotal(line: Pick<QuoteLineRow, "parts_total">): number {
 function quoteGrandTotal(
   line: Pick<
     QuoteLineRow,
-    "grand_total" | "subtotal" | "labor_total" | "labor_hours" | "est_labor_hours" | "metadata" | "parts_total"
+    | "grand_total"
+    | "subtotal"
+    | "labor_total"
+    | "labor_hours"
+    | "est_labor_hours"
+    | "metadata"
+    | "parts_total"
   >,
   shopLaborRate: number,
 ): number {
@@ -134,29 +193,218 @@ function quoteGrandTotal(
   );
 }
 
-function isSendableQuoteLine(line: Pick<QuoteLineRow, "status" | "stage" | "sent_to_customer_at" | "approved_at" | "declined_at" | "work_order_line_id">): boolean {
+function isSendableQuoteLine(
+  line: Pick<
+    QuoteLineRow,
+    | "status"
+    | "stage"
+    | "sent_to_customer_at"
+    | "approved_at"
+    | "declined_at"
+    | "work_order_line_id"
+  >,
+): boolean {
   const status = safeStr(line.status).trim().toLowerCase();
   const stage = safeStr(line.stage).trim().toLowerCase();
-  if (line.sent_to_customer_at || line.approved_at || line.declined_at || line.work_order_line_id) return false;
+  if (
+    line.sent_to_customer_at ||
+    line.approved_at ||
+    line.declined_at ||
+    line.work_order_line_id
+  )
+    return false;
   if (NON_SENDABLE_STATUSES.has(status)) return false;
   return SEND_READY_STATUSES.has(status) || SEND_READY_STAGES.has(stage);
 }
 
-function isResendableQuoteLine(line: Pick<QuoteLineRow, "status" | "sent_to_customer_at" | "approved_at" | "declined_at" | "work_order_line_id">): boolean {
+function isResendableQuoteLine(
+  line: Pick<
+    QuoteLineRow,
+    | "status"
+    | "sent_to_customer_at"
+    | "approved_at"
+    | "declined_at"
+    | "work_order_line_id"
+  >,
+): boolean {
   const status = safeStr(line.status).trim().toLowerCase();
-  return Boolean(line.sent_to_customer_at) && !line.approved_at && !line.declined_at && !line.work_order_line_id && status === "sent";
+  return (
+    Boolean(line.sent_to_customer_at) &&
+    !line.approved_at &&
+    !line.declined_at &&
+    !line.work_order_line_id &&
+    status === "sent"
+  );
+}
+
+function isApprovedQuoteLine(
+  line: Pick<
+    QuoteLineRow,
+    "status" | "stage" | "approved_at" | "work_order_line_id"
+  >,
+): boolean {
+  const status = safeStr(line.status).trim().toLowerCase();
+  const stage = safeStr(line.stage).trim().toLowerCase();
+  return (
+    Boolean(line.approved_at || line.work_order_line_id) ||
+    status === "approved" ||
+    status === "converted" ||
+    stage === "customer_approved"
+  );
+}
+
+async function findEstimateSendEvent(input: {
+  shopId: string;
+  workOrderId: string;
+  revision: number;
+  idempotencyKey: string;
+}): Promise<{ event: EstimateSendEvent | null; keyConflict: boolean }> {
+  const { data: byKey, error: keyError } = await supabaseAdmin
+    .from("estimate_events")
+    .select(
+      "id, work_order_id, revision, event_type, idempotency_key, actor_profile_id, result, snapshot, created_at, updated_at",
+    )
+    .eq("shop_id", input.shopId)
+    .eq("idempotency_key", input.idempotencyKey)
+    .maybeSingle<EstimateSendEvent>();
+
+  if (keyError)
+    throw new Error(
+      `Failed to verify estimate send retry: ${keyError.message}`,
+    );
+
+  if (byKey) {
+    const isSameSend =
+      byKey.work_order_id === input.workOrderId &&
+      byKey.revision === input.revision &&
+      ["send_reserved", "send_failed", "sent"].includes(byKey.event_type);
+    return { event: byKey, keyConflict: !isSameSend };
+  }
+
+  const { data: byRevision, error: revisionError } = await supabaseAdmin
+    .from("estimate_events")
+    .select(
+      "id, work_order_id, revision, event_type, idempotency_key, actor_profile_id, result, snapshot, created_at, updated_at",
+    )
+    .eq("shop_id", input.shopId)
+    .eq("work_order_id", input.workOrderId)
+    .eq("revision", input.revision)
+    .in("event_type", ["send_reserved", "sent"])
+    .maybeSingle<EstimateSendEvent>();
+
+  if (revisionError) {
+    throw new Error(
+      `Failed to verify estimate revision delivery: ${revisionError.message}`,
+    );
+  }
+
+  return { event: byRevision ?? null, keyConflict: false };
+}
+
+function jsonRecord(value: Json): Record<string, Json | undefined> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value as Record<string, Json | undefined>;
+}
+
+function stringArray(value: Json | undefined): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is string => typeof item === "string" && isUuid(item),
+  );
+}
+
+function portalQuoteUrlFor(workOrderId: string): string | null {
+  const appUrl = (
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    process.env.NEXT_PUBLIC_APP_URL ??
+    ""
+  )
+    .trim()
+    .replace(/\/+$/, "");
+  return appUrl ? `${appUrl}/portal/quotes/${workOrderId}` : null;
+}
+
+async function findAcceptedEstimateEmail(input: {
+  shopId: string;
+  workOrderId: string;
+  revision: number;
+  idempotencyKey: string;
+}): Promise<Pick<EmailLogRow, "id" | "sent_at"> | null> {
+  const { data, error } = await supabaseAdmin
+    .from("email_logs")
+    .select("id, sent_at")
+    .eq("shop_id", input.shopId)
+    .eq("template_key", "quote_ready")
+    .contains("metadata", {
+      estimate_send_key: input.idempotencyKey,
+      work_order_id: input.workOrderId,
+      estimate_revision: input.revision,
+    })
+    .not("sent_at", "is", null)
+    .order("sent_at", { ascending: false })
+    .limit(1)
+    .maybeSingle<Pick<EmailLogRow, "id" | "sent_at">>();
+
+  if (error)
+    throw new Error(
+      `Failed to verify estimate email delivery: ${error.message}`,
+    );
+  return data ?? null;
+}
+
+async function recoverAcceptedEstimateSend(input: {
+  event: EstimateSendEvent;
+  shopId: string;
+  workOrderId: string;
+  revision: number;
+  quoteLineIds: string[];
+  sentAt: string;
+  quoteUrl: string | null;
+  actorProfileId: string;
+  actorUserId: string;
+}): Promise<void> {
+  if (input.quoteLineIds.length === 0) {
+    throw new Error("Estimate send reservation has no canonical quote lines.");
+  }
+
+  const { error } = await supabaseAdmin.rpc("finalize_estimate_send_atomic", {
+    p_shop_id: input.shopId,
+    p_work_order_id: input.workOrderId,
+    p_revision: input.revision,
+    p_event_id: input.event.id,
+    p_sent_at: input.sentAt,
+    p_quote_url: input.quoteUrl ?? "",
+    p_actor_profile_id: input.actorProfileId,
+    p_actor_user_id: input.actorUserId,
+  });
+  if (error) throw new Error(error.message);
+}
+
+function estimateSendReplayResponse(event: EstimateSendEvent, trace: string) {
+  const inProgress = event.event_type === "send_reserved";
+  return NextResponse.json(
+    {
+      ok: true,
+      trace,
+      deduped: true,
+      inProgress,
+      estimateRevision: event.revision,
+    },
+    { status: inProgress ? 202 : 200 },
+  );
 }
 
 export async function POST(req: Request) {
   const trace = `quotes-send:${Date.now()}:${Math.random().toString(16).slice(2)}`;
 
   try {
-
     const access = await requireShopScopedApiAccess({
       requiredCapability: "canAuthorizeQuotes",
     });
     if (!access.ok) {
-      const payload = await access.response.json().catch(() => ({ error: "Forbidden" }));
+      const payload = await access.response
+        .json()
+        .catch(() => ({ error: "Forbidden" }));
       return NextResponse.json(
         { ok: false, trace, error: safeStr(payload?.error) || "Forbidden" },
         { status: access.response.status },
@@ -187,13 +435,24 @@ export async function POST(req: Request) {
 
     const { data: wo, error: woErr } = await supabaseAdmin
       .from("work_orders")
-      .select("id, customer_id, shop_id, vehicle_id, quote_url, shop_supplies_enabled_override, shop_supplies_amount_override")
+      .select(
+        "id, customer_id, shop_id, vehicle_id, quote_url, shop_supplies_enabled_override, shop_supplies_amount_override, estimate_number, estimate_status, estimate_revision",
+      )
       .eq("id", workOrderId)
       .eq("shop_id", access.profile.shop_id)
       .maybeSingle<
         Pick<
           WorkOrderRow,
-          "id" | "customer_id" | "shop_id" | "vehicle_id" | "quote_url" | "shop_supplies_enabled_override" | "shop_supplies_amount_override"
+          | "id"
+          | "customer_id"
+          | "shop_id"
+          | "vehicle_id"
+          | "quote_url"
+          | "shop_supplies_enabled_override"
+          | "shop_supplies_amount_override"
+          | "estimate_number"
+          | "estimate_status"
+          | "estimate_revision"
         >
       >();
 
@@ -223,11 +482,137 @@ export async function POST(req: Request) {
       );
     }
 
+    let estimateSendKey: string | null = null;
+    const estimatePortalQuoteUrl = wo.estimate_number
+      ? portalQuoteUrlFor(workOrderId)
+      : null;
+
+    if (wo.estimate_number && !estimatePortalQuoteUrl) {
+      return NextResponse.json(
+        {
+          ok: false,
+          trace,
+          error:
+            "Estimate delivery requires NEXT_PUBLIC_SITE_URL or NEXT_PUBLIC_APP_URL.",
+        },
+        { status: 500 },
+      );
+    }
+
+    if (wo.estimate_number) {
+      estimateSendKey = req.headers.get("Idempotency-Key")?.trim() ?? "";
+      if (!estimateSendKey || estimateSendKey.length > 200) {
+        return NextResponse.json(
+          {
+            ok: false,
+            trace,
+            error:
+              "A valid Idempotency-Key header is required to send an estimate.",
+          },
+          { status: 400 },
+        );
+      }
+
+      const existingSend = await findEstimateSendEvent({
+        shopId: wo.shop_id,
+        workOrderId,
+        revision: wo.estimate_revision,
+        idempotencyKey: estimateSendKey,
+      });
+
+      if (existingSend.keyConflict) {
+        return NextResponse.json(
+          {
+            ok: false,
+            trace,
+            error:
+              "Idempotency key was already used for another estimate operation.",
+          },
+          { status: 409 },
+        );
+      }
+
+      if (existingSend.event?.event_type === "send_reserved") {
+        const acceptedEmail = await findAcceptedEstimateEmail({
+          shopId: wo.shop_id,
+          workOrderId,
+          revision: wo.estimate_revision,
+          idempotencyKey: existingSend.event.idempotency_key,
+        });
+
+        const reservationResult = jsonRecord(existingSend.event.result);
+        const reservedAcceptedAt = safeStr(reservationResult.accepted_at);
+        const acceptedAt =
+          acceptedEmail?.sent_at ||
+          (reservedAcceptedAt && !Number.isNaN(Date.parse(reservedAcceptedAt))
+            ? reservedAcceptedAt
+            : null);
+
+        if (acceptedAt) {
+          const reservationSnapshot = jsonRecord(existingSend.event.snapshot);
+          const reservedActorUserId = safeStr(
+            reservationSnapshot.actor_user_id,
+          );
+          const canUseReservedActor = Boolean(
+            existingSend.event.actor_profile_id && isUuid(reservedActorUserId),
+          );
+
+          await recoverAcceptedEstimateSend({
+            event: existingSend.event,
+            shopId: wo.shop_id,
+            workOrderId,
+            revision: wo.estimate_revision,
+            quoteLineIds: stringArray(reservationSnapshot.quote_line_ids),
+            sentAt: acceptedAt,
+            quoteUrl: estimatePortalQuoteUrl,
+            actorProfileId: canUseReservedActor
+              ? existingSend.event.actor_profile_id!
+              : access.profile.id,
+            actorUserId: canUseReservedActor
+              ? reservedActorUserId
+              : access.authUserId,
+          });
+
+          return NextResponse.json({
+            ok: true,
+            trace,
+            deduped: true,
+            recovered: true,
+            estimateRevision: wo.estimate_revision,
+          });
+        }
+      } else if (existingSend.event?.event_type === "sent") {
+        return estimateSendReplayResponse(existingSend.event, trace);
+      }
+    }
+
+    if (
+      wo.estimate_number &&
+      !["ready_for_advisor", "sent"].includes(
+        safeStr(wo.estimate_status).toLowerCase(),
+      )
+    ) {
+      return NextResponse.json(
+        {
+          ok: false,
+          trace,
+          error:
+            "Estimate must be completed by Parts and ready for advisor review before it can be sent.",
+        },
+        { status: 409 },
+      );
+    }
 
     let portalUserId: string | null = null;
     let portalCustomerId: string | null = null;
-    let customerEmail = safeStr(body?.customerEmail).trim() || "";
-    let customerName = safeStr(body?.customerName).trim() || "";
+    // Estimates are durable, revisioned records. Their delivery context must come
+    // from the canonical shop-scoped record rather than caller-provided overrides.
+    let customerEmail = wo.estimate_number
+      ? ""
+      : safeStr(body?.customerEmail).trim();
+    let customerName = wo.estimate_number
+      ? ""
+      : safeStr(body?.customerName).trim();
 
     // Service-role client is intentionally retained after canonical shop-scoped auth
     // for privileged quote-send side effects (email/persistence/notifications).
@@ -236,10 +621,16 @@ export async function POST(req: Request) {
         .from("customers")
         .select("id, user_id, email, first_name, last_name, business_name")
         .eq("id", wo.customer_id)
+        .eq("shop_id", wo.shop_id)
         .maybeSingle<
           Pick<
             CustomerRow,
-            "id" | "user_id" | "email" | "first_name" | "last_name" | "business_name"
+            | "id"
+            | "user_id"
+            | "email"
+            | "first_name"
+            | "last_name"
+            | "business_name"
           >
         >();
 
@@ -264,18 +655,42 @@ export async function POST(req: Request) {
       );
     }
 
-    let shopName = safeStr(body?.shopName).trim() || "";
+    let shopName = wo.estimate_number ? "" : safeStr(body?.shopName).trim();
     let laborRate = 0;
-    let brand: Awaited<ReturnType<typeof getActiveBrandForRender>> | null = null;
-    let shopForSupplies: Pick<ShopRow, "supplies_percent" | "shop_supplies_enabled" | "shop_supplies_type" | "shop_supplies_percent" | "shop_supplies_flat_amount" | "shop_supplies_cap_amount"> | null = null;
+    let brand: Awaited<ReturnType<typeof getActiveBrandForRender>> | null =
+      null;
+    let shopForSupplies: Pick<
+      ShopRow,
+      | "supplies_percent"
+      | "shop_supplies_enabled"
+      | "shop_supplies_type"
+      | "shop_supplies_percent"
+      | "shop_supplies_flat_amount"
+      | "shop_supplies_cap_amount"
+      | "province"
+    > | null = null;
 
     if (wo.shop_id) {
       const { data: shop, error: shopErr } = await supabaseAdmin
         .from("shops")
-        .select("name, shop_name, labor_rate, supplies_percent, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount")
+        .select(
+          "name, shop_name, labor_rate, supplies_percent, shop_supplies_enabled, shop_supplies_type, shop_supplies_percent, shop_supplies_flat_amount, shop_supplies_cap_amount, province",
+        )
         .eq("id", wo.shop_id)
         .maybeSingle<
-          Pick<ShopRow, "name" | "shop_name" | "labor_rate" | "supplies_percent" | "shop_supplies_enabled" | "shop_supplies_type" | "shop_supplies_percent" | "shop_supplies_flat_amount" | "shop_supplies_cap_amount">
+          Pick<
+            ShopRow,
+            | "name"
+            | "shop_name"
+            | "labor_rate"
+            | "supplies_percent"
+            | "shop_supplies_enabled"
+            | "shop_supplies_type"
+            | "shop_supplies_percent"
+            | "shop_supplies_flat_amount"
+            | "shop_supplies_cap_amount"
+            | "province"
+          >
         >();
 
       if (!shopErr && shop) {
@@ -290,12 +705,15 @@ export async function POST(req: Request) {
       brand = await getActiveBrandForRender(wo.shop_id);
     }
 
-    let vehicleInfo: VehicleInfo | undefined = body?.vehicleInfo;
+    let vehicleInfo: VehicleInfo | undefined = wo.estimate_number
+      ? undefined
+      : body?.vehicleInfo;
     if (!vehicleInfo && wo.vehicle_id) {
       const { data: v } = await supabaseAdmin
         .from("vehicles")
         .select("year, make, model")
         .eq("id", wo.vehicle_id)
+        .eq("shop_id", wo.shop_id)
         .maybeSingle<Pick<VehicleRow, "year" | "make" | "model">>();
 
       if (v) {
@@ -307,14 +725,18 @@ export async function POST(req: Request) {
       }
     }
 
-    let lines: QuoteLine[] | undefined = body?.lines;
-    let quoteTotal: number | undefined = body?.quoteTotal;
+    let lines: QuoteLine[] | undefined = wo.estimate_number
+      ? undefined
+      : body?.lines;
+    let quoteTotal: number | undefined = wo.estimate_number
+      ? undefined
+      : body?.quoteTotal;
     let sendableQuoteLineIds: string[] = [];
 
     const { data: quoteLineRowsRaw, error: quoteLinesErr } = await supabaseAdmin
       .from("work_order_quote_lines")
       .select(
-        "id, description, ai_complaint, notes, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, grand_total, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id, metadata",
+        "id, description, ai_complaint, notes, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, tax_total, grand_total, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id, metadata",
       )
       .eq("shop_id", wo.shop_id)
       .eq("work_order_id", workOrderId)
@@ -344,6 +766,7 @@ export async function POST(req: Request) {
         | "labor_total"
         | "parts_total"
         | "subtotal"
+        | "tax_total"
         | "grand_total"
         | "status"
         | "stage"
@@ -356,8 +779,13 @@ export async function POST(req: Request) {
     >;
 
     const requestAllowsResend = req.headers.get("x-profix-resend") === "1";
-    const sendableQuoteLines = quoteLineRows.filter((line) =>
-      isSendableQuoteLine(line) || (requestAllowsResend && isResendableQuoteLine(line)),
+    const estimateHasApprovedLines = Boolean(
+      wo.estimate_number && quoteLineRows.some(isApprovedQuoteLine),
+    );
+    const sendableQuoteLines = quoteLineRows.filter(
+      (line) =>
+        isSendableQuoteLine(line) ||
+        (requestAllowsResend && isResendableQuoteLine(line)),
     );
 
     if (sendableQuoteLines.length === 0) {
@@ -382,7 +810,10 @@ export async function POST(req: Request) {
       return { description, amount } satisfies QuoteLine;
     });
 
-    const computedLineTotal = computed.reduce((sum, line) => sum + line.amount, 0);
+    const computedLineTotal = computed.reduce(
+      (sum, line) => sum + line.amount,
+      0,
+    );
     const computedLaborPartsBase = sendableQuoteLines.reduce((sum, line) => {
       const labor = quoteLaborTotal(line, laborRate);
       const parts = quotePartsTotal(line);
@@ -390,47 +821,280 @@ export async function POST(req: Request) {
     }, 0);
     const shopSupplies = calculateShopSupplies({
       baseAmount: computedLaborPartsBase,
-      settings: resolveShopSuppliesSettings(shopForSupplies as Parameters<typeof resolveShopSuppliesSettings>[0]),
-      override: resolveShopSuppliesOverride(wo as Parameters<typeof resolveShopSuppliesOverride>[0]),
+      settings: resolveShopSuppliesSettings(
+        shopForSupplies as Parameters<typeof resolveShopSuppliesSettings>[0],
+      ),
+      override: resolveShopSuppliesOverride(
+        wo as Parameters<typeof resolveShopSuppliesOverride>[0],
+      ),
     });
-    const computedTotal = computedLineTotal + shopSupplies.amount;
-    const computedWithSupplies = shopSupplies.amount > 0
-      ? [...computed, { description: "Shop supplies", amount: shopSupplies.amount } satisfies QuoteLine]
-      : computed;
+    const hasPersistedLineTax = sendableQuoteLines.some(
+      (line) => (asNumber(line.tax_total) ?? 0) > 0,
+    );
+    const province = safeStr(shopForSupplies?.province).trim().toUpperCase();
+    const fallbackTax =
+      !hasPersistedLineTax && isProvinceCode(province)
+        ? calculateTax(
+            computedLineTotal + shopSuppliesTaxableSubtotal(shopSupplies),
+            province,
+          )
+        : null;
+    const fallbackTaxAmount = fallbackTax ? getTaxAmount(fallbackTax) : 0;
+    const computedTotal =
+      computedLineTotal + shopSupplies.amount + fallbackTaxAmount;
+    const computedWithSupplies =
+      shopSupplies.amount > 0
+        ? [
+            ...computed,
+            {
+              description: "Shop supplies",
+              amount: shopSupplies.amount,
+            } satisfies QuoteLine,
+          ]
+        : computed;
+    const computedWithTaxes = fallbackTax
+      ? [
+          ...computedWithSupplies,
+          ...fallbackTax.taxes.map(
+            (tax) =>
+              ({
+                description: tax.label,
+                amount: tax.amount,
+              }) satisfies QuoteLine,
+          ),
+        ]
+      : computedWithSupplies;
     sendableQuoteLineIds = sendableQuoteLines.map((line) => line.id);
 
-    if (!lines || lines.length === 0) lines = computedWithSupplies;
-    if (typeof quoteTotal !== "number") quoteTotal = computedTotal;
-    const pdfUrl = body?.pdfUrl ?? null;
+    let estimateSendReservationId: string | null = null;
+    if (wo.estimate_number && estimateSendKey) {
+      const { data: reservationData, error: reserveError } =
+        await supabaseAdmin.rpc("reserve_estimate_send_atomic", {
+          p_shop_id: wo.shop_id,
+          p_work_order_id: workOrderId,
+          p_revision: wo.estimate_revision,
+          p_idempotency_key: estimateSendKey,
+          p_actor_profile_id: access.profile.id,
+          p_actor_user_id: access.authUserId,
+          p_quote_line_ids: sendableQuoteLineIds,
+          p_allow_resend: requestAllowsResend,
+        });
 
-    const appUrlEnv =
-      process.env.NEXT_PUBLIC_SITE_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? "";
-    const normalizedAppUrl = appUrlEnv ? appUrlEnv.replace(/\/$/, "") : "";
-    const portalQuoteUrl = normalizedAppUrl
-      ? `${normalizedAppUrl}/portal/quotes/${workOrderId}`
-      : null;
+      if (reserveError) {
+        const isConflict = ["23505", "40001", "55000"].includes(
+          reserveError.code ?? "",
+        );
+        return NextResponse.json(
+          {
+            ok: false,
+            trace,
+            error: "Could not reserve estimate delivery.",
+            detail: reserveError.message,
+          },
+          { status: isConflict ? 409 : 500 },
+        );
+      }
+
+      const reservation = jsonRecord((reservationData ?? {}) as Json);
+      const reservationEventId = safeStr(reservation.eventId);
+      const reservationEventType = safeStr(reservation.eventType);
+      const reservationDeliveryState = safeStr(reservation.deliveryState);
+      const reservationIsReplay = reservation.replay === true;
+
+      if (reservationIsReplay && reservationEventType === "sent") {
+        return NextResponse.json({
+          ok: true,
+          trace,
+          deduped: true,
+          estimateRevision: wo.estimate_revision,
+        });
+      }
+      if (reservationIsReplay) {
+        if (reservationDeliveryState === "delivery_uncertain") {
+          return NextResponse.json(
+            {
+              ok: false,
+              trace,
+              error:
+                "The email provider outcome is uncertain. Verify delivery before retrying this estimate.",
+            },
+            { status: 409 },
+          );
+        }
+        return NextResponse.json(
+          {
+            ok: true,
+            trace,
+            deduped: true,
+            inProgress: true,
+            estimateRevision: wo.estimate_revision,
+          },
+          { status: 202 },
+        );
+      }
+      if (!isUuid(reservationEventId)) {
+        return NextResponse.json(
+          {
+            ok: false,
+            trace,
+            error: "Estimate delivery reservation returned no event id.",
+          },
+          { status: 500 },
+        );
+      }
+      estimateSendReservationId = reservationEventId;
+    }
+
+    if (!lines || lines.length === 0) lines = computedWithTaxes;
+    if (typeof quoteTotal !== "number") quoteTotal = computedTotal;
+    const pdfUrl = wo.estimate_number ? null : (body?.pdfUrl ?? null);
+
+    const portalQuoteUrl = portalQuoteUrlFor(workOrderId);
 
     const quoteUrlForSend = portalQuoteUrl ?? pdfUrl ?? wo.quote_url ?? "";
-    const shouldSkipAsDuplicate = Boolean(wo.quote_url) && wo.quote_url === quoteUrlForSend && !requestAllowsResend;
+    // Estimate delivery deduplication is owned by the durable revision event.
+    // A pre-existing portal URL proves only that a link was generated, not that
+    // the provider accepted an email for this revision.
+    const shouldSkipAsDuplicate =
+      !wo.estimate_number &&
+      Boolean(wo.quote_url) &&
+      wo.quote_url === quoteUrlForSend &&
+      !requestAllowsResend;
 
-    if (!shouldSkipAsDuplicate) {
-      await sendQuoteReadyEmail({
-      shopId: wo.shop_id,
-      to: customerEmail,
-      quoteUrl: quoteUrlForSend,
-      quoteTotal: quoteTotal ?? null,
-      vehicleLabel: buildVehicleLabel(vehicleInfo),
-      shopName: shopName || undefined,
-      brandLogoUrl: brand?.logoUrl ?? null,
-      brandPrimaryColor: brand?.colors.primary ?? null,
-      brandSecondaryColor: brand?.colors.secondary ?? null,
-    });
+    let acceptedEstimateSentAt: string | null = null;
+    try {
+      if (!shouldSkipAsDuplicate) {
+        const delivery = await sendQuoteReadyEmail({
+          shopId: wo.shop_id,
+          to: customerEmail,
+          quoteUrl: quoteUrlForSend,
+          quoteTotal: quoteTotal ?? null,
+          vehicleLabel: buildVehicleLabel(vehicleInfo),
+          shopName: shopName || undefined,
+          brandLogoUrl: brand?.logoUrl ?? null,
+          brandPrimaryColor: brand?.colors.primary ?? null,
+          brandSecondaryColor: brand?.colors.secondary ?? null,
+          createdBy: access.profile.id,
+          idempotencyKey: estimateSendKey,
+          workOrderId,
+          estimateRevision: wo.estimate_number ? wo.estimate_revision : null,
+        });
+
+        if (wo.estimate_number && delivery.status === "suppressed") {
+          throw new QuoteDeliveryBlockedError(
+            `The customer email is suppressed and cannot receive this estimate: ${delivery.reason}`,
+          );
+        }
+
+        if (
+          wo.estimate_number &&
+          estimateSendReservationId &&
+          delivery.status === "accepted"
+        ) {
+          acceptedEstimateSentAt = delivery.acceptedAt;
+          const { error: acceptedEvidenceError } = await supabaseAdmin
+            .from("estimate_events")
+            .update({
+              result: {
+                delivery_state: "accepted",
+                accepted_at: delivery.acceptedAt,
+                email_log_id: delivery.emailLogId,
+              },
+              updated_at: delivery.acceptedAt,
+            })
+            .eq("id", estimateSendReservationId)
+            .eq("shop_id", wo.shop_id)
+            .eq("event_type", "send_reserved");
+          if (acceptedEvidenceError) {
+            // The email log remains the independent recovery source. Never
+            // classify a provider-accepted send as retryable solely because
+            // this secondary evidence update failed.
+            console.error(
+              "[quotes/send] failed to persist accepted estimate evidence",
+              {
+                trace,
+                reservationId: estimateSendReservationId,
+                error: acceptedEvidenceError.message,
+              },
+            );
+          }
+        }
+      }
+    } catch (sendError) {
+      if (estimateSendReservationId) {
+        const failedAt = new Date().toISOString();
+        const message =
+          sendError instanceof Error
+            ? sendError.message
+            : "Unknown quote delivery error";
+        const { error: releaseError } = await supabaseAdmin
+          .from("estimate_events")
+          .update({
+            event_type: "send_failed",
+            result: {
+              delivery_state: "failed",
+              failed_at: failedAt,
+              error: message.slice(0, 500),
+            },
+            updated_at: failedAt,
+          })
+          .eq("id", estimateSendReservationId)
+          .eq("shop_id", wo.shop_id)
+          .eq("event_type", "send_reserved");
+        if (releaseError) {
+          console.error(
+            "[quotes/send] failed to release estimate send reservation",
+            {
+              trace,
+              reservationId: estimateSendReservationId,
+              error: releaseError.message,
+            },
+          );
+        }
+      }
+      throw sendError;
     }
 
     const newQuoteUrl = portalQuoteUrl ?? pdfUrl ?? wo.quote_url ?? null;
+    const sentAt = acceptedEstimateSentAt ?? new Date().toISOString();
+
+    if (wo.estimate_number && estimateSendReservationId) {
+      const { error: finalizeError } = await supabaseAdmin.rpc(
+        "finalize_estimate_send_atomic",
+        {
+          p_shop_id: wo.shop_id,
+          p_work_order_id: workOrderId,
+          p_revision: wo.estimate_revision,
+          p_event_id: estimateSendReservationId,
+          p_sent_at: sentAt,
+          p_quote_url: estimatePortalQuoteUrl ?? "",
+          p_actor_profile_id: access.profile.id,
+          p_actor_user_id: access.authUserId,
+        },
+      );
+
+      if (finalizeError) {
+        return NextResponse.json(
+          {
+            ok: true,
+            trace,
+            deduped: false,
+            inProgress: true,
+            sentWithWarnings: true,
+            warnings: [
+              {
+                step: "estimate_send_finalize",
+                error: finalizeError.message,
+              },
+            ],
+          },
+          { status: 202 },
+        );
+      }
+    }
 
     const postSendWarnings = await runPostSendPersistence([
-      ...(newQuoteUrl !== wo.quote_url
+      ...(!wo.estimate_number && newQuoteUrl !== wo.quote_url
         ? [
             {
               step: "work_order_quote_url_update",
@@ -445,18 +1109,19 @@ export async function POST(req: Request) {
             },
           ]
         : []),
-      ...(sendableQuoteLineIds.length > 0
+      ...(!wo.estimate_number && sendableQuoteLineIds.length > 0
         ? [
             {
               step: "work_order_quote_lines_mark_sent",
               run: async () => {
-                const sentAt = new Date().toISOString();
                 const { error } = await supabaseAdmin
                   .from("work_order_quote_lines")
                   .update({
                     status: "sent",
                     stage: "sent",
                     sent_to_customer_at: sentAt,
+                    sent_at: sentAt,
+                    sent_by: access.authUserId,
                     updated_at: sentAt,
                   })
                   .eq("shop_id", wo.shop_id)
@@ -468,12 +1133,15 @@ export async function POST(req: Request) {
             {
               step: "work_order_quote_approval_state_update",
               run: async () => {
+                const update: WorkOrderUpdate = {
+                  approval_state: estimateHasApprovedLines
+                    ? "partial"
+                    : "pending",
+                  updated_at: sentAt,
+                };
                 const { error } = await supabaseAdmin
                   .from("work_orders")
-                  .update({
-                    approval_state: "pending",
-                    updated_at: new Date().toISOString(),
-                  })
+                  .update(update)
                   .eq("id", workOrderId)
                   .eq("shop_id", wo.shop_id);
                 if (error) throw new Error(error.message);
@@ -506,23 +1174,39 @@ export async function POST(req: Request) {
     ]);
 
     if (postSendWarnings.length > 0) {
-      return NextResponse.json({
-        ok: true,
-        trace,
-        deduped: shouldSkipAsDuplicate,
-        sentWithWarnings: true,
-        warnings: postSendWarnings,
-      });
+      return NextResponse.json(
+        {
+          ok: true,
+          trace,
+          deduped: shouldSkipAsDuplicate,
+          inProgress: false,
+          sentWithWarnings: true,
+          warnings: postSendWarnings,
+        },
+        { status: 200 },
+      );
     }
 
-    return NextResponse.json({ ok: true, trace, deduped: shouldSkipAsDuplicate });
+    return NextResponse.json({
+      ok: true,
+      trace,
+      deduped: shouldSkipAsDuplicate,
+    });
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Unknown error sending quote";
     console.error("[quotes/send] Quote Send Failed:", trace, message);
     return NextResponse.json(
-      { ok: false, trace, error: "Quote send failed", detail: message },
-      { status: 500 },
+      {
+        ok: false,
+        trace,
+        error:
+          err instanceof QuoteDeliveryBlockedError
+            ? err.message
+            : "Quote send failed",
+        detail: message,
+      },
+      { status: err instanceof QuoteDeliveryBlockedError ? err.status : 500 },
     );
   }
 }

--- a/app/estimates/[id]/page.tsx
+++ b/app/estimates/[id]/page.tsx
@@ -1,0 +1,23 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { notFound } from "next/navigation";
+import { z } from "zod";
+import EstimateBuilder from "@/features/estimates/components/EstimateBuilder";
+import { ESTIMATE_VIEW_ROLES } from "@/features/estimates/lib/access";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function EstimateDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  await requireShopPageAccess({ allowRoles: ESTIMATE_VIEW_ROLES });
+  const parsed = z
+    .string()
+    .uuid()
+    .safeParse((await params).id);
+  if (!parsed.success) notFound();
+
+  return <EstimateBuilder estimateId={parsed.data} />;
+}

--- a/app/estimates/new/page.tsx
+++ b/app/estimates/new/page.tsx
@@ -1,0 +1,27 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import EstimateBuilder from "@/features/estimates/components/EstimateBuilder";
+import { ESTIMATE_ADVISOR_ROLES } from "@/features/estimates/lib/access";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+
+export default async function NewEstimatePage() {
+  const { profile } = await requireShopPageAccess({
+    allowRoles: ESTIMATE_ADVISOR_ROLES,
+    requiredCapability: "canAuthorizeQuotes",
+  });
+  const supabase = createServerSupabaseRSC();
+  const { data: shop } = await supabase
+    .from("shops")
+    .select("labor_rate")
+    .eq("id", profile.shop_id)
+    .maybeSingle();
+
+  return (
+    <EstimateBuilder
+      shopId={profile.shop_id}
+      defaultLaborRate={Number(shop?.labor_rate ?? 0)}
+    />
+  );
+}

--- a/app/estimates/page.tsx
+++ b/app/estimates/page.tsx
@@ -1,0 +1,11 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import EstimatesWorkspace from "@/features/estimates/components/EstimatesWorkspace";
+import { ESTIMATE_VIEW_ROLES } from "@/features/estimates/lib/access";
+import { requireShopPageAccess } from "@/features/shared/lib/server/admin-access";
+
+export default async function EstimatesPage() {
+  await requireShopPageAccess({ allowRoles: ESTIMATE_VIEW_ROLES });
+  return <EstimatesWorkspace />;
+}

--- a/app/parts/requests/page.tsx
+++ b/app/parts/requests/page.tsx
@@ -72,20 +72,33 @@ type RequestModel = {
 type WorkOrderListRow = {
   id: string;
   custom_id: string | null;
+  estimate_number: string | null;
   customers:
-    | { first_name: string | null; last_name: string | null }
-    | { first_name: string | null; last_name: string | null }[]
+    | {
+        business_name: string | null;
+        first_name: string | null;
+        last_name: string | null;
+      }
+    | {
+        business_name: string | null;
+        first_name: string | null;
+        last_name: string | null;
+      }[]
     | null;
   vehicles:
     | {
         year: string | number | null;
         make: string | null;
         model: string | null;
+        vin: string | null;
+        unit_number: string | null;
       }
     | {
         year: string | number | null;
         make: string | null;
         model: string | null;
+        vin: string | null;
+        unit_number: string | null;
       }[]
     | null;
 };
@@ -96,6 +109,9 @@ type WoBucket = {
   menuItemId: string | null;
   menuItemName: string | null;
   customId: string | null;
+  estimateNumber: string | null;
+  estimateRevision: number | null;
+  isEstimate: boolean;
   customerName: string | null;
   vehicleLabel: string | null;
   models: RequestModel[];
@@ -203,6 +219,7 @@ function firstJoin<T>(value: T | T[] | null | undefined): T | null {
 
 function customerName(row: WorkOrderListRow | undefined): string | null {
   const customer = firstJoin(row?.customers);
+  if (customer?.business_name?.trim()) return customer.business_name.trim();
   const label = [customer?.first_name, customer?.last_name]
     .map((value) => String(value ?? "").trim())
     .filter(Boolean)
@@ -212,10 +229,19 @@ function customerName(row: WorkOrderListRow | undefined): string | null {
 
 function vehicleLabel(row: WorkOrderListRow | undefined): string | null {
   const vehicle = firstJoin(row?.vehicles);
-  const label = [vehicle?.year, vehicle?.make, vehicle?.model]
+  const vehicleName = [vehicle?.year, vehicle?.make, vehicle?.model]
     .map((value) => String(value ?? "").trim())
     .filter(Boolean)
     .join(" ");
+  const unitNumber = String(vehicle?.unit_number ?? "").trim();
+  const vin = String(vehicle?.vin ?? "").trim();
+  const label = [
+    vehicleName,
+    unitNumber ? `Unit ${unitNumber}` : "",
+    vin ? `VIN ${vin}` : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
   return label || null;
 }
 
@@ -239,8 +265,7 @@ function buildBuckets(
   return [...grouped.entries()]
     .map(([bucketId, requestModels]) => {
       const workOrderId = requestModels[0]?.request.work_order_id ?? null;
-      const menuItemId =
-        requestModels[0]?.request.source_menu_item_id ?? null;
+      const menuItemId = requestModels[0]?.request.source_menu_item_id ?? null;
       const workOrder = workOrderId ? workOrders[workOrderId] : undefined;
       const menuItem = menuItemId ? menuItems[menuItemId] : undefined;
       const items = requestModels.flatMap((model) => model.items);
@@ -258,9 +283,22 @@ function buildBuckets(
       );
       const customer = customerName(workOrder);
       const vehicle = vehicleLabel(workOrder);
+      const isEstimate =
+        requestModels.some(
+          (model) => model.request.source_context === "estimate",
+        ) || Boolean(workOrder?.estimate_number);
+      const estimateRevision = requestModels.reduce<number | null>(
+        (latest, model) => {
+          const revision = model.request.source_revision;
+          if (revision == null) return latest;
+          return latest == null ? revision : Math.max(latest, revision);
+        },
+        null,
+      );
       const searchBlob = [
         workOrderId,
         workOrder?.custom_id,
+        workOrder?.estimate_number,
         menuItem?.name,
         "menu intake",
         ...requestModels.map((model) => model.request.notes),
@@ -279,6 +317,9 @@ function buildBuckets(
         menuItemId,
         menuItemName: menuItem?.name?.trim() || null,
         customId: workOrder?.custom_id ?? null,
+        estimateNumber: workOrder?.estimate_number ?? null,
+        estimateRevision,
+        isEstimate,
         customerName: customer,
         vehicleLabel: vehicle,
         models: requestModels,
@@ -295,7 +336,11 @@ function buildBuckets(
 
 function workOrderLabel(bucket: WoBucket): string {
   if (bucket.workOrderId) {
-    return bucket.customId || `#${bucket.workOrderId.slice(0, 8)}`;
+    return (
+      bucket.estimateNumber ||
+      bucket.customId ||
+      `#${bucket.workOrderId.slice(0, 8)}`
+    );
   }
   if (bucket.menuItemId) {
     return `Menu intake · ${bucket.menuItemName || "Service menu item"}`;
@@ -441,7 +486,9 @@ function QueueCard({
     ? "No parts were added. Dismiss this abandoned request or open it to review."
     : bucket.menuItemId && !bucket.workOrderId
       ? "Link each requested part to the inventory catalog and confirm its cost on the menu item."
-    : (meta?.next ?? "Review the completed request history.");
+      : bucket.isEstimate && bucket.stage === "needs_quote"
+        ? "Price every estimate item here, then complete the current revision from Estimates."
+        : (meta?.next ?? "Review the completed request history.");
 
   return (
     <article className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-3 shadow-[var(--theme-shadow-soft)]">
@@ -461,21 +508,31 @@ function QueueCard({
             </p>
           ) : null}
         </div>
-        {canDismissEmpty ? (
-          <span className="max-w-[48%] truncate rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[10px] font-semibold text-[color:var(--theme-text-secondary)]">
-            Empty request
-          </span>
-        ) : meta ? (
-          <span
-            className={`max-w-[48%] truncate rounded-md border px-2 py-1 text-[10px] font-semibold ${meta.pill}`}
-          >
-            Next: {isMenuIntake ? "Review recipe" : meta.action}
-          </span>
-        ) : (
-          <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-1 text-[10px] font-semibold text-[color:var(--theme-text-secondary)]">
-            Closed
-          </span>
-        )}
+        <div className="flex max-w-[52%] flex-col items-end gap-1">
+          {bucket.isEstimate ? (
+            <span className="truncate rounded-md border border-violet-400/35 bg-violet-400/10 px-2 py-1 text-[10px] font-semibold text-violet-700 dark:text-violet-300">
+              Estimate
+              {bucket.estimateRevision
+                ? ` · Rev ${bucket.estimateRevision}`
+                : ""}
+            </span>
+          ) : null}
+          {canDismissEmpty ? (
+            <span className="truncate rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1 text-[10px] font-semibold text-[color:var(--theme-text-secondary)]">
+              Empty request
+            </span>
+          ) : meta ? (
+            <span
+              className={`truncate rounded-md border px-2 py-1 text-[10px] font-semibold ${meta.pill}`}
+            >
+              Next: {isMenuIntake ? "Review recipe" : meta.action}
+            </span>
+          ) : (
+            <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-1 text-[10px] font-semibold text-[color:var(--theme-text-secondary)]">
+              Closed
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="mt-2.5 grid grid-cols-2 divide-x divide-[color:var(--theme-border-soft)] border-y border-[color:var(--theme-border-soft)] py-2 text-center">
@@ -740,7 +797,7 @@ export default function PartsRequestsPage(): JSX.Element {
           const { data: rows, error: workOrderError } = await supabase
             .from("work_orders")
             .select(
-              "id,custom_id,customers(first_name,last_name),vehicles(year,make,model)",
+              "id,custom_id,estimate_number,customers(business_name,first_name,last_name),vehicles(year,make,model,vin,unit_number)",
             )
             .in("id", workOrderIds.slice(chunkStart, chunkStart + 200));
           if (workOrderError) throw workOrderError;
@@ -1087,7 +1144,9 @@ export default function PartsRequestsPage(): JSX.Element {
           <Metric
             icon={ClipboardList}
             value={metricBuckets.length}
-            label={tab === "active" ? "Active request groups" : "Completed groups"}
+            label={
+              tab === "active" ? "Active request groups" : "Completed groups"
+            }
             tone="copper"
           />
           <Metric
@@ -1205,20 +1264,14 @@ export default function PartsRequestsPage(): JSX.Element {
       />
       <MenuItemPartsIntakeModal
         open={menuIntakeBucket !== null}
-        menuItemName={
-          menuIntakeBucket?.menuItemName || "Service menu item"
-        }
+        menuItemName={menuIntakeBucket?.menuItemName || "Service menu item"}
         items={(menuIntakeBucket?.items ?? []).map(
           (item): MenuIntakeQueueItem => ({
             id: item.id,
             description: item.description,
             partId: item.part_id,
-            quantity: Math.max(
-              Number(item.qty_requested ?? item.qty ?? 1),
-              1,
-            ),
-            unitCost:
-              item.unit_cost === null ? null : Number(item.unit_cost),
+            quantity: Math.max(Number(item.qty_requested ?? item.qty ?? 1), 1),
+            unitCost: item.unit_cost === null ? null : Number(item.unit_cost),
             unitPrice:
               item.unit_price === null ? null : Number(item.unit_price),
             quotedPrice:

--- a/app/portal/quotes/page.tsx
+++ b/app/portal/quotes/page.tsx
@@ -2,7 +2,10 @@ import Link from "next/link";
 import { CheckCircle2, Clock3, PackageOpen, Plus, Wrench } from "lucide-react";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
-import { PortalPageHeader, PortalEmptyState } from "@/features/portal/components/PortalUi";
+import {
+  PortalPageHeader,
+  PortalEmptyState,
+} from "@/features/portal/components/PortalUi";
 
 export const dynamic = "force-dynamic";
 
@@ -11,7 +14,36 @@ function clean(value: unknown): string {
 }
 
 function metadata(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function isCustomerVisibleEstimateLine(line: {
+  status: unknown;
+  stage: unknown;
+  sent_to_customer_at: unknown;
+  approved_at: unknown;
+  work_order_line_id: unknown;
+}): boolean {
+  const status = clean(line.status).toLowerCase();
+  const stage = clean(line.stage).toLowerCase();
+  if (["cancelled", "rejected", "superseded"].includes(status)) return false;
+  return (
+    Boolean(
+      line.sent_to_customer_at || line.approved_at || line.work_order_line_id,
+    ) ||
+    ["sent", "approved", "converted", "declined", "deferred"].includes(
+      status,
+    ) ||
+    [
+      "sent",
+      "customer_review",
+      "customer_approved",
+      "customer_declined",
+      "customer_deferred",
+    ].includes(stage)
+  );
 }
 
 export default async function PortalQuotesPage() {
@@ -22,15 +54,30 @@ export default async function PortalQuotesPage() {
   const { data: workOrders, error } = shopId
     ? await supabase
         .from("work_orders")
-        .select("id,vehicle_id,created_at,scheduled_at,invoice_sent_at,work_order_quote_lines(id,description,status,stage,approved_at,work_order_line_id,sent_to_customer_at,metadata)")
+        .select(
+          "id,vehicle_id,created_at,scheduled_at,invoice_sent_at,estimate_number,work_order_quote_lines(id,description,status,stage,approved_at,work_order_line_id,sent_to_customer_at,metadata)",
+        )
         .eq("shop_id", shopId)
         .eq("customer_id", actor.customer.id)
-        .like("external_id", "portal_quote:%")
+        .or("external_id.like.portal_quote:%,estimate_number.not.is.null")
         .order("created_at", { ascending: false })
     : { data: [], error: null };
 
   if (error) throw new Error(error.message);
-  const rows = workOrders ?? [];
+  const rows = (workOrders ?? [])
+    .map((workOrder) => ({
+      ...workOrder,
+      work_order_quote_lines: workOrder.estimate_number
+        ? (workOrder.work_order_quote_lines ?? []).filter(
+            isCustomerVisibleEstimateLine,
+          )
+        : (workOrder.work_order_quote_lines ?? []),
+    }))
+    .filter(
+      (workOrder) =>
+        !workOrder.estimate_number ||
+        workOrder.work_order_quote_lines.length > 0,
+    );
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-5 text-[color:var(--theme-text-primary)]">
@@ -39,38 +86,81 @@ export default async function PortalQuotesPage() {
         title="Quotes"
         subtitle="Request pricing, review the shop’s response, and continue when you are ready."
         actions={
-          <Link href="/portal/quotes/request" className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)]">
+          <Link
+            href="/portal/quotes/request"
+            className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)]"
+          >
             <Plus className="h-4 w-4" /> Request a quote
           </Link>
         }
       />
 
-      {rows.length === 0 ? <PortalEmptyState title="No quote requests yet" body="Request a repair estimate or ask Parts to price an item for pickup." /> : (
+      {rows.length === 0 ? (
+        <PortalEmptyState
+          title="No quote requests yet"
+          body="Request a repair estimate or ask Parts to price an item for pickup."
+        />
+      ) : (
         <div className="grid gap-4 sm:grid-cols-2">
-          {rows.flatMap((workOrder) => (workOrder.work_order_quote_lines ?? []).map((line) => {
-            const meta = metadata(line.metadata);
-            const partsOnly = clean(meta.request_kind) === "parts_only";
-            const sent = Boolean(line.sent_to_customer_at) || ["sent", "customer_review", "customer_approved"].includes(clean(line.stage).toLowerCase());
-            const approved = Boolean(line.approved_at || line.work_order_line_id);
-            const Icon = partsOnly ? PackageOpen : Wrench;
-            const StatusIcon = approved ? CheckCircle2 : Clock3;
-            const status = approved ? (partsOnly ? "Approved for pickup order" : workOrder.scheduled_at ? "Appointment requested" : "Approved — book when ready") : sent ? "Ready for your review" : "Shop is preparing your quote";
-            return (
-              <article key={line.id} className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 shadow-card">
-                <div className="flex items-start justify-between gap-3">
-                  <span className="grid h-11 w-11 place-items-center rounded-2xl bg-[color:var(--theme-surface-subtle)] text-[var(--accent-copper-light)]"><Icon className="h-5 w-5" /></span>
-                  <span className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--theme-border-soft)] px-2.5 py-1 text-[11px] text-[color:var(--theme-text-secondary)]"><StatusIcon className="h-3.5 w-3.5" /> {status}</span>
-                </div>
-                <h2 className="mt-4 text-base font-semibold">{clean(line.description) || "Quote request"}</h2>
-                <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{partsOnly ? "Parts-only • Pickup" : "Repair quote • Appointment after approval"}</p>
-                {sent ? (
-                  <Link href={`/portal/quotes/${workOrder.id}`} className="mt-5 inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[var(--accent-copper-light)]">
-                    {approved ? "View approved quote" : "Review quote"}
-                  </Link>
-                ) : null}
-              </article>
-            );
-          }))}
+          {rows.flatMap((workOrder) =>
+            (workOrder.work_order_quote_lines ?? []).map((line) => {
+              const meta = metadata(line.metadata);
+              const partsOnly = clean(meta.request_kind) === "parts_only";
+              const sent =
+                Boolean(line.sent_to_customer_at) ||
+                ["sent", "customer_review", "customer_approved"].includes(
+                  clean(line.stage).toLowerCase(),
+                );
+              const approved = Boolean(
+                line.approved_at || line.work_order_line_id,
+              );
+              const Icon = partsOnly ? PackageOpen : Wrench;
+              const StatusIcon = approved ? CheckCircle2 : Clock3;
+              const status = approved
+                ? partsOnly
+                  ? "Approved for pickup order"
+                  : workOrder.scheduled_at
+                    ? "Appointment requested"
+                    : "Approved — book when ready"
+                : sent
+                  ? "Ready for your review"
+                  : "Shop is preparing your quote";
+              return (
+                <article
+                  key={line.id}
+                  className="rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 shadow-card"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <span className="grid h-11 w-11 place-items-center rounded-2xl bg-[color:var(--theme-surface-subtle)] text-[var(--accent-copper-light)]">
+                      <Icon className="h-5 w-5" />
+                    </span>
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--theme-border-soft)] px-2.5 py-1 text-[11px] text-[color:var(--theme-text-secondary)]">
+                      <StatusIcon className="h-3.5 w-3.5" /> {status}
+                    </span>
+                  </div>
+                  <h2 className="mt-4 text-base font-semibold">
+                    {clean(line.description) || "Quote request"}
+                  </h2>
+                  <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                    {workOrder.estimate_number
+                      ? `${workOrder.estimate_number} • `
+                      : ""}
+                    {partsOnly
+                      ? "Parts-only • Pickup"
+                      : "Repair quote • Appointment after approval"}
+                  </p>
+                  {sent ? (
+                    <Link
+                      href={`/portal/quotes/${workOrder.id}`}
+                      className="mt-5 inline-flex min-h-11 w-full items-center justify-center rounded-xl border border-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[var(--accent-copper-light)]"
+                    >
+                      {approved ? "View approved quote" : "Review quote"}
+                    </Link>
+                  ) : null}
+                </article>
+              );
+            }),
+          )}
         </div>
       )}
     </div>

--- a/docs/audits/api-route-boundary-inventory.json
+++ b/docs/audits/api-route-boundary-inventory.json
@@ -73,6 +73,24 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/admin/people/[id]/documents/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/admin/people/[id]/route.ts",
     "methods": [
       "GET",
@@ -1413,6 +1431,98 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/estimates/[id]/parts-complete/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/estimates/[id]/return-to-parts/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/estimates/[id]/route.ts",
+    "methods": [
+      "GET",
+      "PATCH"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/estimates/[id]/submit-parts/route.ts",
+    "methods": [
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/estimates/route.ts",
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": true,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/fleet/ai-summary/route.ts",
     "methods": [
       "POST"
@@ -1721,6 +1831,22 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/inspections/[id]/report/pdf/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/inspections/build-from-prompt/route.ts",
     "methods": [
       "POST"
@@ -1813,7 +1939,7 @@
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [],
     "riskLevel": "low"
@@ -1824,6 +1950,22 @@
       "POST"
     ],
     "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": true,
+    "hasServiceRolePattern": false,
+    "hasShopReference": false,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/inspections/reports/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
@@ -2142,7 +2284,7 @@
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
     "riskFlags": [],
     "riskLevel": "low"
@@ -2338,14 +2480,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "public_or_token",
-    "riskFlags": [],
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -2514,14 +2658,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
-    "routeClassGuess": "public_or_token",
-    "riskFlags": [],
+    "hasRoleOrCapabilityReference": true,
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -3277,14 +3423,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
-    "hasRoleOrCapabilityReference": false,
+    "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "customer_or_portal",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -3539,10 +3687,9 @@
   {
     "path": "app/api/payroll-time/periods/route.ts",
     "methods": [
-      "GET",
-      "PUT"
+      "GET"
     ],
-    "isMutating": true,
+    "isMutating": false,
     "hasRequireShopScopedApiAccess": false,
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": false,
@@ -3550,10 +3697,8 @@
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [
-      "mutating_without_obvious_auth_marker"
-    ],
-    "riskLevel": "high"
+    "riskFlags": [],
+    "riskLevel": "low"
   },
   {
     "path": "app/api/payroll-time/rebuild/route.ts",
@@ -3901,6 +4046,22 @@
     "riskFlags": [
       "has_stronger_boundary_signal"
     ],
+    "riskLevel": "low"
+  },
+  {
+    "path": "app/api/portal/fleet/units/[unitId]/evidence/route.ts",
+    "methods": [
+      "GET"
+    ],
+    "isMutating": false,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
     "riskLevel": "low"
   },
   {
@@ -4322,14 +4483,16 @@
       "GET"
     ],
     "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4338,14 +4501,16 @@
       "GET"
     ],
     "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4354,14 +4519,16 @@
       "GET"
     ],
     "isMutating": false,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4371,14 +4538,16 @@
       "DELETE"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
+    "hasShopReference": false,
     "hasRoleOrCapabilityReference": true,
-    "routeClassGuess": "public_or_token",
-    "riskFlags": [],
+    "routeClassGuess": "staff_or_admin",
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4387,14 +4556,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4404,14 +4575,16 @@
       "DELETE"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
-    "hasShopReference": true,
+    "hasShopReference": false,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "staff_or_admin",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -4421,14 +4594,16 @@
       "POST"
     ],
     "isMutating": true,
-    "hasRequireShopScopedApiAccess": false,
+    "hasRequireShopScopedApiAccess": true,
     "hasRouteHandlerSupabaseAuthClient": false,
-    "hasAuthGetUser": true,
+    "hasAuthGetUser": false,
     "hasServiceRolePattern": false,
     "hasShopReference": true,
     "hasRoleOrCapabilityReference": true,
     "routeClassGuess": "public_or_token",
-    "riskFlags": [],
+    "riskFlags": [
+      "has_stronger_boundary_signal"
+    ],
     "riskLevel": "low"
   },
   {
@@ -5808,6 +5983,23 @@
     "riskLevel": "low"
   },
   {
+    "path": "app/api/work-orders/[id]/media/route.ts",
+    "methods": [
+      "GET",
+      "PATCH"
+    ],
+    "isMutating": true,
+    "hasRequireShopScopedApiAccess": false,
+    "hasRouteHandlerSupabaseAuthClient": false,
+    "hasAuthGetUser": false,
+    "hasServiceRolePattern": false,
+    "hasShopReference": true,
+    "hasRoleOrCapabilityReference": false,
+    "routeClassGuess": "customer_or_portal",
+    "riskFlags": [],
+    "riskLevel": "low"
+  },
+  {
     "path": "app/api/work-orders/[id]/quote-history-insights/route.ts",
     "methods": [
       "GET"
@@ -6066,7 +6258,7 @@
     "hasRouteHandlerSupabaseAuthClient": false,
     "hasAuthGetUser": true,
     "hasServiceRolePattern": false,
-    "hasShopReference": false,
+    "hasShopReference": true,
     "hasRoleOrCapabilityReference": false,
     "routeClassGuess": "staff_or_admin",
     "riskFlags": [],

--- a/docs/audits/api-route-boundary-inventory.md
+++ b/docs/audits/api-route-boundary-inventory.md
@@ -1,17 +1,17 @@
 # API Route Boundary Inventory (Static Heuristic)
 
-Generated: 2026-07-28T20:38:19.027Z
+Generated: 2026-08-02T02:31:19.456Z
 
 ## Summary
-- Total route count: **388**
-- Routes exporting GET: **125**
-- Routes exporting POST: **273**
-- Routes exporting PUT: **10**
-- Routes exporting PATCH: **23**
+- Total route count: **398**
+- Routes exporting GET: **131**
+- Routes exporting POST: **278**
+- Routes exporting PUT: **9**
+- Routes exporting PATCH: **25**
 - Routes exporting DELETE: **12**
 - Routes with service-role pattern: **22**
-- Routes using requireShopScopedApiAccess: **132**
-- Routes with auth.getUser references: **137**
+- Routes using requireShopScopedApiAccess: **148**
+- Routes with auth.getUser references: **129**
 
 ## High-Risk Routes
 - `app/api/auth/resolve-login/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
@@ -56,7 +56,6 @@ Generated: 2026-07-28T20:38:19.027Z
 - `app/api/payments/checkout/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/approve/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/export/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
-- `app/api/payroll-time/periods/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/rebuild/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/settings/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/scheduling/shifts/[id]/route.ts` | methods: PATCH, DELETE | riskFlags: mutating_without_obvious_auth_marker
@@ -175,7 +174,7 @@ Generated: 2026-07-28T20:38:19.027Z
 - `app/api/payroll-time/export/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/exports/[batchId]/download/route.ts` | methods: GET | riskFlags: none
 - `app/api/payroll-time/exports/route.ts` | methods: GET | riskFlags: none
-- `app/api/payroll-time/periods/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
+- `app/api/payroll-time/periods/route.ts` | methods: GET | riskFlags: none
 - `app/api/payroll-time/rebuild/route.ts` | methods: POST | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/payroll-time/settings/route.ts` | methods: GET, PUT | riskFlags: mutating_without_obvious_auth_marker
 - `app/api/scheduling/shifts/[id]/route.ts` | methods: PATCH, DELETE | riskFlags: mutating_without_obvious_auth_marker

--- a/features/dashboard/server/dashboard-shell-data.ts
+++ b/features/dashboard/server/dashboard-shell-data.ts
@@ -1,4 +1,5 @@
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import { resolveAuthenticatedStaffProfile } from "@/features/shared/lib/server/admin-access";
 import type { Database } from "@shared/types/types/supabase";
 
 type DashboardProfile = Pick<
@@ -73,12 +74,9 @@ export async function resolveDashboardServerContext(
     };
   }
 
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("completed_onboarding, email, full_name, role, shop_id")
-    .eq("id", userId)
-    .limit(1)
-    .maybeSingle<DashboardProfile>();
+  const { profile: resolvedProfile, error: profileError } =
+    await resolveAuthenticatedStaffProfile(supabase, userId);
+  const profile: DashboardProfile | null = resolvedProfile;
 
   const shopId = profile?.shop_id ?? null;
   let shop: DashboardShop | null = null;
@@ -111,7 +109,7 @@ export async function resolveDashboardServerContext(
   logDashboardContextDiagnostics({
     userId,
     profile: profile ?? null,
-    profileError: profileError?.message ?? null,
+    profileError,
     shopLoaded: Boolean(shop),
     shopIdUsed: shopId,
     shopError: shopErrorMessage,

--- a/features/email/server/emailEvents.ts
+++ b/features/email/server/emailEvents.ts
@@ -50,6 +50,9 @@ export async function sendQuoteReadyEmail(input: {
   brandSecondaryColor?: string | null;
   year?: number;
   createdBy?: string | null;
+  idempotencyKey?: string | null;
+  workOrderId?: string | null;
+  estimateRevision?: number | null;
 }) {
   return sendDynamicTemplateEmail({
     shopId: input.shopId,
@@ -58,6 +61,13 @@ export async function sendQuoteReadyEmail(input: {
     createdBy: input.createdBy,
     metadata: {
       kind: "quote_ready",
+      ...(input.idempotencyKey
+        ? {
+            estimate_send_key: input.idempotencyKey,
+            work_order_id: input.workOrderId ?? null,
+            estimate_revision: input.estimateRevision ?? null,
+          }
+        : {}),
     } as Json,
     dynamicTemplateData: {
       quote_url: input.quoteUrl,

--- a/features/email/server/sendDynamicTemplateEmail.ts
+++ b/features/email/server/sendDynamicTemplateEmail.ts
@@ -16,6 +16,18 @@ type SendDynamicTemplateEmailInput = {
   metadata?: Json;
 };
 
+export type EmailDeliveryResult =
+  | {
+      status: "accepted";
+      acceptedAt: string;
+      emailLogId: string;
+    }
+  | {
+      status: "suppressed";
+      reason: string;
+      emailLogId: string;
+    };
+
 function requiredEnv(name: string): string {
   const value = process.env[name]?.trim();
   if (!value) {
@@ -41,7 +53,7 @@ function ensureSendGridConfigured() {
 
 export async function sendDynamicTemplateEmail(
   input: SendDynamicTemplateEmailInput,
-): Promise<void> {
+): Promise<EmailDeliveryResult> {
   ensureSendGridConfigured();
 
   const supabase = getAdminClient();
@@ -57,7 +69,9 @@ export async function sendDynamicTemplateEmail(
     .maybeSingle<{ reason: string | null }>();
 
   if (suppressionError) {
-    throw new Error(`Failed to verify email suppression: ${suppressionError.message}`);
+    throw new Error(
+      `Failed to verify email suppression: ${suppressionError.message}`,
+    );
   }
 
   const { data: logRow, error: insertError } = await supabase
@@ -83,15 +97,16 @@ export async function sendDynamicTemplateEmail(
   }
 
   if (suppression) {
+    const reason = suppression.reason ?? "Recipient is suppressed";
     const { error: suppressedLogError } = await supabase
       .from("email_logs")
       .update({
         status: "suppressed",
-        error_text: suppression.reason ?? "Recipient is suppressed",
+        error_text: reason,
       })
       .eq("id", logRow.id);
     if (suppressedLogError) throw new Error(suppressedLogError.message);
-    return;
+    return { status: "suppressed", reason, emailLogId: logRow.id };
   }
 
   try {
@@ -107,18 +122,21 @@ export async function sendDynamicTemplateEmail(
     });
 
     const headerValue =
-      response.headers["x-message-id"] ?? response.headers["X-Message-Id"] ?? null;
+      response.headers["x-message-id"] ??
+      response.headers["X-Message-Id"] ??
+      null;
 
     const providerMessageId = Array.isArray(headerValue)
       ? headerValue[0]
       : headerValue;
 
+    const acceptedAt = new Date().toISOString();
     const { error: updateError } = await supabase
       .from("email_logs")
       .update({
         status: "accepted",
         provider_message_id: providerMessageId,
-        sent_at: new Date().toISOString(),
+        sent_at: acceptedAt,
       })
       .eq("id", logRow.id);
 
@@ -133,6 +151,8 @@ export async function sendDynamicTemplateEmail(
         },
       );
     }
+
+    return { status: "accepted", acceptedAt, emailLogId: logRow.id };
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Unknown SendGrid error";

--- a/features/estimates/components/EstimateBuilder.tsx
+++ b/features/estimates/components/EstimateBuilder.tsx
@@ -1,0 +1,1718 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  Check,
+  CheckCircle2,
+  ChevronRight,
+  CircleDollarSign,
+  Clock3,
+  FileText,
+  Loader2,
+  PackageSearch,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Send,
+  Trash2,
+  UserRound,
+  Wrench,
+} from "lucide-react";
+import CustomerVehicleForm from "@/features/inspections/components/inspection/CustomerVehicleForm";
+import type {
+  EstimateCustomerForm,
+  EstimateDetail,
+  EstimateLineDraft,
+  EstimatePartDraft,
+  EstimateStatus,
+  EstimateVehicleForm,
+} from "@/features/estimates/types";
+import {
+  EMPTY_ESTIMATE_CUSTOMER,
+  EMPTY_ESTIMATE_VEHICLE,
+} from "@/features/estimates/types";
+import {
+  estimateNextOwner,
+  estimateStatusLabel,
+} from "@/features/estimates/lib/status";
+
+type Props = {
+  estimateId?: string;
+  shopId?: string;
+  defaultLaborRate?: number;
+};
+
+type MutationResult = {
+  ok?: boolean;
+  idempotent?: boolean;
+  workOrderId?: string;
+  estimateStatus?: EstimateStatus;
+  estimateRevision?: number;
+  error?: string;
+};
+
+type ReturnableEstimateLine = EstimateLineDraft & { id: string };
+
+const RETURN_REASONS = [
+  { value: "lower_cost_option", label: "Find a lower-cost option" },
+  { value: "confirm_availability", label: "Confirm availability" },
+  { value: "correct_quantity", label: "Correct quantity" },
+  { value: "incorrect_application", label: "Incorrect vehicle application" },
+  { value: "missing_parts", label: "Add missing parts" },
+  { value: "review_price", label: "Review markup or price" },
+  { value: "customer_alternative", label: "Customer requested an alternative" },
+  { value: "other", label: "Other" },
+] as const;
+
+const inputClass =
+  "min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)] px-3 py-2 text-sm text-[color:var(--theme-text-primary)] outline-none transition placeholder:text-[color:var(--theme-text-muted)] focus:border-[color:var(--brand-primary)] disabled:cursor-not-allowed disabled:opacity-60";
+const panelClass =
+  "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] shadow-[var(--theme-shadow-soft)]";
+
+function newPart(): EstimatePartDraft {
+  return {
+    clientKey: crypto.randomUUID(),
+    description: "",
+    quantity: 1,
+    partNumber: "",
+    manufacturer: "",
+  };
+}
+
+function newLine(defaultLaborRate: number): EstimateLineDraft {
+  return {
+    clientKey: crypto.randomUUID(),
+    title: "",
+    customerDescription: "",
+    advisorNotes: "",
+    laborHours: 0,
+    laborRate: defaultLaborRate,
+    parts: [],
+    partsTotal: 0,
+    grandTotal: 0,
+  };
+}
+
+function money(value: number): string {
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+  }).format(Number.isFinite(value) ? value : 0);
+}
+
+function dateTime(value: string | null | undefined): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return parsed.toLocaleString("en-CA", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function dateInput(value: string | null | undefined): string {
+  if (!value) return "";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return parsed.toISOString().slice(0, 10);
+}
+
+function expiryIso(value: string): string | null {
+  if (!value) return null;
+  const parsed = new Date(`${value}T23:59:59`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function customerName(customer: EstimateCustomerForm): string {
+  return (
+    customer.business_name?.trim() ||
+    [customer.first_name, customer.last_name]
+      .filter(Boolean)
+      .join(" ")
+      .trim() ||
+    customer.name?.trim() ||
+    "Unnamed customer"
+  );
+}
+
+function vehicleLabel(vehicle: EstimateVehicleForm): string {
+  return (
+    [vehicle.year, vehicle.make, vehicle.model]
+      .filter(Boolean)
+      .join(" ")
+      .trim() ||
+    vehicle.unit_number?.trim() ||
+    vehicle.license_plate?.trim() ||
+    vehicle.vin?.trim() ||
+    "Unnamed vehicle"
+  );
+}
+
+function statusTone(status: EstimateStatus): string {
+  if (["approved", "partially_approved"].includes(status)) {
+    return "border-emerald-400/40 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300";
+  }
+  if (status === "waiting_for_parts") {
+    return "border-amber-400/40 bg-amber-400/10 text-amber-700 dark:text-amber-300";
+  }
+  if (status === "ready_for_advisor") {
+    return "border-sky-400/40 bg-sky-400/10 text-sky-700 dark:text-sky-300";
+  }
+  if (status === "sent") {
+    return "border-violet-400/40 bg-violet-400/10 text-violet-700 dark:text-violet-300";
+  }
+  return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)] text-[color:var(--theme-text-secondary)]";
+}
+
+function isReturnableEstimateLine(
+  line: EstimateLineDraft,
+): line is ReturnableEstimateLine {
+  return Boolean(
+    line.id &&
+    line.parts.length > 0 &&
+    !line.approvedAt &&
+    !line.workOrderLineId,
+  );
+}
+
+async function mutation(
+  url: string,
+  options: {
+    method?: "POST" | "PATCH";
+    body: unknown;
+    idempotencyKey: string;
+    headers?: Record<string, string>;
+  },
+): Promise<MutationResult> {
+  const response = await fetch(url, {
+    method: options.method ?? "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": options.idempotencyKey,
+      ...options.headers,
+    },
+    body: JSON.stringify(options.body),
+  });
+  const result = (await response
+    .json()
+    .catch(() => null)) as MutationResult | null;
+  if (!response.ok) {
+    throw new Error(
+      result?.error || "The estimate action could not be completed.",
+    );
+  }
+  return result ?? { ok: true };
+}
+
+export default function EstimateBuilder({
+  estimateId,
+  shopId: initialShopId,
+  defaultLaborRate = 0,
+}: Props) {
+  const router = useRouter();
+  const isNew = !estimateId;
+  const idempotencyKeysRef = useRef(new Map<string, string>());
+  const createdEstimateRef = useRef<MutationResult | null>(null);
+  const [detail, setDetail] = useState<EstimateDetail | null>(null);
+  const [loading, setLoading] = useState(!isNew);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [customer, setCustomer] = useState<EstimateCustomerForm>({
+    ...EMPTY_ESTIMATE_CUSTOMER,
+  });
+  const [vehicle, setVehicle] = useState<EstimateVehicleForm>({
+    ...EMPTY_ESTIMATE_VEHICLE,
+  });
+  const [selectedCustomerId, setSelectedCustomerId] = useState<string | null>(
+    null,
+  );
+  const [selectedVehicleId, setSelectedVehicleId] = useState<string | null>(
+    null,
+  );
+  const [lines, setLines] = useState<EstimateLineDraft[]>(() => [
+    newLine(defaultLaborRate),
+  ]);
+  const [notes, setNotes] = useState("");
+  const [expiresOn, setExpiresOn] = useState("");
+  const [returnOpen, setReturnOpen] = useState(false);
+  const [returnReason, setReturnReason] =
+    useState<(typeof RETURN_REASONS)[number]["value"]>("lower_cost_option");
+  const [returnNote, setReturnNote] = useState("");
+  const [returnLineIds, setReturnLineIds] = useState<Set<string>>(new Set());
+
+  const loadDetail = useCallback(async () => {
+    if (!estimateId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/estimates/${estimateId}`, {
+        cache: "no-store",
+      });
+      const body = (await response.json().catch(() => null)) as
+        | EstimateDetail
+        | { error?: string }
+        | null;
+      if (!response.ok || !body || !("estimate" in body)) {
+        throw new Error(
+          body && "error" in body && body.error
+            ? body.error
+            : "Could not load estimate.",
+        );
+      }
+      setDetail(body);
+      setCustomer(body.estimate.customer);
+      setVehicle(body.estimate.vehicle);
+      setSelectedCustomerId(body.estimate.customer.id ?? null);
+      setSelectedVehicleId(body.estimate.vehicle.id ?? null);
+      setLines(body.estimate.lines);
+      setNotes(body.estimate.notes ?? "");
+      setExpiresOn(dateInput(body.estimate.expiresAt));
+      setReturnLineIds(
+        new Set(
+          body.estimate.lines
+            .filter(isReturnableEstimateLine)
+            .map((line) => line.id),
+        ),
+      );
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Could not load estimate.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [estimateId]);
+
+  useEffect(() => {
+    void loadDetail();
+  }, [loadDetail]);
+
+  const shopId = detail?.shop.id ?? initialShopId ?? null;
+  const laborRate = detail?.shop.laborRate ?? defaultLaborRate;
+  const status = detail?.estimate.estimateStatus ?? "draft";
+  const editable =
+    isNew || (status === "draft" && Boolean(detail?.actor.canEdit));
+  const advisorMode = detail?.actor.mode !== "parts";
+  const hasDeliveryEmail = Boolean(customer.email?.trim());
+
+  const totals = useMemo(() => {
+    return lines.reduce(
+      (sum, line) => {
+        const labor =
+          Math.max(0, Number(line.laborHours) || 0) *
+          Math.max(0, Number(line.laborRate) || 0);
+        const parts = Math.max(0, Number(line.partsTotal) || 0);
+        return { labor: sum.labor + labor, parts: sum.parts + parts };
+      },
+      { labor: 0, parts: 0 },
+    );
+  }, [lines]);
+
+  const requestsByLine = useMemo(() => {
+    const map = new Map<string, EstimateDetail["estimate"]["requests"]>();
+    for (const request of detail?.estimate.requests ?? []) {
+      if (!request.quoteLineId) continue;
+      const current = map.get(request.quoteLineId) ?? [];
+      current.push(request);
+      map.set(request.quoteLineId, current);
+    }
+    return map;
+  }, [detail]);
+
+  const partsReady = useMemo(() => {
+    const requests = detail?.estimate.requests ?? [];
+    return (
+      requests.length > 0 &&
+      requests.every(
+        (request) =>
+          request.items.length > 0 &&
+          request.items.every((item) => item.priced),
+      )
+    );
+  }, [detail]);
+
+  async function runMutation(
+    actionKey: string,
+    url: string,
+    options: {
+      method?: "POST" | "PATCH";
+      body: unknown;
+      headers?: Record<string, string>;
+    },
+  ): Promise<MutationResult> {
+    const existingKey = idempotencyKeysRef.current.get(actionKey);
+    const idempotencyKey = existingKey ?? crypto.randomUUID();
+    if (!existingKey) idempotencyKeysRef.current.set(actionKey, idempotencyKey);
+
+    const result = await mutation(url, { ...options, idempotencyKey });
+    idempotencyKeysRef.current.delete(actionKey);
+    return result;
+  }
+
+  function updateLine(clientKey: string, patch: Partial<EstimateLineDraft>) {
+    setLines((current) =>
+      current.map((line) =>
+        line.clientKey === clientKey ? { ...line, ...patch } : line,
+      ),
+    );
+  }
+
+  function updatePart(
+    lineKey: string,
+    partKey: string,
+    patch: Partial<EstimatePartDraft>,
+  ) {
+    setLines((current) =>
+      current.map((line) => {
+        if (line.clientKey !== lineKey) return line;
+        return {
+          ...line,
+          parts: line.parts.map((part) =>
+            part.clientKey === partKey ? { ...part, ...patch } : part,
+          ),
+        };
+      }),
+    );
+  }
+
+  function removePart(lineKey: string, partKey: string) {
+    setLines((current) =>
+      current.map((line) =>
+        line.clientKey === lineKey
+          ? {
+              ...line,
+              parts: line.parts.filter((part) => part.clientKey !== partKey),
+            }
+          : line,
+      ),
+    );
+  }
+
+  function validateDraft(): string | null {
+    const hasCustomer = Boolean(
+      selectedCustomerId ||
+      customer.business_name?.trim() ||
+      customer.first_name?.trim() ||
+      customer.last_name?.trim(),
+    );
+    if (!hasCustomer) return "Select a customer or enter a customer name.";
+    const hasVehicle = Boolean(
+      selectedVehicleId || (vehicle.make?.trim() && vehicle.model?.trim()),
+    );
+    if (!hasVehicle) return "Select a vehicle or enter its make and model.";
+    if (lines.length === 0 || lines.some((line) => !line.title.trim())) {
+      return "Every repair line needs a service title.";
+    }
+    if (
+      lines.some((line) =>
+        line.parts.some(
+          (part) => !part.description.trim() || part.quantity <= 0,
+        ),
+      )
+    ) {
+      return "Every requested part needs a description and positive quantity.";
+    }
+    return null;
+  }
+
+  function draftBody() {
+    return {
+      customer: { ...customer, id: selectedCustomerId },
+      vehicle: { ...vehicle, id: selectedVehicleId },
+      lines: lines.map((line) => ({
+        clientKey: line.clientKey,
+        title: line.title,
+        customerDescription: line.customerDescription,
+        advisorNotes: line.advisorNotes,
+        laborHours: Number(line.laborHours) || 0,
+        laborRate: Number(line.laborRate) || 0,
+        parts: line.parts.map((part) => ({
+          clientKey: part.clientKey,
+          description: part.description,
+          quantity: Number(part.quantity) || 1,
+          partNumber: part.partNumber,
+          manufacturer: part.manufacturer,
+        })),
+      })),
+      notes: notes || null,
+      expiresAt: expiryIso(expiresOn),
+    };
+  }
+
+  async function createEstimate(submitToParts: boolean) {
+    const validationError = validateDraft();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setBusy(submitToParts ? "submit" : "save");
+    setError(null);
+    setNotice(null);
+    try {
+      const existingCreated = createdEstimateRef.current;
+      const created =
+        existingCreated ??
+        (await runMutation("create-estimate", "/api/estimates", {
+          body: draftBody(),
+        }));
+      if (!created.workOrderId)
+        throw new Error("Estimate was created without an id.");
+      createdEstimateRef.current = created;
+      if (existingCreated || created.idempotent) {
+        try {
+          await runMutation(
+            `save-created-draft:${created.workOrderId}`,
+            `/api/estimates/${created.workOrderId}`,
+            {
+              method: "PATCH",
+              body: {
+                ...draftBody(),
+                expectedRevision: created.estimateRevision ?? 1,
+              },
+            },
+          );
+        } catch (saveError) {
+          // A lost submit response can leave this browser on the new page even
+          // though the server already advanced the canonical estimate. Verify
+          // that state before treating the draft-save conflict as a failure.
+          if (submitToParts) {
+            const stateResponse = await fetch(
+              `/api/estimates/${created.workOrderId}`,
+              {
+                cache: "no-store",
+              },
+            );
+            const stateBody = (await stateResponse
+              .json()
+              .catch(() => null)) as EstimateDetail | null;
+            if (
+              stateResponse.ok &&
+              stateBody?.estimate &&
+              stateBody.estimate.estimateStatus !== "draft"
+            ) {
+              router.push(`/estimates/${created.workOrderId}`);
+              router.refresh();
+              return;
+            }
+          }
+          throw saveError;
+        }
+      }
+      if (submitToParts) {
+        await runMutation(
+          `submit-parts:${created.workOrderId}`,
+          `/api/estimates/${created.workOrderId}/submit-parts`,
+          {
+            body: { expectedRevision: created.estimateRevision ?? 1 },
+          },
+        );
+      }
+      router.push(`/estimates/${created.workOrderId}`);
+      router.refresh();
+    } catch (actionError) {
+      setError(
+        actionError instanceof Error
+          ? actionError.message
+          : "Could not create estimate.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function saveDraft(showNotice = true) {
+    if (!detail) return;
+    const validationError = validateDraft();
+    if (validationError) throw new Error(validationError);
+    await runMutation(
+      `save-draft:${detail.estimate.id}`,
+      `/api/estimates/${detail.estimate.id}`,
+      {
+        method: "PATCH",
+        body: {
+          ...draftBody(),
+          expectedRevision: detail.estimate.estimateRevision,
+        },
+      },
+    );
+    if (showNotice) setNotice("Draft saved.");
+  }
+
+  async function handleSave() {
+    setBusy("save");
+    setError(null);
+    setNotice(null);
+    try {
+      await saveDraft();
+      await loadDetail();
+    } catch (actionError) {
+      setError(
+        actionError instanceof Error
+          ? actionError.message
+          : "Could not save draft.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function submitToParts() {
+    if (!detail) return;
+    setBusy("submit");
+    setError(null);
+    setNotice(null);
+    try {
+      await saveDraft(false);
+      await runMutation(
+        `submit-parts:${detail.estimate.id}`,
+        `/api/estimates/${detail.estimate.id}/submit-parts`,
+        {
+          body: { expectedRevision: detail.estimate.estimateRevision },
+        },
+      );
+      setNotice("Estimate submitted to Parts.");
+      await loadDetail();
+    } catch (actionError) {
+      setError(
+        actionError instanceof Error
+          ? actionError.message
+          : "Could not submit estimate.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function completeParts() {
+    if (!detail) return;
+    setBusy("parts-complete");
+    setError(null);
+    setNotice(null);
+    try {
+      await runMutation(
+        `complete-parts:${detail.estimate.id}`,
+        `/api/estimates/${detail.estimate.id}/parts-complete`,
+        {
+          body: { expectedRevision: detail.estimate.estimateRevision },
+        },
+      );
+      setNotice("Parts quote completed and returned to the advisor.");
+      await loadDetail();
+    } catch (actionError) {
+      setError(
+        actionError instanceof Error
+          ? actionError.message
+          : "Could not complete parts quote.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function sendEstimate() {
+    if (!detail) return;
+    if (!hasDeliveryEmail) {
+      setError(
+        "Add an email address to the customer record before sending this estimate.",
+      );
+      return;
+    }
+    setBusy("send");
+    setError(null);
+    setNotice(null);
+    try {
+      const actionKey = `send-estimate:${detail.estimate.id}:${detail.estimate.estimateRevision}`;
+      const existingKey = idempotencyKeysRef.current.get(actionKey);
+      const idempotencyKey = existingKey ?? crypto.randomUUID();
+      if (!existingKey)
+        idempotencyKeysRef.current.set(actionKey, idempotencyKey);
+      const response = await fetch("/api/quotes/send", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Idempotency-Key": idempotencyKey,
+          ...(detail.estimate.estimateRevision > 1
+            ? { "x-profix-resend": "1" }
+            : {}),
+        },
+        body: JSON.stringify({ workOrderId: detail.estimate.id }),
+      });
+      const body = (await response.json().catch(() => null)) as {
+        error?: string;
+        detail?: string;
+        inProgress?: boolean;
+      } | null;
+      if (!response.ok)
+        throw new Error(
+          body?.error || body?.detail || "Could not send estimate.",
+        );
+      idempotencyKeysRef.current.delete(actionKey);
+      setNotice(
+        body?.inProgress
+          ? "This estimate delivery was already accepted and is still being finalized."
+          : "Estimate sent to the customer.",
+      );
+      await loadDetail();
+    } catch (actionError) {
+      setError(
+        actionError instanceof Error
+          ? actionError.message
+          : "Could not send estimate.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function returnToParts() {
+    if (!detail || returnLineIds.size === 0) {
+      setError("Select at least one parts-bearing repair line.");
+      return;
+    }
+    setBusy("return");
+    setError(null);
+    setNotice(null);
+    try {
+      await runMutation(
+        `return-to-parts:${detail.estimate.id}`,
+        `/api/estimates/${detail.estimate.id}/return-to-parts`,
+        {
+          body: {
+            expectedRevision: detail.estimate.estimateRevision,
+            quoteLineIds: [...returnLineIds],
+            reasonCode: returnReason,
+            note: returnNote || null,
+          },
+        },
+      );
+      setReturnOpen(false);
+      setReturnNote("");
+      setNotice("Selected lines returned to Parts as a new revision.");
+      await loadDetail();
+    } catch (actionError) {
+      setError(
+        actionError instanceof Error
+          ? actionError.message
+          : "Could not return estimate.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (loading && !detail) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center text-[color:var(--theme-text-secondary)]">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Loading estimate…
+      </div>
+    );
+  }
+
+  if (!isNew && !detail) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-10">
+        <div className={`${panelClass} p-8 text-center`}>
+          <h1 className="text-xl font-semibold text-[color:var(--theme-text-primary)]">
+            Estimate unavailable
+          </h1>
+          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+            {error ?? "This estimate could not be found."}
+          </p>
+          <Link
+            href="/estimates"
+            className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-[color:var(--brand-primary)]"
+          >
+            <ArrowLeft className="h-4 w-4" /> Back to Estimates
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const reference = detail?.estimate.estimateNumber ?? "New estimate";
+  const revision = detail?.estimate.estimateRevision ?? 1;
+  const partsWorkbenchHref = detail
+    ? `/parts/requests/${encodeURIComponent(detail.estimate.customId ?? detail.estimate.id)}`
+    : "/parts/requests";
+
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 py-5 sm:px-6 lg:px-8">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <Link
+          href="/estimates"
+          className="inline-flex items-center gap-2 text-sm font-semibold text-[color:var(--theme-text-secondary)] hover:text-[color:var(--brand-primary)]"
+        >
+          <ArrowLeft className="h-4 w-4" /> Estimates
+        </Link>
+        {detail ? (
+          <div className="flex items-center gap-2">
+            <span
+              className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${statusTone(status)}`}
+            >
+              {estimateStatusLabel(status)}
+            </span>
+            <span className="rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs text-[color:var(--theme-text-secondary)]">
+              Revision {revision}
+            </span>
+          </div>
+        ) : null}
+      </div>
+
+      <header className={`${panelClass} mb-5 overflow-hidden`}>
+        <div className="border-b border-[color:var(--theme-border-soft)] p-5 sm:p-7">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <div className="text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--brand-primary)]">
+                {reference}
+              </div>
+              <h1 className="mt-2 text-2xl font-bold text-[color:var(--theme-text-primary)] sm:text-3xl">
+                {isNew
+                  ? "Build an estimate"
+                  : `${customerName(customer)} · ${vehicleLabel(vehicle)}`}
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm text-[color:var(--theme-text-secondary)]">
+                {isNew
+                  ? "Select or create the customer and vehicle, describe the requested work, then submit only parts-bearing lines to Parts."
+                  : `Current owner: ${estimateNextOwner(status)}. ${status === "waiting_for_parts" ? "Pricing stays in the existing Parts request workbench." : "The estimate stays attached to the same work-order record through approval."}`}
+              </p>
+            </div>
+            {!isNew && detail?.actor.canEdit ? (
+              <button
+                type="button"
+                onClick={() => void loadDetail()}
+                disabled={Boolean(busy)}
+                className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-sm font-semibold text-[color:var(--theme-text-secondary)] hover:border-[color:var(--brand-primary)]"
+              >
+                <RefreshCw className="h-4 w-4" /> Refresh
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 divide-x divide-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)]">
+          {[
+            { label: "Customer & Vehicle", icon: UserRound, active: true },
+            { label: "Estimate", icon: FileText, active: lines.length > 0 },
+            {
+              label: "Parts & Send",
+              icon: Send,
+              active: !isNew && status !== "draft",
+            },
+          ].map((step, index) => (
+            <div
+              key={step.label}
+              className={`flex min-h-16 items-center justify-center gap-2 px-2 text-center text-xs font-semibold sm:text-sm ${step.active ? "text-[color:var(--theme-text-primary)]" : "text-[color:var(--theme-text-muted)]"}`}
+            >
+              <span
+                className={`hidden h-7 w-7 items-center justify-center rounded-full sm:flex ${step.active ? "bg-[color:var(--brand-primary)] text-white" : "border border-[color:var(--theme-border-soft)]"}`}
+              >
+                {step.active && index < 2 ? (
+                  <Check className="h-4 w-4" />
+                ) : (
+                  <step.icon className="h-4 w-4" />
+                )}
+              </span>
+              {step.label}
+            </div>
+          ))}
+        </div>
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mb-4 rounded-2xl border border-red-400/40 bg-red-400/10 p-4 text-sm text-red-700 dark:text-red-300"
+        >
+          {error}
+        </div>
+      ) : null}
+      {notice ? (
+        <div
+          role="status"
+          className="mb-4 flex items-center gap-2 rounded-2xl border border-emerald-400/40 bg-emerald-400/10 p-4 text-sm text-emerald-700 dark:text-emerald-300"
+        >
+          <CheckCircle2 className="h-4 w-4" /> {notice}
+        </div>
+      ) : null}
+      {detail &&
+      status === "ready_for_advisor" &&
+      detail.actor.canSend &&
+      !hasDeliveryEmail ? (
+        <div
+          role="alert"
+          className="mb-4 flex flex-col gap-3 rounded-2xl border border-amber-400/40 bg-amber-400/10 p-4 text-sm text-amber-800 dark:text-amber-200 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <span>
+            Add an email address to the customer record before sending this
+            estimate.
+          </span>
+          {customer.id ? (
+            <Link
+              href={`/customers/${customer.id}`}
+              className="inline-flex min-h-10 shrink-0 items-center justify-center rounded-xl border border-amber-500/50 px-3 font-semibold hover:bg-amber-400/10"
+            >
+              Open customer
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="space-y-5">
+          <section className={`${panelClass} p-4 sm:p-5`}>
+            <div className="mb-4 flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] pb-4">
+              <div>
+                <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                  Customer &amp; vehicle
+                </h2>
+                <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  Same customer and vehicle contract as Create Work Order.
+                </p>
+              </div>
+              {!isNew ? (
+                <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+              ) : null}
+            </div>
+
+            {isNew ? (
+              shopId ? (
+                <CustomerVehicleForm
+                  customer={customer}
+                  vehicle={vehicle}
+                  saving={Boolean(busy)}
+                  workOrderExists={false}
+                  shopId={shopId}
+                  selectedCustomerId={selectedCustomerId}
+                  selectedVehicleId={selectedVehicleId}
+                  handlers={{
+                    onCustomerChange: (
+                      field: keyof EstimateCustomerForm,
+                      value: string | null,
+                    ) => {
+                      setCustomer((current) => ({
+                        ...current,
+                        [field]: value,
+                      }));
+                    },
+                    onVehicleChange: (
+                      field: keyof EstimateVehicleForm,
+                      value: string | null,
+                    ) => {
+                      setVehicle((current) => ({ ...current, [field]: value }));
+                    },
+                    onCustomerSelected: (id: string) =>
+                      setSelectedCustomerId(id),
+                    onVehicleSelected: (id: string) => setSelectedVehicleId(id),
+                  }}
+                />
+              ) : (
+                <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                  Shop context is unavailable.
+                </p>
+              )
+            ) : (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-xl bg-[color:var(--theme-surface-muted)] p-4">
+                  <div className="text-xs uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                    Customer
+                  </div>
+                  <div className="mt-1 font-semibold text-[color:var(--theme-text-primary)]">
+                    {customerName(customer)}
+                  </div>
+                  {advisorMode ? (
+                    <div className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+                      {[customer.phone, customer.email]
+                        .filter(Boolean)
+                        .join(" · ") || "No contact recorded"}
+                    </div>
+                  ) : null}
+                </div>
+                <div className="rounded-xl bg-[color:var(--theme-surface-muted)] p-4">
+                  <div className="text-xs uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                    Vehicle
+                  </div>
+                  <div className="mt-1 font-semibold text-[color:var(--theme-text-primary)]">
+                    {vehicleLabel(vehicle)}
+                  </div>
+                  <div className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+                    {[
+                      vehicle.unit_number
+                        ? `Unit ${vehicle.unit_number}`
+                        : null,
+                      vehicle.vin,
+                    ]
+                      .filter(Boolean)
+                      .join(" · ") || "No VIN or unit recorded"}
+                  </div>
+                </div>
+              </div>
+            )}
+          </section>
+
+          <section className={`${panelClass} p-4 sm:p-5`}>
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] pb-4">
+              <div>
+                <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                  Requested work
+                </h2>
+                <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  Customer-readable repair lines with advisor-entered labor and
+                  requested parts.
+                </p>
+              </div>
+              {editable ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setLines((current) => [...current, newLine(laborRate)])
+                  }
+                  className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:border-[color:var(--brand-primary)]"
+                >
+                  <Plus className="h-4 w-4" /> Add repair line
+                </button>
+              ) : null}
+            </div>
+
+            <div className="space-y-4">
+              {lines.map((line, lineIndex) => {
+                const linkedRequests = line.id
+                  ? (requestsByLine.get(line.id) ?? [])
+                  : [];
+                const laborTotal =
+                  (Number(line.laborHours) || 0) *
+                  (Number(line.laborRate) || 0);
+                return (
+                  <article
+                    key={line.clientKey}
+                    className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)] p-4"
+                  >
+                    <div className="mb-4 flex items-start justify-between gap-3">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--brand-primary)] text-sm font-bold text-white">
+                        {lineIndex + 1}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        {editable ? (
+                          <input
+                            value={line.title}
+                            onChange={(event) =>
+                              updateLine(line.clientKey, {
+                                title: event.target.value,
+                              })
+                            }
+                            placeholder="Service title — e.g. Replace front brake pads and rotors"
+                            aria-label={`Repair line ${lineIndex + 1} title`}
+                            className={`${inputClass} font-semibold`}
+                          />
+                        ) : (
+                          <h3 className="font-semibold text-[color:var(--theme-text-primary)]">
+                            {line.title}
+                          </h3>
+                        )}
+                        {!editable && line.status ? (
+                          <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                            {line.status.replaceAll("_", " ")}{" "}
+                            {line.stage
+                              ? `· ${line.stage.replaceAll("_", " ")}`
+                              : ""}
+                          </div>
+                        ) : null}
+                      </div>
+                      {editable && lines.length > 1 ? (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setLines((current) =>
+                              current.filter(
+                                (item) => item.clientKey !== line.clientKey,
+                              ),
+                            )
+                          }
+                          className="rounded-lg p-2 text-[color:var(--theme-text-muted)] hover:bg-red-400/10 hover:text-red-600"
+                          aria-label={`Remove repair line ${lineIndex + 1}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      ) : null}
+                    </div>
+
+                    {editable ? (
+                      <div className="grid gap-3 lg:grid-cols-2">
+                        <label className="block">
+                          <span className="mb-1 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                            Customer-facing explanation
+                          </span>
+                          <textarea
+                            value={line.customerDescription}
+                            onChange={(event) =>
+                              updateLine(line.clientKey, {
+                                customerDescription: event.target.value,
+                              })
+                            }
+                            rows={3}
+                            placeholder="What is being recommended and why"
+                            className={inputClass}
+                          />
+                        </label>
+                        <label className="block">
+                          <span className="mb-1 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                            Internal advisor notes
+                          </span>
+                          <textarea
+                            value={line.advisorNotes}
+                            onChange={(event) =>
+                              updateLine(line.clientKey, {
+                                advisorNotes: event.target.value,
+                              })
+                            }
+                            rows={3}
+                            placeholder="Symptoms, sourcing instructions, application details"
+                            className={inputClass}
+                          />
+                        </label>
+                      </div>
+                    ) : line.customerDescription ? (
+                      <p className="mt-3 text-sm text-[color:var(--theme-text-secondary)]">
+                        {line.customerDescription}
+                      </p>
+                    ) : null}
+
+                    <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                      <label className="block">
+                        <span className="mb-1 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                          Labor hours
+                        </span>
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.1"
+                          value={line.laborHours}
+                          onChange={(event) =>
+                            updateLine(line.clientKey, {
+                              laborHours: Number(event.target.value),
+                            })
+                          }
+                          disabled={!editable}
+                          className={inputClass}
+                        />
+                      </label>
+                      <label className="block">
+                        <span className="mb-1 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                          Labor rate
+                        </span>
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          value={line.laborRate}
+                          onChange={(event) =>
+                            updateLine(line.clientKey, {
+                              laborRate: Number(event.target.value),
+                            })
+                          }
+                          disabled={!editable}
+                          className={inputClass}
+                        />
+                      </label>
+                      <div>
+                        <span className="mb-1 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                          Line total
+                        </span>
+                        <div className="flex min-h-11 items-center rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-3 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                          {detail?.actor.mode === "parts"
+                            ? money(Number(line.partsTotal) || 0)
+                            : money(
+                                Number(line.grandTotal) ||
+                                  laborTotal + (Number(line.partsTotal) || 0),
+                              )}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="mt-4 border-t border-[color:var(--theme-border-soft)] pt-4">
+                      <div className="mb-3 flex items-center justify-between gap-3">
+                        <div>
+                          <h4 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                            Requested parts
+                          </h4>
+                          <p className="text-xs text-[color:var(--theme-text-muted)]">
+                            Labor-only lines bypass Parts automatically.
+                          </p>
+                        </div>
+                        {editable ? (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              updateLine(line.clientKey, {
+                                parts: [...line.parts, newPart()],
+                              })
+                            }
+                            className="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold text-[color:var(--brand-primary)] hover:bg-[color:var(--theme-surface-panel)]"
+                          >
+                            <Plus className="h-3.5 w-3.5" /> Add part
+                          </button>
+                        ) : null}
+                      </div>
+
+                      {editable ? (
+                        line.parts.length === 0 ? (
+                          <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-4 text-center text-xs text-[color:var(--theme-text-muted)]">
+                            No parts required.
+                          </div>
+                        ) : (
+                          <div className="space-y-2">
+                            {line.parts.map((part) => (
+                              <div
+                                key={part.clientKey}
+                                className="grid gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3 sm:grid-cols-[minmax(0,1fr)_90px_150px_150px_36px]"
+                              >
+                                <input
+                                  value={part.description}
+                                  onChange={(event) =>
+                                    updatePart(line.clientKey, part.clientKey, {
+                                      description: event.target.value,
+                                    })
+                                  }
+                                  placeholder="Part description"
+                                  aria-label="Requested part description"
+                                  className={inputClass}
+                                />
+                                <input
+                                  type="number"
+                                  min="0.01"
+                                  step="0.01"
+                                  value={part.quantity}
+                                  onChange={(event) =>
+                                    updatePart(line.clientKey, part.clientKey, {
+                                      quantity: Number(event.target.value),
+                                    })
+                                  }
+                                  aria-label="Requested part quantity"
+                                  className={inputClass}
+                                />
+                                <input
+                                  value={part.partNumber}
+                                  onChange={(event) =>
+                                    updatePart(line.clientKey, part.clientKey, {
+                                      partNumber: event.target.value,
+                                    })
+                                  }
+                                  placeholder="Part # (optional)"
+                                  aria-label="Requested part number"
+                                  className={inputClass}
+                                />
+                                <input
+                                  value={part.manufacturer}
+                                  onChange={(event) =>
+                                    updatePart(line.clientKey, part.clientKey, {
+                                      manufacturer: event.target.value,
+                                    })
+                                  }
+                                  placeholder="Brand (optional)"
+                                  aria-label="Requested manufacturer"
+                                  className={inputClass}
+                                />
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    removePart(line.clientKey, part.clientKey)
+                                  }
+                                  className="flex h-11 items-center justify-center rounded-lg text-[color:var(--theme-text-muted)] hover:bg-red-400/10 hover:text-red-600"
+                                  aria-label="Remove requested part"
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </button>
+                              </div>
+                            ))}
+                          </div>
+                        )
+                      ) : linkedRequests.length > 0 ? (
+                        <div className="space-y-3">
+                          {linkedRequests
+                            .flatMap((request) => request.items)
+                            .map((item) => (
+                              <div
+                                key={item.id}
+                                className="flex flex-col gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3 sm:flex-row sm:items-center sm:justify-between"
+                              >
+                                <div>
+                                  <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+                                    {item.quantity} × {item.description}
+                                  </div>
+                                  <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                                    {[
+                                      item.requestedPartNumber,
+                                      item.requestedManufacturer,
+                                      item.vendor,
+                                    ]
+                                      .filter(Boolean)
+                                      .join(" · ") || "Manual sourcing"}
+                                  </div>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <span
+                                    className={`rounded-full px-2 py-1 text-[11px] font-semibold ${item.priced ? "bg-emerald-400/10 text-emerald-700 dark:text-emerald-300" : "bg-amber-400/10 text-amber-700 dark:text-amber-300"}`}
+                                  >
+                                    {item.priced
+                                      ? money(
+                                          (item.quotedPrice ?? 0) *
+                                            item.quantity,
+                                        )
+                                      : "Needs price"}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
+                        </div>
+                      ) : line.parts.length > 0 ? (
+                        <div className="space-y-2">
+                          {line.parts.map((part) => (
+                            <div
+                              key={part.clientKey}
+                              className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3 text-sm text-[color:var(--theme-text-primary)]"
+                            >
+                              {part.quantity} × {part.description}
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-4 text-center text-xs text-[color:var(--theme-text-muted)]">
+                          Labor-only line.
+                        </div>
+                      )}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+
+          {detail && status === "waiting_for_parts" ? (
+            <section className={`${panelClass} p-4 sm:p-5`}>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="flex items-center gap-2 text-sm font-semibold text-amber-700 dark:text-amber-300">
+                    <PackageSearch className="h-5 w-5" /> Parts owns the next
+                    action
+                  </div>
+                  <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+                    {detail.actor.canCompleteParts
+                      ? "Enter vendor, part identity, cost and selling price in the existing Parts request workbench. Completing here does not send the customer anything."
+                      : "The Parts team is sourcing and pricing this revision. You can review and send it after Parts completes the quote."}
+                  </p>
+                </div>
+                {detail.actor.canCompleteParts ? (
+                  <Link
+                    href={partsWorkbenchHref}
+                    className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-xl border border-[color:var(--brand-primary)] px-4 text-sm font-semibold text-[color:var(--brand-primary)] hover:bg-[color:var(--brand-primary)] hover:text-white"
+                  >
+                    Open Parts Workbench <ChevronRight className="h-4 w-4" />
+                  </Link>
+                ) : null}
+              </div>
+              {detail.actor.canCompleteParts ? (
+                <div className="mt-4 flex flex-col gap-2 border-t border-[color:var(--theme-border-soft)] pt-4 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                    {partsReady
+                      ? "Every current request item has pricing."
+                      : "All current request items need quantity, identity and selling price."}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => void completeParts()}
+                    disabled={!partsReady || Boolean(busy)}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {busy === "parts-complete" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <CheckCircle2 className="h-4 w-4" />
+                    )}
+                    Complete Parts Quote
+                  </button>
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+
+          {detail && returnOpen && detail.actor.canSend ? (
+            <section className={`${panelClass} border-amber-400/35 p-4 sm:p-5`}>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                    Return selected lines to Parts
+                  </h2>
+                  <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+                    This creates revision {revision + 1}. Previous sent pricing
+                    remains in the audit trail and cannot be silently
+                    overwritten.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setReturnOpen(false)}
+                  className="text-sm font-semibold text-[color:var(--theme-text-secondary)]"
+                >
+                  Cancel
+                </button>
+              </div>
+
+              <div className="mt-4 space-y-2">
+                {lines.filter(isReturnableEstimateLine).map((line) => (
+                  <label
+                    key={line.id}
+                    className="flex cursor-pointer items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)] p-3"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={Boolean(line.id && returnLineIds.has(line.id))}
+                      onChange={(event) => {
+                        if (!line.id) return;
+                        setReturnLineIds((current) => {
+                          const next = new Set(current);
+                          if (event.target.checked) next.add(line.id);
+                          else next.delete(line.id);
+                          return next;
+                        });
+                      }}
+                      className="h-4 w-4 rounded border-[color:var(--theme-border-soft)] text-[color:var(--brand-primary)]"
+                    />
+                    <span className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+                      {line.title}
+                    </span>
+                  </label>
+                ))}
+              </div>
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                <label>
+                  <span className="mb-1 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                    Reason
+                  </span>
+                  <select
+                    value={returnReason}
+                    onChange={(event) =>
+                      setReturnReason(
+                        event.target
+                          .value as (typeof RETURN_REASONS)[number]["value"],
+                      )
+                    }
+                    className={inputClass}
+                  >
+                    {RETURN_REASONS.map((reason) => (
+                      <option key={reason.value} value={reason.value}>
+                        {reason.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  <span className="mb-1 block text-xs font-medium text-[color:var(--theme-text-secondary)]">
+                    Instructions for Parts
+                  </span>
+                  <textarea
+                    value={returnNote}
+                    onChange={(event) => setReturnNote(event.target.value)}
+                    rows={2}
+                    className={inputClass}
+                    placeholder="What needs to change?"
+                  />
+                </label>
+              </div>
+              <div className="mt-4 flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => void returnToParts()}
+                  disabled={returnLineIds.size === 0 || Boolean(busy)}
+                  className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-amber-600 px-4 text-sm font-semibold text-white hover:bg-amber-700 disabled:opacity-50"
+                >
+                  {busy === "return" ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <RotateCcw className="h-4 w-4" />
+                  )}
+                  Create revision &amp; return
+                </button>
+              </div>
+            </section>
+          ) : null}
+
+          {advisorMode ? (
+            <section className={`${panelClass} p-4 sm:p-5`}>
+              <label>
+                <span className="mb-1 block text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  Estimate notes
+                </span>
+                <textarea
+                  value={notes}
+                  onChange={(event) => setNotes(event.target.value)}
+                  disabled={!editable}
+                  rows={3}
+                  className={inputClass}
+                  placeholder="Internal context for this estimate"
+                />
+              </label>
+              <label className="mt-3 block max-w-xs">
+                <span className="mb-1 block text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  Expires on
+                </span>
+                <input
+                  type="date"
+                  value={expiresOn}
+                  onChange={(event) => setExpiresOn(event.target.value)}
+                  disabled={!editable}
+                  className={inputClass}
+                />
+              </label>
+            </section>
+          ) : null}
+        </div>
+
+        <aside className="space-y-4 xl:sticky xl:top-5 xl:self-start">
+          <section className={`${panelClass} p-5`}>
+            <div className="flex items-center gap-2 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+              <CircleDollarSign className="h-5 w-5 text-[color:var(--brand-primary)]" />{" "}
+              Estimate summary
+            </div>
+            <dl className="mt-4 space-y-3 text-sm">
+              {advisorMode ? (
+                <>
+                  <div className="flex justify-between gap-3">
+                    <dt className="text-[color:var(--theme-text-secondary)]">
+                      Labor
+                    </dt>
+                    <dd className="font-medium text-[color:var(--theme-text-primary)]">
+                      {money(totals.labor)}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <dt className="text-[color:var(--theme-text-secondary)]">
+                      Parts
+                    </dt>
+                    <dd className="font-medium text-[color:var(--theme-text-primary)]">
+                      {money(totals.parts)}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between gap-3 border-t border-[color:var(--theme-border-soft)] pt-3">
+                    <dt className="font-semibold text-[color:var(--theme-text-primary)]">
+                      Repair subtotal
+                    </dt>
+                    <dd className="text-lg font-bold text-[color:var(--theme-text-primary)]">
+                      {money(totals.labor + totals.parts)}
+                    </dd>
+                  </div>
+                  <p className="text-xs leading-5 text-[color:var(--theme-text-muted)]">
+                    The customer-facing total adds configured shop supplies and
+                    tax when the estimate is sent.
+                  </p>
+                </>
+              ) : (
+                <div className="flex justify-between gap-3">
+                  <dt className="text-[color:var(--theme-text-secondary)]">
+                    Quoted parts
+                  </dt>
+                  <dd className="text-lg font-bold text-[color:var(--theme-text-primary)]">
+                    {money(totals.parts)}
+                  </dd>
+                </div>
+              )}
+              <div className="flex justify-between gap-3 border-t border-[color:var(--theme-border-soft)] pt-3">
+                <dt className="text-[color:var(--theme-text-secondary)]">
+                  Repair lines
+                </dt>
+                <dd className="font-medium text-[color:var(--theme-text-primary)]">
+                  {lines.length}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-3">
+                <dt className="text-[color:var(--theme-text-secondary)]">
+                  Next owner
+                </dt>
+                <dd className="font-medium text-[color:var(--theme-text-primary)]">
+                  {estimateNextOwner(status)}
+                </dd>
+              </div>
+              {detail?.estimate.expiresAt ? (
+                <div className="flex justify-between gap-3">
+                  <dt className="text-[color:var(--theme-text-secondary)]">
+                    Expires
+                  </dt>
+                  <dd className="font-medium text-[color:var(--theme-text-primary)]">
+                    {dateTime(detail.estimate.expiresAt)}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+
+            <div className="mt-5 space-y-2 border-t border-[color:var(--theme-border-soft)] pt-4">
+              {isNew ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => void createEstimate(true)}
+                    disabled={Boolean(busy)}
+                    className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-[color:var(--brand-primary)] px-4 text-sm font-semibold text-white hover:brightness-110 disabled:opacity-50"
+                  >
+                    {busy === "submit" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <PackageSearch className="h-4 w-4" />
+                    )}{" "}
+                    Submit to Parts
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void createEstimate(false)}
+                    disabled={Boolean(busy)}
+                    className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-4 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:border-[color:var(--brand-primary)] disabled:opacity-50"
+                  >
+                    {busy === "save" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <FileText className="h-4 w-4" />
+                    )}{" "}
+                    Save Draft
+                  </button>
+                </>
+              ) : status === "draft" && detail?.actor.canEdit ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => void submitToParts()}
+                    disabled={Boolean(busy)}
+                    className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-[color:var(--brand-primary)] px-4 text-sm font-semibold text-white hover:brightness-110 disabled:opacity-50"
+                  >
+                    {busy === "submit" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <PackageSearch className="h-4 w-4" />
+                    )}{" "}
+                    Submit to Parts
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleSave()}
+                    disabled={Boolean(busy)}
+                    className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-4 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:border-[color:var(--brand-primary)] disabled:opacity-50"
+                  >
+                    {busy === "save" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <FileText className="h-4 w-4" />
+                    )}{" "}
+                    Save Draft
+                  </button>
+                </>
+              ) : status === "ready_for_advisor" && detail?.actor.canSend ? (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => void sendEstimate()}
+                    disabled={Boolean(busy) || !hasDeliveryEmail}
+                    title={
+                      !hasDeliveryEmail
+                        ? "Add a customer email before sending"
+                        : undefined
+                    }
+                    className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-4 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {busy === "send" ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Send className="h-4 w-4" />
+                    )}{" "}
+                    {revision > 1 ? "Resend Estimate" : "Send Estimate"}
+                  </button>
+                  {lines.some(isReturnableEstimateLine) ? (
+                    <button
+                      type="button"
+                      onClick={() => setReturnOpen(true)}
+                      disabled={Boolean(busy)}
+                      className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-amber-500/50 px-4 text-sm font-semibold text-amber-700 hover:bg-amber-400/10 dark:text-amber-300"
+                    >
+                      <RotateCcw className="h-4 w-4" /> Return to Parts
+                    </button>
+                  ) : null}
+                </>
+              ) : status === "sent" &&
+                detail?.actor.canSend &&
+                lines.some(isReturnableEstimateLine) ? (
+                <button
+                  type="button"
+                  onClick={() => setReturnOpen(true)}
+                  disabled={Boolean(busy)}
+                  className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-amber-500/50 px-4 text-sm font-semibold text-amber-700 hover:bg-amber-400/10 dark:text-amber-300"
+                >
+                  <RotateCcw className="h-4 w-4" /> Return to Parts
+                </button>
+              ) : status === "waiting_for_parts" ? (
+                <div className="flex min-h-11 items-center justify-center gap-2 rounded-xl bg-amber-400/10 px-4 text-sm font-semibold text-amber-700 dark:text-amber-300">
+                  <Clock3 className="h-4 w-4" /> Waiting for Parts
+                </div>
+              ) : ["approved", "partially_approved"].includes(status) &&
+                detail ? (
+                <>
+                  <Link
+                    href={`/work-orders/view/${detail.estimate.id}`}
+                    className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl bg-[color:var(--brand-primary)] px-4 text-sm font-semibold text-white hover:brightness-110"
+                  >
+                    <Wrench className="h-4 w-4" /> Open Work Order
+                  </Link>
+                  {status === "partially_approved" &&
+                  detail.actor.canSend &&
+                  lines.some(isReturnableEstimateLine) ? (
+                    <button
+                      type="button"
+                      onClick={() => setReturnOpen(true)}
+                      disabled={Boolean(busy)}
+                      className="inline-flex min-h-11 w-full items-center justify-center gap-2 rounded-xl border border-amber-500/50 px-4 text-sm font-semibold text-amber-700 hover:bg-amber-400/10 dark:text-amber-300"
+                    >
+                      <RotateCcw className="h-4 w-4" /> Revise unapproved lines
+                    </button>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+          </section>
+
+          {detail?.estimate.events.length ? (
+            <section className={`${panelClass} p-5`}>
+              <h2 className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                Recent workflow
+              </h2>
+              <div className="mt-4 space-y-4">
+                {detail.estimate.events.slice(0, 6).map((event) => (
+                  <div
+                    key={event.id}
+                    className="relative border-l border-[color:var(--theme-border-soft)] pl-4"
+                  >
+                    <span className="absolute -left-1.5 top-1 h-3 w-3 rounded-full border-2 border-[color:var(--theme-surface-panel)] bg-[color:var(--brand-primary)]" />
+                    <div className="text-xs font-semibold text-[color:var(--theme-text-primary)]">
+                      {event.eventType.replaceAll("_", " ")}
+                    </div>
+                    <div className="mt-1 text-[11px] text-[color:var(--theme-text-muted)]">
+                      Revision {event.revision} · {dateTime(event.createdAt)}
+                    </div>
+                    {event.note ? (
+                      <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                        {event.note}
+                      </p>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </section>
+          ) : null}
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/features/estimates/components/EstimatesWorkspace.tsx
+++ b/features/estimates/components/EstimatesWorkspace.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  ArrowRight,
+  ClipboardList,
+  Plus,
+  RefreshCw,
+  Search,
+  UserRound,
+  Wrench,
+} from "lucide-react";
+import type {
+  EstimateListPayload,
+  EstimateStatus,
+} from "@/features/estimates/types";
+import {
+  estimateNextOwner,
+  estimatePrimaryAction,
+  estimateStatusLabel,
+} from "@/features/estimates/lib/status";
+
+type StatusFilter = "all" | EstimateStatus;
+
+const STATUS_FILTERS: Array<{ value: StatusFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "draft", label: "Draft" },
+  { value: "waiting_for_parts", label: "With Parts" },
+  { value: "ready_for_advisor", label: "Advisor Review" },
+  { value: "sent", label: "Sent" },
+  { value: "approved", label: "Approved" },
+  { value: "declined", label: "Closed" },
+];
+
+function money(value: number): string {
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+  }).format(value);
+}
+
+function shortDate(value: string | null): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return parsed.toLocaleDateString("en-CA", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function statusClass(status: EstimateStatus): string {
+  switch (status) {
+    case "waiting_for_parts":
+      return "border-amber-400/35 bg-amber-400/10 text-amber-700 dark:text-amber-300";
+    case "ready_for_advisor":
+      return "border-sky-400/35 bg-sky-400/10 text-sky-700 dark:text-sky-300";
+    case "sent":
+      return "border-violet-400/35 bg-violet-400/10 text-violet-700 dark:text-violet-300";
+    case "approved":
+    case "partially_approved":
+      return "border-emerald-400/35 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300";
+    case "declined":
+    case "deferred":
+    case "expired":
+      return "border-slate-400/35 bg-slate-400/10 text-slate-600 dark:text-slate-300";
+    case "draft":
+      return "border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)] text-[color:var(--theme-text-secondary)]";
+  }
+}
+
+export default function EstimatesWorkspace() {
+  const [payload, setPayload] = useState<EstimateListPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [status, setStatus] = useState<StatusFilter>("all");
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/estimates", { cache: "no-store" });
+      const body = (await response.json().catch(() => null)) as
+        | EstimateListPayload
+        | { error?: string }
+        | null;
+      if (!response.ok || !body || !("estimates" in body)) {
+        throw new Error(
+          body && "error" in body && body.error
+            ? body.error
+            : "Could not load estimates.",
+        );
+      }
+      setPayload(body);
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Could not load estimates.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const visible = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return (payload?.estimates ?? []).filter((estimate) => {
+      const matchesStatus =
+        status === "all" ||
+        estimate.estimateStatus === status ||
+        (status === "approved" &&
+          estimate.estimateStatus === "partially_approved") ||
+        (status === "declined" &&
+          ["deferred", "expired"].includes(estimate.estimateStatus));
+      if (!matchesStatus) return false;
+      if (!term) return true;
+      return [
+        estimate.estimateNumber,
+        estimate.customId,
+        estimate.customerName,
+        estimate.vehicleLabel,
+        estimate.vehicleVin,
+        estimate.vehicleUnitNumber,
+      ].some((value) => value?.toLowerCase().includes(term));
+    });
+  }, [payload, search, status]);
+
+  const queueCounts = useMemo(() => {
+    const estimates = payload?.estimates ?? [];
+    return {
+      waiting: estimates.filter(
+        (item) => item.estimateStatus === "waiting_for_parts",
+      ).length,
+      advisor: estimates.filter(
+        (item) => item.estimateStatus === "ready_for_advisor",
+      ).length,
+      sent: estimates.filter((item) => item.estimateStatus === "sent").length,
+    };
+  }, [payload]);
+
+  return (
+    <main className="mx-auto min-h-screen w-full max-w-7xl px-4 py-5 sm:px-6 lg:px-8">
+      <header className="mb-6 rounded-3xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5 shadow-[var(--theme-shadow-soft)] sm:p-7">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--brand-primary)]">
+              <ClipboardList className="h-4 w-4" />
+              Estimate workspace
+            </div>
+            <h1 className="text-2xl font-bold text-[color:var(--theme-text-primary)] sm:text-3xl">
+              {payload?.actor.mode === "parts"
+                ? "Estimate parts queue"
+                : "Estimates"}
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm text-[color:var(--theme-text-secondary)]">
+              {payload?.actor.mode === "parts"
+                ? "Price the current revision in Parts, then return the completed quote to its advisor."
+                : "Build requested work, hand parts lines to Parts, review the completed pricing, and send one continuous record to the customer."}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void load()}
+              disabled={loading}
+              className="inline-flex min-h-11 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)] px-4 text-sm font-semibold text-[color:var(--theme-text-primary)] hover:border-[color:var(--brand-primary)] disabled:opacity-50"
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+              />
+              Refresh
+            </button>
+            {payload?.actor.canCreate ? (
+              <Link
+                href="/estimates/new"
+                className="inline-flex min-h-11 items-center gap-2 rounded-xl bg-[color:var(--brand-primary)] px-4 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(23,71,255,0.2)] hover:brightness-110"
+              >
+                <Plus className="h-4 w-4" />
+                New Estimate
+              </Link>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-3 sm:grid-cols-3">
+          {[
+            { label: "With Parts", value: queueCounts.waiting, icon: Wrench },
+            {
+              label: "Advisor review",
+              value: queueCounts.advisor,
+              icon: UserRound,
+            },
+            {
+              label: "Customer review",
+              value: queueCounts.sent,
+              icon: ArrowRight,
+            },
+          ].map((metric) => (
+            <div
+              key={metric.label}
+              className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)] p-4"
+            >
+              <div className="flex items-center justify-between text-sm text-[color:var(--theme-text-secondary)]">
+                {metric.label}
+                <metric.icon className="h-4 w-4" />
+              </div>
+              <div className="mt-2 text-2xl font-bold text-[color:var(--theme-text-primary)]">
+                {metric.value}
+              </div>
+            </div>
+          ))}
+        </div>
+      </header>
+
+      <section className="mb-4 flex flex-col gap-3 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3 sm:flex-row sm:items-center sm:justify-between">
+        <label className="relative block flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--theme-text-muted)]" />
+          <span className="sr-only">Search estimates</span>
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Customer, vehicle, VIN, unit or estimate number"
+            className="min-h-11 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-muted)] pl-10 pr-3 text-sm text-[color:var(--theme-text-primary)] outline-none focus:border-[color:var(--brand-primary)]"
+          />
+        </label>
+        {payload?.actor.mode !== "parts" ? (
+          <div className="flex max-w-full gap-1 overflow-x-auto pb-1 sm:pb-0">
+            {STATUS_FILTERS.map((filter) => (
+              <button
+                key={filter.value}
+                type="button"
+                onClick={() => setStatus(filter.value)}
+                className={`whitespace-nowrap rounded-lg px-3 py-2 text-xs font-semibold transition ${
+                  status === filter.value
+                    ? "bg-[color:var(--brand-primary)] text-white"
+                    : "text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-muted)]"
+                }`}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </section>
+
+      {error ? (
+        <div
+          role="alert"
+          className="mb-4 rounded-2xl border border-red-400/40 bg-red-400/10 p-4 text-sm text-red-700 dark:text-red-300"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {loading && !payload ? (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {[0, 1, 2, 3, 4, 5].map((item) => (
+            <div
+              key={item}
+              className="h-64 animate-pulse rounded-2xl bg-[color:var(--theme-surface-muted)]"
+            />
+          ))}
+        </div>
+      ) : visible.length === 0 ? (
+        <div className="rounded-3xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] px-6 py-16 text-center">
+          <ClipboardList className="mx-auto h-10 w-10 text-[color:var(--theme-text-muted)]" />
+          <h2 className="mt-4 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+            No estimates in this view
+          </h2>
+          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+            {payload?.actor.mode === "parts"
+              ? "New estimate requests will appear here when an advisor submits them."
+              : "Change the filters or start a new estimate."}
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {visible.map((estimate) => {
+            const total = estimate.laborTotal + estimate.partsTotal;
+            return (
+              <Link
+                key={estimate.id}
+                href={`/estimates/${estimate.id}`}
+                className="group flex min-h-64 flex-col rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-5 shadow-[var(--theme-shadow-soft)] transition hover:-translate-y-0.5 hover:border-[color:var(--brand-primary)]"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="font-mono text-sm font-bold text-[color:var(--theme-text-primary)]">
+                      {estimate.estimateNumber}
+                    </div>
+                    <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                      Revision {estimate.estimateRevision} · Updated{" "}
+                      {shortDate(estimate.updatedAt)}
+                    </div>
+                  </div>
+                  <span
+                    className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold ${statusClass(estimate.estimateStatus)}`}
+                  >
+                    {estimateStatusLabel(estimate.estimateStatus)}
+                  </span>
+                </div>
+
+                <div className="mt-5">
+                  <h2 className="text-base font-semibold text-[color:var(--theme-text-primary)]">
+                    {estimate.customerName}
+                  </h2>
+                  <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+                    {estimate.vehicleLabel}
+                  </p>
+                  <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                    {estimate.vehicleUnitNumber
+                      ? `Unit ${estimate.vehicleUnitNumber}`
+                      : estimate.vehicleVin || "No VIN recorded"}
+                  </p>
+                </div>
+
+                <div className="mt-auto border-t border-[color:var(--theme-border-soft)] pt-4">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-[color:var(--theme-text-secondary)]">
+                      Next:{" "}
+                      <strong className="text-[color:var(--theme-text-primary)]">
+                        {estimateNextOwner(estimate.estimateStatus)}
+                      </strong>
+                    </span>
+                    <span className="font-semibold text-[color:var(--theme-text-primary)]">
+                      {payload?.actor.mode === "parts"
+                        ? `${money(estimate.partsTotal)} parts`
+                        : `${money(total)} subtotal`}
+                    </span>
+                  </div>
+                  <div className="mt-3 flex items-center justify-between text-sm font-semibold text-[color:var(--brand-primary)]">
+                    {estimatePrimaryAction(
+                      estimate.estimateStatus,
+                      payload?.actor.mode ?? "advisor",
+                    )}
+                    <ArrowRight className="h-4 w-4 transition group-hover:translate-x-1" />
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/features/estimates/lib/access.ts
+++ b/features/estimates/lib/access.ts
@@ -1,0 +1,47 @@
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import type { EstimateActor } from "@/features/estimates/types";
+
+export const ESTIMATE_ADVISOR_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "foreman",
+] as const satisfies readonly CanonicalRole[];
+
+export const ESTIMATE_PARTS_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "parts",
+  "lead_hand",
+  "foreman",
+] as const satisfies readonly CanonicalRole[];
+
+export const ESTIMATE_VIEW_ROLES = [
+  "owner",
+  "admin",
+  "manager",
+  "advisor",
+  "service",
+  "foreman",
+  "parts",
+  "lead_hand",
+] as const satisfies readonly CanonicalRole[];
+
+export function estimateActorForRole(role: CanonicalRole): EstimateActor {
+  const advisorRoles = new Set<CanonicalRole>(ESTIMATE_ADVISOR_ROLES);
+  const partsRoles = new Set<CanonicalRole>(ESTIMATE_PARTS_ROLES);
+  const canUseAdvisorFlow = advisorRoles.has(role);
+  const canUsePartsFlow = partsRoles.has(role);
+
+  return {
+    role,
+    mode: canUsePartsFlow && !canUseAdvisorFlow ? "parts" : "advisor",
+    canCreate: canUseAdvisorFlow,
+    canEdit: canUseAdvisorFlow,
+    canSend: canUseAdvisorFlow,
+    canCompleteParts: canUsePartsFlow,
+  };
+}

--- a/features/estimates/lib/status.ts
+++ b/features/estimates/lib/status.ts
@@ -1,0 +1,93 @@
+import type {
+  EstimateStatus,
+  EstimateWorkspaceMode,
+} from "@/features/estimates/types";
+
+export type EstimateOwner = "Advisor" | "Parts" | "Customer" | "Operations";
+
+export function estimateStatusLabel(status: EstimateStatus): string {
+  switch (status) {
+    case "draft":
+      return "Draft";
+    case "waiting_for_parts":
+      return "Waiting for Parts";
+    case "ready_for_advisor":
+      return "Ready for Advisor";
+    case "sent":
+      return "Sent to Customer";
+    case "partially_approved":
+      return "Partially Approved";
+    case "approved":
+      return "Approved";
+    case "declined":
+      return "Declined";
+    case "deferred":
+      return "Deferred";
+    case "expired":
+      return "Expired";
+  }
+}
+
+export function estimateNextOwner(status: EstimateStatus): EstimateOwner {
+  switch (status) {
+    case "waiting_for_parts":
+      return "Parts";
+    case "sent":
+      return "Customer";
+    case "approved":
+    case "partially_approved":
+      return "Operations";
+    case "draft":
+    case "ready_for_advisor":
+    case "declined":
+    case "deferred":
+    case "expired":
+      return "Advisor";
+  }
+}
+
+export function estimatePrimaryAction(
+  status: EstimateStatus,
+  mode: EstimateWorkspaceMode,
+): string {
+  if (mode === "parts") {
+    return status === "waiting_for_parts"
+      ? "Complete Parts Quote"
+      : "View Estimate";
+  }
+
+  switch (status) {
+    case "draft":
+      return "Submit to Parts";
+    case "ready_for_advisor":
+      return "Send Estimate";
+    case "sent":
+      return "Review Sent Estimate";
+    case "waiting_for_parts":
+      return "Waiting for Parts";
+    case "partially_approved":
+    case "approved":
+      return "Open Work Order";
+    case "declined":
+    case "deferred":
+    case "expired":
+      return "View Estimate";
+  }
+}
+
+export function isEstimateStatus(value: unknown): value is EstimateStatus {
+  return (
+    typeof value === "string" &&
+    [
+      "draft",
+      "waiting_for_parts",
+      "ready_for_advisor",
+      "sent",
+      "partially_approved",
+      "approved",
+      "declined",
+      "deferred",
+      "expired",
+    ].includes(value)
+  );
+}

--- a/features/estimates/server/data.ts
+++ b/features/estimates/server/data.ts
@@ -1,0 +1,562 @@
+import "server-only";
+
+import type { Json, Database } from "@shared/types/types/supabase";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+import { estimateActorForRole } from "@/features/estimates/lib/access";
+import { isEstimateStatus } from "@/features/estimates/lib/status";
+import { isPartsRequestItemPriced } from "@/features/parts/lib/status-display";
+import type {
+  EstimateCustomerForm,
+  EstimateDetail,
+  EstimateEvent,
+  EstimateLineDraft,
+  EstimateListItem,
+  EstimateListPayload,
+  EstimatePartDraft,
+  EstimatePartRequest,
+  EstimateRequestItem,
+  EstimateVehicleForm,
+} from "@/features/estimates/types";
+
+type DB = Database;
+type ServerSupabase = ReturnType<typeof createServerSupabaseRoute>;
+type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
+type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
+type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
+type QuoteLineRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type PartRequestRow = DB["public"]["Tables"]["part_requests"]["Row"];
+type PartRequestItemRow = DB["public"]["Tables"]["part_request_items"]["Row"];
+type EstimateEventRow = DB["public"]["Tables"]["estimate_events"]["Row"];
+type EstimateInternalDetailsRow =
+  DB["public"]["Tables"]["estimate_internal_details"]["Row"];
+
+type CustomerSummary = Pick<
+  CustomerRow,
+  | "id"
+  | "business_name"
+  | "name"
+  | "first_name"
+  | "last_name"
+  | "phone"
+  | "email"
+  | "address"
+  | "city"
+  | "province"
+  | "postal_code"
+>;
+
+type VehicleSummary = Pick<
+  VehicleRow,
+  | "id"
+  | "year"
+  | "make"
+  | "model"
+  | "vin"
+  | "license_plate"
+  | "mileage"
+  | "color"
+  | "unit_number"
+  | "engine_hours"
+  | "engine"
+  | "transmission"
+  | "fuel_type"
+  | "drivetrain"
+>;
+
+type EstimateJoinedRow = Pick<
+  WorkOrderRow,
+  | "id"
+  | "estimate_number"
+  | "estimate_status"
+  | "estimate_revision"
+  | "record_type"
+  | "custom_id"
+  | "customer_id"
+  | "vehicle_id"
+  | "advisor_id"
+  | "notes"
+  | "labor_total"
+  | "parts_total"
+  | "created_at"
+  | "updated_at"
+  | "estimate_expires_at"
+  | "estimate_sent_at"
+> & {
+  customers: CustomerSummary | CustomerSummary[] | null;
+  vehicles: VehicleSummary | VehicleSummary[] | null;
+};
+
+const ESTIMATE_SELECT = `
+  id,
+  estimate_number,
+  estimate_status,
+  estimate_revision,
+  record_type,
+  custom_id,
+  customer_id,
+  vehicle_id,
+  advisor_id,
+  notes,
+  labor_total,
+  parts_total,
+  created_at,
+  updated_at,
+  estimate_expires_at,
+  estimate_sent_at,
+  customers (
+    id,
+    business_name,
+    name,
+    first_name,
+    last_name,
+    phone,
+    email,
+    address,
+    city,
+    province,
+    postal_code
+  ),
+  vehicles (
+    id,
+    year,
+    make,
+    model,
+    vin,
+    license_plate,
+    mileage,
+    color,
+    unit_number,
+    engine_hours,
+    engine,
+    transmission,
+    fuel_type,
+    drivetrain
+  )
+`;
+
+function firstRelation<T>(value: T | T[] | null): T | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value;
+}
+
+function asNumber(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function asNullableNumber(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function asText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function customerDisplayName(customer: CustomerSummary | null): string {
+  if (!customer) return "Unknown customer";
+  return (
+    asText(customer.business_name) ||
+    [customer.first_name, customer.last_name]
+      .map(asText)
+      .filter(Boolean)
+      .join(" ") ||
+    asText(customer.name) ||
+    "Unnamed customer"
+  );
+}
+
+function vehicleDisplayLabel(vehicle: VehicleSummary | null): string {
+  if (!vehicle) return "Unknown vehicle";
+  return (
+    [
+      vehicle.year == null ? "" : String(vehicle.year),
+      vehicle.make,
+      vehicle.model,
+    ]
+      .map(asText)
+      .filter(Boolean)
+      .join(" ") ||
+    asText(vehicle.unit_number) ||
+    asText(vehicle.license_plate) ||
+    asText(vehicle.vin) ||
+    "Unnamed vehicle"
+  );
+}
+
+function metadataObject(value: Json | null): {
+  [key: string]: Json | undefined;
+} {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return value;
+}
+
+function requestedParts(metadata: {
+  [key: string]: Json | undefined;
+}): EstimatePartDraft[] {
+  const raw = metadata.requested_parts;
+  if (!Array.isArray(raw)) return [];
+
+  return raw.flatMap((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const description = asText(entry.description);
+    if (!description) return [];
+    return [
+      {
+        clientKey: asText(entry.clientKey) || `legacy-part-${index + 1}`,
+        description,
+        quantity: Math.max(1, asNumber(entry.quantity) || 1),
+        partNumber: asText(entry.partNumber),
+        manufacturer: asText(entry.manufacturer),
+      },
+    ];
+  });
+}
+
+function customerPayload(
+  customer: CustomerSummary | null,
+  redactContact: boolean,
+): EstimateCustomerForm {
+  return {
+    id: customer?.id ?? null,
+    business_name: customer?.business_name ?? null,
+    name: customer?.name ?? null,
+    first_name: customer?.first_name ?? null,
+    last_name: customer?.last_name ?? null,
+    phone: redactContact ? null : (customer?.phone ?? null),
+    email: redactContact ? null : (customer?.email ?? null),
+    address: redactContact ? null : (customer?.address ?? null),
+    city: redactContact ? null : (customer?.city ?? null),
+    province: redactContact ? null : (customer?.province ?? null),
+    postal_code: redactContact ? null : (customer?.postal_code ?? null),
+  };
+}
+
+function vehiclePayload(vehicle: VehicleSummary | null): EstimateVehicleForm {
+  return {
+    id: vehicle?.id ?? null,
+    year: vehicle?.year == null ? null : String(vehicle.year),
+    make: vehicle?.make ?? null,
+    model: vehicle?.model ?? null,
+    vin: vehicle?.vin ?? null,
+    license_plate: vehicle?.license_plate ?? null,
+    mileage: vehicle?.mileage ?? null,
+    color: vehicle?.color ?? null,
+    unit_number: vehicle?.unit_number ?? null,
+    engine_hours:
+      vehicle?.engine_hours == null ? null : String(vehicle.engine_hours),
+    engine: vehicle?.engine ?? null,
+    transmission: vehicle?.transmission ?? null,
+    fuel_type: vehicle?.fuel_type ?? null,
+    drivetrain: vehicle?.drivetrain ?? null,
+  };
+}
+
+function listItem(row: EstimateJoinedRow): EstimateListItem {
+  const customer = firstRelation(row.customers);
+  const vehicle = firstRelation(row.vehicles);
+  const rawStatus = row.estimate_status;
+  return {
+    id: row.id,
+    estimateNumber:
+      row.estimate_number ?? `EST-${row.id.slice(0, 8).toUpperCase()}`,
+    estimateStatus: isEstimateStatus(rawStatus) ? rawStatus : "draft",
+    estimateRevision: row.estimate_revision,
+    recordType: row.record_type,
+    customId: row.custom_id,
+    customerName: customerDisplayName(customer),
+    vehicleLabel: vehicleDisplayLabel(vehicle),
+    vehicleVin: vehicle?.vin ?? null,
+    vehicleUnitNumber: vehicle?.unit_number ?? null,
+    advisorId: row.advisor_id,
+    laborTotal: asNumber(row.labor_total),
+    partsTotal: asNumber(row.parts_total),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    expiresAt: row.estimate_expires_at,
+  };
+}
+
+export async function loadEstimateList(input: {
+  supabase: ServerSupabase;
+  shopId: string;
+  role: CanonicalRole;
+}): Promise<EstimateListPayload> {
+  const actor = estimateActorForRole(input.role);
+  let query = input.supabase
+    .from("work_orders")
+    .select(ESTIMATE_SELECT)
+    .eq("shop_id", input.shopId)
+    .not("estimate_number", "is", null)
+    .order("updated_at", { ascending: false })
+    .limit(150);
+
+  if (actor.mode === "parts") {
+    query = query.eq("estimate_status", "waiting_for_parts");
+  }
+
+  const [estimateResult, shopResult] = await Promise.all([
+    query.returns<EstimateJoinedRow[]>(),
+    input.supabase
+      .from("shops")
+      .select("id,labor_rate")
+      .eq("id", input.shopId)
+      .maybeSingle<
+        Pick<DB["public"]["Tables"]["shops"]["Row"], "id" | "labor_rate">
+      >(),
+  ]);
+
+  if (estimateResult.error) throw new Error(estimateResult.error.message);
+  if (shopResult.error) throw new Error(shopResult.error.message);
+
+  return {
+    actor,
+    shop: {
+      id: input.shopId,
+      laborRate: asNumber(shopResult.data?.labor_rate),
+    },
+    estimates: (estimateResult.data ?? []).map((row) => {
+      const item = listItem(row);
+      return actor.mode === "parts" ? { ...item, laborTotal: 0 } : item;
+    }),
+  };
+}
+
+function linePayload(
+  row: QuoteLineRow,
+  shopLaborRate: number,
+  redactFinancials: boolean,
+  internalLineNotes: { [key: string]: Json | undefined },
+): EstimateLineDraft {
+  const metadata = metadataObject(row.metadata);
+  const clientKey = asText(metadata.client_key) || row.id;
+  const laborRate =
+    asNumber(row.labor_rate) || asNumber(metadata.labor_rate) || shopLaborRate;
+  return {
+    id: row.id,
+    clientKey,
+    title: asText(row.title) || asText(row.description) || "Repair line",
+    customerDescription:
+      asText(metadata.customer_description) || asText(row.description),
+    advisorNotes: asText(internalLineNotes[clientKey]) || asText(row.notes),
+    laborHours: redactFinancials
+      ? 0
+      : asNumber(row.labor_hours) || asNumber(row.est_labor_hours),
+    laborRate: redactFinancials ? 0 : laborRate,
+    parts: requestedParts(metadata),
+    status: row.status,
+    stage: row.stage,
+    partsTotal: asNumber(row.parts_total),
+    grandTotal: redactFinancials
+      ? asNumber(row.parts_total)
+      : asNumber(row.grand_total),
+    sentAt: row.sent_to_customer_at,
+    approvedAt: row.approved_at,
+    workOrderLineId: row.work_order_line_id,
+  };
+}
+
+function requestItemPayload(
+  row: PartRequestItemRow,
+  includeInternalCost: boolean,
+): EstimateRequestItem {
+  return {
+    id: row.id,
+    requestId: row.request_id,
+    quoteLineId: row.quote_line_id,
+    sourceRowId: row.source_row_id,
+    description: row.description,
+    quantity: Math.max(asNumber(row.qty_requested), asNumber(row.qty), 1),
+    requestedPartNumber: row.requested_part_number,
+    requestedManufacturer: row.requested_manufacturer,
+    quotedPrice: asNullableNumber(row.quoted_price ?? row.unit_price),
+    unitCost: includeInternalCost ? asNullableNumber(row.unit_cost) : null,
+    vendor: row.vendor,
+    status: String(row.status),
+    priced: isPartsRequestItemPriced({
+      description: row.description,
+      partId: row.part_id,
+      requestedPartNumber: row.requested_part_number,
+      requestedManufacturer: row.requested_manufacturer,
+      qty: row.qty,
+      qtyRequested: row.qty_requested,
+      quotedPrice: row.quoted_price,
+      unitPrice: row.unit_price,
+    }),
+  };
+}
+
+function requestPayload(
+  request: PartRequestRow,
+  items: PartRequestItemRow[],
+  includeInternalCost: boolean,
+): EstimatePartRequest {
+  return {
+    id: request.id,
+    quoteLineId: request.quote_line_id,
+    status: String(request.status),
+    sourceRevision: request.source_revision,
+    notes: request.notes,
+    createdAt: request.created_at,
+    items: items
+      .filter(
+        (item) =>
+          item.request_id === request.id && String(item.status) !== "cancelled",
+      )
+      .map((item) => requestItemPayload(item, includeInternalCost)),
+  };
+}
+
+function eventPayload(row: EstimateEventRow): EstimateEvent {
+  return {
+    id: row.id,
+    revision: row.revision,
+    eventType: row.event_type,
+    reasonCode: row.reason_code,
+    note: row.note,
+    changedQuoteLineIds: row.changed_quote_line_ids,
+    createdAt: row.created_at,
+  };
+}
+
+export async function loadEstimateDetail(input: {
+  supabase: ServerSupabase;
+  shopId: string;
+  role: CanonicalRole;
+  workOrderId: string;
+}): Promise<EstimateDetail | null> {
+  const actor = estimateActorForRole(input.role);
+  const includeInternalCost = ["owner", "admin", "manager", "parts"].includes(
+    input.role,
+  );
+  const { data: estimateRow, error: estimateError } = await input.supabase
+    .from("work_orders")
+    .select(ESTIMATE_SELECT)
+    .eq("id", input.workOrderId)
+    .eq("shop_id", input.shopId)
+    .not("estimate_number", "is", null)
+    .maybeSingle<EstimateJoinedRow>();
+
+  if (estimateError) throw new Error(estimateError.message);
+  if (!estimateRow) return null;
+
+  const [
+    lineResult,
+    requestResult,
+    itemResult,
+    eventResult,
+    shopResult,
+    internalDetailsResult,
+  ] = await Promise.all([
+    input.supabase
+      .from("work_order_quote_lines")
+      .select("*")
+      .eq("shop_id", input.shopId)
+      .eq("work_order_id", input.workOrderId)
+      .order("created_at", { ascending: true })
+      .returns<QuoteLineRow[]>(),
+    input.supabase
+      .from("part_requests")
+      .select("*")
+      .eq("shop_id", input.shopId)
+      .eq("work_order_id", input.workOrderId)
+      .eq("source_context", "estimate")
+      .order("created_at", { ascending: true })
+      .returns<PartRequestRow[]>(),
+    input.supabase
+      .from("part_request_items")
+      .select("*")
+      .eq("shop_id", input.shopId)
+      .eq("work_order_id", input.workOrderId)
+      .order("created_at", { ascending: true })
+      .returns<PartRequestItemRow[]>(),
+    input.supabase
+      .from("estimate_events")
+      .select("*")
+      .eq("shop_id", input.shopId)
+      .eq("work_order_id", input.workOrderId)
+      .order("created_at", { ascending: false })
+      .limit(50)
+      .returns<EstimateEventRow[]>(),
+    input.supabase
+      .from("shops")
+      .select("id,labor_rate")
+      .eq("id", input.shopId)
+      .maybeSingle<
+        Pick<DB["public"]["Tables"]["shops"]["Row"], "id" | "labor_rate">
+      >(),
+    input.supabase
+      .from("estimate_internal_details")
+      .select("notes,line_notes")
+      .eq("shop_id", input.shopId)
+      .eq("work_order_id", input.workOrderId)
+      .maybeSingle<Pick<EstimateInternalDetailsRow, "notes" | "line_notes">>(),
+  ]);
+
+  const queryError =
+    lineResult.error ??
+    requestResult.error ??
+    itemResult.error ??
+    eventResult.error ??
+    shopResult.error ??
+    internalDetailsResult.error;
+  if (queryError) throw new Error(queryError.message);
+
+  const shopLaborRate = asNumber(shopResult.data?.labor_rate);
+  const activeLines = (lineResult.data ?? []).filter(
+    (line) =>
+      !["cancelled", "superseded"].includes(String(line.status).toLowerCase()),
+  );
+  const currentRequests = (requestResult.data ?? []).filter(
+    (request) =>
+      request.source_revision === estimateRow.estimate_revision &&
+      String(request.status).toLowerCase() !== "cancelled",
+  );
+  const customer = firstRelation(estimateRow.customers);
+  const vehicle = firstRelation(estimateRow.vehicles);
+  const rawStatus = estimateRow.estimate_status;
+  const internalLineNotes = metadataObject(
+    internalDetailsResult.data?.line_notes ?? null,
+  );
+
+  return {
+    actor,
+    shop: { id: input.shopId, laborRate: shopLaborRate },
+    estimate: {
+      id: estimateRow.id,
+      estimateNumber:
+        estimateRow.estimate_number ??
+        `EST-${estimateRow.id.slice(0, 8).toUpperCase()}`,
+      estimateStatus: isEstimateStatus(rawStatus) ? rawStatus : "draft",
+      estimateRevision: estimateRow.estimate_revision,
+      recordType: estimateRow.record_type,
+      customId: estimateRow.custom_id,
+      notes: internalDetailsResult.data?.notes ?? estimateRow.notes,
+      expiresAt: estimateRow.estimate_expires_at,
+      createdAt: estimateRow.created_at,
+      updatedAt: estimateRow.updated_at,
+      sentAt: estimateRow.estimate_sent_at,
+      customer: customerPayload(customer, actor.mode === "parts"),
+      vehicle: vehiclePayload(vehicle),
+      lines: activeLines.map((line) =>
+        linePayload(
+          line,
+          shopLaborRate,
+          actor.mode === "parts",
+          internalLineNotes,
+        ),
+      ),
+      requests: currentRequests.map((request) =>
+        requestPayload(request, itemResult.data ?? [], includeInternalCost),
+      ),
+      events: (eventResult.data ?? [])
+        .filter(
+          (event) =>
+            !["send_reserved", "send_failed"].includes(event.event_type),
+        )
+        .map(eventPayload),
+    },
+  };
+}

--- a/features/estimates/server/http.ts
+++ b/features/estimates/server/http.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+
+export function requireIdempotencyKey(
+  request: Request,
+): { ok: true; key: string } | { ok: false; response: NextResponse } {
+  const key = request.headers.get("Idempotency-Key")?.trim() ?? "";
+  if (!key || key.length > 200) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "A valid Idempotency-Key header is required." },
+        { status: 400 },
+      ),
+    };
+  }
+  return { ok: true, key };
+}
+
+type EstimateMutationFailure =
+  | string
+  | { message: string; code?: string | null };
+
+export function estimateMutationError(
+  failure: EstimateMutationFailure,
+): NextResponse {
+  const message = typeof failure === "string" ? failure : failure.message;
+  const code = typeof failure === "string" ? null : (failure.code ?? null);
+  const normalized = message.toLowerCase();
+  const status =
+    code === "P0002" || normalized.includes("not found")
+      ? 404
+      : code === "42501" ||
+          code === "28000" ||
+          normalized.includes("actor cannot") ||
+          normalized.includes("forbidden")
+        ? 403
+        : ["23505", "40001", "40P01", "55000"].includes(code ?? "") ||
+            normalized.includes("stale") ||
+            normalized.includes("current state") ||
+            normalized.includes("cannot be") ||
+            normalized.includes("idempotency key") ||
+            normalized.includes("locked")
+          ? 409
+          : ["22023", "23502", "23503", "23514"].includes(code ?? "") ||
+              normalized.includes("required") ||
+              normalized.includes("requires") ||
+              normalized.includes("must be") ||
+              normalized.includes("outside") ||
+              normalized.includes("invalid")
+            ? 400
+            : 500;
+
+  return NextResponse.json({ error: message }, { status });
+}

--- a/features/estimates/server/http.ts
+++ b/features/estimates/server/http.ts
@@ -2,6 +2,14 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 
+// PostgreSQL allows NULL function arguments, but generated Supabase RPC types
+// cannot represent parameter nullability. Keep that mismatch at this boundary.
+export function nullableRpcString(
+  value: string | null | undefined,
+): string {
+  return value ?? (null as unknown as string);
+}
+
 export function requireIdempotencyKey(
   request: Request,
 ): { ok: true; key: string } | { ok: false; response: NextResponse } {

--- a/features/estimates/server/schemas.ts
+++ b/features/estimates/server/schemas.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { z } from "zod";
+
+const nullableTrimmed = z.string().trim().max(500).nullable().optional();
+const optionalUuid = z.string().uuid().nullable().optional();
+
+const customerSchema = z.object({
+  id: optionalUuid,
+  business_name: nullableTrimmed,
+  name: nullableTrimmed,
+  first_name: nullableTrimmed,
+  last_name: nullableTrimmed,
+  phone: nullableTrimmed,
+  email: z
+    .string()
+    .trim()
+    .email()
+    .max(320)
+    .nullable()
+    .optional()
+    .or(z.literal("")),
+  address: nullableTrimmed,
+  city: nullableTrimmed,
+  province: nullableTrimmed,
+  postal_code: nullableTrimmed,
+});
+
+const vehicleSchema = z.object({
+  id: optionalUuid,
+  year: z.string().trim().max(4).nullable().optional(),
+  make: nullableTrimmed,
+  model: nullableTrimmed,
+  vin: z.string().trim().max(17).nullable().optional(),
+  license_plate: nullableTrimmed,
+  mileage: nullableTrimmed,
+  color: nullableTrimmed,
+  unit_number: nullableTrimmed,
+  engine: nullableTrimmed,
+  transmission: nullableTrimmed,
+  fuel_type: nullableTrimmed,
+  drivetrain: nullableTrimmed,
+});
+
+const estimatePartSchema = z.object({
+  clientKey: z.string().trim().min(1).max(80),
+  description: z.string().trim().min(1).max(500),
+  quantity: z.coerce.number().positive().max(10_000),
+  partNumber: z.string().trim().max(200).default(""),
+  manufacturer: z.string().trim().max(200).default(""),
+});
+
+const estimateLineSchema = z.object({
+  clientKey: z.string().trim().min(1).max(80),
+  title: z.string().trim().min(1).max(500),
+  customerDescription: z.string().trim().max(4_000).default(""),
+  advisorNotes: z.string().trim().max(4_000).default(""),
+  laborHours: z.coerce.number().min(0).max(1_000),
+  laborRate: z.coerce.number().min(0).max(100_000),
+  parts: z.array(estimatePartSchema).max(100),
+});
+
+export const createEstimateSchema = z.object({
+  customer: customerSchema,
+  vehicle: vehicleSchema,
+  lines: z.array(estimateLineSchema).min(1).max(50),
+  notes: z.string().trim().max(8_000).nullable().optional(),
+  expiresAt: z.string().datetime().nullable().optional(),
+});
+
+export const saveEstimateSchema = z.object({
+  expectedRevision: z.number().int().positive(),
+  lines: z.array(estimateLineSchema).min(1).max(50),
+  notes: z.string().trim().max(8_000).nullable().optional(),
+  expiresAt: z.string().datetime().nullable().optional(),
+});
+
+export const estimateRevisionSchema = z.object({
+  expectedRevision: z.number().int().positive(),
+});
+
+export const returnEstimateSchema = estimateRevisionSchema.extend({
+  quoteLineIds: z.array(z.string().uuid()).min(1).max(50),
+  reasonCode: z.enum([
+    "lower_cost_option",
+    "confirm_availability",
+    "correct_quantity",
+    "incorrect_application",
+    "missing_parts",
+    "review_price",
+    "customer_alternative",
+    "other",
+  ]),
+  note: z.string().trim().max(4_000).nullable().optional(),
+});
+
+export type CreateEstimateInput = z.infer<typeof createEstimateSchema>;
+export type SaveEstimateInput = z.infer<typeof saveEstimateSchema>;

--- a/features/estimates/types.ts
+++ b/features/estimates/types.ts
@@ -1,0 +1,206 @@
+import type { CanonicalRole } from "@/features/shared/lib/rbac";
+
+export const ESTIMATE_STATUSES = [
+  "draft",
+  "waiting_for_parts",
+  "ready_for_advisor",
+  "sent",
+  "partially_approved",
+  "approved",
+  "declined",
+  "deferred",
+  "expired",
+] as const;
+
+export type EstimateStatus = (typeof ESTIMATE_STATUSES)[number];
+export type EstimateWorkspaceMode = "advisor" | "parts";
+
+export type EstimateCustomerForm = {
+  id?: string | null;
+  business_name?: string | null;
+  name?: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  city: string | null;
+  province: string | null;
+  postal_code: string | null;
+};
+
+export type EstimateVehicleForm = {
+  id?: string | null;
+  year: string | null;
+  make: string | null;
+  model: string | null;
+  vin: string | null;
+  license_plate: string | null;
+  mileage: string | null;
+  color: string | null;
+  unit_number?: string | null;
+  engine_hours?: string | null;
+  engine?: string | null;
+  submodel?: string | null;
+  engine_family?: string | null;
+  engine_type?: string | null;
+  transmission?: string | null;
+  transmission_type?: string | null;
+  fuel_type?: string | null;
+  drivetrain?: string | null;
+};
+
+export type EstimatePartDraft = {
+  clientKey: string;
+  description: string;
+  quantity: number;
+  partNumber: string;
+  manufacturer: string;
+};
+
+export type EstimateLineDraft = {
+  id?: string | null;
+  clientKey: string;
+  title: string;
+  customerDescription: string;
+  advisorNotes: string;
+  laborHours: number;
+  laborRate: number;
+  parts: EstimatePartDraft[];
+  status?: string | null;
+  stage?: string | null;
+  partsTotal?: number;
+  grandTotal?: number;
+  sentAt?: string | null;
+  approvedAt?: string | null;
+  workOrderLineId?: string | null;
+};
+
+export type EstimateListItem = {
+  id: string;
+  estimateNumber: string;
+  estimateStatus: EstimateStatus;
+  estimateRevision: number;
+  recordType: string;
+  customId: string | null;
+  customerName: string;
+  vehicleLabel: string;
+  vehicleVin: string | null;
+  vehicleUnitNumber: string | null;
+  advisorId: string | null;
+  laborTotal: number;
+  partsTotal: number;
+  createdAt: string | null;
+  updatedAt: string | null;
+  expiresAt: string | null;
+};
+
+export type EstimateRequestItem = {
+  id: string;
+  requestId: string;
+  quoteLineId: string | null;
+  sourceRowId: string | null;
+  description: string;
+  quantity: number;
+  requestedPartNumber: string | null;
+  requestedManufacturer: string | null;
+  quotedPrice: number | null;
+  unitCost: number | null;
+  vendor: string | null;
+  status: string;
+  priced: boolean;
+};
+
+export type EstimatePartRequest = {
+  id: string;
+  quoteLineId: string | null;
+  status: string;
+  sourceRevision: number | null;
+  notes: string | null;
+  createdAt: string;
+  items: EstimateRequestItem[];
+};
+
+export type EstimateEvent = {
+  id: string;
+  revision: number;
+  eventType: string;
+  reasonCode: string | null;
+  note: string | null;
+  changedQuoteLineIds: string[];
+  createdAt: string;
+};
+
+export type EstimateActor = {
+  role: CanonicalRole;
+  mode: EstimateWorkspaceMode;
+  canCreate: boolean;
+  canEdit: boolean;
+  canSend: boolean;
+  canCompleteParts: boolean;
+};
+
+export type EstimateDetail = {
+  actor: EstimateActor;
+  shop: {
+    id: string;
+    laborRate: number;
+  };
+  estimate: {
+    id: string;
+    estimateNumber: string;
+    estimateStatus: EstimateStatus;
+    estimateRevision: number;
+    recordType: string;
+    customId: string | null;
+    notes: string | null;
+    expiresAt: string | null;
+    createdAt: string | null;
+    updatedAt: string | null;
+    sentAt: string | null;
+    customer: EstimateCustomerForm;
+    vehicle: EstimateVehicleForm;
+    lines: EstimateLineDraft[];
+    requests: EstimatePartRequest[];
+    events: EstimateEvent[];
+  };
+};
+
+export type EstimateListPayload = {
+  actor: EstimateActor;
+  shop: { id: string; laborRate: number };
+  estimates: EstimateListItem[];
+};
+
+export const EMPTY_ESTIMATE_CUSTOMER: EstimateCustomerForm = {
+  business_name: null,
+  name: null,
+  first_name: null,
+  last_name: null,
+  phone: null,
+  email: null,
+  address: null,
+  city: null,
+  province: null,
+  postal_code: null,
+};
+
+export const EMPTY_ESTIMATE_VEHICLE: EstimateVehicleForm = {
+  year: null,
+  make: null,
+  model: null,
+  vin: null,
+  license_plate: null,
+  mileage: null,
+  color: null,
+  unit_number: null,
+  engine_hours: null,
+  engine: null,
+  submodel: null,
+  engine_family: null,
+  engine_type: null,
+  transmission: null,
+  transmission_type: null,
+  fuel_type: null,
+  drivetrain: null,
+};

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -29,8 +29,25 @@ import {
 } from "@/features/work-orders/lib/evidence/workOrderEvidence";
 
 const COPPER = "#C57A4A";
-const CUSTOMER_VISIBLE_QUOTE_STATUSES = new Set(["sent", "approved", "converted", "declined", "deferred"]);
-const CUSTOMER_VISIBLE_QUOTE_STAGES = new Set(["sent", "customer_review", "customer_approved", "customer_declined", "customer_deferred"]);
+const CUSTOMER_VISIBLE_QUOTE_STATUSES = new Set([
+  "sent",
+  "approved",
+  "converted",
+  "declined",
+  "deferred",
+]);
+const CUSTOMER_VISIBLE_QUOTE_STAGES = new Set([
+  "sent",
+  "customer_review",
+  "customer_approved",
+  "customer_declined",
+  "customer_deferred",
+]);
+const HIDDEN_QUOTE_REVISION_STATUSES = new Set([
+  "cancelled",
+  "rejected",
+  "superseded",
+]);
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -70,7 +87,7 @@ type QuoteLineRow = Pick<
 type QuotePartView = {
   name: string;
   qty: number;
-  unitCost: number;
+  unitPrice: number;
   total: number;
   meta: string | null;
 };
@@ -106,7 +123,7 @@ type LineView = {
 
 function paramToString(value: string | string[] | undefined): string | null {
   if (!value) return null;
-  return Array.isArray(value) ? value[0] ?? null : value;
+  return Array.isArray(value) ? (value[0] ?? null) : value;
 }
 
 function safeTrim(x: unknown): string {
@@ -144,44 +161,90 @@ function formatDate(value: string | null | undefined): string {
 }
 
 function getShopProvinceCode(shop: ShopRow | null): ProvinceCode | null {
-  const s = shop as unknown as { province_code?: unknown; province?: unknown } | null;
+  const s = shop as unknown as {
+    province_code?: unknown;
+    province?: unknown;
+  } | null;
   const raw = safeTrim(s?.province_code ?? s?.province ?? "").toUpperCase();
   if (!raw) return null;
   return isProvinceCode(raw) ? raw : null;
 }
 
-function quoteMetadata(line: Pick<QuoteLineRow, "metadata">): Record<string, unknown> {
-  if (!line.metadata || typeof line.metadata !== "object" || Array.isArray(line.metadata)) return {};
+function quoteMetadata(
+  line: Pick<QuoteLineRow, "metadata">,
+): Record<string, unknown> {
+  if (
+    !line.metadata ||
+    typeof line.metadata !== "object" ||
+    Array.isArray(line.metadata)
+  )
+    return {};
   return line.metadata as Record<string, unknown>;
 }
 
-function metadataArray(metadata: Record<string, unknown>, key: string): unknown[] {
+function metadataArray(
+  metadata: Record<string, unknown>,
+  key: string,
+): unknown[] {
   const value = metadata[key];
   return Array.isArray(value) ? value : [];
 }
 
 function getPartName(part: Record<string, unknown>): string {
-  return safeTrim(part.name) || safeTrim(part.description) || safeTrim(part.part_number) || safeTrim(part.sku) || "Part";
+  return (
+    safeTrim(part.name) ||
+    safeTrim(part.selected_name) ||
+    safeTrim(part.description) ||
+    safeTrim(part.part_number) ||
+    safeTrim(part.requested_part_number) ||
+    safeTrim(part.sku) ||
+    "Part"
+  );
 }
 
 function getPartMeta(part: Record<string, unknown>): string | null {
-  const pn = safeTrim(part.part_number ?? part.partNumber);
+  const pn = safeTrim(
+    part.part_number ?? part.partNumber ?? part.requested_part_number,
+  );
   const sku = safeTrim(part.sku);
   return [pn, sku].filter(Boolean).join(" • ") || null;
 }
 
-function getQuoteParts(line: QuoteLineRow): QuotePartView[] {
+function getQuoteParts(
+  line: QuoteLineRow,
+  allowCanonicalPartsQuote: boolean,
+): QuotePartView[] {
   const metadata = quoteMetadata(line);
-  return metadataArray(metadata, "parts")
-    .filter((part): part is Record<string, unknown> => Boolean(part) && typeof part === "object" && !Array.isArray(part))
+  const directParts = metadataArray(metadata, "parts");
+  const partsQuote = metadata.parts_quote;
+  const quotedParts =
+    partsQuote && typeof partsQuote === "object" && !Array.isArray(partsQuote)
+      ? metadataArray(partsQuote as Record<string, unknown>, "items")
+      : [];
+  return (
+    directParts.length > 0
+      ? directParts
+      : allowCanonicalPartsQuote
+        ? quotedParts
+        : []
+  )
+    .filter(
+      (part): part is Record<string, unknown> =>
+        Boolean(part) && typeof part === "object" && !Array.isArray(part),
+    )
     .map((part) => {
       const qty = asNumber(part.qty ?? part.quantity ?? 1) || 1;
-      const unitCost = asNumber(part.unitCost ?? part.unit_cost ?? part.unitPrice ?? part.unit_price);
-      const total = nullableNumber(part.total ?? part.totalCost ?? part.total_cost ?? part.totalPrice ?? part.total_price) ?? qty * unitCost;
+      const unitPrice = asNumber(
+        part.unitPrice ?? part.unit_price ?? part.quoted_price ?? part.price,
+      );
+      const total =
+        nullableNumber(
+          part.totalPrice ?? part.total_price ?? part.line_total ?? part.total,
+        ) ?? qty * unitPrice;
       return {
         name: getPartName(part),
         qty,
-        unitCost,
+        unitPrice,
         total,
         meta: getPartMeta(part),
       };
@@ -200,7 +263,11 @@ function getEvidencePhotos(
   if (metadataPhotos.length > 0) return metadataPhotos.slice(0, 6);
   if (photos.length === 0) return [];
 
-  const text = [safeTrim(line.description), safeTrim(line.ai_complaint), safeTrim(line.notes)]
+  const text = [
+    safeTrim(line.description),
+    safeTrim(line.ai_complaint),
+    safeTrim(line.notes),
+  ]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
@@ -209,7 +276,10 @@ function getEvidencePhotos(
   return photos
     .filter((photo) => {
       const itemName = safeTrim(photo.item_name).toLowerCase();
-      return itemName && (text.includes(itemName) || itemName.includes(text.slice(0, 20)));
+      return (
+        itemName &&
+        (text.includes(itemName) || itemName.includes(text.slice(0, 20)))
+      );
     })
     .map((photo) => safeTrim(photo.image_url))
     .filter(Boolean)
@@ -219,14 +289,31 @@ function getEvidencePhotos(
 function isCustomerVisibleQuoteLine(line: QuoteLineRow): boolean {
   const status = safeTrim(line.status).toLowerCase();
   const stage = safeTrim(line.stage).toLowerCase();
-  return Boolean(line.sent_to_customer_at) || CUSTOMER_VISIBLE_QUOTE_STATUSES.has(status) || CUSTOMER_VISIBLE_QUOTE_STAGES.has(stage);
+  if (HIDDEN_QUOTE_REVISION_STATUSES.has(status)) return false;
+  return (
+    Boolean(line.sent_to_customer_at) ||
+    CUSTOMER_VISIBLE_QUOTE_STATUSES.has(status) ||
+    CUSTOMER_VISIBLE_QUOTE_STAGES.has(stage)
+  );
 }
 
 function quoteApprovalState(line: QuoteLineRow): LineView["approvalState"] {
   const status = safeTrim(line.status).toLowerCase();
   const stage = safeTrim(line.stage).toLowerCase();
-  if (status === "approved" || status === "converted" || stage === "customer_approved" || line.approved_at || line.work_order_line_id) return "approved";
-  if (status === "declined" || stage === "customer_declined" || line.declined_at) return "declined";
+  if (
+    status === "approved" ||
+    status === "converted" ||
+    stage === "customer_approved" ||
+    line.approved_at ||
+    line.work_order_line_id
+  )
+    return "approved";
+  if (
+    status === "declined" ||
+    stage === "customer_declined" ||
+    line.declined_at
+  )
+    return "declined";
   if (status === "deferred" || stage === "customer_deferred") return "deferred";
   return "pending";
 }
@@ -234,7 +321,10 @@ function quoteApprovalState(line: QuoteLineRow): LineView["approvalState"] {
 export default function QuotePageClient(): JSX.Element {
   const router = useRouter();
   const params = useParams();
-  const workOrderId = useMemo(() => paramToString((params as ParamsShape).id), [params]);
+  const workOrderId = useMemo(
+    () => paramToString((params as ParamsShape).id),
+    [params],
+  );
   const supabase = useMemo(() => createBrowserSupabase(), []);
 
   const [loading, setLoading] = useState(true);
@@ -288,9 +378,15 @@ export default function QuotePageClient(): JSX.Element {
     let shopRow: ShopRow | null = null;
     let laborRate = 0;
 
-    const { data: shopData } = await supabase.from("shops").select("*").eq("id", wo.shop_id).maybeSingle();
+    const { data: shopData } = await supabase
+      .from("shops")
+      .select("*")
+      .eq("id", wo.shop_id)
+      .maybeSingle();
     shopRow = (shopData ?? null) as ShopRow | null;
-    laborRate = asNumber((shopData as { labor_rate?: unknown } | null)?.labor_rate);
+    laborRate = asNumber(
+      (shopData as { labor_rate?: unknown } | null)?.labor_rate,
+    );
     setShop(shopRow);
 
     const { data: quoteRowsRaw, error: quoteErr } = await supabase
@@ -308,8 +404,12 @@ export default function QuotePageClient(): JSX.Element {
       return;
     }
 
-    let inspectionPhotos: Array<Pick<InspectionPhotoRow, "image_url" | "item_name">> = [];
-    const inspectionId = safeTrim((wo as { inspection_id?: unknown } | null)?.inspection_id);
+    let inspectionPhotos: Array<
+      Pick<InspectionPhotoRow, "image_url" | "item_name">
+    > = [];
+    const inspectionId = safeTrim(
+      (wo as { inspection_id?: unknown } | null)?.inspection_id,
+    );
     if (inspectionId) {
       const { data: photos } = await supabase
         .from("inspection_photos")
@@ -317,32 +417,47 @@ export default function QuotePageClient(): JSX.Element {
         .eq("inspection_id", inspectionId)
         .order("created_at", { ascending: false })
         .limit(100);
-      inspectionPhotos = (photos ?? []) as Array<Pick<InspectionPhotoRow, "image_url" | "item_name">>;
+      inspectionPhotos = (photos ?? []) as Array<
+        Pick<InspectionPhotoRow, "image_url" | "item_name">
+      >;
     }
 
     const evidenceResponse = await fetch(
       `/api/work-orders/${workOrderId}/media?scope=all`,
       { cache: "no-store" },
     );
-    const evidenceBody = (await evidenceResponse.json().catch(() => null)) as
-      | { items?: WorkOrderEvidenceItem[] }
-      | null;
-    const canonicalEvidence = evidenceResponse.ok ? evidenceBody?.items ?? [] : [];
+    const evidenceBody = (await evidenceResponse.json().catch(() => null)) as {
+      items?: WorkOrderEvidenceItem[];
+    } | null;
+    const canonicalEvidence = evidenceResponse.ok
+      ? (evidenceBody?.items ?? [])
+      : [];
 
     const mapped: LineView[] = ((quoteRowsRaw ?? []) as QuoteLineRow[])
       .filter(isCustomerVisibleQuoteLine)
       .map((line, index) => {
-        const parts = getQuoteParts(line);
+        const parts = getQuoteParts(line, Boolean(wo.estimate_number));
         const metadata = quoteMetadata(line);
+        const customerLineNotes = wo.estimate_number
+          ? ""
+          : safeTrim(line.notes);
         const requestKind = safeTrim(metadata.request_kind);
         const fulfillment = safeTrim(metadata.fulfillment);
-        const laborHours = nullableNumber(line.labor_hours) ?? nullableNumber(line.est_labor_hours) ?? 0;
-        const computedLabor = laborHours * (nullableNumber(metadata.labor_rate) ?? laborRate);
-        const partsAmount = nullableNumber(line.parts_total) ?? parts.reduce((sum, part) => sum + part.total, 0);
+        const laborHours =
+          nullableNumber(line.labor_hours) ??
+          nullableNumber(line.est_labor_hours) ??
+          0;
+        const computedLabor =
+          laborHours * (nullableNumber(metadata.labor_rate) ?? laborRate);
+        const partsAmount =
+          nullableNumber(line.parts_total) ??
+          parts.reduce((sum, part) => sum + part.total, 0);
         const laborAmount = nullableNumber(line.labor_total) ?? computedLabor;
-        const subtotalAmount = nullableNumber(line.subtotal) ?? laborAmount + partsAmount;
+        const subtotalAmount =
+          nullableNumber(line.subtotal) ?? laborAmount + partsAmount;
         const taxAmount = nullableNumber(line.tax_total) ?? 0;
-        const totalAmount = nullableNumber(line.grand_total) ?? subtotalAmount + taxAmount;
+        const totalAmount =
+          nullableNumber(line.grand_total) ?? subtotalAmount + taxAmount;
 
         const linkedEvidence = canonicalEvidence.filter(
           (item) =>
@@ -353,30 +468,35 @@ export default function QuotePageClient(): JSX.Element {
         const fallbackEvidence: WorkOrderEvidenceItem[] =
           linkedEvidence.length > 0
             ? []
-            : getEvidencePhotos(line, inspectionPhotos).map((url, photoIndex) => ({
-                id: `${line.id}-legacy-${photoIndex}`,
-                workOrderId,
-                workOrderLineId: line.work_order_line_id,
-                quoteLineId: line.id,
-                kind: "photo",
-                source: "inspection_finding",
-                visibility: "customer",
-                fileName: null,
-                contentType: "image/jpeg",
-                fileSize: null,
-                createdAt: null,
-                displayUrl: url,
-                annotation: null,
-              }));
+            : getEvidencePhotos(line, inspectionPhotos).map(
+                (url, photoIndex) => ({
+                  id: `${line.id}-legacy-${photoIndex}`,
+                  workOrderId,
+                  workOrderLineId: line.work_order_line_id,
+                  quoteLineId: line.id,
+                  kind: "photo",
+                  source: "inspection_finding",
+                  visibility: "customer",
+                  fileName: null,
+                  contentType: "image/jpeg",
+                  fileSize: null,
+                  createdAt: null,
+                  displayUrl: url,
+                  annotation: null,
+                }),
+              );
 
         return {
           id: line.id,
           lineNo: index + 1,
-          title: safeTrim(line.description) || safeTrim(line.ai_complaint) || "Quote line",
-          complaint: safeTrim(line.ai_complaint) || safeTrim(line.notes) || null,
+          title:
+            safeTrim(line.description) ||
+            safeTrim(line.ai_complaint) ||
+            "Quote line",
+          complaint: safeTrim(line.ai_complaint) || customerLineNotes || null,
           cause: safeTrim(line.ai_cause) || null,
           correction: safeTrim(line.ai_correction) || null,
-          notes: safeTrim(line.notes) || null,
+          notes: customerLineNotes || null,
           laborHours,
           laborAmount,
           partsAmount,
@@ -393,9 +513,20 @@ export default function QuotePageClient(): JSX.Element {
           createdAt: line.created_at ?? null,
           updatedAt: line.updated_at ?? null,
           parts,
-          evidence: linkedEvidence.length > 0 ? linkedEvidence : fallbackEvidence,
-          requestKind: requestKind === "parts_only" ? "parts_only" : requestKind === "repair" ? "repair" : null,
-          fulfillment: fulfillment === "pickup" ? "pickup" : fulfillment === "appointment" ? "appointment" : null,
+          evidence:
+            linkedEvidence.length > 0 ? linkedEvidence : fallbackEvidence,
+          requestKind:
+            requestKind === "parts_only"
+              ? "parts_only"
+              : requestKind === "repair"
+                ? "repair"
+                : null,
+          fulfillment:
+            fulfillment === "pickup"
+              ? "pickup"
+              : fulfillment === "appointment"
+                ? "appointment"
+                : null,
         };
       });
 
@@ -408,7 +539,11 @@ export default function QuotePageClient(): JSX.Element {
   }, [load]);
 
   if (!workOrderId) {
-    return <div className="min-h-screen px-4 py-10 text-center text-red-300">Missing quote id.</div>;
+    return (
+      <div className="min-h-screen px-4 py-10 text-center text-red-300">
+        Missing quote id.
+      </div>
+    );
   }
 
   if (loading || !workOrder) {
@@ -419,28 +554,59 @@ export default function QuotePageClient(): JSX.Element {
     );
   }
 
-  const titleLabel = workOrder.custom_id || `Work Order ${workOrder.id.slice(0, 8)}…`;
+  const titleLabel =
+    workOrder.estimate_number ||
+    workOrder.custom_id ||
+    `Work Order ${workOrder.id.slice(0, 8)}…`;
 
   const pendingLines = lines.filter((line) => line.approvalState === "pending");
-  const approvedLines = lines.filter((line) => line.approvalState === "approved");
-  const declinedDeferredLines = lines.filter((line) => line.approvalState === "declined" || line.approvalState === "deferred");
-  const pendingSubtotal = pendingLines.reduce((sum, line) => sum + line.totalAmount, 0);
-  const approvedSubtotal = approvedLines.reduce((sum, line) => sum + line.totalAmount, 0);
-  const declinedDeferredSubtotal = declinedDeferredLines.reduce((sum, line) => sum + line.totalAmount, 0);
+  const approvedLines = lines.filter(
+    (line) => line.approvalState === "approved",
+  );
+  const declinedDeferredLines = lines.filter(
+    (line) =>
+      line.approvalState === "declined" || line.approvalState === "deferred",
+  );
+  const pendingSubtotal = pendingLines.reduce(
+    (sum, line) => sum + line.totalAmount,
+    0,
+  );
+  const approvedSubtotal = approvedLines.reduce(
+    (sum, line) => sum + line.totalAmount,
+    0,
+  );
+  const declinedDeferredSubtotal = declinedDeferredLines.reduce(
+    (sum, line) => sum + line.totalAmount,
+    0,
+  );
   const lineSubtotal = lines.reduce((sum, line) => sum + line.totalAmount, 0);
   const laborSubtotal = lines.reduce((sum, line) => sum + line.laborAmount, 0);
   const partsSubtotal = lines.reduce((sum, line) => sum + line.partsAmount, 0);
   const shopSupplies = calculateShopSupplies({
     baseAmount: laborSubtotal + partsSubtotal,
-    settings: resolveShopSuppliesSettings(shop as Parameters<typeof resolveShopSuppliesSettings>[0]),
-    override: resolveShopSuppliesOverride(workOrder as Parameters<typeof resolveShopSuppliesOverride>[0]),
+    settings: resolveShopSuppliesSettings(
+      shop as Parameters<typeof resolveShopSuppliesSettings>[0],
+    ),
+    override: resolveShopSuppliesOverride(
+      workOrder as Parameters<typeof resolveShopSuppliesOverride>[0],
+    ),
   });
   const subtotal = lineSubtotal + shopSupplies.amount;
 
   const provinceCode = getShopProvinceCode(shop);
-  const taxRes = provinceCode ? calculateTax(lineSubtotal + shopSuppliesTaxableSubtotal(shopSupplies), provinceCode) : null;
-  const taxAmount = lines.some((line) => line.taxAmount > 0) ? lines.reduce((sum, line) => sum + line.taxAmount, 0) : taxRes ? getTaxAmount(taxRes) : 0;
-  const grandTotal = subtotal + (lines.some((line) => line.taxAmount > 0) ? 0 : taxAmount);
+  const taxRes = provinceCode
+    ? calculateTax(
+        lineSubtotal + shopSuppliesTaxableSubtotal(shopSupplies),
+        provinceCode,
+      )
+    : null;
+  const taxAmount = lines.some((line) => line.taxAmount > 0)
+    ? lines.reduce((sum, line) => sum + line.taxAmount, 0)
+    : taxRes
+      ? getTaxAmount(taxRes)
+      : 0;
+  const grandTotal =
+    subtotal + (lines.some((line) => line.taxAmount > 0) ? 0 : taxAmount);
   return (
     <div
       className="
@@ -464,7 +630,9 @@ export default function QuotePageClient(): JSX.Element {
               href="/portal"
               className="inline-flex items-center gap-2 rounded-full border border-[color:var(--metal-border-soft,var(--theme-border-soft))] bg-[color:var(--theme-surface-overlay)] px-3 py-1.5 text-[11px] uppercase tracking-[0.2em] text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-overlay)] hover:text-[color:var(--theme-text-primary)]"
             >
-              <span aria-hidden className="text-base leading-none">←</span>
+              <span aria-hidden className="text-base leading-none">
+                ←
+              </span>
               Back
             </Link>
 
@@ -484,51 +652,89 @@ export default function QuotePageClient(): JSX.Element {
               {titleLabel}
             </h1>
             <p className="text-xs text-[color:var(--theme-text-secondary)] sm:text-sm">
-              Review sent recommendations and choose what you want the shop to perform. Only approved items become authorized work.
+              Review sent recommendations and choose what you want the shop to
+              perform. Only approved items become authorized work.
             </p>
           </div>
 
           <div className="mb-6 grid gap-4 sm:grid-cols-4">
             <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Pending authorization</div>
-              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{formatCurrency(pendingSubtotal)}</div>
-              <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">{pendingLines.length} item(s)</div>
-            </div>
-
-            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Approved</div>
-              <div className="mt-1 text-lg font-semibold text-emerald-100">{formatCurrency(approvedSubtotal)}</div>
-              <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">{approvedLines.length} item(s)</div>
-            </div>
-
-            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Declined / Deferred</div>
-              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{formatCurrency(declinedDeferredSubtotal)}</div>
-              <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">{declinedDeferredLines.length} item(s)</div>
-            </div>
-
-            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Visible quote total</div>
-              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{formatCurrency(grandTotal)}</div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Pending authorization
+              </div>
+              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                {formatCurrency(pendingSubtotal)}
+              </div>
               <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">
-                Tax: {formatCurrency(taxAmount)} {provinceCode ? `(${provinceCode})` : ""}
+                {pendingLines.length} item(s)
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Approved
+              </div>
+              <div className="mt-1 text-lg font-semibold text-emerald-100">
+                {formatCurrency(approvedSubtotal)}
+              </div>
+              <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">
+                {approvedLines.length} item(s)
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Declined / Deferred
+              </div>
+              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                {formatCurrency(declinedDeferredSubtotal)}
+              </div>
+              <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">
+                {declinedDeferredLines.length} item(s)
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Visible quote total
+              </div>
+              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                {formatCurrency(grandTotal)}
+              </div>
+              <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">
+                Tax: {formatCurrency(taxAmount)}{" "}
+                {provinceCode ? `(${provinceCode})` : ""}
               </div>
             </div>
           </div>
 
           <div className="mb-6 grid gap-4 sm:grid-cols-3">
             <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Labor total</div>
-              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{formatCurrency(laborSubtotal)}</div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Labor total
+              </div>
+              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                {formatCurrency(laborSubtotal)}
+              </div>
             </div>
             <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Parts total</div>
-              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{formatCurrency(partsSubtotal)}</div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Parts total
+              </div>
+              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                {formatCurrency(partsSubtotal)}
+              </div>
             </div>
             <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">Shop supplies</div>
-              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">{formatCurrency(shopSupplies.amount)}</div>
-              <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">{shopSuppliesSummaryText(shopSupplies)}</div>
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
+                Shop supplies
+              </div>
+              <div className="mt-1 text-lg font-semibold text-[color:var(--theme-text-primary)]">
+                {formatCurrency(shopSupplies.amount)}
+              </div>
+              <div className="mt-0.5 text-[11px] text-[color:var(--theme-text-muted)]">
+                {shopSuppliesSummaryText(shopSupplies)}
+              </div>
             </div>
           </div>
 
@@ -539,27 +745,41 @@ export default function QuotePageClient(): JSX.Element {
               </div>
             ) : (
               lines.map((line) => (
-                <div key={line.id} className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-4">
+                <div
+                  key={line.id}
+                  className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-4"
+                >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div>
-                      <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">Recommendation</div>
+                      <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+                        Recommendation
+                      </div>
                       <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                        {line.lineNo ? `#${line.lineNo} • ` : ""}{line.title}
+                        {line.lineNo ? `#${line.lineNo} • ` : ""}
+                        {line.title}
                       </div>
                       {line.complaint ? (
                         <div className="mt-1 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-1.5 text-xs text-[color:var(--theme-text-secondary)]">
-                          <span className="text-[color:var(--theme-text-muted)]">Issue observed:</span> {line.complaint}
+                          <span className="text-[color:var(--theme-text-muted)]">
+                            Issue observed:
+                          </span>{" "}
+                          {line.complaint}
                         </div>
                       ) : null}
                     </div>
 
                     <div className="text-right">
-                      <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">{formatCurrency(line.totalAmount)}</div>
+                      <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                        {formatCurrency(line.totalAmount)}
+                      </div>
                       <div className="mt-1 flex justify-end">
                         <StatusBadge
                           variant={
                             formatDecisionStatus({
-                              approvalState: line.approvalState === "deferred" ? "pending" : line.approvalState,
+                              approvalState:
+                                line.approvalState === "deferred"
+                                  ? "pending"
+                                  : line.approvalState,
                               workStatus: line.status,
                             }).variant
                           }
@@ -578,26 +798,40 @@ export default function QuotePageClient(): JSX.Element {
                   <div className="mt-4 grid gap-3 sm:grid-cols-2">
                     {line.cause ? (
                       <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3">
-                        <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Cause</div>
-                        <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{line.cause}</div>
+                        <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                          Cause
+                        </div>
+                        <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                          {line.cause}
+                        </div>
                       </div>
                     ) : null}
                     {line.correction ? (
                       <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3">
-                        <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Correction</div>
-                        <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{line.correction}</div>
+                        <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                          Correction
+                        </div>
+                        <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                          {line.correction}
+                        </div>
                       </div>
                     ) : null}
                     {line.notes ? (
                       <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 sm:col-span-2">
-                        <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Advisor / technician notes</div>
-                        <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{line.notes}</div>
+                        <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                          Advisor / technician notes
+                        </div>
+                        <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                          {line.notes}
+                        </div>
                       </div>
                     ) : null}
                   </div>
 
                   <div className="mt-4 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] p-3">
-                    <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Repair evidence</div>
+                    <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                      Repair evidence
+                    </div>
                     {line.evidence.length > 0 ? (
                       <div className="mt-2 grid grid-cols-2 gap-2 sm:grid-cols-3">
                         {line.evidence.map((item, idx) =>
@@ -631,48 +865,84 @@ export default function QuotePageClient(): JSX.Element {
                         )}
                       </div>
                     ) : (
-                      <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">No customer-visible evidence attached.</div>
+                      <div className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
+                        No customer-visible evidence attached.
+                      </div>
                     )}
                   </div>
 
                   <div className="mt-4 grid gap-3 sm:grid-cols-4">
                     <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Labor</div>
-                      <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">{formatCurrency(line.laborAmount)}</div>
-                      <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{line.laborHours.toFixed(1)} hr</div>
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                        Labor
+                      </div>
+                      <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">
+                        {formatCurrency(line.laborAmount)}
+                      </div>
+                      <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                        {line.laborHours.toFixed(1)} hr
+                      </div>
                     </div>
 
                     <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Parts</div>
-                      <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">{formatCurrency(line.partsAmount)}</div>
-                      <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{line.parts.length} item(s)</div>
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                        Parts
+                      </div>
+                      <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">
+                        {formatCurrency(line.partsAmount)}
+                      </div>
+                      <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                        {line.parts.length} item(s)
+                      </div>
                     </div>
 
                     <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Tax</div>
-                      <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">{formatCurrency(line.taxAmount)}</div>
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                        Tax
+                      </div>
+                      <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">
+                        {formatCurrency(line.taxAmount)}
+                      </div>
                     </div>
 
                     <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Decision total</div>
-                      <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">{formatCurrency(line.totalAmount)}</div>
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                        Decision total
+                      </div>
+                      <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">
+                        {formatCurrency(line.totalAmount)}
+                      </div>
                     </div>
                   </div>
 
                   {line.parts.length > 0 ? (
                     <div className="mt-4 space-y-2">
-                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Parts breakdown</div>
+                      <div className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                        Parts breakdown
+                      </div>
                       {line.parts.map((part, idx) => (
-                        <div key={`${line.id}-${idx}`} className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3">
+                        <div
+                          key={`${line.id}-${idx}`}
+                          className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3"
+                        >
                           <div className="flex flex-wrap items-start justify-between gap-3">
                             <div>
-                              <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">{part.name}</div>
-                              {part.meta ? <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{part.meta}</div> : null}
+                              <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+                                {part.name}
+                              </div>
+                              {part.meta ? (
+                                <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                                  {part.meta}
+                                </div>
+                              ) : null}
                               <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
-                                Qty {part.qty} × {formatCurrency(part.unitCost)}
+                                Qty {part.qty} ×{" "}
+                                {formatCurrency(part.unitPrice)}
                               </div>
                             </div>
-                            <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">{formatCurrency(part.total)}</div>
+                            <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+                              {formatCurrency(part.total)}
+                            </div>
                           </div>
                         </div>
                       ))}
@@ -683,9 +953,15 @@ export default function QuotePageClient(): JSX.Element {
                     <div>Status: {line.status || "—"}</div>
                     <div>Stage: {line.stage || "—"}</div>
                     <div>Sent: {formatDate(line.sentAt)}</div>
-                    {line.approvedAt ? <div>Approved: {formatDate(line.approvedAt)}</div> : null}
-                    {line.declinedAt ? <div>Declined: {formatDate(line.declinedAt)}</div> : null}
-                    {line.convertedWorkOrderLineId ? <div>Authorized work created</div> : null}
+                    {line.approvedAt ? (
+                      <div>Approved: {formatDate(line.approvedAt)}</div>
+                    ) : null}
+                    {line.declinedAt ? (
+                      <div>Declined: {formatDate(line.declinedAt)}</div>
+                    ) : null}
+                    {line.convertedWorkOrderLineId ? (
+                      <div>Authorized work created</div>
+                    ) : null}
                   </div>
                 </div>
               ))
@@ -707,8 +983,12 @@ export default function QuotePageClient(): JSX.Element {
 
           {approvedLines.some((line) => line.requestKind === "repair") ? (
             <div className="mt-6 rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
-              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Ready to schedule the approved repair?</div>
-              <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">Choose a time without creating another quote or work order.</p>
+              <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                Ready to schedule the approved repair?
+              </div>
+              <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                Choose a time without creating another quote or work order.
+              </p>
               <Link
                 href={`/portal/request/when?quote=${encodeURIComponent(approvedLines.find((line) => line.requestKind === "repair")?.id ?? "")}`}
                 className="mt-3 inline-flex min-h-11 items-center justify-center rounded-xl bg-[var(--accent-copper)] px-4 py-2 text-sm font-semibold text-[color:var(--theme-text-on-accent)]"
@@ -721,9 +1001,13 @@ export default function QuotePageClient(): JSX.Element {
           {approvedLines.some((line) => line.requestKind === "parts_only") ? (
             <div className="mt-6 space-y-3">
               <div className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
-                <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">Parts pickup approved</div>
+                <div className="text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  Parts pickup approved
+                </div>
                 <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                  Parts can now order or reserve the approved items. The shop will send the invoice when the pickup order is ready for payment.
+                  Parts can now order or reserve the approved items. The shop
+                  will send the invoice when the pickup order is ready for
+                  payment.
                 </p>
               </div>
               {workOrder.invoice_sent_at && shop?.id ? (

--- a/features/portal/lib/quoteApprovalPresentation.ts
+++ b/features/portal/lib/quoteApprovalPresentation.ts
@@ -6,7 +6,9 @@ function number(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-export function isPendingCustomerQuoteLine(row: Record<string, unknown>): boolean {
+export function isPendingCustomerQuoteLine(
+  row: Record<string, unknown>,
+): boolean {
   const status = (text(row.status) ?? "").trim().toLowerCase();
   const stage = (text(row.stage) ?? "").trim().toLowerCase();
   const terminalStatuses = new Set([
@@ -16,6 +18,7 @@ export function isPendingCustomerQuoteLine(row: Record<string, unknown>): boolea
     "deferred",
     "rejected",
     "cancelled",
+    "superseded",
   ]);
 
   if (

--- a/features/shared/components/RoleSidebar.tsx
+++ b/features/shared/components/RoleSidebar.tsx
@@ -35,7 +35,7 @@ const GROUP_ORDER = [
 
 function normalizeRole(raw: string | null | undefined): Role | null {
   const canonical = canonicalizeRole(raw);
-  if (canonical === "unknown" || canonical === "customer" || canonical === "service") {
+  if (canonical === "unknown" || canonical === "customer") {
     return null;
   }
   return canonical;
@@ -84,7 +84,7 @@ export default function RoleSidebar({
         .eq("id", uid)
         .single();
 
-      setRole(normalizeRole(profile?.role ?? null));
+      if (profile?.role) setRole(normalizeRole(profile.role));
     })();
   }, [supabase]);
 
@@ -161,8 +161,7 @@ export default function RoleSidebar({
     <nav
       className="flex-1 overflow-y-auto space-y-3 py-3"
       style={{
-        background:
-          "var(--theme-gradient-panel)",
+        background: "var(--theme-gradient-panel)",
       }}
     >
       {sortedGroups.map(([group, groupTiles]) => {
@@ -208,7 +207,8 @@ export default function RoleSidebar({
                   <span
                     className="inline-block h-1.5 w-1.5 rounded-full opacity-40"
                     style={{
-                      background: "var(--theme-text-secondary,var(--theme-text-muted))",
+                      background:
+                        "var(--theme-text-secondary,var(--theme-text-muted))",
                     }}
                   />
                 )}

--- a/features/shared/config/tiles.ts
+++ b/features/shared/config/tiles.ts
@@ -3,6 +3,7 @@ export type Role =
   | "admin"
   | "manager"
   | "advisor"
+  | "service"
   | "mechanic"
   | "parts"
   | "dispatcher"
@@ -53,6 +54,8 @@ export const TILES: Tile[] = [
     href: "/dashboard",
     title: "Shop Overview",
     subtitle: "Today at a glance",
+    // Retained because a legacy navigation contract verifies this literal role set.
+    // prettier-ignore
     roles: ["manager", "owner", "admin", "advisor", "parts", "fleet_manager", "dispatcher", "driver", "lead_hand", "foreman"],
     scopes: ["all"],
     section: "Dashboard",
@@ -85,7 +88,19 @@ export const TILES: Tile[] = [
     href: "/chat",
     title: "Team Chat",
     subtitle: "Messages & updates",
-    roles: ["mechanic", "manager", "owner", "admin", "advisor", "parts", "fleet_manager", "dispatcher", "driver", "lead_hand", "foreman"],
+    roles: [
+      "mechanic",
+      "manager",
+      "owner",
+      "admin",
+      "advisor",
+      "parts",
+      "fleet_manager",
+      "dispatcher",
+      "driver",
+      "lead_hand",
+      "foreman",
+    ],
     scopes: ["all"],
     section: "Tech",
   },
@@ -111,6 +126,15 @@ export const TILES: Tile[] = [
     section: "Operations",
   },
   {
+    href: "/estimates",
+    title: "Estimates",
+    subtitle: "Build, price & send",
+    cta: "+",
+    roles: ["advisor", "service", "manager", "owner", "admin", "foreman"],
+    scopes: ["work_orders", "all"],
+    section: "Operations",
+  },
+  {
     href: "/work-orders/view",
     title: "View Work Orders",
     subtitle: "Browse & manage",
@@ -127,12 +151,12 @@ export const TILES: Tile[] = [
     section: "Operations",
   },
   {
-  href: "/customers/search",
-  title: "Customers",
-  subtitle: "Search customer files",
-  roles: ["advisor", "manager", "owner", "admin"],
-  scopes: ["work_orders", "all"],
-  section: "Operations",
+    href: "/customers/search",
+    title: "Customers",
+    subtitle: "Search customer files",
+    roles: ["advisor", "manager", "owner", "admin"],
+    scopes: ["work_orders", "all"],
+    section: "Operations",
   },
   {
     href: "/vehicles",
@@ -158,7 +182,7 @@ export const TILES: Tile[] = [
     scopes: ["work_orders", "all"],
     section: "Operations",
   },
-    /* ---------------------------------------------------------------------- */
+  /* ---------------------------------------------------------------------- */
   /* MENU (owner/advisor)                                                    */
   /* ---------------------------------------------------------------------- */
   {
@@ -182,7 +206,7 @@ export const TILES: Tile[] = [
     section: "Operations",
   },
 
-    /* ---------------------------------------------------------------------- */
+  /* ---------------------------------------------------------------------- */
   /* INSPECTIONS (no mechanic/tech sidebar access)                           */
   /* ---------------------------------------------------------------------- */
   {
@@ -219,92 +243,100 @@ export const TILES: Tile[] = [
   },
 
   /* ---------------------------------------------------------------------- */
-/* PARTS                                                                   */
-/* ---------------------------------------------------------------------- */
-{
-  href: "/parts",
-  title: "Parts Dashboard",
-  subtitle: "Orders & receiving",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
-{
-  href: "/parts/requests",
-  title: "Requests",
-  subtitle: "View requests",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
-{
-  href: "/parts/receiving",
-  title: "Receiving Inbox",
-  subtitle: "Partial receive & allocations",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
-{
-  href: "/parts/receive",
-  title: "Scan to Receive",
-  subtitle: "Barcode receiving",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
-{
-  href: "/parts/inventory",
-  title: "Inventory",
-  subtitle: "On-hand stock",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
-{
-  href: "/parts/po",
-  title: "Purchase Orders",
-  subtitle: "Create & manage POs",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
+  /* PARTS                                                                   */
+  /* ---------------------------------------------------------------------- */
+  {
+    href: "/parts",
+    title: "Parts Dashboard",
+    subtitle: "Orders & receiving",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
+  {
+    href: "/parts/requests",
+    title: "Requests",
+    subtitle: "View requests",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
+  {
+    href: "/estimates",
+    title: "Estimate Queue",
+    subtitle: "Price advisor estimates",
+    roles: ["parts", "lead_hand"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
+  {
+    href: "/parts/receiving",
+    title: "Receiving Inbox",
+    subtitle: "Partial receive & allocations",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
+  {
+    href: "/parts/receive",
+    title: "Scan to Receive",
+    subtitle: "Barcode receiving",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
+  {
+    href: "/parts/inventory",
+    title: "Inventory",
+    subtitle: "On-hand stock",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
+  {
+    href: "/parts/po",
+    title: "Purchase Orders",
+    subtitle: "Create & manage POs",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
 
-// Optional: if you create a “choose PO then receive” landing page.
-// If you don’t plan to build /parts/po/receive, delete this tile.
-{
-  href: "/parts/po/receive",
-  title: "Receive from PO",
-  subtitle: "Receive + auto-allocate",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
+  // Optional: if you create a “choose PO then receive” landing page.
+  // If you don’t plan to build /parts/po/receive, delete this tile.
+  {
+    href: "/parts/po/receive",
+    title: "Receive from PO",
+    subtitle: "Receive + auto-allocate",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
 
-{
-  href: "/parts/movements",
-  title: "Stock Movements",
-  subtitle: "Inventory ledger",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
-{
-  href: "/parts/allocations",
-  title: "Allocations",
-  subtitle: "Parts used on jobs",
-  roles: ["parts", "manager", "owner", "admin"],
-  scopes: ["parts", "all"],
-  section: "Parts",
-},
-{
-  href: "/parts/vendors",
-  title: "Vendors",
-  subtitle: "Supplier records & activity",
-  roles: ["owner", "admin", "manager", "parts"],
-  scopes: ["parts", "settings", "all"],
-  section: "Parts",
-},
+  {
+    href: "/parts/movements",
+    title: "Stock Movements",
+    subtitle: "Inventory ledger",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
+  {
+    href: "/parts/allocations",
+    title: "Allocations",
+    subtitle: "Parts used on jobs",
+    roles: ["parts", "manager", "owner", "admin"],
+    scopes: ["parts", "all"],
+    section: "Parts",
+  },
+  {
+    href: "/parts/vendors",
+    title: "Vendors",
+    subtitle: "Supplier records & activity",
+    roles: ["owner", "admin", "manager", "parts"],
+    scopes: ["parts", "settings", "all"],
+    section: "Parts",
+  },
   /* ---------------------------------------------------------------------- */
   /* FLEET                                                                   */
   /* ---------------------------------------------------------------------- */
@@ -399,14 +431,13 @@ export const TILES: Tile[] = [
     section: "Dashboard",
   },
   {
-  href: "/tech/performance",
-  title: "My Performance",
-  subtitle: "Hours, billed & efficiency",
-  roles: [ "mechanic",],
-  scopes: ["tech", "all"],
-  section: "Tech",
+    href: "/tech/performance",
+    title: "My Performance",
+    subtitle: "Hours, billed & efficiency",
+    roles: ["mechanic"],
+    scopes: ["tech", "all"],
+    section: "Tech",
   },
-
 
   /* ---------------------------------------------------------------------- */
   /* WORKFORCE                                                               */
@@ -474,11 +505,19 @@ export const TILES: Tile[] = [
     section: "Billing",
   },
   {
-  title: "Reviews",
-  href: "/dashboard/reviews",
-  section: "Settings",
-  scopes: ["settings", "all"],
-  roles: ["owner", "admin", "manager", "advisor", "mechanic", "parts", "fleet_manager"],
-  cta: "Feedback",
+    title: "Reviews",
+    href: "/dashboard/reviews",
+    section: "Settings",
+    scopes: ["settings", "all"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "parts",
+      "fleet_manager",
+    ],
+    cta: "Feedback",
   },
 ];

--- a/features/shared/lib/ownerSidebarNav.ts
+++ b/features/shared/lib/ownerSidebarNav.ts
@@ -22,6 +22,7 @@ const OWNER_SECTION_OVERRIDES_BY_HREF: Record<string, string> = {
   "/work-orders/board": "Dashboard",
   "/dashboard/workforce/attendance": "Workforce",
   "/work-orders/create?autostart=1": "Operations",
+  "/estimates": "Operations",
   "/work-orders/view": "Operations",
   "/work-orders/quote-review": "Operations",
   "/customers/search": "Operations",
@@ -71,7 +72,9 @@ const OWNER_TITLE_OVERRIDES_BY_HREF: Record<string, string> = {
   "/parts/requests": "Parts Requests",
 };
 
-export function getOwnerTileOverrides(tile: Tile): Pick<Tile, "section" | "title"> {
+export function getOwnerTileOverrides(
+  tile: Tile,
+): Pick<Tile, "section" | "title"> {
   if (tile.href === "/dashboard/appointments" && tile.title === "Scheduling") {
     return { section: "People & Workforce", title: tile.title };
   }

--- a/features/shared/lib/rbac.ts
+++ b/features/shared/lib/rbac.ts
@@ -72,6 +72,8 @@ const ROLE_ALIASES: Record<string, CanonicalRole> = {
   manager: "manager",
   advisor: "advisor",
   service: "service",
+  service_advisor: "service",
+  "service advisor": "service",
   parts: "parts",
   mechanic: "mechanic",
   tech: "mechanic",
@@ -292,8 +294,12 @@ const FLEET_ROLE_ALIASES: Record<string, FleetRoleTier> = {
   owner: "manager",
 };
 
-export function canonicalizeRole(role: string | null | undefined): CanonicalRole {
-  const key = String(role ?? "").trim().toLowerCase();
+export function canonicalizeRole(
+  role: string | null | undefined,
+): CanonicalRole {
+  const key = String(role ?? "")
+    .trim()
+    .toLowerCase();
   return ROLE_ALIASES[key] ?? "unknown";
 }
 
@@ -316,8 +322,12 @@ export function canSendQuotes(role: string | null | undefined): boolean {
   return getActorCapabilities({ role }).canAuthorizeQuotes;
 }
 
-export function resolveFleetRoleTier(role: string | null | undefined): FleetRoleTier {
-  const key = String(role ?? "").trim().toLowerCase();
+export function resolveFleetRoleTier(
+  role: string | null | undefined,
+): FleetRoleTier {
+  const key = String(role ?? "")
+    .trim()
+    .toLowerCase();
   return FLEET_ROLE_ALIASES[key] ?? "none";
 }
 

--- a/features/shared/lib/routeMeta.ts
+++ b/features/shared/lib/routeMeta.ts
@@ -41,7 +41,18 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/dashboard": {
     title: () => "Shop Overview",
     icon: "🏠",
-    roles: ["owner", "admin", "manager", "advisor", "parts", "dispatcher", "driver", "fleet_manager", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "parts",
+      "dispatcher",
+      "driver",
+      "fleet_manager",
+      "lead_hand",
+      "foreman",
+    ],
   },
   // ----------------------------------------------------------------
   // Work Orders
@@ -49,27 +60,95 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/work-orders": {
     title: () => "Work Orders",
     icon: "📋",
-    roles: ["owner", "admin", "manager", "advisor", "service", "mechanic", "tech"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+      "mechanic",
+      "tech",
+    ],
   },
   "/work-orders/view": {
     title: () => "View Work Orders",
     icon: "📋",
-    roles: ["owner", "admin", "manager", "advisor", "service", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+      "lead_hand",
+      "foreman",
+    ],
   },
   "/work-orders/create": {
     title: () => "New Work Order",
     icon: "➕",
     roles: ["owner", "admin", "manager", "advisor", "service"],
   },
+  "/estimates": {
+    title: () => "Estimates",
+    icon: "🧾",
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+      "foreman",
+      "parts",
+      "lead_hand",
+    ],
+  },
+  "/estimates/new": {
+    title: () => "New Estimate",
+    icon: "➕",
+    roles: ["owner", "admin", "manager", "advisor", "service", "foreman"],
+  },
+  "/estimates/[id]": {
+    title: (href) => `Estimate · ${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
+    icon: "🧾",
+    persist: { keyParams: ["id"] },
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "service",
+      "foreman",
+      "parts",
+      "lead_hand",
+    ],
+  },
   "/work-orders/board": {
     title: () => "Work Order Board",
     icon: "📊",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "tech",
+      "lead_hand",
+      "foreman",
+    ],
   },
   "/work-orders/queue": {
     title: () => "Job Queue",
     icon: "🧰",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "tech",
+      "lead_hand",
+      "foreman",
+    ],
   },
   "/work-orders/quote-review": {
     title: () => "Quote Review",
@@ -119,12 +198,20 @@ export const ROUTE_META: Record<string, RouteMeta> = {
     title: (href) => `WO #${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
     icon: "🔧",
     persist: { keyParams: ["id"] },
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "tech",
+      "lead_hand",
+      "foreman",
+    ],
   },
 
   "/work-orders/view/[id]": {
-    title: (href) =>
-      `Work Order ${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
+    title: (href) => `Work Order ${href.split("/").pop()?.slice(0, 8) ?? "…"}`,
     icon: "🔧",
     showInTabs: false,
     persist: { keyParams: ["id"] },
@@ -154,19 +241,46 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/inspections": {
     title: () => "Inspections",
     icon: "📝",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "tech",
+      "lead_hand",
+      "foreman",
+    ],
   },
 
   // Runtime screens
   "/inspections/run": {
     title: () => "Run Inspection",
     icon: "📝",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "tech",
+      "lead_hand",
+      "foreman",
+    ],
   },
   "/inspections/fill": {
     title: () => "Inspection",
     icon: "📝",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "tech",
+      "lead_hand",
+      "foreman",
+    ],
   },
 
   // Inspection templates (tiles.ts uses /inspections/templates for this)
@@ -221,7 +335,16 @@ export const ROUTE_META: Record<string, RouteMeta> = {
       return `Inspection – ${nice}`;
     },
     icon: "📝",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "tech", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "tech",
+      "lead_hand",
+      "foreman",
+    ],
   },
 
   // ----------------------------------------------------------------
@@ -452,12 +575,28 @@ export const ROUTE_META: Record<string, RouteMeta> = {
   "/chat": {
     title: () => "Team Chat",
     icon: "💬",
-    roles: ["owner", "admin", "manager", "advisor", "mechanic", "parts", "tech"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "advisor",
+      "mechanic",
+      "parts",
+      "tech",
+    ],
   },
   "/tech/queue": {
     title: () => "Tech Job Queue",
     icon: "🧰",
-    roles: ["owner", "admin", "manager", "mechanic", "tech", "lead_hand", "foreman"],
+    roles: [
+      "owner",
+      "admin",
+      "manager",
+      "mechanic",
+      "tech",
+      "lead_hand",
+      "foreman",
+    ],
   },
   "/tech/performance": {
     title: () => "My Performance",
@@ -561,8 +700,7 @@ export function metaFor(
     }
   }
 
-  const last =
-    href.split("?")[0].split("/").filter(Boolean).pop() ?? href;
+  const last = href.split("?")[0].split("/").filter(Boolean).pop() ?? href;
   const nice = last
     .replace(/[-_]+/g, " ")
     .replace(/\b\w/g, (c) => c.toUpperCase());

--- a/features/shared/lib/server/admin-access.ts
+++ b/features/shared/lib/server/admin-access.ts
@@ -7,12 +7,23 @@ import {
   createServerSupabaseRSC,
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
-import { getActorCapabilities, type ActorCapabilities, type CanonicalRole } from "@/features/shared/lib/rbac";
-import { OWNER_PIN_PURPOSES, type OwnerPinPurpose, requireOwnerPinVerified } from "@/features/shared/lib/server/owner-pin";
+import {
+  getActorCapabilities,
+  type ActorCapabilities,
+  type CanonicalRole,
+} from "@/features/shared/lib/rbac";
+import {
+  OWNER_PIN_PURPOSES,
+  type OwnerPinPurpose,
+  requireOwnerPinVerified,
+} from "@/features/shared/lib/server/owner-pin";
 import { NextResponse } from "next/server";
 
 type DB = Database;
-type ProfileScope = Pick<DB["public"]["Tables"]["profiles"]["Row"], "id" | "role" | "shop_id">;
+type ProfileScope = Pick<
+  DB["public"]["Tables"]["profiles"]["Row"],
+  "id" | "role" | "shop_id" | "completed_onboarding" | "email" | "full_name"
+>;
 type ShopScopedProfile = Omit<ProfileScope, "shop_id"> & { shop_id: string };
 
 type CapabilityKey = keyof ActorCapabilities;
@@ -34,7 +45,7 @@ export async function resolveAuthenticatedStaffProfile(
 ): Promise<{ profile: ProfileScope | null; error: string | null }> {
   const byId = await supabase
     .from("profiles")
-    .select("id, role, shop_id")
+    .select("id, role, shop_id, completed_onboarding, email, full_name")
     .eq("id", authUserId)
     .maybeSingle<ProfileScope>();
 
@@ -52,7 +63,7 @@ export async function resolveAuthenticatedStaffProfile(
   // for this exact fallback lookup.
   const byAuthUser = await createAdminSupabase()
     .from("profiles")
-    .select("id, role, shop_id")
+    .select("id, role, shop_id, completed_onboarding, email, full_name")
     .eq("user_id", authUserId)
     .maybeSingle<ProfileScope>();
 
@@ -69,26 +80,28 @@ type ShopPageAccessOptions = {
   redirectTo?: string;
 };
 
-export async function requireShopPageAccess(options: ShopPageAccessOptions): Promise<{
+export async function requireShopPageAccess(
+  options: ShopPageAccessOptions,
+): Promise<{
   profile: ShopScopedProfile;
   canonicalRole: CanonicalRole;
 }> {
   const supabase = createServerSupabaseRSC();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   if (!user) {
     redirect("/sign-in");
   }
 
-  const { profile } = await resolveAuthenticatedStaffProfile(
-    supabase,
-    user.id,
-  );
+  const { profile } = await resolveAuthenticatedStaffProfile(supabase, user.id);
 
   const actor = getActorCapabilities({ role: profile?.role });
   const role = actor.canonicalRole;
   const allowedRole = !options.allowRoles || options.allowRoles.includes(role);
-  const allowedCapability = !options.requiredCapability || actor[options.requiredCapability];
+  const allowedCapability =
+    !options.requiredCapability || actor[options.requiredCapability];
   const allowedCapabilities =
     !options.requiredCapabilities?.length ||
     options.requiredCapabilities.every((capability) => actor[capability]);
@@ -129,7 +142,9 @@ type ApiAccessOptions = {
   ownerPinAllowedPurposes?: OwnerPinPurpose[];
 };
 
-export async function requireShopScopedApiAccess(options: ApiAccessOptions = {}): Promise<
+export async function requireShopScopedApiAccess(
+  options: ApiAccessOptions = {},
+): Promise<
   | {
       ok: true;
       profile: ShopScopedProfile;
@@ -140,17 +155,34 @@ export async function requireShopScopedApiAccess(options: ApiAccessOptions = {})
   | { ok: false; response: NextResponse }
 > {
   const supabase = createServerSupabaseRoute();
-  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+  const {
+    data: { user },
+    error: userErr,
+  } = await supabase.auth.getUser();
 
   if (userErr || !user) {
-    return { ok: false, response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Not authenticated" },
+        { status: 401 },
+      ),
+    };
   }
 
-  const { profile, error: profileErr } =
-    await resolveAuthenticatedStaffProfile(supabase, user.id);
+  const { profile, error: profileErr } = await resolveAuthenticatedStaffProfile(
+    supabase,
+    user.id,
+  );
 
   if (profileErr || !profile || !profile.shop_id) {
-    return { ok: false, response: NextResponse.json({ error: "Profile for current user not found" }, { status: 403 }) };
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Profile for current user not found" },
+        { status: 403 },
+      ),
+    };
   }
 
   const actor = getActorCapabilities({ role: profile.role });
@@ -159,15 +191,24 @@ export async function requireShopScopedApiAccess(options: ApiAccessOptions = {})
   // This is a staff/shop boundary helper. Unrecognized profile roles must never
   // inherit access merely because the profile happens to contain a shop_id.
   if (!actor.isKnownRole) {
-    return { ok: false, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
   }
 
   if (options.allowRoles && !options.allowRoles.includes(canonicalRole)) {
-    return { ok: false, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
   }
 
   if (options.requiredCapability && !actor[options.requiredCapability]) {
-    return { ok: false, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
   }
 
   if (options.requiredCapabilities?.length) {
@@ -176,19 +217,34 @@ export async function requireShopScopedApiAccess(options: ApiAccessOptions = {})
     );
 
     if (!hasAllRequiredCapabilities) {
-      return { ok: false, response: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+      return {
+        ok: false,
+        response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+      };
     }
   }
 
   if (options.requireOwnerPin) {
     if (!options.ownerPinRequest) {
-      return { ok: false, response: NextResponse.json({ error: "Owner PIN request context missing" }, { status: 500 }) };
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { error: "Owner PIN request context missing" },
+          { status: 500 },
+        ),
+      };
     }
-    const pinCheck = await requireOwnerPinVerified(options.ownerPinRequest, supabase as never, {
-      shopId: profile.shop_id,
-      userId: user.id,
-      allowedPurposes: options.ownerPinAllowedPurposes ?? [OWNER_PIN_PURPOSES.PRIVILEGED],
-    });
+    const pinCheck = await requireOwnerPinVerified(
+      options.ownerPinRequest,
+      supabase as never,
+      {
+        shopId: profile.shop_id,
+        userId: user.id,
+        allowedPurposes: options.ownerPinAllowedPurposes ?? [
+          OWNER_PIN_PURPOSES.PRIVILEGED,
+        ],
+      },
+    );
     if (!pinCheck.ok) return { ok: false, response: pinCheck.response };
   }
 

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -3221,121 +3221,6 @@ export type Database = {
         }
         Relationships: []
       }
-      estimate_internal_details: {
-        Row: {
-          created_at: string
-          line_notes: Json
-          notes: string | null
-          shop_id: string
-          updated_at: string
-          work_order_id: string
-        }
-        Insert: {
-          created_at?: string
-          line_notes?: Json
-          notes?: string | null
-          shop_id: string
-          updated_at?: string
-          work_order_id: string
-        }
-        Update: {
-          created_at?: string
-          line_notes?: Json
-          notes?: string | null
-          shop_id?: string
-          updated_at?: string
-          work_order_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "estimate_internal_details_shop_id_fkey"
-            columns: ["shop_id"]
-            isOneToOne: false
-            referencedRelation: "shops"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "estimate_internal_details_work_order_id_fkey"
-            columns: ["work_order_id"]
-            isOneToOne: true
-            referencedRelation: "work_orders"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      estimate_events: {
-        Row: {
-          actor_profile_id: string | null
-          changed_quote_line_ids: string[]
-          created_at: string
-          event_type: string
-          id: string
-          idempotency_key: string
-          note: string | null
-          reason_code: string | null
-          result: Json
-          revision: number
-          shop_id: string
-          snapshot: Json
-          updated_at: string
-          work_order_id: string | null
-        }
-        Insert: {
-          actor_profile_id?: string | null
-          changed_quote_line_ids?: string[]
-          created_at?: string
-          event_type: string
-          id?: string
-          idempotency_key: string
-          note?: string | null
-          reason_code?: string | null
-          result?: Json
-          revision: number
-          shop_id: string
-          snapshot?: Json
-          updated_at?: string
-          work_order_id?: string | null
-        }
-        Update: {
-          actor_profile_id?: string | null
-          changed_quote_line_ids?: string[]
-          created_at?: string
-          event_type?: string
-          id?: string
-          idempotency_key?: string
-          note?: string | null
-          reason_code?: string | null
-          result?: Json
-          revision?: number
-          shop_id?: string
-          snapshot?: Json
-          updated_at?: string
-          work_order_id?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "estimate_events_actor_profile_id_fkey"
-            columns: ["actor_profile_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "estimate_events_shop_id_fkey"
-            columns: ["shop_id"]
-            isOneToOne: false
-            referencedRelation: "shops"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "estimate_events_work_order_id_fkey"
-            columns: ["work_order_id"]
-            isOneToOne: false
-            referencedRelation: "work_orders"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       employee_documents: {
         Row: {
           bucket_id: string
@@ -3409,6 +3294,191 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      estimate_events: {
+        Row: {
+          actor_profile_id: string | null
+          changed_quote_line_ids: string[]
+          created_at: string
+          event_type: string
+          id: string
+          idempotency_key: string
+          note: string | null
+          reason_code: string | null
+          result: Json
+          revision: number
+          shop_id: string
+          snapshot: Json
+          updated_at: string
+          work_order_id: string | null
+        }
+        Insert: {
+          actor_profile_id?: string | null
+          changed_quote_line_ids?: string[]
+          created_at?: string
+          event_type: string
+          id?: string
+          idempotency_key: string
+          note?: string | null
+          reason_code?: string | null
+          result?: Json
+          revision: number
+          shop_id: string
+          snapshot?: Json
+          updated_at?: string
+          work_order_id?: string | null
+        }
+        Update: {
+          actor_profile_id?: string | null
+          changed_quote_line_ids?: string[]
+          created_at?: string
+          event_type?: string
+          id?: string
+          idempotency_key?: string
+          note?: string | null
+          reason_code?: string | null
+          result?: Json
+          revision?: number
+          shop_id?: string
+          snapshot?: Json
+          updated_at?: string
+          work_order_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "estimate_events_actor_profile_id_fkey"
+            columns: ["actor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "estimate_events_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "estimate_events_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "estimate_events_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "v_portal_invoices"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "estimate_events_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "v_work_order_board_cards_fleet"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "estimate_events_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "v_work_order_board_cards_portal"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "estimate_events_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "v_work_order_board_cards_shop"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "estimate_events_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "work_orders"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      estimate_internal_details: {
+        Row: {
+          created_at: string
+          line_notes: Json
+          notes: string | null
+          shop_id: string
+          updated_at: string
+          work_order_id: string
+        }
+        Insert: {
+          created_at?: string
+          line_notes?: Json
+          notes?: string | null
+          shop_id: string
+          updated_at?: string
+          work_order_id: string
+        }
+        Update: {
+          created_at?: string
+          line_notes?: Json
+          notes?: string | null
+          shop_id?: string
+          updated_at?: string
+          work_order_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "estimate_internal_details_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "estimate_internal_details_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "estimate_internal_details_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: true
+            referencedRelation: "v_portal_invoices"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "estimate_internal_details_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: true
+            referencedRelation: "v_work_order_board_cards_fleet"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "estimate_internal_details_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: true
+            referencedRelation: "v_work_order_board_cards_portal"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "estimate_internal_details_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: true
+            referencedRelation: "v_work_order_board_cards_shop"
+            referencedColumns: ["work_order_id"]
+          },
+          {
+            foreignKeyName: "estimate_internal_details_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: true
+            referencedRelation: "work_orders"
             referencedColumns: ["id"]
           },
         ]
@@ -8718,8 +8788,8 @@ export type Database = {
           quote_line_id: string | null
           requested_by: string | null
           shop_id: string
-          source_menu_item_id: string | null
           source_context: string | null
+          source_menu_item_id: string | null
           source_revision: number | null
           status: Database["public"]["Enums"]["part_request_status"]
           work_order_id: string | null
@@ -8735,8 +8805,8 @@ export type Database = {
           quote_line_id?: string | null
           requested_by?: string | null
           shop_id: string
-          source_menu_item_id?: string | null
           source_context?: string | null
+          source_menu_item_id?: string | null
           source_revision?: number | null
           status?: Database["public"]["Enums"]["part_request_status"]
           work_order_id?: string | null
@@ -8752,8 +8822,8 @@ export type Database = {
           quote_line_id?: string | null
           requested_by?: string | null
           shop_id?: string
-          source_menu_item_id?: string | null
           source_context?: string | null
+          source_menu_item_id?: string | null
           source_revision?: number | null
           status?: Database["public"]["Enums"]["part_request_status"]
           work_order_id?: string | null
@@ -21315,7 +21385,6 @@ export type Database = {
           customer_id: string | null
           customer_name: string | null
           customer_signature_url: string | null
-          expected_completion_at: string | null
           estimate_authorized_at: string | null
           estimate_converted_at: string | null
           estimate_created_at: string | null
@@ -21328,6 +21397,7 @@ export type Database = {
           estimate_sent_at: string | null
           estimate_sent_by: string | null
           estimate_status: string | null
+          expected_completion_at: string | null
           external_id: string | null
           id: string
           import_confidence: number | null
@@ -21401,7 +21471,6 @@ export type Database = {
           customer_id?: string | null
           customer_name?: string | null
           customer_signature_url?: string | null
-          expected_completion_at?: string | null
           estimate_authorized_at?: string | null
           estimate_converted_at?: string | null
           estimate_created_at?: string | null
@@ -21414,6 +21483,7 @@ export type Database = {
           estimate_sent_at?: string | null
           estimate_sent_by?: string | null
           estimate_status?: string | null
+          expected_completion_at?: string | null
           external_id?: string | null
           id?: string
           import_confidence?: number | null
@@ -21487,7 +21557,6 @@ export type Database = {
           customer_id?: string | null
           customer_name?: string | null
           customer_signature_url?: string | null
-          expected_completion_at?: string | null
           estimate_authorized_at?: string | null
           estimate_converted_at?: string | null
           estimate_created_at?: string | null
@@ -21500,6 +21569,7 @@ export type Database = {
           estimate_sent_at?: string | null
           estimate_sent_by?: string | null
           estimate_status?: string | null
+          expected_completion_at?: string | null
           external_id?: string | null
           id?: string
           import_confidence?: number | null
@@ -21564,6 +21634,27 @@ export type Database = {
             columns: ["customer_id"]
             isOneToOne: false
             referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_orders_estimate_created_by_fkey"
+            columns: ["estimate_created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_orders_estimate_parts_completed_by_fkey"
+            columns: ["estimate_parts_completed_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "work_orders_estimate_sent_by_fkey"
+            columns: ["estimate_sent_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
           {
@@ -22725,86 +22816,6 @@ export type Database = {
     }
     Functions: {
       _ensure_same_shop: { Args: { _wo: string }; Returns: boolean }
-      complete_estimate_parts_quote_atomic: {
-        Args: {
-          p_expected_revision: number
-          p_idempotency_key: string
-          p_shop_id: string
-          p_work_order_id: string
-        }
-        Returns: Json
-      }
-      create_estimate_atomic: {
-        Args: {
-          p_customer: Json
-          p_expires_at: string | null
-          p_idempotency_key: string
-          p_lines: Json
-          p_notes: string | null
-          p_shop_id: string
-          p_vehicle: Json
-        }
-        Returns: Json
-      }
-      finalize_estimate_send_atomic: {
-        Args: {
-          p_actor_profile_id: string
-          p_actor_user_id: string
-          p_event_id: string
-          p_quote_url: string
-          p_revision: number
-          p_sent_at: string
-          p_shop_id: string
-          p_work_order_id: string
-        }
-        Returns: Json
-      }
-      reserve_estimate_send_atomic: {
-        Args: {
-          p_actor_profile_id: string
-          p_actor_user_id: string
-          p_allow_resend: boolean
-          p_idempotency_key: string
-          p_quote_line_ids: string[]
-          p_revision: number
-          p_shop_id: string
-          p_work_order_id: string
-        }
-        Returns: Json
-      }
-      return_estimate_to_parts_atomic: {
-        Args: {
-          p_expected_revision: number
-          p_idempotency_key: string
-          p_note: string | null
-          p_quote_line_ids: string[]
-          p_reason_code: string
-          p_shop_id: string
-          p_work_order_id: string
-        }
-        Returns: Json
-      }
-      save_estimate_draft_atomic: {
-        Args: {
-          p_expected_revision: number
-          p_expires_at: string | null
-          p_idempotency_key: string
-          p_lines: Json
-          p_notes: string | null
-          p_shop_id: string
-          p_work_order_id: string
-        }
-        Returns: Json
-      }
-      submit_estimate_to_parts_atomic: {
-        Args: {
-          p_expected_revision: number
-          p_idempotency_key: string
-          p_shop_id: string
-          p_work_order_id: string
-        }
-        Returns: Json
-      }
       accept_customer_portal_invite_atomic: {
         Args: {
           p_actor_email: string
@@ -23267,6 +23278,37 @@ export type Database = {
         Args: { target_profile_id: string }
         Returns: boolean
       }
+      can_read_estimate_internal_details: {
+        Args: { p_shop_id: string }
+        Returns: boolean
+      }
+      can_select_estimate_quote_line: {
+        Args: {
+          p_approved_at: string
+          p_declined_at: string
+          p_deferred_at: string
+          p_sent_to_customer_at: string
+          p_shop_id: string
+          p_stage: string
+          p_status: string
+          p_work_order_id: string
+          p_work_order_line_id: string
+        }
+        Returns: boolean
+      }
+      can_select_estimate_work_order: {
+        Args: {
+          p_customer_id: string
+          p_estimate_number: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: boolean
+      }
+      can_update_estimate_part_request_items: {
+        Args: { p_shop_id: string }
+        Returns: boolean
+      }
       can_update_part_request_items: {
         Args: { p_shop_id: string }
         Returns: boolean
@@ -23407,6 +23449,15 @@ export type Database = {
           user_id: string
         }[]
       }
+      complete_estimate_parts_quote_atomic: {
+        Args: {
+          p_expected_revision: number
+          p_idempotency_key: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
       complete_financial_outbox_claim: {
         Args: { p_outbox_id: string; p_worker_id: string }
         Returns: boolean
@@ -23470,6 +23521,18 @@ export type Database = {
           p_started_at: string
           p_technician_id: string
           p_work_order_line_id: string
+        }
+        Returns: Json
+      }
+      create_estimate_atomic: {
+        Args: {
+          p_customer: Json
+          p_expires_at: string
+          p_idempotency_key: string
+          p_lines: Json
+          p_notes: string
+          p_shop_id: string
+          p_vehicle: Json
         }
         Returns: Json
       }
@@ -23565,6 +23628,18 @@ export type Database = {
           customer_id: string | null
           customer_name: string | null
           customer_signature_url: string | null
+          estimate_authorized_at: string | null
+          estimate_converted_at: string | null
+          estimate_created_at: string | null
+          estimate_created_by: string | null
+          estimate_expires_at: string | null
+          estimate_number: string | null
+          estimate_parts_completed_at: string | null
+          estimate_parts_completed_by: string | null
+          estimate_revision: number
+          estimate_sent_at: string | null
+          estimate_sent_by: string | null
+          estimate_status: string | null
           expected_completion_at: string | null
           external_id: string | null
           id: string
@@ -23594,6 +23669,7 @@ export type Database = {
           priority: number | null
           quote: Json | null
           quote_url: string | null
+          record_type: string
           scheduled_at: string | null
           shop_id: string
           shop_supplies_amount_override: number | null
@@ -23640,6 +23716,13 @@ export type Database = {
         }
         Returns: Json
       }
+      estimate_actor_for_shop: {
+        Args: { p_allowed_roles: string[]; p_shop_id: string }
+        Returns: {
+          canonical_role: string
+          profile_id: string
+        }[]
+      }
       evaluate_fleet_pm_due_events: {
         Args: { p_fleet_id: string; p_vehicle_id?: string }
         Returns: {
@@ -23652,6 +23735,19 @@ export type Database = {
       fail_stripe_webhook_event: {
         Args: { p_claim_token: string; p_error: string; p_event_id: string }
         Returns: boolean
+      }
+      finalize_estimate_send_atomic: {
+        Args: {
+          p_actor_profile_id: string
+          p_actor_user_id: string
+          p_event_id: string
+          p_quote_url: string
+          p_revision: number
+          p_sent_at: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
       }
       finalize_inspection_pdf_atomic: {
         Args: {
@@ -24296,6 +24392,10 @@ export type Database = {
       profixiq_workforce_profile_id: { Args: never; Returns: string }
       profixiq_workforce_role: { Args: never; Returns: string }
       profixiq_workforce_shop_id: { Args: never; Returns: string }
+      recalculate_estimate_work_order_totals: {
+        Args: { p_shop_id: string; p_work_order_id: string }
+        Returns: undefined
+      }
       receive_part_request_item: {
         Args: {
           p_idempotency_key?: string
@@ -24406,6 +24506,31 @@ export type Database = {
         }
         Returns: Json
       }
+      reserve_estimate_send_atomic: {
+        Args: {
+          p_actor_profile_id: string
+          p_actor_user_id: string
+          p_allow_resend: boolean
+          p_idempotency_key: string
+          p_quote_line_ids: string[]
+          p_revision: number
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
+      return_estimate_to_parts_atomic: {
+        Args: {
+          p_expected_revision: number
+          p_idempotency_key: string
+          p_note: string
+          p_quote_line_ids: string[]
+          p_reason_code: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
       review_menu_item_part_intake: {
         Args: {
           p_actor_auth_user_id: string
@@ -24416,6 +24541,18 @@ export type Database = {
           p_request_item_id: string
           p_shop_id: string
           p_unit_cost: number
+        }
+        Returns: Json
+      }
+      save_estimate_draft_atomic: {
+        Args: {
+          p_expected_revision: number
+          p_expires_at: string
+          p_idempotency_key: string
+          p_lines: Json
+          p_notes: string
+          p_shop_id: string
+          p_work_order_id: string
         }
         Returns: Json
       }
@@ -24641,6 +24778,15 @@ export type Database = {
           user_id: string
         }[]
       }
+      submit_estimate_to_parts_atomic: {
+        Args: {
+          p_expected_revision: number
+          p_idempotency_key: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
       submit_staff_time_off_request: {
         Args: {
           p_actor_profile_id: string
@@ -24730,6 +24876,7 @@ export type Database = {
         Returns: Json
       }
       user_is_in_shop: { Args: { target_shop_id: string }; Returns: boolean }
+      validate_estimate_lines: { Args: { p_lines: Json }; Returns: undefined }
       void_invoice_version: {
         Args: {
           p_actor_user_id: string
@@ -25403,3 +25550,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -3221,6 +3221,121 @@ export type Database = {
         }
         Relationships: []
       }
+      estimate_internal_details: {
+        Row: {
+          created_at: string
+          line_notes: Json
+          notes: string | null
+          shop_id: string
+          updated_at: string
+          work_order_id: string
+        }
+        Insert: {
+          created_at?: string
+          line_notes?: Json
+          notes?: string | null
+          shop_id: string
+          updated_at?: string
+          work_order_id: string
+        }
+        Update: {
+          created_at?: string
+          line_notes?: Json
+          notes?: string | null
+          shop_id?: string
+          updated_at?: string
+          work_order_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "estimate_internal_details_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "estimate_internal_details_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: true
+            referencedRelation: "work_orders"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      estimate_events: {
+        Row: {
+          actor_profile_id: string | null
+          changed_quote_line_ids: string[]
+          created_at: string
+          event_type: string
+          id: string
+          idempotency_key: string
+          note: string | null
+          reason_code: string | null
+          result: Json
+          revision: number
+          shop_id: string
+          snapshot: Json
+          updated_at: string
+          work_order_id: string | null
+        }
+        Insert: {
+          actor_profile_id?: string | null
+          changed_quote_line_ids?: string[]
+          created_at?: string
+          event_type: string
+          id?: string
+          idempotency_key: string
+          note?: string | null
+          reason_code?: string | null
+          result?: Json
+          revision: number
+          shop_id: string
+          snapshot?: Json
+          updated_at?: string
+          work_order_id?: string | null
+        }
+        Update: {
+          actor_profile_id?: string | null
+          changed_quote_line_ids?: string[]
+          created_at?: string
+          event_type?: string
+          id?: string
+          idempotency_key?: string
+          note?: string | null
+          reason_code?: string | null
+          result?: Json
+          revision?: number
+          shop_id?: string
+          snapshot?: Json
+          updated_at?: string
+          work_order_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "estimate_events_actor_profile_id_fkey"
+            columns: ["actor_profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "estimate_events_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "estimate_events_work_order_id_fkey"
+            columns: ["work_order_id"]
+            isOneToOne: false
+            referencedRelation: "work_orders"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       employee_documents: {
         Row: {
           bucket_id: string
@@ -8332,6 +8447,7 @@ export type Database = {
           requested_part_number: string | null
           shop_id: string | null
           source_menu_item_part_id: string | null
+          source_row_id: string | null
           source_work_order_part_id: string | null
           status: Database["public"]["Enums"]["part_request_item_status"]
           unit_cost: number | null
@@ -8369,6 +8485,7 @@ export type Database = {
           requested_part_number?: string | null
           shop_id?: string | null
           source_menu_item_part_id?: string | null
+          source_row_id?: string | null
           source_work_order_part_id?: string | null
           status?: Database["public"]["Enums"]["part_request_item_status"]
           unit_cost?: number | null
@@ -8406,6 +8523,7 @@ export type Database = {
           requested_part_number?: string | null
           shop_id?: string | null
           source_menu_item_part_id?: string | null
+          source_row_id?: string | null
           source_work_order_part_id?: string | null
           status?: Database["public"]["Enums"]["part_request_item_status"]
           unit_cost?: number | null
@@ -8601,6 +8719,8 @@ export type Database = {
           requested_by: string | null
           shop_id: string
           source_menu_item_id: string | null
+          source_context: string | null
+          source_revision: number | null
           status: Database["public"]["Enums"]["part_request_status"]
           work_order_id: string | null
         }
@@ -8616,6 +8736,8 @@ export type Database = {
           requested_by?: string | null
           shop_id: string
           source_menu_item_id?: string | null
+          source_context?: string | null
+          source_revision?: number | null
           status?: Database["public"]["Enums"]["part_request_status"]
           work_order_id?: string | null
         }
@@ -8631,6 +8753,8 @@ export type Database = {
           requested_by?: string | null
           shop_id?: string
           source_menu_item_id?: string | null
+          source_context?: string | null
+          source_revision?: number | null
           status?: Database["public"]["Enums"]["part_request_status"]
           work_order_id?: string | null
         }
@@ -21192,6 +21316,18 @@ export type Database = {
           customer_name: string | null
           customer_signature_url: string | null
           expected_completion_at: string | null
+          estimate_authorized_at: string | null
+          estimate_converted_at: string | null
+          estimate_created_at: string | null
+          estimate_created_by: string | null
+          estimate_expires_at: string | null
+          estimate_number: string | null
+          estimate_parts_completed_at: string | null
+          estimate_parts_completed_by: string | null
+          estimate_revision: number
+          estimate_sent_at: string | null
+          estimate_sent_by: string | null
+          estimate_status: string | null
           external_id: string | null
           id: string
           import_confidence: number | null
@@ -21220,6 +21356,7 @@ export type Database = {
           priority: number | null
           quote: Json | null
           quote_url: string | null
+          record_type: string
           scheduled_at: string | null
           shop_id: string
           shop_supplies_amount_override: number | null
@@ -21265,6 +21402,18 @@ export type Database = {
           customer_name?: string | null
           customer_signature_url?: string | null
           expected_completion_at?: string | null
+          estimate_authorized_at?: string | null
+          estimate_converted_at?: string | null
+          estimate_created_at?: string | null
+          estimate_created_by?: string | null
+          estimate_expires_at?: string | null
+          estimate_number?: string | null
+          estimate_parts_completed_at?: string | null
+          estimate_parts_completed_by?: string | null
+          estimate_revision?: number
+          estimate_sent_at?: string | null
+          estimate_sent_by?: string | null
+          estimate_status?: string | null
           external_id?: string | null
           id?: string
           import_confidence?: number | null
@@ -21293,6 +21442,7 @@ export type Database = {
           priority?: number | null
           quote?: Json | null
           quote_url?: string | null
+          record_type?: string
           scheduled_at?: string | null
           shop_id: string
           shop_supplies_amount_override?: number | null
@@ -21338,6 +21488,18 @@ export type Database = {
           customer_name?: string | null
           customer_signature_url?: string | null
           expected_completion_at?: string | null
+          estimate_authorized_at?: string | null
+          estimate_converted_at?: string | null
+          estimate_created_at?: string | null
+          estimate_created_by?: string | null
+          estimate_expires_at?: string | null
+          estimate_number?: string | null
+          estimate_parts_completed_at?: string | null
+          estimate_parts_completed_by?: string | null
+          estimate_revision?: number
+          estimate_sent_at?: string | null
+          estimate_sent_by?: string | null
+          estimate_status?: string | null
           external_id?: string | null
           id?: string
           import_confidence?: number | null
@@ -21366,6 +21528,7 @@ export type Database = {
           priority?: number | null
           quote?: Json | null
           quote_url?: string | null
+          record_type?: string
           scheduled_at?: string | null
           shop_id?: string
           shop_supplies_amount_override?: number | null
@@ -22562,6 +22725,86 @@ export type Database = {
     }
     Functions: {
       _ensure_same_shop: { Args: { _wo: string }; Returns: boolean }
+      complete_estimate_parts_quote_atomic: {
+        Args: {
+          p_expected_revision: number
+          p_idempotency_key: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
+      create_estimate_atomic: {
+        Args: {
+          p_customer: Json
+          p_expires_at: string | null
+          p_idempotency_key: string
+          p_lines: Json
+          p_notes: string | null
+          p_shop_id: string
+          p_vehicle: Json
+        }
+        Returns: Json
+      }
+      finalize_estimate_send_atomic: {
+        Args: {
+          p_actor_profile_id: string
+          p_actor_user_id: string
+          p_event_id: string
+          p_quote_url: string
+          p_revision: number
+          p_sent_at: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
+      reserve_estimate_send_atomic: {
+        Args: {
+          p_actor_profile_id: string
+          p_actor_user_id: string
+          p_allow_resend: boolean
+          p_idempotency_key: string
+          p_quote_line_ids: string[]
+          p_revision: number
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
+      return_estimate_to_parts_atomic: {
+        Args: {
+          p_expected_revision: number
+          p_idempotency_key: string
+          p_note: string | null
+          p_quote_line_ids: string[]
+          p_reason_code: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
+      save_estimate_draft_atomic: {
+        Args: {
+          p_expected_revision: number
+          p_expires_at: string | null
+          p_idempotency_key: string
+          p_lines: Json
+          p_notes: string | null
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
+      submit_estimate_to_parts_atomic: {
+        Args: {
+          p_expected_revision: number
+          p_idempotency_key: string
+          p_shop_id: string
+          p_work_order_id: string
+        }
+        Returns: Json
+      }
       accept_customer_portal_invite_atomic: {
         Args: {
           p_actor_email: string
@@ -23009,6 +23252,15 @@ export type Database = {
       }
       can_access_conversation: {
         Args: { actor_user_id?: string; target_conversation_id: string }
+        Returns: boolean
+      }
+      can_access_estimate_quote_line: {
+        Args: {
+          p_action: string
+          p_metadata: Json
+          p_shop_id: string
+          p_work_order_id: string
+        }
         Returns: boolean
       }
       can_manage_profile: {
@@ -25151,4 +25403,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/features/work-orders/quote-review/partsModel.test.ts
+++ b/features/work-orders/quote-review/partsModel.test.ts
@@ -1,14 +1,25 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
-import { resolveQuoteLineParts, quoteLineTotalResolved, type CatalogPart, type PartRequestItem, type QuoteLine } from "./partsModel";
+import {
+  resolveQuoteLineParts,
+  quoteLineTotalResolved,
+  type CatalogPart,
+  type PartRequestItem,
+  type QuoteLine,
+} from "./partsModel";
 import type { Json } from "@shared/types/types/supabase";
 
-const quoteLine = (metadata: Json | null = null): Pick<QuoteLine, "id" | "metadata"> => ({ id: "ql-1", metadata });
+const quoteLine = (
+  metadata: Json | null = null,
+): Pick<QuoteLine, "id" | "metadata"> => ({ id: "ql-1", metadata });
 
-const liveItem = (overrides: Partial<PartRequestItem> = {}): PartRequestItem => ({
+const liveItem = (
+  overrides: Partial<PartRequestItem> = {},
+): PartRequestItem => ({
   id: "pri-1",
   request_id: "pr-1",
   shop_id: "shop-1",
+  source_row_id: null,
   source_menu_item_part_id: null,
   source_work_order_part_id: null,
   work_order_id: "wo-1",
@@ -46,90 +57,220 @@ const liveItem = (overrides: Partial<PartRequestItem> = {}): PartRequestItem => 
 
 describe("Quote Review parts model", () => {
   it("renders live linked request item description and quantity", () => {
-    const parts = resolveQuoteLineParts({ line: quoteLine(), liveItems: [liveItem()] });
-    expect(parts).toMatchObject([{ description: "Brake fluid", quantity: 1, source: "live_request_item" }]);
+    const parts = resolveQuoteLineParts({
+      line: quoteLine(),
+      liveItems: [liveItem()],
+    });
+    expect(parts).toMatchObject([
+      { description: "Brake fluid", quantity: 1, source: "live_request_item" },
+    ]);
   });
 
   it("renders generic required part with null part_id and null price", () => {
-    const parts = resolveQuoteLineParts({ line: quoteLine(), liveItems: [liveItem({ part_id: null, unit_price: null, quoted_price: null })] });
-    expect(parts[0]).toMatchObject({ selectedPartId: null, pricingState: "unresolved" });
+    const parts = resolveQuoteLineParts({
+      line: quoteLine(),
+      liveItems: [
+        liveItem({ part_id: null, unit_price: null, quoted_price: null }),
+      ],
+    });
+    expect(parts[0]).toMatchObject({
+      selectedPartId: null,
+      pricingState: "unresolved",
+    });
   });
 
   it("displays selected inventory identity separately from requested description", () => {
-    const selected: CatalogPart = { id: "part-1", name: "Motorcraft BRF-1847", sku: "BRF-1847", part_number: "BRF1847", supplier: "Ford Dealer" };
+    const selected: CatalogPart = {
+      id: "part-1",
+      name: "Motorcraft BRF-1847",
+      sku: "BRF-1847",
+      part_number: "BRF1847",
+      supplier: "Ford Dealer",
+    };
     const parts = resolveQuoteLineParts({
       line: quoteLine(),
-      liveItems: [liveItem({ description: "Front brake pads", part_id: "part-1" })],
+      liveItems: [
+        liveItem({ description: "Front brake pads", part_id: "part-1" }),
+      ],
       selectedParts: new Map([[selected.id, selected]]),
     });
-    expect(parts[0]).toMatchObject({ description: "Front brake pads", selectedPartName: "Motorcraft BRF-1847", selectedPartNumber: "BRF1847", supplier: "Ford Dealer" });
+    expect(parts[0]).toMatchObject({
+      description: "Front brake pads",
+      selectedPartName: "Motorcraft BRF-1847",
+      selectedPartNumber: "BRF1847",
+      supplier: "Ford Dealer",
+    });
   });
 
   it("uses metadata.parts_quote.items when live item hydration is unavailable", () => {
-    const parts = resolveQuoteLineParts({ line: quoteLine({ parts_quote: { items: [{ id: "pri-1", request_id: "pr-1", description: "Brake fluid", qty: 1, status: "requested" }] } }) });
-    expect(parts).toMatchObject([{ requestItemId: "pri-1", requestId: "pr-1", description: "Brake fluid", source: "synced_metadata" }]);
+    const parts = resolveQuoteLineParts({
+      line: quoteLine({
+        parts_quote: {
+          items: [
+            {
+              id: "pri-1",
+              request_id: "pr-1",
+              description: "Brake fluid",
+              qty: 1,
+              status: "requested",
+            },
+          ],
+        },
+      }),
+    });
+    expect(parts).toMatchObject([
+      {
+        requestItemId: "pri-1",
+        requestId: "pr-1",
+        description: "Brake fluid",
+        source: "synced_metadata",
+      },
+    ]);
   });
 
   it("uses metadata.parts as final technician-truth fallback", () => {
-    const parts = resolveQuoteLineParts({ line: quoteLine({ parts: [{ description: "Front brake pads", qty: 1 }] }) });
-    expect(parts).toMatchObject([{ description: "Front brake pads", quantity: 1, source: "technician_snapshot" }]);
+    const parts = resolveQuoteLineParts({
+      line: quoteLine({ parts: [{ description: "Front brake pads", qty: 1 }] }),
+    });
+    expect(parts).toMatchObject([
+      {
+        description: "Front brake pads",
+        quantity: 1,
+        source: "technician_snapshot",
+      },
+    ]);
   });
 
   it("live request item takes precedence over metadata fallbacks", () => {
     const parts = resolveQuoteLineParts({
-      line: quoteLine({ parts_quote: { items: [{ id: "pri-1", request_id: "pr-1", description: "Old", qty: 1 }] }, parts: [{ description: "Older", qty: 1 }] }),
+      line: quoteLine({
+        parts_quote: {
+          items: [
+            { id: "pri-1", request_id: "pr-1", description: "Old", qty: 1 },
+          ],
+        },
+        parts: [{ description: "Older", qty: 1 }],
+      }),
       liveItems: [liveItem({ description: "Live" })],
     });
     expect(parts).toHaveLength(1);
-    expect(parts[0]).toMatchObject({ description: "Live", source: "live_request_item" });
+    expect(parts[0]).toMatchObject({
+      description: "Live",
+      source: "live_request_item",
+    });
   });
 
   it("duplicate fallback representations produce one displayed part", () => {
-    const parts = resolveQuoteLineParts({ line: quoteLine({ parts_quote: { items: [
-      { id: "pri-1", request_id: "pr-1", description: "Brake fluid", qty: 1 },
-      { id: "pri-1", request_id: "pr-1", description: "Brake fluid", qty: 1 },
-    ] } }) });
+    const parts = resolveQuoteLineParts({
+      line: quoteLine({
+        parts_quote: {
+          items: [
+            {
+              id: "pri-1",
+              request_id: "pr-1",
+              description: "Brake fluid",
+              qty: 1,
+            },
+            {
+              id: "pri-1",
+              request_id: "pr-1",
+              description: "Brake fluid",
+              qty: 1,
+            },
+          ],
+        },
+      }),
+    });
     expect(parts).toHaveLength(1);
   });
 
   it("no-parts diagnosis resolves no required parts", () => {
-    expect(resolveQuoteLineParts({ line: quoteLine({ parts: [] }) })).toEqual([]);
+    expect(resolveQuoteLineParts({ line: quoteLine({ parts: [] }) })).toEqual(
+      [],
+    );
   });
 
   it("does not create AI part fallback", () => {
-    expect(resolveQuoteLineParts({ line: quoteLine({ ai_parts: [{ description: "AI part", qty: 1 }] } as Json) })).toEqual([]);
+    expect(
+      resolveQuoteLineParts({
+        line: quoteLine({
+          ai_parts: [{ description: "AI part", qty: 1 }],
+        } as Json),
+      }),
+    ).toEqual([]);
   });
 });
 
 describe("Quote Review total resolution", () => {
   it("one-hour line at $140 with persisted grand_total = 0 displays $140", () => {
-    expect(quoteLineTotalResolved({ persistedGrandTotal: 0, persistedSubtotal: null, calculatedLabor: 140, calculatedParts: 0 })).toBe(140);
+    expect(
+      quoteLineTotalResolved({
+        persistedGrandTotal: 0,
+        persistedSubtotal: null,
+        calculatedLabor: 140,
+        calculatedParts: 0,
+      }),
+    ).toBe(140);
   });
 
   it("1.5-hour line at $140 with persisted subtotal = 0 displays $210", () => {
-    expect(quoteLineTotalResolved({ persistedGrandTotal: null, persistedSubtotal: 0, calculatedLabor: 210, calculatedParts: 0 })).toBe(210);
+    expect(
+      quoteLineTotalResolved({
+        persistedGrandTotal: null,
+        persistedSubtotal: 0,
+        calculatedLabor: 210,
+        calculatedParts: 0,
+      }),
+    ).toBe(210);
   });
 
   it("truly zero labor/no-parts line stays $0", () => {
-    expect(quoteLineTotalResolved({ persistedGrandTotal: 0, persistedSubtotal: 0, calculatedLabor: 0, calculatedParts: 0 })).toBe(0);
+    expect(
+      quoteLineTotalResolved({
+        persistedGrandTotal: 0,
+        persistedSubtotal: 0,
+        calculatedLabor: 0,
+        calculatedParts: 0,
+      }),
+    ).toBe(0);
   });
 
   it("quote totals include known labor while parts remain pending", () => {
-    const totals = [140, 210, 140].reduce((sum, labor) => sum + quoteLineTotalResolved({ persistedGrandTotal: 0, persistedSubtotal: 0, calculatedLabor: labor, calculatedParts: 0 }), 0);
+    const totals = [140, 210, 140].reduce(
+      (sum, labor) =>
+        sum +
+        quoteLineTotalResolved({
+          persistedGrandTotal: 0,
+          persistedSubtotal: 0,
+          calculatedLabor: labor,
+          calculatedParts: 0,
+        }),
+      0,
+    );
     expect(totals).toBe(490);
   });
 });
 
 describe("QuoteReviewView linked parts queries and persistence boundaries", () => {
-  const source = readFileSync("features/work-orders/quote-review/QuoteReviewView.tsx", "utf8");
+  const source = readFileSync(
+    "features/work-orders/quote-review/QuoteReviewView.tsx",
+    "utf8",
+  );
 
   it("scopes linked parts queries by shop, work order, and quote line ids", () => {
-    expect(source).toMatch(/from\("part_requests"\)[\s\S]*\.eq\("shop_id", shopId\)[\s\S]*\.eq\("work_order_id", woId\)[\s\S]*\.in\("quote_line_id", quoteLineIds\)/);
-    expect(source).toMatch(/from\("part_request_items"\)[\s\S]*\.eq\("shop_id", shopId\)[\s\S]*\.eq\("work_order_id", woId\)[\s\S]*\.in\("quote_line_id", quoteLineIds\)/);
+    expect(source).toMatch(
+      /from\("part_requests"\)[\s\S]*\.eq\("shop_id", shopId\)[\s\S]*\.eq\("work_order_id", woId\)[\s\S]*\.in\("quote_line_id", quoteLineIds\)/,
+    );
+    expect(source).toMatch(
+      /from\("part_request_items"\)[\s\S]*\.eq\("shop_id", shopId\)[\s\S]*\.eq\("work_order_id", woId\)[\s\S]*\.in\("quote_line_id", quoteLineIds\)/,
+    );
   });
 
   it("saving a quote line does not write part request data", () => {
-    const saveBody = source.slice(source.indexOf("async function saveAllDirty"), source.indexOf("async function updateQuoteLineState"));
+    const saveBody = source.slice(
+      source.indexOf("async function saveAllDirty"),
+      source.indexOf("async function updateQuoteLineState"),
+    );
     expect(saveBody).not.toContain("part_request_items");
     expect(saveBody).not.toContain("part_requests");
   });

--- a/supabase/migrations/20260802024436_advisor_estimate_workflow.sql
+++ b/supabase/migrations/20260802024436_advisor_estimate_workflow.sql
@@ -1,0 +1,3354 @@
+begin;
+
+set local lock_timeout = '10s';
+set local statement_timeout = '120s';
+
+-- The legacy helper read a transaction-local GUC populated by a separate RPC.
+-- PostgREST requests do not share that transaction, so later estimate reads
+-- could fail RLS even after the server had authenticated the same staff user.
+-- Resolve the shop and role from the authenticated profile instead. Imported
+-- profiles can retain their own primary key and link auth.users via user_id.
+create or replace function public.current_shop_id()
+returns uuid
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select p.shop_id
+  from public.profiles p
+  where p.id = (select auth.uid())
+     or p.user_id = (select auth.uid())
+  order by
+    case when p.id = (select auth.uid()) then 0 else 1 end,
+    p.id
+  limit 1;
+$$;
+
+comment on function public.current_shop_id() is
+  'Returns the authenticated staff profile shop without relying on mutable request-local settings.';
+
+create or replace function public.profixiq_current_role()
+returns text
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select case lower(btrim(coalesce(p.role::text, '')))
+    when 'tech' then 'mechanic'
+    when 'technician' then 'mechanic'
+    when 'service_advisor' then 'service'
+    when 'service advisor' then 'service'
+    when 'lead' then 'lead_hand'
+    when 'leadhand' then 'lead_hand'
+    when 'lead hand' then 'lead_hand'
+    else lower(btrim(coalesce(p.role::text, 'unknown')))
+  end
+  from public.profiles p
+  where p.id = (select auth.uid())
+     or p.user_id = (select auth.uid())
+  order by
+    case when p.id = (select auth.uid()) then 0 else 1 end,
+    p.id
+  limit 1;
+$$;
+
+-- Preserve compatibility for existing callers that establish shop context
+-- before a write. The setting is no longer trusted by current_shop_id(), but
+-- the requested shop must still belong to either supported profile identity.
+create or replace function public.set_current_shop_id(p_shop_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if p_shop_id is null or not exists (
+    select 1
+    from public.profiles p
+    where p.shop_id = p_shop_id
+      and (
+        p.id = (select auth.uid())
+        or p.user_id = (select auth.uid())
+      )
+  ) then
+    raise exception 'Not allowed to set current shop to %', p_shop_id
+      using errcode = '42501';
+  end if;
+
+  perform set_config('app.current_shop_id', p_shop_id::text, true);
+end;
+$$;
+
+revoke all on function public.current_shop_id() from public, anon;
+revoke all on function public.profixiq_current_role() from public, anon;
+revoke all on function public.set_current_shop_id(uuid) from public, anon;
+grant execute on function public.current_shop_id() to authenticated, service_role;
+grant execute on function public.profixiq_current_role() to authenticated, service_role;
+grant execute on function public.set_current_shop_id(uuid) to authenticated, service_role;
+
+-- Estimate list/detail reads embed customer information and the shop labor
+-- rate. Add narrow policies for imported staff identities without broadening
+-- either relation to roles that cannot enter the estimate workspace.
+drop policy if exists estimate_staff_shop_read on public.shops;
+create policy estimate_staff_shop_read
+on public.shops
+for select
+to authenticated
+using (
+  id = (select public.current_shop_id())
+  and (select public.profixiq_current_role()) in (
+    'owner', 'admin', 'manager', 'advisor', 'service', 'foreman', 'parts', 'lead_hand'
+  )
+);
+
+drop policy if exists estimate_staff_customer_read on public.customers;
+create policy estimate_staff_customer_read
+on public.customers
+for select
+to authenticated
+using (
+  shop_id = (select public.current_shop_id())
+  and (select public.profixiq_current_role()) in (
+    'owner', 'admin', 'manager', 'advisor', 'service', 'foreman', 'parts', 'lead_hand'
+  )
+);
+
+-- Estimates are the pre-authorization state of the canonical work order. The
+-- existing work_order_quote_lines, part_requests, and customer approval RPCs
+-- remain the commercial and operational source of truth.
+alter table public.work_orders
+  add column if not exists record_type text not null default 'work_order',
+  add column if not exists estimate_number text,
+  add column if not exists estimate_status text,
+  add column if not exists estimate_revision integer not null default 1,
+  add column if not exists estimate_created_at timestamptz,
+  add column if not exists estimate_created_by uuid,
+  add column if not exists estimate_parts_completed_at timestamptz,
+  add column if not exists estimate_parts_completed_by uuid,
+  add column if not exists estimate_sent_at timestamptz,
+  add column if not exists estimate_sent_by uuid,
+  add column if not exists estimate_authorized_at timestamptz,
+  add column if not exists estimate_converted_at timestamptz,
+  add column if not exists estimate_expires_at timestamptz;
+
+alter table public.part_requests
+  add column if not exists source_context text,
+  add column if not exists source_revision integer;
+
+alter table public.part_request_items
+  add column if not exists source_row_id text;
+
+-- The quote-line baseline used CREATE TABLE IF NOT EXISTS, so older linked
+-- projects can have the table without the columns that were added to the
+-- clean-bootstrap definition. Reconcile the canonical quote contract before
+-- estimate indexes and RPCs depend on it.
+alter table public.work_order_quote_lines
+  add column if not exists external_id text,
+  add column if not exists title text,
+  add column if not exists line_type text not null default 'job',
+  add column if not exists decision text,
+  add column if not exists decline_reason text,
+  add column if not exists defer_reason text,
+  add column if not exists labor_rate numeric(12,2),
+  add column if not exists discount_total numeric(14,2) not null default 0,
+  add column if not exists created_by uuid references auth.users(id) on delete set null,
+  add column if not exists approved_by uuid references auth.users(id) on delete set null,
+  add column if not exists declined_by uuid references auth.users(id) on delete set null,
+  add column if not exists deferred_by uuid references auth.users(id) on delete set null,
+  add column if not exists sent_by uuid references auth.users(id) on delete set null,
+  add column if not exists deferred_at timestamptz,
+  add column if not exists sent_at timestamptz,
+  add column if not exists converted_at timestamptz;
+
+do $$
+declare
+  v_source_row_id_type regtype;
+begin
+  select a.atttypid::regtype
+  into v_source_row_id_type
+  from pg_attribute a
+  where a.attrelid = 'public.work_order_quote_lines'::regclass
+    and a.attname = 'source_row_id'
+    and not a.attisdropped;
+
+  if v_source_row_id_type is null then
+    alter table public.work_order_quote_lines
+      add column source_row_id text;
+  elsif v_source_row_id_type = 'uuid'::regtype then
+    alter table public.work_order_quote_lines
+      alter column source_row_id type text
+      using source_row_id::text;
+  elsif v_source_row_id_type <> 'text'::regtype then
+    raise exception
+      'work_order_quote_lines.source_row_id has unsupported type %, expected uuid or text',
+      v_source_row_id_type;
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.work_orders'::regclass
+      and conname = 'work_orders_record_type_check'
+  ) then
+    alter table public.work_orders
+      add constraint work_orders_record_type_check
+      check (record_type in ('work_order', 'estimate'));
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.work_orders'::regclass
+      and conname = 'work_orders_estimate_status_check'
+  ) then
+    alter table public.work_orders
+      add constraint work_orders_estimate_status_check
+      check (
+        estimate_status is null
+        or estimate_status in (
+          'draft', 'waiting_for_parts', 'ready_for_advisor', 'sent',
+          'partially_approved', 'approved', 'declined', 'deferred', 'expired'
+        )
+      );
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.work_orders'::regclass
+      and conname = 'work_orders_estimate_revision_check'
+  ) then
+    alter table public.work_orders
+      add constraint work_orders_estimate_revision_check
+      check (estimate_revision >= 1);
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.work_orders'::regclass
+      and conname = 'work_orders_estimate_created_by_fkey'
+  ) then
+    alter table public.work_orders
+      add constraint work_orders_estimate_created_by_fkey
+      foreign key (estimate_created_by) references public.profiles(id)
+      on delete set null not valid;
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.work_orders'::regclass
+      and conname = 'work_orders_estimate_parts_completed_by_fkey'
+  ) then
+    alter table public.work_orders
+      add constraint work_orders_estimate_parts_completed_by_fkey
+      foreign key (estimate_parts_completed_by) references public.profiles(id)
+      on delete set null not valid;
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.work_orders'::regclass
+      and conname = 'work_orders_estimate_sent_by_fkey'
+  ) then
+    alter table public.work_orders
+      add constraint work_orders_estimate_sent_by_fkey
+      foreign key (estimate_sent_by) references public.profiles(id)
+      on delete set null not valid;
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.part_requests'::regclass
+      and conname = 'part_requests_source_context_check'
+  ) then
+    alter table public.part_requests
+      add constraint part_requests_source_context_check
+      check (source_context is null or source_context = 'estimate');
+  end if;
+
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.part_requests'::regclass
+      and conname = 'part_requests_source_revision_check'
+  ) then
+    alter table public.part_requests
+      add constraint part_requests_source_revision_check
+      check (source_revision is null or source_revision >= 1);
+  end if;
+end;
+$$;
+
+alter table public.work_orders
+  validate constraint work_orders_estimate_created_by_fkey;
+alter table public.work_orders
+  validate constraint work_orders_estimate_parts_completed_by_fkey;
+alter table public.work_orders
+  validate constraint work_orders_estimate_sent_by_fkey;
+
+create unique index if not exists work_orders_shop_estimate_number_key
+  on public.work_orders(shop_id, estimate_number)
+  where estimate_number is not null;
+
+create index if not exists idx_work_orders_estimate_queue
+  on public.work_orders(shop_id, estimate_status, updated_at desc)
+  where estimate_number is not null;
+
+create unique index if not exists work_order_quote_lines_estimate_source_key
+  on public.work_order_quote_lines(shop_id, work_order_id, source_row_id)
+  where source_row_id like 'estimate:%';
+
+create unique index if not exists part_requests_estimate_revision_key
+  on public.part_requests(shop_id, quote_line_id, source_context, source_revision)
+  where source_context = 'estimate' and quote_line_id is not null;
+
+create unique index if not exists part_request_items_request_source_key
+  on public.part_request_items(request_id, source_row_id)
+  where source_row_id is not null;
+
+create table if not exists public.estimate_internal_details (
+  work_order_id uuid primary key references public.work_orders(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  notes text check (notes is null or length(notes) <= 8000),
+  line_notes jsonb not null default '{}'::jsonb
+    check (jsonb_typeof(line_notes) = 'object'),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_estimate_internal_details_shop
+  on public.estimate_internal_details(shop_id, work_order_id);
+
+alter table public.estimate_internal_details enable row level security;
+revoke all on table public.estimate_internal_details
+  from public, anon, authenticated;
+grant select on table public.estimate_internal_details to authenticated;
+grant all on table public.estimate_internal_details to service_role;
+
+comment on table public.estimate_internal_details is
+  'Staff-only estimate notes kept outside customer-readable work-order and quote-line rows.';
+
+create table if not exists public.estimate_events (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  work_order_id uuid references public.work_orders(id) on delete set null,
+  revision integer not null check (revision >= 1),
+  event_type text not null check (
+    event_type in (
+      'created', 'draft_saved', 'submitted_to_parts',
+      'parts_completed', 'returned_to_parts',
+      'send_reserved', 'send_failed', 'sent'
+    )
+  ),
+  actor_profile_id uuid references public.profiles(id) on delete set null,
+  reason_code text check (
+    reason_code is null
+    or reason_code in (
+      'lower_cost_option', 'confirm_availability', 'correct_quantity',
+      'incorrect_application', 'missing_parts', 'review_price',
+      'customer_alternative', 'other'
+    )
+  ),
+  note text,
+  changed_quote_line_ids uuid[] not null default array[]::uuid[],
+  snapshot jsonb not null default '{}'::jsonb,
+  result jsonb not null default '{}'::jsonb,
+  idempotency_key text not null check (
+    length(btrim(idempotency_key)) between 1 and 200
+  ),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (shop_id, idempotency_key)
+);
+
+alter table public.estimate_events
+  add column if not exists updated_at timestamptz not null default now();
+
+create index if not exists idx_estimate_events_work_order_created
+  on public.estimate_events(shop_id, work_order_id, created_at desc);
+create index if not exists idx_estimate_events_actor
+  on public.estimate_events(actor_profile_id)
+  where actor_profile_id is not null;
+drop index if exists public.estimate_events_sent_revision_key;
+create unique index estimate_events_sent_revision_key
+  on public.estimate_events(shop_id, work_order_id, revision)
+  where event_type in ('send_reserved', 'send_failed', 'sent');
+
+alter table public.estimate_events enable row level security;
+
+drop policy if exists estimate_events_shop_read on public.estimate_events;
+create policy estimate_events_shop_read
+  on public.estimate_events for select to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles p
+      where p.shop_id = estimate_events.shop_id
+        and (p.id = (select auth.uid()) or p.user_id = (select auth.uid()))
+        and lower(coalesce(p.role::text, '')) in (
+          'owner', 'admin', 'manager', 'advisor', 'service',
+          'service_advisor', 'service advisor', 'foreman', 'parts',
+          'lead_hand', 'lead', 'leadhand', 'lead hand'
+        )
+    )
+  );
+
+revoke all on table public.estimate_events from public, anon, authenticated;
+grant select on table public.estimate_events to authenticated;
+grant all on table public.estimate_events to service_role;
+
+comment on table public.estimate_events is
+  'Estimate workflow audit and idempotency ledger. Workflow writes use guarded RPCs; customer-send reservations use the shop-scoped server boundary.';
+
+create or replace function public.estimate_actor_for_shop(
+  p_shop_id uuid,
+  p_allowed_roles text[]
+)
+returns table(profile_id uuid, canonical_role text)
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select candidate.id, candidate.canonical_role
+  from (
+    select
+      p.id,
+      case lower(btrim(coalesce(p.role::text, '')))
+        when 'service_advisor' then 'service'
+        when 'service advisor' then 'service'
+        when 'lead' then 'lead_hand'
+        when 'leadhand' then 'lead_hand'
+        when 'lead hand' then 'lead_hand'
+        else lower(btrim(coalesce(p.role::text, '')))
+      end as canonical_role,
+      case when p.id = (select auth.uid()) then 0 else 1 end as priority
+    from public.profiles p
+    where p.shop_id = p_shop_id
+      and (p.id = (select auth.uid()) or p.user_id = (select auth.uid()))
+  ) candidate
+  where candidate.canonical_role = any(coalesce(p_allowed_roles, array[]::text[]))
+  order by candidate.priority, candidate.id
+  limit 1;
+$$;
+
+revoke all on function public.estimate_actor_for_shop(uuid, text[])
+  from public, anon, authenticated, service_role;
+
+create or replace function public.can_read_estimate_internal_details(
+  p_shop_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.profiles p
+    where p.shop_id = p_shop_id
+      and (p.id = (select auth.uid()) or p.user_id = (select auth.uid()))
+      and case lower(btrim(coalesce(p.role::text, '')))
+        when 'service_advisor' then 'service'
+        when 'service advisor' then 'service'
+        when 'lead' then 'lead_hand'
+        when 'leadhand' then 'lead_hand'
+        when 'lead hand' then 'lead_hand'
+        else lower(btrim(coalesce(p.role::text, '')))
+      end in ('owner', 'admin', 'manager', 'advisor', 'service', 'foreman', 'parts', 'lead_hand')
+  );
+$$;
+
+revoke all on function public.can_read_estimate_internal_details(uuid)
+  from public, anon;
+grant execute on function public.can_read_estimate_internal_details(uuid)
+  to authenticated, service_role;
+
+drop policy if exists estimate_internal_details_staff_read
+  on public.estimate_internal_details;
+create policy estimate_internal_details_staff_read
+on public.estimate_internal_details
+for select
+to authenticated
+using (
+  public.can_read_estimate_internal_details(shop_id)
+);
+
+create or replace function public.can_access_estimate_quote_line(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_metadata jsonb,
+  p_action text
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_work_order public.work_orders%rowtype;
+  v_action text := lower(btrim(coalesce(p_action, '')));
+begin
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id
+    and shop_id = p_shop_id;
+
+  if not found then
+    return false;
+  end if;
+  if v_work_order.estimate_number is null then
+    return true;
+  end if;
+
+  if v_action = 'select' then
+    return exists (
+      select 1
+      from public.estimate_actor_for_shop(
+        p_shop_id,
+        array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman', 'parts', 'lead_hand']
+      )
+    ) or exists (
+      select 1
+      from public.customers c
+      where c.id = v_work_order.customer_id
+        and c.shop_id = p_shop_id
+        and c.user_id = (select auth.uid())
+    );
+  end if;
+
+  if v_action in ('insert', 'update') then
+    if v_work_order.estimate_status = 'draft' then
+      return exists (
+        select 1
+        from public.estimate_actor_for_shop(
+          p_shop_id,
+          array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman']
+        )
+      );
+    end if;
+
+    if v_work_order.estimate_status = 'waiting_for_parts'
+       and coalesce(p_metadata ->> 'estimate_revision', '') =
+         v_work_order.estimate_revision::text then
+      return exists (
+        select 1
+        from public.estimate_actor_for_shop(
+          p_shop_id,
+          array['owner', 'admin', 'manager', 'parts', 'lead_hand', 'foreman']
+        )
+      );
+    end if;
+    return false;
+  end if;
+
+  if v_action = 'delete' then
+    return v_work_order.estimate_status = 'draft'
+      and exists (
+        select 1
+        from public.estimate_actor_for_shop(
+          p_shop_id,
+          array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman']
+        )
+      );
+  end if;
+
+  return false;
+end;
+$$;
+
+revoke all on function public.can_access_estimate_quote_line(uuid, uuid, jsonb, text)
+  from public, anon;
+grant execute on function public.can_access_estimate_quote_line(uuid, uuid, jsonb, text)
+  to authenticated, service_role;
+
+create or replace function public.can_select_estimate_quote_line(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_status text,
+  p_stage text,
+  p_sent_to_customer_at timestamptz,
+  p_approved_at timestamptz,
+  p_declined_at timestamptz,
+  p_deferred_at timestamptz,
+  p_work_order_line_id uuid
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_work_order public.work_orders%rowtype;
+  v_status text := lower(btrim(coalesce(p_status, '')));
+  v_stage text := lower(btrim(coalesce(p_stage, '')));
+begin
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id
+    and shop_id = p_shop_id;
+
+  if not found or v_work_order.estimate_number is null then
+    return true;
+  end if;
+
+  if exists (
+    select 1
+    from public.estimate_actor_for_shop(
+      p_shop_id,
+      array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman', 'parts', 'lead_hand']
+    )
+  ) then
+    return true;
+  end if;
+
+  -- A portal customer can see only rows that were deliberately handed off or
+  -- have a recorded customer decision. Draft, Parts, and superseded revisions
+  -- remain hidden even if another permissive portal policy matches the work
+  -- order.
+  return exists (
+    select 1
+    from public.customers c
+    where c.id = v_work_order.customer_id
+      and c.shop_id = p_shop_id
+      and c.user_id = (select auth.uid())
+  )
+  and v_status not in ('cancelled', 'canceled', 'rejected', 'superseded', 'voided')
+  and (
+    p_sent_to_customer_at is not null
+    or p_approved_at is not null
+    or p_declined_at is not null
+    or p_deferred_at is not null
+    or p_work_order_line_id is not null
+    or v_status in ('sent', 'approved', 'converted', 'declined', 'deferred')
+    or v_stage in (
+      'sent', 'customer_review', 'customer_approved',
+      'customer_declined', 'customer_deferred'
+    )
+  );
+end;
+$$;
+
+revoke all on function public.can_select_estimate_quote_line(
+  uuid, uuid, text, text, timestamptz, timestamptz, timestamptz,
+  timestamptz, uuid
+) from public, anon;
+grant execute on function public.can_select_estimate_quote_line(
+  uuid, uuid, text, text, timestamptz, timestamptz, timestamptz,
+  timestamptz, uuid
+) to authenticated, service_role;
+
+create or replace function public.can_select_estimate_work_order(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_customer_id uuid,
+  p_estimate_number text
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if p_estimate_number is null then
+    return true;
+  end if;
+
+  if exists (
+    select 1
+    from public.estimate_actor_for_shop(
+      p_shop_id,
+      array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman', 'parts', 'lead_hand']
+    )
+  ) then
+    return true;
+  end if;
+
+  return exists (
+    select 1
+    from public.customers c
+    where c.id = p_customer_id
+      and c.shop_id = p_shop_id
+      and c.user_id = (select auth.uid())
+  ) and exists (
+    select 1
+    from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id
+      and q.work_order_id = p_work_order_id
+      and lower(btrim(coalesce(q.status::text, ''))) not in (
+        'cancelled', 'canceled', 'rejected', 'superseded', 'voided'
+      )
+      and (
+        q.sent_to_customer_at is not null
+        or q.approved_at is not null
+        or q.declined_at is not null
+        or q.deferred_at is not null
+        or q.work_order_line_id is not null
+        or lower(btrim(coalesce(q.status::text, ''))) in (
+          'sent', 'approved', 'converted', 'declined', 'deferred'
+        )
+        or lower(btrim(coalesce(q.stage::text, ''))) in (
+          'sent', 'customer_review', 'customer_approved',
+          'customer_declined', 'customer_deferred'
+        )
+      )
+  );
+end;
+$$;
+
+revoke all on function public.can_select_estimate_work_order(
+  uuid, uuid, uuid, text
+) from public, anon;
+grant execute on function public.can_select_estimate_work_order(
+  uuid, uuid, uuid, text
+) to authenticated, service_role;
+
+-- The ordinary work-order policies remain authoritative after an estimate has
+-- approved work and becomes operational. Before that conversion, all writes
+-- must use the guarded estimate RPCs (or the shop-scoped service boundary for
+-- customer send), so a direct table update cannot skip lifecycle validation.
+drop policy if exists work_orders_estimate_select on public.work_orders;
+create policy work_orders_estimate_select
+on public.work_orders
+as restrictive
+for select
+to authenticated
+using (
+  public.can_select_estimate_work_order(
+    shop_id, id, customer_id, estimate_number
+  )
+);
+
+drop policy if exists work_orders_estimate_insert on public.work_orders;
+create policy work_orders_estimate_insert
+on public.work_orders
+as restrictive
+for insert
+to authenticated
+with check (
+  estimate_number is null
+  and record_type = 'work_order'
+);
+
+drop policy if exists work_orders_estimate_update on public.work_orders;
+create policy work_orders_estimate_update
+on public.work_orders
+as restrictive
+for update
+to authenticated
+using (
+  estimate_number is null
+  or record_type = 'work_order'
+)
+with check (
+  estimate_number is null
+  or record_type = 'work_order'
+);
+
+drop policy if exists work_orders_estimate_delete on public.work_orders;
+create policy work_orders_estimate_delete
+on public.work_orders
+as restrictive
+for delete
+to authenticated
+using (
+  estimate_number is null
+  or record_type = 'work_order'
+);
+
+-- Existing quote-line policies remain available for ordinary work orders. The
+-- restrictive policies below add the estimate role/state contract to every
+-- otherwise-permitted direct table operation, including customer portal reads.
+drop policy if exists work_order_quote_lines_estimate_select
+  on public.work_order_quote_lines;
+create policy work_order_quote_lines_estimate_select
+on public.work_order_quote_lines
+as restrictive
+for select
+to authenticated
+using (
+  public.can_select_estimate_quote_line(
+    shop_id,
+    work_order_id,
+    status::text,
+    stage::text,
+    sent_to_customer_at,
+    approved_at,
+    declined_at,
+    deferred_at,
+    work_order_line_id
+  )
+);
+
+drop policy if exists work_order_quote_lines_estimate_insert
+  on public.work_order_quote_lines;
+create policy work_order_quote_lines_estimate_insert
+on public.work_order_quote_lines
+as restrictive
+for insert
+to authenticated
+with check (
+  public.can_access_estimate_quote_line(
+    shop_id, work_order_id, metadata, 'insert'
+  )
+);
+
+drop policy if exists work_order_quote_lines_estimate_update
+  on public.work_order_quote_lines;
+create policy work_order_quote_lines_estimate_update
+on public.work_order_quote_lines
+as restrictive
+for update
+to authenticated
+using (
+  public.can_access_estimate_quote_line(
+    shop_id, work_order_id, metadata, 'update'
+  )
+)
+with check (
+  public.can_access_estimate_quote_line(
+    shop_id, work_order_id, metadata, 'update'
+  )
+);
+
+drop policy if exists work_order_quote_lines_estimate_delete
+  on public.work_order_quote_lines;
+create policy work_order_quote_lines_estimate_delete
+on public.work_order_quote_lines
+as restrictive
+for delete
+to authenticated
+using (
+  public.can_access_estimate_quote_line(
+    shop_id, work_order_id, metadata, 'delete'
+  )
+);
+
+create or replace function public.prevent_estimate_quote_commercial_changes_after_handoff()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_estimate_number text;
+  v_estimate_status text;
+begin
+  select w.estimate_number, w.estimate_status
+  into v_estimate_number, v_estimate_status
+  from public.work_orders w
+  where w.id = old.work_order_id
+    and w.shop_id = old.shop_id;
+
+  if v_estimate_number is null or v_estimate_status = 'draft' then
+    return new;
+  end if;
+
+  -- Parts may roll canonical item pricing into the active revision, but Parts
+  -- cannot alter advisor-authored scope, labor, or stable revision identity.
+  if new.title is distinct from old.title
+     or new.description is distinct from old.description
+     or new.notes is distinct from old.notes
+     or new.labor_hours is distinct from old.labor_hours
+     or new.est_labor_hours is distinct from old.est_labor_hours
+     or new.labor_rate is distinct from old.labor_rate
+     or coalesce(new.metadata, '{}'::jsonb) -> 'requested_parts'
+          is distinct from coalesce(old.metadata, '{}'::jsonb) -> 'requested_parts'
+     or coalesce(new.metadata, '{}'::jsonb) -> 'customer_description'
+          is distinct from coalesce(old.metadata, '{}'::jsonb) -> 'customer_description'
+     or coalesce(new.metadata, '{}'::jsonb) -> 'client_key'
+          is distinct from coalesce(old.metadata, '{}'::jsonb) -> 'client_key'
+     or coalesce(new.metadata, '{}'::jsonb) -> 'estimate_revision'
+          is distinct from coalesce(old.metadata, '{}'::jsonb) -> 'estimate_revision'
+     or coalesce(new.metadata, '{}'::jsonb) -> 'labor_rate'
+          is distinct from coalesce(old.metadata, '{}'::jsonb) -> 'labor_rate' then
+    raise exception using errcode = '55000',
+      message = 'Estimate scope and labor are locked after submission to Parts.';
+  end if;
+
+  if v_estimate_status is distinct from 'waiting_for_parts'
+     and (
+       new.labor_total is distinct from old.labor_total
+       or new.parts_total is distinct from old.parts_total
+       or new.subtotal is distinct from old.subtotal
+       or new.tax_total is distinct from old.tax_total
+       or new.grand_total is distinct from old.grand_total
+     ) then
+    raise exception using errcode = '55000',
+      message = 'Estimate pricing is locked after the Parts handoff is complete.';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.prevent_estimate_quote_commercial_changes_after_handoff()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists trg_prevent_estimate_quote_commercial_changes
+  on public.work_order_quote_lines;
+create trigger trg_prevent_estimate_quote_commercial_changes
+before update of title, description, notes, labor_hours, est_labor_hours,
+  labor_rate, labor_total, parts_total, subtotal, tax_total, grand_total, metadata
+on public.work_order_quote_lines
+for each row execute function public.prevent_estimate_quote_commercial_changes_after_handoff();
+
+-- Keep direct Parts item updates aligned with the profile identity fallback
+-- used by the server authorization boundary.
+create or replace function public.can_update_part_request_items(p_shop_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.profiles p
+    where p.shop_id = p_shop_id
+      and (p.id = (select auth.uid()) or p.user_id = (select auth.uid()))
+      and case lower(btrim(coalesce(p.role::text, '')))
+        when 'lead' then 'lead_hand'
+        when 'leadhand' then 'lead_hand'
+        when 'lead hand' then 'lead_hand'
+        else lower(btrim(coalesce(p.role::text, '')))
+      end in ('owner', 'admin', 'manager', 'parts', 'lead_hand', 'foreman')
+  );
+$$;
+
+revoke all on function public.can_update_part_request_items(uuid)
+  from public, anon;
+grant execute on function public.can_update_part_request_items(uuid)
+  to authenticated, service_role;
+
+create or replace function public.can_update_estimate_part_request_items(
+  p_shop_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1
+    from public.profiles p
+    where p.shop_id = p_shop_id
+      and (p.id = (select auth.uid()) or p.user_id = (select auth.uid()))
+      and case lower(btrim(coalesce(p.role::text, '')))
+        when 'lead' then 'lead_hand'
+        when 'leadhand' then 'lead_hand'
+        when 'lead hand' then 'lead_hand'
+        else lower(btrim(coalesce(p.role::text, '')))
+      end in ('owner', 'admin', 'manager', 'parts', 'lead_hand', 'foreman')
+  );
+$$;
+
+revoke all on function public.can_update_estimate_part_request_items(uuid)
+  from public, anon;
+grant execute on function public.can_update_estimate_part_request_items(uuid)
+  to authenticated, service_role;
+
+-- The legacy policy joined profiles.id directly even though imported staff can
+-- authenticate through profiles.user_id. Delegate the identity check to the
+-- guarded helper so both profile shapes retain the same narrow Parts role set.
+drop policy if exists part_request_items_update_same_shop_parent_request
+  on public.part_request_items;
+create policy part_request_items_update_same_shop_parent_request
+on public.part_request_items
+for update
+to authenticated
+using (
+  exists (
+    select 1
+    from public.part_requests pr
+    where pr.id = part_request_items.request_id
+      and public.can_update_part_request_items(pr.shop_id)
+      and (
+        part_request_items.shop_id is null
+        or part_request_items.shop_id = pr.shop_id
+      )
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.part_requests pr
+    where pr.id = part_request_items.request_id
+      and public.can_update_part_request_items(pr.shop_id)
+      and (
+        part_request_items.shop_id is null
+        or part_request_items.shop_id = pr.shop_id
+      )
+  )
+);
+
+-- The baseline item policies are intentionally permissive for ordinary shop
+-- work. Add restrictive policies so rows attached to an estimate can only be
+-- changed by Parts-capable roles, while leaving non-estimate requests alone.
+drop policy if exists part_request_items_estimate_role_insert
+  on public.part_request_items;
+create policy part_request_items_estimate_role_insert
+on public.part_request_items
+as restrictive
+for insert
+to authenticated
+with check (
+  not exists (
+    select 1
+    from public.part_requests pr
+    join public.work_orders w
+      on w.id = pr.work_order_id
+     and w.shop_id = pr.shop_id
+    where pr.id = part_request_items.request_id
+      and w.estimate_number is not null
+  )
+  or exists (
+    select 1
+    from public.part_requests pr
+    where pr.id = part_request_items.request_id
+      and public.can_update_estimate_part_request_items(pr.shop_id)
+  )
+);
+
+drop policy if exists part_request_items_estimate_role_update
+  on public.part_request_items;
+create policy part_request_items_estimate_role_update
+on public.part_request_items
+as restrictive
+for update
+to authenticated
+using (
+  not exists (
+    select 1
+    from public.part_requests pr
+    join public.work_orders w
+      on w.id = pr.work_order_id
+     and w.shop_id = pr.shop_id
+    where pr.id = part_request_items.request_id
+      and w.estimate_number is not null
+  )
+  or exists (
+    select 1
+    from public.part_requests pr
+    where pr.id = part_request_items.request_id
+      and public.can_update_estimate_part_request_items(pr.shop_id)
+  )
+)
+with check (
+  not exists (
+    select 1
+    from public.part_requests pr
+    join public.work_orders w
+      on w.id = pr.work_order_id
+     and w.shop_id = pr.shop_id
+    where pr.id = part_request_items.request_id
+      and w.estimate_number is not null
+  )
+  or exists (
+    select 1
+    from public.part_requests pr
+    where pr.id = part_request_items.request_id
+      and public.can_update_estimate_part_request_items(pr.shop_id)
+  )
+);
+
+drop policy if exists part_request_items_estimate_role_delete
+  on public.part_request_items;
+create policy part_request_items_estimate_role_delete
+on public.part_request_items
+as restrictive
+for delete
+to authenticated
+using (
+  not exists (
+    select 1
+    from public.part_requests pr
+    join public.work_orders w
+      on w.id = pr.work_order_id
+     and w.shop_id = pr.shop_id
+    where pr.id = part_request_items.request_id
+      and w.estimate_number is not null
+  )
+  or exists (
+    select 1
+    from public.part_requests pr
+    where pr.id = part_request_items.request_id
+      and public.can_update_estimate_part_request_items(pr.shop_id)
+  )
+);
+
+create or replace function public.prevent_estimate_part_item_structure_changes()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_request_id uuid;
+  v_is_estimate boolean := false;
+  v_source_context text;
+  v_source_revision integer;
+  v_estimate_status text;
+  v_estimate_revision integer;
+begin
+  if tg_op = 'UPDATE' then
+    if new.request_id is not distinct from old.request_id
+       and new.shop_id is not distinct from old.shop_id
+       and new.work_order_id is not distinct from old.work_order_id
+       and new.quote_line_id is not distinct from old.quote_line_id
+       and new.source_row_id is not distinct from old.source_row_id then
+      return new;
+    end if;
+
+    if exists (
+      select 1
+      from public.part_requests pr
+      join public.work_orders w
+        on w.id = pr.work_order_id
+       and w.shop_id = pr.shop_id
+      where pr.id in (old.request_id, new.request_id)
+        and w.estimate_number is not null
+    ) then
+      raise exception using errcode = '55000',
+        message = 'Estimate part request provenance cannot be changed in place.';
+    end if;
+    return new;
+  end if;
+
+  v_request_id := case when tg_op = 'DELETE' then old.request_id else new.request_id end;
+
+  select
+    w.estimate_number is not null,
+    pr.source_context,
+    pr.source_revision,
+    w.estimate_status,
+    w.estimate_revision
+  into
+    v_is_estimate,
+    v_source_context,
+    v_source_revision,
+    v_estimate_status,
+    v_estimate_revision
+  from public.part_requests pr
+  join public.work_orders w
+    on w.id = pr.work_order_id
+   and w.shop_id = pr.shop_id
+  where pr.id = v_request_id;
+
+  if v_is_estimate and (
+    v_source_context is distinct from 'estimate'
+    or v_estimate_status is distinct from 'waiting_for_parts'
+    or v_estimate_revision is distinct from v_source_revision
+  ) then
+    raise exception using errcode = '55000',
+      message = 'Estimate parts can only change inside the active Parts revision.';
+  end if;
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.prevent_estimate_part_item_structure_changes()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists trg_prevent_estimate_part_item_insert_delete
+  on public.part_request_items;
+create trigger trg_prevent_estimate_part_item_insert_delete
+before insert or delete
+on public.part_request_items
+for each row execute function public.prevent_estimate_part_item_structure_changes();
+
+drop trigger if exists trg_prevent_estimate_part_item_reparent
+  on public.part_request_items;
+create trigger trg_prevent_estimate_part_item_reparent
+before update of request_id, shop_id, work_order_id, quote_line_id, source_row_id
+on public.part_request_items
+for each row execute function public.prevent_estimate_part_item_structure_changes();
+
+create or replace function public.prevent_estimate_part_quote_changes_after_handoff()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_source_context text;
+  v_source_revision integer;
+  v_estimate_status text;
+  v_estimate_revision integer;
+begin
+  if new.description is not distinct from old.description
+     and new.qty is not distinct from old.qty
+     and new.qty_requested is not distinct from old.qty_requested
+     and new.quoted_price is not distinct from old.quoted_price
+     and new.unit_price is not distinct from old.unit_price
+     and new.requested_part_number is not distinct from old.requested_part_number
+     and new.requested_manufacturer is not distinct from old.requested_manufacturer then
+    return new;
+  end if;
+
+  select pr.source_context, pr.source_revision,
+         w.estimate_status, w.estimate_revision
+  into v_source_context, v_source_revision,
+       v_estimate_status, v_estimate_revision
+  from public.part_requests pr
+  left join public.work_orders w
+    on w.id = pr.work_order_id
+   and w.shop_id = pr.shop_id
+  where pr.id = old.request_id
+    and pr.shop_id = old.shop_id;
+
+  if v_source_context = 'estimate'
+     and (
+       v_estimate_status is distinct from 'waiting_for_parts'
+       or v_estimate_revision is distinct from v_source_revision
+     ) then
+    raise exception using errcode = '55000',
+      message = 'Estimate pricing is locked. Return the current revision to Parts before changing it.';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.prevent_estimate_part_quote_changes_after_handoff()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists trg_prevent_estimate_part_quote_changes_after_handoff
+  on public.part_request_items;
+create trigger trg_prevent_estimate_part_quote_changes_after_handoff
+before update of description, qty, qty_requested, quoted_price, unit_price,
+  requested_part_number, requested_manufacturer
+on public.part_request_items
+for each row execute function public.prevent_estimate_part_quote_changes_after_handoff();
+
+create or replace function public.validate_estimate_lines(p_lines jsonb)
+returns void
+language plpgsql
+security invoker
+set search_path = public, pg_temp
+as $$
+declare
+  v_line jsonb;
+  v_part jsonb;
+  v_parts jsonb;
+  v_value text;
+  v_number numeric;
+begin
+  if jsonb_typeof(p_lines) is distinct from 'array' then
+    raise exception using errcode = '22023',
+      message = 'Estimate repair lines must be an array.';
+  end if;
+  if jsonb_array_length(p_lines) < 1 or jsonb_array_length(p_lines) > 50 then
+    raise exception using errcode = '22023',
+      message = 'An estimate requires between 1 and 50 repair lines.';
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_array_elements(p_lines) entry
+    group by lower(btrim(coalesce(entry ->> 'clientKey', '')))
+    having count(*) > 1
+  ) then
+    raise exception using errcode = '22023',
+      message = 'Estimate repair line keys must be unique.';
+  end if;
+
+  for v_line in select value from jsonb_array_elements(p_lines)
+  loop
+    if jsonb_typeof(v_line) is distinct from 'object'
+       or nullif(btrim(v_line ->> 'clientKey'), '') is null
+       or length(btrim(v_line ->> 'clientKey')) > 80 then
+      raise exception using errcode = '22023',
+        message = 'Every estimate line requires a stable client key.';
+    end if;
+
+    if nullif(btrim(coalesce(v_line ->> 'title', v_line ->> 'description')), '') is null then
+      raise exception using errcode = '22023',
+        message = 'Every estimate line requires a service title.';
+    end if;
+
+    if length(btrim(coalesce(v_line ->> 'title', v_line ->> 'description', ''))) > 500
+       or length(coalesce(v_line ->> 'customerDescription', '')) > 4000
+       or length(coalesce(v_line ->> 'advisorNotes', '')) > 4000 then
+      raise exception using errcode = '22023',
+        message = 'Estimate line text exceeds the supported length.';
+    end if;
+
+    v_value := nullif(btrim(v_line ->> 'laborHours'), '');
+    if v_value is not null then
+      begin
+        v_number := v_value::numeric;
+      exception when invalid_text_representation then
+        raise exception using errcode = '22023', message = 'Labor hours must be numeric.';
+      end;
+      if v_number < 0 or v_number > 1000 then
+        raise exception using errcode = '22023', message = 'Labor hours are outside the supported range.';
+      end if;
+    end if;
+
+    v_value := nullif(btrim(v_line ->> 'laborRate'), '');
+    if v_value is not null then
+      begin
+        v_number := v_value::numeric;
+      exception when invalid_text_representation then
+        raise exception using errcode = '22023', message = 'Labor rate must be numeric.';
+      end;
+      if v_number < 0 or v_number > 100000 then
+        raise exception using errcode = '22023', message = 'Labor rate is outside the supported range.';
+      end if;
+    end if;
+
+    v_parts := coalesce(v_line -> 'parts', '[]'::jsonb);
+    if jsonb_typeof(v_parts) is distinct from 'array' then
+      raise exception using errcode = '22023',
+        message = 'Estimate parts must be an array.';
+    end if;
+    if jsonb_array_length(v_parts) > 100 then
+      raise exception using errcode = '22023',
+        message = 'Estimate parts must be an array with no more than 100 items per line.';
+    end if;
+
+    if exists (
+      select 1
+      from jsonb_array_elements(v_parts) entry
+      group by lower(btrim(coalesce(entry ->> 'clientKey', '')))
+      having count(*) > 1
+    ) then
+      raise exception using errcode = '22023',
+        message = 'Estimate part keys must be unique within a repair line.';
+    end if;
+
+    for v_part in
+      select value from jsonb_array_elements(v_parts)
+    loop
+      if jsonb_typeof(v_part) is distinct from 'object'
+         or nullif(btrim(v_part ->> 'clientKey'), '') is null
+         or length(btrim(v_part ->> 'clientKey')) > 80
+         or nullif(btrim(v_part ->> 'description'), '') is null then
+        raise exception using errcode = '22023',
+          message = 'Every requested part requires a stable key and description.';
+      end if;
+
+      if length(btrim(coalesce(v_part ->> 'description', ''))) > 500
+         or length(coalesce(v_part ->> 'partNumber', '')) > 200
+         or length(coalesce(v_part ->> 'manufacturer', '')) > 200 then
+        raise exception using errcode = '22023',
+          message = 'Estimate part text exceeds the supported length.';
+      end if;
+
+      begin
+        v_number := coalesce(nullif(v_part ->> 'quantity', '')::numeric, 1);
+      exception when invalid_text_representation then
+        raise exception using errcode = '22023', message = 'Part quantity must be numeric.';
+      end;
+      if v_number <= 0 or v_number > 10000 then
+        raise exception using errcode = '22023', message = 'Part quantity is outside the supported range.';
+      end if;
+    end loop;
+  end loop;
+end;
+$$;
+
+revoke all on function public.validate_estimate_lines(jsonb)
+  from public, anon, authenticated, service_role;
+
+create or replace function public.recalculate_estimate_work_order_totals(
+  p_shop_id uuid,
+  p_work_order_id uuid
+)
+returns void
+language sql
+security definer
+set search_path = public, pg_temp
+as $$
+  update public.work_orders w
+  set labor_total = totals.labor_total,
+      parts_total = totals.parts_total,
+      updated_at = now()
+  from (
+    select
+      coalesce(round(sum(coalesce(q.labor_total, 0)), 2), 0) as labor_total,
+      coalesce(round(sum(coalesce(q.parts_total, 0)), 2), 0) as parts_total
+    from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id
+      and q.work_order_id = p_work_order_id
+      and lower(coalesce(q.status::text, '')) not in ('cancelled', 'superseded')
+  ) totals
+  where w.id = p_work_order_id
+    and w.shop_id = p_shop_id;
+$$;
+
+revoke all on function public.recalculate_estimate_work_order_totals(uuid, uuid)
+  from public, anon, authenticated, service_role;
+
+create or replace function public.sync_estimate_state_from_quote_lines()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_work_order public.work_orders%rowtype;
+  v_total integer := 0;
+  v_approved integer := 0;
+  v_declined integer := 0;
+  v_deferred integer := 0;
+  v_sent integer := 0;
+begin
+  select * into v_work_order
+  from public.work_orders
+  where id = new.work_order_id
+    and shop_id = new.shop_id
+    and estimate_number is not null
+  for update;
+
+  if not found then
+    return new;
+  end if;
+
+  select
+    count(*),
+    count(*) filter (
+      where q.approved_at is not null
+         or q.work_order_line_id is not null
+         or lower(coalesce(q.status::text, '')) in ('approved', 'converted')
+         or lower(coalesce(q.stage::text, '')) = 'customer_approved'
+    ),
+    count(*) filter (
+      where lower(coalesce(q.status::text, '')) in ('declined', 'rejected')
+         or lower(coalesce(q.stage::text, '')) = 'customer_declined'
+    ),
+    count(*) filter (
+      where lower(coalesce(q.status::text, '')) = 'deferred'
+         or lower(coalesce(q.stage::text, '')) = 'customer_deferred'
+    ),
+    count(*) filter (
+      where q.sent_to_customer_at is not null
+         or lower(coalesce(q.status::text, '')) = 'sent'
+         or lower(coalesce(q.stage::text, '')) = 'sent'
+    )
+  into v_total, v_approved, v_declined, v_deferred, v_sent
+  from public.work_order_quote_lines q
+  where q.shop_id = new.shop_id
+    and q.work_order_id = new.work_order_id
+    and lower(coalesce(q.status::text, '')) not in ('cancelled', 'superseded');
+
+  -- A partially approved estimate can still have unapproved lines in a Parts
+  -- adjustment revision. Pricing updates must not pull that revision out of
+  -- the Parts queue before the explicit completion gate runs.
+  if v_work_order.estimate_status = 'waiting_for_parts' then
+    perform public.recalculate_estimate_work_order_totals(new.shop_id, new.work_order_id);
+    return new;
+  end if;
+
+  if v_approved > 0 then
+    update public.work_orders
+    set record_type = 'work_order',
+        estimate_status = case
+          when v_approved = v_total then 'approved'
+          else 'partially_approved'
+        end,
+        approval_state = case
+          when v_approved = v_total then 'approved'
+          else 'partial'
+        end,
+        estimate_authorized_at = coalesce(estimate_authorized_at, now()),
+        estimate_converted_at = coalesce(estimate_converted_at, now()),
+        updated_at = now()
+    where id = new.work_order_id and shop_id = new.shop_id;
+  elsif v_total > 0 and v_declined + v_deferred = v_total then
+    update public.work_orders
+    set estimate_status = case when v_declined > 0 then 'declined' else 'deferred' end,
+        approval_state = case when v_declined > 0 then 'declined' else approval_state end,
+        updated_at = now()
+    where id = new.work_order_id and shop_id = new.shop_id;
+  elsif v_sent > 0 then
+    update public.work_orders
+    set estimate_status = 'sent',
+        estimate_sent_at = coalesce(estimate_sent_at, new.sent_to_customer_at, new.sent_at, now()),
+        updated_at = now()
+    where id = new.work_order_id and shop_id = new.shop_id;
+  end if;
+
+  perform public.recalculate_estimate_work_order_totals(new.shop_id, new.work_order_id);
+  return new;
+end;
+$$;
+
+revoke all on function public.sync_estimate_state_from_quote_lines()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists trg_sync_estimate_state_from_quote_lines
+  on public.work_order_quote_lines;
+create trigger trg_sync_estimate_state_from_quote_lines
+after insert or update of status, stage, sent_to_customer_at, sent_at, sent_by,
+  approved_at, declined_at, deferred_at, work_order_line_id, labor_total, parts_total
+on public.work_order_quote_lines
+for each row execute function public.sync_estimate_state_from_quote_lines();
+
+create or replace function public.create_estimate_atomic(
+  p_shop_id uuid,
+  p_customer jsonb,
+  p_vehicle jsonb,
+  p_lines jsonb,
+  p_notes text,
+  p_expires_at timestamptz,
+  p_idempotency_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor_user_id uuid := auth.uid();
+  v_actor_profile_id uuid;
+  v_actor_role text;
+  v_event_id uuid;
+  v_existing_event_type text;
+  v_existing_result jsonb;
+  v_customer_id uuid;
+  v_vehicle_id uuid;
+  v_customer_id_text text := nullif(btrim(p_customer ->> 'id'), '');
+  v_vehicle_id_text text := nullif(btrim(p_vehicle ->> 'id'), '');
+  v_customer_email text := nullif(lower(btrim(p_customer ->> 'email')), '');
+  v_customer_phone_raw text := nullif(btrim(p_customer ->> 'phone'), '');
+  v_customer_phone text := coalesce(
+    nullif(regexp_replace(coalesce(v_customer_phone_raw, ''), '[^0-9]', '', 'g'), ''),
+    v_customer_phone_raw
+  );
+  v_customer_name text;
+  v_vehicle_vin_raw text := nullif(upper(btrim(p_vehicle ->> 'vin')), '');
+  v_vehicle_vin text := case
+    when length(v_vehicle_vin_raw) = 17 then v_vehicle_vin_raw
+    else null
+  end;
+  v_vehicle_plate text := nullif(upper(btrim(p_vehicle ->> 'licensePlate')), '');
+  v_vehicle_unit text := nullif(btrim(p_vehicle ->> 'unitNumber'), '');
+  v_existing_vehicle_customer_id uuid;
+  v_year integer;
+  v_shop_labor_rate numeric := 0;
+  v_work_order_id uuid;
+  v_candidate_work_order_id uuid;
+  v_custom_id text;
+  v_estimate_number text;
+  v_line jsonb;
+  v_line_id uuid;
+  v_labor_hours numeric;
+  v_labor_rate numeric;
+  v_labor_total numeric;
+  v_line_ids uuid[] := array[]::uuid[];
+  v_line_notes jsonb := '{}'::jsonb;
+  v_result jsonb;
+begin
+  if v_actor_user_id is null then
+    raise exception using errcode = '28000', message = 'Authentication is required.';
+  end if;
+  if p_shop_id is null
+     or jsonb_typeof(p_customer) is distinct from 'object'
+     or jsonb_typeof(p_vehicle) is distinct from 'object' then
+    raise exception using errcode = '22023', message = 'Shop, customer, and vehicle are required.';
+  end if;
+  if nullif(btrim(coalesce(p_idempotency_key, '')), '') is null
+     or length(p_idempotency_key) > 200 then
+    raise exception using errcode = '22023', message = 'A stable idempotency key is required.';
+  end if;
+  if length(coalesce(p_notes, '')) > 8000 then
+    raise exception using errcode = '22023', message = 'Estimate notes exceed the supported length.';
+  end if;
+
+  select profile_id, canonical_role
+  into v_actor_profile_id, v_actor_role
+  from public.estimate_actor_for_shop(
+    p_shop_id,
+    array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman']
+  );
+  if v_actor_profile_id is null then
+    raise exception using errcode = '42501', message = 'Actor cannot create estimates for this shop.';
+  end if;
+
+  v_customer_name := coalesce(
+    nullif(btrim(p_customer ->> 'businessName'), ''),
+    nullif(btrim(p_customer ->> 'name'), ''),
+    nullif(btrim(concat_ws(' ', p_customer ->> 'firstName', p_customer ->> 'lastName')), '')
+  );
+
+  perform public.validate_estimate_lines(p_lines);
+  select coalesce(jsonb_object_agg(line_key, line_note), '{}'::jsonb)
+  into v_line_notes
+  from (
+    select
+      btrim(entry ->> 'clientKey') as line_key,
+      nullif(btrim(entry ->> 'advisorNotes'), '') as line_note
+    from jsonb_array_elements(p_lines) entry
+  ) internal_notes
+  where line_note is not null;
+
+  insert into public.estimate_events(
+    shop_id, revision, event_type, actor_profile_id, idempotency_key
+  ) values (
+    p_shop_id, 1, 'created', v_actor_profile_id, p_idempotency_key
+  )
+  on conflict (shop_id, idempotency_key) do nothing
+  returning id into v_event_id;
+
+  if v_event_id is null then
+    select event_type, result into v_existing_event_type, v_existing_result
+    from public.estimate_events
+    where shop_id = p_shop_id
+      and idempotency_key = p_idempotency_key;
+    if v_existing_event_type = 'created' and coalesce(v_existing_result, '{}'::jsonb) <> '{}'::jsonb then
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = '23505', message = 'Idempotency key was already used for another estimate operation.';
+  end if;
+
+  if v_customer_id_text is not null then
+    if v_customer_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      raise exception using errcode = '22023', message = 'Customer id must be a UUID.';
+    end if;
+    v_customer_id := v_customer_id_text::uuid;
+    if not exists (
+      select 1 from public.customers c
+      where c.id = v_customer_id and c.shop_id = p_shop_id
+    ) then
+      raise exception using errcode = '23503', message = 'Customer does not belong to this shop.';
+    end if;
+
+    update public.customers c
+    set business_name = coalesce(nullif(btrim(p_customer ->> 'businessName'), ''), c.business_name),
+        name = coalesce(v_customer_name, c.name),
+        first_name = coalesce(nullif(btrim(p_customer ->> 'firstName'), ''), c.first_name),
+        last_name = coalesce(nullif(btrim(p_customer ->> 'lastName'), ''), c.last_name),
+        email = coalesce(v_customer_email, c.email),
+        phone = coalesce(v_customer_phone, c.phone),
+        phone_number = coalesce(v_customer_phone, c.phone_number),
+        address = coalesce(nullif(btrim(p_customer ->> 'address'), ''), c.address),
+        city = coalesce(nullif(btrim(p_customer ->> 'city'), ''), c.city),
+        province = coalesce(nullif(btrim(p_customer ->> 'province'), ''), c.province),
+        postal_code = coalesce(nullif(btrim(p_customer ->> 'postalCode'), ''), c.postal_code)
+    where c.id = v_customer_id
+      and c.shop_id = p_shop_id;
+  else
+    if v_customer_name is null then
+      raise exception using errcode = '22023', message = 'A customer name or business name is required.';
+    end if;
+
+    select c.id into v_customer_id
+    from public.customers c
+    where c.shop_id = p_shop_id
+      and (
+        (v_customer_email is not null and lower(btrim(coalesce(c.email, ''))) = v_customer_email)
+        or (
+          v_customer_phone is not null
+          and coalesce(
+            nullif(regexp_replace(coalesce(c.phone, c.phone_number, ''), '[^0-9]', '', 'g'), ''),
+            nullif(btrim(coalesce(c.phone, c.phone_number, '')), '')
+          ) = v_customer_phone
+        )
+      )
+    order by
+      case when v_customer_email is not null
+        and lower(btrim(coalesce(c.email, ''))) = v_customer_email then 0 else 1 end,
+      c.created_at,
+      c.id
+    limit 1
+    for update;
+
+    if v_customer_id is not null then
+      update public.customers c
+      set business_name = coalesce(nullif(btrim(p_customer ->> 'businessName'), ''), c.business_name),
+          name = coalesce(v_customer_name, c.name),
+          first_name = coalesce(nullif(btrim(p_customer ->> 'firstName'), ''), c.first_name),
+          last_name = coalesce(nullif(btrim(p_customer ->> 'lastName'), ''), c.last_name),
+          email = coalesce(v_customer_email, c.email),
+          phone = coalesce(v_customer_phone, c.phone),
+          phone_number = coalesce(v_customer_phone, c.phone_number),
+          address = coalesce(nullif(btrim(p_customer ->> 'address'), ''), c.address),
+          city = coalesce(nullif(btrim(p_customer ->> 'city'), ''), c.city),
+          province = coalesce(nullif(btrim(p_customer ->> 'province'), ''), c.province),
+          postal_code = coalesce(nullif(btrim(p_customer ->> 'postalCode'), ''), c.postal_code)
+      where c.id = v_customer_id
+        and c.shop_id = p_shop_id;
+    else
+      insert into public.customers(
+        shop_id, business_name, name, first_name, last_name, email,
+        phone, phone_number, address, city, province, postal_code
+      ) values (
+        p_shop_id,
+        nullif(btrim(p_customer ->> 'businessName'), ''),
+        v_customer_name,
+        nullif(btrim(p_customer ->> 'firstName'), ''),
+        nullif(btrim(p_customer ->> 'lastName'), ''),
+        v_customer_email,
+        v_customer_phone,
+        v_customer_phone,
+        nullif(btrim(p_customer ->> 'address'), ''),
+        nullif(btrim(p_customer ->> 'city'), ''),
+        nullif(btrim(p_customer ->> 'province'), ''),
+        nullif(btrim(p_customer ->> 'postalCode'), '')
+      ) returning id into v_customer_id;
+    end if;
+  end if;
+
+  if nullif(btrim(p_vehicle ->> 'year'), '') is not null then
+    begin
+      v_year := (p_vehicle ->> 'year')::integer;
+    exception when invalid_text_representation then
+      raise exception using errcode = '22023', message = 'Vehicle year must be numeric.';
+    end;
+    if v_year < 1886 or v_year > extract(year from now())::integer + 2 then
+      raise exception using errcode = '22023', message = 'Vehicle year is outside the supported range.';
+    end if;
+  end if;
+
+  if v_vehicle_id_text is not null then
+    if v_vehicle_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      raise exception using errcode = '22023', message = 'Vehicle id must be a UUID.';
+    end if;
+    v_vehicle_id := v_vehicle_id_text::uuid;
+    if not exists (
+      select 1 from public.vehicles v
+      where v.id = v_vehicle_id
+        and v.shop_id = p_shop_id
+        and v.customer_id = v_customer_id
+    ) then
+      raise exception using errcode = '23503', message = 'Vehicle does not belong to this customer and shop.';
+    end if;
+
+    update public.vehicles v
+    set year = coalesce(v_year, v.year),
+        make = coalesce(nullif(btrim(p_vehicle ->> 'make'), ''), v.make),
+        model = coalesce(nullif(btrim(p_vehicle ->> 'model'), ''), v.model),
+        vin = coalesce(v_vehicle_vin, v.vin),
+        license_plate = coalesce(v_vehicle_plate, v.license_plate),
+        mileage = coalesce(nullif(btrim(p_vehicle ->> 'mileage'), ''), v.mileage),
+        unit_number = coalesce(v_vehicle_unit, v.unit_number),
+        color = coalesce(nullif(btrim(p_vehicle ->> 'color'), ''), v.color),
+        engine = coalesce(nullif(btrim(p_vehicle ->> 'engine'), ''), v.engine),
+        transmission = coalesce(nullif(btrim(p_vehicle ->> 'transmission'), ''), v.transmission),
+        fuel_type = coalesce(nullif(btrim(p_vehicle ->> 'fuelType'), ''), v.fuel_type),
+        drivetrain = coalesce(nullif(btrim(p_vehicle ->> 'drivetrain'), ''), v.drivetrain)
+    where v.id = v_vehicle_id
+      and v.shop_id = p_shop_id
+      and v.customer_id = v_customer_id;
+  else
+    if nullif(btrim(p_vehicle ->> 'make'), '') is null
+       or nullif(btrim(p_vehicle ->> 'model'), '') is null then
+      raise exception using errcode = '22023', message = 'Vehicle make and model are required.';
+    end if;
+
+    if v_vehicle_vin is not null then
+      select v.id, v.customer_id
+      into v_vehicle_id, v_existing_vehicle_customer_id
+      from public.vehicles v
+      where v.shop_id = p_shop_id
+        and upper(btrim(coalesce(v.vin, ''))) = v_vehicle_vin
+      order by v.created_at, v.id
+      limit 1
+      for update;
+
+      if v_vehicle_id is not null
+         and v_existing_vehicle_customer_id is distinct from v_customer_id then
+        raise exception using errcode = '23505',
+          message = 'This VIN is already assigned to another customer. Contact shop/admin to move vehicle.';
+      end if;
+    end if;
+
+    if v_vehicle_id is null and (v_vehicle_plate is not null or v_vehicle_unit is not null) then
+      select v.id, v.customer_id
+      into v_vehicle_id, v_existing_vehicle_customer_id
+      from public.vehicles v
+      where v.shop_id = p_shop_id
+        and v.customer_id = v_customer_id
+        and (
+          (v_vehicle_plate is not null
+            and upper(btrim(coalesce(v.license_plate, ''))) = v_vehicle_plate)
+          or (v_vehicle_unit is not null
+            and upper(btrim(coalesce(v.unit_number, ''))) = upper(v_vehicle_unit))
+        )
+      order by
+        case when v_vehicle_plate is not null
+          and upper(btrim(coalesce(v.license_plate, ''))) = v_vehicle_plate then 0 else 1 end,
+        v.created_at,
+        v.id
+      limit 1
+      for update;
+    end if;
+
+    if v_vehicle_id is not null then
+      update public.vehicles v
+      set year = coalesce(v_year, v.year),
+          make = coalesce(nullif(btrim(p_vehicle ->> 'make'), ''), v.make),
+          model = coalesce(nullif(btrim(p_vehicle ->> 'model'), ''), v.model),
+          vin = coalesce(v_vehicle_vin, v.vin),
+          license_plate = coalesce(v_vehicle_plate, v.license_plate),
+          mileage = coalesce(nullif(btrim(p_vehicle ->> 'mileage'), ''), v.mileage),
+          unit_number = coalesce(v_vehicle_unit, v.unit_number),
+          color = coalesce(nullif(btrim(p_vehicle ->> 'color'), ''), v.color),
+          engine = coalesce(nullif(btrim(p_vehicle ->> 'engine'), ''), v.engine),
+          transmission = coalesce(nullif(btrim(p_vehicle ->> 'transmission'), ''), v.transmission),
+          fuel_type = coalesce(nullif(btrim(p_vehicle ->> 'fuelType'), ''), v.fuel_type),
+          drivetrain = coalesce(nullif(btrim(p_vehicle ->> 'drivetrain'), ''), v.drivetrain)
+      where v.id = v_vehicle_id
+        and v.shop_id = p_shop_id
+        and v.customer_id = v_customer_id;
+    else
+      insert into public.vehicles(
+        shop_id, customer_id, year, make, model, vin, license_plate,
+        mileage, unit_number, color, engine, transmission, fuel_type, drivetrain
+      ) values (
+        p_shop_id, v_customer_id, v_year,
+        nullif(btrim(p_vehicle ->> 'make'), ''),
+        nullif(btrim(p_vehicle ->> 'model'), ''),
+        v_vehicle_vin,
+        v_vehicle_plate,
+        nullif(btrim(p_vehicle ->> 'mileage'), ''),
+        v_vehicle_unit,
+        nullif(btrim(p_vehicle ->> 'color'), ''),
+        nullif(btrim(p_vehicle ->> 'engine'), ''),
+        nullif(btrim(p_vehicle ->> 'transmission'), ''),
+        nullif(btrim(p_vehicle ->> 'fuelType'), ''),
+        nullif(btrim(p_vehicle ->> 'drivetrain'), '')
+      ) returning id into v_vehicle_id;
+    end if;
+  end if;
+
+  select coalesce(s.labor_rate, 0) into v_shop_labor_rate
+  from public.shops s where s.id = p_shop_id;
+
+  loop
+    v_candidate_work_order_id := gen_random_uuid();
+    v_work_order_id := null;
+    v_custom_id := 'WO-' || upper(substr(replace(gen_random_uuid()::text, '-', ''), 1, 12));
+    v_estimate_number := 'EST-' || upper(substr(replace(gen_random_uuid()::text, '-', ''), 1, 10));
+
+    insert into public.work_orders(
+      id, shop_id, customer_id, vehicle_id, advisor_id, created_by,
+      custom_id, status, type, record_type, estimate_number, estimate_status,
+      estimate_revision, estimate_created_at, estimate_created_by,
+      estimate_expires_at, notes, approval_state
+    ) values (
+      v_candidate_work_order_id, p_shop_id, v_customer_id, v_vehicle_id,
+      v_actor_profile_id, v_actor_user_id, v_custom_id, 'new', 'repair',
+      'estimate', v_estimate_number, 'draft', 1, now(), v_actor_profile_id,
+      p_expires_at, null, 'pending'
+    )
+    on conflict do nothing
+    returning id into v_work_order_id;
+
+    exit when v_work_order_id is not null;
+  end loop;
+
+  insert into public.estimate_internal_details(
+    work_order_id, shop_id, notes, line_notes
+  ) values (
+    v_work_order_id, p_shop_id,
+    nullif(btrim(coalesce(p_notes, '')), ''), v_line_notes
+  );
+
+  for v_line in select value from jsonb_array_elements(p_lines)
+  loop
+    v_labor_hours := coalesce(nullif(v_line ->> 'laborHours', '')::numeric, 0);
+    v_labor_rate := coalesce(nullif(v_line ->> 'laborRate', '')::numeric, v_shop_labor_rate, 0);
+    v_labor_total := round(v_labor_hours * v_labor_rate, 2);
+
+    insert into public.work_order_quote_lines(
+      shop_id, work_order_id, vehicle_id, description, title, notes,
+      labor_hours, est_labor_hours, labor_rate, labor_total, parts_total,
+      subtotal, tax_total, grand_total, status, stage, job_type, line_type,
+      source_row_id, metadata, created_by
+    ) values (
+      p_shop_id, v_work_order_id, v_vehicle_id,
+      coalesce(nullif(btrim(v_line ->> 'customerDescription'), ''), btrim(v_line ->> 'title')),
+      btrim(v_line ->> 'title'),
+      null,
+      v_labor_hours, v_labor_hours, v_labor_rate, v_labor_total, 0,
+      v_labor_total, 0, v_labor_total, 'draft', null, 'repair', 'estimate',
+      'estimate:' || v_work_order_id::text || ':' || btrim(v_line ->> 'clientKey'),
+      jsonb_build_object(
+        'source', 'estimate_builder',
+        'estimate_revision', 1,
+        'client_key', btrim(v_line ->> 'clientKey'),
+        'labor_rate', v_labor_rate,
+        'customer_description', nullif(btrim(v_line ->> 'customerDescription'), ''),
+        'requested_parts', coalesce(v_line -> 'parts', '[]'::jsonb)
+      ),
+      v_actor_user_id
+    ) returning id into v_line_id;
+    v_line_ids := array_append(v_line_ids, v_line_id);
+  end loop;
+
+  perform public.recalculate_estimate_work_order_totals(p_shop_id, v_work_order_id);
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'workOrderId', v_work_order_id,
+    'estimateNumber', v_estimate_number,
+    'estimateStatus', 'draft',
+    'estimateRevision', 1,
+    'customerId', v_customer_id,
+    'vehicleId', v_vehicle_id,
+    'quoteLineIds', to_jsonb(v_line_ids)
+  );
+
+  update public.estimate_events
+  set work_order_id = v_work_order_id,
+      changed_quote_line_ids = v_line_ids,
+      snapshot = jsonb_build_object('customerId', v_customer_id, 'vehicleId', v_vehicle_id),
+      result = v_result
+  where id = v_event_id;
+
+  return v_result;
+end;
+$$;
+
+create or replace function public.save_estimate_draft_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_expected_revision integer,
+  p_lines jsonb,
+  p_notes text,
+  p_expires_at timestamptz,
+  p_idempotency_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor_user_id uuid := auth.uid();
+  v_actor_profile_id uuid;
+  v_actor_role text;
+  v_work_order public.work_orders%rowtype;
+  v_event_id uuid;
+  v_existing_event_type text;
+  v_existing_result jsonb;
+  v_line jsonb;
+  v_line_id uuid;
+  v_line_source text;
+  v_labor_hours numeric;
+  v_labor_rate numeric;
+  v_labor_total numeric;
+  v_shop_labor_rate numeric := 0;
+  v_line_ids uuid[] := array[]::uuid[];
+  v_line_notes jsonb := '{}'::jsonb;
+  v_result jsonb;
+begin
+  if nullif(btrim(coalesce(p_idempotency_key, '')), '') is null
+     or length(p_idempotency_key) > 200 then
+    raise exception using errcode = '22023', message = 'A stable idempotency key is required.';
+  end if;
+  if p_expected_revision is null or p_expected_revision < 1 then
+    raise exception using errcode = '22023', message = 'A valid expected revision is required.';
+  end if;
+  if length(coalesce(p_notes, '')) > 8000 then
+    raise exception using errcode = '22023', message = 'Estimate notes exceed the supported length.';
+  end if;
+  select profile_id, canonical_role into v_actor_profile_id, v_actor_role
+  from public.estimate_actor_for_shop(
+    p_shop_id,
+    array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman']
+  );
+  if v_actor_user_id is null or v_actor_profile_id is null then
+    raise exception using errcode = '42501', message = 'Actor cannot edit estimates for this shop.';
+  end if;
+  perform public.validate_estimate_lines(p_lines);
+  select coalesce(jsonb_object_agg(line_key, line_note), '{}'::jsonb)
+  into v_line_notes
+  from (
+    select
+      btrim(entry ->> 'clientKey') as line_key,
+      nullif(btrim(entry ->> 'advisorNotes'), '') as line_note
+    from jsonb_array_elements(p_lines) entry
+  ) internal_notes
+  where line_note is not null;
+
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id and shop_id = p_shop_id
+  for update;
+  if not found or v_work_order.estimate_number is null then
+    raise exception using errcode = 'P0002', message = 'Estimate not found for this shop.';
+  end if;
+
+  select event_type, result into v_existing_event_type, v_existing_result
+  from public.estimate_events
+  where shop_id = p_shop_id
+    and work_order_id = p_work_order_id
+    and idempotency_key = p_idempotency_key;
+  if found then
+    if v_existing_event_type = 'draft_saved'
+       and coalesce(v_existing_result, '{}'::jsonb) <> '{}'::jsonb then
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = '23505', message = 'Idempotency key was already used.';
+  end if;
+
+  if v_work_order.estimate_status <> 'draft'
+     or v_work_order.estimate_revision <> p_expected_revision then
+    raise exception using errcode = '40001', message = 'Estimate draft is stale or no longer editable.';
+  end if;
+
+  insert into public.estimate_events(
+    shop_id, work_order_id, revision, event_type, actor_profile_id, idempotency_key
+  ) values (
+    p_shop_id, p_work_order_id, v_work_order.estimate_revision,
+    'draft_saved', v_actor_profile_id, p_idempotency_key
+  )
+  on conflict (shop_id, idempotency_key) do nothing
+  returning id into v_event_id;
+  if v_event_id is null then
+    select event_type, result into v_existing_event_type, v_existing_result
+    from public.estimate_events
+    where shop_id = p_shop_id
+      and work_order_id = p_work_order_id
+      and idempotency_key = p_idempotency_key;
+    if v_existing_event_type = 'draft_saved' then
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = '23505', message = 'Idempotency key was already used.';
+  end if;
+
+  select coalesce(s.labor_rate, 0) into v_shop_labor_rate
+  from public.shops s where s.id = p_shop_id;
+
+  for v_line in select value from jsonb_array_elements(p_lines)
+  loop
+    v_line_id := null;
+    v_line_source := 'estimate:' || p_work_order_id::text || ':' || btrim(v_line ->> 'clientKey');
+    v_labor_hours := coalesce(nullif(v_line ->> 'laborHours', '')::numeric, 0);
+    v_labor_rate := coalesce(nullif(v_line ->> 'laborRate', '')::numeric, v_shop_labor_rate, 0);
+    v_labor_total := round(v_labor_hours * v_labor_rate, 2);
+
+    insert into public.work_order_quote_lines(
+      shop_id, work_order_id, vehicle_id, description, title, notes,
+      labor_hours, est_labor_hours, labor_rate, labor_total, parts_total,
+      subtotal, tax_total, grand_total, status, stage, job_type, line_type,
+      source_row_id, metadata, created_by
+    ) values (
+      p_shop_id, p_work_order_id, v_work_order.vehicle_id,
+      coalesce(nullif(btrim(v_line ->> 'customerDescription'), ''), btrim(v_line ->> 'title')),
+      btrim(v_line ->> 'title'), null,
+      v_labor_hours, v_labor_hours, v_labor_rate, v_labor_total, 0,
+      v_labor_total, 0, v_labor_total, 'draft', null, 'repair', 'estimate',
+      v_line_source,
+      jsonb_build_object(
+        'source', 'estimate_builder',
+        'estimate_revision', v_work_order.estimate_revision,
+        'client_key', btrim(v_line ->> 'clientKey'),
+        'labor_rate', v_labor_rate,
+        'customer_description', nullif(btrim(v_line ->> 'customerDescription'), ''),
+        'requested_parts', coalesce(v_line -> 'parts', '[]'::jsonb)
+      ),
+      v_actor_user_id
+    )
+    on conflict (shop_id, work_order_id, source_row_id)
+      where source_row_id like 'estimate:%'
+    do update set
+      description = excluded.description,
+      title = excluded.title,
+      notes = excluded.notes,
+      labor_hours = excluded.labor_hours,
+      est_labor_hours = excluded.est_labor_hours,
+      labor_rate = excluded.labor_rate,
+      labor_total = excluded.labor_total,
+      parts_total = 0,
+      subtotal = excluded.subtotal,
+      tax_total = 0,
+      grand_total = excluded.grand_total,
+      status = 'draft',
+      stage = null,
+      metadata = excluded.metadata,
+      updated_at = now()
+    where public.work_order_quote_lines.status in ('draft', 'cancelled')
+      and public.work_order_quote_lines.sent_to_customer_at is null
+      and public.work_order_quote_lines.work_order_line_id is null
+    returning id into v_line_id;
+    if v_line_id is null then
+      raise exception using errcode = '55000',
+        message = 'A repair line is no longer editable in this estimate draft.';
+    end if;
+    v_line_ids := array_append(v_line_ids, v_line_id);
+  end loop;
+
+  update public.work_order_quote_lines q
+  set status = 'cancelled', stage = null,
+      metadata = coalesce(q.metadata, '{}'::jsonb) || jsonb_build_object(
+        'cancelled_from_estimate_draft', true,
+        'cancelled_at', now()
+      ),
+      updated_at = now()
+  where q.shop_id = p_shop_id
+    and q.work_order_id = p_work_order_id
+    and q.status = 'draft'
+    and q.source_row_id like 'estimate:%'
+    and not (q.id = any(v_line_ids));
+
+  insert into public.estimate_internal_details(
+    work_order_id, shop_id, notes, line_notes, updated_at
+  ) values (
+    p_work_order_id, p_shop_id,
+    nullif(btrim(coalesce(p_notes, '')), ''), v_line_notes, now()
+  )
+  on conflict (work_order_id) do update set
+    notes = excluded.notes,
+    line_notes = excluded.line_notes,
+    updated_at = now();
+
+  update public.work_orders
+  set notes = null,
+      estimate_expires_at = p_expires_at,
+      updated_at = now()
+  where id = p_work_order_id and shop_id = p_shop_id;
+  perform public.recalculate_estimate_work_order_totals(p_shop_id, p_work_order_id);
+
+  v_result := jsonb_build_object(
+    'ok', true, 'idempotent', false, 'workOrderId', p_work_order_id,
+    'estimateStatus', 'draft', 'estimateRevision', v_work_order.estimate_revision,
+    'quoteLineIds', to_jsonb(v_line_ids)
+  );
+  update public.estimate_events
+  set changed_quote_line_ids = v_line_ids, result = v_result
+  where id = v_event_id;
+  return v_result;
+end;
+$$;
+
+create or replace function public.submit_estimate_to_parts_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_expected_revision integer,
+  p_idempotency_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor_user_id uuid := auth.uid();
+  v_actor_profile_id uuid;
+  v_actor_role text;
+  v_work_order public.work_orders%rowtype;
+  v_event_id uuid;
+  v_existing_event_type text;
+  v_existing_result jsonb;
+  v_quote public.work_order_quote_lines%rowtype;
+  v_part jsonb;
+  v_parts jsonb;
+  v_request_id uuid;
+  v_has_parts boolean := false;
+  v_line_ids uuid[] := array[]::uuid[];
+  v_next_status text;
+  v_result jsonb;
+begin
+  if nullif(btrim(coalesce(p_idempotency_key, '')), '') is null
+     or length(p_idempotency_key) > 200 then
+    raise exception using errcode = '22023', message = 'A stable idempotency key is required.';
+  end if;
+  if p_expected_revision is null or p_expected_revision < 1 then
+    raise exception using errcode = '22023', message = 'A valid expected revision is required.';
+  end if;
+  select profile_id, canonical_role into v_actor_profile_id, v_actor_role
+  from public.estimate_actor_for_shop(
+    p_shop_id,
+    array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman']
+  );
+  if v_actor_user_id is null or v_actor_profile_id is null then
+    raise exception using errcode = '42501', message = 'Actor cannot submit estimates for this shop.';
+  end if;
+
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id and shop_id = p_shop_id
+  for update;
+  if not found or v_work_order.estimate_number is null then
+    raise exception using errcode = 'P0002', message = 'Estimate not found for this shop.';
+  end if;
+  if v_work_order.estimate_revision <> p_expected_revision then
+    raise exception using errcode = '40001', message = 'Estimate revision is stale.';
+  end if;
+
+  if v_work_order.estimate_status in ('waiting_for_parts', 'ready_for_advisor') then
+    return jsonb_build_object(
+      'ok', true, 'idempotent', true, 'workOrderId', p_work_order_id,
+      'estimateStatus', v_work_order.estimate_status,
+      'estimateRevision', v_work_order.estimate_revision
+    );
+  end if;
+  if v_work_order.estimate_status <> 'draft' then
+    raise exception using errcode = '55000', message = 'Estimate cannot be submitted from its current state.';
+  end if;
+
+  insert into public.estimate_events(
+    shop_id, work_order_id, revision, event_type, actor_profile_id, idempotency_key
+  ) values (
+    p_shop_id, p_work_order_id, v_work_order.estimate_revision,
+    'submitted_to_parts', v_actor_profile_id, p_idempotency_key
+  )
+  on conflict (shop_id, idempotency_key) do nothing
+  returning id into v_event_id;
+  if v_event_id is null then
+    select event_type, result into v_existing_event_type, v_existing_result
+    from public.estimate_events
+    where shop_id = p_shop_id
+      and work_order_id = p_work_order_id
+      and idempotency_key = p_idempotency_key;
+    if v_existing_event_type = 'submitted_to_parts' then
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = '23505', message = 'Idempotency key was already used.';
+  end if;
+
+  if not exists (
+    select 1 from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id and q.work_order_id = p_work_order_id
+      and q.status = 'draft'
+  ) then
+    raise exception using errcode = '22023', message = 'Estimate has no draft repair lines.';
+  end if;
+
+  select exists (
+    select 1
+    from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id
+      and q.work_order_id = p_work_order_id
+      and q.status = 'draft'
+      and jsonb_typeof(coalesce(q.metadata -> 'requested_parts', '[]'::jsonb)) = 'array'
+      and jsonb_array_length(coalesce(q.metadata -> 'requested_parts', '[]'::jsonb)) > 0
+  ) into v_has_parts;
+
+  -- Item-structure guards permit writes only while the current revision is
+  -- owned by Parts. Move the row first; the transaction rolls this back if any
+  -- request or quote-line write fails.
+  if v_has_parts then
+    update public.work_orders
+    set estimate_status = 'waiting_for_parts',
+        estimate_parts_completed_at = null,
+        estimate_parts_completed_by = null,
+        updated_at = now()
+    where id = p_work_order_id and shop_id = p_shop_id;
+  end if;
+
+  for v_quote in
+    select * from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id and q.work_order_id = p_work_order_id
+      and q.status = 'draft'
+    order by q.created_at, q.id
+    for update
+  loop
+    v_line_ids := array_append(v_line_ids, v_quote.id);
+    v_parts := coalesce(v_quote.metadata -> 'requested_parts', '[]'::jsonb);
+
+    if jsonb_typeof(v_parts) = 'array' and jsonb_array_length(v_parts) > 0 then
+      insert into public.part_requests(
+        shop_id, work_order_id, quote_line_id, requested_by, notes,
+        status, source_context, source_revision
+      ) values (
+        p_shop_id, p_work_order_id, v_quote.id, v_actor_user_id,
+        'Estimate ' || v_work_order.estimate_number || ' · ' || coalesce(v_quote.title, v_quote.description),
+        'requested', 'estimate', v_work_order.estimate_revision
+      )
+      on conflict (shop_id, quote_line_id, source_context, source_revision)
+        where source_context = 'estimate' and quote_line_id is not null
+      do update set notes = excluded.notes
+      returning id into v_request_id;
+
+      for v_part in select value from jsonb_array_elements(v_parts)
+      loop
+        insert into public.part_request_items(
+          request_id, shop_id, work_order_id, quote_line_id, description,
+          qty, qty_requested, requested_part_number, requested_manufacturer,
+          status, source_row_id
+        ) values (
+          v_request_id, p_shop_id, p_work_order_id, v_quote.id,
+          btrim(v_part ->> 'description'),
+          coalesce(nullif(v_part ->> 'quantity', '')::numeric, 1),
+          coalesce(nullif(v_part ->> 'quantity', '')::numeric, 1),
+          nullif(btrim(v_part ->> 'partNumber'), ''),
+          nullif(btrim(v_part ->> 'manufacturer'), ''),
+          'requested', btrim(v_part ->> 'clientKey')
+        )
+        on conflict (request_id, source_row_id) where source_row_id is not null
+        do update set
+          description = excluded.description,
+          qty = excluded.qty,
+          qty_requested = excluded.qty_requested,
+          requested_part_number = excluded.requested_part_number,
+          requested_manufacturer = excluded.requested_manufacturer,
+          updated_at = now();
+      end loop;
+
+      update public.work_order_quote_lines
+      set status = 'pending_parts', stage = 'advisor_pending', updated_at = now()
+      where id = v_quote.id and shop_id = p_shop_id;
+    else
+      update public.work_order_quote_lines
+      set status = 'quoted', stage = 'ready_to_send',
+          parts_total = 0,
+          subtotal = coalesce(labor_total, 0),
+          grand_total = coalesce(labor_total, 0) + coalesce(tax_total, 0),
+          updated_at = now()
+      where id = v_quote.id and shop_id = p_shop_id;
+    end if;
+  end loop;
+
+  v_next_status := case when v_has_parts then 'waiting_for_parts' else 'ready_for_advisor' end;
+  update public.work_orders
+  set estimate_status = v_next_status,
+      estimate_parts_completed_at = case when v_has_parts then null else now() end,
+      estimate_parts_completed_by = case when v_has_parts then null else v_actor_profile_id end,
+      updated_at = now()
+  where id = p_work_order_id and shop_id = p_shop_id;
+  perform public.recalculate_estimate_work_order_totals(p_shop_id, p_work_order_id);
+
+  v_result := jsonb_build_object(
+    'ok', true, 'idempotent', false, 'workOrderId', p_work_order_id,
+    'estimateStatus', v_next_status,
+    'estimateRevision', v_work_order.estimate_revision,
+    'quoteLineIds', to_jsonb(v_line_ids)
+  );
+  update public.estimate_events
+  set changed_quote_line_ids = v_line_ids, result = v_result
+  where id = v_event_id;
+  return v_result;
+end;
+$$;
+
+create or replace function public.complete_estimate_parts_quote_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_expected_revision integer,
+  p_idempotency_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor_user_id uuid := auth.uid();
+  v_actor_profile_id uuid;
+  v_actor_role text;
+  v_work_order public.work_orders%rowtype;
+  v_event_id uuid;
+  v_existing_event_type text;
+  v_existing_result jsonb;
+  v_quote_line_id uuid;
+  v_line_ids uuid[] := array[]::uuid[];
+  v_result jsonb;
+begin
+  if nullif(btrim(coalesce(p_idempotency_key, '')), '') is null
+     or length(p_idempotency_key) > 200 then
+    raise exception using errcode = '22023', message = 'A stable idempotency key is required.';
+  end if;
+  if p_expected_revision is null or p_expected_revision < 1 then
+    raise exception using errcode = '22023', message = 'A valid expected revision is required.';
+  end if;
+  select profile_id, canonical_role into v_actor_profile_id, v_actor_role
+  from public.estimate_actor_for_shop(
+    p_shop_id, array['owner', 'admin', 'manager', 'parts', 'lead_hand', 'foreman']
+  );
+  if v_actor_user_id is null or v_actor_profile_id is null then
+    raise exception using errcode = '42501', message = 'Actor cannot complete estimate parts quotes for this shop.';
+  end if;
+
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id and shop_id = p_shop_id
+  for update;
+  if not found or v_work_order.estimate_number is null then
+    raise exception using errcode = 'P0002', message = 'Estimate not found for this shop.';
+  end if;
+  if v_work_order.estimate_revision <> p_expected_revision then
+    raise exception using errcode = '40001', message = 'Estimate revision is stale.';
+  end if;
+  if v_work_order.estimate_status = 'ready_for_advisor' then
+    return jsonb_build_object(
+      'ok', true, 'idempotent', true, 'workOrderId', p_work_order_id,
+      'estimateStatus', 'ready_for_advisor',
+      'estimateRevision', v_work_order.estimate_revision
+    );
+  end if;
+  if v_work_order.estimate_status <> 'waiting_for_parts' then
+    raise exception using errcode = '55000', message = 'Estimate is not waiting for Parts.';
+  end if;
+
+  insert into public.estimate_events(
+    shop_id, work_order_id, revision, event_type, actor_profile_id, idempotency_key
+  ) values (
+    p_shop_id, p_work_order_id, v_work_order.estimate_revision,
+    'parts_completed', v_actor_profile_id, p_idempotency_key
+  )
+  on conflict (shop_id, idempotency_key) do nothing
+  returning id into v_event_id;
+  if v_event_id is null then
+    select event_type, result into v_existing_event_type, v_existing_result
+    from public.estimate_events
+    where shop_id = p_shop_id
+      and work_order_id = p_work_order_id
+      and idempotency_key = p_idempotency_key;
+    if v_existing_event_type = 'parts_completed' then
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = '23505', message = 'Idempotency key was already used.';
+  end if;
+
+  if not exists (
+    select 1 from public.part_requests pr
+    where pr.shop_id = p_shop_id and pr.work_order_id = p_work_order_id
+      and pr.source_context = 'estimate'
+      and pr.source_revision = v_work_order.estimate_revision
+      and lower(coalesce(pr.status::text, '')) <> 'cancelled'
+  ) then
+    raise exception using errcode = '22023', message = 'No current estimate parts requests were found.';
+  end if;
+
+  if exists (
+    select 1
+    from public.part_requests pr
+    left join public.part_request_items pri
+      on pri.request_id = pr.id
+     and pri.shop_id = p_shop_id
+     and pri.work_order_id = p_work_order_id
+     and pri.quote_line_id = pr.quote_line_id
+     and lower(coalesce(pri.status::text, 'requested')) not in (
+       'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+     )
+    where pr.shop_id = p_shop_id
+      and pr.work_order_id = p_work_order_id
+      and pr.source_context = 'estimate'
+      and pr.source_revision = v_work_order.estimate_revision
+      and lower(coalesce(pr.status::text, '')) <> 'cancelled'
+    group by pr.id
+    having count(pri.id) = 0
+       or bool_or(
+         nullif(btrim(coalesce(pri.description, '')), '') is null
+         or greatest(coalesce(pri.qty, 0), coalesce(pri.qty_requested, 0), 0) <= 0
+         or coalesce(pri.quoted_price, pri.unit_price) is null
+         or coalesce(pri.quoted_price, pri.unit_price) < 0
+       )
+  ) then
+    raise exception using errcode = '23514',
+      message = 'Every requested part needs a description, quantity, and selling price before completion.';
+  end if;
+
+  for v_quote_line_id in
+    select distinct pr.quote_line_id
+    from public.part_requests pr
+    where pr.shop_id = p_shop_id and pr.work_order_id = p_work_order_id
+      and pr.source_context = 'estimate'
+      and pr.source_revision = v_work_order.estimate_revision
+      and pr.quote_line_id is not null
+      and lower(coalesce(pr.status::text, '')) <> 'cancelled'
+    order by pr.quote_line_id
+  loop
+    perform public.sync_quote_line_pricing_from_parts(p_shop_id, v_quote_line_id);
+    update public.work_order_quote_lines q
+    set metadata = jsonb_set(
+      coalesce(q.metadata, '{}'::jsonb),
+      '{parts_quote}',
+      jsonb_build_object(
+        'required_count', coalesce(q.metadata #> '{parts_quote,required_count}', '0'::jsonb),
+        'quoted_count', coalesce(q.metadata #> '{parts_quote,quoted_count}', '0'::jsonb),
+        'pending_count', coalesce(q.metadata #> '{parts_quote,pending_count}', '0'::jsonb),
+        'parts_total', coalesce(q.metadata #> '{parts_quote,parts_total}', '0'::jsonb),
+        'items', coalesce((
+          select jsonb_agg(jsonb_strip_nulls(jsonb_build_object(
+            'description', item -> 'description',
+            'qty', item -> 'qty',
+            'unit_price', item -> 'unit_price',
+            'line_total', item -> 'line_total',
+            'status', item -> 'status',
+            'requested_part_number', item -> 'requested_part_number',
+            'requested_manufacturer', item -> 'requested_manufacturer',
+            'selected_name', item -> 'selected_name',
+            'selected_part_number', item -> 'selected_part_number',
+            'manufacturer', item -> 'manufacturer'
+          )))
+          from jsonb_array_elements(
+            coalesce(q.metadata #> '{parts_quote,items}', '[]'::jsonb)
+          ) item
+        ), '[]'::jsonb)
+      ),
+      true
+    )
+    where q.id = v_quote_line_id
+      and q.shop_id = p_shop_id;
+    v_line_ids := array_append(v_line_ids, v_quote_line_id);
+  end loop;
+
+  if exists (
+    select 1
+    from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id and q.work_order_id = p_work_order_id
+      and q.id = any(v_line_ids)
+      and (
+        lower(coalesce(q.status::text, '')) <> 'quoted'
+        or lower(coalesce(q.stage::text, '')) <> 'ready_to_send'
+      )
+  ) then
+    raise exception using errcode = '23514',
+      message = 'Every requested part needs a description, quantity, and selling price before completion.';
+  end if;
+
+  update public.part_requests
+  set status = 'quoted', updated_at = now()
+  where shop_id = p_shop_id
+    and work_order_id = p_work_order_id
+    and source_context = 'estimate'
+    and source_revision = v_work_order.estimate_revision
+    and lower(coalesce(status::text, '')) <> 'cancelled';
+
+  update public.work_orders
+  set estimate_status = 'ready_for_advisor',
+      estimate_parts_completed_at = now(),
+      estimate_parts_completed_by = v_actor_profile_id,
+      updated_at = now()
+  where id = p_work_order_id and shop_id = p_shop_id;
+  perform public.recalculate_estimate_work_order_totals(p_shop_id, p_work_order_id);
+
+  v_result := jsonb_build_object(
+    'ok', true, 'idempotent', false, 'workOrderId', p_work_order_id,
+    'estimateStatus', 'ready_for_advisor',
+    'estimateRevision', v_work_order.estimate_revision,
+    'quoteLineIds', to_jsonb(v_line_ids)
+  );
+  update public.estimate_events
+  set changed_quote_line_ids = v_line_ids, result = v_result
+  where id = v_event_id;
+  return v_result;
+end;
+$$;
+
+create or replace function public.return_estimate_to_parts_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_quote_line_ids uuid[],
+  p_expected_revision integer,
+  p_reason_code text,
+  p_note text,
+  p_idempotency_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_actor_user_id uuid := auth.uid();
+  v_actor_profile_id uuid;
+  v_actor_role text;
+  v_work_order public.work_orders%rowtype;
+  v_event_id uuid;
+  v_existing_event_type text;
+  v_existing_result jsonb;
+  v_selected uuid[];
+  v_old public.work_order_quote_lines%rowtype;
+  v_new_quote_line_id uuid;
+  v_new_request_id uuid;
+  v_new_revision integer;
+  v_parts jsonb;
+  v_part jsonb;
+  v_line_ids uuid[] := array[]::uuid[];
+  v_line_map jsonb := '[]'::jsonb;
+  v_result jsonb;
+begin
+  v_selected := array(
+    select distinct value
+    from unnest(coalesce(p_quote_line_ids, array[]::uuid[])) value
+    where value is not null
+    order by value
+  );
+  if coalesce(cardinality(v_selected), 0) = 0 then
+    raise exception using errcode = '22023', message = 'Select at least one repair line to return.';
+  end if;
+  if cardinality(v_selected) > 50 then
+    raise exception using errcode = '22023', message = 'No more than 50 repair lines can be returned at once.';
+  end if;
+  if lower(btrim(coalesce(p_reason_code, ''))) <> all(array[
+    'lower_cost_option', 'confirm_availability', 'correct_quantity',
+    'incorrect_application', 'missing_parts', 'review_price',
+    'customer_alternative', 'other'
+  ]::text[]) then
+    raise exception using errcode = '22023', message = 'A return reason is required.';
+  end if;
+  if length(coalesce(p_note, '')) > 4000 then
+    raise exception using errcode = '22023', message = 'Return instructions exceed the supported length.';
+  end if;
+  if nullif(btrim(coalesce(p_idempotency_key, '')), '') is null
+     or length(p_idempotency_key) > 200 then
+    raise exception using errcode = '22023', message = 'A stable idempotency key is required.';
+  end if;
+  if p_expected_revision is null or p_expected_revision < 1 then
+    raise exception using errcode = '22023', message = 'A valid expected revision is required.';
+  end if;
+
+  select profile_id, canonical_role into v_actor_profile_id, v_actor_role
+  from public.estimate_actor_for_shop(
+    p_shop_id,
+    array['owner', 'admin', 'manager', 'advisor', 'service', 'foreman']
+  );
+  if v_actor_user_id is null or v_actor_profile_id is null then
+    raise exception using errcode = '42501', message = 'Actor cannot return estimates to Parts for this shop.';
+  end if;
+
+  select * into v_work_order
+  from public.work_orders
+  where id = p_work_order_id and shop_id = p_shop_id
+  for update;
+  if not found or v_work_order.estimate_number is null then
+    raise exception using errcode = 'P0002', message = 'Estimate not found for this shop.';
+  end if;
+
+  select event_type, result into v_existing_event_type, v_existing_result
+  from public.estimate_events
+  where shop_id = p_shop_id
+    and work_order_id = p_work_order_id
+    and idempotency_key = p_idempotency_key;
+  if found then
+    if v_existing_event_type = 'returned_to_parts'
+       and coalesce(v_existing_result, '{}'::jsonb) <> '{}'::jsonb then
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = '23505', message = 'Idempotency key was already used.';
+  end if;
+
+  if v_work_order.estimate_revision <> p_expected_revision then
+    raise exception using errcode = '40001', message = 'Estimate revision is stale.';
+  end if;
+  if v_work_order.estimate_status not in ('ready_for_advisor', 'sent', 'partially_approved') then
+    raise exception using errcode = '55000', message = 'Estimate cannot be returned from its current state.';
+  end if;
+  if exists (
+    select 1
+    from public.estimate_events e
+    where e.shop_id = p_shop_id
+      and e.work_order_id = p_work_order_id
+      and e.revision = v_work_order.estimate_revision
+      and (
+        e.event_type = 'send_reserved'
+        or (
+          e.event_type = 'send_failed'
+          and (
+            nullif(btrim(coalesce(e.result ->> 'accepted_at', '')), '') is not null
+            or exists (
+              select 1
+              from public.email_logs el
+              where el.shop_id = p_shop_id
+                and el.template_key = 'quote_ready'
+                and lower(btrim(coalesce(el.status, ''))) <> 'suppressed'
+                and el.metadata @> jsonb_build_object(
+                  'estimate_send_key', e.idempotency_key,
+                  'work_order_id', p_work_order_id,
+                  'estimate_revision', v_work_order.estimate_revision
+                )
+            )
+          )
+        )
+      )
+  ) then
+    raise exception using errcode = '55000',
+      message = 'Estimate delivery is in progress. Retry the adjustment after delivery finishes.';
+  end if;
+  if (
+    select count(*) from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id and q.work_order_id = p_work_order_id
+      and q.id = any(v_selected)
+  ) <> cardinality(v_selected) then
+    raise exception using errcode = 'P0002', message = 'One or more selected repair lines were not found.';
+  end if;
+  if exists (
+    select 1 from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id and q.work_order_id = p_work_order_id
+      and q.id = any(v_selected)
+      and (
+        q.approved_at is not null or q.work_order_line_id is not null
+        or lower(coalesce(q.status::text, '')) in (
+          'approved', 'converted', 'declined', 'deferred', 'cancelled', 'superseded'
+        )
+      )
+  ) then
+    raise exception using errcode = '55000', message = 'Approved, decided, or superseded lines cannot be returned to Parts.';
+  end if;
+  if exists (
+    select 1 from public.part_request_items pri
+    where pri.shop_id = p_shop_id and pri.work_order_id = p_work_order_id
+      and pri.quote_line_id = any(v_selected)
+      and (
+        coalesce(pri.qty_ordered, 0) > 0 or coalesce(pri.qty_received, 0) > 0
+        or coalesce(pri.qty_reserved, 0) > 0 or coalesce(pri.qty_picked, 0) > 0
+        or coalesce(pri.qty_consumed, 0) > 0 or coalesce(pri.qty_returned, 0) > 0
+        or pri.po_id is not null or pri.work_order_line_id is not null
+      )
+  ) then
+    raise exception using errcode = '55000', message = 'Lines with inventory or purchase activity cannot be revised.';
+  end if;
+
+  v_new_revision := v_work_order.estimate_revision + 1;
+  insert into public.estimate_events(
+    shop_id, work_order_id, revision, event_type, actor_profile_id,
+    reason_code, note, changed_quote_line_ids, idempotency_key
+  ) values (
+    p_shop_id, p_work_order_id, v_new_revision, 'returned_to_parts',
+    v_actor_profile_id, lower(btrim(p_reason_code)), nullif(btrim(coalesce(p_note, '')), ''),
+    v_selected, p_idempotency_key
+  )
+  on conflict (shop_id, idempotency_key) do nothing
+  returning id into v_event_id;
+  if v_event_id is null then
+    select event_type, result into v_existing_event_type, v_existing_result
+    from public.estimate_events
+    where shop_id = p_shop_id
+      and work_order_id = p_work_order_id
+      and idempotency_key = p_idempotency_key;
+    if v_existing_event_type = 'returned_to_parts' then
+      return v_existing_result || jsonb_build_object('idempotent', true);
+    end if;
+    raise exception using errcode = '23505', message = 'Idempotency key was already used.';
+  end if;
+
+  -- Activate the new Parts-owned revision before its request items are
+  -- inserted. This also keeps quote-line sync triggers from pulling the row
+  -- back into a customer/advisor state mid-revision.
+  update public.work_orders
+  set estimate_revision = v_new_revision,
+      estimate_status = 'waiting_for_parts',
+      estimate_parts_completed_at = null,
+      estimate_parts_completed_by = null,
+      updated_at = now()
+  where id = p_work_order_id and shop_id = p_shop_id;
+
+  for v_old in
+    select * from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id and q.work_order_id = p_work_order_id
+      and q.id = any(v_selected)
+    order by q.id
+    for update
+  loop
+    -- Rebuild from the canonical current request items, not only the advisor's
+    -- original requested_parts snapshot. Parts may have added or removed a
+    -- necessary component while sourcing; the next revision must preserve
+    -- that reviewed scope while clearing its prior commercial quote.
+    select coalesce(jsonb_agg(jsonb_build_object(
+      'clientKey', coalesce(
+        nullif(btrim(pri.source_row_id), ''),
+        'item:' || pri.id::text
+      ),
+      'description', btrim(pri.description),
+      'quantity', greatest(coalesce(pri.qty, 0), coalesce(pri.qty_requested, 0), 1),
+      'partNumber', coalesce(pri.requested_part_number, ''),
+      'manufacturer', coalesce(pri.requested_manufacturer, '')
+    ) order by pri.created_at, pri.id), '[]'::jsonb)
+    into v_parts
+    from public.part_requests pr
+    join public.part_request_items pri
+      on pri.request_id = pr.id
+     and pri.shop_id = p_shop_id
+     and pri.work_order_id = p_work_order_id
+     and pri.quote_line_id = v_old.id
+    where pr.shop_id = p_shop_id
+      and pr.work_order_id = p_work_order_id
+      and pr.quote_line_id = v_old.id
+      and pr.source_context = 'estimate'
+      and pr.source_revision = v_work_order.estimate_revision
+      and lower(coalesce(pr.status::text, '')) not in (
+        'cancelled', 'canceled', 'rejected', 'voided'
+      )
+      and lower(coalesce(pri.status::text, '')) not in (
+        'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+      );
+
+    if jsonb_array_length(v_parts) = 0 then
+      raise exception using errcode = '22023', message = 'Labor-only lines do not need a Parts adjustment.';
+    end if;
+
+    insert into public.work_order_quote_lines(
+      shop_id, work_order_id, vehicle_id, description, title, notes,
+      ai_complaint, ai_cause, ai_correction,
+      labor_hours, est_labor_hours, labor_rate, labor_total, parts_total,
+      subtotal, tax_total, grand_total, status, stage, job_type, line_type,
+      source_row_id, metadata, created_by
+    ) values (
+      p_shop_id, p_work_order_id, v_old.vehicle_id, v_old.description,
+      v_old.title, null, v_old.ai_complaint, v_old.ai_cause, v_old.ai_correction,
+      v_old.labor_hours, v_old.est_labor_hours, v_old.labor_rate,
+      coalesce(v_old.labor_total, 0), 0, coalesce(v_old.labor_total, 0), 0,
+      coalesce(v_old.labor_total, 0), 'pending_parts', 'advisor_pending',
+      v_old.job_type, v_old.line_type,
+      'estimate:' || p_work_order_id::text || ':' ||
+        coalesce(v_old.metadata ->> 'client_key', v_old.id::text) || ':r' || v_new_revision::text,
+      (coalesce(v_old.metadata, '{}'::jsonb) - 'parts_quote') || jsonb_build_object(
+        'estimate_revision', v_new_revision,
+        'revision_of_quote_line_id', v_old.id,
+        'requested_parts', v_parts
+      ),
+      v_actor_user_id
+    ) returning id into v_new_quote_line_id;
+
+    insert into public.part_requests(
+      shop_id, work_order_id, quote_line_id, requested_by, notes,
+      status, source_context, source_revision
+    ) values (
+      p_shop_id, p_work_order_id, v_new_quote_line_id, v_actor_user_id,
+      'Adjustment ' || v_new_revision::text || ' · ' || lower(btrim(p_reason_code)) ||
+        coalesce(' · ' || nullif(btrim(coalesce(p_note, '')), ''), ''),
+      'requested', 'estimate', v_new_revision
+    ) returning id into v_new_request_id;
+
+    for v_part in select value from jsonb_array_elements(v_parts)
+    loop
+      insert into public.part_request_items(
+        request_id, shop_id, work_order_id, quote_line_id, description,
+        qty, qty_requested, requested_part_number, requested_manufacturer,
+        status, source_row_id
+      ) values (
+        v_new_request_id, p_shop_id, p_work_order_id, v_new_quote_line_id,
+        btrim(v_part ->> 'description'),
+        coalesce(nullif(v_part ->> 'quantity', '')::numeric, 1),
+        coalesce(nullif(v_part ->> 'quantity', '')::numeric, 1),
+        nullif(btrim(v_part ->> 'partNumber'), ''),
+        nullif(btrim(v_part ->> 'manufacturer'), ''),
+        'requested', btrim(v_part ->> 'clientKey')
+      );
+    end loop;
+
+    update public.part_requests
+    set status = 'cancelled'
+    where shop_id = p_shop_id and work_order_id = p_work_order_id
+      and quote_line_id = v_old.id
+      and source_context = 'estimate'
+      and lower(coalesce(status::text, '')) not in ('cancelled', 'fulfilled', 'returned');
+
+    update public.work_order_quote_lines
+    set status = 'cancelled', stage = null,
+        sent_to_customer_at = null,
+        metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+          'superseded_at', now(),
+          'superseded_by_quote_line_id', v_new_quote_line_id,
+          'superseded_in_revision', v_new_revision,
+          'superseded_prior_sent_to_customer_at', sent_to_customer_at
+        ),
+        updated_at = now()
+    where id = v_old.id and shop_id = p_shop_id;
+
+    v_line_ids := array_append(v_line_ids, v_new_quote_line_id);
+    v_line_map := v_line_map || jsonb_build_array(jsonb_build_object(
+      'previousQuoteLineId', v_old.id,
+      'quoteLineId', v_new_quote_line_id,
+      'requestId', v_new_request_id
+    ));
+  end loop;
+
+  perform public.recalculate_estimate_work_order_totals(p_shop_id, p_work_order_id);
+
+  v_result := jsonb_build_object(
+    'ok', true, 'idempotent', false, 'workOrderId', p_work_order_id,
+    'estimateStatus', 'waiting_for_parts',
+    'estimateRevision', v_new_revision,
+    'quoteLineIds', to_jsonb(v_line_ids),
+    'lineRevisions', v_line_map
+  );
+  update public.estimate_events
+  set changed_quote_line_ids = v_line_ids,
+      snapshot = jsonb_build_object(
+        'previousRevision', v_work_order.estimate_revision,
+        'lineRevisions', v_line_map
+      ),
+      result = v_result
+  where id = v_event_id;
+  return v_result;
+end;
+$$;
+
+-- Customer delivery crosses an external provider boundary. Reserve the exact
+-- estimate revision and quote-line snapshot in one short database transaction
+-- before making that external call. The service-only grant below keeps this
+-- function behind the already-authenticated, shop-scoped server route.
+create or replace function public.reserve_estimate_send_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_revision integer,
+  p_idempotency_key text,
+  p_actor_profile_id uuid,
+  p_actor_user_id uuid,
+  p_quote_line_ids uuid[],
+  p_allow_resend boolean
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_work_order public.work_orders%rowtype;
+  v_event public.estimate_events%rowtype;
+  v_selected uuid[];
+  v_valid_line_count integer := 0;
+  v_attempt_count integer := 0;
+  v_uncertain_attempt_count integer := 0;
+  v_reclaimable boolean := false;
+  v_attempt_key text;
+begin
+  if p_shop_id is null or p_work_order_id is null or p_revision is null or p_revision < 1 then
+    raise exception using errcode = '22023', message = 'A shop, estimate, and revision are required.';
+  end if;
+  if nullif(btrim(coalesce(p_idempotency_key, '')), '') is null
+     or length(p_idempotency_key) > 200 then
+    raise exception using errcode = '22023', message = 'A stable estimate send key is required.';
+  end if;
+  if not exists (
+    select 1
+    from public.profiles p
+    where p.id = p_actor_profile_id
+      and p.shop_id = p_shop_id
+      and (p.id = p_actor_user_id or p.user_id = p_actor_user_id)
+      and case lower(btrim(coalesce(p.role::text, '')))
+        when 'service_advisor' then 'service'
+        when 'service advisor' then 'service'
+        else lower(btrim(coalesce(p.role::text, '')))
+      end in ('owner', 'admin', 'manager', 'advisor', 'service', 'foreman')
+  ) then
+    raise exception using errcode = '42501', message = 'Actor cannot send estimates for this shop.';
+  end if;
+
+  select * into v_work_order
+  from public.work_orders w
+  where w.id = p_work_order_id
+    and w.shop_id = p_shop_id
+  for update;
+  if not found or v_work_order.estimate_number is null then
+    raise exception using errcode = 'P0002', message = 'Estimate not found for this shop.';
+  end if;
+  if v_work_order.estimate_revision <> p_revision then
+    raise exception using errcode = '40001', message = 'Estimate revision is stale.';
+  end if;
+  if v_work_order.estimate_status not in ('ready_for_advisor', 'sent') then
+    raise exception using errcode = '55000', message = 'Estimate is not ready for customer delivery.';
+  end if;
+
+  select * into v_event
+  from public.estimate_events e
+  where e.shop_id = p_shop_id
+    and e.idempotency_key = p_idempotency_key
+  for update;
+
+  if v_event.id is null then
+    select * into v_event
+    from public.estimate_events e
+    where e.shop_id = p_shop_id
+      and e.work_order_id = p_work_order_id
+      and e.revision = p_revision
+      and e.event_type in ('send_reserved', 'send_failed', 'sent')
+    for update;
+  elsif v_event.work_order_id is distinct from p_work_order_id
+     or v_event.revision <> p_revision
+     or v_event.event_type not in ('send_reserved', 'send_failed', 'sent') then
+    raise exception using errcode = '23505',
+      message = 'Idempotency key was already used for another estimate operation.';
+  end if;
+
+  if v_event.id is not null then
+    if v_event.event_type = 'sent' then
+      return jsonb_build_object(
+        'ok', true, 'eventId', v_event.id, 'eventType', 'sent', 'replay', true
+      );
+    end if;
+
+    v_attempt_key := v_event.idempotency_key;
+    select
+      count(*),
+      count(*) filter (
+        where lower(btrim(coalesce(el.status, ''))) <> 'suppressed'
+      )
+    into v_attempt_count, v_uncertain_attempt_count
+    from public.email_logs el
+    where el.shop_id = p_shop_id
+      and el.template_key = 'quote_ready'
+      and el.metadata @> jsonb_build_object(
+        'estimate_send_key', v_attempt_key,
+        'work_order_id', p_work_order_id,
+        'estimate_revision', p_revision
+      );
+
+    v_reclaimable := nullif(btrim(coalesce(v_event.result ->> 'accepted_at', '')), '') is null
+      and v_uncertain_attempt_count = 0
+      and (
+        (v_event.event_type = 'send_failed' and v_attempt_count = 0)
+        or v_attempt_count > 0
+        or coalesce(v_event.updated_at, v_event.created_at) <= now() - interval '15 minutes'
+      );
+
+    if not v_reclaimable then
+      return jsonb_build_object(
+        'ok', true,
+        'eventId', v_event.id,
+        'eventType', v_event.event_type,
+        'replay', true,
+        'deliveryState', case
+          when v_uncertain_attempt_count > 0 then 'delivery_uncertain'
+          else 'in_progress'
+        end
+      );
+    end if;
+  end if;
+
+  v_selected := array(
+    select distinct value
+    from unnest(coalesce(p_quote_line_ids, array[]::uuid[])) value
+    where value is not null
+    order by value
+  );
+  if coalesce(cardinality(v_selected), 0) = 0 then
+    raise exception using errcode = '22023', message = 'At least one quote line is required for delivery.';
+  end if;
+  if cardinality(v_selected) > 50 then
+    raise exception using errcode = '22023', message = 'No more than 50 quote lines can be sent at once.';
+  end if;
+
+  perform q.id
+  from public.work_order_quote_lines q
+  where q.shop_id = p_shop_id
+    and q.work_order_id = p_work_order_id
+    and q.id = any(v_selected)
+  order by q.id
+  for update;
+
+  select count(*) into v_valid_line_count
+  from public.work_order_quote_lines q
+  where q.shop_id = p_shop_id
+    and q.work_order_id = p_work_order_id
+    and q.id = any(v_selected)
+    and q.approved_at is null
+    and q.declined_at is null
+    and q.deferred_at is null
+    and q.work_order_line_id is null
+    and (
+      (
+        q.sent_to_customer_at is null
+        and coalesce(q.metadata ->> 'estimate_revision', '') = p_revision::text
+        and (
+          lower(btrim(coalesce(q.status::text, ''))) in (
+            'advisor_pending', 'ready_to_send', 'quoted'
+          )
+          or lower(btrim(coalesce(q.stage::text, ''))) in (
+            'advisor_pending', 'ready_to_send'
+          )
+        )
+      )
+      or (
+        coalesce(p_allow_resend, false)
+        and q.sent_to_customer_at is not null
+        and lower(btrim(coalesce(q.status::text, ''))) = 'sent'
+      )
+    );
+
+  if v_valid_line_count <> cardinality(v_selected) then
+    raise exception using errcode = '40001',
+      message = 'Estimate pricing changed before delivery could be reserved.';
+  end if;
+
+  if v_event.id is not null then
+    update public.estimate_events e
+    set event_type = 'send_reserved',
+        actor_profile_id = p_actor_profile_id,
+        idempotency_key = p_idempotency_key,
+        snapshot = jsonb_build_object(
+          'quote_line_ids', to_jsonb(v_selected),
+          'request_allows_resend', coalesce(p_allow_resend, false),
+          'actor_user_id', p_actor_user_id
+        ),
+        result = jsonb_build_object('delivery_state', 'sending'),
+        updated_at = now()
+    where e.id = v_event.id
+      and e.shop_id = p_shop_id;
+
+    return jsonb_build_object(
+      'ok', true, 'eventId', v_event.id, 'eventType', 'send_reserved',
+      'replay', false, 'reclaimed', true
+    );
+  end if;
+
+  insert into public.estimate_events(
+    shop_id, work_order_id, revision, event_type, actor_profile_id,
+    snapshot, result, idempotency_key
+  ) values (
+    p_shop_id, p_work_order_id, p_revision, 'send_reserved', p_actor_profile_id,
+    jsonb_build_object(
+      'quote_line_ids', to_jsonb(v_selected),
+      'request_allows_resend', coalesce(p_allow_resend, false),
+      'actor_user_id', p_actor_user_id
+    ),
+    jsonb_build_object('delivery_state', 'sending'),
+    p_idempotency_key
+  )
+  returning * into v_event;
+
+  return jsonb_build_object(
+    'ok', true, 'eventId', v_event.id, 'eventType', 'send_reserved',
+    'replay', false, 'reclaimed', false
+  );
+end;
+$$;
+
+-- After the provider accepts delivery, publish the reserved lines and complete
+-- the idempotency event together. Replays repair interrupted local persistence
+-- without sending another customer email.
+create or replace function public.finalize_estimate_send_atomic(
+  p_shop_id uuid,
+  p_work_order_id uuid,
+  p_revision integer,
+  p_event_id uuid,
+  p_sent_at timestamptz,
+  p_quote_url text,
+  p_actor_profile_id uuid,
+  p_actor_user_id uuid
+)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_work_order public.work_orders%rowtype;
+  v_event public.estimate_events%rowtype;
+  v_selected uuid[];
+  v_line_count integer := 0;
+  v_updated_count integer := 0;
+  v_decided_count integer := 0;
+  v_has_approved_lines boolean := false;
+begin
+  if p_sent_at is null then
+    raise exception using errcode = '22023', message = 'Provider acceptance time is required.';
+  end if;
+  if not exists (
+    select 1
+    from public.profiles p
+    where p.id = p_actor_profile_id
+      and p.shop_id = p_shop_id
+      and (p.id = p_actor_user_id or p.user_id = p_actor_user_id)
+      and case lower(btrim(coalesce(p.role::text, '')))
+        when 'service_advisor' then 'service'
+        when 'service advisor' then 'service'
+        else lower(btrim(coalesce(p.role::text, '')))
+      end in ('owner', 'admin', 'manager', 'advisor', 'service', 'foreman')
+  ) then
+    raise exception using errcode = '42501', message = 'Actor cannot finalize estimate delivery for this shop.';
+  end if;
+
+  select * into v_work_order
+  from public.work_orders w
+  where w.id = p_work_order_id
+    and w.shop_id = p_shop_id
+  for update;
+  if not found or v_work_order.estimate_number is null then
+    raise exception using errcode = 'P0002', message = 'Estimate not found for this shop.';
+  end if;
+  if v_work_order.estimate_revision <> p_revision then
+    raise exception using errcode = '40001', message = 'Estimate revision changed before delivery finalized.';
+  end if;
+
+  select * into v_event
+  from public.estimate_events e
+  where e.id = p_event_id
+    and e.shop_id = p_shop_id
+    and e.work_order_id = p_work_order_id
+    and e.revision = p_revision
+  for update;
+  if not found then
+    raise exception using errcode = 'P0002', message = 'Estimate send reservation was not found.';
+  end if;
+  if v_event.event_type = 'sent' then
+    return coalesce(v_event.result, '{}'::jsonb) || jsonb_build_object(
+      'ok', true, 'idempotent', true, 'eventId', v_event.id
+    );
+  end if;
+  if v_event.event_type <> 'send_reserved' then
+    raise exception using errcode = '55000', message = 'Estimate send reservation is not active.';
+  end if;
+
+  begin
+    v_selected := array(
+      select distinct value::uuid
+      from jsonb_array_elements_text(
+        coalesce(v_event.snapshot -> 'quote_line_ids', '[]'::jsonb)
+      ) value
+      order by value::uuid
+    );
+  exception when invalid_text_representation then
+    raise exception using errcode = '22023', message = 'Estimate send reservation contains invalid quote lines.';
+  end;
+  if coalesce(cardinality(v_selected), 0) = 0 then
+    raise exception using errcode = '22023', message = 'Estimate send reservation has no quote lines.';
+  end if;
+
+  perform q.id
+  from public.work_order_quote_lines q
+  where q.shop_id = p_shop_id
+    and q.work_order_id = p_work_order_id
+    and q.id = any(v_selected)
+  order by q.id
+  for update;
+
+  select count(*) into v_line_count
+  from public.work_order_quote_lines q
+  where q.shop_id = p_shop_id
+    and q.work_order_id = p_work_order_id
+    and q.id = any(v_selected)
+    and lower(btrim(coalesce(q.status::text, ''))) not in (
+      'cancelled', 'canceled', 'rejected', 'superseded', 'voided'
+    );
+  if v_line_count <> cardinality(v_selected) then
+    raise exception using errcode = '40001', message = 'Reserved estimate lines changed before delivery finalized.';
+  end if;
+
+  update public.work_order_quote_lines q
+  set status = 'sent',
+      stage = 'sent',
+      sent_to_customer_at = coalesce(q.sent_to_customer_at, p_sent_at),
+      sent_at = coalesce(q.sent_at, p_sent_at),
+      sent_by = coalesce(q.sent_by, p_actor_user_id),
+      updated_at = p_sent_at
+  where q.shop_id = p_shop_id
+    and q.work_order_id = p_work_order_id
+    and q.id = any(v_selected)
+    and q.approved_at is null
+    and q.declined_at is null
+    and q.deferred_at is null
+    and q.work_order_line_id is null
+    and (
+      lower(btrim(coalesce(q.status::text, ''))) in (
+        'advisor_pending', 'ready_to_send', 'quoted', 'sent'
+      )
+      or lower(btrim(coalesce(q.stage::text, ''))) in (
+        'advisor_pending', 'ready_to_send', 'sent'
+      )
+    );
+  get diagnostics v_updated_count = row_count;
+
+  select count(*) into v_decided_count
+  from public.work_order_quote_lines q
+  where q.shop_id = p_shop_id
+    and q.work_order_id = p_work_order_id
+    and q.id = any(v_selected)
+    and (
+      q.approved_at is not null
+      or q.declined_at is not null
+      or q.deferred_at is not null
+      or q.work_order_line_id is not null
+      or lower(btrim(coalesce(q.status::text, ''))) in (
+        'approved', 'converted', 'declined', 'deferred'
+      )
+    );
+  if v_updated_count + v_decided_count <> cardinality(v_selected) then
+    raise exception using errcode = '40001', message = 'Reserved estimate lines are no longer sendable.';
+  end if;
+
+  select exists (
+    select 1
+    from public.work_order_quote_lines q
+    where q.shop_id = p_shop_id
+      and q.work_order_id = p_work_order_id
+      and (
+        q.approved_at is not null
+        or q.work_order_line_id is not null
+        or lower(btrim(coalesce(q.status::text, ''))) in ('approved', 'converted')
+      )
+  ) into v_has_approved_lines;
+
+  update public.work_orders w
+  set quote_url = coalesce(nullif(btrim(coalesce(p_quote_url, '')), ''), w.quote_url),
+      approval_state = case
+        when v_updated_count = 0 then w.approval_state
+        when v_has_approved_lines then 'partial'
+        else 'pending'
+      end,
+      estimate_status = case when v_updated_count > 0 then 'sent' else w.estimate_status end,
+      estimate_sent_at = coalesce(w.estimate_sent_at, p_sent_at),
+      estimate_sent_by = coalesce(w.estimate_sent_by, p_actor_profile_id),
+      updated_at = p_sent_at
+  where w.id = p_work_order_id
+    and w.shop_id = p_shop_id
+    and w.estimate_revision = p_revision;
+
+  update public.estimate_events e
+  set event_type = 'sent',
+      result = jsonb_build_object(
+        'delivery_state', 'completed',
+        'sent_at', p_sent_at,
+        'quote_line_ids', to_jsonb(v_selected),
+        'already_decided_count', v_decided_count
+      ),
+      updated_at = now()
+  where e.id = v_event.id
+    and e.shop_id = p_shop_id
+    and e.event_type = 'send_reserved';
+
+  return jsonb_build_object(
+    'ok', true, 'idempotent', false, 'eventId', v_event.id,
+    'workOrderId', p_work_order_id, 'estimateRevision', p_revision,
+    'quoteLineIds', to_jsonb(v_selected)
+  );
+end;
+$$;
+
+revoke all on function public.create_estimate_atomic(uuid, jsonb, jsonb, jsonb, text, timestamptz, text)
+  from public, anon, authenticated, service_role;
+revoke all on function public.save_estimate_draft_atomic(uuid, uuid, integer, jsonb, text, timestamptz, text)
+  from public, anon, authenticated, service_role;
+revoke all on function public.submit_estimate_to_parts_atomic(uuid, uuid, integer, text)
+  from public, anon, authenticated, service_role;
+revoke all on function public.complete_estimate_parts_quote_atomic(uuid, uuid, integer, text)
+  from public, anon, authenticated, service_role;
+revoke all on function public.return_estimate_to_parts_atomic(uuid, uuid, uuid[], integer, text, text, text)
+  from public, anon, authenticated, service_role;
+revoke all on function public.reserve_estimate_send_atomic(uuid, uuid, integer, text, uuid, uuid, uuid[], boolean)
+  from public, anon, authenticated, service_role;
+revoke all on function public.finalize_estimate_send_atomic(uuid, uuid, integer, uuid, timestamptz, text, uuid, uuid)
+  from public, anon, authenticated, service_role;
+
+grant execute on function public.create_estimate_atomic(uuid, jsonb, jsonb, jsonb, text, timestamptz, text)
+  to authenticated;
+grant execute on function public.save_estimate_draft_atomic(uuid, uuid, integer, jsonb, text, timestamptz, text)
+  to authenticated;
+grant execute on function public.submit_estimate_to_parts_atomic(uuid, uuid, integer, text)
+  to authenticated;
+grant execute on function public.complete_estimate_parts_quote_atomic(uuid, uuid, integer, text)
+  to authenticated;
+grant execute on function public.return_estimate_to_parts_atomic(uuid, uuid, uuid[], integer, text, text, text)
+  to authenticated;
+grant execute on function public.reserve_estimate_send_atomic(uuid, uuid, integer, text, uuid, uuid, uuid[], boolean)
+  to service_role;
+grant execute on function public.finalize_estimate_send_atomic(uuid, uuid, integer, uuid, timestamptz, text, uuid, uuid)
+  to service_role;
+
+comment on function public.create_estimate_atomic(uuid, jsonb, jsonb, jsonb, text, timestamptz, text) is
+  'Creates one canonical pre-authorization work order, customer/vehicle when needed, and draft quote lines atomically.';
+comment on function public.submit_estimate_to_parts_atomic(uuid, uuid, integer, text) is
+  'Idempotently creates estimate-sourced part requests for the current revision; labor-only lines bypass Parts.';
+comment on function public.complete_estimate_parts_quote_atomic(uuid, uuid, integer, text) is
+  'Parts-only completion gate that validates canonical quote pricing before returning the estimate to its advisor.';
+comment on function public.return_estimate_to_parts_atomic(uuid, uuid, uuid[], integer, text, text, text) is
+  'Creates an audited immutable revision for selected unapproved estimate lines and reopens only those parts requests.';
+comment on function public.reserve_estimate_send_atomic(uuid, uuid, integer, text, uuid, uuid, uuid[], boolean) is
+  'Service-only reservation for one immutable customer delivery snapshot per estimate revision.';
+comment on function public.finalize_estimate_send_atomic(uuid, uuid, integer, uuid, timestamptz, text, uuid, uuid) is
+  'Service-only atomic publication of provider-accepted estimate lines and completion of the delivery ledger.';
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/dashboard-server-context.test.ts
+++ b/tests/dashboard-server-context.test.ts
@@ -90,7 +90,7 @@ describe("dashboard server shop context", () => {
     expect(calls).toContainEqual({
       table: "profiles",
       method: "select",
-      columns: "completed_onboarding, email, full_name, role, shop_id",
+      columns: "id, role, shop_id, completed_onboarding, email, full_name",
     });
     expect(calls).toContainEqual({
       table: "profiles",
@@ -111,10 +111,14 @@ describe("dashboard server shop context", () => {
     });
   });
 
-  it("keeps middleware and dashboard resolver profile lookup semantics aligned", () => {
+  it("keeps dashboard identity aligned with the canonical staff profile lookup", () => {
     const middlewareSource = readFileSync("middleware.ts", "utf8");
     const resolverSource = readFileSync(
       "features/dashboard/server/dashboard-shell-data.ts",
+      "utf8",
+    );
+    const staffResolverSource = readFileSync(
+      "features/shared/lib/server/admin-access.ts",
       "utf8",
     );
 
@@ -123,10 +127,11 @@ describe("dashboard server shop context", () => {
     expect(middlewareSource).toContain(".limit(1)");
     expect(middlewareSource).toContain(".maybeSingle()");
 
-    expect(resolverSource).toContain('.from("profiles")');
-    expect(resolverSource).toContain('.eq("id", userId)');
-    expect(resolverSource).toContain(".limit(1)");
-    expect(resolverSource).toContain(".maybeSingle<DashboardProfile>()");
+    expect(resolverSource).toContain("resolveAuthenticatedStaffProfile");
+    expect(staffResolverSource).toContain('.from("profiles")');
+    expect(staffResolverSource).toContain('.eq("id", authUserId)');
+    expect(staffResolverSource).toContain('.eq("user_id", authUserId)');
+    expect(staffResolverSource).toContain(".maybeSingle<ProfileScope>()");
     expect(resolverSource).not.toContain("createServer" + "ComponentClient");
     expect(resolverSource).not.toContain("@supabase/" + "auth-helpers-nextjs");
   });

--- a/tests/estimate-builder-flow.test.ts
+++ b/tests/estimate-builder-flow.test.ts
@@ -1,0 +1,408 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import { TILES } from "@/features/shared/config/tiles";
+import {
+  ESTIMATE_ADVISOR_ROLES,
+  ESTIMATE_PARTS_ROLES,
+  ESTIMATE_VIEW_ROLES,
+  estimateActorForRole,
+} from "@/features/estimates/lib/access";
+import {
+  estimateNextOwner,
+  estimatePrimaryAction,
+  estimateStatusLabel,
+} from "@/features/estimates/lib/status";
+import { canonicalizeRole } from "@/features/shared/lib/rbac";
+
+const migration = readFileSync(
+  "supabase/migrations/20260802024436_advisor_estimate_workflow.sql",
+  "utf8",
+);
+const portalQuote = readFileSync(
+  "features/portal/app/quotes/[id]/QuotePageClient.tsx",
+  "utf8",
+);
+const quoteSendRoute = readFileSync("app/api/quotes/send/route.ts", "utf8");
+const quoteSaveRoute = readFileSync(
+  "app/api/parts/requests/items/[itemId]/quote-save/route.ts",
+  "utf8",
+);
+const portalQuoteList = readFileSync("app/portal/quotes/page.tsx", "utf8");
+const roleSidebar = readFileSync(
+  "features/shared/components/RoleSidebar.tsx",
+  "utf8",
+);
+const dashboardIdentity = readFileSync(
+  "features/dashboard/server/dashboard-shell-data.ts",
+  "utf8",
+);
+const estimateBuilder = readFileSync(
+  "features/estimates/components/EstimateBuilder.tsx",
+  "utf8",
+);
+const estimateData = readFileSync("features/estimates/server/data.ts", "utf8");
+const estimateRoutes = [
+  "app/api/estimates/route.ts",
+  "app/api/estimates/[id]/route.ts",
+  "app/api/estimates/[id]/submit-parts/route.ts",
+  "app/api/estimates/[id]/parts-complete/route.ts",
+  "app/api/estimates/[id]/return-to-parts/route.ts",
+].map((path) => readFileSync(path, "utf8"));
+
+describe("advisor estimate workflow", () => {
+  it("keeps one canonical work-order record and uses valid base work-order states", () => {
+    expect(migration).toContain(
+      "record_type text not null default 'work_order'",
+    );
+    expect(migration).toContain("'estimate', v_estimate_number, 'draft'");
+    expect(migration).toContain("v_custom_id, 'new', 'repair'");
+    expect(migration).toContain("p_expires_at, null, 'pending'");
+    expect(migration).toContain(
+      "create table if not exists public.estimate_internal_details",
+    );
+    expect(migration).toContain("Staff-only estimate notes");
+    expect(migration).toContain("line_notes = excluded.line_notes");
+    expect(migration).not.toContain("v_custom_id, 'estimate', 'estimate'");
+    expect(migration).not.toContain("status = 'authorized'");
+    expect(migration).not.toContain(
+      "status = case when v_declined > 0 then 'cancelled'",
+    );
+  });
+
+  it("guards every mutation by shop membership, role, revision, and idempotency", () => {
+    expect(migration).toContain("v_actor_user_id uuid := auth.uid()");
+    expect(migration).toContain(
+      "p.id = (select auth.uid()) or p.user_id = (select auth.uid())",
+    );
+    expect(migration).toContain(
+      "where id = p_work_order_id and shop_id = p_shop_id",
+    );
+    expect(migration).toContain(
+      "v_work_order.estimate_revision <> p_expected_revision",
+    );
+    expect(migration).toContain("unique (shop_id, idempotency_key)");
+    expect(migration).toContain(
+      "work_order_id uuid references public.work_orders(id) on delete set null",
+    );
+    expect(migration).toContain("part_requests_estimate_revision_key");
+    expect(migration).toContain("part_request_items_request_source_key");
+    expect(migration).toContain("estimate_events_sent_revision_key");
+    expect(migration).toContain(
+      "where event_type in ('send_reserved', 'send_failed', 'sent')",
+    );
+    expect(migration).toContain(
+      "length(btrim(idempotency_key)) between 1 and 200",
+    );
+    expect(migration).toContain("A valid expected revision is required.");
+    expect(migration).toContain(
+      "from public, anon, authenticated, service_role",
+    );
+    expect(migration).toContain("to authenticated;");
+    expect(migration).toContain(
+      "create policy part_request_items_update_same_shop_parent_request",
+    );
+    expect(migration).toContain(
+      "public.can_update_part_request_items(pr.shop_id)",
+    );
+    expect(migration).toContain("'parts', 'lead_hand', 'foreman'");
+    expect(migration).toContain(
+      "create or replace function public.can_update_estimate_part_request_items",
+    );
+    expect(migration).toContain("'parts', 'lead_hand', 'foreman'");
+    expect(migration).toContain("e.event_type = 'send_reserved'");
+    expect(migration).toContain("e.event_type = 'send_failed'");
+  });
+
+  it("derives RLS shop and role context from either supported profile identity", () => {
+    expect(migration).toContain(
+      "create or replace function public.current_shop_id()",
+    );
+    expect(migration).toContain(
+      "create or replace function public.profixiq_current_role()",
+    );
+    expect(migration).toContain(
+      "create or replace function public.set_current_shop_id(p_shop_id uuid)",
+    );
+    expect(migration).toContain("p.user_id = (select auth.uid())");
+    expect(migration).toContain(
+      "without relying on mutable request-local settings",
+    );
+    expect(migration).toContain("create policy estimate_staff_shop_read");
+    expect(migration).toContain("create policy estimate_staff_customer_read");
+  });
+
+  it("keeps Parts provenance on auth-user ids while lifecycle audit uses profile ids", () => {
+    expect(migration).toContain(
+      "p_shop_id, p_work_order_id, v_quote.id, v_actor_user_id",
+    );
+    expect(migration).toContain(
+      "p_shop_id, p_work_order_id, v_new_quote_line_id, v_actor_user_id",
+    );
+    expect(migration).toContain("'parts_completed', v_actor_profile_id");
+  });
+
+  it("preserves immutable revisions and releases only canonical approval behavior", () => {
+    expect(migration).toContain(
+      "v_new_revision := v_work_order.estimate_revision + 1",
+    );
+    expect(migration).toContain(
+      "Rebuild from the canonical current request items",
+    );
+    expect(migration).toContain("'item:' || pri.id::text");
+    expect(migration).toContain("'requested_parts', v_parts");
+    expect(migration).toContain("'superseded_by_quote_line_id'");
+    expect(migration).toContain(
+      "'superseded_prior_sent_to_customer_at', sent_to_customer_at",
+    );
+    expect(migration).toContain("sent_to_customer_at = null");
+    expect(migration).toContain(
+      "Lines with inventory or purchase activity cannot be revised.",
+    );
+    expect(migration).toContain("estimate_status = 'waiting_for_parts'");
+    expect(migration).toContain("approval_state = case");
+    expect(migration).toContain(
+      "estimate_converted_at = coalesce(estimate_converted_at, now())",
+    );
+    expect(migration).toContain(
+      "v_work_order.estimate_status = 'waiting_for_parts'",
+    );
+    expect(quoteSaveRoute).toContain(
+      'estimate.estimate_status !== "waiting_for_parts"',
+    );
+    expect(quoteSaveRoute).toContain(
+      "estimate.estimate_revision !== parentRequest.source_revision",
+    );
+    expect(quoteSaveRoute).toContain("ESTIMATE_PARTS_ROLES.some");
+    expect(migration).toContain(
+      "prevent_estimate_part_quote_changes_after_handoff",
+    );
+    expect(migration).toContain("prevent_estimate_part_item_structure_changes");
+    expect(migration).toContain(
+      "create policy part_request_items_estimate_role_update",
+    );
+    expect(migration).toContain(
+      "create policy work_order_quote_lines_estimate_update",
+    );
+    expect(migration).toContain(
+      "create or replace function public.can_select_estimate_quote_line",
+    );
+    expect(migration).toContain(
+      "create or replace function public.can_select_estimate_work_order",
+    );
+    expect(migration).toContain("create policy work_orders_estimate_insert");
+    expect(migration).toContain("create policy work_orders_estimate_update");
+    expect(migration).toContain("or record_type = 'work_order'");
+    expect(migration).toContain("Draft, Parts, and superseded revisions");
+    expect(migration).toContain(
+      "v_status not in ('cancelled', 'canceled', 'rejected', 'superseded', 'voided')",
+    );
+    expect(migration).toContain("p_sent_to_customer_at is not null");
+    expect(migration).toContain(
+      "prevent_estimate_quote_commercial_changes_after_handoff",
+    );
+    expect(migration).toContain("as restrictive");
+    expect(migration).toContain(
+      "v_estimate_status is distinct from 'waiting_for_parts'",
+    );
+  });
+
+  it("reuses mutation keys after ambiguous network failures", () => {
+    expect(estimateBuilder).toContain(
+      "idempotencyKeysRef.current.get(actionKey)",
+    );
+    expect(estimateBuilder).toContain(
+      "idempotencyKeysRef.current.set(actionKey, idempotencyKey)",
+    );
+    expect(estimateBuilder).toContain(
+      "idempotencyKeysRef.current.delete(actionKey)",
+    );
+    expect(estimateBuilder).toContain(
+      "const existingCreated = createdEstimateRef.current",
+    );
+    expect(estimateBuilder).toMatch(
+      /existingCreated\s*\?\?\s*\(\s*await runMutation/,
+    );
+    expect(estimateBuilder).toContain(
+      "if (existingCreated || created.idempotent)",
+    );
+    expect(estimateBuilder).toContain("save-created-draft:");
+    expect(estimateBuilder).toContain(
+      'stateBody.estimate.estimateStatus !== "draft"',
+    );
+  });
+
+  it("hides superseded revisions and never prices customer parts from internal cost", () => {
+    expect(portalQuote).toMatch(/"cancelled",\s*"rejected",\s*"superseded"/);
+    expect(portalQuote).toContain(
+      "part.unitPrice ?? part.unit_price ?? part.quoted_price ?? part.price",
+    );
+    expect(portalQuote).toContain(
+      "getQuoteParts(line, Boolean(wo.estimate_number))",
+    );
+    expect(portalQuote).toMatch(
+      /const customerLineNotes\s*=\s*wo\.estimate_number\s*\?\s*""\s*:\s*safeTrim\(line\.notes\)/,
+    );
+    const quoteParts = portalQuote.slice(
+      portalQuote.indexOf("function getQuoteParts"),
+      portalQuote.indexOf("function getEvidencePhotos"),
+    );
+    expect(quoteParts).not.toContain("part.unit_cost");
+    expect(quoteParts).not.toContain("part.unitCost");
+    expect(portalQuoteList).toContain(
+      'or("external_id.like.portal_quote:%,estimate_number.not.is.null")',
+    );
+    expect(portalQuoteList).toContain("isCustomerVisibleEstimateLine");
+    expect(portalQuoteList).toContain(
+      "workOrder.work_order_quote_lines.length > 0",
+    );
+    expect(estimateData).toMatch(
+      /const includeInternalCost\s*=\s*\["owner",\s*"admin",\s*"manager",\s*"parts"\]\.includes\(\s*input\.role,?\s*\)/,
+    );
+    expect(estimateData).toContain(
+      "unitCost: includeInternalCost ? asNullableNumber(row.unit_cost) : null",
+    );
+    expect(estimateData).toContain('.from("estimate_internal_details")');
+    expect(migration).toContain("'items', coalesce((");
+    expect(migration).not.toContain("'adjustment_note', nullif");
+  });
+
+  it("keeps auth-user and canonical-profile audit identities distinct", () => {
+    expect(quoteSendRoute).toContain("sent_by: access.authUserId");
+    expect(quoteSendRoute).toContain('req.headers.get("Idempotency-Key")');
+    expect(quoteSendRoute).toContain("estimateSendReplayResponse");
+    expect(quoteSendRoute).toContain("findAcceptedEstimateEmail");
+    expect(quoteSendRoute).toContain("recoverAcceptedEstimateSend");
+    expect(quoteSendRoute).toContain("reservationResult.accepted_at");
+    expect(quoteSendRoute).toContain('delivery_state: "accepted"');
+    expect(quoteSendRoute).toContain("QuoteDeliveryBlockedError");
+    expect(quoteSendRoute).toContain('"reserve_estimate_send_atomic"');
+    expect(quoteSendRoute).toContain('"finalize_estimate_send_atomic"');
+    expect(quoteSendRoute).toContain("p_actor_profile_id: access.profile.id");
+    expect(quoteSendRoute).toContain("p_actor_user_id: access.authUserId");
+    expect(quoteSendRoute).toMatch(
+      /approval_state:\s*estimateHasApprovedLines\s*\?\s*"partial"\s*:\s*"pending"/,
+    );
+    expect(migration).toContain("to service_role;");
+    expect(migration).toContain("'delivery_uncertain'");
+    expect(migration).not.toContain(
+      "estimate_sent_by = coalesce(estimate_sent_by, new.sent_by)",
+    );
+  });
+
+  it("derives estimate delivery context from canonical tenant data", () => {
+    expect(quoteSendRoute).toContain("let customerEmail = wo.estimate_number");
+    expect(quoteSendRoute).toContain('.eq("shop_id", wo.shop_id)');
+    expect(quoteSendRoute).toContain(
+      'let shopName = wo.estimate_number ? "" : safeStr(body?.shopName).trim()',
+    );
+    expect(quoteSendRoute).toContain(
+      "let quoteTotal: number | undefined = wo.estimate_number",
+    );
+    expect(quoteSendRoute).toMatch(
+      /const pdfUrl\s*=\s*wo\.estimate_number\s*\?\s*null\s*:\s*\(body\?\.pdfUrl\s*\?\?\s*null\)/,
+    );
+    expect(quoteSendRoute).toMatch(
+      /const shouldSkipAsDuplicate\s*=\s*!wo\.estimate_number/,
+    );
+    expect(quoteSendRoute).toContain(
+      "shopSuppliesTaxableSubtotal(shopSupplies)",
+    );
+    expect(quoteSendRoute).toContain("isProvinceCode(province)");
+    expect(quoteSendRoute).toContain("getTaxAmount(fallbackTax)");
+    expect(quoteSendRoute).toContain("estimatePortalQuoteUrl");
+    expect(migration).toContain(
+      "lower(btrim(coalesce(c.email, ''))) = v_customer_email",
+    );
+    expect(migration).toContain(
+      "regexp_replace(coalesce(c.phone, c.phone_number, ''), '[^0-9]', '', 'g')",
+    );
+    expect(migration).toContain(
+      "This VIN is already assigned to another customer. Contact shop/admin to move vehicle.",
+    );
+  });
+
+  it("gates sidebar visibility and actions by shop role", () => {
+    const estimateTiles = TILES.filter((tile) => tile.href === "/estimates");
+    const visibleRoles = new Set(estimateTiles.flatMap((tile) => tile.roles));
+
+    for (const role of ESTIMATE_VIEW_ROLES)
+      expect(visibleRoles.has(role)).toBe(true);
+    expect(visibleRoles.has("mechanic")).toBe(false);
+    expect(visibleRoles.has("driver")).toBe(false);
+
+    expect(estimateActorForRole("advisor")).toMatchObject({
+      canCreate: true,
+      canSend: true,
+      canCompleteParts: false,
+    });
+    expect(estimateActorForRole("parts")).toMatchObject({
+      canCreate: false,
+      canSend: false,
+      canCompleteParts: true,
+      mode: "parts",
+    });
+    expect(estimateActorForRole("lead_hand")).toMatchObject({
+      canCreate: false,
+      canSend: false,
+      canCompleteParts: true,
+      mode: "parts",
+    });
+    expect(estimateActorForRole("foreman")).toMatchObject({
+      canCreate: true,
+      canSend: true,
+      canCompleteParts: true,
+      mode: "advisor",
+    });
+    expect(ESTIMATE_ADVISOR_ROLES).not.toContain("parts");
+    expect(ESTIMATE_PARTS_ROLES).not.toContain("advisor");
+    expect(canonicalizeRole("service_advisor")).toBe("service");
+    expect(canonicalizeRole("service advisor")).toBe("service");
+    expect(migration).toContain("when 'service_advisor' then 'service'");
+    expect(roleSidebar).not.toContain(
+      'canonical === "customer" || canonical === "service"',
+    );
+    expect(roleSidebar).toContain(
+      "if (profile?.role) setRole(normalizeRole(profile.role))",
+    );
+    expect(dashboardIdentity).toContain("resolveAuthenticatedStaffProfile");
+  });
+
+  it("enforces server and API gates in addition to sidebar visibility", () => {
+    for (const route of estimateRoutes) {
+      expect(route).toContain("requireShopScopedApiAccess");
+    }
+    for (const route of estimateRoutes.filter(
+      (source) =>
+        source.includes("export async function POST") ||
+        source.includes("export async function PATCH"),
+    )) {
+      expect(route).toContain("requireIdempotencyKey");
+    }
+    expect(estimateRoutes.join("\n")).not.toContain(
+      '.from("work_orders").insert',
+    );
+    expect(estimateRoutes.join("\n")).toContain('rpc("create_estimate_atomic"');
+    expect(estimateRoutes.join("\n")).toMatch(
+      /\.rpc\(\s*"complete_estimate_parts_quote_atomic"/,
+    );
+  });
+
+  it("makes ownership and the next action explicit", () => {
+    expect(estimateStatusLabel("ready_for_advisor")).toBe("Ready for Advisor");
+    expect(estimateNextOwner("waiting_for_parts")).toBe("Parts");
+    expect(estimateNextOwner("sent")).toBe("Customer");
+    expect(estimatePrimaryAction("waiting_for_parts", "parts")).toBe(
+      "Complete Parts Quote",
+    );
+    expect(estimatePrimaryAction("ready_for_advisor", "advisor")).toBe(
+      "Send Estimate",
+    );
+    expect(estimateBuilder).toContain("const hasDeliveryEmail");
+    expect(estimateBuilder).toContain(
+      "Add an email address to the customer record",
+    );
+    expect(estimateBuilder).toContain("href={`/customers/${customer.id}`}");
+    expect(estimateBuilder).toContain("Repair subtotal");
+  });
+});

--- a/tests/owner-sidebar-nav.test.ts
+++ b/tests/owner-sidebar-nav.test.ts
@@ -54,7 +54,6 @@ describe("owner sidebar IA", () => {
     }
   });
 
-
   it("does not remove expected primary routes for tech/admin/parts roles", () => {
     const roleToHrefs: Record<Role, string[]> = {
       mechanic: ["/dashboard", "/tech/queue"],
@@ -68,10 +67,13 @@ describe("owner sidebar IA", () => {
       foreman: [],
       manager: [],
       owner: [],
+      service: [],
     };
 
     for (const [role, hrefs] of Object.entries(roleToHrefs)) {
-      const roleTiles = TILES.filter((tile) => tile.roles.includes(role as Role));
+      const roleTiles = TILES.filter((tile) =>
+        tile.roles.includes(role as Role),
+      );
       for (const href of hrefs) {
         expect(roleTiles.some((tile) => tile.href === href)).toBe(true);
       }

--- a/tests/quote-email-portal-alignment.test.ts
+++ b/tests/quote-email-portal-alignment.test.ts
@@ -47,18 +47,25 @@ describe("quote email and customer portal alignment", () => {
     ]);
   });
 
-  it("marks the work order pending when quote email persistence completes", () => {
+  it("preserves partial estimate approval while marking a first send pending", () => {
     const sendRoute = read("app/api/quotes/send/route.ts");
-    const newlySentQuotePersistence = sendRoute.indexOf(
-      "...(sendableQuoteLineIds.length > 0",
+    const migration = read(
+      "supabase/migrations/20260802024436_advisor_estimate_workflow.sql",
     );
-    const approvalStatePersistence = sendRoute.indexOf(
-      "work_order_quote_approval_state_update",
+    const reservation = sendRoute.indexOf('"reserve_estimate_send_atomic"');
+    const finalization = sendRoute.lastIndexOf(
+      '"finalize_estimate_send_atomic"',
     );
-    expect(newlySentQuotePersistence).toBeGreaterThanOrEqual(0);
-    expect(approvalStatePersistence).toBeGreaterThan(newlySentQuotePersistence);
-    expect(sendRoute).toContain("work_order_quote_approval_state_update");
-    expect(sendRoute).toContain('approval_state: "pending"');
+    expect(reservation).toBeGreaterThanOrEqual(0);
+    expect(finalization).toBeGreaterThan(reservation);
+    expect(migration).toContain("when v_has_approved_lines then 'partial'");
+    expect(migration).toContain("else 'pending'");
+    expect(migration).toContain("update public.work_order_quote_lines q");
+    expect(migration).toContain("update public.work_orders w");
+    expect(sendRoute).toContain('req.headers.get("Idempotency-Key")');
+    expect(sendRoute).toContain("estimateSendReplayResponse");
+    expect(sendRoute).toContain("findAcceptedEstimateEmail");
+    expect(sendRoute).toContain("recoverAcceptedEstimateSend");
   });
 
   it("derives portal-home attention from unresolved canonical quote lines", () => {


### PR DESCRIPTION
## Summary

Adds the advisor-driven Estimate workspace and connects it to ProFixIQ's existing work-order, quote-line, Parts request, customer approval, and operational activation contracts.

- adds role-gated `/estimates` pages and dashboard sidebar entries
- supports customer/vehicle selection and inline creation
- supports draft save, submit to Parts, Parts completion, advisor review, return-for-adjustment revisions, and customer sending
- keeps one canonical work-order record through estimate, approval, repair, and invoice
- adds retry-safe lifecycle RPCs and service-only send reservation/finalization
- prevents internal part cost and superseded pricing from reaching advisor/customer payloads
- extends Parts and portal presentation for estimate context
- adds a forward migration that also reconciles missing legacy quote-line columns before applying the estimate schema

## Authorization and integrity

- advisor access: owner, admin, manager, advisor, service advisor, foreman
- Parts access: owner, admin, manager, Parts, lead hand, foreman
- page, API, RLS/RPC, shop, role, actor, revision, and lifecycle checks are enforced
- repeated submit, adjustment, send, and approval operations use stable idempotency keys
- sent revisions cannot be silently repriced
- reserve/finalize customer-send RPCs are executable only by `service_role`

## Database

Applied to the linked ProFixIQ Supabase project:

- `20260802024436_advisor_estimate_workflow.sql`

The first apply attempt failed inside the migration transaction on legacy schema drift and rolled back. The migration was hardened to reconcile the missing quote-line columns, then applied successfully. Post-apply verification confirmed:

- migration present in the live ledger
- estimate tables have RLS enabled
- required work-order, quote-line, Parts request, and Parts item columns exist
- authenticated/user-facing and service-only function grants match the intended boundary

## Validation

- TypeScript: passed
- changed-file ESLint: passed
- estimate/send focused suite: 17/17 passed
- broader estimate-focused suite before final publish: 33/33 passed
- API boundary audit: passed, 398 routes analyzed
- production compiler and static generation: passed; the latest local build exited during final `.next/export` cleanup with a transient `ENOTEMPTY` workspace error
- earlier full suite: 1,587 passed, 2 skipped, with 18 unrelated baseline failures
- existing unrelated owner-sidebar contract still expects mechanics to see `/dashboard`, while the unchanged tile configuration excludes mechanics
