### PR TITLE
Separate fleet and customer portal sign-in surfaces

### DIFF
--- a/app/portal/auth/sign-in/PortalSignInForm.tsx
+++ b/app/portal/auth/sign-in/PortalSignInForm.tsx
@@ -3,36 +3,44 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Building2, CarFront, Eye, EyeOff, Loader2 } from "lucide-react";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
 import AuthShell from "@/features/auth/components/AuthShell";
 import AuthStatus from "@/features/auth/components/AuthStatus";
-import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
+import {
+  PORTAL_SIGN_IN,
+  resolvePortalSurfaceRedirect,
+  type PortalSurface,
+} from "@/features/auth/lib/portalSurfaceRouting";
 import { signInWithIdentifier } from "@/features/auth/lib/signInClient";
 
-type PortalType = "customer" | "fleet";
+type PortalSignInFormProps = {
+  portalType: PortalSurface;
+};
 
 const inputClass =
   "w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3.5 py-3 text-sm text-[color:var(--theme-input-text)] outline-none transition placeholder:text-[color:var(--theme-text-muted)] focus:border-[var(--accent-copper)] focus:ring-4 focus:ring-[color:color-mix(in_srgb,var(--accent-copper)_16%,transparent)]";
 
-export default function PortalSignInForm() {
+export default function PortalSignInForm({
+  portalType,
+}: PortalSignInFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [portalType, setPortalType] = useState<PortalType>("customer");
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const isFleet = portalType === "fleet";
 
   useEffect(() => {
-    const requested = searchParams.get("portal");
-    if (requested === "fleet" || requested === "customer") setPortalType(requested);
     if (searchParams.get("activation") === "invalid") {
       setError(
-        "This activation link is invalid or has expired. Ask your shop to resend your customer portal invitation.",
+        isFleet
+          ? "This activation link is invalid or has expired. Ask your shop or fleet administrator to resend the fleet invitation."
+          : "This activation link is invalid or has expired. Ask your shop to resend your customer portal invitation.",
       );
     }
-  }, [searchParams]);
+  }, [isFleet, searchParams]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -47,17 +55,17 @@ export default function PortalSignInForm() {
       });
       if (!result.ok) {
         setError(
-          portalType === "fleet"
+          isFleet
             ? "We couldn't verify an invited fleet account with those details."
             : "We couldn't verify an activated customer portal account with those details.",
         );
         return;
       }
-      const allowedPrefixes = portalType === "fleet" ? ["/portal/fleet"] : ["/portal"];
-      const destination = safeInternalRedirect(
+
+      const destination = resolvePortalSurfaceRedirect(
         searchParams.get("redirect"),
         result.destination,
-        allowedPrefixes,
+        portalType,
       );
       router.replace(destination);
       router.refresh();
@@ -65,8 +73,6 @@ export default function PortalSignInForm() {
       setLoading(false);
     }
   }
