### PR TITLE
Restore legacy complaint text in service history

### DIFF
--- a/.github/workflows/customer-document-consistency-validation.yml
+++ b/.github/workflows/customer-document-consistency-validation.yml
@@ -35,6 +35,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: >-
           pnpm exec eslint
+          app/work-orders/history/WorkOrdersHistoryClient.tsx
           features/work-orders/components/ImportedHistoryRecordCard.tsx
           features/work-orders/lib/display/historyNarratives.ts
           features/work-orders/lib/display/historyNarratives.test.ts

--- a/.github/workflows/customer-document-consistency-validation.yml
+++ b/.github/workflows/customer-document-consistency-validation.yml
@@ -1,0 +1,46 @@
+name: Customer Document Consistency
+
+on:
+  pull_request:
+    paths:
+      - "app/billing/**"
+      - "app/portal/invoices/**"
+      - "app/work-orders/history/**"
+      - "features/invoices/**"
+      - "features/work-orders/components/ImportedHistoryRecordCard.tsx"
+      - "features/work-orders/components/InvoicePreviewPageClient.tsx"
+      - "features/work-orders/lib/display/historyNarratives.ts"
+      - "features/work-orders/lib/display/historyNarratives.test.ts"
+      - "features/work-orders/lib/display/workOrderPresentation.ts"
+      - "features/work-orders/lib/display/workOrderPresentation.test.ts"
+      - "tests/customer-document-consistency.test.ts"
+      - ".github/workflows/customer-document-consistency-validation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: >-
+          pnpm exec eslint
+          features/work-orders/components/ImportedHistoryRecordCard.tsx
+          features/work-orders/lib/display/historyNarratives.ts
+          features/work-orders/lib/display/historyNarratives.test.ts
+      - run: >-
+          pnpm exec vitest run
+          features/invoices/server/canonicalDocumentIdentity.test.ts
+          features/work-orders/lib/display/historyNarratives.test.ts
+          features/work-orders/lib/display/workOrderPresentation.test.ts
+          tests/customer-document-consistency.test.ts

--- a/.github/workflows/customer-document-consistency-validation.yml
+++ b/.github/workflows/customer-document-consistency-validation.yml
@@ -35,6 +35,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: >-
           pnpm exec eslint
+          app/billing/page.tsx
           app/work-orders/history/WorkOrdersHistoryClient.tsx
           features/work-orders/components/ImportedHistoryRecordCard.tsx
           features/work-orders/lib/display/historyNarratives.ts

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -655,8 +655,13 @@ export default function BillingPage(): JSX.Element {
 
             const laborTotal = Number(r.resolved_labor_total ?? 0);
             const partsTotal = Number(r.resolved_parts_total ?? 0);
+            const shopSuppliesTotal = Number(
+              r.resolved_shop_supplies_total ?? 0,
+            );
+            const taxTotal = Number(r.resolved_tax_total ?? 0);
             const invoiceTotal = Number(
-              r.resolved_invoice_total ?? laborTotal + partsTotal,
+              r.resolved_invoice_total ??
+                laborTotal + partsTotal + shopSuppliesTotal + taxTotal,
             );
             const pricingAvailable = !r.pricing_error;
             const billingState = r.pricing_error
@@ -764,6 +769,26 @@ export default function BillingPage(): JSX.Element {
                       </div>
                       <div className="mt-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
                         {pricingAvailable ? formatMoney(partsTotal) : "—"}
+                      </div>
+                    </div>
+
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-3">
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                        Shop supplies
+                      </div>
+                      <div className="mt-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                        {pricingAvailable
+                          ? formatMoney(shopSuppliesTotal)
+                          : "—"}
+                      </div>
+                    </div>
+
+                    <div className="rounded-xl border border-[color:var(--desktop-border)] bg-[color:var(--desktop-item-bg)] px-3 py-3">
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--theme-text-muted)]">
+                        Tax
+                      </div>
+                      <div className="mt-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
+                        {pricingAvailable ? formatMoney(taxTotal) : "—"}
                       </div>
                     </div>
 

