### PR TITLE
Fix observability cron before migration apply

### DIFF
--- a/app/api/internal/observability/health/route.ts
+++ b/app/api/internal/observability/health/route.ts
@@ -12,6 +12,12 @@ export const dynamic = "force-dynamic";
 const MAX_SHOPS_PER_RUN = 500;
 const CONCURRENCY = 5;
 
+type ProjectionWarning = {
+  code: "projection_unavailable" | "projection_failed";
+  databaseCode: string | null;
+  message: string;
+};
+
 function parseBearerSecret(request: Request): string | null {
   const authorization = request.headers.get("authorization")?.trim();
   if (!authorization) return null;
@@ -48,6 +54,18 @@ function projectionUnavailable(error: unknown): boolean {
   );
 }
 
+function toProjectionWarning(error: unknown): ProjectionWarning {
+  const candidate = error as { code?: string } | null;
+  const unavailable = projectionUnavailable(error);
+  return {
+    code: unavailable ? "projection_unavailable" : "projection_failed",
+    databaseCode: candidate?.code ? String(candidate.code) : null,
+    message: unavailable
+      ? "Observability health projection is not installed; using per-shop fallback."
+      : "Observability health projection failed; using per-shop fallback.",
+  };
+}
+
 async function loadHealthInputs() {
   const supabase = createAdminSupabase();
   const now = new Date();
@@ -72,15 +90,15 @@ async function loadHealthInputs() {
         MAX_SHOPS_PER_RUN,
       ),
       projectionUsed: true,
+      projectionWarning: null,
     };
   }
 
-  if (!projectionUnavailable(projectionResult.error)) {
-    const message =
-      (projectionResult.error as { message?: string } | null)?.message ??
-      "Failed to load observability health projection";
-    throw new Error(message);
-  }
+  const projectionWarning = toProjectionWarning(projectionResult.error);
+  console.warn("[operational-observability] health projection fallback", {
+    code: projectionWarning.code,
+    databaseCode: projectionWarning.databaseCode,
+  });
 
   const { data: shops, error } = await supabase
     .from("shops")
@@ -109,6 +127,7 @@ async function loadHealthInputs() {
       ai_cron_probably_running: null,
     })) satisfies OperationalHealthProjection[],
     projectionUsed: false,
+    projectionWarning,
   };
 }
 
