### PR TITLE
Add QuickBooks company link

### DIFF
--- a/features/integrations/quickbooks/components/QuickBooksConnectCard.test.tsx
+++ b/features/integrations/quickbooks/components/QuickBooksConnectCard.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import QuickBooksConnectCard from "./QuickBooksConnectCard";
+
+function mockConnectedStatus(environment: "sandbox" | "production") {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        connected: true,
+        connection: {
+          id: "connection-1",
+          realmId: "realm-1",
+          environment,
+          connectedAt: "2026-07-20T18:08:17.000Z",
+          isActive: true,
+          lastSyncAt: null,
+          lastError: null,
+        },
+      }),
+    }),
+  );
+}
+
+describe("QuickBooksConnectCard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("links a connected sandbox company to the QuickBooks sandbox", async () => {
+    mockConnectedStatus("sandbox");
+
+    render(<QuickBooksConnectCard />);
+
+    expect(await screen.findByRole("link", { name: "Open QuickBooks" })).toHaveAttribute(
+      "href",
+      "https://sandbox.qbo.intuit.com/app/homepage",
+    );
+  });
+
+  it("links a connected production company to QuickBooks Online", async () => {
+    mockConnectedStatus("production");
+
+    render(<QuickBooksConnectCard />);
+
+    const link = await screen.findByRole("link", { name: "Open QuickBooks" });
+    expect(link).toHaveAttribute("href", "https://qbo.intuit.com/app/homepage");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/features/integrations/quickbooks/components/QuickBooksConnectCard.tsx
+++ b/features/integrations/quickbooks/components/QuickBooksConnectCard.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
-import  Card  from "@shared/components/ui/Card";
+import Card from "@shared/components/ui/Card";
+import LinkButton from "@shared/components/ui/LinkButton";
 
 type StatusResponse = {
   ok: boolean;
@@ -18,6 +19,11 @@ type StatusResponse = {
   } | null;
   error?: string;
 };
+
+const QUICKBOOKS_COMPANY_URL = {
+  sandbox: "https://sandbox.qbo.intuit.com/app/homepage",
+  production: "https://qbo.intuit.com/app/homepage",
+} as const;
 
 export default function QuickBooksConnectCard() {
   const [loading, setLoading] = useState(true);
@@ -105,7 +111,8 @@ export default function QuickBooksConnectCard() {
     }
   }
 
-  const connected = Boolean(status?.connected && status.connection);
+  const connection = status?.connected ? status.connection : null;
+  const connected = Boolean(connection);
 
   return (
     <Card className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-6 text-[color:var(--theme-text-primary)]">
@@ -122,29 +129,29 @@ export default function QuickBooksConnectCard() {
         </div>
       </div>
 
-      {connected && status?.connection ? (
+      {connection ? (
         <div className="mb-4 space-y-1 text-sm text-[color:var(--theme-text-secondary)]">
           <div>
             <span className="text-[color:var(--theme-text-secondary)]">Realm ID:</span>{" "}
-            {status.connection.realmId}
+            {connection.realmId}
           </div>
           <div>
             <span className="text-[color:var(--theme-text-secondary)]">Environment:</span>{" "}
-            {status.connection.environment}
+            {connection.environment}
           </div>
           <div>
             <span className="text-[color:var(--theme-text-secondary)]">Connected:</span>{" "}
-            {new Date(status.connection.connectedAt).toLocaleString()}
+            {new Date(connection.connectedAt).toLocaleString()}
           </div>
           <div>
             <span className="text-[color:var(--theme-text-secondary)]">Last sync:</span>{" "}
-            {status.connection.lastSyncAt
-              ? new Date(status.connection.lastSyncAt).toLocaleString()
+            {connection.lastSyncAt
+              ? new Date(connection.lastSyncAt).toLocaleString()
               : "—"}
           </div>
           <div>
             <span className="text-[color:var(--theme-text-secondary)]">Last error:</span>{" "}
-            {status.connection.lastError || "—"}
+            {connection.lastError || "—"}
           </div>
         </div>
       ) : null}
@@ -156,12 +163,22 @@ export default function QuickBooksConnectCard() {
       ) : null}
 
       <div className="flex flex-wrap gap-3">
-        {!connected ? (
+        {!connection ? (
           <Button onClick={handleConnect} disabled={busy || loading}>
             {busy ? "Connecting…" : "Connect QuickBooks"}
           </Button>
         ) : (
           <>
+            <LinkButton
+              href={QUICKBOOKS_COMPANY_URL[connection.environment]}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="outline"
+              size="md"
+              className="text-sm"
+            >
+              Open QuickBooks
+            </LinkButton>
             <Button onClick={() => void loadStatus()} disabled={busy || loading}>
               Refresh Status
             </Button>


### PR DESCRIPTION
## What changed

- adds an **Open QuickBooks** action to connected QuickBooks integration cards
- routes sandbox connections to the QuickBooks sandbox and production connections to QuickBooks Online
- opens the external company portal in a new tab with safe link attributes
- adds focused component coverage for sandbox and production destinations

## Why

The owner settings integration card exposed connection status, refresh, and disconnect actions, but did not provide a direct way to open QuickBooks and inspect the connected company.

## User impact

Owners and admins can move directly from the ProFixIQ integration status card to the appropriate QuickBooks environment to check the connection.

## Validation

- `git diff --check` passed locally
- GitHub branch comparison confirms only the component and its test changed
- QuickBooks sandbox destination was opened in-browser and correctly reached Intuit authentication
- Automated tests were not run locally because Node.js and pnpm are unavailable in the local Codex environment
