### PR TITLE
Add fleet.profixiq.com application boundary

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,10 @@ import PwaRuntime from "@/features/shared/components/pwa/PwaRuntime";
 import type { Metadata, Viewport } from "next";
 
 import ThemedToaster from "@/features/shared/components/ThemedToaster";
-import { isStandalonePublicRoute } from "@/features/shared/lib/routes/shellBoundaries";
+import {
+  isOutsideDesktopAppShell,
+  isStandalonePublicRoute,
+} from "@/features/shared/lib/routes/shellBoundaries";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -60,6 +63,7 @@ export default async function RootLayout({
   const pathname = hdrs.get("x-next-pathname") ?? "";
 
   const isPublicRoute = isStandalonePublicRoute(pathname);
+  const isOutsideDesktopShell = isOutsideDesktopAppShell(pathname);
 
   const useAppShell = !isPublicRoute;
 
@@ -76,7 +80,12 @@ export default async function RootLayout({
     <VoiceProvider>
       <BrandThemeBoot />
       {useAppShell ? (
-        <AppShell initialIdentity={dashboardIdentity}>{children}</AppShell>
+        <AppShell
+          initialIdentity={dashboardIdentity}
+          initialOutsideDesktopShell={isOutsideDesktopShell}
+        >
+          {children}
+        </AppShell>
       ) : (
         children
       )}

--- a/app/portal/auth/fleet-sign-in/page.tsx
+++ b/app/portal/auth/fleet-sign-in/page.tsx
@@ -1,20 +1,26 @@
-"use client";
-
 import { Suspense } from "react";
+import { headers } from "next/headers";
 import PortalSignInForm from "../sign-in/PortalSignInForm";
 import AuthShell from "@/features/auth/components/AuthShell";
+import { isFleetProductHostname } from "@/features/fleet/lib/fleetProductRouting";
 
-const COPPER = "#C57A4A";
+const FLEET_BLUE = "#38BDF8";
 
 function FleetLoadingCard() {
   return (
-    <AuthShell cardClassName="rounded-2xl border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 backdrop-blur-md sm:p-6">
+    <AuthShell
+      productLabel="ProFixIQ Fleet"
+      heroTitle="Keep every unit moving."
+      heroDescription="Asset readiness, preventive maintenance, service decisions, and repair history in one dedicated Fleet workspace."
+      highlights={["Fleet control tower", "Maintenance planning", "Connected repair history"]}
+      cardClassName="rounded-2xl border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-5 backdrop-blur-md sm:p-6"
+    >
       <div>
         <div
           className="inline-flex items-center rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-[11px] uppercase tracking-[0.2em]"
-          style={{ color: COPPER }}
+          style={{ color: FLEET_BLUE }}
         >
-          Fleet Portal
+          ProFixIQ Fleet
         </div>
         <div className="mt-4 text-sm text-[color:var(--theme-text-secondary)]">
           Loading fleet sign in…
@@ -22,7 +28,7 @@ function FleetLoadingCard() {
         <div className="mt-4 h-1.5 w-full overflow-hidden rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)]">
           <div
             className="h-full w-1/2 animate-pulse rounded-full"
-            style={{ backgroundColor: COPPER }}
+            style={{ backgroundColor: FLEET_BLUE }}
           />
         </div>
       </div>
@@ -30,10 +36,17 @@ function FleetLoadingCard() {
   );
 }
 
-export default function FleetPortalSignInPage() {
+export default async function FleetPortalSignInPage() {
+  const requestHeaders = await headers();
+  const productHost =
+    requestHeaders.get("x-profixiq-product-host") === "fleet" ||
+    isFleetProductHostname(
+      requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host"),
+    );
+
   return (
     <Suspense fallback={<FleetLoadingCard />}>
-      <PortalSignInForm portalType="fleet" />
+      <PortalSignInForm portalType="fleet" productHost={productHost} />
     </Suspense>
   );
 }

--- a/app/portal/auth/sign-in/PortalSignInForm.tsx
+++ b/app/portal/auth/sign-in/PortalSignInForm.tsx
@@ -11,10 +11,15 @@ import {
   resolvePortalSurfaceRedirect,
   type PortalSurface,
 } from "@/features/auth/lib/portalSurfaceRouting";
+import {
+  toFleetInternalHref,
+  toFleetPublicHref,
+} from "@/features/fleet/lib/fleetProductRouting";
 import { signInWithIdentifier } from "@/features/auth/lib/signInClient";
 
 type PortalSignInFormProps = {
   portalType: PortalSurface;
+  productHost?: boolean;
 };
 
 const inputClass =
@@ -22,6 +27,7 @@ const inputClass =
 
 export default function PortalSignInForm({
   portalType,
+  productHost = false,
 }: PortalSignInFormProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -38,6 +44,13 @@ export default function PortalSignInForm({
         isFleet
           ? "This activation link is invalid or has expired. Ask your shop or fleet administrator to resend the fleet invitation."
           : "This activation link is invalid or has expired. Ask your shop to resend your customer portal invitation.",
+      );
+      return;
+    }
+
+    if (isFleet && searchParams.get("access") === "required") {
+      setError(
+        "This account does not have access to a Fleet workspace. Sign in with an invited Fleet account or ask a fleet administrator for access.",
       );
     }
   }, [isFleet, searchParams]);
@@ -62,11 +75,20 @@ export default function PortalSignInForm({
         return;
       }
 
-      const destination = resolvePortalSurfaceRedirect(
-        searchParams.get("redirect"),
+      const requestedRedirect = searchParams.get("redirect");
+      const internalRedirect =
+        isFleet && productHost
+          ? toFleetInternalHref(requestedRedirect) ?? requestedRedirect
+          : requestedRedirect;
+      const internalDestination = resolvePortalSurfaceRedirect(
+        internalRedirect,
         result.destination,
         portalType,
       );
+      const destination =
+        isFleet && productHost
+          ? toFleetPublicHref(internalDestination) ?? "/"
+          : internalDestination;
       router.replace(destination);
       router.refresh();
     } finally {
@@ -76,22 +98,22 @@ export default function PortalSignInForm({
 
   return (
     <AuthShell
-      productLabel={isFleet ? "Fleet portal" : "Customer portal"}
+      productLabel={isFleet ? "ProFixIQ Fleet" : "Customer portal"}
       heroTitle={isFleet ? "Keep every unit moving." : "Your service, all in one place."}
       heroDescription={
         isFleet
-          ? "Approvals, pre-trips, service requests, and shop visibility in one secure portal."
+          ? "Asset readiness, preventive maintenance, service decisions, and repair history in one dedicated Fleet workspace."
           : "Approve work, follow progress, and keep every service record connected to your vehicle."
       }
       highlights={
         isFleet
-          ? ["Invite-only access", "Fleet-scoped records", "Service visibility"]
+          ? ["Fleet control tower", "Maintenance planning", "Connected repair history"]
           : ["Secure approvals", "Live progress", "Service history"]
       }
     >
       <div className="mb-6">
         <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
-          {isFleet ? "Fleet portal" : "Customer portal"}
+          {isFleet ? "ProFixIQ Fleet" : "Customer portal"}
         </div>
         <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em] text-[color:var(--theme-text-primary)] sm:text-4xl">
           Sign in
@@ -176,15 +198,17 @@ export default function PortalSignInForm({
           {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
           {loading
             ? "Verifying access…"
-            : `Sign in to ${isFleet ? "fleet" : "customer"} portal`}
+            : isFleet
+              ? "Sign in to ProFixIQ Fleet"
+              : "Sign in to customer portal"}
         </button>
       </form>
 
       <div className="mt-5 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] px-3.5 py-3 text-xs leading-5 text-[color:var(--theme-text-secondary)]">
         {isFleet ? (
           <>
-            Fleet access is invitation-only. Contact your shop or fleet administrator if
-            you need an invitation.
+            Fleet access is invitation-only. Contact your fleet administrator if you
+            need access to this workspace.
           </>
         ) : (
           <>
@@ -205,7 +229,13 @@ export default function PortalSignInForm({
       <div className="mt-4 text-center text-xs text-[color:var(--theme-text-muted)]">
         {isFleet ? "Looking for a customer service record?" : "Managing a fleet?"}{" "}
         <Link
-          href={isFleet ? PORTAL_SIGN_IN.customer : PORTAL_SIGN_IN.fleet}
+          href={
+            isFleet && productHost
+              ? `${process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, "") || "https://profixiq.com"}${PORTAL_SIGN_IN.customer}`
+              : isFleet
+                ? PORTAL_SIGN_IN.customer
+                : PORTAL_SIGN_IN.fleet
+          }
           className="font-semibold text-[var(--accent-copper)] hover:underline"
         >
           Sign in to the {isFleet ? "customer" : "fleet"} portal

--- a/app/portal/fleet/layout.tsx
+++ b/app/portal/fleet/layout.tsx
@@ -1,13 +1,25 @@
 import type { ReactNode } from "react";
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import FleetProductShell from "@/features/fleet/components/FleetProductShell";
+import { isFleetProductHostname } from "@/features/fleet/lib/fleetProductRouting";
 import { requireFleetPortalActor } from "./_lib/requireFleetPortalActor";
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://fleet.profixiq.com"),
   title: "ProFixIQ Fleet | Maintenance Command",
   description:
     "Fleet asset readiness, preventive maintenance, service approvals, history and costs in one connected workspace.",
   applicationName: "ProFixIQ Fleet",
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    url: "/",
+    siteName: "ProFixIQ Fleet",
+    title: "ProFixIQ Fleet | Maintenance Command",
+    description:
+      "Fleet asset readiness, preventive maintenance, service approvals, history and costs in one connected workspace.",
+  },
 };
 
 export default async function PortalFleetLayout({
@@ -15,7 +27,15 @@ export default async function PortalFleetLayout({
 }: {
   children: ReactNode;
 }) {
-  const actor = await requireFleetPortalActor();
+  const [actor, requestHeaders] = await Promise.all([
+    requireFleetPortalActor(),
+    headers(),
+  ]);
+  const productHost =
+    requestHeaders.get("x-profixiq-product-host") === "fleet" ||
+    isFleetProductHostname(
+      requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host"),
+    );
 
   const subtitle =
     actor.experience === "external_driver"
@@ -29,6 +49,7 @@ export default async function PortalFleetLayout({
       actorLabel={actor.actorLabel}
       experience={actor.experience}
       userId={actor.userId}
+      productHost={productHost}
     >
       {children}
     </FleetProductShell>

--- a/docs/plans/profixiq-fleet-product-separation.md
+++ b/docs/plans/profixiq-fleet-product-separation.md
@@ -14,10 +14,11 @@ migrations, authorization code and the Shop/Fleet exchange contract.
 
 ## Deployment boundary
 
-The first separation checkpoint keeps the existing Next.js project and promotes
-the fleet-scoped `/portal/fleet` surface into the ProFixIQ Fleet application
-shell. `fleet.profixiq.com` will become its public entry point after host routing
-is added and verified.
+The separation keeps the existing Next.js project and promotes the fleet-scoped
+`/portal/fleet` surface into the ProFixIQ Fleet application shell.
+`fleet.profixiq.com` is the public entry point; host-aware middleware rewrites
+clean Fleet URLs to the existing authorized implementation without duplicating
+pages, APIs or business logic.
 
 Do not create a second Vercel project from the current repository root yet. The
 root `vercel.json` owns production cron jobs; connecting the same root to another
@@ -58,9 +59,9 @@ package boundaries.
 
 ## Route transition
 
-`/portal/fleet` is the temporary internal route prefix while the product is
-separated inside the current Next.js application. It is not the long-term public
-brand or information architecture.
+`/portal/fleet` remains the internal canonical route prefix while the product is
+separated inside the current Next.js application. It is not exposed as the Fleet
+product's public information architecture.
 
 The intended public mappings on `fleet.profixiq.com` are:
 
@@ -70,16 +71,21 @@ The intended public mappings on `fleet.profixiq.com` are:
 | `/assets` | `/portal/fleet/units` |
 | `/drivers` | `/portal/fleet/drivers` |
 | `/pre-trips` | `/portal/fleet/pretrip-history` |
+| `/pre-trips/start/:unitId` | `/portal/fleet/pretrip/:unitId` |
 | `/maintenance` | `/portal/fleet/maintenance` |
 | `/calendar` | `/portal/fleet/calendar` |
 | `/requests` | `/portal/fleet/service-requests` |
+| `/requests/new` | `/portal/fleet/request/build` |
+| `/dispatch` | `/portal/fleet/board` |
 | `/history` | `/portal/fleet/billing` |
 | `/reports` | `/portal/fleet/reports` |
 | `/settings` | `/portal/fleet/settings` |
+| `/sign-in` | `/portal/auth/fleet-sign-in` |
 
-Host routing must preserve query strings, nested asset/pre-trip routes, password
-activation, and fleet invite tokens. It must reject Shop routes on the Fleet
-host and must not weaken fleet membership authorization.
+Host routing preserves query strings, nested asset/pre-trip routes and password
+recovery. Fleet invitation creation and activation remain on the primary
+ProFixIQ domain. The Fleet host rejects Shop page routes and continues through
+the canonical fleet membership authorization before rendering data.
 
 ## Current checkpoint
 
@@ -91,6 +97,9 @@ host and must not weaken fleet membership authorization.
 - Shop navigation no longer exposes Fleet operations.
 - Shop retains one `Fleet Access Invites` entry point.
 - Existing fleet-scoped APIs and RLS-backed actor resolution remain canonical.
+- `fleet.profixiq.com` owns clean Fleet routes and redirects legacy prefixed URLs.
+- Unknown Shop page routes cannot render on the Fleet hostname.
+- Fleet sign-in and password recovery preserve clean deep-link destinations.
 
 ## Remaining build sequence
 
@@ -99,11 +108,20 @@ host and must not weaken fleet membership authorization.
 2. Move fleet creation, asset enrollment and user management into Fleet.
 3. Convert Shop's invite screen into a relationship invitation rather than a
    fleet administration screen.
-4. Add host-aware clean routing for `fleet.profixiq.com` and verify authentication,
-   invite activation, password reset and deep links.
-5. Add a Fleet-owned subscription record and Stripe checkout while preserving the
+4. Add a Fleet-owned subscription record and Stripe checkout while preserving the
    single canonical webhook and replay-safe billing synchronization.
-6. Redirect or retire the remaining legacy Shop `/fleet/*` operational routes
+5. Redirect or retire the remaining legacy Shop `/fleet/*` operational routes
    only after their Fleet replacements are complete.
-7. Run the end-to-end acceptance test: a fleet manager can operate maintenance
+6. Run the end-to-end acceptance test: a fleet manager can operate maintenance
    without opening ProFixIQ Shop.
+
+## Domain activation checklist
+
+1. Add `fleet.profixiq.com` to the existing ProFixIQ Vercel project.
+2. Create the DNS record Vercel provides for that domain.
+3. Add `https://fleet.profixiq.com/auth/reset` to the Supabase Auth redirect URL
+   allowlist so Fleet password recovery returns to the Fleet product.
+4. Verify `/`, `/sign-in`, an asset deep link, a service-request deep link and
+   password recovery on the production hostname.
+5. Keep the primary-domain `/portal/fleet/*` routes available until all existing
+   invite emails, bookmarks and operational links have transitioned.

--- a/features/auth/api/send-reset/route.ts
+++ b/features/auth/api/send-reset/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { safeInternalRedirect } from "@/features/auth/lib/safeRedirect";
+import { isFleetProductHostname } from "@/features/fleet/lib/fleetProductRouting";
 
 function mustEnv(name: string): string {
   const value = process.env[name];
@@ -10,7 +11,12 @@ function mustEnv(name: string): string {
   return value;
 }
 
-function getBaseUrl(): string {
+export function resolvePasswordResetBaseUrl(req: Request): string {
+  const requestUrl = new URL(req.url);
+  if (isFleetProductHostname(requestUrl.hostname)) {
+    return requestUrl.origin;
+  }
+
   if (process.env.NEXT_PUBLIC_SITE_URL?.trim()) {
     return process.env.NEXT_PUBLIC_SITE_URL.trim().replace(/\/$/, "");
   }
@@ -29,7 +35,7 @@ function buildRedirectTo(req: Request): string {
     "",
     ["/auth/set-password"],
   );
-  const baseUrl = getBaseUrl();
+  const baseUrl = resolvePasswordResetBaseUrl(req);
 
   if (!requestedRedirect) {
     return `${baseUrl}/auth/reset`;

--- a/features/fleet/components/FleetProductShell.tsx
+++ b/features/fleet/components/FleetProductShell.tsx
@@ -24,6 +24,10 @@ import {
 
 import ThemeToggleButton from "@/features/shared/components/ThemeToggleButton";
 import ForcePasswordChangeModal from "@/features/auth/components/ForcePasswordChangeModal";
+import {
+  toFleetInternalPath,
+  toFleetPublicPath,
+} from "@/features/fleet/lib/fleetProductRouting";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import { cn } from "@/features/shared/utils/cn";
 
@@ -144,11 +148,13 @@ function isActivePath(pathname: string, href: string): boolean {
 
 function NavItem({
   item,
+  href,
   compact,
   active,
   onNavigate,
 }: {
   item: FleetNavItem;
+  href: string;
   compact: boolean;
   active: boolean;
   onNavigate?: () => void;
@@ -157,7 +163,7 @@ function NavItem({
 
   return (
     <Link
-      href={item.href}
+      href={href}
       onClick={onNavigate}
       aria-current={active ? "page" : undefined}
       title={compact ? item.label : undefined}
@@ -200,6 +206,7 @@ export default function FleetProductShell({
   actorLabel,
   experience,
   userId,
+  productHost,
   children,
 }: {
   title: string;
@@ -207,9 +214,11 @@ export default function FleetProductShell({
   actorLabel: string;
   experience: FleetExperience;
   userId: string | null;
+  productHost: boolean;
   children: React.ReactNode;
 }) {
   const pathname = usePathname() ?? "/portal/fleet";
+  const internalPathname = toFleetInternalPath(pathname) ?? pathname;
   const router = useRouter();
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -253,9 +262,9 @@ export default function FleetProductShell({
     () =>
       groups
         .flatMap((group) => group.items)
-        .filter((item) => isActivePath(pathname, item.href))
+        .filter((item) => isActivePath(internalPathname, item.href))
         .sort((a, b) => b.href.length - a.href.length)[0] ?? null,
-    [groups, pathname],
+    [groups, internalPathname],
   );
 
   async function signOut() {
@@ -264,7 +273,7 @@ export default function FleetProductShell({
     try {
       await supabase.auth.signOut();
     } finally {
-      router.replace("/portal/auth/fleet-sign-in");
+      router.replace(productHost ? "/sign-in" : "/portal/auth/fleet-sign-in");
       setSigningOut(false);
     }
   }
@@ -305,6 +314,11 @@ export default function FleetProductShell({
                 <NavItem
                   key={item.href}
                   item={item}
+                  href={
+                    productHost
+                      ? toFleetPublicPath(item.href) ?? item.href
+                      : item.href
+                  }
                   compact={compact && !isMobile}
                   active={activeItem?.href === item.href}
                   onNavigate={isMobile ? () => setMobileOpen(false) : undefined}

--- a/features/fleet/lib/fleetProductRouting.ts
+++ b/features/fleet/lib/fleetProductRouting.ts
@@ -1,0 +1,151 @@
+const FLEET_PRODUCT_HOSTNAMES = new Set([
+  "fleet.profixiq.com",
+  "fleet.localhost",
+]);
+
+type FleetRouteMapping = {
+  publicPath: string;
+  internalPath: string;
+};
+
+const FLEET_ROUTE_MAPPINGS: readonly FleetRouteMapping[] = [
+  {
+    publicPath: "/requests/new",
+    internalPath: "/portal/fleet/request/build",
+  },
+  {
+    publicPath: "/pre-trips/start",
+    internalPath: "/portal/fleet/pretrip",
+  },
+  {
+    publicPath: "/requests",
+    internalPath: "/portal/fleet/service-requests",
+  },
+  {
+    publicPath: "/pre-trips",
+    internalPath: "/portal/fleet/pretrip-history",
+  },
+  { publicPath: "/assets", internalPath: "/portal/fleet/units" },
+  { publicPath: "/dispatch", internalPath: "/portal/fleet/board" },
+  { publicPath: "/maintenance", internalPath: "/portal/fleet/maintenance" },
+  { publicPath: "/calendar", internalPath: "/portal/fleet/calendar" },
+  { publicPath: "/drivers", internalPath: "/portal/fleet/drivers" },
+  { publicPath: "/history", internalPath: "/portal/fleet/billing" },
+  { publicPath: "/reports", internalPath: "/portal/fleet/reports" },
+  { publicPath: "/settings", internalPath: "/portal/fleet/settings" },
+  { publicPath: "/sign-in", internalPath: "/portal/auth/fleet-sign-in" },
+  { publicPath: "/", internalPath: "/portal/fleet" },
+] as const;
+
+const FLEET_LEGACY_SIGN_IN_PATHS = new Set([
+  "/portal/fleet/auth/sign-in",
+  "/portal/fleet/auth/sign-in/",
+]);
+
+function normalizePathname(pathname: string): string {
+  const trimmed = pathname.trim();
+  if (!trimmed || trimmed === "/") return "/";
+  return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+}
+
+function replaceRouteBase(
+  pathname: string,
+  sourceBase: string,
+  destinationBase: string,
+): string | null {
+  const normalized = normalizePathname(pathname);
+  if (normalized === sourceBase) return destinationBase;
+  if (sourceBase === "/" || !normalized.startsWith(`${sourceBase}/`)) {
+    return null;
+  }
+  return `${destinationBase}${normalized.slice(sourceBase.length)}`;
+}
+
+function mapFleetPathname(
+  pathname: string,
+  sourceKey: keyof FleetRouteMapping,
+  destinationKey: keyof FleetRouteMapping,
+): string | null {
+  for (const mapping of FLEET_ROUTE_MAPPINGS) {
+    const mapped = replaceRouteBase(
+      pathname,
+      mapping[sourceKey],
+      mapping[destinationKey],
+    );
+    if (mapped) return mapped;
+  }
+  return null;
+}
+
+function mapFleetHref(
+  href: string | null | undefined,
+  mapper: (pathname: string) => string | null,
+): string | null {
+  const candidate = String(href ?? "").trim();
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) return null;
+
+  const parsed = new URL(candidate, "https://fleet-routing.invalid");
+  const mappedPathname = mapper(parsed.pathname);
+  if (!mappedPathname) return null;
+  return `${mappedPathname}${parsed.search}${parsed.hash}`;
+}
+
+export function normalizeRequestHostname(value: string | null | undefined): string {
+  const forwardedHost = String(value ?? "")
+    .split(",", 1)[0]
+    .trim()
+    .toLowerCase();
+  if (!forwardedHost) return "";
+
+  if (forwardedHost.startsWith("[")) {
+    const closingBracket = forwardedHost.indexOf("]");
+    return closingBracket >= 0
+      ? forwardedHost.slice(0, closingBracket + 1)
+      : forwardedHost;
+  }
+
+  return forwardedHost.split(":", 1)[0];
+}
+
+export function isFleetProductHostname(
+  value: string | null | undefined,
+): boolean {
+  return FLEET_PRODUCT_HOSTNAMES.has(normalizeRequestHostname(value));
+}
+
+export function toFleetInternalPath(pathname: string): string | null {
+  return mapFleetPathname(pathname, "publicPath", "internalPath");
+}
+
+export function toFleetPublicPath(pathname: string): string | null {
+  if (FLEET_LEGACY_SIGN_IN_PATHS.has(pathname)) return "/sign-in";
+  return mapFleetPathname(pathname, "internalPath", "publicPath");
+}
+
+export function toFleetInternalHref(
+  href: string | null | undefined,
+): string | null {
+  return mapFleetHref(href, toFleetInternalPath);
+}
+
+export function toFleetPublicHref(
+  href: string | null | undefined,
+): string | null {
+  return mapFleetHref(href, toFleetPublicPath);
+}
+
+export function isFleetProductSharedPath(pathname: string): boolean {
+  const normalized = normalizePathname(pathname);
+  return (
+    normalized === "/forgot-password" ||
+    normalized === "/auth/reset" ||
+    normalized === "/auth/set-password" ||
+    normalized === "/auth/callback" ||
+    normalized === "/confirm" ||
+    normalized === "/robots.txt" ||
+    normalized === "/sitemap.xml" ||
+    normalized === "/manifest.webmanifest" ||
+    normalized === "/api" ||
+    normalized.startsWith("/api/")
+  );
+}

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -81,9 +81,11 @@ function daysUntil(iso: string | null): number | null {
 export default function AppShell({
   children,
   initialIdentity,
+  initialOutsideDesktopShell = false,
 }: {
   children: React.ReactNode;
   initialIdentity?: AppShellInitialIdentity | null;
+  initialOutsideDesktopShell?: boolean;
 }) {
   const pathname = usePathname() ?? "/";
   const router = useRouter();
@@ -117,7 +119,8 @@ export default function AppShell({
 
   const punchRef = useRef<HTMLDivElement | null>(null);
 
-  const isAppRoute = !isOutsideDesktopAppShell(pathname);
+  const isAppRoute =
+    !initialOutsideDesktopShell && !isOutsideDesktopAppShell(pathname);
 
   const canSeeAgentConsole =
     !!userRole &&

--- a/middleware.ts
+++ b/middleware.ts
@@ -11,6 +11,14 @@ import {
   type PortalSurface,
 } from "@/features/auth/lib/portalSurfaceRouting";
 import { resolveMobileHref } from "@/features/mobile/navigation/mobile-route-continuity";
+import {
+  isFleetProductHostname,
+  isFleetProductSharedPath,
+  toFleetInternalHref,
+  toFleetInternalPath,
+  toFleetPublicHref,
+  toFleetPublicPath,
+} from "@/features/fleet/lib/fleetProductRouting";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   hasSupabasePublicEnv,
@@ -40,6 +48,45 @@ function safeRedirectPath(v: string | null): string | null {
   if (!v.startsWith("/")) return null;
   if (v.startsWith("//")) return null;
   return v;
+}
+
+function requestHostname(req: NextRequest): string {
+  return (
+    req.headers.get("x-forwarded-host") ??
+    req.headers.get("host") ??
+    req.nextUrl.hostname
+  );
+}
+
+function productRequestUrl(
+  req: NextRequest,
+  path: string,
+  fleetProductRequest: boolean,
+): URL {
+  const target = new URL(path, req.url);
+  if (fleetProductRequest) {
+    const publicPath = toFleetPublicPath(target.pathname);
+    if (publicPath) target.pathname = publicPath;
+  }
+  return target;
+}
+
+function redirectWithResponseHeaders(
+  target: URL,
+  response: NextResponse,
+): NextResponse {
+  const headers = new Headers(response.headers);
+  for (const header of Array.from(headers.keys())) {
+    if (
+      header === "x-middleware-next" ||
+      header === "x-middleware-rewrite" ||
+      header === "x-middleware-override-headers" ||
+      header.startsWith("x-middleware-request-")
+    ) {
+      headers.delete(header);
+    }
+  }
+  return NextResponse.redirect(target, { headers });
 }
 
 type PortalAccess = {
@@ -101,24 +148,66 @@ async function resolvePortalAccessServer(
 }
 
 export async function middleware(req: NextRequest) {
-  const { pathname, search } = req.nextUrl;
+  const requestPathname = req.nextUrl.pathname;
+  const { search } = req.nextUrl;
+  const fleetProductRequest = isFleetProductHostname(requestHostname(req));
   const mobileDeviceRequest = isMobileDeviceRequest(req);
+
+  if (isAssetPath(requestPathname)) {
+    return NextResponse.next();
+  }
+
+  if (fleetProductRequest) {
+    const canonicalPublicPath = toFleetPublicPath(requestPathname);
+    if (canonicalPublicPath && canonicalPublicPath !== requestPathname) {
+      const target = req.nextUrl.clone();
+      target.pathname = canonicalPublicPath;
+      return NextResponse.redirect(target, 308);
+    }
+  }
+
+  const fleetInternalPath = fleetProductRequest
+    ? toFleetInternalPath(requestPathname)
+    : null;
+
+  if (
+    fleetProductRequest &&
+    !fleetInternalPath &&
+    !isFleetProductSharedPath(requestPathname)
+  ) {
+    const target = req.nextUrl.clone();
+    target.pathname = "/";
+    target.search = "";
+    return NextResponse.redirect(target);
+  }
+
+  const pathname = fleetInternalPath ?? requestPathname;
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-next-pathname", pathname);
+  if (fleetProductRequest) {
+    requestHeaders.set("x-profixiq-product-host", "fleet");
+  }
 
   if (
     pathname === "/portal/fleet/auth/sign-in" ||
     pathname === "/portal/fleet/auth/sign-in/"
   ) {
-    const target = new URL(PORTAL_SIGN_IN.fleet, req.url);
+    const target = productRequestUrl(
+      req,
+      PORTAL_SIGN_IN.fleet,
+      fleetProductRequest,
+    );
     return NextResponse.redirect(target, 308);
   }
 
-  if (isAssetPath(pathname)) {
-    return NextResponse.next();
-  }
+  const fleetRewriteTarget = req.nextUrl.clone();
+  if (fleetInternalPath) fleetRewriteTarget.pathname = fleetInternalPath;
 
-  const res = NextResponse.next({ request: { headers: requestHeaders } });
+  const res = fleetInternalPath
+    ? NextResponse.rewrite(fleetRewriteTarget, {
+        request: { headers: requestHeaders },
+      })
+    : NextResponse.next({ request: { headers: requestHeaders } });
 
   if (pathname.startsWith("/api")) {
     if (!hasSupabasePublicEnv()) return res;
@@ -225,13 +314,15 @@ export async function middleware(req: NextRequest) {
   if (pathname === "/" && user) {
     if (isPortalOnlyAccount) {
       const access = await resolvePortalAccessServer(supabase, user.id);
-      const target = new URL(
+      const target = productRequestUrl(
+        req,
         access.fleet && !access.customer ? "/portal/fleet" : "/portal",
-        req.url,
+        fleetProductRequest,
       );
-      return NextResponse.redirect(target, { headers: res.headers });
+      return redirectWithResponseHeaders(target, res);
     }
-    const target = new URL(
+    const target = productRequestUrl(
+      req,
       !completed
         ? "/onboarding"
         : needsShopBoostIntake
@@ -239,15 +330,18 @@ export async function middleware(req: NextRequest) {
           : mobileDeviceRequest
             ? "/mobile"
             : "/dashboard",
-      req.url,
+      fleetProductRequest,
     );
-    return NextResponse.redirect(target, { headers: res.headers });
+    return redirectWithResponseHeaders(target, res);
   }
 
   if (isPublic) {
-    const redirectParam = safeRedirectPath(
+    const requestedRedirect = safeRedirectPath(
       req.nextUrl.searchParams.get("redirect"),
     );
+    const redirectParam = fleetProductRequest
+      ? toFleetInternalHref(requestedRedirect) ?? requestedRedirect
+      : requestedRedirect;
     const isMainSignIn =
       pathname.startsWith("/sign-in") || pathname.startsWith("/signup");
     const isMobileSignIn = pathname.startsWith("/mobile/sign-in");
@@ -255,11 +349,12 @@ export async function middleware(req: NextRequest) {
     if (user && (isMainSignIn || isMobileSignIn)) {
       if (isPortalOnlyAccount) {
         const access = await resolvePortalAccessServer(supabase, user.id);
-        const target = new URL(
+        const target = productRequestUrl(
+          req,
           access.fleet && !access.customer ? "/portal/fleet" : "/portal",
-          req.url,
+          fleetProductRequest,
         );
-        return NextResponse.redirect(target, { headers: res.headers });
+        return redirectWithResponseHeaders(target, res);
       }
 
       const defaultAuthenticatedPath = !completed
@@ -270,8 +365,22 @@ export async function middleware(req: NextRequest) {
             ? "/mobile"
             : "/dashboard";
       const to = redirectParam ?? defaultAuthenticatedPath;
-      const target = new URL(to, req.url);
-      return NextResponse.redirect(target, { headers: res.headers });
+      const target = productRequestUrl(req, to, fleetProductRequest);
+      return redirectWithResponseHeaders(target, res);
+    }
+
+    if (fleetProductRequest && isFleetPortalAuthPage && user) {
+      const access = await resolvePortalAccessServer(supabase, user.id);
+      if (!access.fleet) return res;
+
+      const target = productRequestUrl(
+        req,
+        isPortalPathForSurface(redirectParam, "fleet")
+          ? redirectParam!
+          : "/portal/fleet",
+        true,
+      );
+      return redirectWithResponseHeaders(target, res);
     }
 
     if (
@@ -302,8 +411,8 @@ export async function middleware(req: NextRequest) {
         ? redirectParam!
         : PORTAL_HOME[surface];
 
-      const target = new URL(to, req.url);
-      return NextResponse.redirect(target, { headers: res.headers });
+      const target = productRequestUrl(req, to, fleetProductRequest);
+      return redirectWithResponseHeaders(target, res);
     }
 
     if (
@@ -311,11 +420,20 @@ export async function middleware(req: NextRequest) {
       pathname === PORTAL_SIGN_IN.customer &&
       req.nextUrl.searchParams.get("portal") === "fleet"
     ) {
-      const login = new URL(PORTAL_SIGN_IN.fleet, req.url);
+      const login = productRequestUrl(
+        req,
+        PORTAL_SIGN_IN.fleet,
+        fleetProductRequest,
+      );
       if (isPortalPathForSurface(redirectParam, "fleet")) {
-        login.searchParams.set("redirect", redirectParam!);
+        login.searchParams.set(
+          "redirect",
+          fleetProductRequest
+            ? toFleetPublicHref(redirectParam) ?? redirectParam!
+            : redirectParam!,
+        );
       }
-      return NextResponse.redirect(login, { headers: res.headers });
+      return redirectWithResponseHeaders(login, res);
     }
 
     return res;
@@ -324,25 +442,33 @@ export async function middleware(req: NextRequest) {
   if (!user) {
     if (isPortal) {
       const surface: PortalSurface = isFleetPortalPath ? "fleet" : "customer";
-      const login = new URL(PORTAL_SIGN_IN[surface], req.url);
-      login.searchParams.set("redirect", pathname + search);
-      return NextResponse.redirect(login, { headers: res.headers });
+      const login = productRequestUrl(
+        req,
+        PORTAL_SIGN_IN[surface],
+        fleetProductRequest,
+      );
+      login.searchParams.set(
+        "redirect",
+        fleetProductRequest ? requestPathname + search : pathname + search,
+      );
+      return redirectWithResponseHeaders(login, res);
     }
 
     const isMobileRoute = pathname.startsWith("/mobile");
     const loginPath = isMobileRoute ? "/mobile/sign-in" : "/sign-in";
-    const login = new URL(loginPath, req.url);
+    const login = productRequestUrl(req, loginPath, fleetProductRequest);
     login.searchParams.set("redirect", pathname + search);
-    return NextResponse.redirect(login, { headers: res.headers });
+    return redirectWithResponseHeaders(login, res);
   }
 
   if (isPortalOnlyAccount && !isPortal) {
     const access = await resolvePortalAccessServer(supabase, user.id);
-    const target = new URL(
+    const target = productRequestUrl(
+      req,
       access.fleet && !access.customer ? "/portal/fleet" : "/portal",
-      req.url,
+      fleetProductRequest,
     );
-    return NextResponse.redirect(target, { headers: res.headers });
+    return redirectWithResponseHeaders(target, res);
   }
 
   if (
@@ -355,22 +481,26 @@ export async function middleware(req: NextRequest) {
     const requestedHref = `${pathname}${search}`;
     const mobileHref = resolveMobileHref(requestedHref);
     if (mobileHref && mobileHref !== requestedHref) {
-      const target = new URL(mobileHref, req.url);
-      return NextResponse.redirect(target, { headers: res.headers });
+      const target = productRequestUrl(req, mobileHref, fleetProductRequest);
+      return redirectWithResponseHeaders(target, res);
     }
   }
 
   if (pathname.startsWith("/mobile") && !canUseMobile) {
     if (!completed) {
-      const target = new URL("/onboarding", req.url);
-      return NextResponse.redirect(target, { headers: res.headers });
+      const target = productRequestUrl(
+        req,
+        "/onboarding",
+        fleetProductRequest,
+      );
+      return redirectWithResponseHeaders(target, res);
     }
 
     // Keep completed but unsupported/legacy roles inside the mobile surface.
     // `/mobile` renders the role-not-configured state without exposing desktop.
     if (pathname !== "/mobile") {
-      const target = new URL("/mobile", req.url);
-      return NextResponse.redirect(target, { headers: res.headers });
+      const target = productRequestUrl(req, "/mobile", fleetProductRequest);
+      return redirectWithResponseHeaders(target, res);
     }
     return res;
   }
@@ -379,19 +509,33 @@ export async function middleware(req: NextRequest) {
     const access = await resolvePortalAccessServer(supabase, user.id);
 
     if (!access.customer && access.fleet && !isFleetPortalPath) {
-      const target = new URL("/portal/fleet", req.url);
-      return NextResponse.redirect(target, { headers: res.headers });
+      const target = productRequestUrl(
+        req,
+        "/portal/fleet",
+        fleetProductRequest,
+      );
+      return redirectWithResponseHeaders(target, res);
     }
 
     if (!access.fleet && isFleetPortalPath) {
-      const target = new URL("/portal", req.url);
-      return NextResponse.redirect(target, { headers: res.headers });
+      const target = productRequestUrl(
+        req,
+        fleetProductRequest
+          ? "/portal/auth/fleet-sign-in?access=required"
+          : "/portal",
+        fleetProductRequest,
+      );
+      return redirectWithResponseHeaders(target, res);
     }
   }
 
   if (!isPortal && !completed && !pathname.startsWith("/onboarding")) {
-    const target = new URL("/onboarding", req.url);
-    return NextResponse.redirect(target, { headers: res.headers });
+    const target = productRequestUrl(
+      req,
+      "/onboarding",
+      fleetProductRequest,
+    );
+    return redirectWithResponseHeaders(target, res);
   }
 
   return res;
@@ -399,6 +543,14 @@ export async function middleware(req: NextRequest) {
 
 export const config = {
   matcher: [
+    {
+      source: "/((?!_next/static|_next/image|favicon.ico).*)",
+      has: [{ type: "host", value: "fleet.profixiq.com" }],
+    },
+    {
+      source: "/((?!_next/static|_next/image|favicon.ico).*)",
+      has: [{ type: "host", value: "fleet.localhost" }],
+    },
     "/",
     "/sign-in",
     "/compare-plans",
@@ -410,6 +562,16 @@ export const config = {
     "/auth/set-password",
     "/demo/:path*",
     "/portal/:path*",
+    "/assets/:path*",
+    "/drivers/:path*",
+    "/pre-trips/:path*",
+    "/maintenance/:path*",
+    "/calendar/:path*",
+    "/requests/:path*",
+    "/history/:path*",
+    "/reports/:path*",
+    "/settings/:path*",
+    "/dispatch/:path*",
     "/mobile/sign-in",
     "/launch",
     "/offline/:path*",

--- a/tests/fleet-password-reset-origin.test.ts
+++ b/tests/fleet-password-reset-origin.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolvePasswordResetBaseUrl } from "@/features/auth/api/send-reset/route";
+
+const originalSiteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+afterEach(() => {
+  if (originalSiteUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_SITE_URL;
+  } else {
+    process.env.NEXT_PUBLIC_SITE_URL = originalSiteUrl;
+  }
+});
+
+describe("Fleet password reset origin", () => {
+  it("returns Fleet password recovery to the Fleet product host", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://profixiq.com";
+
+    expect(
+      resolvePasswordResetBaseUrl(
+        new Request("https://fleet.profixiq.com/api/auth/send-reset"),
+      ),
+    ).toBe("https://fleet.profixiq.com");
+  });
+
+  it("keeps Shop password recovery on the configured primary origin", () => {
+    process.env.NEXT_PUBLIC_SITE_URL = "https://profixiq.com/";
+
+    expect(
+      resolvePasswordResetBaseUrl(
+        new Request("https://deployment-preview.vercel.app/api/auth/send-reset"),
+      ),
+    ).toBe("https://profixiq.com");
+  });
+});

--- a/tests/fleet-product-domain-routing.test.ts
+++ b/tests/fleet-product-domain-routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  isFleetProductHostname,
+  isFleetProductSharedPath,
+  normalizeRequestHostname,
+  toFleetInternalHref,
+  toFleetInternalPath,
+  toFleetPublicHref,
+  toFleetPublicPath,
+} from "@/features/fleet/lib/fleetProductRouting";
+
+describe("Fleet product domain routing", () => {
+  it("recognizes the production and local Fleet hosts without trusting lookalikes", () => {
+    expect(isFleetProductHostname("fleet.profixiq.com")).toBe(true);
+    expect(isFleetProductHostname("fleet.profixiq.com:443")).toBe(true);
+    expect(isFleetProductHostname("fleet.localhost:3000")).toBe(true);
+    expect(isFleetProductHostname("Fleet.ProFixIQ.com, proxy.internal")).toBe(true);
+    expect(isFleetProductHostname("fleet.profixiq.com.attacker.test")).toBe(false);
+    expect(isFleetProductHostname("profixiq.com")).toBe(false);
+    expect(normalizeRequestHostname("[::1]:3000")).toBe("[::1]");
+  });
+
+  it.each([
+    ["/", "/portal/fleet"],
+    ["/assets", "/portal/fleet/units"],
+    ["/assets/unit-42", "/portal/fleet/units/unit-42"],
+    ["/drivers", "/portal/fleet/drivers"],
+    ["/pre-trips", "/portal/fleet/pretrip-history"],
+    ["/pre-trips/start/unit-42", "/portal/fleet/pretrip/unit-42"],
+    ["/maintenance", "/portal/fleet/maintenance"],
+    ["/calendar", "/portal/fleet/calendar"],
+    ["/requests", "/portal/fleet/service-requests"],
+    ["/requests/new", "/portal/fleet/request/build"],
+    ["/history", "/portal/fleet/billing"],
+    ["/reports", "/portal/fleet/reports"],
+    ["/settings", "/portal/fleet/settings"],
+    ["/sign-in", "/portal/auth/fleet-sign-in"],
+  ])("maps the public route %s to the canonical route and back", (publicPath, internalPath) => {
+    expect(toFleetInternalPath(publicPath)).toBe(internalPath);
+    expect(toFleetPublicPath(internalPath)).toBe(publicPath);
+  });
+
+  it("preserves query strings and fragments for deep-link authentication", () => {
+    expect(toFleetInternalHref("/assets/unit-42?tab=history#invoice")).toBe(
+      "/portal/fleet/units/unit-42?tab=history#invoice",
+    );
+    expect(
+      toFleetPublicHref(
+        "/portal/fleet/request/build?unitId=unit-42&source=pretrip",
+      ),
+    ).toBe("/requests/new?unitId=unit-42&source=pretrip");
+  });
+
+  it("does not map unknown, unsafe, or similarly prefixed routes", () => {
+    expect(toFleetInternalPath("/assets-private")).toBeNull();
+    expect(toFleetInternalPath("/dashboard")).toBeNull();
+    expect(toFleetPublicPath("/portal/fleetish")).toBeNull();
+    expect(toFleetInternalHref("https://attacker.test/assets")).toBeNull();
+    expect(toFleetInternalHref("//attacker.test/assets")).toBeNull();
+  });
+
+  it("only passes shared API and account-recovery paths through the Fleet host", () => {
+    expect(isFleetProductSharedPath("/api/portal/fleet/units")).toBe(true);
+    expect(isFleetProductSharedPath("/forgot-password")).toBe(true);
+    expect(isFleetProductSharedPath("/auth/reset")).toBe(true);
+    expect(isFleetProductSharedPath("/portal")).toBe(false);
+    expect(isFleetProductSharedPath("/dashboard")).toBe(false);
+  });
+});

--- a/tests/fleet-product-middleware-boundary.test.ts
+++ b/tests/fleet-product-middleware-boundary.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { config, middleware } from "../middleware";
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: () => ({
+    auth: {
+      getUser: async () => ({ data: { user: null }, error: null }),
+    },
+  }),
+}));
+
+const originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const originalSupabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+afterEach(() => {
+  if (originalSupabaseUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+  } else {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+  }
+
+  if (originalSupabaseAnonKey === undefined) {
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  } else {
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalSupabaseAnonKey;
+  }
+});
+
+function fleetRequest(pathname: string): NextRequest {
+  return new NextRequest(`https://fleet.profixiq.com${pathname}`, {
+    headers: { host: "fleet.profixiq.com" },
+  });
+}
+
+describe("Fleet product middleware boundary", () => {
+  it("canonicalizes legacy Fleet paths onto clean Fleet product URLs", async () => {
+    const response = await middleware(
+      fleetRequest("/portal/fleet/units/unit-42?tab=history"),
+    );
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "https://fleet.profixiq.com/assets/unit-42?tab=history",
+    );
+  });
+
+  it("does not expose Shop routes on the Fleet product host", async () => {
+    const response = await middleware(fleetRequest("/dashboard/work-orders"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://fleet.profixiq.com/",
+    );
+  });
+
+  it("rewrites the clean Fleet sign-in route to the existing protected implementation", async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    const response = await middleware(fleetRequest("/sign-in?redirect=%2Fassets"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "https://fleet.profixiq.com/portal/auth/fleet-sign-in?redirect=%2Fassets",
+    );
+  });
+
+  it("redirects protected clean routes to sign-in without leaking rewrite control headers", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "test-anon-key";
+
+    const response = await middleware(
+      fleetRequest("/assets/unit-42?tab=history"),
+    );
+    const location = new URL(String(response.headers.get("location")));
+
+    expect(response.status).toBe(307);
+    expect(location.pathname).toBe("/sign-in");
+    expect(location.searchParams.get("redirect")).toBe(
+      "/assets/unit-42?tab=history",
+    );
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBeNull();
+  });
+
+  it("registers a host-wide matcher so future Shop routes remain outside Fleet", () => {
+    expect(config.matcher).toContainEqual({
+      source: "/((?!_next/static|_next/image|favicon.ico).*)",
+      has: [{ type: "host", value: "fleet.profixiq.com" }],
+    });
+  });
+});


### PR DESCRIPTION
## Stack

This PR is stacked on [#1340](https://github.com/EdwardLakin/ProFixIQ/pull/1340). Merge #1340 first, then this PR.

## Summary

- make `fleet.profixiq.com` a hostname-scoped application boundary inside the existing ProFixIQ Vercel project
- expose clean Fleet URLs such as `/assets`, `/maintenance`, `/requests`, `/history`, and `/settings`
- rewrite clean URLs to the existing authorized `/portal/fleet/*` implementation without duplicating Fleet pages or domain logic
- canonicalize legacy Fleet-prefixed URLs back to clean public routes while preserving nested paths and query strings
- prevent Shop page routes from rendering on the Fleet hostname
- keep Fleet sign-in, authenticated deep links, sign-out, and password recovery on the Fleet product host
- keep Fleet invitation creation and activation on the primary ProFixIQ domain
- add Fleet canonical metadata and update the separation/deployment plan

## Routing safety

- the existing Fleet actor resolver and page-level authorization remain authoritative
- middleware routing does not replace membership or tenant authorization
- shared API paths remain on the same data platform and retain their current authentication/RLS boundaries
- redirect responses preserve auth cookies but strip internal rewrite-control headers
- the primary-domain `/portal/fleet/*` routes remain available during the transition

## Validation

- `tsc --noEmit`
- focused ESLint across all changed TypeScript/TSX files
- 12 Fleet, auth, routing, and middleware suites: 68 tests passed
- `git diff --check`
- Next.js production compiler completed successfully
- full `next build` page-data collection remains blocked by existing module-level credential requirements outside this diff; after non-secret Supabase placeholders it advances to the unrelated `/api/assistant/export` route requiring `OPENAI_API_KEY`

## Database and environment

- no database migration
- no new environment variables
- no second Vercel project

## Manual deployment actions after merge

1. Add `fleet.profixiq.com` to the existing ProFixIQ Vercel project.
2. Create the DNS record Vercel provides.
3. Add `https://fleet.profixiq.com/auth/reset` to the Supabase Auth redirect allowlist.
4. Verify Fleet root, sign-in, asset deep links, service-request deep links, and password recovery on the production hostname.
