### PR TITLE
Fix parts dashboard catalog count

### DIFF
--- a/app/parts/page.tsx
+++ b/app/parts/page.tsx
@@ -67,7 +67,6 @@ type RecentMove = Pick<
 type TrustExtendedPart = Pick<PartRow, "id" | "created_at" | "sku"> & {
   part_number?: string | null;
   normalized_part_key?: string | null;
-  import_confidence?: number | null;
 };
 type TrustSummary = {
   lowTrust: number;
@@ -223,7 +222,7 @@ export default function PartsDashboardPage(): JSX.Element {
         supabase
           .from("parts")
           .select(
-            "id, created_at, sku, part_number, normalized_part_key, import_confidence, source_intake_id",
+            "id, created_at, sku, part_number, normalized_part_key, source_intake_id",
           ),
         supabase
           .from("stock_moves")
@@ -256,9 +255,7 @@ export default function PartsDashboardPage(): JSX.Element {
         (part) =>
           !part.sku?.trim() ||
           !part.part_number?.trim() ||
-          !part.normalized_part_key?.trim() ||
-          (typeof part.import_confidence === "number" &&
-            part.import_confidence < 0.75),
+          !part.normalized_part_key?.trim(),
       ).length;
       const reviewStaging = (stagingRes.data ?? []).filter((row) =>
         ["pending", "review", "ambiguous"].includes(


### PR DESCRIPTION
## Root cause
The dashboard selected `parts.import_confidence`, but that column is not present in the deployed `public.parts` schema. PostgREST rejected the full select, the page ignored the response error, and the null result was displayed as zero catalog SKUs.

## What changed
- Remove the undeployed column from the catalog query and local row shape
- Keep catalog-health scoring on deployed SKU, part-number, and normalized-key fields

## Evidence
Production schema inspection confirms `parts` has `source_intake_id`, `external_id`, and `import_notes`, but no `import_confidence`. The inventory page independently returns 87 visible catalog rows.

## Why safe
No database change or write is involved. The card now reads the same deployed catalog columns used elsewhere. CI will run on this PR.