### PR TITLE
Fix partial PO receipts skipping inventory movements

### DIFF
--- a/app/api/receive-scan/route.ts
+++ b/app/api/receive-scan/route.ts
@@ -65,6 +65,7 @@ export async function POST(req: Request) {
           p_part_id: partId,
           p_location_id: locationId,
           p_qty: qty,
+          p_operation_id: operationId ?? crypto.randomUUID(),
         } as unknown as DB["public"]["Functions"]["receive_po_part_and_allocate"]["Args"],
       );
 

--- a/app/parts/po/[id]/receive/page.tsx
+++ b/app/parts/po/[id]/receive/page.tsx
@@ -155,6 +155,7 @@ export default function PoReceivePage(): JSX.Element {
   const [scanning, setScanning] = useState<boolean>(false);
   const [lastScan, setLastScan] = useState<string>("");
   const onDetectedRef = useRef<QuaggaDetectedHandler | null>(null);
+  const receiveOperationRef = useRef<{ key: string; id: string } | null>(null);
 
   // last receive output
   const [result, setResult] = useState<ReceiveResult | null>(null);
@@ -334,11 +335,37 @@ export default function PoReceivePage(): JSX.Element {
       return;
     }
 
+    const partRemaining = lines
+      .filter((line) => String(line.part_id ?? "") === partId)
+      .reduce(
+        (sum, line) =>
+          sum + Math.max(0, n(line.qty) - n(line.received_qty)),
+        0,
+      );
+
+    if (partRemaining <= 0) {
+      setErr("This part has no remaining quantity on the purchase order.");
+      return;
+    }
+    if (receiveQty > partRemaining) {
+      setErr(`Quantity exceeds the ${partRemaining} remaining on this purchase order.`);
+      return;
+    }
+
+    const operationKey = [poId, partId, selectedLoc, receiveQty].join(":");
+    if (receiveOperationRef.current?.key !== operationKey) {
+      receiveOperationRef.current = {
+        key: operationKey,
+        id: crypto.randomUUID(),
+      };
+    }
+
     const args = {
       p_po_id: poId,
       p_part_id: partId,
       p_location_id: selectedLoc,
       p_qty: receiveQty,
+      p_operation_id: receiveOperationRef.current.id,
     };
 
     const { data, error } = await supabase.rpc(
@@ -350,6 +377,8 @@ export default function PoReceivePage(): JSX.Element {
       setErr(error.message);
       return;
     }
+
+    receiveOperationRef.current = null;
 
     const parsed = extractReceiveResult(data);
     setResult(parsed ?? {});
@@ -597,7 +626,8 @@ export default function PoReceivePage(): JSX.Element {
                 {!scanning ? (
                   <button
                     onClick={startScan}
-                    className="rounded-full border border-sky-500/40 bg-sky-950/25 px-4 py-2 text-sm text-[rgba(242,210,187,0.94)] hover:bg-sky-900/25"
+                    disabled={remaining <= 0}
+                    className="rounded-full border border-sky-500/40 bg-sky-950/25 px-4 py-2 text-sm text-[rgba(242,210,187,0.94)] hover:bg-sky-900/25 disabled:cursor-not-allowed disabled:opacity-50"
                     type="button"
                   >
                     Start Scanner
@@ -712,8 +742,8 @@ export default function PoReceivePage(): JSX.Element {
 
                 <button
                   onClick={() => void doReceive(manualPartId, qty)}
-                  disabled={!manualPartId || !selectedLoc || qty <= 0}
-                  className="rounded-full border border-sky-500/40 bg-sky-950/25 px-4 py-2 text-sm text-[rgba(242,210,187,0.94)] hover:bg-sky-900/25 disabled:opacity-50"
+                  disabled={!manualPartId || !selectedLoc || qty <= 0 || remaining <= 0}
+                  className="rounded-full border border-sky-500/40 bg-sky-950/25 px-4 py-2 text-sm text-[rgba(242,210,187,0.94)] hover:bg-sky-900/25 disabled:cursor-not-allowed disabled:opacity-50"
                   type="button"
                 >
                   Receive & Allocate →

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -25426,15 +25426,26 @@ export type Database = {
         }
         Returns: Json
       }
-      receive_po_part_and_allocate: {
-        Args: {
-          p_location_id: string
-          p_part_id: string
-          p_po_id: string
-          p_qty: number
-        }
-        Returns: Json
-      }
+      receive_po_part_and_allocate:
+        | {
+            Args: {
+              p_location_id: string
+              p_part_id: string
+              p_po_id: string
+              p_qty: number
+            }
+            Returns: Json
+          }
+        | {
+            Args: {
+              p_location_id: string
+              p_operation_id: string
+              p_part_id: string
+              p_po_id: string
+              p_qty: number
+            }
+            Returns: Json
+          }
       reconcile_work_order_approval_state_atomic: {
         Args: {
           p_actor_user_id: string

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -15706,6 +15706,7 @@ export type Database = {
       receive_po_part_and_allocate: {
         Args: {
           p_location_id: string
+          p_operation_id?: string
           p_part_id: string
           p_po_id: string
           p_qty: number

--- a/shared/types/types/supabase.ts
+++ b/shared/types/types/supabase.ts
@@ -15703,16 +15703,26 @@ export type Database = {
           status: Database["public"]["Enums"]["part_request_item_status"]
         }[]
       }
-      receive_po_part_and_allocate: {
-        Args: {
-          p_location_id: string
-          p_operation_id?: string
-          p_part_id: string
-          p_po_id: string
-          p_qty: number
-        }
-        Returns: Json
-      }
+      receive_po_part_and_allocate:
+        | {
+            Args: {
+              p_location_id: string
+              p_part_id: string
+              p_po_id: string
+              p_qty: number
+            }
+            Returns: Json
+          }
+        | {
+            Args: {
+              p_location_id: string
+              p_operation_id: string
+              p_part_id: string
+              p_po_id: string
+              p_qty: number
+            }
+            Returns: Json
+          }
       recompute_live_invoice_costs: {
         Args: { p_work_order_id: string }
         Returns: undefined

--- a/supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql
+++ b/supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql
@@ -1,0 +1,362 @@
+-- Make purchase-order receiving atomic and retry-safe.
+--
+-- The legacy four-argument RPC used the PO id as the stock-move reference.
+-- Repeated partial receipts therefore reused one inventory ledger row while
+-- independently advancing purchase_order_lines.received_qty.
+--
+-- New callers supply a stable operation id. The operation id is bound to the
+-- PO in reference_kind, so retries return the prior result while separate
+-- partial receipts create separate stock moves.
+
+create or replace function public.receive_po_part_and_allocate(
+  p_po_id uuid,
+  p_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_operation_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_uid uuid;
+  v_shop_id uuid;
+  v_ref_kind text;
+
+  v_move public.stock_moves%rowtype;
+  v_result jsonb;
+
+  v_po_remaining numeric;
+  v_remaining numeric;
+  v_po_closed boolean := false;
+  v_po_status text;
+
+  v_item record;
+  v_item_target numeric;
+  v_item_received numeric;
+  v_need numeric;
+  v_take numeric;
+
+  v_alloc jsonb := '[]'::jsonb;
+begin
+  v_uid := auth.uid();
+  if v_uid is null then
+    raise exception using errcode = '42501', message = 'Not authenticated';
+  end if;
+
+  if p_po_id is null then
+    raise exception using errcode = '22023', message = 'p_po_id is required';
+  end if;
+  if p_part_id is null then
+    raise exception using errcode = '22023', message = 'p_part_id is required';
+  end if;
+  if p_location_id is null then
+    raise exception using errcode = '22023', message = 'p_location_id is required';
+  end if;
+  if p_operation_id is null then
+    raise exception using errcode = '22023', message = 'p_operation_id is required';
+  end if;
+  if p_qty is null or p_qty <= 0 or p_qty::text in ('NaN', 'Infinity', '-Infinity') then
+    raise exception using errcode = '22023', message = 'p_qty must be a finite number greater than 0';
+  end if;
+
+  -- Serialise receives for a PO before checking the operation ledger or
+  -- calculating remaining quantities.
+  select po.shop_id, po.status::text
+    into v_shop_id, v_po_status
+  from public.purchase_orders po
+  where po.id = p_po_id
+  for update;
+
+  if v_shop_id is null then
+    raise exception using errcode = 'P0002', message = 'Purchase order not found';
+  end if;
+
+  if not exists (
+    select 1
+    from public.profiles p
+    where (p.user_id = v_uid or p.id = v_uid)
+      and p.shop_id = v_shop_id
+      and lower(coalesce(p.role, '')) in (
+        'owner', 'admin', 'manager', 'advisor', 'service',
+        'lead_hand', 'foreman', 'mechanic', 'parts'
+      )
+  ) then
+    raise exception using errcode = '42501', message = 'Not allowed';
+  end if;
+
+  if not exists (
+    select 1
+    from public.parts part
+    where part.id = p_part_id
+      and part.shop_id = v_shop_id
+  ) then
+    raise exception using errcode = '42501', message = 'Part does not belong to purchase-order shop';
+  end if;
+
+  if not exists (
+    select 1
+    from public.stock_locations location
+    where location.id = p_location_id
+      and location.shop_id = v_shop_id
+  ) then
+    raise exception using errcode = '42501', message = 'Location does not belong to purchase-order shop';
+  end if;
+
+  v_ref_kind := 'purchase_order_receipt:' || p_po_id::text;
+
+  -- A replay of the same action must not advance PO lines or allocations again.
+  select move.*
+    into v_move
+  from public.stock_moves move
+  where move.shop_id = v_shop_id
+    and move.reference_kind = v_ref_kind
+    and move.reference_id = p_operation_id
+  for update;
+
+  if found then
+    if v_move.part_id is distinct from p_part_id
+       or v_move.location_id is distinct from p_location_id
+       or v_move.qty_change is distinct from p_qty
+       or v_move.reason::text is distinct from 'receive' then
+      raise exception using
+        errcode = '22023',
+        message = 'PO_RECEIVE_IDEMPOTENCY_CONFLICT';
+    end if;
+
+    v_result := v_move.metadata -> 'receipt_result';
+    if v_result is not null then
+      return v_result || jsonb_build_object('replayed', true);
+    end if;
+
+    return jsonb_build_object(
+      'ok', true,
+      'replayed', true,
+      'move_id', v_move.id,
+      'po_id', p_po_id,
+      'po_closed', v_po_status = 'received',
+      'po_status', v_po_status,
+      'part_id', p_part_id,
+      'qty_received_total', p_qty,
+      'allocations', '[]'::jsonb,
+      'unallocated_qty', p_qty
+    );
+  end if;
+
+  -- Lock all matching lines before calculating and applying the receipt.
+  perform 1
+  from public.purchase_order_lines line
+  where line.po_id = p_po_id
+    and line.part_id = p_part_id
+  order by line.created_at asc, line.id asc
+  for update;
+
+  select coalesce(
+      sum(greatest(coalesce(line.qty, 0) - coalesce(line.received_qty, 0), 0)),
+      0
+    )
+    into v_po_remaining
+  from public.purchase_order_lines line
+  where line.po_id = p_po_id
+    and line.part_id = p_part_id;
+
+  if v_po_remaining <= 0 then
+    raise exception using
+      errcode = '22023',
+      message = 'PO_PART_FULLY_RECEIVED';
+  end if;
+
+  if p_qty > v_po_remaining then
+    raise exception using
+      errcode = '22023',
+      message = format(
+        'PO_RECEIVE_QUANTITY_EXCEEDS_REMAINING requested=%s remaining=%s',
+        p_qty,
+        v_po_remaining
+      );
+  end if;
+
+  select *
+    into v_move
+  from public.apply_stock_move(
+    p_part => p_part_id,
+    p_loc => p_location_id,
+    p_qty => p_qty,
+    p_reason => 'receive',
+    p_ref_kind => v_ref_kind,
+    p_ref_id => p_operation_id
+  );
+
+  -- Advance PO lines FIFO by exactly the quantity recorded in the stock ledger.
+  v_remaining := p_qty;
+
+  for v_item in
+    select line.id, line.qty, line.received_qty
+    from public.purchase_order_lines line
+    where line.po_id = p_po_id
+      and line.part_id = p_part_id
+    order by line.created_at asc, line.id asc
+    for update
+  loop
+    exit when v_remaining <= 0;
+
+    v_need := greatest(coalesce(v_item.qty, 0) - coalesce(v_item.received_qty, 0), 0);
+    v_take := least(v_remaining, v_need);
+
+    if v_take > 0 then
+      update public.purchase_order_lines
+      set received_qty = coalesce(received_qty, 0) + v_take
+      where id = v_item.id;
+
+      v_remaining := v_remaining - v_take;
+    end if;
+  end loop;
+
+  if v_remaining <> 0 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'PO_RECEIVE_LINE_RECONCILIATION_FAILED';
+  end if;
+
+  if exists (
+    select 1
+    from public.purchase_order_lines line
+    where line.po_id = p_po_id
+      and coalesce(line.received_qty, 0) < coalesce(line.qty, 0)
+  ) then
+    v_po_closed := false;
+  else
+    update public.purchase_orders
+    set status = 'received'
+    where id = p_po_id;
+
+    v_po_closed := true;
+  end if;
+
+  select po.status::text
+    into v_po_status
+  from public.purchase_orders po
+  where po.id = p_po_id;
+
+  -- Allocate the newly received quantity to matching request items FIFO.
+  v_remaining := p_qty;
+
+  for v_item in
+    select
+      item.id,
+      item.status,
+      item.qty,
+      item.qty_requested,
+      item.qty_approved,
+      item.qty_received
+    from public.part_request_items item
+    where item.shop_id = v_shop_id
+      and item.part_id = p_part_id
+      and item.status in (
+        'approved', 'reserved', 'ordered', 'picking',
+        'picked', 'partially_received'
+      )
+      and greatest(
+        coalesce(item.qty_approved, 0),
+        coalesce(item.qty_requested, 0),
+        coalesce(item.qty, 0),
+        0
+      ) > greatest(coalesce(item.qty_received, 0), 0)
+    order by item.created_at asc, item.id asc
+    for update
+  loop
+    exit when v_remaining <= 0;
+
+    v_item_target := greatest(
+      coalesce(v_item.qty_approved, 0),
+      coalesce(v_item.qty_requested, 0),
+      coalesce(v_item.qty, 0),
+      0
+    );
+    v_item_received := greatest(coalesce(v_item.qty_received, 0), 0);
+    v_need := greatest(v_item_target - v_item_received, 0);
+    v_take := least(v_remaining, v_need);
+
+    if v_take > 0 then
+      update public.part_request_items
+      set
+        qty_received = v_item_received + v_take,
+        status = case
+          when (v_item_received + v_take) >= v_item_target
+            then 'received'::public.part_request_item_status
+          else 'partially_received'::public.part_request_item_status
+        end
+      where id = v_item.id;
+
+      v_alloc := v_alloc || jsonb_build_object(
+        'request_item_id', v_item.id,
+        'qty_allocated', v_take,
+        'status', case
+          when (v_item_received + v_take) >= v_item_target then 'received'
+          else 'partially_received'
+        end
+      );
+
+      v_remaining := v_remaining - v_take;
+    end if;
+  end loop;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'replayed', false,
+    'move_id', v_move.id,
+    'po_id', p_po_id,
+    'po_closed', v_po_closed,
+    'po_status', v_po_status,
+    'part_id', p_part_id,
+    'qty_received_total', p_qty,
+    'allocations', v_alloc,
+    'unallocated_qty', greatest(v_remaining, 0)
+  );
+
+  update public.stock_moves
+  set metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+    'po_id', p_po_id,
+    'operation_id', p_operation_id,
+    'receipt_result', v_result
+  )
+  where id = v_move.id;
+
+  return v_result;
+end;
+$function$;
+
+-- Backward-compatible legacy signature. It receives correctly but cannot make
+-- a caller retry-safe without an operation id, so each invocation is a new
+-- bounded receipt.
+create or replace function public.receive_po_part_and_allocate(
+  p_po_id uuid,
+  p_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'public', 'pg_temp'
+as $function$
+begin
+  return public.receive_po_part_and_allocate(
+    p_po_id => p_po_id,
+    p_part_id => p_part_id,
+    p_location_id => p_location_id,
+    p_qty => p_qty,
+    p_operation_id => gen_random_uuid()
+  );
+end;
+$function$;
+
+revoke all on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid) from public, anon;
+revoke all on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric) from public, anon;
+grant execute on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid) to authenticated, service_role;
+grant execute on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric) to authenticated, service_role;
+
+comment on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid)
+is 'Atomically receives a PO part exactly once per operation id, advances PO lines, and allocates matching requests.';

--- a/supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql
+++ b/supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql
@@ -19,7 +19,7 @@ create function public.receive_po_part_and_allocate(
   p_part_id uuid,
   p_location_id uuid,
   p_qty numeric,
-  p_operation_id uuid default gen_random_uuid()
+  p_operation_id uuid
 )
 returns jsonb
 language plpgsql
@@ -334,10 +334,37 @@ begin
 end;
 $function$;
 
--- The default keeps legacy four-argument SQL/PostgREST calls working. Callers
--- that need retry safety supply p_operation_id explicitly.
+-- Preserve the deployed four-argument routine identity for schema contracts and
+-- legacy callers. Each legacy call is a distinct receipt operation; retry-aware
+-- callers use the five-argument overload with a stable p_operation_id.
+create function public.receive_po_part_and_allocate(
+  p_po_id uuid,
+  p_part_id uuid,
+  p_location_id uuid,
+  p_qty numeric
+)
+returns jsonb
+language sql
+security invoker
+set search_path to 'public', 'pg_temp'
+as $function$
+  select public.receive_po_part_and_allocate(
+    p_po_id,
+    p_part_id,
+    p_location_id,
+    p_qty,
+    gen_random_uuid()
+  );
+$function$;
+
+revoke all on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric) from public, anon;
+grant execute on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric) to authenticated, service_role;
+
 revoke all on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid) from public, anon;
 grant execute on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid) to authenticated, service_role;
 
 comment on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid)
 is 'Atomically receives a PO part exactly once per operation id, advances PO lines, and allocates matching requests.';
