### PR TITLE
Reconcile purchase order costs and totals

### DIFF
--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -1237,7 +1237,14 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
       return true;
     }
 
-    const rawUnitCost = Number(item.unit_cost);
+    const selectedInventoryPart = parts.find(
+      (part) => String(part.id) === String(item.part_id),
+    );
+    const rawUnitCost = Number(
+      selectedInventoryPart?.default_cost ??
+        selectedInventoryPart?.cost ??
+        item.unit_cost,
+    );
     const unitCost = Number.isFinite(rawUnitCost) ? Math.max(rawUnitCost, 0) : null;
     const idempotencyKey = [
       "request-order",

--- a/app/work-orders/view/[id]/page.tsx
+++ b/app/work-orders/view/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { format } from "date-fns";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import { formatWorkOrderHeaderStatus } from "@/features/work-orders/lib/display/workOrderPresentation";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
@@ -142,6 +143,10 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
   const expectedCompletionAt = wo?.expected_completion_at
     ? format(new Date(wo.expected_completion_at), "PPpp")
     : "—";
+  const statusView = formatWorkOrderHeaderStatus(
+    wo?.status,
+    wo?.payment_status,
+  );
 
   const goBack = () => {
     const r = safeTrim(returnUrl);
@@ -207,10 +212,10 @@ export default function WorkOrderReadOnlyStoryPage(): JSX.Element {
                   <span
                     className={
                       "rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] " +
-                      chipClass(wo.status)
+                      chipClass(statusView.label)
                     }
                   >
-                    {String(wo.status ?? "—").replaceAll("_", " ")}
+                    {statusView.label}
                   </span>
                   <span className="desktop-pill px-2 py-0.5 text-[10px] font-mono text-[color:var(--theme-text-secondary)]">
                     {wo.id.slice(0, 8)}

--- a/supabase/migrations/20260805143000_reconcile_purchase_order_costs_and_totals.sql
+++ b/supabase/migrations/20260805143000_reconcile_purchase_order_costs_and_totals.sql
@@ -1,0 +1,228 @@
+begin;
+
+-- A request can begin as a customer-facing quote before an inventory record is
+-- selected. In that state legacy rows may carry the sell price in unit_cost.
+-- Once a catalog-backed PO line is created, prefer the catalog acquisition cost
+-- only when the submitted value is absent or is the unchanged mirrored sell
+-- price. A genuinely distinct supplier quote remains authoritative.
+create or replace function public.normalize_purchase_order_line_cost()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_request_cost numeric;
+  v_request_sell numeric;
+  v_catalog_cost numeric;
+begin
+  if new.part_request_item_id is null or new.part_id is null then
+    return new;
+  end if;
+
+  select
+    item.unit_cost,
+    coalesce(item.unit_price, item.quoted_price),
+    coalesce(part.default_cost, part.cost)
+  into v_request_cost, v_request_sell, v_catalog_cost
+  from public.part_request_items item
+  join public.parts part
+    on part.id = new.part_id
+   and part.shop_id = item.shop_id
+  join public.purchase_orders po
+    on po.id = new.po_id
+   and po.shop_id = item.shop_id
+  where item.id = new.part_request_item_id
+    and item.part_id = new.part_id;
+
+  if found
+     and v_catalog_cost is not null
+     and (
+       new.unit_cost is null
+       or (
+         v_request_cost is not null
+         and round(new.unit_cost, 4) = round(v_request_cost, 4)
+         and v_request_sell is not null
+         and round(v_request_cost, 4) = round(v_request_sell, 4)
+       )
+     ) then
+    new.unit_cost := v_catalog_cost;
+  end if;
+
+  if new.unit_cost is null then
+    new.unit_cost := 0;
+  end if;
+  if new.unit_cost < 0 then
+    raise exception using errcode = '22023', message = 'PO line unit cost cannot be negative.';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.normalize_purchase_order_line_cost()
+  from public, anon, authenticated;
+
+drop trigger if exists trg_normalize_purchase_order_line_cost
+  on public.purchase_order_lines;
+create trigger trg_normalize_purchase_order_line_cost
+before insert or update of part_request_item_id, part_id, unit_cost
+on public.purchase_order_lines
+for each row
+execute function public.normalize_purchase_order_line_cost();
+
+-- The PO line is the durable procurement-cost boundary. Keep its linked
+-- lifecycle rows aligned so margins do not continue using a pre-inventory
+-- customer sell price.
+create or replace function public.sync_purchase_order_line_cost_to_parts()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if new.part_request_item_id is not null then
+    update public.part_request_items item
+    set unit_cost = new.unit_cost,
+        updated_at = now()
+    where item.id = new.part_request_item_id
+      and item.unit_cost is distinct from new.unit_cost;
+  end if;
+
+  if new.work_order_part_id is not null then
+    update public.work_order_parts part
+    set unit_cost_snapshot = new.unit_cost,
+        updated_at = now()
+    where part.id = new.work_order_part_id
+      and part.unit_cost_snapshot is distinct from new.unit_cost;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.sync_purchase_order_line_cost_to_parts()
+  from public, anon, authenticated;
+
+drop trigger if exists trg_sync_purchase_order_line_cost_to_parts
+  on public.purchase_order_lines;
+create trigger trg_sync_purchase_order_line_cost_to_parts
+after insert or update of part_request_item_id, work_order_part_id, unit_cost
+on public.purchase_order_lines
+for each row
+execute function public.sync_purchase_order_line_cost_to_parts();
+
+create or replace function public.recalculate_purchase_order_totals(
+  p_po_id uuid
+)
+returns void
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_subtotal numeric;
+begin
+  select round(
+    coalesce(sum(
+      greatest(coalesce(line.qty, 0) - coalesce(line.cancelled_qty, 0), 0)
+      * greatest(coalesce(line.unit_cost, 0), 0)
+    ), 0),
+    2
+  )
+  into v_subtotal
+  from public.purchase_order_lines line
+  where line.po_id = p_po_id;
+
+  update public.purchase_orders po
+  set subtotal = v_subtotal,
+      total = round(
+        v_subtotal
+        + greatest(coalesce(po.tax_total, 0), 0)
+        + greatest(coalesce(po.shipping_total, 0), 0),
+        2
+      )
+  where po.id = p_po_id;
+end;
+$$;
+
+revoke all on function public.recalculate_purchase_order_totals(uuid)
+  from public, anon, authenticated;
+
+create or replace function public.sync_purchase_order_totals_from_line()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if tg_op = 'DELETE' then
+    perform public.recalculate_purchase_order_totals(old.po_id);
+    return old;
+  end if;
+
+  perform public.recalculate_purchase_order_totals(new.po_id);
+  if tg_op = 'UPDATE' and old.po_id is distinct from new.po_id then
+    perform public.recalculate_purchase_order_totals(old.po_id);
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.sync_purchase_order_totals_from_line()
+  from public, anon, authenticated;
+
+drop trigger if exists trg_sync_purchase_order_totals_from_line
+  on public.purchase_order_lines;
+create trigger trg_sync_purchase_order_totals_from_line
+after insert or delete or update of po_id, qty, unit_cost, cancelled_qty
+on public.purchase_order_lines
+for each row
+execute function public.sync_purchase_order_totals_from_line();
+
+-- Repair header arithmetic only where line detail exists. Header-only imports
+-- retain their original totals because no deterministic line rollup is possible.
+do $$
+declare
+  v_po record;
+begin
+  for v_po in
+    select distinct line.po_id
+    from public.purchase_order_lines line
+    where line.po_id is not null
+  loop
+    perform public.recalculate_purchase_order_totals(v_po.po_id);
+  end loop;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.purchase_order_lines'::regclass
+      and tgname = 'trg_normalize_purchase_order_line_cost'
+      and not tgisinternal
+  ) then
+    raise exception 'Purchase-order cost normalization trigger is missing.';
+  end if;
+  if not exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.purchase_order_lines'::regclass
+      and tgname = 'trg_sync_purchase_order_line_cost_to_parts'
+      and not tgisinternal
+  ) then
+    raise exception 'Purchase-order lifecycle cost sync trigger is missing.';
+  end if;
+  if not exists (
+    select 1 from pg_trigger
+    where tgrelid = 'public.purchase_order_lines'::regclass
+      and tgname = 'trg_sync_purchase_order_totals_from_line'
+      and not tgisinternal
+  ) then
+    raise exception 'Purchase-order total rollup trigger is missing.';
+  end if;
+end;
+$$;
+
+commit;

--- a/supabase/migrations/20260805143000_reconcile_purchase_order_costs_and_totals.sql
+++ b/supabase/migrations/20260805143000_reconcile_purchase_order_costs_and_totals.sql
@@ -5,7 +5,7 @@ begin;
 -- Once a catalog-backed PO line is created, prefer the catalog acquisition cost
 -- only when the submitted value is absent or is the unchanged mirrored sell
 -- price. A genuinely distinct supplier quote remains authoritative.
-create or replace function public.normalize_purchase_order_line_cost()
+create or replace function private.normalize_purchase_order_line_cost()
 returns trigger
 language plpgsql
 security definer
@@ -60,7 +60,7 @@ begin
 end;
 $$;
 
-revoke all on function public.normalize_purchase_order_line_cost()
+revoke all on function private.normalize_purchase_order_line_cost()
   from public, anon, authenticated;
 
 drop trigger if exists trg_normalize_purchase_order_line_cost
@@ -69,12 +69,12 @@ create trigger trg_normalize_purchase_order_line_cost
 before insert or update of part_request_item_id, part_id, unit_cost
 on public.purchase_order_lines
 for each row
-execute function public.normalize_purchase_order_line_cost();
+execute function private.normalize_purchase_order_line_cost();
 
 -- The PO line is the durable procurement-cost boundary. Keep its linked
 -- lifecycle rows aligned so margins do not continue using a pre-inventory
 -- customer sell price.
-create or replace function public.sync_purchase_order_line_cost_to_parts()
+create or replace function private.sync_purchase_order_line_cost_to_parts()
 returns trigger
 language plpgsql
 security definer
@@ -101,7 +101,7 @@ begin
 end;
 $$;
 
-revoke all on function public.sync_purchase_order_line_cost_to_parts()
+revoke all on function private.sync_purchase_order_line_cost_to_parts()
   from public, anon, authenticated;
 
 drop trigger if exists trg_sync_purchase_order_line_cost_to_parts
@@ -110,9 +110,9 @@ create trigger trg_sync_purchase_order_line_cost_to_parts
 after insert or update of part_request_item_id, work_order_part_id, unit_cost
 on public.purchase_order_lines
 for each row
-execute function public.sync_purchase_order_line_cost_to_parts();
+execute function private.sync_purchase_order_line_cost_to_parts();
 
-create or replace function public.recalculate_purchase_order_totals(
+create or replace function private.recalculate_purchase_order_totals(
   p_po_id uuid
 )
 returns void
@@ -146,10 +146,10 @@ begin
 end;
 $$;
 
-revoke all on function public.recalculate_purchase_order_totals(uuid)
+revoke all on function private.recalculate_purchase_order_totals(uuid)
   from public, anon, authenticated;
 
-create or replace function public.sync_purchase_order_totals_from_line()
+create or replace function private.sync_purchase_order_totals_from_line()
 returns trigger
 language plpgsql
 security definer
@@ -157,19 +157,19 @@ set search_path = public, pg_temp
 as $$
 begin
   if tg_op = 'DELETE' then
-    perform public.recalculate_purchase_order_totals(old.po_id);
+    perform private.recalculate_purchase_order_totals(old.po_id);
     return old;
   end if;
 
-  perform public.recalculate_purchase_order_totals(new.po_id);
+  perform private.recalculate_purchase_order_totals(new.po_id);
   if tg_op = 'UPDATE' and old.po_id is distinct from new.po_id then
-    perform public.recalculate_purchase_order_totals(old.po_id);
+    perform private.recalculate_purchase_order_totals(old.po_id);
   end if;
   return new;
 end;
 $$;
 
-revoke all on function public.sync_purchase_order_totals_from_line()
+revoke all on function private.sync_purchase_order_totals_from_line()
   from public, anon, authenticated;
 
 drop trigger if exists trg_sync_purchase_order_totals_from_line
@@ -178,7 +178,7 @@ create trigger trg_sync_purchase_order_totals_from_line
 after insert or delete or update of po_id, qty, unit_cost, cancelled_qty
 on public.purchase_order_lines
 for each row
-execute function public.sync_purchase_order_totals_from_line();
+execute function private.sync_purchase_order_totals_from_line();
 
 -- Repair header arithmetic only where line detail exists. Header-only imports
 -- retain their original totals because no deterministic line rollup is possible.
@@ -191,7 +191,7 @@ begin
     from public.purchase_order_lines line
     where line.po_id is not null
   loop
-    perform public.recalculate_purchase_order_totals(v_po.po_id);
+    perform private.recalculate_purchase_order_totals(v_po.po_id);
   end loop;
 end;
 $$;

--- a/tests/parts/purchase-order-cost-rollup.test.ts
+++ b/tests/parts/purchase-order-cost-rollup.test.ts
@@ -18,13 +18,13 @@ describe("purchase-order cost and total reconciliation", () => {
   it("prefers catalog acquisition cost when the request still mirrors sell price", () => {
     expect(requestPage).toContain("selectedInventoryPart?.default_cost");
     expect(requestPage).toContain("selectedInventoryPart?.cost");
-    expect(migration).toContain("create or replace function public.normalize_purchase_order_line_cost()");
+    expect(migration).toContain("create or replace function private.normalize_purchase_order_line_cost()");
     expect(migration).toContain("round(v_request_cost, 4) = round(v_request_sell, 4)");
     expect(migration).toContain("new.unit_cost := v_catalog_cost");
   });
 
   it("synchronizes the durable request and work-order cost snapshots", () => {
-    expect(migration).toContain("create or replace function public.sync_purchase_order_line_cost_to_parts()");
+    expect(migration).toContain("create or replace function private.sync_purchase_order_line_cost_to_parts()");
     expect(migration).toContain("set unit_cost = new.unit_cost");
     expect(migration).toContain("set unit_cost_snapshot = new.unit_cost");
   });

--- a/tests/parts/purchase-order-cost-rollup.test.ts
+++ b/tests/parts/purchase-order-cost-rollup.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  new URL(
+    "../../supabase/migrations/20260805143000_reconcile_purchase_order_costs_and_totals.sql",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+const requestPage = readFileSync(
+  new URL("../../app/parts/requests/[id]/page.tsx", import.meta.url),
+  "utf8",
+);
+
+describe("purchase-order cost and total reconciliation", () => {
+  it("prefers catalog acquisition cost when the request still mirrors sell price", () => {
+    expect(requestPage).toContain("selectedInventoryPart?.default_cost");
+    expect(requestPage).toContain("selectedInventoryPart?.cost");
+    expect(migration).toContain("create or replace function public.normalize_purchase_order_line_cost()");
+    expect(migration).toContain("round(v_request_cost, 4) = round(v_request_sell, 4)");
+    expect(migration).toContain("new.unit_cost := v_catalog_cost");
+  });
+
+  it("synchronizes the durable request and work-order cost snapshots", () => {
+    expect(migration).toContain("create or replace function public.sync_purchase_order_line_cost_to_parts()");
+    expect(migration).toContain("set unit_cost = new.unit_cost");
+    expect(migration).toContain("set unit_cost_snapshot = new.unit_cost");
+  });
+
+  it("rolls active line cost into the PO header including tax and shipping", () => {
+    expect(migration).toContain("coalesce(line.qty, 0) - coalesce(line.cancelled_qty, 0)");
+    expect(migration).toContain("+ greatest(coalesce(po.tax_total, 0), 0)");
+    expect(migration).toContain("+ greatest(coalesce(po.shipping_total, 0), 0)");
+    expect(migration).toContain("trg_sync_purchase_order_totals_from_line");
+  });
+
+  it("backfills only PO headers that have deterministic line detail", () => {
+    expect(migration).toContain("select distinct line.po_id");
+    expect(migration).toContain("where line.po_id is not null");
+  });
+});

--- a/tests/work-order-paid-closeout.test.ts
+++ b/tests/work-order-paid-closeout.test.ts
@@ -27,6 +27,7 @@ const shopHistory = read("app/work-orders/history/WorkOrdersHistoryClient.tsx");
 const historyCard = read(
   "features/work-orders/components/ImportedHistoryRecordCard.tsx",
 );
+const readOnlyWorkOrder = read("app/work-orders/view/[id]/page.tsx");
 
 describe("work-order paid closeout boundary", () => {
   it("derives the shell from durable line and quote state", () => {
@@ -65,6 +66,13 @@ describe("work-order paid closeout boundary", () => {
     expect(shopHistory).toContain("badgeLabel={");
     expect(historyCard).toContain('badgeLabel = "Read-only imported"');
     expect(historyCard).toContain("{badgeLabel}");
+  });
+
+  it("shows the paid state on the read-only work-order story", () => {
+    expect(readOnlyWorkOrder).toContain(
+      "formatWorkOrderHeaderStatus(\n    wo?.status,\n    wo?.payment_status",
+    );
+    expect(readOnlyWorkOrder).toContain("{statusView.label}");
   });
 
   it("keeps direct lines visible and routes pending decisions to the line API", () => {


### PR DESCRIPTION
## Summary
- prefer catalog acquisition cost when a parts request still mirrors the customer sell price
- normalize PO-line costs at the database boundary and synchronize request/work-order cost snapshots
- roll active PO-line value into header subtotal and total, including tax and shipping
- show paid state on the read-only work-order story linked from service history

## Production evidence
- the completed QA flow stored catalog costs of CAD 5.25 and CAD 4.25 but copied CAD 9.99 sell prices into request/PO cost fields
- the same PO retained zero subtotal/total despite two received lines
- service history correctly linked the paid work order but its story displayed raw `invoiced`

## Validation
- `git diff --cached --check` passed
- React review: shared status presenter reused; no new state/effects; catalog lookup occurs only in the order action
- static regression contracts added for PO cost normalization, lifecycle cost synchronization, header rollups, and paid history status
- local Node/pnpm unavailable; Supabase clean replay and Vercel preview requested