### PR TITLE
Fix invoice finalization and QuickBooks readiness

### DIFF
--- a/app/api/invoices/finalize/route.ts
+++ b/app/api/invoices/finalize/route.ts
@@ -36,6 +36,7 @@ function invoicePartSignature(
 }
 
 export async function POST(request: Request) {
+  let workOrderId = "";
   try {
     const access = await requireShopScopedApiAccess({
       requiredCapabilities: ["canManageWorkOrders", "canAuthorizeQuotes"],
@@ -44,7 +45,7 @@ export async function POST(request: Request) {
     if (!access.ok) return access.response;
 
     const body = (await request.json().catch(() => null)) as Body | null;
-    const workOrderId = body?.workOrderId?.trim() ?? "";
+    workOrderId = body?.workOrderId?.trim() ?? "";
     if (!workOrderId) {
       return NextResponse.json(
         { error: "Missing work order ID." },
@@ -148,13 +149,12 @@ export async function POST(request: Request) {
       );
     }
 
-    const now = new Date().toISOString();
     const { data: pending, error: pendingError } = await admin
       .from("invoices")
       .select("id")
       .eq("work_order_id", workOrderId)
       .eq("shop_id", workOrder.shop_id)
-      .in("status", ["draft", "issued_pending_send"])
+      .eq("status", "draft")
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle<{ id: string }>();
@@ -171,8 +171,8 @@ export async function POST(request: Request) {
       discount_total: snapshot.discountTotal ?? 0,
       tax_total: snapshot.taxTotal ?? 0,
       total,
-      status: "issued_pending_send",
-      issued_at: now,
+      status: "draft",
+      issued_at: null,
     } as DB["public"]["Tables"]["invoices"]["Insert"];
 
     let invoiceId = pending?.id ?? null;
@@ -214,25 +214,6 @@ export async function POST(request: Request) {
         `invoice-finalize:${workOrder.shop_id}:${workOrderId}`,
     });
 
-    const [{ error: invoiceUpdateError }, { error: workOrderUpdateError }] =
-      await Promise.all([
-        admin
-          .from("invoices")
-          .update({ status: "issued", issued_at: now })
-          .eq("id", invoiceId)
-          .eq("shop_id", workOrder.shop_id),
-        admin
-          .from("work_orders")
-          .update({
-            status: "invoiced",
-            invoice_total: version.total,
-          } as DB["public"]["Tables"]["work_orders"]["Update"])
-          .eq("id", workOrderId)
-          .eq("shop_id", workOrder.shop_id),
-      ]);
-    if (invoiceUpdateError) throw new Error(invoiceUpdateError.message);
-    if (workOrderUpdateError) throw new Error(workOrderUpdateError.message);
-
     await logOperationalEvent({
       supabase: admin,
       event: "invoice_finalized",
@@ -253,8 +234,16 @@ export async function POST(request: Request) {
       inspectionAttachment,
     });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Failed to finalize invoice.";
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error("[invoices/finalize] failed", {
+      workOrderId: workOrderId || null,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      {
+        error:
+          "Invoice finalization failed. Please retry; if it continues, contact support.",
+      },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -223,7 +223,7 @@ export async function POST(request: Request) {
         .select("id")
         .eq("work_order_id", workOrderId)
         .eq("shop_id", workOrder.shop_id)
-        .in("status", ["draft", "issued_pending_send"])
+        .eq("status", "draft")
         .order("created_at", { ascending: false })
         .limit(1)
         .maybeSingle<{ id: string }>();
@@ -240,8 +240,8 @@ export async function POST(request: Request) {
         discount_total: snapshot.discountTotal ?? 0,
         tax_total: snapshot.taxTotal ?? 0,
         total: snapshot.total ?? 0,
-        status: "issued_pending_send",
-        issued_at: now,
+        status: "draft",
+        issued_at: null,
       } as DB["public"]["Tables"]["invoices"]["Insert"];
       invoiceId = pending?.id ?? null;
       if (invoiceId) {

--- a/features/integrations/ai/index.ts
+++ b/features/integrations/ai/index.ts
@@ -9,7 +9,7 @@ async function getRuntimeOpenAIClient() {
 
 import { getOpenAIModelForPurpose, openAITemperatureParam } from "@/features/shared/lib/server/openai-models";
 import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
-import type { Json } from "@/features/shared/types/types/supabase";
+import type { Database, Json } from "@/features/shared/types/types/supabase";
 /* ========================================================================== */
 /*  QUOTE ENGINE – CENTRAL AI ENTRYPOINT                                      */
 /* ========================================================================== */
@@ -210,6 +210,21 @@ export interface AITrainingEvent {
   createdAt?: string;
 }
 
+function canonicalTrainingSource(
+  source: AIRecordSource,
+): Database["public"]["Enums"]["ai_training_source"] {
+  switch (source) {
+    case "apply_ai_quote":
+      return "quote";
+    case "inspection_to_quote":
+      return "inspection";
+    case "invoice_review":
+    case "menu_learning":
+    case "chat":
+      return "work_order";
+  }
+}
+
 async function insertTrainingEvent(event: AITrainingEvent): Promise<void> {
   const supabase = createAdminSupabase();
 
@@ -226,7 +241,7 @@ async function insertTrainingEvent(event: AITrainingEvent): Promise<void> {
     p_event_type: "training.event",
     p_payload: eventPayload,
     p_shop_id: shopId,
-    p_training_source: source,
+    p_training_source: canonicalTrainingSource(source),
   });
 
   if (error) {

--- a/features/integrations/ai/quoteSuggestionCompatibility.test.ts
+++ b/features/integrations/ai/quoteSuggestionCompatibility.test.ts
@@ -16,6 +16,10 @@ describe("quote suggestion OpenAI compatibility", () => {
     expect(source).toContain("p_payload");
     expect(source).toContain("p_shop_id");
     expect(source).toContain("p_training_source");
+    expect(source).toContain("canonicalTrainingSource(source)");
+    expect(source).toContain('return "quote"');
+    expect(source).toContain('return "work_order"');
+    expect(source).toContain('return "inspection"');
     expect(source).not.toContain("trainingSource: source,\n    p_shop_id");
   });
 });

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { toast } from "sonner";
 
 import type { Database } from "@shared/types/types/supabase";
 import type { RepairLine } from "@ai/lib/parseRepairOutput";
@@ -105,6 +106,7 @@ type ActiveInvoiceVersionSummary = {
 type SendInvoiceResponse = {
   ok?: boolean;
   error?: string;
+  issues?: ReviewIssue[];
   invoiceId?: string;
   invoiceVersion?: ActiveInvoiceVersionSummary;
 };
@@ -918,6 +920,7 @@ export default function InvoicePreviewPageClient({
 
   const finalizeInvoice = useCallback(async () => {
     if (finalizing || activeInvoiceVersion || !reviewOk) return;
+    let serverIssues: ReviewIssue[] = [];
     try {
       setFinalizing(true);
       setReviewError(null);
@@ -931,19 +934,23 @@ export default function InvoicePreviewPageClient({
       });
       const result = (await response.json().catch(() => null)) as SendInvoiceResponse | null;
       if (!response.ok || !result?.ok || !result.invoiceVersion) {
+        serverIssues = Array.isArray(result?.issues) ? result.issues : [];
         throw new Error(result?.error ?? "Invoice could not be finalized.");
       }
+      setReviewIssues([]);
       setInvoiceId(result.invoiceId ?? result.invoiceVersion.invoice_id);
       setActiveInvoiceVersion(result.invoiceVersion);
       setCanonicalInvoiceTotal(Math.max(0, Number(result.invoiceVersion.total)));
       if (result.invoiceVersion.snapshot) {
         setCanonicalSnapshot(result.invoiceVersion.snapshot);
       }
+      toast.success("Invoice finalized. QuickBooks sync is now available.");
       router.refresh();
     } catch (caught) {
       const message = caught instanceof Error ? caught.message : "Invoice could not be finalized.";
       setReviewError(message);
-      setReviewIssues([{ kind: "error", message }]);
+      setReviewIssues(serverIssues);
+      toast.error(message);
     } finally {
       setFinalizing(false);
     }
@@ -1239,13 +1246,18 @@ export default function InvoicePreviewPageClient({
         ) : null}
 
         {/* Review issues panel */}
-        {!activeInvoiceVersion && !reviewOk ? (
-          <div className="rounded-xl border border-amber-500/30 bg-[color:var(--theme-surface-inset)] px-3 py-2">
+        {!activeInvoiceVersion && (!reviewOk || reviewError) ? (
+          <div
+            aria-live="polite"
+            className="rounded-xl border border-amber-500/30 bg-[color:var(--theme-surface-inset)] px-3 py-2"
+          >
             <div className="text-[0.7rem] uppercase tracking-[0.18em] text-amber-200">
-              Invoice needs attention
+              {reviewOk ? "Invoice finalization failed" : "Invoice needs attention"}
             </div>
             <div className="mt-1 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
-              Complete the required items below before sending the invoice.
+              {reviewOk
+                ? "No invoice was issued. Review the error below and retry when ready."
+                : "Complete the required items below before sending the invoice."}
             </div>
 
             {reviewError ? (

--- a/supabase/migrations/20260803173514_invoice_finalize_production_contract.sql
+++ b/supabase/migrations/20260803173514_invoice_finalize_production_contract.sql
@@ -1,0 +1,111 @@
+begin;
+
+create table if not exists public.invoice_pricing_overrides (
+  work_order_id uuid primary key references public.work_orders(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  line_labor_totals jsonb not null default '{}'::jsonb,
+  part_unit_prices jsonb not null default '{}'::jsonb,
+  shop_supplies_amount numeric(12,2),
+  updated_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (jsonb_typeof(line_labor_totals) = 'object'),
+  check (jsonb_typeof(part_unit_prices) = 'object'),
+  check (shop_supplies_amount is null or shop_supplies_amount >= 0)
+);
+
+create index if not exists invoice_pricing_overrides_shop_idx
+  on public.invoice_pricing_overrides(shop_id, work_order_id);
+
+alter table public.invoice_pricing_overrides enable row level security;
+revoke all on public.invoice_pricing_overrides from public, anon, authenticated;
+grant select, insert, update, delete on public.invoice_pricing_overrides to service_role;
+grant select on public.invoice_pricing_overrides to authenticated;
+
+drop policy if exists invoice_pricing_overrides_shop_read
+  on public.invoice_pricing_overrides;
+create policy invoice_pricing_overrides_shop_read
+  on public.invoice_pricing_overrides
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from public.profiles profile
+      where profile.shop_id = invoice_pricing_overrides.shop_id
+        and (profile.id = (select auth.uid()) or profile.user_id = (select auth.uid()))
+    )
+  );
+
+-- Delivery metadata is intentionally mutable after financial finalization. It
+-- does not affect the immutable invoice snapshot, totals, parts, or labor.
+create or replace function public.guard_financially_locked_work_order()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_locked boolean;
+  v_has_financial_history boolean;
+  v_old_source jsonb;
+  v_new_source jsonb;
+  v_allowed_keys text[] := array[
+    'updated_at',
+    'invoice_total',
+    'payment_status',
+    'outstanding_balance',
+    'paid_at',
+    'status',
+    'invoice_sent_at',
+    'invoice_last_sent_to',
+    'invoice_url',
+    'invoice_pdf_url'
+  ];
+begin
+  v_locked := public.work_order_is_financially_locked(old.shop_id, old.id);
+  if not v_locked then
+    return new;
+  end if;
+
+  v_has_financial_history := coalesce(
+    (public.work_order_financial_lock_state(new.shop_id, new.id) ->> 'has_financial_history')::boolean,
+    false
+  );
+
+  v_old_source := to_jsonb(old) - v_allowed_keys;
+  v_new_source := to_jsonb(new) - v_allowed_keys;
+
+  if v_old_source is distinct from v_new_source then
+    raise exception using
+      errcode = 'P0001',
+      message = 'WORK_ORDER_FINANCIALLY_LOCKED',
+      detail = format(
+        'Operational work-order fields cannot change after invoice finalization for work order %s',
+        old.id
+      ),
+      hint = 'Open an audited correction session before changing finalized work-order source data.';
+  end if;
+
+  if old.status is distinct from new.status then
+    if not (
+      v_has_financial_history
+      and lower(coalesce(new.status::text, '')) = 'invoiced'
+      and lower(coalesce(old.status::text, '')) <> 'invoiced'
+    ) then
+      raise exception using
+        errcode = 'P0001',
+        message = 'WORK_ORDER_FINANCIALLY_LOCKED',
+        detail = format(
+          'Work-order status cannot change after invoice finalization for work order %s',
+          old.id
+        ),
+        hint = 'Open an audited correction session before changing finalized work-order source data.';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+commit;

--- a/tests/invoice-workflow-completion.test.ts
+++ b/tests/invoice-workflow-completion.test.ts
@@ -35,8 +35,27 @@ describe("invoice and work-order workflow completion", () => {
     expect(finalize).toContain("getActiveInvoiceVersion");
     expect(finalize).toContain("documentConfiguration: brand.document");
     expect(finalize).toContain("invoicePartSignature");
+    expect(finalize).toContain('status: "draft"');
+    expect(finalize).toContain("issued_at: null");
+    expect(finalize).not.toContain("issued_pending_send");
+    expect(finalize).not.toContain("invoiceUpdateError");
     expect(send).toContain("if (version)");
     expect(send).toContain("snapshot = version.snapshot");
+    expect(send).toContain('status: "draft"');
+    expect(send).not.toContain("issued_pending_send");
+    expect(preview).toContain("Invoice finalization failed");
+    expect(preview).toContain("toast.error(message)");
+  });
+
+  it("allows delivery metadata updates after the financial snapshot is locked", () => {
+    const migration = source(
+      "supabase/migrations/20260803173514_invoice_finalize_production_contract.sql",
+    );
+    expect(migration).toContain("invoice_sent_at");
+    expect(migration).toContain("invoice_last_sent_to");
+    expect(migration).toContain("invoice_url");
+    expect(migration).toContain("invoice_pdf_url");
+    expect(migration).toContain("WORK_ORDER_FINANCIALLY_LOCKED");
   });
 
   it("keeps payment and QuickBooks actions on the immutable invoice", () => {


### PR DESCRIPTION
## What changed

- keep invoice rows in the valid `draft` state until the atomic finalization RPC issues the immutable invoice version
- remove redundant post-RPC invoice/work-order updates that could report failure after successful issuance
- show finalization failures inline and through a toast; confirm when QuickBooks sync becomes available
- normalize AI training sources to the database enum
- add the production contract migration for invoice pricing overrides and post-finalization delivery metadata

## Root cause

The deployed finalize and send routes wrote `issued_pending_send`, but production's invoice status constraint only permits `draft`, `issued`, `paid`, and `void`. The request failed before an invoice version was created. The client stored the error but hid the panel while review state remained valid, making the button appear to do nothing. QuickBooks correctly remained disabled because no immutable invoice version existed.

## Impact

Approve & Finalize can complete through the existing atomic RPC, errors are visible if it cannot, and QuickBooks sync becomes available after the immutable invoice version is created.

## Validation

- targeted TypeScript semantic diagnostics: 0
- targeted ESLint diagnostics: 0 errors / 0 warnings
- invoice workflow contract assertions: passing
- staged diff whitespace check: clean
- production-safe Supabase migration applied and verified