### PR TITLE
Fix parts receiving idempotency contract

### DIFF
--- a/features/parts/components/ReceiveDrawer.test.tsx
+++ b/features/parts/components/ReceiveDrawer.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ReceiveDrawer from "./ReceiveDrawer";
+
+const itemId = "226ac5f1-c762-4beb-a1a1-ed80dbcd3a7f";
+const locationId = "04c9f1c8-e8a2-4dd5-90f4-fadfe5ea9241";
+const poId = "b16a3a32-341e-407c-a254-1be0903e3adc";
+
+function failedResponse(): Response {
+  return {
+    ok: false,
+    status: 503,
+    text: vi.fn().mockResolvedValue("Temporary failure"),
+  } as unknown as Response;
+}
+
+describe("ReceiveDrawer", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(failedResponse()));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("sends the receive contract idempotency key and reuses it for an identical retry", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ReceiveDrawer
+        open
+        item={{
+          id: itemId,
+          part_name: "5W30 oil",
+          qty_approved: 6,
+          qty_received: 0,
+          qty_remaining: 6,
+        }}
+        locations={[{ value: locationId, label: "MAIN" }]}
+        defaultLocationId={locationId}
+        purchaseOrders={[{ value: poId, label: "QA purchase order" }]}
+        defaultPoId={poId}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Receive remaining" }));
+    await user.click(screen.getByRole("button", { name: "Receive" }));
+    await screen.findByText("Temporary failure");
+    await user.click(screen.getByRole("button", { name: "Receive" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    const firstRequest = vi.mocked(fetch).mock.calls[0]?.[1];
+    const secondRequest = vi.mocked(fetch).mock.calls[1]?.[1];
+    const firstBody = JSON.parse(String(firstRequest?.body)) as Record<string, unknown>;
+    const secondBody = JSON.parse(String(secondRequest?.body)) as Record<string, unknown>;
+    const firstHeaders = firstRequest?.headers as Record<string, string>;
+    const secondHeaders = secondRequest?.headers as Record<string, string>;
+
+    expect(firstBody).toMatchObject({
+      location_id: locationId,
+      qty: 6,
+      po_id: poId,
+    });
+    expect(firstBody.idempotencyKey).toEqual(expect.any(String));
+    expect(firstBody.idempotencyKey).not.toBe("");
+    expect(firstHeaders["Idempotency-Key"]).toBe(firstBody.idempotencyKey);
+    expect(secondBody.idempotencyKey).toBe(firstBody.idempotencyKey);
+    expect(secondHeaders["Idempotency-Key"]).toBe(firstHeaders["Idempotency-Key"]);
+  });
+});

--- a/features/parts/components/ReceiveDrawer.tsx
+++ b/features/parts/components/ReceiveDrawer.tsx
@@ -1,7 +1,7 @@
 // features/parts/components/ReceiveDrawer.tsx
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { itemFlowLabel, toItemFlowDisplay } from "@/features/parts/lib/status-display";
 import { trustBadgeTone, trustLevelLabel, type PartTrustLevel } from "@/features/parts/lib/trust-signals";
 
@@ -73,6 +73,7 @@ export default function ReceiveDrawer(props: {
 
   const [submitting, setSubmitting] = useState<boolean>(false);
   const [err, setErr] = useState<string | null>(null);
+  const receiveOperationRef = useRef<{ signature: string; key: string } | null>(null);
 
   const remaining = useMemo(() => {
     if (!item) return 0;
@@ -100,6 +101,7 @@ export default function ReceiveDrawer(props: {
     setErr(null);
     setSubmitting(false);
     setQty("");
+    receiveOperationRef.current = null;
 
     // ✅ Always reset when opening / switching items (prevents stale PO/location)
     setLocationId(resolvedDefaultLocationId);
@@ -141,6 +143,7 @@ export default function ReceiveDrawer(props: {
   function close(): void {
     setErr(null);
     setSubmitting(false);
+    receiveOperationRef.current = null;
 
     if (onClose) onClose();
     if (closeEventName) window.dispatchEvent(new Event(closeEventName));
@@ -170,16 +173,34 @@ export default function ReceiveDrawer(props: {
     setSubmitting(true);
 
     try {
+      const normalizedPoId = poId?.trim() ? poId.trim() : null;
+      const signature = JSON.stringify({
+        itemId: item.id,
+        locationId,
+        qty: q,
+        poId: normalizedPoId,
+      });
+      const existingOperation = receiveOperationRef.current;
+      const idempotencyKey =
+        existingOperation?.signature === signature
+          ? existingOperation.key
+          : crypto.randomUUID();
+      receiveOperationRef.current = { signature, key: idempotencyKey };
+
       // ✅ Canonical endpoint: item-scoped receive
       const res = await fetch(
         `/api/parts/requests/items/${encodeURIComponent(item.id)}/receive`,
         {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotencyKey,
+          },
           body: JSON.stringify({
             location_id: locationId,
             qty: q,
-            po_id: poId?.trim() ? poId.trim() : null,
+            po_id: normalizedPoId,
+            idempotencyKey,
           }),
         },
       );
@@ -204,6 +225,7 @@ export default function ReceiveDrawer(props: {
 
       // ✅ tell any pages to refresh
       window.dispatchEvent(new Event("parts:received"));
+      receiveOperationRef.current = null;
 
       setSubmitting(false);
       close();


### PR DESCRIPTION
## Root cause
The receiving drawer omitted the stable idempotency key required by the canonical item-scoped receive API, so every receive attempt was rejected before inventory mutation.

## What changed
- Generate an operation key from the exact item/location/quantity/PO payload.
- Send the same key in the `Idempotency-Key` header and request body.
- Reuse the key for an identical retry and reset it after success, close, or switching items.
- Add a component regression test that verifies the contract and retry stability.

## Validation
- `git diff --check`
- Focused component regression test added (local Node/pnpm runtime is unavailable in this workspace; GitHub/Vercel checks are the executable gate).

No schema migrations or environment-variable changes.