### PR TITLE
Fix approval-time release of menu parts

### DIFF
--- a/supabase/migrations/20260804130000_fix_approval_menu_part_release.sql
+++ b/supabase/migrations/20260804130000_fix_approval_menu_part_release.sql
@@ -37,7 +37,9 @@ create unique index uq_pri_line_desc_nullpart
   )
   where part_id is null
     and work_order_line_id is not null
-    and source_work_order_part_id is null;
+    and source_work_order_part_id is null
+    and approved is true
+    and nullif(trim(description), '') is not null;
 
 -- Preserve menu-part identity on every new staged work-order part. This is
 -- consumed by the approval-time Parts release and by quote/invoice display.
@@ -96,11 +98,11 @@ begin
     select case
       when mip.part_id is not null then
         coalesce(
-          p.default_price,
           p.price,
+          p.default_price,
           mip.unit_cost,
-          p.default_cost,
           p.cost,
+          p.default_cost,
           0
         )::numeric
       else coalesce(mip.unit_cost, 0)::numeric
@@ -113,9 +115,16 @@ begin
 end;
 $$;
 
+drop trigger if exists trg_wol_copy_menu_parts
+  on public.work_order_lines;
+create trigger trg_wol_copy_menu_parts
+after insert on public.work_order_lines
+for each row
+execute function public.wol_copy_menu_parts_to_work_order_parts();
+
 -- Repair historical menu-derived rows that were staged before the trigger
