### PR TITLE
Repair inspection signing and portal approvals

### DIFF
--- a/app/api/inspections/sign/route.ts
+++ b/app/api/inspections/sign/route.ts
@@ -6,6 +6,7 @@ import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server
 import { createAdminClient } from "@/features/integrations/shopreel/server/createAdminClient";
 import { publishInspectionPdf } from "@/features/inspections/server/publishInspectionPdf";
 import type { InspectionSession } from "@/features/inspections/lib/inspection/types";
+import { insertPrioritizedJobsFromInspection } from "@/features/work-orders/lib/work-orders/insertPrioritizedJobsFromInspection";
 
 type Role = "technician" | "customer" | "advisor";
 
@@ -352,6 +353,44 @@ export async function POST(req: NextRequest) {
       { error: resolved.error },
       { status: resolved.status },
     );
+  }
+
+  if (bodyUnknown.role === "technician") {
+    const { data: inspectionContext, error: inspectionContextError } =
+      await supabase
+        .from("inspections")
+        .select("work_order_id, vehicle_id")
+        .eq("id", resolved.inspectionId)
+        .eq("shop_id", profile.shop_id)
+        .eq("is_canonical", true)
+        .maybeSingle<{
+          work_order_id: string | null;
+          vehicle_id: string | null;
+        }>();
+
+    if (inspectionContextError || !inspectionContext?.work_order_id) {
+      return NextResponse.json(
+        {
+          error:
+            inspectionContextError?.message ??
+            "Inspection is not attached to a work order; findings cannot be submitted.",
+        },
+        { status: inspectionContextError ? 400 : 409 },
+      );
+    }
+
+    const imported = await insertPrioritizedJobsFromInspection({
+      supabase,
+      inspectionId: resolved.inspectionId,
+      workOrderId: inspectionContext.work_order_id,
+      vehicleId: inspectionContext.vehicle_id,
+      userId: user.id,
+      operationKey: `sign:${resolved.inspectionId}:${bodyUnknown.expectedSyncRevision}`,
+    });
+
+    if (!imported.ok) {
+      return NextResponse.json({ error: imported.error }, { status: 400 });
+    }
   }
 
   const { data, error } = await callSignInspectionRpc(supabase, {

--- a/app/api/work-orders/quotes/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/quotes/[id]/approval-decision/route.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
 import { NextResponse, type NextRequest } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import type { Database } from "@shared/types/types/supabase";
+import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
+import { PortalAccessError } from "@/features/portal/server/portalAuth";
 import {
   applyWorkOrderQuoteLineDecision,
   type QuoteApprovalDecision,
@@ -11,7 +11,6 @@ import {
 
 export const runtime = "nodejs";
 
-type DB = Database;
 type RouteContext = { params: Promise<{ id: string }> };
 type Body = {
   decision?: QuoteApprovalDecision;
@@ -26,27 +25,22 @@ function safeTrim(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function serviceSupabase() {
-  return createClient<DB>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  );
-}
-
 export async function POST(req: NextRequest, context: RouteContext) {
   const routeSupabase = createServerSupabaseRoute();
   const { id } = await context.params;
   const routeQuoteLineId = safeTrim(id);
 
-  const {
-    data: { user },
-    error: userError,
-  } = await routeSupabase.auth.getUser();
-
-  if (userError || !user) {
+  let actor;
+  try {
+    actor = await requirePortalCustomerActor(routeSupabase);
+  } catch (error) {
+    const status = error instanceof PortalAccessError ? error.status : 400;
     return NextResponse.json(
-      { ok: false, error: "Unauthorized" },
-      { status: 401 },
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : "Unable to authorize portal access",
+      },
+      { status },
     );
   }
 
@@ -82,30 +76,11 @@ export async function POST(req: NextRequest, context: RouteContext) {
     );
   }
 
-  const { data: customer, error: customerError } = await routeSupabase
-    .from("customers")
-    .select("id")
-    .eq("user_id", user.id)
-    .maybeSingle();
-
-  if (customerError) {
-    return NextResponse.json(
-      { ok: false, error: customerError.message },
-      { status: 400 },
-    );
-  }
-  if (!customer?.id) {
-    return NextResponse.json(
-      { ok: false, error: "Customer profile not found" },
-      { status: 403 },
-    );
-  }
-
   const { data: workOrder, error: workOrderError } = await routeSupabase
     .from("work_orders")
     .select("id, shop_id, customer_id")
     .eq("id", workOrderId)
-    .eq("customer_id", customer.id)
+    .eq("customer_id", actor.customer.id)
     .maybeSingle();
 
   if (workOrderError) {
@@ -117,7 +92,7 @@ export async function POST(req: NextRequest, context: RouteContext) {
   if (
     !workOrder?.id ||
     !workOrder.shop_id ||
-    workOrder.customer_id !== customer.id
+    workOrder.customer_id !== actor.customer.id
   ) {
     return NextResponse.json(
       { ok: false, error: "Quote not found" },
@@ -126,12 +101,12 @@ export async function POST(req: NextRequest, context: RouteContext) {
   }
 
   const result = await applyWorkOrderQuoteLineDecision({
-    supabase: serviceSupabase(),
+    supabase: routeSupabase,
     quoteLineIds,
     workOrderId: workOrder.id,
     shopId: workOrder.shop_id,
-    customerId: customer.id,
-    actorUserId: user.id,
+    customerId: actor.customer.id,
+    actorUserId: actor.userId,
     decision,
     declineRemaining: body?.declineRemaining === true,
     operationKey,

--- a/app/inspections/findings/page.tsx
+++ b/app/inspections/findings/page.tsx
@@ -1,1 +1,5 @@
-export { default } from "@/features/inspections/lib/inspection/findings/page";
+import { redirect } from "next/navigation";
+
+export default function LegacyInspectionFindingsPage(): never {
+  redirect("/inspections");
+}

--- a/features/inspections/components/inspection/InspectionSignaturePanel.tsx
+++ b/features/inspections/components/inspection/InspectionSignaturePanel.tsx
@@ -39,7 +39,7 @@ function roleLabel(role: SignatureRole): string {
 
 function roleSubtext(role: SignatureRole): string {
   if (role === "technician")
-    return "Uses the saved signature from your profile (no re-signing every time).";
+    return "Signing submits failed and recommended findings to Quote Review, then locks this inspection.";
   if (role === "advisor")
     return "Sign to approve/confirm this inspection snapshot.";
   return "A staff user records the customer's typed acknowledgement; no drawn customer signature is captured.";
@@ -258,7 +258,11 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
         throw new Error(json?.error || "Signature failed");
       }
 
-      toast.success(`${roleLabel(role)} signature captured.`);
+      toast.success(
+        role === "technician"
+          ? "Inspection signed and findings submitted to Quote Review."
+          : `${roleLabel(role)} signature captured.`,
+      );
       onSigned?.();
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -376,4 +380,3 @@ const InspectionSignaturePanel: React.FC<InspectionSignaturePanelProps> = ({
 };
 
 export default InspectionSignaturePanel;
-

--- a/features/inspections/lib/inspection/SectionDisplay.tsx
+++ b/features/inspections/lib/inspection/SectionDisplay.tsx
@@ -202,9 +202,6 @@ export default function SectionDisplay(props: SectionDisplayProps) {
     onUpdateStatus,
     onUpdateNote,
     onUpdatePhotos,
-    requireNoteForAI,
-    onSubmitAI,
-    isSubmittingAI,
     smartMatchByKey,
     smartMatchLoadingByKey,
     onAcceptSmartMatch,
@@ -450,15 +447,6 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                   const isFailOrRec = isFail || isRec;
 
                   const note = getNote(item).trim();
-
-                  const canShowSubmit =
-                    !!requireNoteForAI &&
-                    isFailOrRec &&
-                    note.length > 0 &&
-                    typeof onSubmitAI === "function";
-
-                  const submitting =
-                    isSubmittingAI?.(sectionIndex, itemIndex) ?? false;
 
                   const rail = isFail
                     ? "before:bg-red-500/70"
@@ -1024,59 +1012,6 @@ export default function SectionDisplay(props: SectionDisplayProps) {
                         </div>
                       ) : null}
 
-                      {canShowSubmit && (
-                        <div className="mt-2 flex items-center justify-end gap-2">
-                          {(() => {
-                            if (!submitted) {
-                              return (
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="sm"
-                                  className="px-3"
-                                  disabled={submitting}
-                                  onClick={() =>
-                                    onSubmitAI?.(sectionIndex, itemIndex)
-                                  }
-                                >
-                                  {submitting
-                                    ? "Submitting…"
-                                    : "Submit for estimate"}
-                                </Button>
-                              );
-                            }
-
-                            if (isEditing) {
-                              return (
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="sm"
-                                  className="px-3"
-                                  disabled={submitting}
-                                  onClick={() =>
-                                    onSubmitAI?.(sectionIndex, itemIndex)
-                                  }
-                                >
-                                  {submitting ? "Updating…" : "Update estimate"}
-                                </Button>
-                              );
-                            }
-
-                            return (
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                className="px-3 opacity-70"
-                                disabled
-                              >
-                                Submitted
-                              </Button>
-                            );
-                          })()}
-                        </div>
-                      )}
                     </div>
                   );
                 })}

--- a/features/inspections/lib/inspection/ui/TireCornerGrid.tsx
+++ b/features/inspections/lib/inspection/ui/TireCornerGrid.tsx
@@ -6,7 +6,6 @@ import { useInspectionForm } from "@inspections/lib/inspection/ui/InspectionForm
 import type {
   InspectionItem,
 } from "@inspections/lib/inspection/types";
-import { Button } from "@shared/components/ui/Button";
 
 type PartLine = { description: string; qty: number };
 
@@ -273,11 +272,6 @@ function getLabel(it: InspectionItem): string {
   return String(anyIt.item ?? anyIt.name ?? "").trim();
 }
 
-function readNotes(it: InspectionItem): string {
-  const anyIt = it as unknown as { notes?: unknown; note?: unknown };
-  return String(anyIt.notes ?? anyIt.note ?? "").trim();
-}
-
 function readParts(it: InspectionItem): PartLine[] {
   const anyIt = it as unknown as { parts?: unknown };
   if (!Array.isArray(anyIt.parts)) return [];
@@ -347,8 +341,6 @@ export default function TireGrid(props: Props) {
     unitHint,
     onAddAxle,
     requireNoteForAI,
-    onSubmitAI,
-    isSubmittingAI,
     onUpdateParts,
     onUpdateLaborHours,
   } = props;
@@ -498,18 +490,6 @@ export default function TireGrid(props: Props) {
 
     if (!isFailOrRec && !requireNoteForAI) return null;
 
-    const note = readNotes(it).trim();
-    const canShowSubmit =
-      !!requireNoteForAI &&
-      isFailOrRec &&
-      note.length > 0 &&
-      typeof onSubmitAI === "function";
-
-    const submitting =
-      typeof isSubmittingAI === "function"
-        ? isSubmittingAI(sectionIndex, itemIndex)
-        : false;
-
     const currentParts = readParts(it);
     const currentLabor = readLaborHours(it);
 
@@ -609,20 +589,6 @@ export default function TireGrid(props: Props) {
           </div>
         ) : null}
 
-        {canShowSubmit ? (
-          <div className="mt-2 flex items-center justify-end">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="px-3"
-              disabled={submitting}
-              onClick={() => onSubmitAI!(sectionIndex, itemIndex)}
-            >
-              {submitting ? "Submitting…" : "Submit for estimate"}
-            </Button>
-          </div>
-        ) : null}
       </>
     );
   };

--- a/features/inspections/screens/GenericInspectionScreen.tsx
+++ b/features/inspections/screens/GenericInspectionScreen.tsx
@@ -3,7 +3,7 @@
 
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { v4 as uuidv4 } from "uuid";
 import { toast } from "sonner";
 
@@ -44,7 +44,6 @@ import TireGridHydraulic from "@inspections/lib/inspection/ui/TireGridHydraulic"
 import BatteryGrid from "@inspections/lib/inspection/ui/BatteryGrid";
 
 import { InspectionFormCtx } from "@inspections/lib/inspection/ui/InspectionFormContext";
-import FinishInspectionButton from "@inspections/components/inspection/FinishInspectionButton";
 import CustomerVehicleHeader from "@inspections/lib/inspection/ui/CustomerVehicleHeader";
 import InspectionSignaturePanel from "@inspections/components/inspection/InspectionSignaturePanel";
 import PageShell from "@/features/shared/components/PageShell";
@@ -604,7 +603,6 @@ export default function GenericInspectionScreen(
   props: GenericInspectionScreenProps,
 ): JSX.Element {
   const routeSp = useSearchParams();
-  const router = useRouter();
   const rootRef = useRef<HTMLDivElement | null>(null);
 
   type ItemPatch = Partial<InspectionSection["items"][number]>;
@@ -924,7 +922,6 @@ type SmartMatchRow = {
 
   const {
     hydrated: serverBootLoaded,
-    flush: flushAutosave,
     flushToServer: flushAutosaveToServer,
     label: autosaveLabel,
     lastError: autosaveError,
@@ -2608,18 +2605,6 @@ type SmartMatchRow = {
     "mt-1 block text-xs text-[color:var(--theme-text-secondary)]";
 
 
-  const findingsHref = useMemo(() => {
-    const params = new URLSearchParams();
-    params.set("inspectionId", inspectionId);
-
-    if (workOrderId) params.set("workOrderId", workOrderId);
-    if (workOrderLineId) params.set("workOrderLineId", workOrderLineId);
-    if (templateName) params.set("template", templateName);
-
-    return `/inspections/findings?${params.toString()}`;
-  }, [inspectionId, workOrderId, workOrderLineId, templateName]);
-
-
   const allItems = (session.sections ?? []).flatMap((s) => s.items ?? []);
   const failed = allItems.filter(
     (it) => String(it.status ?? "").toLowerCase() === "fail",
@@ -2635,37 +2620,6 @@ type SmartMatchRow = {
 
   const actions = (
     <>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="font-medium border-[color:var(--theme-border-soft)] text-[11px] tracking-[0.16em] uppercase text-[color:var(--theme-text-primary)]"
-        onClick={async () => {
-          try {
-            await flushAutosave();
-            router.push(findingsHref);
-          } catch (error) {
-            toast.error(
-              error instanceof Error
-                ? error.message
-                : "Wait for the inspection to finish saving.",
-            );
-          }
-        }}
-        disabled={isLocked}
-      >
-        Open findings list
-      </Button>
-
-      {workOrderLineId && (
-        <FinishInspectionButton
-          session={session}
-          workOrderLineId={workOrderLineId}
-          disabled={isLocked}
-          beforeNavigate={() => flushAutosaveToServer()}
-        />
-      )}
-
       {isLocked && (
         <Button
           type="button"

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -27,6 +27,7 @@ import {
   isVideoEvidence,
   type WorkOrderEvidenceItem,
 } from "@/features/work-orders/lib/evidence/workOrderEvidence";
+import { selectCustomerVisibleQuoteParts } from "@/features/portal/lib/customerVisibleQuoteParts";
 
 const COPPER = "#C57A4A";
 const CUSTOMER_VISIBLE_QUOTE_STATUSES = new Set([
@@ -253,19 +254,7 @@ function getQuoteParts(
   allowCanonicalPartsQuote: boolean,
 ): QuotePartView[] {
   const metadata = quoteMetadata(line);
-  const directParts = metadataArray(metadata, "parts");
-  const partsQuote = metadata.parts_quote;
-  const quotedParts =
-    partsQuote && typeof partsQuote === "object" && !Array.isArray(partsQuote)
-      ? metadataArray(partsQuote as Record<string, unknown>, "items")
-      : [];
-  return (
-    directParts.length > 0
-      ? directParts
-      : allowCanonicalPartsQuote
-        ? quotedParts
-        : []
-  )
+  return selectCustomerVisibleQuoteParts(metadata, allowCanonicalPartsQuote)
     .filter(
       (part): part is Record<string, unknown> =>
         Boolean(part) && typeof part === "object" && !Array.isArray(part),

--- a/features/portal/components/QuoteApprovalActions.tsx
+++ b/features/portal/components/QuoteApprovalActions.tsx
@@ -93,6 +93,7 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
               operationKey,
             }),
             cache: "no-store",
+            credentials: "include",
           }),
         );
       }
@@ -114,6 +115,7 @@ export default function QuoteApprovalActions({ workOrderId, lines, onChanged }: 
                 idempotencyKey: lineOperationKey,
               }),
               cache: "no-store",
+              credentials: "include",
             },
           ),
         );

--- a/features/portal/lib/customerVisibleQuoteParts.ts
+++ b/features/portal/lib/customerVisibleQuoteParts.ts
@@ -1,0 +1,25 @@
+function metadataArray(
+  metadata: Record<string, unknown>,
+  key: string,
+): unknown[] {
+  const value = metadata[key];
+  return Array.isArray(value) ? value : [];
+}
+
+export function selectCustomerVisibleQuoteParts(
+  metadata: Record<string, unknown>,
+  allowCanonicalPartsQuote: boolean,
+): unknown[] {
+  const requestedParts = metadataArray(metadata, "parts");
+  const partsQuote = metadata.parts_quote;
+  const quotedParts =
+    partsQuote && typeof partsQuote === "object" && !Array.isArray(partsQuote)
+      ? metadataArray(partsQuote as Record<string, unknown>, "items")
+      : [];
+
+  if (allowCanonicalPartsQuote && quotedParts.length > 0) {
+    return quotedParts;
+  }
+
+  return requestedParts;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -114,11 +114,18 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(target, 308);
   }
 
-  if (isAssetPath(pathname) || pathname.startsWith("/api")) {
+  if (isAssetPath(pathname)) {
     return NextResponse.next();
   }
 
   const res = NextResponse.next({ request: { headers: requestHeaders } });
+
+  if (pathname.startsWith("/api")) {
+    if (!hasSupabasePublicEnv()) return res;
+    const supabase = createMiddlewareSupabase(req, res);
+    await supabase.auth.getUser();
+    return res;
+  }
 
   const isPortal = pathname === "/portal" || pathname.startsWith("/portal/");
   const isFleetPortalAuthPage = pathname === PORTAL_SIGN_IN.fleet;
@@ -414,6 +421,7 @@ export const config = {
     "/inspections/:path*",
     "/mobile/:path*",
     "/parts/:path*",
+    "/api/:path*",
     "/tech/queue",
   ],
 };

--- a/supabase/migrations/20260805145119_allow_reopened_inspection_cycle_edits.sql
+++ b/supabase/migrations/20260805145119_allow_reopened_inspection_cycle_edits.sql
@@ -1,0 +1,43 @@
+-- Historical signatures belong to an immutable signing cycle. An authorized
+-- reopen increments inspections.signing_cycle, so evidence from an earlier
+-- cycle must not prevent edits to the newly opened draft.
+create or replace function public.prevent_finalized_inspection_mutation()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $inspection_evidence_guard$
+declare
+  v_has_signature_for_cycle boolean := false;
+  v_internal_transition boolean :=
+    current_setting('profixiq.inspection_sign', true) = 'on'
+    or current_setting('profixiq.inspection_reopen', true) = 'on';
+begin
+  if v_internal_transition then
+    return case when tg_op = 'DELETE' then old else new end;
+  end if;
+
+  select exists (
+    select 1
+    from public.inspection_signatures s
+    where s.inspection_id = old.id
+      and s.signing_cycle = coalesce(old.signing_cycle, 0)
+  ) into v_has_signature_for_cycle;
+
+  if coalesce(old.locked, false)
+     or coalesce(old.completed, false)
+     or not coalesce(old.is_draft, true)
+     or old.finalized_at is not null
+     or old.finalized_by is not null
+     or lower(coalesce(old.status, 'draft')) in ('completed', 'finalized', 'signed')
+     or v_has_signature_for_cycle then
+    raise exception using
+      errcode = 'P0001',
+      message = 'Finalized inspection evidence is immutable; use the authorized reopen operation.';
+  end if;
+
+  return case when tg_op = 'DELETE' then old else new end;
+end;
+$inspection_evidence_guard$;
+
+revoke all on function public.prevent_finalized_inspection_mutation() from public;

--- a/tests/inspection-live-autosave-signature.test.ts
+++ b/tests/inspection-live-autosave-signature.test.ts
@@ -59,9 +59,7 @@ describe("inspection live autosave and saved signatures", () => {
     expect(screen).not.toContain("<SaveInspectionButton");
     expect(screen).not.toContain("import { SaveInspectionButton }");
     expect(screen).toContain("beforeSign={() => flushAutosaveToServer()}");
-    expect(screen).toContain(
-      "beforeNavigate={() => flushAutosaveToServer()}",
-    );
+    expect(screen).not.toContain("<FinishInspectionButton");
     expect(findings).toContain("await flushAutosaveToServer(nextSession)");
     expect(autosave).toContain("flushToServer");
     expect(autosave).toContain("A signing/finalization flush is a barrier");

--- a/tests/inspection-sign-portal-regressions.test.ts
+++ b/tests/inspection-sign-portal-regressions.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { selectCustomerVisibleQuoteParts } from "@/features/portal/lib/customerVisibleQuoteParts";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+describe("inspection sign and portal approval regressions", () => {
+  it("imports findings through the idempotent canonical command before signing", () => {
+    const route = read("app/api/inspections/sign/route.ts");
+    const importAt = route.indexOf("insertPrioritizedJobsFromInspection({");
+    const signAt = route.indexOf("callSignInspectionRpc(supabase");
+
+    expect(importAt).toBeGreaterThan(-1);
+    expect(signAt).toBeGreaterThan(importAt);
+    expect(route).toContain(
+      "operationKey: `sign:${resolved.inspectionId}:${bodyUnknown.expectedSyncRevision}`",
+    );
+  });
+
+  it("removes the redundant findings review and per-card submission paths", () => {
+    const screen = read("features/inspections/screens/GenericInspectionScreen.tsx");
+    const section = read("features/inspections/lib/inspection/SectionDisplay.tsx");
+    const tire = read("features/inspections/lib/inspection/ui/TireCornerGrid.tsx");
+    const legacyPage = read("app/inspections/findings/page.tsx");
+
+    expect(screen).not.toContain("Open findings list");
+    expect(screen).not.toContain("<FinishInspectionButton");
+    expect(section).not.toContain("Submit for estimate");
+    expect(section).not.toContain("Update estimate");
+    expect(tire).not.toContain("Submit for estimate");
+    expect(legacyPage).toContain('redirect("/inspections")');
+  });
+
+  it("allows edits only when the active reopened signing cycle is unsigned", () => {
+    const migration = read(
+      "supabase/migrations/20260805145119_allow_reopened_inspection_cycle_edits.sql",
+    );
+
+    expect(migration).toContain(
+      "s.signing_cycle = coalesce(old.signing_cycle, 0)",
+    );
+    expect(migration).toContain("v_has_signature_for_cycle");
+    expect(migration).toContain(
+      "Finalized inspection evidence is immutable; use the authorized reopen operation.",
+    );
+  });
+
+  it("refreshes Supabase auth cookies for API requests", () => {
+    const middleware = read("middleware.ts");
+    const apiBranch = middleware.indexOf('pathname.startsWith("/api")');
+    const refresh = middleware.indexOf("await supabase.auth.getUser()", apiBranch);
+
+    expect(middleware).toContain('"/api/:path*"');
+    expect(apiBranch).toBeGreaterThan(-1);
+    expect(refresh).toBeGreaterThan(apiBranch);
+  });
+
+  it("uses the shared portal actor and customer-scoped client for quote decisions", () => {
+    const route = read(
+      "app/api/work-orders/quotes/[id]/approval-decision/route.ts",
+    );
+    const actions = read("features/portal/components/QuoteApprovalActions.tsx");
+
+    expect(route).toContain("requirePortalCustomerActor(routeSupabase)");
+    expect(route).toContain("supabase: routeSupabase");
+    expect(route).not.toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(route).toContain('.eq("customer_id", actor.customer.id)');
+    expect(actions.match(/credentials: "include"/g)).toHaveLength(2);
+  });
+
+  it("prefers canonical priced parts over unpriced requested parts", () => {
+    const requested = [{ description: "Front brake pads", qty: 1 }];
+    const quoted = [
+      { description: "Front brake pads", qty: 1, unitPrice: 98.54 },
+      { description: "Front rotors", qty: 2, unitPrice: 222.78 },
+    ];
+    const metadata = {
+      parts: requested,
+      parts_quote: { items: quoted },
+    };
+
+    expect(selectCustomerVisibleQuoteParts(metadata, true)).toEqual(quoted);
+    expect(selectCustomerVisibleQuoteParts(metadata, false)).toEqual(requested);
+  });
+});


### PR DESCRIPTION
## Root cause

- Inspection signing finalized and locked evidence before the separate findings-review workflow could save.
- Historical signatures blocked edits after an authorized reopen because the mutation guard was not signing-cycle aware.
- Portal quote approval used a separate cookie-only auth path while API requests skipped Supabase session refresh.
- The customer quote page preferred unpriced requested parts over canonical priced quote items.

## What changed

- Submit eligible inspection findings through the existing idempotent import command before technician signing locks the inspection.
- Remove the redundant findings-review and per-card estimate-submission controls.
- Make the finalized-inspection guard aware of the active signing cycle.
- Refresh Supabase auth for API requests and use the shared portal customer actor for quote approval.
- Prefer canonical priced parts in the customer-facing breakdown.
- Add focused regression coverage for all four boundaries.

## Safety

- Tenant/customer scoping remains enforced before quote decisions.
- The portal approval route no longer uses a service-role client.
- Sign retries reuse a revision-bound idempotency key.
- Historical signed cycles remain immutable; only the active reopened cycle is editable.
- No backfill or table/RLS changes are required.

## Validation

- Focused regression suite: 6/6 passed
- Changed autosave/signing assertion: passed
- Broader inspection/estimate/portal contracts: 87 passed, 1 known baseline stale assertion
- TypeScript: passed
- ESLint on changed TS/TSX files: passed
- API route boundary audit: passed (412 routes)
- `git diff --check`: passed

## Database

Forward migration included:

`20260805145119_allow_reopened_inspection_cycle_edits.sql`

No environment variables are added or changed.

## Smoke checks before merge

1. Sign an inspection with failed findings and confirm it routes directly to Quote Review.
2. Reopen, edit, autosave, and re-sign while preserving historical evidence.
3. Approve a quote through the customer portal on iOS/Safari.
4. Confirm priced parts render instead of `$0`.
5. Confirm a different customer cannot access or approve the quote.
