### PR TITLE
Seed canonical shop membership for provisioned users

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -350,6 +350,43 @@ export async function POST(req: Request) {
       );
     }
 
+    const { error: membershipErr } = await serviceSupabase
+      .from("shop_members")
+      .upsert(
+        {
+          shop_id: effectiveShopId,
+          user_id: newUserId,
+          role: canonicalRole,
+          created_by: access.profile.id,
+        } as Database["public"]["Tables"]["shop_members"]["Insert"],
+        { onConflict: "shop_id,user_id" },
+      );
+
+    if (membershipErr) {
+      const rolledBack = await rollbackCreatedAuthUser({
+        serviceSupabase,
+        authUserId: newUserId,
+        adminId: access.profile.id,
+        shopId: effectiveShopId,
+      });
+      logCreateUserError("shop_membership_seed_failed", {
+        adminId: access.profile.id,
+        targetShopId: effectiveShopId,
+        role: canonicalRole,
+        authUserId: newUserId,
+        error: membershipErr.message,
+      });
+      return NextResponse.json(
+        {
+          error: rolledBack
+            ? "User setup could not be completed. No account was created; you can try again."
+            : "User setup could not be completed, and automatic cleanup failed. Contact support before retrying.",
+          code: rolledBack ? "shop_membership_seed_failed" : "provisioning_rollback_failed",
+        },
+        { status: 500 },
+      );
+    }
+
     // Seed the canonical workforce profile row so People detail is immediately usable.
     const { error: workforceErr } = await serviceSupabase
       .from("people_workforce_profiles")

--- a/supabase/migrations/20260804053000_seed_canonical_shop_membership.sql
+++ b/supabase/migrations/20260804053000_seed_canonical_shop_membership.sql
@@ -1,0 +1,65 @@
+begin;
+
+-- shop_members is the canonical membership source for is_shop_member_v2 and
+-- the RLS policies that protect stock locations and other shop resources.
+-- Keep its role vocabulary aligned with the staff roles the provisioning API
+-- already accepts, then backfill staff profiles created before membership
+-- seeding was added.
+alter table public.shop_members
+  drop constraint if exists shop_members_role_check;
+
+alter table public.shop_members
+  add constraint shop_members_role_check
+  check (
+    role = any (
+      array[
+        'owner',
+        'admin',
+        'manager',
+        'foreman',
+        'lead_hand',
+        'advisor',
+        'service',
+        'dispatcher',
+        'parts',
+        'mechanic',
+        'fleet_manager',
+        'driver',
+        'viewer'
+      ]::text[]
+    )
+  );
+
+insert into public.shop_members (
+  shop_id,
+  user_id,
+  role,
+  created_by
+)
+select
+  p.shop_id,
+  p.id,
+  lower(trim(p.role::text)),
+  p.created_by
+from public.profiles p
+where p.shop_id is not null
+  and lower(trim(p.role::text)) = any (
+    array[
+      'owner',
+      'admin',
+      'manager',
+      'foreman',
+      'lead_hand',
+      'advisor',
+      'service',
+      'dispatcher',
+      'parts',
+      'mechanic',
+      'fleet_manager',
+      'driver'
+    ]::text[]
+  )
+on conflict (shop_id, user_id)
+do update set role = excluded.role;
+
+commit;

--- a/tests/canonical-shop-membership-provisioning.test.ts
+++ b/tests/canonical-shop-membership-provisioning.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const routePath = "app/api/admin/create-user/route.ts";
+const migrationPath =
+  "supabase/migrations/20260804053000_seed_canonical_shop_membership.sql";
+
+describe("canonical shop membership provisioning", () => {
+  it("seeds shop_members before completing user provisioning", () => {
+    const source = readFileSync(routePath, "utf8");
+
+    expect(source).toContain('.from("shop_members")');
+    expect(source).toContain('onConflict: "shop_id,user_id"');
+    expect(source).toContain("shop_membership_seed_failed");
+    expect(source).toContain("rollbackCreatedAuthUser");
+  });
+
+  it("backfills staff profiles and supports every provisionable staff role", () => {
+    const migration = readFileSync(migrationPath, "utf8");
+
+    expect(migration).toContain("insert into public.shop_members");
+    expect(migration).toContain("from public.profiles p");
+    expect(migration).toContain("on conflict (shop_id, user_id)");
+    expect(migration).toContain("'lead_hand'");
+    expect(migration).toContain("'foreman'");
+    expect(migration).toContain("'service'");
+  });
+});


### PR DESCRIPTION
## Root cause

The owner/admin user-provisioning route creates `auth.users`, `profiles`, and workforce rows but never creates the canonical `shop_members` row. RLS helpers such as `is_shop_member_v2` read `shop_members`, so newly created staff can sign in yet cannot see protected same-shop resources such as stock locations. This leaves parts receiving disabled and produces inconsistent role dashboards.

The existing `shop_members_role_check` also omits accepted staff roles such as `lead_hand`, `foreman`, and `service`.

## What changed

- seeds `shop_members` as part of the transactional provisioning sequence
- rolls the new auth user back if canonical membership cannot be created
- aligns the membership role constraint with provisionable staff roles
- backfills missing memberships from existing shop-scoped staff profiles
- adds focused provisioning/migration coverage

## Validation

- all four QA-created accounts have valid `profiles.shop_id` but no matching `shop_members` row
- `MAIN / Main Stock` exists, yet `profixpartsqa` receives an empty stock-location selector because `stock_locations` RLS calls `is_shop_member_v2`
- manager/mechanic/parts/lead-hand role behavior otherwise confirms the accounts are in the intended shop
- CI pending

## Database

Migration required: `20260804053000_seed_canonical_shop_membership.sql`.