### PR TITLE
Allow technician notes on active jobs

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -36,6 +36,10 @@ import { cn } from "@shared/lib/utils";
 import { formatDecisionStatus, resolveDecisionStatus } from "@/features/shared/lib/decisionStatus";
 import { deriveEventsFromWorkOrder } from "@/features/shared/lib/decisionEvents";
 import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/resolveWorkOrderLinePricing";
+import {
+  countActiveWorkOrderLines,
+  formatWorkOrderHeaderStatus,
+} from "@/features/work-orders/lib/display/workOrderPresentation";
 import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
 import {
   getPartsRequestDisplayState,
@@ -290,6 +294,10 @@ export default function WorkOrderIdClient(): JSX.Element {
   );
   const [propertyContext, setPropertyContext] = useState<PropertyContext | null>(null);
   const isPropertySourcedWorkOrder = propertyContext !== null;
+  const workOrderStatusView = useMemo(
+    () => formatWorkOrderHeaderStatus(wo?.status),
+    [wo?.status],
+  );
 
   // ✅ read job from query (desktop panel)
   const jobFromQuery = searchParams?.get("job") || null;
@@ -317,9 +325,9 @@ export default function WorkOrderIdClient(): JSX.Element {
         ? `${workOrderLabel} · ${customerName}`
         : workOrderLabel,
       subtitle: vehicleLabel || undefined,
-      status: formatDecisionStatus({ workStatus: wo.status }).label,
+      status: workOrderStatusView.label,
     });
