### PR TITLE
Fix purchase-order detail line quantity writes

### DIFF
--- a/app/parts/po/[id]/page.tsx
+++ b/app/parts/po/[id]/page.tsx
@@ -360,14 +360,11 @@ export default function PurchaseOrderDetailPage(): JSX.Element {
 
     setBusyAddLine(true);
     try {
-      // NOTE: your schema might name these columns differently.
-      // We use the strongly-typed Insert shape, then fill common fields.
-      // If your generated types don't include ordered_qty/unit_cost, rename them to match your schema.
       const insert = {
         po_id: po.id,
         part_id: pid || null,
         description: description || null,
-        ordered_qty: qty,
+        qty,
         unit_cost: n(lineUnitCost),
       } as unknown as POLineInsert;
 

--- a/tests/po-detail-line-quantity.test.ts
+++ b/tests/po-detail-line-quantity.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const pagePath = "app/parts/po/[id]/page.tsx";
+
+describe("purchase order detail line quantity", () => {
+  it("writes the canonical purchase_order_lines qty column", () => {
+    const source = readFileSync(pagePath, "utf8");
+    const addLineSource = source.slice(
+      source.indexOf("async function addLine"),
+      source.indexOf("async function deleteLine"),
+    );
+
+    expect(addLineSource).toContain("qty,");
+    expect(addLineSource).not.toContain("ordered_qty: qty");
+  });
+});


### PR DESCRIPTION
## Root cause

The PO detail page still inserts `purchase_order_lines.ordered_qty`, but production's canonical schema uses `qty`. Adding any stock line therefore fails at the PostgREST schema-cache boundary before receiving can begin.

## What changed

- writes the canonical `qty` column from the existing validated quantity input
- removes the stale schema-guessing comment
- adds a focused source-contract test

## Validation

- production reproduction as `profixpartsqa`: adding 2 × `BRA-00075 — Motorcraft Brake Pads Front` at 50.00 to PO `813913ca` reports `Could not find the 'ordered_qty' column of 'purchase_order_lines' in the schema cache`
- database schema confirmed `qty` and `received_qty`; no PO line was created
- CI pending

## Database

No migration.