### PR TITLE
Select the next uncovered item when creating a PO

### DIFF
--- a/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbench.test.tsx
@@ -175,6 +175,41 @@ describe("PartsRequestWorkbench inventory attach flow", () => {
     });
     expect(attached.items[0]?.insights?.some((insight) => insight.kind === "no_stock")).toBe(true);
   });
+
+  it("opens Create PO for the first item that is not already assigned to a PO", async () => {
+    const user = userEvent.setup();
+    const twoItemModel = model("part-1");
+    twoItemModel.defaultSupplierId = "supplier-1";
+    twoItemModel.supplierOptions = [
+      { value: "supplier-1", label: "AutoValue Local" },
+    ];
+    twoItemModel.items = [
+      {
+        ...twoItemModel.items[0],
+        id: "item-oil",
+        description: "5W30 oil",
+        qty: 6,
+        poId: "po-existing",
+      },
+      {
+        ...twoItemModel.items[0],
+        id: "item-filter",
+        description: "Oil filter",
+        qty: 1,
+        poId: null,
+      },
+    ];
+
+    render(<PartsRequestWorkbench model={twoItemModel} />);
+
+    await user.click(screen.getByRole("button", { name: "Create PO" }));
+
+    expect(screen.getByText(/Order Part.*Oil filter/)).toBeInTheDocument();
+    expect(screen.getByRole("spinbutton", { name: "Qty" })).toHaveValue(1);
+    expect(screen.getByRole("combobox", { name: "Supplier" })).toHaveValue(
+      "supplier-1",
+    );
+  });
 });
 
 describe("PartsRequestWorkbench inventory picker mobile layout", () => {

--- a/features/parts/components/request-workbench/PartsRequestWorkbench.tsx
+++ b/features/parts/components/request-workbench/PartsRequestWorkbench.tsx
@@ -161,8 +161,14 @@ export function PartsRequestWorkbench({
         supplierOptions={model.supplierOptions}
         onDefaultSupplierChange={setDefaultSupplierId}
         onCreatePo={() => {
-          const firstItem = items[0];
-          if (firstItem) setActiveModal({ type: "order", itemId: firstItem.id });
+          const firstItem =
+            items.find((item) => !item.poId) ?? items[0];
+          if (firstItem) {
+            setOrderDraft(
+              createOrderDraftFromItem(firstItem, defaultSupplierId),
+            );
+            setActiveModal({ type: "order", itemId: firstItem.id });
+          }
         }}
         onCommitPackage={onCommitPackage}
         commitPackageDisabled={items.length === 0}


### PR DESCRIPTION
## Root cause
The request workbench header always opened its first item when **Create PO** was clicked. Once that item had a PO, subsequent clicks reopened the already-ordered item and left later approved items with no ordering path. The header path also failed to seed the order draft from the selected item, so quantity defaulted to 1.

## What changed
- Prefer the first item without a `poId`, preserving the prior first-item fallback only when all items are already covered.
- Initialize the order draft from that selected item and the current default supplier.
- Add a component regression test with an ordered 6-unit oil item followed by an uncovered filter.

## Validation
- `git diff --check` passes.
- The regression test asserts the modal targets the uncovered filter, seeds quantity 1, and carries the default supplier.
- Repository CI/deployment remains the executable build gate because local Node tooling is unavailable in this workspace shell.

## Production evidence
On work order `#d29739dd`, the first item was ordered successfully. The summary then showed one item still needing order, but **Create PO** reopened `5W30 oil` instead of `Oil filter`.