### PR TITLE
Fix direct-line customer approvals

### DIFF
--- a/.github/workflows/phase-7-customer-portal-validation.yml
+++ b/.github/workflows/phase-7-customer-portal-validation.yml
@@ -7,10 +7,13 @@ on:
       - "app/api/work-orders/lines/**"
       - "app/portal/auth/confirm/page.tsx"
       - "app/portal/auth/fleet-invite/page.tsx"
+      - "features/portal/app/quotes/**"
+      - "features/portal/components/QuoteApprovalActions.tsx"
       - "features/portal/server/**"
       - "supabase/migrations/20260715080*.sql"
       - "tests/auth-portal-hardening.test.ts"
       - "tests/phase7-*.test.ts"
+      - "tests/work-order-paid-closeout.test.ts"
       - ".github/workflows/phase-7-customer-portal-validation.yml"
 
 jobs:
@@ -44,14 +47,18 @@ jobs:
           app/api/work-orders/lines/[id]/approval-decision/route.ts
           app/portal/auth/confirm/page.tsx
           app/portal/auth/fleet-invite/page.tsx
+          features/portal/app/quotes/[id]/QuotePageClient.tsx
+          features/portal/components/QuoteApprovalActions.tsx
           features/portal/server/addPortalRequestLine.ts
           features/portal/server/createPortalBooking.ts
           features/portal/server/customerBookings.ts
           tests/auth-portal-hardening.test.ts
           tests/phase7-portal-invite-booking-contract.test.ts
           tests/phase7-portal-request-approval-contract.test.ts
+          tests/work-order-paid-closeout.test.ts
       - run: >-
           pnpm exec vitest run
           tests/auth-portal-hardening.test.ts
           tests/phase7-portal-invite-booking-contract.test.ts
           tests/phase7-portal-request-approval-contract.test.ts
+          tests/work-order-paid-closeout.test.ts

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -54,6 +54,7 @@ type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
 type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
 type QuoteLineDbRow = DB["public"]["Tables"]["work_order_quote_lines"]["Row"];
 type WorkOrderLineDbRow = DB["public"]["Tables"]["work_order_lines"]["Row"];
+type WorkOrderPartDbRow = DB["public"]["Tables"]["work_order_parts"]["Row"];
 type InspectionPhotoRow = DB["public"]["Tables"]["inspection_photos"]["Row"];
 
 type ParamsShape = Record<string, string | string[] | undefined>;
@@ -105,6 +106,19 @@ type DirectLineRow = Pick<
   | "created_at"
   | "updated_at"
   | "voided_at"
