### PR TITLE
Refine work order cockpit state and surfaces

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1530,6 +1530,20 @@ export default function WorkOrderIdClient(): JSX.Element {
 
   // ✅ layout: desktop keeps the focused cockpit open with a selected (or first) line.
   const panelLineId = focusedJobId ?? sortedLines[0]?.id ?? null;
+  const panelLine = panelLineId
+    ? sortedLines.find((line) => line.id === panelLineId) ?? null
+    : null;
+  const panelPrimaryTech = panelLine?.assigned_tech_id
+    ? assignables.find((profile) => profile.id === panelLine.assigned_tech_id) ?? null
+    : null;
+  const panelActiveTechnicianIds = panelLine
+    ? activeTechsByLine[panelLine.id] ?? []
+    : [];
+  const panelLineIsPunchedIn = Boolean(
+    panelLine &&
+      (panelActiveTechnicianIds.length > 0 ||
+        (panelLine.punched_in_at && !panelLine.punched_out_at)),
+  );
 
   return (
     <div className="w-full bg-[var(--theme-surface-2,var(--theme-surface-page))] px-2 py-3 text-foreground sm:px-3 lg:px-4">
@@ -1567,7 +1581,7 @@ export default function WorkOrderIdClient(): JSX.Element {
           <div className="mt-2 text-sm text-red-400">Work order not found.</div>
         ) : (
           <div className={cn("space-y-2", supportFullyCollapsed && "space-y-1.5")}>
-            <section className="overflow-hidden border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 sm:px-4">
+            <section className="overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 shadow-[0_14px_36px_rgba(15,23,42,0.08)] sm:px-4">
               <div className="flex flex-wrap items-center gap-2">
                 <PreviousPageButton />
                 <div className="text-sm font-semibold text-foreground">
@@ -2017,8 +2031,8 @@ export default function WorkOrderIdClient(): JSX.Element {
             </section>
 
           {/* Full-height cockpit: navigate left, work center, act right. */}
-          <section className="grid overflow-hidden border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] lg:h-[calc(100vh-12.5rem)] lg:min-h-[44rem] lg:grid-cols-[17rem_minmax(0,1fr)]">
-            <aside className="flex min-h-0 flex-col border-b border-[color:var(--theme-border-soft)] lg:border-b-0 lg:border-r">
+          <section className="grid gap-2 rounded-[24px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] p-2 shadow-[0_20px_55px_rgba(15,23,42,0.1)] lg:h-[calc(100vh-12.5rem)] lg:min-h-[44rem] lg:grid-cols-[17rem_minmax(0,1fr)]">
+            <aside className="flex min-h-0 flex-col overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[0_16px_42px_rgba(15,23,42,0.08)]">
               <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-3 py-3">
                 <div>
                   <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">Jobs</div>
@@ -2294,13 +2308,16 @@ export default function WorkOrderIdClient(): JSX.Element {
             </aside>
 
             {/* Center workspace and right command center are owned by the selected job. */}
-            <div className="min-w-0">
+            <div className="min-h-0 min-w-0">
               {prefersPanel && panelLineId ? (
                 <FocusedJobModal
                   key={panelLineId}
                   isOpen={true}
                   onClose={closeFocusedPanel}
                   workOrderLineId={panelLineId}
+                  lineSnapshot={panelLine}
+                  primaryTechSnapshot={panelPrimaryTech}
+                  isPunchedInSnapshot={panelLineIsPunchedIn}
                   onChanged={fetchAll}
                   mode="tech"
                   variant="cockpit"
@@ -2320,10 +2337,10 @@ export default function WorkOrderIdClient(): JSX.Element {
                 setShowWoContext(true);
                 setShowTimeline(true);
               }}
-              className="flex w-full items-center gap-2 border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-left text-[11px] text-[color:var(--theme-text-secondary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
+              className="flex w-full items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-left text-[11px] text-[color:var(--theme-text-secondary)] shadow-[0_8px_22px_rgba(15,23,42,0.06)] transition hover:bg-[color:var(--theme-surface-subtle)]"
             >
               <Clock3 className="h-3.5 w-3.5 shrink-0 text-[color:var(--brand-primary)]" />
-              <span className="font-semibold text-[color:var(--theme-text-primary)]">Latest activity</span>
+              <span className="font-semibold text-[color:var(--theme-text-primary)]">Work order activity</span>
               <span className="h-1 w-1 rounded-full bg-[color:var(--brand-primary)]" />
               <span className="truncate">{latestDecisionEvent.label}{latestDecisionEvent.meta ? ` · ${latestDecisionEvent.meta}` : ""}</span>
               <time className="ml-auto hidden shrink-0 font-mono text-[10px] sm:inline">

--- a/features/work-orders/components/JobCard.tsx
+++ b/features/work-orders/components/JobCard.tsx
@@ -20,6 +20,7 @@ import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-st
 import {
   formatLaborSummary,
   formatPartsSummary,
+  resolveOperationalLineStatusLabel,
   resolvePrimaryTechDisplay,
 } from "@/features/work-orders/lib/display/linePresentation";
 import JobEvidenceStrip from "@/features/work-orders/components/evidence/JobEvidenceStrip";
@@ -350,10 +351,13 @@ export function JobCard({
 }: JobCardProps): JSX.Element {
   const [collapsed, setCollapsed] = useState<boolean>(false);
 
-  const statusVisual = useMemo(
-    () => resolveStatusVisual(line.status),
-    [line.status],
-  );
+  const statusVisual = useMemo(() => {
+    const visual = resolveStatusVisual(line.status);
+    return {
+      ...visual,
+      label: resolveOperationalLineStatusLabel(line, { isActive: isPunchedIn }),
+    };
+  }, [isPunchedIn, line]);
 
   const isCompletedLike = statusVisual.muted;
   const isSelected = isSelectedForPanel ?? selected;
@@ -432,10 +436,10 @@ export function JobCard({
     return (
       <article
         className={cn(
-          "border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] transition",
+          "mx-2 my-2 overflow-hidden rounded-2xl border bg-[color:var(--theme-surface-inset)] shadow-[0_10px_28px_rgba(15,23,42,0.08)] transition",
           isSelected
-            ? "border-l-[3px] border-l-[color:var(--brand-primary)] bg-[color:var(--theme-surface-subtle)]"
-            : "border-l-[3px] border-l-transparent hover:bg-[color:var(--theme-surface-subtle)]",
+            ? "border-[color:var(--brand-primary)] bg-[color:var(--theme-surface-subtle)] ring-1 ring-[color:var(--brand-primary)]/20"
+            : "border-[color:var(--theme-border-soft)] hover:-translate-y-px hover:bg-[color:var(--theme-surface-subtle)] hover:shadow-[0_14px_32px_rgba(15,23,42,0.12)]",
           statusVisual.muted && "opacity-75",
         )}
       >
@@ -471,13 +475,10 @@ export function JobCard({
                   </span>
                 ) : null}
               </div>
-              <div className="mt-2 flex items-center justify-between gap-2 text-[11px] text-[color:var(--theme-text-secondary)]">
+              <div className="mt-2 flex items-center gap-2 text-[11px] text-[color:var(--theme-text-secondary)]">
                 <span className="inline-flex min-w-0 items-center gap-1 truncate">
                   <UserRound className="h-3.5 w-3.5 shrink-0" />
                   <span className="truncate">{assignedTech}</span>
-                </span>
-                <span className="shrink-0 font-mono font-semibold text-[color:var(--theme-text-primary)]">
-                  {lineTotal > 0 ? formatCurrency(lineTotal) : "Estimate pending"}
                 </span>
               </div>
             </div>
@@ -485,7 +486,7 @@ export function JobCard({
         </button>
 
         {isSelected ? (
-          <div className="border-t border-[color:var(--theme-border-soft)] px-3 py-2">
+          <div className="border-t border-[color:var(--theme-border-soft)] px-3 py-2.5">
             {canAssign && onAssign ? (
               <label className="relative mb-2 block">
                 <UserRound className="pointer-events-none absolute left-2 top-2 h-3.5 w-3.5 text-[color:var(--theme-text-muted)]" />
@@ -509,8 +510,9 @@ export function JobCard({
             ) : null}
 
             <details className="group">
-              <summary className="cursor-pointer list-none text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-secondary)] hover:text-[color:var(--theme-text-primary)]">
-                Job actions
+              <summary className="flex cursor-pointer list-none items-center justify-between rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2.5 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-text-secondary)] transition hover:bg-[color:var(--theme-surface-subtle)] hover:text-[color:var(--theme-text-primary)]">
+                More actions
+                <ChevronDown className="h-3.5 w-3.5 transition group-open:rotate-180" aria-hidden="true" />
               </summary>
               <div className="mt-2 grid grid-cols-2 gap-1.5">
                 {onOpenInspection ? (

--- a/features/work-orders/components/JobPunchButton.tsx
+++ b/features/work-orders/components/JobPunchButton.tsx
@@ -10,6 +10,7 @@ type Props = {
   punchedInAt?: string | null;
   punchedOutAt?: string | null;
   status?: string | null;
+  isActive?: boolean;
   onUpdated?: () => void | Promise<void>;
   onFinishRequested?: () => void;
   disabled?: boolean;
@@ -26,6 +27,7 @@ export default function JobPunchButton({
   punchedInAt,
   punchedOutAt,
   status,
+  isActive,
   onUpdated,
   onFinishRequested,
   disabled = false,
@@ -36,7 +38,7 @@ export default function JobPunchButton({
   const normalizedStatus = (status ?? "").toLowerCase();
   const isOnHold = normalizedStatus === "on_hold";
 
-  const isStarted = !!punchedInAt && !punchedOutAt && !isOnHold;
+  const isStarted = (isActive ?? (!!punchedInAt && !punchedOutAt)) && !isOnHold;
   const effectiveDisabled = disabled || isOnHold;
 
   const showFlash = (kind: typeof flash) => {

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -14,7 +14,6 @@ import {
   MessageSquare,
   PackageSearch,
   PauseCircle,
-  Plus,
   Sparkles,
   UserRound,
 } from "lucide-react";
@@ -35,6 +34,7 @@ import { runJobPunchTransition } from "@/features/work-orders/lib/jobPunchTransi
 import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
 import {
   formatLaborSummary,
+  resolveOperationalLineStatusLabel,
   resolvePartsBottleneckDisplay,
   resolvePrimaryTechDisplay,
 } from "@/features/work-orders/lib/display/linePresentation";
@@ -84,19 +84,6 @@ const statusTextColor: Record<string, string> = {
 };
 
 const chip = (status: string) => statusTextColor[status] ?? "text-[color:var(--theme-text-primary)]";
-
-const displayStatusLabel = (status: string, punchedInAt: string | null): string => {
-  if (status === "in_progress" || (!!punchedInAt && status !== "completed" && status !== "declined" && status !== "deferred")) return "Active";
-  if (status === "waiting_parts") return "Waiting Parts";
-  if (status === "on_hold") return "On Hold";
-  if (status === "completed") return "Completed";
-  if (status === "declined") return "Declined";
-  if (status === "deferred") return "Deferred";
-  if (status === "awaiting_approval") return "Awaiting Approval";
-  if (status === "approved") return "Queued";
-  if (status === "pending" || status === "awaiting") return "Awaiting";
-  return status.replaceAll("_", " ");
-};
 
 const btnBase =
   "inline-flex items-center justify-center rounded-xl border px-3 py-2 text-sm font-medium transition";
@@ -194,6 +181,13 @@ export default function FocusedJobModal(props: {
   isOpen: boolean;
   onClose: () => void;
   workOrderLineId: string;
+  lineSnapshot?: WorkOrderLine | null;
+  primaryTechSnapshot?: {
+    id: string;
+    full_name: string | null;
+    role: string | null;
+  } | null;
+  isPunchedInSnapshot?: boolean;
   onChanged?: () => void | Promise<void>;
   mode?: Mode;
   variant?: Variant;
@@ -202,6 +196,9 @@ export default function FocusedJobModal(props: {
     isOpen,
     onClose,
     workOrderLineId,
+    lineSnapshot,
+    primaryTechSnapshot,
+    isPunchedInSnapshot,
     onChanged,
     mode = "tech",
     variant = "modal",
@@ -293,6 +290,12 @@ export default function FocusedJobModal(props: {
   }, [workOrderLineId]);
 
   useEffect(() => {
+    if (lineSnapshot?.id === workOrderLineId) {
+      setLine(lineSnapshot);
+    }
+  }, [lineSnapshot, workOrderLineId]);
+
+  useEffect(() => {
     if (!isOpen || !workOrderLineId) return;
 
     let cancelled = false;
@@ -310,16 +313,6 @@ export default function FocusedJobModal(props: {
 
         setLine(l ?? null);
         setTechNotes(l?.technician_notes ?? "");
-        if (l?.assigned_tech_id) {
-          const { data: profile } = await supabase
-            .from("profiles")
-            .select("id, full_name, role")
-            .eq("id", l.assigned_tech_id)
-            .maybeSingle<{ id: string; full_name: string | null; role: string | null }>();
-          if (!cancelled) setAssignedTechProfile(profile ?? null);
-        } else {
-          setAssignedTechProfile(null);
-        }
 
         if (l?.work_order_id) {
           const { data: wo, error: we } = await supabase
@@ -396,6 +389,42 @@ export default function FocusedJobModal(props: {
       cancelled = true;
     };
   }, [isOpen, workOrderLineId, supabase, ensureShopContext]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const assignedTechId = line?.assigned_tech_id ?? null;
+    if (!assignedTechId) {
+      setAssignedTechProfile(null);
+      return;
+    }
+    if (primaryTechSnapshot?.id === assignedTechId) {
+      setAssignedTechProfile(primaryTechSnapshot);
+      return;
+    }
+
+    let cancelled = false;
+    setAssignedTechProfile(null);
+
+    void (async () => {
+      const { data: profile, error } = await supabase
+        .from("profiles")
+        .select("id, full_name, role")
+        .eq("id", assignedTechId)
+        .maybeSingle<{ id: string; full_name: string | null; role: string | null }>();
+
+      if (cancelled) return;
+      if (error) {
+        console.warn("[FocusedJob] assigned technician lookup failed:", error);
+        return;
+      }
+      setAssignedTechProfile(profile ?? null);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, line?.assigned_tech_id, primaryTechSnapshot, supabase]);
 
   useEffect(() => {
     if (!isOpen || !workOrderLineId) return;
@@ -655,9 +684,18 @@ export default function FocusedJobModal(props: {
     "Job";
 
   const normalizedLineStatus = normalizeWorkOrderLineStatus(line?.status);
-  const statusLabel = displayStatusLabel(normalizedLineStatus, line?.punched_in_at ?? null);
+  const isOperationallyActive =
+    isPunchedInSnapshot ??
+    (Boolean(line?.punched_in_at) && !line?.punched_out_at);
+  const statusLabel = line
+    ? resolveOperationalLineStatusLabel(line, { isActive: isOperationallyActive })
+    : "Loading";
 
-  const createdStart = startAt ? format(new Date(startAt), "PPpp") : "—";
+  const createdStart = startAt
+    ? format(new Date(startAt), "PPpp")
+    : isOperationallyActive
+      ? "Active session"
+      : "—";
   const createdFinish = finishAt ? format(new Date(finishAt), "PPpp") : "—";
 
   const completionBlocked =
@@ -689,6 +727,16 @@ export default function FocusedJobModal(props: {
           ""
         ).trim() || resolvePrimaryTechDisplay(line, assignedTechProfile)
       : "Unassigned";
+  const customerDisplay = customer
+    ? customer.business_name?.trim() ||
+      [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ") ||
+      "Customer"
+    : "No customer linked";
+  const vehicleDisplay = vehicle
+    ? [vehicle.year, vehicle.make, vehicle.model]
+        .filter((value) => value != null && String(value).trim())
+        .join(" ") || "Vehicle linked"
+    : "No vehicle linked";
 
   if (!isOpen) return null;
 
@@ -799,6 +847,7 @@ export default function FocusedJobModal(props: {
                       punchedInAt={line.punched_in_at}
                       punchedOutAt={line.punched_out_at}
                       status={line.status as WorkflowStatus}
+                      isActive={isOperationallyActive}
                       onFinishRequested={() => {
                         closeAllSubModals();
                         setPrefillCause(line.cause ?? "");
@@ -1341,16 +1390,16 @@ export default function FocusedJobModal(props: {
   const CockpitBody = (
     <div
       data-work-order-cockpit="true"
-      className="grid min-h-[40rem] overflow-hidden border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] lg:h-[calc(100vh-13.5rem)] lg:min-h-[42rem] lg:grid-cols-[minmax(0,1fr)_21rem]"
+      className="grid h-full min-h-[40rem] gap-2 bg-transparent lg:min-h-0 lg:grid-cols-[minmax(0,1fr)_20rem]"
     >
-      <section className="flex min-h-0 min-w-0 flex-col bg-[color:var(--theme-surface-page)]">
-        <header className="border-b border-[color:var(--theme-border-soft)] px-5 pb-0 pt-4">
+      <section className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] shadow-[0_16px_42px_rgba(15,23,42,0.1)]">
+        <header className="border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-5 pb-0 pt-4">
           <div className="flex flex-wrap items-start justify-between gap-3 pb-4">
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="inline-flex h-2.5 w-2.5 rounded-full bg-[color:var(--brand-primary)]" aria-hidden="true" />
-                <span className={`text-[10px] font-semibold uppercase tracking-[0.16em] ${chip(normalizedLineStatus)}`}>
-                  {statusLabel}
+                <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-secondary)]">
+                  {String(line?.job_type ?? "Selected job").replaceAll("_", " ")}
                 </span>
                 {line?.approval_state ? (
                   <span className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
@@ -1359,24 +1408,18 @@ export default function FocusedJobModal(props: {
                 ) : null}
               </div>
               <h2 className="mt-2 line-clamp-2 text-lg font-semibold tracking-tight text-[color:var(--theme-text-primary)]">
-                {titleText}
+                {lineLabel}
               </h2>
-              <div className="mt-1 font-mono text-[11px] text-[color:var(--theme-text-muted)]">
-                {workOrder ? `WO ${workOrder.custom_id || workOrder.id.slice(0, 8)}` : "Selected job"}
+              <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-[color:var(--theme-text-muted)]">
+                <span className="font-mono">
+                  {workOrder ? `WO ${workOrder.custom_id || workOrder.id.slice(0, 8)}` : "Selected job"}
+                </span>
+                <span aria-hidden="true">•</span>
+                <span>{customerDisplay}</span>
+                <span aria-hidden="true">•</span>
+                <span>{vehicleDisplay}</span>
               </div>
             </div>
-            <button
-              type="button"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2 text-xs font-semibold text-[color:var(--theme-text-primary)] transition hover:bg-[color:var(--theme-surface-subtle)]"
-              onClick={() => {
-                closeAllSubModals();
-                setOpenAddJob(true);
-              }}
-              disabled={busy || !workOrder?.id}
-            >
-              <Plus className="h-3.5 w-3.5" />
-              Add job
-            </button>
           </div>
           <div className="flex gap-1 overflow-x-auto" role="tablist" aria-label="Selected job workspace">
             {WORKSPACE_TABS.map((tab) => (
@@ -1399,7 +1442,7 @@ export default function FocusedJobModal(props: {
           </div>
         </header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-6">
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 [scrollbar-gutter:stable]">
           {busy && !line ? (
             <div className="grid gap-3">
               <div className="h-6 w-40 animate-pulse rounded bg-[color:var(--theme-surface-subtle)]" />
@@ -1496,7 +1539,7 @@ export default function FocusedJobModal(props: {
         </div>
       </section>
 
-      <aside className="min-h-0 overflow-y-auto border-t border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] lg:border-l lg:border-t-0">
+      <aside className="min-h-0 overflow-y-auto rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[0_16px_42px_rgba(15,23,42,0.1)] [scrollbar-gutter:stable]">
         <div className="border-b border-[color:var(--theme-border-soft)] px-4 py-4">
           <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">
             Command center
@@ -1534,6 +1577,7 @@ export default function FocusedJobModal(props: {
                     punchedInAt={line.punched_in_at}
                     punchedOutAt={line.punched_out_at}
                     status={line.status as WorkflowStatus}
+                    isActive={isOperationallyActive}
                     onFinishRequested={() => {
                       closeAllSubModals();
                       setPrefillCause(line.cause ?? "");
@@ -1573,7 +1617,11 @@ export default function FocusedJobModal(props: {
                     disabled={busy}
                   >
                     <PauseCircle className="h-4 w-4" />
-                    {normalizedLineStatus === "on_hold" ? "On hold" : "Hold"}
+                    {normalizedLineStatus === "on_hold"
+                      ? "Manage hold"
+                      : isOperationallyActive
+                        ? "Hold"
+                        : "Add blocker"}
                   </button>
                   <button
                     type="button"
@@ -1627,20 +1675,6 @@ export default function FocusedJobModal(props: {
                   </button>
                 </div>
 
-                <button
-                  type="button"
-                  className={cn(btnDanger, "mt-2 w-full text-xs")}
-                  onClick={() => {
-                    closeAllSubModals();
-                    setPrefillCause(line.cause ?? "");
-                    setPrefillCorrection(line.correction ?? "");
-                    setOpenComplete(true);
-                  }}
-                  disabled={completionBlocked}
-                >
-                  Complete job
-                </button>
-
                 {completionBlocked ? (
                   <div className="mt-2 text-[11px] text-amber-300">
                     {normalizedLineStatus === "awaiting_approval"
@@ -1659,7 +1693,7 @@ export default function FocusedJobModal(props: {
               <div className="grid gap-3 text-sm">
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-[color:var(--theme-text-secondary)]">Approval</span>
-                  <span className="font-semibold capitalize text-[color:var(--theme-text-primary)]">{line.approval_state ?? "—"}</span>
+                  <span className="font-semibold capitalize text-[color:var(--theme-text-primary)]">{line.approval_state ?? "Not required"}</span>
                 </div>
                 <div className="flex items-center justify-between gap-3">
                   <span className="text-[color:var(--theme-text-secondary)]">Primary tech</span>
@@ -1667,10 +1701,6 @@ export default function FocusedJobModal(props: {
                     <UserRound className="h-4 w-4 shrink-0" />
                     {primaryTechDisplay}
                   </span>
-                </div>
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-[color:var(--theme-text-secondary)]">Line total</span>
-                  <span className="font-mono font-semibold text-[color:var(--theme-text-primary)]">{lineTotal > 0 ? money(lineTotal) : "—"}</span>
                 </div>
               </div>
             </section>
@@ -1680,7 +1710,6 @@ export default function FocusedJobModal(props: {
               <dl className="mt-3 grid gap-2 text-xs">
                 <div className="flex justify-between gap-3"><dt className="text-[color:var(--theme-text-secondary)]">Start</dt><dd className="text-right text-[color:var(--theme-text-primary)]">{createdStart}</dd></div>
                 <div className="flex justify-between gap-3"><dt className="text-[color:var(--theme-text-secondary)]">Finish</dt><dd className="text-right text-[color:var(--theme-text-primary)]">{createdFinish}</dd></div>
-                <div className="flex justify-between gap-3"><dt className="text-[color:var(--theme-text-secondary)]">Labor</dt><dd className="text-right text-[color:var(--theme-text-primary)]">{laborDisplay}</dd></div>
               </dl>
             </section>
           </div>

--- a/features/work-orders/lib/display/linePresentation.test.ts
+++ b/features/work-orders/lib/display/linePresentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatLaborSummary,
   formatPartsSummary,
+  resolveOperationalLineStatusLabel,
   resolvePartsBottleneckDisplay,
   resolvePrimaryTechDisplay,
 } from "./linePresentation";
@@ -55,18 +56,61 @@ describe("linePresentation", () => {
     expect(
       resolvePrimaryTechDisplay(
         { assigned_tech_id: "cc4edd23-aaaa-4bbb-8ccc-123456789012" },
-        { id: "1", full_name: "Owner Demo", role: "owner" },
+        { id: "cc4edd23-aaaa-4bbb-8ccc-123456789012", full_name: "Owner Demo", role: "owner" },
       ),
     ).toBe("Unassigned");
   });
 
-  it("returns technician full name for resolvable tech profile", () => {
+  it("returns technician full name for canonical mechanic and technician profiles", () => {
     expect(
       resolvePrimaryTechDisplay(
         { assigned_tech_id: "cc4edd23-aaaa-4bbb-8ccc-123456789012" },
-        { id: "1", full_name: "Lead Tech", role: "tech" },
+        {
+          id: "cc4edd23-aaaa-4bbb-8ccc-123456789012",
+          full_name: "Test Mechanic",
+          role: "mechanic",
+        },
+      ),
+    ).toBe("Test Mechanic");
+    expect(
+      resolvePrimaryTechDisplay(
+        { assigned_tech_id: "cc4edd23-aaaa-4bbb-8ccc-123456789012" },
+        {
+          id: "cc4edd23-aaaa-4bbb-8ccc-123456789012",
+          full_name: "Lead Tech",
+          role: "tech",
+        },
       ),
     ).toBe("Lead Tech");
+  });
+
+  it("does not show a stale technician profile after assignment changes", () => {
+    expect(
+      resolvePrimaryTechDisplay(
+        { assigned_tech_id: "new-tech" },
+        { id: "previous-tech", full_name: "Previous Tech", role: "mechanic" },
+      ),
+    ).toBe("Unassigned");
+  });
+
+  it("uses one explicit operational status label across cockpit surfaces", () => {
+    const baseLine = {
+      approval_state: "approved",
+      assigned_tech_id: "tech-1",
+      hold_reason: null,
+      punched_in_at: null,
+      punched_out_at: null,
+      status: "awaiting",
+    };
+
+    expect(resolveOperationalLineStatusLabel(baseLine)).toBe("Ready to start");
+    expect(resolveOperationalLineStatusLabel({ ...baseLine, assigned_tech_id: null })).toBe(
+      "Awaiting technician",
+    );
+    expect(resolveOperationalLineStatusLabel(baseLine, { isActive: true })).toBe("In progress");
+    expect(
+      resolveOperationalLineStatusLabel({ ...baseLine, hold_reason: "Awaiting parts" }),
+    ).toBe("On hold");
   });
 
   it("formats labor summary with non-zero labor dollars", () => {

--- a/features/work-orders/lib/display/linePresentation.ts
+++ b/features/work-orders/lib/display/linePresentation.ts
@@ -1,7 +1,18 @@
 import type { Database } from "@shared/types/types/supabase";
+import { normalizeWorkOrderLineStatus } from "@/features/work-orders/lib/line-status";
 
 type WorkOrderLine = Database["public"]["Tables"]["work_order_lines"]["Row"];
 type Profile = Pick<Database["public"]["Tables"]["profiles"]["Row"], "id" | "full_name" | "role">;
+
+const ASSIGNABLE_TECH_ROLES = new Set([
+  "mechanic",
+  "tech",
+  "technician",
+  "lead_tech",
+  "leadtech",
+  "foreman",
+  "lead_hand",
+]);
 
 export function isLikelyUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
@@ -13,10 +24,59 @@ export function resolvePrimaryTechDisplay(
 ): string {
   if (!line.assigned_tech_id) return "Unassigned";
   const role = String(profile?.role ?? "").toLowerCase();
-  if (profile?.full_name && ["tech", "lead_tech", "leadtech", "foreman", "lead_hand"].includes(role)) {
+  if (
+    profile?.id === line.assigned_tech_id &&
+    profile.full_name &&
+    ASSIGNABLE_TECH_ROLES.has(role)
+  ) {
     return profile.full_name;
   }
   return "Unassigned";
+}
+
+export function resolveOperationalLineStatusLabel(
+  line: Pick<
+    WorkOrderLine,
+    | "approval_state"
+    | "assigned_tech_id"
+    | "hold_reason"
+    | "punched_in_at"
+    | "punched_out_at"
+    | "status"
+  >,
+  options?: { isActive?: boolean },
+): string {
+  const normalized = normalizeWorkOrderLineStatus(line.status);
+  const approvalState = String(line.approval_state ?? "").trim().toLowerCase();
+  const isActive =
+    options?.isActive === true ||
+    (Boolean(line.punched_in_at) && !line.punched_out_at);
+
+  if (normalized === "completed" || normalized === "ready_to_invoice" || normalized === "invoiced") {
+    return normalized === "completed"
+      ? "Completed"
+      : normalized === "invoiced"
+        ? "Invoiced"
+        : "Ready to invoice";
+  }
+  if (normalized === "declined") return "Declined";
+  if (normalized === "deferred") return "Deferred";
+  if (normalized === "on_hold" || line.hold_reason) return "On hold";
+  if (normalized === "waiting_parts") return "Waiting parts";
+  if (normalized === "awaiting_approval" || approvalState === "pending") {
+    return "Awaiting approval";
+  }
+  if (isActive || normalized === "in_progress") return "In progress";
+  if (!line.assigned_tech_id) return "Awaiting technician";
+  if (
+    ["awaiting", "pending", "queued", "approved", "assigned", "unassigned"].includes(
+      normalized,
+    )
+  ) {
+    return "Ready to start";
+  }
+
+  return normalized.replaceAll("_", " ").replace(/\b\w/g, (character) => character.toUpperCase());
 }
 
 export function formatLaborSummary(hours: number | null | undefined, laborTotal: number): string {

--- a/tests/work-order-cockpit-layout.test.ts
+++ b/tests/work-order-cockpit-layout.test.ts
@@ -15,13 +15,16 @@ describe("desktop work-order cockpit", () => {
   it("uses stable navigator, workspace, command-center, and activity surfaces", () => {
     expect(detail).toContain('display="navigator"');
     expect(detail).toContain('variant="cockpit"');
-    expect(detail).toContain("Latest activity");
+    expect(detail).toContain("Work order activity");
+    expect(detail).toContain("primaryTechSnapshot={panelPrimaryTech}");
+    expect(detail).toContain("isPunchedInSnapshot={panelLineIsPunchedIn}");
     expect(detail).not.toContain("<PageShell");
 
     expect(focusedJob).toContain('data-work-order-cockpit="true"');
     expect(focusedJob).toContain("Command center");
     expect(focusedJob).toContain('role="tablist"');
     expect(focusedJob).toContain('activeWorkspaceTab === "overview"');
+    expect(focusedJob).toContain("resolveOperationalLineStatusLabel");
     expect(jobCard).toContain('display === "navigator"');
   });
 


### PR DESCRIPTION
## What changed

- Uses the selected work-order line snapshot, active technician state, and matching profile in both the navigator and command center.
- Recognizes the canonical `mechanic` role and rejects stale technician profiles whose IDs no longer match the assignment.
- Replaces vague `Awaiting` labels with explicit operational states such as `Awaiting technician`, `Ready to start`, and `In progress`.
- Treats an active labor session as active even when its source is the canonical line-technician context.
- Removes the duplicate always-visible completion control; the primary Start / Finish control remains the canonical completion entry point.
- Renames pre-start hold handling to `Add blocker` while keeping the existing hold workflow.
- Removes duplicate price/labor summaries from supporting rails and distinguishes the bottom strip as work-order-level activity.
- Softens the cockpit into three rounded, separated surfaces and adds customer/vehicle context to the selected-job header.
- Replaces the empty-looking Job Actions row with a compact More actions disclosure.

## Why

The first cockpit pass exposed state from multiple independently loaded sources. That allowed the navigator to show an assigned technician while the command center displayed Unassigned, and allowed work-order activity to read like selected-job activity. The rigid edge-to-edge framing also made the workspace feel more like a spreadsheet than an all-day operational surface.

## Root cause

The command center filtered assigned profiles through a role list that omitted the canonical `mechanic` role, and it only loaded the assigned profile during the initial line request. The parent navigator had fresher line/technician context but did not pass it into the focused workspace.

## Impact and safety

The existing assignment API, punch transitions, hold modal, parts workflows, evidence, inspections, approvals, chat, AI, and completion modal remain intact. This adds presentation synchronization and display derivation only; there are no schema, migration, API-contract, or environment-variable changes.

## Validation

- TypeScript: passed
- Focused ESLint: passed
- Focused work-order suite: 9 files / 68 tests passed
- React review: client boundaries, hook dependencies, realtime cleanup, accessibility, and bundle impact reviewed