### PR TITLE
Fix paid work order closeout flow

### DIFF
--- a/app/api/parts/_lib/lifecycleCommand.ts
+++ b/app/api/parts/_lib/lifecycleCommand.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { toSafeDatabaseError } from "@/features/shared/lib/server/safeDatabaseError";
 
 export function isUuid(value: unknown): value is string {
   return (
@@ -64,8 +65,28 @@ export async function runPartsLifecycleRpc(
   const rpc = access.supabase as unknown as RpcClient;
   const { data, error } = await rpc.rpc(rpcName, scopedArgs);
   if (error) {
-    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
-    return NextResponse.json({ ok: false, error: message }, { status: 409 });
+    const safeError = toSafeDatabaseError(error, {
+      context: `parts/${rpcName}`,
+      fallback: "The parts operation could not be completed.",
+      publicMessagePatterns: [
+        /^FINANCIALLY_LOCKED\b/i,
+        /^A stable idempotency key is required\.?$/i,
+        /^Request item .*not found\.?$/i,
+        /^Part request .*not found\.?$/i,
+        /^Receipt quantity .*$/i,
+        /^Requested .* quantity .*$/i,
+        /^No outstanding .*$/i,
+        /^Cannot .*$/i,
+      ],
+    });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: safeError.message,
+        correlationId: safeError.correlationId,
+      },
+      { status: safeError.isPublicMessage ? 409 : 500 },
+    );
   }
   return NextResponse.json({ ok: true, result: data });
 }

--- a/app/api/parts/_lib/receivePartRequestItem.ts
+++ b/app/api/parts/_lib/receivePartRequestItem.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { toSafeDatabaseError } from "@/features/shared/lib/server/safeDatabaseError";
 
 type ReceivePayload = {
   itemId: string;
@@ -78,7 +79,16 @@ export async function receivePartRequestItem(payload: ReceivePayload): Promise<N
     .eq("id", payload.itemId)
     .eq("shop_id", access.profile.shop_id)
     .maybeSingle();
-  if (itemError) return NextResponse.json({ error: itemError.message }, { status: 500 });
+  if (itemError) {
+    const safeError = toSafeDatabaseError(itemError, {
+      context: "parts/receive-item-lookup",
+      fallback: "The part request could not be loaded.",
+    });
+    return NextResponse.json(
+      { error: safeError.message, correlationId: safeError.correlationId },
+      { status: 500 },
+    );
+  }
   if (!item) return NextResponse.json({ error: "Request item not found for shop." }, { status: 404 });
 
   const rpc = access.supabase as unknown as RpcClient;
@@ -91,9 +101,27 @@ export async function receivePartRequestItem(payload: ReceivePayload): Promise<N
   });
 
   if (error) {
-    const message = [error.message, error.details, error.hint].filter(Boolean).join(" — ");
-    const status = error.message.includes("FINANCIALLY_LOCKED") ? 409 : 400;
-    return NextResponse.json({ error: message }, { status });
+    const safeError = toSafeDatabaseError(error, {
+      context: "parts/receive-item",
+      fallback: "The part receipt could not be completed.",
+      publicMessagePatterns: [
+        /^FINANCIALLY_LOCKED\b/i,
+        /^A stable idempotency key is required\.?$/i,
+        /^Request item .*not found\.?$/i,
+        /^Receipt quantity .*$/i,
+        /^Requested receive quantity .*$/i,
+        /^No outstanding purchase order line .*$/i,
+      ],
+    });
+    const status = error.message.includes("FINANCIALLY_LOCKED")
+      ? 409
+      : safeError.isPublicMessage
+        ? 400
+        : 500;
+    return NextResponse.json(
+      { error: safeError.message, correlationId: safeError.correlationId },
+      { status },
+    );
   }
 
   return NextResponse.json({ ok: true, result: Array.isArray(data) ? data[0] : data });

--- a/app/api/receive-scan/route.ts
+++ b/app/api/receive-scan/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
+import { toSafeDatabaseError } from "@/features/shared/lib/server/safeDatabaseError";
 
 type DB = Database;
 
@@ -139,10 +140,22 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ ok: true, mode: "manual" });
   } catch (e: unknown) {
-    const message =
-      e instanceof Error ? e.message : typeof e === "string" ? e : "Server error";
-
-    console.error("[receive-scan] error:", message);
-    return NextResponse.json({ error: message }, { status: 500 });
+    const databaseError =
+      e && typeof e === "object"
+        ? (e as {
+            message?: string;
+            details?: string;
+            hint?: string;
+            code?: string;
+          })
+        : { message: typeof e === "string" ? e : "Server error" };
+    const safeError = toSafeDatabaseError(databaseError, {
+      context: "receive-scan",
+      fallback: "The stock receipt could not be completed.",
+    });
+    return NextResponse.json(
+      { error: safeError.message, correlationId: safeError.correlationId },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/work-orders/[id]/mark-ready/route.ts
+++ b/app/api/work-orders/[id]/mark-ready/route.ts
@@ -2,7 +2,6 @@ import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { buildWorkOrderCompletedEvent } from "@/features/integrations/shopreel/server/buildProFixIQStoryEvents";
 import { postStoryEventToShopReel } from "@/features/integrations/shopreel/server/postStoryEventToShopReel";
-import { syncWorkOrderToHistory } from "@/features/work-orders/server/syncWorkOrderToHistory";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
 import { seedCompletedWorkOrderIntelligence } from "@/features/ai/server/workOrderIntelligence";
 import { getInvoiceSnapshotForWorkOrder } from "@/features/invoices/server/getInvoiceSnapshot";
@@ -145,15 +144,6 @@ export async function POST(req: Request) {
     });
   }
 