--- a/app/work-orders/history/WorkOrdersHistoryClient.tsx
+++ b/app/work-orders/history/WorkOrdersHistoryClient.tsx
@@ -119,7 +119,6 @@ export default function WorkOrdersHistoryClient(): JSX.Element {
           ? "CAD"
           : "USD",
       );
-      setLoading(false);
     })();
   }, [supabase]);
 

--- a/features/work-orders/components/ImportedHistoryRecordCard.tsx
+++ b/features/work-orders/components/ImportedHistoryRecordCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { resolveHistoryNarratives } from "@/features/work-orders/lib/display/historyNarratives";
 
 type VehicleLike = {
   year?: string | number | null;
@@ -112,10 +113,11 @@ export function ImportedHistoryRecordCard({
   currency = "CAD",
 }: Props): JSX.Element {
   const detailsId = `imported-history-details-${row.id}`;
+  const resolvedNarratives = resolveHistoryNarratives(row);
   const narratives = [
-    ["Complaint", row.symptom],
-    ["Cause", row.cause],
-    ["Correction", row.correction],
+    ["Complaint", resolvedNarratives.complaint],
+    ["Cause", resolvedNarratives.cause],
+    ["Correction", resolvedNarratives.correction],
   ] as const;
   const hasNarratives = narratives.some(([, value]) => Boolean(value?.trim()));
   const serviceSummary =

--- a/features/work-orders/lib/display/historyNarratives.test.ts
+++ b/features/work-orders/lib/display/historyNarratives.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveHistoryNarratives } from "./historyNarratives";
+
+describe("history narratives", () => {
+  it("uses canonical complaint, cause, and correction when present", () => {
+    expect(
+      resolveHistoryNarratives({
+        description: "Legacy complaint / Legacy cause / Legacy correction",
+        symptom: "Customer complaint",
+        cause: "Verified cause",
+        correction: "Completed correction",
+      }),
+    ).toEqual({
+      complaint: "Customer complaint",
+      cause: "Verified cause",
+      correction: "Completed correction",
+    });
+  });
+
+  it("recovers a missing complaint from a legacy slash-delimited description", () => {
+    expect(
+      resolveHistoryNarratives({
+        description:
+          "Oil and filter change. / Scheduled oil service was due based on mileage. / Replaced the oil filter and verified there were no leaks.",
+        symptom: null,
+        cause: "Scheduled oil service was due based on mileage.",
+        correction:
+          "Replaced the oil filter and verified there were no leaks.",
+      }),
+    ).toEqual({
+      complaint: "Oil and filter change.",
+      cause: "Scheduled oil service was due based on mileage.",
+      correction:
+        "Replaced the oil filter and verified there were no leaks.",
+    });
+  });
+
+  it("does not mistake an unstructured service summary for a complaint", () => {
+    expect(
+      resolveHistoryNarratives({
+        description: "Routine maintenance service",
+      }),
+    ).toEqual({ complaint: null, cause: null, correction: null });
+  });
+});

--- a/features/work-orders/lib/display/historyNarratives.ts
+++ b/features/work-orders/lib/display/historyNarratives.ts
@@ -1,0 +1,37 @@
+export type HistoryNarratives = {
+  complaint: string | null;
+  cause: string | null;
+  correction: string | null;
+};
+
+function clean(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+export function resolveHistoryNarratives(input: {
+  description?: string | null;
+  symptom?: string | null;
+  cause?: string | null;
+  correction?: string | null;
+}): HistoryNarratives {
+  const descriptionParts = (input.description ?? "")
+    .split(/\s+\/\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const hasLegacyStructuredDescription = descriptionParts.length >= 2;
+
+  return {
+    complaint:
+      clean(input.symptom) ??
+      (hasLegacyStructuredDescription ? descriptionParts[0] : null),
+    cause:
+      clean(input.cause) ??
+      (hasLegacyStructuredDescription ? descriptionParts[1] : null),
+    correction:
+      clean(input.correction) ??
+      (descriptionParts.length >= 3
+        ? descriptionParts.slice(2).join(" / ")
+        : null),
+  };
+}

--- a/tests/customer-document-consistency.test.ts
+++ b/tests/customer-document-consistency.test.ts
@@ -15,6 +15,9 @@ const billing = read("app/billing/page.tsx");
 const history = read(
   "features/work-orders/components/ImportedHistoryRecordCard.tsx",
 );
+const historyNarratives = read(
+  "features/work-orders/lib/display/historyNarratives.ts",
+);
 const paidWorkOrder = read("app/work-orders/[id]/Client.tsx");
 
 describe("customer document consistency", () => {
@@ -49,9 +52,12 @@ describe("customer document consistency", () => {
     expect(migration).toContain("v_odometer := coalesce(");
     expect(migration).toContain("new.vehicle_mileage,");
     expect(migration).toContain("new.odometer_km");
-    expect(history).toContain('["Complaint", row.symptom]');
-    expect(history).toContain('["Cause", row.cause]');
-    expect(history).toContain('["Correction", row.correction]');
+    expect(history).toContain("resolveHistoryNarratives(row)");
+    expect(history).toContain('["Complaint", resolvedNarratives.complaint]');
+    expect(history).toContain('["Cause", resolvedNarratives.cause]');
+    expect(history).toContain('["Correction", resolvedNarratives.correction]');
+    expect(historyNarratives).toContain("clean(input.symptom)");
+    expect(historyNarratives).toContain(".split(/\\s+\\/\\s+/)");
   });
 
   it("shows customer-facing identity and narratives throughout invoice views", () => {

--- a/tests/customer-document-consistency.test.ts
+++ b/tests/customer-document-consistency.test.ts
@@ -69,6 +69,9 @@ describe("customer document consistency", () => {
     expect(portalInvoice).toContain("identity.invoiceNumber");
     expect(portalInvoice).toContain("Complaint:");
     expect(portalInvoiceList).toContain("invoiceLabels");
+    expect(billing).toContain("resolved_shop_supplies_total");
+    expect(billing).toContain("Shop supplies");
+    expect(billing).toContain("resolved_tax_total");
   });
 
   it("treats paid work as immutable history across billing and the cockpit", () => {


### PR DESCRIPTION
## Root cause

Live closeout history can have `symptom = null` while retaining Complaint / Cause / Correction in the legacy slash-delimited `description`. The structured card trusted only `symptom`, so it displayed “Complaint: Not recorded” even though the complaint was durable.

The history bootstrap also ended its loading state immediately after resolving the shop, before the history query had resolved. That could briefly present “No service history found” on first load.

Billing cards showed labor and parts but hid shop supplies and tax, so their visible components did not reconcile to the invoice total.

## What changed

- resolve structured history narratives in one pure helper
- prefer canonical `symptom`, `cause`, and `correction` fields
- fall back only when the legacy description uses explicit spaced slash delimiters
- keep History loading until the records query completes
- show Labor, Parts, Shop supplies, Tax, and Invoice total on Billing cards
- cover canonical precedence, legacy recovery, unstructured summaries, and complete billing totals
- add a focused customer-document presentation CI gate

## Validation

- `git diff --check` passed
- focused ESLint passed for Billing, History, and narrative presentation
- 12 focused Vitest assertions passed across invoice identity, history narratives, paid-state presentation, and the customer-document consistency contract
- CI: https://github.com/EdwardLakin/ProFixIQ/actions/runs/31065750090
- live production evidence: the affected history record has a null `symptom` and a three-part legacy description; the $266.86 invoice consists of $181.93 labor, $69.93 parts, and $15.00 shop supplies