+
+comment on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric)
+is 'Legacy receipt entry point that assigns a unique operation id and delegates to the retry-safe overload.';

--- a/supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql
+++ b/supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql
@@ -7,6 +7,10 @@
 -- New callers supply a stable operation id. The operation id is bound to the
 -- PO in reference_kind, so retries return the prior result while separate
 -- partial receipts create separate stock moves.
+--
+-- apply_stock_move already maintains part_stock. The legacy AFTER INSERT
+-- snapshot trigger performs the same increment a second time.
+drop trigger if exists trg_stock_moves_apply_snapshot on public.stock_moves;
 
 create or replace function public.receive_po_part_and_allocate(
   p_po_id uuid,

--- a/supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql
+++ b/supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql
@@ -12,12 +12,14 @@
 -- snapshot trigger performs the same increment a second time.
 drop trigger if exists trg_stock_moves_apply_snapshot on public.stock_moves;
 
-create or replace function public.receive_po_part_and_allocate(
+drop function if exists public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric);
+
+create function public.receive_po_part_and_allocate(
   p_po_id uuid,
   p_part_id uuid,
   p_location_id uuid,
   p_qty numeric,
-  p_operation_id uuid
+  p_operation_id uuid default gen_random_uuid()
 )
 returns jsonb
 language plpgsql
@@ -332,35 +334,10 @@ begin
 end;
 $function$;
 
--- Backward-compatible legacy signature. It receives correctly but cannot make
--- a caller retry-safe without an operation id, so each invocation is a new
--- bounded receipt.
-create or replace function public.receive_po_part_and_allocate(
-  p_po_id uuid,
-  p_part_id uuid,
-  p_location_id uuid,
-  p_qty numeric
-)
-returns jsonb
-language plpgsql
-security definer
-set search_path to 'public', 'pg_temp'
-as $function$
-begin
-  return public.receive_po_part_and_allocate(
-    p_po_id => p_po_id,
-    p_part_id => p_part_id,
-    p_location_id => p_location_id,
-    p_qty => p_qty,
-    p_operation_id => gen_random_uuid()
-  );
-end;
-$function$;
-
+-- The default keeps legacy four-argument SQL/PostgREST calls working. Callers
+-- that need retry safety supply p_operation_id explicitly.
 revoke all on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid) from public, anon;
