### PR TITLE
Add Forged Redline Brand Studio theme

### DIFF
--- a/features/branding/components/BrandThemeBoot.tsx
+++ b/features/branding/components/BrandThemeBoot.tsx
@@ -181,6 +181,14 @@ function setPresetVars(root: HTMLElement, preset: string | null | undefined) {
       appGlow =
         "var(--theme-gradient-panel)";
       break;
+    case "forged-redline":
+      glassBg = "rgba(17, 18, 20, 0.88)";
+      glassBgSoft = "rgba(9, 9, 10, 0.72)";
+      metalBorderSoft = "rgba(201, 205, 209, 0.32)";
+      metalBorderStrong = "rgba(201, 205, 209, 0.64)";
+      appGlow =
+        "radial-gradient(900px 480px at 90% -10%, rgba(226, 27, 35, 0.16), transparent 60%), var(--theme-gradient-panel)";
+      break;
     case "fleet-utility":
       glassBg = "var(--theme-surface-inset)";
       glassBgSoft = "var(--theme-surface-inset)";

--- a/features/branding/lib/brandStylePresets.test.ts
+++ b/features/branding/lib/brandStylePresets.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { BRAND_STYLE_PRESETS, getBrandStylePreset } from "./brandStylePresets";
 
 describe("brand style presets", () => {
-  it("provides five complete and visually distinct presets", () => {
-    expect(BRAND_STYLE_PRESETS).toHaveLength(5);
+  it("provides complete and visually distinct presets", () => {
+    expect(BRAND_STYLE_PRESETS).toHaveLength(12);
 
     const values = BRAND_STYLE_PRESETS.map(({ value }) =>
       getBrandStylePreset(value),
     );
-    expect(new Set(values.map((preset) => preset.primaryColor)).size).toBe(5);
+    expect(new Set(values.map((preset) => preset.primaryColor)).size).toBe(12);
     expect(
       new Set(values.map((preset) => preset.appBackground)).size,
     ).toBeGreaterThan(2);
@@ -20,6 +20,16 @@ describe("brand style presets", () => {
       expect(preset.inputText).toMatch(/^#[0-9A-F]{6}$/i);
       expect(preset.dashboardBackgroundBase).toMatch(/^#[0-9A-F]{6}$/i);
     }
+  });
+
+  it("provides the original red, black, and chrome Forged Redline system", () => {
+    const preset = getBrandStylePreset("forged-redline");
+
+    expect(preset.primaryColor).toBe("#E21B23");
+    expect(preset.secondaryColor).toBe("#0A0A0B");
+    expect(preset.accentColor).toBe("#C9CDD1");
+    expect(preset.dashboardBackgroundMode).toBe("gradient");
+    expect(preset.stylePreset).toBe("forged-redline");
   });
 
   it("returns a copy so callers cannot mutate the catalog", () => {

--- a/features/branding/lib/brandStylePresets.ts
+++ b/features/branding/lib/brandStylePresets.ts
@@ -1,6 +1,7 @@
 export type BrandStylePreset =
   | "profixiq-blue"
   | "industrial-dark"
+  | "forged-redline"
   | "clean-oem"
   | "performance"
   | "fleet-utility"
@@ -59,6 +60,12 @@ export const BRAND_STYLE_PRESETS: ReadonlyArray<{
     value: "industrial-dark",
     label: "Industrial Dark",
     description: "Graphite surfaces with warm copper service accents.",
+  },
+  {
+    value: "forged-redline",
+    label: "Forged Redline",
+    description:
+      "Signal red, carbon black, and satin chrome with a precision-shop feel.",
   },
   {
     value: "clean-oem",
@@ -150,6 +157,16 @@ const PRESETS: Record<BrandStylePreset, BrandStylePresetValues> = {
     buttonSecondaryBg: "#1E293B", buttonSecondaryText: "#F8FAFC", inputBackground: "#0F172A", inputBorder: "#475569",
     inputText: "#F8FAFC", dashboardBackgroundMode: "solid", dashboardBackgroundBase: "#0B1120", dashboardAmbientTint: "#C97A3D",
     dashboardGradientStart: "#1E293B", dashboardGradientEnd: "#0B1120", dashboardGradientAccent: "#7C2D12",
+  },
+  "forged-redline": {
+    primaryColor: "#E21B23", secondaryColor: "#0A0A0B", accentColor: "#C9CDD1", stylePreset: "forged-redline",
+    appBackground: "#070708", appBackgroundSecondary: "#111214", sidebarBackground: "#09090A", sidebarText: "#D7DADD",
+    sidebarActiveBackground: "#E21B23", sidebarActiveText: "#FFFFFF", headerBackground: "#0B0B0C", headerText: "#F7F7F5",
+    cardBackground: "#151719", cardBorder: "#6D747C", surface2Background: "#202327", textPrimary: "#F5F6F7",
+    textSecondary: "#C5C9CD", textMuted: "#8A9096", buttonPrimaryBg: "#E21B23", buttonPrimaryText: "#FFFFFF",
+    buttonSecondaryBg: "#2C3034", buttonSecondaryText: "#F4F5F6", inputBackground: "#0D0F11", inputBorder: "#59616A",
+    inputText: "#F7F7F5", dashboardBackgroundMode: "gradient", dashboardBackgroundBase: "#08090A", dashboardAmbientTint: "#E21B23",
+    dashboardGradientStart: "#3B0B0F", dashboardGradientEnd: "#08090A", dashboardGradientAccent: "#C9CDD1",
   },
   "clean-oem": {
     primaryColor: "#1F4E79", secondaryColor: "#E8EEF5", accentColor: "#3B82B6", stylePreset: "clean-oem",

--- a/features/branding/server/logo-generation.test.ts
+++ b/features/branding/server/logo-generation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { buildLogoPrompt } from "./logo-generation";
+
+describe("brand logo generation", () => {
+  it("keeps Forged Redline original and free of existing tool branding", () => {
+    const prompt = buildLogoPrompt({
+      shopName: "Precision Auto",
+      prompt: "Create a strong shop mark",
+      stylePreset: "forged-redline",
+      transparentBackground: true,
+    });
+
+    expect(prompt).toContain("signal red, carbon black, and satin chrome");
+    expect(prompt).toContain("Do not reference or imitate");
+    expect(prompt).not.toMatch(/snap[- ]?on/i);
+  });
+});

--- a/features/branding/server/logo-generation.ts
+++ b/features/branding/server/logo-generation.ts
@@ -2,6 +2,7 @@ import OpenAI from "openai";
 
 export type LogoPreset =
   | "industrial-dark"
+  | "forged-redline"
   | "clean-oem"
   | "performance"
   | "fleet-utility"
@@ -17,6 +18,8 @@ type BuildLogoPromptInput = {
 const PRESET_GUIDANCE: Record<LogoPreset, string> = {
   "industrial-dark":
     "Industrial premium aesthetic. Dark metallic feel, sharp geometry, strong contrast, rugged but refined.",
+  "forged-redline":
+    "Original precision-shop aesthetic with signal red, carbon black, and satin chrome. Use bold engineered geometry, subtle metalwork cues, and strong contrast. Do not reference or imitate any existing tool manufacturer, trademark, logo, or trade dress.",
   "clean-oem":
     "Clean OEM service aesthetic. Minimal, trustworthy, modern, dealership-grade, balanced spacing.",
   performance:


### PR DESCRIPTION
## What changed

- adds **Forged Redline** as a native Brand Studio preset
- applies an original signal-red, carbon-black, gunmetal, and satin-chrome token system across app surfaces, navigation, controls, and dashboard ambience
- adds preset-specific chrome/glass runtime material styling
- adds logo-generation guidance that explicitly avoids existing tool manufacturers, trademarks, logos, and trade dress
- updates preset coverage and adds a regression test for the originality constraint

## Why

Brand Studio did not have a precision-shop red/black/chrome option. This adds that industrial direction through the existing preset architecture, without introducing third-party branding or a parallel theming system.

## User impact

Owners can select **Forged Redline** from the existing Brand Studio style preset menu, preview it, customize it, and save it using the current workflow.

## Validation

- `vitest run features/branding/lib/brandStylePresets.test.ts features/branding/server/logo-generation.test.ts` — 2 files, 4 tests passed
- focused ESLint on all five changed files — passed
- focused TypeScript validation on all five changed files — passed
- `git diff --check` — passed

Full repository-wide typecheck, lint, test, and build were not run because this checkout intentionally materialized only the Brand Studio dependency slice of the very large repository.

## Operations

- Database migration: none
- Environment variables: none
- Manual deployment steps: none