### PR TITLE
Retire legacy invoice status sync trigger

### DIFF
--- a/supabase/migrations/20260803193215_retire_legacy_invoice_status_sync.sql
+++ b/supabase/migrations/20260803193215_retire_legacy_invoice_status_sync.sql
@@ -6,7 +6,13 @@ begin;
 -- back to a financially locked work order.
 drop trigger if exists trg_sync_invoice_from_work_order on public.work_orders;
 
-comment on function public.sync_invoice_from_work_order() is
-  'Legacy trigger function retained for migration compatibility; no longer attached to work_orders. Invoice issuance is owned by finalize_invoice_version.';
+do $block$
+begin
+  if to_regprocedure('public.sync_invoice_from_work_order()') is not null then
+    comment on function public.sync_invoice_from_work_order() is
+      'Legacy trigger function retained for migration compatibility; no longer attached to work_orders. Invoice issuance is owned by finalize_invoice_version.';
+  end if;
+end
+$block$;
 
 commit;

--- a/supabase/migrations/20260803193215_retire_legacy_invoice_status_sync.sql
+++ b/supabase/migrations/20260803193215_retire_legacy_invoice_status_sync.sql
@@ -1,0 +1,12 @@
+begin;
+
+-- Invoice finalization is owned by finalize_invoice_version. This legacy
+-- status trigger independently rebuilt invoice totals from work_order_lines,
+-- folded shop supplies into parts, and recursively wrote those stale values
+-- back to a financially locked work order.
+drop trigger if exists trg_sync_invoice_from_work_order on public.work_orders;
+
+comment on function public.sync_invoice_from_work_order() is
+  'Legacy trigger function retained for migration compatibility; no longer attached to work_orders. Invoice issuance is owned by finalize_invoice_version.';
+
+commit;

--- a/tests/invoice-financial-integrity.test.ts
+++ b/tests/invoice-financial-integrity.test.ts
@@ -7,6 +7,8 @@ function source(path: string) {
 
 const migrationPath =
   "supabase/migrations/20260803174543_fix_invoice_financial_integrity.sql";
+const legacyTriggerRetirementPath =
+  "supabase/migrations/20260803193215_retire_legacy_invoice_status_sync.sql";
 
 describe("invoice financial integrity repair", () => {
   it("persists shop supplies and computes subtotal, discount, tax, and total once", () => {
@@ -52,6 +54,16 @@ describe("invoice financial integrity repair", () => {
     expect(finalize).toContain("finalizedWithWarnings");
     expect(send).not.toContain('status: "draft"');
     expect(send).toContain("issuanceWarnings");
+  });
+
+  it("retires the legacy status trigger that competes with atomic issuance", () => {
+    const migration = source(legacyTriggerRetirementPath);
+    expect(migration).toContain(
+      "drop trigger if exists trg_sync_invoice_from_work_order on public.work_orders",
+    );
+    expect(migration).not.toContain(
+      "drop function public.sync_invoice_from_work_order()",
+    );
   });
 
   it("reads the persisted shop-supplies amount for issued snapshots", () => {

--- a/tests/invoice-financial-integrity.test.ts
+++ b/tests/invoice-financial-integrity.test.ts
@@ -61,6 +61,9 @@ describe("invoice financial integrity repair", () => {
     expect(migration).toContain(
       "drop trigger if exists trg_sync_invoice_from_work_order on public.work_orders",
     );
+    expect(migration).toContain(
+      "to_regprocedure('public.sync_invoice_from_work_order()') is not null",
+    );
     expect(migration).not.toContain(
       "drop function public.sync_invoice_from_work_order()",
     );


### PR DESCRIPTION
## Root cause

Production rollback verification after deploying PR #1298 exposed the legacy `trg_sync_invoice_from_work_order` trigger. When finalization changes the work-order status to `invoiced`, that trigger independently rebuilds the invoice from `work_order_lines`, folds shop supplies into parts, and recursively writes stale totals back to the now financially locked work order.

The lock correctly rejects that recursive write with `WORK_ORDER_FINANCIALLY_LOCKED`.

## Change

- drop only `trg_sync_invoice_from_work_order` from `public.work_orders`
- retain the legacy no-argument trigger function for migration compatibility
- retain the authenticated `sync_invoice_from_work_order(uuid)` RPC
- add a source regression assertion

## Validation

- `pnpm typecheck` — passed
- focused invoice tests — 17/17 passed
- changed-file ESLint — passed
- `git diff --check` — passed

## Production status

The PR #1298 migration is already applied in production. This follow-up migration is **not applied** and requires explicit approval after CI passes. The rollback-only test left the affected work order unchanged and created no invoice version or AI verification event.