### PR TITLE
fix(chat): separate actor identity and deliver notifications

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+features/shared/types/types/supabase.ts whitespace=-blank-at-eof

--- a/app/api/chat/delete-message/route.ts
+++ b/app/api/chat/delete-message/route.ts
@@ -1,6 +1,9 @@
 // app/api/chat/delete-message/route.ts
 import { NextResponse } from "next/server";
-import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
@@ -20,7 +23,10 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const body = (await req.json().catch(() => null)) as { id?: string } | null;
+  const body = (await req.json().catch(() => null)) as {
+    id?: string;
+    actor_kind?: "staff" | "customer";
+  } | null;
   const messageId = body?.id;
 
   if (!messageId) {
@@ -30,7 +36,7 @@ export async function POST(req: Request): Promise<NextResponse> {
   const admin = createAdminSupabase();
   const { data: message, error: fetchError } = await admin
     .from("messages")
-    .select("id, sender_id, conversation_id")
+    .select("id, sender_id, sender_participant_id, conversation_id")
     .eq("id", messageId)
     .maybeSingle();
 
@@ -43,20 +49,27 @@ export async function POST(req: Request): Promise<NextResponse> {
   }
 
   if (!message.conversation_id) {
-    return NextResponse.json({ error: "Message has no conversation" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Message has no conversation" },
+      { status: 400 },
+    );
   }
 
   const access = await authorizeConversationActor({
     supabase: admin,
     conversationId: message.conversation_id,
     actorUserId: user.id,
+    preferredKind: body?.actor_kind,
   });
 
   if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
+    return NextResponse.json(
+      { error: access.error },
+      { status: access.status },
+    );
   }
 
-  if (message.sender_id !== user.id) {
+  if (message.sender_participant_id !== access.actorParticipant.id) {
     return NextResponse.json({ error: "Not authorized" }, { status: 403 });
   }
 

--- a/app/api/chat/get-messages/route.ts
+++ b/app/api/chat/get-messages/route.ts
@@ -4,10 +4,7 @@ import {
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
 import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
-import type { Database } from "@shared/types/types/supabase";
-
-type DB = Database;
-type MessageRow = DB["public"]["Tables"]["messages"]["Row"];
+import type { ChatMessage } from "@/features/chat/types";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +20,7 @@ export async function POST(req: Request): Promise<NextResponse> {
 
   const body = (await req.json().catch(() => null)) as {
     conversationId?: string;
+    actor_kind?: "staff" | "customer";
   } | null;
 
   const conversationId = body?.conversationId;
@@ -38,10 +36,14 @@ export async function POST(req: Request): Promise<NextResponse> {
     supabase: admin,
     conversationId,
     actorUserId: user.id,
+    preferredKind: body?.actor_kind,
   });
 
   if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
+    return NextResponse.json(
+      { error: access.error },
+      { status: access.status },
+    );
   }
 
   const { data: messages, error: msgErr } = await admin
@@ -55,16 +57,75 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: msgErr.message }, { status: 500 });
   }
 
