### PR TITLE
Fix parts workbench links from Pick / Order

### DIFF
--- a/features/parts/components/PickOrderTaskModal.tsx
+++ b/features/parts/components/PickOrderTaskModal.tsx
@@ -118,7 +118,7 @@ export default function PickOrderTaskModal({
   }, [load, open]);
 
   const detailHref = `/parts/requests/${encodeURIComponent(
-    workOrderLabel || workOrderId || "",
+    workOrderId || workOrderLabel || "",
   )}`;
 
   const pickable = useMemo(

--- a/tests/parts/parts-line-pick-order-release.test.ts
+++ b/tests/parts/parts-line-pick-order-release.test.ts
@@ -86,6 +86,8 @@ describe("work-order line parts release and Pick / Order flow", () => {
     expect(pickModal).toContain("Idempotency-Key");
     expect(pickModal).toContain("Dismiss duplicate");
     expect(pickModal).toContain("/cancel");
+    expect(pickModal).toContain("workOrderId || workOrderLabel");
+    expect(pickModal).not.toContain("workOrderLabel || workOrderId");
   });
 
   it("keeps the action footer visible while only the item list scrolls", () => {


### PR DESCRIPTION
## Root cause
The Pick / Order modal built its detail URL from the display label (for example `#d29739dd`) before the real work-order UUID. URL encoding turned that into `%23d29739dd`, which the request workbench could not resolve.

## What changed
- Build all workbench links from the canonical work-order UUID.
- Retain the display label only as a defensive fallback.
- Add a focused regression assertion to the existing Pick / Order flow test.

## Validation
- `git diff --check` passes.
- Local Node tooling is unavailable in this workspace shell, so the repository CI suite is the executable validation gate before merge.

## Production evidence
Reproduced on the live appointment parts request: the modal opened correctly, but both **Attach inventory** and **Open full request workbench** navigated to `/parts/requests/%23d29739dd` and showed “Work order not found / not visible.”