### PR TITLE
Fix fleet sign-in for dual-role invited users

### DIFF
--- a/features/fleet/lib/resolveFleetActorContext.ts
+++ b/features/fleet/lib/resolveFleetActorContext.ts
@@ -136,6 +136,8 @@ export async function resolveFleetActorContext(
   const canonicalRole = canonicalizeRole(profileRole);
   const internalRole = INTERNAL_STAFF_ROLES.includes(canonicalRole);
   const fleetTier = resolveFleetRoleTier(membershipRole);
+  // A dual-role user can enter the fleet portal only when they have an explicit fleet membership.
+  const hasFleetPortalMembership = fleetTier !== "none";
 
   const actorType: FleetActorType = internalRole
     ? "internal_staff"
@@ -179,7 +181,7 @@ export async function resolveFleetActorContext(
         isInternal || actorType === "fleet_manager",
       canConvertServiceRequestToWorkOrder: isInternal,
       canAccessFleetIntake: isInternal || isFleetActor,
-      canAccessPortalFleetWrappers: isFleetActor,
+      canAccessPortalFleetWrappers: hasFleetPortalMembership,
       canRunFleetDispatchActions:
         isInternal || actorCaps.canManageFleetApprovals,
       canOverrideShopScope: isInternal,

--- a/tests/auth-portal-hardening.test.ts
+++ b/tests/auth-portal-hardening.test.ts
@@ -45,12 +45,24 @@ describe("authentication and portal hardening", () => {
     const customerSignIn = read("app/portal/auth/sign-in/page.tsx");
     const fleetSignIn = read("app/portal/auth/fleet-sign-in/page.tsx");
     const signInForm = read("app/portal/auth/sign-in/PortalSignInForm.tsx");
+    const fleetActorResolver = read(
+      "features/fleet/lib/resolveFleetActorContext.ts",
+    );
     const middleware = read("middleware.ts");
 
     expect(customerSignIn).toContain('portalType="customer"');
     expect(fleetSignIn).toContain('portalType="fleet"');
     expect(signInForm).not.toContain('setPortalType');
     expect(signInForm).toContain("resolvePortalSurfaceRedirect");
+    expect(fleetActorResolver).toContain(
+      'const hasFleetPortalMembership = fleetTier !== "none";',
+    );
+    expect(fleetActorResolver).toContain(
+      "canAccessPortalFleetWrappers: hasFleetPortalMembership",
+    );
+    expect(fleetActorResolver).not.toContain(
+      "canAccessPortalFleetWrappers: isFleetActor",
+    );
     expect(middleware).toContain("isFleetPortalAuthPage");
     expect(middleware).toContain("PORTAL_SIGN_IN[surface]");
   });


### PR DESCRIPTION
## Root cause

Password authentication succeeds, but the fleet sign-in exchange rejects and signs out users who are both internal shop staff and explicit fleet members. Internal-role precedence makes `actorType` equal `internal_staff`, while the fleet portal gate previously only accepted the external fleet actor types.

## What changed

- Authorize fleet portal wrappers from an explicit recognized fleet membership tier.
- Keep internal actor classification and shop-side capabilities unchanged.
- Add an auth/portal regression contract for dual-role fleet members.

## Safety

- Users without a fleet membership still fail closed.
- Customer and fleet portal routes remain separate.
- No database schema, auth user, invite, or environment changes.

## Validation plan

- Authentication and portal hardening checks
- TypeScript/build/lint CI
- Fleet workspace validation
- Production route and runtime verification after merge