### PR TITLE
Fix idempotent technician assignment requests

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { format } from "date-fns";
@@ -46,6 +46,10 @@ import {
   type WorkOrderPartRequestRow as PartRequestRow,
 } from "@/features/work-orders/lib/data/loadCanonicalWorkOrderLineContext";
 import { isReviewableQuoteLine } from "@/features/work-orders/lib/quotes/reviewableQuoteLines";
+import {
+  assignWorkOrderLineTechnician,
+  createAssignTechnicianOperationKey,
+} from "@/features/work-orders/lib/assignTechnicianClient";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
@@ -264,6 +268,9 @@ export default function WorkOrderIdClient(): JSX.Element {
   const [assignables, setAssignables] = useState<
     Array<Pick<Profile, "id" | "full_name" | "role">>
   >([]);
+  const assignmentOperationsRef = useRef<
+    Map<string, { technicianId: string; operationKey: string }>
+  >(new Map());
 
   const [activeTechsByLine, setActiveTechsByLine] = useState<Record<string, string[]>>({});
 
@@ -2038,28 +2045,35 @@ export default function WorkOrderIdClient(): JSX.Element {
                         onAssign={
                           canAssign
                             ? async (techId: string) => {
+                                const existingOperation =
+                                  assignmentOperationsRef.current.get(ln.id);
+                                const operationKey =
+                                  existingOperation?.technicianId === techId
+                                    ? existingOperation.operationKey
+                                    : createAssignTechnicianOperationKey(
+                                        ln.id,
+                                        techId,
+                                      );
+
+                                assignmentOperationsRef.current.set(ln.id, {
+                                  technicianId: techId,
+                                  operationKey,
+                                });
+
                                 try {
-                                  const res = await fetch("/api/work-orders/assign-line", {
-                                    method: "POST",
-                                    headers: { "Content-Type": "application/json" },
-                                    body: JSON.stringify({
-                                      work_order_line_id: ln.id,
-                                      tech_id: techId,
-                                    }),
+                                  await assignWorkOrderLineTechnician({
+                                    lineId: ln.id,
+                                    technicianId: techId,
+                                    operationKey,
                                   });
-
-                                  const json = await res.json().catch(() => ({}));
-
-                                  if (!res.ok) {
-                                    throw new Error(
-                                      typeof json?.error === "string"
-                                        ? json.error
-                                        : "Failed to update primary tech."
-                                    );
-                                  }
-
-                                  toast.success("Primary tech updated.");
                                   await fetchAll();
+                                  if (
+                                    assignmentOperationsRef.current.get(ln.id)
+                                      ?.operationKey === operationKey
+                                  ) {
+                                    assignmentOperationsRef.current.delete(ln.id);
+                                  }
+                                  toast.success("Primary tech updated.");
                                 } catch (e) {
                                   const msg = e instanceof Error ? e.message : "Failed to update primary tech.";
                                   toast.error(msg);

--- a/features/work-orders/components/workorders/extras/AssignTechModal.tsx
+++ b/features/work-orders/components/workorders/extras/AssignTechModal.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import ModalShell from "@/features/shared/components/ModalShell";
 import { toast } from "sonner";
+import {
+  assignWorkOrderLineTechnician,
+  createAssignTechnicianOperationKey,
+} from "@/features/work-orders/lib/assignTechnicianClient";
 
 interface Assignable {
   id: string;
@@ -32,6 +36,10 @@ export default function AssignTechModal({
   const [users, setUsers] = useState<Assignable[]>(() => mechanics ?? initialMechanics ?? []);
   const [techId, setTechId] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
+  const assignmentOperationRef = useRef<{
+    technicianId: string;
+    operationKey: string;
+  } | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -75,23 +83,24 @@ export default function AssignTechModal({
     }
 
     setSubmitting(true);
+    const existingOperation = assignmentOperationRef.current;
+    const operationKey =
+      existingOperation?.technicianId === techId
+        ? existingOperation.operationKey
+        : createAssignTechnicianOperationKey(workOrderLineId, techId);
+    assignmentOperationRef.current = { technicianId: techId, operationKey };
+
     try {
-      const res = await fetch("/api/work-orders/assign-line", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          work_order_line_id: workOrderLineId,
-          tech_id: techId,
-        }),
+      await assignWorkOrderLineTechnician({
+        lineId: workOrderLineId,
+        technicianId: techId,
+        operationKey,
       });
-
-      if (!res.ok) {
-        const json = (await res.json().catch(() => null)) as { error?: string } | null;
-        throw new Error(json?.error || "Failed to update primary tech.");
-      }
-
-      toast.success("Primary tech updated.");
       await onAssigned?.(techId);
+      if (assignmentOperationRef.current?.operationKey === operationKey) {
+        assignmentOperationRef.current = null;
+      }
+      toast.success("Primary tech updated.");
       onClose();
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Failed to update primary tech.";

--- a/features/work-orders/lib/assignTechnicianClient.ts
+++ b/features/work-orders/lib/assignTechnicianClient.ts
@@ -1,0 +1,75 @@
+type AssignTechnicianInput = {
+  lineId: string;
+  technicianId: string;
+  operationKey?: string;
+};
+
+type AssignTechnicianResult = {
+  ok?: boolean;
+  idempotent?: boolean;
+  primary_technician_id?: string;
+};
+
+type ApiErrorPayload = {
+  error?: string;
+};
+
+export function createAssignTechnicianOperationKey(
+  lineId: string,
+  technicianId: string,
+): string {
+  const randomId =
+    typeof globalThis.crypto?.randomUUID === "function"
+      ? globalThis.crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  return `assign-technician:${lineId}:${technicianId}:${randomId}`;
+}
+
+export async function assignWorkOrderLineTechnician({
+  lineId,
+  technicianId,
+  operationKey,
+}: AssignTechnicianInput): Promise<AssignTechnicianResult> {
+  const normalizedLineId = lineId.trim();
+  const normalizedTechnicianId = technicianId.trim();
+
+  if (!normalizedLineId || !normalizedTechnicianId) {
+    throw new Error("A work-order line and technician are required.");
+  }
+
+  const normalizedOperationKey =
+    operationKey?.trim() ||
+    createAssignTechnicianOperationKey(
+      normalizedLineId,
+      normalizedTechnicianId,
+    );
+
+  const response = await fetch("/api/work-orders/assign-line", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": normalizedOperationKey,
+    },
+    body: JSON.stringify({
+      work_order_line_id: normalizedLineId,
+      tech_id: normalizedTechnicianId,
+      operationKey: normalizedOperationKey,
+      idempotencyKey: normalizedOperationKey,
+    }),
+  });
+
+  const payload = (await response
+    .json()
+    .catch(() => null)) as (AssignTechnicianResult & ApiErrorPayload) | null;
+
+  if (!response.ok) {
+    const error = new Error(
+      payload?.error || "Failed to update primary tech.",
+    ) as Error & { status?: number };
+    error.status = response.status;
+    throw error;
+  }
+
+  return payload ?? {};
+}

--- a/tests/work-order-assign-technician-client.test.ts
+++ b/tests/work-order-assign-technician-client.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  assignWorkOrderLineTechnician,
+  createAssignTechnicianOperationKey,
+} from "@/features/work-orders/lib/assignTechnicianClient";
+
+describe("work-order technician assignment client", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends the same stable operation key in the header and body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ ok: true, idempotent: false }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await assignWorkOrderLineTechnician({
+      lineId: "line-1",
+      technicianId: "tech-1",
+      operationKey: "stable-assignment-key",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [path, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(path).toBe("/api/work-orders/assign-line");
+    expect(new Headers(init.headers).get("Idempotency-Key")).toBe(
+      "stable-assignment-key",
+    );
+    expect(JSON.parse(String(init.body))).toEqual({
+      work_order_line_id: "line-1",
+      tech_id: "tech-1",
+      operationKey: "stable-assignment-key",
+      idempotencyKey: "stable-assignment-key",
+    });
+  });
+
+  it("generates a unique key for each new assignment intent", () => {
+    const first = createAssignTechnicianOperationKey("line-1", "tech-1");
+    const second = createAssignTechnicianOperationKey("line-1", "tech-1");
+
+    expect(first).toContain("assign-technician:line-1:tech-1:");
+    expect(second).toContain("assign-technician:line-1:tech-1:");
+    expect(first).not.toBe(second);
+  });
+
+  it("surfaces the route error to the assigning control", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: vi.fn().mockResolvedValue({ error: "FINANCIALLY_LOCKED" }),
+      }),
+    );
+
+    await expect(
+      assignWorkOrderLineTechnician({
+        lineId: "line-1",
+        technicianId: "tech-1",
+        operationKey: "failed-assignment-key",
+      }),
+    ).rejects.toMatchObject({
+      message: "FINANCIALLY_LOCKED",
+      status: 409,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- route both technician-assignment UI entry points through one client helper
- send the same stable operation identity in the `Idempotency-Key` header and request body
- retain an ambiguous assignment operation key for safe retry, then clear it after refresh succeeds
- add focused regression coverage for request shape, distinct assignment intents, and API error propagation

## Production evidence
The production work-order technician selector returned `A stable Idempotency-Key is required.` after PR #1318 hardened `/api/work-orders/assign-line`. The route/RPC security and tenant checks were correct; the two UI callers had not been updated to supply the required key.

## Validation
- `git diff --check` passed
- TypeScript syntax transpilation passed for all four changed files
- Local `pnpm`/Node command execution was unavailable in this Windows shell; GitHub/Vercel checks are required before merge

## Database
No migration required.

## Environment variables
None required.