--- copied snapshots. Matching uses the same quantity and sell-price contract
--- as the trigger; an ordinal only disambiguates financially identical rows.
+-- copied snapshots. Only one-to-one financial matches on mutable work orders
+-- are safe to repair; ambiguous or locked rows are deliberately left alone.
 with menu_candidates as (
   select
     wol.id as work_order_line_id,
@@ -142,7 +151,7 @@ with menu_candidates as (
     nullif(trim(p.part_number), '') as part_number_snapshot,
     nullif(trim(p.manufacturer), '') as manufacturer_snapshot,
     coalesce(mip.unit_cost, p.default_cost, p.cost) as unit_cost_snapshot,
-    row_number() over (
+    count(*) over (
       partition by
         wol.id,
         greatest(1, coalesce(round(mip.quantity)::int, 1)),
@@ -158,8 +167,7 @@ with menu_candidates as (
             )::numeric
           else coalesce(mip.unit_cost, 0)::numeric
         end
-      order by mip.id
-    ) as match_ordinal
+    ) as match_count
   from public.work_order_lines wol
   join public.menu_item_parts mip
     on mip.menu_item_id = wol.menu_item_id
@@ -168,19 +176,22 @@ with menu_candidates as (
     on p.id = mip.part_id
    and (p.shop_id is null or p.shop_id = wol.shop_id)
   where wol.menu_item_id is not null
+    and not public.work_order_is_financially_locked(
+      wol.shop_id,
+      wol.work_order_id
+    )
 ), work_order_candidates as (
   select
     wop.id,
     wop.work_order_line_id,
     coalesce(wop.quantity, 0)::numeric as quantity,
     coalesce(wop.unit_price, 0)::numeric as sell_price,
-    row_number() over (
+    count(*) over (
       partition by
         wop.work_order_line_id,
         coalesce(wop.quantity, 0),
         coalesce(wop.unit_price, 0)
-      order by wop.id
-    ) as match_ordinal
+    ) as match_count
   from public.work_order_parts wop
   where nullif(trim(wop.description_snapshot), '') is null
 ), matched as (
@@ -190,13 +201,14 @@ with menu_candidates as (
     menu.part_number_snapshot,
     menu.manufacturer_snapshot,
     menu.unit_cost_snapshot,
-    menu.sell_price
+    wop.sell_price
   from work_order_candidates wop
   join menu_candidates menu
     on menu.work_order_line_id = wop.work_order_line_id
    and menu.quantity = wop.quantity
    and menu.sell_price = wop.sell_price
-   and menu.match_ordinal = wop.match_ordinal
+   and menu.match_count = 1
+   and wop.match_count = 1
 )
 update public.work_order_parts wop
 set description_snapshot = matched.description_snapshot,

--- a/supabase/migrations/20260804130000_fix_approval_menu_part_release.sql
+++ b/supabase/migrations/20260804130000_fix_approval_menu_part_release.sql
@@ -1,0 +1,226 @@
+begin;
+
+-- Canonical request items are identified by the work-order part they came
+-- from. Legacy/manual items without that source still use the line-level
+-- part/description guards.
+do $$
+begin
+  if exists (
+    select 1
+    from public.part_request_items
+    where source_work_order_part_id is not null
+    group by request_id, source_work_order_part_id
+    having count(*) > 1
+  ) then
+    raise exception
+      'Cannot enforce request/source work-order-part uniqueness: duplicates exist.';
+  end if;
+end
+$$;
+
+create unique index if not exists uq_pri_request_source_work_order_part
+  on public.part_request_items(request_id, source_work_order_part_id)
+  where source_work_order_part_id is not null;
+
+drop index if exists public.uq_pri_line_part;
+create unique index uq_pri_line_part
+  on public.part_request_items(work_order_line_id, part_id)
+  where part_id is not null
+    and work_order_line_id is not null
+    and source_work_order_part_id is null;
+
+drop index if exists public.uq_pri_line_desc_nullpart;
+create unique index uq_pri_line_desc_nullpart
+  on public.part_request_items(
+    work_order_line_id,
+    lower(trim(description))
+  )
+  where part_id is null
+    and work_order_line_id is not null
+    and source_work_order_part_id is null;
+
+-- Preserve menu-part identity on every new staged work-order part. This is
+-- consumed by the approval-time Parts release and by quote/invoice display.
+create or replace function public.wol_copy_menu_parts_to_work_order_parts()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_shop uuid;
+begin
+  if new.menu_item_id is null then
+    return new;
+  end if;
+
+  v_shop := new.shop_id;
+
+  insert into public.work_order_parts (
+    work_order_id,
+    work_order_line_id,
+    part_id,
+    quantity,
+    unit_price,
+    total_price,
+    shop_id,
+    description_snapshot,
+    part_number_snapshot,
+    manufacturer_snapshot,
+    unit_cost_snapshot,
+    unit_sell_price_snapshot
+  )
+  select
+    new.work_order_id,
+    new.id,
+    mip.part_id,
+    greatest(1, coalesce(round(mip.quantity)::int, 1)),
+    prices.sell_price,
+    greatest(1, coalesce(round(mip.quantity)::int, 1))
+      * prices.sell_price,
+    v_shop,
+    coalesce(
+      nullif(trim(mip.name), ''),
+      nullif(trim(p.name), ''),
+      'Menu part ' || left(mip.id::text, 8)
+    ),
+    nullif(trim(p.part_number), ''),
+    nullif(trim(p.manufacturer), ''),
+    coalesce(mip.unit_cost, p.default_cost, p.cost),
+    prices.sell_price
+  from public.menu_item_parts mip
+  left join public.parts p
+    on p.id = mip.part_id
+   and (p.shop_id is null or p.shop_id = v_shop)
+  cross join lateral (
+    select case
+      when mip.part_id is not null then
+        coalesce(
+          p.default_price,
+          p.price,
+          mip.unit_cost,
+          p.default_cost,
+          p.cost,
+          0
+        )::numeric
+      else coalesce(mip.unit_cost, 0)::numeric
+    end as sell_price
+  ) prices
+  where mip.menu_item_id = new.menu_item_id
+    and (mip.shop_id is null or mip.shop_id = v_shop);
+
+  return new;
+end;
+$$;
+
+-- Repair historical menu-derived rows that were staged before the trigger
+-- copied snapshots. Matching uses the same quantity and sell-price contract
+-- as the trigger; an ordinal only disambiguates financially identical rows.
+with menu_candidates as (
+  select
+    wol.id as work_order_line_id,
+    mip.id as menu_item_part_id,
+    greatest(1, coalesce(round(mip.quantity)::int, 1))::numeric
+      as quantity,
+    case
+      when mip.part_id is not null then
+        coalesce(
+          p.default_price,
+          p.price,
+          mip.unit_cost,
+          p.default_cost,
+          p.cost,
+          0
+        )::numeric
+      else coalesce(mip.unit_cost, 0)::numeric
+    end as sell_price,
+    coalesce(
+      nullif(trim(mip.name), ''),
+      nullif(trim(p.name), ''),
+      'Menu part ' || left(mip.id::text, 8)
+    ) as description_snapshot,
+    nullif(trim(p.part_number), '') as part_number_snapshot,
+    nullif(trim(p.manufacturer), '') as manufacturer_snapshot,
+    coalesce(mip.unit_cost, p.default_cost, p.cost) as unit_cost_snapshot,
+    row_number() over (
+      partition by
+        wol.id,
+        greatest(1, coalesce(round(mip.quantity)::int, 1)),
+        case
+          when mip.part_id is not null then
+            coalesce(
+              p.default_price,
+              p.price,
+              mip.unit_cost,
+              p.default_cost,
+              p.cost,
+              0
+            )::numeric
+          else coalesce(mip.unit_cost, 0)::numeric
+        end
+      order by mip.id
+    ) as match_ordinal
+  from public.work_order_lines wol
+  join public.menu_item_parts mip
+    on mip.menu_item_id = wol.menu_item_id
+   and (mip.shop_id is null or mip.shop_id = wol.shop_id)
+  left join public.parts p
+    on p.id = mip.part_id
+   and (p.shop_id is null or p.shop_id = wol.shop_id)
+  where wol.menu_item_id is not null
+), work_order_candidates as (
+  select
+    wop.id,
+    wop.work_order_line_id,
+    coalesce(wop.quantity, 0)::numeric as quantity,
+    coalesce(wop.unit_price, 0)::numeric as sell_price,
+    row_number() over (
+      partition by
+        wop.work_order_line_id,
+        coalesce(wop.quantity, 0),
+        coalesce(wop.unit_price, 0)
+      order by wop.id
+    ) as match_ordinal
+  from public.work_order_parts wop
+  where nullif(trim(wop.description_snapshot), '') is null
+), matched as (
+  select
+    wop.id,
+    menu.description_snapshot,
+    menu.part_number_snapshot,
+    menu.manufacturer_snapshot,
+    menu.unit_cost_snapshot,
+    menu.sell_price
+  from work_order_candidates wop
+  join menu_candidates menu
+    on menu.work_order_line_id = wop.work_order_line_id
+   and menu.quantity = wop.quantity
+   and menu.sell_price = wop.sell_price
+   and menu.match_ordinal = wop.match_ordinal
+)
+update public.work_order_parts wop
+set description_snapshot = matched.description_snapshot,
+    part_number_snapshot = coalesce(
+      wop.part_number_snapshot,
+      matched.part_number_snapshot
+    ),
+    manufacturer_snapshot = coalesce(
+      wop.manufacturer_snapshot,
+      matched.manufacturer_snapshot
+    ),
+    unit_cost_snapshot = coalesce(
+      wop.unit_cost_snapshot,
+      matched.unit_cost_snapshot
+    ),
+    unit_sell_price_snapshot = coalesce(
+      wop.unit_sell_price_snapshot,
+      matched.sell_price
+    ),
+    updated_at = now()
+from matched
+where wop.id = matched.id;
+
+comment on function public.wol_copy_menu_parts_to_work_order_parts() is
+  'Stages menu parts with durable identity and pricing snapshots for approval-time Parts release.';
+
+commit;

--- a/tests/parts/approval-menu-part-release-migration.test.ts
+++ b/tests/parts/approval-menu-part-release-migration.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260804130000_fix_approval_menu_part_release.sql",
+  "utf8",
+);
+
+describe("approval-time menu parts release migration", () => {
+  it("uses source work-order-part identity for canonical request items", () => {
+    expect(migration).toContain(
+      "uq_pri_request_source_work_order_part",
+    );
+    expect(migration).toContain(
+      "on public.part_request_items(request_id, source_work_order_part_id)",
+    );
+    expect(migration.match(/and source_work_order_part_id is null;/g)).toHaveLength(2);
+  });
+
+  it("preserves the legacy line-level duplicate guards", () => {
+    expect(migration).toContain("create unique index uq_pri_line_part");
+    expect(migration).toContain("create unique index uq_pri_line_desc_nullpart");
+    expect(migration).toContain("lower(trim(description))");
+  });
+
+  it("stages durable menu identity and pricing snapshots going forward", () => {
+    expect(migration).toContain(
+      "function public.wol_copy_menu_parts_to_work_order_parts()",
+    );
+    for (const column of [
+      "description_snapshot",
+      "part_number_snapshot",
+      "manufacturer_snapshot",
+      "unit_cost_snapshot",
+      "unit_sell_price_snapshot",
+    ]) {
+      expect(migration).toContain(column);
+    }
+    expect(migration).toContain("'Menu part ' || left(mip.id::text, 8)");
+  });
+
+  it("repairs only historical menu-derived rows missing descriptions", () => {
+    expect(migration).toContain("with menu_candidates as");
+    expect(migration).toContain("join public.menu_item_parts mip");
+    expect(migration).toContain(
+      "where nullif(trim(wop.description_snapshot), '') is null",
+    );
+    expect(migration).toContain("menu.match_ordinal = wop.match_ordinal");
+  });
+
+  it("contains no production row identifiers", () => {
+    expect(migration).not.toMatch(
+      /a2be3728|d29739dd|e8f0dd57|e9e87cda/i,
+    );
+  });
+});

--- a/tests/parts/approval-menu-part-release-migration.test.ts
+++ b/tests/parts/approval-menu-part-release-migration.test.ts
@@ -21,6 +21,7 @@ describe("approval-time menu parts release migration", () => {
     expect(migration).toContain("create unique index uq_pri_line_part");
     expect(migration).toContain("create unique index uq_pri_line_desc_nullpart");
     expect(migration).toContain("lower(trim(description))");
+    expect(migration).toContain("and approved is true");
   });
 
   it("stages durable menu identity and pricing snapshots going forward", () => {
@@ -37,15 +38,20 @@ describe("approval-time menu parts release migration", () => {
       expect(migration).toContain(column);
     }
     expect(migration).toContain("'Menu part ' || left(mip.id::text, 8)");
+    expect(migration).toContain("create trigger trg_wol_copy_menu_parts");
+    expect(migration).toContain("p.price,\n          p.default_price");
   });
 
-  it("repairs only historical menu-derived rows missing descriptions", () => {
+  it("repairs only safe one-to-one historical menu matches", () => {
     expect(migration).toContain("with menu_candidates as");
     expect(migration).toContain("join public.menu_item_parts mip");
     expect(migration).toContain(
       "where nullif(trim(wop.description_snapshot), '') is null",
     );
-    expect(migration).toContain("menu.match_ordinal = wop.match_ordinal");
+    expect(migration).toContain("menu.match_count = 1");
+    expect(migration).toContain("wop.match_count = 1");
+    expect(migration).toContain("not public.work_order_is_financially_locked");
+    expect(migration).not.toContain("row_number()");
   });
 
   it("contains no production row identifiers", () => {

--- a/tests/parts/use-part-handoff.runtime.sql
+++ b/tests/parts/use-part-handoff.runtime.sql
@@ -96,17 +96,29 @@ insert into public.parts (
   default_cost,
   price,
   default_price
-) values (
-  'e0000000-0000-4000-8000-000000000001',
-  'a0000000-0000-4000-8000-000000000001',
-  'Runtime Brake Pad',
-  'RUNTIME-BP',
-  'RUNTIME-BP',
-  10,
-  11,
-  null,
-  25
-);
+) values
+  (
+    'e0000000-0000-4000-8000-000000000001',
+    'a0000000-0000-4000-8000-000000000001',
+    'Runtime Brake Pad',
+    'RUNTIME-BP',
+    'RUNTIME-BP',
+    10,
+    11,
+    null,
+    25
+  ),
+  (
+    'e0000000-0000-4000-8000-000000000002',
+    'a0000000-0000-4000-8000-000000000001',
+    'Runtime Rotor',
+    'RUNTIME-ROT',
+    'RUNTIME-ROT',
+    20,
+    22,
+    null,
+    50
+  );
 
 insert into public.stock_locations (id, shop_id, code, name)
 values (
@@ -955,7 +967,7 @@ insert into public.part_request_items (
     'a0000000-0000-4000-8000-000000000001',
     'c0000000-0000-4000-8000-000000000001',
     'd0000000-0000-4000-8000-000000000001',
-    'e0000000-0000-4000-8000-000000000001',
+    'e0000000-0000-4000-8000-000000000002',
     'Runtime rollback missing allocation',
     1,
     1,

--- a/tests/parts/use-part-handoff.runtime.sql
+++ b/tests/parts/use-part-handoff.runtime.sql
@@ -909,6 +909,22 @@ $$;
 
 -- Build an inconsistent two-item package. The second item advertises reserved
 -- stock but has no allocation, so Complete must roll back the first item issue.
+insert into public.work_order_lines (
+  id,
+  work_order_id,
+  shop_id,
+  status,
+  approval_state,
+  assigned_tech_id
+) values (
+  'd0000000-0000-4000-8000-000000000002',
+  'c0000000-0000-4000-8000-000000000001',
+  'a0000000-0000-4000-8000-000000000001',
+  'active',
+  'approved',
+  '10000000-0000-4000-8000-000000000001'
+);
+
 insert into public.part_requests (
   id,
   shop_id,
@@ -920,7 +936,7 @@ insert into public.part_requests (
   '92000000-0000-4000-8000-000000000002',
   'a0000000-0000-4000-8000-000000000001',
   'c0000000-0000-4000-8000-000000000001',
-  'd0000000-0000-4000-8000-000000000001',
+  'd0000000-0000-4000-8000-000000000002',
   '10000000-0000-4000-8000-000000000001',
   'approved'
 );
@@ -948,7 +964,7 @@ insert into public.part_request_items (
     '92000000-0000-4000-8000-000000000002',
     'a0000000-0000-4000-8000-000000000001',
     'c0000000-0000-4000-8000-000000000001',
-    'd0000000-0000-4000-8000-000000000001',
+    'd0000000-0000-4000-8000-000000000002',
     'e0000000-0000-4000-8000-000000000001',
     'Runtime rollback first item',
     1,
@@ -966,7 +982,7 @@ insert into public.part_request_items (
     '92000000-0000-4000-8000-000000000002',
     'a0000000-0000-4000-8000-000000000001',
     'c0000000-0000-4000-8000-000000000001',
-    'd0000000-0000-4000-8000-000000000001',
+    'd0000000-0000-4000-8000-000000000002',
     'e0000000-0000-4000-8000-000000000002',
     'Runtime rollback missing allocation',
     1,


### PR DESCRIPTION
## Root cause

Customer approval transitions the line to approved, which auto-releases every staged `work_order_part` into `part_request_items`. Menu-derived work-order parts did not retain their names or identity snapshots. Two unidentified parts therefore both became `Part`, while the legacy line/description unique index rejected the second canonical source-backed item and rolled back the entire approval.

## What changed

- use `(request_id, source_work_order_part_id)` as the uniqueness identity for canonical source-backed request items
- retain the existing line/part and line/description duplicate guards for legacy/manual items without source identity
- copy menu-part descriptions and pricing identity snapshots into new staged work-order parts
- backfill only historical menu-derived rows missing descriptions, using the same quantity/sell-price contract as the trigger
- add a focused migration contract test
- align the multi-item rollback runtime fixture with the production uniqueness contract by using two distinct catalog parts

## Production preflight

- live schema columns/types match every migration reference
- zero duplicate `(request_id, source_work_order_part_id)` rows
- read-only rehearsal matched exactly two rows: `Oil filter` and `5W30 oil`
- no hard-coded production IDs are present in the migration
- the newer work-order cockpit merge does not overlap schema or migration files

## Validation

- `git diff --check`
- TypeScript 5.4.5 transpile of the new test: zero diagnostics
- Supabase Preview: green
- fresh migration-chain apply: green
- full reset/replay: green
- the first parts runtime run exposed an invalid test fixture that duplicated the same legacy part on one line; the fixture now models the intended two-part rollback case and the full workflow is rerunning
- full production browser retest will resume after merge and migration application