-  let historySync:
-    | { ok: true; historyId: string | null; skippedReason?: string }
-    | null = null;
-  try {
-    historySync = await syncWorkOrderToHistory(access.supabase, workOrderId);
-  } catch (historyError) {
-    console.warn("[work-orders/mark-ready] history sync failed:", historyError);
-  }
-
   try {
     await seedCompletedWorkOrderIntelligence({
       supabase: access.supabase,
@@ -170,6 +160,5 @@ export async function POST(req: Request) {
 
   return NextResponse.json({
     ...(data && typeof data === "object" ? data : { ok: true }),
-    historySync,
   });
 }

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -53,6 +53,7 @@ type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
 type QuoteLineDbRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
+type WorkOrderLineDbRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
 type InspectionPhotoRow = DB["public"]["Tables"]["inspection_photos"]["Row"];
 
 type ParamsShape = Record<string, string | string[] | undefined>;
@@ -84,6 +85,28 @@ type QuoteLineRow = Pick<
   | "updated_at"
 >;
 
+type DirectLineRow = Pick<
+  WorkOrderLineDbRow,
+  | "id"
+  | "line_no"
+  | "description"
+  | "complaint"
+  | "cause"
+  | "correction"
+  | "notes"
+  | "technician_notes"
+  | "labor_time"
+  | "price_estimate"
+  | "status"
+  | "line_status"
+  | "approval_state"
+  | "approval_at"
+  | "quoted_at"
+  | "created_at"
+  | "updated_at"
+  | "voided_at"
+>;
+
 type QuotePartView = {
   name: string;
   qty: number;
@@ -94,6 +117,7 @@ type QuotePartView = {
 
 type LineView = {
   id: string;
+  source: "quote" | "work_order";
   lineNo: number | null;
   title: string;
   complaint: string | null;
@@ -389,16 +413,28 @@ export default function QuotePageClient(): JSX.Element {
     );
     setShop(shopRow);
 
-    const { data: quoteRowsRaw, error: quoteErr } = await supabase
-      .from("work_order_quote_lines")
-      .select(
-        "id, description, ai_complaint, ai_cause, ai_correction, notes, job_type, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, tax_total, grand_total, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id, metadata, created_at, updated_at",
-      )
-      .eq("work_order_id", workOrderId)
-      .eq("shop_id", wo.shop_id)
-      .order("created_at", { ascending: true });
+    const [quoteResult, directLineResult] = await Promise.all([
+      supabase
+        .from("work_order_quote_lines")
+        .select(
+          "id, description, ai_complaint, ai_cause, ai_correction, notes, job_type, labor_hours, est_labor_hours, labor_total, parts_total, subtotal, tax_total, grand_total, status, stage, sent_to_customer_at, approved_at, declined_at, work_order_line_id, metadata, created_at, updated_at",
+        )
+        .eq("work_order_id", workOrderId)
+        .eq("shop_id", wo.shop_id)
+        .order("created_at", { ascending: true }),
+      supabase
+        .from("work_order_lines")
+        .select(
+          "id,line_no,description,complaint,cause,correction,notes,technician_notes,labor_time,price_estimate,status,line_status,approval_state,approval_at,quoted_at,created_at,updated_at,voided_at",
+        )
+        .eq("work_order_id", workOrderId)
+        .eq("shop_id", wo.shop_id)
+        .order("line_no", { ascending: true }),
+    ]);
+    const { data: quoteRowsRaw, error: quoteErr } = quoteResult;
+    const { data: directRowsRaw, error: directLineErr } = directLineResult;
 
-    if (quoteErr) {
+    if (quoteErr || directLineErr) {
       setLines([]);
       setLoading(false);
       return;
@@ -433,7 +469,7 @@ export default function QuotePageClient(): JSX.Element {
       ? (evidenceBody?.items ?? [])
       : [];
 
-    const mapped: LineView[] = ((quoteRowsRaw ?? []) as QuoteLineRow[])
+    const mappedQuoteLines: LineView[] = ((quoteRowsRaw ?? []) as QuoteLineRow[])
       .filter(isCustomerVisibleQuoteLine)
       .map((line, index) => {
         const parts = getQuoteParts(line, Boolean(wo.estimate_number));
@@ -488,6 +524,7 @@ export default function QuotePageClient(): JSX.Element {
 
         return {
           id: line.id,
+          source: "quote" as const,
           lineNo: index + 1,
           title:
             safeTrim(line.description) ||
@@ -530,7 +567,72 @@ export default function QuotePageClient(): JSX.Element {
         };
       });
 
-    setLines(mapped);
+    const linkedWorkOrderLineIds = new Set(
+      mappedQuoteLines
+        .map((line) => line.convertedWorkOrderLineId)
+        .filter((id): id is string => Boolean(id)),
+    );
+    const mappedDirectLines: LineView[] = (
+      (directRowsRaw ?? []) as DirectLineRow[]
+    )
+      .filter((line) => {
+        if (line.voided_at || linkedWorkOrderLineIds.has(line.id)) return false;
+        const status = safeTrim(line.status).toLowerCase();
+        const lineStatus = safeTrim(line.line_status).toLowerCase();
+        const approvalState = safeTrim(line.approval_state).toLowerCase();
+        return (
+          approvalState === "approved" ||
+          lineStatus === "authorized" ||
+          Boolean(line.approval_at) ||
+          ["completed", "ready_to_invoice", "invoiced"].includes(status)
+        );
+      })
+      .map((line, index) => {
+        const laborHours = asNumber(line.labor_time);
+        const computedLabor = laborHours * laborRate;
+        const totalAmount = nullableNumber(line.price_estimate) ?? computedLabor;
+        const laborAmount =
+          totalAmount > 0 ? Math.min(computedLabor, totalAmount) : computedLabor;
+        const partsAmount = Math.max(totalAmount - laborAmount, 0);
+        const linkedEvidence = canonicalEvidence.filter(
+          (item) => item.workOrderLineId === line.id,
+        );
+        return {
+          id: line.id,
+          source: "work_order" as const,
+          lineNo: line.line_no ?? index + 1,
+          title:
+            safeTrim(line.description) ||
+            safeTrim(line.complaint) ||
+            "Authorized work",
+          complaint: safeTrim(line.complaint) || null,
+          cause: safeTrim(line.cause) || null,
+          correction: safeTrim(line.correction) || null,
+          notes:
+            safeTrim(line.technician_notes) || safeTrim(line.notes) || null,
+          laborHours,
+          laborAmount,
+          partsAmount,
+          subtotalAmount: totalAmount,
+          taxAmount: 0,
+          totalAmount,
+          approvalState: "approved" as const,
+          status: line.status,
+          stage: null,
+          sentAt: line.quoted_at ?? null,
+          approvedAt: line.approval_at ?? null,
+          declinedAt: null,
+          convertedWorkOrderLineId: line.id,
+          createdAt: line.created_at ?? null,
+          updatedAt: line.updated_at ?? null,
+          parts: [],
+          evidence: linkedEvidence,
+          requestKind: null,
+          fulfillment: null,
+        };
+      });
+
+    setLines([...mappedQuoteLines, ...mappedDirectLines]);
     setLoading(false);
   }, [router, supabase, workOrderId]);
 
@@ -970,12 +1072,14 @@ export default function QuotePageClient(): JSX.Element {
 
           <QuoteApprovalActions
             workOrderId={workOrder.id}
-            lines={lines.map((line) => ({
-              id: line.id,
-              description: line.title,
-              approval_state: line.approvalState,
-              status: line.status,
-            }))}
+            lines={lines
+              .filter((line) => line.source === "quote")
+              .map((line) => ({
+                id: line.id,
+                description: line.title,
+                approval_state: line.approvalState,
+                status: line.status,
+              }))}
             onChanged={() => {
               void load();
             }}

--- a/features/portal/lib/workOrderPresentation.ts
+++ b/features/portal/lib/workOrderPresentation.ts
@@ -22,6 +22,8 @@ type PortalWorkOrderStatusInput = {
   approvalState?: string | null;
   scheduledAt?: string | null;
   invoiceSentAt?: string | null;
+  paymentStatus?: string | null;
+  paidAt?: string | null;
 };
 
 function normalize(value: string | null | undefined): string {
@@ -84,6 +86,18 @@ export function toPortalWorkOrderStatus(
 ): PortalWorkOrderStatus {
   const status = normalize(input.status);
   const approvalState = normalize(input.approvalState);
+  const paymentStatus = normalize(input.paymentStatus);
+
+  if (paymentStatus === "paid" || Boolean(input.paidAt)) {
+    return {
+      key: "completed",
+      label: "Completed",
+      nextStep:
+        "This service visit is paid and remains available in your history.",
+      actionRequired: false,
+      complete: true,
+    };
+  }
 
   if (
     status === "awaiting_approval" ||

--- a/features/portal/server/portalWorkOrders.ts
+++ b/features/portal/server/portalWorkOrders.ts
@@ -29,6 +29,8 @@ type WorkOrderSummaryRow = Pick<
   | "expected_completion_at"
   | "invoice_sent_at"
   | "invoice_total"
+  | "payment_status"
+  | "paid_at"
   | "vehicle_year"
   | "vehicle_make"
   | "vehicle_model"
@@ -117,6 +119,12 @@ function primaryAction(
       label: "Review estimate",
     };
   }
+  if (status.complete) {
+    return {
+      href: "/portal/history",
+      label: "View history",
+    };
+  }
   if (workOrder.invoice_sent_at) {
     return {
       href: `/portal/invoices/${workOrder.id}`,
@@ -143,7 +151,7 @@ export async function listPortalWorkOrdersForCustomer({
   const { data: workOrders, error: workOrderError } = await supabase
     .from("work_orders")
     .select(
-      "id,custom_id,shop_id,customer_id,vehicle_id,advisor_id,status,approval_state,created_at,updated_at,scheduled_at,expected_completion_at,invoice_sent_at,invoice_total,vehicle_year,vehicle_make,vehicle_model,vehicle_unit_number,vehicle_license_plate,external_id",
+      "id,custom_id,shop_id,customer_id,vehicle_id,advisor_id,status,approval_state,created_at,updated_at,scheduled_at,expected_completion_at,invoice_sent_at,invoice_total,payment_status,paid_at,vehicle_year,vehicle_make,vehicle_model,vehicle_unit_number,vehicle_license_plate,external_id",
     )
     .eq("shop_id", shopId)
     .eq("customer_id", customerId)
@@ -259,6 +267,8 @@ export async function listPortalWorkOrdersForCustomer({
         : workOrder.approval_state,
       scheduledAt: workOrder.scheduled_at,
       invoiceSentAt: workOrder.invoice_sent_at,
+      paymentStatus: workOrder.payment_status,
+      paidAt: workOrder.paid_at,
     });
     const vehicle = vehiclePresentation(
       workOrder,

--- a/features/shared/components/ShiftTracker.tsx
+++ b/features/shared/components/ShiftTracker.tsx
@@ -66,7 +66,7 @@ export default function ShiftTracker({
     setErr(null);
 
     try {
-      applyShiftState(await fetchMobileShiftState(), false);
+      applyShiftState(await fetchMobileShiftState(), true);
     } catch (error) {
       setErr(formatErr(error, "Failed to load shift state"));
       setShiftState(null);

--- a/features/shared/hooks/useWorkOrderBoard.ts
+++ b/features/shared/hooks/useWorkOrderBoard.ts
@@ -70,30 +70,117 @@ export function useWorkOrderBoard(
       return;
     }
 
-    const workOrderIds = boardRows.map((row) => row.work_order_id);
-    const [activeSegmentsResult, requestResults] = await Promise.all([
-      supabase
-        .from("work_order_line_labor_segments")
-        .select("work_order_id")
-        .in("work_order_id", workOrderIds)
-        .is("ended_at", null),
-      Promise.all(
-        Array.from(
-          { length: Math.ceil(workOrderIds.length / 200) },
-          (_, index) =>
-            supabase
-              .from("part_requests")
-              .select("id,work_order_id,status")
-              .in("work_order_id", workOrderIds.slice(index * 200, index * 200 + 200)),
+    const boardWorkOrderIds = boardRows.map((row) => row.work_order_id);
+    const workOrderStateResult = await supabase
+      .from("work_orders")
+      .select("id,payment_status")
+      .in("id", boardWorkOrderIds);
+
+    if (workOrderStateResult.error) {
+      setError(workOrderStateResult.error.message);
+      setRows([]);
+      setLoading(false);
+      return;
+    }
+
+    const paidWorkOrderIds = new Set(
+      (workOrderStateResult.data ?? [])
+        .filter((workOrder) => workOrder.payment_status === "paid")
+        .map((workOrder) => workOrder.id),
+    );
+    const activeBoardRows = boardRows.filter(
+      (row) => !paidWorkOrderIds.has(row.work_order_id),
+    );
+    const workOrderIds = activeBoardRows.map((row) => row.work_order_id);
+
+    if (workOrderIds.length === 0) {
+      setRows([]);
+      setLoading(false);
+      return;
+    }
+
+    const [activeSegmentsResult, assignedLinesResult, requestResults] =
+      await Promise.all([
+        supabase
+          .from("work_order_line_labor_segments")
+          .select("work_order_id")
+          .in("work_order_id", workOrderIds)
+          .is("ended_at", null),
+        supabase
+          .from("work_order_lines")
+          .select("work_order_id,assigned_tech_id,assigned_to")
+          .in("work_order_id", workOrderIds)
+          .is("voided_at", null),
+        Promise.all(
+          Array.from(
+            { length: Math.ceil(workOrderIds.length / 200) },
+            (_, index) =>
+              supabase
+                .from("part_requests")
+                .select("id,work_order_id,status")
+                .in(
+                  "work_order_id",
+                  workOrderIds.slice(index * 200, index * 200 + 200),
+                ),
+          ),
         ),
-      ),
-    ]);
+      ]);
 
     const activeWorkOrderIds = new Set(
       (activeSegmentsResult.data ?? [])
         .map((segment) => segment.work_order_id)
         .filter((id): id is string => typeof id === "string" && id.length > 0),
     );
+
+    const assignedTechIdsByWorkOrder = new Map<string, Set<string>>();
+    for (const line of assignedLinesResult.data ?? []) {
+      const technicianId = line.assigned_tech_id ?? line.assigned_to;
+      if (!technicianId) continue;
+      const ids =
+        assignedTechIdsByWorkOrder.get(line.work_order_id) ?? new Set<string>();
+      ids.add(technicianId);
+      assignedTechIdsByWorkOrder.set(line.work_order_id, ids);
+    }
+    const assignedTechIds = Array.from(
+      new Set(
+        Array.from(assignedTechIdsByWorkOrder.values()).flatMap((ids) =>
+          Array.from(ids),
+        ),
+      ),
+    );
+    const profileNamesById = new Map<string, string>();
+    if (assignedTechIds.length > 0) {
+      const { data: profiles } = await supabase
+        .from("profiles")
+        .select("id,full_name")
+        .in("id", assignedTechIds);
+      for (const profile of profiles ?? []) {
+        profileNamesById.set(
+          profile.id,
+          profile.full_name?.trim() || "Assigned",
+        );
+      }
+    }
+
+    const rowsWithDirectTechnicians = activeBoardRows.map((row) => {
+      const directNames = Array.from(
+        assignedTechIdsByWorkOrder.get(row.work_order_id) ?? [],
+      ).map((id) => profileNamesById.get(id) ?? "Assigned");
+      const techNames = Array.from(
+        new Set([...(row.tech_names ?? []), ...directNames].filter(Boolean)),
+      );
+      if (techNames.length === 0) return row;
+      return {
+        ...row,
+        assigned_tech_count: techNames.length,
+        first_tech_name: techNames[0] ?? null,
+        tech_names: techNames,
+        assigned_summary:
+          techNames.length === 1
+            ? techNames[0]
+            : `${techNames[0]} +${techNames.length - 1}`,
+      };
+    });
 
     const requests = requestResults.flatMap((result) =>
       result.error ? [] : ((result.data ?? []) as OpenPartsRequest[]),
@@ -117,7 +204,7 @@ export function useWorkOrderBoard(
 
     setRows(
       reconcileBoardPartsState(
-        boardRows,
+        rowsWithDirectTechnicians,
         countOpenPartsObligationsByWorkOrder(requests, items),
         activeWorkOrderIds,
       ),

--- a/features/shared/lib/server/safeDatabaseError.ts
+++ b/features/shared/lib/server/safeDatabaseError.ts
@@ -1,0 +1,42 @@
+import crypto from "node:crypto";
+
+export type DatabaseErrorLike = {
+  message?: string | null;
+  details?: string | null;
+  hint?: string | null;
+  code?: string | null;
+};
+
+type SafeDatabaseErrorOptions = {
+  context: string;
+  fallback: string;
+  publicMessagePatterns?: RegExp[];
+};
+
+export type SafeDatabaseError = {
+  message: string;
+  correlationId: string;
+  isPublicMessage: boolean;
+};
+
+export function toSafeDatabaseError(
+  error: DatabaseErrorLike,
+  options: SafeDatabaseErrorOptions,
+): SafeDatabaseError {
+  const correlationId = crypto.randomUUID();
+  const rawMessage = error.message?.trim() ?? "";
+  const isPublicMessage = (options.publicMessagePatterns ?? []).some(
+    (pattern) => pattern.test(rawMessage),
+  );
+
+  console.error(`[${options.context}] database operation failed`, {
+    correlationId,
+    error,
+  });
+
+  return {
+    message: isPublicMessage && rawMessage ? rawMessage : options.fallback,
+    correlationId,
+    isPublicMessage,
+  };
+}

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -13468,6 +13468,13 @@ export type Database = {
             foreignKeyName: "purchase_order_lines_work_order_part_id_fkey"
             columns: ["work_order_part_id"]
             isOneToOne: false
+            referencedRelation: "invoice_net_issued_parts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchase_order_lines_work_order_part_id_fkey"
+            columns: ["work_order_part_id"]
+            isOneToOne: false
             referencedRelation: "work_order_parts"
             referencedColumns: ["id"]
           },

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -13385,6 +13385,7 @@ export type Database = {
           created_at: string
           description: string | null
           id: string
+          idempotency_key: string | null
           location_id: string | null
           part_id: string | null
           part_request_item_id: string | null
@@ -13393,12 +13394,14 @@ export type Database = {
           received_qty: number
           sku: string | null
           unit_cost: number | null
+          work_order_part_id: string | null
         }
         Insert: {
           cancelled_qty?: number
           created_at?: string
           description?: string | null
           id?: string
+          idempotency_key?: string | null
           location_id?: string | null
           part_id?: string | null
           part_request_item_id?: string | null
@@ -13407,12 +13410,14 @@ export type Database = {
           received_qty?: number
           sku?: string | null
           unit_cost?: number | null
+          work_order_part_id?: string | null
         }
         Update: {
           cancelled_qty?: number
           created_at?: string
           description?: string | null
           id?: string
+          idempotency_key?: string | null
           location_id?: string | null
           part_id?: string | null
           part_request_item_id?: string | null
@@ -13421,6 +13426,7 @@ export type Database = {
           received_qty?: number
           sku?: string | null
           unit_cost?: number | null
+          work_order_part_id?: string | null
         }
         Relationships: [
           {
@@ -13456,6 +13462,13 @@ export type Database = {
             columns: ["po_id"]
             isOneToOne: false
             referencedRelation: "purchase_orders"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "purchase_order_lines_work_order_part_id_fkey"
+            columns: ["work_order_part_id"]
+            isOneToOne: false
+            referencedRelation: "work_order_parts"
             referencedColumns: ["id"]
           },
         ]

--- a/supabase/migrations/20260805042000_fix_parts_lifecycle_ensure_lookup.sql
+++ b/supabase/migrations/20260805042000_fix_parts_lifecycle_ensure_lookup.sql
@@ -1,5 +1,37 @@
 begin;
 
+-- The production schema already had these lifecycle links, but the generated
+-- bootstrap baseline did not. Declare the function's table prerequisites so a
+-- clean install and an existing production upgrade converge on the same shape.
+alter table public.purchase_order_lines
+  add column if not exists work_order_part_id uuid,
+  add column if not exists idempotency_key text;
+
+do $constraint$
+begin
+  if not exists (
+    select 1
+    from pg_constraint c
+    where c.conrelid = 'public.purchase_order_lines'::regclass
+      and c.conname = 'purchase_order_lines_work_order_part_id_fkey'
+  ) then
+    alter table public.purchase_order_lines
+      add constraint purchase_order_lines_work_order_part_id_fkey
+      foreign key (work_order_part_id)
+      references public.work_order_parts(id)
+      on delete restrict;
+  end if;
+end
+$constraint$;
+
+create index if not exists idx_purchase_order_lines_wop
+  on public.purchase_order_lines(work_order_part_id)
+  where work_order_part_id is not null;
+
+create unique index if not exists uq_purchase_order_lines_idempotency
+  on public.purchase_order_lines(po_id, idempotency_key)
+  where idempotency_key is not null;
+
 -- Resolve the lifecycle row in a separate statement. Calling the mutating
 -- ensure function from a table WHERE clause can scan past the row that the
 -- function creates or updates and leave the row variable empty.

--- a/supabase/migrations/20260805050000_reconcile_work_order_paid_closeout.sql
+++ b/supabase/migrations/20260805050000_reconcile_work_order_paid_closeout.sql
@@ -1,0 +1,710 @@
+begin;
+
+-- A completed line used to be unable to advance a work order whose stale
+-- header still said awaiting_approval. Reconcile the header from durable line
+-- and quote state instead of treating the old header as an immutable gate.
+create or replace function private.reconcile_work_order_state(
+  p_work_order_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_work_order public.work_orders%rowtype;
+  v_actionable_count integer := 0;
+  v_nonterminal_count integer := 0;
+  v_pending_line_count integer := 0;
+  v_pending_quote_count integer := 0;
+  v_approved_count integer := 0;
+  v_declined_count integer := 0;
+  v_any_in_progress boolean := false;
+  v_any_on_hold boolean := false;
+  v_next_status text;
+  v_next_approval text;
+begin
+  select wo.*
+  into v_work_order
+  from public.work_orders wo
+  where wo.id = p_work_order_id
+  for update;
+
+  if not found
+     or lower(coalesce(v_work_order.status, '')) in ('invoiced', 'cancelled')
+     or public.work_order_is_financially_locked(v_work_order.shop_id, v_work_order.id) then
+    return;
+  end if;
+
+  select
+    count(*) filter (
+      where wol.voided_at is null
+        and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+    ),
+    count(*) filter (
+      where wol.voided_at is null
+        and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+        and lower(coalesce(wol.status::text, '')) not in (
+          'completed', 'ready_to_invoice', 'invoiced'
+        )
+        and lower(coalesce(wol.line_status::text, '')) not in (
+          'declined', 'deferred', 'voided', 'cancelled', 'canceled'
+        )
+    ),
+    count(*) filter (
+      where wol.voided_at is null
+        and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+        and (
+          lower(coalesce(wol.approval_state::text, '')) in (
+            'pending', 'awaiting_approval', 'sent'
+          )
+          or lower(coalesce(wol.status::text, '')) = 'awaiting_approval'
+          or lower(coalesce(wol.line_status::text, '')) = 'pending'
+        )
+        and lower(coalesce(wol.status::text, '')) not in (
+          'completed', 'ready_to_invoice', 'invoiced'
+        )
+        and lower(coalesce(wol.line_status::text, '')) not in (
+          'declined', 'deferred', 'voided', 'cancelled', 'canceled'
+        )
+    ),
+    count(*) filter (
+      where wol.voided_at is null
+        and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+        and (
+          lower(coalesce(wol.approval_state::text, '')) = 'approved'
+          or lower(coalesce(wol.line_status::text, '')) = 'authorized'
+          or lower(coalesce(wol.status::text, '')) in (
+            'completed', 'ready_to_invoice', 'invoiced'
+          )
+        )
+    ),
+    count(*) filter (
+      where wol.voided_at is null
+        and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+        and (
+          lower(coalesce(wol.approval_state::text, '')) = 'declined'
+          or lower(coalesce(wol.line_status::text, '')) in ('declined', 'deferred')
+        )
+    ),
+    coalesce(bool_or(
+      wol.voided_at is null
+      and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+      and (
+        lower(coalesce(wol.status::text, '')) in ('in_progress', 'active')
+        or (wol.punched_in_at is not null and wol.punched_out_at is null)
+      )
+    ), false),
+    coalesce(bool_or(
+      wol.voided_at is null
+      and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+      and lower(coalesce(wol.line_status::text, '')) not in (
+        'declined', 'deferred', 'voided', 'cancelled', 'canceled'
+      )
+      and lower(coalesce(wol.status::text, '')) in (
+        'on_hold', 'waiting_parts', 'paused'
+      )
+    ), false)
+  into
+    v_actionable_count,
+    v_nonterminal_count,
+    v_pending_line_count,
+    v_approved_count,
+    v_declined_count,
+    v_any_in_progress,
+    v_any_on_hold
+  from public.work_order_lines wol
+  where wol.work_order_id = p_work_order_id;
+
+  select count(*)
+  into v_pending_quote_count
+  from public.work_order_quote_lines q
+  where q.work_order_id = p_work_order_id
+    and q.shop_id = v_work_order.shop_id
+    and (
+      q.sent_to_customer_at is not null
+      or lower(coalesce(q.status::text, '')) in ('sent', 'ready_to_send', 'quoted')
+    )
+    and not (
+      lower(coalesce(q.status::text, '')) in (
+        'approved', 'converted', 'declined', 'deferred', 'rejected',
+        'cancelled', 'canceled'
+      )
+      or q.stage::text in (
+        'customer_approved', 'customer_declined', 'customer_deferred'
+      )
+      or q.approved_at is not null
+      or q.declined_at is not null
+      or q.work_order_line_id is not null
+    );
+
+  v_next_approval := case
+    when v_pending_quote_count + v_pending_line_count > 0
+         and v_approved_count > 0 then 'partial'
+    when v_pending_quote_count + v_pending_line_count > 0 then 'pending'
+    when v_approved_count > 0 and v_declined_count > 0 then 'partial'
+    when v_approved_count > 0 then 'approved'
+    when v_declined_count > 0 then 'declined'
+    else v_work_order.approval_state
+  end;
+
+  v_next_status := case
+    when v_actionable_count = 0 then 'queued'
+    when v_pending_quote_count + v_pending_line_count > 0 then 'awaiting_approval'
+    when v_nonterminal_count = 0 then 'ready_to_invoice'
+    when v_any_in_progress then 'in_progress'
+    when v_any_on_hold then 'on_hold'
+    else 'queued'
+  end;
+
+  if v_work_order.status is distinct from v_next_status
+     or v_work_order.approval_state is distinct from v_next_approval then
+    update public.work_orders
+    set status = v_next_status,
+        approval_state = v_next_approval,
+        updated_at = pg_catalog.now()
+    where id = p_work_order_id;
+  end if;
+end;
+$function$;
+
+revoke all on function private.reconcile_work_order_state(uuid)
+  from public, anon, authenticated;
+
+create or replace function public.refresh_work_order_status()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+begin
+  if new.work_order_id is not null then
+    perform private.reconcile_work_order_state(new.work_order_id);
+  end if;
+  return new;
+end;
+$function$;
+
+create or replace function public.refresh_work_order_status_del()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+begin
+  if old.work_order_id is not null then
+    perform private.reconcile_work_order_state(old.work_order_id);
+  end if;
+  return old;
+end;
+$function$;
+
+revoke all on function public.refresh_work_order_status()
+  from public, anon, authenticated;
+revoke all on function public.refresh_work_order_status_del()
+  from public, anon, authenticated;
+
+drop trigger if exists trg_wol_status_refresh on public.work_order_lines;
+create trigger trg_wol_status_refresh
+after insert or update of
+  status,
+  punched_in_at,
+  punched_out_at,
+  approval_state,
+  line_status,
+  voided_at
+on public.work_order_lines
+for each row execute function public.refresh_work_order_status();
+
+drop trigger if exists trg_wol_status_refresh_del on public.work_order_lines;
+create trigger trg_wol_status_refresh_del
+after delete on public.work_order_lines
+for each row execute function public.refresh_work_order_status_del();
+
+-- Preserve a durable approval audit whenever a line first becomes approved.
+create or replace function public.capture_work_order_line_approval_audit()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_customer_user_id uuid;
+  v_method text := 'advisor';
+  v_approved_at timestamptz := coalesce(new.approval_at, pg_catalog.now());
+begin
+  if lower(coalesce(new.approval_state::text, '')) <> 'approved'
+     or lower(coalesce(old.approval_state::text, '')) = 'approved'
+     or new.approval_by is null then
+    return new;
+  end if;
+
+  select c.user_id
+  into v_customer_user_id
+  from public.work_orders wo
+  join public.customers c on c.id = wo.customer_id
+  where wo.id = new.work_order_id;
+
+  if v_customer_user_id is not distinct from new.approval_by then
+    v_method := 'customer';
+  end if;
+
+  if not exists (
+    select 1
+    from public.work_order_approvals a
+    where a.work_order_id = new.work_order_id
+      and a.approved_by is not distinct from new.approval_by
+      and a.approved_at is not distinct from v_approved_at
+      and a.method is not distinct from v_method
+  ) then
+    insert into public.work_order_approvals(
+      work_order_id, approved_by, approved_at, method
+    ) values (
+      new.work_order_id, new.approval_by, v_approved_at, v_method
+    );
+  end if;
+
+  return new;
+end;
+$function$;
+
+revoke all on function public.capture_work_order_line_approval_audit()
+  from public, anon, authenticated;
+
+drop trigger if exists trg_work_order_line_approval_audit
+  on public.work_order_lines;
+create trigger trg_work_order_line_approval_audit
+after update of approval_state on public.work_order_lines
+for each row execute function public.capture_work_order_line_approval_audit();
+
+insert into public.work_order_approvals(
+  work_order_id, approved_by, approved_at, method
+)
+select
+  wol.work_order_id,
+  wol.approval_by,
+  wol.approval_at,
+  case when c.user_id is not distinct from wol.approval_by then 'customer' else 'advisor' end
+from public.work_order_lines wol
+join public.work_orders wo on wo.id = wol.work_order_id
+left join public.customers c on c.id = wo.customer_id
+where lower(coalesce(wol.approval_state::text, '')) = 'approved'
+  and lower(coalesce(wo.status, '')) = 'awaiting_approval'
+  and lower(coalesce(wol.status::text, '')) in (
+    'completed', 'ready_to_invoice', 'invoiced'
+  )
+  and wol.approval_by is not null
+  and wol.approval_at is not null
+  and not exists (
+    select 1
+    from public.work_order_approvals a
+    where a.work_order_id = wol.work_order_id
+      and a.approved_by is not distinct from wol.approval_by
+      and a.approved_at is not distinct from wol.approval_at
+  );
+
+-- Payment is the closeout boundary. Once the immutable invoice is paid, copy
+-- the completed visit to customer history in the same database transaction.
+create or replace function public.sync_paid_work_order_history()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_invoice public.invoices%rowtype;
+  v_history_id uuid;
+  v_description text;
+  v_causes text;
+  v_corrections text;
+  v_labor_hours numeric := 0;
+  v_advisor_name text;
+  v_technician_name text;
+  v_notes text;
+begin
+  if lower(coalesce(new.payment_status, '')) <> 'paid'
+     or new.customer_id is null then
+    return new;
+  end if;
+
+  select i.*
+  into v_invoice
+  from public.invoices i
+  where i.work_order_id = new.id
+    and i.shop_id = new.shop_id
+  order by
+    (i.active_invoice_version_id is not null) desc,
+    i.issued_at desc nulls last,
+    i.created_at desc
+  limit 1;
+
+  select
+    pg_catalog.string_agg(
+      nullif(pg_catalog.concat_ws(
+        ' / ',
+        nullif(pg_catalog.btrim(wol.description), ''),
+        nullif(pg_catalog.btrim(wol.complaint), ''),
+        nullif(pg_catalog.btrim(wol.cause), ''),
+        nullif(pg_catalog.btrim(wol.correction), '')
+      ), ''),
+      E'\n' order by wol.created_at, wol.id
+    ),
+    pg_catalog.string_agg(
+      distinct nullif(pg_catalog.btrim(wol.cause), ''), E'\n'
+    ),
+    pg_catalog.string_agg(
+      distinct nullif(pg_catalog.btrim(wol.correction), ''), E'\n'
+    ),
+    coalesce(pg_catalog.sum(wol.labor_time), 0)
+  into v_description, v_causes, v_corrections, v_labor_hours
+  from public.work_order_lines wol
+  where wol.work_order_id = new.id
+    and wol.voided_at is null;
+
+  select nullif(pg_catalog.btrim(p.full_name), '')
+  into v_advisor_name
+  from public.profiles p
+  where p.id = new.advisor_id;
+
+  select pg_catalog.string_agg(distinct nullif(pg_catalog.btrim(p.full_name), ''), ', ')
+  into v_technician_name
+  from public.work_order_lines wol
+  left join public.work_order_line_technicians wolt
+    on wolt.work_order_line_id = wol.id
+  left join public.profiles p
+    on p.id = coalesce(wolt.technician_id, wol.assigned_tech_id, wol.assigned_to)
+  where wol.work_order_id = new.id
+    and wol.voided_at is null;
+
+  v_description := coalesce(
+    nullif(pg_catalog.btrim(v_description), ''),
+    nullif(pg_catalog.btrim(new.notes), ''),
+    'Completed work order ' || coalesce(new.custom_id, new.id::text)
+  );
+
+  v_notes := pg_catalog.concat_ws(
+    E'\n',
+    'Work order: ' || coalesce(new.custom_id, new.id::text),
+    case when v_invoice.invoice_number is not null
+      then 'Invoice: ' || v_invoice.invoice_number else null end,
+    'Payment: paid',
+    nullif(pg_catalog.btrim(new.notes), '')
+  );
+
+  select h.id
+  into v_history_id
+  from public.history h
+  where h.work_order_id = new.id
+  order by h.created_at asc nulls last, h.id
+  limit 1
+  for update;
+
+  if v_history_id is null then
+    insert into public.history(
+      customer_id,
+      vehicle_id,
+      work_order_id,
+      service_date,
+      description,
+      notes,
+      source_system,
+      source_external_id,
+      work_order_number,
+      invoice_number,
+      opened_at,
+      closed_at,
+      historical_status,
+      advisor_name,
+      assigned_tech_name,
+      priority,
+      cause,
+      correction,
+      labor_hours,
+      labor_sale,
+      parts_sale,
+      shop_supplies,
+      discount,
+      tax,
+      total,
+      approval_state,
+      payment_state,
+      source_payload,
+      shop_id
+    ) values (
+      new.customer_id,
+      new.vehicle_id,
+      new.id,
+      coalesce(new.paid_at, pg_catalog.now()),
+      v_description,
+      v_notes,
+      'profixiq_live',
+      new.id::text,
+      new.custom_id,
+      v_invoice.invoice_number,
+      new.created_at,
+      coalesce(new.paid_at, pg_catalog.now()),
+      'paid',
+      v_advisor_name,
+      v_technician_name,
+      new.priority::text,
+      v_causes,
+      v_corrections,
+      v_labor_hours,
+      coalesce(v_invoice.labor_cost, new.labor_total, 0),
+      coalesce(v_invoice.parts_cost, new.parts_total, 0),
+      coalesce(v_invoice.shop_supplies_total, 0),
+      coalesce(v_invoice.discount_total, 0),
+      coalesce(v_invoice.tax_total, 0),
+      coalesce(v_invoice.total, new.invoice_total, 0),
+      new.approval_state,
+      new.payment_status,
+      pg_catalog.jsonb_build_object(
+        'work_order_id', new.id,
+        'invoice_id', v_invoice.id,
+        'closed_from', 'paid_invoice'
+      ),
+      new.shop_id
+    )
+    returning id into v_history_id;
+  else
+    update public.history
+    set customer_id = new.customer_id,
+        vehicle_id = new.vehicle_id,
+        service_date = coalesce(new.paid_at, pg_catalog.now()),
+        description = v_description,
+        notes = v_notes,
+        source_system = 'profixiq_live',
+        source_external_id = new.id::text,
+        work_order_number = new.custom_id,
+        invoice_number = v_invoice.invoice_number,
+        opened_at = new.created_at,
+        closed_at = coalesce(new.paid_at, pg_catalog.now()),
+        historical_status = 'paid',
+        advisor_name = v_advisor_name,
+        assigned_tech_name = v_technician_name,
+        priority = new.priority::text,
+        cause = v_causes,
+        correction = v_corrections,
+        labor_hours = v_labor_hours,
+        labor_sale = coalesce(v_invoice.labor_cost, new.labor_total, 0),
+        parts_sale = coalesce(v_invoice.parts_cost, new.parts_total, 0),
+        shop_supplies = coalesce(v_invoice.shop_supplies_total, 0),
+        discount = coalesce(v_invoice.discount_total, 0),
+        tax = coalesce(v_invoice.tax_total, 0),
+        total = coalesce(v_invoice.total, new.invoice_total, 0),
+        approval_state = new.approval_state,
+        payment_state = new.payment_status,
+        source_payload = pg_catalog.jsonb_build_object(
+          'work_order_id', new.id,
+          'invoice_id', v_invoice.id,
+          'closed_from', 'paid_invoice'
+        ),
+        shop_id = new.shop_id
+    where id = v_history_id;
+  end if;
+
+  return new;
+end;
+$function$;
+
+revoke all on function public.sync_paid_work_order_history()
+  from public, anon, authenticated;
+
+drop trigger if exists trg_sync_paid_work_order_history
+  on public.work_orders;
+create trigger trg_sync_paid_work_order_history
+after insert or update of payment_status, paid_at
+on public.work_orders
+for each row
+when (new.payment_status = 'paid')
+execute function public.sync_paid_work_order_history();
+
+-- Receiving the last outstanding line closes the PO header automatically.
+create or replace function public.receive_part_request_item(
+  p_item_id uuid,
+  p_location_id uuid,
+  p_qty numeric,
+  p_po_id uuid default null,
+  p_idempotency_key text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_line_id uuid;
+  v_po_id uuid;
+  v_remaining numeric;
+  v_existing public.stock_moves%rowtype;
+  v_result jsonb;
+begin
+  if coalesce(pg_catalog.btrim(p_idempotency_key), '') = '' then
+    raise exception 'A stable idempotency key is required.';
+  end if;
+
+  select
+    pol.id,
+    pol.po_id,
+    greatest(
+      coalesce(pol.qty, 0) - coalesce(pol.cancelled_qty, 0)
+        - coalesce(pol.received_qty, 0),
+      0
+    )
+  into v_line_id, v_po_id, v_remaining
+  from public.purchase_order_lines pol
+  where pol.part_request_item_id = p_item_id
+    and (p_po_id is null or pol.po_id = p_po_id)
+    and coalesce(pol.received_qty, 0)
+      < greatest(coalesce(pol.qty, 0) - coalesce(pol.cancelled_qty, 0), 0)
+  order by pol.created_at asc, pol.id asc
+  limit 1
+  for update;
+
+  if v_line_id is null and p_po_id is not null then
+    select sm.*
+    into v_existing
+    from public.stock_moves sm
+    where sm.idempotency_key = p_idempotency_key
+    for update;
+
+    if found then
+      return coalesce(v_existing.metadata, '{}'::jsonb)
+        || pg_catalog.jsonb_build_object(
+          'ok', true,
+          'idempotent', true,
+          'stock_move_id', v_existing.id,
+          'purchase_order_id', p_po_id,
+          'purchase_order_closed', true
+        );
+    end if;
+
+    raise exception 'No outstanding purchase order line was found for this item.';
+  end if;
+
+  if v_line_id is not null and p_qty > v_remaining then
+    raise exception 'Receipt quantity exceeds the remaining purchase order quantity.';
+  end if;
+
+  v_result := public.parts_receive_request_item(
+    p_item_id,
+    p_location_id,
+    p_qty,
+    v_line_id,
+    null,
+    p_idempotency_key
+  );
+
+  if v_po_id is not null
+     and not exists (
+       select 1
+       from public.purchase_order_lines pol
+       where pol.po_id = v_po_id
+         and coalesce(pol.received_qty, 0)
+           < greatest(coalesce(pol.qty, 0) - coalesce(pol.cancelled_qty, 0), 0)
+     ) then
+    update public.purchase_orders
+    set status = 'received',
+        received_at = coalesce(received_at, current_date)
+    where id = v_po_id
+      and lower(coalesce(status, '')) <> 'received';
+  end if;
+
+  return coalesce(v_result, '{}'::jsonb) || pg_catalog.jsonb_build_object(
+    'purchase_order_id', v_po_id,
+    'purchase_order_closed', v_po_id is not null and not exists (
+      select 1
+      from public.purchase_order_lines pol
+      where pol.po_id = v_po_id
+        and coalesce(pol.received_qty, 0)
+          < greatest(coalesce(pol.qty, 0) - coalesce(pol.cancelled_qty, 0), 0)
+    )
+  );
+end;
+$function$;
+
+revoke all on function public.receive_part_request_item(uuid, uuid, numeric, uuid, text)
+  from public, anon;
+grant execute on function public.receive_part_request_item(uuid, uuid, numeric, uuid, text)
+  to authenticated, service_role;
+
+-- Repair only rows that satisfy the same durable reconciliation rules. The
+-- production preflight found exactly one candidate: the current QA work order.
+do $block$
+declare
+  v_id uuid;
+begin
+  for v_id in
+    select wo.id
+    from public.work_orders wo
+    where lower(coalesce(wo.status, '')) = 'awaiting_approval'
+      and not public.work_order_is_financially_locked(wo.shop_id, wo.id)
+      and exists (
+        select 1
+        from public.work_order_lines wol
+        where wol.work_order_id = wo.id
+          and wol.voided_at is null
+          and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+          and (
+            lower(coalesce(wol.approval_state::text, '')) = 'approved'
+            or lower(coalesce(wol.line_status::text, '')) = 'authorized'
+            or lower(coalesce(wol.status::text, '')) in (
+              'completed', 'ready_to_invoice', 'invoiced'
+            )
+          )
+      )
+      and not exists (
+        select 1
+        from public.work_order_lines wol
+        where wol.work_order_id = wo.id
+          and wol.voided_at is null
+          and lower(coalesce(wol.line_type::text, '')) not in ('info', 'note')
+          and lower(coalesce(wol.status::text, '')) not in (
+            'completed', 'ready_to_invoice', 'invoiced'
+          )
+          and lower(coalesce(wol.line_status::text, '')) not in (
+            'declined', 'deferred', 'voided', 'cancelled', 'canceled'
+          )
+      )
+      and not exists (
+        select 1
+        from public.work_order_quote_lines q
+        where q.work_order_id = wo.id
+          and q.shop_id = wo.shop_id
+          and (
+            q.sent_to_customer_at is not null
+            or lower(coalesce(q.status::text, '')) in (
+              'sent', 'ready_to_send', 'quoted'
+            )
+          )
+          and not (
+            lower(coalesce(q.status::text, '')) in (
+              'approved', 'converted', 'declined', 'deferred', 'rejected',
+              'cancelled', 'canceled'
+            )
+            or q.stage::text in (
+              'customer_approved', 'customer_declined', 'customer_deferred'
+            )
+            or q.approved_at is not null
+            or q.declined_at is not null
+            or q.work_order_line_id is not null
+          )
+      )
+  loop
+    perform private.reconcile_work_order_state(v_id);
+  end loop;
+end
+$block$;
+
+-- Backfill the paid-history projection for any pre-existing paid work order
+-- that does not already have a service-history record.
+update public.work_orders wo
+set payment_status = wo.payment_status
+where wo.payment_status = 'paid'
+  and not exists (
+    select 1 from public.history h where h.work_order_id = wo.id
+  );
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/customer-portal-mobile-refactor.test.ts
+++ b/tests/customer-portal-mobile-refactor.test.ts
@@ -37,6 +37,18 @@ describe("customer portal mobile refactor", () => {
       key: "completed",
       complete: true,
     });
+    expect(
+      toPortalWorkOrderStatus({
+        status: "awaiting_approval",
+        approvalState: "pending",
+        paymentStatus: "paid",
+        paidAt: "2026-08-04T12:00:00.000Z",
+      }),
+    ).toMatchObject({
+      key: "completed",
+      complete: true,
+      actionRequired: false,
+    });
   });
 
   it("removes the internal shop board from every customer portal entry point", () => {

--- a/tests/work-order-paid-closeout.test.ts
+++ b/tests/work-order-paid-closeout.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { toSafeDatabaseError } from "@/features/shared/lib/server/safeDatabaseError";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const migration = read(
+  "supabase/migrations/20260805050000_reconcile_work_order_paid_closeout.sql",
+);
+const markReadyRoute = read("app/api/work-orders/[id]/mark-ready/route.ts");
+const portalLoader = read("features/portal/server/portalWorkOrders.ts");
+const quoteClient = read(
+  "features/portal/app/quotes/[id]/QuotePageClient.tsx",
+);
+const boardHook = read("features/shared/hooks/useWorkOrderBoard.ts");
+const shiftTracker = read("features/shared/components/ShiftTracker.tsx");
+const receiveItem = read("app/api/parts/_lib/receivePartRequestItem.ts");
+const lifecycleCommand = read("app/api/parts/_lib/lifecycleCommand.ts");
+
+describe("work-order paid closeout boundary", () => {
+  it("derives the shell from durable line and quote state", () => {
+    expect(migration).toContain(
+      "create or replace function private.reconcile_work_order_state",
+    );
+    expect(migration).toContain("v_nonterminal_count = 0 then 'ready_to_invoice'");
+    expect(migration).toContain("v_pending_quote_count + v_pending_line_count");
+    expect(migration).toContain("after insert or update of");
+    expect(migration).toContain("approval_state,");
+    expect(migration).toContain("line_status,");
+    expect(migration).not.toContain("pg_catalog.current_date()");
+  });
+
+  it("moves history creation from operational completion to paid settlement", () => {
+    expect(markReadyRoute).not.toContain("syncWorkOrderToHistory");
+    expect(migration).toContain(
+      "create or replace function public.sync_paid_work_order_history",
+    );
+    expect(migration).toContain("when (new.payment_status = 'paid')");
+    expect(migration).toContain("insert into public.history(");
+    expect(migration).toContain("'closed_from', 'paid_invoice'");
+  });
+
+  it("removes paid work from the active board and routes the portal to history", () => {
+    expect(boardHook).toContain('workOrder.payment_status === "paid"');
+    expect(boardHook).toContain("!paidWorkOrderIds.has(row.work_order_id)");
+    expect(portalLoader).toContain('href: "/portal/history"');
+    expect(portalLoader).toContain("paymentStatus: workOrder.payment_status");
+    expect(portalLoader).toContain("paidAt: workOrder.paid_at");
+  });
+
+  it("keeps authorized direct lines visible without making them actionable quotes", () => {
+    expect(quoteClient).toContain('.from("work_order_lines")');
+    expect(quoteClient).toContain('source: "work_order" as const');
+    expect(quoteClient).toContain(
+      '.filter((line) => line.source === "quote")',
+    );
+    expect(quoteClient).toContain("item.workOrderLineId === line.id");
+  });
+
+  it("reconciles direct technicians, shift display, approval audits, and PO closeout", () => {
+    expect(boardHook).toContain("assigned_tech_id,assigned_to");
+    expect(shiftTracker).toContain(
+      "applyShiftState(await fetchMobileShiftState(), true)",
+    );
+    expect(migration).toContain("trg_work_order_line_approval_audit");
+    expect(migration).toContain("insert into public.work_order_approvals(");
+    expect(migration).toContain("set status = 'received'");
+    expect(migration).toContain("received_at = coalesce(received_at, current_date)");
+  });
+
+  it("maps unexpected database failures to a correlation id", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const result = toSafeDatabaseError(
+      {
+        message: 'new row violates check constraint "secret_constraint"',
+        details: "Failing row contains private values",
+        code: "23514",
+      },
+      {
+        context: "test",
+        fallback: "The operation could not be completed.",
+      },
+    );
+
+    expect(result.message).toBe("The operation could not be completed.");
+    expect(result.correlationId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(result.message).not.toContain("constraint");
+    expect(receiveItem).toContain("toSafeDatabaseError");
+    expect(lifecycleCommand).toContain("toSafeDatabaseError");
+    consoleError.mockRestore();
+  });
+});

--- a/tests/work-order-paid-closeout.test.ts
+++ b/tests/work-order-paid-closeout.test.ts
@@ -16,6 +16,10 @@ const boardHook = read("features/shared/hooks/useWorkOrderBoard.ts");
 const shiftTracker = read("features/shared/components/ShiftTracker.tsx");
 const receiveItem = read("app/api/parts/_lib/receivePartRequestItem.ts");
 const lifecycleCommand = read("app/api/parts/_lib/lifecycleCommand.ts");
+const lifecycleEnsureMigration = read(
+  "supabase/migrations/20260805042000_fix_parts_lifecycle_ensure_lookup.sql",
+);
+const generatedTypes = read("features/shared/types/types/supabase.ts");
 
 describe("work-order paid closeout boundary", () => {
   it("derives the shell from durable line and quote state", () => {
@@ -66,6 +70,20 @@ describe("work-order paid closeout boundary", () => {
     expect(migration).toContain("insert into public.work_order_approvals(");
     expect(migration).toContain("set status = 'received'");
     expect(migration).toContain("received_at = coalesce(received_at, current_date)");
+  });
+
+  it("keeps the clean bootstrap schema aligned with production PO lifecycle links", () => {
+    expect(lifecycleEnsureMigration).toContain(
+      "add column if not exists work_order_part_id uuid",
+    );
+    expect(lifecycleEnsureMigration).toContain(
+      "add column if not exists idempotency_key text",
+    );
+    expect(lifecycleEnsureMigration).toContain(
+      "create unique index if not exists uq_purchase_order_lines_idempotency",
+    );
+    expect(generatedTypes).toContain("work_order_part_id: string | null");
+    expect(generatedTypes).toContain("idempotency_key: string | null");
   });
 
   it("maps unexpected database failures to a correlation id", () => {


### PR DESCRIPTION
## Summary

- reconcile work-order shell and customer-facing state from durable line/quote approvals and completion
- make paid invoice settlement the history closeout boundary and remove paid work from the active shop board
- preserve authorized direct work-order lines in the customer quote/history view
- reconcile direct technician assignments and shift header state
- auto-close fully received purchase orders
- replace raw database error details with safe correlation IDs

## Database scope

The migration is transactional and has **not** been applied to production. Live preflight found:
- 0 missing referenced columns
- exactly 1 contradictory work order eligible for reconciliation: `d29739dd-eb17-4cb4-8f17-4f49ffc55f03`
- exactly 1 approval-audit row eligible for backfill
- 0 paid work orders missing history
- 0 fully received open POs

Production application is intentionally paused pending fresh explicit approval after safety review.

## Validation

- `git diff --check` passed
- live Supabase schema/function/RLS preflight passed
- Node/pnpm are unavailable in this workspace, so typecheck/lint/Vitest are delegated to CI
