### PR TITLE
Fix fleet invite password activation

### DIFF
--- a/.github/workflows/phase-7-customer-portal-validation.yml
+++ b/.github/workflows/phase-7-customer-portal-validation.yml
@@ -6,8 +6,10 @@ on:
       - "app/api/portal/**"
       - "app/api/work-orders/lines/**"
       - "app/portal/auth/confirm/page.tsx"
+      - "app/portal/auth/fleet-invite/page.tsx"
       - "features/portal/server/**"
       - "supabase/migrations/20260715080*.sql"
+      - "tests/auth-portal-hardening.test.ts"
       - "tests/phase7-*.test.ts"
       - ".github/workflows/phase-7-customer-portal-validation.yml"
 
@@ -31,6 +33,8 @@ jobs:
           app/api/portal/bookings/[id]/route.ts
           app/api/portal/bookings/route.ts
           app/api/portal/customer-bookings/[id]/route.ts
+          app/api/portal/fleet/invites/accept/route.ts
+          app/api/portal/fleet/invites/route.ts
           app/api/portal/invites/accept/route.ts
           app/api/portal/qr/setup/route.ts
           app/api/portal/request/start/route.ts
@@ -39,12 +43,15 @@ jobs:
           app/api/portal/request/add-inspection-line/route.ts
           app/api/work-orders/lines/[id]/approval-decision/route.ts
           app/portal/auth/confirm/page.tsx
+          app/portal/auth/fleet-invite/page.tsx
           features/portal/server/addPortalRequestLine.ts
           features/portal/server/createPortalBooking.ts
           features/portal/server/customerBookings.ts
+          tests/auth-portal-hardening.test.ts
           tests/phase7-portal-invite-booking-contract.test.ts
           tests/phase7-portal-request-approval-contract.test.ts
       - run: >-
           pnpm exec vitest run
+          tests/auth-portal-hardening.test.ts
           tests/phase7-portal-invite-booking-contract.test.ts
           tests/phase7-portal-request-approval-contract.test.ts

--- a/app/api/portal/fleet/invites/accept/route.ts
+++ b/app/api/portal/fleet/invites/accept/route.ts
@@ -3,48 +3,174 @@ export const dynamic = "force-dynamic";
 
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { enforceAuthRateLimit } from "@/features/auth/server/authRateLimit";
 import { supabaseAdmin } from "@/features/shared/lib/supabase/admin";
 
+type AcceptBody = {
+  token?: string;
+  password?: string;
+};
+
+function isValidInviteToken(token: string): boolean {
+  return /^[A-Za-z0-9_-]{40,128}$/.test(token);
+}
+
+function isValidPassword(password: string): boolean {
+  return password.length >= 12 && password.length <= 128;
+}
+
+function activationError(status = 403) {
+  return NextResponse.json(
+    { error: "Fleet access could not be activated. Request a new invitation." },
+    { status, headers: { "Cache-Control": "no-store" } },
+  );
+}
+
 export async function POST(req: Request) {
-  const supabase = createServerSupabaseRoute();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user?.id || !user.email) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  const body = (await req.json().catch(() => null)) as { token?: string } | null;
+  const body = (await req.json().catch(() => null)) as AcceptBody | null;
   const token = String(body?.token ?? "").trim();
