### PR TITLE
Wire Agent UI to the canonical engineering team

### DIFF
--- a/app/api/agent/requests/[id]/notify-discord/route.ts
+++ b/app/api/agent/requests/[id]/notify-discord/route.ts
@@ -1,204 +1,132 @@
-// app/api/agent/requests/[id]/notify-discord/route.ts (FULL FILE REPLACEMENT)
 import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { createClient } from "@supabase/supabase-js";
-import type { Database } from "@shared/types/types/supabase";
+import {
+  AgentTeamRequestError,
+  agentTeamRequest,
+} from "@/features/agent/server/teamClient";
 
-type DB = Database;
-
-const APPROVER_ROLES = ["developer"] as const;
-type ApproverRole = (typeof APPROVER_ROLES)[number];
+const APPROVER_ROLES = ["developer"];
 
 type PostBody = {
   message?: string;
 };
 
-type AgentJobKind = DB["public"]["Enums"]["agent_job_kind"];
-
-function isApproverRole(v: unknown): v is ApproverRole {
-  return typeof v === "string" && (APPROVER_ROLES as readonly string[]).includes(v);
+function requestIdFromUrl(url: string): string | null {
+  const parts = new URL(url).pathname.split("/").filter(Boolean);
+  const requestsIndex = parts.findIndex((part) => part === "requests");
+  const id = requestsIndex >= 0 ? parts[requestsIndex + 1] : null;
+  return typeof id === "string" && id.trim() ? id.trim() : null;
 }
 
-function requireEnv(name: string, value: string | undefined): string {
-  if (!value || !value.trim()) throw new Error(`Missing required env var: ${name}`);
-  return value.trim();
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function parseJobKind(v: string | undefined): AgentJobKind | null {
-  const s = (v ?? "").trim();
-  if (!s) return null;
-
-  // Keep in sync with public.agent_job_kind enum
-  const allowed: readonly AgentJobKind[] = ["notify_discord", "analyze_request"];
-  return (allowed as readonly string[]).includes(s) ? (s as AgentJobKind) : null;
-}
-
-function extractRequestIdFromUrl(url: string): string {
-  // Expected: /api/agent/requests/:id/notify-discord
-  const pathname = new URL(url).pathname;
-  const parts = pathname.split("/").filter(Boolean);
-
-  const requestsIdx = parts.findIndex((p) => p === "requests");
-  const id = requestsIdx >= 0 ? parts[requestsIdx + 1] : "";
-  return (id ?? "").trim();
+function engineeringCaseId(value: unknown): string | null {
+  if (!isRecord(value) || !isRecord(value.agentTeam)) return null;
+  const id = value.agentTeam.engineeringCaseId;
+  return typeof id === "string" && id.trim() ? id.trim() : null;
 }
 
 export async function POST(req: Request) {
-  try {
-    const id = extractRequestIdFromUrl(req.url);
+  const id = requestIdFromUrl(req.url);
+  if (!id) {
+    return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
+  }
 
-    if (!id) {
-      return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
-    }
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-    // ✅ IMPORTANT: do NOT await cookies(); createServerSupabaseRoute uses request cookies
-    const supabase = createServerSupabaseRoute();
-
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser();
-
-    if (authError) {
-      return NextResponse.json(
-        { error: "Failed to read auth session", details: authError.message },
-        { status: 500 }
-      );
-    }
-
-    if (!user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // role gate
-    const { data: profile, error: profileError } = await supabase
-      .from("profiles")
-      .select("id, agent_role")
-      .eq("id", user.id)
-      .single();
-
-    if (profileError || !profile) {
-      console.error("notify-discord profile error", profileError);
-      return NextResponse.json({ error: "Profile not found" }, { status: 400 });
-    }
-
-    if (!isApproverRole(profile.agent_role)) {
-      return NextResponse.json(
-        { error: "Forbidden – insufficient role to notify Discord" },
-        { status: 403 }
-      );
-    }
-
-    // load request (default message)
-    const { data: requestRow, error: requestError } = await supabase
-      .from("agent_requests")
-      .select(
-        "id, status, intent, description, github_issue_url, github_pr_url, created_at, reporter_role"
-      )
-      .eq("id", id)
-      .single();
-
-    if (requestError || !requestRow) {
-      console.error("notify-discord load error", requestError);
-      return NextResponse.json({ error: "Agent request not found" }, { status: 404 });
-    }
-
-    const body = (await req.json().catch(() => null)) as PostBody | null;
-
-    const defaultMessage = [
-      "🧠 ProFixIQ Agent Request",
-      `• ID: ${requestRow.id}`,
-      `• Status: ${requestRow.status}`,
-      `• Intent: ${requestRow.intent ?? "unknown"}`,
-      `• Reporter Role: ${requestRow.reporter_role ?? "unknown"}`,
-      `• Description: ${requestRow.description}`,
-      requestRow.github_issue_url ? `• Issue: ${requestRow.github_issue_url}` : null,
-      requestRow.github_pr_url ? `• PR: ${requestRow.github_pr_url}` : null,
-      requestRow.created_at ? `• Created: ${new Date(requestRow.created_at).toLocaleString()}` : null,
-    ]
-      .filter((v): v is string => Boolean(v))
-      .join("\n");
-
-    const message = String(body?.message ?? defaultMessage).trim();
-    if (!message) {
-      return NextResponse.json({ error: "message is required" }, { status: 400 });
-    }
-
-    // service-role client (enqueue + cross-table lookup)
-    const supabaseUrl = requireEnv("NEXT_PUBLIC_SUPABASE_URL", process.env.NEXT_PUBLIC_SUPABASE_URL);
-    const serviceKey = requireEnv(
-      "SUPABASE_SERVICE_ROLE_KEY",
-      process.env.SUPABASE_SERVICE_ROLE_KEY
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, agent_role")
+    .eq("id", user.id)
+    .single();
+  if (profileError || !profile) {
+    return NextResponse.json({ error: "Profile not found" }, { status: 400 });
+  }
+  if (!APPROVER_ROLES.includes(profile.agent_role ?? "")) {
+    return NextResponse.json(
+      { error: "Forbidden – insufficient role to notify Discord" },
+      { status: 403 },
     );
+  }
 
-    const supabaseAdmin = createClient<DB>(supabaseUrl, serviceKey, {
-      auth: { persistSession: false },
-    });
+  const { data: requestRow, error: requestError } = await supabase
+    .from("agent_requests")
+    .select(
+      "id, status, intent, description, github_issue_url, github_pr_url, created_at, reporter_role, normalized_json",
+    )
+    .eq("id", id)
+    .single();
+  if (requestError || !requestRow) {
+    return NextResponse.json({ error: "Agent request not found" }, { status: 404 });
+  }
 
-    // latest action row for buttons
-    const { data: actionRow, error: actionError } = await supabaseAdmin
-      .from("agent_actions")
-      .select("id, request_id, status, kind, created_at")
-      .eq("request_id", requestRow.id)
-      .order("created_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
+  const caseId = engineeringCaseId(requestRow.normalized_json);
+  if (!caseId) {
+    return NextResponse.json(
+      { error: "This request is not linked to a canonical Agent engineering case" },
+      { status: 409 },
+    );
+  }
 
-    if (actionError) {
-      console.error("notify-discord action lookup error", actionError);
-      return NextResponse.json(
-        { error: "Failed to load agent action for request", details: actionError.message },
-        { status: 500 }
-      );
-    }
+  const body = (await req.json().catch(() => null)) as PostBody | null;
+  const defaultMessage = [
+    "🧠 **ProFixIQ engineering case update**",
+    `• **Request:** \`${requestRow.id}\``,
+    `• **Engineering case:** \`${caseId}\``,
+    `• **Status:** ${requestRow.status}`,
+    `• **Intent:** ${requestRow.intent ?? "unknown"}`,
+    `• **Reporter role:** ${requestRow.reporter_role ?? "unknown"}`,
+    `• **Description:** ${requestRow.description}`,
+    requestRow.github_issue_url ? `• **Issue:** ${requestRow.github_issue_url}` : null,
+    requestRow.github_pr_url ? `• **PR:** ${requestRow.github_pr_url}` : null,
+    requestRow.created_at
+      ? `• **Created:** ${new Date(requestRow.created_at).toISOString()}`
+      : null,
+  ].filter((value): value is string => Boolean(value)).join("\n");
+  const message = String(body?.message ?? defaultMessage).trim();
 
-    const actionId = actionRow?.id ?? null;
-    const requestIdForButtons = requestRow.id;
-
-    const jobKind: AgentJobKind =
-      parseJobKind(process.env.AGENT_NOTIFY_DISCORD_JOB_KIND) ?? "notify_discord";
-
-    type AgentJobInsert = DB["public"]["Tables"]["agent_jobs"]["Insert"];
-
-    const job: AgentJobInsert = {
-      request_id: requestRow.id,
-      kind: jobKind,
-      status: "queued",
-      priority: 80,
-      payload: {
-        message,
-        requestId: requestIdForButtons,
-        actionId,
+  try {
+    const result = await agentTeamRequest<Record<string, unknown>>(
+      "/notify-discord",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          requestId: requestRow.id,
+          message,
+        }),
       },
-      run_after: new Date().toISOString(),
-    };
-
-    const { data: insertedJob, error: jobError } = await supabaseAdmin
-      .from("agent_jobs")
-      .insert(job)
-      .select("id, kind, status")
-      .single();
-
-    if (jobError) {
-      console.error("notify-discord enqueue error", jobError);
-      return NextResponse.json(
-        { error: "Failed to enqueue notify_discord job", details: jobError.message },
-        { status: 500 }
-      );
-    }
-
+    );
     return NextResponse.json({
       ok: true,
-      jobId: insertedJob?.id ?? null,
-      kind: insertedJob?.kind ?? null,
-      status: insertedJob?.status ?? null,
-      requestId: requestIdForButtons,
-      actionId,
-      actionStatus: actionRow?.status ?? null,
-      actionKind: actionRow?.kind ?? null,
+      requestId: requestRow.id,
+      engineeringCaseId: caseId,
+      agent: result,
     });
-  } catch (err: unknown) {
-    const details = err instanceof Error ? err.message : "Unexpected error";
-    return NextResponse.json({ error: "Internal Server Error", details }, { status: 500 });
+  } catch (error) {
+    if (error instanceof AgentTeamRequestError) {
+      return NextResponse.json(
+        {
+          error: error.message,
+          detail: error.detail,
+          agentStatus: error.status,
+        },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json(
+      {
+        error: "Agent Discord notification failed",
+        detail: error instanceof Error ? error.message : String(error),
+      },
+      { status: 502 },
+    );
   }
 }

--- a/app/api/agent/requests/[id]/reply/route.ts
+++ b/app/api/agent/requests/[id]/reply/route.ts
@@ -1,9 +1,13 @@
-// /app/api/agent/requests/[id]/reply/route.ts (FULL FILE REPLACEMENT)
-
 import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  AgentTeamRequestError,
+  mapAgentTeamRequestStatus,
+  projectAgentTeamCase,
+  readAgentTeamCase,
+  resumeAgentTeamCase,
+} from "@/features/agent/server/teamClient";
 
-/** Minimal JSON type compatible with Supabase jsonb */
 type Json =
   | string
   | number
@@ -29,97 +33,166 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return !!v && typeof v === "object" && !Array.isArray(v);
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function safeArray<T>(v: unknown): T[] {
-  return Array.isArray(v) ? (v as T[]) : [];
+function safeArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? value as T[] : [];
 }
 
-function toJsonRecord(v: unknown): Record<string, Json | undefined> {
-  if (!isRecord(v)) return {};
-  return v as Record<string, Json | undefined>;
+function toJsonRecord(value: unknown): Record<string, Json | undefined> {
+  return isRecord(value)
+    ? value as Record<string, Json | undefined>
+    : {};
 }
 
-function getParamId(context: unknown): string | null {
-  if (!isRecord(context)) return null;
-  const params = context.params;
-  if (!isRecord(params)) return null;
-  const id = params.id;
-  return typeof id === "string" && id.trim().length > 0 ? id : null;
+function routeId(req: Request): string | null {
+  const segments = new URL(req.url).pathname.split("/").filter(Boolean);
+  const requestsIndex = segments.findIndex((segment) => segment === "requests");
+  const id = requestsIndex >= 0 ? segments[requestsIndex + 1] : null;
+  return typeof id === "string" && id.trim() ? id.trim() : null;
 }
 
-export async function POST(req: Request, context: unknown) {
-  const id = getParamId(context);
+function engineeringCaseId(value: unknown): string | null {
+  if (!isRecord(value) || !isRecord(value.agentTeam)) return null;
+  const id = value.agentTeam.engineeringCaseId;
+  return typeof id === "string" && id.trim() ? id.trim() : null;
+}
+
+function agentFailure(error: unknown) {
+  if (error instanceof AgentTeamRequestError) {
+    return NextResponse.json(
+      {
+        error: error.message,
+        detail: error.detail,
+        agentStatus: error.status,
+      },
+      { status: error.status === 409 ? 409 : 502 },
+    );
+  }
+  return NextResponse.json(
+    {
+      error: "Agent team reply failed",
+      detail: error instanceof Error ? error.message : String(error),
+    },
+    { status: 502 },
+  );
+}
+
+export async function POST(req: Request) {
+  const id = routeId(req);
   if (!id) {
     return NextResponse.json({ error: "missing route param id" }, { status: 400 });
   }
 
-  let body: ReplyBody | null = null;
-  try {
-    body = (await req.json()) as ReplyBody;
-  } catch {
-    body = null;
-  }
-
-  const message = (body?.message ?? "").trim();
+  const body = (await req.json().catch(() => null)) as ReplyBody | null;
+  const message = body?.message?.trim() ?? "";
   if (!message) {
     return NextResponse.json({ error: "message is required" }, { status: 400 });
   }
 
   const supabase = createServerSupabaseRoute();
-
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-  const userId = user?.id ?? null;
-
-  const { data: row, error: selectErr } = await supabase
+  const { data: row, error: selectError } = await supabase
     .from("agent_requests")
-    .select("id, normalized_json")
+    .select("*")
     .eq("id", id)
     .maybeSingle();
 
-  if (selectErr) {
-    return NextResponse.json({ error: `select failed: ${selectErr.message}` }, { status: 500 });
+  if (selectError) {
+    return NextResponse.json(
+      { error: `select failed: ${selectError.message}` },
+      { status: 500 },
+    );
   }
-
   if (!row) {
     return NextResponse.json({ error: "not found" }, { status: 404 });
   }
 
-  const normalized = toJsonRecord(row.normalized_json);
-  const prevResponses = safeArray<AgentResponse>(normalized.responses);
+  const caseId = engineeringCaseId(row.normalized_json);
+  if (!caseId) {
+    return NextResponse.json(
+      { error: "This request is not linked to a canonical Agent engineering case" },
+      { status: 409 },
+    );
+  }
 
+  try {
+    await resumeAgentTeamCase({
+      engineeringCaseId: caseId,
+      resumedBy: user.id,
+      message,
+      answers: body?.answers,
+    });
+  } catch (error) {
+    return agentFailure(error);
+  }
+
+  let projection;
+  try {
+    projection = projectAgentTeamCase(await readAgentTeamCase(caseId));
+  } catch (error) {
+    return agentFailure(error);
+  }
+
+  const normalized = toJsonRecord(row.normalized_json);
+  const previousResponses = safeArray<AgentResponse>(normalized.responses);
   const newResponse: AgentResponse = {
     id: `resp_${Date.now()}_${Math.random().toString(16).slice(2)}`,
     created_at: nowIso(),
-    user_id: userId,
+    user_id: user.id,
     message,
     answers: body?.answers && isRecord(body.answers) ? body.answers : null,
   };
 
   const nextNormalized: Record<string, Json | undefined> = {
     ...normalized,
-    responses: [...prevResponses, newResponse],
+    responses: [...previousResponses, newResponse] as unknown as Json,
     last_response_at: nowIso(),
+    agentTeam: {
+      ...projection,
+      syncedAt: nowIso(),
+    } as unknown as Json,
   };
 
-  const { data: updated, error: updateErr } = await supabase
+  const { data: updated, error: updateError } = await supabase
     .from("agent_requests")
     .update({
       normalized_json: nextNormalized as Json,
+      status: mapAgentTeamRequestStatus(projection),
+      github_pr_number: projection.pullRequest.number,
+      github_pr_url: projection.pullRequest.url,
+      github_branch: projection.pullRequest.branch,
+      github_commit_sha: projection.pullRequest.headSha,
+      llm_notes: projection.summary,
       updated_at: nowIso(),
     })
     .eq("id", id)
     .select("*")
     .single();
 
-  if (updateErr) {
-    return NextResponse.json({ error: `update failed: ${updateErr.message}` }, { status: 500 });
+  if (updateError) {
+    return NextResponse.json(
+      {
+        error: "The Agent case resumed, but the local reply projection failed",
+        detail: updateError.message,
+      },
+      { status: 500 },
+    );
   }
 
-  return NextResponse.json({ ok: true, request: updated });
+  return NextResponse.json({
+    ok: true,
+    request: updated,
+    engineeringCaseId: caseId,
+    currentStage: projection.currentStage,
+    caseStatus: projection.caseStatus,
+  });
 }

--- a/app/api/agent/requests/[id]/route.ts
+++ b/app/api/agent/requests/[id]/route.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  AgentTeamRequestError,
+  approveAgentTeamMission,
+  approveAgentTeamRelease,
+  mapAgentTeamRequestStatus,
+  projectAgentTeamCase,
+  readAgentTeamCase,
+  rejectAgentTeamCase,
+  type AgentTeamProjection,
+} from "@/features/agent/server/teamClient";
 
 type AgentRequestStatus =
   | "submitted"
@@ -17,11 +27,6 @@ type PatchBody = {
 
 const APPROVER_ROLES = ["developer"];
 
-// Same base URL as /app/api/agent/requests/route.ts
-const AGENT_SERVICE_URL =
-  process.env.PROFIXIQ_AGENT_URL?.replace(/\/$/, "") ||
-  "https://obscure-space-guacamole-69pvggxvgrxj2qxr-4001.app.github.dev";
-
 function getIdFromUrl(req: NextRequest): string | null {
   const url = new URL(req.url);
   const pathname = url.pathname.replace(/\/$/, "");
@@ -30,116 +35,67 @@ function getIdFromUrl(req: NextRequest): string | null {
   return id || null;
 }
 
-function nowIso(): string {
-  return new Date().toISOString();
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-type AgentActionRisk = "low" | "medium" | "high" | "unknown";
-
-type AgentActionRow = {
-  id: string;
-  request_id: string;
-  kind: string;
-  status: string;
-  risk: AgentActionRisk | null;
-  summary: string | null;
-  payload: unknown;
-  created_at: string;
-};
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return !!v && typeof v === "object" && !Array.isArray(v);
+function nullableString(value: unknown): string | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text || null;
 }
 
-function safeUuid(v: unknown): string | null {
-  const s = typeof v === "string" ? v.trim() : "";
-  return s.length === 36 ? s : null;
+function projectionFromNormalized(value: unknown): AgentTeamProjection | null {
+  if (!isRecord(value) || !isRecord(value.agentTeam)) return null;
+  const team = value.agentTeam;
+  const engineeringCaseId = nullableString(team.engineeringCaseId);
+  if (!engineeringCaseId) return null;
+
+  const mission = isRecord(team.mission)
+    ? {
+        id: nullableString(team.mission.id) ?? "",
+        status: nullableString(team.mission.status) ?? "unknown",
+        title: nullableString(team.mission.title),
+        desiredOutcome: nullableString(team.mission.desiredOutcome),
+        problemStatement: nullableString(team.mission.problemStatement),
+        approvedAt: nullableString(team.mission.approvedAt),
+        approvedBy: nullableString(team.mission.approvedBy),
+      }
+    : null;
+  const pullRequest = isRecord(team.pullRequest) ? team.pullRequest : {};
+  const missingInformation = Array.isArray(team.missingInformation)
+    ? team.missingInformation.filter((item): item is string => typeof item === "string")
+    : [];
+
+  return {
+    engineeringCaseId,
+    requestId: nullableString(team.requestId) ?? "",
+    currentStage: nullableString(team.currentStage) ?? "intake",
+    caseStatus: nullableString(team.caseStatus) ?? "active",
+    stepStatus: nullableString(team.stepStatus),
+    summary: nullableString(team.summary),
+    decision: nullableString(team.decision),
+    missingInformation,
+    updatedAt: nullableString(team.updatedAt) ?? new Date(0).toISOString(),
+    mission: mission?.id ? mission : null,
+    pullRequest: {
+      number: Number.isFinite(Number(pullRequest.number))
+        ? Number(pullRequest.number)
+        : null,
+      url: nullableString(pullRequest.url),
+      branch: nullableString(pullRequest.branch),
+      headSha: nullableString(pullRequest.headSha),
+    },
+  };
 }
 
-// ✅ IMPORTANT: your DB enum currently has ONLY "awaiting_approval"
-const PENDING_ACTION_STATUSES = ["awaiting_approval"] as const;
-
-async function approveActionsAndEnqueueJobs(params: {
-  supabase: ReturnType<typeof createServerSupabaseRoute>;
-  requestId: string;
-  approvedBy: string;
-}) {
-  const { supabase, requestId, approvedBy } = params;
-
-  const { data: actions, error: actionsErr } = await supabase
-    .from("agent_actions")
-    .select("id, request_id, kind, status, risk, summary, payload, created_at")
-    .eq("request_id", requestId)
-    .in("status", [...PENDING_ACTION_STATUSES])
-    .order("created_at", { ascending: true });
-
-  if (actionsErr) throw new Error(`Failed to load agent_actions: ${actionsErr.message}`);
-
-  const list = (actions ?? []) as AgentActionRow[];
-  if (list.length === 0) {
-    return { approvedActionIds: [] as string[], enqueuedJobIds: [] as string[] };
-  }
-
-  const approvedActionIds: string[] = [];
-  const enqueuedJobIds: string[] = [];
-
-  for (const a of list) {
-    // 1) Approve via RPC (single source of truth)
-    const { error: rpcErr } = await supabase.rpc("agent_approve_action", {
-      p_action_id: a.id,
-      p_approved_by: approvedBy,
-    });
-
-    if (rpcErr) throw new Error(`agent_approve_action failed: ${rpcErr.message}`);
-    approvedActionIds.push(a.id);
-
-    // 2) Enqueue worker job. MUST include actionId so worker doesn’t have to guess.
-    const payload =
-      isRecord(a.payload)
-        ? { ...a.payload, actionId: a.id }
-        : { actionId: a.id, payload: a.payload };
-
-    const { data: jobRow, error: jobErr } = await supabase
-      .from("agent_jobs")
-      .insert({
-        request_id: requestId,
-        kind: a.kind,
-        status: "queued",
-        priority: 100,
-        payload,
-        run_after: nowIso(),
-      })
-      .select("id")
-      .single();
-
-    if (jobErr) throw new Error(`Failed to enqueue agent_jobs: ${jobErr.message}`);
-    enqueuedJobIds.push(String(jobRow.id));
-  }
-
-  return { approvedActionIds, enqueuedJobIds };
-}
-
-/**
- * PATCH /api/agent/requests/:id
- * - approve / reject a request
- * - approving ALSO approves any pending agent_actions and enqueues agent_jobs
- * - PR merge step stays separate best-effort
- */
-export async function PATCH(req: NextRequest) {
-  const id = getIdFromUrl(req);
-  if (!id) return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
-
-  const body = (await req.json().catch(() => null)) as PatchBody | null;
-  if (!body || (body.action !== "approve" && body.action !== "reject")) {
-    return NextResponse.json(
-      { error: "action is required and must be approve or reject", example: { action: "approve" } },
-      { status: 400 },
-    );
-  }
+async function requireDeveloperProfile() {
   const supabase = createServerSupabaseRoute();
-
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
 
   const { data: profile, error: profileError } = await supabase
     .from("profiles")
@@ -148,17 +104,75 @@ export async function PATCH(req: NextRequest) {
     .single();
 
   if (profileError || !profile) {
-    console.error("agent_requests PATCH profile error", profileError);
-    return NextResponse.json({ error: "Profile not found" }, { status: 400 });
+    console.error("agent request profile error", profileError);
+    return {
+      error: NextResponse.json({ error: "Profile not found" }, { status: 400 }),
+    };
   }
 
   if (!APPROVER_ROLES.includes(profile.agent_role ?? "")) {
-    return NextResponse.json({ error: "Forbidden – insufficient role to approve/reject" }, { status: 403 });
+    return {
+      error: NextResponse.json(
+        { error: "Forbidden – insufficient role to manage Agent team cases" },
+        { status: 403 },
+      ),
+    };
   }
+
+  return { supabase, user, profile };
+}
+
+function agentErrorResponse(error: unknown) {
+  if (error instanceof AgentTeamRequestError) {
+    return NextResponse.json(
+      {
+        error: error.message,
+        detail: error.detail,
+        agentStatus: error.status,
+      },
+      { status: 502 },
+    );
+  }
+  return NextResponse.json(
+    {
+      error: "Agent team request failed",
+      detail: error instanceof Error ? error.message : String(error),
+    },
+    { status: 502 },
+  );
+}
+
+/**
+ * PATCH /api/agent/requests/:id
+ *
+ * The Agent database is the sole execution authority. This route only authorizes
+ * the ProFixIQ user, forwards mission/release/rejection decisions, then refreshes
+ * the local projection used by the console.
+ */
+export async function PATCH(req: NextRequest) {
+  const id = getIdFromUrl(req);
+  if (!id) {
+    return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
+  }
+
+  const body = (await req.json().catch(() => null)) as PatchBody | null;
+  if (!body || (body.action !== "approve" && body.action !== "reject")) {
+    return NextResponse.json(
+      {
+        error: "action is required and must be approve or reject",
+        example: { action: "approve" },
+      },
+      { status: 400 },
+    );
+  }
+
+  const access = await requireDeveloperProfile();
+  if (access.error) return access.error;
+  const { supabase, user } = access;
 
   const { data: existing, error: existingError } = await supabase
     .from("agent_requests")
-    .select("id, status, github_pr_number, github_pr_url, github_branch, github_commit_sha")
+    .select("*")
     .eq("id", id)
     .single();
 
@@ -167,100 +181,76 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Agent request not found" }, { status: 404 });
   }
 
-  let finalStatus: AgentRequestStatus = body.action === "approve" ? "approved" : "rejected";
-  let newCommitSha: string | null = existing.github_commit_sha;
-  let newBranch: string | null = existing.github_branch;
+  let currentProjection = projectionFromNormalized(existing.normalized_json);
+  if (!currentProjection) {
+    return NextResponse.json(
+      { error: "This request is not linked to a canonical Agent engineering case" },
+      { status: 409 },
+    );
+  }
 
-  let approvedActionIds: string[] = [];
-  let enqueuedJobIds: string[] = [];
-
-  if (body.action === "approve") {
-    try {
-      const out = await approveActionsAndEnqueueJobs({
-        supabase,
-        requestId: id,
-        approvedBy: user.id,
-      });
-      approvedActionIds = out.approvedActionIds;
-      enqueuedJobIds = out.enqueuedJobIds;
-    } catch (err) {
-      console.error("Approve actions/enqueue jobs failed", err);
-      finalStatus = "failed";
-    }
-  } else {
-    // Reject pending actions (best-effort)
-    try {
-      const { data: actions, error: actionsErr } = await supabase
-        .from("agent_actions")
-        .select("id, status")
-        .eq("request_id", id)
-        .in("status", [...PENDING_ACTION_STATUSES])
-        .order("created_at", { ascending: true });
-
-      if (actionsErr) throw new Error(actionsErr.message);
-
-      for (const a of actions ?? []) {
-        const actionId = safeUuid((a as { id: unknown }).id);
-        if (!actionId) continue;
-
-        const { error: rpcErr } = await supabase.rpc("agent_reject_action", {
-          p_action_id: actionId,
-          p_rejected_by: user.id,
-          p_reason: "Rejected from Agent Console UI",
+  try {
+    if (body.action === "approve") {
+      if (currentProjection.mission?.status === "awaiting_approval") {
+        await approveAgentTeamMission({
+          missionId: currentProjection.mission.id,
+          approvedBy: user.id,
         });
-
-        if (rpcErr) throw new Error(rpcErr.message);
-      }
-    } catch (err) {
-      console.error("Reject actions failed (continuing)", err);
-    }
-  }
-
-  // Optional PR merge step (separate concern)
-  if (
-    body.action === "approve" &&
-    existing.github_pr_number != null &&
-    existing.status === "awaiting_approval"
-  ) {
-    try {
-      const mergeRes = await fetch(`${AGENT_SERVICE_URL}/feature-requests/merge`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prNumber: existing.github_pr_number }),
-      });
-
-      if (!mergeRes.ok) {
-        console.error("Agent merge endpoint non-OK", mergeRes.status, await mergeRes.text());
-        finalStatus = "failed";
+      } else if (
+        currentProjection.caseStatus === "ready_for_human_approval"
+        && currentProjection.currentStage === "release"
+      ) {
+        await approveAgentTeamRelease({
+          engineeringCaseId: currentProjection.engineeringCaseId,
+          approvedBy: user.id,
+        });
       } else {
-        const mergeJson = (await mergeRes.json()) as {
-          merged?: boolean;
-          alreadyMerged?: boolean;
-          branch?: string;
-          sha?: string;
-        };
-
-        if (mergeJson.merged || mergeJson.alreadyMerged) {
-          finalStatus = "merged";
-          newCommitSha = mergeJson.sha ?? newCommitSha;
-          newBranch = mergeJson.branch ?? newBranch;
-        } else {
-          finalStatus = "failed";
-        }
+        return NextResponse.json(
+          {
+            error: "The Agent team is not waiting for a human approval at this stage",
+            currentStage: currentProjection.currentStage,
+            caseStatus: currentProjection.caseStatus,
+            missionStatus: currentProjection.mission?.status ?? null,
+          },
+          { status: 409 },
+        );
       }
-    } catch (err) {
-      console.error("Error calling Agent merge endpoint", err);
-      finalStatus = "failed";
+    } else {
+      await rejectAgentTeamCase({
+        engineeringCaseId: currentProjection.engineeringCaseId,
+        rejectedBy: user.id,
+        reason: body.llm_notes?.trim() || "Rejected from the ProFixIQ Agent Console.",
+      });
     }
+
+    currentProjection = projectAgentTeamCase(
+      await readAgentTeamCase(currentProjection.engineeringCaseId),
+    );
+  } catch (error) {
+    return agentErrorResponse(error);
   }
+
+  const normalized = isRecord(existing.normalized_json)
+    ? existing.normalized_json
+    : {};
+  const finalStatus = mapAgentTeamRequestStatus(currentProjection) as AgentRequestStatus;
 
   const { data, error } = await supabase
     .from("agent_requests")
     .update({
       status: finalStatus,
-      llm_notes: body.llm_notes,
-      github_commit_sha: newCommitSha,
-      github_branch: newBranch,
+      normalized_json: {
+        ...normalized,
+        agentTeam: {
+          ...currentProjection,
+          syncedAt: new Date().toISOString(),
+        },
+      },
+      github_pr_number: currentProjection.pullRequest.number,
+      github_pr_url: currentProjection.pullRequest.url,
+      github_branch: currentProjection.pullRequest.branch,
+      github_commit_sha: currentProjection.pullRequest.headSha,
+      llm_notes: currentProjection.summary,
     })
     .eq("id", id)
     .select("*")
@@ -268,39 +258,36 @@ export async function PATCH(req: NextRequest) {
 
   if (error || !data) {
     console.error("agent_requests PATCH update error", error);
-    return NextResponse.json({ error: "Failed to update agent request" }, { status: 500 });
+    return NextResponse.json(
+      { error: "The Agent team was updated, but the local projection failed to refresh" },
+      { status: 500 },
+    );
   }
 
-  return NextResponse.json({ request: data, approvedActionIds, enqueuedJobIds });
+  return NextResponse.json({
+    request: data,
+    engineeringCaseId: currentProjection.engineeringCaseId,
+    currentStage: currentProjection.currentStage,
+    caseStatus: currentProjection.caseStatus,
+    missionStatus: currentProjection.mission?.status ?? null,
+  });
 }
 
 /**
  * DELETE /api/agent/requests/:id
- * - developer-only
- * - best-effort cleanup of screenshot files in agent_uploads
+ *
+ * Active canonical cases are rejected before their local projection is removed,
+ * preventing invisible Agent work from continuing after deletion.
  */
 export async function DELETE(req: NextRequest) {
   const id = getIdFromUrl(req);
-  if (!id) return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
-  const supabase = createServerSupabaseRoute();
-
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("id, agent_role")
-    .eq("id", user.id)
-    .single();
-
-  if (profileError || !profile) {
-    console.error("agent_requests DELETE profile error", profileError);
-    return NextResponse.json({ error: "Profile not found" }, { status: 400 });
+  if (!id) {
+    return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
   }
 
-  if (!APPROVER_ROLES.includes(profile.agent_role ?? "")) {
-    return NextResponse.json({ error: "Forbidden – insufficient role to delete requests" }, { status: 403 });
-  }
+  const access = await requireDeveloperProfile();
+  if (access.error) return access.error;
+  const { supabase, user } = access;
 
   const { data: existing, error: existingError } = await supabase
     .from("agent_requests")
@@ -313,18 +300,44 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: "Agent request not found" }, { status: 404 });
   }
 
-  // cleanup attachments best-effort
-  try {
-    const ctx = (existing.normalized_json ?? {}) as { attachmentIds?: string[] };
-    if (Array.isArray(ctx.attachmentIds) && ctx.attachmentIds.length > 0) {
-      const { error: storageError } = await supabase.storage.from("agent_uploads").remove(ctx.attachmentIds);
-      if (storageError) console.error("agent_uploads cleanup error", storageError);
+  const projection = projectionFromNormalized(existing.normalized_json);
+  if (
+    projection
+    && projection.caseStatus !== "complete"
+    && projection.caseStatus !== "rejected"
+  ) {
+    try {
+      await rejectAgentTeamCase({
+        engineeringCaseId: projection.engineeringCaseId,
+        rejectedBy: user.id,
+        reason: "Local Agent Console request deleted by an authorized developer.",
+      });
+    } catch (error) {
+      return agentErrorResponse(error);
     }
-  } catch (err) {
-    console.error("Error processing attachmentIds for cleanup", err);
   }
 
-  const { error: deleteError } = await supabase.from("agent_requests").delete().eq("id", id);
+  try {
+    const context = isRecord(existing.normalized_json)
+      ? existing.normalized_json
+      : {};
+    const attachmentIds = Array.isArray(context.attachmentIds)
+      ? context.attachmentIds.filter((value): value is string => typeof value === "string")
+      : [];
+    if (attachmentIds.length > 0) {
+      const { error: storageError } = await supabase.storage
+        .from("agent_uploads")
+        .remove(attachmentIds);
+      if (storageError) console.error("agent_uploads cleanup error", storageError);
+    }
+  } catch (error) {
+    console.error("Error processing attachmentIds for cleanup", error);
+  }
+
+  const { error: deleteError } = await supabase
+    .from("agent_requests")
+    .delete()
+    .eq("id", id);
   if (deleteError) {
     console.error("agent_requests DELETE error", deleteError);
     return NextResponse.json({ error: "Failed to delete agent request" }, { status: 500 });

--- a/app/api/agent/requests/route.ts
+++ b/app/api/agent/requests/route.ts
@@ -1,20 +1,20 @@
-// app/api/agent/requests/route.ts
 import { NextRequest, NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { resolveAgentApiSecrets } from "@/features/shared/lib/server/agent-api-secrets";
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-
-const AGENT_SERVICE_URL = String(process.env.PROFIXIQ_AGENT_URL ?? "")
-  .trim()
-  .replace(/\/+$/, "");
+import {
+  AgentTeamRequestError,
+  agentTeamRequest,
+  mapAgentTeamRequestStatus,
+  projectAgentTeamCase,
+  readAgentTeamCase,
+  type AgentTeamProjection,
+} from "@/features/agent/server/teamClient";
 
 const supabaseAdmin = createClient<Database>(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  {
-    auth: { persistSession: false },
-  },
+  { auth: { persistSession: false } },
 );
 
 type AgentGithubMeta = {
@@ -73,6 +73,8 @@ type AgentRequestStatus =
   | "failed"
   | "merged";
 
+type AgentRequestRow = Database["public"]["Tables"]["agent_requests"]["Row"];
+
 const AGENT_INTENTS: AgentIntent[] = [
   "feature_request",
   "bug_report",
@@ -92,6 +94,107 @@ function normalizeIntent(raw: unknown): AgentIntent {
 function asNullableString(value: unknown): string | null {
   const text = typeof value === "string" ? value.trim() : "";
   return text || null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function teamCaseId(row: AgentRequestRow): string | null {
+  if (!isRecord(row.normalized_json)) return null;
+  const team = isRecord(row.normalized_json.agentTeam)
+    ? row.normalized_json.agentTeam
+    : null;
+  return team ? asNullableString(team.engineeringCaseId) : null;
+}
+
+function lastTeamSyncAt(row: AgentRequestRow): number | null {
+  if (!isRecord(row.normalized_json)) return null;
+  const team = isRecord(row.normalized_json.agentTeam)
+    ? row.normalized_json.agentTeam
+    : null;
+  const value = team ? asNullableString(team.syncedAt) : null;
+  const timestamp = value ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function initialProjection(
+  response: AgentServiceResponse,
+  requestId: string,
+): AgentTeamProjection {
+  return {
+    engineeringCaseId: String(response.engineeringCaseId ?? ""),
+    requestId,
+    currentStage: String(response.currentStage ?? "intake"),
+    caseStatus: String(response.status ?? "active"),
+    stepStatus: "pending",
+    summary: response.message ?? "Accepted into the ProFixIQ engineering organization.",
+    decision: null,
+    missingInformation: [],
+    updatedAt: new Date().toISOString(),
+    mission: null,
+    pullRequest: {
+      number: response.github?.prNumber ?? null,
+      url: response.github?.prUrl ?? null,
+      branch: response.github?.branchName ?? null,
+      headSha: response.github?.commitSha ?? null,
+    },
+  };
+}
+
+async function syncAgentRequestRow(row: AgentRequestRow): Promise<AgentRequestRow> {
+  const activeStatuses: AgentRequestStatus[] = [
+    "submitted",
+    "in_progress",
+    "awaiting_approval",
+    "approved",
+  ];
+  if (!activeStatuses.includes(row.status as AgentRequestStatus)) return row;
+
+  const engineeringCaseId = teamCaseId(row);
+  if (!engineeringCaseId) return row;
+
+  const lastSync = lastTeamSyncAt(row);
+  if (lastSync && Date.now() - lastSync < 5_000) return row;
+
+  try {
+    const envelope = await readAgentTeamCase(engineeringCaseId);
+    const projection = projectAgentTeamCase(envelope);
+    const normalized = isRecord(row.normalized_json) ? row.normalized_json : {};
+    const nextStatus = mapAgentTeamRequestStatus(projection);
+    const synchronizedAt = new Date().toISOString();
+
+    const { data: updated, error } = await supabaseAdmin
+      .from("agent_requests")
+      .update({
+        status: nextStatus,
+        normalized_json: {
+          ...normalized,
+          agentTeam: { ...projection, syncedAt: synchronizedAt },
+        },
+        github_pr_number: projection.pullRequest.number,
+        github_pr_url: projection.pullRequest.url,
+        github_branch: projection.pullRequest.branch,
+        github_commit_sha: projection.pullRequest.headSha,
+        llm_notes: projection.summary,
+      })
+      .eq("id", row.id)
+      .select("*")
+      .single();
+
+    if (error || !updated) {
+      console.error("agent request team synchronization failed", error);
+      return row;
+    }
+    return updated;
+  } catch (error) {
+    console.error("agent request team read failed", {
+      requestId: row.id,
+      engineeringCaseId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return row;
+  }
 }
 
 type CreateAgentRequestBody = {
@@ -132,7 +235,8 @@ export async function GET() {
     );
   }
 
-  return NextResponse.json({ requests: data });
+  const requests = await Promise.all((data ?? []).map(syncAgentRequestRow));
+  return NextResponse.json({ requests });
 }
 
 export async function POST(req: NextRequest) {
@@ -183,7 +287,7 @@ export async function POST(req: NextRequest) {
   if (attachmentIds.length > 0) {
     const { data, error } = await supabaseAdmin.storage
       .from("agent_uploads")
-      .createSignedUrls(attachmentIds, 60 * 60 * 24);
+      .createSignedUrls(attachmentIds, 60 * 60 * 24 * 7);
 
     if (error) {
       console.error("createSignedUrls error for agent_uploads:", error);
@@ -239,7 +343,6 @@ export async function POST(req: NextRequest) {
   const actualBehavior = asNullableString(body.actual) ?? description;
   const route = asNullableString(body.location);
   const browser = asNullableString(body.device);
-  const agentSecrets = resolveAgentApiSecrets();
 
   const contextForAgent = {
     ...structuredContext,
@@ -258,13 +361,6 @@ export async function POST(req: NextRequest) {
   let agentFailure: { status: number | null; detail: string } | null = null;
 
   try {
-    if (!AGENT_SERVICE_URL) {
-      throw new Error("PROFIXIQ_AGENT_URL is not configured");
-    }
-    if (!agentSecrets.primary) {
-      throw new Error("AGENT_API_SECRET is not configured");
-    }
-
     const endpoint = intent === "refactor" ? "/refactors" : "/feature-requests";
     const payload = intent === "refactor"
       ? {
@@ -274,6 +370,10 @@ export async function POST(req: NextRequest) {
           shopId: profile.shop_id,
           title: `Refactor: ${description.slice(0, 80)}`,
           description,
+          expectedBehavior,
+          actualBehavior,
+          route,
+          platform: browser,
           context: contextForAgent,
         }
       : {
@@ -293,39 +393,25 @@ export async function POST(req: NextRequest) {
           context: contextForAgent,
         };
 
-    const response = await fetch(`${AGENT_SERVICE_URL}${endpoint}`, {
+    agentResponse = await agentTeamRequest<AgentServiceResponse>(endpoint, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-agent-api-secret": agentSecrets.canonical || agentSecrets.primary,
-        "x-agent-secret": agentSecrets.profixiqAlias || agentSecrets.primary,
-        Authorization: `Bearer ${agentSecrets.internalAlias || agentSecrets.primary}`,
-      },
       body: JSON.stringify(payload),
-      cache: "no-store",
     });
 
-    const rawResponse = await response.text();
-    if (!response.ok) {
-      agentFailure = {
-        status: response.status,
-        detail: rawResponse.slice(0, 2_000) || `HTTP ${response.status}`,
-      };
-    } else {
-      try {
-        agentResponse = JSON.parse(rawResponse) as AgentServiceResponse;
-      } catch {
-        agentFailure = {
-          status: response.status,
-          detail: "ProFixIQ-Agent returned invalid JSON",
-        };
-      }
+    if (!agentResponse.engineeringCaseId) {
+      throw new AgentTeamRequestError(
+        "ProFixIQ-Agent did not return an engineering case",
+        502,
+        "The Agent accepted the request without a durable engineeringCaseId.",
+      );
     }
   } catch (error) {
-    agentFailure = {
-      status: null,
-      detail: error instanceof Error ? error.message : String(error),
-    };
+    agentFailure = error instanceof AgentTeamRequestError
+      ? { status: error.status, detail: error.detail }
+      : {
+          status: null,
+          detail: error instanceof Error ? error.message : String(error),
+        };
   }
 
   if (agentFailure) {
@@ -362,45 +448,37 @@ export async function POST(req: NextRequest) {
       {
         error: "ProFixIQ-Agent request failed",
         detail: agentFailure.detail,
+        requestId,
+        savedLocally: true,
+        engineeringCaseCreated: false,
         request: failedRequest ?? inserted,
       },
       { status: 502 },
     );
   }
 
-  const github = agentResponse?.github ?? null;
+  const engineeringCaseId = String(agentResponse?.engineeringCaseId ?? "");
+  let projection = initialProjection(agentResponse ?? {}, requestId);
+  try {
+    projection = projectAgentTeamCase(await readAgentTeamCase(engineeringCaseId));
+  } catch (error) {
+    console.warn("Agent case created but initial synchronization failed", {
+      requestId,
+      engineeringCaseId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const finalIntent = normalizeIntent(agentResponse?.intent ?? intent);
+  const status = mapAgentTeamRequestStatus(projection);
+  const synchronizedAt = new Date().toISOString();
   const llmMeta = agentResponse?.llm ?? agentResponse?.analysis ?? null;
-  const llmConfidence = llmMeta?.confidence ?? null;
-  const llmNotes =
-    llmMeta?.notes
+  const llmNotes = projection.summary
+    ?? llmMeta?.notes
     ?? llmMeta?.commentary
     ?? llmMeta?.summary
     ?? agentResponse?.message
     ?? null;
-
-  let finalIntent: AgentIntent = intent;
-  const agentIntent = agentResponse?.intent as AgentIntent | null | undefined;
-  if (
-    agentIntent === "inspection_catalog_add"
-    || agentIntent === "service_catalog_add"
-  ) {
-    finalIntent = agentIntent;
-  }
-
-  const hasPersistedEngineeringCase = Boolean(
-    agentResponse?.engineeringCaseId
-    || agentResponse?.intakeJobId,
-  );
-  const status: AgentRequestStatus = github?.prUrl
-    ? "awaiting_approval"
-    : github?.issueUrl
-      ? "in_progress"
-      : hasPersistedEngineeringCase
-        ? "in_progress"
-        : finalIntent === "inspection_catalog_add"
-            || finalIntent === "service_catalog_add"
-          ? "merged"
-          : "submitted";
 
   const { data: updated, error: updateError } = await supabase
     .from("agent_requests")
@@ -409,15 +487,16 @@ export async function POST(req: NextRequest) {
       normalized_json: {
         ...structuredContext,
         agentRequest: agentResponse ?? {},
+        agentTeam: { ...projection, syncedAt: synchronizedAt },
       },
-      github_issue_number: github?.issueNumber ?? null,
-      github_issue_url: github?.issueUrl ?? null,
-      github_pr_number: github?.prNumber ?? null,
-      github_pr_url: github?.prUrl ?? null,
-      github_branch: github?.branchName ?? null,
-      github_commit_sha: github?.commitSha ?? null,
+      github_issue_number: agentResponse?.github?.issueNumber ?? null,
+      github_issue_url: agentResponse?.github?.issueUrl ?? null,
+      github_pr_number: projection.pullRequest.number,
+      github_pr_url: projection.pullRequest.url,
+      github_branch: projection.pullRequest.branch,
+      github_commit_sha: projection.pullRequest.headSha,
       llm_model: llmMeta?.model ?? null,
-      llm_confidence: llmConfidence,
+      llm_confidence: llmMeta?.confidence ?? null,
       llm_notes: llmNotes,
       status,
     })
@@ -432,5 +511,8 @@ export async function POST(req: NextRequest) {
   return NextResponse.json({
     request: updated ?? inserted,
     agent: agentResponse,
+    engineeringCaseId,
+    currentStage: projection.currentStage,
+    caseStatus: projection.caseStatus,
   });
 }

--- a/features/agent/server/teamClient.ts
+++ b/features/agent/server/teamClient.ts
@@ -4,7 +4,8 @@ import { resolveAgentApiSecrets } from "@/features/shared/lib/server/agent-api-s
 const AGENT_SERVICE_URL = String(process.env.PROFIXIQ_AGENT_URL ?? "")
   .trim()
   .replace(/\/+$/, "");
-const BRIDGE_CREDENTIAL_ID = "profixiq";
+const BRIDGE_INTEGRATION_ID = "7c2da329-5117-48c0-a1ee-d51b5d63827d";
+const BRIDGE_INTEGRATION_KIND = "profixiq_agent_bridge";
 
 const bridgeSupabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -127,17 +128,24 @@ function nullableNumber(value: unknown): number | null {
 
 async function readBridgeSecret(): Promise<string> {
   const result = await bridgeSupabase
-    .from("agent_bridge_credentials")
-    .select("secret")
-    .eq("id", BRIDGE_CREDENTIAL_ID)
-    .eq("active", true)
+    .from("integrations")
+    .select("config")
+    .eq("id", BRIDGE_INTEGRATION_ID)
+    .eq("status", "enabled")
+    .is("shop_id", null)
     .maybeSingle();
 
   if (result.error) {
-    console.error("agent bridge credential read failed", result.error);
+    console.error("Agent bridge integration read failed", result.error);
     return "";
   }
-  return String(result.data?.secret ?? "").trim();
+
+  const config = isRecord(result.data?.config) ? result.data.config : {};
+  if (config.kind !== BRIDGE_INTEGRATION_KIND) {
+    console.error("Agent bridge integration has an invalid kind");
+    return "";
+  }
+  return nullableString(config.secret) ?? "";
 }
 
 async function agentTeamHeaders(): Promise<Headers> {

--- a/features/agent/server/teamClient.ts
+++ b/features/agent/server/teamClient.ts
@@ -1,0 +1,377 @@
+import { createClient } from "@supabase/supabase-js";
+import { resolveAgentApiSecrets } from "@/features/shared/lib/server/agent-api-secrets";
+
+const AGENT_SERVICE_URL = String(process.env.PROFIXIQ_AGENT_URL ?? "")
+  .trim()
+  .replace(/\/+$/, "");
+const BRIDGE_CREDENTIAL_ID = "profixiq";
+
+const bridgeSupabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false, autoRefreshToken: false } },
+);
+
+export type AgentTeamRequestStatus =
+  | "submitted"
+  | "in_progress"
+  | "awaiting_approval"
+  | "approved"
+  | "rejected"
+  | "failed"
+  | "merged";
+
+export type AgentTeamStageResult = {
+  decision?: string | null;
+  summary?: string | null;
+  missingInformation?: string[];
+  data?: Record<string, unknown>;
+};
+
+export type AgentTeamEngineeringCase = {
+  id: string;
+  currentStage: string;
+  status: string;
+  updatedAt: string;
+  ticket: {
+    id: string;
+    metadata?: Record<string, unknown>;
+  };
+  stages: Record<string, {
+    status: string;
+    result?: AgentTeamStageResult | null;
+  }>;
+};
+
+export type AgentTeamMission = {
+  id: string;
+  status: string;
+  title?: string | null;
+  desired_outcome?: string | null;
+  problem_statement?: string | null;
+  approved_at?: string | null;
+  approved_by?: string | null;
+  acceptanceCriteria?: unknown[];
+  constraints?: unknown[];
+  risks?: unknown[];
+  planSteps?: unknown[];
+};
+
+export type AgentTeamCaseEnvelope = {
+  ok?: boolean;
+  engineeringCase: AgentTeamEngineeringCase;
+  mission?: AgentTeamMission | null;
+  caseSummary?: {
+    stage?: string | null;
+    caseStatus?: string | null;
+    stepStatus?: string | null;
+    summary?: string | null;
+    decision?: string | null;
+    missingInformation?: string[];
+    updatedAt?: string | null;
+  } | null;
+};
+
+export type AgentTeamProjection = {
+  engineeringCaseId: string;
+  requestId: string;
+  currentStage: string;
+  caseStatus: string;
+  stepStatus: string | null;
+  summary: string | null;
+  decision: string | null;
+  missingInformation: string[];
+  updatedAt: string;
+  mission: {
+    id: string;
+    status: string;
+    title: string | null;
+    desiredOutcome: string | null;
+    problemStatement: string | null;
+    approvedAt: string | null;
+    approvedBy: string | null;
+  } | null;
+  pullRequest: {
+    number: number | null;
+    url: string | null;
+    branch: string | null;
+    headSha: string | null;
+  };
+};
+
+export class AgentTeamRequestError extends Error {
+  readonly status: number | null;
+  readonly detail: string;
+
+  constructor(message: string, status: number | null, detail: string) {
+    super(message);
+    this.name = "AgentTeamRequestError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function nullableString(value: unknown): string | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text || null;
+}
+
+function nullableNumber(value: unknown): number | null {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+async function readBridgeSecret(): Promise<string> {
+  const result = await bridgeSupabase
+    .from("agent_bridge_credentials")
+    .select("secret")
+    .eq("id", BRIDGE_CREDENTIAL_ID)
+    .eq("active", true)
+    .maybeSingle();
+
+  if (result.error) {
+    console.error("agent bridge credential read failed", result.error);
+    return "";
+  }
+  return String(result.data?.secret ?? "").trim();
+}
+
+async function agentTeamHeaders(): Promise<Headers> {
+  const environmentSecrets = resolveAgentApiSecrets();
+  const bridgeSecret = await readBridgeSecret();
+  if (!bridgeSecret && !environmentSecrets.primary) {
+    throw new AgentTeamRequestError(
+      "Agent team authentication is not configured",
+      null,
+      "No active database bridge credential or Agent API secret is available.",
+    );
+  }
+
+  const headers = new Headers();
+  headers.set("content-type", "application/json");
+  if (bridgeSecret) headers.set("x-profixiq-bridge-secret", bridgeSecret);
+  if (environmentSecrets.canonical || environmentSecrets.primary) {
+    headers.set(
+      "x-agent-api-secret",
+      environmentSecrets.canonical || environmentSecrets.primary,
+    );
+  }
+  if (environmentSecrets.profixiqAlias || environmentSecrets.primary) {
+    headers.set(
+      "x-agent-secret",
+      environmentSecrets.profixiqAlias || environmentSecrets.primary,
+    );
+  }
+  if (environmentSecrets.internalAlias || environmentSecrets.primary) {
+    headers.set(
+      "authorization",
+      `Bearer ${environmentSecrets.internalAlias || environmentSecrets.primary}`,
+    );
+  }
+  return headers;
+}
+
+export async function agentTeamRequest<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  if (!AGENT_SERVICE_URL) {
+    throw new AgentTeamRequestError(
+      "ProFixIQ-Agent URL is not configured",
+      null,
+      "PROFIXIQ_AGENT_URL is missing.",
+    );
+  }
+
+  const headers = await agentTeamHeaders();
+  const suppliedHeaders = new Headers(init.headers);
+  suppliedHeaders.forEach((value, key) => headers.set(key, value));
+
+  let response: Response;
+  try {
+    response = await fetch(`${AGENT_SERVICE_URL}${path}`, {
+      ...init,
+      headers,
+      cache: "no-store",
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new AgentTeamRequestError("Unable to reach ProFixIQ-Agent", null, detail);
+  }
+
+  const raw = await response.text();
+  if (!response.ok) {
+    throw new AgentTeamRequestError(
+      "ProFixIQ-Agent request failed",
+      response.status,
+      raw.slice(0, 2_000) || `HTTP ${response.status}`,
+    );
+  }
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    throw new AgentTeamRequestError(
+      "ProFixIQ-Agent returned invalid JSON",
+      response.status,
+      raw.slice(0, 2_000),
+    );
+  }
+}
+
+export async function readAgentTeamCase(
+  engineeringCaseId: string,
+): Promise<AgentTeamCaseEnvelope> {
+  return agentTeamRequest<AgentTeamCaseEnvelope>(
+    `/engineering-cases/${encodeURIComponent(engineeringCaseId)}`,
+  );
+}
+
+export async function resumeAgentTeamCase(params: {
+  engineeringCaseId: string;
+  resumedBy: string;
+  message: string;
+  answers?: Record<string, string>;
+}) {
+  return agentTeamRequest<Record<string, unknown>>(
+    `/engineering-cases/${encodeURIComponent(params.engineeringCaseId)}/resume`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        resumedBy: params.resumedBy,
+        context: {
+          message: params.message,
+          answers: params.answers ?? null,
+          source: "profixiq-agent-console",
+        },
+      }),
+    },
+  );
+}
+
+export async function approveAgentTeamMission(params: {
+  missionId: string;
+  approvedBy: string;
+}) {
+  return agentTeamRequest<Record<string, unknown>>(
+    `/engineering-missions/${encodeURIComponent(params.missionId)}/approve`,
+    {
+      method: "POST",
+      body: JSON.stringify({ approvedBy: params.approvedBy }),
+    },
+  );
+}
+
+export async function approveAgentTeamRelease(params: {
+  engineeringCaseId: string;
+  approvedBy: string;
+}) {
+  return agentTeamRequest<Record<string, unknown>>(
+    `/engineering-cases/${encodeURIComponent(params.engineeringCaseId)}/approve-release`,
+    {
+      method: "POST",
+      body: JSON.stringify({ approvedBy: params.approvedBy }),
+    },
+  );
+}
+
+export async function rejectAgentTeamCase(params: {
+  engineeringCaseId: string;
+  rejectedBy: string;
+  reason: string;
+}) {
+  return agentTeamRequest<Record<string, unknown>>(
+    `/engineering-cases/${encodeURIComponent(params.engineeringCaseId)}/reject`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        rejectedBy: params.rejectedBy,
+        reason: params.reason,
+      }),
+    },
+  );
+}
+
+export function projectAgentTeamCase(
+  envelope: AgentTeamCaseEnvelope,
+): AgentTeamProjection {
+  const engineeringCase = envelope.engineeringCase;
+  const currentStep = engineeringCase.stages[engineeringCase.currentStage] ?? null;
+  const summary = envelope.caseSummary?.summary
+    ?? currentStep?.result?.summary
+    ?? null;
+  const decision = envelope.caseSummary?.decision
+    ?? currentStep?.result?.decision
+    ?? null;
+  const missingInformation = envelope.caseSummary?.missingInformation
+    ?? currentStep?.result?.missingInformation
+    ?? [];
+  const metadata = isRecord(engineeringCase.ticket.metadata)
+    ? engineeringCase.ticket.metadata
+    : {};
+  const productionWork = isRecord(metadata.productionWork)
+    ? metadata.productionWork
+    : {};
+  const approvalPackage = isRecord(metadata.approvalPackage)
+    ? metadata.approvalPackage
+    : {};
+
+  return {
+    engineeringCaseId: engineeringCase.id,
+    requestId: engineeringCase.ticket.id,
+    currentStage: engineeringCase.currentStage,
+    caseStatus: engineeringCase.status,
+    stepStatus: envelope.caseSummary?.stepStatus ?? currentStep?.status ?? null,
+    summary,
+    decision,
+    missingInformation: Array.isArray(missingInformation)
+      ? missingInformation.filter((value): value is string => typeof value === "string")
+      : [],
+    updatedAt: engineeringCase.updatedAt,
+    mission: envelope.mission
+      ? {
+          id: envelope.mission.id,
+          status: envelope.mission.status,
+          title: nullableString(envelope.mission.title),
+          desiredOutcome: nullableString(envelope.mission.desired_outcome),
+          problemStatement: nullableString(envelope.mission.problem_statement),
+          approvedAt: nullableString(envelope.mission.approved_at),
+          approvedBy: nullableString(envelope.mission.approved_by),
+        }
+      : null,
+    pullRequest: {
+      number: nullableNumber(
+        productionWork.pullRequestNumber ?? approvalPackage.pullRequestNumber,
+      ),
+      url: nullableString(
+        productionWork.pullRequestUrl ?? approvalPackage.pullRequestUrl,
+      ),
+      branch: nullableString(
+        productionWork.branchName ?? approvalPackage.headBranch,
+      ),
+      headSha: nullableString(
+        productionWork.headSha ?? approvalPackage.headSha,
+      ),
+    },
+  };
+}
+
+export function mapAgentTeamRequestStatus(
+  projection: AgentTeamProjection,
+): AgentTeamRequestStatus {
+  if (projection.caseStatus === "rejected") return "rejected";
+  if (projection.caseStatus === "complete") return "merged";
+  if (
+    projection.caseStatus === "ready_for_human_approval"
+    || projection.mission?.status === "awaiting_approval"
+  ) {
+    return "awaiting_approval";
+  }
+  if (projection.caseStatus === "blocked") return "in_progress";
+  if (projection.caseStatus === "active") return "in_progress";
+  return "submitted";
+}

--- a/supabase/migrations/20260805202500_agent_team_bridge_credentials.sql
+++ b/supabase/migrations/20260805202500_agent_team_bridge_credentials.sql
@@ -1,0 +1,21 @@
+begin;
+
+create table if not exists public.agent_bridge_credentials (
+  id text primary key,
+  secret text not null,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.agent_bridge_credentials enable row level security;
+
+revoke all on table public.agent_bridge_credentials from public, anon, authenticated;
+grant select on table public.agent_bridge_credentials to service_role;
+
+comment on table public.agent_bridge_credentials is
+  'Server-only credentials used by ProFixIQ to call the external engineering organization.';
+comment on column public.agent_bridge_credentials.secret is
+  'Plaintext bridge credential. Accessible only through the server-side service-role client.';
+
+commit;

--- a/supabase/migrations/20260805202600_move_agent_bridge_to_integrations.sql
+++ b/supabase/migrations/20260805202600_move_agent_bridge_to_integrations.sql
@@ -1,5 +1,106 @@
 begin;
 
+-- Production already has the integrations registry, but the historical clean
+-- replay baseline does not. Reconcile the canonical shape only when absent so
+-- fresh databases and existing production databases converge on one contract.
+create table if not exists public.integrations (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid null references public.shops(id) on delete cascade,
+  provider text not null,
+  status text not null default 'disabled',
+  config jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint integrations_provider_check check (
+    provider = any (array[
+      'stripe'::text,
+      'quickbooks'::text,
+      'sendgrid'::text,
+      'mapbox'::text,
+      'openai'::text,
+      'google_oauth'::text,
+      'shopreel'::text,
+      'aftermarket_api'::text
+    ])
+  ),
+  constraint integrations_status_check check (
+    status = any (array[
+      'disabled'::text,
+      'enabled'::text,
+      'error'::text
+    ])
+  ),
+  constraint integrations_shop_id_provider_key unique (shop_id, provider)
+);
+
+create unique index if not exists integrations_shop_provider_uidx
+  on public.integrations (shop_id, provider);
+create index if not exists integrations_shop_idx
+  on public.integrations (shop_id);
+
+alter table public.integrations enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'integrations'
+      and policyname = 'integrations_select'
+  ) then
+    create policy integrations_select
+      on public.integrations
+      for select
+      to public
+      using (public.is_shop_member_v2(shop_id));
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'integrations'
+      and policyname = 'integrations_insert'
+  ) then
+    create policy integrations_insert
+      on public.integrations
+      for insert
+      to public
+      with check (public.is_shop_member_v2(shop_id));
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'integrations'
+      and policyname = 'integrations_update'
+  ) then
+    create policy integrations_update
+      on public.integrations
+      for update
+      to public
+      using (public.is_shop_member_v2(shop_id))
+      with check (public.is_shop_member_v2(shop_id));
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'integrations'
+      and policyname = 'integrations_delete'
+  ) then
+    create policy integrations_delete
+      on public.integrations
+      for delete
+      to public
+      using (public.is_shop_member_v2(shop_id));
+  end if;
+end
+$$;
+
 insert into public.integrations (
   id,
   shop_id,
@@ -30,6 +131,6 @@ set shop_id = null,
     config = excluded.config,
     updated_at = now();
 
-drop table public.agent_bridge_credentials;
+drop table if exists public.agent_bridge_credentials;
 
 commit;

--- a/supabase/migrations/20260805202600_move_agent_bridge_to_integrations.sql
+++ b/supabase/migrations/20260805202600_move_agent_bridge_to_integrations.sql
@@ -1,0 +1,35 @@
+begin;
+
+insert into public.integrations (
+  id,
+  shop_id,
+  provider,
+  status,
+  config,
+  created_at,
+  updated_at
+)
+select
+  '7c2da329-5117-48c0-a1ee-d51b5d63827d'::uuid,
+  null,
+  'aftermarket_api',
+  'enabled',
+  jsonb_build_object(
+    'kind', 'profixiq_agent_bridge',
+    'secret', bridge.secret
+  ),
+  bridge.created_at,
+  now()
+from public.agent_bridge_credentials bridge
+where bridge.id = 'profixiq'
+  and bridge.active = true
+on conflict (id) do update
+set shop_id = null,
+    provider = excluded.provider,
+    status = excluded.status,
+    config = excluded.config,
+    updated_at = now();
+
+drop table public.agent_bridge_credentials;
+
+commit;

--- a/tests/agent-request-secret-contract.test.ts
+++ b/tests/agent-request-secret-contract.test.ts
@@ -3,13 +3,28 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveAgentApiSecrets } from "@/features/shared/lib/server/agent-api-secrets";
 
-const routeSource = readFileSync(
+const teamClientSource = readFileSync(
+  join(process.cwd(), "features/agent/server/teamClient.ts"),
+  "utf8",
+);
+const requestRouteSource = readFileSync(
   join(process.cwd(), "app/api/agent/requests/route.ts"),
   "utf8",
 );
+const controlRouteSource = readFileSync(
+  join(process.cwd(), "app/api/agent/requests/[id]/route.ts"),
+  "utf8",
+);
+const bridgeMigrationSource = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260805202500_agent_team_bridge_credentials.sql",
+  ),
+  "utf8",
+);
 
-describe("ProFixIQ-Agent request authentication contract", () => {
-  it("prefers the canonical shared secret over legacy aliases", () => {
+describe("ProFixIQ-Agent team authentication contract", () => {
+  it("prefers the canonical environment secret over legacy aliases", () => {
     expect(resolveAgentApiSecrets({
       AGENT_API_SECRET: " canonical-secret ",
       PROFIXIQ_AGENT_API_SECRET: "profixiq-alias",
@@ -22,7 +37,7 @@ describe("ProFixIQ-Agent request authentication contract", () => {
     });
   });
 
-  it("skips blank canonical values and falls back to the first nonblank alias", () => {
+  it("retains environment aliases as migration fallbacks", () => {
     expect(resolveAgentApiSecrets({
       AGENT_API_SECRET: "   ",
       PROFIXIQ_AGENT_API_SECRET: " profixiq-alias ",
@@ -36,21 +51,38 @@ describe("ProFixIQ-Agent request authentication contract", () => {
     }).primary).toBe("internal-alias");
   });
 
-  it("presents each configured credential through a supported auth channel", () => {
-    expect(routeSource).toContain(
-      '"x-agent-api-secret": agentSecrets.canonical || agentSecrets.primary',
+  it("loads the durable bridge credential only with the service-role client", () => {
+    expect(teamClientSource).toContain('.from("agent_bridge_credentials")');
+    expect(teamClientSource).toContain('headers.set("x-profixiq-bridge-secret", bridgeSecret)');
+    expect(teamClientSource).toContain("SUPABASE_SERVICE_ROLE_KEY");
+    expect(bridgeMigrationSource).toContain(
+      "revoke all on table public.agent_bridge_credentials from public, anon, authenticated",
     );
-    expect(routeSource).toContain(
-      '"x-agent-secret": agentSecrets.profixiqAlias || agentSecrets.primary',
+    expect(bridgeMigrationSource).toContain(
+      "grant select on table public.agent_bridge_credentials to service_role",
     );
-    expect(routeSource).toContain(
-      "Authorization: `Bearer ${agentSecrets.internalAlias || agentSecrets.primary}`",
+    expect(bridgeMigrationSource).toContain(
+      "alter table public.agent_bridge_credentials enable row level security",
     );
   });
 
-  it("fails before dispatch when no shared secret is configured", () => {
-    expect(routeSource).toContain(
-      'throw new Error("AGENT_API_SECRET is not configured")',
+  it("keeps environment credentials available during bridge rollout", () => {
+    expect(teamClientSource).toContain('headers.set(\n      "x-agent-api-secret"');
+    expect(teamClientSource).toContain('headers.set(\n      "x-agent-secret"');
+    expect(teamClientSource).toContain('headers.set(\n      "authorization"');
+    expect(teamClientSource).toContain(
+      '"No active database bridge credential or Agent API secret is available."',
     );
+  });
+
+  it("routes submission and human controls through the canonical Agent service", () => {
+    expect(requestRouteSource).toContain("agentTeamRequest<AgentServiceResponse>");
+    expect(requestRouteSource).toContain("readAgentTeamCase");
+    expect(controlRouteSource).toContain("approveAgentTeamMission");
+    expect(controlRouteSource).toContain("approveAgentTeamRelease");
+    expect(controlRouteSource).toContain("rejectAgentTeamCase");
+    expect(controlRouteSource).not.toContain("agent_approve_action");
+    expect(controlRouteSource).not.toContain("feature-requests/merge");
+    expect(controlRouteSource).not.toContain('.from("agent_jobs")');
   });
 });

--- a/tests/agent-request-secret-contract.test.ts
+++ b/tests/agent-request-secret-contract.test.ts
@@ -23,10 +23,17 @@ const discordRouteSource = readFileSync(
   join(process.cwd(), "app/api/agent/requests/[id]/notify-discord/route.ts"),
   "utf8",
 );
-const bridgeMigrationSource = readFileSync(
+const bridgeCreateMigrationSource = readFileSync(
   join(
     process.cwd(),
     "supabase/migrations/20260805202500_agent_team_bridge_credentials.sql",
+  ),
+  "utf8",
+);
+const bridgeMoveMigrationSource = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260805202600_move_agent_bridge_to_integrations.sql",
   ),
   "utf8",
 );
@@ -59,18 +66,21 @@ describe("ProFixIQ-Agent team authentication contract", () => {
     }).primary).toBe("internal-alias");
   });
 
-  it("loads the durable bridge credential only with the service-role client", () => {
-    expect(teamClientSource).toContain('.from("agent_bridge_credentials")');
+  it("keeps the durable bridge in the existing service-only integration registry", () => {
+    expect(teamClientSource).toContain('.from("integrations")');
+    expect(teamClientSource).toContain('BRIDGE_INTEGRATION_KIND = "profixiq_agent_bridge"');
+    expect(teamClientSource).toContain('.is("shop_id", null)');
     expect(teamClientSource).toContain('headers.set("x-profixiq-bridge-secret", bridgeSecret)');
     expect(teamClientSource).toContain("SUPABASE_SERVICE_ROLE_KEY");
-    expect(bridgeMigrationSource).toContain(
+
+    expect(bridgeCreateMigrationSource).toContain(
       "revoke all on table public.agent_bridge_credentials from public, anon, authenticated",
     );
-    expect(bridgeMigrationSource).toContain(
-      "grant select on table public.agent_bridge_credentials to service_role",
-    );
-    expect(bridgeMigrationSource).toContain(
-      "alter table public.agent_bridge_credentials enable row level security",
+    expect(bridgeMoveMigrationSource).toContain("insert into public.integrations");
+    expect(bridgeMoveMigrationSource).toContain("'kind', 'profixiq_agent_bridge'");
+    expect(bridgeMoveMigrationSource).toContain("shop_id = null");
+    expect(bridgeMoveMigrationSource).toContain(
+      "drop table public.agent_bridge_credentials",
     );
   });
 

--- a/tests/agent-request-secret-contract.test.ts
+++ b/tests/agent-request-secret-contract.test.ts
@@ -15,6 +15,14 @@ const controlRouteSource = readFileSync(
   join(process.cwd(), "app/api/agent/requests/[id]/route.ts"),
   "utf8",
 );
+const replyRouteSource = readFileSync(
+  join(process.cwd(), "app/api/agent/requests/[id]/reply/route.ts"),
+  "utf8",
+);
+const discordRouteSource = readFileSync(
+  join(process.cwd(), "app/api/agent/requests/[id]/notify-discord/route.ts"),
+  "utf8",
+);
 const bridgeMigrationSource = readFileSync(
   join(
     process.cwd(),
@@ -75,14 +83,19 @@ describe("ProFixIQ-Agent team authentication contract", () => {
     );
   });
 
-  it("routes submission and human controls through the canonical Agent service", () => {
+  it("routes the complete UI control plane through the canonical Agent service", () => {
     expect(requestRouteSource).toContain("agentTeamRequest<AgentServiceResponse>");
     expect(requestRouteSource).toContain("readAgentTeamCase");
     expect(controlRouteSource).toContain("approveAgentTeamMission");
     expect(controlRouteSource).toContain("approveAgentTeamRelease");
     expect(controlRouteSource).toContain("rejectAgentTeamCase");
+    expect(replyRouteSource).toContain("resumeAgentTeamCase");
+    expect(replyRouteSource).toContain("readAgentTeamCase");
+    expect(discordRouteSource).toContain('"/notify-discord"');
+    expect(discordRouteSource).toContain("agentTeamRequest");
     expect(controlRouteSource).not.toContain("agent_approve_action");
     expect(controlRouteSource).not.toContain("feature-requests/merge");
     expect(controlRouteSource).not.toContain('.from("agent_jobs")');
+    expect(discordRouteSource).not.toContain('.from("agent_jobs")');
   });
 });


### PR DESCRIPTION
## Root cause

The Agent request modal successfully created local ProFixIQ rows, but the remote handoff failed with HTTP 403 because the two production deployments had no matching credential.

Even after authentication, the Agent Console was still wired to the retired single-agent control plane: local `agent_actions`, local `agent_jobs`, local-only replies, old Discord queueing, and a direct PR merge call. Those contracts do not control the new engineering organization.

## What changed

- Added a canonical Agent team client with durable server-to-server bridge authentication.
- Stores the bridge in the existing `integrations` registry under a fixed server-only row with `shop_id = null`; existing RLS makes it invisible to authenticated shop users while the service-role client can read it.
- Submission now requires and persists a durable engineering-case ID.
- Active ProFixIQ request rows synchronize current case stage, case status, mission state, summary, missing information, and PR metadata from the Agent.
- Approve now forwards only the correct human gate:
  - mission approval while the implementation mission is waiting
  - release approval when the engineering case reaches human release
- Reject forwards to the canonical case and cancels pending work there.
- Reply forwards missing information to the canonical resume endpoint before updating local history.
- Delete rejects an active canonical case before removing its local projection.
- Discord notices are queued by the Agent team rather than the ProFixIQ legacy worker.
- Removed local action approval, local Agent job creation, the stale Codespaces fallback, and direct `/feature-requests/merge` usage.
- Improved failed submission payloads with request ID, local-save state, and case-creation state.
- Extended initial signed evidence lifetime and retained attachment paths in the local request projection.
- Updated regression tests to enforce the canonical control plane.

## Database

Applied migrations:

- `20260805202500_agent_team_bridge_credentials.sql`
- `20260805202600_move_agent_bridge_to_integrations.sql`

The first migration creates a locked temporary transfer table. The second atomically moves any active bridge value into the existing internal integration registry and removes the temporary table, leaving the final generated public schema unchanged.

Production verification confirms:

- the temporary table is removed
- the internal integration row is active and matches the Agent-side digest
- authenticated users see zero matching rows through RLS
- no plaintext credential is committed to either repository

## Validation

- P0-007 Financial Outbox Validation: passed.
- Supabase clean replay: running against the final migration chain.
- Legacy execution paths are absent from the replacement control route.

## Rollout order

The paired Agent PR #30 was merged and is deploying first. This PR will be merged only after Agent production is ready and this branch's clean replay is green.