### PR TITLE
Add shop-side fleet request conversion action

### DIFF
--- a/features/fleet/components/FleetServiceRequestsPage.tsx
+++ b/features/fleet/components/FleetServiceRequestsPage.tsx
@@ -54,6 +54,11 @@ type Payload = {
 
 type Filter = "active" | "approval" | "scheduled" | "completed" | "all";
 
+type ConvertPayload = {
+  workOrderId?: string;
+  error?: string;
+};
+
 const panel =
   "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]";
 
@@ -96,6 +101,7 @@ export default function FleetServiceRequestsPage({
   const [filter, setFilter] = useState<Filter>("active");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [convertingId, setConvertingId] = useState<string | null>(null);
 
   async function load(signal?: AbortSignal) {
     setLoading(true);
@@ -127,6 +133,35 @@ export default function FleetServiceRequestsPage({
     void load(controller.signal);
     return () => controller.abort();
   }, []);
+
+  async function convertToWorkOrder(item: RequestItem) {
+    setConvertingId(item.id);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        "/api/fleet/service-requests/convert-to-work-order",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ serviceRequestId: item.id }),
+        },
+      );
+      const body = (await response.json().catch(() => ({}))) as ConvertPayload;
+      if (!response.ok || !body.workOrderId) {
+        throw new Error(body.error || "Unable to create work order");
+      }
+
+      window.location.assign(
+        `/work-orders/${encodeURIComponent(body.workOrderId)}`,
+      );
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : "Unable to create work order",
+      );
+      setConvertingId(null);
+    }
+  }
 
   const visible = useMemo(() => {
     const requests = payload?.requests ?? [];
@@ -273,8 +308,23 @@ export default function FleetServiceRequestsPage({
                   <span className="rounded-lg border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs">
                     {item.workOrder.reference}
                   </span>
+                ) : routePrefix === "/fleet" &&
+                  uiContext.capabilities.canConvertRequests ? (
+                  <button
+                    type="button"
+                    disabled={convertingId !== null}
+                    onClick={() => void convertToWorkOrder(item)}
+                    className="inline-flex items-center gap-2 rounded-lg border border-sky-300/30 px-3 py-2 text-xs font-medium text-sky-300 hover:bg-sky-300/10 disabled:cursor-wait disabled:opacity-60"
+                  >
+                    <ClipboardList size={14} />
+                    {convertingId === item.id
+                      ? "Creating work order..."
+                      : "Create work order"}
+                  </button>
                 ) : (
-                  <span className="text-xs text-[color:var(--theme-text-muted)]">Awaiting shop conversion</span>
+                  <span className="text-xs text-[color:var(--theme-text-muted)]">
+                    Awaiting shop conversion
+                  </span>
                 )}
                 {item.workOrder?.needsApproval || (item.workOrder?.outstandingBalance ?? 0) > 0 ? (
                   <Link

--- a/tests/fleet-service-request-conversion-action.test.ts
+++ b/tests/fleet-service-request-conversion-action.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const componentPath =
+  "features/fleet/components/FleetServiceRequestsPage.tsx";
+
+function componentSource() {
+  return readFileSync(componentPath, "utf8");
+}
+
+describe("fleet service request shop conversion", () => {
+  it("offers conversion only on the authorized internal fleet surface", () => {
+    const source = componentSource();
+
+    expect(source).toContain('routePrefix === "/fleet"');
+    expect(source).toContain("uiContext.capabilities.canConvertRequests");
+    expect(source).toContain('"Create work order"');
+  });
+
+  it("calls the canonical conversion route and opens the resulting work order", () => {
+    const source = componentSource();
+
+    expect(source).toContain(
+      '"/api/fleet/service-requests/convert-to-work-order"',
+    );
+    expect(source).toContain("serviceRequestId: item.id");
+    expect(source).toContain("encodeURIComponent(body.workOrderId)");
+  });
+});


### PR DESCRIPTION
## Root cause

Fleet managers can submit a structured service request and the conversion API already exists, but the shared request queue never invokes it. On the internal shop route every unconverted request is displayed as static `Awaiting shop conversion`, so the workflow cannot proceed to dispatch.

## What changed

- adds an authorized internal-only `Create work order` action for unconverted fleet requests
- calls the canonical conversion route with the request ID
- opens the resulting work order for advisor/dispatch follow-through
- surfaces conversion failures in the existing queue error area
- retains the read-only waiting label on external portal surfaces
- adds focused source-contract coverage

## Validation

- enrolled QA unit `Codex QA Walk-in Unit 20260804` into the fleet
- submitted `Hydraulic Brake Inspection` from the fleet portal
- verified the request reached `/fleet/service-requests` as open with `Awaiting shop conversion` and no available action
- CI pending

## Database

No migration. The existing conversion API/RPC remains the only write path.