### PR TITLE
Repair production invoice finalization schema drift

### DIFF
--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -295,8 +295,8 @@ export default function WorkOrderIdClient(): JSX.Element {
   const [propertyContext, setPropertyContext] = useState<PropertyContext | null>(null);
   const isPropertySourcedWorkOrder = propertyContext !== null;
   const workOrderStatusView = useMemo(
-    () => formatWorkOrderHeaderStatus(wo?.status),
-    [wo?.status],
+    () => formatWorkOrderHeaderStatus(wo?.status, wo?.payment_status),
+    [wo?.payment_status, wo?.status],
   );
 
   // ✅ read job from query (desktop panel)

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -48,6 +48,7 @@ type Row = Pick<
   | "correction"
   | "source_external_id"
   | "source_row_id"
+  | "source_system"
   | "imported_from_session_id"
 > & {
   customers: Pick<
@@ -114,7 +115,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
     let query = supabase
       .from("history")
       .select(
-        "id, customer_id, vehicle_id, work_order_id, service_date, description, notes, created_at, work_order_number, invoice_number, historical_status, payment_state, approval_state, odometer, advisor_name, assigned_tech_name, labor_sale, parts_sale, tax, total, symptom, cause, correction, source_external_id, source_row_id, imported_from_session_id, customers:customers(first_name,last_name,email,phone), vehicles:vehicles(year,make,model,license_plate,vin,unit_number)",
+        "id, customer_id, vehicle_id, work_order_id, service_date, description, notes, created_at, work_order_number, invoice_number, historical_status, payment_state, approval_state, odometer, advisor_name, assigned_tech_name, labor_sale, parts_sale, tax, total, symptom, cause, correction, source_system, source_external_id, source_row_id, imported_from_session_id, customers:customers(first_name,last_name,email,phone), vehicles:vehicles(year,make,model,license_plate,vin,unit_number)",
       )
       .order("service_date", { ascending: false })
       .limit(300);
@@ -286,6 +287,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
             <div className="grid gap-2">
               {rows.map((r) => {
                 const p = parseHistoryNotes(r.notes);
+                const isLiveServiceRecord = r.source_system === "profixiq_live";
                 return (
                   <ImportedHistoryRecordCard
                     key={r.id}
@@ -298,7 +300,16 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                     summary={
                       r.description?.trim() ||
                       p.extraLines.join(" • ") ||
-                      "Imported historical service record"
+                      (isLiveServiceRecord
+                        ? "Closed service record"
+                        : "Imported historical service record")
+                    }
+                    badgeLabel={
+                      isLiveServiceRecord
+                        ? r.payment_state === "paid"
+                          ? "Paid service"
+                          : "Service history"
+                        : undefined
                     }
                     action={
                       <div className="flex flex-wrap items-center gap-3">

--- a/features/work-orders/components/ImportedHistoryRecordCard.tsx
+++ b/features/work-orders/components/ImportedHistoryRecordCard.tsx
@@ -47,6 +47,7 @@ type Props = {
   onToggle?: () => void;
   action?: ReactNode;
   className?: string;
+  badgeLabel?: string;
 };
 
 function formatMoney(value: number | null | undefined): string | null {
@@ -101,6 +102,7 @@ export function ImportedHistoryRecordCard({
   onToggle,
   action,
   className = "",
+  badgeLabel = "Read-only imported",
 }: Props): JSX.Element {
   const detailsId = `imported-history-details-${row.id}`;
   const serviceSummary =
@@ -139,7 +141,7 @@ export function ImportedHistoryRecordCard({
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <span className="rounded-full border border-[var(--accent-copper-soft)]/45 bg-[var(--accent-copper-soft)]/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--accent-copper,#C57A4A)]">
-            Read-only imported
+            {badgeLabel}
           </span>
           {onToggle ? (
             <button

--- a/features/work-orders/lib/display/workOrderPresentation.test.ts
+++ b/features/work-orders/lib/display/workOrderPresentation.test.ts
@@ -11,6 +11,7 @@ describe("work-order presentation", () => {
       "Ready to invoice",
     );
     expect(formatWorkOrderHeaderStatus("invoiced").label).toBe("Invoiced");
+    expect(formatWorkOrderHeaderStatus("invoiced", "paid").label).toBe("Paid");
     expect(formatWorkOrderHeaderStatus("completed").label).toBe("Completed");
   });
 

--- a/features/work-orders/lib/display/workOrderPresentation.ts
+++ b/features/work-orders/lib/display/workOrderPresentation.ts
@@ -18,9 +18,18 @@ const NON_ACTIVE_LINE_STATUSES = new Set<WorkOrderLineStatus>([
 
 export function formatWorkOrderHeaderStatus(
   status: string | null | undefined,
+  paymentStatus?: string | null,
 ): DecisionStatusView {
   const normalized = normalizeWorkOrderStatus(status);
   const decisionStatus = formatDecisionStatus({ workStatus: normalized });
+  const normalizedPaymentStatus = String(paymentStatus ?? "")
+    .trim()
+    .toLowerCase()
+    .replaceAll(" ", "_");
+
+  if (normalizedPaymentStatus === "paid") {
+    return { ...decisionStatus, label: "Paid", variant: "success" };
+  }
 
   if (normalized === "ready_to_invoice") {
     return { ...decisionStatus, label: "Ready to invoice" };

--- a/supabase/migrations/20260805135500_restore_invoice_created_by.sql
+++ b/supabase/migrations/20260805135500_restore_invoice_created_by.sql
@@ -1,0 +1,46 @@
+begin;
+
+-- Older production shops can predate the invoice dependency baseline. Because
+-- that baseline uses CREATE TABLE IF NOT EXISTS, it cannot add this audit
+-- column to an already-existing invoices table. Invoice finalization writes
+-- the actor through this column, so reconcile the shape explicitly.
+alter table public.invoices
+  add column if not exists created_by uuid;
+
+do $block$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.invoices'::regclass
+      and conname = 'invoices_created_by_fkey'
+  ) then
+    alter table public.invoices
+      add constraint invoices_created_by_fkey
+      foreign key (created_by)
+      references auth.users(id)
+      on delete set null
+      not valid;
+  end if;
+end
+$block$;
+
+alter table public.invoices
+  validate constraint invoices_created_by_fkey;
+
+do $block$
+begin
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'invoices'
+      and column_name = 'created_by'
+      and data_type = 'uuid'
+  ) then
+    raise exception 'invoices.created_by reconciliation failed';
+  end if;
+end
+$block$;
+
+commit;

--- a/tests/live-invoice-flow-safety.test.ts
+++ b/tests/live-invoice-flow-safety.test.ts
@@ -12,6 +12,10 @@ const invoiceRoute = readFileSync("app/api/work-orders/[id]/invoice/route.ts", "
 const invoicePdfRoute = readFileSync("app/api/work-orders/[id]/invoice-pdf/route.ts", "utf8");
 const workOrderView = readFileSync("features/work-orders/app/work-orders/view/page.tsx", "utf8");
 const manualPayment = readFileSync("features/invoices/components/RecordManualPayment.tsx", "utf8");
+const invoiceCreatedByReconciliation = readFileSync(
+  "supabase/migrations/20260805135500_restore_invoice_created_by.sql",
+  "utf8",
+);
 
 describe("regular live invoice flow safety", () => {
   it("prices 1.0 labor hour from explicit total or labor rate, never as $1.00", () => {
@@ -121,5 +125,20 @@ describe("regular live invoice flow safety", () => {
     expect(previewClient).toContain("SyncInvoiceToQuickBooksButton");
     expect(previewClient).toContain("RecordManualPayment");
     expect(manualPayment).toContain('fetch("/api/payments/manual"');
+  });
+
+  it("reconciles the invoice audit column required by finalization", () => {
+    expect(invoiceCreatedByReconciliation).toContain(
+      "add column if not exists created_by uuid",
+    );
+    expect(invoiceCreatedByReconciliation).toContain(
+      "constraint invoices_created_by_fkey",
+    );
+    expect(invoiceCreatedByReconciliation).toContain(
+      "references auth.users(id)",
+    );
+    expect(invoiceCreatedByReconciliation).toContain(
+      "invoices.created_by reconciliation failed",
+    );
   });
 });

--- a/tests/work-order-paid-closeout.test.ts
+++ b/tests/work-order-paid-closeout.test.ts
@@ -23,6 +23,10 @@ const lifecycleEnsureMigration = read(
   "supabase/migrations/20260805042000_fix_parts_lifecycle_ensure_lookup.sql",
 );
 const generatedTypes = read("features/shared/types/types/supabase.ts");
+const shopHistory = read("app/work-orders/history/WorkOrdersHistoryClient.tsx");
+const historyCard = read(
+  "features/work-orders/components/ImportedHistoryRecordCard.tsx",
+);
 
 describe("work-order paid closeout boundary", () => {
   it("derives the shell from durable line and quote state", () => {
@@ -53,6 +57,14 @@ describe("work-order paid closeout boundary", () => {
     expect(portalLoader).toContain('href: "/portal/history"');
     expect(portalLoader).toContain("paymentStatus: workOrder.payment_status");
     expect(portalLoader).toContain("paidAt: workOrder.paid_at");
+  });
+
+  it("identifies live paid closeouts as service history instead of imports", () => {
+    expect(shopHistory).toContain('r.source_system === "profixiq_live"');
+    expect(shopHistory).toContain('? "Paid service"');
+    expect(shopHistory).toContain("badgeLabel={");
+    expect(historyCard).toContain('badgeLabel = "Read-only imported"');
+    expect(historyCard).toContain("{badgeLabel}");
   });
 
   it("keeps direct lines visible and routes pending decisions to the line API", () => {


### PR DESCRIPTION
## Summary
- reconcile the nullable `invoices.created_by` audit column required by the canonical invoice finalization RPC
- preserve the expected `auth.users` foreign key and add a migration postcondition
- distinguish live paid service history from imported read-only records in the shop history UI
- add invoice and paid-closeout regression contracts

## Production evidence
- reproduced `/api/invoices/finalize` failing safely because `invoices.created_by` did not exist
- verified the live admin actor exists in `auth.users` and the generated/bootstrap schema already expects the column
- applied the forward-only migration to production
- retried the same idempotent finalization successfully
- recorded one CAD 266.86 cash payment, producing one paid invoice version, one payment event, one zero-balance receipt, and one history row
- verified the paid work order is absent from the active job board and present in both shop and customer history
- verified the customer invoice shows paid in full with CAD 0.00 balance

## Validation
- `git diff --check` passed
- production transaction and portal evidence passed
- local Node/pnpm is unavailable; Vercel preview validation requested