### PR TITLE
Restore cockpit technician assignment

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -1176,6 +1176,41 @@ export default function WorkOrderIdClient(): JSX.Element {
 
   const canDeleteLine = currentUserRole ? LINE_DELETE_ROLES.has(currentUserRole) : false;
 
+  const assignLineTechnician = useCallback(
+    async (lineId: string, technicianId: string): Promise<void> => {
+      const existingOperation = assignmentOperationsRef.current.get(lineId);
+      const operationKey =
+        existingOperation?.technicianId === technicianId
+          ? existingOperation.operationKey
+          : createAssignTechnicianOperationKey(lineId, technicianId);
+
+      assignmentOperationsRef.current.set(lineId, {
+        technicianId,
+        operationKey,
+      });
+
+      try {
+        await assignWorkOrderLineTechnician({
+          lineId,
+          technicianId,
+          operationKey,
+        });
+        await fetchAll();
+        if (
+          assignmentOperationsRef.current.get(lineId)?.operationKey === operationKey
+        ) {
+          assignmentOperationsRef.current.delete(lineId);
+        }
+        toast.success("Primary tech updated.");
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to update primary tech.";
+        toast.error(message);
+      }
+    },
+    [fetchAll],
+  );
+
   const selectedDelLine = useMemo(() => {
     if (!delLineId) return null;
     return lines.find((l) => l.id === delLineId) ?? null;
@@ -2031,7 +2066,7 @@ export default function WorkOrderIdClient(): JSX.Element {
             </section>
 
           {/* Full-height cockpit: navigate left, work center, act right. */}
-          <section className="grid gap-2 rounded-[24px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] p-2 shadow-[0_20px_55px_rgba(15,23,42,0.1)] lg:h-[calc(100vh-12.5rem)] lg:min-h-[44rem] lg:grid-cols-[17rem_minmax(0,1fr)]">
+          <section className="grid items-start gap-2 rounded-[24px] border border-[color:var(--theme-border-soft)] bg-[var(--theme-gradient-panel)] p-2 shadow-[0_20px_55px_rgba(15,23,42,0.1)] lg:grid-cols-[17rem_minmax(0,1fr)]">
             <aside className="flex min-h-0 flex-col overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[0_16px_42px_rgba(15,23,42,0.08)]">
               <div className="flex items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] px-3 py-3">
                 <div>
@@ -2135,41 +2170,8 @@ export default function WorkOrderIdClient(): JSX.Element {
                         onOpen={() => openFocusedJob(ln.id)}
                         onAssign={
                           canAssign
-                            ? async (techId: string) => {
-                                const existingOperation =
-                                  assignmentOperationsRef.current.get(ln.id);
-                                const operationKey =
-                                  existingOperation?.technicianId === techId
-                                    ? existingOperation.operationKey
-                                    : createAssignTechnicianOperationKey(
-                                        ln.id,
-                                        techId,
-                                      );
-
-                                assignmentOperationsRef.current.set(ln.id, {
-                                  technicianId: techId,
-                                  operationKey,
-                                });
-
-                                try {
-                                  await assignWorkOrderLineTechnician({
-                                    lineId: ln.id,
-                                    technicianId: techId,
-                                    operationKey,
-                                  });
-                                  await fetchAll();
-                                  if (
-                                    assignmentOperationsRef.current.get(ln.id)
-                                      ?.operationKey === operationKey
-                                  ) {
-                                    assignmentOperationsRef.current.delete(ln.id);
-                                  }
-                                  toast.success("Primary tech updated.");
-                                } catch (e) {
-                                  const msg = e instanceof Error ? e.message : "Failed to update primary tech.";
-                                  toast.error(msg);
-                                }
-                              }
+                            ? (technicianId: string) =>
+                                void assignLineTechnician(ln.id, technicianId)
                             : undefined
                         }
                         onOpenInspection={
@@ -2318,6 +2320,9 @@ export default function WorkOrderIdClient(): JSX.Element {
                   lineSnapshot={panelLine}
                   primaryTechSnapshot={panelPrimaryTech}
                   isPunchedInSnapshot={panelLineIsPunchedIn}
+                  canAssignTechnician={canAssign}
+                  technicianOptions={assignables}
+                  onAssignTechnician={assignLineTechnician}
                   onChanged={fetchAll}
                   mode="tech"
                   variant="cockpit"

--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -102,6 +102,13 @@ type WorkOrderLine = DB["public"]["Tables"]["work_order_lines"]["Row"] & { techn
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
 type Vehicle = DB["public"]["Tables"]["vehicles"]["Row"];
 type Customer = DB["public"]["Tables"]["customers"]["Row"];
+type TechnicianOption = {
+  id: string;
+  full_name: string | null;
+  role: string | null;
+};
+
+const EMPTY_TECHNICIAN_OPTIONS: readonly TechnicianOption[] = [];
 
 type AllocationRow = DB["public"]["Tables"]["work_order_part_allocations"]["Row"] & {
   parts?: { name: string | null } | null;
@@ -182,12 +189,14 @@ export default function FocusedJobModal(props: {
   onClose: () => void;
   workOrderLineId: string;
   lineSnapshot?: WorkOrderLine | null;
-  primaryTechSnapshot?: {
-    id: string;
-    full_name: string | null;
-    role: string | null;
-  } | null;
+  primaryTechSnapshot?: TechnicianOption | null;
   isPunchedInSnapshot?: boolean;
+  canAssignTechnician?: boolean;
+  technicianOptions?: readonly TechnicianOption[];
+  onAssignTechnician?: (
+    lineId: string,
+    technicianId: string,
+  ) => void | Promise<void>;
   onChanged?: () => void | Promise<void>;
   mode?: Mode;
   variant?: Variant;
@@ -199,6 +208,9 @@ export default function FocusedJobModal(props: {
     lineSnapshot,
     primaryTechSnapshot,
     isPunchedInSnapshot,
+    canAssignTechnician = false,
+    technicianOptions = EMPTY_TECHNICIAN_OPTIONS,
+    onAssignTechnician,
     onChanged,
     mode = "tech",
     variant = "modal",
@@ -238,7 +250,8 @@ export default function FocusedJobModal(props: {
     () => filterAllocationsNotBackedByCanonicalParts(allocs, requiredParts),
     [allocs, requiredParts],
   );
-  const [assignedTechProfile, setAssignedTechProfile] = useState<{ id: string; full_name: string | null; role: string | null } | null>(null);
+  const [assignedTechProfile, setAssignedTechProfile] = useState<TechnicianOption | null>(null);
+  const [assigningTechnician, setAssigningTechnician] = useState(false);
   const [allocsLoading, setAllocsLoading] = useState(false);
 
   const showErr = (prefix: string, err?: { message?: string } | null) => {
@@ -411,7 +424,7 @@ export default function FocusedJobModal(props: {
         .from("profiles")
         .select("id, full_name, role")
         .eq("id", assignedTechId)
-        .maybeSingle<{ id: string; full_name: string | null; role: string | null }>();
+        .maybeSingle<TechnicianOption>();
 
       if (cancelled) return;
       if (error) {
@@ -543,6 +556,19 @@ export default function FocusedJobModal(props: {
     await onChanged?.();
     await loadAllocations();
   }, [supabase, workOrderLineId, onChanged, loadAllocations]);
+
+  const assignTechnician = useCallback(
+    async (technicianId: string): Promise<void> => {
+      if (!line?.id || !onAssignTechnician || assigningTechnician) return;
+      setAssigningTechnician(true);
+      try {
+        await onAssignTechnician(line.id, technicianId);
+      } finally {
+        setAssigningTechnician(false);
+      }
+    },
+    [assigningTechnician, line?.id, onAssignTechnician],
+  );
 
   useEffect(() => {
     const handler = () => void refresh();
@@ -727,6 +753,10 @@ export default function FocusedJobModal(props: {
           ""
         ).trim() || resolvePrimaryTechDisplay(line, assignedTechProfile)
       : "Unassigned";
+  const assignedTechnicianIsSelectable = Boolean(
+    line?.assigned_tech_id &&
+      technicianOptions.some((technician) => technician.id === line.assigned_tech_id),
+  );
   const customerDisplay = customer
     ? customer.business_name?.trim() ||
       [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ") ||
@@ -1390,9 +1420,10 @@ export default function FocusedJobModal(props: {
   const CockpitBody = (
     <div
       data-work-order-cockpit="true"
-      className="grid h-full min-h-[40rem] gap-2 bg-transparent lg:min-h-0 lg:grid-cols-[minmax(0,1fr)_20rem]"
+      data-work-order-scroll-owner="page"
+      className="grid items-start gap-2 bg-transparent lg:grid-cols-[minmax(0,1fr)_20rem]"
     >
-      <section className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] shadow-[0_16px_42px_rgba(15,23,42,0.1)]">
+      <section className="flex min-w-0 flex-col overflow-hidden rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] shadow-[0_16px_42px_rgba(15,23,42,0.1)]">
         <header className="border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] px-5 pb-0 pt-4">
           <div className="flex flex-wrap items-start justify-between gap-3 pb-4">
             <div className="min-w-0">
@@ -1442,7 +1473,7 @@ export default function FocusedJobModal(props: {
           </div>
         </header>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 [scrollbar-gutter:stable]">
+        <div className="px-5 py-5">
           {busy && !line ? (
             <div className="grid gap-3">
               <div className="h-6 w-40 animate-pulse rounded bg-[color:var(--theme-surface-subtle)]" />
@@ -1539,7 +1570,7 @@ export default function FocusedJobModal(props: {
         </div>
       </section>
 
-      <aside className="min-h-0 overflow-y-auto rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[0_16px_42px_rgba(15,23,42,0.1)] [scrollbar-gutter:stable]">
+      <aside className="rounded-[20px] border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[0_16px_42px_rgba(15,23,42,0.1)]">
         <div className="border-b border-[color:var(--theme-border-soft)] px-4 py-4">
           <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">
             Command center
@@ -1695,13 +1726,45 @@ export default function FocusedJobModal(props: {
                   <span className="text-[color:var(--theme-text-secondary)]">Approval</span>
                   <span className="font-semibold capitalize text-[color:var(--theme-text-primary)]">{line.approval_state ?? "Not required"}</span>
                 </div>
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-[color:var(--theme-text-secondary)]">Primary tech</span>
-                  <span className="inline-flex min-w-0 items-center gap-1.5 truncate font-semibold text-[color:var(--theme-text-primary)]">
-                    <UserRound className="h-4 w-4 shrink-0" />
-                    {primaryTechDisplay}
-                  </span>
-                </div>
+                {canAssignTechnician && onAssignTechnician && technicianOptions.length > 0 ? (
+                  <label className="grid gap-1.5">
+                    <span className="text-[color:var(--theme-text-secondary)]">Primary tech</span>
+                    <span className="relative block">
+                      <UserRound className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-[color:var(--theme-text-muted)]" />
+                      <select
+                        aria-label="Primary technician"
+                        value={line.assigned_tech_id ?? ""}
+                        onChange={(event) => void assignTechnician(event.target.value)}
+                        disabled={busy || assigningTechnician}
+                        className="h-10 w-full appearance-none rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-page)] py-2 pl-9 pr-3 text-sm font-semibold text-[color:var(--theme-text-primary)] outline-none transition focus:border-[color:var(--brand-primary)] focus:ring-2 focus:ring-[color:var(--brand-primary)]/20 disabled:cursor-wait disabled:opacity-60"
+                      >
+                        <option value="" disabled>
+                          Choose technician
+                        </option>
+                        {line.assigned_tech_id && !assignedTechnicianIsSelectable ? (
+                          <option value={line.assigned_tech_id}>
+                            {primaryTechDisplay === "Unassigned"
+                              ? "Current technician"
+                              : primaryTechDisplay}
+                          </option>
+                        ) : null}
+                        {technicianOptions.map((technician) => (
+                          <option key={technician.id} value={technician.id}>
+                            {technician.full_name || "Unnamed technician"}
+                          </option>
+                        ))}
+                      </select>
+                    </span>
+                  </label>
+                ) : (
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-[color:var(--theme-text-secondary)]">Primary tech</span>
+                    <span className="inline-flex min-w-0 items-center gap-1.5 truncate font-semibold text-[color:var(--theme-text-primary)]">
+                      <UserRound className="h-4 w-4 shrink-0" />
+                      {primaryTechDisplay}
+                    </span>
+                  </div>
+                )}
               </div>
             </section>
 

--- a/tests/work-order-cockpit-layout.test.ts
+++ b/tests/work-order-cockpit-layout.test.ts
@@ -18,10 +18,13 @@ describe("desktop work-order cockpit", () => {
     expect(detail).toContain("Work order activity");
     expect(detail).toContain("primaryTechSnapshot={panelPrimaryTech}");
     expect(detail).toContain("isPunchedInSnapshot={panelLineIsPunchedIn}");
+    expect(detail).toContain("onAssignTechnician={assignLineTechnician}");
     expect(detail).not.toContain("<PageShell");
 
     expect(focusedJob).toContain('data-work-order-cockpit="true"');
+    expect(focusedJob).toContain('data-work-order-scroll-owner="page"');
     expect(focusedJob).toContain("Command center");
+    expect(focusedJob).toContain('aria-label="Primary technician"');
     expect(focusedJob).toContain('role="tablist"');
     expect(focusedJob).toContain('activeWorkspaceTab === "overview"');
     expect(focusedJob).toContain("resolveOperationalLineStatusLabel");


### PR DESCRIPTION
## What changed

- Adds an explicit Primary technician selector to the command center for users who already have technician-assignment permission.
- Reuses the existing idempotent `assignWorkOrderLineTechnician` helper and operation-key retry behavior.
- Extracts the shared assignment callback so the navigator and command center cannot drift onto different mutation paths.
- Preserves the current assigned technician when that profile is no longer in the selectable roster.
- Removes the desktop cockpit's fixed viewport height and the center workspace's nested vertical scrollbar.
- Makes the document/page the vertical scroll owner while retaining tabbed job content.

## Why

The redesign kept assignment in the selected navigator card, but it was easy to miss and looked removed—especially when the Job actions disclosure was collapsed. The fixed-height cockpit also forced the center workspace into a second scrollbar inside the page.

## Permissions and safety

Assignment permissions are unchanged. Mechanics and other read-only roles continue to see the technician value without an editable selector. Authorized users call the same existing assignment API/helper; there are no schema, migration, RLS, API-contract, or environment-variable changes.

## Validation

- TypeScript: passed
- Focused ESLint: passed
- Focused work-order suite: 9 files / 68 tests passed
- Final targeted cockpit tests: 2 files / 13 tests passed
- React review: stable callback extraction, controlled selector accessibility, client boundaries, and scroll ownership reviewed