-
-  const isFleet = portalType === "fleet";
 
   return (
     <AuthShell
@@ -97,37 +103,14 @@ export default function PortalSignInForm() {
         </p>
       </div>
 
-      <div className="mb-6 grid grid-cols-2 gap-2">
-        {(["customer", "fleet"] as const).map((value) => {
-          const Icon = value === "customer" ? CarFront : Building2;
-          const active = portalType === value;
-          return (
-            <button
-              key={value}
-              type="button"
-              onClick={() => {
-                setPortalType(value);
-                setError("");
-              }}
-              aria-pressed={active}
-              className={`flex items-center justify-center gap-2 rounded-xl border px-3 py-3 text-xs font-semibold transition ${
-                active
-                  ? "border-[var(--accent-copper)] bg-[color:color-mix(in_srgb,var(--accent-copper)_12%,transparent)] text-[color:var(--theme-text-primary)]"
-                  : "border-[color:var(--theme-border-soft)] text-[color:var(--theme-text-muted)] hover:text-[color:var(--theme-text-primary)]"
-              }`}
-            >
-              <Icon className="h-4 w-4" aria-hidden />
-              {value === "customer" ? "Customer" : "Fleet"}
-            </button>
-          );
-        })}
-      </div>
-
       {error ? <AuthStatus tone="error">{error}</AuthStatus> : null}
 
       <form className="mt-5 space-y-4" onSubmit={handleSubmit}>
         <div>
-          <label htmlFor="portal-identifier" className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+          <label
+            htmlFor="portal-identifier"
+            className="mb-1.5 block text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+          >
             {isFleet ? "Email or fleet username" : "Email or username"}
           </label>
           <input
@@ -135,7 +118,9 @@ export default function PortalSignInForm() {
             className={inputClass}
             type="text"
             autoComplete="username"
-            placeholder={isFleet ? "dispatch@fleet.com or username" : "you@example.com or username"}
+            placeholder={
+              isFleet ? "dispatch@fleet.com or username" : "you@example.com or username"
+            }
             value={identifier}
             onChange={(event) => setIdentifier(event.target.value)}
             required
@@ -144,10 +129,16 @@ export default function PortalSignInForm() {
 
         <div>
           <div className="mb-1.5 flex items-center justify-between">
-            <label htmlFor="portal-password" className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+            <label
+              htmlFor="portal-password"
+              className="text-xs font-semibold text-[color:var(--theme-text-secondary)]"
+            >
               Password
             </label>
-            <Link href="/forgot-password" className="text-xs font-semibold text-[var(--accent-copper)] hover:underline">
+            <Link
+              href="/forgot-password"
+              className="text-xs font-semibold text-[var(--accent-copper)] hover:underline"
+            >
               Forgot password?
             </Link>
           </div>
@@ -168,7 +159,11 @@ export default function PortalSignInForm() {
               aria-label={showPassword ? "Hide password" : "Show password"}
               className="absolute inset-y-0 right-0 grid w-11 place-items-center text-[color:var(--theme-text-muted)]"
             >
-              {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              {showPassword ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
             </button>
           </div>
         </div>
@@ -179,22 +174,42 @@ export default function PortalSignInForm() {
           className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--accent-copper)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-on-accent)] transition hover:brightness-105 disabled:opacity-60"
         >
           {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-          {loading ? "Verifying access…" : `Sign in to ${isFleet ? "fleet" : "customer"} portal`}
+          {loading
+            ? "Verifying access…"
+            : `Sign in to ${isFleet ? "fleet" : "customer"} portal`}
         </button>
       </form>
 
       <div className="mt-5 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3.5 py-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
         {isFleet ? (
-          <>Fleet access is invitation-only. Contact your shop or fleet administrator if you need an invitation.</>
+          <>
+            Fleet access is invitation-only. Contact your shop or fleet administrator if
+            you need an invitation.
+          </>
         ) : (
           <>
-            Portal access is created from your shop invitation. There is no separate account sign-up. If you need access, ask your shop to resend the invitation or{" "}
-            <Link href="/portal/auth/sign-up" className="font-semibold text-[var(--accent-copper)] hover:underline">
+            Portal access is created from your shop invitation. There is no separate
+            account sign-up. If you need access, ask your shop to resend the invitation
+            or{" "}
+            <Link
+              href="/portal/auth/sign-up"
+              className="font-semibold text-[var(--accent-copper)] hover:underline"
+            >
               view activation help
             </Link>
             .
           </>
         )}
+      </div>
+
+      <div className="mt-4 text-center text-xs text-[color:var(--theme-text-muted)]">
+        {isFleet ? "Looking for a customer service record?" : "Managing a fleet?"}{" "}
+        <Link
+          href={isFleet ? PORTAL_SIGN_IN.customer : PORTAL_SIGN_IN.fleet}
+          className="font-semibold text-[var(--accent-copper)] hover:underline"
+        >
+          Sign in to the {isFleet ? "customer" : "fleet"} portal
+        </Link>
       </div>
     </AuthShell>
   );

--- a/app/portal/auth/sign-in/page.tsx
+++ b/app/portal/auth/sign-in/page.tsx
@@ -32,7 +32,7 @@ function LoadingCard({ label }: { label: string }) {
 export default function PortalSignInPage() {
   return (
     <Suspense fallback={<LoadingCard label="Loading sign in…" />}>
-      <PortalSignInForm />
+      <PortalSignInForm portalType="customer" />
     </Suspense>
   );
 }

--- a/app/portal/fleet/auth/sign-in/page.tsx
+++ b/app/portal/fleet/auth/sign-in/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
-import PortalSignInForm from "@/app/portal/auth/sign-in/PortalSignInForm";
+import PortalSignInForm from "../../../auth/sign-in/PortalSignInForm";
 import AuthShell from "@/features/auth/components/AuthShell";
 
 const COPPER = "#C57A4A";

--- a/app/portal/fleet/auth/sign-in/page.tsx
+++ b/app/portal/fleet/auth/sign-in/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Suspense } from "react";
+import PortalSignInForm from "@/app/portal/auth/sign-in/PortalSignInForm";
+import AuthShell from "@/features/auth/components/AuthShell";
+
+const COPPER = "#C57A4A";
+
+function FleetLoadingCard() {
+  return (
+    <AuthShell cardClassName="rounded-2xl border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 backdrop-blur-md sm:p-6">
+      <div>
+        <div
+          className="inline-flex items-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-[11px] uppercase tracking-[0.2em]"
+          style={{ color: COPPER }}
+        >
+          Fleet Portal
+        </div>
+        <div className="mt-4 text-sm text-[color:var(--theme-text-secondary)]">
+          Loading fleet sign in…
+        </div>
+        <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]">
+          <div
+            className="h-full w-1/2 animate-pulse rounded-full"
+            style={{ backgroundColor: COPPER }}
+          />
+        </div>
+      </div>
+    </AuthShell>
+  );
+}
+
+export default function FleetPortalSignInPage() {
+  return (
+    <Suspense fallback={<FleetLoadingCard />}>
+      <PortalSignInForm portalType="fleet" />
+    </Suspense>
+  );
+}

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -262,12 +262,15 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         </button>
       </form>
 
-      <div className="mt-6 grid gap-2 border-t border-[color:var(--theme-border-soft)] pt-5 sm:grid-cols-2">
+      <div className="mt-6 grid gap-2 border-t border-[color:var(--theme-border-soft)] pt-5 sm:grid-cols-3">
         <Link href="/mobile/sign-in" className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]">
           Mobile companion
         </Link>
         <Link href="/portal/auth/sign-in" className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]">
-          Customer & fleet portals
+          Customer portal
+        </Link>
+        <Link href="/portal/fleet/auth/sign-in" className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2.5 text-center text-xs font-semibold text-[color:var(--theme-text-secondary)] transition hover:border-[var(--accent-copper)] hover:text-[color:var(--theme-text-primary)]">
+          Fleet portal
         </Link>
       </div>
     </AuthShell>

--- a/features/auth/lib/portalSurfaceRouting.ts
+++ b/features/auth/lib/portalSurfaceRouting.ts
@@ -1,0 +1,43 @@
+import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
+
+export type PortalSurface = "customer" | "fleet";
+
+export const PORTAL_HOME: Record<PortalSurface, string> = {
+  customer: "/portal",
+  fleet: "/portal/fleet",
+};
+
+export const PORTAL_SIGN_IN: Record<PortalSurface, string> = {
+  customer: "/portal/auth/sign-in",
+  fleet: "/portal/fleet/auth/sign-in",
+};
+
+function isFleetPortalPath(path: string): boolean {
+  return (
+    path === "/portal/fleet" ||
+    path.startsWith("/portal/fleet/") ||
+    path.startsWith("/portal/fleet?")
+  );
+}
+
+export function isPortalPathForSurface(
+  path: string | null | undefined,
+  surface: PortalSurface,
+): boolean {
+  const safePath = safeInternalRedirect(path, "", ["/portal"]);
+  if (!safePath) return false;
+
+  return surface === "fleet"
+    ? isFleetPortalPath(safePath)
+    : !isFleetPortalPath(safePath);
+}
+
+export function resolvePortalSurfaceRedirect(
+  requested: string | null | undefined,
+  fallback: string,
+  surface: PortalSurface,
+): string {
+  return isPortalPathForSurface(requested, surface)
+    ? String(requested).trim()
+    : fallback;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,12 @@ import { createServerClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import {
+  isPortalPathForSurface,
+  PORTAL_HOME,
+  PORTAL_SIGN_IN,
+  type PortalSurface,
+} from "@/features/auth/lib/portalSurfaceRouting";
 import { resolveMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
@@ -107,7 +113,11 @@ export async function middleware(req: NextRequest) {
   const res = NextResponse.next({ request: { headers: requestHeaders } });
 
   const isPortal = pathname === "/portal" || pathname.startsWith("/portal/");
-  const isPortalAuthPage = pathname.startsWith("/portal/auth/");
+  const isCustomerPortalAuthPage = pathname.startsWith("/portal/auth/");
+  const isFleetPortalAuthPage = pathname.startsWith("/portal/fleet/auth/");
+  const isPortalAuthPage =
+    isCustomerPortalAuthPage || isFleetPortalAuthPage;
+  const isFleetPortalPath = isPortalPathForSurface(pathname, "fleet");
   const isPortalActivationPage =
     pathname === "/portal/auth/confirm" ||
     pathname === "/portal/auth/fleet-invite";
@@ -258,18 +268,41 @@ export async function middleware(req: NextRequest) {
       !isPortalActivationPage
     ) {
       const access = await resolvePortalAccessServer(supabase, user.id);
-      const requestedFleet = redirectParam?.startsWith("/portal/fleet") ?? false;
-      let to =
-        redirectParam ??
-        (access.fleet && !access.customer ? "/portal/fleet" : "/portal");
-
-      if (requestedFleet && !access.fleet) to = "/portal";
-      if (!requestedFleet && !access.customer && access.fleet) {
-        to = "/portal/fleet";
-      }
+      const requestedSurface: PortalSurface =
+        isFleetPortalAuthPage ||
+        req.nextUrl.searchParams.get("portal") === "fleet" ||
+        isPortalPathForSurface(redirectParam, "fleet")
+          ? "fleet"
+          : "customer";
+      const hasRequestedAccess =
+        requestedSurface === "fleet" ? access.fleet : access.customer;
+      const otherSurface: PortalSurface =
+        requestedSurface === "fleet" ? "customer" : "fleet";
+      const hasOtherAccess =
+        otherSurface === "fleet" ? access.fleet : access.customer;
+      const surface = hasRequestedAccess
+        ? requestedSurface
+        : hasOtherAccess
+          ? otherSurface
+          : requestedSurface;
+      const to = isPortalPathForSurface(redirectParam, surface)
+        ? redirectParam!
+        : PORTAL_HOME[surface];
 
       const target = new URL(to, req.url);
       return NextResponse.redirect(target, { headers: res.headers });
+    }
+
+    if (
+      !user &&
+      pathname === PORTAL_SIGN_IN.customer &&
+      req.nextUrl.searchParams.get("portal") === "fleet"
+    ) {
+      const login = new URL(PORTAL_SIGN_IN.fleet, req.url);
+      if (isPortalPathForSurface(redirectParam, "fleet")) {
+        login.searchParams.set("redirect", redirectParam!);
+      }
+      return NextResponse.redirect(login, { headers: res.headers });
     }
 
     return res;
@@ -277,7 +310,8 @@ export async function middleware(req: NextRequest) {
 
   if (!user) {
     if (isPortal) {
-      const login = new URL("/portal/auth/sign-in", req.url);
+      const surface: PortalSurface = isFleetPortalPath ? "fleet" : "customer";
+      const login = new URL(PORTAL_SIGN_IN[surface], req.url);
       login.searchParams.set("redirect", pathname + search);
       return NextResponse.redirect(login, { headers: res.headers });
     }
@@ -330,8 +364,6 @@ export async function middleware(req: NextRequest) {
 
   if (isPortal) {
     const access = await resolvePortalAccessServer(supabase, user.id);
-    const isFleetPortalPath =
-      pathname === "/portal/fleet" || pathname.startsWith("/portal/fleet/");
 
     if (!access.customer && access.fleet && !isFleetPortalPath) {
       const target = new URL("/portal/fleet", req.url);

--- a/tests/auth-portal-hardening.test.ts
+++ b/tests/auth-portal-hardening.test.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
+  isPortalPathForSurface,
+  resolvePortalSurfaceRedirect,
+} from "../features/auth/lib/portalSurfaceRouting";
+import {
   isSafeInternalRedirect,
   safeInternalRedirect,
 } from "../features/auth/lib/safeRedirect";
@@ -25,6 +29,30 @@ describe("authentication and portal hardening", () => {
     );
     expect(isSafeInternalRedirect("/portal?tab=quotes", allowed)).toBe(true);
     expect(isSafeInternalRedirect("/portal\\evil", allowed)).toBe(false);
+  });
+
+  it("keeps customer and fleet sign-in routes on separate portal surfaces", () => {
+    expect(isPortalPathForSurface("/portal/fleet", "fleet")).toBe(true);
+    expect(isPortalPathForSurface("/portal/fleet/units", "customer")).toBe(false);
+    expect(isPortalPathForSurface("/portal/invoices", "customer")).toBe(true);
+    expect(
+      resolvePortalSurfaceRedirect("/portal", "/portal/fleet", "fleet"),
+    ).toBe("/portal/fleet");
+    expect(
+      resolvePortalSurfaceRedirect("/portal/fleet", "/portal", "customer"),
+    ).toBe("/portal");
+
+    const customerSignIn = read("app/portal/auth/sign-in/page.tsx");
+    const fleetSignIn = read("app/portal/fleet/auth/sign-in/page.tsx");
+    const signInForm = read("app/portal/auth/sign-in/PortalSignInForm.tsx");
+    const middleware = read("middleware.ts");
+
+    expect(customerSignIn).toContain('portalType="customer"');
+    expect(fleetSignIn).toContain('portalType="fleet"');
+    expect(signInForm).not.toContain('setPortalType');
+    expect(signInForm).toContain("resolvePortalSurfaceRedirect");
+    expect(middleware).toContain("isFleetPortalAuthPage");
+    expect(middleware).toContain("PORTAL_SIGN_IN[surface]");
   });
 
   it("keeps email identity resolution inside the server-owned sign-in exchange", () => {


### PR DESCRIPTION
## Summary

Fixes the production routing defect where an account with both fleet and customer access could enter through fleet sign-in and be redirected to the customer portal.

- adds a dedicated fleet sign-in route at `/portal/fleet/auth/sign-in`
- keeps `/portal/auth/sign-in` customer-only
- removes the ambiguous customer/fleet toggle from the shared form
- preserves explicit fleet intent for authenticated dual-access users in middleware
- sends signed-out fleet routes to the fleet sign-in page
- constrains post-auth redirects to the selected portal surface
- preserves legacy `?portal=fleet` links with a canonical redirect
- exposes separate customer and fleet links from the shop sign-in page
- adds focused regression coverage

## Evidence

The latest accepted fleet invitation belongs to an account that has both a fleet membership and a customer record. That confirms the dual-access middleware default as the production edge case.

## Database

No migration required.

## Environment variables

None required.
