### PR TITLE
Run fleet pre-trip compliance in Supabase Cron

### DIFF
--- a/supabase/migrations/20260803041000_schedule_fleet_pretrip_compliance.sql
+++ b/supabase/migrations/20260803041000_schedule_fleet_pretrip_compliance.sql
@@ -1,0 +1,27 @@
+-- Keep fleet pre-trip compliance evaluation close to its authoritative data.
+-- The scheduler runs as postgres; application roles still cannot execute the evaluator.
+
+create extension if not exists pg_cron with schema pg_catalog;
+
+grant usage on schema cron to postgres;
+grant all privileges on all tables in schema cron to postgres;
+
+do $schedule$
+declare
+  v_job_id bigint;
+begin
+  for v_job_id in
+    select jobid
+    from cron.job
+    where jobname = 'fleet-pretrip-compliance-hourly'
+  loop
+    perform cron.unschedule(v_job_id);
+  end loop;
+
+  perform cron.schedule(
+    'fleet-pretrip-compliance-hourly',
+    '11 * * * *',
+    $command$select public.evaluate_fleet_pretrip_compliance(clock_timestamp());$command$
+  );
+end;
+$schedule$;

--- a/tests/fleet-pretrip-defect-compliance.test.ts
+++ b/tests/fleet-pretrip-defect-compliance.test.ts
@@ -77,14 +77,19 @@ describe("fleet pre-trip, defects, and compliance", () => {
     expect(migration).toContain("revoke execute on function public.evaluate_fleet_pretrip_compliance");
   });
 
-  it("schedules missed-pretrip evaluation and keeps the retired sign-in URL safe", () => {
+  it("schedules missed-pretrip evaluation in Supabase and keeps the retired sign-in URL safe", () => {
     const config = JSON.parse(read("vercel.json")) as {
       crons: Array<{ path: string; schedule: string }>;
     };
-    expect(config.crons).toContainEqual({
+    expect(config.crons).not.toContainEqual(expect.objectContaining({
       path: "/api/internal/fleet/pretrip-compliance",
-      schedule: "11 * * * *",
-    });
+    }));
+    const scheduler = read(
+      "supabase/migrations/20260803041000_schedule_fleet_pretrip_compliance.sql",
+    );
+    expect(scheduler).toContain("create extension if not exists pg_cron");
+    expect(scheduler).toContain("'fleet-pretrip-compliance-hourly'");
+    expect(scheduler).toContain("public.evaluate_fleet_pretrip_compliance(clock_timestamp())");
     const cronRoute = read("app/api/internal/fleet/pretrip-compliance/route.ts");
     expect(cronRoute).toContain("process.env.CRON_SECRET");
     expect(cronRoute).toContain("`Bearer ${cronSecret}`");

--- a/vercel.json
+++ b/vercel.json
@@ -23,10 +23,6 @@
     {
       "path": "/api/internal/stripe/reconcile-pending-billing",
       "schedule": "*/5 * * * *"
-    },
-    {
-      "path": "/api/internal/fleet/pretrip-compliance",
-      "schedule": "11 * * * *"
     }
   ],
   "git": {


### PR DESCRIPTION
## Summary

- schedules `evaluate_fleet_pretrip_compliance` hourly inside Supabase with `pg_cron`
- removes the duplicate Vercel HTTP schedule, eliminating its missing-secret dependency
- preserves the authenticated HTTP route for future/manual internal use
- adds the scheduler migration to the fleet contract tests

## Production

The migration has already been applied in schema-first order. Production now has one active `fleet-pretrip-compliance-hourly` job owned by `postgres`, scheduled at minute 11 each hour. A manual evaluator execution completed successfully.
