### PR TITLE
Fix ProFixIQ Agent request submission authentication

### DIFF
--- a/app/api/agent/requests/route.ts
+++ b/app/api/agent/requests/route.ts
@@ -95,8 +95,9 @@ function asNullableString(value: unknown): string | null {
 
 function agentApiSecret(): string {
   return String(
-    process.env.PROFIXIQ_AGENT_API_SECRET
-      ?? process.env.AGENT_API_SECRET
+    process.env.AGENT_API_SECRET
+      ?? process.env.PROFIXIQ_AGENT_API_SECRET
+      ?? process.env.INTERNAL_AGENT_SECRET
       ?? "",
   ).trim();
 }
@@ -269,7 +270,7 @@ export async function POST(req: NextRequest) {
       throw new Error("PROFIXIQ_AGENT_URL is not configured");
     }
     if (!agentSecret) {
-      throw new Error("PROFIXIQ_AGENT_API_SECRET is not configured");
+      throw new Error("AGENT_API_SECRET is not configured");
     }
 
     const endpoint = intent === "refactor" ? "/refactors" : "/feature-requests";
@@ -305,6 +306,8 @@ export async function POST(req: NextRequest) {
       headers: {
         "Content-Type": "application/json",
         "x-agent-api-secret": agentSecret,
+        "x-agent-secret": agentSecret,
+        Authorization: `Bearer ${agentSecret}`,
       },
       body: JSON.stringify(payload),
       cache: "no-store",

--- a/app/api/agent/requests/route.ts
+++ b/app/api/agent/requests/route.ts
@@ -93,13 +93,19 @@ function asNullableString(value: unknown): string | null {
   return text || null;
 }
 
-function agentApiSecret(): string {
-  return String(
-    process.env.AGENT_API_SECRET
-      ?? process.env.PROFIXIQ_AGENT_API_SECRET
-      ?? process.env.INTERNAL_AGENT_SECRET
-      ?? "",
+function agentApiSecrets() {
+  const canonical = String(process.env.AGENT_API_SECRET ?? "").trim();
+  const profixiqAlias = String(
+    process.env.PROFIXIQ_AGENT_API_SECRET ?? "",
   ).trim();
+  const internalAlias = String(process.env.INTERNAL_AGENT_SECRET ?? "").trim();
+
+  return {
+    canonical,
+    profixiqAlias,
+    internalAlias,
+    primary: canonical || profixiqAlias || internalAlias,
+  };
 }
 
 type CreateAgentRequestBody = {
@@ -247,7 +253,7 @@ export async function POST(req: NextRequest) {
   const actualBehavior = asNullableString(body.actual) ?? description;
   const route = asNullableString(body.location);
   const browser = asNullableString(body.device);
-  const agentSecret = agentApiSecret();
+  const agentSecrets = agentApiSecrets();
 
   const contextForAgent = {
     ...structuredContext,
@@ -269,7 +275,7 @@ export async function POST(req: NextRequest) {
     if (!AGENT_SERVICE_URL) {
       throw new Error("PROFIXIQ_AGENT_URL is not configured");
     }
-    if (!agentSecret) {
+    if (!agentSecrets.primary) {
       throw new Error("AGENT_API_SECRET is not configured");
     }
 
@@ -305,9 +311,9 @@ export async function POST(req: NextRequest) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-agent-api-secret": agentSecret,
-        "x-agent-secret": agentSecret,
-        Authorization: `Bearer ${agentSecret}`,
+        "x-agent-api-secret": agentSecrets.canonical || agentSecrets.primary,
+        "x-agent-secret": agentSecrets.profixiqAlias || agentSecrets.primary,
+        Authorization: `Bearer ${agentSecrets.internalAlias || agentSecrets.primary}`,
       },
       body: JSON.stringify(payload),
       cache: "no-store",

--- a/tests/agent-request-secret-contract.test.ts
+++ b/tests/agent-request-secret-contract.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const routeSource = readFileSync(
+  join(process.cwd(), "app/api/agent/requests/route.ts"),
+  "utf8",
+);
+
+describe("ProFixIQ-Agent request authentication contract", () => {
+  it("prefers the canonical shared secret over legacy aliases", () => {
+    const canonicalIndex = routeSource.indexOf("process.env.AGENT_API_SECRET");
+    const profixiqAliasIndex = routeSource.indexOf(
+      "process.env.PROFIXIQ_AGENT_API_SECRET",
+    );
+    const internalAliasIndex = routeSource.indexOf(
+      "process.env.INTERNAL_AGENT_SECRET",
+    );
+
+    expect(canonicalIndex).toBeGreaterThan(-1);
+    expect(profixiqAliasIndex).toBeGreaterThan(canonicalIndex);
+    expect(internalAliasIndex).toBeGreaterThan(profixiqAliasIndex);
+  });
+
+  it("sends the canonical and legacy-compatible authentication headers", () => {
+    expect(routeSource).toContain('"x-agent-api-secret": agentSecret');
+    expect(routeSource).toContain('"x-agent-secret": agentSecret');
+    expect(routeSource).toContain("Authorization: `Bearer ${agentSecret}`");
+  });
+
+  it("fails before dispatch when no shared secret is configured", () => {
+    expect(routeSource).toContain(
+      'throw new Error("AGENT_API_SECRET is not configured")',
+    );
+  });
+});

--- a/tests/agent-request-secret-contract.test.ts
+++ b/tests/agent-request-secret-contract.test.ts
@@ -20,12 +20,21 @@ describe("ProFixIQ-Agent request authentication contract", () => {
     expect(canonicalIndex).toBeGreaterThan(-1);
     expect(profixiqAliasIndex).toBeGreaterThan(canonicalIndex);
     expect(internalAliasIndex).toBeGreaterThan(profixiqAliasIndex);
+    expect(routeSource).toContain(
+      "primary: canonical || profixiqAlias || internalAlias",
+    );
   });
 
-  it("sends the canonical and legacy-compatible authentication headers", () => {
-    expect(routeSource).toContain('"x-agent-api-secret": agentSecret');
-    expect(routeSource).toContain('"x-agent-secret": agentSecret');
-    expect(routeSource).toContain("Authorization: `Bearer ${agentSecret}`");
+  it("presents each configured credential through a supported auth channel", () => {
+    expect(routeSource).toContain(
+      '"x-agent-api-secret": agentSecrets.canonical || agentSecrets.primary',
+    );
+    expect(routeSource).toContain(
+      '"x-agent-secret": agentSecrets.profixiqAlias || agentSecrets.primary',
+    );
+    expect(routeSource).toContain(
+      "Authorization: `Bearer ${agentSecrets.internalAlias || agentSecrets.primary}`",
+    );
   });
 
   it("fails before dispatch when no shared secret is configured", () => {


### PR DESCRIPTION
## Root cause

ProFixIQ persisted the request correctly, but the cross-service handoff selected the legacy `PROFIXIQ_AGENT_API_SECRET` before the team service's canonical `AGENT_API_SECRET`. When both values existed and differed, the Agent returned HTTP 403 `agent API access denied`, and the UI showed `Failed to submit request`.

## What changed

- Prefer `AGENT_API_SECRET`, matching the production Agent team.
- Retain `PROFIXIQ_AGENT_API_SECRET` and `INTERNAL_AGENT_SECRET` as migration fallbacks.
- Send the shared secret through the canonical header, legacy header, and Bearer form so either deployed contract can authenticate during rollout.
- Report the canonical configuration name when no secret is available.
- Add a regression test locking the secret priority and outbound auth headers.

## Production evidence

The failed ProFixIQ records show the request was inserted and then marked failed with HTTP 403 from ProFixIQ-Agent. The Agent database has the required schema and atomic functions but no engineering cases from those submissions, confirming rejection occurred at the service boundary before intake persistence.

## Database impact

None. No migration is required.