@@ -171,8 +190,10 @@ export async function GET(request: Request) {
 
   return NextResponse.json({
     ok: warnings.length === 0,
+    degraded: healthInputs.projectionWarning !== null || warnings.length > 0,
     checkedShops: healthInputs.rows.length,
     projectionUsed: healthInputs.projectionUsed,
+    projectionWarning: healthInputs.projectionWarning,
     alerts: {
       pipelineStalled: summaries.filter((item) => item.pipelineStalled).length,
       activeFailures: summaries.reduce(

--- a/tests/internal-operational-observability-health-route.test.ts
+++ b/tests/internal-operational-observability-health-route.test.ts
@@ -26,13 +26,16 @@ function createShopQuery(input?: {
   error?: { message: string } | null;
 }) {
   const query = {
-    select: vi.fn(() => query),
-    order: vi.fn(() => query),
-    limit: vi.fn().mockResolvedValue({
-      data: input?.data ?? [{ id: "shop_1" }],
-      error: input?.error ?? null,
-    }),
+    select: vi.fn(),
+    order: vi.fn(),
+    limit: vi.fn(),
   };
+  query.select.mockReturnValue(query);
+  query.order.mockReturnValue(query);
+  query.limit.mockResolvedValue({
+    data: input?.data ?? [{ id: "shop_1" }],
+    error: input?.error ?? null,
+  });
   return query;
 }
 

--- a/tests/internal-operational-observability-health-route.test.ts
+++ b/tests/internal-operational-observability-health-route.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const requireInternalApiSecretMock = vi.fn();
+const createAdminSupabaseMock = vi.fn();
+const syncOperationalObservabilityAlertsMock = vi.fn();
+
+vi.mock("@/features/shared/lib/server/api-route-guard", () => ({
+  requireInternalApiSecret: requireInternalApiSecretMock,
+}));
+
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: createAdminSupabaseMock,
+}));
+
+vi.mock(
+  "@/features/operations/server/syncOperationalObservabilityAlerts",
+  () => ({
+    syncOperationalObservabilityAlerts:
+      syncOperationalObservabilityAlertsMock,
+  }),
+);
+
+function createShopQuery(input?: {
+  data?: Array<{ id: string }>;
+  error?: { message: string } | null;
+}) {
+  const query = {
+    select: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn().mockResolvedValue({
+      data: input?.data ?? [{ id: "shop_1" }],
+      error: input?.error ?? null,
+    }),
+  };
+  return query;
+}
+
+function createSupabase(input: {
+  projectionError: { code?: string; message?: string } | null;
+  shopsError?: { message: string } | null;
+}) {
+  const shopQuery = createShopQuery({ error: input.shopsError });
+  return {
+    rpc: vi.fn().mockResolvedValue({
+      data: null,
+      error: input.projectionError,
+    }),
+    from: vi.fn((table: string) => {
+      if (table !== "shops") throw new Error(`Unexpected table: ${table}`);
+      return shopQuery;
+    }),
+  };
+}
+
+describe("GET /api/internal/observability/health", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    requireInternalApiSecretMock.mockReturnValue({ ok: true });
+    syncOperationalObservabilityAlertsMock.mockResolvedValue({
+      shopId: "shop_1",
+      installed: false,
+      pipelineStatus: "not_installed",
+      pipelineStalled: false,
+      activeFailures: 0,
+      eventVolumeDropped: false,
+      aiExpirationNeedsReview: false,
+    });
+  });
+
+  it("rejects requests that fail the internal secret guard", async () => {
+    requireInternalApiSecretMock.mockReturnValue({
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+    createAdminSupabaseMock.mockReturnValue(
+      createSupabase({ projectionError: null }),
+    );
+
+    const { GET } = await import(
+      "../app/api/internal/observability/health/route"
+    );
+    const response = await GET(
+      new Request("https://example.test/api/internal/observability/health"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(createAdminSupabaseMock).not.toHaveBeenCalled();
+  });
+
+  it("uses degraded mode when the projection is not installed", async () => {
+    const supabase = createSupabase({
+      projectionError: {
+        code: "PGRST202",
+        message: "Function is missing from the schema cache",
+      },
+    });
+    createAdminSupabaseMock.mockReturnValue(supabase);
+
+    const { GET } = await import(
+      "../app/api/internal/observability/health/route"
+    );
+    const response = await GET(
+      new Request("https://example.test/api/internal/observability/health"),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body.degraded).toBe(true);
+    expect(body.projectionUsed).toBe(false);
+    expect(body.projectionWarning).toEqual(
+      expect.objectContaining({
+        code: "projection_unavailable",
+        databaseCode: "PGRST202",
+      }),
+    );
+    expect(syncOperationalObservabilityAlertsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shopId: "shop_1",
+        operationalHealth: undefined,
+      }),
+    );
+  });
+
+  it("also degrades on an unexpected projection error", async () => {
+    createAdminSupabaseMock.mockReturnValue(
+      createSupabase({
+        projectionError: {
+          code: "42501",
+          message: "Projection permission error",
+        },
+      }),
+    );
+
+    const { GET } = await import(
+      "../app/api/internal/observability/health/route"
+    );
+    const response = await GET(
+      new Request("https://example.test/api/internal/observability/health"),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(200);
+    expect(body.degraded).toBe(true);
+    expect(body.projectionWarning).toEqual(
+      expect.objectContaining({
+        code: "projection_failed",
+        databaseCode: "42501",
+      }),
+    );
+  });
+
+  it("still returns 500 when the database fallback cannot list shops", async () => {
+    createAdminSupabaseMock.mockReturnValue(
+      createSupabase({
+        projectionError: { code: "08006", message: "Connection failed" },
+        shopsError: { message: "Database unavailable" },
+      }),
+    );
+
+    const { GET } = await import(
+      "../app/api/internal/observability/health/route"
+    );
+    const response = await GET(
+      new Request("https://example.test/api/internal/observability/health"),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Database unavailable");
+    expect(syncOperationalObservabilityAlertsMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Root cause

The operational observability code was deployed to `main` before its database migrations were applied. The hourly health cron executed at 10:07 a.m. Edmonton time and returned HTTP 500 while attempting to load the unavailable health projection.

The existing route only entered fallback mode for a small set of recognized PostgREST error shapes. Any other projection error was treated as fatal even though the per-shop fallback could still run safely.

## Fix

- Treat any health-projection RPC error as degraded mode.
- Continue to the existing shop-scoped fallback.
- Return HTTP 200 with `degraded: true` and a safe `projectionWarning`.
- Log only the safe warning category and database error code.
- Preserve HTTP 500 when the fallback database query itself fails.

## Tests

Added route-level coverage for:

- internal-secret rejection
- missing projection (`PGRST202`) → degraded HTTP 200
- unexpected projection failure → degraded HTTP 200
- actual database fallback failure → HTTP 500

## Evidence

- The four observability migrations are not present in live migration history.
- `operational_events` and `operational_event_failures` do not exist in the live database.
- Vercel runtime logs show `/api/internal/observability/health` returned 500 at 2026-08-02 10:07 a.m. Edmonton time.
- No `assistant_notifications` rows with `source = 'observability'` were written.

## Boundaries

- No database changes.
- No production data changes.
- No deployment triggered.
- Draft PR only; do not merge without review and approval.
