### PR TITLE
Build Fleet PM scheduling and maintenance calendar

### DIFF
--- a/.github/workflows/fleet-premier-validation.yml
+++ b/.github/workflows/fleet-premier-validation.yml
@@ -9,6 +9,7 @@ on:
       - "app/portal/fleet/**"
       - "features/fleet/**"
       - "tests/fleet-operations-core.test.ts"
+      - "tests/fleet-pm-calendar-management.test.ts"
       - "tests/fleet-premier-workspaces.test.ts"
       - "tests/fleet-pretrip-defect-compliance.test.ts"
       - ".github/workflows/fleet-premier-validation.yml"
@@ -39,6 +40,7 @@ jobs:
           app/api/fleet/billing/checkout/route.ts
           app/api/fleet/billing/route.ts
           app/api/fleet/maintenance/route.ts
+          app/api/fleet/calendar/route.ts
           app/api/fleet/service-requests/route.ts
           app/api/fleet/units/route.ts
           app/api/internal/fleet/pretrip-compliance/route.ts
@@ -48,6 +50,7 @@ jobs:
           app/fleet/service-requests/page.tsx
           "app/fleet/units/[unitId]/page.tsx"
           app/portal/fleet/layout.tsx
+          app/portal/fleet/calendar/page.tsx
           app/portal/fleet/maintenance/page.tsx
           app/portal/fleet/service-requests/page.tsx
           app/portal/fleet/units/page.tsx
@@ -56,16 +59,20 @@ jobs:
           features/fleet/components/FleetBillingWorkspace.tsx
           features/fleet/components/FleetControlTower.tsx
           features/fleet/components/FleetMaintenanceWorkspace.tsx
+          features/fleet/components/FleetMaintenanceCalendar.tsx
+          features/fleet/components/FleetPmProgramEditor.tsx
           features/fleet/components/FleetServiceRequestsPage.tsx
           features/fleet/components/FleetUnitDetailWorkspace.tsx
           features/fleet/components/FleetUnitsPage.tsx
           features/fleet/components/FleetWorkspaceNav.tsx
           features/fleet/types/workspace.ts
           tests/fleet-premier-workspaces.test.ts
+          tests/fleet-pm-calendar-management.test.ts
           tests/fleet-pretrip-defect-compliance.test.ts
       - name: Fleet contracts
         run: >-
           pnpm exec vitest run
           tests/fleet-operations-core.test.ts
+          tests/fleet-pm-calendar-management.test.ts
           tests/fleet-premier-workspaces.test.ts
           tests/fleet-pretrip-defect-compliance.test.ts