-  if (!token) return NextResponse.json({ error: "Invite token is required." }, { status: 400 });
-  const { data: existingProfile } = await supabaseAdmin
-    .from("profiles")
-    .select("id")
-    .eq("id", user.id)
-    .maybeSingle();
+  const password = String(body?.password ?? "");
+
+  if (!isValidInviteToken(token)) {
+    return NextResponse.json(
+      { error: "This fleet invitation is invalid or expired." },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  if (!isValidPassword(password)) {
+    return NextResponse.json(
+      { error: "Use a password between 12 and 128 characters." },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
   const tokenHash = crypto.createHash("sha256").update(token).digest("hex");
-  const rpc = supabaseAdmin as unknown as {
-    rpc: (name: string, args: Record<string, unknown>) => Promise<{ data: unknown; error: { message: string } | null }>;
-  };
-  const { data, error } = await rpc.rpc("accept_fleet_portal_invite_atomic", {
-    p_token_hash: tokenHash,
-    p_actor_user_id: user.id,
-    p_actor_email: user.email,
-    p_at: new Date().toISOString(),
-  });
-  if (error) return NextResponse.json({ error: error.message }, { status: 403 });
-  if (!existingProfile?.id) {
-    const { error: metadataError } = await supabaseAdmin.auth.admin.updateUserById(
-      user.id,
+  const rateLimit = enforceAuthRateLimit(
+    req,
+    "fleet-invite-activation",
+    tokenHash,
+    { max: 6, windowMs: 15 * 60_000 },
+  );
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "Too many activation attempts. Wait a few minutes and try again." },
       {
-        app_metadata: {
-          ...user.app_metadata,
-          profixiq_portal_only: true,
+        status: 429,
+        headers: {
+          "Cache-Control": "no-store",
+          "Retry-After": String(rateLimit.retryAfterSeconds),
         },
       },
     );
-    if (metadataError) {
-      return NextResponse.json(
-        { error: "Fleet access was linked, but account routing could not be finalized. Retry this link." },
-        { status: 500 },
-      );
-    }
   }
-  return NextResponse.json(data ?? { ok: true });
+
+  const { data: invite, error: inviteError } = await supabaseAdmin
+    .from("fleet_portal_invites")
+    .select(
+      "id, email, expires_at, accepted_at, accepted_by_user_id, revoked_at",
+    )
+    .eq("token_hash", tokenHash)
+    .maybeSingle();
+
+  if (
+    inviteError ||
+    !invite?.id ||
+    invite.revoked_at ||
+    new Date(invite.expires_at) <= new Date()
+  ) {
+    return activationError();
+  }
+
+  if (invite.accepted_at) {
+    if (!invite.accepted_by_user_id) return activationError();
+    const { data: acceptedIdentity, error: acceptedIdentityError } =
+      await supabaseAdmin.auth.admin.getUserById(invite.accepted_by_user_id);
+    if (
+      acceptedIdentityError ||
+      acceptedIdentity.user?.email?.trim().toLowerCase() !==
+        invite.email.trim().toLowerCase()
+    ) {
+      return activationError();
+    }
+    return NextResponse.json(
+      { ok: true, email: invite.email, alreadyAccepted: true },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  // Generate, but never deliver, a Supabase link so Auth resolves both new and
+  // existing identities. The customer-facing email uses only ProFixIQ's
+  // durable, hashed invitation token and cannot be consumed by link scanners.
+  const { data: identityLink, error: identityError } =
+    await supabaseAdmin.auth.admin.generateLink({
+      type: "magiclink",
+      email: invite.email,
+    });
+  const identity = identityLink?.user;
+  if (identityError || !identity?.id || !identity.email) {
+    return activationError(500);
+  }
+  if (
+    identity.email.trim().toLowerCase() !== invite.email.trim().toLowerCase()
+  ) {
+    return activationError();
+  }
+
+  const { data: existingProfile } = await supabaseAdmin
+    .from("profiles")
+    .select("id, shop_id, role")
+    .eq("id", identity.id)
+    .maybeSingle();
+  const normalizedRole = String(existingProfile?.role ?? "")
+    .trim()
+    .toLowerCase();
+  const isExistingShopStaff = Boolean(
+    existingProfile?.shop_id &&
+      normalizedRole !== "customer" &&
+      normalizedRole !== "fleet_manager",
+  );
+  const appMetadata = isExistingShopStaff
+    ? identity.app_metadata
+    : {
+        ...identity.app_metadata,
+        profixiq_portal_only: true,
+      };
+
+  const { error: passwordError } =
+    await supabaseAdmin.auth.admin.updateUserById(identity.id, {
+      password,
+      email_confirm: true,
+      app_metadata: appMetadata,
+    });
+  if (passwordError) {
+    return NextResponse.json(
+      {
+        error:
+          "Your password does not meet the account security requirements. Try a different password.",
+      },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  const rpc = supabaseAdmin as unknown as {
+    rpc: (
+      name: string,
+      args: Record<string, unknown>,
+    ) => Promise<{ data: unknown; error: { message: string } | null }>;
+  };
+  const { error: acceptError } = await rpc.rpc(
+    "accept_fleet_portal_invite_atomic",
+    {
+      p_token_hash: tokenHash,
+      p_actor_user_id: identity.id,
+      p_actor_email: identity.email,
+      p_at: new Date().toISOString(),
+    },
+  );
+  if (acceptError) return activationError();
+
+  return NextResponse.json(
+    { ok: true, email: invite.email },
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/app/api/portal/fleet/invites/route.ts
+++ b/app/api/portal/fleet/invites/route.ts
@@ -70,15 +70,7 @@ export async function POST(req: Request) {
   });
   if (insertError) return NextResponse.json({ error: insertError.message }, { status: 400 });
 
-  const redirectTo = `${siteUrl()}/portal/auth/fleet-invite?token=${encodeURIComponent(rawToken)}`;
-  const { data: linkData, error: linkError } = await supabaseAdmin.auth.admin.generateLink({
-    type: "magiclink",
-    email,
-    options: { redirectTo },
-  });
-  const actionLink = linkData?.properties?.action_link;
-  if (linkError || !actionLink) return NextResponse.json({ error: "Fleet invite link could not be created." }, { status: 500 });
-
+  const portalLink = `${siteUrl()}/portal/auth/fleet-invite?token=${encodeURIComponent(rawToken)}`;
   const [{ data: shop }, brand] = await Promise.all([
     supabaseAdmin.from("shops").select("name, shop_name").eq("id", access.profile.shop_id).maybeSingle(),
     getActiveBrandForRender(access.profile.shop_id),
@@ -87,7 +79,7 @@ export async function POST(req: Request) {
   await sendPortalInviteEmail({
     shopId: access.profile.shop_id,
     to: email,
-    portalLink: actionLink,
+    portalLink,
     shopName,
     brandLogoUrl: brand?.logoUrl ?? null,
     brandPrimaryColor: brand?.colors.primary ?? null,

--- a/app/portal/auth/fleet-invite/page.tsx
+++ b/app/portal/auth/fleet-invite/page.tsx
@@ -34,11 +34,6 @@ export default function FleetInvitePage() {
     let cancelled = false;
     void (async () => {
       try {
-        const code = searchParams.get("code")?.trim();
-        if (code) {
-          const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
-          if (exchangeError) throw new Error("This invitation could not be verified.");
-        }
         const response = await fetch(`/api/portal/fleet/invites/preview?token=${encodeURIComponent(token)}`, { cache: "no-store" });
         const payload = (await response.json().catch(() => null)) as { invite?: Invite; error?: string } | null;
         if (!response.ok || !payload?.invite) throw new Error(payload?.error || "This fleet invitation is unavailable.");
@@ -52,26 +47,31 @@ export default function FleetInvitePage() {
     return () => {
       cancelled = true;
     };
-  }, [searchParams, supabase, token]);
+  }, [token]);
 
   async function activate(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError("");
-    if (password.length < 12) return setError("Use at least 12 characters for your password.");
+    if (password.length < 12 || password.length > 128) return setError("Use between 12 and 128 characters for your password.");
     if (password !== confirmPassword) return setError("Passwords do not match.");
     setSubmitting(true);
     try {
-      const { data: userData } = await supabase.auth.getUser();
-      if (!userData.user) throw new Error("Open the one-time invitation email on this device before activating access.");
-      const { error: passwordError } = await supabase.auth.updateUser({ password });
-      if (passwordError) throw new Error("Your password could not be saved. Try a different password.");
       const response = await fetch("/api/portal/fleet/invites/accept", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token }),
+        body: JSON.stringify({ token, password }),
       });
-      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
-      if (!response.ok) throw new Error(payload?.error || "Fleet access could not be activated.");
+      const payload = (await response.json().catch(() => null)) as { email?: string; error?: string } | null;
+      if (!response.ok || !payload?.email) throw new Error(payload?.error || "Fleet access could not be activated.");
+
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email: payload.email,
+        password,
+      });
+      if (signInError) {
+        throw new Error("Fleet access is active, but automatic sign-in failed. Sign in through the fleet portal with the password you just created.");
+      }
+
       router.replace("/portal/fleet");
       router.refresh();
     } catch (value) {
@@ -111,9 +111,9 @@ export default function FleetInvitePage() {
           <form onSubmit={activate} className="mt-5 space-y-4">
             <div>
               <label htmlFor="fleet-password" className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">Create password</label>
-              <div className="relative"><input id="fleet-password" className={`${inputClass} pr-11`} type={showPassword ? "text" : "password"} autoComplete="new-password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 12 characters" required minLength={12} /><button type="button" onClick={() => setShowPassword((current) => !current)} aria-label={showPassword ? "Hide password" : "Show password"} className="absolute inset-y-0 right-0 grid w-11 place-items-center text-[color:var(--theme-text-muted)]">{showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}</button></div>
+              <div className="relative"><input id="fleet-password" className={`${inputClass} pr-11`} type={showPassword ? "text" : "password"} autoComplete="new-password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 12 characters" required minLength={12} maxLength={128} /><button type="button" onClick={() => setShowPassword((current) => !current)} aria-label={showPassword ? "Hide password" : "Show password"} className="absolute inset-y-0 right-0 grid w-11 place-items-center text-[color:var(--theme-text-muted)]">{showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}</button></div>
             </div>
-            <div><label htmlFor="fleet-confirm" className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">Confirm password</label><input id="fleet-confirm" className={inputClass} type={showPassword ? "text" : "password"} autoComplete="new-password" value={confirmPassword} onChange={(event) => setConfirmPassword(event.target.value)} required /></div>
+            <div><label htmlFor="fleet-confirm" className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">Confirm password</label><input id="fleet-confirm" className={inputClass} type={showPassword ? "text" : "password"} autoComplete="new-password" value={confirmPassword} onChange={(event) => setConfirmPassword(event.target.value)} required minLength={12} maxLength={128} /></div>
             <button type="submit" disabled={submitting} className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-on-accent)] disabled:opacity-60">{submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}{submitting ? "Activating…" : "Create account & continue"}</button>
           </form>
           <div className="mt-4 text-center text-[11px] text-[color:var(--theme-text-muted)]">Invitation expires {new Date(invite.expiresAt).toLocaleDateString()}.</div>

--- a/tests/auth-portal-hardening.test.ts
+++ b/tests/auth-portal-hardening.test.ts
@@ -74,6 +74,24 @@ describe("authentication and portal hardening", () => {
     expect(middleware).toContain("canUseMobile");
   });
 
+  it("activates fleet invites without a consumable email magic link", () => {
+    const inviteRoute = read("app/api/portal/fleet/invites/route.ts");
+    const acceptRoute = read("app/api/portal/fleet/invites/accept/route.ts");
+    const activationPage = read("app/portal/auth/fleet-invite/page.tsx");
+
+    expect(inviteRoute).toContain("portalLink,");
+    expect(inviteRoute).not.toContain("properties?.action_link");
+    expect(acceptRoute).toContain("password?: string");
+    expect(acceptRoute).toContain("enforceAuthRateLimit");
+    expect(acceptRoute).toContain("updateUserById");
+    expect(acceptRoute).toContain("email_confirm: true");
+    expect(acceptRoute).toContain("accept_fleet_portal_invite_atomic");
+    expect(activationPage).toContain("signInWithPassword");
+    expect(activationPage).not.toContain(
+      "Open the one-time invitation email on this device",
+    );
+  });
+
   it("keeps mobile as a separate premium surface with shared server validation", () => {
     const mobile = read("app/mobile/sign-in/page.tsx");
     const main = read("features/auth/components/SignIn.tsx");


### PR DESCRIPTION
## Summary

Fixes fleet portal invitations that reach the activation page with `otp_expired` and then fail when the user creates a password.

### Root cause

Fleet invitation emails contained a Supabase one-time magic link. Email security prefetchers and repeated link opens can consume that token before password submission even though the separate ProFixIQ fleet invitation remains valid.

### Changes

- Email the durable ProFixIQ fleet invite URL directly instead of a consumable Supabase action link.
- Validate the hashed, expiring, revocable fleet token on explicit password submission.
- Resolve/create the Auth identity server-side, confirm the email, set the password, and call the existing atomic fleet invite acceptance RPC.
- Sign the user in with the newly created password and continue to the fleet portal.
- Preserve established shop staff routing while marking portal-only identities correctly.
- Add rate limiting, bounded password/token validation, no-store responses, and retry support for an already accepted invite.
- Add regression coverage proving the email no longer contains a consumable magic link.

### Compatibility

Existing invite emails remain usable after this deploy: even if their Supabase token has already expired, the embedded ProFixIQ invite token still reaches the repaired activation flow.

### Database

No migration required.

### Environment variables

None required.
