### PR TITLE
Restore the protected app shell after password setup

### DIFF
--- a/app/auth/set-password/page.tsx
+++ b/app/auth/set-password/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
 
@@ -23,7 +23,6 @@ function getReturnPath(role: string | null | undefined): string {
 }
 
 export default function SetPasswordPage() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const isPortalActivation = searchParams.get("mode") === "portal";
@@ -134,13 +133,21 @@ export default function SetPasswordPage() {
       const nextRole = data.user?.user_metadata?.role as string | undefined;
 
       if (userId) {
-        await supabase
+        const { error: profileError } = await supabase
           .from("profiles")
           .update({
             must_change_password: false,
             updated_at: new Date().toISOString(),
           } as Database["public"]["Tables"]["profiles"]["Update"])
           .eq("id", userId);
+
+        if (profileError) {
+          setStatusTone("error");
+          setStatusMessage(
+            `Password updated, but account activation failed: ${profileError.message}`,
+          );
+          return;
+        }
       }
 
       setStatusTone("success");
@@ -157,7 +164,7 @@ export default function SetPasswordPage() {
       );
 
       window.setTimeout(() => {
-        router.replace(redirect);
+        window.location.replace(redirect);
       }, 700);
     } catch (error) {
       const message =

--- a/tests/set-password-shell-transition.test.ts
+++ b/tests/set-password-shell-transition.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const pagePath = "app/auth/set-password/page.tsx";
+
+function pageSource() {
+  return readFileSync(pagePath, "utf8");
+}
+
+describe("set-password protected-shell transition", () => {
+  it("fails visibly when the profile activation flag cannot be cleared", () => {
+    const source = pageSource();
+
+    expect(source).toContain("const { error: profileError } = await supabase");
+    expect(source).toContain("if (profileError)");
+    expect(source).toContain("account activation failed");
+  });
+
+  it("performs a document navigation so the root shell is recalculated", () => {
+    const source = pageSource();
+
+    expect(source).toContain("window.location.replace(redirect)");
+    expect(source).not.toContain("router.replace(redirect)");
+  });
+});


### PR DESCRIPTION
## Root cause

The password setup page is rendered as a standalone public route. After a successful first-login password change it used a client-side router transition into `/dashboard`, so the root layout was reused without recalculating the protected AppShell. The user landed on live shop content with no navigation, header, or sign-out control until a full reload.

The page also ignored errors while clearing `must_change_password`, allowing it to display success and navigate even when activation remained incomplete.

## What changed

- uses a document-level internal redirect after successful password setup so the protected root shell is rebuilt
- checks and surfaces the profile activation update error before claiming success
- adds focused source-contract coverage

## Validation

- production reproduction as `profixleadhandqa`: password setup navigated to `/dashboard/operations` without AppShell; a full reload restored the correct lead-hand sidebar/header
- the same account's profile flag was verified cleared after activation
- CI pending

## Database

No migration is included in this PR. PR #1307 addresses the underlying intermittent profile-update trigger conflict separately.