### PR TITLE
Fix customer-facing invoice and history consistency

### DIFF
--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -258,6 +258,20 @@ jobs:
             -f tests/security/work-order-parts-portal-policy.runtime.sql \
             2>&1 | tee work-order-parts-portal-policy-runtime.log
 
+      - name: Execute customer document numbering integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/invoices/customer-document-numbering.runtime.sql \
+            2>&1 | tee customer-document-numbering-runtime.log
+
       - name: Execute P0 schema reconciliation integration
         shell: bash
         env:

--- a/app/api/billing/work-orders/route.ts
+++ b/app/api/billing/work-orders/route.ts
@@ -46,6 +46,7 @@ export async function GET() {
           resolved_shop_supplies_total: snapshot.shopSuppliesTotal ?? 0,
           resolved_tax_total: snapshot.taxTotal ?? 0,
           resolved_invoice_total: snapshot.total ?? 0,
+          resolved_invoice_number: snapshot.invoice?.invoice_number ?? null,
           pricing_error: null,
         };
       } catch (error: unknown) {
@@ -56,6 +57,7 @@ export async function GET() {
           resolved_shop_supplies_total: null,
           resolved_tax_total: null,
           resolved_invoice_total: null,
+          resolved_invoice_number: null,
           pricing_error:
             error instanceof Error
               ? error.message

--- a/app/api/invoice-versions/[id]/pdf/route.ts
+++ b/app/api/invoice-versions/[id]/pdf/route.ts
@@ -14,6 +14,7 @@ import {
   premiumInvoiceFilename,
   renderPremiumInvoicePdf,
 } from "@/features/invoices/server/renderPremiumInvoicePdf";
+import { overlayCanonicalDocumentIdentity } from "@/features/invoices/server/canonicalDocumentIdentity";
 
 type DB = Database;
 
@@ -59,10 +60,13 @@ export async function GET(
         .maybeSingle<{ shop_id: string | null }>(),
       admin
         .from("work_orders")
-        .select("customer_id")
+        .select("customer_id,custom_id")
         .eq("id", version.work_order_id)
         .eq("shop_id", version.shop_id)
-        .maybeSingle<{ customer_id: string | null }>(),
+        .maybeSingle<{
+          customer_id: string | null;
+          custom_id: string | null;
+        }>(),
     ]);
 
     let customerAccess = false;
@@ -109,8 +113,12 @@ export async function GET(
       notes: invoice?.notes ?? version.snapshot.invoice?.notes,
       draft: false,
     };
+    const snapshot = overlayCanonicalDocumentIdentity(version.snapshot, {
+      workOrderNumber: workOrder?.custom_id ?? null,
+      invoiceNumber: invoice?.invoice_number ?? null,
+    });
     const bytes = await renderPremiumInvoicePdf({
-      snapshot: version.snapshot,
+      snapshot,
       document: pdfDocument,
       brand,
     });
@@ -120,7 +128,7 @@ export async function GET(
       status: 200,
       headers: {
         "Content-Type": "application/pdf",
-        "Content-Disposition": `${download ? "attachment" : "inline"}; filename="${premiumInvoiceFilename(version.snapshot, pdfDocument)}"`,
+        "Content-Disposition": `${download ? "attachment" : "inline"}; filename="${premiumInvoiceFilename(snapshot, pdfDocument)}"`,
         "Cache-Control": "private, no-store",
         "X-Content-Type-Options": "nosniff",
       },

--- a/app/api/work-orders/[id]/invoice-pdf/route.ts
+++ b/app/api/work-orders/[id]/invoice-pdf/route.ts
@@ -13,6 +13,7 @@ import {
   premiumInvoiceFilename,
   renderPremiumInvoicePdf,
 } from "@/features/invoices/server/renderPremiumInvoicePdf";
+import { overlayCanonicalDocumentIdentity } from "@/features/invoices/server/canonicalDocumentIdentity";
 
 export async function GET(
   req: NextRequest,
@@ -37,9 +38,13 @@ export async function GET(
     // The session-scoped client keeps the read inside the caller's shop RLS boundary.
     const { data: workOrder, error: workOrderError } = await supabase
       .from("work_orders")
-      .select("id,shop_id")
+      .select("id,shop_id,custom_id")
       .eq("id", workOrderId)
-      .maybeSingle<{ id: string; shop_id: string }>();
+      .maybeSingle<{
+        id: string;
+        shop_id: string;
+        custom_id: string | null;
+      }>();
     if (workOrderError) throw workOrderError;
     if (!workOrder) {
       return NextResponse.json(
@@ -53,7 +58,7 @@ export async function GET(
       workOrderId,
       shopId: workOrder.shop_id,
     });
-    const snapshot =
+    const storedSnapshot =
       activeVersion?.snapshot ??
       (await getIssuableInvoiceSnapshot({
         supabase,
@@ -71,6 +76,10 @@ export async function GET(
             notes: string | null;
           }>()
       : { data: null };
+    const snapshot = overlayCanonicalDocumentIdentity(storedSnapshot, {
+      workOrderNumber: workOrder.custom_id,
+      invoiceNumber: invoice?.invoice_number ?? null,
+    });
     const brand =
       activeVersion &&
       isFrozenInvoiceDocumentConfiguration(snapshot.documentConfiguration)

--- a/app/api/work-orders/[id]/invoice/route.ts
+++ b/app/api/work-orders/[id]/invoice/route.ts
@@ -8,6 +8,10 @@ import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server
 import { reviewWorkOrder } from "../_lib/reviewWorkOrder";
 import { getIssuableInvoiceSnapshot } from "@/features/invoices/server/getIssuableInvoiceSnapshot";
 import { getActiveInvoiceVersion } from "@/features/invoices/server/financialLifecycle";
+import {
+  getCanonicalDocumentIdentity,
+  overlayCanonicalDocumentIdentity,
+} from "@/features/invoices/server/canonicalDocumentIdentity";
 
 
 function isError(x: unknown): x is Error {
@@ -93,15 +97,25 @@ export async function GET(
       workOrderId: woId,
       shopId: scopedWorkOrder.shop_id,
     });
-    const snapshot =
+    const storedSnapshot =
       activeInvoiceVersion?.snapshot ??
       (await getIssuableInvoiceSnapshot({
         supabase,
         workOrderId: woId,
         shopId: scopedWorkOrder.shop_id,
       }));
+    const identity = await getCanonicalDocumentIdentity({
+      supabase,
+      workOrderId: woId,
+      shopId: scopedWorkOrder.shop_id,
+      invoiceId: activeInvoiceVersion?.invoice_id,
+    });
+    const snapshot = overlayCanonicalDocumentIdentity(
+      storedSnapshot,
+      identity,
+    );
     return NextResponse.json(
-      { snapshot, activeInvoiceVersion },
+      { snapshot, activeInvoiceVersion, documentIdentity: identity },
       { headers: { "Cache-Control": "private, no-store" } },
     );
   } catch (e: unknown) {

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -23,6 +23,7 @@ type Row = WorkOrder & {
   resolved_shop_supplies_total?: number | null;
   resolved_tax_total?: number | null;
   resolved_invoice_total?: number | null;
+  resolved_invoice_number?: string | null;
   pricing_error?: string | null;
 };
 
@@ -93,6 +94,14 @@ function stageAccent(status: string | null | undefined): {
       badge: "border-emerald-400/70 bg-emerald-500/10 text-emerald-100",
       border: "border-emerald-500/25",
       progress: "bg-emerald-400",
+    };
+  }
+
+  if (key === "paid") {
+    return {
+      badge: "border-emerald-300/80 bg-emerald-500/15 text-emerald-100",
+      border: "border-emerald-400/35",
+      progress: "bg-emerald-300",
     };
   }
 
@@ -231,10 +240,14 @@ export default function BillingPage(): JSX.Element {
                 .toLowerCase();
 
               const cid = (r.custom_id ?? "").toLowerCase();
+              const invoiceNumber = (
+                r.resolved_invoice_number ?? ""
+              ).toLowerCase();
 
               return (
                 r.id.toLowerCase().includes(qlc) ||
                 cid.includes(qlc) ||
+                invoiceNumber.includes(qlc) ||
                 name.includes(qlc) ||
                 plate.includes(qlc) ||
                 ymm.includes(qlc)
@@ -613,8 +626,12 @@ export default function BillingPage(): JSX.Element {
       ) : (
         <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {rows.map((r) => {
-            const href = `/work-orders/${r.custom_id ?? r.id}?mode=view`;
-            const accent = stageAccent(r.status);
+            const isPaid = r.payment_status === "paid";
+            const href = isPaid
+              ? `/work-orders/view/${r.id}`
+              : `/work-orders/${r.custom_id ?? r.id}?mode=view`;
+            const visualStatus = isPaid ? "paid" : r.status;
+            const accent = stageAccent(visualStatus);
 
             const customerName = r.customers
               ? [r.customers.first_name ?? "", r.customers.last_name ?? ""]
@@ -644,7 +661,9 @@ export default function BillingPage(): JSX.Element {
             const pricingAvailable = !r.pricing_error;
             const billingState = r.pricing_error
               ? "Pricing unavailable"
-              : statusLower === "invoiced"
+              : isPaid
+                ? "Paid in full"
+                : statusLower === "invoiced"
                 ? "Invoice issued"
                 : statusLower === "ready_to_invoice"
                   ? "Ready for invoice review"
@@ -672,8 +691,14 @@ export default function BillingPage(): JSX.Element {
                         <span
                           className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] ${accent.badge}`}
                         >
-                          {String(r.status ?? "completed").replaceAll("_", " ")}
+                          {String(visualStatus ?? "completed").replaceAll("_", " ")}
                         </span>
+
+                        {r.resolved_invoice_number ? (
+                          <span className="inline-flex items-center rounded-full border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-2.5 py-1 text-[11px] font-semibold text-[color:var(--theme-text-secondary)]">
+                            Invoice {r.resolved_invoice_number}
+                          </span>
+                        ) : null}
 
                         {priorityText ? (
                           <span
@@ -760,23 +785,25 @@ export default function BillingPage(): JSX.Element {
                       Open WO
                     </Link>
 
-                    <button
-                      type="button"
-                      onClick={() => void handleAiReview(r)}
-                      className="rounded-full border border-sky-500/60 bg-sky-500/10 px-3 py-1.5 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
-                      title="Run AI checklist"
-                    >
-                      AI Review
-                    </button>
+                    {!isPaid ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleAiReview(r)}
+                        className="rounded-full border border-sky-500/60 bg-sky-500/10 px-3 py-1.5 text-sm font-semibold text-sky-100 transition hover:bg-sky-500/20"
+                        title="Run AI checklist"
+                      >
+                        AI Review
+                      </button>
+                    ) : null}
 
-                    {statusLower === "ready_to_invoice" ? (
+                    {!isPaid && statusLower === "ready_to_invoice" ? (
                       <span
                         className="inline-flex items-center rounded-full border border-emerald-400/60 bg-emerald-500/10 px-3 py-1.5 text-sm font-semibold text-emerald-100"
                         title="This work order is already ready to invoice"
                       >
                         Ready ✓
                       </span>
-                    ) : statusLower !== "invoiced" ? (
+                    ) : !isPaid && statusLower !== "invoiced" ? (
                       <button
                         type="button"
                         onClick={() => void handleMarkReady(r.id)}
@@ -793,7 +820,11 @@ export default function BillingPage(): JSX.Element {
                       className="rounded-full border border-emerald-400/70 bg-emerald-500/10 px-3 py-1.5 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
                       title={statusLower === "invoiced" ? "Open issued invoice" : "Open invoice preview"}
                     >
-                      {statusLower === "invoiced" ? "Open Invoice" : "Invoice"}
+                      {isPaid
+                        ? "Open paid invoice"
+                        : statusLower === "invoiced"
+                          ? "Open Invoice"
+                          : "Invoice"}
                     </button>
                   </div>
                 </div>

--- a/app/portal/invoices/[id]/page.tsx
+++ b/app/portal/invoices/[id]/page.tsx
@@ -13,6 +13,10 @@ import {
   getInvoiceVersionById,
   getLatestCustomerVisibleInvoiceVersion,
 } from "@/features/invoices/server/invoiceVersionQueries";
+import {
+  getCanonicalDocumentIdentity,
+  overlayCanonicalDocumentIdentity,
+} from "@/features/invoices/server/canonicalDocumentIdentity";
 
 export const dynamic = "force-dynamic";
 
@@ -68,14 +72,22 @@ export default async function PortalInvoicePage({
 
     if (!selectedVersion) redirect("/portal/invoices");
 
-    const snapshot = selectedVersion.snapshot;
+    const identity = await getCanonicalDocumentIdentity({
+      supabase,
+      shopId: workOrder.shop_id,
+      workOrderId,
+      invoiceId: selectedVersion.invoice_id,
+    });
+    const snapshot = overlayCanonicalDocumentIdentity(
+      selectedVersion.snapshot,
+      identity,
+    );
     const payable =
       ["issued", "partially_paid"].includes(selectedVersion.lifecycle_status) &&
       Number(selectedVersion.outstanding_total) >= 0.5;
-    const title =
-      snapshot.workOrder.custom_id ||
-      selectedVersion.invoice_id ||
-      `Work order ${workOrderId.slice(0, 8)}`;
+    const title = identity.invoiceNumber || "Invoice";
+    const workOrderNumber =
+      identity.workOrderNumber || `#${workOrderId.slice(0, 8)}`;
 
     return (
       <div className="min-h-screen bg-background px-4 py-10 text-foreground">
@@ -102,7 +114,7 @@ export default async function PortalInvoicePage({
                 <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">Invoice</div>
                 <h1 className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{title}</h1>
                 <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-                  Issued {dateLabel(selectedVersion.issued_at)}
+                  Work order {workOrderNumber} · Issued {dateLabel(selectedVersion.issued_at)}
                 </div>
               </div>
               <div className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-2 text-sm capitalize text-[color:var(--theme-text-primary)]">
@@ -188,6 +200,7 @@ export default async function PortalInvoicePage({
               {snapshot.lines.map((line) => (
                 <div key={line.id} className="rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
                   <div className="font-semibold text-[color:var(--theme-text-primary)]">{line.description || line.complaint || "Service line"}</div>
+                  {line.complaint ? <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Complaint: {line.complaint}</div> : null}
                   {line.cause ? <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Cause: {line.cause}</div> : null}
                   {line.correction ? <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">Correction: {line.correction}</div> : null}
                 </div>

--- a/app/portal/invoices/page.tsx
+++ b/app/portal/invoices/page.tsx
@@ -30,11 +30,27 @@ export default async function PortalInvoicesPage() {
       .returns<Array<{ id: string; custom_id: string | null }>>();
     if (workOrderError) throw new Error(workOrderError.message);
 
-    const labels = new Map((workOrders ?? []).map((row) => [row.id, row.custom_id]));
+    const workOrderLabels = new Map(
+      (workOrders ?? []).map((row) => [row.id, row.custom_id]),
+    );
     const versions = await listCustomerVisibleInvoiceVersions({
       supabase,
       workOrderIds: (workOrders ?? []).map((row) => row.id),
     });
+    const invoiceIds = versions
+      .map((version) => version.invoice_id)
+      .filter((id): id is string => Boolean(id));
+    const { data: invoices, error: invoiceError } = invoiceIds.length
+      ? await supabase
+          .from("invoices")
+          .select("id,invoice_number")
+          .in("id", invoiceIds)
+          .returns<Array<{ id: string; invoice_number: string | null }>>()
+      : { data: [], error: null };
+    if (invoiceError) throw new Error(invoiceError.message);
+    const invoiceLabels = new Map(
+      (invoices ?? []).map((invoice) => [invoice.id, invoice.invoice_number]),
+    );
 
     return (
       <div className="space-y-6 text-[color:var(--theme-text-primary)]">
@@ -61,7 +77,13 @@ export default async function PortalInvoicesPage() {
           ) : (
             <div className="space-y-3">
               {versions.map((version) => {
-                const label = labels.get(version.work_order_id) || `Work order ${version.work_order_id.slice(0, 8)}`;
+                const workOrderLabel =
+                  workOrderLabels.get(version.work_order_id) ||
+                  `Work order ${version.work_order_id.slice(0, 8)}`;
+                const invoiceLabel =
+                  (version.invoice_id
+                    ? invoiceLabels.get(version.invoice_id)
+                    : null) || "Invoice";
                 return (
                   <Link
                     key={version.id}
@@ -70,9 +92,9 @@ export default async function PortalInvoicesPage() {
                   >
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                       <div>
-                        <div className="font-semibold text-[color:var(--theme-text-primary)]">{label}</div>
+                        <div className="font-semibold text-[color:var(--theme-text-primary)]">{invoiceLabel}</div>
                         <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
-                          Version {version.version_number} • Issued {dateLabel(version.issued_at)}
+                          {workOrderLabel} • Version {version.version_number} • Issued {dateLabel(version.issued_at)}
                         </div>
                         <div className="mt-1 text-xs capitalize text-[color:var(--theme-text-secondary)]">
                           {version.lifecycle_status.replaceAll("_", " ")}

--- a/app/work-orders/[id]/Client.tsx
+++ b/app/work-orders/[id]/Client.tsx
@@ -39,6 +39,7 @@ import { resolveWorkOrderLinePricing } from "@/features/work-orders/lib/pricing/
 import {
   countActiveWorkOrderLines,
   formatWorkOrderHeaderStatus,
+  shouldUseReadOnlyWorkOrderView,
 } from "@/features/work-orders/lib/display/workOrderPresentation";
 import { filterAllocationsNotBackedByCanonicalParts } from "@/features/work-orders/lib/display/workOrderParts";
 import {
@@ -298,6 +299,11 @@ export default function WorkOrderIdClient(): JSX.Element {
     () => formatWorkOrderHeaderStatus(wo?.status, wo?.payment_status),
     [wo?.payment_status, wo?.status],
   );
+
+  useEffect(() => {
+    if (!wo?.id || !shouldUseReadOnlyWorkOrderView(wo.payment_status)) return;
+    router.replace(`/work-orders/view/${wo.id}`);
+  }, [router, wo?.id, wo?.payment_status]);
 
   // ✅ read job from query (desktop panel)
   const jobFromQuery = searchParams?.get("job") || null;

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -20,6 +20,7 @@ type HistoryRow = DB["public"]["Tables"]["history"]["Row"];
 type CustomerRow = DB["public"]["Tables"]["customers"]["Row"];
 type VehicleRow = DB["public"]["Tables"]["vehicles"]["Row"];
 type ProfileRow = DB["public"]["Tables"]["profiles"]["Row"];
+type ShopRow = DB["public"]["Tables"]["shops"]["Row"];
 
 type Row = Pick<
   HistoryRow,
@@ -39,8 +40,11 @@ type Row = Pick<
   | "odometer"
   | "advisor_name"
   | "assigned_tech_name"
+  | "labor_hours"
   | "labor_sale"
   | "parts_sale"
+  | "shop_supplies"
+  | "discount"
   | "tax"
   | "total"
   | "symptom"
@@ -72,6 +76,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
   const vehicleHistoryGuidedQuery = usePersistentGuidedOnboardingQuery("vehicle_history");
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const [shopId, setShopId] = useState<string | null>(null);
+  const [currency, setCurrency] = useState<"CAD" | "USD">("CAD");
   const [rows, setRows] = useState<Row[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
@@ -104,6 +109,16 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
           setLoading(false)
         );
       setShopId(profile.shop_id);
+      const { data: shop } = await supabase
+        .from("shops")
+        .select("country")
+        .eq("id", profile.shop_id)
+        .maybeSingle<Pick<ShopRow, "country">>();
+      setCurrency(
+        String(shop?.country ?? "CA").trim().toUpperCase() === "CA"
+          ? "CAD"
+          : "USD",
+      );
       setLoading(false);
     })();
   }, [supabase]);
@@ -115,7 +130,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
     let query = supabase
       .from("history")
       .select(
-        "id, customer_id, vehicle_id, work_order_id, service_date, description, notes, created_at, work_order_number, invoice_number, historical_status, payment_state, approval_state, odometer, advisor_name, assigned_tech_name, labor_sale, parts_sale, tax, total, symptom, cause, correction, source_system, source_external_id, source_row_id, imported_from_session_id, customers:customers(first_name,last_name,email,phone), vehicles:vehicles(year,make,model,license_plate,vin,unit_number)",
+        "id, customer_id, vehicle_id, work_order_id, service_date, description, notes, created_at, work_order_number, invoice_number, historical_status, payment_state, approval_state, odometer, advisor_name, assigned_tech_name, labor_hours, labor_sale, parts_sale, shop_supplies, discount, tax, total, symptom, cause, correction, source_system, source_external_id, source_row_id, imported_from_session_id, customers:customers(first_name,last_name,email,phone), vehicles:vehicles(year,make,model,license_plate,vin,unit_number)",
       )
       .order("service_date", { ascending: false })
       .limit(300);
@@ -292,7 +307,10 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                   <ImportedHistoryRecordCard
                     key={r.id}
                     row={r}
-                    serviceDateLabel={fmtDate(r.service_date ?? r.created_at)}
+                    serviceDateLabel={fmtDate(
+                      r.service_date ?? r.created_at,
+                      "PPp",
+                    )}
                     vehicleLabel={fmtVehicle(r.vehicles)}
                     vehicleIdentifiers={
                       r.vehicles?.vin ? `VIN ${r.vehicles.vin}` : null
@@ -311,6 +329,7 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
                           : "Service history"
                         : undefined
                     }
+                    currency={currency}
                     action={
                       <div className="flex flex-wrap items-center gap-3">
                         <Link

--- a/features/invoices/server/canonicalDocumentIdentity.test.ts
+++ b/features/invoices/server/canonicalDocumentIdentity.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { InvoiceSnapshot } from "@/features/invoices/server/getInvoiceSnapshot";
+import { overlayCanonicalDocumentIdentity } from "./canonicalDocumentIdentity";
+
+function snapshotFixture(): InvoiceSnapshot {
+  return {
+    workOrder: {
+      id: "work-order-id",
+      shop_id: "shop-id",
+      customer_id: "customer-id",
+      vehicle_id: "vehicle-id",
+      customer_name: "Customer",
+      custom_id: null,
+      status: "invoiced",
+      labor_total: 100,
+      parts_total: 50,
+      invoice_total: 165,
+      shop_supplies_enabled_override: null,
+      shop_supplies_amount_override: null,
+      created_at: "2026-08-05T00:00:00.000Z",
+    },
+    invoice: {
+      id: "invoice-id",
+      invoice_number: null,
+      status: "paid",
+      currency: "CAD",
+      subtotal: 165,
+      parts_cost: 50,
+      labor_cost: 100,
+      shop_supplies_total: 15,
+      discount_total: 0,
+      tax_total: 0,
+      total: 165,
+      issued_at: "2026-08-05T01:00:00.000Z",
+      created_at: "2026-08-05T01:00:00.000Z",
+      notes: null,
+    },
+    shop: null,
+    customer: null,
+    vehicle: null,
+    lines: [],
+    parts: [],
+    currency: "CAD",
+    laborCost: 100,
+    partsCost: 50,
+    shopSuppliesTotal: 15,
+    subtotal: 165,
+    discountTotal: 0,
+    taxTotal: 0,
+    total: 165,
+  };
+}
+
+describe("canonical invoice document identity", () => {
+  it("overlays repaired customer-facing numbers without mutating the frozen snapshot", () => {
+    const original = snapshotFixture();
+    const overlaid = overlayCanonicalDocumentIdentity(original, {
+      workOrderNumber: "WO-000009",
+      invoiceNumber: "INV-000003",
+    });
+
+    expect(overlaid.workOrder.custom_id).toBe("WO-000009");
+    expect(overlaid.invoice?.invoice_number).toBe("INV-000003");
+    expect(original.workOrder.custom_id).toBeNull();
+    expect(original.invoice?.invoice_number).toBeNull();
+  });
+});

--- a/features/invoices/server/canonicalDocumentIdentity.ts
+++ b/features/invoices/server/canonicalDocumentIdentity.ts
@@ -1,0 +1,75 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database } from "@shared/types/types/supabase";
+import type { InvoiceSnapshot } from "@/features/invoices/server/getInvoiceSnapshot";
+
+type DB = Database;
+
+export type CanonicalDocumentIdentity = {
+  workOrderNumber: string | null;
+  invoiceNumber: string | null;
+};
+
+function clean(value: string | null | undefined): string | null {
+  const normalized = value?.trim() ?? "";
+  return normalized.length > 0 ? normalized : null;
+}
+
+export async function getCanonicalDocumentIdentity(args: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  workOrderId: string;
+  invoiceId?: string | null;
+}): Promise<CanonicalDocumentIdentity> {
+  const workOrderPromise = args.supabase
+    .from("work_orders")
+    .select("custom_id")
+    .eq("id", args.workOrderId)
+    .eq("shop_id", args.shopId)
+    .maybeSingle<{ custom_id: string | null }>();
+
+  let invoiceQuery = args.supabase
+    .from("invoices")
+    .select("invoice_number")
+    .eq("work_order_id", args.workOrderId)
+    .eq("shop_id", args.shopId);
+  if (args.invoiceId) invoiceQuery = invoiceQuery.eq("id", args.invoiceId);
+
+  const [workOrderResult, invoiceResult] = await Promise.all([
+    workOrderPromise,
+    invoiceQuery
+      .order("issued_at", { ascending: false, nullsFirst: false })
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle<{ invoice_number: string | null }>(),
+  ]);
+
+  if (workOrderResult.error) throw new Error(workOrderResult.error.message);
+  if (invoiceResult.error) throw new Error(invoiceResult.error.message);
+
+  return {
+    workOrderNumber: clean(workOrderResult.data?.custom_id),
+    invoiceNumber: clean(invoiceResult.data?.invoice_number),
+  };
+}
+
+export function overlayCanonicalDocumentIdentity(
+  snapshot: InvoiceSnapshot,
+  identity: CanonicalDocumentIdentity,
+): InvoiceSnapshot {
+  return {
+    ...snapshot,
+    workOrder: {
+      ...snapshot.workOrder,
+      custom_id:
+        identity.workOrderNumber ?? clean(snapshot.workOrder.custom_id),
+    },
+    invoice: snapshot.invoice
+      ? {
+          ...snapshot.invoice,
+          invoice_number:
+            identity.invoiceNumber ?? clean(snapshot.invoice.invoice_number),
+        }
+      : snapshot.invoice,
+  };
+}

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -6881,6 +6881,51 @@ export type Database = {
           },
         ]
       }
+      integrations: {
+        Row: {
+          config: Json
+          created_at: string
+          id: string
+          provider: string
+          shop_id: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          config?: Json
+          created_at?: string
+          id?: string
+          provider: string
+          shop_id?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          config?: Json
+          created_at?: string
+          id?: string
+          provider?: string
+          shop_id?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "integrations_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "integrations_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       intelligence_story_signals: {
         Row: {
           created_at: string

--- a/features/work-orders/components/ImportedHistoryRecordCard.tsx
+++ b/features/work-orders/components/ImportedHistoryRecordCard.tsx
@@ -26,6 +26,8 @@ export type ImportedHistoryRecordLike = {
   labor_hours?: string | number | null;
   labor_sale?: number | null;
   parts_sale?: number | null;
+  shop_supplies?: number | null;
+  discount?: number | null;
   tax?: number | null;
   total?: number | null;
   advisor_name?: string | null;
@@ -48,13 +50,17 @@ type Props = {
   action?: ReactNode;
   className?: string;
   badgeLabel?: string;
+  currency?: "CAD" | "USD";
 };
 
-function formatMoney(value: number | null | undefined): string | null {
+function formatMoney(
+  value: number | null | undefined,
+  currency: "CAD" | "USD",
+): string | null {
   if (value == null || !Number.isFinite(value)) return null;
-  return new Intl.NumberFormat("en-US", {
+  return new Intl.NumberFormat(currency === "CAD" ? "en-CA" : "en-US", {
     style: "currency",
-    currency: "USD",
+    currency,
   }).format(value);
 }
 
@@ -103,23 +109,34 @@ export function ImportedHistoryRecordCard({
   action,
   className = "",
   badgeLabel = "Read-only imported",
+  currency = "CAD",
 }: Props): JSX.Element {
   const detailsId = `imported-history-details-${row.id}`;
+  const narratives = [
+    ["Complaint", row.symptom],
+    ["Cause", row.cause],
+    ["Correction", row.correction],
+  ] as const;
+  const hasNarratives = narratives.some(([, value]) => Boolean(value?.trim()));
   const serviceSummary =
-    (summary ??
-      [
-        row.symptom ? `Complaint: ${row.symptom}` : null,
-        row.cause ? `Cause: ${row.cause}` : null,
-        row.correction ? `Correction: ${row.correction}` : null,
-      ]
-        .filter(Boolean)
-        .join(" • ")) ||
+    summary?.trim() ||
     row.description?.trim() ||
     row.notes?.trim() ||
     "Imported historical service record";
   const moneyParts = [
-    row.total != null ? `Total ${formatMoney(row.total)}` : null,
-    row.labor_sale != null ? `Labor ${formatMoney(row.labor_sale)}` : null,
+    row.total != null ? `Total ${formatMoney(row.total, currency)}` : null,
+    row.labor_sale != null
+      ? `Labor ${formatMoney(row.labor_sale, currency)}`
+      : null,
+    row.parts_sale != null
+      ? `Parts ${formatMoney(row.parts_sale, currency)}`
+      : null,
+    row.shop_supplies != null && row.shop_supplies !== 0
+      ? `Supplies ${formatMoney(row.shop_supplies, currency)}`
+      : null,
+    row.tax != null && row.tax !== 0
+      ? `Tax ${formatMoney(row.tax, currency)}`
+      : null,
     row.labor_hours != null
       ? `${formatNumberLike(row.labor_hours)} labor hrs`
       : null,
@@ -172,7 +189,9 @@ export function ImportedHistoryRecordCard({
             <Detail
               label="Odometer"
               value={
-                row.odometer != null ? formatNumberLike(row.odometer) : "—"
+                row.odometer != null
+                  ? formatNumberLike(row.odometer)
+                  : "Not recorded"
               }
             />
             <Detail label="Amount" value={moneyParts.join(" • ") || "—"} />
@@ -181,7 +200,23 @@ export function ImportedHistoryRecordCard({
             <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
               Service summary
             </div>
-            {serviceSummary}
+            {hasNarratives ? (
+              <dl className="grid gap-2">
+                {narratives.map(([label, value]) => (
+                  <div
+                    key={label}
+                    className="grid gap-1 sm:grid-cols-[7rem_minmax(0,1fr)] sm:gap-3"
+                  >
+                    <dt className="font-medium text-[color:var(--theme-text-secondary)]">
+                      {label}
+                    </dt>
+                    <dd>{value?.trim() || "Not recorded"}</dd>
+                  </div>
+                ))}
+              </dl>
+            ) : (
+              serviceSummary
+            )}
           </div>
         </div>
       ) : null}

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -226,6 +226,8 @@ type SnapshotLine = {
   line_no?: number | null;
   description?: string | null;
   complaint?: string | null;
+  cause?: string | null;
+  correction?: string | null;
   labor_time?: number | null;
   resolvedLaborHours?: number;
   resolvedLaborRate?: number;
@@ -246,6 +248,16 @@ type InvoiceSnapshotView = {
   total?: number | null;
   parts?: SnapshotPart[];
   lines?: SnapshotLine[];
+  invoice?: {
+    invoice_number?: string | null;
+    issued_at?: string | null;
+    status?: string | null;
+  } | null;
+};
+
+type DocumentIdentityView = {
+  workOrderNumber?: string | null;
+  invoiceNumber?: string | null;
 };
 
 function formatInvoiceMoney(
@@ -256,6 +268,18 @@ function formatInvoiceMoney(
     style: "currency",
     currency: invoiceCurrency,
   }).format(safeMoney(value));
+}
+
+function formatInvoiceDate(value: string | null | undefined): string {
+  if (!value) return "Not issued";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "Not issued"
+    : date.toLocaleDateString("en-CA", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
 }
 
 type InspectionPdfInfo = {
@@ -286,6 +310,8 @@ export default function InvoicePreviewPageClient({
 
   const [shopInfo, setShopInfo] = useState<ShopInfo | undefined>(undefined);
   const [invoiceId, setInvoiceId] = useState<string | null>(null);
+  const [invoiceNumber, setInvoiceNumber] = useState<string | null>(null);
+  const [invoiceIssuedAt, setInvoiceIssuedAt] = useState<string | null>(null);
   const [workOrderLabel, setWorkOrderLabel] = useState<string | null>(null);
   const [canonicalSnapshot, setCanonicalSnapshot] =
     useState<InvoiceSnapshotView | null>(null);
@@ -323,7 +349,7 @@ export default function InvoicePreviewPageClient({
   const effectiveCustomerInfo = customerInfo ?? fCustomerInfo;
 
   useEffect(() => {
-    const label = workOrderLabel || workOrderId.slice(0, 8);
+    const label = invoiceNumber || workOrderLabel || "Draft invoice";
     updateActiveTab({
       title: `Invoice · ${label}`,
       subtitle:
@@ -341,6 +367,7 @@ export default function InvoicePreviewPageClient({
     reviewLoading,
     reviewOk,
     updateActiveTab,
+    invoiceNumber,
     workOrderId,
     workOrderLabel,
   ]);
@@ -491,14 +518,20 @@ export default function InvoicePreviewPageClient({
 
       const { data: invoiceRow } = await supabase
         .from("invoices")
-        .select("id")
+        .select("id,invoice_number,issued_at")
         .eq("work_order_id", workOrderId)
         .order("created_at", { ascending: false })
         .limit(1)
-        .maybeSingle<{ id: string }>();
+        .maybeSingle<{
+          id: string;
+          invoice_number: string | null;
+          issued_at: string | null;
+        }>();
 
       if (cancelled) return;
       setInvoiceId(invoiceRow?.id ?? null);
+      setInvoiceNumber(invoiceRow?.invoice_number?.trim() || null);
+      setInvoiceIssuedAt(invoiceRow?.issued_at ?? null);
       const snapshotPartsByLine = new Map<string, PdfLinePart[]>();
       try {
         const snapshotRes = await fetch(`/api/work-orders/${workOrderId}/invoice`, { method: "GET" });
@@ -506,13 +539,28 @@ export default function InvoicePreviewPageClient({
           | {
               snapshot?: InvoiceSnapshotView;
               activeInvoiceVersion?: ActiveInvoiceVersionSummary | null;
+              documentIdentity?: DocumentIdentityView;
             }
           | null;
         const loadedSnapshot = snapshotJson?.snapshot ?? null;
         const loadedVersion = snapshotJson?.activeInvoiceVersion ?? null;
+        const loadedIdentity = snapshotJson?.documentIdentity;
         const snapshotTotal = loadedSnapshot?.total;
         setCanonicalSnapshot(loadedSnapshot);
         setActiveInvoiceVersion(loadedVersion);
+        setWorkOrderLabel(
+          loadedIdentity?.workOrderNumber?.trim() ||
+            woRow.custom_id?.trim() ||
+            null,
+        );
+        setInvoiceNumber(
+          loadedIdentity?.invoiceNumber?.trim() ||
+            invoiceRow?.invoice_number?.trim() ||
+            null,
+        );
+        setInvoiceIssuedAt(
+          loadedSnapshot?.invoice?.issued_at ?? invoiceRow?.issued_at ?? null,
+        );
         if (loadedVersion?.invoice_id) setInvoiceId(loadedVersion.invoice_id);
         for (const part of loadedSnapshot?.parts ?? []) {
           const lineId = typeof part.lineId === "string" ? part.lineId.trim() : "";
@@ -889,6 +937,13 @@ export default function InvoicePreviewPageClient({
         setCanonicalInvoiceTotal(Math.max(0, Number(json.invoiceVersion.total)));
         if (json.invoiceVersion.snapshot) {
           setCanonicalSnapshot(json.invoiceVersion.snapshot);
+          setInvoiceNumber(
+            json.invoiceVersion.snapshot.invoice?.invoice_number?.trim() ||
+              null,
+          );
+          setInvoiceIssuedAt(
+            json.invoiceVersion.snapshot.invoice?.issued_at ?? null,
+          );
         }
       }
       await onSent?.();
@@ -943,6 +998,13 @@ export default function InvoicePreviewPageClient({
       setCanonicalInvoiceTotal(Math.max(0, Number(result.invoiceVersion.total)));
       if (result.invoiceVersion.snapshot) {
         setCanonicalSnapshot(result.invoiceVersion.snapshot);
+        setInvoiceNumber(
+          result.invoiceVersion.snapshot.invoice?.invoice_number?.trim() ||
+            null,
+        );
+        setInvoiceIssuedAt(
+          result.invoiceVersion.snapshot.invoice?.issued_at ?? null,
+        );
       }
       toast.success("Invoice finalized. QuickBooks sync is now available.");
       router.refresh();
@@ -973,8 +1035,13 @@ export default function InvoicePreviewPageClient({
             <div className="text-[0.7rem] uppercase tracking-[0.22em] text-[color:var(--theme-text-secondary)]">
               Invoice
               <span className="ml-2 rounded-full border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-[0.65rem] text-[color:var(--theme-text-primary)]">
-                #{workOrderId}
+                {invoiceNumber || "Draft invoice"}
               </span>
+              {workOrderLabel ? (
+                <span className="ml-2 text-[0.65rem] normal-case tracking-normal text-[color:var(--theme-text-muted)]">
+                  Work order {workOrderLabel}
+                </span>
+              ) : null}
             </div>
 
             {loading ? (
@@ -1115,6 +1182,53 @@ export default function InvoicePreviewPageClient({
               </div>
             </div>
 
+            <div className="grid gap-3 border-b border-[color:var(--theme-border-soft)] px-4 py-4 sm:grid-cols-3">
+              <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-3">
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                  Customer
+                </div>
+                <div className="mt-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  {effectiveCustomerInfo?.name ||
+                    effectiveCustomerInfo?.business_name ||
+                    "Customer not recorded"}
+                </div>
+                <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  {effectiveCustomerInfo?.email ||
+                    effectiveCustomerInfo?.phone ||
+                    "No contact details recorded"}
+                </div>
+              </div>
+              <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-3">
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                  Vehicle
+                </div>
+                <div className="mt-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  {[effectiveVehicleInfo?.year, effectiveVehicleInfo?.make, effectiveVehicleInfo?.model]
+                    .filter(Boolean)
+                    .join(" ") || "Vehicle not recorded"}
+                </div>
+                <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  {effectiveVehicleInfo?.vin
+                    ? `VIN ${effectiveVehicleInfo.vin}`
+                    : effectiveVehicleInfo?.license_plate
+                      ? `Plate ${effectiveVehicleInfo.license_plate}`
+                      : "No VIN or plate recorded"}
+                </div>
+              </div>
+              <div className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-3 py-3">
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                  Document
+                </div>
+                <div className="mt-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                  {invoiceNumber || "Draft invoice"}
+                </div>
+                <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                  {workOrderLabel ? `Work order ${workOrderLabel}` : "Work order number pending"}
+                  {` · ${formatInvoiceDate(invoiceIssuedAt)}`}
+                </div>
+              </div>
+            </div>
+
             <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
               <div className="space-y-3">
                 {(canonicalSnapshot.lines ?? []).map((line, index) => {
@@ -1143,6 +1257,26 @@ export default function InvoicePreviewPageClient({
                           {formatInvoiceMoney(line.resolvedLineTotal, invoiceCurrency)}
                         </div>
                       </div>
+
+                      <dl className="mt-3 grid gap-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-xs sm:grid-cols-[6rem_minmax(0,1fr)]">
+                        {[
+                          ["Complaint", line.complaint],
+                          ["Cause", line.cause],
+                          ["Correction", line.correction],
+                        ].map(([narrativeLabel, value]) => (
+                          <div
+                            key={narrativeLabel}
+                            className="grid gap-1 sm:col-span-2 sm:grid-cols-[6rem_minmax(0,1fr)]"
+                          >
+                            <dt className="font-medium text-[color:var(--theme-text-secondary)]">
+                              {narrativeLabel}
+                            </dt>
+                            <dd className="text-[color:var(--theme-text-primary)]">
+                              {value?.trim() || "Not recorded"}
+                            </dd>
+                          </div>
+                        ))}
+                      </dl>
 
                       <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-[color:var(--theme-text-secondary)]">
                         <div>Labor</div>
@@ -1316,8 +1450,9 @@ export default function InvoicePreviewPageClient({
           </div>
         ) : null}
 
-        {/* Inspection PDF Panel (works even when invoice doesn't exist yet) */}
-        <div className="rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
+        {/* Inspection reports only occupy invoice space when one exists. */}
+        {inspectionPdfLoading || inspectionPdf ? (
+          <div className="rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
               <div className="text-[0.7rem] uppercase tracking-[0.18em] text-[color:var(--theme-text-secondary)]">
@@ -1366,7 +1501,8 @@ export default function InvoicePreviewPageClient({
               No inspection PDF is attached to this work order yet. Finish/finalize an inspection to generate it.
             </div>
           ) : null}
-        </div>
+          </div>
+        ) : null}
 
         {/* PDF Download Panel */}
         <div className="rounded-xl border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] p-4">

--- a/features/work-orders/lib/display/workOrderPresentation.test.ts
+++ b/features/work-orders/lib/display/workOrderPresentation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   countActiveWorkOrderLines,
   formatWorkOrderHeaderStatus,
+  shouldUseReadOnlyWorkOrderView,
 } from "./workOrderPresentation";
 
 describe("work-order presentation", () => {
@@ -27,5 +28,11 @@ describe("work-order presentation", () => {
         { status: "deferred" },
       ]),
     ).toBe(2);
+  });
+
+  it("routes paid work orders to the immutable service view", () => {
+    expect(shouldUseReadOnlyWorkOrderView("paid")).toBe(true);
+    expect(shouldUseReadOnlyWorkOrderView("unpaid")).toBe(false);
+    expect(shouldUseReadOnlyWorkOrderView(null)).toBe(false);
   });
 });

--- a/features/work-orders/lib/display/workOrderPresentation.ts
+++ b/features/work-orders/lib/display/workOrderPresentation.ts
@@ -53,3 +53,9 @@ export function countActiveWorkOrderLines(
     (line) => !NON_ACTIVE_LINE_STATUSES.has(normalizeWorkOrderLineStatus(line.status)),
   ).length;
 }
+
+export function shouldUseReadOnlyWorkOrderView(
+  paymentStatus: string | null | undefined,
+): boolean {
+  return String(paymentStatus ?? "").trim().toLowerCase() === "paid";
+}

--- a/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
+++ b/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
@@ -30,7 +30,7 @@ select
   wo.shop_id,
   'work_order',
   pg_catalog.max(
-    pg_catalog.substring(wo.custom_id from '([0-9]+)$')::bigint
+    pg_catalog.substring(wo.custom_id, '([0-9]+)$')::bigint
   )
 from public.work_orders wo
 where wo.shop_id is not null
@@ -55,7 +55,7 @@ select
   i.shop_id,
   'invoice',
   pg_catalog.max(
-    pg_catalog.substring(i.invoice_number from '^INV-([0-9]+)$')::bigint
+    pg_catalog.substring(i.invoice_number, '^INV-([0-9]+)$')::bigint
   )
 from public.invoices i
 where i.shop_id is not null

--- a/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
+++ b/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
@@ -256,7 +256,7 @@ declare
   v_symptoms text;
   v_causes text;
   v_corrections text;
-  v_odometer text;
+  v_odometer numeric;
   v_labor_hours numeric := 0;
   v_advisor_name text;
   v_technician_name text;
@@ -307,12 +307,12 @@ begin
   );
 
   v_odometer := coalesce(
-    new.vehicle_mileage::text,
-    new.odometer_km::text
+    new.vehicle_mileage,
+    new.odometer_km
   );
 
   if v_odometer is null then
-    select v.mileage::text
+    select v.mileage
     into v_odometer
     from public.vehicles v
     where v.id = new.vehicle_id
@@ -531,9 +531,9 @@ set work_order_number = paid.custom_id,
     cause = lines.cause,
     correction = lines.correction,
     odometer = coalesce(
-      paid.vehicle_mileage::text,
-      paid.odometer_km::text,
-      paid.vehicle_odometer::text,
+      paid.vehicle_mileage,
+      paid.odometer_km,
+      paid.vehicle_odometer,
       h.odometer
     ),
     labor_hours = lines.labor_hours,

--- a/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
+++ b/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
@@ -312,7 +312,11 @@ begin
   );
 
   if v_odometer is null then
-    select v.mileage
+    select case
+      when pg_catalog.btrim(v.mileage::text) ~ '^[0-9]+([.][0-9]+)?$'
+        then pg_catalog.btrim(v.mileage::text)::numeric
+      else null
+    end
     into v_odometer
     from public.vehicles v
     where v.id = new.vehicle_id
@@ -470,7 +474,11 @@ with paid_rows as (
     wo.payment_status,
     wo.vehicle_mileage,
     wo.odometer_km,
-    v.mileage as vehicle_odometer,
+    case
+      when pg_catalog.btrim(v.mileage::text) ~ '^[0-9]+([.][0-9]+)?$'
+        then pg_catalog.btrim(v.mileage::text)::numeric
+      else null
+    end as vehicle_odometer,
     i.id as invoice_id,
     i.invoice_number,
     coalesce(i.labor_cost, wo.labor_total, 0) as labor_sale,

--- a/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
+++ b/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
@@ -365,7 +365,7 @@ begin
       invoice_number, opened_at, closed_at, historical_status, advisor_name,
       assigned_tech_name, priority, odometer, symptom, cause, correction,
       labor_hours, labor_sale, parts_sale, shop_supplies, discount, tax, total,
-      approval_state, payment_state, source_payload, shop_id
+      approval_state, payment_state, source_payload
     ) values (
       new.customer_id, new.vehicle_id, new.id,
       coalesce(new.paid_at, pg_catalog.now()), v_description,
@@ -385,8 +385,7 @@ begin
         'work_order_id', new.id,
         'invoice_id', v_invoice.id,
         'closed_from', 'paid_invoice'
-      ),
-      new.shop_id
+      )
     )
     returning id into v_history_id;
   else
@@ -431,9 +430,21 @@ begin
           'work_order_id', new.id,
           'invoice_id', v_invoice.id,
           'closed_from', 'paid_invoice'
-        ),
-        shop_id = new.shop_id
+        )
     where id = v_history_id;
+  end if;
+
+  -- Production has an optional history.shop_id column that is absent from the
+  -- clean baseline. Keep both shapes valid while preserving production scope.
+  if exists (
+    select 1
+    from pg_catalog.pg_attribute attribute
+    where attribute.attrelid = 'public.history'::pg_catalog.regclass
+      and attribute.attname = 'shop_id'
+      and not attribute.attisdropped
+  ) then
+    execute 'update public.history set shop_id = $1 where id = $2'
+    using new.shop_id, v_history_id;
   end if;
 
   return new;
@@ -542,7 +553,26 @@ set work_order_number = paid.custom_id,
       )
 from paid_rows paid
 join line_rollup lines on lines.work_order_id = paid.work_order_id
-where h.work_order_id = paid.work_order_id
-  and h.shop_id = paid.shop_id;
+where h.work_order_id = paid.work_order_id;
+
+do $optional_history_shop_scope$
+begin
+  if exists (
+    select 1
+    from pg_catalog.pg_attribute attribute
+    where attribute.attrelid = 'public.history'::pg_catalog.regclass
+      and attribute.attname = 'shop_id'
+      and not attribute.attisdropped
+  ) then
+    execute $sql$
+      update public.history history_row
+      set shop_id = work_order.shop_id
+      from public.work_orders work_order
+      where history_row.work_order_id = work_order.id
+        and history_row.shop_id is distinct from work_order.shop_id
+    $sql$;
+  end if;
+end
+$optional_history_shop_scope$;
 
 commit;

--- a/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
+++ b/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
@@ -40,7 +40,7 @@ where wo.shop_id is not null
   )
 group by wo.shop_id
 on conflict (shop_id, document_kind) do update
-set last_value = pg_catalog.greatest(
+set last_value = greatest(
       private.document_number_counters.last_value,
       excluded.last_value
     ),
@@ -61,11 +61,11 @@ from public.invoices i
 where i.shop_id is not null
   and i.invoice_number ~ '^INV-[0-9]{6,}$'
   and not public.invoice_is_historical_import(
-    pg_catalog.coalesce(i.metadata, '{}'::jsonb)
+    coalesce(i.metadata, '{}'::jsonb)
   )
 group by i.shop_id
 on conflict (shop_id, document_kind) do update
-set last_value = pg_catalog.greatest(
+set last_value = greatest(
       private.document_number_counters.last_value,
       excluded.last_value
     ),
@@ -134,7 +134,7 @@ as $function$
 begin
   if new.shop_id is not null
      and (
-       pg_catalog.nullif(pg_catalog.btrim(new.custom_id), '') is null
+       nullif(pg_catalog.btrim(new.custom_id), '') is null
        or new.custom_id ~ '^WO-[0-9A-Fa-f]{12}$'
      ) then
     new.custom_id := private.next_customer_document_number(
@@ -166,10 +166,10 @@ set search_path = ''
 as $function$
 begin
   if not public.invoice_is_historical_import(
-       pg_catalog.coalesce(new.metadata, '{}'::jsonb)
+       coalesce(new.metadata, '{}'::jsonb)
      )
      and (
-       pg_catalog.nullif(pg_catalog.btrim(new.invoice_number), '') is null
+       nullif(pg_catalog.btrim(new.invoice_number), '') is null
        or new.invoice_number ~ '^WO-[0-9A-Fa-f]{8}$'
      ) then
     new.invoice_number := private.next_customer_document_number(
@@ -205,7 +205,7 @@ begin
     from public.work_orders wo
     where wo.shop_id is not null
       and (
-        pg_catalog.nullif(pg_catalog.btrim(wo.custom_id), '') is null
+        nullif(pg_catalog.btrim(wo.custom_id), '') is null
         or wo.custom_id ~ '^WO-[0-9A-Fa-f]{12}$'
       )
     order by wo.created_at nulls last, wo.id
@@ -225,10 +225,10 @@ begin
     select i.id
     from public.invoices i
     where not public.invoice_is_historical_import(
-            pg_catalog.coalesce(i.metadata, '{}'::jsonb)
+            coalesce(i.metadata, '{}'::jsonb)
           )
       and (
-        pg_catalog.nullif(pg_catalog.btrim(i.invoice_number), '') is null
+        nullif(pg_catalog.btrim(i.invoice_number), '') is null
         or i.invoice_number ~ '^WO-[0-9A-Fa-f]{8}$'
       )
     order by i.created_at nulls last, i.id
@@ -262,7 +262,7 @@ declare
   v_technician_name text;
   v_notes text;
 begin
-  if pg_catalog.lower(pg_catalog.coalesce(new.payment_status, '')) <> 'paid'
+  if pg_catalog.lower(coalesce(new.payment_status, '')) <> 'paid'
      or new.customer_id is null then
     return new;
   end if;
@@ -280,33 +280,33 @@ begin
 
   select
     pg_catalog.string_agg(
-      distinct pg_catalog.coalesce(
-        pg_catalog.nullif(pg_catalog.btrim(wol.complaint), ''),
-        pg_catalog.nullif(pg_catalog.btrim(wol.description), '')
+      distinct coalesce(
+        nullif(pg_catalog.btrim(wol.complaint), ''),
+        nullif(pg_catalog.btrim(wol.description), '')
       ),
       E'\n'
     ),
     pg_catalog.string_agg(
-      distinct pg_catalog.nullif(pg_catalog.btrim(wol.cause), ''),
+      distinct nullif(pg_catalog.btrim(wol.cause), ''),
       E'\n'
     ),
     pg_catalog.string_agg(
-      distinct pg_catalog.nullif(pg_catalog.btrim(wol.correction), ''),
+      distinct nullif(pg_catalog.btrim(wol.correction), ''),
       E'\n'
     ),
-    pg_catalog.coalesce(pg_catalog.sum(wol.labor_time), 0)
+    coalesce(pg_catalog.sum(wol.labor_time), 0)
   into v_symptoms, v_causes, v_corrections, v_labor_hours
   from public.work_order_lines wol
   where wol.work_order_id = new.id
     and wol.voided_at is null;
 
-  v_description := pg_catalog.coalesce(
-    pg_catalog.nullif(pg_catalog.btrim(v_symptoms), ''),
-    pg_catalog.nullif(pg_catalog.btrim(new.notes), ''),
-    'Completed work order ' || pg_catalog.coalesce(new.custom_id, new.id::text)
+  v_description := coalesce(
+    nullif(pg_catalog.btrim(v_symptoms), ''),
+    nullif(pg_catalog.btrim(new.notes), ''),
+    'Completed work order ' || coalesce(new.custom_id, new.id::text)
   );
 
-  v_odometer := pg_catalog.coalesce(
+  v_odometer := coalesce(
     new.vehicle_mileage::text,
     new.odometer_km::text
   );
@@ -319,13 +319,13 @@ begin
       and v.shop_id = new.shop_id;
   end if;
 
-  select pg_catalog.nullif(pg_catalog.btrim(p.full_name), '')
+  select nullif(pg_catalog.btrim(p.full_name), '')
   into v_advisor_name
   from public.profiles p
   where p.id = new.advisor_id;
 
   select pg_catalog.string_agg(
-    distinct pg_catalog.nullif(pg_catalog.btrim(p.full_name), ''),
+    distinct nullif(pg_catalog.btrim(p.full_name), ''),
     ', '
   )
   into v_technician_name
@@ -333,7 +333,7 @@ begin
   left join public.work_order_line_technicians wolt
     on wolt.work_order_line_id = wol.id
   left join public.profiles p
-    on p.id = pg_catalog.coalesce(
+    on p.id = coalesce(
       wolt.technician_id,
       wol.assigned_tech_id,
       wol.assigned_to
@@ -343,11 +343,11 @@ begin
 
   v_notes := pg_catalog.concat_ws(
     E'\n',
-    'Work order: ' || pg_catalog.coalesce(new.custom_id, new.id::text),
+    'Work order: ' || coalesce(new.custom_id, new.id::text),
     case when v_invoice.invoice_number is not null
       then 'Invoice: ' || v_invoice.invoice_number else null end,
     'Payment: paid',
-    pg_catalog.nullif(pg_catalog.btrim(new.notes), '')
+    nullif(pg_catalog.btrim(new.notes), '')
   );
 
   select h.id
@@ -368,18 +368,18 @@ begin
       approval_state, payment_state, source_payload, shop_id
     ) values (
       new.customer_id, new.vehicle_id, new.id,
-      pg_catalog.coalesce(new.paid_at, pg_catalog.now()), v_description,
+      coalesce(new.paid_at, pg_catalog.now()), v_description,
       v_notes, 'profixiq_live', new.id::text, new.custom_id,
       v_invoice.invoice_number, new.created_at,
-      pg_catalog.coalesce(new.paid_at, pg_catalog.now()), 'paid',
+      coalesce(new.paid_at, pg_catalog.now()), 'paid',
       v_advisor_name, v_technician_name, new.priority::text, v_odometer,
       v_symptoms, v_causes, v_corrections, v_labor_hours,
-      pg_catalog.coalesce(v_invoice.labor_cost, new.labor_total, 0),
-      pg_catalog.coalesce(v_invoice.parts_cost, new.parts_total, 0),
-      pg_catalog.coalesce(v_invoice.shop_supplies_total, 0),
-      pg_catalog.coalesce(v_invoice.discount_total, 0),
-      pg_catalog.coalesce(v_invoice.tax_total, 0),
-      pg_catalog.coalesce(v_invoice.total, new.invoice_total, 0),
+      coalesce(v_invoice.labor_cost, new.labor_total, 0),
+      coalesce(v_invoice.parts_cost, new.parts_total, 0),
+      coalesce(v_invoice.shop_supplies_total, 0),
+      coalesce(v_invoice.discount_total, 0),
+      coalesce(v_invoice.tax_total, 0),
+      coalesce(v_invoice.total, new.invoice_total, 0),
       new.approval_state, new.payment_status,
       pg_catalog.jsonb_build_object(
         'work_order_id', new.id,
@@ -393,7 +393,7 @@ begin
     update public.history
     set customer_id = new.customer_id,
         vehicle_id = new.vehicle_id,
-        service_date = pg_catalog.coalesce(new.paid_at, pg_catalog.now()),
+        service_date = coalesce(new.paid_at, pg_catalog.now()),
         description = v_description,
         notes = v_notes,
         source_system = 'profixiq_live',
@@ -401,7 +401,7 @@ begin
         work_order_number = new.custom_id,
         invoice_number = v_invoice.invoice_number,
         opened_at = new.created_at,
-        closed_at = pg_catalog.coalesce(new.paid_at, pg_catalog.now()),
+        closed_at = coalesce(new.paid_at, pg_catalog.now()),
         historical_status = 'paid',
         advisor_name = v_advisor_name,
         assigned_tech_name = v_technician_name,
@@ -411,20 +411,20 @@ begin
         cause = v_causes,
         correction = v_corrections,
         labor_hours = v_labor_hours,
-        labor_sale = pg_catalog.coalesce(
+        labor_sale = coalesce(
           v_invoice.labor_cost,
           new.labor_total,
           0
         ),
-        parts_sale = pg_catalog.coalesce(
+        parts_sale = coalesce(
           v_invoice.parts_cost,
           new.parts_total,
           0
         ),
-        shop_supplies = pg_catalog.coalesce(v_invoice.shop_supplies_total, 0),
-        discount = pg_catalog.coalesce(v_invoice.discount_total, 0),
-        tax = pg_catalog.coalesce(v_invoice.tax_total, 0),
-        total = pg_catalog.coalesce(v_invoice.total, new.invoice_total, 0),
+        shop_supplies = coalesce(v_invoice.shop_supplies_total, 0),
+        discount = coalesce(v_invoice.discount_total, 0),
+        tax = coalesce(v_invoice.tax_total, 0),
+        total = coalesce(v_invoice.total, new.invoice_total, 0),
         approval_state = new.approval_state,
         payment_state = new.payment_status,
         source_payload = pg_catalog.jsonb_build_object(
@@ -462,12 +462,12 @@ with paid_rows as (
     v.mileage as vehicle_odometer,
     i.id as invoice_id,
     i.invoice_number,
-    pg_catalog.coalesce(i.labor_cost, wo.labor_total, 0) as labor_sale,
-    pg_catalog.coalesce(i.parts_cost, wo.parts_total, 0) as parts_sale,
-    pg_catalog.coalesce(i.shop_supplies_total, 0) as shop_supplies,
-    pg_catalog.coalesce(i.discount_total, 0) as discount,
-    pg_catalog.coalesce(i.tax_total, 0) as tax,
-    pg_catalog.coalesce(i.total, wo.invoice_total, 0) as total
+    coalesce(i.labor_cost, wo.labor_total, 0) as labor_sale,
+    coalesce(i.parts_cost, wo.parts_total, 0) as parts_sale,
+    coalesce(i.shop_supplies_total, 0) as shop_supplies,
+    coalesce(i.discount_total, 0) as discount,
+    coalesce(i.tax_total, 0) as tax,
+    coalesce(i.total, wo.invoice_total, 0) as total
   from public.work_orders wo
   left join public.vehicles v
     on v.id = wo.vehicle_id
@@ -489,21 +489,21 @@ line_rollup as (
   select
     wol.work_order_id,
     pg_catalog.string_agg(
-      distinct pg_catalog.coalesce(
-        pg_catalog.nullif(pg_catalog.btrim(wol.complaint), ''),
-        pg_catalog.nullif(pg_catalog.btrim(wol.description), '')
+      distinct coalesce(
+        nullif(pg_catalog.btrim(wol.complaint), ''),
+        nullif(pg_catalog.btrim(wol.description), '')
       ),
       E'\n'
     ) as symptom,
     pg_catalog.string_agg(
-      distinct pg_catalog.nullif(pg_catalog.btrim(wol.cause), ''),
+      distinct nullif(pg_catalog.btrim(wol.cause), ''),
       E'\n'
     ) as cause,
     pg_catalog.string_agg(
-      distinct pg_catalog.nullif(pg_catalog.btrim(wol.correction), ''),
+      distinct nullif(pg_catalog.btrim(wol.correction), ''),
       E'\n'
     ) as correction,
-    pg_catalog.coalesce(pg_catalog.sum(wol.labor_time), 0) as labor_hours
+    coalesce(pg_catalog.sum(wol.labor_time), 0) as labor_hours
   from public.work_order_lines wol
   join paid_rows paid on paid.work_order_id = wol.work_order_id
   where wol.voided_at is null
@@ -512,14 +512,14 @@ line_rollup as (
 update public.history h
 set work_order_number = paid.custom_id,
     invoice_number = paid.invoice_number,
-    description = pg_catalog.coalesce(
-      pg_catalog.nullif(pg_catalog.btrim(lines.symptom), ''),
+    description = coalesce(
+      nullif(pg_catalog.btrim(lines.symptom), ''),
       h.description
     ),
     symptom = lines.symptom,
     cause = lines.cause,
     correction = lines.correction,
-    odometer = pg_catalog.coalesce(
+    odometer = coalesce(
       paid.vehicle_mileage::text,
       paid.odometer_km::text,
       paid.vehicle_odometer::text,
@@ -534,7 +534,7 @@ set work_order_number = paid.custom_id,
     total = paid.total,
     historical_status = 'paid',
     payment_state = 'paid',
-    source_payload = pg_catalog.coalesce(h.source_payload, '{}'::jsonb)
+    source_payload = coalesce(h.source_payload, '{}'::jsonb)
       || pg_catalog.jsonb_build_object(
         'work_order_id', paid.work_order_id,
         'invoice_id', paid.invoice_id,

--- a/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
+++ b/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
@@ -18,6 +18,16 @@ create table if not exists private.document_number_counters (
 revoke all on table private.document_number_counters
   from public, anon, authenticated;
 
+-- The clean baseline still carries a legacy global custom-id constraint,
+-- while production is correctly tenant-scoped. Per-shop counters require the
+-- same tenant-scoped uniqueness contract in both database shapes.
+alter table public.work_orders
+  drop constraint if exists work_orders_custom_id_key;
+
+create unique index if not exists work_orders_shop_custom_id_uniq
+  on public.work_orders (shop_id, custom_id)
+  where custom_id is not null;
+
 -- Preserve the numeric sequence already used by legacy staff-created work
 -- orders (for example EL000008). Imported invoice numbers are intentionally
 -- excluded because they belong to the source system's numbering sequence.

--- a/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
+++ b/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
@@ -1,0 +1,548 @@
+-- Give every live work order and invoice a stable, shop-scoped customer-facing
+-- document number. The counters live outside the exposed Data API schema and
+-- are advanced atomically so concurrent portal/staff creation cannot collide.
+
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '15min';
+
+create table if not exists private.document_number_counters (
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  document_kind text not null check (document_kind in ('work_order', 'invoice')),
+  last_value bigint not null default 0 check (last_value >= 0),
+  updated_at timestamptz not null default pg_catalog.now(),
+  primary key (shop_id, document_kind)
+);
+
+revoke all on table private.document_number_counters
+  from public, anon, authenticated;
+
+-- Preserve the numeric sequence already used by legacy staff-created work
+-- orders (for example EL000008). Imported invoice numbers are intentionally
+-- excluded because they belong to the source system's numbering sequence.
+insert into private.document_number_counters (
+  shop_id,
+  document_kind,
+  last_value
+)
+select
+  wo.shop_id,
+  'work_order',
+  pg_catalog.max(
+    pg_catalog.substring(wo.custom_id from '([0-9]+)$')::bigint
+  )
+from public.work_orders wo
+where wo.shop_id is not null
+  and (
+    wo.custom_id ~ '^[A-Za-z]{1,4}[0-9]{6}$'
+    or wo.custom_id ~ '^WO-[0-9]{6,}$'
+  )
+group by wo.shop_id
+on conflict (shop_id, document_kind) do update
+set last_value = pg_catalog.greatest(
+      private.document_number_counters.last_value,
+      excluded.last_value
+    ),
+    updated_at = pg_catalog.now();
+
+insert into private.document_number_counters (
+  shop_id,
+  document_kind,
+  last_value
+)
+select
+  i.shop_id,
+  'invoice',
+  pg_catalog.max(
+    pg_catalog.substring(i.invoice_number from '^INV-([0-9]+)$')::bigint
+  )
+from public.invoices i
+where i.shop_id is not null
+  and i.invoice_number ~ '^INV-[0-9]{6,}$'
+  and not public.invoice_is_historical_import(
+    pg_catalog.coalesce(i.metadata, '{}'::jsonb)
+  )
+group by i.shop_id
+on conflict (shop_id, document_kind) do update
+set last_value = pg_catalog.greatest(
+      private.document_number_counters.last_value,
+      excluded.last_value
+    ),
+    updated_at = pg_catalog.now();
+
+create or replace function private.next_customer_document_number(
+  p_shop_id uuid,
+  p_document_kind text
+)
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_next bigint;
+  v_prefix text;
+begin
+  if p_shop_id is null then
+    raise exception using
+      errcode = '23502',
+      message = 'A shop is required to allocate a document number.';
+  end if;
+
+  v_prefix := case p_document_kind
+    when 'work_order' then 'WO-'
+    when 'invoice' then 'INV-'
+    else null
+  end;
+
+  if v_prefix is null then
+    raise exception using
+      errcode = '22023',
+      message = 'Unsupported customer document kind.';
+  end if;
+
+  insert into private.document_number_counters (
+    shop_id,
+    document_kind,
+    last_value,
+    updated_at
+  ) values (
+    p_shop_id,
+    p_document_kind,
+    1,
+    pg_catalog.now()
+  )
+  on conflict (shop_id, document_kind) do update
+  set last_value = private.document_number_counters.last_value + 1,
+      updated_at = pg_catalog.now()
+  returning last_value into v_next;
+
+  return v_prefix || pg_catalog.lpad(v_next::text, 6, '0');
+end;
+$function$;
+
+revoke all on function private.next_customer_document_number(uuid, text)
+  from public, anon, authenticated, service_role;
+
+create or replace function private.assign_work_order_customer_number()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+begin
+  if new.shop_id is not null
+     and (
+       pg_catalog.nullif(pg_catalog.btrim(new.custom_id), '') is null
+       or new.custom_id ~ '^WO-[0-9A-Fa-f]{12}$'
+     ) then
+    new.custom_id := private.next_customer_document_number(
+      new.shop_id,
+      'work_order'
+    );
+  end if;
+
+  return new;
+end;
+$function$;
+
+revoke all on function private.assign_work_order_customer_number()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists trg_assign_work_order_customer_number
+  on public.work_orders;
+create trigger trg_assign_work_order_customer_number
+before insert or update of shop_id, custom_id
+on public.work_orders
+for each row
+execute function private.assign_work_order_customer_number();
+
+create or replace function private.assign_invoice_customer_number()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+begin
+  if not public.invoice_is_historical_import(
+       pg_catalog.coalesce(new.metadata, '{}'::jsonb)
+     )
+     and (
+       pg_catalog.nullif(pg_catalog.btrim(new.invoice_number), '') is null
+       or new.invoice_number ~ '^WO-[0-9A-Fa-f]{8}$'
+     ) then
+    new.invoice_number := private.next_customer_document_number(
+      new.shop_id,
+      'invoice'
+    );
+  end if;
+
+  return new;
+end;
+$function$;
+
+revoke all on function private.assign_invoice_customer_number()
+  from public, anon, authenticated, service_role;
+
+drop trigger if exists trg_assign_invoice_customer_number
+  on public.invoices;
+create trigger trg_assign_invoice_customer_number
+before insert or update of shop_id, invoice_number, metadata
+on public.invoices
+for each row
+execute function private.assign_invoice_customer_number();
+
+-- Backfill live records deterministically. Existing legitimate custom/imported
+-- identifiers remain unchanged; only missing numbers and the old WO-<uuid>
+-- invoice fallback are replaced.
+do $backfill_work_orders$
+declare
+  v_id uuid;
+begin
+  for v_id in
+    select wo.id
+    from public.work_orders wo
+    where wo.shop_id is not null
+      and (
+        pg_catalog.nullif(pg_catalog.btrim(wo.custom_id), '') is null
+        or wo.custom_id ~ '^WO-[0-9A-Fa-f]{12}$'
+      )
+    order by wo.created_at nulls last, wo.id
+  loop
+    update public.work_orders
+    set custom_id = null
+    where id = v_id;
+  end loop;
+end;
+$backfill_work_orders$;
+
+do $backfill_invoices$
+declare
+  v_id uuid;
+begin
+  for v_id in
+    select i.id
+    from public.invoices i
+    where not public.invoice_is_historical_import(
+            pg_catalog.coalesce(i.metadata, '{}'::jsonb)
+          )
+      and (
+        pg_catalog.nullif(pg_catalog.btrim(i.invoice_number), '') is null
+        or i.invoice_number ~ '^WO-[0-9A-Fa-f]{8}$'
+      )
+    order by i.created_at nulls last, i.id
+  loop
+    update public.invoices
+    set invoice_number = null
+    where id = v_id;
+  end loop;
+end;
+$backfill_invoices$;
+
+-- Repair the paid-history projection. Complaint/cause/correction remain
+-- separate fields, the summary no longer concatenates them with slashes, and
+-- the recorded odometer follows work-order intake before vehicle fallback.
+create or replace function public.sync_paid_work_order_history()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_invoice public.invoices%rowtype;
+  v_history_id uuid;
+  v_description text;
+  v_symptoms text;
+  v_causes text;
+  v_corrections text;
+  v_odometer text;
+  v_labor_hours numeric := 0;
+  v_advisor_name text;
+  v_technician_name text;
+  v_notes text;
+begin
+  if pg_catalog.lower(pg_catalog.coalesce(new.payment_status, '')) <> 'paid'
+     or new.customer_id is null then
+    return new;
+  end if;
+
+  select i.*
+  into v_invoice
+  from public.invoices i
+  where i.work_order_id = new.id
+    and i.shop_id = new.shop_id
+  order by
+    (i.active_invoice_version_id is not null) desc,
+    i.issued_at desc nulls last,
+    i.created_at desc
+  limit 1;
+
+  select
+    pg_catalog.string_agg(
+      distinct pg_catalog.coalesce(
+        pg_catalog.nullif(pg_catalog.btrim(wol.complaint), ''),
+        pg_catalog.nullif(pg_catalog.btrim(wol.description), '')
+      ),
+      E'\n'
+    ),
+    pg_catalog.string_agg(
+      distinct pg_catalog.nullif(pg_catalog.btrim(wol.cause), ''),
+      E'\n'
+    ),
+    pg_catalog.string_agg(
+      distinct pg_catalog.nullif(pg_catalog.btrim(wol.correction), ''),
+      E'\n'
+    ),
+    pg_catalog.coalesce(pg_catalog.sum(wol.labor_time), 0)
+  into v_symptoms, v_causes, v_corrections, v_labor_hours
+  from public.work_order_lines wol
+  where wol.work_order_id = new.id
+    and wol.voided_at is null;
+
+  v_description := pg_catalog.coalesce(
+    pg_catalog.nullif(pg_catalog.btrim(v_symptoms), ''),
+    pg_catalog.nullif(pg_catalog.btrim(new.notes), ''),
+    'Completed work order ' || pg_catalog.coalesce(new.custom_id, new.id::text)
+  );
+
+  v_odometer := pg_catalog.coalesce(
+    new.vehicle_mileage::text,
+    new.odometer_km::text
+  );
+
+  if v_odometer is null then
+    select v.mileage::text
+    into v_odometer
+    from public.vehicles v
+    where v.id = new.vehicle_id
+      and v.shop_id = new.shop_id;
+  end if;
+
+  select pg_catalog.nullif(pg_catalog.btrim(p.full_name), '')
+  into v_advisor_name
+  from public.profiles p
+  where p.id = new.advisor_id;
+
+  select pg_catalog.string_agg(
+    distinct pg_catalog.nullif(pg_catalog.btrim(p.full_name), ''),
+    ', '
+  )
+  into v_technician_name
+  from public.work_order_lines wol
+  left join public.work_order_line_technicians wolt
+    on wolt.work_order_line_id = wol.id
+  left join public.profiles p
+    on p.id = pg_catalog.coalesce(
+      wolt.technician_id,
+      wol.assigned_tech_id,
+      wol.assigned_to
+    )
+  where wol.work_order_id = new.id
+    and wol.voided_at is null;
+
+  v_notes := pg_catalog.concat_ws(
+    E'\n',
+    'Work order: ' || pg_catalog.coalesce(new.custom_id, new.id::text),
+    case when v_invoice.invoice_number is not null
+      then 'Invoice: ' || v_invoice.invoice_number else null end,
+    'Payment: paid',
+    pg_catalog.nullif(pg_catalog.btrim(new.notes), '')
+  );
+
+  select h.id
+  into v_history_id
+  from public.history h
+  where h.work_order_id = new.id
+  order by h.created_at asc nulls last, h.id
+  limit 1
+  for update;
+
+  if v_history_id is null then
+    insert into public.history (
+      customer_id, vehicle_id, work_order_id, service_date, description,
+      notes, source_system, source_external_id, work_order_number,
+      invoice_number, opened_at, closed_at, historical_status, advisor_name,
+      assigned_tech_name, priority, odometer, symptom, cause, correction,
+      labor_hours, labor_sale, parts_sale, shop_supplies, discount, tax, total,
+      approval_state, payment_state, source_payload, shop_id
+    ) values (
+      new.customer_id, new.vehicle_id, new.id,
+      pg_catalog.coalesce(new.paid_at, pg_catalog.now()), v_description,
+      v_notes, 'profixiq_live', new.id::text, new.custom_id,
+      v_invoice.invoice_number, new.created_at,
+      pg_catalog.coalesce(new.paid_at, pg_catalog.now()), 'paid',
+      v_advisor_name, v_technician_name, new.priority::text, v_odometer,
+      v_symptoms, v_causes, v_corrections, v_labor_hours,
+      pg_catalog.coalesce(v_invoice.labor_cost, new.labor_total, 0),
+      pg_catalog.coalesce(v_invoice.parts_cost, new.parts_total, 0),
+      pg_catalog.coalesce(v_invoice.shop_supplies_total, 0),
+      pg_catalog.coalesce(v_invoice.discount_total, 0),
+      pg_catalog.coalesce(v_invoice.tax_total, 0),
+      pg_catalog.coalesce(v_invoice.total, new.invoice_total, 0),
+      new.approval_state, new.payment_status,
+      pg_catalog.jsonb_build_object(
+        'work_order_id', new.id,
+        'invoice_id', v_invoice.id,
+        'closed_from', 'paid_invoice'
+      ),
+      new.shop_id
+    )
+    returning id into v_history_id;
+  else
+    update public.history
+    set customer_id = new.customer_id,
+        vehicle_id = new.vehicle_id,
+        service_date = pg_catalog.coalesce(new.paid_at, pg_catalog.now()),
+        description = v_description,
+        notes = v_notes,
+        source_system = 'profixiq_live',
+        source_external_id = new.id::text,
+        work_order_number = new.custom_id,
+        invoice_number = v_invoice.invoice_number,
+        opened_at = new.created_at,
+        closed_at = pg_catalog.coalesce(new.paid_at, pg_catalog.now()),
+        historical_status = 'paid',
+        advisor_name = v_advisor_name,
+        assigned_tech_name = v_technician_name,
+        priority = new.priority::text,
+        odometer = v_odometer,
+        symptom = v_symptoms,
+        cause = v_causes,
+        correction = v_corrections,
+        labor_hours = v_labor_hours,
+        labor_sale = pg_catalog.coalesce(
+          v_invoice.labor_cost,
+          new.labor_total,
+          0
+        ),
+        parts_sale = pg_catalog.coalesce(
+          v_invoice.parts_cost,
+          new.parts_total,
+          0
+        ),
+        shop_supplies = pg_catalog.coalesce(v_invoice.shop_supplies_total, 0),
+        discount = pg_catalog.coalesce(v_invoice.discount_total, 0),
+        tax = pg_catalog.coalesce(v_invoice.tax_total, 0),
+        total = pg_catalog.coalesce(v_invoice.total, new.invoice_total, 0),
+        approval_state = new.approval_state,
+        payment_state = new.payment_status,
+        source_payload = pg_catalog.jsonb_build_object(
+          'work_order_id', new.id,
+          'invoice_id', v_invoice.id,
+          'closed_from', 'paid_invoice'
+        ),
+        shop_id = new.shop_id
+    where id = v_history_id;
+  end if;
+
+  return new;
+end;
+$function$;
+
+revoke all on function public.sync_paid_work_order_history()
+  from public, anon, authenticated, service_role;
+
+-- Refresh existing live paid-history projections without altering immutable
+-- invoice versions or payment events.
+with paid_rows as (
+  select
+    wo.id as work_order_id,
+    wo.shop_id,
+    wo.customer_id,
+    wo.vehicle_id,
+    wo.custom_id,
+    wo.created_at,
+    wo.paid_at,
+    wo.priority,
+    wo.approval_state,
+    wo.payment_status,
+    wo.vehicle_mileage,
+    wo.odometer_km,
+    v.mileage as vehicle_odometer,
+    i.id as invoice_id,
+    i.invoice_number,
+    pg_catalog.coalesce(i.labor_cost, wo.labor_total, 0) as labor_sale,
+    pg_catalog.coalesce(i.parts_cost, wo.parts_total, 0) as parts_sale,
+    pg_catalog.coalesce(i.shop_supplies_total, 0) as shop_supplies,
+    pg_catalog.coalesce(i.discount_total, 0) as discount,
+    pg_catalog.coalesce(i.tax_total, 0) as tax,
+    pg_catalog.coalesce(i.total, wo.invoice_total, 0) as total
+  from public.work_orders wo
+  left join public.vehicles v
+    on v.id = wo.vehicle_id
+   and v.shop_id = wo.shop_id
+  left join lateral (
+    select invoice.*
+    from public.invoices invoice
+    where invoice.work_order_id = wo.id
+      and invoice.shop_id = wo.shop_id
+    order by
+      (invoice.active_invoice_version_id is not null) desc,
+      invoice.issued_at desc nulls last,
+      invoice.created_at desc
+    limit 1
+  ) i on true
+  where wo.payment_status = 'paid'
+),
+line_rollup as (
+  select
+    wol.work_order_id,
+    pg_catalog.string_agg(
+      distinct pg_catalog.coalesce(
+        pg_catalog.nullif(pg_catalog.btrim(wol.complaint), ''),
+        pg_catalog.nullif(pg_catalog.btrim(wol.description), '')
+      ),
+      E'\n'
+    ) as symptom,
+    pg_catalog.string_agg(
+      distinct pg_catalog.nullif(pg_catalog.btrim(wol.cause), ''),
+      E'\n'
+    ) as cause,
+    pg_catalog.string_agg(
+      distinct pg_catalog.nullif(pg_catalog.btrim(wol.correction), ''),
+      E'\n'
+    ) as correction,
+    pg_catalog.coalesce(pg_catalog.sum(wol.labor_time), 0) as labor_hours
+  from public.work_order_lines wol
+  join paid_rows paid on paid.work_order_id = wol.work_order_id
+  where wol.voided_at is null
+  group by wol.work_order_id
+)
+update public.history h
+set work_order_number = paid.custom_id,
+    invoice_number = paid.invoice_number,
+    description = pg_catalog.coalesce(
+      pg_catalog.nullif(pg_catalog.btrim(lines.symptom), ''),
+      h.description
+    ),
+    symptom = lines.symptom,
+    cause = lines.cause,
+    correction = lines.correction,
+    odometer = pg_catalog.coalesce(
+      paid.vehicle_mileage::text,
+      paid.odometer_km::text,
+      paid.vehicle_odometer::text,
+      h.odometer
+    ),
+    labor_hours = lines.labor_hours,
+    labor_sale = paid.labor_sale,
+    parts_sale = paid.parts_sale,
+    shop_supplies = paid.shop_supplies,
+    discount = paid.discount,
+    tax = paid.tax,
+    total = paid.total,
+    historical_status = 'paid',
+    payment_state = 'paid',
+    source_payload = pg_catalog.coalesce(h.source_payload, '{}'::jsonb)
+      || pg_catalog.jsonb_build_object(
+        'work_order_id', paid.work_order_id,
+        'invoice_id', paid.invoice_id,
+        'closed_from', 'paid_invoice'
+      )
+from paid_rows paid
+join line_rollup lines on lines.work_order_id = paid.work_order_id
+where h.work_order_id = paid.work_order_id
+  and h.shop_id = paid.shop_id;
+
+commit;

--- a/tests/customer-document-consistency.test.ts
+++ b/tests/customer-document-consistency.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const migration = read(
+  "supabase/migrations/20260806010306_canonical_customer_document_numbers.sql",
+);
+const invoicePreview = read(
+  "features/work-orders/components/InvoicePreviewPageClient.tsx",
+);
+const portalInvoice = read("app/portal/invoices/[id]/page.tsx");
+const portalInvoiceList = read("app/portal/invoices/page.tsx");
+const billing = read("app/billing/page.tsx");
+const history = read(
+  "features/work-orders/components/ImportedHistoryRecordCard.tsx",
+);
+const paidWorkOrder = read("app/work-orders/[id]/Client.tsx");
+
+describe("customer document consistency", () => {
+  it("allocates stable shop-scoped work-order and invoice numbers", () => {
+    expect(migration).toContain("private.document_number_counters");
+    expect(migration).toContain("on conflict (shop_id, document_kind) do update");
+    expect(migration).toContain("'WO-'");
+    expect(migration).toContain("'INV-'");
+    expect(migration).toContain("trg_assign_work_order_customer_number");
+    expect(migration).toContain("trg_assign_invoice_customer_number");
+    expect(migration).toContain("^WO-[0-9A-Fa-f]{12}$");
+    expect(migration).toContain("^WO-[0-9A-Fa-f]{8}$");
+  });
+
+  it("keeps private numbering helpers unavailable through the Data API", () => {
+    expect(migration).toContain("set search_path = ''");
+    expect(migration).toContain(
+      "from public, anon, authenticated, service_role;",
+    );
+    expect(migration).not.toContain("grant execute");
+  });
+
+  it("repairs paid history without flattening the repair story", () => {
+    expect(migration).toContain("v_symptoms, v_causes, v_corrections");
+    expect(migration).toContain("symptom = lines.symptom");
+    expect(migration).toContain("cause = lines.cause");
+    expect(migration).toContain("correction = lines.correction");
+    expect(migration).toContain("new.vehicle_mileage::text");
+    expect(migration).toContain("new.odometer_km::text");
+    expect(history).toContain('["Complaint", row.symptom]');
+    expect(history).toContain('["Cause", row.cause]');
+    expect(history).toContain('["Correction", row.correction]');
+  });
+
+  it("shows customer-facing identity and narratives throughout invoice views", () => {
+    expect(invoicePreview).toContain('{invoiceNumber || "Draft invoice"}');
+    expect(invoicePreview).toContain('["Complaint", line.complaint]');
+    expect(invoicePreview).toContain('["Cause", line.cause]');
+    expect(invoicePreview).toContain('["Correction", line.correction]');
+    expect(invoicePreview).toContain("inspectionPdfLoading || inspectionPdf");
+    expect(portalInvoice).toContain("identity.invoiceNumber");
+    expect(portalInvoice).toContain("Complaint:");
+    expect(portalInvoiceList).toContain("invoiceLabels");
+  });
+
+  it("treats paid work as immutable history across billing and the cockpit", () => {
+    expect(billing).toContain('r.payment_status === "paid"');
+    expect(billing).toContain("Open paid invoice");
+    expect(billing).toContain("`/work-orders/view/${r.id}`");
+    expect(paidWorkOrder).toContain("shouldUseReadOnlyWorkOrderView");
+    expect(paidWorkOrder).toContain("router.replace(`/work-orders/view/${wo.id}`)");
+  });
+});

--- a/tests/customer-document-consistency.test.ts
+++ b/tests/customer-document-consistency.test.ts
@@ -21,6 +21,10 @@ describe("customer document consistency", () => {
   it("allocates stable shop-scoped work-order and invoice numbers", () => {
     expect(migration).toContain("private.document_number_counters");
     expect(migration).toContain("on conflict (shop_id, document_kind) do update");
+    expect(migration).toContain(
+      "drop constraint if exists work_orders_custom_id_key",
+    );
+    expect(migration).toContain("work_orders_shop_custom_id_uniq");
     expect(migration).toContain("'WO-'");
     expect(migration).toContain("'INV-'");
     expect(migration).toContain("trg_assign_work_order_customer_number");

--- a/tests/customer-document-consistency.test.ts
+++ b/tests/customer-document-consistency.test.ts
@@ -42,8 +42,9 @@ describe("customer document consistency", () => {
     expect(migration).toContain("symptom = lines.symptom");
     expect(migration).toContain("cause = lines.cause");
     expect(migration).toContain("correction = lines.correction");
-    expect(migration).toContain("new.vehicle_mileage::text");
-    expect(migration).toContain("new.odometer_km::text");
+    expect(migration).toContain("v_odometer := coalesce(");
+    expect(migration).toContain("new.vehicle_mileage,");
+    expect(migration).toContain("new.odometer_km");
     expect(history).toContain('["Complaint", row.symptom]');
     expect(history).toContain('["Cause", row.cause]');
     expect(history).toContain('["Correction", row.correction]');

--- a/tests/invoices/customer-document-numbering.runtime.sql
+++ b/tests/invoices/customer-document-numbering.runtime.sql
@@ -1,0 +1,137 @@
+\set ON_ERROR_STOP on
+
+begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values (
+  'a6000000-0000-4000-8000-000000000001',
+  'document-number-runtime-owner@example.com',
+  '{"full_name":"Document Number Runtime Owner"}'::jsonb
+)
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values (
+  'a6000000-0000-4000-8000-000000000001',
+  'a6000000-0000-4000-8000-000000000001',
+  'owner',
+  'Document Number Runtime Owner'
+)
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+insert into public.shops (id, owner_id, business_name, name)
+values (
+  'b6000000-0000-4000-8000-000000000001',
+  'a6000000-0000-4000-8000-000000000001',
+  'Document Number Runtime Shop',
+  'Document Number Runtime Shop'
+)
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = 'b6000000-0000-4000-8000-000000000001'
+where id = 'a6000000-0000-4000-8000-000000000001';
+
+insert into public.work_orders (id, shop_id, status, type, custom_id)
+values
+  (
+    'c6000000-0000-4000-8000-000000000001',
+    'b6000000-0000-4000-8000-000000000001',
+    'in_progress',
+    'repair',
+    null
+  ),
+  (
+    'c6000000-0000-4000-8000-000000000002',
+    'b6000000-0000-4000-8000-000000000001',
+    'in_progress',
+    'repair',
+    'WO-deadbeefcafe'
+  );
+
+do $$
+declare
+  v_first text;
+  v_second text;
+begin
+  select custom_id into v_first
+  from public.work_orders
+  where id = 'c6000000-0000-4000-8000-000000000001';
+
+  select custom_id into v_second
+  from public.work_orders
+  where id = 'c6000000-0000-4000-8000-000000000002';
+
+  if v_first !~ '^WO-[0-9]{6,}$'
+     or v_second !~ '^WO-[0-9]{6,}$'
+     or v_first = v_second then
+    raise exception 'Runtime assertion failed: work-order numbers are not canonical and unique.';
+  end if;
+end
+$$;
+
+insert into public.invoices (
+  id,
+  shop_id,
+  work_order_id,
+  invoice_number,
+  status,
+  subtotal,
+  discount_total,
+  tax_total,
+  total,
+  currency
+)
+values
+  (
+    'd6000000-0000-4000-8000-000000000001',
+    'b6000000-0000-4000-8000-000000000001',
+    'c6000000-0000-4000-8000-000000000001',
+    null,
+    'draft',
+    0,
+    0,
+    0,
+    0,
+    'CAD'
+  ),
+  (
+    'd6000000-0000-4000-8000-000000000002',
+    'b6000000-0000-4000-8000-000000000001',
+    'c6000000-0000-4000-8000-000000000002',
+    'WO-deadbeef',
+    'draft',
+    0,
+    0,
+    0,
+    0,
+    'CAD'
+  );
+
+do $$
+declare
+  v_first text;
+  v_second text;
+begin
+  select invoice_number into v_first
+  from public.invoices
+  where id = 'd6000000-0000-4000-8000-000000000001';
+
+  select invoice_number into v_second
+  from public.invoices
+  where id = 'd6000000-0000-4000-8000-000000000002';
+
+  if v_first !~ '^INV-[0-9]{6,}$'
+     or v_second !~ '^INV-[0-9]{6,}$'
+     or v_first = v_second then
+    raise exception 'Runtime assertion failed: invoice numbers are not canonical and unique.';
+  end if;
+end
+$$;
+
+select 'customer_document_numbering_runtime_ok' as result;
+
+rollback;


### PR DESCRIPTION
## What changed

- allocate durable shop-scoped customer-facing work-order and invoice numbers
- backfill missing and machine-generated UUID-derived document labels
- overlay repaired canonical numbers onto immutable invoice snapshots and PDFs
- show complaint, cause, and correction separately in shop and portal invoice views
- repair paid service history numbers, odometer, amounts, currency, and narrative fields
- route paid work orders to the read-only service view and remove mutable billing actions
- hide empty inspection sections when no inspection exists
- add focused unit/source tests and a clean-replay PostgreSQL runtime integration

## Root cause

Portal-created records and invoice finalization could persist null or UUID-derived labels, while frozen invoice snapshots retained those missing values. Paid-history projection flattened complaint/cause/correction into a slash-delimited description and did not reliably carry odometer or canonical document identity. Paid work orders also remained reachable through mutable cockpit routes.

The visually duplicated billing cards are two separate durable work orders. This PR fixes representation and future numbering; cancelling the exact stale QA booking/work order remains an explicit production data-cleanup step after deployment approval.

## Safety

- counters live in the private schema and are advanced atomically per shop/document kind
- trigger helpers use an empty search path and have execution revoked from API roles
- historical imported invoice numbers are preserved
- immutable invoice versions and payment events are not rewritten
- customer portal invoice reads remain constrained by the existing own-work-order RLS policy
- production DDL and stale-record cancellation are not performed by this PR

## Validation

- local diff and whitespace checks passed
- local Node/Docker tooling is unavailable in this workspace
- CI is configured to run TypeScript, lint, tests, the full Supabase clean replay, and the new customer-document numbering runtime integration