-  }, [customer, updateActiveTab, vehicle, wo]);
+  }, [customer, updateActiveTab, vehicle, wo, workOrderStatusView.label]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -1039,6 +1047,7 @@ export default function WorkOrderIdClient(): JSX.Element {
   const approvalPending = useMemo(() => jobLines.filter(isPendingApprovalLine), [jobLines]);
 
   const activeJobLines = useMemo(() => jobLines, [jobLines]);
+  const activeJobCount = useMemo(() => countActiveWorkOrderLines(jobLines), [jobLines]);
 
   const approvalPendingQuotes = useMemo(
     () => quoteLines.filter((q) => isReviewableQuoteLine(q)),
@@ -1622,8 +1631,8 @@ export default function WorkOrderIdClient(): JSX.Element {
                 <div className="text-sm font-semibold text-foreground">
                   {wo.custom_id ?? `WO-${wo.id.slice(0, 8)}`}
                 </div>
-                <StatusBadge variant={formatDecisionStatus({ workStatus: wo.status }).variant} size="sm">
-                  {formatDecisionStatus({ workStatus: wo.status }).label}
+                <StatusBadge variant={workOrderStatusView.variant} size="sm">
+                  {workOrderStatusView.label}
                 </StatusBadge>
                 {isWaiter ? (
                   <StatusBadge variant="danger" size="sm">
@@ -1642,8 +1651,8 @@ export default function WorkOrderIdClient(): JSX.Element {
                   : `${customer ? [customer.first_name ?? "", customer.last_name ?? ""].filter(Boolean).join(" ") || "Customer" : "No customer linked"} • ${vehicle ? `${vehicle.year ?? ""} ${vehicle.make ?? ""} ${vehicle.model ?? ""}`.trim() || "Vehicle linked" : "No vehicle linked"}`}
               </div>
               <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px]">
-                <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-muted-foreground">State: {formatDecisionStatus({ workStatus: wo.status }).label}</span>
-                <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-muted-foreground">Active jobs: {sortedLines.length}</span>
+                <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-muted-foreground">State: {workOrderStatusView.label}</span>
+                <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-muted-foreground">Active jobs: {activeJobCount}</span>
                 <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-muted-foreground">In progress: {inProgressCount}</span>
                 <span className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-muted-foreground">Blocked: {blockedCount}</span>
                 {hasAnyApprovalItems ? (
@@ -1729,10 +1738,10 @@ export default function WorkOrderIdClient(): JSX.Element {
                     </div>
                     <div className="mt-1 flex flex-wrap items-center gap-1.5">
                       <StatusBadge
-                        variant={formatDecisionStatus({ workStatus: wo.status }).variant}
+                        variant={workOrderStatusView.variant}
                         size="sm"
                       >
-                        {formatDecisionStatus({ workStatus: wo.status }).label}
+                        {workOrderStatusView.label}
                       </StatusBadge>
                     </div>
                   </div>

--- a/features/work-orders/lib/display/workOrderPresentation.test.ts
+++ b/features/work-orders/lib/display/workOrderPresentation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  countActiveWorkOrderLines,
+  formatWorkOrderHeaderStatus,
+} from "./workOrderPresentation";
+
+describe("work-order presentation", () => {
+  it("keeps financial readiness distinct from generic completion", () => {
+    expect(formatWorkOrderHeaderStatus("ready_to_invoice").label).toBe(
+      "Ready to invoice",
+    );
+    expect(formatWorkOrderHeaderStatus("invoiced").label).toBe("Invoiced");
+    expect(formatWorkOrderHeaderStatus("completed").label).toBe("Completed");
+  });
+
+  it("counts only nonterminal job lines as active", () => {
+    expect(
+      countActiveWorkOrderLines([
+        { status: "active" },
+        { status: "waiting_parts" },
+        { status: "completed" },
+        { status: "ready_to_invoice" },
+        { status: "invoiced" },
+        { status: "declined" },
+        { status: "deferred" },
+      ]),
+    ).toBe(2);
+  });
+});

--- a/features/work-orders/lib/display/workOrderPresentation.ts
+++ b/features/work-orders/lib/display/workOrderPresentation.ts
@@ -1,0 +1,46 @@
+import {
+  formatDecisionStatus,
+  type DecisionStatusView,
+} from "@/features/shared/lib/decisionStatus";
+import {
+  normalizeWorkOrderLineStatus,
+  type WorkOrderLineStatus,
+} from "@/features/work-orders/lib/line-status";
+import { normalizeWorkOrderStatus } from "@/features/work-orders/lib/work-order-status";
+
+const NON_ACTIVE_LINE_STATUSES = new Set<WorkOrderLineStatus>([
+  "completed",
+  "ready_to_invoice",
+  "invoiced",
+  "declined",
+  "deferred",
+]);
+
+export function formatWorkOrderHeaderStatus(
+  status: string | null | undefined,
+): DecisionStatusView {
+  const normalized = normalizeWorkOrderStatus(status);
+  const decisionStatus = formatDecisionStatus({ workStatus: normalized });
+
+  if (normalized === "ready_to_invoice") {
+    return { ...decisionStatus, label: "Ready to invoice" };
+  }
+
+  if (normalized === "invoiced") {
+    return { ...decisionStatus, label: "Invoiced" };
+  }
+
+  if (normalized === "cancelled") {
+    return { ...decisionStatus, label: "Cancelled", variant: "danger" };
+  }
+
+  return decisionStatus;
+}
+
+export function countActiveWorkOrderLines(
+  lines: ReadonlyArray<{ status?: string | null }>,
+): number {
+  return lines.filter(
+    (line) => !NON_ACTIVE_LINE_STATUSES.has(normalizeWorkOrderLineStatus(line.status)),
+  ).length;
+}

--- a/supabase/migrations/20260805134500_restore_active_technician_notes.sql
+++ b/supabase/migrations/20260805134500_restore_active_technician_notes.sql
@@ -1,0 +1,113 @@
+begin;
+
+-- The follow-up hardening migration narrowed note mutations to an explicit
+-- status allowlist, but accidentally omitted the canonical status written by
+-- the mobile Start Job command. Preserve all hardening guards while restoring
+-- technician notes and story drafts for actively punched jobs.
+create or replace function public.apply_offline_line_mutation_atomic(
+  p_shop_id uuid,
+  p_actor_user_id uuid,
+  p_operation_key text,
+  p_action_type text,
+  p_work_order_line_id uuid,
+  p_payload jsonb
+) returns jsonb
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_line public.work_order_lines%rowtype;
+  v_role text;
+  v_existing public.offline_mutation_receipts%rowtype;
+  v_receipt_id uuid;
+  v_payload jsonb := coalesce(p_payload,'{}'::jsonb);
+  v_payload_hash text := encode(digest(coalesce(p_payload,'{}'::jsonb)::text,'sha256'),'hex');
+  v_base_updated_at timestamptz;
+  v_result jsonb;
+begin
+  if auth.uid() is not null and auth.uid()<>p_actor_user_id then raise exception using errcode='P0001',message='Authenticated actor does not match the mutation actor.'; end if;
+  if nullif(trim(p_operation_key),'') is null or length(p_operation_key)>240 then raise exception using errcode='P0001',message='A stable operation key is required.'; end if;
+  if p_action_type not in ('update_work_order_line_notes','save_story_draft') then raise exception using errcode='P0001',message='Unsupported offline line mutation.'; end if;
+
+  select * into v_existing from public.offline_mutation_receipts receipt
+  where receipt.shop_id=p_shop_id and receipt.operation_key=p_operation_key;
+  if found then
+    if v_existing.action_type<>p_action_type or v_existing.payload_hash<>v_payload_hash then raise exception using errcode='P0001',message='IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.'; end if;
+    return v_existing.result||jsonb_build_object('idempotent',true,'receipt_id',v_existing.id);
+  end if;
+
+  select lower(coalesce(profile.role::text,'')) into v_role
+  from public.profiles profile where profile.id=p_actor_user_id and profile.shop_id=p_shop_id;
+  if not found then raise exception using errcode='P0001',message='Actor is not available for this shop.'; end if;
+
+  select * into v_line from public.work_order_lines line
+  where line.id=p_work_order_line_id and line.shop_id=p_shop_id for update;
+  if not found then raise exception using errcode='P0001',message='Work-order line not found for shop.'; end if;
+  if v_line.voided_at is not null
+     or lower(coalesce(v_line.status::text,'')) not in (
+       'awaiting','assigned','queued','approved','active','in_progress','on_hold','paused','waiting_parts'
+     ) then
+    raise exception using errcode='P0001',message='Work-order line is not active.';
+  end if;
+  if v_role not in ('owner','admin','manager','advisor','service','lead_hand','lead hand','leadhand','foreman')
+     and v_line.assigned_tech_id is distinct from p_actor_user_id
+     and not exists (
+       select 1 from public.work_order_line_technicians assignment
+       where assignment.work_order_line_id=p_work_order_line_id and assignment.technician_id=p_actor_user_id
+     ) then raise exception using errcode='P0001',message='Actor is not assigned to this work-order line.'; end if;
+
+  if nullif(trim(v_payload->>'baseUpdatedAt'),'') is not null then
+    begin v_base_updated_at := (v_payload->>'baseUpdatedAt')::timestamptz;
+    exception when invalid_datetime_format then raise exception using errcode='P0001',message='Invalid offline base version.'; end;
+    if v_line.updated_at is distinct from v_base_updated_at then raise exception using errcode='P0001',message='OFFLINE_VERSION_CONFLICT: this job changed on another device. Review the server state before retrying.'; end if;
+  end if;
+
+  if p_action_type='update_work_order_line_notes' then
+    update public.work_order_lines set technician_notes=coalesce(v_payload->>'notes',''),updated_at=now()
+    where id=p_work_order_line_id and shop_id=p_shop_id;
+  else
+    update public.work_order_lines
+    set cause=coalesce(v_payload->>'cause',''),correction=coalesce(v_payload->>'correction',''),updated_at=now()
+    where id=p_work_order_line_id and shop_id=p_shop_id;
+  end if;
+
+  v_result := jsonb_build_object('ok',true,'idempotent',false,'action_type',p_action_type,'work_order_id',v_line.work_order_id,'work_order_line_id',p_work_order_line_id,'completed_at',now());
+  insert into public.offline_mutation_receipts(
+    shop_id,actor_user_id,operation_key,action_type,payload_hash,entity_type,entity_id,result
+  ) values (
+    p_shop_id,p_actor_user_id,p_operation_key,p_action_type,v_payload_hash,'work_order_line',p_work_order_line_id,v_result
+  ) returning id into v_receipt_id;
+  return v_result||jsonb_build_object('receipt_id',v_receipt_id);
+exception when unique_violation then
+  select * into v_existing from public.offline_mutation_receipts receipt
+  where receipt.shop_id=p_shop_id and receipt.operation_key=p_operation_key;
+  if found and v_existing.action_type=p_action_type and v_existing.payload_hash=v_payload_hash then
+    return v_existing.result||jsonb_build_object('idempotent',true,'receipt_id',v_existing.id);
+  end if;
+  raise exception using errcode='P0001',message='IDEMPOTENCY_KEY_REUSE: operation key belongs to different mutation data.';
+end;
+$$;
+
+revoke all on function public.apply_offline_line_mutation_atomic(uuid,uuid,text,text,uuid,jsonb) from public,anon;
+grant execute on function public.apply_offline_line_mutation_atomic(uuid,uuid,text,text,uuid,jsonb) to authenticated,service_role;
+
+do $$
+declare
+  v_definition text;
+begin
+  select pg_get_functiondef(
+    'public.apply_offline_line_mutation_atomic(uuid,uuid,text,text,uuid,jsonb)'::regprocedure
+  ) into v_definition;
+
+  if position('''active''' in v_definition) = 0 then
+    raise exception 'Active technician-note status was not restored';
+  end if;
+  if position('v_line.voided_at is not null' in v_definition) = 0 then
+    raise exception 'Voided-line guard was not preserved';
+  end if;
+end;
+$$;
+
+notify pgrst,'reload schema';
+commit;

--- a/tests/mobile-active-approved-notes.test.ts
+++ b/tests/mobile-active-approved-notes.test.ts
@@ -6,6 +6,8 @@ const originalMigrationPath =
   "supabase/migrations/20260804055000_allow_active_approved_job_notes.sql";
 const hardeningMigrationPath =
   "supabase/migrations/20260804120000_codex_review_followup_hardening.sql";
+const activeStatusRepairPath =
+  "supabase/migrations/20260805134500_restore_active_technician_notes.sql";
 
 describe("mobile technician notes on active approved jobs", () => {
   it("keeps the mobile editor available for active approved work", () => {
@@ -20,6 +22,7 @@ describe("mobile technician notes on active approved jobs", () => {
   it("preserves the original permission repair and supersedes it with active-state and void guards", () => {
     const original = readFileSync(originalMigrationPath, "utf8");
     const hardening = readFileSync(hardeningMigrationPath, "utf8");
+    const activeStatusRepair = readFileSync(activeStatusRepairPath, "utf8");
 
     expect(original).toContain(
       "create or replace function public.apply_offline_line_mutation_atomic",
@@ -30,5 +33,11 @@ describe("mobile technician notes on active approved jobs", () => {
     expect(hardening).toContain("OFFLINE_VERSION_CONFLICT");
     expect(hardening).toContain("Actor is not assigned to this work-order line.");
     expect(hardening).toContain("offline_mutation_receipts");
+    expect(activeStatusRepair).toContain(
+      "create or replace function public.apply_offline_line_mutation_atomic",
+    );
+    expect(activeStatusRepair).toContain("'active'");
+    expect(activeStatusRepair).toContain("v_line.voided_at is not null");
+    expect(activeStatusRepair).toContain("OFFLINE_VERSION_CONFLICT");
   });
 });


### PR DESCRIPTION
## Summary
- restore the canonical `active` job status to the offline technician-note mutation allowlist
- preserve void, assignment, idempotency, and optimistic-version guards
- add a forward-only migration postcondition and regression coverage

## Production verification
- reproduced on work-order line `fdab1109-8ae7-4903-8d9d-25d10a723a0d`: Start Job wrote `status=active`, then notes were rejected as inactive
- applied the forward migration to production
- retried the same active punch and received `Notes saved`; the durable technician note is being verified as part of the continued E2E flow

## Validation
- `git diff --check` passed
- full CI requested; local Node/pnpm is unavailable in this workspace