### PR TITLE
Fix duplicate allocated parts in work-order views

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1996,7 +1996,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                       } as unknown as AllocationRow;
                     });
 
-                    const partsForLine = [...allocPartsForLine, ...stagedAsAllocShape];
+                    const displayAllocations = filterAllocationsNotBackedByCanonicalParts(
+                      allocPartsForLine,
+                      stagedForLine,
+                    );
+                    const partsForLine = [...displayAllocations, ...stagedAsAllocShape];
 
                     const isPunchedIn = punchedIn;
                     const isCurrentUserWorkingThisLine = Boolean(

--- a/features/work-orders/mobile/MobileFocusedJob.tsx
+++ b/features/work-orders/mobile/MobileFocusedJob.tsx
@@ -37,6 +37,7 @@ import NewChatModal from "@/features/ai/components/chat/NewChatModal";
 import SuggestedQuickAdd from "@work-orders/components/SuggestedQuickAdd";
 import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransitionsClient";
 import {
+  filterAllocationsNotBackedByCanonicalParts,
   getCanonicalPartDescription,
   getCanonicalPartManufacturer,
   getCanonicalPartNumber,
@@ -187,6 +188,10 @@ export default function MobileFocusedJob(props: {
   const [allocs, setAllocs] = useState<AllocationRow[]>([]);
   const [requiredParts, setRequiredParts] = useState<RequiredPartRow[]>([]);
   const [allocsLoading, setAllocsLoading] = useState(false);
+  const displayOnlyAllocations = useMemo(
+    () => filterAllocationsNotBackedByCanonicalParts(allocs, requiredParts),
+    [allocs, requiredParts],
+  );
 
   const showErr = (prefix: string, err?: { message?: string } | null) => {
     toast.error(`${prefix}: ${err?.message ?? "Something went wrong."}`);
@@ -1358,7 +1363,7 @@ export default function MobileFocusedJob(props: {
 
                   {allocsLoading ? (
                     <div className="text-sm text-[color:var(--theme-text-secondary)]">Loading…</div>
-                  ) : (allocs.length + requiredParts.length) === 0 ? (
+                  ) : (displayOnlyAllocations.length + requiredParts.length) === 0 ? (
                     <div className="text-sm text-[color:var(--theme-text-secondary)]">No parts used yet.</div>
                   ) : (
                     <div className="mobile-tech-subpanel overflow-hidden">
@@ -1384,7 +1389,7 @@ export default function MobileFocusedJob(props: {
                             </div>
                           </li>
                         ))}
-                        {allocs.map((a) => (
+                        {displayOnlyAllocations.map((a) => (
                           <li
                             key={a.id}
                             className="grid grid-cols-12 items-center px-3 py-2 text-sm"


### PR DESCRIPTION
## Root cause
Work-order detail and mobile focused-job views rendered both the canonical `work_order_parts` row and its linked allocation, so one reserved part appeared twice and inflated the visible required-parts count.

## What changed
- Reuse `filterAllocationsNotBackedByCanonicalParts` on the desktop work-order card
- Apply the same canonical-part filter in the mobile focused-job parts list
- Derive the filtered list with `useMemo` so both the empty state and rendered rows use the same data

## Why safe
Unlinked/manual allocations still render. Only allocations already represented by a canonical part id or request-item id are hidden.

## Validation
The shared helper already has Vitest coverage for direct canonical links, request-item links, and unlinked allocations. CI will run on this PR.