### PR TITLE
Redesign work order detail as cockpit

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -8,6 +8,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { format } from "date-fns";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
+import { BrainCircuit, Clock3, ListChecks, Plus, ReceiptText } from "lucide-react";
 
 import { supabaseBrowser as supabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
@@ -25,7 +26,6 @@ import WorkOrderAiOperationalRecommendations from "@/features/work-orders/compon
 import WorkOrderAiFreshnessBadge from "@/features/work-orders/components/WorkOrderAiFreshnessBadge";
 import WorkOrderMediaGallery from "@/features/work-orders/components/workorders/extras/WorkOrderMediaGallery";
 import type { WorkOrderEvidenceItem } from "@/features/work-orders/lib/evidence/workOrderEvidence";
-import PageShell from "@/features/shared/components/PageShell";
 import StatusBadge from "@/features/shared/components/ui/StatusBadge";
 import DecisionTimeline, {
   type DecisionTimelineStage,
@@ -128,6 +128,14 @@ function partsRequestActionLabel(requests: PartRequestRow[]): string {
     case "handoff": return "Parts handed off";
     case "history": return "View parts history";
   }
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+    maximumFractionDigits: 2,
+  }).format(value);
 }
 
 /** Normalize “where is the inspection template id stored for this line?” */
@@ -1002,6 +1010,17 @@ export default function WorkOrderIdClient(): JSX.Element {
     return byLine;
   }, [activeQuotesByLine, allocsByLine, lines, shopLaborRate, stagedPartsByLine]);
 
+  const workOrderTotal = useMemo(
+    () =>
+      lines
+        .filter((line) => (line.line_type ?? "job") !== "info")
+        .reduce(
+        (total, line) => total + Number(pricingByLine[line.id]?.lineTotal ?? 0),
+        0,
+      ),
+    [lines, pricingByLine],
+  );
+
   const isPendingApprovalLine = (l: WorkOrderLine) => {
     const a = (l.approval_state ?? "").toLowerCase();
     const s = (l.status ?? "").toLowerCase();
@@ -1091,6 +1110,7 @@ export default function WorkOrderIdClient(): JSX.Element {
       }),
     [wo, jobLines],
   );
+  const latestDecisionEvent = decisionEvents[decisionEvents.length - 1] ?? null;
 
   const sortedLines = useMemo(() => {
     const pr: Record<string, number> = {
@@ -1510,10 +1530,9 @@ export default function WorkOrderIdClient(): JSX.Element {
 
   // ✅ layout: desktop keeps the focused cockpit open with a selected (or first) line.
   const panelLineId = focusedJobId ?? sortedLines[0]?.id ?? null;
-  const showPanel = prefersPanel && !!panelLineId;
 
   return (
-    <div className="w-full bg-[var(--theme-surface-2,var(--theme-surface-page))] px-3 py-4 text-foreground sm:px-5 lg:px-8 xl:px-10">
+    <div className="w-full bg-[var(--theme-surface-2,var(--theme-surface-page))] px-2 py-3 text-foreground sm:px-3 lg:px-4">
       <VoiceContextSetter
         currentView="work_order_page"
         workOrderId={wo?.id}
@@ -1522,7 +1541,6 @@ export default function WorkOrderIdClient(): JSX.Element {
         lineId={focusedJobId}
       />
 
-      <PageShell eyebrow="" title="" description="" actions={null}>
         {authChecked && !currentUserId && (
           <section className={cn(PANEL_VARIANTS.secondary, "p-3 text-sm text-amber-100")}>
             You appear signed out on this tab. If actions fail, open{" "}
@@ -1548,8 +1566,8 @@ export default function WorkOrderIdClient(): JSX.Element {
         ) : !wo ? (
           <div className="mt-2 text-sm text-red-400">Work order not found.</div>
         ) : (
-          <div className={cn("space-y-2.5", supportFullyCollapsed && "space-y-2")}>
-            <section className={cn(PANEL_VARIANTS.secondary, "px-3 py-2")}>
+          <div className={cn("space-y-2", supportFullyCollapsed && "space-y-1.5")}>
+            <section className="overflow-hidden border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 sm:px-4">
               <div className="flex flex-wrap items-center gap-2">
                 <PreviousPageButton />
                 <div className="text-sm font-semibold text-foreground">
@@ -1583,6 +1601,51 @@ export default function WorkOrderIdClient(): JSX.Element {
                   <span className="rounded-full border border-sky-400/30 bg-sky-500/10 px-2 py-0.5 text-sky-200">Approval queue: {approvalPending.length + approvalPendingQuotes.length}</span>
                 ) : null}
               </div>
+              <div className="mt-3 flex flex-wrap items-center gap-1 border-t border-[color:var(--theme-border-soft)] pt-2">
+                <button
+                  type="button"
+                  onClick={() => setShowWoContext((prev) => !prev)}
+                  aria-expanded={showWoContext}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-semibold transition",
+                    showWoContext
+                      ? "bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]"
+                      : "text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-subtle)]",
+                  )}
+                >
+                  <BrainCircuit className="h-3.5 w-3.5" />
+                  Context &amp; AI
+                </button>
+                <button
+                  type="button"
+                  onClick={openQuoteReview}
+                  className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--theme-text-secondary)] transition hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)]"
+                >
+                  <ReceiptText className="h-3.5 w-3.5" />
+                  Approvals{hasAnyApprovalItems ? ` (${approvalPending.length + approvalPendingQuotes.length})` : ""}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowWoContext(true);
+                    setShowTimeline((prev) => !prev);
+                  }}
+                  aria-expanded={showTimeline}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-semibold transition",
+                    showTimeline
+                      ? "bg-[color:var(--theme-surface-subtle)] text-[color:var(--theme-text-primary)]"
+                      : "text-[color:var(--theme-text-secondary)] hover:bg-[color:var(--theme-surface-subtle)]",
+                  )}
+                >
+                  <Clock3 className="h-3.5 w-3.5" />
+                  Activity
+                </button>
+                <span className="ml-auto inline-flex items-center gap-2 font-mono text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
+                  <ListChecks className="h-3.5 w-3.5 text-[color:var(--theme-text-secondary)]" />
+                  {sortedLines.length} jobs · {formatCurrency(workOrderTotal)}
+                </span>
+              </div>
             </section>
 
             {loading ? (
@@ -1590,7 +1653,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                 Refreshing work order data…
               </div>
             ) : null}
