### PR TITLE
Fix customer portal appointment start and date labels

### DIFF
--- a/app/portal/request/when/page.tsx
+++ b/app/portal/request/when/page.tsx
@@ -36,7 +36,10 @@ function pillClass(active: boolean) {
 }
 
 function toIsoDate(d: Date) {
-  return d.toISOString().slice(0, 10);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 function addDays(base: Date, days: number) {

--- a/supabase/migrations/20260804050000_allow_service_role_portal_booking_start.sql
+++ b/supabase/migrations/20260804050000_allow_service_role_portal_booking_start.sql
@@ -1,0 +1,71 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.guard_customer_booking_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_customer_user_id uuid;
+BEGIN
+  -- Portal request creation is performed by a tenant-validated server route
+  -- through the service-role client. Service role already bypasses RLS and is
+  -- the only non-user actor allowed to bypass the customer mutation rules.
+  IF coalesce(auth.role(), '') = 'service_role' THEN
+    RETURN new;
+  END IF;
+
+  IF public.is_staff_for_shop(new.shop_id) THEN
+    RETURN new;
+  END IF;
+
+  SELECT c.user_id
+  INTO v_customer_user_id
+  FROM public.customers c
+  WHERE c.id = new.customer_id;
+
+  IF v_customer_user_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'Booking does not belong to the current customer';
+  END IF;
+
+  IF tg_op = 'INSERT' THEN
+    IF coalesce(new.status, 'pending') <> 'pending' THEN
+      RAISE EXCEPTION 'Customer bookings must begin as pending';
+    END IF;
+    RETURN new;
+  END IF;
+
+  IF old.status IN ('cancelled', 'completed')
+    AND new.status IS DISTINCT FROM old.status THEN
+    RAISE EXCEPTION 'Completed or cancelled bookings cannot be changed';
+  END IF;
+
+  IF new.status IS DISTINCT FROM old.status
+    AND NOT (
+      old.status IN ('pending', 'confirmed')
+      AND new.status = 'cancelled'
+    ) THEN
+    RAISE EXCEPTION 'Customers may only cancel an active booking';
+  END IF;
+
+  IF new.shop_id IS DISTINCT FROM old.shop_id
+    OR new.customer_id IS DISTINCT FROM old.customer_id
+    OR new.vehicle_id IS DISTINCT FROM old.vehicle_id
+    OR new.work_order_id IS DISTINCT FROM old.work_order_id
+    OR new.starts_at IS DISTINCT FROM old.starts_at
+    OR new.ends_at IS DISTINCT FROM old.ends_at
+    OR new.notes IS DISTINCT FROM old.notes THEN
+    RAISE EXCEPTION 'Customers cannot edit protected booking fields';
+  END IF;
+
+  RETURN new;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.guard_customer_booking_mutation()
+  FROM PUBLIC, anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.guard_customer_booking_mutation()
+  TO service_role;
+
+COMMIT;

--- a/tests/phase7-portal-request-approval-contract.test.ts
+++ b/tests/phase7-portal-request-approval-contract.test.ts
@@ -9,6 +9,10 @@ const approvalSql = read(
   "supabase/migrations/20260715080300_phase7_atomic_portal_line_decisions.sql",
 );
 const requestStart = read("app/api/portal/request/start/route.ts");
+const requestWhen = read("app/portal/request/when/page.tsx");
+const bookingGuardRepair = read(
+  "supabase/migrations/20260804050000_allow_service_role_portal_booking_start.sql",
+);
 const customRoute = read("app/api/portal/request/add-custom-line/route.ts");
 const menuRoute = read("app/api/portal/request/add-menu-line/route.ts");
 const inspectionRoute = read(
@@ -24,6 +28,28 @@ describe("Phase 7 portal requests and approvals", () => {
     expect(requestStart).toContain("A stable Idempotency-Key is required.");
     expect(requestStart).toContain('.eq("customer_id", customer.id)');
     expect(requestStart).toContain('.eq("shop_id", customer.shop_id)');
+  });
+
+  it("keeps appointment date values aligned with their local calendar labels", () => {
+    expect(requestWhen).toContain("d.getFullYear()");
+    expect(requestWhen).toContain("d.getMonth() + 1");
+    expect(requestWhen).toContain("d.getDate()");
+    expect(requestWhen).not.toContain('d.toISOString().slice(0, 10)');
+  });
+
+  it("allows trusted server booking writes without weakening portal-user checks", () => {
+    expect(bookingGuardRepair).toContain(
+      "coalesce(auth.role(), '') = 'service_role'",
+    );
+    expect(bookingGuardRepair).toContain(
+      "IF public.is_staff_for_shop(new.shop_id) THEN",
+    );
+    expect(bookingGuardRepair).toContain(
+      "v_customer_user_id IS DISTINCT FROM auth.uid()",
+    );
+    expect(bookingGuardRepair).toContain(
+      "Booking does not belong to the current customer",
+    );
   });
 
   it("routes all request line kinds through one atomic command", () => {


### PR DESCRIPTION
## What changed
- format appointment date values from local calendar components so the displayed label and submitted date stay on the same day
- add a migration that lets the trusted service-role booking path pass the customer-only booking trigger after the server route has authenticated and tenant-validated the actor, customer, shop, and vehicle
- preserve all staff and authenticated-customer mutation checks
- add Phase 7 regression contracts for both invariants

## Root cause
Two independent defects blocked the customer appointment flow:
1. `toISOString().slice(0, 10)` converted the local date to UTC before storing the option value, shifting it one day ahead in negative UTC offsets.
2. `/api/portal/request/start` correctly performs its atomic write with the service-role client, but `guard_customer_booking_mutation()` only recognized staff or a customer JWT. The trusted server write therefore failed with `P0001: Booking does not belong to the current customer`.

## Validation
- reproduced the failed POST in production (`409`)
- confirmed the exact database error in Vercel runtime logs
- `git diff --check` passed locally
- Phase 7 typecheck, lint, and focused tests will run in CI

## Deployment
Apply `20260804050000_allow_service_role_portal_booking_start.sql` to Supabase before or with the application deployment.