### PR TITLE
Allow first-login profile activation to complete

### DIFF
--- a/supabase/migrations/20260804052000_narrow_profile_user_count_trigger.sql
+++ b/supabase/migrations/20260804052000_narrow_profile_user_count_trigger.sql
@@ -6,11 +6,24 @@ begin;
 -- server-managed shops.active_user_count column as the authenticated user,
 -- causing the billing-identity guard to reject the entire profile update.
 -- Recalculate only when shop membership can actually change the count.
-drop trigger if exists profiles_recalc_shop_user_count on public.profiles;
+--
+-- The legacy trigger/function currently exist only in production drift. Keep a
+-- clean replay unchanged until that contract is promoted into the baseline.
+do $migration$
+begin
+  if to_regclass('public.profiles') is null
+     or to_regprocedure('public.tg_profiles_recalc_shop_user_count()') is null then
+    return;
+  end if;
 
+  execute 'drop trigger if exists profiles_recalc_shop_user_count on public.profiles';
+  execute $ddl$
 create trigger profiles_recalc_shop_user_count
 after insert or delete or update of shop_id on public.profiles
 for each row
-execute function public.tg_profiles_recalc_shop_user_count();
+execute function public.tg_profiles_recalc_shop_user_count()
+$ddl$;
+end
+$migration$;
 
 commit;

--- a/supabase/migrations/20260804052000_narrow_profile_user_count_trigger.sql
+++ b/supabase/migrations/20260804052000_narrow_profile_user_count_trigger.sql
@@ -1,0 +1,16 @@
+begin;
+
+-- Profile self-service updates (including clearing must_change_password after a
+-- successful first-login password change) do not affect shop seat counts. The
+-- legacy trigger fired for every profile update and attempted to rewrite the
+-- server-managed shops.active_user_count column as the authenticated user,
+-- causing the billing-identity guard to reject the entire profile update.
+-- Recalculate only when shop membership can actually change the count.
+drop trigger if exists profiles_recalc_shop_user_count on public.profiles;
+
+create trigger profiles_recalc_shop_user_count
+after insert or delete or update of shop_id on public.profiles
+for each row
+execute function public.tg_profiles_recalc_shop_user_count();
+
+commit;

--- a/tests/profile-user-count-trigger-contract.test.ts
+++ b/tests/profile-user-count-trigger-contract.test.ts
@@ -27,4 +27,13 @@ describe("profile user count trigger scope", () => {
       "execute function public.tg_profiles_recalc_shop_user_count()",
     );
   });
+
+  it("leaves clean replay unchanged when the drifted function is absent", () => {
+    const migration = migrationSource();
+
+    expect(migration).toContain(
+      "to_regprocedure('public.tg_profiles_recalc_shop_user_count()') is null",
+    );
+    expect(migration).toContain("execute $ddl$");
+  });
 });

--- a/tests/profile-user-count-trigger-contract.test.ts
+++ b/tests/profile-user-count-trigger-contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migrationPath =
+  "supabase/migrations/20260804052000_narrow_profile_user_count_trigger.sql";
+
+function migrationSource() {
+  return readFileSync(migrationPath, "utf8");
+}
+
+describe("profile user count trigger scope", () => {
+  it("recalculates counts only when shop membership can change", () => {
+    const migration = migrationSource();
+
+    expect(migration).toContain(
+      "after insert or delete or update of shop_id on public.profiles",
+    );
+    expect(migration).not.toContain(
+      "after insert or delete or update on public.profiles",
+    );
+  });
+
+  it("retains the canonical count recalculation function", () => {
+    const migration = migrationSource();
+
+    expect(migration).toContain(
+      "execute function public.tg_profiles_recalc_shop_user_count()",
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

The legacy `profiles_recalc_shop_user_count` trigger fires after every profile update. Clearing `must_change_password` therefore recalculates and rewrites `shops.active_user_count` as the authenticated user; the billing-identity guard correctly rejects that server-managed shop write, leaving the account permanently blocked even though the auth password has already changed.

## What changed

- narrows the active-user-count trigger to insert, delete, or updates of `shop_id`
- leaves the canonical count recalculation function and server provisioning behavior intact
- adds a focused migration source contract test

## Validation

- production reproduction as `profixmanagerqa`: auth password update succeeds, then profile flag update fails with `shop billing and payment fields are server managed`
- production profile remains `must_change_password = true`, confirming the failure is atomic for the profile write
- CI pending

## Database

Migration required: `20260804052000_narrow_profile_user_count_trigger.sql`.

This does not loosen billing-field permissions; it prevents unrelated self-service profile updates from invoking the billing-count path.