### PR TITLE
Fix production correction-session closeout ordering

### DIFF
--- a/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
+++ b/supabase/migrations/20260806010306_canonical_customer_document_numbers.sql
@@ -288,8 +288,8 @@ begin
   loop
     perform public.close_work_order_correction_session(
       v_correction.shop_id,
-      v_correction.correction_session_id,
       v_correction.work_order_id,
+      v_correction.correction_session_id,
       null,
       pg_catalog.jsonb_build_object(
         'migration', 'canonical_customer_document_numbers',

--- a/tests/customer-document-consistency.test.ts
+++ b/tests/customer-document-consistency.test.ts
@@ -34,6 +34,9 @@ describe("customer document consistency", () => {
     expect(migration).toContain("trg_assign_invoice_customer_number");
     expect(migration).toContain("open_work_order_correction_session");
     expect(migration).toContain("close_work_order_correction_session");
+    expect(migration).toMatch(
+      /close_work_order_correction_session\(\s*v_correction\.shop_id,\s*v_correction\.work_order_id,\s*v_correction\.correction_session_id,/,
+    );
     expect(migration).toContain("work_order_number_backfill");
     expect(migration).toContain("^WO-[0-9A-Fa-f]{12}$");
     expect(migration).toContain("^WO-[0-9A-Fa-f]{8}$");


### PR DESCRIPTION
## Summary
- pass `work_order_id` before `correction_session_id` when closing audited backfill sessions
- add a regression assertion for the production function signature

## Why
Production correctly rejected the initial backfill because its finalized-work-order correction helper expects `(shop_id, work_order_id, correction_session_id, actor_user_id, metadata)`. The attempted migration rolled back atomically. This follow-up aligns the migration with that durable production contract before retrying it.