-revoke all on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric) from public, anon;
 grant execute on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid) to authenticated, service_role;
-grant execute on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric) to authenticated, service_role;
 
 comment on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric, uuid)
 is 'Atomically receives a PO part exactly once per operation id, advances PO lines, and allocates matching requests.';

--- a/tests/parts/po-receive-idempotency.test.ts
+++ b/tests/parts/po-receive-idempotency.test.ts
@@ -11,6 +11,12 @@ describe("purchase-order receipt idempotency", () => {
     const sql = readFileSync(migrationPath, "utf8");
 
     expect(sql).toContain("p_operation_id uuid");
+    expect(sql).toMatch(
+      /create function public\.receive_po_part_and_allocate\(\s*p_po_id uuid,\s*p_part_id uuid,\s*p_location_id uuid,\s*p_qty numeric\s*\)/,
+    );
+    expect(sql).toContain(
+      "grant execute on function public.receive_po_part_and_allocate(uuid, uuid, uuid, numeric) to authenticated, service_role",
+    );
     expect(sql).toContain(
       "drop trigger if exists trg_stock_moves_apply_snapshot on public.stock_moves",
     );

--- a/tests/parts/po-receive-idempotency.test.ts
+++ b/tests/parts/po-receive-idempotency.test.ts
@@ -11,6 +11,9 @@ describe("purchase-order receipt idempotency", () => {
     const sql = readFileSync(migrationPath, "utf8");
 
     expect(sql).toContain("p_operation_id uuid");
+    expect(sql).toContain(
+      "drop trigger if exists trg_stock_moves_apply_snapshot on public.stock_moves",
+    );
     expect(sql).toContain("purchase_order_receipt:");
     expect(sql).toContain("PO_RECEIVE_IDEMPOTENCY_CONFLICT");
     expect(sql).toContain("v_move.metadata -> 'receipt_result'");

--- a/tests/parts/po-receive-idempotency.test.ts
+++ b/tests/parts/po-receive-idempotency.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const migrationPath =
+  "supabase/migrations/20260804054000_fix_po_partial_receive_idempotency.sql";
+const receivePagePath = "app/parts/po/[id]/receive/page.tsx";
+const receiveRoutePath = "app/api/receive-scan/route.ts";
+
+describe("purchase-order receipt idempotency", () => {
+  it("binds each receipt to an operation id and makes replays no-ops", () => {
+    const sql = readFileSync(migrationPath, "utf8");
+
+    expect(sql).toContain("p_operation_id uuid");
+    expect(sql).toContain("purchase_order_receipt:");
+    expect(sql).toContain("PO_RECEIVE_IDEMPOTENCY_CONFLICT");
+    expect(sql).toContain("v_move.metadata -> 'receipt_result'");
+    expect(sql).toContain("'replayed', true");
+  });
+
+  it("locks and bounds PO quantities before writing inventory", () => {
+    const sql = readFileSync(migrationPath, "utf8");
+
+    const lockIndex = sql.indexOf("for update;");
+    const remainingIndex = sql.indexOf("into v_po_remaining");
+    const stockMoveIndex = sql.indexOf("from public.apply_stock_move(");
+
+    expect(lockIndex).toBeGreaterThan(-1);
+    expect(remainingIndex).toBeGreaterThan(lockIndex);
+    expect(stockMoveIndex).toBeGreaterThan(remainingIndex);
+    expect(sql).toContain("PO_RECEIVE_QUANTITY_EXCEEDS_REMAINING");
+    expect(sql).toContain("PO_RECEIVE_LINE_RECONCILIATION_FAILED");
+  });
+
+  it("keeps the stock ledger, PO lines, and allocation result on one quantity", () => {
+    const sql = readFileSync(migrationPath, "utf8");
+
+    expect(sql).toContain("p_qty => p_qty");
+    expect(sql).toContain("v_remaining := p_qty");
+    expect(sql).toContain("'request_item_id', v_item.id");
+    expect(sql).toContain("'qty_allocated', v_take");
+    expect(sql).toContain("'receipt_result', v_result");
+  });
+
+  it("sends stable operation ids from both PO receiving entry points", () => {
+    const page = readFileSync(receivePagePath, "utf8");
+    const route = readFileSync(receiveRoutePath, "utf8");
+
+    expect(page).toContain("receiveOperationRef");
+    expect(page).toContain("crypto.randomUUID()");
+    expect(page).toContain("p_operation_id: receiveOperationRef.current.id");
+    expect(page).toContain("receiveOperationRef.current = null");
+    expect(page).toContain("disabled={!manualPartId || !selectedLoc || qty <= 0 || remaining <= 0}");
+
+    expect(route).toContain("p_operation_id: operationId ?? crypto.randomUUID()");
+  });
+});


### PR DESCRIPTION
## Root cause

`receive_po_part_and_allocate` used the PO id as the stock-move reference. Every partial receipt for the same PO/part/location therefore reused one idempotent stock move while PO lines and request allocations advanced again.

The canonical stock-move core also updates `part_stock`, while a legacy `AFTER INSERT` trigger applies the same snapshot delta a second time.

## What changed

- adds a receipt operation id with a default for backward-compatible four-argument calls
- serializes PO receipts and rejects quantities beyond the true remaining amount
- replays the prior result for the same operation id without changing lines or allocations
- binds operation identity to the PO, part, location, and quantity
- removes the duplicate legacy stock snapshot trigger
- passes stable operation ids from the PO page and receive-scan API
- disables receipt controls when the PO has no remaining quantity
- returns allocation keys that match the UI contract
- updates generated Supabase types and adds focused regression coverage

## Production QA evidence

Two partial receipts of quantity 1 advanced the test PO line to 2 received but produced only one stock move of quantity 1. The second call returned the same move id. A one-unit corrective ledger movement then increased the legacy cache by two, confirming the duplicate snapshot path.

The QA data was repaired: two received PO units now have two units of receipt movements, and the affected `part_stock` cache was reconciled to the authoritative ledger.

No deployment or merge has been performed.