### PR TITLE
Keep customer shell off Fleet sign-in

### DIFF
--- a/app/portal/layout.tsx
+++ b/app/portal/layout.tsx
@@ -1,7 +1,22 @@
 // app/portal/layout.tsx
 import type { ReactNode } from "react";
+import { headers } from "next/headers";
 import PortalShell from "@/features/portal/components/PortalShell";
+import { isFleetProductHostname } from "@/features/fleet/lib/fleetProductRouting";
 
-export default function PortalLayout({ children }: { children: ReactNode }) {
+export default async function PortalLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const requestHeaders = await headers();
+  const isFleetProductHost =
+    requestHeaders.get("x-profixiq-product-host") === "fleet" ||
+    isFleetProductHostname(
+      requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host"),
+    );
+
+  if (isFleetProductHost) return children;
+
   return <PortalShell>{children}</PortalShell>;
 }

--- a/tests/portal-shell-product-boundary.test.tsx
+++ b/tests/portal-shell-product-boundary.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import PortalLayout from "../app/portal/layout";
+
+const headerFixture = vi.hoisted(() => ({
+  values: new Map<string, string>(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: async () => ({
+    get: (name: string) => headerFixture.values.get(name) ?? null,
+  }),
+}));
+
+vi.mock("@/features/portal/components/PortalShell", () => ({
+  default: ({ children }: { children: ReactNode }) => (
+    <div data-testid="customer-portal-shell">{children}</div>
+  ),
+}));
+
+beforeEach(() => {
+  headerFixture.values.clear();
+});
+
+describe("Portal shell product boundary", () => {
+  it("does not wrap Fleet rewrites in the customer portal shell", async () => {
+    headerFixture.values.set("x-profixiq-product-host", "fleet");
+    const children = <main>Fleet sign in</main>;
+
+    await expect(PortalLayout({ children })).resolves.toBe(children);
+  });
+
+  it("does not wrap direct Fleet host requests in the customer portal shell", async () => {
+    headerFixture.values.set("host", "fleet.profixiq.com");
+    const children = <main>Fleet workspace</main>;
+
+    await expect(PortalLayout({ children })).resolves.toBe(children);
+  });
+
+  it("preserves the customer portal shell on the Shop host", async () => {
+    headerFixture.values.set("host", "profixiq.com");
+    const children = <main>Customer portal</main>;
+
+    const result = await PortalLayout({ children });
+
+    expect(result).not.toBe(children);
+    expect(result).toMatchObject({ props: { children } });
+  });
+});


### PR DESCRIPTION
## What changed
- make the portal layout bypass the customer portal shell for trusted Fleet product-host requests
- retain the customer portal shell on the Shop/customer host
- add focused coverage for middleware-marked Fleet rewrites, direct Fleet host requests, and the Shop host

## Root cause
The Fleet public route `/sign-in` is internally rewritten to `/portal/auth/fleet-sign-in`. The client-side `PortalShell` uses the browser-visible pathname, so it continued to see `/sign-in` and did not recognize the route as portal auth. That wrapped the Fleet sign-in page in the customer portal shell.

## Validation
The connected Vercel project received both commits. Preview builds are configured with an ignored-build rule and were intentionally canceled before build execution, so production verification will follow the main deployment.