+>;
+
+type DirectPartRow = Pick<
+  WorkOrderPartDbRow,
+  | "id"
+  | "work_order_line_id"
+  | "description_snapshot"
+  | "part_number_snapshot"
+  | "manufacturer_snapshot"
+  | "quantity"
+  | "unit_price"
+  | "total_price"
+  | "is_active"
 >;
 
 type QuotePartView = {
@@ -413,7 +427,7 @@ export default function QuotePageClient(): JSX.Element {
     );
     setShop(shopRow);
 
-    const [quoteResult, directLineResult] = await Promise.all([
+    const [quoteResult, directLineResult, directPartResult] = await Promise.all([
       supabase
         .from("work_order_quote_lines")
         .select(
@@ -430,11 +444,20 @@ export default function QuotePageClient(): JSX.Element {
         .eq("work_order_id", workOrderId)
         .eq("shop_id", wo.shop_id)
         .order("line_no", { ascending: true }),
+      supabase
+        .from("work_order_parts")
+        .select(
+          "id,work_order_line_id,description_snapshot,part_number_snapshot,manufacturer_snapshot,quantity,unit_price,total_price,is_active",
+        )
+        .eq("work_order_id", workOrderId)
+        .eq("shop_id", wo.shop_id)
+        .eq("is_active", true),
     ]);
     const { data: quoteRowsRaw, error: quoteErr } = quoteResult;
     const { data: directRowsRaw, error: directLineErr } = directLineResult;
+    const { data: directPartsRaw, error: directPartErr } = directPartResult;
 
-    if (quoteErr || directLineErr) {
+    if (quoteErr || directLineErr || directPartErr) {
       setLines([]);
       setLoading(false);
       return;
@@ -581,7 +604,10 @@ export default function QuotePageClient(): JSX.Element {
         const lineStatus = safeTrim(line.line_status).toLowerCase();
         const approvalState = safeTrim(line.approval_state).toLowerCase();
         return (
+          (approvalState === "pending" && status === "awaiting_approval") ||
           approvalState === "approved" ||
+          approvalState === "declined" ||
+          approvalState === "deferred" ||
           lineStatus === "authorized" ||
           Boolean(line.approval_at) ||
           ["completed", "ready_to_invoice", "invoiced"].includes(status)
@@ -590,13 +616,54 @@ export default function QuotePageClient(): JSX.Element {
       .map((line, index) => {
         const laborHours = asNumber(line.labor_time);
         const computedLabor = laborHours * laborRate;
-        const totalAmount = nullableNumber(line.price_estimate) ?? computedLabor;
-        const laborAmount =
-          totalAmount > 0 ? Math.min(computedLabor, totalAmount) : computedLabor;
-        const partsAmount = Math.max(totalAmount - laborAmount, 0);
+        const laborAmount = nullableNumber(line.price_estimate) ?? computedLabor;
+        const directParts: QuotePartView[] = (
+          (directPartsRaw ?? []) as DirectPartRow[]
+        )
+          .filter((part) => part.work_order_line_id === line.id)
+          .map((part) => {
+            const qty = asNumber(part.quantity);
+            const unitPrice = asNumber(part.unit_price);
+            return {
+              name: safeTrim(part.description_snapshot) || "Part",
+              qty,
+              unitPrice,
+              total: nullableNumber(part.total_price) ?? qty * unitPrice,
+              meta:
+                [
+                  safeTrim(part.manufacturer_snapshot),
+                  safeTrim(part.part_number_snapshot),
+                ]
+                  .filter(Boolean)
+                  .join(" • ") || null,
+            };
+          });
+        const partsAmount = directParts.reduce(
+          (sum, part) => sum + part.total,
+          0,
+        );
+        const totalAmount = laborAmount + partsAmount;
         const linkedEvidence = canonicalEvidence.filter(
           (item) => item.workOrderLineId === line.id,
         );
+        const normalizedApprovalState = safeTrim(
+          line.approval_state,
+        ).toLowerCase();
+        const approvalState: LineView["approvalState"] = [
+          "pending",
+          "approved",
+          "declined",
+          "deferred",
+        ].includes(normalizedApprovalState)
+          ? (normalizedApprovalState as Exclude<
+              LineView["approvalState"],
+              null
+            >)
+          : ["completed", "ready_to_invoice", "invoiced"].includes(
+                safeTrim(line.status).toLowerCase(),
+              ) || safeTrim(line.line_status).toLowerCase() === "authorized"
+            ? "approved"
+            : null;
         return {
           id: line.id,
           source: "work_order" as const,
@@ -616,7 +683,7 @@ export default function QuotePageClient(): JSX.Element {
           subtotalAmount: totalAmount,
           taxAmount: 0,
           totalAmount,
-          approvalState: "approved" as const,
+          approvalState,
           status: line.status,
           stage: null,
           sentAt: line.quoted_at ?? null,
@@ -625,7 +692,7 @@ export default function QuotePageClient(): JSX.Element {
           convertedWorkOrderLineId: line.id,
           createdAt: line.created_at ?? null,
           updatedAt: line.updated_at ?? null,
-          parts: [],
+          parts: directParts,
           evidence: linkedEvidence,
           requestKind: null,
           fulfillment: null,
@@ -1072,14 +1139,13 @@ export default function QuotePageClient(): JSX.Element {
 
           <QuoteApprovalActions
             workOrderId={workOrder.id}
-            lines={lines
-              .filter((line) => line.source === "quote")
-              .map((line) => ({
-                id: line.id,
-                description: line.title,
-                approval_state: line.approvalState,
-                status: line.status,
-              }))}
+            lines={lines.map((line) => ({
+              id: line.id,
+              source: line.source,
+              description: line.title,
+              approval_state: line.approvalState,
+              status: line.status,
+            }))}
             onChanged={() => {
               void load();
             }}

--- a/features/portal/components/QuoteApprovalActions.tsx
+++ b/features/portal/components/QuoteApprovalActions.tsx
@@ -9,6 +9,7 @@ type ApprovalState = "pending" | "approved" | "declined" | "deferred" | null;
 
 type LineLite = {
   id: string;
+  source: "quote" | "work_order";
   description: string | null;
   approval_state: ApprovalState;
   status: string | null;
@@ -60,22 +61,78 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
     setError(null);
 
     try {
-      const res = await fetch(`/api/work-orders/quotes/${ids[0]}/approval-decision`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Idempotency-Key": operationKey,
-        },
-        body: JSON.stringify({ decision, lineIds: ids, workOrderId, declineRemaining, operationKey }),
-        cache: "no-store",
-      });
+      const targetLines = ids
+        .map((id) => lines.find((line) => line.id === id))
+        .filter((line): line is LineLite => Boolean(line));
+      if (targetLines.length !== ids.length) {
+        setError("One or more approval items could not be found.");
+        return;
+      }
 
-      const json = (await res.json().catch(() => null)) as
-        | { ok?: boolean; error?: string }
-        | null;
+      const quoteIds = targetLines
+        .filter((line) => line.source === "quote")
+        .map((line) => line.id);
+      const workOrderLineIds = targetLines
+        .filter((line) => line.source === "work_order")
+        .map((line) => line.id);
+      const requests: Promise<Response>[] = [];
 
-      if (!res.ok || !json?.ok) {
-        setError(json?.error ?? "Unable to update quote decision.");
+      if (quoteIds.length > 0) {
+        requests.push(
+          fetch(`/api/work-orders/quotes/${quoteIds[0]}/approval-decision`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Idempotency-Key": operationKey,
+            },
+            body: JSON.stringify({
+              decision,
+              lineIds: quoteIds,
+              workOrderId,
+              declineRemaining,
+              operationKey,
+            }),
+            cache: "no-store",
+          }),
+        );
+      }
+
+      for (const lineId of workOrderLineIds) {
+        const lineOperationKey = `${operationKey}:${lineId}`;
+        requests.push(
+          fetch(
+            `/api/work-orders/lines/${encodeURIComponent(lineId)}/approval-decision`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "Idempotency-Key": lineOperationKey,
+              },
+              body: JSON.stringify({
+                decision,
+                workOrderId,
+                idempotencyKey: lineOperationKey,
+              }),
+              cache: "no-store",
+            },
+          ),
+        );
+      }
+
+      const responses = await Promise.all(requests);
+      const results = await Promise.all(
+        responses.map(async (response) => ({
+          response,
+          json: (await response.json().catch(() => null)) as
+            | { ok?: boolean; error?: string }
+            | null,
+        })),
+      );
+      const failed = results.find(
+        ({ response, json }) => !response.ok || !json?.ok,
+      );
+      if (failed) {
+        setError(failed.json?.error ?? "Unable to update approval decision.");
         return;
       }
 

--- a/tests/work-order-paid-closeout.test.ts
+++ b/tests/work-order-paid-closeout.test.ts
@@ -66,6 +66,7 @@ describe("work-order paid closeout boundary", () => {
     expect(quoteApprovalActions).toContain(
       "/api/work-orders/lines/${encodeURIComponent(lineId)}/approval-decision",
     );
+    expect(quoteClient).toContain("source: line.source");
     expect(quoteApprovalActions).toContain('line.source === "work_order"');
     expect(quoteClient).toContain("item.workOrderLineId === line.id");
   });

--- a/tests/work-order-paid-closeout.test.ts
+++ b/tests/work-order-paid-closeout.test.ts
@@ -12,6 +12,9 @@ const portalLoader = read("features/portal/server/portalWorkOrders.ts");
 const quoteClient = read(
   "features/portal/app/quotes/[id]/QuotePageClient.tsx",
 );
+const quoteApprovalActions = read(
+  "features/portal/components/QuoteApprovalActions.tsx",
+);
 const boardHook = read("features/shared/hooks/useWorkOrderBoard.ts");
 const shiftTracker = read("features/shared/components/ShiftTracker.tsx");
 const receiveItem = read("app/api/parts/_lib/receivePartRequestItem.ts");
@@ -52,12 +55,18 @@ describe("work-order paid closeout boundary", () => {
     expect(portalLoader).toContain("paidAt: workOrder.paid_at");
   });
 
-  it("keeps authorized direct lines visible without making them actionable quotes", () => {
+  it("keeps direct lines visible and routes pending decisions to the line API", () => {
     expect(quoteClient).toContain('.from("work_order_lines")');
+    expect(quoteClient).toContain('.from("work_order_parts")');
     expect(quoteClient).toContain('source: "work_order" as const');
     expect(quoteClient).toContain(
-      '.filter((line) => line.source === "quote")',
+      'approvalState === "pending" && status === "awaiting_approval"',
     );
+    expect(quoteClient).toContain("partsAmount = directParts.reduce");
+    expect(quoteApprovalActions).toContain(
+      "/api/work-orders/lines/${encodeURIComponent(lineId)}/approval-decision",
+    );
+    expect(quoteApprovalActions).toContain('line.source === "work_order"');
     expect(quoteClient).toContain("item.workOrderLineId === line.id");
   });
 


### PR DESCRIPTION
## What changed

- show pending direct work-order lines on the customer quote page
- include attached work-order parts in the customer-visible decision total
- route direct-line approve, decline, and defer actions through the existing tenant-scoped line-decision API
- preserve mixed quote/direct bulk decisions with stable idempotency keys

## Root cause

Customer-created menu services are durable `work_order_lines`, not `work_order_quote_lines`. The quote page intentionally preserved approved direct lines for history but filtered pending direct lines and only rendered actions for quote-line records, leaving the portal card actionable while the decision page showed zero items.

## Validation

- reproduced on production work order `0ce48e1c-2058-4055-bb2c-36387513a5d3`
- confirmed the line and two attached parts are durable and tenant-scoped
- `git diff --check` passed
- Node/pnpm remain unavailable locally; typecheck, lint, and focused Vitest run in CI