-            <section className={cn(PANEL_VARIANTS.secondary, "p-2")}>
+            <section className={cn(PANEL_VARIANTS.secondary, showWoContext ? "p-2" : "hidden")}>
               <button
                 type="button"
                 className="flex w-full items-center justify-between gap-2 text-left"
@@ -1953,12 +2016,26 @@ export default function WorkOrderIdClient(): JSX.Element {
               )}
             </section>
 
-          {/* Workspace */}
-          <section className={cn("grid lg:grid-cols-[minmax(0,58fr)_minmax(0,42fr)] lg:items-start", supportFullyCollapsed ? "gap-2.5 lg:gap-3" : "gap-3 lg:gap-4")}>
-            {/* Left: jobs list/cards */}
-            <div className="space-y-2">
+          {/* Full-height cockpit: navigate left, work center, act right. */}
+          <section className="grid overflow-hidden border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] lg:h-[calc(100vh-12.5rem)] lg:min-h-[44rem] lg:grid-cols-[17rem_minmax(0,1fr)]">
+            <aside className="flex min-h-0 flex-col border-b border-[color:var(--theme-border-soft)] lg:border-b-0 lg:border-r">
+              <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-3 py-3">
+                <div>
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">Jobs</div>
+                  <div className="mt-0.5 text-xs text-[color:var(--theme-text-secondary)]">{sortedLines.length} on this work order</div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setAddJobOpen(true)}
+                  className="inline-flex h-8 items-center gap-1 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add
+                </button>
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto">
               {sortedLines.length === 0 ? (
-                <section className={cn(PANEL_VARIANTS.secondary, "rounded-2xl p-4")}>
+                <section className="p-4">
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div>
                       <p className="text-sm font-semibold text-foreground">No jobs added yet.</p>
@@ -1976,7 +2053,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                   </div>
                 </section>
               ) : (
-                <div className="space-y-2.5">
+                <div>
                   {sortedLines.map((ln, idx) => {
                     const activeTechnicianIds = activeTechsByLine[ln.id] ?? [];
                     const punchedIn =
@@ -2099,7 +2176,8 @@ export default function WorkOrderIdClient(): JSX.Element {
                         reviewIssues={reviewIssuesByLine[ln.id] ?? []}
                         canDelete={canDeleteLine}
                         onDelete={() => openDeleteForLine(ln.id)}
-                        compact={showPanel}
+                        display="navigator"
+                        compact
                         selected={isSelectedForPanel}
                         hideExecutionStageCompletenessPills
                         evidence={evidence.filter(
@@ -2127,7 +2205,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                       Open Quote Review
                     </Link>
                   </div>
-                  <div className="grid gap-3 md:grid-cols-2">
+                  <div className="grid gap-3">
                     {approvalPendingQuotes.map((q) => {
                       const meta = isRecord(q.metadata) ? q.metadata : {};
                       const parts = Array.isArray(meta.parts) ? meta.parts : [];
@@ -2152,7 +2230,7 @@ export default function WorkOrderIdClient(): JSX.Element {
                               {String(q.stage ?? q.status ?? "advisor_pending").replaceAll("_", " ")}
                             </span>
                           </div>
-                          <div className="mt-3 grid gap-2 text-xs text-[color:var(--theme-text-secondary)] sm:grid-cols-2">
+                          <div className="mt-3 grid gap-2 text-xs text-[color:var(--theme-text-secondary)]">
                             <div>Tech notes: <span className="text-[color:var(--theme-text-primary)]">{technicianNotes}</span></div>
                             <div>Labor: <span className="text-[color:var(--theme-text-primary)]">{typeof q.labor_hours === "number" ? `${q.labor_hours}h` : typeof q.est_labor_hours === "number" ? `${q.est_labor_hours}h` : "—"}</span></div>
                             <div>Parts: <span className="text-[color:var(--theme-text-primary)]">{parts.length > 0 ? `${parts.length} requirement(s)` : "None / labor-only"}</span></div>
@@ -2213,10 +2291,11 @@ export default function WorkOrderIdClient(): JSX.Element {
                 />
               ) : null}
             </div>
+            </aside>
 
-            {/* Right: focused job workspace pane */}
-            <div className="min-w-0 lg:sticky lg:top-20">
-              {panelLineId ? (
+            {/* Center workspace and right command center are owned by the selected job. */}
+            <div className="min-w-0">
+              {prefersPanel && panelLineId ? (
                 <FocusedJobModal
                   key={panelLineId}
                   isOpen={true}
@@ -2224,19 +2303,37 @@ export default function WorkOrderIdClient(): JSX.Element {
                   workOrderLineId={panelLineId}
                   onChanged={fetchAll}
                   mode="tech"
-                  variant="panel"
+                  variant="cockpit"
                 />
               ) : (
-                <section className={cn(PANEL_VARIANTS.passive, "rounded-2xl p-4 text-sm text-muted-foreground")}>
-                  Select a job
+                <section className="flex min-h-64 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+                  Select a job to open its focused workspace.
                 </section>
               )}
             </div>
           </section>
 
+          {latestDecisionEvent ? (
+            <button
+              type="button"
+              onClick={() => {
+                setShowWoContext(true);
+                setShowTimeline(true);
+              }}
+              className="flex w-full items-center gap-2 border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-left text-[11px] text-[color:var(--theme-text-secondary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+            >
+              <Clock3 className="h-3.5 w-3.5 shrink-0 text-[color:var(--brand-primary)]" />
+              <span className="font-semibold text-[color:var(--theme-text-primary)]">Latest activity</span>
+              <span className="h-1 w-1 rounded-full bg-[color:var(--brand-primary)]" />
+              <span className="truncate">{latestDecisionEvent.label}{latestDecisionEvent.meta ? ` · ${latestDecisionEvent.meta}` : ""}</span>
+              <time className="ml-auto hidden shrink-0 font-mono text-[10px] sm:inline">
+                {format(new Date(latestDecisionEvent.timestamp), "PP p")}
+              </time>
+            </button>
+          ) : null}
+
         </div>
       )}
-      </PageShell>
 
       {/* Focused job modal (mobile fallback) */}
       {!prefersPanel && focusedOpen && focusedJobId && (

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -75,6 +75,7 @@ type JobCardProps = {
   reviewIssues?: ReviewIssue[];
   reviewOk?: boolean;
   compact?: boolean;
+  display?: "card" | "navigator";
   selected?: boolean;
   hideExecutionStageCompletenessPills?: boolean;
   evidence?: WorkOrderEvidenceItem[];
@@ -90,6 +91,8 @@ type StatusVisual = {
 };
 
 const METALLIC_CARD_SURFACE = "bg-[var(--theme-gradient-panel)]";
+const btnLikeNavigatorAction =
+  "inline-flex min-h-8 items-center justify-center rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-1.5 text-[10px] font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)] disabled:cursor-not-allowed disabled:opacity-50";
 
 function norm(s: unknown): string {
   return String(s ?? "")
@@ -340,6 +343,7 @@ export function JobCard({
   reviewIssues,
   reviewOk,
   compact = false,
+  display = "card",
   selected = false,
   hideExecutionStageCompletenessPills = false,
   evidence = [],
@@ -423,6 +427,124 @@ export function JobCard({
     event.stopPropagation();
     onRequestParts?.();
   };
+
+  if (display === "navigator") {
+    return (
+      <article
+        className={cn(
+          "border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] transition",
+          isSelected
+            ? "border-l-[3px] border-l-[color:var(--brand-primary)] bg-[color:var(--theme-surface-subtle)]"
+            : "border-l-[3px] border-l-transparent hover:bg-[color:var(--theme-surface-subtle)]",
+          statusVisual.muted && "opacity-75",
+        )}
+      >
+        <button
+          type="button"
+          onClick={onOpen}
+          className="w-full px-3 py-3 text-left outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[color:var(--brand-primary)]"
+          aria-label={`Open job ${index + 1}: ${jobLabel}`}
+          aria-pressed={isSelected}
+        >
+          <div className="flex items-start gap-2.5">
+            <span className="mt-0.5 inline-flex h-6 min-w-6 items-center justify-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-1.5 text-[11px] font-semibold text-[color:var(--theme-text-primary)]">
+              {index + 1}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="line-clamp-2 text-sm font-semibold leading-5 text-[color:var(--theme-text-primary)]">
+                {jobLabel}
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                {statusVisual.label ? (
+                  <span
+                    className={cn(
+                      "inline-flex rounded-md border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.1em]",
+                      statusVisual.chipClass,
+                    )}
+                  >
+                    {statusVisual.label}
+                  </span>
+                ) : null}
+                {liveMarkerLabel ? (
+                  <span className="inline-flex rounded-md border border-cyan-300/50 bg-cyan-400/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.1em] text-cyan-100">
+                    {liveMarkerLabel}
+                  </span>
+                ) : null}
+              </div>
+              <div className="mt-2 flex items-center justify-between gap-2 text-[11px] text-[color:var(--theme-text-secondary)]">
+                <span className="inline-flex min-w-0 items-center gap-1 truncate">
+                  <UserRound className="h-3.5 w-3.5 shrink-0" />
+                  <span className="truncate">{assignedTech}</span>
+                </span>
+                <span className="shrink-0 font-mono font-semibold text-[color:var(--theme-text-primary)]">
+                  {lineTotal > 0 ? formatCurrency(lineTotal) : "Estimate pending"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </button>
+
+        {isSelected ? (
+          <div className="border-t border-[color:var(--theme-border-soft)] px-3 py-2">
+            {canAssign && onAssign ? (
+              <label className="relative mb-2 block">
+                <UserRound className="pointer-events-none absolute left-2 top-2 h-3.5 w-3.5 text-[color:var(--theme-text-muted)]" />
+                <span className="sr-only">Assigned technician</span>
+                <select
+                  aria-label="Assigned technician"
+                  value={line.assigned_tech_id ?? ""}
+                  onChange={(event) => onAssign(event.target.value)}
+                  className="h-8 w-full appearance-none truncate rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] py-1 pl-7 pr-3 text-[10px] font-semibold text-[color:var(--theme-text-primary)]"
+                >
+                  <option value="" disabled>
+                    Unassigned
+                  </option>
+                  {technicians.map((tech) => (
+                    <option key={tech.id} value={tech.id}>
+                      {tech.full_name || "Unnamed tech"}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+
+            <details className="group">
+              <summary className="cursor-pointer list-none text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]">
+                Job actions
+              </summary>
+              <div className="mt-2 grid grid-cols-2 gap-1.5">
+                {onOpenInspection ? (
+                  <button type="button" className={btnLikeNavigatorAction} onClick={onOpenInspection}>
+                    Inspection
+                  </button>
+                ) : null}
+                {onAddPart ? (
+                  <button type="button" className={btnLikeNavigatorAction} onClick={onAddPart}>
+                    Add part
+                  </button>
+                ) : null}
+                {onRequestParts ? (
+                  <button
+                    type="button"
+                    className={btnLikeNavigatorAction}
+                    onClick={onRequestParts}
+                    disabled={requestPartsBusy}
+                  >
+                    {requestPartsBusy ? "Requesting…" : requestPartsLabel}
+                  </button>
+                ) : null}
+                {showDeleteAction ? (
+                  <button type="button" className={btnLikeNavigatorAction} onClick={onDelete}>
+                    Delete / Void
+                  </button>
+                ) : null}
+              </div>
+            </details>
+          </div>
+        ) : null}
+      </article>
+    );
+  }
 
   return (
     <div

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -5,6 +5,19 @@ import { Dialog } from "@headlessui/react";
 import { format } from "date-fns";
 import { toast } from "sonner";
 import { v4 as uuidv4 } from "uuid";
+import {
+  AlertTriangle,
+  Camera,
+  CheckCircle2,
+  Clock3,
+  History,
+  MessageSquare,
+  PackageSearch,
+  PauseCircle,
+  Plus,
+  Sparkles,
+  UserRound,
+} from "lucide-react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { cn } from "@shared/lib/utils";
 
@@ -42,7 +55,16 @@ import type { RealtimePostgresChangesPayload } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 
 type Mode = "tech" | "view";
-type Variant = "modal" | "panel";
+type Variant = "modal" | "panel" | "cockpit";
+type WorkspaceTab = "overview" | "story" | "parts" | "evidence" | "details";
+
+const WORKSPACE_TABS: ReadonlyArray<{ id: WorkspaceTab; label: string }> = [
+  { id: "overview", label: "Overview" },
+  { id: "story", label: "Story" },
+  { id: "parts", label: "Parts" },
+  { id: "evidence", label: "Evidence" },
+  { id: "details", label: "Details" },
+];
 
 const statusTextColor: Record<string, string> = {
   in_progress: "text-sky-200",
@@ -208,6 +230,7 @@ export default function FocusedJobModal(props: {
   const [openAi, setOpenAi] = useState(false);
   const [openDtc, setOpenDtc] = useState(false);
   const [openVehicleHistory, setOpenVehicleHistory] = useState(false);
+  const [activeWorkspaceTab, setActiveWorkspaceTab] = useState<WorkspaceTab>("overview");
 
   const [prefillCause, setPrefillCause] = useState("");
   const [prefillCorrection, setPrefillCorrection] = useState("");
@@ -264,6 +287,10 @@ export default function FocusedJobModal(props: {
     }
     closeAllSubModals();
   }, [isOpen, workOrderLineId, closeAllSubModals, variant]);
+
+  useEffect(() => {
+    setActiveWorkspaceTab("overview");
+  }, [workOrderLineId]);
 
   useEffect(() => {
     if (!isOpen || !workOrderLineId) return;
@@ -1143,8 +1170,529 @@ export default function FocusedJobModal(props: {
     </div>
   );
 
+  const repairStoryWorkspace = line ? (
+    <section className="border-b border-[color:var(--theme-border-soft)] pb-6">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+            Repair story
+          </div>
+          <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+            Complaint, cause &amp; correction
+          </h3>
+        </div>
+        <button
+          type="button"
+          className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1.5 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+          onClick={() => {
+            closeAllSubModals();
+            setPrefillCause(line.cause ?? "");
+            setPrefillCorrection(line.correction ?? "");
+            setOpenComplete(true);
+          }}
+        >
+          Edit story
+        </button>
+      </div>
+      <dl className="grid gap-3 text-sm">
+        {[
+          ["Complaint", line.complaint?.trim() || line.description?.trim() || "Add complaint"],
+          ["Cause", line.cause?.trim() || "Add cause"],
+          ["Correction", line.correction?.trim() || "Add correction"],
+          ["Blocker", line.hold_reason?.trim() || "None"],
+        ].map(([label, value]) => (
+          <div key={label} className="grid gap-1 sm:grid-cols-[7rem_minmax(0,1fr)] sm:gap-4">
+            <dt className="font-medium text-[color:var(--theme-text-secondary)]">{label}</dt>
+            <dd className="text-[color:var(--theme-text-primary)]">{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  ) : null;
+
+  const partsWorkspace = line ? (
+    <section>
+      <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+            Parts &amp; labor
+          </div>
+          <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+            Job economics and fulfillment
+          </h3>
+        </div>
+        <button
+          type="button"
+          className="rounded-lg border border-sky-400/40 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
+          onClick={() => {
+            closeAllSubModals();
+            setOpenParts(true);
+          }}
+          disabled={busy}
+        >
+          Request parts
+        </button>
+      </div>
+      <div className="grid divide-y divide-[color:var(--theme-border-soft)] border-y border-[color:var(--theme-border-soft)] sm:grid-cols-3 sm:divide-x sm:divide-y-0">
+        <div className="px-3 py-3 sm:first:pl-0">
+          <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Labor</div>
+          <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">{laborDisplay}</div>
+        </div>
+        <div className="px-3 py-3">
+          <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Parts</div>
+          <div className="mt-1 text-sm font-medium text-[color:var(--theme-text-primary)]">
+            {allocsLoading
+              ? "Loading…"
+              : `${allocs.length + requiredParts.length} attached or required`}
+          </div>
+        </div>
+        <div className="px-3 py-3">
+          <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Line total</div>
+          <div className="mt-1 font-mono text-sm font-semibold text-[color:var(--theme-text-primary)]">
+            {lineTotal > 0 ? money(lineTotal) : "Estimate pending"}
+          </div>
+        </div>
+      </div>
+      {partsBottleneckDisplay ? (
+        <div className="mt-4 flex items-start gap-2 rounded-xl border border-amber-400/30 bg-amber-400/8 px-3 py-3 text-sm text-amber-100">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <div>
+            <div className="font-semibold">{partsBottleneckDisplay.heading}</div>
+            <div className="mt-0.5 text-xs text-amber-100/80">{partsBottleneckDisplay.detail}</div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  ) : null;
+
+  const fullPartsWorkspace = line ? (
+    <section>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+            Fulfillment
+          </div>
+          <h3 className="mt-1 text-base font-semibold text-[color:var(--theme-text-primary)]">
+            {partsBottleneckDisplay?.heading ?? "Parts used and required"}
+          </h3>
+        </div>
+        <button
+          type="button"
+          className="rounded-lg border border-sky-400/40 bg-sky-500/10 px-3 py-1.5 text-xs font-semibold text-sky-100 transition hover:bg-sky-500/20"
+          onClick={() => {
+            closeAllSubModals();
+            setOpenParts(true);
+          }}
+          disabled={busy}
+        >
+          Request parts
+        </button>
+      </div>
+      {allocsLoading ? (
+        <div className="text-sm text-[color:var(--theme-text-secondary)]">Loading…</div>
+      ) : allocs.length + requiredParts.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] px-4 py-8 text-center text-sm text-[color:var(--theme-text-secondary)]">
+          {partsBottleneckDisplay?.detail ?? "No parts used yet."}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-xl border border-[color:var(--theme-border-soft)]">
+          <div className="grid grid-cols-12 bg-[color:var(--theme-surface-subtle)] px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.15em] text-[color:var(--theme-text-secondary)]">
+            <div className="col-span-7">Part</div>
+            <div className="col-span-3">Price / location</div>
+            <div className="col-span-2 text-right">Qty</div>
+          </div>
+          <ul className="divide-y divide-[color:var(--theme-border-soft)]">
+            {requiredParts.map((part) => {
+              const qty = getCanonicalPartQuantity(part);
+              const unit = getCanonicalPartUnitPrice(part);
+              return (
+                <li key={`cockpit-required-${part.id}`} className="grid grid-cols-12 items-center gap-2 px-3 py-3 text-sm">
+                  <div className="col-span-7 min-w-0 text-[color:var(--theme-text-primary)]">
+                    <div className="truncate font-medium">{getCanonicalPartDescription(part) ?? "Part"}</div>
+                    <div className="mt-0.5 truncate text-[11px] text-[color:var(--theme-text-secondary)]">
+                      {[getCanonicalPartNumber(part), getCanonicalPartManufacturer(part), part.lifecycle_status ?? "requested"].filter(Boolean).join(" • ")}
+                    </div>
+                  </div>
+                  <div className="col-span-3 truncate text-[color:var(--theme-text-secondary)]">{unit > 0 ? money(unit) : "—"}</div>
+                  <div className="col-span-2 text-right font-semibold text-[color:var(--theme-text-primary)]">{qty}</div>
+                </li>
+              );
+            })}
+            {allocs.map((allocation) => {
+              const qty =
+                (allocation as unknown as { qty?: number | null }).qty ??
+                (allocation as unknown as { quantity?: number | null }).quantity ??
+                0;
+              const locationId = (allocation as unknown as { location_id?: string | null }).location_id;
+              return (
+                <li key={`cockpit-allocated-${allocation.id}`} className="grid grid-cols-12 items-center gap-2 px-3 py-3 text-sm">
+                  <div className="col-span-7 truncate font-medium text-[color:var(--theme-text-primary)]">{allocation.parts?.name ?? "Part"}</div>
+                  <div className="col-span-3 truncate text-[color:var(--theme-text-secondary)]">{locationId ? `loc ${locationId.slice(0, 6)}…` : "—"}</div>
+                  <div className="col-span-2 text-right font-semibold text-[color:var(--theme-text-primary)]">{qty}</div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </section>
+  ) : null;
+
+  const CockpitBody = (
+    <div
+      data-work-order-cockpit="true"
+      className="grid min-h-[40rem] overflow-hidden border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] lg:h-[calc(100vh-13.5rem)] lg:min-h-[42rem] lg:grid-cols-[minmax(0,1fr)_21rem]"
+    >
+      <section className="flex min-h-0 min-w-0 flex-col bg-[color:var(--theme-surface-page)]">
+        <header className="border-b border-[color:var(--theme-border-soft)] px-5 pb-0 pt-4">
+          <div className="flex flex-wrap items-start justify-between gap-3 pb-4">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="inline-flex h-2.5 w-2.5 rounded-full bg-[color:var(--brand-primary)]" aria-hidden="true" />
+                <span className={`text-[10px] font-semibold uppercase tracking-[0.16em] ${chip(normalizedLineStatus)}`}>
+                  {statusLabel}
+                </span>
+                {line?.approval_state ? (
+                  <span className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
+                    Approval {line.approval_state}
+                  </span>
+                ) : null}
+              </div>
+              <h2 className="mt-2 line-clamp-2 text-lg font-semibold tracking-tight text-[color:var(--theme-text-primary)]">
+                {titleText}
+              </h2>
+              <div className="mt-1 font-mono text-[11px] text-[color:var(--theme-text-muted)]">
+                {workOrder ? `WO ${workOrder.custom_id || workOrder.id.slice(0, 8)}` : "Selected job"}
+              </div>
+            </div>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+              onClick={() => {
+                closeAllSubModals();
+                setOpenAddJob(true);
+              }}
+              disabled={busy || !workOrder?.id}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Add job
+            </button>
+          </div>
+          <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="Selected job workspace">
+            {WORKSPACE_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                aria-selected={activeWorkspaceTab === tab.id}
+                onClick={() => setActiveWorkspaceTab(tab.id)}
+                className={cn(
+                  "border-b-2 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] transition",
+                  activeWorkspaceTab === tab.id
+                    ? "border-[color:var(--brand-primary)] text-[color:var(--theme-text-primary)]"
+                    : "border-transparent text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]",
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6">
+          {busy && !line ? (
+            <div className="grid gap-3">
+              <div className="h-6 w-40 animate-pulse rounded bg-[color:var(--theme-surface-subtle)]" />
+              <div className="h-32 animate-pulse rounded-xl bg-[color:var(--theme-surface-subtle)]" />
+            </div>
+          ) : !line ? (
+            <div className="text-sm text-[color:var(--theme-text-secondary)]">No job found.</div>
+          ) : activeWorkspaceTab === "overview" ? (
+            <div className="space-y-6">
+              {repairStoryWorkspace}
+              {partsWorkspace}
+              {workOrder?.id ? (
+                <section className="border-t border-[color:var(--theme-border-soft)] pt-6">
+                  <WorkOrderMediaGallery
+                    workOrderId={workOrder.id}
+                    workOrderLineId={workOrderLineId}
+                    refreshKey={mediaRefreshKey}
+                  />
+                </section>
+              ) : null}
+            </div>
+          ) : activeWorkspaceTab === "story" ? (
+            <div className="space-y-6">
+              {repairStoryWorkspace}
+              <section>
+                <div className="mb-3 text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+                  Technician notes
+                </div>
+                <textarea
+                  rows={10}
+                  value={techNotes}
+                  onChange={(event) => setTechNotes(event.target.value)}
+                  onBlur={saveNotes}
+                  disabled={savingNotes}
+                  className="w-full resize-y rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-3 text-sm leading-6 text-[color:var(--theme-text-primary)] placeholder:text-[color:var(--theme-text-muted)] focus:border-[color:var(--brand-primary)] focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-primary)]/20"
+                  placeholder="Add notes for this job…"
+                />
+                <div className="mt-2 text-[11px] text-[color:var(--theme-text-muted)]">
+                  Notes save when focus leaves the field.
+                </div>
+              </section>
+            </div>
+          ) : activeWorkspaceTab === "parts" ? (
+            fullPartsWorkspace
+          ) : activeWorkspaceTab === "evidence" ? (
+            workOrder?.id ? (
+              <WorkOrderMediaGallery
+                workOrderId={workOrder.id}
+                workOrderLineId={workOrderLineId}
+                refreshKey={mediaRefreshKey}
+              />
+            ) : null
+          ) : (
+            <div className="space-y-6">
+              <section>
+                <div className="mb-4 text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--theme-text-muted)]">
+                  Job details
+                </div>
+                <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-3">
+                  <MetaStat label="Start" value={createdStart} />
+                  <MetaStat label="Finish" value={createdFinish} />
+                  <MetaStat label="Hold reason" value={line.hold_reason ?? "—"} />
+                  <MetaStat label="Job type" value={String(line.job_type ?? "—").replaceAll("_", " ")} />
+                  <MetaStat label="Primary tech" value={primaryTechDisplay} />
+                  <MetaStat label="Labor" value={laborDisplay} />
+                  <MetaStat label="Line total" value={lineTotal > 0 ? money(lineTotal) : "Estimate pending"} />
+                </div>
+              </section>
+              <section className="border-t border-[color:var(--theme-border-soft)] pt-6">
+                <details className="group">
+                  <summary className="cursor-pointer text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                    AI suggested repairs
+                  </summary>
+                  <div className="mt-3">
+                    {line && workOrder ? (
+                      <SuggestedQuickAdd
+                        jobId={line.id}
+                        workOrderId={workOrder.id}
+                        vehicleId={vehicle?.id ?? null}
+                        onAdded={async () => {
+                          toast.success("Suggested line added");
+                          await refresh();
+                        }}
+                      />
+                    ) : null}
+                  </div>
+                </details>
+              </section>
+              <div className="font-mono text-[11px] text-[color:var(--theme-text-muted)]">
+                Job ID {line.id}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <aside className="min-h-0 overflow-y-auto border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] lg:border-l lg:border-t-0">
+        <div className="border-b border-[color:var(--theme-border-soft)] px-4 py-4">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">
+            Command center
+          </div>
+          <div className="mt-4 grid gap-3">
+            <div className="flex items-start gap-3">
+              <Clock3 className="mt-0.5 h-5 w-5 text-sky-300" />
+              <div>
+                <div className="text-[11px] text-[color:var(--theme-text-secondary)]">Current state</div>
+                <div className={`mt-0.5 text-sm font-semibold ${chip(normalizedLineStatus)}`}>{statusLabel}</div>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <AlertTriangle className={cn("mt-0.5 h-5 w-5", line?.hold_reason ? "text-amber-300" : "text-[color:var(--theme-text-muted)]")} />
+              <div>
+                <div className="text-[11px] text-[color:var(--theme-text-secondary)]">Blocker</div>
+                <div className="mt-0.5 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  {line?.hold_reason || partsBottleneckDisplay?.detail || "None"}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {line ? (
+          <div className="space-y-4 px-4 py-4">
+            {mode === "tech" ? (
+              <section>
+                <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                  Next action
+                </div>
+                {line.status !== "completed" ? (
+                  <JobPunchButton
+                    lineId={line.id}
+                    punchedInAt={line.punched_in_at}
+                    punchedOutAt={line.punched_out_at}
+                    status={line.status as WorkflowStatus}
+                    onFinishRequested={() => {
+                      closeAllSubModals();
+                      setPrefillCause(line.cause ?? "");
+                      setPrefillCorrection(line.correction ?? "");
+                      setOpenComplete(true);
+                    }}
+                    onUpdated={refresh}
+                    disabled={completionBlocked}
+                  />
+                ) : (
+                  <div className="flex items-center gap-2 rounded-xl border border-emerald-400/30 bg-emerald-400/10 px-3 py-3 text-sm font-semibold text-emerald-100">
+                    <CheckCircle2 className="h-4 w-4" />
+                    Job completed
+                  </div>
+                )}
+
+                <div className="mt-2 grid grid-cols-2 gap-2">
+                  <button
+                    type="button"
+                    className={cn(btnInfo, "gap-1.5 text-xs")}
+                    onClick={() => {
+                      closeAllSubModals();
+                      setOpenParts(true);
+                    }}
+                    disabled={busy}
+                  >
+                    <PackageSearch className="h-4 w-4" />
+                    Parts
+                  </button>
+                  <button
+                    type="button"
+                    className={cn(btnInfo, "gap-1.5 text-xs")}
+                    onClick={() => {
+                      closeAllSubModals();
+                      setOpenHold(true);
+                    }}
+                    disabled={busy}
+                  >
+                    <PauseCircle className="h-4 w-4" />
+                    {normalizedLineStatus === "on_hold" ? "On hold" : "Hold"}
+                  </button>
+                  <button
+                    type="button"
+                    className={cn(btnTertiary, "gap-1.5 text-xs")}
+                    onClick={() => {
+                      closeAllSubModals();
+                      setOpenPhoto(true);
+                    }}
+                    disabled={busy}
+                  >
+                    <Camera className="h-4 w-4" />
+                    Add photo
+                  </button>
+                  <button
+                    type="button"
+                    className={cn(btnTertiary, "gap-1.5 text-xs")}
+                    onClick={() => {
+                      closeAllSubModals();
+                      setOpenChat(true);
+                    }}
+                  >
+                    <MessageSquare className="h-4 w-4" />
+                    Message
+                  </button>
+                  <button
+                    type="button"
+                    className={cn(btnTertiary, "gap-1.5 text-xs")}
+                    onClick={() => {
+                      closeAllSubModals();
+                      setOpenAi(true);
+                    }}
+                  >
+                    <Sparkles className="h-4 w-4" />
+                    AI assist
+                  </button>
+                  <button
+                    type="button"
+                    className={cn(btnTertiary, "gap-1.5 text-xs")}
+                    onClick={() => {
+                      if (!vehicle?.id) {
+                        toast.error("No vehicle linked to this work order yet.");
+                        return;
+                      }
+                      closeAllSubModals();
+                      setOpenVehicleHistory(true);
+                    }}
+                    disabled={busy || !vehicle?.id}
+                  >
+                    <History className="h-4 w-4" />
+                    History
+                  </button>
+                </div>
+
+                <button
+                  type="button"
+                  className={cn(btnDanger, "mt-2 w-full text-xs")}
+                  onClick={() => {
+                    closeAllSubModals();
+                    setPrefillCause(line.cause ?? "");
+                    setPrefillCorrection(line.correction ?? "");
+                    setOpenComplete(true);
+                  }}
+                  disabled={completionBlocked}
+                >
+                  Complete job
+                </button>
+
+                {completionBlocked ? (
+                  <div className="mt-2 text-[11px] text-amber-300">
+                    {normalizedLineStatus === "awaiting_approval"
+                      ? "Awaiting approval — labor actions disabled"
+                      : normalizedLineStatus === "declined"
+                        ? "Declined — labor actions disabled"
+                        : line.approval_state && line.approval_state !== "approved"
+                          ? "Not approved — labor actions disabled"
+                          : ""}
+                  </div>
+                ) : null}
+              </section>
+            ) : null}
+
+            <section className="border-t border-[color:var(--theme-border-soft)] pt-4">
+              <div className="grid gap-3 text-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[color:var(--theme-text-secondary)]">Approval</span>
+                  <span className="font-semibold capitalize text-[color:var(--theme-text-primary)]">{line.approval_state ?? "—"}</span>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[color:var(--theme-text-secondary)]">Primary tech</span>
+                  <span className="inline-flex min-w-0 items-center gap-1.5 truncate font-semibold text-[color:var(--theme-text-primary)]">
+                    <UserRound className="h-4 w-4 shrink-0" />
+                    {primaryTechDisplay}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[color:var(--theme-text-secondary)]">Line total</span>
+                  <span className="font-mono font-semibold text-[color:var(--theme-text-primary)]">{lineTotal > 0 ? money(lineTotal) : "—"}</span>
+                </div>
+              </div>
+            </section>
+
+            <section className="border-t border-[color:var(--theme-border-soft)] pt-4">
+              <div className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">Timing</div>
+              <dl className="mt-3 grid gap-2 text-xs">
+                <div className="flex justify-between gap-3"><dt className="text-[color:var(--theme-text-secondary)]">Start</dt><dd className="text-right text-[color:var(--theme-text-primary)]">{createdStart}</dd></div>
+                <div className="flex justify-between gap-3"><dt className="text-[color:var(--theme-text-secondary)]">Finish</dt><dd className="text-right text-[color:var(--theme-text-primary)]">{createdFinish}</dd></div>
+                <div className="flex justify-between gap-3"><dt className="text-[color:var(--theme-text-secondary)]">Labor</dt><dd className="text-right text-[color:var(--theme-text-primary)]">{laborDisplay}</dd></div>
+              </dl>
+            </section>
+          </div>
+        ) : null}
+      </aside>
+    </div>
+  );
+
   const Shell =
-    variant === "panel" ? (
+    variant === "cockpit" ? (
+      <div className="relative h-full">{CockpitBody}</div>
+    ) : variant === "panel" ? (
       <div className="relative h-full">{Body}</div>
     ) : (
       <Dialog

--- a/tests/work-order-cockpit-layout.test.ts
+++ b/tests/work-order-cockpit-layout.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const detail = readFileSync("app/work-orders/[id]/Client.tsx", "utf8");
+const focusedJob = readFileSync(
+  "features/work-orders/components/workorders/FocusedJobModal.tsx",
+  "utf8",
+);
+const jobCard = readFileSync(
+  "features/work-orders/components/JobCard.tsx",
+  "utf8",
+);
+
+describe("desktop work-order cockpit", () => {
+  it("uses stable navigator, workspace, command-center, and activity surfaces", () => {
+    expect(detail).toContain('display="navigator"');
+    expect(detail).toContain('variant="cockpit"');
+    expect(detail).toContain("Latest activity");
+    expect(detail).not.toContain("<PageShell");
+
+    expect(focusedJob).toContain('data-work-order-cockpit="true"');
+    expect(focusedJob).toContain("Command center");
+    expect(focusedJob).toContain('role="tablist"');
+    expect(focusedJob).toContain('activeWorkspaceTab === "overview"');
+    expect(jobCard).toContain('display === "navigator"');
+  });
+
+  it("keeps canonical work-order actions behind their existing handlers", () => {
+    expect(detail).toContain("assignWorkOrderLineTechnician");
+    expect(detail).toContain("requestAllPartsForLine");
+    expect(detail).toContain("openInspectionForLine");
+    expect(detail).toContain("<DeleteOrVoidLineModal");
+    expect(detail).toContain("<PartsDrawer");
+    expect(detail).toContain('variant="modal"');
+
+    expect(focusedJob).toContain('runJobPunchTransition(workOrderLineId, "pause"');
+    expect(focusedJob).toContain('runJobPunchTransition(workOrderLineId, "resume"');
+    expect(focusedJob).toContain('runJobPunchTransition(line.id, "finish"');
+    expect(focusedJob).toContain("<PartsRequestModal");
+    expect(focusedJob).toContain("<PhotoCaptureModal");
+    expect(focusedJob).toContain("<NewChatModal");
+    expect(focusedJob).toContain("<AIAssistantModal");
+    expect(focusedJob).toContain("<VehicleHistoryModal");
+  });
+});


### PR DESCRIPTION
## What changed

- Reworked the desktop work-order detail into a fixed navigator, selected-job workspace, and persistent command center.
- Added focused Overview, Story, Parts, Evidence, and Details tabs.
- Preserved Context & AI, approvals, activity, pending quotes, informational lines, and the mobile modal fallback.
- Added a compact navigator presentation to the existing JobCard.
- Added a regression contract for the cockpit layout and canonical action wiring.

## Why

The previous page grew vertically with every job and duplicated selected-job content, making long work orders harder to scan and pushing operational actions off-screen. The cockpit keeps the active job and its actions visible for an all-day workflow.

## Safety / impact

This is a presentation-focused redesign. It reuses the existing canonical APIs, helpers, and transitions for assignment, punches, holds, completion, parts, evidence, inspections, approvals, chat, AI, and delete/void. No database schema, API contract, migration, or environment-variable changes are included.

## Validation

- TypeScript: passed
- Focused ESLint: passed
- Work-order regression suite: 8 files / 57 tests passed
- Production build: application compilation and lint/type phases passed; page-data collection cannot complete in the isolated local copy because its existing Supabase environment values are unavailable