### PR TITLE
Align focused job status and hold labels

### DIFF
--- a/features/work-orders/components/workorders/FocusedJobModal.tsx
+++ b/features/work-orders/components/workorders/FocusedJobModal.tsx
@@ -1652,7 +1652,7 @@ export default function FocusedJobModal(props: {
                       ? "Manage hold"
                       : isOperationallyActive
                         ? "Hold"
-                        : "Add blocker"}
+                        : "Add hold"}
                   </button>
                   <button
                     type="button"

--- a/features/work-orders/lib/display/linePresentation.test.ts
+++ b/features/work-orders/lib/display/linePresentation.test.ts
@@ -109,6 +109,9 @@ describe("linePresentation", () => {
     );
     expect(resolveOperationalLineStatusLabel(baseLine, { isActive: true })).toBe("In progress");
     expect(
+      resolveOperationalLineStatusLabel({ ...baseLine, status: "in_progress" }),
+    ).toBe("Ready to start");
+    expect(
       resolveOperationalLineStatusLabel({ ...baseLine, hold_reason: "Awaiting parts" }),
     ).toBe("On hold");
   });

--- a/features/work-orders/lib/display/linePresentation.ts
+++ b/features/work-orders/lib/display/linePresentation.ts
@@ -66,10 +66,14 @@ export function resolveOperationalLineStatusLabel(
   if (normalized === "awaiting_approval" || approvalState === "pending") {
     return "Awaiting approval";
   }
-  if (isActive || normalized === "in_progress") return "In progress";
+  // A line can retain the workflow status `in_progress` after approval or a
+  // previous punch. The operational UI should only say it is in progress
+  // while there is a live job punch; otherwise the primary action correctly
+  // remains "Start job".
+  if (isActive) return "In progress";
   if (!line.assigned_tech_id) return "Awaiting technician";
   if (
-    ["awaiting", "pending", "queued", "approved", "assigned", "unassigned"].includes(
+    ["awaiting", "pending", "queued", "approved", "assigned", "unassigned", "in_progress"].includes(
       normalized,
     )
   ) {

--- a/tests/work-order-cockpit-layout.test.ts
+++ b/tests/work-order-cockpit-layout.test.ts
@@ -28,6 +28,8 @@ describe("desktop work-order cockpit", () => {
     expect(focusedJob).toContain('role="tablist"');
     expect(focusedJob).toContain('activeWorkspaceTab === "overview"');
     expect(focusedJob).toContain("resolveOperationalLineStatusLabel");
+    expect(focusedJob).toContain('"Add hold"');
+    expect(focusedJob).not.toContain('"Add blocker"');
     expect(jobCard).toContain('display === "navigator"');
   });
 


### PR DESCRIPTION
## What changed

- Treat a line as **In progress** only when it has a live technician job punch.
- Show an assigned, approved line with no active punch as **Ready to start**, including when its stored lifecycle value remains `in_progress`.
- Rename the focused-job action from **Add blocker** to **Add hold** because it opens the hold modal.
- Add focused regression coverage for both behaviors.

## Root cause

The status label trusted the stored work-order-line lifecycle value, while the primary action used the live punch state. A stale `in_progress` value could therefore display **In progress** beside **Start job**. The hold action also used outdated blocker wording even though it opens the hold workflow.

## Impact

Technicians now see one consistent operational state and action in the focused-job experience. This does not change lifecycle transitions, punch behavior, parts flow, authorization, or database state.

## Validation

- Focused Vitest suite: 13/13 passed
- ESLint on all changed TypeScript/TSX files: passed
- `git diff --check`: passed
- Remote comparison: exactly four intended files, one commit, based on current `main`

## Database

No migration required.