### PR TITLE
Fix quote part auto-anchor conflicts

### DIFF
--- a/app/api/work-orders/quotes/[id]/approval-decision/route.ts
+++ b/app/api/work-orders/quotes/[id]/approval-decision/route.ts
@@ -113,15 +113,20 @@ export async function POST(req: NextRequest, context: RouteContext) {
   });
 
   if (!result.ok) {
+    const partRelinkConflict = result.error?.includes("PART_RELINK_CONFLICT");
     const status =
-      result.expired || result.error?.includes("FINANCIALLY_LOCKED")
+      result.expired ||
+      partRelinkConflict ||
+      result.error?.includes("FINANCIALLY_LOCKED")
         ? 409
         : 400;
     return NextResponse.json(
       {
         ok: false,
         expired: result.expired === true,
-        error: result.error ?? "Unable to update quote decision",
+        error: partRelinkConflict
+          ? "This quote needs a parts review by the shop before it can be approved. No approval was recorded."
+          : (result.error ?? "Unable to update quote decision"),
       },
       { status },
     );

--- a/supabase/migrations/20260805162923_remove_legacy_quote_part_auto_anchor.sql
+++ b/supabase/migrations/20260805162923_remove_legacy_quote_part_auto_anchor.sql
@@ -1,0 +1,155 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- This legacy trigger ignores the caller's explicit NULL anchor and attaches
+-- every new request item to the oldest line on the work order. Quote-origin
+-- parts must remain unanchored until the atomic approval command materializes
+-- (or deliberately reuses) their canonical work-order line.
+drop trigger if exists trg_link_part_request_item
+  on public.part_request_items;
+drop function if exists public.link_part_request_item_to_line();
+
+do $$
+begin
+  if to_regprocedure(
+    'public.prevent_part_request_item_anchor_changes()'
+  ) is null then
+    raise exception
+      'Canonical part-request item anchor guard is missing';
+  end if;
+end;
+$$;
+
+-- The canonical guard correctly prevents ordinary non-null -> NULL reparenting.
+-- Suspend it only for this deterministic repair, then restore it before commit.
+drop trigger if exists trg_prevent_part_request_item_anchor_changes
+  on public.part_request_items;
+
+update public.part_request_items pri
+set work_order_line_id = null,
+    updated_at = now()
+from public.part_requests pr,
+     public.work_order_quote_lines q
+where pr.id = pri.request_id
+  and pr.shop_id = pri.shop_id
+  and pr.work_order_id = pri.work_order_id
+  and pr.quote_line_id = pri.quote_line_id
+  and q.id = pri.quote_line_id
+  and q.shop_id = pri.shop_id
+  and q.work_order_id = pri.work_order_id
+  and pri.work_order_line_id is not null
+  and pr.job_id is null
+  and q.source_work_order_line_id is null
+  and q.work_order_line_id is null
+  and q.approved_at is null
+  and lower(coalesce(q.status::text, '')) not in (
+    'approved', 'converted', 'declined', 'deferred', 'rejected', 'cancelled'
+  )
+  and lower(coalesce(pr.status::text, 'requested')) in ('requested', 'quoted')
+  and lower(coalesce(pri.status::text, 'requested')) in (
+    'requested', 'quoted', 'awaiting_customer_approval'
+  )
+  and coalesce(pri.qty_ordered, 0) = 0
+  and coalesce(pri.qty_received, 0) = 0
+  and coalesce(pri.qty_reserved, 0) = 0
+  and coalesce(pri.qty_consumed, 0) = 0
+  and coalesce(pri.qty_returned, 0) = 0
+  and pri.po_id is null
+  and not public.work_order_is_financially_locked(
+    pri.shop_id,
+    pri.work_order_id
+  )
+  and not exists (
+    select 1
+    from public.purchase_order_lines pol
+    where pol.part_request_item_id = pri.id
+  )
+  and not exists (
+    select 1
+    from public.work_order_parts wop
+    where wop.source_parts_request_item_id = pri.id
+  );
+
+create trigger trg_prevent_part_request_item_anchor_changes
+before update on public.part_request_items
+for each row
+execute function public.prevent_part_request_item_anchor_changes();
+
+do $$
+begin
+  if exists (
+    select 1
+    from pg_trigger t
+    where t.tgrelid = 'public.part_request_items'::regclass
+      and t.tgname = 'trg_link_part_request_item'
+      and not t.tgisinternal
+  ) then
+    raise exception 'Legacy part-request auto-anchor trigger still exists';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_trigger t
+    where t.tgrelid = 'public.part_request_items'::regclass
+      and t.tgname = 'trg_prevent_part_request_item_anchor_changes'
+      and not t.tgisinternal
+  ) then
+    raise exception 'Canonical part-request anchor guard was not restored';
+  end if;
+
+  if exists (
+    select 1
+    from public.part_request_items pri
+    join public.part_requests pr
+      on pr.id = pri.request_id
+     and pr.shop_id = pri.shop_id
+     and pr.work_order_id = pri.work_order_id
+     and pr.quote_line_id = pri.quote_line_id
+    join public.work_order_quote_lines q
+      on q.id = pri.quote_line_id
+     and q.shop_id = pri.shop_id
+     and q.work_order_id = pri.work_order_id
+    where pri.work_order_line_id is not null
+      and pr.job_id is null
+      and q.source_work_order_line_id is null
+      and q.work_order_line_id is null
+      and q.approved_at is null
+      and lower(coalesce(q.status::text, '')) not in (
+        'approved', 'converted', 'declined', 'deferred', 'rejected', 'cancelled'
+      )
+      and lower(coalesce(pr.status::text, 'requested')) in (
+        'requested', 'quoted'
+      )
+      and lower(coalesce(pri.status::text, 'requested')) in (
+        'requested', 'quoted', 'awaiting_customer_approval'
+      )
+      and coalesce(pri.qty_ordered, 0) = 0
+      and coalesce(pri.qty_received, 0) = 0
+      and coalesce(pri.qty_reserved, 0) = 0
+      and coalesce(pri.qty_consumed, 0) = 0
+      and coalesce(pri.qty_returned, 0) = 0
+      and pri.po_id is null
+      and not public.work_order_is_financially_locked(
+        pri.shop_id,
+        pri.work_order_id
+      )
+      and not exists (
+        select 1
+        from public.purchase_order_lines pol
+        where pol.part_request_item_id = pri.id
+      )
+      and not exists (
+        select 1
+        from public.work_order_parts wop
+        where wop.source_parts_request_item_id = pri.id
+      )
+  ) then
+    raise exception
+      'Safe unreleased quote-part auto-anchors remain after repair';
+  end if;
+end;
+$$;
+
+commit;

