### PR TITLE
Fix invoice AI, QuickBooks, and advisor contracts

### DIFF
--- a/app/api/work-orders/suggest-lines/route.ts
+++ b/app/api/work-orders/suggest-lines/route.ts
@@ -262,7 +262,7 @@ export async function POST(req: Request) {
           { role: "system", content: system },
           { role: "user", content: userContext },
         ],
-        max_tokens: policy.maxTokens,
+        max_completion_tokens: policy.maxTokens,
       }),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error("AI request timed out")), policy.timeoutMs),

--- a/features/integrations/ai/quoteSuggestionCompatibility.test.ts
+++ b/features/integrations/ai/quoteSuggestionCompatibility.test.ts
@@ -16,6 +16,7 @@ describe("quote suggestion OpenAI compatibility", () => {
     expect(source).toContain("p_payload");
     expect(source).toContain("p_shop_id");
     expect(source).toContain("p_training_source");
+    expect(source).toContain('p_event_type: "training.event"');
     expect(source).toContain("canonicalTrainingSource(source)");
     expect(source).toContain('return "quote"');
     expect(source).toContain('return "work_order"');

--- a/features/integrations/quickbooks/server/env.ts
+++ b/features/integrations/quickbooks/server/env.ts
@@ -37,8 +37,16 @@ export function getQuickBooksTokenUrl(): string {
   return "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer";
 }
 
-export function getQuickBooksApiBaseUrl(): string {
-  return "https://quickbooks.api.intuit.com";
+export function getQuickBooksApiBaseUrl(
+  environment: string,
+): string {
+  if (environment === "sandbox") {
+    return "https://sandbox-quickbooks.api.intuit.com";
+  }
+  if (environment === "production") {
+    return "https://quickbooks.api.intuit.com";
+  }
+  throw new Error(`Unsupported QuickBooks environment: ${environment}`);
 }
 
 export function getAppBaseUrl(): string {

--- a/features/integrations/quickbooks/server/http.ts
+++ b/features/integrations/quickbooks/server/http.ts
@@ -11,6 +11,74 @@ type TokenExchangeResponse = {
   scope?: string;
 };
 
+type QuickBooksFaultError = {
+  Message?: string;
+  Detail?: string;
+  code?: string;
+  element?: string;
+};
+
+type QuickBooksErrorResponse = {
+  Fault?: {
+    type?: string;
+    Error?: QuickBooksFaultError[];
+  };
+};
+
+export type QuickBooksApiFailureDetails = {
+  status: number;
+  statusText: string | null;
+  requestId: string | null;
+  faultType: string | null;
+  errors: Array<{
+    code: string | null;
+    element: string | null;
+    message: string | null;
+    detail: string | null;
+  }>;
+};
+
+export class QuickBooksApiError extends Error {
+  readonly details: QuickBooksApiFailureDetails;
+
+  constructor(message: string, details: QuickBooksApiFailureDetails) {
+    super(message);
+    this.name = "QuickBooksApiError";
+    this.details = details;
+  }
+}
+
+function safeQuickBooksText(
+  value: string | null | undefined,
+  maxLength = 500,
+): string | null {
+  if (!value) return null;
+  return value
+    .replace(/(access_token|refresh_token|authorization)([\s:=\"]+)[^\s,}\"]+/gi, "$1$2[redacted]")
+    .slice(0, maxLength);
+}
+
+function buildQuickBooksFailureDetails(
+  res: Response,
+  json: QuickBooksErrorResponse,
+): QuickBooksApiFailureDetails {
+  return {
+    status: res.status,
+    statusText: safeQuickBooksText(res.statusText, 100),
+    requestId: safeQuickBooksText(
+      res.headers.get("intuit_tid") ?? res.headers.get("intuit-tid"),
+      128,
+    ),
+    faultType: safeQuickBooksText(json.Fault?.type, 100),
+    errors: (json.Fault?.Error ?? []).slice(0, 5).map((error) => ({
+      code: safeQuickBooksText(error.code, 100),
+      element: safeQuickBooksText(error.element, 100),
+      message: safeQuickBooksText(error.Message),
+      detail: safeQuickBooksText(error.Detail),
+    })),
+  };
+}
+
 function buildBasicAuthHeader(clientId: string, clientSecret: string): string {
   return `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`;
 }
@@ -155,7 +223,7 @@ export async function quickBooksFetch<T>(
   path: string,
   init?: RequestInit,
 ): Promise<T> {
-  const url = `${getQuickBooksApiBaseUrl()}/v3/company/${connection.realm_id}${path}`;
+  const url = `${getQuickBooksApiBaseUrl(connection.environment)}/v3/company/${connection.realm_id}${path}`;
   const res = await fetch(url, {
     ...init,
     headers: {
@@ -167,18 +235,21 @@ export async function quickBooksFetch<T>(
     cache: "no-store",
   });
 
-  const json = (await res.json().catch(() => ({}))) as T & {
-    Fault?: {
-      Error?: Array<{ Message?: string; Detail?: string }>;
-    };
-  };
+  const json = (await res.json().catch(() => ({}))) as T & QuickBooksErrorResponse;
 
   if (!res.ok) {
+    const details = buildQuickBooksFailureDetails(res, json);
     const qbMessage =
-      json?.Fault?.Error?.[0]?.Detail ||
-      json?.Fault?.Error?.[0]?.Message ||
+      details.errors[0]?.detail ||
+      details.errors[0]?.message ||
       "QuickBooks API request failed.";
-    throw new Error(qbMessage);
+    console.error("[quickbooks/http] request failed", {
+      environment: connection.environment,
+      resource: path.split("?", 1)[0] || "/",
+      method: init?.method ?? "GET",
+      ...details,
+    });
+    throw new QuickBooksApiError(qbMessage, details);
   }
 
   return json;

--- a/features/integrations/quickbooks/server/syncInvoice.ts
+++ b/features/integrations/quickbooks/server/syncInvoice.ts
@@ -6,7 +6,7 @@ import type {
   QuickBooksConnectionRow,
 } from "../types";
 import type { Json } from "@shared/types/types/supabase";
-import { quickBooksFetch } from "./http";
+import { QuickBooksApiError, quickBooksFetch } from "./http";
 import { ensureQuickBooksCustomer } from "./syncCustomer";
 import { mapInvoiceToQuickBooksPayload } from "./mapInvoice";
 import {
@@ -25,7 +25,26 @@ async function logSyncEvent(
   supabase: SupabaseClient<DB>,
   payload: DB["public"]["Tables"]["quickbooks_sync_events"]["Insert"],
 ) {
-  await supabase.from("quickbooks_sync_events").insert(payload);
+  const { error } = await supabase.from("quickbooks_sync_events").insert(payload);
+  if (error) {
+    console.error("[quickbooks/sync-audit] insert failed", {
+      shopId: payload.shop_id,
+      connectionId: payload.connection_id ?? null,
+      entityType: payload.entity_type,
+      entityId: payload.entity_id ?? null,
+      action: payload.action,
+      status: payload.status,
+      code: error.code,
+      message: error.message,
+      details: error.details,
+      hint: error.hint,
+    });
+  }
+}
+
+function quickBooksFailurePayload(error: unknown): Json | null {
+  if (!(error instanceof QuickBooksApiError)) return null;
+  return error.details as unknown as Json;
 }
 
 async function ensureQuickBooksSalesItem(connection: QuickBooksConnectionRow): Promise<string> {
@@ -319,6 +338,7 @@ export async function syncInvoiceToQuickBooks(
       status: "failed",
       created_by: actorId ?? null,
       error_message: message,
+      response_payload: quickBooksFailurePayload(error),
     });
     throw error;
   }

--- a/supabase/migrations/20260804031005_harden_invoice_ai_contracts.sql
+++ b/supabase/migrations/20260804031005_harden_invoice_ai_contracts.sql
@@ -85,85 +85,73 @@ $block$;
 
 -- Financial mutations are invoked only after server-side authorization with
 -- the service-role client. Remove the inherited PUBLIC/anon execution path.
-revoke all on function public.post_payment_event(
-  uuid,uuid,uuid,text,numeric,text,text,text,text,text,text,uuid,timestamptz,jsonb
-) from public, anon, authenticated;
-grant execute on function public.post_payment_event(
-  uuid,uuid,uuid,text,numeric,text,text,text,text,text,text,uuid,timestamptz,jsonb
-) to service_role;
-
-revoke all on function public.void_invoice_version(uuid,uuid,uuid,text,text)
-  from public, anon, authenticated;
-grant execute on function public.void_invoice_version(uuid,uuid,uuid,text,text)
-  to service_role;
-
--- This compatibility RPC has no caller authorization and no application
--- consumers. Keep it for server-side compatibility without exposing it.
-revoke all on function public.get_invoice_net_issued_parts(uuid,uuid)
-  from public, anon, authenticated;
-grant execute on function public.get_invoice_net_issued_parts(uuid,uuid)
-  to service_role;
-
-revoke all on function public.recompute_live_invoice_costs(uuid)
-  from public, anon, authenticated;
-grant execute on function public.recompute_live_invoice_costs(uuid)
-  to service_role;
-
--- Trigger functions are internal database implementation details, not RPCs.
-revoke all on function public.link_superseded_invoice_version()
-  from public, anon, authenticated;
-revoke all on function public.sync_invoice_version_financial_rollup()
-  from public, anon, authenticated;
-grant execute on function public.link_superseded_invoice_version()
-  to service_role;
-grant execute on function public.sync_invoice_version_financial_rollup()
-  to service_role;
+-- Some helpers exist only in production because of historical schema drift.
+-- Apply the intended boundary wherever each signature is present.
+do $block$
+declare
+  v_signature text;
+begin
+  foreach v_signature in array array[
+    'public.post_payment_event(uuid,uuid,uuid,text,numeric,text,text,text,text,text,text,uuid,timestamp with time zone,jsonb)',
+    'public.void_invoice_version(uuid,uuid,uuid,text,text)',
+    'public.get_invoice_net_issued_parts(uuid,uuid)',
+    'public.recompute_live_invoice_costs(uuid)',
+    'public.link_superseded_invoice_version()',
+    'public.sync_invoice_version_financial_rollup()'
+  ] loop
+    if to_regprocedure(v_signature) is not null then
+      execute format(
+        'revoke all on function %s from public, anon, authenticated',
+        v_signature
+      );
+      execute format(
+        'grant execute on function %s to service_role',
+        v_signature
+      );
+    end if;
+  end loop;
+end
+$block$;
 
 -- Pin the lookup path for invoice functions flagged by Security Advisor.
 -- Every referenced relation/function is schema-qualified, while pg_catalog
 -- remains implicitly available.
-alter function public.compute_labor_cost_for_work_order(uuid)
-  set search_path = '';
-alter function public.compute_parts_cost_for_work_order(uuid)
-  set search_path = '';
-alter function public.enforce_invoice_amount_consistency()
-  set search_path = '';
-alter function public.enforce_invoice_lifecycle()
-  set search_path = '';
-alter function public.enforce_invoice_work_order_for_active_invoices()
-  set search_path = '';
-alter function public.get_live_invoice_id(uuid)
-  set search_path = '';
-alter function public.get_invoice_net_issued_parts(uuid,uuid)
-  set search_path = '';
-alter function public.invoice_is_historical_import(jsonb)
-  set search_path = '';
-alter function public.invoice_is_locked(text,timestamptz)
-  set search_path = '';
-alter function public.invoices_sync_work_orders_aiu()
-  set search_path = '';
-alter function public.link_superseded_invoice_version()
-  set search_path = '';
-alter function public.post_payment_event(
-  uuid,uuid,uuid,text,numeric,text,text,text,text,text,text,uuid,timestamptz,jsonb
-) set search_path = '';
-alter function public.recompute_live_invoice_costs(uuid)
-  set search_path = '';
-alter function public.sync_invoice_from_work_order()
-  set search_path = '';
-alter function public.sync_invoice_from_work_order(uuid)
-  set search_path = '';
-alter function public.sync_invoice_version_financial_rollup()
-  set search_path = '';
-alter function public.tg_invoices_compute_totals()
-  set search_path = '';
-alter function public.tg_invoices_sync_work_orders()
-  set search_path = '';
-alter function public.void_invoice_version(uuid,uuid,uuid,text,text)
-  set search_path = '';
-alter function public.wo_alloc_recompute_invoice_aiu()
-  set search_path = '';
-alter function public.wol_recompute_invoice_aiu()
-  set search_path = '';
+do $block$
+declare
+  v_signature text;
+begin
+  foreach v_signature in array array[
+    'public.compute_labor_cost_for_work_order(uuid)',
+    'public.compute_parts_cost_for_work_order(uuid)',
+    'public.enforce_invoice_amount_consistency()',
+    'public.enforce_invoice_lifecycle()',
+    'public.enforce_invoice_work_order_for_active_invoices()',
+    'public.get_live_invoice_id(uuid)',
+    'public.get_invoice_net_issued_parts(uuid,uuid)',
+    'public.invoice_is_historical_import(jsonb)',
+    'public.invoice_is_locked(text,timestamp with time zone)',
+    'public.invoices_sync_work_orders_aiu()',
+    'public.link_superseded_invoice_version()',
+    'public.post_payment_event(uuid,uuid,uuid,text,numeric,text,text,text,text,text,text,uuid,timestamp with time zone,jsonb)',
+    'public.recompute_live_invoice_costs(uuid)',
+    'public.sync_invoice_from_work_order()',
+    'public.sync_invoice_from_work_order(uuid)',
+    'public.sync_invoice_version_financial_rollup()',
+    'public.tg_invoices_compute_totals()',
+    'public.tg_invoices_sync_work_orders()',
+    'public.void_invoice_version(uuid,uuid,uuid,text,text)',
+    'public.wo_alloc_recompute_invoice_aiu()',
+    'public.wol_recompute_invoice_aiu()'
+  ] loop
+    if to_regprocedure(v_signature) is not null then
+      execute format(
+        'alter function %s set search_path = %L',
+        v_signature,
+        ''
+      );
+    end if;
+  end loop;
+end
+$block$;
 
 commit;

--- a/supabase/migrations/20260804031005_harden_invoice_ai_contracts.sql
+++ b/supabase/migrations/20260804031005_harden_invoice_ai_contracts.sql
@@ -38,17 +38,50 @@ alter table public.ai_events
 alter table public.ai_events
   validate constraint ai_events_event_type_check;
 
+-- Invoice exports are audited against the immutable issued version. Align
+-- that canonical entity name with the QuickBooks event contract while
+-- retaining every existing integration event type.
+alter table public.quickbooks_sync_events
+  drop constraint if exists quickbooks_sync_events_entity_type_check;
+
+alter table public.quickbooks_sync_events
+  add constraint quickbooks_sync_events_entity_type_check
+  check (
+    entity_type = any (
+      array[
+        'connection',
+        'customer',
+        'invoice',
+        'invoice_version',
+        'item',
+        'token'
+      ]::text[]
+    )
+  ) not valid;
+
+alter table public.quickbooks_sync_events
+  validate constraint quickbooks_sync_events_entity_type_check;
+
 -- These views expose tenant-scoped data and must evaluate the underlying
 -- tables' RLS policies as the caller, never as the view owner.
 alter view public.invoice_net_issued_parts
   set (security_invoker = true);
-alter view public.v_work_order_line_labor_rollups
-  set (security_invoker = true);
 
 revoke all on public.invoice_net_issued_parts from public, anon;
-revoke all on public.v_work_order_line_labor_rollups from public, anon;
 grant select on public.invoice_net_issued_parts to authenticated, service_role;
-grant select on public.v_work_order_line_labor_rollups to authenticated, service_role;
+
+-- This view exists in production but is not part of the clean migration
+-- history. Harden it where present without making clean database replay depend
+-- on production-only schema drift.
+do $block$
+begin
+  if to_regclass('public.v_work_order_line_labor_rollups') is not null then
+    execute 'alter view public.v_work_order_line_labor_rollups set (security_invoker = true)';
+    execute 'revoke all on public.v_work_order_line_labor_rollups from public, anon';
+    execute 'grant select on public.v_work_order_line_labor_rollups to authenticated, service_role';
+  end if;
+end
+$block$;
 
 -- Financial mutations are invoked only after server-side authorization with
 -- the service-role client. Remove the inherited PUBLIC/anon execution path.

--- a/supabase/migrations/20260804031005_harden_invoice_ai_contracts.sql
+++ b/supabase/migrations/20260804031005_harden_invoice_ai_contracts.sql
@@ -1,0 +1,136 @@
+begin;
+
+-- The application records AI-learning activity as `training.event` and
+-- stores the narrower invoice-review label in the payload. Preserve the
+-- existing event taxonomy while admitting that canonical event type.
+alter table public.ai_events
+  drop constraint if exists ai_events_event_type_check;
+
+alter table public.ai_events
+  add constraint ai_events_event_type_check
+  check (
+    event_type = any (
+      array[
+        'quote_created',
+        'quote_updated',
+        'work_order_created',
+        'work_order_updated',
+        'inspection_created',
+        'inspection_updated',
+        'booking_created',
+        'booking_updated',
+        'message',
+        'customer_added',
+        'vehicle_added',
+        'parts_added',
+        'labor_added',
+        'fleet_pretrip_submitted',
+        'fleet_pm_due',
+        'fleet_request_created',
+        'fleet_work_deferred',
+        'fleet_work_declined',
+        'fleet_work_completed',
+        'training.event'
+      ]::text[]
+    )
+  ) not valid;
+
+alter table public.ai_events
+  validate constraint ai_events_event_type_check;
+
+-- These views expose tenant-scoped data and must evaluate the underlying
+-- tables' RLS policies as the caller, never as the view owner.
+alter view public.invoice_net_issued_parts
+  set (security_invoker = true);
+alter view public.v_work_order_line_labor_rollups
+  set (security_invoker = true);
+
+revoke all on public.invoice_net_issued_parts from public, anon;
+revoke all on public.v_work_order_line_labor_rollups from public, anon;
+grant select on public.invoice_net_issued_parts to authenticated, service_role;
+grant select on public.v_work_order_line_labor_rollups to authenticated, service_role;
+
+-- Financial mutations are invoked only after server-side authorization with
+-- the service-role client. Remove the inherited PUBLIC/anon execution path.
+revoke all on function public.post_payment_event(
+  uuid,uuid,uuid,text,numeric,text,text,text,text,text,text,uuid,timestamptz,jsonb
+) from public, anon, authenticated;
+grant execute on function public.post_payment_event(
+  uuid,uuid,uuid,text,numeric,text,text,text,text,text,text,uuid,timestamptz,jsonb
+) to service_role;
+
+revoke all on function public.void_invoice_version(uuid,uuid,uuid,text,text)
+  from public, anon, authenticated;
+grant execute on function public.void_invoice_version(uuid,uuid,uuid,text,text)
+  to service_role;
+
+-- This compatibility RPC has no caller authorization and no application
+-- consumers. Keep it for server-side compatibility without exposing it.
+revoke all on function public.get_invoice_net_issued_parts(uuid,uuid)
+  from public, anon, authenticated;
+grant execute on function public.get_invoice_net_issued_parts(uuid,uuid)
+  to service_role;
+
+revoke all on function public.recompute_live_invoice_costs(uuid)
+  from public, anon, authenticated;
+grant execute on function public.recompute_live_invoice_costs(uuid)
+  to service_role;
+
+-- Trigger functions are internal database implementation details, not RPCs.
+revoke all on function public.link_superseded_invoice_version()
+  from public, anon, authenticated;
+revoke all on function public.sync_invoice_version_financial_rollup()
+  from public, anon, authenticated;
+grant execute on function public.link_superseded_invoice_version()
+  to service_role;
+grant execute on function public.sync_invoice_version_financial_rollup()
+  to service_role;
+
+-- Pin the lookup path for invoice functions flagged by Security Advisor.
+-- Every referenced relation/function is schema-qualified, while pg_catalog
+-- remains implicitly available.
+alter function public.compute_labor_cost_for_work_order(uuid)
+  set search_path = '';
+alter function public.compute_parts_cost_for_work_order(uuid)
+  set search_path = '';
+alter function public.enforce_invoice_amount_consistency()
+  set search_path = '';
+alter function public.enforce_invoice_lifecycle()
+  set search_path = '';
+alter function public.enforce_invoice_work_order_for_active_invoices()
+  set search_path = '';
+alter function public.get_live_invoice_id(uuid)
+  set search_path = '';
+alter function public.get_invoice_net_issued_parts(uuid,uuid)
+  set search_path = '';
+alter function public.invoice_is_historical_import(jsonb)
+  set search_path = '';
+alter function public.invoice_is_locked(text,timestamptz)
+  set search_path = '';
+alter function public.invoices_sync_work_orders_aiu()
+  set search_path = '';
+alter function public.link_superseded_invoice_version()
+  set search_path = '';
+alter function public.post_payment_event(
+  uuid,uuid,uuid,text,numeric,text,text,text,text,text,text,uuid,timestamptz,jsonb
+) set search_path = '';
+alter function public.recompute_live_invoice_costs(uuid)
+  set search_path = '';
+alter function public.sync_invoice_from_work_order()
+  set search_path = '';
+alter function public.sync_invoice_from_work_order(uuid)
+  set search_path = '';
+alter function public.sync_invoice_version_financial_rollup()
+  set search_path = '';
+alter function public.tg_invoices_compute_totals()
+  set search_path = '';
+alter function public.tg_invoices_sync_work_orders()
+  set search_path = '';
+alter function public.void_invoice_version(uuid,uuid,uuid,text,text)
+  set search_path = '';
+alter function public.wo_alloc_recompute_invoice_aiu()
+  set search_path = '';
+alter function public.wol_recompute_invoice_aiu()
+  set search_path = '';
+
+commit;

--- a/tests/invoice-ai-advisor-hardening.test.ts
+++ b/tests/invoice-ai-advisor-hardening.test.ts
@@ -48,16 +48,19 @@ describe("invoice AI and advisor hardening", () => {
   it("keeps financial mutations service-only and trigger functions internal", () => {
     const migration = migrationSource();
     expect(migration).toContain(
-      "revoke all on function public.post_payment_event(",
+      "public.post_payment_event(uuid,uuid,uuid,text,numeric",
     );
     expect(migration).toContain(
-      "grant execute on function public.post_payment_event(",
+      "'revoke all on function %s from public, anon, authenticated'",
     );
     expect(migration).toContain(
-      "revoke all on function public.void_invoice_version(uuid,uuid,uuid,text,text)",
+      "'grant execute on function %s to service_role'",
     );
     expect(migration).toContain(
-      "revoke all on function public.link_superseded_invoice_version()",
+      "public.void_invoice_version(uuid,uuid,uuid,text,text)",
+    );
+    expect(migration).toContain(
+      "public.link_superseded_invoice_version()",
     );
     expect(migration).not.toContain(
       "revoke all on function public.sync_invoice_from_work_order(uuid)",
@@ -67,11 +70,14 @@ describe("invoice AI and advisor hardening", () => {
   it("pins search paths for the invoice functions found by Security Advisor", () => {
     const migration = migrationSource();
     expect(migration).toContain(
-      "alter function public.sync_invoice_from_work_order(uuid)",
+      "public.sync_invoice_from_work_order(uuid)",
     );
     expect(migration).toContain(
-      "alter function public.recompute_live_invoice_costs(uuid)",
+      "public.recompute_live_invoice_costs(uuid)",
     );
-    expect(migration).toContain("set search_path = ''");
+    expect(migration).toContain(
+      "'alter function %s set search_path = %L'",
+    );
+    expect(migration).toContain("to_regprocedure(v_signature) is not null");
   });
 });

--- a/tests/invoice-ai-advisor-hardening.test.ts
+++ b/tests/invoice-ai-advisor-hardening.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migrationPath =
+  "supabase/migrations/20260804031005_harden_invoice_ai_contracts.sql";
+
+function migrationSource() {
+  return readFileSync(migrationPath, "utf8");
+}
+
+describe("invoice AI and advisor hardening", () => {
+  it("admits the application training event without losing existing event types", () => {
+    const migration = migrationSource();
+    expect(migration).toContain("'training.event'");
+    expect(migration).toContain("'work_order_updated'");
+    expect(migration).toContain("'fleet_work_completed'");
+    expect(migration).toContain(
+      "validate constraint ai_events_event_type_check",
+    );
+  });
+
+  it("makes tenant-scoped invoice views honor caller RLS", () => {
+    const migration = migrationSource();
+    expect(migration).toContain(
+      "alter view public.invoice_net_issued_parts\n  set (security_invoker = true)",
+    );
+    expect(migration).toContain(
+      "alter view public.v_work_order_line_labor_rollups\n  set (security_invoker = true)",
+    );
+    expect(migration).toContain(
+      "revoke all on public.invoice_net_issued_parts from public, anon",
+    );
+  });
+
+  it("keeps financial mutations service-only and trigger functions internal", () => {
+    const migration = migrationSource();
+    expect(migration).toContain(
+      "revoke all on function public.post_payment_event(",
+    );
+    expect(migration).toContain(
+      "grant execute on function public.post_payment_event(",
+    );
+    expect(migration).toContain(
+      "revoke all on function public.void_invoice_version(uuid,uuid,uuid,text,text)",
+    );
+    expect(migration).toContain(
+      "revoke all on function public.link_superseded_invoice_version()",
+    );
+    expect(migration).not.toContain(
+      "revoke all on function public.sync_invoice_from_work_order(uuid)",
+    );
+  });
+
+  it("pins search paths for the invoice functions found by Security Advisor", () => {
+    const migration = migrationSource();
+    expect(migration).toContain(
+      "alter function public.sync_invoice_from_work_order(uuid)",
+    );
+    expect(migration).toContain(
+      "alter function public.recompute_live_invoice_costs(uuid)",
+    );
+    expect(migration).toContain("set search_path = ''");
+  });
+});

--- a/tests/invoice-ai-advisor-hardening.test.ts
+++ b/tests/invoice-ai-advisor-hardening.test.ts
@@ -19,13 +19,26 @@ describe("invoice AI and advisor hardening", () => {
     );
   });
 
+  it("admits immutable invoice versions in the QuickBooks audit contract", () => {
+    const migration = migrationSource();
+    expect(migration).toContain("'invoice_version'");
+    expect(migration).toContain("'connection'");
+    expect(migration).toContain("'token'");
+    expect(migration).toContain(
+      "validate constraint quickbooks_sync_events_entity_type_check",
+    );
+  });
+
   it("makes tenant-scoped invoice views honor caller RLS", () => {
     const migration = migrationSource();
     expect(migration).toContain(
       "alter view public.invoice_net_issued_parts\n  set (security_invoker = true)",
     );
     expect(migration).toContain(
-      "alter view public.v_work_order_line_labor_rollups\n  set (security_invoker = true)",
+      "to_regclass('public.v_work_order_line_labor_rollups') is not null",
+    );
+    expect(migration).toContain(
+      "alter view public.v_work_order_line_labor_rollups set (security_invoker = true)",
     );
     expect(migration).toContain(
       "revoke all on public.invoice_net_issued_parts from public, anon",

--- a/tests/invoice-financial-integrity.test.ts
+++ b/tests/invoice-financial-integrity.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 function source(path: string) {
-  return readFileSync(path, "utf8");
+  return readFileSync(path, "utf8").replace(/\r\n/g, "\n");
 }
 
 const migrationPath =

--- a/tests/quickbooks-ai-secondary-operations.test.ts
+++ b/tests/quickbooks-ai-secondary-operations.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getQuickBooksApiBaseUrl } from "@/features/integrations/quickbooks/server/env";
+import { quickBooksFetch } from "@/features/integrations/quickbooks/server/http";
+import type { QuickBooksConnectionRow } from "@/features/integrations/quickbooks/types";
+
+function source(path: string) {
+  return readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+}
+
+function connection(
+  environment: "sandbox" | "production",
+): QuickBooksConnectionRow {
+  return {
+    environment,
+    realm_id: "test-realm",
+    access_token: "test-access-token",
+  } as QuickBooksConnectionRow;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("QuickBooks and AI secondary-operation contracts", () => {
+  it("routes accounting calls to the connected company's environment", () => {
+    expect(getQuickBooksApiBaseUrl("sandbox")).toBe(
+      "https://sandbox-quickbooks.api.intuit.com",
+    );
+    expect(getQuickBooksApiBaseUrl("production")).toBe(
+      "https://quickbooks.api.intuit.com",
+    );
+    expect(() => getQuickBooksApiBaseUrl("invalid")).toThrow(
+      "Unsupported QuickBooks environment",
+    );
+  });
+
+  it("captures safe QuickBooks HTTP diagnostics without logging query contents", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          Fault: {
+            type: "ValidationFault",
+            Error: [
+              {
+                code: "6000",
+                Message: "A business validation error occurred.",
+                Detail: "Customer could not be found.",
+              },
+            ],
+          },
+        }),
+        {
+          status: 400,
+          statusText: "Bad Request",
+          headers: { intuit_tid: "request-123" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const request = quickBooksFetch(
+      connection("sandbox"),
+      "/query?query=select%20customer-secret",
+      { method: "GET" },
+    );
+
+    await expect(request).rejects.toMatchObject({
+      name: "QuickBooksApiError",
+      details: {
+        status: 400,
+        requestId: "request-123",
+        faultType: "ValidationFault",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://sandbox-quickbooks.api.intuit.com/v3/company/test-realm/query?query=select%20customer-secret",
+      expect.any(Object),
+    );
+    expect(errorLog).toHaveBeenCalledWith(
+      "[quickbooks/http] request failed",
+      expect.objectContaining({
+        environment: "sandbox",
+        resource: "/query",
+        status: 400,
+      }),
+    );
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain("customer-secret");
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain("test-access-token");
+    expect(JSON.stringify(errorLog.mock.calls)).not.toContain("test-realm");
+  });
+
+  it("surfaces audit insert failures and persists safe HTTP failure metadata", () => {
+    const sync = source(
+      "features/integrations/quickbooks/server/syncInvoice.ts",
+    );
+    expect(sync).toContain(
+      'const { error } = await supabase.from("quickbooks_sync_events").insert(payload)',
+    );
+    expect(sync).toContain("[quickbooks/sync-audit] insert failed");
+    expect(sync).toContain("response_payload: quickBooksFailurePayload(error)");
+  });
+
+  it("uses the current completion-token parameter for work-order suggestions", () => {
+    const route = source("app/api/work-orders/suggest-lines/route.ts");
+    expect(route).toContain("max_completion_tokens: policy.maxTokens");
+    expect(route).not.toContain("max_tokens: policy.maxTokens");
+  });
+});


### PR DESCRIPTION
## Root cause

Invoice finalization succeeded, but four secondary contracts were inconsistent:

- The application emits AI review events as `training.event`, while production's `ai_events_event_type_check` rejects that value.
- QuickBooks invoice sync uses the production accounting host even when the stored connection is `sandbox`. Intuit documents separate [sandbox and production accounting base URLs](https://developer.intuit.com/app/developer/qbo/docs/get-started/create-a-request).
- QuickBooks audit rows use the immutable `invoice_version` entity, while the database constraint rejects it; the insert result was ignored.
- Work-order suggestions send deprecated `max_tokens` to a newer reasoning model. OpenAI documents `max_completion_tokens` as the replacement in the [Chat Completions API](https://platform.openai.com/docs/api-reference/chat).

The advisor audit also found invoice views running with owner privileges and sensitive invoice RPCs retaining broader execution privileges than their server-only call paths require.

## What changed

- Admit `training.event` without removing existing AI event types.
- Admit `invoice_version` without removing existing QuickBooks audit entity types.
- Select the QuickBooks accounting host from `quickbooks_connections.environment`, and reject unknown environments instead of silently routing them to production.
- Capture allowlisted, length-limited QuickBooks HTTP diagnostics: status, request ID, fault type, error code/message/detail, method, environment, and resource path. Tokens, realm IDs, and query contents are not logged.
- Persist safe QuickBooks HTTP failure metadata with failed sync events.
- Check and report QuickBooks audit insert errors instead of discarding them.
- Send `max_completion_tokens` for work-order suggestions.
- Convert invoice rollup views to caller-permission behavior and remove anonymous access.
- Apply production-only view/function hardening conditionally so clean migration replay does not depend on historical schema drift.
- Restrict sensitive invoice mutations and internal trigger helpers to the service role, and pin invoice-function search paths.
- Add regression coverage for all contracts above.

## Why this is safe

The final migration was executed against production inside an explicit transaction and rolled back. Representative `training.event` and `invoice_version` rows inserted successfully; the production-only view and function privileges hardened successfully. Post-rollback verification confirmed zero test rows and confirmed production remained unchanged.

The QuickBooks host is selected from an existing database-constrained value (`sandbox` or `production`). Invalid values fail closed. Error diagnostics exclude authorization headers, access/refresh tokens, realm IDs, and customer query contents.

Authenticated `sync_invoice_from_work_order(uuid)` access remains because that RPC performs its own membership authorization.

## Files changed

- Database migration and advisor regression coverage
- QuickBooks environment selection, HTTP diagnostics, sync auditing, and tests
- Work-order AI suggestion token parameter
- AI training-event compatibility coverage
- Portable financial-integrity source test

## Validation

- Full `tsc --noEmit`: passed
- ESLint on all changed TypeScript files: passed
- Combined focused Vitest suite: 17/17 passed
- Follow-up migration/QuickBooks tests: 9/9 passed
- Earlier focused invoice suite: 19/19 passed
- `git diff --check`: passed
- Final production transaction preflight and rollback verification: passed
- Supabase fresh database apply: passed
- Supabase reset and complete migration replay: passed
- Generated types and bootstrap compatibility: passed
- All Supabase runtime integrations: passed
- GitHub financial outbox, Phase 2, technician labor, and system consistency workflows: passed
- Supabase preview branch reports `FUNCTIONS_DEPLOYED` and `ACTIVE_HEALTHY`

## Database

Updates the not-yet-deployed migration `20260804031005_harden_invoice_ai_contracts.sql`. It has not been applied to production.

## Environment variables

No new environment variables.

## Manual/deployment actions

After approval and merge, apply the migration to production as a separate explicitly authorized operation. Then retry the QuickBooks sync for the issued invoice; the existing document-number lookup runs before creation to recover an external invoice if one already exists.

## Remaining risks or unverified assumptions

No external QuickBooks invoice was observed from the failed attempt, and the first customer request failed before invoice creation. The retry remains protected by the existing document-number recovery lookup.

This PR resolves the immediate AI/QuickBooks failures and a targeted set of high-risk invoice security findings. The broader advisor backlog still requires staged, usage-aware remediation rather than one mass migration.