### PR TITLE
Fix fleet compliance scheduler authorization

### DIFF
--- a/.github/workflows/fleet-premier-validation.yml
+++ b/.github/workflows/fleet-premier-validation.yml
@@ -63,9 +63,9 @@ jobs:
           features/fleet/types/workspace.ts
           tests/fleet-premier-workspaces.test.ts
           tests/fleet-pretrip-defect-compliance.test.ts
-          tests/fleet-pretrip-defect-compliance.test.ts
       - name: Fleet contracts
         run: >-
           pnpm exec vitest run
           tests/fleet-operations-core.test.ts
           tests/fleet-premier-workspaces.test.ts
+          tests/fleet-pretrip-defect-compliance.test.ts

--- a/.github/workflows/fleet-premier-validation.yml
+++ b/.github/workflows/fleet-premier-validation.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - "app/api/fleet/**"
+      - "app/api/internal/fleet/**"
       - "app/fleet/**"
       - "app/portal/fleet/**"
       - "features/fleet/**"
       - "tests/fleet-operations-core.test.ts"
       - "tests/fleet-premier-workspaces.test.ts"
+      - "tests/fleet-pretrip-defect-compliance.test.ts"
       - ".github/workflows/fleet-premier-validation.yml"
 
 permissions:
@@ -39,6 +41,7 @@ jobs:
           app/api/fleet/maintenance/route.ts
           app/api/fleet/service-requests/route.ts
           app/api/fleet/units/route.ts
+          app/api/internal/fleet/pretrip-compliance/route.ts
           "app/api/fleet/units/[unitId]/workspace/route.ts"
           app/fleet/layout.tsx
           app/fleet/maintenance/page.tsx
@@ -59,6 +62,8 @@ jobs:
           features/fleet/components/FleetWorkspaceNav.tsx
           features/fleet/types/workspace.ts
           tests/fleet-premier-workspaces.test.ts
+          tests/fleet-pretrip-defect-compliance.test.ts
+          tests/fleet-pretrip-defect-compliance.test.ts
       - name: Fleet contracts
         run: >-
           pnpm exec vitest run

--- a/app/api/internal/fleet/pretrip-compliance/route.ts
+++ b/app/api/internal/fleet/pretrip-compliance/route.ts
@@ -5,21 +5,25 @@ import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function bearer(request: Request) {
-  const value = request.headers.get("authorization")?.trim() ?? "";
-  const [scheme, token] = value.split(/\s+/, 2);
-  return scheme?.toLowerCase() === "bearer" ? token ?? null : null;
-}
+function authorize(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  const authorization = request.headers.get("authorization");
 
-export async function GET(request: Request) {
-  const gate = requireInternalApiSecret({
+  if (cronSecret && authorization === `Bearer ${cronSecret}`) {
+    return { ok: true } as const;
+  }
+
+  return requireInternalApiSecret({
     request,
     envSecretName: "INTERNAL_CRON_SECRET",
     headerName: "x-internal-cron-secret",
     routeLabel: "internal/fleet/pretrip-compliance",
   });
-  const configured = process.env.INTERNAL_CRON_SECRET;
-  if (!gate.ok && (!configured || bearer(request) !== configured)) {
+}
+
+export async function GET(request: Request) {
+  const gate = authorize(request);
+  if (!gate.ok) {
     return gate.response;
   }
 

--- a/tests/fleet-pretrip-defect-compliance.test.ts
+++ b/tests/fleet-pretrip-defect-compliance.test.ts
@@ -85,6 +85,10 @@ describe("fleet pre-trip, defects, and compliance", () => {
       path: "/api/internal/fleet/pretrip-compliance",
       schedule: "11 * * * *",
     });
+    const cronRoute = read("app/api/internal/fleet/pretrip-compliance/route.ts");
+    expect(cronRoute).toContain("process.env.CRON_SECRET");
+    expect(cronRoute).toContain("`Bearer ${cronSecret}`");
+    expect(cronRoute).toContain('envSecretName: "INTERNAL_CRON_SECRET"');
     const middleware = read("middleware.ts");
     expect(middleware).toContain('pathname === "/portal/fleet/auth/sign-in"');
     expect(middleware).toContain("NextResponse.redirect(target, 308)");


### PR DESCRIPTION
## Summary

- accepts Vercel's signed `Authorization: Bearer $CRON_SECRET` request for the fleet pre-trip compliance schedule
- preserves the separate `INTERNAL_CRON_SECRET` header path for manual/internal execution
- remains fail-closed when neither secret is configured or valid
- adds a regression assertion for both authorization paths

## Production finding

The fleet deployment was healthy, but the new scheduled endpoint returned a configuration error because it only recognized `INTERNAL_CRON_SECRET`. Existing Vercel cron routes use the platform `CRON_SECRET`, which is already configured for the project.