--- a/tests/inspection-sign-portal-regressions.test.ts
+++ b/tests/inspection-sign-portal-regressions.test.ts
@@ -65,6 +65,10 @@ describe("inspection sign and portal approval regressions", () => {
     expect(route).toContain("supabase: routeSupabase");
     expect(route).not.toContain("SUPABASE_SERVICE_ROLE_KEY");
     expect(route).toContain('.eq("customer_id", actor.customer.id)');
+    expect(route).toContain('result.error?.includes("PART_RELINK_CONFLICT")');
+    expect(route).toContain(
+      "This quote needs a parts review by the shop before it can be approved. No approval was recorded.",
+    );
     expect(actions.match(/credentials: "include"/g)).toHaveLength(2);
   });
 

--- a/tests/parts/quote-part-auto-anchor-repair.test.ts
+++ b/tests/parts/quote-part-auto-anchor-repair.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260805162923_remove_legacy_quote_part_auto_anchor.sql",
+  "utf8",
+);
+
+describe("quote part auto-anchor repair", () => {
+  it("removes the legacy oldest-line insert trigger", () => {
+    expect(migration).toContain(
+      "drop trigger if exists trg_link_part_request_item",
+    );
+    expect(migration).toContain(
+      "drop function if exists public.link_part_request_item_to_line()",
+    );
+    expect(migration).toContain(
+      "Legacy part-request auto-anchor trigger still exists",
+    );
+  });
+
+  it("repairs only standalone, unreleased quote items", () => {
+    expect(migration).toContain("set work_order_line_id = null");
+    expect(migration).toContain("and pr.job_id is null");
+    expect(migration).toContain("and q.source_work_order_line_id is null");
+    expect(migration).toContain("and q.work_order_line_id is null");
+    expect(migration).toContain("and q.approved_at is null");
+    expect(migration).toContain("and coalesce(pri.qty_ordered, 0) = 0");
+    expect(migration).toContain("and coalesce(pri.qty_consumed, 0) = 0");
+    expect(migration).toContain("and pri.po_id is null");
+    expect(migration).toContain(
+      "and not public.work_order_is_financially_locked(",
+    );
+    expect(migration).toContain("from public.purchase_order_lines pol");
+    expect(migration).toContain("from public.work_order_parts wop");
+  });
+
+  it("restores the canonical reparenting guard in the same transaction", () => {
+    expect(migration).toContain("begin;");
+    expect(migration).toContain("commit;");
+    expect(migration).toContain(
+      "drop trigger if exists trg_prevent_part_request_item_anchor_changes",
+    );
+    expect(migration).toContain(
+      "create trigger trg_prevent_part_request_item_anchor_changes",
+    );
+    expect(migration).toContain(
+      "Canonical part-request anchor guard was not restored",
+    );
+  });
+
+  it("contains no production row identifiers", () => {
+    expect(migration).not.toMatch(
+      /cd281ab6|fe089955|7e56a0d2|5287faad|b34acafd|234061e5/i,
+    );
+  });
+});


### PR DESCRIPTION
## Root cause

A legacy `BEFORE INSERT` trigger assigned intentionally unanchored quote parts to the oldest work-order line. Customer approval then correctly raised `PART_RELINK_CONFLICT` instead of silently moving those parts to the newly authorized repair line.

## What changed

- Remove the legacy quote-part auto-anchor trigger and function.
- Clear only safe, unreleased false anchors: no ordering, receiving, reservation, consumption, return, PO, materialization, financial lock, or approved quote state.
- Restore and verify the canonical anchor-change guard in the same transaction.
- Translate a future relink conflict into a customer-friendly portal message while preserving the 409 guard.
- Add focused migration and portal regression coverage.

## User impact

The blocked quote can be retried after the migration. Future quote-origin parts remain unanchored until the atomic approval operation creates or reuses their canonical work-order line.

## Validation

- Focused lifecycle tests: 23/23 passed.
- TypeScript: passed.
- Changed-file ESLint: passed.
- API boundary audit: passed (412 routes).
- `git diff --check`: passed.

## Rollout

Apply `20260805162923_remove_legacy_quote_part_auto_anchor.sql` to the repository-linked Supabase project. The migration is transactional and contains postconditions that fail closed if either the legacy trigger remains, the canonical guard is not restored, or safe false anchors remain.