-  const visibleMessages = (messages ?? []).map((message) =>
-    message.deleted_at
-      ? {
-          ...message,
-          content: "Message removed",
-          attachments: [],
-          metadata: {},
-        }
-      : message,
+  const profileIds = access.participants
+    .map((participant) => participant.profile_id)
+    .filter((id): id is string => Boolean(id));
+  const customerIds = access.participants
+    .map((participant) => participant.customer_id)
+    .filter((id): id is string => Boolean(id));
+  const [{ data: profiles }, { data: customers }] = await Promise.all([
+    profileIds.length
+      ? admin
+          .from("profiles")
+          .select("id, full_name, email, avatar_url")
+          .in("id", profileIds)
+      : Promise.resolve({ data: [], error: null }),
+    customerIds.length
+      ? admin
+          .from("customers")
+          .select("id, name, first_name, last_name, email")
+          .in("id", customerIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  const profileById = new Map(
+    (profiles ?? []).map((profile) => [profile.id, profile]),
+  );
+  const customerById = new Map(
+    (customers ?? []).map((customer) => [customer.id, customer]),
+  );
+  const participantById = new Map(
+    access.participants.map((participant) => [participant.id, participant]),
   );
 
-  return NextResponse.json<MessageRow[]>(visibleMessages);
+  const visibleMessages: ChatMessage[] = (messages ?? []).map((message) => {
+    const sender = message.sender_participant_id
+      ? participantById.get(message.sender_participant_id)
+      : undefined;
+    const profile = sender?.profile_id
+      ? profileById.get(sender.profile_id)
+      : undefined;
+    const customer = sender?.customer_id
+      ? customerById.get(sender.customer_id)
+      : undefined;
+    const customerName = customer
+      ? customer.name?.trim() ||
+        [customer.first_name, customer.last_name]
+          .filter(Boolean)
+          .join(" ")
+          .trim() ||
+        customer.email?.trim() ||
+        "Customer"
+      : null;
+    const isMine = message.sender_participant_id === access.actorParticipant.id;
+    return {
+      ...message,
+      ...(message.deleted_at
+        ? { content: "Message removed", attachments: [], metadata: {} }
+        : {}),
+      sender_kind:
+        message.sender_kind === "customer"
+          ? "customer"
+          : message.sender_kind === "staff"
+            ? "staff"
+            : sender?.participant_kind === "customer"
+              ? "customer"
+              : "staff",
+      sender_name: profile?.full_name ?? profile?.email ?? customerName,
+      sender_avatar_url: profile?.avatar_url ?? null,
+      is_mine: isMine,
+      can_delete: isMine && message.deleted_at == null,
+    };
+  });
+
+  return NextResponse.json<ChatMessage[]>(visibleMessages);
 }

--- a/app/api/chat/mark-read/route.ts
+++ b/app/api/chat/mark-read/route.ts
@@ -1,32 +1,67 @@
 import { NextResponse } from "next/server";
-import { createAdminSupabase, createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
 
 export const dynamic = "force-dynamic";
 
 export async function POST(req: Request): Promise<NextResponse> {
   const userClient = createServerSupabaseRoute();
-  const { data: { user } } = await userClient.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  const {
+    data: { user },
+  } = await userClient.auth.getUser();
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
-  const body = (await req.json().catch(() => null)) as { conversationId?: string } | null;
-  if (!body?.conversationId) return NextResponse.json({ error: "conversationId required" }, { status: 400 });
+  const body = (await req.json().catch(() => null)) as {
+    conversationId?: string;
+    actor_kind?: "staff" | "customer";
+  } | null;
+  if (!body?.conversationId)
+    return NextResponse.json(
+      { error: "conversationId required" },
+      { status: 400 },
+    );
 
   const admin = createAdminSupabase();
   const access = await authorizeConversationActor({
     supabase: admin,
     conversationId: body.conversationId,
     actorUserId: user.id,
+    preferredKind: body.actor_kind,
   });
 
   if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
+    return NextResponse.json(
+      { error: access.error },
+      { status: access.status },
+    );
   }
 
-  const { error } = await admin
-    .from("message_reads")
-    .upsert({ user_id: user.id, conversation_id: body.conversationId, last_read_at: new Date().toISOString() }, { onConflict: "user_id,conversation_id" });
+  const readAt = new Date().toISOString();
+  const { error: deliveryError } = await admin
+    .from("message_deliveries")
+    .update({ read_at: readAt })
+    .eq("conversation_id", body.conversationId)
+    .eq("recipient_participant_id", access.actorParticipant.id)
+    .is("read_at", null);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (deliveryError) {
+    return NextResponse.json({ error: deliveryError.message }, { status: 500 });
+  }
+
+  const { error } = await admin.from("message_reads").upsert(
+    {
+      user_id: user.id,
+      conversation_id: body.conversationId,
+      last_read_at: readAt,
+    },
+    { onConflict: "user_id,conversation_id" },
+  );
+
+  if (error)
+    return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/chat/my-conversations/route.ts
+++ b/app/api/chat/my-conversations/route.ts
@@ -14,11 +14,12 @@ export const dynamic = "force-dynamic";
 type DB = Database;
 type ConversationRow = DB["public"]["Tables"]["conversations"]["Row"];
 type MessageRow = DB["public"]["Tables"]["messages"]["Row"];
-type ParticipantRow = DB["public"]["Tables"]["conversation_participants"]["Row"];
-type MessageReadRow = DB["public"]["Tables"]["message_reads"]["Row"];
+type ParticipantRow =
+  DB["public"]["Tables"]["conversation_participants"]["Row"];
 
 type ParticipantInfo = {
   id: string;
+  user_id: string;
   kind: "staff" | "customer";
   full_name: string | null;
   avatar_url: string | null;
@@ -38,6 +39,7 @@ type ConversationPayload = {
   participants: ParticipantInfo[];
   unread_count: number;
   context: ConversationContextPayload | null;
+  actor_participant_id: string;
 };
 
 function customerName(row: {
@@ -60,7 +62,8 @@ export async function GET(req: Request): Promise<NextResponse> {
     data: { user },
   } = await userClient.auth.getUser();
 
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  if (!user)
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
   const admin = createAdminSupabase();
   const preferredKind =
@@ -73,15 +76,22 @@ export async function GET(req: Request): Promise<NextResponse> {
     preferredKind,
   });
   if (!actorResult.ok) {
-    return NextResponse.json({ error: actorResult.error }, { status: actorResult.status });
+    return NextResponse.json(
+      { error: actorResult.error },
+      { status: actorResult.status },
+    );
   }
 
-  const { ids: conversationIds, error: accessError } = await getActorConversationIds({
-    supabase: admin,
-    actorUserId: user.id,
-  });
-  if (accessError) return NextResponse.json({ error: accessError }, { status: 500 });
-  if (conversationIds.length === 0) return NextResponse.json<ConversationPayload[]>([]);
+  const { ids: conversationIds, error: accessError } =
+    await getActorConversationIds({
+      supabase: admin,
+      actorUserId: user.id,
+      participantKind: actorResult.actor.kind,
+    });
+  if (accessError)
+    return NextResponse.json({ error: accessError }, { status: 500 });
+  if (conversationIds.length === 0)
+    return NextResponse.json<ConversationPayload[]>([]);
 
   let conversationQuery = admin
     .from("conversations")
@@ -100,60 +110,85 @@ export async function GET(req: Request): Promise<NextResponse> {
     );
   }
 
-  const { data: conversations, error: conversationError } = await conversationQuery;
+  const { data: conversations, error: conversationError } =
+    await conversationQuery;
   if (conversationError) {
-    return NextResponse.json({ error: conversationError.message }, { status: 500 });
+    return NextResponse.json(
+      { error: conversationError.message },
+      { status: 500 },
+    );
   }
 
   const safeConversations = conversations ?? [];
   const safeConversationIds = safeConversations.map((row) => row.id);
-  if (safeConversationIds.length === 0) return NextResponse.json<ConversationPayload[]>([]);
+  if (safeConversationIds.length === 0)
+    return NextResponse.json<ConversationPayload[]>([]);
 
-  const [{ data: messages, error: messageError }, { data: participants, error: participantError }] =
-    await Promise.all([
-      admin
-        .from("messages")
-        .select("*")
-        .in("conversation_id", safeConversationIds)
-        .order("sent_at", { ascending: false })
-        .order("created_at", { ascending: false }),
-      admin
-        .from("conversation_participants")
-        .select("conversation_id, user_id, participant_kind, role")
-        .in("conversation_id", safeConversationIds),
-    ]);
-
-  if (messageError) return NextResponse.json({ error: messageError.message }, { status: 500 });
-  if (participantError) return NextResponse.json({ error: participantError.message }, { status: 500 });
-
-  const participantRows = (participants ?? []) as ParticipantRow[];
-  const participantUserIds = Array.from(
-    new Set(participantRows.map((row) => row.user_id).filter(Boolean)),
-  );
-
-  const [{ data: profiles }, { data: customers }, { data: readRows }] = await Promise.all([
-    participantUserIds.length
-      ? admin
-          .from("profiles")
-          .select("id, user_id, full_name, email, avatar_url, role")
-          .or(participantUserIds.map((id) => `user_id.eq.${id},id.eq.${id}`).join(","))
-      : Promise.resolve({ data: [], error: null }),
-    participantUserIds.length
-      ? admin
-          .from("customers")
-          .select("id, user_id, name, first_name, last_name, email")
-          .in("user_id", participantUserIds)
-      : Promise.resolve({ data: [], error: null }),
+  const [
+    { data: messages, error: messageError },
+    { data: participants, error: participantError },
+  ] = await Promise.all([
     admin
-      .from("message_reads")
-      .select("conversation_id, last_read_at")
-      .eq("user_id", user.id)
+      .from("messages")
+      .select("*")
+      .in("conversation_id", safeConversationIds)
+      .order("sent_at", { ascending: false })
+      .order("created_at", { ascending: false }),
+    admin
+      .from("conversation_participants")
+      .select(
+        "id, conversation_id, user_id, participant_kind, role, profile_id, customer_id",
+      )
       .in("conversation_id", safeConversationIds),
   ]);
 
-  const identityByUserId = new Map<
+  if (messageError)
+    return NextResponse.json({ error: messageError.message }, { status: 500 });
+  if (participantError)
+    return NextResponse.json(
+      { error: participantError.message },
+      { status: 500 },
+    );
+
+  const participantRows = (participants ?? []) as ParticipantRow[];
+  const profileIds = Array.from(
+    new Set(
+      participantRows
+        .map((row) => row.profile_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  const participantCustomerIds = Array.from(
+    new Set(
+      participantRows
+        .map((row) => row.customer_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+
+  const [{ data: profiles }, { data: customers }] = await Promise.all([
+    profileIds.length
+      ? admin
+          .from("profiles")
+          .select("id, user_id, full_name, email, avatar_url, role")
+          .in("id", profileIds)
+      : Promise.resolve({ data: [], error: null }),
+    participantCustomerIds.length
+      ? admin
+          .from("customers")
+          .select("id, user_id, name, first_name, last_name, email")
+          .in("id", participantCustomerIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  const identityByActorKey = new Map<
     string,
-    { full_name: string | null; avatar_url: string | null; role: string | null; kind: "staff" | "customer" }
+    {
+      full_name: string | null;
+      avatar_url: string | null;
+      role: string | null;
+      kind: "staff" | "customer";
+    }
   >();
   (profiles ?? []).forEach((profile) => {
     const identity = {
@@ -162,12 +197,10 @@ export async function GET(req: Request): Promise<NextResponse> {
       role: profile.role,
       kind: "staff" as const,
     };
-    identityByUserId.set(profile.user_id ?? profile.id, identity);
-    identityByUserId.set(profile.id, identity);
+    identityByActorKey.set(`staff:${profile.id}`, identity);
   });
   (customers ?? []).forEach((customer) => {
-    if (!customer.user_id) return;
-    identityByUserId.set(customer.user_id, {
+    identityByActorKey.set(`customer:${customer.id}`, {
       full_name: customerName(customer),
       avatar_url: null,
       role: "customer",
@@ -177,11 +210,19 @@ export async function GET(req: Request): Promise<NextResponse> {
 
   const participantsByConversation = new Map<string, ParticipantInfo[]>();
   participantRows.forEach((row) => {
-    const identity = identityByUserId.get(row.user_id);
+    const identity = identityByActorKey.get(
+      row.participant_kind === "customer"
+        ? `customer:${row.customer_id ?? ""}`
+        : `staff:${row.profile_id ?? ""}`,
+    );
     const list = participantsByConversation.get(row.conversation_id) ?? [];
     list.push({
-      id: row.user_id,
-      kind: row.participant_kind === "customer" ? "customer" : identity?.kind ?? "staff",
+      id: row.id,
+      user_id: row.user_id,
+      kind:
+        row.participant_kind === "customer"
+          ? "customer"
+          : (identity?.kind ?? "staff"),
       full_name: identity?.full_name ?? null,
       avatar_url: identity?.avatar_url ?? null,
       role: identity?.role ?? row.role,
@@ -191,41 +232,121 @@ export async function GET(req: Request): Promise<NextResponse> {
 
   const latestByConversation = new Map<string, MessageRow>();
   (messages ?? []).forEach((message) => {
-    if (message.conversation_id && !latestByConversation.has(message.conversation_id)) {
+    if (
+      message.conversation_id &&
+      !latestByConversation.has(message.conversation_id)
+    ) {
       latestByConversation.set(message.conversation_id, message);
     }
   });
-  const readByConversation = new Map(
-    ((readRows ?? []) as MessageReadRow[]).map((row) => [row.conversation_id, row.last_read_at]),
+  const actorParticipantIds = participantRows
+    .filter(
+      (participant) =>
+        participant.user_id === user.id &&
+        participant.participant_kind === actorResult.actor.kind,
+    )
+    .map((participant) => participant.id);
+  const { data: unreadDeliveries, error: deliveryError } =
+    actorParticipantIds.length
+      ? await admin
+          .from("message_deliveries")
+          .select("conversation_id")
+          .in("recipient_participant_id", actorParticipantIds)
+          .is("read_at", null)
+          .in("conversation_id", safeConversationIds)
+      : { data: [], error: null };
+  if (deliveryError) {
+    return NextResponse.json({ error: deliveryError.message }, { status: 500 });
+  }
+  const unreadByConversation = new Map<string, number>();
+  (unreadDeliveries ?? []).forEach((delivery) => {
+    unreadByConversation.set(
+      delivery.conversation_id,
+      (unreadByConversation.get(delivery.conversation_id) ?? 0) + 1,
+    );
+  });
+  const actorParticipantByConversation = new Map(
+    participantRows
+      .filter(
+        (participant) =>
+          participant.user_id === user.id &&
+          participant.participant_kind === actorResult.actor.kind,
+      )
+      .map((participant) => [participant.conversation_id, participant.id]),
   );
 
-  const workOrderIds = Array.from(new Set(safeConversations.map((row) => row.work_order_id).filter((id): id is string => Boolean(id))));
-  const vehicleIds = Array.from(new Set(safeConversations.map((row) => row.vehicle_id).filter((id): id is string => Boolean(id))));
-  const bookingIds = Array.from(new Set(safeConversations.map((row) => row.booking_id).filter((id): id is string => Boolean(id))));
-  const customerIds = Array.from(new Set(safeConversations.map((row) => row.customer_id).filter((id): id is string => Boolean(id))));
+  const workOrderIds = Array.from(
+    new Set(
+      safeConversations
+        .map((row) => row.work_order_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  const vehicleIds = Array.from(
+    new Set(
+      safeConversations
+        .map((row) => row.vehicle_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  const bookingIds = Array.from(
+    new Set(
+      safeConversations
+        .map((row) => row.booking_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
+  const customerIds = Array.from(
+    new Set(
+      safeConversations
+        .map((row) => row.customer_id)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  );
 
-  const [{ data: workOrders }, { data: vehicles }, { data: bookings }, { data: contextCustomers }] = await Promise.all([
+  const [
+    { data: workOrders },
+    { data: vehicles },
+    { data: bookings },
+    { data: contextCustomers },
+  ] = await Promise.all([
     workOrderIds.length
-      ? admin.from("work_orders").select("id, custom_id, status, customer_name").in("id", workOrderIds)
+      ? admin
+          .from("work_orders")
+          .select("id, custom_id, status, customer_name")
+          .in("id", workOrderIds)
       : Promise.resolve({ data: [], error: null }),
     vehicleIds.length
-      ? admin.from("vehicles").select("id, year, make, model, unit_number").in("id", vehicleIds)
+      ? admin
+          .from("vehicles")
+          .select("id, year, make, model, unit_number")
+          .in("id", vehicleIds)
       : Promise.resolve({ data: [], error: null }),
     bookingIds.length
-      ? admin.from("bookings").select("id, starts_at, status").in("id", bookingIds)
+      ? admin
+          .from("bookings")
+          .select("id, starts_at, status")
+          .in("id", bookingIds)
       : Promise.resolve({ data: [], error: null }),
     customerIds.length
-      ? admin.from("customers").select("id, name, first_name, last_name, email").in("id", customerIds)
+      ? admin
+          .from("customers")
+          .select("id, name, first_name, last_name, email")
+          .in("id", customerIds)
       : Promise.resolve({ data: [], error: null }),
   ]);
 
   const workOrderById = new Map((workOrders ?? []).map((row) => [row.id, row]));
   const vehicleById = new Map((vehicles ?? []).map((row) => [row.id, row]));
   const bookingById = new Map((bookings ?? []).map((row) => [row.id, row]));
-  const customerById = new Map((contextCustomers ?? []).map((row) => [row.id, row]));
+  const customerById = new Map(
+    (contextCustomers ?? []).map((row) => [row.id, row]),
+  );
   const portal = actorResult.actor.kind === "customer";
 
-  const contextFor = (conversation: ConversationRow): ConversationContextPayload | null => {
+  const contextFor = (
+    conversation: ConversationRow,
+  ): ConversationContextPayload | null => {
     if (conversation.work_order_id) {
       const workOrder = workOrderById.get(conversation.work_order_id);
       return {
@@ -239,7 +360,9 @@ export async function GET(req: Request): Promise<NextResponse> {
     }
     if (conversation.booking_id) {
       const booking = bookingById.get(conversation.booking_id);
-      const startsAt = booking?.starts_at ? new Date(booking.starts_at).toLocaleString() : null;
+      const startsAt = booking?.starts_at
+        ? new Date(booking.starts_at).toLocaleString()
+        : null;
       return {
         type: "booking",
         label: "Appointment",
@@ -271,7 +394,8 @@ export async function GET(req: Request): Promise<NextResponse> {
     if (conversation.context_type && conversation.context_id) {
       return {
         type: conversation.context_type,
-        label: conversation.title ?? conversation.context_type.replaceAll("_", " "),
+        label:
+          conversation.title ?? conversation.context_type.replaceAll("_", " "),
         secondary: null,
         href:
           !portal && conversation.context_type === "inspection"
@@ -282,27 +406,41 @@ export async function GET(req: Request): Promise<NextResponse> {
     return null;
   };
 
-  const payload: ConversationPayload[] = safeConversations.map((conversation) => {
-    const latest = latestByConversation.get(conversation.id) ?? null;
-    const lastReadAt = readByConversation.get(conversation.id);
-    const unreadCount = (messages ?? []).filter((message) => {
-      if (message.conversation_id !== conversation.id || message.sender_id === user.id) return false;
-      const sentAt = message.sent_at ?? message.created_at;
-      return !lastReadAt || sentAt > lastReadAt;
-    }).length;
+  const payload: ConversationPayload[] = safeConversations.map(
+    (conversation) => {
+      const latest = latestByConversation.get(conversation.id) ?? null;
+      const unreadCount = unreadByConversation.get(conversation.id) ?? 0;
+      const actorParticipantId = actorParticipantByConversation.get(
+        conversation.id,
+      );
+      if (!actorParticipantId) {
+        throw new Error(
+          `Missing actor participant for conversation ${conversation.id}`,
+        );
+      }
 
-    return {
-      conversation,
-      latest_message: latest,
-      participants: participantsByConversation.get(conversation.id) ?? [],
-      unread_count: unreadCount,
-      context: contextFor(conversation),
-    };
-  });
+      return {
+        conversation,
+        latest_message: latest,
+        participants: participantsByConversation.get(conversation.id) ?? [],
+        unread_count: unreadCount,
+        context: contextFor(conversation),
+        actor_participant_id: actorParticipantId,
+      };
+    },
+  );
 
   payload.sort((a, b) => {
-    const aTime = a.conversation.last_message_at ?? a.latest_message?.sent_at ?? a.conversation.created_at ?? "";
-    const bTime = b.conversation.last_message_at ?? b.latest_message?.sent_at ?? b.conversation.created_at ?? "";
+    const aTime =
+      a.conversation.last_message_at ??
+      a.latest_message?.sent_at ??
+      a.conversation.created_at ??
+      "";
+    const bTime =
+      b.conversation.last_message_at ??
+      b.latest_message?.sent_at ??
+      b.conversation.created_at ??
+      "";
     return bTime.localeCompare(aTime);
   });
 

--- a/app/api/chat/send-message/route.ts
+++ b/app/api/chat/send-message/route.ts
@@ -4,6 +4,7 @@ import {
   createAdminSupabase,
 } from "@/features/shared/lib/supabase/server";
 import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
+import type { ChatMessage } from "@/features/chat/types";
 
 export const dynamic = "force-dynamic";
 
@@ -18,14 +19,13 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
 
-  const body = (await req.json().catch(() => null)) as
-    | {
-        conversationId?: string;
-        content?: string;
-        metadata?: Record<string, unknown>;
-        clientMessageId?: string;
-      }
-    | null;
+  const body = (await req.json().catch(() => null)) as {
+    conversationId?: string;
+    content?: string;
+    metadata?: Record<string, unknown>;
+    clientMessageId?: string;
+    actor_kind?: "staff" | "customer";
+  } | null;
 
   const conversationId = body?.conversationId;
   const content = body?.content?.trim() ?? "";
@@ -44,9 +44,14 @@ export async function POST(req: Request): Promise<NextResponse> {
   const clientMessageId = body?.clientMessageId?.trim() ?? null;
   if (
     clientMessageId &&
-    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(clientMessageId)
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      clientMessageId,
+    )
   ) {
-    return NextResponse.json({ error: "clientMessageId must be a UUID" }, { status: 400 });
+    return NextResponse.json(
+      { error: "clientMessageId must be a UUID" },
+      { status: 400 },
+    );
   }
 
   const admin = createAdminSupabase();
@@ -54,28 +59,51 @@ export async function POST(req: Request): Promise<NextResponse> {
     supabase: admin,
     conversationId,
     actorUserId: user.id,
+    preferredKind: body?.actor_kind,
   });
 
   if (!access.ok) {
-    return NextResponse.json({ error: access.error }, { status: access.status });
+    return NextResponse.json(
+      { error: access.error },
+      { status: access.status },
+    );
   }
 
-  const recipients = access.participantUserIds.filter((id) => id !== user.id);
+  const recipients = Array.from(
+    new Set(
+      access.participants
+        .filter((participant) => participant.id !== access.actorParticipant.id)
+        .map((participant) => participant.user_id),
+    ),
+  );
 
   if (clientMessageId) {
     const { data: existing, error: existingError } = await admin
       .from("messages")
       .select("*")
       .eq("conversation_id", conversationId)
-      .eq("sender_id", user.id)
+      .eq("sender_participant_id", access.actorParticipant.id)
       .eq("client_message_id", clientMessageId)
       .maybeSingle();
 
     if (existingError) {
-      return NextResponse.json({ error: existingError.message }, { status: 500 });
+      return NextResponse.json(
+        { error: existingError.message },
+        { status: 500 },
+      );
     }
     if (existing) {
-      return NextResponse.json(existing, { status: 200 });
+      return NextResponse.json<ChatMessage>(
+        {
+          ...existing,
+          sender_kind: access.actor.kind,
+          sender_name: null,
+          sender_avatar_url: null,
+          is_mine: true,
+          can_delete: existing.deleted_at == null,
+        },
+        { status: 200 },
+      );
     }
   }
 
@@ -85,11 +113,16 @@ export async function POST(req: Request): Promise<NextResponse> {
     .insert({
       conversation_id: conversationId,
       sender_id: user.id,
+      sender_participant_id: access.actorParticipant.id,
+      sender_kind: access.actor.kind,
       recipients,
       content,
       sent_at: now,
       attachments: [],
-      metadata: body?.metadata ?? {},
+      metadata: {
+        ...(body?.metadata ?? {}),
+        actor_kind: access.actor.kind,
+      },
       client_message_id: clientMessageId,
     })
     .select("*")
@@ -99,5 +132,15 @@ export async function POST(req: Request): Promise<NextResponse> {
     return NextResponse.json({ error: insertErr.message }, { status: 500 });
   }
 
-  return NextResponse.json(inserted, { status: 200 });
+  return NextResponse.json<ChatMessage>(
+    {
+      ...inserted,
+      sender_kind: access.actor.kind,
+      sender_name: null,
+      sender_avatar_url: null,
+      is_mine: true,
+      can_delete: true,
+    },
+    { status: 200 },
+  );
 }

--- a/app/api/chat/start-conversation/route.ts
+++ b/app/api/chat/start-conversation/route.ts
@@ -7,6 +7,8 @@ import {
 import {
   authorizeConversationCreate,
   isCustomerMessagingRole,
+  participantSeedForActor,
+  type MessagingParticipantSeed,
 } from "@/features/ai/lib/chat/authorization";
 import { authorizeConversationContext } from "@/features/chat/server/conversationContext";
 import type { Database } from "@/features/shared/types/types/supabase";
@@ -14,7 +16,7 @@ import type { Database } from "@/features/shared/types/types/supabase";
 export const dynamic = "force-dynamic";
 
 type CreateMessagingConversationArgs =
-  Database["public"]["Functions"]["create_messaging_conversation"]["Args"];
+  Database["public"]["Functions"]["create_actor_messaging_conversation"]["Args"];
 type NullableConversationArgument =
   | "_booking_id"
   | "_context_id"
@@ -29,13 +31,32 @@ type CreateMessagingConversationInput = Omit<
 > &
   Record<NullableConversationArgument, string | null>;
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+function uniqueParticipants(
+  participants: MessagingParticipantSeed[],
+): MessagingParticipantSeed[] {
+  return participants.filter(
+    (participant, index, rows) =>
+      rows.findIndex(
+        (candidate) =>
+          candidate.kind === participant.kind &&
+          candidate.userId === participant.userId &&
+          candidate.profileId === participant.profileId &&
+          candidate.customerId === participant.customerId,
+      ) === index,
+  );
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function isUuid(value: string): boolean {
   return UUID_RE.test(value);
 }
 
-function deterministicUuidFromRequestId(requestId: string, actorUserId: string): string {
+function deterministicUuidFromRequestId(
+  requestId: string,
+  actorUserId: string,
+): string {
   const hex = createHash("sha256")
     .update(`chat:start-conversation:${actorUserId}:${requestId}`)
     .digest("hex");
@@ -123,12 +144,14 @@ export async function POST(req: Request): Promise<NextResponse> {
     );
   }
 
-  let recipientUserIds = createAccess.recipientUserIds;
-  let participantKindByUserId = createAccess.participantKinds;
+  let recipientParticipants = createAccess.recipientParticipants;
 
   const requestedWorkOrderId =
-    body?.context_type === "work_order" && body?.context_id ? body.context_id : null;
-  const routedWorkOrderId = context.anchors.work_order_id ?? requestedWorkOrderId;
+    body?.context_type === "work_order" && body?.context_id
+      ? body.context_id
+      : null;
+  const routedWorkOrderId =
+    context.anchors.work_order_id ?? requestedWorkOrderId;
 
   if (
     createAccess.actor.kind === "customer" &&
@@ -175,19 +198,26 @@ export async function POST(req: Request): Promise<NextResponse> {
       );
     }
 
-    const advisorUserId = assignedAdvisor && isCustomerMessagingRole(assignedAdvisor.role)
-      ? assignedAdvisor.user_id ?? assignedAdvisor.id
-      : null;
-    const coverageUserIds = (coverage ?? [])
-      .map((profile) => profile.user_id ?? profile.id)
-      .filter((id): id is string => Boolean(id) && id !== user.id);
+    const advisorUserId =
+      assignedAdvisor && isCustomerMessagingRole(assignedAdvisor.role)
+        ? (assignedAdvisor.user_id ?? assignedAdvisor.id)
+        : null;
+    const routedProfiles = [
+      ...(assignedAdvisor && advisorUserId ? [assignedAdvisor] : []),
+      ...(coverage ?? []),
+    ];
 
-    if (advisorUserId || coverageUserIds.length > 0) {
-      recipientUserIds = Array.from(
-        new Set([...(advisorUserId ? [advisorUserId] : []), ...coverageUserIds]),
-      ).filter((id) => id !== user.id);
-      participantKindByUserId = Object.fromEntries(
-        recipientUserIds.map((id) => [id, "staff" as const]),
+    if (routedProfiles.length > 0) {
+      recipientParticipants = uniqueParticipants(
+        routedProfiles
+          .filter((profile) => isCustomerMessagingRole(profile.role))
+          .map((profile) => ({
+            userId: profile.user_id ?? profile.id,
+            kind: "staff" as const,
+            profileId: profile.id,
+            customerId: null,
+            role: profile.role,
+          })),
       );
     }
   }
@@ -233,12 +263,10 @@ export async function POST(req: Request): Promise<NextResponse> {
     }
   }
 
-  const allParticipantIds = Array.from(new Set([user.id, ...recipientUserIds]));
-  const participantKindValues = allParticipantIds.map((id) =>
-    id === user.id
-      ? createAccess.actor.kind
-      : (participantKindByUserId[id] ?? "staff"),
-  );
+  const allParticipants = uniqueParticipants([
+    participantSeedForActor(createAccess.actor),
+    ...recipientParticipants,
+  ]);
 
   const createConversationInput: CreateMessagingConversationInput = {
     _conversation_id: conversationId,
@@ -252,14 +280,19 @@ export async function POST(req: Request): Promise<NextResponse> {
     _context_type: context.anchors.context_type,
     _context_id: context.anchors.context_id,
     _title: body?.title?.trim().slice(0, 160) || null,
-    _participant_user_ids: allParticipantIds,
-    _participant_kinds: participantKindValues,
+    _participants: allParticipants.map((participant) => ({
+      user_id: participant.userId,
+      participant_kind: participant.kind,
+      profile_id: participant.profileId,
+      customer_id: participant.customerId,
+      role: participant.role,
+    })),
   };
 
   // PostgreSQL accepts nullable context anchors; the local Supabase generator
   // does not preserve function-argument nullability in its TypeScript output.
   const { data: createdId, error: createError } = await admin.rpc(
-    "create_messaging_conversation",
+    "create_actor_messaging_conversation",
     createConversationInput as CreateMessagingConversationArgs,
   );
 

--- a/app/api/invoices/send/route.ts
+++ b/app/api/invoices/send/route.ts
@@ -19,6 +19,7 @@ import { attachInspectionReportToInvoice } from "@/features/invoices/server/atta
 import { reviewWorkOrder } from "../../work-orders/[id]/_lib/reviewWorkOrder";
 import { logOperationalEvent } from "@/features/work-orders/server/logOperationalEvent";
 import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { upsertPortalNotification } from "@/features/portal/server/upsertPortalNotification";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -336,17 +337,16 @@ export async function POST(request: Request) {
             {
               step: "portal_invoice_notification_insert",
               run: async () => {
-                const { error } = await admin
-                  .from("portal_notifications")
-                  .insert({
-                    user_id: customer.user_id,
-                    customer_id: customer.id,
-                    work_order_id: workOrderId,
-                    kind: "invoice_ready",
-                    title: "Invoice ready",
-                    body: `Your invoice for Work Order ${workOrderId} at ${shopLabel} is ready to view.`,
-                  });
-                if (error) throw new Error(error.message);
+                await upsertPortalNotification(admin, {
+                  userId: customer.user_id!,
+                  customerId: customer.id,
+                  workOrderId,
+                  kind: "invoice_ready",
+                  title: "Invoice ready",
+                  body: `Your invoice for Work Order ${workOrderId} at ${shopLabel} is ready to view.`,
+                  eventKey: `invoice_ready:${workOrderId}:version:${version.id}`,
+                  href: `/portal/invoices/${workOrderId}`,
+                });
               },
             },
           ]

--- a/app/api/quotes/send/route.ts
+++ b/app/api/quotes/send/route.ts
@@ -18,6 +18,7 @@ import {
   resolveShopSuppliesSettings,
   shopSuppliesTaxableSubtotal,
 } from "@/features/work-orders/lib/shopSupplies";
+import { upsertPortalNotification } from "@/features/portal/server/upsertPortalNotification";
 
 type DB = Database;
 
@@ -331,19 +332,16 @@ async function upsertEstimatePortalNotification(input: {
   revision: number;
   shopName: string;
 }): Promise<void> {
-  const { error } = await supabaseAdmin.from("portal_notifications").upsert(
-    {
-      user_id: input.userId,
-      customer_id: input.customerId,
-      work_order_id: input.workOrderId,
-      kind: "quote_ready",
-      title: "Quote ready",
-      body: `Your estimate at ${input.shopName || "the shop"} is ready to review in your portal.`,
-      event_key: `estimate:quote_ready:${input.workOrderId}:revision:${input.revision}`,
-    },
-    { onConflict: "user_id,event_key" },
-  );
-  if (error) throw new Error(error.message);
+  await upsertPortalNotification(supabaseAdmin, {
+    userId: input.userId,
+    customerId: input.customerId,
+    workOrderId: input.workOrderId,
+    kind: "quote_ready",
+    title: "Quote ready",
+    body: `Your estimate at ${input.shopName || "the shop"} is ready to review in your portal.`,
+    eventKey: `estimate:quote_ready:${input.workOrderId}:revision:${input.revision}`,
+    href: `/portal/quotes/${input.workOrderId}`,
+  });
 }
 
 async function repairEstimatePortalNotification(input: {
@@ -1253,19 +1251,18 @@ export async function POST(req: Request) {
                   });
                   return;
                 }
-                const { error } = await supabaseAdmin
-                  .from("portal_notifications")
-                  .insert({
-                    user_id: portalUserId,
-                    customer_id: portalCustomerId,
-                    work_order_id: workOrderId,
-                    kind: "quote_ready",
-                    title: "Quote ready",
-                    body: `Your quote for Work Order ${workOrderId} at ${
-                      shopName || "the shop"
-                    } is ready to review in your portal.`,
-                  });
-                if (error) throw new Error(error.message);
+                await upsertPortalNotification(supabaseAdmin, {
+                  userId: portalUserId,
+                  customerId: portalCustomerId,
+                  workOrderId,
+                  kind: "quote_ready",
+                  title: "Quote ready",
+                  body: `Your quote for Work Order ${workOrderId} at ${
+                    shopName || "the shop"
+                  } is ready to review in your portal.`,
+                  eventKey: `quote_ready:${workOrderId}:revision:${wo.estimate_revision}`,
+                  href: `/portal/quotes/${workOrderId}`,
+                });
               },
             },
           ]

--- a/app/chat/[chatId]/page.tsx
+++ b/app/chat/[chatId]/page.tsx
@@ -12,7 +12,11 @@ type DB = Database;
 type ConversationPayload = {
   conversation: DB["public"]["Tables"]["conversations"]["Row"];
   latest_message: DB["public"]["Tables"]["messages"]["Row"] | null;
-  participants: Array<{ id: string; full_name: string | null }>;
+  participants: Array<{
+    id: string;
+    user_id: string;
+    full_name: string | null;
+  }>;
   unread_count: number;
 };
 
@@ -47,7 +51,7 @@ export default function ChatThreadPage(): JSX.Element {
             const others =
               user?.id == null
                 ? found.participants
-                : found.participants.filter((p) => p.id !== user.id);
+                : found.participants.filter((p) => p.user_id !== user.id);
             const label =
               others[0]?.full_name ??
               found.conversation.context_type ??

--- a/app/mobile/messages/[chatId]/page.tsx
+++ b/app/mobile/messages/[chatId]/page.tsx
@@ -11,7 +11,7 @@ import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
 type ConversationRow = DB["public"]["Tables"]["conversations"]["Row"];
-type Participant = { id: string; full_name: string | null };
+type Participant = { id: string; user_id: string; full_name: string | null };
 
 type ConversationPayload = {
   conversation: ConversationRow;
@@ -53,7 +53,7 @@ export default function MobileChatThreadPage() {
           currentUserId == null
             ? found.participants
             : found.participants.filter(
-                (participant) => participant.id !== currentUserId,
+                (participant) => participant.user_id !== currentUserId,
               );
         setTitle(
           others[0]?.full_name ??

--- a/app/mobile/messages/page.tsx
+++ b/app/mobile/messages/page.tsx
@@ -4,7 +4,7 @@ import { formatDistanceToNow } from "date-fns";
 import { ChevronRight, MessageCircle, Plus } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { Database } from "@shared/types/types/supabase";
 
@@ -13,7 +13,11 @@ type DB = Database;
 type ConversationRow = {
   conversation: DB["public"]["Tables"]["conversations"]["Row"];
   latest_message: DB["public"]["Tables"]["messages"]["Row"] | null;
-  participants: Array<{ id: string; full_name: string | null }>;
+  participants: Array<{
+    id: string;
+    user_id: string;
+    full_name: string | null;
+  }>;
   unread_count: number;
 };
 
@@ -23,34 +27,42 @@ export default function MobileMessagesPage() {
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
 
-  useEffect(() => {
-    void (async () => {
-      setLoading(true);
-      setErr(null);
-      try {
-        const response = await fetch("/api/chat/my-conversations", {
-          method: "GET",
-          credentials: "include",
-        });
+  const loadConversations = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const response = await fetch("/api/chat/my-conversations", {
+        method: "GET",
+        credentials: "include",
+      });
 
-        if (!response.ok) {
-          throw new Error(`Failed to load conversations (${response.status})`);
-        }
-
-        const data = (await response.json()) as ConversationRow[];
-        setRows(data ?? []);
-      } catch (error) {
-        setErr(
-          error instanceof Error
-            ? error.message
-            : "Failed to load conversations.",
-        );
-        setRows([]);
-      } finally {
-        setLoading(false);
+      if (!response.ok) {
+        throw new Error(`Failed to load conversations (${response.status})`);
       }
-    })();
+
+      const data = (await response.json()) as ConversationRow[];
+      setRows(data ?? []);
+    } catch (error) {
+      setErr(
+        error instanceof Error
+          ? error.message
+          : "Failed to load conversations.",
+      );
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    void loadConversations();
+    const interval = window.setInterval(() => void loadConversations(), 30_000);
+    window.addEventListener("profixiq:inbox-refresh", loadConversations);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("profixiq:inbox-refresh", loadConversations);
+    };
+  }, [loadConversations]);
 
   const unreadTotal = rows.reduce((sum, row) => sum + row.unread_count, 0);
 
@@ -59,7 +71,9 @@ export default function MobileMessagesPage() {
       <section className="mobile-dashboard-hero">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
-            <div className="mobile-dashboard-hero__eyebrow">Shop communication</div>
+            <div className="mobile-dashboard-hero__eyebrow">
+              Shop communication
+            </div>
             <h1 className="mobile-dashboard-hero__title">Team chat</h1>
             <p className="mobile-dashboard-hero__subtitle">
               {unreadTotal > 0
@@ -140,8 +154,10 @@ export default function MobileMessagesPage() {
                 unread_count: unreadCount,
               } = row;
               const href = `/mobile/messages/${conversation.id}`;
-              const preview = latestMessage?.content?.slice(0, 100) ?? "No messages yet.";
-              const timestamp = latestMessage?.created_at ?? conversation.created_at;
+              const preview =
+                latestMessage?.content?.slice(0, 100) ?? "No messages yet.";
+              const timestamp =
+                latestMessage?.created_at ?? conversation.created_at;
               const when = timestamp
                 ? formatDistanceToNow(new Date(timestamp), { addSuffix: true })
                 : "";

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -89,16 +89,20 @@ function isActivePath(pathname: string, href: string) {
 
 function roleLabel(role: MobileRole | null): string {
   if (!role) return "Mobile workspace";
-  return role.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+  return role
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
 function iconForHref(href: string): LucideIcon {
   if (href === "/mobile") return Home;
-  if (href.includes("tech/queue") || href.includes("work-orders")) return BriefcaseBusiness;
+  if (href.includes("tech/queue") || href.includes("work-orders"))
+    return BriefcaseBusiness;
   if (href.includes("inspections")) return ClipboardCheck;
   if (href.includes("appointments")) return CalendarDays;
   if (href.includes("messages")) return MessageCircle;
-  if (href.includes("performance") || href.includes("reports")) return BarChart3;
+  if (href.includes("performance") || href.includes("reports"))
+    return BarChart3;
   if (href.includes("workforce") || href.includes("technicians")) return Users;
   if (href.includes("dispatch")) return RadioTower;
   if (href.includes("parts")) return Boxes;
@@ -130,7 +134,11 @@ function MenuLink({
       className="mobile-command-nav-row"
     >
       <span className="mobile-command-nav-row__icon">
-        <Icon aria-hidden className="h-[1.05rem] w-[1.05rem]" strokeWidth={2.1} />
+        <Icon
+          aria-hidden
+          className="h-[1.05rem] w-[1.05rem]"
+          strokeWidth={2.1}
+        />
       </span>
       <span className="mobile-command-nav-row__label">{item.label}</span>
       {item.badge != null ? (
@@ -155,7 +163,9 @@ function MenuSection({
 
   return (
     <section className="space-y-1.5">
-      <h2 className="mobile-command-drawer__section-title px-2 pb-1">{title}</h2>
+      <h2 className="mobile-command-drawer__section-title px-2 pb-1">
+        {title}
+      </h2>
       <div className="space-y-0.5">
         {items.map((item) => (
           <MenuLink
@@ -178,6 +188,7 @@ export function MobileBottomNav({ open, onClose }: Props) {
   const [userId, setUserId] = useState<string | null>(null);
   const [profileName, setProfileName] = useState<string>("Team member");
   const [role, setRole] = useState<MobileRole | null>(null);
+  const [messageUnreadCount, setMessageUnreadCount] = useState(0);
   const [signingOut, setSigningOut] = useState(false);
   const [install, setInstall] = useState<InstallAvailability>({
     available: false,
@@ -218,6 +229,42 @@ export function MobileBottomNav({ open, onClose }: Props) {
   }, [supabase]);
 
   useEffect(() => {
+    if (!userId) {
+      setMessageUnreadCount(0);
+      return;
+    }
+
+    const loadUnread = async () => {
+      const response = await fetch("/api/chat/my-conversations", {
+        credentials: "include",
+      }).catch(() => null);
+      if (!response?.ok) return;
+      const conversations = (await response.json().catch(() => [])) as Array<{
+        unread_count?: number | null;
+      }>;
+      setMessageUnreadCount(
+        Array.isArray(conversations)
+          ? conversations.reduce(
+              (total, conversation) =>
+                total + Math.max(0, Number(conversation.unread_count ?? 0)),
+              0,
+            )
+          : 0,
+      );
+    };
+
+    void loadUnread();
+    const interval = window.setInterval(() => void loadUnread(), 30_000);
+    window.addEventListener("profixiq:inbox-refresh", loadUnread);
+    window.addEventListener("profixiq:inbox-read", loadUnread);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("profixiq:inbox-refresh", loadUnread);
+      window.removeEventListener("profixiq:inbox-read", loadUnread);
+    };
+  }, [userId]);
+
+  useEffect(() => {
     const onAvailability = (event: Event) => {
       const custom = event as CustomEvent<InstallAvailability>;
       setInstall(custom.detail);
@@ -227,14 +274,25 @@ export function MobileBottomNav({ open, onClose }: Props) {
       setRuntimeStatus(custom.detail);
     };
 
-    window.addEventListener("profixiq:pwa-install-availability", onAvailability);
+    window.addEventListener(
+      "profixiq:pwa-install-availability",
+      onAvailability,
+    );
     window.addEventListener("profixiq:pwa-runtime-status", onRuntimeStatus);
-    window.dispatchEvent(new Event("profixiq:pwa-install-availability-request"));
+    window.dispatchEvent(
+      new Event("profixiq:pwa-install-availability-request"),
+    );
     window.dispatchEvent(new Event("profixiq:pwa-runtime-status-request"));
 
     return () => {
-      window.removeEventListener("profixiq:pwa-install-availability", onAvailability);
-      window.removeEventListener("profixiq:pwa-runtime-status", onRuntimeStatus);
+      window.removeEventListener(
+        "profixiq:pwa-install-availability",
+        onAvailability,
+      );
+      window.removeEventListener(
+        "profixiq:pwa-runtime-status",
+        onRuntimeStatus,
+      );
     };
   }, [open]);
 
@@ -257,13 +315,19 @@ export function MobileBottomNav({ open, onClose }: Props) {
       href: tile.href,
       label: tile.title,
       icon: iconForHref(tile.href),
+      badge:
+        tile.href.includes("messages") && messageUnreadCount > 0
+          ? messageUnreadCount > 99
+            ? "99+"
+            : messageUnreadCount
+          : null,
     }));
 
     return [home, ...dynamic].filter(
       (item, index, items) =>
         items.findIndex((candidate) => candidate.href === item.href) === index,
     );
-  }, [role]);
+  }, [messageUnreadCount, role]);
 
   const utilityItems = useMemo<NavItem[]>(() => {
     if (role === "mechanic") return [];
@@ -322,7 +386,9 @@ export function MobileBottomNav({ open, onClose }: Props) {
         aria-label="Close menu"
         onClick={onClose}
         className={`mobile-command-backdrop fixed inset-0 z-40 transition-opacity ${
-          open ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
+          open
+            ? "pointer-events-auto opacity-100"
+            : "pointer-events-none opacity-0"
         }`}
       />
 
@@ -340,7 +406,9 @@ export function MobileBottomNav({ open, onClose }: Props) {
             <div className="mt-1 truncate text-sm font-semibold text-white">
               {profileName}
             </div>
-            <div className="mt-0.5 text-xs text-slate-300">{roleLabel(role)}</div>
+            <div className="mt-0.5 text-xs text-slate-300">
+              {roleLabel(role)}
+            </div>
           </div>
           <button
             type="button"
@@ -365,7 +433,10 @@ export function MobileBottomNav({ open, onClose }: Props) {
               </div>
               <div className="space-y-2">
                 {openWorkItems.map((item) => (
-                  <div key={item.key} className="mobile-command-resume-card flex items-center gap-2">
+                  <div
+                    key={item.key}
+                    className="mobile-command-resume-card flex items-center gap-2"
+                  >
                     <button
                       type="button"
                       onClick={() => {
@@ -378,7 +449,10 @@ export function MobileBottomNav({ open, onClose }: Props) {
                       className="min-w-0 flex-1 text-left"
                     >
                       <span className="flex items-center gap-2">
-                        <Wrench aria-hidden className="h-4 w-4 shrink-0 text-[#7dcfff]" />
+                        <Wrench
+                          aria-hidden
+                          className="h-4 w-4 shrink-0 text-[#7dcfff]"
+                        />
                         <span className="truncate text-sm font-semibold text-white">
                           {item.title}
                         </span>
@@ -422,7 +496,9 @@ export function MobileBottomNav({ open, onClose }: Props) {
           />
 
           <section className="space-y-2">
-            <h2 className="mobile-command-drawer__section-title px-2">Device & sync</h2>
+            <h2 className="mobile-command-drawer__section-title px-2">
+              Device & sync
+            </h2>
             <div
               className="mobile-command-device-card"
               data-attention={deviceNeedsAttention ? "true" : "false"}
@@ -430,13 +506,21 @@ export function MobileBottomNav({ open, onClose }: Props) {
               <div className="flex items-start gap-3">
                 <span className="mt-0.5 inline-grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-white/[0.08]">
                   {runtimeStatus.online ? (
-                    <Wifi aria-hidden className="h-4.5 w-4.5 text-emerald-300" />
+                    <Wifi
+                      aria-hidden
+                      className="h-4.5 w-4.5 text-emerald-300"
+                    />
                   ) : (
-                    <CloudOff aria-hidden className="h-4.5 w-4.5 text-amber-300" />
+                    <CloudOff
+                      aria-hidden
+                      className="h-4.5 w-4.5 text-amber-300"
+                    />
                   )}
                 </span>
                 <div className="min-w-0 flex-1">
-                  <div className="text-sm font-semibold text-white">{deviceLabel}</div>
+                  <div className="text-sm font-semibold text-white">
+                    {deviceLabel}
+                  </div>
                   <div className="mt-1 text-[0.69rem] leading-4 text-slate-300">
                     {runtimeStatus.syncBlocked
                       ? runtimeStatus.syncBlocked
@@ -463,10 +547,13 @@ export function MobileBottomNav({ open, onClose }: Props) {
                   <button
                     type="button"
                     onClick={() =>
-                      window.dispatchEvent(new Event("profixiq:pwa-update-request"))
+                      window.dispatchEvent(
+                        new Event("profixiq:pwa-update-request"),
+                      )
                     }
                     disabled={
-                      runtimeStatus.activatingUpdate || runtimeStatus.pending > 0
+                      runtimeStatus.activatingUpdate ||
+                      runtimeStatus.pending > 0
                     }
                     className="inline-flex min-h-10 flex-1 items-center justify-center gap-2 rounded-xl bg-[#32b9f3] px-3 text-xs font-bold text-[#041022] disabled:opacity-55"
                   >
@@ -490,7 +577,9 @@ export function MobileBottomNav({ open, onClose }: Props) {
               <button
                 type="button"
                 onClick={() =>
-                  window.dispatchEvent(new Event("profixiq:pwa-install-request"))
+                  window.dispatchEvent(
+                    new Event("profixiq:pwa-install-request"),
+                  )
                 }
                 className="mobile-command-nav-row w-full text-left"
               >

--- a/features/ai/components/chat/ChatWindow.tsx
+++ b/features/ai/components/chat/ChatWindow.tsx
@@ -1,15 +1,8 @@
 // features/ai/components/chat/ChatWindow.tsx
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
-import type { Database } from "@shared/types/types/supabase";
 import {
   createMessageDraft,
   getOfflineMessageDraft,
@@ -19,54 +12,32 @@ import {
   type OfflineMessageDraft,
 } from "@/features/chat/offline/messageDrafts";
 import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+import type { ChatMessage, MessageActorKind } from "@/features/chat/types";
 
-type Message = Database["public"]["Tables"]["messages"]["Row"];
+type Message = ChatMessage;
 
 type ChatWindowProps = {
   conversationId: string;
   userId: string;
   title?: string;
+  actorKind?: MessageActorKind;
 };
-
-// Helper type for Realtime broadcast payloads coming from realtime.broadcast_changes
-type BroadcastPayload<T> = {
-  payload?: {
-    record?: T;
-    new?: T;
-    old?: T | null;
-    [key: string]: unknown;
-  };
-  record?: T;
-  new?: T;
-  old?: T | null;
-  [key: string]: unknown;
-};
-
-function extractRecord<T>(payload: BroadcastPayload<T>): T | null {
-  return (
-    payload?.payload?.record ??
-    payload?.payload?.new ??
-    payload?.record ??
-    payload?.new ??
-    null
-  ) as T | null;
-}
 
 export default function ChatWindow({
   conversationId,
   userId,
   title = "Conversation",
+  actorKind = "staff",
 }: ChatWindowProps) {
-  const supabase = useMemo(
-    () => createBrowserSupabase(),
-    [],
-  );
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [messages, setMessages] = useState<Message[]>([]);
   const [newMessage, setNewMessage] = useState("");
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(null);
+  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(
+    null,
+  );
   const [draft, setDraft] = useState<OfflineMessageDraft | null>(null);
   const [draftReady, setDraftReady] = useState(false);
   const [draftSaved, setDraftSaved] = useState(false);
@@ -86,9 +57,13 @@ export default function ChatWindow({
         );
         return;
       }
-      const stored = await getOfflineMessageDraft({ scope, targetId: draftTargetId });
+      const stored = await getOfflineMessageDraft({
+        scope,
+        targetId: draftTargetId,
+      });
       if (cancelled) return;
-      const next = stored ?? createMessageDraft({ scope, targetId: draftTargetId });
+      const next =
+        stored ?? createMessageDraft({ scope, targetId: draftTargetId });
       setDraftScope(scope);
       setDraft(next);
       setNewMessage(next.content);
@@ -104,15 +79,32 @@ export default function ChatWindow({
     if (!draftReady || !draftScope || !draft || sending) return;
     const timer = window.setTimeout(() => {
       if (!newMessage.trim()) {
-        void removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        void removeOfflineMessageDraft({
+          scope: draftScope,
+          targetId: draftTargetId,
+        });
         setDraftSaved(false);
         return;
       }
-      const next = { ...draft, content: newMessage, updatedAt: new Date().toISOString() };
+      const next = {
+        ...draft,
+        content: newMessage,
+        updatedAt: new Date().toISOString(),
+      };
       void saveOfflineMessageDraft(next).then(() => setDraftSaved(true));
     }, 350);
     return () => window.clearTimeout(timer);
   }, [draft, draftReady, draftScope, draftTargetId, newMessage, sending]);
+
+  const markRead = useCallback(async () => {
+    if (!conversationId) return;
+    await fetch("/api/chat/mark-read", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversationId, actor_kind: actorKind }),
+    }).catch(() => undefined);
+    window.dispatchEvent(new CustomEvent("profixiq:inbox-read"));
+  }, [actorKind, conversationId]);
 
   const fetchMessages = useCallback(async () => {
     if (!conversationId) return;
@@ -121,20 +113,21 @@ export default function ChatWindow({
       const res = await fetch("/api/chat/get-messages", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ conversationId }),
+        body: JSON.stringify({ conversationId, actor_kind: actorKind }),
       });
       if (!res.ok) throw new Error(String(res.status));
       const data = (await res.json()) as Message[];
       setMessages((prev) =>
         prev.length > 0 && data.length === 0 ? prev : data,
       );
+      await markRead();
     } catch (err) {
       console.error("[ChatWindow] fetchMessages error:", err);
       setError("Couldn't load messages.");
     } finally {
       setLoading(false);
     }
-  }, [conversationId]);
+  }, [actorKind, conversationId, markRead]);
 
   // initial load
   useEffect(() => {
@@ -185,49 +178,22 @@ export default function ChatWindow({
     const channel = supabase
       .channel(topic, {
         config: {
+          private: true,
           broadcast: {
             self: true,
             ack: true,
           },
         },
+      } as unknown as NonNullable<Parameters<typeof supabase.channel>[1]>)
+      .on("broadcast", { event: "INSERT" }, () => {
+        void fetchMessages();
       })
-      .on(
-        "broadcast",
-        { event: "INSERT" },
-        (payload: BroadcastPayload<Message>) => {
-          console.log("[ChatWindow] broadcast INSERT", payload);
-          const msg = extractRecord<Message>(payload);
-          if (!msg) return;
-          setMessages((prev) =>
-            prev.some((m) => m.id === msg.id) ? prev : [...prev, msg],
-          );
-        },
-      )
-      .on(
-        "broadcast",
-        { event: "UPDATE" },
-        (payload: BroadcastPayload<Message>) => {
-          console.log("[ChatWindow] broadcast UPDATE", payload);
-          const msg = extractRecord<Message>(payload);
-          if (!msg) return;
-          setMessages((prev) =>
-            prev.map((m) => (m.id === msg.id ? msg : m)),
-          );
-        },
-      )
-      .on(
-        "broadcast",
-        { event: "DELETE" },
-        (payload: BroadcastPayload<Message>) => {
-          console.log("[ChatWindow] broadcast DELETE", payload);
-          const msg =
-            (payload?.payload?.old as Message | undefined) ??
-            (payload.old as Message | undefined) ??
-            null;
-          if (!msg) return;
-          setMessages((prev) => prev.filter((m) => m.id !== msg.id));
-        },
-      )
+      .on("broadcast", { event: "UPDATE" }, () => {
+        void fetchMessages();
+      })
+      .on("broadcast", { event: "DELETE" }, () => {
+        void fetchMessages();
+      })
       .subscribe((status) => {
         console.log("[ChatWindow] broadcast subscribe status", status, topic);
       });
@@ -235,7 +201,7 @@ export default function ChatWindow({
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [supabase, conversationId]);
+  }, [supabase, conversationId, fetchMessages]);
 
   // scroll to bottom on new messages
   useEffect(() => {
@@ -265,10 +231,14 @@ export default function ChatWindow({
         await saveOfflineMessageDraft(savedDraft);
         setDraft(savedDraft);
         setDraftSaved(true);
-        setError("Offline — this message is saved as a draft and has not been sent.");
+        setError(
+          "Offline — this message is saved as a draft and has not been sent.",
+        );
       } catch {
         setDraftSaved(false);
-        setError("Offline draft could not be saved. Keep this window open and try again.");
+        setError(
+          "Offline draft could not be saved. Keep this window open and try again.",
+        );
       }
       return;
     }
@@ -282,6 +252,12 @@ export default function ChatWindow({
       content,
       sent_at: new Date().toISOString(),
       client_message_id: clientMessageId,
+      sender_kind: actorKind,
+      sender_participant_id: null,
+      sender_name: null,
+      sender_avatar_url: null,
+      is_mine: true,
+      can_delete: false,
     } as Message;
 
     setMessages((prev) => [...prev, optimistic]);
@@ -297,13 +273,11 @@ export default function ChatWindow({
           conversationId,
           content,
           clientMessageId,
+          actor_kind: actorKind,
         }),
       });
       if (!res.ok) {
-        console.error(
-          "[ChatWindow] send-message failed:",
-          await res.text(),
-        );
+        console.error("[ChatWindow] send-message failed:", await res.text());
         setMessages((prev) => prev.filter((message) => message.id !== tempId));
         setNewMessage(content);
         setError("Message failed to send.");
@@ -321,10 +295,15 @@ export default function ChatWindow({
         inserted,
       ]);
       if (draftScope) {
-        await removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        await removeOfflineMessageDraft({
+          scope: draftScope,
+          targetId: draftTargetId,
+        });
       }
       setDraft(
-        draftScope ? createMessageDraft({ scope: draftScope, targetId: draftTargetId }) : null,
+        draftScope
+          ? createMessageDraft({ scope: draftScope, targetId: draftTargetId })
+          : null,
       );
       setDraftSaved(false);
     } catch (err) {
@@ -335,7 +314,17 @@ export default function ChatWindow({
     } finally {
       setSending(false);
     }
-  }, [conversationId, draft, draftReady, draftScope, draftTargetId, newMessage, sending, userId]);
+  }, [
+    actorKind,
+    conversationId,
+    draft,
+    draftReady,
+    draftScope,
+    draftTargetId,
+    newMessage,
+    sending,
+    userId,
+  ]);
 
   const deleteMessage = useCallback(
     async (id: string) => {
@@ -345,7 +334,7 @@ export default function ChatWindow({
         const res = await fetch("/api/chat/delete-message", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ id }),
+          body: JSON.stringify({ id, actor_kind: actorKind }),
         });
         if (!res.ok) {
           console.error(
@@ -359,7 +348,7 @@ export default function ChatWindow({
         setMessages(prev);
       }
     },
-    [messages],
+    [actorKind, messages],
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -387,21 +376,23 @@ export default function ChatWindow({
         lastSender = "";
       }
 
-      const isMine = m.sender_id === userId;
-      const showAvatar = m.sender_id !== lastSender;
+      const isMine = m.is_mine;
+      const showAvatar = m.sender_participant_id !== lastSender;
       byDay.push({ type: "msg", msg: m, isMine, showAvatar });
 
-      lastSender = m.sender_id ?? "";
+      lastSender = m.sender_participant_id ?? m.sender_id ?? "";
     });
 
     return byDay;
-  }, [messages, userId]);
+  }, [messages]);
 
   return (
     <div className="flex h-full flex-col rounded border border-[var(--metal-border-soft)] bg-[var(--metal-surface)] text-[color:var(--theme-text-primary)]">
       {/* header */}
       <div className="border-b border-[var(--metal-border-soft)] px-4 py-3 flex items-center justify-between">
-        <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">{title}</div>
+        <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+          {title}
+        </div>
         {error ? (
           <div className="text-[10px] text-red-200/80">{error}</div>
         ) : null}
@@ -446,7 +437,7 @@ export default function ChatWindow({
               >
                 {!isMine && showAvatar ? (
                   <div className="mt-6 h-7 w-7 rounded-full bg-[color:var(--theme-surface-panel-strong)] flex items-center justify-center text-[10px] text-[color:var(--theme-text-secondary)]">
-                    U
+                    {(msg.sender_name?.trim().charAt(0) || "U").toUpperCase()}
                   </div>
                 ) : (
                   !isMine && <div className="w-7" />
@@ -457,8 +448,8 @@ export default function ChatWindow({
                     className={[
                       "inline-flex",
                       "flex-col",
-                      "min-w-[140px]",   // 👈 prevents super-narrow bubbles
-                      "max-w-[80%]",     // 👈 lets them stretch nicely on wider screens
+                      "min-w-[140px]", // 👈 prevents super-narrow bubbles
+                      "max-w-[80%]", // 👈 lets them stretch nicely on wider screens
                       "rounded-2xl",
                       "px-3 py-2 text-sm",
                       "whitespace-pre-wrap break-words",
@@ -467,12 +458,19 @@ export default function ChatWindow({
                         : "bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-primary)]",
                     ].join(" ")}
                   >
+                    {!isMine && msg.sender_name ? (
+                      <p className="mb-0.5 text-[10px] font-semibold text-[color:var(--theme-text-secondary)]">
+                        {msg.sender_name}
+                      </p>
+                    ) : null}
                     <p>{msg.content}</p>
                     {time ? (
                       <p
                         className={[
                           "mt-1 text-[10px]",
-                          isMine ? "text-[color:var(--theme-text-on-accent)]" : "text-[color:var(--theme-text-secondary)]",
+                          isMine
+                            ? "text-[color:var(--theme-text-on-accent)]"
+                            : "text-[color:var(--theme-text-secondary)]",
                         ].join(" ")}
                       >
                         {time}
@@ -480,7 +478,7 @@ export default function ChatWindow({
                     ) : null}
                   </div>
 
-                  {isMine ? (
+                  {msg.can_delete ? (
                     <button
                       type="button"
                       onClick={() => void deleteMessage(msg.id)}

--- a/features/ai/components/chat/NewChatModal.tsx
+++ b/features/ai/components/chat/NewChatModal.tsx
@@ -1,13 +1,7 @@
 // features/ai/components/chat/NewChatModal.tsx
 "use client";
 
-import {
-  useEffect,
-  useMemo,
-  useState,
-  useCallback,
-  useRef,
-} from "react";
+import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { toast } from "sonner";
 import ModalShell from "@/features/shared/components/ModalShell";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
@@ -32,8 +26,11 @@ type MessageRow = {
   id: string;
   conversation_id: string;
   sender_id: string | null;
+  sender_participant_id?: string | null;
+  sender_kind?: "staff" | "customer" | null;
   content: string | null;
   sent_at: string | null;
+  is_mine?: boolean;
   // client-only
   recipients?: string[] | null;
 };
@@ -56,28 +53,8 @@ type Props = {
 const LOCAL_ACTIVE_KEY = "pfq-chat-last-conversation";
 const LOCAL_RECENT_KEY = "pfq-chat-recent-convos";
 
-// Realtime broadcast payload helper
-type BroadcastPayload<T> = {
-  payload?: {
-    record?: T;
-    new?: T;
-    old?: T | null;
-    [key: string]: unknown;
-  };
-  record?: T;
-  new?: T;
-  old?: T | null;
-  [key: string]: unknown;
-};
-
-function extractRecord<T>(payload: BroadcastPayload<T>): T | null {
-  return (
-    payload?.payload?.record ??
-    payload?.payload?.new ??
-    payload?.record ??
-    payload?.new ??
-    null
-  ) as T | null;
+function scopedStorageKey(key: string, userId: string): string {
+  return `${key}:${userId}`;
 }
 
 export default function NewChatModal({
@@ -161,21 +138,29 @@ export default function NewChatModal({
 
   // helpers for localStorage
   const loadRecentFromStorage = useCallback(() => {
-    if (typeof window === "undefined") return [];
+    if (typeof window === "undefined" || !currentUserId) return [];
     try {
-      const raw = window.localStorage.getItem(LOCAL_RECENT_KEY);
+      const raw = window.localStorage.getItem(
+        scopedStorageKey(LOCAL_RECENT_KEY, currentUserId),
+      );
       if (!raw) return [];
       const parsed = JSON.parse(raw);
       return Array.isArray(parsed) ? (parsed as string[]) : [];
     } catch {
       return [];
     }
-  }, []);
+  }, [currentUserId]);
 
-  const saveRecentToStorage = useCallback((ids: string[]) => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(LOCAL_RECENT_KEY, JSON.stringify(ids));
-  }, []);
+  const saveRecentToStorage = useCallback(
+    (ids: string[]) => {
+      if (typeof window === "undefined" || !currentUserId) return;
+      window.localStorage.setItem(
+        scopedStorageKey(LOCAL_RECENT_KEY, currentUserId),
+        JSON.stringify(ids),
+      );
+    },
+    [currentUserId],
+  );
 
   const upsertRecent = useCallback(
     (id: string) => {
@@ -191,7 +176,7 @@ export default function NewChatModal({
 
   // when modal opens
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !currentUserId) return;
 
     (async () => {
       // load recent from storage
@@ -208,15 +193,23 @@ export default function NewChatModal({
           method: "GET",
           credentials: "include",
         });
-        const json = await res.json().catch(() => ({} as any));
+        const rawJson: unknown = await res.json().catch(() => ({}));
+        const json =
+          rawJson && typeof rawJson === "object" && !Array.isArray(rawJson)
+            ? (rawJson as {
+                users?: unknown;
+                data?: unknown;
+                error?: string;
+              })
+            : {};
         if (res.ok) {
-          const list: UserRow[] = Array.isArray(json)
-            ? json
+          const list: UserRow[] = Array.isArray(rawJson)
+            ? (rawJson as UserRow[])
             : Array.isArray(json.users)
-            ? json.users
-            : Array.isArray(json.data)
-            ? json.data
-            : [];
+              ? json.users
+              : Array.isArray(json.data)
+                ? json.data
+                : [];
           setUsers(list ?? []);
           gotUsers = true;
         } else if (res.status !== 401) {
@@ -261,7 +254,9 @@ export default function NewChatModal({
       // restore active convo
       const stored =
         typeof window !== "undefined"
-          ? window.localStorage.getItem(LOCAL_ACTIVE_KEY)
+          ? window.localStorage.getItem(
+              scopedStorageKey(LOCAL_ACTIVE_KEY, currentUserId),
+            )
           : null;
 
       if (forcedConversationId) {
@@ -277,7 +272,14 @@ export default function NewChatModal({
       setLoadingUsers(false);
       setSearch("");
     })();
-  }, [isOpen, supabase, forcedConversationId, loadRecentFromStorage, upsertRecent]);
+  }, [
+    currentUserId,
+    isOpen,
+    supabase,
+    forcedConversationId,
+    loadRecentFromStorage,
+    upsertRecent,
+  ]);
 
   // auto-role filter from context
   useEffect(() => {
@@ -318,10 +320,21 @@ export default function NewChatModal({
             return data;
           });
 
-          if (typeof window !== "undefined") {
-            window.localStorage.setItem(LOCAL_ACTIVE_KEY, activeConvoId);
+          if (typeof window !== "undefined" && currentUserId) {
+            window.localStorage.setItem(
+              scopedStorageKey(LOCAL_ACTIVE_KEY, currentUserId),
+              activeConvoId,
+            );
           }
           upsertRecent(activeConvoId);
+          await fetch("/api/chat/mark-read", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              conversationId: activeConvoId,
+              actor_kind: "staff",
+            }),
+          }).catch(() => undefined);
         }
       } catch (e) {
         console.error("[NewChatModal] get-messages failed:", e);
@@ -333,7 +346,7 @@ export default function NewChatModal({
     return () => {
       cancelled = true;
     };
-  }, [activeConvoId, isOpen, upsertRecent]);
+  }, [activeConvoId, currentUserId, isOpen, upsertRecent]);
 
   // 🔔 Realtime broadcast for current convo (room:<id>:messages)
   useEffect(() => {
@@ -349,25 +362,23 @@ export default function NewChatModal({
             self: true,
             ack: true,
           },
-        } as any,
-      })
-      .on(
-        "broadcast",
-        { event: "INSERT" },
-        (payload: BroadcastPayload<MessageRow>) => {
-          const msg = extractRecord<MessageRow>(payload);
-          if (!msg) {
-            console.warn(
-              "[NewChatModal] INSERT payload missing record",
-              payload,
-            );
-            return;
-          }
-          setMessages((prev) =>
-            prev.some((m) => m.id === msg.id) ? prev : [...prev, msg],
-          );
         },
-      )
+      } as unknown as NonNullable<Parameters<typeof supabase.channel>[1]>)
+      .on("broadcast", { event: "INSERT" }, () => {
+        void fetch("/api/chat/get-messages", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            conversationId: activeConvoId,
+            actor_kind: "staff",
+          }),
+        })
+          .then((response) => response.json())
+          .then((data: unknown) => {
+            if (Array.isArray(data)) setMessages(data as MessageRow[]);
+          })
+          .catch(() => undefined);
+      })
       .subscribe((status) => {
         if (status === "SUBSCRIBED") {
           console.log("[NewChatModal] subscribed to", topic);
@@ -430,7 +441,7 @@ export default function NewChatModal({
   useEffect(() => {
     setActiveConvoId(null);
     setMessages([]);
-  }, [selectedIds.join(",")]);
+  }, [selectedIds]);
 
   const getOrFetchUserId = useCallback(async () => {
     if (currentUserId) return currentUserId;
@@ -460,20 +471,27 @@ export default function NewChatModal({
           }),
         });
 
-        const json = (await res.json().catch(() => null)) as
-          | { id?: string; error?: string }
-          | null;
+        const json = (await res.json().catch(() => null)) as {
+          id?: string;
+          error?: string;
+        } | null;
 
         if (!res.ok || !json?.id) {
-          console.error("conversation create failed:", json?.error ?? `HTTP ${res.status}`);
+          console.error(
+            "conversation create failed:",
+            json?.error ?? `HTTP ${res.status}`,
+          );
           toast.error(json?.error ?? "Could not create conversation");
           return null;
         }
 
         const newId = json.id;
         setActiveConvoId(newId);
-        if (typeof window !== "undefined") {
-          window.localStorage.setItem(LOCAL_ACTIVE_KEY, newId);
+        if (typeof window !== "undefined" && currentUserId) {
+          window.localStorage.setItem(
+            scopedStorageKey(LOCAL_ACTIVE_KEY, currentUserId),
+            newId,
+          );
         }
         onCreated?.(newId);
         upsertRecent(newId);
@@ -488,6 +506,7 @@ export default function NewChatModal({
       activeConvoId,
       context_type,
       context_id,
+      currentUserId,
       onCreated,
       upsertRecent,
     ],
@@ -519,13 +538,15 @@ export default function NewChatModal({
     setSending(true);
 
     // optimistic bubble
-    const tempId = `temp-${Date.now()}`;
+    const clientMessageId = crypto.randomUUID();
+    const tempId = `temp-${clientMessageId}`;
     const optimistic: MessageRow = {
       id: tempId,
       conversation_id: convoId,
       sender_id: actualUserId,
       content: text,
       sent_at: new Date().toISOString(),
+      is_mine: true,
       recipients: targetIds.filter((id) => id !== actualUserId),
     };
     setMessages((prev) => [...prev, optimistic]);
@@ -537,16 +558,29 @@ export default function NewChatModal({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           conversationId: convoId,
-          senderId: actualUserId,
+          actor_kind: "staff",
           content: text,
+          clientMessageId,
         }),
       });
       if (!res.ok) {
         console.error("send-message failed:", await res.text());
+        setMessages((prev) => prev.filter((message) => message.id !== tempId));
+        setSendText(text);
         toast.error("Message failed to send (server).");
+        return;
       }
+      const sent = (await res.json()) as MessageRow;
+      setMessages((prev) => [
+        ...prev.filter(
+          (message) => message.id !== tempId && message.id !== sent.id,
+        ),
+        sent,
+      ]);
     } catch (e) {
       console.error("send failed:", e);
+      setMessages((prev) => prev.filter((message) => message.id !== tempId));
+      setSendText(text);
       toast.error("Message failed to send (network).");
     } finally {
       setSending(false);
@@ -606,12 +640,7 @@ export default function NewChatModal({
   }, [recentConversationIds, buildRecentLabel]);
 
   return (
-    <ModalShell
-      isOpen={isOpen}
-      onClose={onClose}
-      title="Team chat"
-      size="xl"
-    >
+    <ModalShell isOpen={isOpen} onClose={onClose} title="Team chat" size="xl">
       {/* helper row */}
       <div className="mb-3 flex items-center justify-between gap-3">
         <div className="text-xs text-[color:var(--theme-text-secondary)]">
@@ -752,8 +781,7 @@ export default function NewChatModal({
             </button>
             <div className="text-[11px] text-[color:var(--theme-text-muted)]">
               Current:{" "}
-              {ROLE_OPTIONS.find((r) => r.value === role)?.label ??
-                "All roles"}
+              {ROLE_OPTIONS.find((r) => r.value === role)?.label ?? "All roles"}
             </div>
           </div>
 
@@ -787,7 +815,9 @@ export default function NewChatModal({
 
       {/* Recents */}
       <div className="mt-3 flex items-center gap-2">
-        <div className="text-[11px] text-[color:var(--theme-text-muted)]">Recent:</div>
+        <div className="text-[11px] text-[color:var(--theme-text-muted)]">
+          Recent:
+        </div>
         <div className="flex flex-wrap gap-2">
           {recentConversationIds.length === 0 ? (
             <div className="text-[11px] text-[color:var(--theme-text-muted)]">
@@ -851,7 +881,7 @@ export default function NewChatModal({
             </div>
           ) : (
             messages.map((m) => {
-              const isMine = m.sender_id === currentUserId;
+              const isMine = m.is_mine ?? m.sender_id === currentUserId;
               const time =
                 m.sent_at &&
                 new Date(m.sent_at).toLocaleTimeString([], {
@@ -861,9 +891,7 @@ export default function NewChatModal({
               return (
                 <div
                   key={m.id}
-                  className={`flex ${
-                    isMine ? "justify-end" : "justify-start"
-                  }`}
+                  className={`flex ${isMine ? "justify-end" : "justify-start"}`}
                 >
                   <div
                     className={`max-w-[70%] break-words rounded-md px-3 py-2 text-xs ${
@@ -876,7 +904,9 @@ export default function NewChatModal({
                     {time ? (
                       <p
                         className={`mt-1 text-[9px] ${
-                          isMine ? "text-[color:var(--theme-text-on-accent)]" : "text-[color:var(--theme-text-secondary)]"
+                          isMine
+                            ? "text-[color:var(--theme-text-on-accent)]"
+                            : "text-[color:var(--theme-text-secondary)]"
                         }`}
                       >
                         {time}

--- a/features/ai/lib/chat/authorization.ts
+++ b/features/ai/lib/chat/authorization.ts
@@ -1,10 +1,23 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
-import { canonicalizeRole, type CanonicalRole } from "@/features/shared/lib/rbac";
+import {
+  canonicalizeRole,
+  type CanonicalRole,
+} from "@/features/shared/lib/rbac";
 
 type ConversationRow = Database["public"]["Tables"]["conversations"]["Row"];
 type MessagingChannel = "internal" | "customer";
-type ParticipantKind = "staff" | "customer";
+export type ParticipantKind = "staff" | "customer";
+export type MessagingParticipant =
+  Database["public"]["Tables"]["conversation_participants"]["Row"];
+
+export type MessagingParticipantSeed = {
+  userId: string;
+  kind: ParticipantKind;
+  profileId: string | null;
+  customerId: string | null;
+  role: string | null;
+};
 
 export const CUSTOMER_MESSAGING_ROLE_LIST = [
   "owner",
@@ -20,7 +33,9 @@ export const CUSTOMER_MESSAGING_ROLES = new Set<CanonicalRole>(
   CUSTOMER_MESSAGING_ROLE_LIST,
 );
 
-export function isCustomerMessagingRole(role: string | null | undefined): boolean {
+export function isCustomerMessagingRole(
+  role: string | null | undefined,
+): boolean {
   return CUSTOMER_MESSAGING_ROLES.has(canonicalizeRole(role));
 }
 
@@ -42,6 +57,26 @@ export type MessagingActor =
       profileId: null;
     };
 
+export function participantSeedForActor(
+  actor: MessagingActor,
+): MessagingParticipantSeed {
+  return actor.kind === "staff"
+    ? {
+        userId: actor.userId,
+        kind: "staff",
+        profileId: actor.profileId,
+        customerId: null,
+        role: actor.role,
+      }
+    : {
+        userId: actor.userId,
+        kind: "customer",
+        profileId: null,
+        customerId: actor.customerId,
+        role: "customer",
+      };
+}
+
 type AccessFailure = {
   ok: false;
   status: 400 | 403 | 404 | 500;
@@ -53,6 +88,8 @@ type AccessResult =
       ok: true;
       actor: MessagingActor;
       conversation: ConversationRow;
+      actorParticipant: MessagingParticipant;
+      participants: MessagingParticipant[];
       participantUserIds: string[];
     }
   | AccessFailure;
@@ -111,7 +148,8 @@ export async function resolveMessagingActor({
     return {
       ok: false,
       status: 403,
-      error: "Messaging requires a customer record linked to this portal account",
+      error:
+        "Messaging requires a customer record linked to this portal account",
     };
   }
 
@@ -154,12 +192,18 @@ export async function authorizeConversationActor({
   supabase,
   conversationId,
   actorUserId,
+  preferredKind,
 }: {
   supabase: SupabaseClient<Database>;
   conversationId: string;
   actorUserId: string;
+  preferredKind?: MessagingActor["kind"];
 }): Promise<AccessResult> {
-  const actorResult = await resolveMessagingActor({ supabase, actorUserId });
+  const actorResult = await resolveMessagingActor({
+    supabase,
+    actorUserId,
+    preferredKind,
+  });
   if (!actorResult.ok) return actorResult;
 
   const { data: conversation, error: conversationError } = await supabase
@@ -178,31 +222,50 @@ export async function authorizeConversationActor({
 
   const { data: participantRows, error: participantsError } = await supabase
     .from("conversation_participants")
-    .select("user_id")
+    .select("*")
     .eq("conversation_id", conversationId);
 
   if (participantsError) {
     return { ok: false, status: 500, error: participantsError.message };
   }
 
+  const participants = (participantRows ?? []) as MessagingParticipant[];
   const participantUserIds = Array.from(
     new Set(
-      (participantRows ?? [])
+      participants
         .map((row) => row.user_id)
         .filter((userId): userId is string => Boolean(userId)),
     ),
   );
 
-  const isMember =
-    conversation.created_by === actorUserId ||
-    participantUserIds.includes(actorUserId);
+  const actorParticipant = participants.find(
+    (participant) =>
+      participant.user_id === actorUserId &&
+      participant.participant_kind === actorResult.actor.kind &&
+      (actorResult.actor.kind === "staff"
+        ? !participant.profile_id ||
+          participant.profile_id === actorResult.actor.profileId
+        : !participant.customer_id ||
+          participant.customer_id === actorResult.actor.customerId),
+  );
 
-  if (!isMember) {
-    return { ok: false, status: 403, error: "You are not part of this conversation" };
+  if (!actorParticipant) {
+    return {
+      ok: false,
+      status: 403,
+      error: "You are not part of this conversation",
+    };
   }
 
-  if (conversation.shop_id && conversation.shop_id !== actorResult.actor.shopId) {
-    return { ok: false, status: 403, error: "Conversation belongs to another shop" };
+  if (
+    conversation.shop_id &&
+    conversation.shop_id !== actorResult.actor.shopId
+  ) {
+    return {
+      ok: false,
+      status: 403,
+      error: "Conversation belongs to another shop",
+    };
   }
 
   if (actorResult.actor.kind === "customer") {
@@ -210,7 +273,11 @@ export async function authorizeConversationActor({
       conversation.channel !== "customer" ||
       conversation.customer_id !== actorResult.actor.customerId
     ) {
-      return { ok: false, status: 403, error: "Conversation is not available in the customer portal" };
+      return {
+        ok: false,
+        status: 403,
+        error: "Conversation is not available in the customer portal",
+      };
     }
   }
 
@@ -218,6 +285,8 @@ export async function authorizeConversationActor({
     ok: true,
     actor: actorResult.actor,
     conversation,
+    actorParticipant,
+    participants,
     participantUserIds,
   };
 }
@@ -237,6 +306,8 @@ export async function authorizeConversationLifecycleAction({
       ok: true;
       actor: MessagingActor;
       conversation: ConversationRow;
+      actorParticipant: MessagingParticipant;
+      participants: MessagingParticipant[];
       participantUserIds: string[];
       actorShopId: string;
     }
@@ -251,7 +322,11 @@ export async function authorizeConversationLifecycleAction({
 
   if (action === "delete" || action === "manage_participants") {
     if (access.actor.kind !== "staff") {
-      return { ok: false, status: 403, error: "Only shop staff can manage conversations" };
+      return {
+        ok: false,
+        status: 403,
+        error: "Only shop staff can manage conversations",
+      };
     }
     if (access.conversation.created_by !== actorUserId) {
       return {
@@ -269,6 +344,8 @@ export async function authorizeConversationLifecycleAction({
     ok: true,
     actor: access.actor,
     conversation: access.conversation,
+    actorParticipant: access.actorParticipant,
+    participants: access.participants,
     participantUserIds: access.participantUserIds,
     actorShopId: access.actor.shopId,
   };
@@ -297,6 +374,7 @@ export async function authorizeConversationCreate({
       customerId: string | null;
       recipientUserIds: string[];
       participantKinds: Record<string, ParticipantKind>;
+      recipientParticipants: MessagingParticipantSeed[];
     }
   | AccessFailure
 > {
@@ -309,18 +387,22 @@ export async function authorizeConversationCreate({
 
   const actor = actorResult.actor;
   if (actor.kind === "customer" && channel !== "customer") {
-    return { ok: false, status: 403, error: "Customers can only start customer conversations" };
+    return {
+      ok: false,
+      status: 403,
+      error: "Customers can only start customer conversations",
+    };
   }
 
   const uniqueStaffIds = Array.from(new Set(participantUserIds))
     .map((id) => id.trim())
-    .filter((id) => id && id !== actorUserId);
+    .filter(Boolean);
 
-  let staffUserIds: string[] = [];
+  let staffParticipants: MessagingParticipantSeed[] = [];
   if (uniqueStaffIds.length > 0) {
     const { data: staff, error: staffError } = await supabase
       .from("profiles")
-      .select("id, user_id")
+      .select("id, user_id, role")
       .eq("shop_id", actor.shopId)
       .or(uniqueStaffIds.map((id) => `user_id.eq.${id},id.eq.${id}`).join(","));
 
@@ -328,30 +410,50 @@ export async function authorizeConversationCreate({
       return { ok: false, status: 500, error: staffError.message };
     }
 
-    staffUserIds = Array.from(
-      new Set(
-        (staff ?? [])
-          .map((row) => row.user_id ?? row.id)
-          .filter((id): id is string => Boolean(id) && id !== actorUserId),
-      ),
-    );
+    staffParticipants = (staff ?? [])
+      .filter(
+        (row, index, rows) =>
+          rows.findIndex((candidate) => candidate.id === row.id) === index,
+      )
+      .filter((row) => actor.kind !== "staff" || row.id !== actor.profileId)
+      .map((row) => ({
+        userId: row.user_id ?? row.id,
+        kind: "staff" as const,
+        profileId: row.id,
+        customerId: null,
+        role: row.role,
+      }));
   }
 
   if (channel === "internal") {
     if (actor.kind !== "staff") {
-      return { ok: false, status: 403, error: "Internal conversations are staff only" };
+      return {
+        ok: false,
+        status: 403,
+        error: "Internal conversations are staff only",
+      };
     }
-    if (staffUserIds.length === 0) {
-      return { ok: false, status: 400, error: "Select at least one same-shop staff recipient" };
+    if (staffParticipants.length === 0) {
+      return {
+        ok: false,
+        status: 400,
+        error: "Select at least one same-shop staff recipient",
+      };
     }
+    const recipientUserIds = Array.from(
+      new Set(staffParticipants.map((participant) => participant.userId)),
+    );
     return {
       ok: true,
       actor,
       actorShopId: actor.shopId,
       channel,
       customerId: null,
-      recipientUserIds: staffUserIds,
-      participantKinds: Object.fromEntries(staffUserIds.map((id) => [id, "staff"])),
+      recipientUserIds,
+      participantKinds: Object.fromEntries(
+        recipientUserIds.map((id) => [id, "staff"]),
+      ),
+      recipientParticipants: staffParticipants,
     };
   }
 
@@ -363,9 +465,14 @@ export async function authorizeConversationCreate({
     };
   }
 
-  const resolvedCustomerId = actor.kind === "customer" ? actor.customerId : customerId;
+  const resolvedCustomerId =
+    actor.kind === "customer" ? actor.customerId : customerId;
   if (!resolvedCustomerId) {
-    return { ok: false, status: 400, error: "Select a customer for this conversation" };
+    return {
+      ok: false,
+      status: 400,
+      error: "Select a customer for this conversation",
+    };
   }
 
   const { data: customer, error: customerError } = await supabase
@@ -382,14 +489,20 @@ export async function authorizeConversationCreate({
     return {
       ok: false,
       status: 400,
-      error: customer ? "Customer must activate their portal before in-app messaging" : "Customer not found in this shop",
+      error: customer
+        ? "Customer must activate their portal before in-app messaging"
+        : "Customer not found in this shop",
     };
   }
   if (actor.kind === "customer" && customer.user_id !== actorUserId) {
-    return { ok: false, status: 403, error: "Customers cannot message on behalf of another customer" };
+    return {
+      ok: false,
+      status: 403,
+      error: "Customers cannot message on behalf of another customer",
+    };
   }
 
-  if (actor.kind === "customer" && staffUserIds.length === 0) {
+  if (actor.kind === "customer" && staffParticipants.length === 0) {
     const { data: serviceTeam, error: serviceTeamError } = await supabase
       .from("profiles")
       .select("id, user_id, role")
@@ -399,30 +512,49 @@ export async function authorizeConversationCreate({
     if (serviceTeamError) {
       return { ok: false, status: 500, error: serviceTeamError.message };
     }
-    staffUserIds = Array.from(
-      new Set(
-        (serviceTeam ?? [])
-          .filter((row) => isCustomerMessagingRole(row.role))
-          .map((row) => row.user_id ?? row.id)
-          .filter((id): id is string => Boolean(id) && id !== actorUserId),
-      ),
-    );
+    staffParticipants = (serviceTeam ?? [])
+      .filter((row) => isCustomerMessagingRole(row.role))
+      .filter(
+        (row, index, rows) =>
+          rows.findIndex((candidate) => candidate.id === row.id) === index,
+      )
+      .map((row) => ({
+        userId: row.user_id ?? row.id,
+        kind: "staff" as const,
+        profileId: row.id,
+        customerId: null,
+        role: row.role,
+      }));
   }
 
-  if (actor.kind === "customer" && staffUserIds.length === 0) {
-    return { ok: false, status: 400, error: "No customer-facing shop staff are available" };
+  if (actor.kind === "customer" && staffParticipants.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: "No customer-facing shop staff are available",
+    };
   }
 
+  const customerParticipant: MessagingParticipantSeed = {
+    userId: customer.user_id,
+    kind: "customer",
+    profileId: null,
+    customerId: customer.id,
+    role: "customer",
+  };
+  const recipientParticipants = [
+    ...staffParticipants,
+    ...(actor.kind === "customer" ? [] : [customerParticipant]),
+  ];
   const recipientUserIds = Array.from(
-    new Set([
-      ...staffUserIds,
-      ...(customer.user_id === actorUserId ? [] : [customer.user_id]),
-    ]),
+    new Set(recipientParticipants.map((participant) => participant.userId)),
   );
   const participantKinds: Record<string, ParticipantKind> = Object.fromEntries(
-    staffUserIds.map((id) => [id, "staff"]),
+    recipientParticipants.map((participant) => [
+      participant.userId,
+      participant.kind,
+    ]),
   );
-  if (customer.user_id !== actorUserId) participantKinds[customer.user_id] = "customer";
 
   return {
     ok: true,
@@ -432,20 +564,25 @@ export async function authorizeConversationCreate({
     customerId: resolvedCustomerId,
     recipientUserIds,
     participantKinds,
+    recipientParticipants,
   };
 }
 
 export async function getActorConversationIds({
   supabase,
   actorUserId,
+  participantKind,
 }: {
   supabase: SupabaseClient<Database>;
   actorUserId: string;
+  participantKind?: ParticipantKind;
 }): Promise<{ ids: string[]; error: string | null }> {
-  const { data: participantRows, error } = await supabase
+  let query = supabase
     .from("conversation_participants")
     .select("conversation_id")
     .eq("user_id", actorUserId);
+  if (participantKind) query = query.eq("participant_kind", participantKind);
+  const { data: participantRows, error } = await query;
 
   if (error) return { ids: [], error: error.message };
 

--- a/features/chat/components/InboxModal.tsx
+++ b/features/chat/components/InboxModal.tsx
@@ -17,6 +17,7 @@ import {
   type OfflineMessageDraft,
 } from "@/features/chat/offline/messageDrafts";
 import type { OfflineMutationScope } from "@/features/shared/lib/offline/mutations";
+import type { ChatMessage } from "@/features/chat/types";
 
 type DB = Database;
 type MessageRow = DB["public"]["Tables"]["messages"]["Row"];
@@ -24,6 +25,7 @@ type ConversationRow = DB["public"]["Tables"]["conversations"]["Row"];
 
 type Participant = {
   id: string;
+  user_id?: string;
   kind?: "staff" | "customer";
   full_name: string | null;
   avatar_url?: string | null;
@@ -136,23 +138,33 @@ export default function InboxModal({
 
   const [me, setMe] = useState<string | null>(null);
   const [rows, setRows] = useState<ConversationPayload[]>([]);
-  const [activeConversationId, setActiveConversationId] = useState<string | null>(
-    null,
-  );
-  const [messages, setMessages] = useState<MessageRow[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<
+    string | null
+  >(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [users, setUsers] = useState<Participant[]>([]);
   const [customers, setCustomers] = useState<CustomerOption[]>([]);
   const [search, setSearch] = useState("");
   const [compose, setCompose] = useState("");
   const [sending, setSending] = useState(false);
   const [selectedRecipients, setSelectedRecipients] = useState<string[]>([]);
-  const [selectedCustomerId, setSelectedCustomerId] = useState<string | null>(null);
-  const [composeAudience, setComposeAudience] = useState<"internal" | "customer">("internal");
+  const [selectedCustomerId, setSelectedCustomerId] = useState<string | null>(
+    null,
+  );
+  const [composeAudience, setComposeAudience] = useState<
+    "internal" | "customer"
+  >("internal");
   const [roleFilter, setRoleFilter] = useState("all");
   const [useContext, setUseContext] = useState(true);
-  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(null);
-  const [messageDraft, setMessageDraft] = useState<OfflineMessageDraft | null>(null);
-  const [loadedDraftTarget, setLoadedDraftTarget] = useState<string | null>(null);
+  const [draftScope, setDraftScope] = useState<OfflineMutationScope | null>(
+    null,
+  );
+  const [messageDraft, setMessageDraft] = useState<OfflineMessageDraft | null>(
+    null,
+  );
+  const [loadedDraftTarget, setLoadedDraftTarget] = useState<string | null>(
+    null,
+  );
   const [draftSaved, setDraftSaved] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
 
@@ -162,9 +174,9 @@ export default function InboxModal({
     : `staff:new:${composeAudience}:${context.context_type ?? "general"}:${context.context_id ?? "none"}`;
   const draftReady = Boolean(
     draftScope &&
-      messageDraft &&
-      loadedDraftTarget === draftTargetId &&
-      messageDraft.targetId === draftTargetId,
+    messageDraft &&
+    loadedDraftTarget === draftTargetId &&
+    messageDraft.targetId === draftTargetId,
   );
   const newConversationFingerprint = useMemo(
     () =>
@@ -187,7 +199,9 @@ export default function InboxModal({
   );
 
   const loadConversations = useCallback(async () => {
-    const res = await fetch("/api/chat/my-conversations", { credentials: "include" });
+    const res = await fetch("/api/chat/my-conversations", {
+      credentials: "include",
+    });
     if (!res.ok) return;
 
     const data = (await res.json()) as ConversationPayload[];
@@ -201,14 +215,14 @@ export default function InboxModal({
     const res = await fetch("/api/chat/get-messages", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ conversationId }),
+      body: JSON.stringify({ conversationId, actor_kind: "staff" }),
     });
     const data = await res.json().catch(() => null);
     setMessages(Array.isArray(data) ? data : []);
     await fetch("/api/chat/mark-read", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ conversationId }),
+      body: JSON.stringify({ conversationId, actor_kind: "staff" }),
     }).catch(() => undefined);
     window.dispatchEvent(new CustomEvent("profixiq:inbox-read"));
   }, []);
@@ -216,7 +230,8 @@ export default function InboxModal({
   useEffect(() => {
     if (!open) return;
 
-    void supabase.auth.getSession().then(({ data }) => setMe(data.session?.user.id ?? null));
+    const sessionPromise = supabase.auth.getSession();
+    void sessionPromise.then(({ data }) => setMe(data.session?.user.id ?? null));
     void loadConversations().catch(() => undefined);
 
     void fetch("/api/chat/users", { credentials: "include" })
@@ -265,21 +280,24 @@ export default function InboxModal({
     if (!open || !draftScope) return;
     let cancelled = false;
     setLoadedDraftTarget(null);
-    void getOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId }).then(
-      (stored) => {
-        if (cancelled) return;
-        const next = stored ?? createMessageDraft({ scope: draftScope, targetId: draftTargetId });
-        setMessageDraft(next);
-        setCompose(next.content);
-        if (!activeConversationId) {
-          setSelectedRecipients(next.recipientIds ?? []);
-          setSelectedCustomerId(next.customerId ?? null);
-          setUseContext(next.useContext ?? true);
-        }
-        setDraftSaved(Boolean(stored?.content));
-        setLoadedDraftTarget(draftTargetId);
-      },
-    );
+    void getOfflineMessageDraft({
+      scope: draftScope,
+      targetId: draftTargetId,
+    }).then((stored) => {
+      if (cancelled) return;
+      const next =
+        stored ??
+        createMessageDraft({ scope: draftScope, targetId: draftTargetId });
+      setMessageDraft(next);
+      setCompose(next.content);
+      if (!activeConversationId) {
+        setSelectedRecipients(next.recipientIds ?? []);
+        setSelectedCustomerId(next.customerId ?? null);
+        setUseContext(next.useContext ?? true);
+      }
+      setDraftSaved(Boolean(stored?.content));
+      setLoadedDraftTarget(draftTargetId);
+    });
     return () => {
       cancelled = true;
     };
@@ -321,10 +339,14 @@ export default function InboxModal({
       !messageDraft ||
       loadedDraftTarget !== draftTargetId ||
       messageDraft.targetId !== draftTargetId
-    ) return;
+    )
+      return;
     const timer = window.setTimeout(() => {
       if (!compose.trim()) {
-        void removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        void removeOfflineMessageDraft({
+          scope: draftScope,
+          targetId: draftTargetId,
+        });
         setDraftSaved(false);
         return;
       }
@@ -339,7 +361,17 @@ export default function InboxModal({
       }).then(() => setDraftSaved(true));
     }, 350);
     return () => window.clearTimeout(timer);
-  }, [compose, composeAudience, draftScope, draftTargetId, loadedDraftTarget, messageDraft, selectedCustomerId, selectedRecipients, useContext]);
+  }, [
+    compose,
+    composeAudience,
+    draftScope,
+    draftTargetId,
+    loadedDraftTarget,
+    messageDraft,
+    selectedCustomerId,
+    selectedRecipients,
+    useContext,
+  ]);
 
   useEffect(() => {
     if (!open || !activeConversationId) return;
@@ -351,7 +383,8 @@ export default function InboxModal({
     if (!open) return;
 
     const refresh = (event: Event) => {
-      const detail = (event as CustomEvent<{ conversationId?: string | null }>).detail;
+      const detail = (event as CustomEvent<{ conversationId?: string | null }>)
+        .detail;
       const conversationId = detail?.conversationId ?? activeConversationId;
       void loadConversations();
       if (conversationId) {
@@ -379,11 +412,8 @@ export default function InboxModal({
           table: "messages",
           filter: `conversation_id=eq.${activeConversationId}`,
         },
-        (payload) => {
-          const message = payload.new as MessageRow;
-          setMessages((prev) =>
-            prev.some((m) => m.id === message.id) ? prev : [...prev, message],
-          );
+        () => {
+          void loadMessages(activeConversationId);
           void loadConversations();
         },
       )
@@ -392,7 +422,7 @@ export default function InboxModal({
     return () => {
       supabase.removeChannel(ch);
     };
-  }, [open, activeConversationId, supabase, loadConversations]);
+  }, [open, activeConversationId, supabase, loadConversations, loadMessages]);
 
   useEffect(() => {
     if (!open) return;
@@ -495,20 +525,23 @@ export default function InboxModal({
           body: JSON.stringify({
             participant_ids: selectedRecipients,
             channel: composeAudience,
-            customer_id: composeAudience === "customer" ? selectedCustomerId : null,
+            customer_id:
+              composeAudience === "customer" ? selectedCustomerId : null,
             context_type: useContext ? context.context_type : null,
             context_id: useContext ? context.context_id : null,
             title:
               useContext && context.context_label !== "General"
                 ? context.context_label
                 : null,
-            is_broadcast: composeAudience === "internal" && selectedRecipients.length > 3,
+            is_broadcast:
+              composeAudience === "internal" && selectedRecipients.length > 3,
             request_id: deliveryDraft.conversationRequestId,
           }),
         });
 
         const data = await res.json();
-        if (!res.ok) throw new Error(data?.error ?? "Could not start inbox thread");
+        if (!res.ok)
+          throw new Error(data?.error ?? "Could not start inbox thread");
 
         conversationId = data.id;
       }
@@ -522,7 +555,7 @@ export default function InboxModal({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           conversationId,
-          senderId: me,
+          actor_kind: "staff",
           content,
           clientMessageId: deliveryDraft.clientMessageId,
           metadata: {
@@ -534,10 +567,14 @@ export default function InboxModal({
       });
 
       if (!res.ok) {
-        const failure = (await res.json().catch(() => null)) as { error?: string } | null;
+        const failure = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
         throw new Error(failure?.error ?? "Could not send message");
       }
-      const sentMessage = (await res.json().catch(() => null)) as MessageRow | null;
+      const sentMessage = (await res
+        .json()
+        .catch(() => null)) as ChatMessage | null;
       if (sentMessage?.id) {
         setMessages((prev) =>
           prev.some((message) => message.id === sentMessage.id)
@@ -546,12 +583,17 @@ export default function InboxModal({
         );
       }
       if (draftScope) {
-        await removeOfflineMessageDraft({ scope: draftScope, targetId: draftTargetId });
+        await removeOfflineMessageDraft({
+          scope: draftScope,
+          targetId: draftTargetId,
+        });
       }
       setCompose("");
       setDraftSaved(false);
       if (draftScope) {
-        setMessageDraft(createMessageDraft({ scope: draftScope, targetId: draftTargetId }));
+        setMessageDraft(
+          createMessageDraft({ scope: draftScope, targetId: draftTargetId }),
+        );
       }
       setActiveConversationId(conversationId);
       await loadConversations();
@@ -562,7 +604,9 @@ export default function InboxModal({
         }),
       );
     } catch (cause) {
-      setSendError(cause instanceof Error ? cause.message : "Could not send message");
+      setSendError(
+        cause instanceof Error ? cause.message : "Could not send message",
+      );
     } finally {
       setSending(false);
     }
@@ -598,7 +642,9 @@ export default function InboxModal({
     >
       <div className="mb-2.5">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="text-[11px] text-[color:var(--theme-text-muted)]">Shop communication center</p>
+          <p className="text-[11px] text-[color:var(--theme-text-muted)]">
+            Shop communication center
+          </p>
           <button
             type="button"
             className="rounded-full border border-[var(--accent-copper-soft)] px-3 py-1 text-[11px] font-semibold text-[var(--accent-copper-soft)]"
@@ -649,11 +695,16 @@ export default function InboxModal({
 
           <div className="min-h-0 flex-1 overflow-auto">
             {visibleRows.map((row) => {
-              const mineExcluded = row.participants.filter((p) => p.id !== me);
+              const mineExcluded = row.participants.filter(
+                (p) => p.user_id !== me,
+              );
               const primary = mineExcluded[0] ?? row.participants[0];
               const title =
                 row.conversation.title ??
-                (mineExcluded.map((p) => p.full_name).filter(Boolean).join(", ") ||
+                (mineExcluded
+                  .map((p) => p.full_name)
+                  .filter(Boolean)
+                  .join(", ") ||
                   `Thread ${row.conversation.id.slice(0, 6)}`);
 
               return (
@@ -694,16 +745,16 @@ export default function InboxModal({
         <section className="flex min-h-0 flex-col rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)]">
           <div className="border-b border-[color:var(--theme-border-soft)] px-3 py-1.5 text-xs font-medium text-[color:var(--theme-text-primary)]">
             {activeConversation
-              ? activeConversation.conversation.title ?? "Thread"
+              ? (activeConversation.conversation.title ?? "Thread")
               : "New message"}
           </div>
 
           <div className="min-h-0 flex-1 space-y-1.5 overflow-auto p-2.5">
             {messages.map((m) => {
-              const mine = m.sender_id === me;
+              const mine = m.is_mine;
               const sender =
                 activeConversation?.participants.find(
-                  (participant) => participant.id === m.sender_id,
+                  (participant) => participant.id === m.sender_participant_id,
                 ) ?? users.find((u) => u.id === m.sender_id);
 
               return (
@@ -713,8 +764,8 @@ export default function InboxModal({
                 >
                   {!mine ? (
                     <UserAvatar
-                      name={sender?.full_name}
-                      avatarUrl={sender?.avatar_url}
+                      name={m.sender_name ?? sender?.full_name}
+                      avatarUrl={m.sender_avatar_url ?? sender?.avatar_url}
                       size="sm"
                     />
                   ) : null}
@@ -734,53 +785,61 @@ export default function InboxModal({
 
           {!activeConversationId ? (
             <div className="space-y-2 border-t border-[color:var(--theme-border-soft)] p-2.5 text-xs">
-              {composeAudience === "internal" ? <><div className="flex gap-2">
-                <select
-                  value={roleFilter}
-                  onChange={(e) => setRoleFilter(e.target.value)}
-                  className="h-8 rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-2 py-1"
-                >
-                  <option value="all">All roles</option>
-                  <option value="tech">Tech</option>
-                  <option value="advisor">Advisor</option>
-                  <option value="parts">Parts</option>
-                  <option value="manager">Manager</option>
-                </select>
-                <button
-                  type="button"
-                  disabled={!draftReady || sending}
-                  className="h-8 rounded border border-[color:var(--theme-border-soft)] px-2"
-                  onClick={() => setSelectedRecipients(recipientOptions.map((u) => u.id))}
-                >
-                  Select all
-                </button>
-              </div>
-
-              <div className="max-h-20 overflow-auto rounded border border-[color:var(--theme-border-soft)] p-2">
-                {recipientOptions.map((u) => (
-                  <label key={u.id} className="mb-1 flex items-center gap-2">
-                    <input
-                      type="checkbox"
+              {composeAudience === "internal" ? (
+                <>
+                  <div className="flex gap-2">
+                    <select
+                      value={roleFilter}
+                      onChange={(e) => setRoleFilter(e.target.value)}
+                      className="h-8 rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-2 py-1"
+                    >
+                      <option value="all">All roles</option>
+                      <option value="tech">Tech</option>
+                      <option value="advisor">Advisor</option>
+                      <option value="parts">Parts</option>
+                      <option value="manager">Manager</option>
+                    </select>
+                    <button
+                      type="button"
                       disabled={!draftReady || sending}
-                      checked={selectedRecipients.includes(u.id)}
-                      onChange={(e) =>
-                        setSelectedRecipients((prev) =>
-                          e.target.checked
-                            ? [...prev, u.id]
-                            : prev.filter((id) => id !== u.id),
-                        )
+                      className="h-8 rounded border border-[color:var(--theme-border-soft)] px-2"
+                      onClick={() =>
+                        setSelectedRecipients(recipientOptions.map((u) => u.id))
                       }
-                    />
-                    <UserAvatar
-                      name={u.full_name}
-                      avatarUrl={u.avatar_url}
-                      size="sm"
-                    />
-                    <span>{u.full_name ?? u.id.slice(0, 6)}</span>
-                  </label>
-                ))}
-              </div>
-              </> : (
+                    >
+                      Select all
+                    </button>
+                  </div>
+
+                  <div className="max-h-20 overflow-auto rounded border border-[color:var(--theme-border-soft)] p-2">
+                    {recipientOptions.map((u) => (
+                      <label
+                        key={u.id}
+                        className="mb-1 flex items-center gap-2"
+                      >
+                        <input
+                          type="checkbox"
+                          disabled={!draftReady || sending}
+                          checked={selectedRecipients.includes(u.id)}
+                          onChange={(e) =>
+                            setSelectedRecipients((prev) =>
+                              e.target.checked
+                                ? [...prev, u.id]
+                                : prev.filter((id) => id !== u.id),
+                            )
+                          }
+                        />
+                        <UserAvatar
+                          name={u.full_name}
+                          avatarUrl={u.avatar_url}
+                          size="sm"
+                        />
+                        <span>{u.full_name ?? u.id.slice(0, 6)}</span>
+                      </label>
+                    ))}
+                  </div>
+                </>
+              ) : (
                 <div className="max-h-32 overflow-auto rounded border border-[color:var(--theme-border-soft)] p-1.5">
                   {customers.map((customer) => (
                     <button
@@ -795,9 +854,15 @@ export default function InboxModal({
                       } disabled:cursor-not-allowed disabled:opacity-50`}
                     >
                       <span>
-                        <span className="block font-medium text-[color:var(--theme-text-primary)]">{customer.full_name}</span>
+                        <span className="block font-medium text-[color:var(--theme-text-primary)]">
+                          {customer.full_name}
+                        </span>
                         <span className="block text-[10px] text-[color:var(--theme-text-muted)]">
-                          {customer.can_message ? customer.email ?? customer.phone ?? "Portal customer" : "Portal activation required"}
+                          {customer.can_message
+                            ? (customer.email ??
+                              customer.phone ??
+                              "Portal customer")
+                            : "Portal activation required"}
                         </span>
                       </span>
                     </button>
@@ -867,13 +932,15 @@ export default function InboxModal({
           {activeConversation ? (
             <>
               <p className="mb-1 text-[color:var(--theme-text-primary)]">
-              Type: {activeConversation.context?.type ?? "general"}
+                Type: {activeConversation.context?.type ?? "general"}
               </p>
 
               {activeConversation.context ? (
                 <p className="mb-3 text-[color:var(--theme-text-secondary)]">
                   {activeConversation.context.label}
-                  {activeConversation.context.secondary ? ` · ${activeConversation.context.secondary}` : ""}
+                  {activeConversation.context.secondary
+                    ? ` · ${activeConversation.context.secondary}`
+                    : ""}
                 </p>
               ) : (
                 <div className="mb-3 rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2 text-[11px] text-[color:var(--theme-text-secondary)]">
@@ -896,7 +963,9 @@ export default function InboxModal({
             </>
           ) : (
             <div className="rounded border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2 text-[11px] text-[color:var(--theme-text-secondary)]">
-              <p className="mb-1 text-[color:var(--theme-text-primary)]">No thread selected.</p>
+              <p className="mb-1 text-[color:var(--theme-text-primary)]">
+                No thread selected.
+              </p>
               <p>Compose mode uses current page context when available.</p>
             </div>
           )}

--- a/features/chat/components/PortalMessagesWorkspace.tsx
+++ b/features/chat/components/PortalMessagesWorkspace.tsx
@@ -52,13 +52,16 @@ type RecipientOption = {
   label: string;
 };
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function ensureUuid(value: string | null | undefined): string {
   return value && UUID_RE.test(value) ? value : crypto.randomUUID();
 }
 
-function normalizeMessageDraft(draft: OfflineMessageDraft): OfflineMessageDraft {
+function normalizeMessageDraft(
+  draft: OfflineMessageDraft,
+): OfflineMessageDraft {
   const conversationRequestId = ensureUuid(draft.conversationRequestId);
   const clientMessageId = ensureUuid(draft.clientMessageId);
   if (
@@ -73,6 +76,8 @@ function normalizeMessageDraft(draft: OfflineMessageDraft): OfflineMessageDraft 
 export default function PortalMessagesWorkspace(): JSX.Element {
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const searchParams = useSearchParams();
+  const requestedConversationId =
+    searchParams.get("conversationId")?.trim() ?? "";
   const requestedWorkOrderId = searchParams.get("workOrderId")?.trim() ?? "";
   const requestedContextKey = requestedWorkOrderId
     ? `work_order:${requestedWorkOrderId}`
@@ -110,8 +115,15 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     if (!response.ok) throw new Error("Could not load messages");
     const payload = (await response.json()) as ConversationPayload[];
     setRows(payload);
-    setActiveId((current) => current ?? payload[0]?.conversation.id ?? null);
-  }, []);
+    setActiveId(
+      (current) =>
+        current ??
+        payload.find((row) => row.conversation.id === requestedConversationId)
+          ?.conversation.id ??
+        payload[0]?.conversation.id ??
+        null,
+    );
+  }, [requestedConversationId]);
 
   useEffect(() => {
     void supabase.auth.getSession().then(({ data }) => {
@@ -238,7 +250,9 @@ export default function PortalMessagesWorkspace(): JSX.Element {
     }
 
     const selectedContext =
-      contextOptions.find((option) => `${option.type}:${option.id}` === contextKey) ??
+      contextOptions.find(
+        (option) => `${option.type}:${option.id}` === contextKey,
+      ) ??
       (requestedWorkOrderId && contextKey === requestedContextKey
         ? {
             type: "work_order" as const,
@@ -293,6 +307,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
           conversationId: created.id,
           content,
           clientMessageId,
+          actor_kind: "customer",
         }),
       });
       if (!messageResponse.ok) {
@@ -563,6 +578,7 @@ export default function PortalMessagesWorkspace(): JSX.Element {
                   conversationId={active.conversation.id}
                   userId={userId}
                   title={active.conversation.title ?? "Shop team"}
+                  actorKind="customer"
                 />
               </div>
             </>

--- a/features/chat/types.ts
+++ b/features/chat/types.ts
@@ -1,0 +1,11 @@
+import type { Database } from "@/features/shared/types/types/supabase";
+
+export type MessageActorKind = "staff" | "customer";
+
+export type ChatMessage = Database["public"]["Tables"]["messages"]["Row"] & {
+  sender_kind: MessageActorKind | null;
+  sender_name: string | null;
+  sender_avatar_url: string | null;
+  is_mine: boolean;
+  can_delete: boolean;
+};

--- a/features/invoices/server/processFinancialOutbox.ts
+++ b/features/invoices/server/processFinancialOutbox.ts
@@ -5,6 +5,7 @@ import {
   assertFinancialEventEmailConfigured,
   sendFinancialEventEmail,
 } from "@/features/email/server/sendFinancialEventEmail";
+import { upsertPortalNotification } from "@/features/portal/server/upsertPortalNotification";
 
 type DB = Database;
 type OutboxRow = {
@@ -45,7 +46,9 @@ type FinancialOutboxRpcClient = {
 type FinancialEmailInput = Parameters<typeof sendFinancialEventEmail>[0];
 type ProcessFinancialOutboxOptions = {
   workerId?: string;
-  sendEmail?: (input: FinancialEmailInput) => Promise<{ providerMessageId: string | null }>;
+  sendEmail?: (
+    input: FinancialEmailInput,
+  ) => Promise<{ providerMessageId: string | null }>;
   now?: () => Date;
 };
 
@@ -72,16 +75,22 @@ function firstRpcRow<T>(value: T[] | T | null): T | null {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "Financial outbox delivery failed";
+  return error instanceof Error
+    ? error.message
+    : "Financial outbox delivery failed";
 }
 
 function retryAt(now: Date, attempts: number): string {
-  const delayMinutes = Math.min(60, Math.max(1, 2 ** Math.min(Math.max(attempts - 1, 0), 5)));
+  const delayMinutes = Math.min(
+    60,
+    Math.max(1, 2 ** Math.min(Math.max(attempts - 1, 0), 5)),
+  );
   return new Date(now.getTime() + delayMinutes * 60_000).toISOString();
 }
 
 function formatMoney(value: unknown, currency: unknown) {
-  const normalized = String(currency ?? "USD").toUpperCase() === "CAD" ? "CAD" : "USD";
+  const normalized =
+    String(currency ?? "USD").toUpperCase() === "CAD" ? "CAD" : "USD";
   return new Intl.NumberFormat(normalized === "CAD" ? "en-CA" : "en-US", {
     style: "currency",
     currency: normalized,
@@ -111,16 +120,19 @@ function eventCopy(eventType: string, payload: Record<string, unknown>) {
     case "payment.failed":
       return {
         customerTitle: "Payment was not completed",
-        customerBody: "Your payment was not completed. Your invoice balance has not been reduced.",
+        customerBody:
+          "Your payment was not completed. Your invoice balance has not been reduced.",
         staffSubject: "Customer payment failed",
-        staffBody: "A customer payment attempt failed and may require follow-up.",
+        staffBody:
+          "A customer payment attempt failed and may require follow-up.",
       };
     case "dispute.opened":
     case "dispute.lost":
     case "dispute.won":
       return {
         customerTitle: "Payment status updated",
-        customerBody: "The status of a payment associated with your invoice has changed.",
+        customerBody:
+          "The status of a payment associated with your invoice has changed.",
         staffSubject: `Payment ${eventType.replaceAll(".", " ")}`,
         staffBody: `A Stripe ${eventType.replaceAll(".", " ")} event was received for an invoice payment.`,
       };
@@ -135,7 +147,10 @@ async function deliverRecipient(input: {
   row: OutboxRow;
   recipientKind: "customer" | "staff";
   recipientEmail: string;
-  message: Omit<FinancialEmailInput, "deliveryKey" | "outboxId" | "recipientKind" | "to">;
+  message: Omit<
+    FinancialEmailInput,
+    "deliveryKey" | "outboxId" | "recipientKind" | "to"
+  >;
   sendEmail: NonNullable<ProcessFinancialOutboxOptions["sendEmail"]>;
 }) {
   // Fail before reserving a provider-send boundary when configuration is missing.
@@ -157,18 +172,27 @@ async function deliverRecipient(input: {
 
   if (TERMINAL_DELIVERY_STATUSES.has(claim.delivery_status)) return;
   if (claim.delivery_status === "ambiguous") {
-    throw new Error(`Financial ${input.recipientKind} delivery requires provider reconciliation`);
+    throw new Error(
+      `Financial ${input.recipientKind} delivery requires provider reconciliation`,
+    );
   }
   if (!claim.should_send || claim.delivery_status !== "claimed") {
-    throw new Error(`Financial ${input.recipientKind} delivery is not available for this worker`);
+    throw new Error(
+      `Financial ${input.recipientKind} delivery is not available for this worker`,
+    );
   }
 
-  const began = await rpc<boolean>(input.admin, "begin_financial_outbox_delivery", {
-    p_delivery_id: claim.delivery_id,
-    p_worker_id: input.workerId,
-    p_lease_seconds: 120,
-  });
-  if (!began) throw new Error("Financial delivery send boundary could not be started");
+  const began = await rpc<boolean>(
+    input.admin,
+    "begin_financial_outbox_delivery",
+    {
+      p_delivery_id: claim.delivery_id,
+      p_worker_id: input.workerId,
+      p_lease_seconds: 120,
+    },
+  );
+  if (!began)
+    throw new Error("Financial delivery send boundary could not be started");
 
   try {
     const result = await input.sendEmail({
@@ -179,21 +203,30 @@ async function deliverRecipient(input: {
       recipientKind: input.recipientKind,
     });
 
-    const accepted = await rpc<boolean>(input.admin, "accept_financial_outbox_delivery", {
-      p_delivery_id: claim.delivery_id,
-      p_worker_id: input.workerId,
-      p_provider_message_id: result.providerMessageId,
-    });
-    if (!accepted) throw new Error("Financial delivery acceptance was not recorded");
+    const accepted = await rpc<boolean>(
+      input.admin,
+      "accept_financial_outbox_delivery",
+      {
+        p_delivery_id: claim.delivery_id,
+        p_worker_id: input.workerId,
+        p_provider_message_id: result.providerMessageId,
+      },
+    );
+    if (!accepted)
+      throw new Error("Financial delivery acceptance was not recorded");
   } catch (error) {
     // SendGrid has no Mail Send idempotency key. Any failure after the request
     // boundary is therefore ambiguous and must not be retried automatically.
     try {
-      await rpc<boolean>(input.admin, "mark_financial_outbox_delivery_ambiguous", {
-        p_delivery_id: claim.delivery_id,
-        p_worker_id: input.workerId,
-        p_error: errorMessage(error),
-      });
+      await rpc<boolean>(
+        input.admin,
+        "mark_financial_outbox_delivery_ambiguous",
+        {
+          p_delivery_id: claim.delivery_id,
+          p_worker_id: input.workerId,
+          p_error: errorMessage(error),
+        },
+      );
     } catch {
       // If this acknowledgement also fails, the delivery lease expiry performs
       // the same safe transition to ambiguous for webhook reconciliation.
@@ -210,11 +243,15 @@ export async function processFinancialOutbox(
   const workerId = options.workerId ?? randomUUID();
   const now = options.now ?? (() => new Date());
   const sendEmail = options.sendEmail ?? sendFinancialEventEmail;
-  const data = await rpc<OutboxRow[] | null>(admin, "claim_financial_outbox_batch", {
-    p_worker_id: workerId,
-    p_limit: Math.max(1, Math.min(limit, 100)),
-    p_lease_seconds: 120,
-  });
+  const data = await rpc<OutboxRow[] | null>(
+    admin,
+    "claim_financial_outbox_batch",
+    {
+      p_worker_id: workerId,
+      p_limit: Math.max(1, Math.min(limit, 100)),
+      p_lease_seconds: 120,
+    },
+  );
 
   let processed = 0;
   let failed = 0;
@@ -223,24 +260,34 @@ export async function processFinancialOutbox(
     try {
       const copy = eventCopy(row.event_type, row.payload ?? {});
       if (!copy) {
-        const completed = await rpc<boolean>(admin, "complete_financial_outbox_claim", {
-          p_outbox_id: row.outbox_id,
-          p_worker_id: workerId,
-        });
-        if (!completed) throw new Error("Unsupported financial event could not be completed");
+        const completed = await rpc<boolean>(
+          admin,
+          "complete_financial_outbox_claim",
+          {
+            p_outbox_id: row.outbox_id,
+            p_worker_id: workerId,
+          },
+        );
+        if (!completed)
+          throw new Error("Unsupported financial event could not be completed");
         processed += 1;
         continue;
       }
 
       const workOrderId = String(row.payload.work_order_id ?? "").trim();
-      if (!workOrderId) throw new Error("Outbox event is missing work_order_id");
+      if (!workOrderId)
+        throw new Error("Outbox event is missing work_order_id");
 
       const { data: workOrder, error: workOrderError } = await admin
         .from("work_orders")
         .select("id,customer_id,custom_id")
         .eq("id", workOrderId)
         .eq("shop_id", row.shop_id)
-        .maybeSingle<{ id: string; customer_id: string | null; custom_id: string | null }>();
+        .maybeSingle<{
+          id: string;
+          customer_id: string | null;
+          custom_id: string | null;
+        }>();
       if (workOrderError || !workOrder) {
         throw new Error(workOrderError?.message ?? "Work order not found");
       }
@@ -267,23 +314,32 @@ export async function processFinancialOutbox(
           shop_name: string | null;
           name: string | null;
         }>();
-      if (shopError || !shop) throw new Error(shopError?.message ?? "Shop not found");
+      if (shopError || !shop)
+        throw new Error(shopError?.message ?? "Shop not found");
 
       const portalUrl = `${process.env.NEXT_PUBLIC_SITE_URL ?? "https://profixiq.com"}/portal/invoices/${workOrderId}`;
       if (customer?.user_id) {
-        const { error: notificationError } = await admin.from("portal_notifications").upsert(
-          {
-            user_id: customer.user_id,
-            customer_id: customer.id,
-            work_order_id: workOrderId,
+        try {
+          await upsertPortalNotification(admin, {
+            userId: customer.user_id,
+            customerId: customer.id,
+            workOrderId,
             kind: row.event_type.replaceAll(".", "_"),
             title: copy.customerTitle,
             body: copy.customerBody,
-            event_key: row.dedupe_key,
-          } as unknown as DB["public"]["Tables"]["portal_notifications"]["Insert"],
-          { onConflict: "user_id,event_key" },
-        );
-        if (notificationError) throw new Error(notificationError.message);
+            eventKey: `financial:${row.dedupe_key}`,
+            href: `/portal/invoices/${workOrderId}`,
+            metadata: { event_type: row.event_type },
+          });
+        } catch (notificationError) {
+          // Portal delivery is independent: a bell failure must never suppress
+          // the customer's transactional email or wedge the outbox claim.
+          console.error("[financial-outbox] portal notification failed", {
+            outboxId: row.outbox_id,
+            eventType: row.event_type,
+            error: errorMessage(notificationError),
+          });
+        }
       }
 
       if (customer?.email) {
@@ -305,7 +361,11 @@ export async function processFinancialOutbox(
         });
       }
 
-      if (shop.email && row.event_type !== "payment.succeeded" && row.event_type !== "manual.payment") {
+      if (
+        shop.email &&
+        row.event_type !== "payment.succeeded" &&
+        row.event_type !== "manual.payment"
+      ) {
         await deliverRecipient({
           admin,
           workerId,
@@ -323,11 +383,16 @@ export async function processFinancialOutbox(
         });
       }
 
-      const completed = await rpc<boolean>(admin, "complete_financial_outbox_claim", {
-        p_outbox_id: row.outbox_id,
-        p_worker_id: workerId,
-      });
-      if (!completed) throw new Error("Financial outbox has unresolved recipient deliveries");
+      const completed = await rpc<boolean>(
+        admin,
+        "complete_financial_outbox_claim",
+        {
+          p_outbox_id: row.outbox_id,
+          p_worker_id: workerId,
+        },
+      );
+      if (!completed)
+        throw new Error("Financial outbox has unresolved recipient deliveries");
       processed += 1;
     } catch (deliveryError) {
       const message = errorMessage(deliveryError);

--- a/features/portal/components/PortalNotificationsBell.tsx
+++ b/features/portal/components/PortalNotificationsBell.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 type DB = Database;
-type PortalNotificationRow = DB["public"]["Tables"]["portal_notifications"]["Row"];
+type PortalNotificationRow =
+  DB["public"]["Tables"]["portal_notifications"]["Row"];
 type RpcClient = ReturnType<typeof createBrowserSupabase> & {
   rpc(
     fn: string,
@@ -18,20 +20,24 @@ function classNames(...parts: Array<string | false | null | undefined>) {
 }
 
 export default function PortalNotificationsBell() {
+  const router = useRouter();
   const supabase = useMemo(() => createBrowserSupabase(), []);
   const rpc = supabase as RpcClient;
   const [items, setItems] = useState<PortalNotificationRow[]>([]);
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
+    setError(null);
     const { data, error } = await supabase
       .from("portal_notifications")
       .select("*")
       .order("created_at", { ascending: false })
       .limit(50);
-    if (!error) setItems(data ?? []);
+    if (error) setError("Notifications could not be loaded.");
+    else setItems(data ?? []);
     setLoading(false);
   }, [supabase]);
 
@@ -58,7 +64,9 @@ export default function PortalNotificationsBell() {
       if (!error) {
         setItems((current) =>
           current.map((item) =>
-            item.id === id ? { ...item, read_at: item.read_at ?? new Date().toISOString() } : item,
+            item.id === id
+              ? { ...item, read_at: item.read_at ?? new Date().toISOString() }
+              : item,
           ),
         );
       }
@@ -70,11 +78,32 @@ export default function PortalNotificationsBell() {
     const { error } = await rpc.rpc("mark_all_portal_notifications_read");
     if (!error) {
       const now = new Date().toISOString();
-      setItems((current) => current.map((item) => ({ ...item, read_at: item.read_at ?? now })));
+      setItems((current) =>
+        current.map((item) => ({ ...item, read_at: item.read_at ?? now })),
+      );
     }
   }, [rpc]);
 
   const unreadCount = items.filter((item) => item.read_at == null).length;
+
+  const openNotification = useCallback(
+    async (item: PortalNotificationRow) => {
+      await markRead(item.id);
+      const metadata =
+        item.metadata &&
+        typeof item.metadata === "object" &&
+        !Array.isArray(item.metadata)
+          ? item.metadata
+          : null;
+      const href =
+        metadata && typeof metadata.href === "string" ? metadata.href : null;
+      if (href?.startsWith("/")) {
+        setOpen(false);
+        router.push(href);
+      }
+    },
+    [markRead, router],
+  );
 
   return (
     <div className="relative">
@@ -111,7 +140,12 @@ export default function PortalNotificationsBell() {
             </button>
           </div>
 
-          {loading ? <div className="py-3 text-[color:var(--theme-text-muted)]">Loading…</div> : null}
+          {loading ? (
+            <div className="py-3 text-[color:var(--theme-text-muted)]">
+              Loading…
+            </div>
+          ) : null}
+          {error ? <div className="py-3 text-red-300">{error}</div> : null}
           {!loading && items.length === 0 ? (
             <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-3 text-[0.7rem] text-[color:var(--theme-text-secondary)]">
               You do not have any notifications yet.
@@ -123,7 +157,7 @@ export default function PortalNotificationsBell() {
               <li key={item.id}>
                 <button
                   type="button"
-                  onClick={() => void markRead(item.id)}
+                  onClick={() => void openNotification(item)}
                   className={classNames(
                     "w-full rounded-xl border px-3 py-2 text-left",
                     item.read_at
@@ -138,7 +172,9 @@ export default function PortalNotificationsBell() {
                     {item.title ?? "Notification"}
                   </div>
                   {item.body ? (
-                    <div className="mt-0.5 text-[0.75rem] text-[color:var(--theme-text-secondary)]">{item.body}</div>
+                    <div className="mt-0.5 text-[0.75rem] text-[color:var(--theme-text-secondary)]">
+                      {item.body}
+                    </div>
                   ) : null}
                   {item.created_at ? (
                     <div className="mt-1 text-[0.65rem] text-[color:var(--theme-text-muted)]">

--- a/features/portal/server/notifyBookingConfirmation.ts
+++ b/features/portal/server/notifyBookingConfirmation.ts
@@ -1,9 +1,11 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { sendBookingConfirmation } from "@/features/shared/lib/email/sendEmail";
+import { upsertPortalNotification } from "@/features/portal/server/upsertPortalNotification";
 
 type BookingForNotification = Pick<
   Database["public"]["Tables"]["bookings"]["Row"],
+  | "id"
   | "starts_at"
   | "ends_at"
   | "customer_id"
@@ -22,7 +24,7 @@ export async function notifyBookingConfirmation(
     await Promise.all([
       supabase
         .from("customers")
-        .select("first_name,last_name,email")
+        .select("id,user_id,first_name,last_name,email")
         .eq("id", booking.customer_id)
         .maybeSingle(),
       booking.vehicle_id
@@ -39,7 +41,7 @@ export async function notifyBookingConfirmation(
         .maybeSingle(),
     ]);
 
-  if (!customer?.email) return false;
+  if (!customer) return false;
 
   const { data: lines } = booking.work_order_id
     ? await supabase
@@ -69,14 +71,30 @@ export async function notifyBookingConfirmation(
     ? [vehicle.year, vehicle.make, vehicle.model].filter(Boolean).join(" ")
     : "Vehicle details on file";
 
-  await sendBookingConfirmation({
-    customerEmail: customer.email,
-    customerName,
-    vehicle: vehicleLabel,
-    services: services.length ? services : ["Service appointment"],
-    estimatedTotal: "Estimate pending",
-    appointmentTime,
-  });
+  if (customer.email) {
+    await sendBookingConfirmation({
+      customerEmail: customer.email,
+      customerName,
+      vehicle: vehicleLabel,
+      services: services.length ? services : ["Service appointment"],
+      estimatedTotal: "Estimate pending",
+      appointmentTime,
+    });
+  }
 
-  return true;
+  if (customer.user_id) {
+    await upsertPortalNotification(supabase, {
+      userId: customer.user_id,
+      customerId: customer.id,
+      workOrderId: booking.work_order_id,
+      kind: "appointment_confirmed",
+      title: "Appointment confirmed",
+      body: `Your service appointment is confirmed for ${appointmentTime}.`,
+      eventKey: `appointment_confirmed:${booking.id}`,
+      href: "/portal/customer-appointments",
+      metadata: { booking_id: booking.id },
+    });
+  }
+
+  return Boolean(customer.email || customer.user_id);
 }

--- a/features/portal/server/upsertPortalNotification.ts
+++ b/features/portal/server/upsertPortalNotification.ts
@@ -1,0 +1,44 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@/features/shared/types/types/supabase";
+
+type PortalNotificationInput = {
+  userId: string;
+  customerId: string | null;
+  workOrderId?: string | null;
+  conversationId?: string | null;
+  messageId?: string | null;
+  kind: string;
+  title: string;
+  body?: string | null;
+  eventKey: string;
+  href?: string | null;
+  metadata?: Record<string, Json | undefined>;
+};
+
+export async function upsertPortalNotification(
+  supabase: SupabaseClient<Database>,
+  input: PortalNotificationInput,
+): Promise<void> {
+  const metadata: Record<string, Json> = {};
+  for (const [key, value] of Object.entries(input.metadata ?? {})) {
+    if (value !== undefined) metadata[key] = value;
+  }
+  if (input.href) metadata.href = input.href;
+  const { error } = await supabase.from("portal_notifications").upsert(
+    {
+      user_id: input.userId,
+      customer_id: input.customerId,
+      work_order_id: input.workOrderId ?? null,
+      conversation_id: input.conversationId ?? null,
+      message_id: input.messageId ?? null,
+      kind: input.kind,
+      title: input.title,
+      body: input.body ?? null,
+      event_key: input.eventKey,
+      metadata,
+    },
+    { onConflict: "user_id,event_key" },
+  );
+
+  if (error) throw new Error(error.message);
+}

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -3,13 +3,17 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import type { Database } from "@shared/types/types/supabase";
 
 import RoleSidebar from "@/features/shared/components/RoleSidebar";
 import ShiftTracker from "@shared/components/ShiftTracker";
-import { fetchMobileShiftState, type MobileShiftState } from "@/features/mobile/shifts/client";
+import {
+  fetchMobileShiftState,
+  type MobileShiftState,
+} from "@/features/mobile/shifts/client";
 import InboxModal from "@/features/chat/components/InboxModal";
 import AgentRequestModal from "@/features/agent/components/AgentRequestModal";
 import { cn } from "@/features/shared/utils/cn";
@@ -19,6 +23,7 @@ import AskAssistantEntry from "@/features/assistant/components/AskAssistantEntry
 import { useActiveBrand } from "@/features/branding/hooks/useActiveBrand";
 import { isBillingAttentionStatus } from "@/features/stripe/lib/stripe/subscriptionStatus";
 import { isOutsideDesktopAppShell } from "@/features/shared/lib/routes/shellBoundaries";
+import OpsNotificationsBell from "@/features/shared/components/OpsNotificationsBell";
 
 const HEADER_OFFSET_DESKTOP = "pt-14";
 
@@ -38,8 +43,7 @@ const ActionButton = ({
     className="app-shell-action inline-flex h-8 items-center justify-center gap-1.5 rounded-md border px-2.5 text-xs font-medium shadow-sm backdrop-blur-md transition-colors"
     style={{
       borderColor: "var(--theme-border-soft)",
-      background:
-        "var(--theme-gradient-panel)",
+      background: "var(--theme-gradient-panel)",
       color: "var(--theme-text-primary)",
     }}
   >
@@ -89,7 +93,7 @@ export default function AppShell({
 }) {
   const pathname = usePathname() ?? "/";
   const router = useRouter();
-  const supabase = createBrowserSupabase();
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const { data: activeBrand } = useActiveBrand();
 
   const [userId, setUserId] = useState<string | null>(
@@ -110,7 +114,8 @@ export default function AppShell({
   const periodDaysLeft = daysUntil(periodEndIso);
 
   const [punchOpen, setPunchOpen] = useState(false);
-  const [headerShiftState, setHeaderShiftState] = useState<MobileShiftState | null>(null);
+  const [headerShiftState, setHeaderShiftState] =
+    useState<MobileShiftState | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
   const [agentDialogOpen, setAgentDialogOpen] = useState(false);
   const [incomingConvoId, setIncomingConvoId] = useState<string | null>(null);
@@ -144,7 +149,9 @@ export default function AppShell({
     }).catch(() => null);
     if (!response?.ok) return;
 
-    const conversations = (await response.json().catch(() => [])) as InboxConversationSummary[];
+    const conversations = (await response
+      .json()
+      .catch(() => [])) as InboxConversationSummary[];
     const count = Array.isArray(conversations)
       ? conversations.reduce(
           (sum, row) => sum + Math.max(0, Number(row.unread_count ?? 0)),
@@ -223,7 +230,7 @@ export default function AppShell({
                 recipients?: string[] | null;
               };
 
-            if (msg.sender_id === uid) return;
+            if (msg.sender_id === uid && msg.sender_kind === "staff") return;
             if (Array.isArray(msg.recipients) && !msg.recipients.includes(uid))
               return;
 
@@ -234,7 +241,13 @@ export default function AppShell({
                 detail: { conversationId: msg.conversation_id },
               }),
             );
-            setChatOpen(true);
+            toast.info("New inbox message", {
+              description: "A customer or teammate sent a message.",
+              action: {
+                label: "Open inbox",
+                onClick: () => setChatOpen(true),
+              },
+            });
           },
         )
         .subscribe();
@@ -272,12 +285,15 @@ export default function AppShell({
       setHeaderShiftState(null);
       return;
     }
-    void fetchMobileShiftState().then(setHeaderShiftState).catch(() => setHeaderShiftState(null));
+    void fetchMobileShiftState()
+      .then(setHeaderShiftState)
+      .catch(() => setHeaderShiftState(null));
     const onShiftState = (event: Event) => {
       setHeaderShiftState((event as CustomEvent<MobileShiftState>).detail);
     };
     window.addEventListener("workforce:shift-state", onShiftState);
-    return () => window.removeEventListener("workforce:shift-state", onShiftState);
+    return () =>
+      window.removeEventListener("workforce:shift-state", onShiftState);
   }, [userId]);
 
   useEffect(() => {
@@ -292,7 +308,15 @@ export default function AppShell({
     return () => document.removeEventListener("mousedown", onClick);
   }, [punchOpen]);
 
-  const NavItem = ({ href, label }: { href: string; label: string }) => {
+  const NavItem = ({
+    href,
+    label,
+    badge = 0,
+  }: {
+    href: string;
+    label: string;
+    badge?: number;
+  }) => {
     const active = pathname.startsWith(href);
     return (
       <Link
@@ -305,7 +329,14 @@ export default function AppShell({
         )}
         style={active ? { color: "var(--brand-accent, #E39A6E)" } : undefined}
       >
-        {label}
+        <span className="relative inline-flex items-center gap-1">
+          {label}
+          {badge > 0 ? (
+            <span className="rounded-full bg-[var(--accent-copper-soft)] px-1 py-0.5 text-[9px] font-bold leading-none text-[color:var(--theme-text-on-accent)]">
+              {badge > 99 ? "99+" : badge}
+            </span>
+          ) : null}
+        </span>
       </Link>
     );
   };
@@ -344,13 +375,14 @@ export default function AppShell({
             className="rounded-full border px-3 py-1 text-[11px] font-semibold shadow-sm backdrop-blur transition"
             style={{
               borderColor: "rgba(255,255,255,0.10)",
-              background:
-                "var(--theme-gradient-panel)",
+              background: "var(--theme-gradient-panel)",
               color: "var(--theme-text-primary)",
             }}
           >
             <span style={{ color: "var(--brand-accent, #E39A6E)" }}>Trial</span>
-            <span className="ml-2 text-[color:var(--theme-text-secondary)]">{label}</span>
+            <span className="ml-2 text-[color:var(--theme-text-secondary)]">
+              {label}
+            </span>
           </div>
         </button>
       );
@@ -402,8 +434,7 @@ export default function AppShell({
           )}
           style={{
             borderColor: "var(--metal-border-soft, rgba(148,163,184,0.3))",
-            background:
-              "var(--theme-gradient-panel)",
+            background: "var(--theme-gradient-panel)",
           }}
         >
           <div
@@ -458,8 +489,7 @@ export default function AppShell({
             style={{
               borderColor:
                 "color-mix(in srgb, var(--brand-primary, #C1663B) 30%, var(--metal-border-soft, rgba(148,163,184,0.3)))",
-              background:
-                "var(--theme-gradient-panel)",
+              background: "var(--theme-gradient-panel)",
               boxShadow:
                 "0 18px 40px var(--theme-surface-inset), 0 0 26px color-mix(in srgb, var(--brand-primary, #C1663B) 18%, transparent)",
             }}
@@ -479,7 +509,10 @@ export default function AppShell({
               </button>
 
               <nav className="flex gap-3 text-sm text-[color:var(--theme-text-secondary)]">
-                <Link href="/dashboard" className="hover:text-[color:var(--theme-text-primary)]">
+                <Link
+                  href="/dashboard"
+                  className="hover:text-[color:var(--theme-text-primary)]"
+                >
                   Dashboard
                 </Link>
               </nav>
@@ -487,6 +520,8 @@ export default function AppShell({
 
             <div className="flex items-center gap-1.5 lg:gap-2">
               <BillingBadge />
+
+              {userId && canSeeAgentConsole ? <OpsNotificationsBell /> : null}
 
               {userId ? (
                 <ActionButton
@@ -498,7 +533,8 @@ export default function AppShell({
                       "inline-block h-2 w-2 rounded-full",
                       headerShiftState?.activity === "working"
                         ? "bg-emerald-400 shadow-[0_0_10px_rgba(16,185,129,0.9)]"
-                        : headerShiftState?.activity === "on_break" || headerShiftState?.activity === "on_lunch"
+                        : headerShiftState?.activity === "on_break" ||
+                            headerShiftState?.activity === "on_lunch"
                           ? "bg-amber-400"
                           : "bg-slate-400",
                     )}
@@ -560,8 +596,7 @@ export default function AppShell({
               className="fixed right-6 top-20 z-30 hidden w-72 rounded-xl border p-3 backdrop-blur-xl md:block"
               style={{
                 borderColor: "var(--metal-border-soft, rgba(148,163,184,0.3))",
-                background:
-                  "var(--theme-gradient-panel)",
+                background: "var(--theme-gradient-panel)",
                 boxShadow: "var(--theme-shadow-medium)",
               }}
             >
@@ -584,15 +619,14 @@ export default function AppShell({
             className="fixed inset-x-0 bottom-0 z-30 border-t pb-[env(safe-area-inset-bottom)] backdrop-blur md:hidden"
             style={{
               borderColor: "var(--metal-border-soft, rgba(148,163,184,0.3))",
-              background:
-                "var(--theme-gradient-panel)",
+              background: "var(--theme-gradient-panel)",
             }}
           >
             <div className="flex px-1">
               <NavItem href="/dashboard" label="Dashboard" />
               <NavItem href="/work-orders" label="Work Orders" />
               <NavItem href="/inspections" label="Inspections" />
-              <NavItem href="/chat" label="Inbox" />
+              <NavItem href="/chat" label="Inbox" badge={inboxUnreadCount} />
               <NavItem href="/mobile/appointments" label="Schedule" />
 
               <button

--- a/features/shared/lib/email/email/sendQuoteEmail.ts
+++ b/features/shared/lib/email/email/sendQuoteEmail.ts
@@ -2,6 +2,7 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
 import { sendQuoteReadyEmail } from "@/features/email/server";
 import { getActiveBrandForRender } from "@/features/branding/server/getActiveBrandForRender";
+import { upsertPortalNotification } from "@/features/portal/server/upsertPortalNotification";
 
 type DB = Database;
 type WorkOrderRow = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -43,18 +44,19 @@ function safeStr(v: unknown): string {
 
 function buildVehicleLabel(vehicleInfo?: QuoteVehicleInfo | null): string {
   if (!vehicleInfo) return "";
-  const year =
-    vehicleInfo.year != null ? String(vehicleInfo.year).trim() : "";
+  const year = vehicleInfo.year != null ? String(vehicleInfo.year).trim() : "";
   const make = safeStr(vehicleInfo.make).trim();
   const model = safeStr(vehicleInfo.model).trim();
   return [year, make, model].filter(Boolean).join(" ");
 }
 
-function buildCustomerName(customer: {
-  first_name?: string | null;
-  last_name?: string | null;
-  business_name?: string | null;
-} | null): string {
+function buildCustomerName(
+  customer: {
+    first_name?: string | null;
+    last_name?: string | null;
+    business_name?: string | null;
+  } | null,
+): string {
   if (!customer) return "";
   if (customer.business_name) return customer.business_name;
   return `${customer.first_name ?? ""} ${customer.last_name ?? ""}`.trim();
@@ -103,9 +105,7 @@ export async function sendQuoteEmail(
       .maybeSingle<Pick<ShopRow, "name" | "shop_name">>();
 
     resolvedShopName =
-      safeStr(shop?.shop_name).trim() ||
-      safeStr(shop?.name).trim() ||
-      "";
+      safeStr(shop?.shop_name).trim() || safeStr(shop?.name).trim() || "";
   }
 
   let resolvedCustomerName = customerName ?? "";
@@ -189,22 +189,22 @@ export async function sendQuoteEmail(
   }
 
   if (portalUserId) {
-    const { error: notifErr } = await supabase
-      .from("portal_notifications")
-      .insert({
-        user_id: portalUserId,
-        customer_id: portalCustomerId,
-        work_order_id: workOrderId,
+    try {
+      await upsertPortalNotification(supabase, {
+        userId: portalUserId,
+        customerId: portalCustomerId,
+        workOrderId,
         kind: "quote_ready",
         title: "Quote ready",
         body: `Your quote for Work Order ${workOrderId} at ${
           resolvedShopName || "the shop"
         } is ready to review in your portal.`,
+        eventKey: `quote_ready:${workOrderId}:${quoteUrl || quoteTotal || "current"}`,
+        href: `/portal/quotes/${workOrderId}`,
       });
-
-    if (notifErr) {
+    } catch (notifErr) {
       console.error(
-        "[sendQuoteEmail] Failed to insert portal quote notification:",
+        "[sendQuoteEmail] Failed to upsert portal quote notification:",
         notifErr,
       );
     }

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -2492,24 +2492,30 @@ export type Database = {
         Row: {
           added_at: string | null
           conversation_id: string
+          customer_id: string | null
           id: string
           participant_kind: string
+          profile_id: string | null
           role: string | null
           user_id: string
         }
         Insert: {
           added_at?: string | null
           conversation_id: string
+          customer_id?: string | null
           id?: string
           participant_kind?: string
+          profile_id?: string | null
           role?: string | null
           user_id: string
         }
         Update: {
           added_at?: string | null
           conversation_id?: string
+          customer_id?: string | null
           id?: string
           participant_kind?: string
+          profile_id?: string | null
           role?: string | null
           user_id?: string
         }
@@ -2519,6 +2525,20 @@ export type Database = {
             columns: ["conversation_id"]
             isOneToOne: false
             referencedRelation: "conversations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "conversation_participants_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "conversation_participants_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -8740,26 +8760,95 @@ export type Database = {
           },
         ]
       }
+      message_deliveries: {
+        Row: {
+          conversation_id: string
+          created_at: string
+          delivered_at: string
+          id: string
+          message_id: string
+          notified_at: string | null
+          read_at: string | null
+          recipient_participant_id: string
+          recipient_user_id: string
+        }
+        Insert: {
+          conversation_id: string
+          created_at?: string
+          delivered_at?: string
+          id?: string
+          message_id: string
+          notified_at?: string | null
+          read_at?: string | null
+          recipient_participant_id: string
+          recipient_user_id: string
+        }
+        Update: {
+          conversation_id?: string
+          created_at?: string
+          delivered_at?: string
+          id?: string
+          message_id?: string
+          notified_at?: string | null
+          read_at?: string | null
+          recipient_participant_id?: string
+          recipient_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "message_deliveries_conversation_id_fkey"
+            columns: ["conversation_id"]
+            isOneToOne: false
+            referencedRelation: "conversations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "message_deliveries_message_id_fkey"
+            columns: ["message_id"]
+            isOneToOne: false
+            referencedRelation: "messages"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "message_deliveries_recipient_conversation_fkey"
+            columns: ["recipient_participant_id", "conversation_id"]
+            isOneToOne: false
+            referencedRelation: "conversation_participants"
+            referencedColumns: ["id", "conversation_id"]
+          },
+        ]
+      }
       message_reads: {
         Row: {
           conversation_id: string
           id: string
           last_read_at: string
+          participant_id: string | null
           user_id: string
         }
         Insert: {
           conversation_id: string
           id?: string
           last_read_at?: string
+          participant_id?: string | null
           user_id: string
         }
         Update: {
           conversation_id?: string
           id?: string
           last_read_at?: string
+          participant_id?: string | null
           user_id?: string
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "message_reads_participant_conversation_fkey"
+            columns: ["participant_id", "conversation_id"]
+            isOneToOne: false
+            referencedRelation: "conversation_participants"
+            referencedColumns: ["id", "conversation_id"]
+          },
+        ]
       }
       messages: {
         Row: {
@@ -8776,6 +8865,8 @@ export type Database = {
           recipients: string[]
           reply_to: string | null
           sender_id: string | null
+          sender_kind: string | null
+          sender_participant_id: string | null
           sent_at: string | null
         }
         Insert: {
@@ -8792,6 +8883,8 @@ export type Database = {
           recipients?: string[]
           reply_to?: string | null
           sender_id?: string | null
+          sender_kind?: string | null
+          sender_participant_id?: string | null
           sent_at?: string | null
         }
         Update: {
@@ -8808,6 +8901,8 @@ export type Database = {
           recipients?: string[]
           reply_to?: string | null
           sender_id?: string | null
+          sender_kind?: string | null
+          sender_participant_id?: string | null
           sent_at?: string | null
         }
         Relationships: [
@@ -8831,6 +8926,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "messages"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "messages_sender_participant_conversation_fkey"
+            columns: ["sender_participant_id", "conversation_id"]
+            isOneToOne: false
+            referencedRelation: "conversation_participants"
+            referencedColumns: ["id", "conversation_id"]
           },
         ]
       }
@@ -12036,11 +12138,13 @@ export type Database = {
       portal_notifications: {
         Row: {
           body: string | null
+          conversation_id: string | null
           created_at: string
           customer_id: string | null
           event_key: string | null
           id: string
           kind: string
+          message_id: string | null
           metadata: Json
           read_at: string | null
           title: string
@@ -12049,11 +12153,13 @@ export type Database = {
         }
         Insert: {
           body?: string | null
+          conversation_id?: string | null
           created_at?: string
           customer_id?: string | null
           event_key?: string | null
           id?: string
           kind?: string
+          message_id?: string | null
           metadata?: Json
           read_at?: string | null
           title: string
@@ -12062,11 +12168,13 @@ export type Database = {
         }
         Update: {
           body?: string | null
+          conversation_id?: string | null
           created_at?: string
           customer_id?: string | null
           event_key?: string | null
           id?: string
           kind?: string
+          message_id?: string | null
           metadata?: Json
           read_at?: string | null
           title?: string
@@ -12075,10 +12183,24 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "portal_notifications_conversation_id_fkey"
+            columns: ["conversation_id"]
+            isOneToOne: false
+            referencedRelation: "conversations"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "portal_notifications_customer_id_fkey"
             columns: ["customer_id"]
             isOneToOne: false
             referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "portal_notifications_message_id_fkey"
+            columns: ["message_id"]
+            isOneToOne: false
+            referencedRelation: "messages"
             referencedColumns: ["id"]
           },
           {
@@ -24760,6 +24882,23 @@ export type Database = {
         }
         Returns: Json
       }
+      create_actor_messaging_conversation: {
+        Args: {
+          _booking_id: string
+          _channel: string
+          _context_id: string
+          _context_type: string
+          _conversation_id: string
+          _created_by: string
+          _customer_id: string
+          _participants: Json
+          _shop_id: string
+          _title: string
+          _vehicle_id: string
+          _work_order_id: string
+        }
+        Returns: string
+      }
       create_estimate_atomic: {
         Args: {
           p_customer: Json
@@ -25730,6 +25869,7 @@ export type Database = {
       profixiq_workforce_profile_id: { Args: never; Returns: string }
       profixiq_workforce_role: { Args: never; Returns: string }
       profixiq_workforce_shop_id: { Args: never; Returns: string }
+      realtime_conversation_id: { Args: { topic: string }; Returns: string }
       recalculate_estimate_work_order_totals: {
         Args: { p_shop_id: string; p_work_order_id: string }
         Returns: undefined

--- a/supabase/migrations/20260806030134_actor_scoped_messaging_notifications.sql
+++ b/supabase/migrations/20260806030134_actor_scoped_messaging_notifications.sql
@@ -1,0 +1,609 @@
+begin;
+
+-- A user can act as both a portal customer and a shop team member. Keep the
+-- authenticated user for delivery, but make the participant row the canonical
+-- actor identity for messages and reads.
+alter table public.conversation_participants
+  add column if not exists profile_id uuid references public.profiles(id) on delete set null,
+  add column if not exists customer_id uuid references public.customers(id) on delete set null;
+
+update public.conversation_participants cp
+set profile_id = (
+  select p.id
+  from public.profiles p
+  join public.conversations c on c.id = cp.conversation_id
+  where cp.participant_kind = 'staff'
+    and (p.user_id = cp.user_id or p.id = cp.user_id)
+    and (c.shop_id is null or p.shop_id = c.shop_id)
+  order by case when p.user_id = cp.user_id then 0 else 1 end
+  limit 1
+)
+where cp.participant_kind = 'staff'
+  and cp.profile_id is null;
+
+update public.conversation_participants cp
+set customer_id = (
+  select customer.id
+  from public.customers customer
+  join public.conversations c on c.id = cp.conversation_id
+  where cp.participant_kind = 'customer'
+    and customer.user_id = cp.user_id
+    and (c.shop_id is null or customer.shop_id = c.shop_id)
+    and (c.customer_id is null or customer.id = c.customer_id)
+  order by case when customer.id = c.customer_id then 0 else 1 end
+  limit 1
+)
+where cp.participant_kind = 'customer'
+  and cp.customer_id is null;
+
+drop index if exists public.uq_conversation_participants_conversation_user;
+alter table public.conversation_participants
+  drop constraint if exists conversation_participants_conversation_id_user_id_key;
+
+create unique index if not exists conversation_participants_actor_identity_uidx
+  on public.conversation_participants (conversation_id, user_id, participant_kind);
+
+create unique index if not exists conversation_participants_id_conversation_uidx
+  on public.conversation_participants (id, conversation_id);
+
+-- Preserve the shop identity in historical customer threads when the customer
+-- login was also the advisor assigned to that work order.
+insert into public.conversation_participants (
+  conversation_id,
+  user_id,
+  role,
+  participant_kind,
+  profile_id
+)
+select distinct
+  c.id,
+  coalesce(advisor.user_id, advisor.id),
+  advisor.role,
+  'staff',
+  advisor.id
+from public.conversations c
+join public.work_orders wo on wo.id = c.work_order_id
+join public.profiles advisor on advisor.id = wo.advisor_id
+join public.conversation_participants customer_actor
+  on customer_actor.conversation_id = c.id
+ and customer_actor.participant_kind = 'customer'
+ and customer_actor.user_id = coalesce(advisor.user_id, advisor.id)
+where c.channel = 'customer'
+on conflict (conversation_id, user_id, participant_kind) do update
+set profile_id = excluded.profile_id,
+    role = coalesce(excluded.role, public.conversation_participants.role);
+
+alter table public.messages
+  add column if not exists sender_participant_id uuid,
+  add column if not exists sender_kind text;
+
+alter table public.messages
+  drop constraint if exists messages_sender_kind_check;
+alter table public.messages
+  add constraint messages_sender_kind_check
+  check (sender_kind is null or sender_kind in ('staff', 'customer')) not valid;
+
+with ranked_actor as (
+  select
+    m.id as message_id,
+    cp.id as participant_id,
+    cp.participant_kind,
+    row_number() over (
+      partition by m.id
+      order by
+        case
+          when m.metadata ->> 'actor_kind' = cp.participant_kind then 0
+          when coalesce(m.metadata ->> 'deep_link', '') <> ''
+            and m.metadata ->> 'deep_link' not like '/portal/%'
+            and cp.participant_kind = 'staff' then 1
+          when c.channel = 'customer'
+            and coalesce(m.metadata ->> 'deep_link', '') = ''
+            and cp.participant_kind = 'customer' then 2
+          when cp.participant_kind = 'staff' then 3
+          else 4
+        end,
+        cp.added_at,
+        cp.id
+    ) as rank
+  from public.messages m
+  join public.conversations c on c.id = m.conversation_id
+  join public.conversation_participants cp
+    on cp.conversation_id = m.conversation_id
+   and cp.user_id = m.sender_id
+  where m.conversation_id is not null
+    and m.sender_id is not null
+)
+update public.messages m
+set sender_participant_id = ranked_actor.participant_id,
+    sender_kind = ranked_actor.participant_kind,
+    metadata = coalesce(m.metadata, '{}'::jsonb)
+      || jsonb_build_object('actor_kind', ranked_actor.participant_kind)
+from ranked_actor
+where ranked_actor.message_id = m.id
+  and ranked_actor.rank = 1
+  and m.sender_participant_id is null;
+
+alter table public.messages
+  drop constraint if exists messages_sender_participant_conversation_fkey;
+alter table public.messages
+  add constraint messages_sender_participant_conversation_fkey
+  foreign key (sender_participant_id, conversation_id)
+  references public.conversation_participants(id, conversation_id)
+  on delete restrict not valid;
+
+drop index if exists public.messages_client_idempotency_idx;
+create unique index messages_actor_client_idempotency_idx
+  on public.messages (conversation_id, sender_participant_id, client_message_id)
+  where client_message_id is not null;
+
+create or replace function public.resolve_message_actor()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_participant public.conversation_participants%rowtype;
+  v_requested_kind text;
+begin
+  if new.conversation_id is null then
+    return new;
+  end if;
+
+  v_requested_kind := nullif(coalesce(new.metadata, '{}'::jsonb) ->> 'actor_kind', '');
+
+  if new.sender_participant_id is not null then
+    select * into v_participant
+    from public.conversation_participants cp
+    where cp.id = new.sender_participant_id
+      and cp.conversation_id = new.conversation_id;
+  else
+    select * into v_participant
+    from public.conversation_participants cp
+    where cp.conversation_id = new.conversation_id
+      and cp.user_id = new.sender_id
+      and (v_requested_kind is null or cp.participant_kind = v_requested_kind)
+    order by
+      case when cp.participant_kind = v_requested_kind then 0 else 1 end,
+      case when cp.participant_kind = 'staff' then 0 else 1 end,
+      cp.added_at,
+      cp.id
+    limit 1;
+  end if;
+
+  if v_participant.id is null then
+    raise exception using errcode = '42501',
+      message = 'Message sender is not an actor in this conversation';
+  end if;
+
+  if new.sender_id is not null and new.sender_id <> v_participant.user_id then
+    raise exception using errcode = '42501',
+      message = 'Message sender does not match the selected actor';
+  end if;
+
+  new.sender_id := v_participant.user_id;
+  new.sender_participant_id := v_participant.id;
+  new.sender_kind := v_participant.participant_kind;
+  new.metadata := coalesce(new.metadata, '{}'::jsonb)
+    || jsonb_build_object('actor_kind', v_participant.participant_kind);
+  return new;
+end;
+$$;
+
+revoke all on function public.resolve_message_actor() from public, anon, authenticated;
+
+drop trigger if exists messages_resolve_actor on public.messages;
+create trigger messages_resolve_actor
+before insert or update of sender_id, sender_participant_id, conversation_id, metadata
+on public.messages
+for each row execute function public.resolve_message_actor();
+
+alter table public.message_reads
+  add column if not exists participant_id uuid;
+
+update public.message_reads mr
+set participant_id = (
+  select cp.id
+  from public.conversation_participants cp
+  join public.conversations c on c.id = cp.conversation_id
+  where cp.conversation_id = mr.conversation_id
+    and cp.user_id = mr.user_id
+  order by
+    case when c.channel = 'customer' and cp.participant_kind = 'customer' then 0 else 1 end,
+    cp.added_at,
+    cp.id
+  limit 1
+)
+where mr.participant_id is null;
+
+alter table public.message_reads
+  drop constraint if exists message_reads_user_id_conversation_id_key;
+alter table public.message_reads
+  drop constraint if exists message_reads_participant_conversation_fkey;
+alter table public.message_reads
+  add constraint message_reads_participant_conversation_fkey
+  foreign key (participant_id, conversation_id)
+  references public.conversation_participants(id, conversation_id)
+  on delete cascade not valid;
+
+create unique index if not exists message_reads_actor_uidx
+  on public.message_reads (conversation_id, participant_id);
+create unique index if not exists message_reads_legacy_user_uidx
+  on public.message_reads (conversation_id, user_id)
+  where participant_id is null;
+
+create table if not exists public.message_deliveries (
+  id uuid primary key default gen_random_uuid(),
+  message_id uuid not null references public.messages(id) on delete cascade,
+  conversation_id uuid not null references public.conversations(id) on delete cascade,
+  recipient_participant_id uuid not null,
+  recipient_user_id uuid not null references auth.users(id) on delete cascade,
+  delivered_at timestamptz not null default now(),
+  read_at timestamptz,
+  notified_at timestamptz,
+  created_at timestamptz not null default now(),
+  constraint message_deliveries_recipient_conversation_fkey
+    foreign key (recipient_participant_id, conversation_id)
+    references public.conversation_participants(id, conversation_id)
+    on delete cascade,
+  constraint message_deliveries_message_actor_uidx
+    unique (message_id, recipient_participant_id)
+);
+
+create index if not exists message_deliveries_actor_unread_idx
+  on public.message_deliveries (recipient_participant_id, delivered_at desc)
+  where read_at is null;
+create index if not exists message_deliveries_user_conversation_idx
+  on public.message_deliveries (recipient_user_id, conversation_id, delivered_at desc);
+
+insert into public.message_deliveries (
+  message_id,
+  conversation_id,
+  recipient_participant_id,
+  recipient_user_id,
+  delivered_at,
+  read_at
+)
+select
+  m.id,
+  m.conversation_id,
+  cp.id,
+  cp.user_id,
+  coalesce(m.sent_at, m.created_at, now()),
+  case
+    when exists (
+      select 1
+      from public.message_reads mr
+      where mr.conversation_id = m.conversation_id
+        and (mr.participant_id = cp.id or (mr.participant_id is null and mr.user_id = cp.user_id))
+        and mr.last_read_at >= coalesce(m.sent_at, m.created_at, now())
+    ) then coalesce(m.sent_at, m.created_at, now())
+    else null
+  end
+from public.messages m
+join public.conversation_participants cp
+  on cp.conversation_id = m.conversation_id
+ and cp.id is distinct from m.sender_participant_id
+join auth.users recipient_user on recipient_user.id = cp.user_id
+where m.conversation_id is not null
+on conflict (message_id, recipient_participant_id) do nothing;
+
+alter table public.portal_notifications
+  add column if not exists metadata jsonb not null default '{}'::jsonb,
+  add column if not exists conversation_id uuid references public.conversations(id) on delete set null,
+  add column if not exists message_id uuid references public.messages(id) on delete set null;
+
+update public.portal_notifications
+set metadata = '{}'
+where metadata is null;
+
+alter table public.portal_notifications
+  drop constraint if exists portal_notifications_kind_check;
+drop index if exists public.portal_notifications_user_wo_kind_uniq;
+
+create index if not exists portal_notifications_conversation_created_idx
+  on public.portal_notifications (conversation_id, created_at desc)
+  where conversation_id is not null;
+
+create or replace function public.deliver_chat_message()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.conversation_id is null or new.sender_participant_id is null then
+    return new;
+  end if;
+
+  insert into public.message_deliveries (
+    message_id,
+    conversation_id,
+    recipient_participant_id,
+    recipient_user_id
+  )
+  select new.id, new.conversation_id, cp.id, cp.user_id
+  from public.conversation_participants cp
+  join auth.users recipient_user on recipient_user.id = cp.user_id
+  where cp.conversation_id = new.conversation_id
+    and cp.id <> new.sender_participant_id
+  on conflict (message_id, recipient_participant_id) do nothing;
+
+  insert into public.portal_notifications (
+    user_id,
+    customer_id,
+    work_order_id,
+    kind,
+    title,
+    body,
+    metadata,
+    event_key,
+    conversation_id,
+    message_id
+  )
+  select
+    recipient.user_id,
+    coalesce(recipient.customer_id, c.customer_id),
+    c.work_order_id,
+    'message_received',
+    'New message from your shop',
+    left(new.content, 240),
+    jsonb_build_object(
+      'href', '/portal/messages?conversationId=' || new.conversation_id::text,
+      'conversation_id', new.conversation_id,
+      'message_id', new.id
+    ),
+    'message_received:' || new.id::text || ':' || recipient.id::text,
+    new.conversation_id,
+    new.id
+  from public.conversation_participants recipient
+  join public.conversations c on c.id = recipient.conversation_id
+  where recipient.conversation_id = new.conversation_id
+    and recipient.id <> new.sender_participant_id
+    and recipient.participant_kind = 'customer'
+    and (coalesce(recipient.customer_id, c.customer_id) is not null or c.work_order_id is not null)
+  on conflict (user_id, event_key) do nothing;
+
+  update public.message_deliveries delivery
+  set notified_at = coalesce(delivery.notified_at, now())
+  from public.conversation_participants recipient
+  where delivery.message_id = new.id
+    and delivery.recipient_participant_id = recipient.id
+    and recipient.participant_kind = 'customer';
+
+  return new;
+end;
+$$;
+
+revoke all on function public.deliver_chat_message() from public, anon, authenticated;
+
+drop trigger if exists messages_deliver_actor_notifications on public.messages;
+create trigger messages_deliver_actor_notifications
+after insert on public.messages
+for each row execute function public.deliver_chat_message();
+
+create or replace function public.create_actor_messaging_conversation(
+  _conversation_id uuid,
+  _created_by uuid,
+  _shop_id uuid,
+  _channel text,
+  _customer_id uuid,
+  _work_order_id uuid,
+  _vehicle_id uuid,
+  _booking_id uuid,
+  _context_type text,
+  _context_id uuid,
+  _title text,
+  _participants jsonb
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_participant_count integer;
+begin
+  if jsonb_typeof(_participants) <> 'array' then
+    raise exception 'Participants must be a JSON array';
+  end if;
+
+  v_participant_count := jsonb_array_length(_participants);
+  if v_participant_count < 2 then
+    raise exception 'A conversation requires at least two actor identities';
+  end if;
+
+  if exists (
+    select 1
+    from jsonb_to_recordset(_participants)
+      as participant(user_id uuid, participant_kind text, profile_id uuid, customer_id uuid, role text)
+    where participant.user_id is null
+      or participant.participant_kind not in ('staff', 'customer')
+      or (participant.participant_kind = 'staff' and participant.profile_id is null)
+      or (participant.participant_kind = 'customer' and participant.customer_id is null)
+  ) then
+    raise exception 'Each participant requires a user, kind, and matching actor anchor';
+  end if;
+
+  insert into public.conversations (
+    id, created_by, shop_id, channel, customer_id, work_order_id,
+    vehicle_id, booking_id, context_type, context_id, title, is_group
+  ) values (
+    _conversation_id, _created_by, _shop_id, _channel, _customer_id,
+    _work_order_id, _vehicle_id, _booking_id, _context_type, _context_id,
+    nullif(trim(_title), ''), v_participant_count > 2
+  );
+
+  insert into public.conversation_participants (
+    conversation_id, user_id, role, participant_kind, profile_id, customer_id
+  )
+  select
+    _conversation_id,
+    participant.user_id,
+    participant.role,
+    participant.participant_kind,
+    participant.profile_id,
+    participant.customer_id
+  from jsonb_to_recordset(_participants)
+    as participant(user_id uuid, participant_kind text, profile_id uuid, customer_id uuid, role text);
+
+  return _conversation_id;
+end;
+$$;
+
+revoke all on function public.create_actor_messaging_conversation(
+  uuid, uuid, uuid, text, uuid, uuid, uuid, uuid, text, uuid, text, jsonb
+) from public, anon, authenticated;
+grant execute on function public.create_actor_messaging_conversation(
+  uuid, uuid, uuid, text, uuid, uuid, uuid, uuid, text, uuid, text, jsonb
+) to service_role;
+
+revoke all on function public.create_messaging_conversation(
+  uuid, uuid, uuid, text, uuid, uuid, uuid, uuid, text, uuid, text, uuid[], text[]
+) from public, anon, authenticated;
+
+-- Canonical private Broadcast topic for message INSERT/UPDATE/DELETE events.
+create or replace function public.broadcast_chat_messages()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, realtime
+as $$
+declare
+  v_conversation_id uuid := coalesce(new.conversation_id, old.conversation_id);
+begin
+  if v_conversation_id is null then
+    return coalesce(new, old);
+  end if;
+
+  perform realtime.broadcast_changes(
+    'room:' || v_conversation_id::text || ':messages',
+    tg_op,
+    tg_op,
+    tg_table_name,
+    tg_table_schema,
+    new,
+    old
+  );
+  return coalesce(new, old);
+end;
+$$;
+
+revoke all on function public.broadcast_chat_messages() from public, anon, authenticated;
+drop trigger if exists messages_broadcast_trigger on public.messages;
+drop trigger if exists broadcast_chat_messages_trigger on public.messages;
+create trigger broadcast_chat_messages_trigger
+after insert or update or delete on public.messages
+for each row execute function public.broadcast_chat_messages();
+
+create or replace function public.realtime_conversation_id(topic text)
+returns uuid
+language sql
+immutable
+set search_path = public
+as $$
+  select case
+    when topic ~ '^room:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}:messages$'
+      then split_part(topic, ':', 2)::uuid
+    else null
+  end
+$$;
+
+revoke all on function public.realtime_conversation_id(text) from public, anon;
+grant execute on function public.realtime_conversation_id(text) to authenticated, service_role;
+
+alter table public.message_deliveries enable row level security;
+
+drop policy if exists message_deliveries_recipient_select on public.message_deliveries;
+create policy message_deliveries_recipient_select
+  on public.message_deliveries for select to authenticated
+  using (
+    recipient_user_id = auth.uid()
+    and public.can_access_conversation(conversation_id, auth.uid())
+  );
+
+drop policy if exists message_deliveries_recipient_update on public.message_deliveries;
+create policy message_deliveries_recipient_update
+  on public.message_deliveries for update to authenticated
+  using (
+    recipient_user_id = auth.uid()
+    and public.can_access_conversation(conversation_id, auth.uid())
+  )
+  with check (
+    recipient_user_id = auth.uid()
+    and public.can_access_conversation(conversation_id, auth.uid())
+  );
+
+drop policy if exists messages_delete_for_conversation on public.messages;
+drop policy if exists messages_insert_for_conversation on public.messages;
+drop policy if exists messages_update_for_conversation on public.messages;
+drop policy if exists messages_select_for_conversation on public.messages;
+
+drop policy if exists conversations_actor_insert on public.conversations;
+drop policy if exists conversations_insert_self on public.conversations;
+drop policy if exists conversations_select_mine_or_participant on public.conversations;
+
+drop policy if exists conversation_participants_creator_delete on public.conversation_participants;
+drop policy if exists conversation_participants_creator_insert on public.conversation_participants;
+drop policy if exists conversation_participants_creator_update on public.conversation_participants;
+drop policy if exists cp_select_for_my_conversations on public.conversation_participants;
+drop policy if exists cp_select_own on public.conversation_participants;
+
+drop policy if exists "portal user can mark own notifications read" on public.portal_notifications;
+drop policy if exists "portal user can view own notifications" on public.portal_notifications;
+drop policy if exists "service_role can manage portal_notifications" on public.portal_notifications;
+drop policy if exists portal_notifications_user_select on public.portal_notifications;
+drop policy if exists portal_notifications_user_update on public.portal_notifications;
+
+create policy portal_notifications_user_select
+  on public.portal_notifications for select to authenticated
+  using (user_id = auth.uid());
+create policy portal_notifications_user_update
+  on public.portal_notifications for update to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid());
+
+drop policy if exists chat_realtime_insert on realtime.messages;
+drop policy if exists chat_realtime_select on realtime.messages;
+drop policy if exists conversation_members_can_read on realtime.messages;
+drop policy if exists conversation_members_can_write on realtime.messages;
+
+create policy chat_realtime_select
+  on realtime.messages for select to authenticated
+  using (
+    public.can_access_conversation(
+      public.realtime_conversation_id(topic),
+      auth.uid()
+    )
+  );
+create policy chat_realtime_insert
+  on realtime.messages for insert to authenticated
+  with check (
+    public.can_access_conversation(
+      public.realtime_conversation_id(topic),
+      auth.uid()
+    )
+  );
+
+revoke all on table public.message_deliveries from anon, authenticated;
+grant select, update on table public.message_deliveries to authenticated;
+grant all on table public.message_deliveries to service_role;
+
+revoke insert, delete on table public.portal_notifications from authenticated;
+grant select, update on table public.portal_notifications to authenticated;
+grant all on table public.portal_notifications to service_role;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'portal_notifications'
+  ) then
+    alter publication supabase_realtime add table public.portal_notifications;
+  end if;
+end;
+$$;
+
+commit;

--- a/supabase/migrations/20260806030520_tune_actor_messaging_advisors.sql
+++ b/supabase/migrations/20260806030520_tune_actor_messaging_advisors.sql
@@ -1,0 +1,140 @@
+begin;
+
+create index if not exists conversation_participants_customer_idx
+  on public.conversation_participants (customer_id)
+  where customer_id is not null;
+create index if not exists conversation_participants_profile_idx
+  on public.conversation_participants (profile_id)
+  where profile_id is not null;
+create index if not exists message_deliveries_conversation_idx
+  on public.message_deliveries (conversation_id);
+create index if not exists message_deliveries_recipient_conversation_idx
+  on public.message_deliveries (recipient_participant_id, conversation_id);
+create index if not exists portal_notifications_message_idx
+  on public.portal_notifications (message_id)
+  where message_id is not null;
+
+drop policy if exists conversations_member_select on public.conversations;
+create policy conversations_member_select
+  on public.conversations for select to authenticated
+  using (public.can_access_conversation(id, (select auth.uid())));
+
+drop policy if exists conversation_participants_member_select
+  on public.conversation_participants;
+create policy conversation_participants_member_select
+  on public.conversation_participants for select to authenticated
+  using (
+    public.can_access_conversation(conversation_id, (select auth.uid()))
+  );
+
+drop policy if exists messages_member_select on public.messages;
+create policy messages_member_select
+  on public.messages for select to authenticated
+  using (
+    conversation_id is not null
+    and public.can_access_conversation(conversation_id, (select auth.uid()))
+  );
+
+drop policy if exists messages_member_insert on public.messages;
+create policy messages_member_insert
+  on public.messages for insert to authenticated
+  with check (
+    sender_id = (select auth.uid())
+    and conversation_id is not null
+    and public.can_access_conversation(conversation_id, (select auth.uid()))
+  );
+
+drop policy if exists message_reads_member_all on public.message_reads;
+create policy message_reads_member_all
+  on public.message_reads to authenticated
+  using (
+    user_id = (select auth.uid())
+    and public.can_access_conversation(
+      conversation_id,
+      (select auth.uid())
+    )
+  )
+  with check (
+    user_id = (select auth.uid())
+    and public.can_access_conversation(
+      conversation_id,
+      (select auth.uid())
+    )
+  );
+
+drop policy if exists message_deliveries_recipient_select
+  on public.message_deliveries;
+create policy message_deliveries_recipient_select
+  on public.message_deliveries for select to authenticated
+  using (
+    recipient_user_id = (select auth.uid())
+    and public.can_access_conversation(
+      conversation_id,
+      (select auth.uid())
+    )
+  );
+
+drop policy if exists message_deliveries_recipient_update
+  on public.message_deliveries;
+create policy message_deliveries_recipient_update
+  on public.message_deliveries for update to authenticated
+  using (
+    recipient_user_id = (select auth.uid())
+    and public.can_access_conversation(
+      conversation_id,
+      (select auth.uid())
+    )
+  )
+  with check (
+    recipient_user_id = (select auth.uid())
+    and public.can_access_conversation(
+      conversation_id,
+      (select auth.uid())
+    )
+  );
+
+drop policy if exists portal_notifications_user_select
+  on public.portal_notifications;
+create policy portal_notifications_user_select
+  on public.portal_notifications for select to authenticated
+  using (user_id = (select auth.uid()));
+
+drop policy if exists portal_notifications_user_update
+  on public.portal_notifications;
+create policy portal_notifications_user_update
+  on public.portal_notifications for update to authenticated
+  using (user_id = (select auth.uid()))
+  with check (user_id = (select auth.uid()));
+
+drop policy if exists chat_realtime_select on realtime.messages;
+create policy chat_realtime_select
+  on realtime.messages for select to authenticated
+  using (
+    public.can_access_conversation(
+      public.realtime_conversation_id(topic),
+      (select auth.uid())
+    )
+  );
+
+drop policy if exists chat_realtime_insert on realtime.messages;
+create policy chat_realtime_insert
+  on realtime.messages for insert to authenticated
+  with check (
+    public.can_access_conversation(
+      public.realtime_conversation_id(topic),
+      (select auth.uid())
+    )
+  );
+
+alter function public.mark_portal_notification_read(uuid) security invoker;
+alter function public.mark_all_portal_notifications_read() security invoker;
+revoke all on function public.mark_portal_notification_read(uuid)
+  from public, anon;
+revoke all on function public.mark_all_portal_notifications_read()
+  from public, anon;
+grant execute on function public.mark_portal_notification_read(uuid)
+  to authenticated;
+grant execute on function public.mark_all_portal_notifications_read()
+  to authenticated;
+
+commit;

--- a/supabase/migrations/20260806032152_harden_actor_messaging_advisors.sql
+++ b/supabase/migrations/20260806032152_harden_actor_messaging_advisors.sql
@@ -1,0 +1,18 @@
+begin;
+
+-- The canonical private Broadcast trigger installed by the actor migration supersedes
+-- this unreferenced legacy SECURITY DEFINER function. Dropping it removes an
+-- unnecessary PostgREST RPC surface flagged by the security advisor.
+drop function if exists public.conversation_messages_broadcast_trigger();
+
+-- Cover composite foreign keys in their declared column order so deletes and
+-- actor-integrity checks do not require table scans.
+create index if not exists message_reads_participant_conversation_idx
+  on public.message_reads (participant_id, conversation_id)
+  where participant_id is not null;
+
+create index if not exists messages_sender_participant_conversation_idx
+  on public.messages (sender_participant_id, conversation_id)
+  where sender_participant_id is not null;
+
+commit;

--- a/supabase/migrations/20260806032244_index_message_replies.sql
+++ b/supabase/migrations/20260806032244_index_message_replies.sql
@@ -1,0 +1,8 @@
+begin;
+
+-- Cover the existing self-reference used for message reply threads.
+create index if not exists messages_reply_to_idx
+  on public.messages (reply_to)
+  where reply_to is not null;
+
+commit;

--- a/supabase/migrations/20260806033550_preserve_legacy_messaging_transition.sql
+++ b/supabase/migrations/20260806033550_preserve_legacy_messaging_transition.sql
@@ -1,0 +1,78 @@
+begin;
+
+-- Keep the deployed mark-read route operational while actor-aware
+-- clients roll out. Actor-specific unread state lives in message_deliveries;
+-- message_reads remains the backward-compatible per-user watermark.
+drop index if exists public.message_reads_legacy_user_uidx;
+create unique index if not exists message_reads_conversation_user_uidx
+  on public.message_reads (conversation_id, user_id);
+
+-- Legacy portal clients do not send actor_kind. Prefer the customer actor for
+-- customer-channel requests without a staff deep link; the new clients always
+-- send actor_kind explicitly and bypass this compatibility heuristic.
+create or replace function public.resolve_message_actor()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_participant public.conversation_participants%rowtype;
+  v_requested_kind text;
+begin
+  if new.conversation_id is null then
+    return new;
+  end if;
+
+  v_requested_kind := nullif(coalesce(new.metadata, '{}'::jsonb) ->> 'actor_kind', '');
+
+  if new.sender_participant_id is not null then
+    select * into v_participant
+    from public.conversation_participants cp
+    where cp.id = new.sender_participant_id
+      and cp.conversation_id = new.conversation_id;
+  else
+    select cp.* into v_participant
+    from public.conversation_participants cp
+    join public.conversations c on c.id = cp.conversation_id
+    where cp.conversation_id = new.conversation_id
+      and cp.user_id = new.sender_id
+      and (v_requested_kind is null or cp.participant_kind = v_requested_kind)
+    order by
+      case when cp.participant_kind = v_requested_kind then 0 else 1 end,
+      case
+        when v_requested_kind is null
+          and c.channel = 'customer'
+          and coalesce(new.metadata ->> 'deep_link', '') = ''
+          and cp.participant_kind = 'customer' then 0
+        when cp.participant_kind = 'staff' then 1
+        else 2
+      end,
+      cp.added_at,
+      cp.id
+    limit 1;
+  end if;
+
+  if v_participant.id is null then
+    raise exception using errcode = '42501',
+      message = 'Message sender is not an actor in this conversation';
+  end if;
+
+  if new.sender_id is not null and new.sender_id <> v_participant.user_id then
+    raise exception using errcode = '42501',
+      message = 'Message sender does not match the selected actor';
+  end if;
+
+  new.sender_id := v_participant.user_id;
+  new.sender_participant_id := v_participant.id;
+  new.sender_kind := v_participant.participant_kind;
+  new.metadata := coalesce(new.metadata, '{}'::jsonb)
+    || jsonb_build_object('actor_kind', v_participant.participant_kind);
+  return new;
+end;
+$$;
+
+revoke all on function public.resolve_message_actor()
+  from public, anon, authenticated;
+
+commit;

--- a/tests/chat-actor-delivery.test.ts
+++ b/tests/chat-actor-delivery.test.ts
@@ -1,0 +1,190 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/features/shared/types/types/supabase";
+import { authorizeConversationActor } from "@/features/ai/lib/chat/authorization";
+import { upsertPortalNotification } from "@/features/portal/server/upsertPortalNotification";
+
+const userId = "11111111-1111-4111-8111-111111111111";
+const conversationId = "22222222-2222-4222-8222-222222222222";
+
+function dualRoleClient(): SupabaseClient<Database> {
+  const from = vi.fn((table: string) => {
+    if (table === "profiles") {
+      return {
+        select: () => ({
+          or: () => ({
+            maybeSingle: async () => ({
+              data: {
+                id: "profile-1",
+                user_id: userId,
+                shop_id: "shop-1",
+                role: "advisor",
+              },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === "customers") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data: {
+                id: "customer-1",
+                user_id: userId,
+                shop_id: "shop-1",
+              },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === "conversations") {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data: {
+                id: conversationId,
+                channel: "customer",
+                customer_id: "customer-1",
+                shop_id: "shop-1",
+              },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === "conversation_participants") {
+      return {
+        select: () => ({
+          eq: async () => ({
+            data: [
+              {
+                id: "customer-participant",
+                conversation_id: conversationId,
+                user_id: userId,
+                participant_kind: "customer",
+                customer_id: "customer-1",
+                profile_id: null,
+                role: "customer",
+                added_at: null,
+              },
+              {
+                id: "staff-participant",
+                conversation_id: conversationId,
+                user_id: userId,
+                participant_kind: "staff",
+                customer_id: null,
+                profile_id: "profile-1",
+                role: "advisor",
+                added_at: null,
+              },
+            ],
+            error: null,
+          }),
+        }),
+      };
+    }
+    throw new Error(`Unexpected table: ${table}`);
+  });
+
+  return { from } as unknown as SupabaseClient<Database>;
+}
+
+describe("actor-scoped messaging and notifications", () => {
+  it("selects independent customer and staff actors for one auth user", async () => {
+    const client = dualRoleClient();
+    const customer = await authorizeConversationActor({
+      supabase: client,
+      conversationId,
+      actorUserId: userId,
+      preferredKind: "customer",
+    });
+    const staff = await authorizeConversationActor({
+      supabase: client,
+      conversationId,
+      actorUserId: userId,
+      preferredKind: "staff",
+    });
+
+    expect(customer.ok && customer.actorParticipant.id).toBe(
+      "customer-participant",
+    );
+    expect(staff.ok && staff.actorParticipant.id).toBe("staff-participant");
+  });
+
+  it("writes idempotent, navigable portal notifications", async () => {
+    const upsert = vi.fn(async () => ({ error: null }));
+    const client = {
+      from: vi.fn(() => ({ upsert })),
+    } as unknown as SupabaseClient<Database>;
+
+    await upsertPortalNotification(client, {
+      userId,
+      customerId: "customer-1",
+      workOrderId: "work-order-1",
+      kind: "invoice_ready",
+      title: "Invoice ready",
+      eventKey: "invoice:1",
+      href: "/portal/invoices/work-order-1",
+    });
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_key: "invoice:1",
+        metadata: { href: "/portal/invoices/work-order-1" },
+      }),
+      { onConflict: "user_id,event_key" },
+    );
+  });
+
+  it("migrates sender identity, actor deliveries, and private Broadcast", () => {
+    const migration = readFileSync(
+      "supabase/migrations/20260806030134_actor_scoped_messaging_notifications.sql",
+      "utf8",
+    );
+
+    expect(migration).toContain(
+      "conversation_participants_actor_identity_uidx",
+    );
+    expect(migration).toContain("sender_participant_id");
+    expect(migration).toContain(
+      "create table if not exists public.message_deliveries",
+    );
+    expect(migration).toContain("'message_received'");
+    expect(migration).toContain(
+      "'room:' || v_conversation_id::text || ':messages'",
+    );
+    expect(migration).toContain("on conflict (user_id, event_key) do nothing");
+  });
+
+  it("keeps legacy read watermarks compatible while deliveries stay actor-scoped", () => {
+    const markReadRoute = readFileSync(
+      "app/api/chat/mark-read/route.ts",
+      "utf8",
+    );
+    const compatibilityMigration = readFileSync(
+      "supabase/migrations/20260806033550_preserve_legacy_messaging_transition.sql",
+      "utf8",
+    );
+
+    expect(markReadRoute).toContain(
+      '.eq("recipient_participant_id", access.actorParticipant.id)',
+    );
+    expect(markReadRoute).toContain(
+      '{ onConflict: "user_id,conversation_id" }',
+    );
+    expect(compatibilityMigration).toContain(
+      "message_reads_conversation_user_uidx",
+    );
+    expect(compatibilityMigration).toContain(
+      "v_requested_kind is null",
+    );
+  });
+});

--- a/tests/chat-start-conversation-route.test.ts
+++ b/tests/chat-start-conversation-route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const mocks = vi.hoisted(() => {
   const conversations = new Map<string, { id: string; created_by: string }>();
@@ -44,6 +45,15 @@ vi.mock("@/features/shared/lib/supabase/server", () => ({
 vi.mock("@/features/ai/lib/chat/authorization", () => ({
   authorizeConversationCreate: mocks.authorizeConversationCreate,
   isCustomerMessagingRole: vi.fn(() => true),
+  participantSeedForActor: vi.fn(
+    (actor: { userId: string; customerId: string }) => ({
+      userId: actor.userId,
+      kind: "customer",
+      profileId: null,
+      customerId: actor.customerId,
+      role: "customer",
+    }),
+  ),
 }));
 
 vi.mock("@/features/chat/server/conversationContext", () => ({
@@ -81,6 +91,15 @@ describe("POST /api/chat/start-conversation", () => {
       customerId: "customer-1",
       recipientUserIds: ["advisor-user-1"],
       participantKinds: { "advisor-user-1": "staff" },
+      recipientParticipants: [
+        {
+          userId: "advisor-user-1",
+          kind: "staff",
+          profileId: "advisor-profile-1",
+          customerId: null,
+          role: "advisor",
+        },
+      ],
     });
     mocks.authorizeConversationContext.mockResolvedValue({
       ok: true,
@@ -93,13 +112,15 @@ describe("POST /api/chat/start-conversation", () => {
         booking_id: null,
       },
     });
-    mocks.rpc.mockImplementation(async (_fn: string, args: Record<string, string>) => {
-      mocks.conversations.set(args._conversation_id, {
-        id: args._conversation_id,
-        created_by: args._created_by,
-      });
-      return { data: args._conversation_id, error: null };
-    });
+    mocks.rpc.mockImplementation(
+      async (_fn: string, args: Record<string, string>) => {
+        mocks.conversations.set(args._conversation_id, {
+          id: args._conversation_id,
+          created_by: args._created_by,
+        });
+        return { data: args._conversation_id, error: null };
+      },
+    );
   });
 
   it("normalizes a stale non-UUID request ID into a replayable conversation ID", async () => {
@@ -120,6 +141,15 @@ describe("POST /api/chat/start-conversation", () => {
     expect(firstResponse.status).toBe(201);
     expect(firstPayload.id).toMatch(UUID_RE);
     expect(mocks.rpc).toHaveBeenCalledTimes(1);
+    expect(mocks.rpc).toHaveBeenCalledWith(
+      "create_actor_messaging_conversation",
+      expect.objectContaining({
+        _participants: expect.arrayContaining([
+          expect.objectContaining({ participant_kind: "customer" }),
+          expect.objectContaining({ participant_kind: "staff" }),
+        ]),
+      }),
+    );
 
     const secondResponse = await POST(startRequest(body));
     const secondPayload = await secondResponse.json();

--- a/tests/portal-messaging-navigation.test.ts
+++ b/tests/portal-messaging-navigation.test.ts
@@ -12,16 +12,14 @@ describe("portal work-order navigation and messaging", () => {
   });
 
   it("treats customer profiles as customers and exposes advisor selection", () => {
-    const authorization = source(
-      "features/ai/lib/chat/authorization.ts",
-    );
+    const authorization = source("features/ai/lib/chat/authorization.ts");
     const contextRoute = source("app/api/chat/context-options/route.ts");
     const startRoute = source("app/api/chat/start-conversation/route.ts");
     const workspace = source(
       "features/chat/components/PortalMessagesWorkspace.tsx",
     );
 
-    expect(authorization).toContain('export type MessagingActor');
+    expect(authorization).toContain("export type MessagingActor");
     expect(authorization).toContain('preferredKind === "customer"');
     expect(authorization).toContain('profileRole === "customer"');
     expect(authorization).toContain("isCustomerMessagingRole");
@@ -29,21 +27,17 @@ describe("portal work-order navigation and messaging", () => {
     expect(contextRoute).toContain("recipients");
     expect(workspace).toContain('aria-label="Message recipient"');
     expect(workspace).toContain("normalizeMessageDraft");
-    expect(workspace).toContain("ensureUuid(newThreadDraft?.conversationRequestId)");
+    expect(workspace).toContain(
+      "ensureUuid(newThreadDraft?.conversationRequestId)",
+    );
     expect(workspace).toContain("setError(null)");
-    expect(workspace).toContain(
-      "/api/chat/my-conversations?actor=customer",
-    );
-    expect(workspace).toContain("actor_kind: \"customer\"");
-    expect(workspace).toContain(
-      "Assigned advisor or service team",
-    );
+    expect(workspace).toContain("/api/chat/my-conversations?actor=customer");
+    expect(workspace).toContain('actor_kind: "customer"');
+    expect(workspace).toContain("Assigned advisor or service team");
     expect(workspace).toContain(
       "participant_ids: recipientUserId ? [recipientUserId] : []",
     );
-    expect(startRoute).toContain(
-      "requestedParticipantIds.length === 0",
-    );
+    expect(startRoute).toContain("requestedParticipantIds.length === 0");
     expect(startRoute).toContain("isCustomerMessagingRole(profile.role)");
     expect(startRoute).toContain("deterministicUuidFromRequestId");
     expect(startRoute).toContain("normalized invalid request_id");
@@ -57,10 +51,14 @@ describe("portal work-order navigation and messaging", () => {
       "supabase/migrations/20260725024500_restore_customer_portal_request_read_access.sql",
     );
 
-    expect(startRoute).toContain("const userClient = createServerSupabaseRoute()");
-    expect(startRoute).toContain("const actor = await requirePortalCustomerActor(userClient)");
+    expect(startRoute).toContain(
+      "const userClient = createServerSupabaseRoute()",
+    );
+    expect(startRoute).toContain(
+      "const actor = await requirePortalCustomerActor(userClient)",
+    );
     expect(startRoute).toContain("const admin = createAdminSupabase()");
-    expect(startRoute).toContain("admin.rpc(");
+    expect(startRoute).toContain('rpc("portal_request_start_atomic"');
     expect(startRoute).toContain("isPortalStartCompatibilityError");
     expect(startRoute).toContain("portalSetupUnavailable");
     expect(startRoute).toContain(


### PR DESCRIPTION
## Summary

Fixes messaging identity, delivery/read state, realtime refresh, and customer/staff notification behavior across desktop, mobile, and portal surfaces.

## Root cause

A conversation participant and message sender were identified only by authenticated user ID. When one login represented both the portal customer and a shop staff profile, the database and UI collapsed both actors into one identity, rendered both sides as the customer, and shared read/unread state. Notification producers were also inconsistent: several inserted non-idempotent rows without navigation metadata, message delivery had no per-recipient ledger, and staff realtime handling forced the inbox open.

## Changes

- Make the conversation participant row the canonical actor identity (`staff` or `customer`) while retaining the authenticated user for delivery.
- Persist `sender_participant_id` / `sender_kind`, actor-scoped idempotency, actor-scoped reads, and per-recipient `message_deliveries`.
- Route conversation creation through a service-role-only actor-aware RPC.
- Broadcast message changes on private `room:<conversation>:messages` topics protected by Realtime RLS.
- Return actor-enriched messages (`is_mine`, sender name/avatar/kind, delete permission) and update every chat surface to send an explicit actor kind.
- Add reliable unread badges/refresh behavior on staff desktop and mobile; replace forced modal opening with a toast action.
- Generate portal message notifications in the database trigger and deep-link them to the exact conversation.
- Centralize idempotent portal notifications for quote, invoice, booking, and financial events with metadata/deep-links.
- Harden portal notification read RPCs, remove an orphaned SECURITY DEFINER messaging RPC surface, and preserve compatibility with the currently deployed mark-read/send routes during rollout.
- Add actor/delivery regression coverage and update generated database types.

## Database

Applied to production Supabase project `scjjkmuwadwkaaqjoigx`:

- `20260806030134_actor_scoped_messaging_notifications`
- `20260806030520_tune_actor_messaging_advisors`
- `20260806032152_harden_actor_messaging_advisors`
- `20260806032244_index_message_replies`
- `20260806033550_preserve_legacy_messaging_transition`

All migrations are additive apart from replacing obsolete uniqueness/policies/functions with actor-aware equivalents.

Production verification:

- Work Order `EL000005` now resolves the customer question and shop reply to distinct participant actors even though both share the same auth user.
- Independent recipient delivery rows exist for both sides.
- Rollback-only trigger smoke produced three deliveries and one customer portal notification.
- Authenticated customer rollback-only smoke selected and marked a portal notification read; zero smoke rows persisted.
- Legacy-route rollback-only smoke verified the old user-scoped mark-read upsert plus customer/staff actor inference; zero smoke messages persisted.
- Supabase advisors now report no messaging/notification-related security findings, auth RLS init-plan findings, or unindexed foreign keys.

## Validation

- `tsc --noEmit` — pass
- ESLint on all changed JS/TS files — pass
- Focused messaging/notification tests — 27/27 pass
- API route-boundary audit — 412 routes analyzed, pass
- Supabase clean replay — pass: full migration replay, runtime integrations, schema reconciliation, and generated-type equality
- Next.js production build — pass with inert local placeholders for required build-time Supabase/OpenAI configuration
- Full Vitest suite — 297 files / 1,832 tests pass; 25 files / 28 tests remain failing in unrelated existing source-contract areas
- Full ESLint baseline — 8 unrelated existing errors; changed-file lint is clean
- `git diff --check` — pass

## Deployment notes

No new environment variables. The production database migrations are already applied; deploy the application commit normally.

## Remaining manual QA

Recommended before merge: open the same customer work-order thread in separate portal and staff browser sessions, exchange messages in both directions, and confirm toast/badge/deep-link behavior on desktop and mobile.