--- a/app/api/fleet/calendar/route.ts
+++ b/app/api/fleet/calendar/route.ts
@@ -1,0 +1,380 @@
+import { NextResponse } from "next/server";
+
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
+import {
+  resolveFleetActorContext,
+  resolveFleetActorScope,
+} from "@/features/fleet/lib/resolveFleetActorContext";
+
+export const dynamic = "force-dynamic";
+
+type Row = Record<string, unknown>;
+type CalendarEvent = {
+  id: string;
+  fleetId: string;
+  fleetName: string;
+  vehicleId: string;
+  unitLabel: string;
+  vehicleDescription: string;
+  date: string | null;
+  endDate: string | null;
+  type:
+    | "pm_due"
+    | "pm_forecast"
+    | "service_request"
+    | "inspection"
+    | "shop_service";
+  state: string;
+  title: string;
+  detail: string;
+  href: string;
+};
+function rows(value: unknown): Row[] {
+  return Array.isArray(value) ? (value as Row[]) : [];
+}
+
+function clean(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function dateOnly(value: unknown): string | null {
+  const raw = clean(value);
+  if (!raw) return null;
+  const date = new Date(raw.length === 10 ? `${raw}T00:00:00Z` : raw);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
+}
+
+function addDays(value: unknown, days: unknown): string | null {
+  const start = dateOnly(value);
+  const interval = Number(days);
+  if (!start || !Number.isFinite(interval) || interval <= 0) return null;
+  const date = new Date(`${start}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + interval);
+  return date.toISOString().slice(0, 10);
+}
+
+export async function GET(request: Request) {
+  try {
+    const supabase = createServerSupabaseRoute();
+    const requestedFleetId = clean(
+      new URL(request.url).searchParams.get("fleetId"),
+    );
+    const actor = await resolveFleetActorContext(supabase, {
+      requestedFleetId,
+    });
+    if (!actor.userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    if (actor.actorType === "fleet_driver") {
+      return NextResponse.json(
+        { error: "Fleet manager access required" },
+        { status: 403 },
+      );
+    }
+
+    const scope = resolveFleetActorScope(actor, {
+      explicitFleetId: requestedFleetId,
+    });
+    if (!scope?.shopId) {
+      return NextResponse.json(
+        { error: "Fleet access required" },
+        { status: 403 },
+      );
+    }
+
+    const admin = createAdminSupabase();
+    let fleetQuery = admin
+      .from("fleets")
+      .select("id,name")
+      .eq("shop_id", scope.shopId)
+      .eq("active", true)
+      .order("name", { ascending: true });
+    if (scope.fleetIds?.length)
+      fleetQuery = fleetQuery.in("id", scope.fleetIds);
+    const { data: fleetData, error: fleetError } = await fleetQuery;
+    if (fleetError) throw new Error(fleetError.message);
+
+    const fleets = rows(fleetData);
+    const fleetIds = fleets.map((fleet) => String(fleet.id));
+    if (!fleetIds.length) {
+      return NextResponse.json({
+        fleets: [],
+        summary: { due: 0, planned: 0, inspections: 0, unscheduled: 0 },
+        events: [],
+      });
+    }
+
+    const { data: enrollmentData, error: enrollmentError } = await admin
+      .from("fleet_vehicles")
+      .select("fleet_id,vehicle_id,nickname")
+      .eq("shop_id", scope.shopId)
+      .in("fleet_id", fleetIds)
+      .eq("active", true);
+    if (enrollmentError) throw new Error(enrollmentError.message);
+    const enrollments = rows(enrollmentData);
+    const vehicleIds = Array.from(
+      new Set(enrollments.map((row) => String(row.vehicle_id))),
+    );
+    if (!vehicleIds.length) {
+      return NextResponse.json({
+        fleets: fleets.map((fleet) => ({
+          id: String(fleet.id),
+          name: clean(fleet.name) ?? "Fleet",
+        })),
+        summary: { due: 0, planned: 0, inspections: 0, unscheduled: 0 },
+        events: [],
+      });
+    }
+
+    const calendarHistoryStart = new Date(
+      Date.now() - 365 * 86_400_000,
+    ).toISOString();
+    const [
+      vehicleResult,
+      policyResult,
+      dueResult,
+      requestResult,
+      inspectionResult,
+      workOrderResult,
+    ] = await Promise.all([
+      admin
+        .from("vehicles")
+        .select("id,unit_number,license_plate,vin,year,make,model")
+        .eq("shop_id", scope.shopId)
+        .in("id", vehicleIds),
+      admin
+        .from("fleet_pm_policies")
+        .select(
+          "id,fleet_id,vehicle_id,program_id,name,interval_days,anchor_date,active",
+        )
+        .in("fleet_id", fleetIds)
+        .eq("active", true),
+      admin
+        .from("fleet_pm_due_events")
+        .select(
+          "id,fleet_id,vehicle_id,policy_id,status,first_due_at,deferred_until,service_request_id",
+        )
+        .in("fleet_id", fleetIds)
+        .in("status", ["pending", "deferred", "converted"]),
+      admin
+        .from("fleet_service_requests")
+        .select(
+          "id,fleet_id,vehicle_id,title,status,requested_for_date,scheduled_for_date,work_order_id,source_pm_due_event_id",
+        )
+        .eq("shop_id", scope.shopId)
+        .in("fleet_id", fleetIds)
+        .not("status", "in", "(completed,closed,cancelled)"),
+      admin
+        .from("fleet_inspection_schedules")
+        .select("id,fleet_id,vehicle_id,next_inspection_date")
+        .eq("shop_id", scope.shopId)
+        .in("fleet_id", fleetIds),
+      admin
+        .from("work_orders")
+        .select(
+          "id,vehicle_id,custom_id,status,scheduled_at,expected_completion_at,source_fleet_service_request_id",
+        )
+        .eq("shop_id", scope.shopId)
+        .in("vehicle_id", vehicleIds)
+        .gte("scheduled_at", calendarHistoryStart)
+        .not("scheduled_at", "is", null),
+    ]);
+    const firstError = [
+      vehicleResult.error,
+      policyResult.error,
+      dueResult.error,
+      requestResult.error,
+      inspectionResult.error,
+      workOrderResult.error,
+    ].find(Boolean);
+    if (firstError) throw new Error(firstError.message);
+
+    const fleetNames = new Map(
+      fleets.map((fleet) => [String(fleet.id), clean(fleet.name) ?? "Fleet"]),
+    );
+    const vehicles = new Map(
+      rows(vehicleResult.data).map((vehicle) => [String(vehicle.id), vehicle]),
+    );
+    const enrollmentByVehicle = new Map(
+      enrollments.map((enrollment) => [
+        String(enrollment.vehicle_id),
+        enrollment,
+      ]),
+    );
+    const vehicleLabel = (vehicleId: string) => {
+      const enrollment = enrollmentByVehicle.get(vehicleId) ?? {};
+      const vehicle = vehicles.get(vehicleId) ?? {};
+      return (
+        clean(enrollment.nickname) ??
+        clean(vehicle.unit_number) ??
+        clean(vehicle.license_plate) ??
+        clean(vehicle.vin) ??
+        "Unit"
+      );
+    };
+    const vehicleDescription = (vehicleId: string) => {
+      const vehicle = vehicles.get(vehicleId) ?? {};
+      return [vehicle.year, clean(vehicle.make), clean(vehicle.model)]
+        .filter(Boolean)
+        .join(" ");
+    };
+
+    const dueByPolicy = new Map(
+      rows(dueResult.data).map((due) => [String(due.policy_id), due]),
+    );
+    const workOrdersByRequest = new Map(
+      rows(workOrderResult.data)
+        .filter((row) => clean(row.source_fleet_service_request_id))
+        .map((row) => [String(row.source_fleet_service_request_id), row]),
+    );
+
+    const events: CalendarEvent[] = [];
+    for (const policy of rows(policyResult.data)) {
+      const vehicleId = String(policy.vehicle_id);
+      const fleetId = String(policy.fleet_id);
+      const due = dueByPolicy.get(String(policy.id));
+      if (clean(due?.status) === "converted") continue;
+      const state = clean(due?.status) ?? "forecast";
+      const date = due
+        ? (dateOnly(due.deferred_until) ?? dateOnly(due.first_due_at))
+        : addDays(policy.anchor_date, policy.interval_days);
+      if (!date && !due) continue;
+      events.push({
+        id: due ? `pm:${String(due.id)}` : `forecast:${String(policy.id)}`,
+        fleetId,
+        fleetName: fleetNames.get(fleetId) ?? "Fleet",
+        vehicleId,
+        unitLabel: vehicleLabel(vehicleId),
+        vehicleDescription: vehicleDescription(vehicleId),
+        date,
+        endDate: null,
+        type: due ? "pm_due" : "pm_forecast",
+        state,
+        title: clean(policy.name) ?? "Preventive maintenance",
+        detail:
+          state === "deferred"
+            ? "Deferred review date"
+            : due
+              ? "Maintenance decision required"
+              : "Calendar-based PM forecast",
+        href: `/maintenance`,
+      });
+    }
+
+    for (const serviceRequest of rows(requestResult.data)) {
+      const requestId = String(serviceRequest.id);
+      const vehicleId = String(serviceRequest.vehicle_id);
+      const fleetId = String(serviceRequest.fleet_id);
+      const workOrder = workOrdersByRequest.get(requestId);
+      events.push({
+        id: `request:${requestId}`,
+        fleetId,
+        fleetName: fleetNames.get(fleetId) ?? "Fleet",
+        vehicleId,
+        unitLabel: vehicleLabel(vehicleId),
+        vehicleDescription: vehicleDescription(vehicleId),
+        date:
+          dateOnly(workOrder?.scheduled_at) ??
+          dateOnly(serviceRequest.scheduled_for_date) ??
+          dateOnly(serviceRequest.requested_for_date),
+        endDate: dateOnly(workOrder?.expected_completion_at),
+        type: "service_request",
+        state: clean(serviceRequest.status) ?? "open",
+        title: clean(serviceRequest.title) ?? "Service request",
+        detail: workOrder
+          ? "Connected Shop appointment"
+          : "Fleet requested service",
+        href: `/service-requests`,
+      });
+    }
+
+    for (const inspection of rows(inspectionResult.data)) {
+      const vehicleId = String(inspection.vehicle_id);
+      const fleetId = String(inspection.fleet_id);
+      events.push({
+        id: `inspection:${String(inspection.id)}`,
+        fleetId,
+        fleetName: fleetNames.get(fleetId) ?? "Fleet",
+        vehicleId,
+        unitLabel: vehicleLabel(vehicleId),
+        vehicleDescription: vehicleDescription(vehicleId),
+        date: dateOnly(inspection.next_inspection_date),
+        endDate: null,
+        type: "inspection",
+        state: "scheduled",
+        title: "Inspection due",
+        detail: "Regulatory or Fleet inspection window",
+        href: `/assets/${encodeURIComponent(vehicleId)}`,
+      });
+    }
+
+    const representedWorkOrders = new Set(
+      rows(requestResult.data)
+        .map((requestRow) => clean(requestRow.work_order_id))
+        .filter((id): id is string => Boolean(id)),
+    );
+    for (const workOrder of rows(workOrderResult.data)) {
+      const workOrderId = String(workOrder.id);
+      if (representedWorkOrders.has(workOrderId)) continue;
+      const vehicleId = String(workOrder.vehicle_id);
+      const enrollment = enrollmentByVehicle.get(vehicleId);
+      if (!enrollment) continue;
+      const fleetId = String(enrollment.fleet_id);
+      events.push({
+        id: `work-order:${workOrderId}`,
+        fleetId,
+        fleetName: fleetNames.get(fleetId) ?? "Fleet",
+        vehicleId,
+        unitLabel: vehicleLabel(vehicleId),
+        vehicleDescription: vehicleDescription(vehicleId),
+        date: dateOnly(workOrder.scheduled_at),
+        endDate: dateOnly(workOrder.expected_completion_at),
+        type: "shop_service",
+        state: clean(workOrder.status) ?? "scheduled",
+        title: clean(workOrder.custom_id) ?? "Connected Shop service",
+        detail: "Shop-planned maintenance for this Fleet asset",
+        href: `/assets/${encodeURIComponent(vehicleId)}`,
+      });
+    }
+
+    events.sort((a, b) => {
+      const aDate = typeof a.date === "string" ? a.date : "9999-12-31";
+      const bDate = typeof b.date === "string" ? b.date : "9999-12-31";
+      return (
+        aDate.localeCompare(bDate) ||
+        String(a.title).localeCompare(String(b.title))
+      );
+    });
+
+    return NextResponse.json({
+      fleets: fleets.map((fleet) => ({
+        id: String(fleet.id),
+        name: clean(fleet.name) ?? "Fleet",
+      })),
+      summary: {
+        due: events.filter((event) => event.type === "pm_due").length,
+        planned: events.filter((event) =>
+          ["service_request", "shop_service"].includes(String(event.type)),
+        ).length,
+        inspections: events.filter((event) => event.type === "inspection")
+          .length,
+        unscheduled: events.filter((event) => !event.date).length,
+      },
+      events,
+    });
+  } catch (error) {
+    console.error("[fleet/calendar] error", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to load Fleet calendar",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/fleet/maintenance/route.ts
+++ b/app/api/fleet/maintenance/route.ts
@@ -4,6 +4,7 @@ import {
   createServerSupabaseRoute,
 } from "@/features/shared/lib/supabase/server";
 import {
+  canAdministerFleetForActor,
   canManageFleetForActor,
   manageableFleetIdsForActor,
   resolveFleetActorContext,
@@ -12,14 +13,41 @@ import {
 
 export const dynamic = "force-dynamic";
 
+const UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 type Row = Record<string, unknown>;
 type Body = {
-  action?: "list" | "evaluate" | "defer" | "create_request";
+  action?:
+    | "list"
+    | "evaluate"
+    | "defer"
+    | "create_request"
+    | "save_program"
+    | "archive_program";
   fleetId?: string | null;
   vehicleId?: string | null;
   dueEventId?: string;
   deferredUntil?: string;
   reason?: string;
+  requestedForDate?: string | null;
+  programId?: string | null;
+  name?: string;
+  cadence?: string;
+  intervalKm?: number | null;
+  intervalHours?: number | null;
+  intervalDays?: number | null;
+  assignmentMode?: "all_units" | "selected_units";
+  vehicleIds?: string[];
+  tasks?: Array<{
+    description?: string;
+    jobType?: string;
+    laborHours?: number | null;
+    sectionKey?: string | null;
+  }>;
+  notes?: string | null;
+  requiresFleetApproval?: boolean;
+  operationKey?: string;
 };
 
 function rows(value: unknown): Row[] {
@@ -31,8 +59,15 @@ function clean(value: unknown): string | null {
 }
 
 function numeric(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+// Supabase's generated RPC types do not encode nullable parameters without
+// defaults, even though PostgreSQL accepts null for these optional fields.
+function nullableRpcArg<T>(value: T | null): T {
+  return value as T;
 }
 
 function canManage(
@@ -40,7 +75,9 @@ function canManage(
   fleetId?: string,
   visibleFleetIds?: string[],
 ) {
-  if (actor.isInternal) return true;
+  if (actor.isInternal) {
+    return ["owner", "admin", "manager"].includes(actor.canonicalRole);
+  }
   if (fleetId) return canManageFleetForActor(actor, fleetId);
   if (visibleFleetIds?.length) {
     return visibleFleetIds.every((id) => canManageFleetForActor(actor, id));
@@ -80,53 +117,67 @@ async function listWorkspace(
   if (!fleetIds.length) {
     return {
       canManage: canManage(actor, explicitFleetId ?? undefined, fleetIds),
+      canManagePrograms: false,
       fleets: [],
       summary: { overdue: 0, due: 0, deferred: 0, converted: 0, clearUnits: 0 },
+      units: [],
       items: [],
       programs: [],
     };
   }
 
-  const [enrollmentResult, vehicleResult, policyResult, dueResult, programResult, readingResult] =
-    await Promise.all([
-      admin
-        .from("fleet_vehicles")
-        .select("fleet_id,vehicle_id,nickname,active")
-        .in("fleet_id", fleetIds)
-        .or("active.is.null,active.eq.true"),
-      admin
-        .from("vehicles")
-        .select("id,unit_number,license_plate,vin,year,make,model")
-        .eq("shop_id", scope.shopId),
-      admin
-        .from("fleet_pm_policies")
-        .select(
-          "id,shop_id,fleet_id,vehicle_id,program_id,name,interval_km,interval_hours,interval_days,anchor_odometer_km,anchor_engine_hours,anchor_date,last_completed_at,requires_fleet_approval,active",
-        )
-        .in("fleet_id", fleetIds)
-        .eq("active", true),
-      admin
-        .from("fleet_pm_due_events")
-        .select(
-          "id,shop_id,fleet_id,vehicle_id,policy_id,program_id,status,due_reasons,due_snapshot,first_due_at,last_evaluated_at,deferred_until,service_request_id",
-        )
-        .in("fleet_id", fleetIds)
-        .in("status", ["pending", "deferred", "converted"])
-        .order("first_due_at", { ascending: true }),
-      admin
-        .from("fleet_programs")
-        .select(
-          "id,fleet_id,name,cadence,interval_km,interval_hours,interval_days,notes",
-        )
-        .in("fleet_id", fleetIds)
-        .order("name", { ascending: true }),
-      admin
-        .from("fleet_unit_readings")
-        .select("id,fleet_id,vehicle_id,odometer_km,engine_hours,recorded_at")
-        .in("fleet_id", fleetIds)
-        .order("recorded_at", { ascending: false })
-        .limit(2000),
-    ]);
+  const [
+    enrollmentResult,
+    vehicleResult,
+    policyResult,
+    dueResult,
+    programResult,
+    readingResult,
+    assignmentResult,
+  ] = await Promise.all([
+    admin
+      .from("fleet_vehicles")
+      .select("fleet_id,vehicle_id,nickname,active")
+      .in("fleet_id", fleetIds)
+      .or("active.is.null,active.eq.true"),
+    admin
+      .from("vehicles")
+      .select("id,unit_number,license_plate,vin,year,make,model")
+      .eq("shop_id", scope.shopId),
+    admin
+      .from("fleet_pm_policies")
+      .select(
+        "id,shop_id,fleet_id,vehicle_id,program_id,name,interval_km,interval_hours,interval_days,anchor_odometer_km,anchor_engine_hours,anchor_date,last_completed_at,requires_fleet_approval,active",
+      )
+      .in("fleet_id", fleetIds)
+      .eq("active", true),
+    admin
+      .from("fleet_pm_due_events")
+      .select(
+        "id,shop_id,fleet_id,vehicle_id,policy_id,program_id,status,due_reasons,due_snapshot,first_due_at,last_evaluated_at,deferred_until,service_request_id",
+      )
+      .in("fleet_id", fleetIds)
+      .in("status", ["pending", "deferred", "converted"])
+      .order("first_due_at", { ascending: true }),
+    admin
+      .from("fleet_programs")
+      .select(
+        "id,fleet_id,name,cadence,interval_km,interval_hours,interval_days,notes,assignment_mode,requires_fleet_approval,active,updated_at",
+      )
+      .in("fleet_id", fleetIds)
+      .eq("active", true)
+      .order("name", { ascending: true }),
+    admin
+      .from("fleet_unit_readings")
+      .select("id,fleet_id,vehicle_id,odometer_km,engine_hours,recorded_at")
+      .in("fleet_id", fleetIds)
+      .order("recorded_at", { ascending: false })
+      .limit(2000),
+    admin
+      .from("fleet_program_assignments")
+      .select("program_id,fleet_id,vehicle_id")
+      .in("fleet_id", fleetIds),
+  ]);
 
   const error = [
     enrollmentResult.error,
@@ -135,15 +186,32 @@ async function listWorkspace(
     dueResult.error,
     programResult.error,
     readingResult.error,
+    assignmentResult.error,
   ].find(Boolean);
   if (error) throw new Error(error.message);
 
-  const vehicles = new Map(rows(vehicleResult.data).map((row) => [String(row.id), row]));
+  const programIds = rows(programResult.data).map((row) => String(row.id));
+  const { data: taskData, error: taskError } = programIds.length
+    ? await admin
+        .from("fleet_program_tasks")
+        .select(
+          "id,program_id,display_order,description,job_type,default_labor_hours,section_key",
+        )
+        .in("program_id", programIds)
+        .order("display_order", { ascending: true })
+    : { data: [] as unknown[], error: null };
+  if (taskError) throw new Error(taskError.message);
+
+  const vehicles = new Map(
+    rows(vehicleResult.data).map((row) => [String(row.id), row]),
+  );
   const enrollments = rows(enrollmentResult.data);
   const enrollmentByVehicle = new Map(
     enrollments.map((row) => [String(row.vehicle_id), row]),
   );
-  const fleetNames = new Map(fleetRows.map((row) => [String(row.id), clean(row.name) ?? "Fleet"]));
+  const fleetNames = new Map(
+    fleetRows.map((row) => [String(row.id), clean(row.name) ?? "Fleet"]),
+  );
   const policies = rows(policyResult.data);
   const policiesById = new Map(policies.map((row) => [String(row.id), row]));
   const latestReadings = new Map<string, Row>();
@@ -185,7 +253,11 @@ async function listWorkspace(
         clean(vehicle.license_plate) ??
         clean(vehicle.vin) ??
         "Unit",
-      vehicleDescription: [vehicle.year, clean(vehicle.make), clean(vehicle.model)]
+      vehicleDescription: [
+        vehicle.year,
+        clean(vehicle.make),
+        clean(vehicle.model),
+      ]
         .filter(Boolean)
         .join(" "),
       policyId: String(due.policy_id),
@@ -213,17 +285,42 @@ async function listWorkspace(
   const assignedByProgram = new Map<string, number>();
   for (const policy of policies) {
     const programId = String(policy.program_id);
-    assignedByProgram.set(programId, (assignedByProgram.get(programId) ?? 0) + 1);
+    assignedByProgram.set(
+      programId,
+      (assignedByProgram.get(programId) ?? 0) + 1,
+    );
   }
   const dueByProgram = new Map<string, number>();
   for (const item of items) {
-    dueByProgram.set(item.programId, (dueByProgram.get(item.programId) ?? 0) + 1);
+    dueByProgram.set(
+      item.programId,
+      (dueByProgram.get(item.programId) ?? 0) + 1,
+    );
   }
 
-  const activeUnitIds = new Set(enrollments.map((row) => String(row.vehicle_id)));
+  const activeUnitIds = new Set(
+    enrollments.map((row) => String(row.vehicle_id)),
+  );
   const unitsWithDue = new Set(items.map((item) => item.vehicleId));
+  const tasksByProgram = new Map<string, Row[]>();
+  for (const task of rows(taskData)) {
+    const programId = String(task.program_id);
+    const current = tasksByProgram.get(programId) ?? [];
+    current.push(task);
+    tasksByProgram.set(programId, current);
+  }
+  const assignedVehicleIdsByProgram = new Map<string, string[]>();
+  for (const assignment of rows(assignmentResult.data)) {
+    const programId = String(assignment.program_id);
+    const current = assignedVehicleIdsByProgram.get(programId) ?? [];
+    current.push(String(assignment.vehicle_id));
+    assignedVehicleIdsByProgram.set(programId, current);
+  }
   return {
     canManage: canManage(actor, explicitFleetId ?? undefined, fleetIds),
+    canManagePrograms: fleetIds.some((id) =>
+      canAdministerFleetForActor(actor, id),
+    ),
     fleets: fleetRows.map((row) => ({
       id: String(row.id),
       name: clean(row.name) ?? "Fleet",
@@ -235,6 +332,23 @@ async function listWorkspace(
       converted: items.filter((item) => item.urgency === "converted").length,
       clearUnits: Math.max(0, activeUnitIds.size - unitsWithDue.size),
     },
+    units: enrollments.map((enrollment) => {
+      const vehicle = vehicles.get(String(enrollment.vehicle_id)) ?? {};
+      return {
+        id: String(enrollment.vehicle_id),
+        fleetId: String(enrollment.fleet_id),
+        fleetName: fleetNames.get(String(enrollment.fleet_id)) ?? "Fleet",
+        label:
+          clean(enrollment.nickname) ??
+          clean(vehicle.unit_number) ??
+          clean(vehicle.license_plate) ??
+          clean(vehicle.vin) ??
+          "Unit",
+        description: [vehicle.year, clean(vehicle.make), clean(vehicle.model)]
+          .filter(Boolean)
+          .join(" "),
+      };
+    }),
     items,
     programs: rows(programResult.data).map((program) => ({
       id: String(program.id),
@@ -246,6 +360,26 @@ async function listWorkspace(
       intervalHours: numeric(program.interval_hours),
       intervalDays: numeric(program.interval_days),
       notes: clean(program.notes),
+      assignmentMode:
+        clean(program.assignment_mode) === "selected_units"
+          ? "selected_units"
+          : "all_units",
+      requiresFleetApproval: program.requires_fleet_approval !== false,
+      assignedVehicleIds:
+        clean(program.assignment_mode) === "selected_units"
+          ? (assignedVehicleIdsByProgram.get(String(program.id)) ?? [])
+          : enrollments
+              .filter(
+                (row) => String(row.fleet_id) === String(program.fleet_id),
+              )
+              .map((row) => String(row.vehicle_id)),
+      tasks: (tasksByProgram.get(String(program.id)) ?? []).map((task) => ({
+        id: String(task.id),
+        description: clean(task.description) ?? "Maintenance task",
+        jobType: clean(task.job_type) ?? "maintenance",
+        laborHours: numeric(task.default_labor_hours),
+        sectionKey: clean(task.section_key),
+      })),
       assignedUnits: assignedByProgram.get(String(program.id)) ?? 0,
       dueUnits: dueByProgram.get(String(program.id)) ?? 0,
     })),
@@ -260,7 +394,16 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     if (actor.actorType === "none" || !actor.shopId) {
-      return NextResponse.json({ error: "Fleet access required" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Fleet access required" },
+        { status: 403 },
+      );
+    }
+    if (actor.actorType === "fleet_driver") {
+      return NextResponse.json(
+        { error: "Fleet manager access required" },
+        { status: 403 },
+      );
     }
 
     const body = (await request.json().catch(() => ({}))) as Body;
@@ -312,10 +455,13 @@ export async function POST(request: Request) {
 
       const evaluations = await Promise.all(
         targetFleetIds.map(async (fleetId) => {
-          const { data, error } = await supabase.rpc("evaluate_fleet_pm_due_events", {
-            p_fleet_id: fleetId,
-            p_vehicle_id: clean(body.vehicleId) ?? undefined,
-          });
+          const { data, error } = await supabase.rpc(
+            "evaluate_fleet_pm_due_events",
+            {
+              p_fleet_id: fleetId,
+              p_vehicle_id: clean(body.vehicleId) ?? undefined,
+            },
+          );
           if (error) throw new Error(error.message);
           return { fleetId, evaluated: data ?? [] };
         }),
@@ -323,13 +469,121 @@ export async function POST(request: Request) {
       return NextResponse.json({ ok: true, evaluations });
     }
 
+    if (["save_program", "archive_program"].includes(action)) {
+      const fleetId = clean(body.fleetId);
+      if (!fleetId || !UUID.test(fleetId)) {
+        return NextResponse.json(
+          { error: "Valid Fleet is required" },
+          { status: 400 },
+        );
+      }
+      if (!canAdministerFleetForActor(actor, fleetId)) {
+        return NextResponse.json(
+          { error: "Fleet manager access required" },
+          { status: 403 },
+        );
+      }
+
+      const { data: fleet, error: fleetError } = await admin
+        .from("fleets")
+        .select("id")
+        .eq("id", fleetId)
+        .eq("shop_id", actor.shopId)
+        .maybeSingle();
+      if (fleetError) throw new Error(fleetError.message);
+      if (!fleet) {
+        return NextResponse.json({ error: "Fleet not found" }, { status: 404 });
+      }
+
+      const programId = clean(body.programId);
+      if (programId && !UUID.test(programId)) {
+        return NextResponse.json(
+          { error: "Valid PM program is required" },
+          { status: 400 },
+        );
+      }
+      if (action === "archive_program" && !programId) {
+        return NextResponse.json(
+          { error: "PM program is required" },
+          { status: 400 },
+        );
+      }
+
+      const vehicleIds = Array.from(
+        new Set((body.vehicleIds ?? []).filter((id) => UUID.test(id))),
+      );
+      if (vehicleIds.length !== (body.vehicleIds ?? []).length) {
+        return NextResponse.json(
+          { error: "A selected asset is invalid" },
+          { status: 400 },
+        );
+      }
+      const tasks = (body.tasks ?? []).map((task) => ({
+        description: clean(task.description)?.slice(0, 500) ?? "",
+        jobType: ["maintenance", "inspection", "repair"].includes(
+          clean(task.jobType) ?? "",
+        )
+          ? clean(task.jobType)
+          : "maintenance",
+        laborHours:
+          task.laborHours == null || !Number.isFinite(Number(task.laborHours))
+            ? null
+            : Math.max(0, Number(task.laborHours)),
+        sectionKey: clean(task.sectionKey)?.slice(0, 80) ?? null,
+      }));
+      const rpcAction =
+        action === "archive_program"
+          ? "archive"
+          : programId
+            ? "update"
+            : "create";
+      const { data: result, error: programError } = await supabase.rpc(
+        "manage_fleet_pm_program",
+        {
+          p_action: rpcAction,
+          p_fleet_id: fleetId,
+          p_program_id: nullableRpcArg(programId),
+          p_name: clean(body.name)?.slice(0, 120) ?? "",
+          p_cadence: clean(body.cadence) ?? "mileage_based",
+          p_interval_km: nullableRpcArg(numeric(body.intervalKm)),
+          p_interval_hours: nullableRpcArg(numeric(body.intervalHours)),
+          p_interval_days: nullableRpcArg(numeric(body.intervalDays)),
+          p_assignment_mode:
+            body.assignmentMode === "selected_units"
+              ? "selected_units"
+              : "all_units",
+          p_vehicle_ids: vehicleIds,
+          p_tasks: tasks,
+          p_notes: nullableRpcArg(clean(body.notes)?.slice(0, 2000) ?? null),
+          p_requires_fleet_approval: body.requiresFleetApproval !== false,
+          p_operation_key: clean(body.operationKey) ?? "",
+        },
+      );
+      if (programError) throw new Error(programError.message);
+
+      if (action === "save_program") {
+        const { error: evaluationError } = await supabase.rpc(
+          "evaluate_fleet_pm_due_events",
+          { p_fleet_id: fleetId },
+        );
+        if (evaluationError) throw new Error(evaluationError.message);
+      }
+      return NextResponse.json({ ok: true, program: result });
+    }
+
     if (!["defer", "create_request"].includes(action)) {
-      return NextResponse.json({ error: "Unsupported PM action" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Unsupported PM action" },
+        { status: 400 },
+      );
     }
 
     const dueEventId = clean(body.dueEventId);
     if (!dueEventId) {
-      return NextResponse.json({ error: "dueEventId is required" }, { status: 400 });
+      return NextResponse.json(
+        { error: "dueEventId is required" },
+        { status: 400 },
+      );
     }
     const { data: dueRow, error: dueError } = await admin
       .from("fleet_pm_due_events")
@@ -428,26 +682,64 @@ export async function POST(request: Request) {
     const dueReasons = Array.isArray(dueRow.due_reasons)
       ? dueRow.due_reasons.map(String)
       : [];
+    const requestedForDate = clean(body.requestedForDate);
+    if (requestedForDate) {
+      const requestedDate = new Date(`${requestedForDate}T00:00:00Z`);
+      const today = new Date();
+      today.setUTCHours(0, 0, 0, 0);
+      if (
+        Number.isNaN(requestedDate.getTime()) ||
+        requestedDate.getTime() < today.getTime()
+      ) {
+        return NextResponse.json(
+          { error: "Requested service date cannot be in the past" },
+          { status: 400 },
+        );
+      }
+    }
 
-    const { data: policy, error: policyError } = await admin
-      .from("fleet_pm_policies")
-      .select("id,name,interval_km,interval_hours,interval_days")
-      .eq("id", dueRow.policy_id)
-      .maybeSingle();
+    const [policyResult, programTaskResult] = await Promise.all([
+      admin
+        .from("fleet_pm_policies")
+        .select("id,name,interval_km,interval_hours,interval_days")
+        .eq("id", dueRow.policy_id)
+        .maybeSingle(),
+      admin
+        .from("fleet_program_tasks")
+        .select(
+          "id,description,job_type,default_labor_hours,section_key,display_order",
+        )
+        .eq("program_id", dueRow.program_id)
+        .order("display_order", { ascending: true }),
+    ]);
+    const { data: policy, error: policyError } = policyResult;
     if (policyError) throw new Error(policyError.message);
     const policyName = clean(policy?.name) ?? "Preventive maintenance";
-    const operationKey = `pm-due:${dueEventId}`;
-    const { data: serviceRequestId, error: createError } = await supabase.rpc(
-      "create_fleet_service_request_atomic",
-      {
-        p_fleet_id: dueRow.fleet_id,
-        p_vehicle_id: dueRow.vehicle_id,
-        p_title: `${policyName} service`,
-        p_summary: `Preventive maintenance due: ${dueReasons.join(", ") || "policy interval reached"}.`,
-        // The SQL function intentionally accepts an unscheduled request.
-        p_requested_for_date: null as unknown as string,
-        p_operation_key: operationKey,
-        p_lines: [
+    const { data: programTasks, error: programTaskError } = programTaskResult;
+    if (programTaskError) throw new Error(programTaskError.message);
+    const requestLines = rows(programTasks).length
+      ? rows(programTasks).map((task) => ({
+          lineKind:
+            clean(task.job_type) === "inspection" ? "inspection" : "custom",
+          description: clean(task.description) ?? policyName,
+          notes: clean(task.section_key)
+            ? `PM section: ${clean(task.section_key)}`
+            : "Created from the Fleet PM template.",
+          quantity: 1,
+          requestedLaborHours: numeric(task.default_labor_hours),
+          unitPriceSnapshot: null,
+          sourceFleetProgramId: dueRow.program_id,
+          sourceSnapshot: {
+            dueEventId,
+            programTaskId: String(task.id),
+            programJobType: clean(task.job_type) ?? "maintenance",
+            intervalKm: policy?.interval_km ?? null,
+            intervalHours: policy?.interval_hours ?? null,
+            intervalDays: policy?.interval_days ?? null,
+            dueReasons,
+          },
+        }))
+      : [
           {
             lineKind: "pm_package",
             description: policyName,
@@ -464,7 +756,19 @@ export async function POST(request: Request) {
               dueReasons,
             },
           },
-        ],
+        ];
+    const operationKey = `pm-due:${dueEventId}`;
+    const { data: serviceRequestId, error: createError } = await supabase.rpc(
+      "create_fleet_service_request_atomic",
+      {
+        p_fleet_id: dueRow.fleet_id,
+        p_vehicle_id: dueRow.vehicle_id,
+        p_title: `${policyName} service`,
+        p_summary: `Preventive maintenance due: ${dueReasons.join(", ") || "policy interval reached"}.`,
+        // The SQL function intentionally accepts an unscheduled request.
+        p_requested_for_date: requestedForDate as unknown as string,
+        p_operation_key: operationKey,
+        p_lines: requestLines,
       },
     );
     if (createError) throw new Error(createError.message);
@@ -505,7 +809,10 @@ export async function POST(request: Request) {
         });
       }
       return NextResponse.json(
-        { error: "PM item changed while the request was being created; retry safely" },
+        {
+          error:
+            "PM item changed while the request was being created; retry safely",
+        },
         { status: 409 },
       );
     }

--- a/app/portal/fleet/calendar/page.tsx
+++ b/app/portal/fleet/calendar/page.tsx
@@ -1,32 +1,11 @@
-import { CalendarDays, Clock3, Wrench } from "lucide-react";
+import { redirect } from "next/navigation";
 
-import FleetModuleFoundation from "@/features/fleet/components/FleetModuleFoundation";
+import FleetMaintenanceCalendar from "@/features/fleet/components/FleetMaintenanceCalendar";
+import { requireFleetPortalActor } from "../_lib/requireFleetPortalActor";
 
-export default function FleetCalendarPage() {
-  return (
-    <FleetModuleFoundation
-      eyebrow="Maintenance planning"
-      title="Maintenance Calendar"
-      description="A fleet-wide planning surface for preventive maintenance, booked repairs, inspections and expected downtime. The calendar will schedule assets—not shop technicians."
-      capabilities={[
-        {
-          title: "Upcoming maintenance",
-          description: "PM due dates and forecasted mileage, hour or calendar thresholds.",
-          icon: CalendarDays,
-        },
-        {
-          title: "Service appointments",
-          description: "Connected-shop bookings and externally recorded maintenance events.",
-          icon: Wrench,
-        },
-        {
-          title: "Downtime planning",
-          description: "Expected out-of-service windows and asset availability conflicts.",
-          icon: Clock3,
-        },
-      ]}
-      primaryHref="/portal/fleet/maintenance"
-      primaryLabel="Open PM queue"
-    />
-  );
+export default async function FleetCalendarPage() {
+  const actor = await requireFleetPortalActor();
+  if (actor.experience === "external_driver") redirect("/portal/fleet");
+
+  return <FleetMaintenanceCalendar />;
 }

--- a/app/portal/fleet/maintenance/page.tsx
+++ b/app/portal/fleet/maintenance/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from "next/navigation";
+
 import FleetMaintenanceWorkspace from "@/features/fleet/components/FleetMaintenanceWorkspace";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
@@ -5,6 +7,7 @@ import { resolveFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities"
 export default async function PortalFleetMaintenancePage() {
   const supabase = createServerSupabaseRSC();
   const uiContext = await resolveFleetUiContext(supabase);
+  if (uiContext.experience === "external_driver") redirect("/portal/fleet");
 
   return (
     <FleetMaintenanceWorkspace

--- a/features/fleet/components/FleetMaintenanceCalendar.tsx
+++ b/features/fleet/components/FleetMaintenanceCalendar.tsx
@@ -1,0 +1,569 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import {
+  CalendarClock,
+  ChevronLeft,
+  ChevronRight,
+  ClipboardCheck,
+  RefreshCw,
+  ShieldAlert,
+  Truck,
+  Wrench,
+} from "lucide-react";
+import { toFleetInternalHref } from "@/features/fleet/lib/fleetProductRouting";
+
+type CalendarEventType =
+  | "pm_due"
+  | "pm_forecast"
+  | "service_request"
+  | "inspection"
+  | "shop_service";
+
+type CalendarEvent = {
+  id: string;
+  fleetId: string;
+  fleetName: string;
+  vehicleId: string;
+  unitLabel: string;
+  vehicleDescription: string;
+  date: string | null;
+  endDate: string | null;
+  type: CalendarEventType;
+  state: string;
+  title: string;
+  detail: string;
+  href: string;
+};
+
+type CalendarPayload = {
+  fleets: Array<{ id: string; name: string }>;
+  summary: {
+    due: number;
+    planned: number;
+    inspections: number;
+    unscheduled: number;
+  };
+  events: CalendarEvent[];
+};
+
+const panel =
+  "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[var(--theme-shadow-soft)]";
+
+const EVENT_META: Record<
+  CalendarEventType,
+  { label: string; icon: typeof Wrench; className: string; dot: string }
+> = {
+  pm_due: {
+    label: "PM due",
+    icon: ShieldAlert,
+    className:
+      "border-amber-400/30 bg-amber-400/10 text-amber-800 dark:text-amber-200",
+    dot: "bg-amber-400",
+  },
+  pm_forecast: {
+    label: "PM forecast",
+    icon: CalendarClock,
+    className: "border-sky-400/25 bg-sky-400/10 text-sky-800 dark:text-sky-200",
+    dot: "bg-sky-400",
+  },
+  service_request: {
+    label: "Fleet request",
+    icon: ClipboardCheck,
+    className:
+      "border-violet-400/25 bg-violet-400/10 text-violet-800 dark:text-violet-200",
+    dot: "bg-violet-400",
+  },
+  inspection: {
+    label: "Inspection",
+    icon: ClipboardCheck,
+    className:
+      "border-emerald-400/25 bg-emerald-400/10 text-emerald-800 dark:text-emerald-200",
+    dot: "bg-emerald-400",
+  },
+  shop_service: {
+    label: "Shop service",
+    icon: Wrench,
+    className:
+      "border-blue-400/25 bg-blue-400/10 text-blue-800 dark:text-blue-200",
+    dot: "bg-blue-400",
+  },
+};
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function localIsoDate(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function monthStart(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+function moveMonth(date: Date, amount: number): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + amount, 1),
+  );
+}
+
+function monthGridDays(month: Date): Date[] {
+  const start = monthStart(month);
+  start.setUTCDate(start.getUTCDate() - start.getUTCDay());
+  return Array.from({ length: 42 }, (_, index) => {
+    const date = new Date(start);
+    date.setUTCDate(start.getUTCDate() + index);
+    return date;
+  });
+}
+
+function displayDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function EventCard({
+  event,
+  compact = false,
+  internalRoutes,
+}: {
+  event: CalendarEvent;
+  compact?: boolean;
+  internalRoutes: boolean;
+}) {
+  const meta = EVENT_META[event.type];
+  const Icon = meta.icon;
+  const href = internalRoutes
+    ? (toFleetInternalHref(event.href) ?? event.href)
+    : event.href;
+  return (
+    <Link
+      href={href}
+      title={`${event.unitLabel}: ${event.title}`}
+      className={`block rounded-lg border transition hover:-translate-y-0.5 hover:shadow-sm ${meta.className} ${
+        compact ? "px-2 py-1" : "p-3"
+      }`}
+    >
+      <div className="flex min-w-0 items-start gap-2">
+        <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <div className="min-w-0">
+          <div
+            className={`${compact ? "truncate text-[10px]" : "text-xs"} font-semibold`}
+          >
+            {event.unitLabel} · {event.title}
+          </div>
+          {!compact ? (
+            <>
+              <div className="mt-1 text-[11px] opacity-80">{event.detail}</div>
+              <div className="mt-2 flex flex-wrap gap-2 text-[10px] uppercase tracking-wide opacity-70">
+                <span>{meta.label}</span>
+                <span>{event.fleetName}</span>
+                <span>{event.state.replaceAll("_", " ")}</span>
+              </div>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export default function FleetMaintenanceCalendar() {
+  const pathname = usePathname();
+  const internalRoutes = pathname.startsWith("/portal/fleet");
+  const [payload, setPayload] = useState<CalendarPayload | null>(null);
+  const [fleetId, setFleetId] = useState("all");
+  const [type, setType] = useState<CalendarEventType | "all">("all");
+  const [month, setMonth] = useState(() =>
+    monthStart(new Date(`${localIsoDate()}T00:00:00Z`)),
+  );
+  const [selectedDate, setSelectedDate] = useState(localIsoDate);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (fleetId !== "all") params.set("fleetId", fleetId);
+      const query = params.size ? `?${params.toString()}` : "";
+      const response = await fetch(`/api/fleet/calendar${query}`, {
+        method: "GET",
+        cache: "no-store",
+      });
+      const body = (await response.json().catch(() => ({}))) as
+        | CalendarPayload
+        | { error?: string };
+      if (!response.ok || !("events" in body)) {
+        throw new Error(
+          "error" in body && body.error
+            ? body.error
+            : "Unable to load calendar",
+        );
+      }
+      setPayload(body);
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Unable to load calendar",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+    // Fleet selection owns the server-side scope.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fleetId]);
+
+  const filteredEvents = useMemo(
+    () =>
+      (payload?.events ?? []).filter(
+        (event) => type === "all" || event.type === type,
+      ),
+    [payload?.events, type],
+  );
+  const eventsByDate = useMemo(() => {
+    const result = new Map<string, CalendarEvent[]>();
+    for (const event of filteredEvents) {
+      if (!event.date) continue;
+      const current = result.get(event.date) ?? [];
+      current.push(event);
+      result.set(event.date, current);
+    }
+    return result;
+  }, [filteredEvents]);
+  const days = useMemo(() => monthGridDays(month), [month]);
+  const selectedEvents = eventsByDate.get(selectedDate) ?? [];
+  const unscheduled = filteredEvents.filter((event) => !event.date);
+  const upcoming = filteredEvents
+    .filter((event) => event.date && event.date >= localIsoDate())
+    .slice(0, 8);
+
+  return (
+    <main className="mx-auto w-full max-w-[1500px] space-y-5 px-4 py-6 text-[color:var(--theme-text-primary)]">
+      <header className={`${panel} p-5`}>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-500 dark:text-sky-300">
+              Maintenance planning
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">
+              Maintenance Calendar
+            </h1>
+            <p className="mt-2 max-w-3xl text-sm text-[color:var(--theme-text-secondary)]">
+              PM forecasts, service requests, inspections and connected Shop
+              appointments—planned around asset availability.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {payload && (payload.fleets.length > 1 || fleetId !== "all") ? (
+              <select
+                value={fleetId}
+                onChange={(event) => setFleetId(event.target.value)}
+                className="min-h-10 rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-xs"
+              >
+                <option value="all">All fleets</option>
+                {payload.fleets.map((fleet) => (
+                  <option key={fleet.id} value={fleet.id}>
+                    {fleet.name}
+                  </option>
+                ))}
+              </select>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void load()}
+              disabled={loading}
+              className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold disabled:opacity-50"
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+              />
+              Refresh
+            </button>
+            <Link
+              href={
+                internalRoutes ? "/portal/fleet/maintenance" : "/maintenance"
+              }
+              className="inline-flex min-h-10 items-center rounded-xl bg-sky-400 px-4 py-2 text-xs font-semibold text-slate-950"
+            >
+              Open PM command
+            </Link>
+          </div>
+        </div>
+
+        <div className="mt-5 grid grid-cols-2 gap-3 lg:grid-cols-4">
+          {(
+            [
+              ["PM decisions", payload?.summary.due ?? 0, ShieldAlert],
+              ["Planned service", payload?.summary.planned ?? 0, Wrench],
+              [
+                "Inspections",
+                payload?.summary.inspections ?? 0,
+                ClipboardCheck,
+              ],
+              [
+                "Needs a date",
+                payload?.summary.unscheduled ?? 0,
+                CalendarClock,
+              ],
+            ] as const
+          ).map(([label, value, Icon]) => (
+            <div
+              key={String(label)}
+              className="rounded-xl border border-[color:var(--theme-border-soft)] p-3"
+            >
+              <Icon
+                className="h-4 w-4 text-sky-500 dark:text-sky-300"
+                aria-hidden="true"
+              />
+              <div className="mt-2 text-2xl font-semibold">{String(value)}</div>
+              <div className="text-[10px] uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                {String(label)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-700 dark:text-red-200"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      <section className={`${panel} p-4`}>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              aria-label="Previous month"
+              onClick={() => setMonth((current) => moveMonth(current, -1))}
+              className="grid h-10 w-10 place-items-center rounded-xl border border-[color:var(--theme-border-soft)]"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const today = localIsoDate();
+                setMonth(monthStart(new Date(`${today}T00:00:00Z`)));
+                setSelectedDate(today);
+              }}
+              className="min-h-10 rounded-xl border border-[color:var(--theme-border-soft)] px-4 text-sm font-semibold"
+            >
+              {new Intl.DateTimeFormat(undefined, {
+                month: "long",
+                year: "numeric",
+                timeZone: "UTC",
+              }).format(month)}
+            </button>
+            <button
+              type="button"
+              aria-label="Next month"
+              onClick={() => setMonth((current) => moveMonth(current, 1))}
+              className="grid h-10 w-10 place-items-center rounded-xl border border-[color:var(--theme-border-soft)]"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {(
+              [
+                "all",
+                "pm_due",
+                "pm_forecast",
+                "service_request",
+                "inspection",
+                "shop_service",
+              ] as const
+            ).map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setType(value)}
+                className={
+                  type === value
+                    ? "shrink-0 rounded-full bg-sky-400 px-3 py-1.5 text-[11px] font-semibold text-slate-950"
+                    : "shrink-0 rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-[11px] font-semibold"
+                }
+              >
+                {value === "all" ? "All events" : EVENT_META[value].label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-4 hidden md:block">
+          <div className="grid grid-cols-7 border-b border-l border-[color:var(--theme-border-soft)]">
+            {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((day) => (
+              <div
+                key={day}
+                className="border-r border-t border-[color:var(--theme-border-soft)] px-2 py-2 text-center text-[10px] font-semibold uppercase tracking-wider text-[color:var(--theme-text-muted)]"
+              >
+                {day}
+              </div>
+            ))}
+            {days.map((day) => {
+              const key = isoDate(day);
+              const dayEvents = eventsByDate.get(key) ?? [];
+              const inMonth = day.getUTCMonth() === month.getUTCMonth();
+              const selected = key === selectedDate;
+              return (
+                <div
+                  key={key}
+                  className={`min-h-28 border-r border-t border-[color:var(--theme-border-soft)] p-2 text-left align-top transition hover:bg-sky-400/[0.05] ${
+                    selected
+                      ? "bg-sky-400/[0.08] ring-1 ring-inset ring-sky-400/40"
+                      : ""
+                  } ${inMonth ? "" : "opacity-40"}`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSelectedDate(key)}
+                    aria-label={`Show agenda for ${displayDate(key)}`}
+                    className="grid h-7 w-7 place-items-center rounded-lg text-xs font-semibold hover:bg-sky-400/10"
+                  >
+                    {day.getUTCDate()}
+                  </button>
+                  <div className="mt-2 space-y-1">
+                    {dayEvents.slice(0, 3).map((event) => (
+                      <div key={event.id}>
+                        <EventCard
+                          event={event}
+                          compact
+                          internalRoutes={internalRoutes}
+                        />
+                      </div>
+                    ))}
+                    {dayEvents.length > 3 ? (
+                      <div className="px-1 text-[10px] text-[color:var(--theme-text-muted)]">
+                        +{dayEvents.length - 3} more
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mt-4 md:hidden">
+          <label className="block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+            Agenda date
+            <input
+              type="date"
+              value={selectedDate}
+              onChange={(event) => {
+                setSelectedDate(event.target.value);
+                setMonth(
+                  monthStart(new Date(`${event.target.value}T00:00:00Z`)),
+                );
+              }}
+              className="mt-1.5 min-h-11 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3"
+            />
+          </label>
+        </div>
+      </section>
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(340px,.85fr)]">
+        <section className={`${panel} p-4`}>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="font-semibold">{displayDate(selectedDate)}</h2>
+              <p className="text-xs text-[color:var(--theme-text-muted)]">
+                Asset maintenance agenda
+              </p>
+            </div>
+            <span className="rounded-full bg-[color:var(--theme-surface-subtle)] px-3 py-1 text-xs font-semibold">
+              {selectedEvents.length} event
+              {selectedEvents.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          <div className="mt-4 space-y-2">
+            {selectedEvents.map((event) => (
+              <EventCard
+                key={event.id}
+                event={event}
+                internalRoutes={internalRoutes}
+              />
+            ))}
+            {!selectedEvents.length ? (
+              <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-6 text-center text-sm text-[color:var(--theme-text-secondary)]">
+                No maintenance activity is planned for this date.
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className={`${panel} p-4`}>
+          <div className="flex items-center gap-2">
+            <Truck className="h-4 w-4 text-sky-500 dark:text-sky-300" />
+            <div>
+              <h2 className="font-semibold">Next across the Fleet</h2>
+              <p className="text-xs text-[color:var(--theme-text-muted)]">
+                Upcoming asset commitments
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 space-y-2">
+            {upcoming.map((event) => (
+              <div key={event.id}>
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                  {event.date ? displayDate(event.date) : "Needs a date"}
+                </div>
+                <EventCard event={event} internalRoutes={internalRoutes} />
+              </div>
+            ))}
+            {!upcoming.length ? (
+              <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                No upcoming events match this filter.
+              </p>
+            ) : null}
+          </div>
+        </section>
+      </div>
+
+      {unscheduled.length ? (
+        <section className={`${panel} p-4`}>
+          <div className="flex items-center gap-2">
+            <CalendarClock className="h-4 w-4 text-amber-500 dark:text-amber-300" />
+            <div>
+              <h2 className="font-semibold">Needs a planning date</h2>
+              <p className="text-xs text-[color:var(--theme-text-muted)]">
+                Open Fleet requests remain visible until a date is chosen.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {unscheduled.map((event) => (
+              <EventCard
+                key={event.id}
+                event={event}
+                internalRoutes={internalRoutes}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/features/fleet/components/FleetMaintenanceWorkspace.tsx
+++ b/features/fleet/components/FleetMaintenanceWorkspace.tsx
@@ -4,13 +4,20 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   AlertTriangle,
+  Archive,
   CalendarClock,
   CheckCircle2,
   ClipboardPlus,
+  Pencil,
+  Plus,
   RefreshCw,
   ShieldCheck,
 } from "lucide-react";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
+import FleetPmProgramEditor, {
+  type FleetPmProgram,
+  type FleetPmUnitOption,
+} from "@/features/fleet/components/FleetPmProgramEditor";
 
 type RoutePrefix = "/fleet" | "/portal/fleet";
 type Filter = "action" | "overdue" | "due" | "deferred" | "converted" | "all";
@@ -41,22 +48,9 @@ type PmItem = {
   requiresApproval: boolean;
 };
 
-type PmProgram = {
-  id: string;
-  fleetId: string;
-  fleetName: string;
-  name: string;
-  cadence: string;
-  intervalKm: number | null;
-  intervalHours: number | null;
-  intervalDays: number | null;
-  notes: string | null;
-  assignedUnits: number;
-  dueUnits: number;
-};
-
 type Payload = {
   canManage: boolean;
+  canManagePrograms: boolean;
   fleets: Array<{ id: string; name: string }>;
   summary: {
     overdue: number;
@@ -65,25 +59,44 @@ type Payload = {
     converted: number;
     clearUnits: number;
   };
+  units: FleetPmUnitOption[];
   items: PmItem[];
-  programs: PmProgram[];
+  programs: FleetPmProgram[];
 };
 
 const card =
   "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-4 shadow-card";
 
-function intervalLabel(item: Pick<PmItem | PmProgram, "intervalKm" | "intervalHours" | "intervalDays">) {
-  return [
-    item.intervalKm ? `${item.intervalKm.toLocaleString()} km` : null,
-    item.intervalHours ? `${item.intervalHours.toLocaleString()} hours` : null,
-    item.intervalDays ? `${item.intervalDays} days` : null,
-  ].filter(Boolean).join(" / ") || "Custom interval";
+function intervalLabel(
+  item: Pick<
+    PmItem | FleetPmProgram,
+    "intervalKm" | "intervalHours" | "intervalDays"
+  >,
+) {
+  return (
+    [
+      item.intervalKm ? `${item.intervalKm.toLocaleString()} km` : null,
+      item.intervalHours
+        ? `${item.intervalHours.toLocaleString()} hours`
+        : null,
+      item.intervalDays ? `${item.intervalDays} days` : null,
+    ]
+      .filter(Boolean)
+      .join(" / ") || "Custom interval"
+  );
 }
 
 function dateInputDefault() {
   const date = new Date();
   date.setDate(date.getDate() + 14);
-  return date.toISOString().slice(0, 10);
+  return localDateInput(date);
+}
+
+function localDateInput(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 export default function FleetMaintenanceWorkspace({
@@ -100,6 +113,11 @@ export default function FleetMaintenanceWorkspace({
   const [loading, setLoading] = useState(true);
   const [workingId, setWorkingId] = useState<string | null>(null);
   const [deferItem, setDeferItem] = useState<PmItem | null>(null);
+  const [requestItem, setRequestItem] = useState<PmItem | null>(null);
+  const [requestedForDate, setRequestedForDate] = useState(dateInputDefault);
+  const [programEditor, setProgramEditor] = useState<
+    FleetPmProgram | null | undefined
+  >(undefined);
   const [deferUntil, setDeferUntil] = useState(dateInputDefault);
   const [deferReason, setDeferReason] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -121,13 +139,17 @@ export default function FleetMaintenanceWorkspace({
         | { error?: string };
       if (!response.ok || !("items" in body)) {
         throw new Error(
-          "error" in body && body.error ? body.error : "Unable to load maintenance",
+          "error" in body && body.error
+            ? body.error
+            : "Unable to load maintenance",
         );
       }
       setData(body);
     } catch (loadError) {
       setError(
-        loadError instanceof Error ? loadError.message : "Unable to load maintenance",
+        loadError instanceof Error
+          ? loadError.message
+          : "Unable to load maintenance",
       );
     } finally {
       setLoading(false);
@@ -157,7 +179,9 @@ export default function FleetMaintenanceWorkspace({
       return true;
     } catch (mutationError) {
       setError(
-        mutationError instanceof Error ? mutationError.message : "PM action failed",
+        mutationError instanceof Error
+          ? mutationError.message
+          : "PM action failed",
       );
       return false;
     } finally {
@@ -168,7 +192,10 @@ export default function FleetMaintenanceWorkspace({
   const filtered = useMemo(() => {
     const query = search.trim().toLowerCase();
     return (data?.items ?? []).filter((item) => {
-      if (filter === "action" && !["overdue", "due", "deferred"].includes(item.urgency)) {
+      if (
+        filter === "action" &&
+        !["overdue", "due", "deferred"].includes(item.urgency)
+      ) {
         return false;
       }
       if (filter !== "action" && filter !== "all" && item.urgency !== filter) {
@@ -205,14 +232,15 @@ export default function FleetMaintenanceWorkspace({
             </div>
             <h1 className="mt-2 text-2xl font-semibold">PM Management</h1>
             <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-              One queue for due work, deferrals, service requests, and PM programs.
+              One queue for due work, deferrals, service requests, and PM
+              programs.
             </p>
             <p className="mt-1 text-[10px] text-[color:var(--theme-text-muted)]">
               {uiContext.actorLabel}
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
-            {data && data.fleets.length > 1 ? (
+            {data && (data.fleets.length > 1 || fleetId !== "all") ? (
               <select
                 value={fleetId}
                 onChange={(event) => setFleetId(event.target.value)}
@@ -220,9 +248,21 @@ export default function FleetMaintenanceWorkspace({
               >
                 <option value="all">All fleets</option>
                 {data.fleets.map((fleet) => (
-                  <option key={fleet.id} value={fleet.id}>{fleet.name}</option>
+                  <option key={fleet.id} value={fleet.id}>
+                    {fleet.name}
+                  </option>
                 ))}
               </select>
+            ) : null}
+            {data?.canManagePrograms ? (
+              <button
+                type="button"
+                disabled={workingId === "workspace" || !data.fleets.length}
+                onClick={() => setProgramEditor(null)}
+                className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-sky-400/35 bg-sky-400/10 px-4 py-2 text-xs font-semibold text-sky-700 dark:text-sky-200 disabled:opacity-50"
+              >
+                <Plus className="h-4 w-4" /> New PM program
+              </button>
             ) : null}
             {data?.canManage ? (
               <button
@@ -259,12 +299,14 @@ export default function FleetMaintenanceWorkspace({
                     ? "converted"
                     : label === "Units clear"
                       ? "all"
-                      : String(label).toLowerCase() as Filter,
+                      : (String(label).toLowerCase() as Filter),
                 )
               }
               className="rounded-xl border border-[color:var(--theme-border-soft)] p-3 text-left"
             >
-              <div className="text-[10px] uppercase tracking-wide text-[color:var(--theme-text-muted)]">{label}</div>
+              <div className="text-[10px] uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                {label}
+              </div>
               <div className="mt-1 text-xl font-semibold">{value}</div>
             </button>
           ))}
@@ -284,20 +326,34 @@ export default function FleetMaintenanceWorkspace({
             <ul className="mt-2 space-y-1 text-xs text-[color:var(--theme-text-secondary)]">
               <li>• Review overdue units, then current due units.</li>
               <li>• Every deferral requires a future date and a reason.</li>
-              <li>• Creating a request keeps the due event linked through work completion.</li>
+              <li>
+                • Creating a request keeps the due event linked through work
+                completion.
+              </li>
             </ul>
           </div>
         </div>
       </section>
 
       {error ? (
-        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-100">{error}</div>
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-100">
+          {error}
+        </div>
       ) : null}
 
       <section className={card}>
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div className="flex gap-2 overflow-x-auto">
-            {(["action", "overdue", "due", "deferred", "converted", "all"] as const).map((value) => (
+            {(
+              [
+                "action",
+                "overdue",
+                "due",
+                "deferred",
+                "converted",
+                "all",
+              ] as const
+            ).map((value) => (
               <button
                 key={value}
                 type="button"
@@ -308,7 +364,9 @@ export default function FleetMaintenanceWorkspace({
                     : "shrink-0 rounded-full border border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs font-semibold"
                 }
               >
-                {value === "action" ? "Needs action" : value[0].toUpperCase() + value.slice(1)}
+                {value === "action"
+                  ? "Needs action"
+                  : value[0].toUpperCase() + value.slice(1)}
               </button>
             ))}
           </div>
@@ -321,78 +379,93 @@ export default function FleetMaintenanceWorkspace({
         </div>
 
         <div className="mt-4 space-y-3">
-          {loading ? <p className="text-sm text-[color:var(--theme-text-secondary)]">Loading PM data…</p> : null}
-          {!loading && filtered.map((item) => (
-            <article key={item.id} className="rounded-xl border border-[color:var(--theme-border-soft)] p-4">
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                <div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Link
-                      href={`${routePrefix}/units/${encodeURIComponent(item.vehicleId)}`}
-                      className="text-base font-semibold text-sky-200 hover:underline"
-                    >
-                      {item.unitLabel}
-                    </Link>
-                    <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-0.5 text-[10px] uppercase">
-                      {item.urgency}
-                    </span>
+          {loading ? (
+            <p className="text-sm text-[color:var(--theme-text-secondary)]">
+              Loading PM data…
+            </p>
+          ) : null}
+          {!loading &&
+            filtered.map((item) => (
+              <article
+                key={item.id}
+                className="rounded-xl border border-[color:var(--theme-border-soft)] p-4"
+              >
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Link
+                        href={`${routePrefix}/units/${encodeURIComponent(item.vehicleId)}`}
+                        className="text-base font-semibold text-sky-200 hover:underline"
+                      >
+                        {item.unitLabel}
+                      </Link>
+                      <span className="rounded-full border border-[color:var(--theme-border-soft)] px-2 py-0.5 text-[10px] uppercase">
+                        {item.urgency}
+                      </span>
+                    </div>
+                    <h3 className="mt-2 text-sm font-semibold">{item.name}</h3>
+                    <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                      {item.dueReasons.join(" • ") ||
+                        "PM policy interval reached"}
+                    </p>
+                    <div className="mt-2 text-[11px] text-[color:var(--theme-text-muted)]">
+                      {item.fleetName} • {intervalLabel(item)}
+                      {item.currentOdometerKm == null
+                        ? ""
+                        : ` • ${item.currentOdometerKm.toLocaleString()} km`}
+                      {item.currentEngineHours == null
+                        ? ""
+                        : ` • ${item.currentEngineHours.toLocaleString()} hours`}
+                    </div>
+                    {item.deferredUntil ? (
+                      <div className="mt-2 inline-flex items-center gap-1 text-xs text-amber-200">
+                        <CalendarClock className="h-3.5 w-3.5" />
+                        Deferred until{" "}
+                        {new Date(item.deferredUntil).toLocaleDateString()}
+                      </div>
+                    ) : null}
                   </div>
-                  <h3 className="mt-2 text-sm font-semibold">{item.name}</h3>
-                  <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                    {item.dueReasons.join(" • ") || "PM policy interval reached"}
-                  </p>
-                  <div className="mt-2 text-[11px] text-[color:var(--theme-text-muted)]">
-                    {item.fleetName} • {intervalLabel(item)}
-                    {item.currentOdometerKm == null ? "" : ` • ${item.currentOdometerKm.toLocaleString()} km`}
-                    {item.currentEngineHours == null ? "" : ` • ${item.currentEngineHours.toLocaleString()} hours`}
-                  </div>
-                  {item.deferredUntil ? (
-                    <div className="mt-2 inline-flex items-center gap-1 text-xs text-amber-200">
-                      <CalendarClock className="h-3.5 w-3.5" />
-                      Deferred until {new Date(item.deferredUntil).toLocaleDateString()}
+                  {data?.canManage ? (
+                    <div className="flex flex-wrap gap-2">
+                      {!item.serviceRequestId ? (
+                        <button
+                          type="button"
+                          disabled={workingId === item.id}
+                          onClick={() => {
+                            setRequestItem(item);
+                            setRequestedForDate(dateInputDefault());
+                          }}
+                          className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-sky-300 px-3 py-2 text-xs font-semibold text-slate-950 disabled:opacity-50"
+                        >
+                          <ClipboardPlus className="h-4 w-4" />
+                          Plan request
+                        </button>
+                      ) : (
+                        <Link
+                          href={`${routePrefix}/service-requests`}
+                          className="inline-flex min-h-10 items-center rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold"
+                        >
+                          View request
+                        </Link>
+                      )}
+                      {item.urgency !== "converted" ? (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeferItem(item);
+                            setDeferUntil(dateInputDefault());
+                            setDeferReason("");
+                          }}
+                          className="min-h-10 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold"
+                        >
+                          Defer
+                        </button>
+                      ) : null}
                     </div>
                   ) : null}
                 </div>
-                {data?.canManage ? (
-                  <div className="flex flex-wrap gap-2">
-                    {!item.serviceRequestId ? (
-                      <button
-                        type="button"
-                        disabled={workingId === item.id}
-                        onClick={() =>
-                          void mutate(
-                            { action: "create_request", dueEventId: item.id },
-                            item.id,
-                          )
-                        }
-                        className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-sky-300 px-3 py-2 text-xs font-semibold text-slate-950 disabled:opacity-50"
-                      >
-                        <ClipboardPlus className="h-4 w-4" />
-                        {workingId === item.id ? "Creating…" : "Create request"}
-                      </button>
-                    ) : (
-                      <Link href={`${routePrefix}/service-requests`} className="inline-flex min-h-10 items-center rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold">
-                        View request
-                      </Link>
-                    )}
-                    {item.urgency !== "converted" ? (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setDeferItem(item);
-                          setDeferUntil(dateInputDefault());
-                          setDeferReason("");
-                        }}
-                        className="min-h-10 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold"
-                      >
-                        Defer
-                      </button>
-                    ) : null}
-                  </div>
-                ) : null}
-              </div>
-            </article>
-          ))}
+              </article>
+            ))}
           {!loading && !filtered.length ? (
             <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-5 text-center text-sm text-[color:var(--theme-text-secondary)]">
               No PM items match this view.
@@ -402,39 +475,207 @@ export default function FleetMaintenanceWorkspace({
       </section>
 
       <section className={card}>
-        <div className="flex items-center gap-2">
-          <ShieldCheck className="h-4 w-4 text-sky-300" />
-          <div>
-            <h2 className="text-sm font-semibold">PM programs</h2>
-            <p className="text-xs text-[color:var(--theme-text-secondary)]">
-              A compact view of intervals, assignments, and units currently due.
-            </p>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-sky-500 dark:text-sky-300" />
+            <div>
+              <h2 className="text-sm font-semibold">PM programs</h2>
+              <p className="text-xs text-[color:var(--theme-text-secondary)]">
+                Fleet-owned templates, intervals, tasks, and asset assignments.
+              </p>
+            </div>
           </div>
+          {data?.canManagePrograms ? (
+            <button
+              type="button"
+              onClick={() => setProgramEditor(null)}
+              className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-sky-400 px-3 text-xs font-semibold text-slate-950"
+            >
+              <Plus className="h-4 w-4" /> Create template
+            </button>
+          ) : null}
         </div>
         <div className="mt-4 grid gap-3 md:grid-cols-2">
           {(data?.programs ?? []).map((program) => (
-            <article key={program.id} className="rounded-xl border border-[color:var(--theme-border-soft)] p-3">
+            <article
+              key={program.id}
+              className="rounded-xl border border-[color:var(--theme-border-soft)] p-3"
+            >
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <h3 className="text-sm font-semibold">{program.name}</h3>
-                  <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{intervalLabel(program)}</p>
+                  <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                    {intervalLabel(program)}
+                  </p>
                 </div>
                 <span className="rounded-full bg-[color:var(--theme-surface-subtle)] px-2 py-1 text-[10px]">
                   {program.dueUnits}/{program.assignedUnits} due
                 </span>
               </div>
-              {program.notes ? <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">{program.notes}</p> : null}
+              <div className="mt-3 flex flex-wrap gap-2 text-[10px] uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                <span>
+                  {program.tasks.length} task
+                  {program.tasks.length === 1 ? "" : "s"}
+                </span>
+                <span>•</span>
+                <span>
+                  {program.assignmentMode === "all_units"
+                    ? "All Fleet assets"
+                    : `${program.assignedVehicleIds.length} selected assets`}
+                </span>
+                <span>•</span>
+                <span>
+                  {program.requiresFleetApproval
+                    ? "Approval required"
+                    : "No approval gate"}
+                </span>
+              </div>
+              {program.notes ? (
+                <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
+                  {program.notes}
+                </p>
+              ) : null}
+              {data?.canManagePrograms ? (
+                <div className="mt-3 flex flex-wrap gap-2 border-t border-[color:var(--theme-border-soft)] pt-3">
+                  <button
+                    type="button"
+                    onClick={() => setProgramEditor(program)}
+                    className="inline-flex min-h-9 items-center gap-2 rounded-lg border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold"
+                  >
+                    <Pencil className="h-3.5 w-3.5" /> Edit
+                  </button>
+                  <button
+                    type="button"
+                    disabled={workingId === program.id}
+                    onClick={() => {
+                      if (
+                        !window.confirm(
+                          `Archive ${program.name}? Existing due items will be dismissed.`,
+                        )
+                      )
+                        return;
+                      void mutate(
+                        {
+                          action: "archive_program",
+                          fleetId: program.fleetId,
+                          programId: program.id,
+                        },
+                        program.id,
+                      );
+                    }}
+                    className="inline-flex min-h-9 items-center gap-2 rounded-lg px-3 text-xs font-semibold text-red-600 hover:bg-red-500/10 dark:text-red-300 disabled:opacity-50"
+                  >
+                    <Archive className="h-3.5 w-3.5" /> Archive
+                  </button>
+                </div>
+              ) : null}
             </article>
           ))}
+          {!loading && !(data?.programs.length ?? 0) ? (
+            <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-5 text-sm text-[color:var(--theme-text-secondary)] md:col-span-2">
+              Create a PM template to define recurring work and assign it to
+              Fleet assets.
+            </div>
+          ) : null}
         </div>
       </section>
 
-      {deferItem ? (
-        <div className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4" role="dialog" aria-modal="true" aria-labelledby="defer-pm-title">
+      {programEditor !== undefined && data ? (
+        <FleetPmProgramEditor
+          fleets={
+            fleetId === "all"
+              ? data.fleets
+              : [
+                  ...data.fleets.filter((fleet) => fleet.id === fleetId),
+                  ...data.fleets.filter((fleet) => fleet.id !== fleetId),
+                ]
+          }
+          units={data.units}
+          program={programEditor}
+          busy={workingId === "workspace"}
+          onClose={() => setProgramEditor(undefined)}
+          onSave={(body) => mutate(body)}
+        />
+      ) : null}
+
+      {requestItem ? (
+        <div
+          className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="plan-pm-title"
+        >
           <div className="w-full max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] p-5 shadow-2xl">
-            <h2 id="defer-pm-title" className="text-lg font-semibold">Defer {deferItem.name}</h2>
+            <h2 id="plan-pm-title" className="text-lg font-semibold">
+              Plan {requestItem.name}
+            </h2>
             <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-              {deferItem.unitLabel} • A future date and reason are retained with the PM evidence.
+              {requestItem.unitLabel} • Fleet chooses the requested date; Shop
+              owns repair execution.
+            </p>
+            <label className="mt-4 block text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+              Requested service date
+              <input
+                type="date"
+                min={localDateInput()}
+                value={requestedForDate}
+                onChange={(event) => setRequestedForDate(event.target.value)}
+                className="mt-1 min-h-11 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3"
+              />
+            </label>
+            <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
+              Leave the date blank to place the request in the calendar’s “Needs
+              a planning date” queue.
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setRequestItem(null)}
+                className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={workingId === requestItem.id}
+                onClick={() =>
+                  void (async () => {
+                    const ok = await mutate(
+                      {
+                        action: "create_request",
+                        dueEventId: requestItem.id,
+                        requestedForDate: requestedForDate || null,
+                      },
+                      requestItem.id,
+                    );
+                    if (ok) setRequestItem(null);
+                  })()
+                }
+                className="rounded-xl bg-sky-400 px-4 py-2 text-xs font-semibold text-slate-950 disabled:opacity-50"
+              >
+                {workingId === requestItem.id
+                  ? "Creating…"
+                  : "Create Fleet request"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {deferItem ? (
+        <div
+          className="fixed inset-0 z-50 grid place-items-center bg-black/70 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="defer-pm-title"
+        >
+          <div className="w-full max-w-md rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] p-5 shadow-2xl">
+            <h2 id="defer-pm-title" className="text-lg font-semibold">
+              Defer {deferItem.name}
+            </h2>
+            <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+              {deferItem.unitLabel} • A future date and reason are retained with
+              the PM evidence.
             </p>
             <label className="mt-4 block text-xs">
               Review again on
@@ -449,19 +690,29 @@ export default function FleetMaintenanceWorkspace({
               Reason
               <textarea
                 value={deferReason}
-                onChange={(event) => setDeferReason(event.target.value.slice(0, 500))}
+                onChange={(event) =>
+                  setDeferReason(event.target.value.slice(0, 500))
+                }
                 rows={3}
                 className="mt-1 w-full rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-2"
                 placeholder="Example: Unit unavailable until route ends."
               />
             </label>
             <div className="mt-4 flex justify-end gap-2">
-              <button type="button" onClick={() => setDeferItem(null)} className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold">
+              <button
+                type="button"
+                onClick={() => setDeferItem(null)}
+                className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold"
+              >
                 Cancel
               </button>
               <button
                 type="button"
-                disabled={!deferReason.trim() || !deferUntil || workingId === deferItem.id}
+                disabled={
+                  !deferReason.trim() ||
+                  !deferUntil ||
+                  workingId === deferItem.id
+                }
                 onClick={() =>
                   void (async () => {
                     const ok = await mutate(

--- a/features/fleet/components/FleetPmProgramEditor.tsx
+++ b/features/fleet/components/FleetPmProgramEditor.tsx
@@ -1,0 +1,516 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Plus, Trash2, X } from "lucide-react";
+
+export type FleetPmUnitOption = {
+  id: string;
+  fleetId: string;
+  fleetName: string;
+  label: string;
+  description: string;
+};
+
+export type FleetPmProgramTask = {
+  id?: string;
+  description: string;
+  jobType: string;
+  laborHours: number | null;
+  sectionKey: string | null;
+};
+
+export type FleetPmProgram = {
+  id: string;
+  fleetId: string;
+  fleetName: string;
+  name: string;
+  cadence: string;
+  intervalKm: number | null;
+  intervalHours: number | null;
+  intervalDays: number | null;
+  notes: string | null;
+  assignmentMode: "all_units" | "selected_units";
+  requiresFleetApproval: boolean;
+  assignedVehicleIds: string[];
+  tasks: FleetPmProgramTask[];
+  assignedUnits: number;
+  dueUnits: number;
+};
+
+type DraftTask = FleetPmProgramTask & { key: string };
+
+function newTask(description = ""): DraftTask {
+  return {
+    key:
+      globalThis.crypto?.randomUUID?.() ??
+      `task-${Date.now()}-${Math.random()}`,
+    description,
+    jobType: "maintenance",
+    laborHours: null,
+    sectionKey: null,
+  };
+}
+
+function nullableNumber(value: string): number | null {
+  if (!value.trim()) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+export default function FleetPmProgramEditor({
+  fleets,
+  units,
+  program,
+  busy,
+  onClose,
+  onSave,
+}: {
+  fleets: Array<{ id: string; name: string }>;
+  units: FleetPmUnitOption[];
+  program: FleetPmProgram | null;
+  busy: boolean;
+  onClose: () => void;
+  onSave: (body: Record<string, unknown>) => Promise<boolean>;
+}) {
+  const [fleetId, setFleetId] = useState(
+    program?.fleetId ?? fleets[0]?.id ?? "",
+  );
+  const [name, setName] = useState(program?.name ?? "");
+  const [cadence, setCadence] = useState(program?.cadence ?? "mileage_based");
+  const [intervalKm, setIntervalKm] = useState(
+    program?.intervalKm?.toString() ?? "",
+  );
+  const [intervalHours, setIntervalHours] = useState(
+    program?.intervalHours?.toString() ?? "",
+  );
+  const [intervalDays, setIntervalDays] = useState(
+    program?.intervalDays?.toString() ?? "",
+  );
+  const [assignmentMode, setAssignmentMode] = useState<
+    "all_units" | "selected_units"
+  >(program?.assignmentMode ?? "all_units");
+  const [selectedVehicleIds, setSelectedVehicleIds] = useState(
+    () => new Set(program?.assignedVehicleIds ?? []),
+  );
+  const [requiresApproval, setRequiresApproval] = useState(
+    program?.requiresFleetApproval ?? true,
+  );
+  const [notes, setNotes] = useState(program?.notes ?? "");
+  const [tasks, setTasks] = useState<DraftTask[]>(() =>
+    program?.tasks.length
+      ? program.tasks.map((task) => ({
+          ...task,
+          key: task.id ?? newTask().key,
+        }))
+      : [newTask("Inspect and complete scheduled preventive maintenance")],
+  );
+  const [operationKey] = useState(() =>
+    program
+      ? `pm-program:update:${program.id}`
+      : `pm-program:create:${globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`}`,
+  );
+  const [validation, setValidation] = useState<string | null>(null);
+
+  const fleetUnits = useMemo(
+    () => units.filter((unit) => unit.fleetId === fleetId),
+    [fleetId, units],
+  );
+
+  function updateTask(key: string, changes: Partial<DraftTask>) {
+    setTasks((current) =>
+      current.map((task) =>
+        task.key === key ? { ...task, ...changes } : task,
+      ),
+    );
+  }
+
+  function toggleVehicle(vehicleId: string) {
+    setSelectedVehicleIds((current) => {
+      const next = new Set(current);
+      if (next.has(vehicleId)) next.delete(vehicleId);
+      else next.add(vehicleId);
+      return next;
+    });
+  }
+
+  async function submit() {
+    const cleanedTasks = tasks
+      .map((task) => ({
+        description: task.description.trim(),
+        jobType: task.jobType,
+        laborHours: task.laborHours,
+        sectionKey: task.sectionKey,
+      }))
+      .filter((task) => task.description);
+    if (!fleetId) return setValidation("Choose a Fleet workspace.");
+    if (!name.trim()) return setValidation("Enter a PM template name.");
+    if (!intervalKm.trim() && !intervalHours.trim() && !intervalDays.trim()) {
+      return setValidation(
+        "Enter at least one kilometre, hour, or calendar interval.",
+      );
+    }
+    if (!cleanedTasks.length) return setValidation("Add at least one PM task.");
+    if (assignmentMode === "selected_units" && selectedVehicleIds.size === 0) {
+      return setValidation("Select at least one Fleet asset.");
+    }
+
+    setValidation(null);
+    const saved = await onSave({
+      action: "save_program",
+      fleetId,
+      programId: program?.id ?? null,
+      name: name.trim(),
+      cadence,
+      intervalKm: nullableNumber(intervalKm),
+      intervalHours: nullableNumber(intervalHours),
+      intervalDays: nullableNumber(intervalDays),
+      assignmentMode,
+      vehicleIds:
+        assignmentMode === "selected_units"
+          ? Array.from(selectedVehicleIds)
+          : [],
+      tasks: cleanedTasks,
+      notes: notes.trim() || null,
+      requiresFleetApproval: requiresApproval,
+      operationKey,
+    });
+    if (saved) onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/75 p-3 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="pm-program-editor-title"
+    >
+      <div className="max-h-[94dvh] w-full max-w-4xl overflow-y-auto rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] shadow-2xl">
+        <div className="sticky top-0 z-10 flex items-start justify-between gap-4 border-b border-sky-400/20 bg-sky-500 px-5 py-4 text-white">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-sky-100">
+              Fleet-owned maintenance template
+            </p>
+            <h2
+              id="pm-program-editor-title"
+              className="mt-1 text-xl font-semibold"
+            >
+              {program ? `Edit ${program.name}` : "Create PM program"}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close PM program editor"
+            className="grid h-10 w-10 place-items-center rounded-xl bg-white/10 hover:bg-white/20"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="space-y-6 p-5 text-[color:var(--theme-text-primary)]">
+          {validation ? (
+            <div
+              role="alert"
+              className="rounded-xl border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200"
+            >
+              {validation}
+            </div>
+          ) : null}
+
+          <section className="grid gap-4 md:grid-cols-2">
+            <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+              Fleet workspace
+              <select
+                value={fleetId}
+                disabled={Boolean(program)}
+                onChange={(event) => {
+                  setFleetId(event.target.value);
+                  setSelectedVehicleIds(new Set());
+                }}
+                className="mt-1.5 min-h-11 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-sm"
+              >
+                {fleets.map((fleet) => (
+                  <option key={fleet.id} value={fleet.id}>
+                    {fleet.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+              Template name
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value.slice(0, 120))}
+                placeholder="Example: Tractor A service"
+                className="mt-1.5 min-h-11 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-sm"
+              />
+            </label>
+          </section>
+
+          <section className="rounded-xl border border-[color:var(--theme-border-soft)] p-4">
+            <h3 className="text-sm font-semibold">Service interval</h3>
+            <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+              The first threshold reached creates one reviewable PM due event.
+            </p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Primary cadence
+                <select
+                  value={cadence}
+                  onChange={(event) => setCadence(event.target.value)}
+                  className="mt-1.5 min-h-11 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-sm"
+                >
+                  <option value="mileage_based">Kilometres</option>
+                  <option value="hours_based">Engine hours</option>
+                  <option value="monthly">Monthly / days</option>
+                  <option value="quarterly">Quarterly / days</option>
+                </select>
+              </label>
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Every kilometres
+                <input
+                  inputMode="numeric"
+                  value={intervalKm}
+                  onChange={(event) =>
+                    setIntervalKm(event.target.value.replace(/[^0-9]/g, ""))
+                  }
+                  placeholder="20,000"
+                  className="mt-1.5 min-h-11 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-sm"
+                />
+              </label>
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Every engine hours
+                <input
+                  inputMode="numeric"
+                  value={intervalHours}
+                  onChange={(event) =>
+                    setIntervalHours(event.target.value.replace(/[^0-9]/g, ""))
+                  }
+                  placeholder="500"
+                  className="mt-1.5 min-h-11 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-sm"
+                />
+              </label>
+              <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+                Every calendar days
+                <input
+                  inputMode="numeric"
+                  value={intervalDays}
+                  onChange={(event) =>
+                    setIntervalDays(event.target.value.replace(/[^0-9]/g, ""))
+                  }
+                  placeholder="90"
+                  className="mt-1.5 min-h-11 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-sm"
+                />
+              </label>
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-[color:var(--theme-border-soft)] p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-semibold">Template tasks</h3>
+                <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                  These become structured PM request lines when maintenance is
+                  due.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setTasks((current) => [...current, newTask()])}
+                className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold"
+              >
+                <Plus className="h-4 w-4" /> Add task
+              </button>
+            </div>
+            <div className="mt-4 space-y-3">
+              {tasks.map((task, index) => (
+                <div
+                  key={task.key}
+                  className="grid gap-2 rounded-xl bg-[color:var(--theme-surface-subtle)] p-3 md:grid-cols-[minmax(0,1fr)_150px_120px_44px]"
+                >
+                  <label className="text-[10px] font-semibold uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                    Task {index + 1}
+                    <input
+                      value={task.description}
+                      onChange={(event) =>
+                        updateTask(task.key, {
+                          description: event.target.value.slice(0, 500),
+                        })
+                      }
+                      placeholder="Inspect, replace, adjust…"
+                      className="mt-1 min-h-10 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-sm normal-case tracking-normal"
+                    />
+                  </label>
+                  <label className="text-[10px] font-semibold uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                    Work type
+                    <select
+                      value={task.jobType}
+                      onChange={(event) =>
+                        updateTask(task.key, { jobType: event.target.value })
+                      }
+                      className="mt-1 min-h-10 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-2 text-xs normal-case tracking-normal"
+                    >
+                      <option value="maintenance">Maintenance</option>
+                      <option value="inspection">Inspection</option>
+                      <option value="repair">Repair</option>
+                    </select>
+                  </label>
+                  <label className="text-[10px] font-semibold uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                    Est. hours
+                    <input
+                      inputMode="decimal"
+                      value={task.laborHours ?? ""}
+                      onChange={(event) => {
+                        const parsed = Number(event.target.value);
+                        updateTask(task.key, {
+                          laborHours:
+                            event.target.value && Number.isFinite(parsed)
+                              ? Math.max(0, parsed)
+                              : null,
+                        });
+                      }}
+                      className="mt-1 min-h-10 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-2 text-xs normal-case tracking-normal"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    aria-label={`Remove task ${index + 1}`}
+                    disabled={tasks.length === 1}
+                    onClick={() =>
+                      setTasks((current) =>
+                        current.filter((item) => item.key !== task.key),
+                      )
+                    }
+                    className="mt-4 grid h-10 w-10 place-items-center rounded-xl text-red-500 hover:bg-red-500/10 disabled:opacity-30"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-[color:var(--theme-border-soft)] p-4">
+            <h3 className="text-sm font-semibold">Asset assignment</h3>
+            <div className="mt-3 grid gap-2 sm:grid-cols-2">
+              {(
+                [
+                  [
+                    "all_units",
+                    "All current and future Fleet assets",
+                    "Best for a universal inspection or service.",
+                  ],
+                  [
+                    "selected_units",
+                    "Selected assets only",
+                    "Use for tractors, trailers, buses, or a specific class.",
+                  ],
+                ] as const
+              ).map(([value, label, description]) => (
+                <button
+                  type="button"
+                  key={value}
+                  onClick={() => setAssignmentMode(value)}
+                  className={`rounded-xl border p-3 text-left ${
+                    assignmentMode === value
+                      ? "border-sky-400/50 bg-sky-400/10"
+                      : "border-[color:var(--theme-border-soft)]"
+                  }`}
+                >
+                  <div className="text-sm font-semibold">{label}</div>
+                  <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                    {description}
+                  </div>
+                </button>
+              ))}
+            </div>
+            {assignmentMode === "selected_units" ? (
+              <div className="mt-4 grid max-h-60 gap-2 overflow-y-auto sm:grid-cols-2">
+                {fleetUnits.map((unit) => (
+                  <label
+                    key={unit.id}
+                    className="flex min-h-12 cursor-pointer items-center gap-3 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedVehicleIds.has(unit.id)}
+                      onChange={() => toggleVehicle(unit.id)}
+                      className="h-4 w-4 rounded border-[color:var(--theme-input-border)]"
+                    />
+                    <span className="min-w-0">
+                      <span className="block truncate text-sm font-semibold">
+                        {unit.label}
+                      </span>
+                      <span className="block truncate text-[10px] text-[color:var(--theme-text-muted)]">
+                        {unit.description || unit.fleetName}
+                      </span>
+                    </span>
+                  </label>
+                ))}
+                {!fleetUnits.length ? (
+                  <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                    Enroll an asset before assigning this template.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-[1fr_260px]">
+            <label className="text-xs font-semibold text-[color:var(--theme-text-secondary)]">
+              Operating notes
+              <textarea
+                rows={3}
+                value={notes}
+                onChange={(event) =>
+                  setNotes(event.target.value.slice(0, 2000))
+                }
+                placeholder="Fluids, OEM schedule, seasonal conditions, or planning notes."
+                className="mt-1.5 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 py-2 text-sm"
+              />
+            </label>
+            <label className="flex cursor-pointer items-start gap-3 rounded-xl border border-[color:var(--theme-border-soft)] p-4">
+              <input
+                type="checkbox"
+                checked={requiresApproval}
+                onChange={(event) => setRequiresApproval(event.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded"
+              />
+              <span>
+                <span className="block text-sm font-semibold">
+                  Fleet approval required
+                </span>
+                <span className="mt-1 block text-xs text-[color:var(--theme-text-muted)]">
+                  Keep estimate decisions with the Fleet before Shop work
+                  begins.
+                </span>
+              </span>
+            </label>
+          </section>
+
+          <div className="flex flex-col-reverse gap-2 border-t border-[color:var(--theme-border-soft)] pt-4 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="min-h-11 rounded-xl border border-[color:var(--theme-border-soft)] px-4 text-sm font-semibold"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void submit()}
+              className="min-h-11 rounded-xl bg-sky-400 px-5 text-sm font-semibold text-slate-950 disabled:opacity-50"
+            >
+              {busy
+                ? "Saving PM program…"
+                : program
+                  ? "Save PM program"
+                  : "Create PM program"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/fleet/lib/resolveFleetActorContext.ts
+++ b/features/fleet/lib/resolveFleetActorContext.ts
@@ -218,6 +218,19 @@ export function canManageFleetForActor(
   return tier === "manager" || tier === "approver";
 }
 
+export function canAdministerFleetForActor(
+  actor: FleetActorContext,
+  fleetId: string,
+): boolean {
+  if (actor.isInternal) {
+    return (
+      ["owner", "admin", "manager"].includes(actor.canonicalRole) &&
+      actor.fleetIds.includes(fleetId)
+    );
+  }
+  return resolveFleetRoleTier(fleetRoleForActor(actor, fleetId)) === "manager";
+}
+
 export function manageableFleetIdsForActor(actor: FleetActorContext): string[] {
   if (actor.isInternal) return [];
   return uniqueStrings(

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -4682,6 +4682,79 @@ export type Database = {
           },
         ]
       }
+      fleet_program_assignments: {
+        Row: {
+          created_at: string
+          created_by: string
+          fleet_id: string
+          id: string
+          program_id: string
+          shop_id: string
+          vehicle_id: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string
+          fleet_id: string
+          id?: string
+          program_id: string
+          shop_id: string
+          vehicle_id: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          fleet_id?: string
+          id?: string
+          program_id?: string
+          shop_id?: string
+          vehicle_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fleet_program_assignments_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleet_program_assignments_fleet_id_fkey"
+            columns: ["fleet_id"]
+            isOneToOne: false
+            referencedRelation: "fleets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleet_program_assignments_program_id_fkey"
+            columns: ["program_id"]
+            isOneToOne: false
+            referencedRelation: "fleet_programs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleet_program_assignments_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shop_public_profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleet_program_assignments_shop_id_fkey"
+            columns: ["shop_id"]
+            isOneToOne: false
+            referencedRelation: "shops"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fleet_program_assignments_vehicle_id_fkey"
+            columns: ["vehicle_id"]
+            isOneToOne: false
+            referencedRelation: "vehicles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       fleet_program_tasks: {
         Row: {
           created_at: string
@@ -4725,6 +4798,8 @@ export type Database = {
       }
       fleet_programs: {
         Row: {
+          active: boolean
+          assignment_mode: string
           base_template_slug: string | null
           cadence: Database["public"]["Enums"]["fleet_program_cadence"]
           created_at: string
@@ -4736,8 +4811,13 @@ export type Database = {
           interval_km: number | null
           name: string
           notes: string | null
+          operation_key: string | null
+          requires_fleet_approval: boolean
+          updated_at: string
         }
         Insert: {
+          active?: boolean
+          assignment_mode?: string
           base_template_slug?: string | null
           cadence: Database["public"]["Enums"]["fleet_program_cadence"]
           created_at?: string
@@ -4749,8 +4829,13 @@ export type Database = {
           interval_km?: number | null
           name: string
           notes?: string | null
+          operation_key?: string | null
+          requires_fleet_approval?: boolean
+          updated_at?: string
         }
         Update: {
+          active?: boolean
+          assignment_mode?: string
           base_template_slug?: string | null
           cadence?: Database["public"]["Enums"]["fleet_program_cadence"]
           created_at?: string
@@ -4762,6 +4847,9 @@ export type Database = {
           interval_km?: number | null
           name?: string
           notes?: string | null
+          operation_key?: string | null
+          requires_fleet_approval?: boolean
+          updated_at?: string
         }
         Relationships: [
           {
@@ -25048,6 +25136,25 @@ export type Database = {
       is_shop_member: { Args: { p_shop: string }; Returns: boolean }
       is_shop_member_v2: { Args: { shop_id: string }; Returns: boolean }
       is_staff_for_shop: { Args: { _shop: string }; Returns: boolean }
+      manage_fleet_pm_program: {
+        Args: {
+          p_action: string
+          p_assignment_mode: string
+          p_cadence: string
+          p_fleet_id: string
+          p_interval_days: number
+          p_interval_hours: number
+          p_interval_km: number
+          p_name: string
+          p_notes: string
+          p_operation_key: string
+          p_program_id: string
+          p_requires_fleet_approval: boolean
+          p_tasks: Json
+          p_vehicle_ids: string[]
+        }
+        Returns: Json
+      }
       manage_fleet_unit_defects: {
         Args: {
           p_action: string

--- a/supabase/migrations/20260806022431_fleet_pm_calendar_management.sql
+++ b/supabase/migrations/20260806022431_fleet_pm_calendar_management.sql
@@ -1,0 +1,436 @@
+begin;
+
+alter table public.fleet_programs
+  add column if not exists assignment_mode text not null default 'all_units',
+  add column if not exists requires_fleet_approval boolean not null default true,
+  add column if not exists active boolean not null default true,
+  add column if not exists operation_key text,
+  add column if not exists updated_at timestamptz not null default now();
+
+alter table public.fleet_programs
+  drop constraint if exists fleet_programs_assignment_mode_check;
+alter table public.fleet_programs
+  add constraint fleet_programs_assignment_mode_check
+  check (assignment_mode in ('all_units', 'selected_units'));
+
+create unique index if not exists fleet_programs_operation_key_uidx
+  on public.fleet_programs (fleet_id, operation_key)
+  where operation_key is not null;
+create index if not exists fleet_programs_fleet_active_idx
+  on public.fleet_programs (fleet_id, active, updated_at desc);
+
+create table if not exists public.fleet_program_assignments (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  fleet_id uuid not null references public.fleets(id) on delete cascade,
+  program_id uuid not null references public.fleet_programs(id) on delete cascade,
+  vehicle_id uuid not null references public.vehicles(id) on delete cascade,
+  created_by uuid not null references public.profiles(id) on delete restrict default auth.uid(),
+  created_at timestamptz not null default now(),
+  unique (program_id, vehicle_id)
+);
+
+create index if not exists fleet_program_assignments_fleet_vehicle_idx
+  on public.fleet_program_assignments (fleet_id, vehicle_id, program_id);
+create index if not exists fleet_program_assignments_shop_idx
+  on public.fleet_program_assignments (shop_id);
+create index if not exists fleet_program_assignments_vehicle_idx
+  on public.fleet_program_assignments (vehicle_id);
+create index if not exists fleet_program_assignments_created_by_idx
+  on public.fleet_program_assignments (created_by);
+
+alter table public.fleet_program_assignments enable row level security;
+revoke all on table public.fleet_program_assignments from public, anon;
+grant select on table public.fleet_program_assignments to authenticated;
+grant all on table public.fleet_program_assignments to service_role;
+
+drop policy if exists "fleet_program_assignments.select.scope" on public.fleet_program_assignments;
+create policy "fleet_program_assignments.select.scope"
+on public.fleet_program_assignments
+for select to authenticated
+using (
+  exists (
+    select 1 from public.profiles p
+    where p.id = (select auth.uid())
+      and p.shop_id = fleet_program_assignments.shop_id
+      and p.role in ('owner', 'admin', 'manager')
+      and exists (
+        select 1 from public.fleet_members explicit_membership
+        where explicit_membership.user_id = p.id
+          and explicit_membership.fleet_id = fleet_program_assignments.fleet_id
+      )
+  )
+  or exists (
+    select 1 from public.fleet_members m
+    where m.user_id = (select auth.uid())
+      and m.fleet_id = fleet_program_assignments.fleet_id
+      and m.role in ('owner', 'admin', 'manager', 'fleet_manager', 'approver')
+  )
+);
+
+drop policy if exists "fleet_program_assignments.write.management" on public.fleet_program_assignments;
+
+create or replace function public.enforce_fleet_pm_program_assignment()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_assignment_mode text;
+  v_program_active boolean;
+begin
+  if not new.active then return new; end if;
+
+  select fp.assignment_mode, fp.active
+  into v_assignment_mode, v_program_active
+  from public.fleet_programs fp
+  where fp.id = new.program_id
+    and fp.fleet_id = new.fleet_id;
+
+  if coalesce(v_program_active, false) is false then return null; end if;
+  if v_assignment_mode = 'selected_units'
+     and not exists (
+       select 1
+       from public.fleet_program_assignments assignment
+       where assignment.program_id = new.program_id
+         and assignment.fleet_id = new.fleet_id
+         and assignment.vehicle_id = new.vehicle_id
+     )
+  then
+    return null;
+  end if;
+
+  return new;
+end;
+$function$;
+
+drop trigger if exists fleet_pm_policy_assignment_guard on public.fleet_pm_policies;
+create trigger fleet_pm_policy_assignment_guard
+before insert or update of active, vehicle_id, program_id, fleet_id
+on public.fleet_pm_policies
+for each row execute function public.enforce_fleet_pm_program_assignment();
+
+create or replace function public.manage_fleet_pm_program(
+  p_action text,
+  p_fleet_id uuid,
+  p_program_id uuid,
+  p_name text,
+  p_cadence text,
+  p_interval_km integer,
+  p_interval_hours integer,
+  p_interval_days integer,
+  p_assignment_mode text,
+  p_vehicle_ids uuid[],
+  p_tasks jsonb,
+  p_notes text,
+  p_requires_fleet_approval boolean,
+  p_operation_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_user_id uuid := auth.uid();
+  v_shop_id uuid;
+  v_program_id uuid;
+  v_task jsonb;
+  v_task_index integer := 0;
+  v_target_vehicle_ids uuid[] := array[]::uuid[];
+begin
+  if v_user_id is null then raise exception 'Authentication required'; end if;
+
+  select f.shop_id into v_shop_id
+  from public.fleets f
+  where f.id = p_fleet_id
+  for update;
+  if v_shop_id is null then raise exception 'Fleet not found'; end if;
+
+  if not (
+    exists (
+      select 1 from public.profiles p
+      where p.id = v_user_id
+        and p.shop_id = v_shop_id
+        and p.role in ('owner', 'admin', 'manager')
+        and exists (
+          select 1 from public.fleet_members explicit_membership
+          where explicit_membership.user_id = v_user_id
+            and explicit_membership.fleet_id = p_fleet_id
+        )
+    )
+    or exists (
+      select 1 from public.fleet_members m
+      where m.user_id = v_user_id
+        and m.fleet_id = p_fleet_id
+        and m.role in ('owner', 'admin', 'manager', 'fleet_manager')
+    )
+  ) then
+    raise exception 'Fleet manager access required';
+  end if;
+
+  if p_action = 'archive' then
+    if p_program_id is null then raise exception 'PM program is required'; end if;
+    select fp.id into v_program_id
+    from public.fleet_programs fp
+    where fp.id = p_program_id and fp.fleet_id = p_fleet_id
+    for update;
+    if v_program_id is null then raise exception 'PM program not found'; end if;
+
+    update public.fleet_programs
+    set active = false, updated_at = now()
+    where id = v_program_id and fleet_id = p_fleet_id;
+    update public.fleet_pm_policies
+    set active = false, updated_at = now()
+    where program_id = v_program_id and fleet_id = p_fleet_id and active;
+    update public.fleet_pm_due_events
+    set status = 'dismissed', updated_at = now()
+    where program_id = v_program_id
+      and fleet_id = p_fleet_id
+      and status in ('pending', 'deferred');
+
+    insert into public.activity_logs (user_id, action, target_table, target_id, context)
+    values (
+      v_user_id, 'fleet_pm_program_archived', 'fleet_programs', v_program_id,
+      jsonb_build_object('fleet_id', p_fleet_id, 'shop_id', v_shop_id)
+    );
+    return jsonb_build_object('ok', true, 'action', p_action, 'programId', v_program_id);
+  end if;
+
+  if p_action not in ('create', 'update') then raise exception 'Unsupported PM program action'; end if;
+  if nullif(btrim(coalesce(p_name, '')), '') is null then raise exception 'PM program name is required'; end if;
+  if length(btrim(p_name)) > 120 then raise exception 'PM program name is too long'; end if;
+  if p_cadence not in ('monthly', 'quarterly', 'mileage_based', 'hours_based') then
+    raise exception 'Select a valid PM cadence';
+  end if;
+  if p_assignment_mode not in ('all_units', 'selected_units') then
+    raise exception 'Select a valid assignment mode';
+  end if;
+  if (p_interval_km is null or p_interval_km <= 0)
+     and (p_interval_hours is null or p_interval_hours <= 0)
+     and (p_interval_days is null or p_interval_days <= 0)
+  then
+    raise exception 'At least one PM interval is required';
+  end if;
+  if p_interval_km is not null and p_interval_km <= 0 then raise exception 'Kilometre interval must be positive'; end if;
+  if p_interval_hours is not null and p_interval_hours <= 0 then raise exception 'Hour interval must be positive'; end if;
+  if p_interval_days is not null and p_interval_days <= 0 then raise exception 'Day interval must be positive'; end if;
+  if coalesce(jsonb_typeof(p_tasks), 'null') <> 'array' then
+    raise exception 'PM tasks must be an array';
+  end if;
+  if jsonb_array_length(p_tasks) = 0 then
+    raise exception 'At least one PM task is required';
+  end if;
+  if jsonb_array_length(p_tasks) > 50 then raise exception 'A PM program can contain at most 50 tasks'; end if;
+
+  select coalesce(array_agg(distinct selected.vehicle_id), array[]::uuid[])
+  into v_target_vehicle_ids
+  from unnest(coalesce(p_vehicle_ids, array[]::uuid[])) as selected(vehicle_id);
+
+  if p_assignment_mode = 'selected_units' and cardinality(v_target_vehicle_ids) = 0 then
+    raise exception 'Select at least one Fleet asset';
+  end if;
+  if exists (
+    select 1
+    from unnest(v_target_vehicle_ids) as selected(vehicle_id)
+    where not exists (
+      select 1 from public.fleet_vehicles fv
+      where fv.fleet_id = p_fleet_id
+        and fv.shop_id = v_shop_id
+        and fv.vehicle_id = selected.vehicle_id
+        and coalesce(fv.active, true)
+    )
+  ) then
+    raise exception 'A selected asset is not active in this Fleet';
+  end if;
+
+  if p_action = 'create' then
+    if nullif(btrim(coalesce(p_operation_key, '')), '') is null then
+      raise exception 'Operation key is required';
+    end if;
+    select fp.id into v_program_id
+    from public.fleet_programs fp
+    where fp.fleet_id = p_fleet_id and fp.operation_key = p_operation_key;
+    if v_program_id is not null then
+      return jsonb_build_object('ok', true, 'action', p_action, 'programId', v_program_id, 'idempotent', true);
+    end if;
+
+    begin
+      insert into public.fleet_programs (
+        fleet_id, name, cadence, interval_km, interval_hours, interval_days,
+        notes, assignment_mode, requires_fleet_approval, active, operation_key, updated_at
+      ) values (
+        p_fleet_id, btrim(p_name), p_cadence::public.fleet_program_cadence,
+        p_interval_km, p_interval_hours, p_interval_days,
+        nullif(btrim(coalesce(p_notes, '')), ''), p_assignment_mode,
+        coalesce(p_requires_fleet_approval, true), true, p_operation_key, now()
+      ) returning id into v_program_id;
+    exception when unique_violation then
+      select fp.id into v_program_id
+      from public.fleet_programs fp
+      where fp.fleet_id = p_fleet_id and fp.operation_key = p_operation_key;
+      if v_program_id is null then raise; end if;
+      return jsonb_build_object('ok', true, 'action', p_action, 'programId', v_program_id, 'idempotent', true);
+    end;
+  else
+    if p_program_id is null then raise exception 'PM program is required'; end if;
+    select fp.id into v_program_id
+    from public.fleet_programs fp
+    where fp.id = p_program_id and fp.fleet_id = p_fleet_id
+    for update;
+    if v_program_id is null then raise exception 'PM program not found'; end if;
+
+    update public.fleet_programs
+    set name = btrim(p_name),
+        cadence = p_cadence::public.fleet_program_cadence,
+        interval_km = p_interval_km,
+        interval_hours = p_interval_hours,
+        interval_days = p_interval_days,
+        notes = nullif(btrim(coalesce(p_notes, '')), ''),
+        assignment_mode = p_assignment_mode,
+        requires_fleet_approval = coalesce(p_requires_fleet_approval, true),
+        active = true,
+        updated_at = now()
+    where id = v_program_id and fleet_id = p_fleet_id;
+  end if;
+
+  delete from public.fleet_program_tasks where program_id = v_program_id;
+  for v_task in select value from jsonb_array_elements(p_tasks)
+  loop
+    if nullif(btrim(coalesce(v_task ->> 'description', '')), '') is null then
+      raise exception 'Every PM task needs a description';
+    end if;
+    insert into public.fleet_program_tasks (
+      program_id, display_order, description, job_type, default_labor_hours, section_key
+    ) values (
+      v_program_id,
+      v_task_index,
+      left(btrim(v_task ->> 'description'), 500),
+      case when coalesce(v_task ->> 'jobType', 'maintenance') in ('maintenance', 'inspection', 'repair')
+        then coalesce(v_task ->> 'jobType', 'maintenance') else 'maintenance' end,
+      case when nullif(v_task ->> 'laborHours', '') is null then null
+        else greatest((v_task ->> 'laborHours')::numeric, 0) end,
+      nullif(left(coalesce(v_task ->> 'sectionKey', ''), 80), '')
+    );
+    v_task_index := v_task_index + 1;
+  end loop;
+
+  if p_assignment_mode = 'all_units' then
+    delete from public.fleet_program_assignments
+    where program_id = v_program_id and fleet_id = p_fleet_id;
+    select coalesce(array_agg(fv.vehicle_id), array[]::uuid[])
+    into v_target_vehicle_ids
+    from public.fleet_vehicles fv
+    where fv.fleet_id = p_fleet_id
+      and fv.shop_id = v_shop_id
+      and coalesce(fv.active, true);
+  else
+    delete from public.fleet_program_assignments assignment
+    where assignment.program_id = v_program_id
+      and assignment.fleet_id = p_fleet_id
+      and not (assignment.vehicle_id = any(v_target_vehicle_ids));
+
+    insert into public.fleet_program_assignments (
+      shop_id, fleet_id, program_id, vehicle_id, created_by
+    )
+    select v_shop_id, p_fleet_id, v_program_id, selected.vehicle_id, v_user_id
+    from unnest(v_target_vehicle_ids) as selected(vehicle_id)
+    on conflict (program_id, vehicle_id) do nothing;
+  end if;
+
+  update public.fleet_pm_policies policy
+  set active = false, updated_at = now()
+  where policy.program_id = v_program_id
+    and policy.fleet_id = p_fleet_id
+    and policy.active
+    and not (policy.vehicle_id = any(v_target_vehicle_ids));
+
+  update public.fleet_pm_due_events due
+  set status = 'dismissed', updated_at = now()
+  where due.program_id = v_program_id
+    and due.fleet_id = p_fleet_id
+    and due.status in ('pending', 'deferred');
+
+  update public.fleet_pm_policies policy
+  set name = btrim(p_name),
+      interval_km = coalesce(fv.custom_interval_km, p_interval_km),
+      interval_hours = coalesce(fv.custom_interval_hours, p_interval_hours),
+      interval_days = coalesce(fv.custom_interval_days, p_interval_days),
+      requires_fleet_approval = coalesce(p_requires_fleet_approval, true),
+      active = true,
+      updated_at = now()
+  from public.fleet_vehicles fv
+  where policy.program_id = v_program_id
+    and policy.fleet_id = p_fleet_id
+    and policy.vehicle_id = fv.vehicle_id
+    and fv.fleet_id = p_fleet_id
+    and policy.vehicle_id = any(v_target_vehicle_ids);
+
+  insert into public.fleet_pm_policies (
+    shop_id, fleet_id, vehicle_id, program_id, name,
+    interval_km, interval_hours, interval_days,
+    anchor_odometer_km, anchor_engine_hours, anchor_date,
+    requires_fleet_approval, active, created_by
+  )
+  select
+    v_shop_id, p_fleet_id, fv.vehicle_id, v_program_id, btrim(p_name),
+    coalesce(fv.custom_interval_km, p_interval_km),
+    coalesce(fv.custom_interval_hours, p_interval_hours),
+    coalesce(fv.custom_interval_days, p_interval_days),
+    latest.odometer_km, latest.engine_hours, current_date,
+    coalesce(p_requires_fleet_approval, true), true, v_user_id
+  from public.fleet_vehicles fv
+  left join lateral (
+    select reading.odometer_km, reading.engine_hours
+    from public.fleet_unit_readings reading
+    where reading.fleet_id = p_fleet_id and reading.vehicle_id = fv.vehicle_id
+    order by reading.recorded_at desc, reading.created_at desc
+    limit 1
+  ) latest on true
+  where fv.fleet_id = p_fleet_id
+    and fv.shop_id = v_shop_id
+    and coalesce(fv.active, true)
+    and fv.vehicle_id = any(v_target_vehicle_ids)
+    and not exists (
+      select 1 from public.fleet_pm_policies existing
+      where existing.program_id = v_program_id
+        and existing.vehicle_id = fv.vehicle_id
+        and existing.active
+    );
+
+  insert into public.activity_logs (user_id, action, target_table, target_id, context)
+  values (
+    v_user_id,
+    case when p_action = 'create' then 'fleet_pm_program_created' else 'fleet_pm_program_updated' end,
+    'fleet_programs',
+    v_program_id,
+    jsonb_build_object(
+      'fleet_id', p_fleet_id,
+      'shop_id', v_shop_id,
+      'assignment_mode', p_assignment_mode,
+      'assigned_units', cardinality(v_target_vehicle_ids),
+      'task_count', jsonb_array_length(p_tasks)
+    )
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'action', p_action,
+    'programId', v_program_id,
+    'assignedUnits', cardinality(v_target_vehicle_ids)
+  );
+end;
+$function$;
+
+revoke execute on function public.manage_fleet_pm_program(
+  text,uuid,uuid,text,text,integer,integer,integer,text,uuid[],jsonb,text,boolean,text
+) from public, anon;
+grant execute on function public.manage_fleet_pm_program(
+  text,uuid,uuid,text,text,integer,integer,integer,text,uuid[],jsonb,text,boolean,text
+) to authenticated, service_role;
+
+revoke execute on function public.enforce_fleet_pm_program_assignment() from public, anon, authenticated;
+grant execute on function public.enforce_fleet_pm_program_assignment() to service_role;
+
+commit;

--- a/tests/fleet-pm-calendar-management.test.ts
+++ b/tests/fleet-pm-calendar-management.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = (path: string) => readFileSync(path, "utf8");
+const migration = source(
+  "supabase/migrations/20260806022431_fleet_pm_calendar_management.sql",
+);
+
+describe("Fleet PM scheduling and maintenance calendar", () => {
+  it("stores Fleet-owned program assignments behind a manager RPC", () => {
+    expect(migration).toContain(
+      "create table if not exists public.fleet_program_assignments",
+    );
+    expect(migration).toContain(
+      "assignment_mode in ('all_units', 'selected_units')",
+    );
+    expect(migration).toContain(
+      "create or replace function public.manage_fleet_pm_program",
+    );
+    expect(migration).toContain("Fleet manager access required");
+    expect(migration).toContain("fleet_programs_operation_key_uidx");
+    expect(migration).toContain("idempotent");
+    expect(migration).toContain(
+      "grant select on table public.fleet_program_assignments to authenticated",
+    );
+    expect(migration).not.toContain(
+      "grant select, insert, update, delete on table public.fleet_program_assignments to authenticated",
+    );
+  });
+
+  it("keeps selected-unit templates from expanding to the whole Fleet", () => {
+    expect(migration).toContain("enforce_fleet_pm_program_assignment");
+    expect(migration).toContain("fleet_pm_policy_assignment_guard");
+    expect(migration).toContain("v_assignment_mode = 'selected_units'");
+    expect(migration).toContain("fleet_program_assignments_vehicle_idx");
+    expect(migration).toContain("set active = false, updated_at = now()");
+    expect(migration).toContain("set status = 'dismissed', updated_at = now()");
+  });
+
+  it("provides manager-only PM template administration and planned requests", () => {
+    const route = source("app/api/fleet/maintenance/route.ts");
+    const workspace = source(
+      "features/fleet/components/FleetMaintenanceWorkspace.tsx",
+    );
+    const editor = source("features/fleet/components/FleetPmProgramEditor.tsx");
+
+    expect(route).toContain("canAdministerFleetForActor");
+    expect(route).toContain('action === "archive_program"');
+    expect(route).toContain('"manage_fleet_pm_program"');
+    expect(route).toContain("p_requested_for_date: requestedForDate");
+    expect(route).toContain('.from("fleet_program_tasks")');
+    expect(route).toContain("programTaskId");
+    expect(workspace).toContain("New PM program");
+    expect(workspace).toContain("Requested service date");
+    expect(workspace).toContain("Fleet chooses the requested date");
+    expect(editor).toContain("Selected assets only");
+    expect(editor).toContain("Fleet approval required");
+  });
+
+  it("replaces the calendar placeholder with live Fleet maintenance events", () => {
+    const route = source("app/api/fleet/calendar/route.ts");
+    const calendar = source(
+      "features/fleet/components/FleetMaintenanceCalendar.tsx",
+    );
+    const page = source("app/portal/fleet/calendar/page.tsx");
+
+    for (const table of [
+      "fleet_pm_policies",
+      "fleet_pm_due_events",
+      "fleet_service_requests",
+      "fleet_inspection_schedules",
+      "work_orders",
+    ]) {
+      expect(route).toContain(`.from("${table}")`);
+    }
+    for (const eventType of [
+      "pm_due",
+      "pm_forecast",
+      "service_request",
+      "inspection",
+      "shop_service",
+    ]) {
+      expect(calendar).toContain(eventType);
+    }
+    expect(calendar).toContain("Maintenance Calendar");
+    expect(calendar).toContain("Needs a planning date");
+    expect(page).toContain('actor.experience === "external_driver"');
+    expect(route).toContain('actor.actorType === "fleet_driver"');
+  });
+});

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -69,7 +69,7 @@ describe("premier fleet workspaces", () => {
     expect(route).toContain("source_pm_due_event_id: dueEventId");
     expect(route).toContain("create_fleet_service_request_atomic");
     expect(workspace).toContain('fleetId: fleetId === "all" ? null : fleetId');
-    expect(workspace).toContain("Create request");
+    expect(workspace).toContain("Plan request");
     expect(workspace).toContain("PM programs");
     expect(workspace).toContain("Confirm deferral");
   });
@@ -100,7 +100,9 @@ describe("premier fleet workspaces", () => {
     expect(actor).toContain("canManageFleetForActor");
     expect(billing).toContain("Fleet billing access required");
     expect(billing).toContain("applyWorkOrderQuoteLineDecision");
-    expect(billing).toContain('decisionSource: actor.isInternal ? "shop" : "customer"');
+    expect(billing).toContain(
+      'decisionSource: actor.isInternal ? "shop" : "customer"',
+    );
     expect(billing).not.toContain("apply_customer_quote_decision_atomic");
     expect(billing).toContain('"issued", "partially_paid", "paid"');
     expect(billing).toContain("byCurrency");


### PR DESCRIPTION
### Root cause

Fleet had a working due-event foundation, but Fleet managers could not own PM templates, selected-asset assignments, or planned request dates. The Fleet maintenance calendar was still a placeholder, and converting due work created a generic package instead of the Fleet-authored task scope.

### What changed

- Added a Fleet-owned PM program editor for cadence, tasks, asset assignment, approval rules, notes, and archival.
- Added a manager-only, audited, idempotent RPC for atomic PM program and assignment management.
- Converted PM templates into structured service-request lines and allowed Fleet managers to plan the requested service date.
- Replaced the calendar placeholder with a responsive Fleet calendar that combines PM due/forecast events, Fleet requests, inspections, and connected Shop appointment facts.
- Kept Shop repair execution out of the Fleet workspace while preserving connected maintenance records.
- Added driver denials, actor-scoped authorization, generated database types, tests, and CI coverage.

### Why this is safe

Fleet actor, fleet, and Shop relationship boundaries are checked in the API and again in the database RPC. Direct authenticated writes to PM assignments are blocked. UUIDs, intervals, dates, task payloads, and selected assets are validated, operations are idempotent, and existing PM programs default to all-unit assignment behavior.

### Files changed

- Fleet maintenance and calendar APIs
- Fleet PM editor, maintenance workspace, and calendar UI
- Fleet page access boundaries
- Fleet actor authorization
- Supabase migration and generated types
- Fleet validation workflow and regression tests

### Validation

- Strict TypeScript passed.
- Targeted ESLint passed for all changed TypeScript and TSX files.
- 57 Fleet tests passed across 7 test files.
- Next.js production build passed with placeholder build-time service values.
- Fleet-host calendar route smoke test passed and redirected an unauthenticated request to Fleet sign-in.
- `git diff --check` passed.
- Remote GitHub diff verified: 13 intended files, one commit, current with `main`.

### Database

Adds `20260806022431_fleet_pm_calendar_management.sql`, including PM assignment storage, program metadata, indexes, RLS, assignment guards, audit logging, and the canonical `manage_fleet_pm_program` RPC. Generated Supabase types are synchronized. Clean replay remains for CI because Docker is unavailable locally.

### Environment variables

None.

### Manual/deployment actions

Apply the migration through the normal Supabase deployment after CI passes. Verify the authenticated Fleet manager editor and calendar in the Vercel preview before merging.

### Remaining risks or unverified assumptions

A clean local Supabase replay could not run without Docker. Authenticated visual browser verification could not run because browser automation tooling is unavailable in this workspace; CI and the Vercel preview should cover those checks.