### PR TITLE
Allow parts ordering without an optional stock location

### DIFF
--- a/app/api/parts/requests/items/[itemId]/po-line/route.ts
+++ b/app/api/parts/requests/items/[itemId]/po-line/route.ts
@@ -6,7 +6,13 @@ export async function POST(req: Request, ctx: { params: Promise<{ itemId: string
   const body = (await req.json().catch(() => null)) as Record<string, unknown> | null;
   const poId = typeof body?.poId === "string" ? body.poId : typeof body?.po_id === "string" ? body.po_id : "";
   const supplierId = typeof body?.supplierId === "string" ? body.supplierId : typeof body?.supplier_id === "string" ? body.supplier_id : "";
-  const locationId = typeof body?.locationId === "string" ? body.locationId : typeof body?.location_id === "string" ? body.location_id : null;
+  const rawLocationId =
+    typeof body?.locationId === "string"
+      ? body.locationId
+      : typeof body?.location_id === "string"
+        ? body.location_id
+        : null;
+  const locationId = rawLocationId?.trim() || null;
   const notes = typeof body?.notes === "string" ? body.notes.trim() : null;
   const qty = positiveNumber(body?.qty);
   const unitCost = body?.unitCost == null ? null : Number(body.unitCost);

--- a/tests/parts/parts-request-ordering-path.test.ts
+++ b/tests/parts/parts-request-ordering-path.test.ts
@@ -31,6 +31,15 @@ describe("parts request ordering path", () => {
     expect(poLineRoute).toContain("p_idempotency_key");
   });
 
+  it("accepts an omitted optional location instead of rejecting the empty UI fallback", () => {
+    expect(poLineRoute).toContain(
+      "const locationId = rawLocationId?.trim() || null",
+    );
+    expect(poLineRoute).toContain(
+      "locationId != null && !isUuid(locationId)",
+    );
+  });
+
   it("validates release before creating a PO header and line in one transaction", () => {
     expect(p0Migration).toContain(
       "create or replace function public.parts_create_or_reuse_po_line_for_request",


### PR DESCRIPTION
## Root cause

The parts workbench sends the optional location fallback as an empty string when a request item has no inventory location and the shop has no default location. The PO-line route treated every non-null string as a supplied UUID, so it rejected the otherwise valid order with HTTP 400.

## What changed

- trims the optional location field and normalizes blank input to `null`
- continues rejecting non-empty invalid UUIDs
- adds focused ordering-path coverage

## Validation

- production reproduction as `profixpartsqa`: ordering approved item `ee53482a-d6ce-40a1-b831-d199d10065ae` returned `POST /api/parts/requests/items/.../po-line 400`; DB confirms the item has `location_id = null` and no PO line was created
- `git diff --check` passes locally
- CI pending