### PR TITLE
Finish premium Fleet dashboard workspaces

### DIFF
--- a/app/portal/fleet/drivers/page.tsx
+++ b/app/portal/fleet/drivers/page.tsx
@@ -1,32 +1,42 @@
-import { ClipboardCheck, Route, UsersRound } from "lucide-react";
+import { redirect } from "next/navigation";
 
-import FleetModuleFoundation from "@/features/fleet/components/FleetModuleFoundation";
+import FleetDriversWorkspace from "@/features/fleet/components/FleetDriversWorkspace";
+import FleetPortalAccessManager from "@/features/fleet/components/FleetPortalAccessManager";
+import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import { getFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
-export default function FleetDriversPage() {
+export default async function FleetDriversPage() {
+  const supabase = createServerSupabaseRSC();
+  const actor = await resolveFleetActorContext(supabase);
+  const uiContext = getFleetUiContext(actor);
+  if (uiContext.experience === "external_driver") redirect("/portal/fleet");
+
+  const canInviteDrivers =
+    actor.isInternal &&
+    ["owner", "admin", "manager"].includes(actor.canonicalRole);
+
   return (
-    <FleetModuleFoundation
-      eyebrow="Fleet operations"
-      title="Drivers"
-      description="Manage the people connected to fleet assets without mixing them into shop staffing. Driver assignments, pre-trips and defect reporting belong to the fleet workspace."
-      capabilities={[
-        {
-          title: "Driver directory",
-          description: "Fleet-owned driver identities, access roles and current status.",
-          icon: UsersRound,
-        },
-        {
-          title: "Asset assignments",
-          description: "Current and historical unit assignments with clear responsibility.",
-          icon: Route,
-        },
-        {
-          title: "Inspection compliance",
-          description: "Pre-trip completion, missed inspections and submitted defects.",
-          icon: ClipboardCheck,
-        },
-      ]}
-      primaryHref="/portal/fleet/pretrip-history"
-      primaryLabel="Review pre-trips"
-    />
+    <div className="space-y-6">
+      <FleetDriversWorkspace
+        actorLabel={uiContext.actorLabel}
+        canInviteDrivers={canInviteDrivers}
+      />
+      {canInviteDrivers ? (
+        <section id="driver-access" className="scroll-mt-24">
+          <FleetPortalAccessManager
+            embedded
+            routePrefix="/portal/fleet"
+            defaultRole="viewer"
+          />
+        </section>
+      ) : (
+        <section className="rounded-2xl border border-sky-300/20 bg-sky-300/[0.08] p-4 text-sm text-[color:var(--theme-text-secondary)]">
+          Driver invitations are issued by the connected Shop administrator.
+          Fleet managers can assign accepted drivers and manage their Fleet-only
+          role from Fleet Settings.
+        </section>
+      )}
+    </div>
   );
 }

--- a/app/portal/fleet/reports/page.tsx
+++ b/app/portal/fleet/reports/page.tsx
@@ -1,32 +1,15 @@
-import { ChartNoAxesCombined, CircleDollarSign, ShieldCheck } from "lucide-react";
+import { redirect } from "next/navigation";
 
-import FleetModuleFoundation from "@/features/fleet/components/FleetModuleFoundation";
+import FleetReportsWorkspace from "@/features/fleet/components/FleetReportsWorkspace";
+import { getFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
+import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
-export default function FleetReportsPage() {
-  return (
-    <FleetModuleFoundation
-      eyebrow="Fleet intelligence"
-      title="Reports"
-      description="Operational reporting for the fleet manager: maintenance compliance, downtime, asset cost and repair performance across every connected or external service provider."
-      capabilities={[
-        {
-          title: "PM compliance",
-          description: "Due, overdue, deferred and completed preventive maintenance.",
-          icon: ShieldCheck,
-        },
-        {
-          title: "Cost performance",
-          description: "Maintenance spend by asset, category, kilometre and engine hour.",
-          icon: CircleDollarSign,
-        },
-        {
-          title: "Downtime & reliability",
-          description: "Unavailable time, repeat repairs and recurring asset issues.",
-          icon: ChartNoAxesCombined,
-        },
-      ]}
-      primaryHref="/portal/fleet/billing"
-      primaryLabel="Review history & costs"
-    />
-  );
+export default async function FleetReportsPage() {
+  const supabase = createServerSupabaseRSC();
+  const actor = await resolveFleetActorContext(supabase);
+  const uiContext = getFleetUiContext(actor);
+  if (uiContext.experience === "external_driver") redirect("/portal/fleet");
+
+  return <FleetReportsWorkspace actorLabel={uiContext.actorLabel} />;
 }

--- a/features/fleet/components/FleetAISummary.tsx
+++ b/features/fleet/components/FleetAISummary.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { ArrowRight, Sparkles } from "lucide-react";
+
+import { toFleetPublicHref } from "@/features/fleet/lib/fleetProductRouting";
 
 type FleetAISummaryProps = {
   shopId?: string | null;
@@ -35,6 +38,8 @@ export default function FleetAISummary({
   shopId,
   routePrefix = "/fleet",
 }: FleetAISummaryProps) {
+  const pathname = usePathname() ?? "";
+  const productRoutes = !pathname.startsWith("/portal/fleet");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [data, setData] = useState<SummaryResponse | null>(null);
@@ -65,7 +70,9 @@ export default function FleetAISummary({
       } catch (cause) {
         if (!cancelled) {
           setError(
-            cause instanceof Error ? cause.message : "Failed to build fleet brief",
+            cause instanceof Error
+              ? cause.message
+              : "Failed to build fleet brief",
           );
         }
       } finally {
@@ -110,17 +117,27 @@ export default function FleetAISummary({
 
       {data && !loading && !error ? (
         <>
-          <p className="mt-3 text-sm font-medium leading-relaxed">{data.headline}</p>
+          <p className="mt-3 text-sm font-medium leading-relaxed">
+            {data.headline}
+          </p>
           <div className="mt-3 space-y-2">
             {data.points.map((point) => (
               <Link
                 key={point.id}
-                href={point.href}
+                href={
+                  productRoutes
+                    ? (toFleetPublicHref(point.href) ?? point.href)
+                    : point.href
+                }
                 className={`group flex items-start justify-between gap-3 rounded-xl border p-3 transition hover:brightness-110 ${tones[point.priority]}`}
               >
                 <span>
-                  <span className="block text-xs font-semibold">{point.label}</span>
-                  <span className="mt-1 block text-[11px] opacity-75">{point.detail}</span>
+                  <span className="block text-xs font-semibold">
+                    {point.label}
+                  </span>
+                  <span className="mt-1 block text-[11px] opacity-75">
+                    {point.detail}
+                  </span>
                 </span>
                 <ArrowRight
                   size={14}

--- a/features/fleet/components/FleetControlTower.tsx
+++ b/features/fleet/components/FleetControlTower.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import FleetSummaryCards from "./FleetSummaryCards";
 import FleetIssueTables from "./FleetIssueTables";
@@ -86,6 +87,9 @@ export default function FleetControlTower({
   uiContext,
   routePrefix = "/fleet",
 }: Props) {
+  const pathname = usePathname() ?? "";
+  const productRoutes =
+    routePrefix === "/portal/fleet" && !pathname.startsWith("/portal/fleet");
   const [data, setData] = useState<TowerPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -189,9 +193,12 @@ export default function FleetControlTower({
       error={
         error ? (
           <div className="rounded-2xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-100">
-            <div className="font-semibold">Live fleet feed is temporarily unavailable</div>
+            <div className="font-semibold">
+              Live fleet feed is temporarily unavailable
+            </div>
             <div className="mt-1 text-xs opacity-80">
-              {error} Dashboard sections remain visible with the data currently available.
+              {error} Dashboard sections remain visible with the data currently
+              available.
             </div>
           </div>
         ) : null
@@ -236,11 +243,12 @@ export default function FleetControlTower({
                   Pre-trip • {todaysAssignment.unitLabel}
                 </h2>
                 <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                  Enter mileage and engine hours, complete the walk-around, and submit defects.
+                  Enter mileage and engine hours, complete the walk-around, and
+                  submit defects.
                 </p>
               </div>
               <Link
-                href={`/portal/fleet/pretrip/${encodeURIComponent(todaysAssignment.unitId)}${fleetId ? `?fleetId=${encodeURIComponent(fleetId)}` : ""}`}
+                href={`${productRoutes ? "/pre-trips/start" : "/portal/fleet/pretrip"}/${encodeURIComponent(todaysAssignment.unitId)}${fleetId ? `?fleetId=${encodeURIComponent(fleetId)}` : ""}`}
                 className="inline-flex min-h-11 items-center justify-center rounded-xl bg-sky-300 px-4 py-2 text-sm font-semibold text-slate-950"
               >
                 Start today’s pre-trip

--- a/features/fleet/components/FleetControlTower.tsx
+++ b/features/fleet/components/FleetControlTower.tsx
@@ -90,6 +90,9 @@ export default function FleetControlTower({
   const pathname = usePathname() ?? "";
   const productRoutes =
     routePrefix === "/portal/fleet" && !pathname.startsWith("/portal/fleet");
+  const pretripStartBase = productRoutes
+    ? "/pre-trips/start/"
+    : "/portal/fleet/pretrip/";
   const [data, setData] = useState<TowerPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -248,7 +251,7 @@ export default function FleetControlTower({
                 </p>
               </div>
               <Link
-                href={`${productRoutes ? "/pre-trips/start" : "/portal/fleet/pretrip"}/${encodeURIComponent(todaysAssignment.unitId)}${fleetId ? `?fleetId=${encodeURIComponent(fleetId)}` : ""}`}
+                href={`${pretripStartBase}${encodeURIComponent(todaysAssignment.unitId)}${fleetId ? `?fleetId=${encodeURIComponent(fleetId)}` : ""}`}
                 className="inline-flex min-h-11 items-center justify-center rounded-xl bg-sky-300 px-4 py-2 text-sm font-semibold text-slate-950"
               >
                 Start today’s pre-trip

--- a/features/fleet/components/FleetDriversWorkspace.tsx
+++ b/features/fleet/components/FleetDriversWorkspace.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  CalendarClock,
+  ClipboardCheck,
+  RefreshCw,
+  Route,
+  Search,
+  Truck,
+  UserPlus,
+  UsersRound,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+type Fleet = { id: string; name: string };
+type Driver = { fleetId: string; id: string; name: string };
+type Vehicle = {
+  id: string;
+  unitNumber: string | null;
+  vin: string | null;
+  licensePlate: string | null;
+  description: string;
+};
+type Enrollment = {
+  fleetId: string;
+  vehicleId: string;
+  nickname: string | null;
+  active: boolean;
+};
+type Assignment = {
+  id: string;
+  fleetId: string;
+  vehicleId: string;
+  driverProfileId: string;
+  driverName: string;
+  routeLabel: string | null;
+  nextPretripDue: string | null;
+  state: string;
+};
+type DriverContext = {
+  fleets: Fleet[];
+  vehicles: Vehicle[];
+  drivers: Driver[];
+  enrollments: Enrollment[];
+  assignments: Assignment[];
+};
+
+const panel =
+  "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[var(--theme-shadow-soft)]";
+
+function dueLabel(value: string | null): string {
+  if (!value) return "Not scheduled";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Not scheduled";
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function stateLabel(value: string): string {
+  if (value === "pretrip_due") return "Pre-trip due";
+  if (value === "en_route") return "En route";
+  if (value === "in_shop") return "In shop";
+  return value.replaceAll("_", " ");
+}
+
+export default function FleetDriversWorkspace({
+  actorLabel,
+  canInviteDrivers,
+}: {
+  actorLabel: string;
+  canInviteDrivers: boolean;
+}) {
+  const pathname = usePathname() ?? "";
+  const internalRoutes = pathname.startsWith("/portal/fleet");
+  const [context, setContext] = useState<DriverContext | null>(null);
+  const [fleetId, setFleetId] = useState("all");
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/fleet/enrollment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "context" }),
+        cache: "no-store",
+      });
+      const body = (await response.json().catch(() => ({}))) as
+        | DriverContext
+        | { error?: string };
+      if (!response.ok || !("drivers" in body)) {
+        throw new Error(
+          "error" in body && body.error
+            ? body.error
+            : "Driver operations could not be loaded.",
+        );
+      }
+      setContext(body);
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Driver operations could not be loaded.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const assignments = useMemo(
+    () =>
+      (context?.assignments ?? []).filter(
+        (assignment) => fleetId === "all" || assignment.fleetId === fleetId,
+      ),
+    [context?.assignments, fleetId],
+  );
+  const drivers = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return (context?.drivers ?? []).filter((driver) => {
+      if (fleetId !== "all" && driver.fleetId !== fleetId) return false;
+      if (!needle) return true;
+      const assigned = assignments.filter(
+        (assignment) => assignment.driverProfileId === driver.id,
+      );
+      return [
+        driver.name,
+        ...assigned.flatMap((assignment) => [
+          assignment.driverName,
+          assignment.routeLabel,
+          assignment.state,
+        ]),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(needle);
+    });
+  }, [assignments, context?.drivers, fleetId, search]);
+  const enrollments = (context?.enrollments ?? []).filter(
+    (enrollment) =>
+      enrollment.active &&
+      (fleetId === "all" || enrollment.fleetId === fleetId),
+  );
+  const assignedVehicleIds = new Set(
+    assignments.map((assignment) => assignment.vehicleId),
+  );
+  const unassignedUnits = enrollments.filter(
+    (enrollment) => !assignedVehicleIds.has(enrollment.vehicleId),
+  ).length;
+  const duePretrips = assignments.filter(
+    (assignment) => assignment.state === "pretrip_due",
+  ).length;
+  const vehicleMap = new Map(
+    (context?.vehicles ?? []).map((vehicle) => [vehicle.id, vehicle]),
+  );
+  const fleetMap = new Map(
+    (context?.fleets ?? []).map((fleet) => [fleet.id, fleet.name]),
+  );
+  const assignmentHref = internalRoutes
+    ? "/portal/fleet/units/new"
+    : "/assets/new";
+  const pretripHref = internalRoutes
+    ? "/portal/fleet/pretrip-history"
+    : "/pre-trips";
+  const assetHref = (vehicleId: string) =>
+    internalRoutes
+      ? `/portal/fleet/units/${encodeURIComponent(vehicleId)}`
+      : `/assets/${encodeURIComponent(vehicleId)}`;
+
+  return (
+    <div className="space-y-5 text-[color:var(--theme-text-primary)]">
+      <header className={`${panel} overflow-hidden p-5 sm:p-6`}>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">
+              Fleet operations
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">
+              Drivers & assignments
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm text-[color:var(--theme-text-secondary)]">
+              Keep driver access, assigned assets, routes, and daily pre-trip
+              responsibility in one Fleet-owned workspace.
+            </p>
+            <p className="mt-2 text-[10px] text-[color:var(--theme-text-muted)]">
+              {actorLabel}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href={assignmentHref}
+              className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-sky-300/40 px-3 py-2 text-xs font-semibold text-sky-300"
+            >
+              <Route className="h-4 w-4" aria-hidden="true" />
+              Assign assets
+            </Link>
+            {canInviteDrivers ? (
+              <a
+                href="#driver-access"
+                className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-sky-300 px-3 py-2 text-xs font-semibold text-slate-950"
+              >
+                <UserPlus className="h-4 w-4" aria-hidden="true" />
+                Invite driver
+              </a>
+            ) : null}
+          </div>
+        </div>
+      </header>
+
+      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {(
+          [
+            ["Active drivers", context?.drivers.length ?? 0, UsersRound],
+            ["Assigned units", assignments.length, Truck],
+            ["Pre-trips due", duePretrips, ClipboardCheck],
+            ["Unassigned units", unassignedUnits, CalendarClock],
+          ] satisfies Array<[string, number, LucideIcon]>
+        ).map(([label, value, Icon]) => (
+          <div key={String(label)} className={`${panel} p-4`}>
+            <Icon className="h-4 w-4 text-sky-300" aria-hidden="true" />
+            <div className="mt-3 text-2xl font-semibold">{String(value)}</div>
+            <div className="text-xs text-[color:var(--theme-text-muted)]">
+              {String(label)}
+            </div>
+          </div>
+        ))}
+      </section>
+
+      <section className={`${panel} overflow-hidden`}>
+        <div className="grid gap-3 border-b border-[color:var(--theme-border-soft)] p-4 sm:grid-cols-[1fr_220px_auto]">
+          <label className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[color:var(--theme-text-muted)]" />
+            <span className="sr-only">Search drivers</span>
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search driver, route, or status"
+              className="h-10 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] pl-9 pr-3 text-sm"
+            />
+          </label>
+          <label>
+            <span className="sr-only">Filter drivers by fleet</span>
+            <select
+              value={fleetId}
+              onChange={(event) => setFleetId(event.target.value)}
+              className="h-10 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 text-sm"
+            >
+              <option value="all">All fleets</option>
+              {(context?.fleets ?? []).map((fleet) => (
+                <option key={fleet.id} value={fleet.id}>
+                  {fleet.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 text-xs font-semibold disabled:opacity-60"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </button>
+        </div>
+
+        {error ? (
+          <div
+            role="alert"
+            className="m-4 rounded-xl border border-red-400/30 bg-red-400/10 p-4 text-sm text-red-200"
+          >
+            {error}
+          </div>
+        ) : null}
+        {loading && !context ? (
+          <div
+            role="status"
+            className="p-8 text-center text-sm text-[color:var(--theme-text-secondary)]"
+          >
+            Loading driver operations…
+          </div>
+        ) : null}
+        {!loading && !error && drivers.length === 0 ? (
+          <div className="p-8 text-center">
+            <UsersRound className="mx-auto h-7 w-7 text-sky-300" />
+            <h2 className="mt-3 font-semibold">No drivers match this view</h2>
+            <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+              Invite a driver, then assign an enrolled asset to activate daily
+              pre-trip tracking.
+            </p>
+          </div>
+        ) : null}
+
+        {drivers.length ? (
+          <div className="divide-y divide-[color:var(--theme-border-soft)]">
+            {drivers.map((driver) => {
+              const driverAssignments = assignments.filter(
+                (assignment) => assignment.driverProfileId === driver.id,
+              );
+              return (
+                <article
+                  key={`${driver.fleetId}:${driver.id}`}
+                  className="p-4 sm:p-5"
+                >
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="truncate text-sm font-semibold">
+                          {driver.name}
+                        </h2>
+                        <span className="rounded-full bg-emerald-400/10 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-emerald-200">
+                          Active
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                        {fleetMap.get(driver.fleetId) ?? "Fleet"} · Fleet driver
+                      </p>
+                    </div>
+                    <div className="text-xs text-[color:var(--theme-text-secondary)]">
+                      {driverAssignments.length
+                        ? `${driverAssignments.length} assigned asset${driverAssignments.length === 1 ? "" : "s"}`
+                        : "Awaiting asset assignment"}
+                    </div>
+                  </div>
+
+                  {driverAssignments.length ? (
+                    <div className="mt-4 grid gap-3 lg:grid-cols-2">
+                      {driverAssignments.map((assignment) => {
+                        const vehicle = vehicleMap.get(assignment.vehicleId);
+                        const enrollment = context?.enrollments.find(
+                          (row) =>
+                            row.fleetId === assignment.fleetId &&
+                            row.vehicleId === assignment.vehicleId,
+                        );
+                        const unitLabel =
+                          enrollment?.nickname ||
+                          vehicle?.unitNumber ||
+                          vehicle?.licensePlate ||
+                          vehicle?.vin ||
+                          "Unit";
+                        return (
+                          <div
+                            key={assignment.id}
+                            className="rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-subtle)] p-3"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div>
+                                <Link
+                                  href={assetHref(assignment.vehicleId)}
+                                  className="text-sm font-semibold hover:underline"
+                                >
+                                  {unitLabel}
+                                </Link>
+                                <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                                  {vehicle?.description || "Fleet asset"}
+                                </div>
+                              </div>
+                              <span className="rounded-full border border-sky-300/25 bg-sky-300/10 px-2 py-1 text-[10px] font-semibold text-sky-200">
+                                {stateLabel(assignment.state)}
+                              </span>
+                            </div>
+                            <div className="mt-3 grid gap-2 text-xs sm:grid-cols-2">
+                              <div>
+                                <div className="text-[color:var(--theme-text-muted)]">
+                                  Route / location
+                                </div>
+                                <div className="mt-0.5 font-medium">
+                                  {assignment.routeLabel || "Not set"}
+                                </div>
+                              </div>
+                              <div>
+                                <div className="text-[color:var(--theme-text-muted)]">
+                                  Next pre-trip
+                                </div>
+                                <div className="mt-0.5 font-medium">
+                                  {dueLabel(assignment.nextPretripDue)}
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })}
+          </div>
+        ) : null}
+      </section>
+
+      <div className="flex justify-end">
+        <Link
+          href={pretripHref}
+          className="text-xs font-semibold text-sky-300 hover:underline"
+        >
+          Review fleet-wide pre-trip compliance
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/features/fleet/components/FleetIssueTables.tsx
+++ b/features/fleet/components/FleetIssueTables.tsx
@@ -3,6 +3,7 @@
 
 import { FleetUnit, FleetIssue, DispatchAssignment } from "./FleetControlTower";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 
 type Props = {
@@ -20,7 +21,19 @@ export default function FleetIssueTables({
   uiContext,
   routePrefix = "/fleet",
 }: Props) {
+  const pathname = usePathname() ?? "";
+  const productHostRoute =
+    routePrefix === "/portal/fleet" && !pathname.startsWith("/portal/fleet");
   const openIssues = issues.filter((i) => i.status !== "completed");
+  const requestHref = productHostRoute
+    ? "/requests/new"
+    : routePrefix === "/portal/fleet"
+      ? "/portal/fleet/request/build"
+      : "/work-orders/create";
+  const unitHref = (unitId: string) =>
+    productHostRoute
+      ? `/assets/${encodeURIComponent(unitId)}`
+      : `${routePrefix}/units/${encodeURIComponent(unitId)}`;
 
   return (
     <div className="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
@@ -38,7 +51,7 @@ export default function FleetIssueTables({
           </div>
           {uiContext.capabilities.canCreateFleetWorkOrders && (
             <Link
-              href="/work-orders/create"
+              href={requestHref}
               className="rounded-xl bg-[color:var(--accent-copper)] px-3 py-1.5 text-xs font-semibold text-[color:var(--theme-text-on-accent)] shadow-[0_0_18px_rgba(193,102,59,0.7)] hover:opacity-95"
             >
               New service request
@@ -61,7 +74,7 @@ export default function FleetIssueTables({
                 <tr key={issue.id} className="align-middle">
                   <td className="px-3 py-1.5 text-[11px] text-[color:var(--theme-text-primary)]">
                     <Link
-                      href={`${routePrefix}/units/${encodeURIComponent(issue.unitId)}`}
+                      href={unitHref(issue.unitId)}
                       className="hover:underline"
                     >
                       {issue.unitLabel}
@@ -125,7 +138,7 @@ export default function FleetIssueTables({
                   <div className="text-[11px] text-[color:var(--theme-text-secondary)]">
                     Assigned to{" "}
                     <Link
-                      href={`${routePrefix}/units/${encodeURIComponent(a.unitId)}`}
+                      href={unitHref(a.unitId)}
                       className="font-medium text-[color:var(--theme-text-primary)] hover:underline"
                     >
                       {a.unitLabel}
@@ -160,7 +173,7 @@ export default function FleetIssueTables({
                   </Link>
                 )}
                 <Link
-                  href={`${routePrefix}/units/${a.unitId}`}
+                  href={unitHref(a.unitId)}
                   className="rounded-full border border-[color:var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[10px] font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-panel)]"
                 >
                   Open unit view
@@ -228,8 +241,7 @@ function StatusPill({ status }: { status: FleetIssue["status"] }) {
     },
     completed: {
       label: "Completed",
-      className:
-        "border-emerald-500/60 bg-emerald-500/10 text-emerald-200",
+      className: "border-emerald-500/60 bg-emerald-500/10 text-emerald-200",
     },
   };
 
@@ -244,11 +256,7 @@ function StatusPill({ status }: { status: FleetIssue["status"] }) {
   );
 }
 
-function DispatchStateBadge({
-  state,
-}: {
-  state: DispatchAssignment["state"];
-}) {
+function DispatchStateBadge({ state }: { state: DispatchAssignment["state"] }) {
   const map: Record<
     DispatchAssignment["state"],
     { label: string; className: string }

--- a/features/fleet/components/FleetPortalAccessManager.tsx
+++ b/features/fleet/components/FleetPortalAccessManager.tsx
@@ -10,6 +10,8 @@ type Fleet = {
   name: string;
 };
 
+type InviteRole = "viewer" | "approver" | "manager";
+
 type Invite = {
   id: string;
   fleet_id: string;
@@ -27,18 +29,30 @@ type InvitePayload = {
   error?: string;
 };
 
-const CREATE_FLEET_HREF =
+const DEFAULT_CREATE_FLEET_HREF =
   "/fleet/programs?returnTo=%2Ffleet%2Fportal-access";
 
-export default function FleetPortalAccessManager() {
+export default function FleetPortalAccessManager({
+  embedded = false,
+  routePrefix = "/fleet",
+  defaultRole = "viewer",
+}: {
+  embedded?: boolean;
+  routePrefix?: "/fleet" | "/portal/fleet";
+  defaultRole?: InviteRole;
+}) {
   const [fleets, setFleets] = useState<Fleet[]>([]);
   const [invites, setInvites] = useState<Invite[]>([]);
   const [fleetId, setFleetId] = useState("");
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState("viewer");
+  const [role, setRole] = useState(defaultRole);
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const createFleetHref =
+    routePrefix === "/portal/fleet" ? "/settings" : DEFAULT_CREATE_FLEET_HREF;
+  const manageFleetsHref =
+    routePrefix === "/portal/fleet" ? "/settings" : "/fleet/programs";
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -62,9 +76,9 @@ export default function FleetPortalAccessManager() {
       setFleets(nextFleets);
       setInvites(payload?.invites ?? []);
 
-      const requestedFleetId = new URLSearchParams(
-        window.location.search,
-      ).get("fleetId");
+      const requestedFleetId = new URLSearchParams(window.location.search).get(
+        "fleetId",
+      );
       setFleetId((current) => {
         const preferred = current || requestedFleetId || "";
         return nextFleets.some((fleet) => fleet.id === preferred)
@@ -109,7 +123,9 @@ export default function FleetPortalAccessManager() {
       await load();
     } catch (value) {
       toast.error(
-        value instanceof Error ? value.message : "Invitation could not be sent.",
+        value instanceof Error
+          ? value.message
+          : "Invitation could not be sent.",
       );
     } finally {
       setSending(false);
@@ -117,19 +133,27 @@ export default function FleetPortalAccessManager() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-6xl space-y-6 px-4 py-6 text-[color:var(--theme-text-primary)] xl:px-6">
-      <header>
-        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
-          Fleet portal
-        </div>
-        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">
-          Invite & access
-        </h1>
-        <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
-          Invite fleet managers, approvers, and drivers into the correct
-          fleet-scoped portal.
-        </p>
-      </header>
+    <div
+      className={
+        embedded
+          ? "w-full space-y-6 text-[color:var(--theme-text-primary)]"
+          : "mx-auto w-full max-w-6xl space-y-6 px-4 py-6 text-[color:var(--theme-text-primary)] xl:px-6"
+      }
+    >
+      {!embedded ? (
+        <header>
+          <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+            Fleet portal
+          </div>
+          <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">
+            Invite & access
+          </h1>
+          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+            Invite fleet managers, approvers, and drivers into the correct
+            fleet-scoped portal.
+          </p>
+        </header>
+      ) : null}
 
       <div className="grid gap-5 lg:grid-cols-[360px_1fr]">
         <form
@@ -166,13 +190,15 @@ export default function FleetPortalAccessManager() {
             </div>
           ) : fleets.length === 0 ? (
             <div className="rounded-xl border border-dashed border-[color:var(--theme-border-soft)] p-5 text-center">
-              <p className="font-semibold">Create a fleet before inviting members.</p>
+              <p className="font-semibold">
+                Create a fleet before inviting members.
+              </p>
               <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
                 Invitations are scoped to one fleet so members only see the
                 correct units and service records.
               </p>
               <Link
-                href={CREATE_FLEET_HREF}
+                href={createFleetHref}
                 className="mt-4 inline-flex rounded-xl bg-[var(--accent-copper)] px-4 py-2.5 text-sm font-bold text-[color:var(--theme-text-on-accent)]"
               >
                 Create fleet
@@ -189,7 +215,7 @@ export default function FleetPortalAccessManager() {
                     Fleet
                   </label>
                   <Link
-                    href="/fleet/programs"
+                    href={manageFleetsHref}
                     className="text-xs font-semibold text-[var(--accent-copper)] hover:underline"
                   >
                     Manage fleets
@@ -239,7 +265,9 @@ export default function FleetPortalAccessManager() {
                 <select
                   id="fleet-invite-role"
                   value={role}
-                  onChange={(event) => setRole(event.target.value)}
+                  onChange={(event) =>
+                    setRole(event.target.value as InviteRole)
+                  }
                   className="mt-1.5 w-full rounded-xl border border-[color:var(--theme-input-border)] bg-[color:var(--theme-input-bg)] px-3 py-2.5 text-sm text-[color:var(--theme-input-text)]"
                 >
                   <option value="viewer">Viewer / driver</option>

--- a/features/fleet/components/FleetReportsWorkspace.tsx
+++ b/features/fleet/components/FleetReportsWorkspace.tsx
@@ -1,0 +1,534 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowDownToLine,
+  ChartNoAxesCombined,
+  CircleDollarSign,
+  ClipboardCheck,
+  RefreshCw,
+  ShieldCheck,
+  Truck,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+type MaintenancePayload = {
+  summary: {
+    overdue: number;
+    due: number;
+    deferred: number;
+    converted: number;
+    clearUnits: number;
+  };
+  units: Array<{ id: string }>;
+  items: Array<{ id: string; vehicleId: string; urgency: string }>;
+  programs: Array<{
+    id: string;
+    name: string;
+    cadence: string;
+    assignedUnits: number;
+    dueUnits: number;
+  }>;
+};
+type EconomicsPayload = {
+  generatedAt: string;
+  units: Array<{
+    unitId: string;
+    label: string;
+    vehicle: string;
+    trailing12MonthSpend: number;
+    currentOdometerKm: number | null;
+    costPerKm: number | null;
+    completedWorkOrders: number;
+    openServiceRequests: number;
+    deferredRequests: number;
+    pmDueCount: number;
+    dataQuality: string;
+  }>;
+};
+type BillingPayload = {
+  summary: {
+    approvals: number;
+    invoices: number;
+    byCurrency: Record<"CAD" | "USD", { outstanding: number; paid: number }>;
+  };
+};
+type TowerPayload = {
+  units: Array<{ id: string; status: "in_service" | "limited" | "oos" }>;
+  issues: Array<{ id: string; status: string }>;
+  assignments: Array<{ id: string; unitId: string }>;
+};
+type PretripPayload = {
+  reports: Array<{ id: string; has_defects: boolean; status: string }>;
+};
+type ReportData = {
+  maintenance: MaintenancePayload;
+  economics: EconomicsPayload;
+  billing: BillingPayload;
+  tower: TowerPayload;
+  pretrips: PretripPayload;
+};
+
+const panel =
+  "rounded-2xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] shadow-[var(--theme-shadow-soft)]";
+
+function money(value: number, currency: "CAD" | "USD" = "CAD") {
+  return new Intl.NumberFormat(currency === "USD" ? "en-US" : "en-CA", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+async function post<T>(url: string, body: object): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+  const payload = (await response.json().catch(() => ({}))) as T & {
+    error?: string;
+  };
+  if (!response.ok) {
+    throw new Error(
+      payload.error || "Fleet reporting data could not be loaded.",
+    );
+  }
+  return payload;
+}
+
+function csvCell(value: string | number | null) {
+  const normalized = value == null ? "" : String(value);
+  return `"${normalized.replaceAll('"', '""')}"`;
+}
+
+export default function FleetReportsWorkspace({
+  actorLabel,
+}: {
+  actorLabel: string;
+}) {
+  const pathname = usePathname() ?? "";
+  const internalRoutes = pathname.startsWith("/portal/fleet");
+  const [data, setData] = useState<ReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [maintenance, economics, billing, tower, pretrips] =
+        await Promise.all([
+          post<MaintenancePayload>("/api/fleet/maintenance", {
+            action: "list",
+          }),
+          post<EconomicsPayload>("/api/fleet/unit-economics", { shopId: null }),
+          post<BillingPayload>("/api/fleet/billing", { action: "list" }),
+          post<TowerPayload>("/api/fleet/tower", {
+            shopId: null,
+            fleetId: null,
+          }),
+          post<PretripPayload>("/api/fleet/pretrip", { shopId: null }),
+        ]);
+      setData({ maintenance, economics, billing, tower, pretrips });
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Fleet reporting data could not be loaded.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const metrics = useMemo(() => {
+    const units = data?.economics.units ?? [];
+    const spend = units.reduce(
+      (total, unit) => total + unit.trailing12MonthSpend,
+      0,
+    );
+    const activeUnits = data?.tower.units.length ?? units.length;
+    const clearUnits = data?.maintenance.summary.clearUnits ?? 0;
+    const compliance = activeUnits
+      ? Math.round((clearUnits / activeUnits) * 100)
+      : 100;
+    const openDefects = (data?.pretrips.reports ?? []).filter(
+      (report) => report.has_defects && report.status !== "reviewed",
+    ).length;
+    const assignedUnits = new Set(
+      (data?.tower.assignments ?? []).map((assignment) => assignment.unitId),
+    ).size;
+    return {
+      spend,
+      activeUnits,
+      clearUnits,
+      compliance,
+      openDefects,
+      assignedUnits,
+    };
+  }, [data]);
+
+  const links = internalRoutes
+    ? {
+        assets: "/portal/fleet/units",
+        history: "/portal/fleet/billing",
+        maintenance: "/portal/fleet/maintenance",
+        pretrips: "/portal/fleet/pretrip-history",
+      }
+    : {
+        assets: "/assets",
+        history: "/history",
+        maintenance: "/maintenance",
+        pretrips: "/pre-trips",
+      };
+
+  const exportCsv = useCallback(() => {
+    if (!data) return;
+    const rows = [
+      [
+        "Asset",
+        "Vehicle",
+        "Trailing 12-month spend (CAD)",
+        "Cost per km",
+        "Current odometer (km)",
+        "Completed work orders",
+        "Open requests",
+        "Deferred requests",
+        "PM due",
+      ],
+      ...data.economics.units.map((unit) => [
+        unit.label,
+        unit.vehicle,
+        unit.trailing12MonthSpend,
+        unit.costPerKm,
+        unit.currentOdometerKm,
+        unit.completedWorkOrders,
+        unit.openServiceRequests,
+        unit.deferredRequests,
+        unit.pmDueCount,
+      ]),
+    ];
+    const csv = rows.map((row) => row.map(csvCell).join(",")).join("\r\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `profixiq-fleet-report-${new Date().toISOString().slice(0, 10)}.csv`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }, [data]);
+
+  return (
+    <div className="space-y-5 text-[color:var(--theme-text-primary)]">
+      <header className={`${panel} p-5 sm:p-6`}>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">
+              Fleet intelligence
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">
+              Reports
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm text-[color:var(--theme-text-secondary)]">
+              Live maintenance compliance, cost, reliability, and driver
+              readiness across every connected fleet asset.
+            </p>
+            <p className="mt-2 text-[10px] text-[color:var(--theme-text-muted)]">
+              {actorLabel}
+              {data?.economics.generatedAt
+                ? ` - Updated ${new Date(data.economics.generatedAt).toLocaleString()}`
+                : ""}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void load()}
+              disabled={loading}
+              className="inline-flex min-h-10 items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold disabled:opacity-60"
+            >
+              <RefreshCw
+                className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+              />
+              Refresh
+            </button>
+            <button
+              type="button"
+              onClick={exportCsv}
+              disabled={!data}
+              className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-sky-300 px-3 py-2 text-xs font-semibold text-slate-950 disabled:opacity-60"
+            >
+              <ArrowDownToLine className="h-4 w-4" />
+              Export CSV
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-400/30 bg-red-400/10 p-4 text-sm text-red-200"
+        >
+          {error}
+        </div>
+      ) : null}
+      {loading && !data ? (
+        <div
+          role="status"
+          className={`${panel} p-8 text-center text-sm text-[color:var(--theme-text-secondary)]`}
+        >
+          Building the fleet intelligence view...
+        </div>
+      ) : null}
+
+      {data ? (
+        <>
+          <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {(
+              [
+                ["Active units", metrics.activeUnits, Truck],
+                ["PM compliance", `${metrics.compliance}%`, ShieldCheck],
+                ["Open defects", metrics.openDefects, ClipboardCheck],
+                ["12-month spend", money(metrics.spend), CircleDollarSign],
+              ] satisfies Array<[string, string | number, LucideIcon]>
+            ).map(([label, value, Icon]) => (
+              <div key={String(label)} className={`${panel} p-4`}>
+                <Icon className="h-4 w-4 text-sky-300" aria-hidden="true" />
+                <div className="mt-3 text-2xl font-semibold">
+                  {String(value)}
+                </div>
+                <div className="text-xs text-[color:var(--theme-text-muted)]">
+                  {String(label)}
+                </div>
+              </div>
+            ))}
+          </section>
+
+          <section className="grid gap-4 xl:grid-cols-3">
+            <article className={`${panel} p-5`}>
+              <ShieldCheck className="h-5 w-5 text-emerald-300" />
+              <h2 className="mt-3 text-lg font-semibold">PM compliance</h2>
+              <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Clear units
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold">
+                    {metrics.clearUnits}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Due / overdue
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold">
+                    {data.maintenance.summary.due +
+                      data.maintenance.summary.overdue}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Deferred
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold">
+                    {data.maintenance.summary.deferred}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    PM programs
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold">
+                    {data.maintenance.programs.length}
+                  </dd>
+                </div>
+              </dl>
+              <Link
+                href={links.maintenance}
+                className="mt-5 inline-flex text-xs font-semibold text-sky-300 hover:underline"
+              >
+                Open maintenance program
+              </Link>
+            </article>
+
+            <article className={`${panel} p-5`}>
+              <CircleDollarSign className="h-5 w-5 text-amber-300" />
+              <h2 className="mt-3 text-lg font-semibold">Cost performance</h2>
+              <dl className="mt-4 space-y-3 text-sm">
+                {(["CAD", "USD"] as const).map((currency) => (
+                  <div key={currency} className="flex justify-between gap-3">
+                    <dt className="text-[color:var(--theme-text-muted)]">
+                      {currency} outstanding / paid
+                    </dt>
+                    <dd className="font-semibold">
+                      {money(
+                        data.billing.summary.byCurrency[currency].outstanding,
+                        currency,
+                      )}{" "}
+                      /{" "}
+                      {money(
+                        data.billing.summary.byCurrency[currency].paid,
+                        currency,
+                      )}
+                    </dd>
+                  </div>
+                ))}
+                <div className="flex justify-between gap-3">
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Invoices
+                  </dt>
+                  <dd className="font-semibold">
+                    {data.billing.summary.invoices}
+                  </dd>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Approvals waiting
+                  </dt>
+                  <dd className="font-semibold">
+                    {data.billing.summary.approvals}
+                  </dd>
+                </div>
+              </dl>
+              <Link
+                href={links.history}
+                className="mt-5 inline-flex text-xs font-semibold text-sky-300 hover:underline"
+              >
+                Review history and costs
+              </Link>
+            </article>
+
+            <article className={`${panel} p-5`}>
+              <ChartNoAxesCombined className="h-5 w-5 text-sky-300" />
+              <h2 className="mt-3 text-lg font-semibold">
+                Downtime & reliability
+              </h2>
+              <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Out of service
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold">
+                    {
+                      data.tower.units.filter((unit) => unit.status === "oos")
+                        .length
+                    }
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Limited
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold">
+                    {
+                      data.tower.units.filter(
+                        (unit) => unit.status === "limited",
+                      ).length
+                    }
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Open issues
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold">
+                    {
+                      data.tower.issues.filter(
+                        (issue) => issue.status !== "completed",
+                      ).length
+                    }
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    Assigned units
+                  </dt>
+                  <dd className="mt-1 text-xl font-semibold">
+                    {metrics.assignedUnits}
+                  </dd>
+                </div>
+              </dl>
+              <Link
+                href={links.pretrips}
+                className="mt-5 inline-flex text-xs font-semibold text-sky-300 hover:underline"
+              >
+                Review pre-trip compliance
+              </Link>
+            </article>
+          </section>
+
+          <section className={`${panel} overflow-hidden`}>
+            <div className="border-b border-[color:var(--theme-border-soft)] p-4 sm:p-5">
+              <h2 className="text-lg font-semibold">
+                Asset cost and maintenance performance
+              </h2>
+              <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                Trailing 12 months. Cost per kilometre appears after at least
+                100 km of recorded evidence.
+              </p>
+            </div>
+            {data.economics.units.length ? (
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-left text-sm">
+                  <thead className="text-xs uppercase tracking-wide text-[color:var(--theme-text-muted)]">
+                    <tr>
+                      <th className="px-5 py-3">Asset</th>
+                      <th className="px-5 py-3">Spend</th>
+                      <th className="px-5 py-3">Cost / km</th>
+                      <th className="px-5 py-3">Work orders</th>
+                      <th className="px-5 py-3">Open / PM due</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-[color:var(--theme-border-soft)]">
+                    {data.economics.units.map((unit) => (
+                      <tr key={unit.unitId}>
+                        <td className="px-5 py-4">
+                          <Link
+                            href={`${links.assets}/${encodeURIComponent(unit.unitId)}`}
+                            className="font-semibold hover:underline"
+                          >
+                            {unit.label}
+                          </Link>
+                          <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                            {unit.vehicle || "Fleet asset"}
+                          </div>
+                        </td>
+                        <td className="px-5 py-4 font-medium">
+                          {money(unit.trailing12MonthSpend)}
+                        </td>
+                        <td className="px-5 py-4">
+                          {unit.costPerKm == null
+                            ? "More readings needed"
+                            : `${money(unit.costPerKm)} / km`}
+                        </td>
+                        <td className="px-5 py-4">
+                          {unit.completedWorkOrders}
+                        </td>
+                        <td className="px-5 py-4">
+                          {unit.openServiceRequests} / {unit.pmDueCount}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <div className="p-8 text-center text-sm text-[color:var(--theme-text-secondary)]">
+                Enroll an asset to begin measuring fleet performance.
+              </div>
+            )}
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/features/fleet/components/FleetServiceRequestsPage.tsx
+++ b/features/fleet/components/FleetServiceRequestsPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import {
   AlertTriangle,
@@ -93,6 +94,9 @@ export default function FleetServiceRequestsPage({
   uiContext: FleetUiContext;
   routePrefix: "/fleet" | "/portal/fleet";
 }) {
+  const pathname = usePathname() ?? "";
+  const productRoutes =
+    routePrefix === "/portal/fleet" && !pathname.startsWith("/portal/fleet");
   const [payload, setPayload] = useState<Payload | null>(null);
   const [filter, setFilter] = useState<Filter>("active");
   const [loading, setLoading] = useState(true);
@@ -165,10 +169,17 @@ export default function FleetServiceRequestsPage({
     );
   }, [filter, payload?.requests]);
 
-  const buildHref =
-    routePrefix === "/portal/fleet"
+  const buildHref = productRoutes
+    ? "/requests/new"
+    : routePrefix === "/portal/fleet"
       ? "/portal/fleet/request/build"
       : "/fleet/service-requests/new";
+  const assetHref = (vehicleId: string) =>
+    productRoutes
+      ? `/assets/${encodeURIComponent(vehicleId)}`
+      : `${routePrefix}/units/${encodeURIComponent(vehicleId)}`;
+  const billingHref = (workOrderId: string) =>
+    `${productRoutes ? "/history" : `${routePrefix}/billing`}?workOrderId=${encodeURIComponent(workOrderId)}`;
 
   return (
     <main className="mx-auto w-full max-w-6xl space-y-5 px-4 py-6 text-[color:var(--theme-text-primary)]">
@@ -286,7 +297,7 @@ export default function FleetServiceRequestsPage({
               <div>
                 <div className="flex flex-wrap items-center gap-2">
                   <Link
-                    href={`${routePrefix}/units/${item.vehicleId}`}
+                    href={assetHref(item.vehicleId)}
                     className="text-sm font-semibold text-sky-300 hover:underline"
                   >
                     {item.unitLabel}
@@ -350,7 +361,7 @@ export default function FleetServiceRequestsPage({
                 {item.workOrder?.needsApproval ||
                 (item.workOrder?.outstandingBalance ?? 0) > 0 ? (
                   <Link
-                    href={`${routePrefix}/billing?workOrderId=${item.workOrder?.id ?? ""}`}
+                    href={billingHref(item.workOrder?.id ?? "")}
                     className="inline-flex items-center gap-2 rounded-lg border border-sky-300/30 px-3 py-2 text-xs font-medium text-sky-300 hover:bg-sky-300/10"
                   >
                     <WalletCards size={14} />

--- a/features/fleet/components/FleetServiceRequestsPage.tsx
+++ b/features/fleet/components/FleetServiceRequestsPage.tsx
@@ -113,11 +113,14 @@ export default function FleetServiceRequestsPage({
       const body = (await response.json().catch(() => ({}))) as Payload & {
         error?: string;
       };
-      if (!response.ok) throw new Error(body.error || "Unable to load requests");
+      if (!response.ok)
+        throw new Error(body.error || "Unable to load requests");
       setPayload(body);
     } catch (cause) {
       if (!signal?.aborted) {
-        setError(cause instanceof Error ? cause.message : "Unable to load requests");
+        setError(
+          cause instanceof Error ? cause.message : "Unable to load requests",
+        );
       }
     } finally {
       if (!signal?.aborted) setLoading(false);
@@ -148,12 +151,18 @@ export default function FleetServiceRequestsPage({
   const visible = useMemo(() => {
     const requests = payload?.requests ?? [];
     if (filter === "all") return requests;
-    if (filter === "approval") return requests.filter((item) => item.workOrder?.needsApproval);
-    if (filter === "scheduled") return requests.filter((item) => item.status === "scheduled");
+    if (filter === "approval")
+      return requests.filter((item) => item.workOrder?.needsApproval);
+    if (filter === "scheduled")
+      return requests.filter((item) => item.status === "scheduled");
     if (filter === "completed") {
-      return requests.filter((item) => ["completed", "closed"].includes(item.status));
+      return requests.filter((item) =>
+        ["completed", "closed"].includes(item.status),
+      );
     }
-    return requests.filter((item) => !TERMINAL_REQUEST_STATUSES.has(item.status));
+    return requests.filter(
+      (item) => !TERMINAL_REQUEST_STATUSES.has(item.status),
+    );
   }, [filter, payload?.requests]);
 
   const buildHref =
@@ -170,8 +179,8 @@ export default function FleetServiceRequestsPage({
           </p>
           <h1 className="mt-2 text-2xl font-semibold">Service requests</h1>
           <p className="mt-1 max-w-2xl text-sm text-[color:var(--theme-text-secondary)]">
-            One timeline from fleet request to shop schedule, approval, completion,
-            and payment.
+            One timeline from fleet request to shop schedule, approval,
+            completion, and payment.
           </p>
         </div>
         {uiContext.capabilities.canCreateFleetWorkOrders ? (
@@ -187,16 +196,24 @@ export default function FleetServiceRequestsPage({
 
       {payload ? (
         <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {([
-            ["Open", payload.summary.open, ClipboardList],
-            ["Scheduled", payload.summary.scheduled, CalendarClock],
-            ["Need approval", payload.summary.awaitingApproval, AlertTriangle],
-            ["Completed", payload.summary.completed, CheckCircle2],
-          ] as const).map(([label, value, Icon]) => (
+          {(
+            [
+              ["Open", payload.summary.open, ClipboardList],
+              ["Scheduled", payload.summary.scheduled, CalendarClock],
+              [
+                "Need approval",
+                payload.summary.awaitingApproval,
+                AlertTriangle,
+              ],
+              ["Completed", payload.summary.completed, CheckCircle2],
+            ] as const
+          ).map(([label, value, Icon]) => (
             <div key={String(label)} className={`${panel} p-4`}>
               <Icon size={17} className="text-sky-300" />
               <div className="mt-3 text-2xl font-semibold">{String(value)}</div>
-              <div className="text-xs text-[color:var(--theme-text-muted)]">{String(label)}</div>
+              <div className="text-xs text-[color:var(--theme-text-muted)]">
+                {String(label)}
+              </div>
             </div>
           ))}
         </section>
@@ -204,14 +221,20 @@ export default function FleetServiceRequestsPage({
 
       <section className={`${panel} overflow-hidden`}>
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-[color:var(--theme-border-soft)] p-3">
-          <div className="flex flex-wrap gap-2" role="tablist" aria-label="Request filters">
-            {([
-              ["active", "Active"],
-              ["approval", "Need approval"],
-              ["scheduled", "Scheduled"],
-              ["completed", "Completed"],
-              ["all", "All"],
-            ] as const).map(([value, label]) => (
+          <div
+            className="flex flex-wrap gap-2"
+            role="tablist"
+            aria-label="Request filters"
+          >
+            {(
+              [
+                ["active", "Active"],
+                ["approval", "Need approval"],
+                ["scheduled", "Scheduled"],
+                ["completed", "Completed"],
+                ["all", "All"],
+              ] as const
+            ).map(([value, label]) => (
               <button
                 key={value}
                 type="button"
@@ -240,7 +263,9 @@ export default function FleetServiceRequestsPage({
 
         {error ? <p className="p-5 text-sm text-red-300">{error}</p> : null}
         {loading && !payload ? (
-          <p className="p-5 text-sm text-[color:var(--theme-text-secondary)]">Loading requests…</p>
+          <p className="p-5 text-sm text-[color:var(--theme-text-secondary)]">
+            Loading requests…
+          </p>
         ) : null}
         {!loading && !error && visible.length === 0 ? (
           <div className="p-8 text-center">
@@ -254,7 +279,10 @@ export default function FleetServiceRequestsPage({
 
         <div className="divide-y divide-[color:var(--theme-border-soft)]">
           {visible.map((item) => (
-            <article key={item.id} className="grid gap-4 p-4 lg:grid-cols-[1fr_auto]">
+            <article
+              key={item.id}
+              className="grid gap-4 p-4 lg:grid-cols-[1fr_auto]"
+            >
               <div>
                 <div className="flex flex-wrap items-center gap-2">
                   <Link
@@ -266,7 +294,9 @@ export default function FleetServiceRequestsPage({
                   <span className="text-xs text-[color:var(--theme-text-muted)]">
                     {item.vehicleDescription}
                   </span>
-                  <span className={`rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${statusTone(item.status)}`}>
+                  <span
+                    className={`rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${statusTone(item.status)}`}
+                  >
                     {item.status}
                   </span>
                   {item.workOrder?.needsApproval ? (
@@ -277,11 +307,18 @@ export default function FleetServiceRequestsPage({
                 </div>
                 <h2 className="mt-2 text-sm font-semibold">{item.title}</h2>
                 {item.summary ? (
-                  <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">{item.summary}</p>
+                  <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
+                    {item.summary}
+                  </p>
                 ) : null}
                 <p className="mt-2 text-xs text-[color:var(--theme-text-muted)]">
-                  Requested {dateLabel(item.createdAt)}
-                  {item.scheduledForDate ? ` • Scheduled ${dateLabel(item.scheduledForDate)}` : ""}
+                  Submitted {dateLabel(item.createdAt)}
+                  {item.requestedForDate
+                    ? ` • Requested ${dateLabel(item.requestedForDate)}`
+                    : ""}
+                  {item.scheduledForDate
+                    ? ` • Scheduled ${dateLabel(item.scheduledForDate)}`
+                    : ""}
                   {item.sourcePmDueEventId ? " • Created from PM" : ""}
                 </p>
               </div>
@@ -310,13 +347,16 @@ export default function FleetServiceRequestsPage({
                     Awaiting shop conversion
                   </span>
                 )}
-                {item.workOrder?.needsApproval || (item.workOrder?.outstandingBalance ?? 0) > 0 ? (
+                {item.workOrder?.needsApproval ||
+                (item.workOrder?.outstandingBalance ?? 0) > 0 ? (
                   <Link
                     href={`${routePrefix}/billing?workOrderId=${item.workOrder?.id ?? ""}`}
                     className="inline-flex items-center gap-2 rounded-lg border border-sky-300/30 px-3 py-2 text-xs font-medium text-sky-300 hover:bg-sky-300/10"
                   >
                     <WalletCards size={14} />
-                    {item.workOrder?.needsApproval ? "Review approval" : "View invoice"}
+                    {item.workOrder?.needsApproval
+                      ? "Review approval"
+                      : "View invoice"}
                   </Link>
                 ) : null}
               </div>

--- a/features/fleet/components/FleetUnitDetailWorkspace.tsx
+++ b/features/fleet/components/FleetUnitDetailWorkspace.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import {
   Activity,
   AlertTriangle,
@@ -58,6 +59,14 @@ export default function FleetUnitDetailWorkspace({
   uiContext: FleetUiContext;
   routePrefix: RoutePrefix;
 }) {
+  const pathname = usePathname() ?? "";
+  const productRoutes =
+    routePrefix === "/portal/fleet" && !pathname.startsWith("/portal/fleet");
+  const unitsHref = productRoutes ? "/assets" : `${routePrefix}/units`;
+  const maintenanceHref = productRoutes
+    ? "/maintenance"
+    : `${routePrefix}/maintenance`;
+  const billingHref = productRoutes ? "/history" : `${routePrefix}/billing`;
   const [data, setData] = useState<FleetUnitWorkspacePayload | null>(null);
   const [tab, setTab] = useState<Tab>("overview");
   const [loading, setLoading] = useState(true);
@@ -83,7 +92,9 @@ export default function FleetUnitDetailWorkspace({
       } catch (loadError) {
         if (!cancelled) {
           setError(
-            loadError instanceof Error ? loadError.message : "Unable to load unit",
+            loadError instanceof Error
+              ? loadError.message
+              : "Unable to load unit",
           );
         }
       } finally {
@@ -154,9 +165,10 @@ export default function FleetUnitDetailWorkspace({
                   ? "Limited use"
                   : "In service"}
             </span>
-            {routePrefix === "/portal/fleet" && uiContext.capabilities.canSubmitPretrip ? (
+            {routePrefix === "/portal/fleet" &&
+            uiContext.capabilities.canSubmitPretrip ? (
               <Link
-                href={`/portal/fleet/pretrip/${encodeURIComponent(unitId)}${fleetId ? `?fleetId=${encodeURIComponent(fleetId)}` : ""}`}
+                href={`${productRoutes ? "/pre-trips/start" : "/portal/fleet/pretrip"}/${encodeURIComponent(unitId)}${fleetId ? `?fleetId=${encodeURIComponent(fleetId)}` : ""}`}
                 className="rounded-xl border border-sky-300/40 px-4 py-2 text-xs font-semibold text-sky-200"
               >
                 Today’s pre-trip
@@ -166,7 +178,7 @@ export default function FleetUnitDetailWorkspace({
               <Link
                 href={
                   routePrefix === "/portal/fleet"
-                    ? `/portal/fleet/request/build?unitId=${encodeURIComponent(unitId)}`
+                    ? `${productRoutes ? "/requests/new" : "/portal/fleet/request/build"}?unitId=${encodeURIComponent(unitId)}`
                     : `/fleet/service-requests/new?unitId=${encodeURIComponent(unitId)}`
                 }
                 className="rounded-xl bg-sky-300 px-4 py-2 text-xs font-semibold text-slate-950"
@@ -179,15 +191,35 @@ export default function FleetUnitDetailWorkspace({
 
         <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-7">
           {[
-            ["Odometer", data.unit.currentOdometerKm == null ? "—" : `${data.unit.currentOdometerKm.toLocaleString()} km`],
-            ["Engine hours", data.unit.currentEngineHours == null ? "—" : data.unit.currentEngineHours.toLocaleString()],
+            [
+              "Odometer",
+              data.unit.currentOdometerKm == null
+                ? "—"
+                : `${data.unit.currentOdometerKm.toLocaleString()} km`,
+            ],
+            [
+              "Engine hours",
+              data.unit.currentEngineHours == null
+                ? "—"
+                : data.unit.currentEngineHours.toLocaleString(),
+            ],
             ["PM due", data.metrics.activePmDue],
             ["Open defects", data.metrics.activeDefects],
             ["Open requests", data.metrics.openRequests],
             ["Approvals", data.metrics.openApprovals],
-            ["Outstanding", money(data.metrics.outstandingBalance, data.workOrders.find((row) => row.invoice)?.invoice?.currency ?? "CAD")],
+            [
+              "Outstanding",
+              money(
+                data.metrics.outstandingBalance,
+                data.workOrders.find((row) => row.invoice)?.invoice?.currency ??
+                  "CAD",
+              ),
+            ],
           ].map(([label, value]) => (
-            <div key={String(label)} className="rounded-xl border border-[color:var(--theme-border-soft)] p-3">
+            <div
+              key={String(label)}
+              className="rounded-xl border border-[color:var(--theme-border-soft)] p-3"
+            >
               <div className="text-[10px] uppercase tracking-wide text-[color:var(--theme-text-muted)]">
                 {label}
               </div>
@@ -220,18 +252,24 @@ export default function FleetUnitDetailWorkspace({
           ))}
         </div>
         <p className="mt-3 text-[11px] text-[color:var(--theme-text-muted)]">
-          Generated from live PM, request, estimate, invoice, and unit-reading data.
-          Select any point to open the underlying records.
+          Generated from live PM, request, estimate, invoice, and unit-reading
+          data. Select any point to open the underlying records.
         </p>
       </section>
 
-      <div className="flex gap-2 overflow-x-auto" role="tablist" aria-label="Unit record sections">
-        {([
-          ["overview", "Overview", ClipboardList],
-          ["maintenance", "Maintenance", ShieldCheck],
-          ["history", "Service & invoices", History],
-          ["activity", "Readings & pre-trips", Activity],
-        ] as const).map(([value, label, Icon]) => (
+      <div
+        className="flex gap-2 overflow-x-auto"
+        role="tablist"
+        aria-label="Unit record sections"
+      >
+        {(
+          [
+            ["overview", "Overview", ClipboardList],
+            ["maintenance", "Maintenance", ShieldCheck],
+            ["history", "Service & invoices", History],
+            ["activity", "Readings & pre-trips", Activity],
+          ] as const
+        ).map(([value, label, Icon]) => (
           <button
             key={value}
             type="button"
@@ -266,8 +304,12 @@ export default function FleetUnitDetailWorkspace({
                 ["Next inspection", dateLabel(data.unit.nextInspectionDate)],
               ].map(([label, value]) => (
                 <div key={label}>
-                  <dt className="text-[color:var(--theme-text-muted)]">{label}</dt>
-                  <dd className="mt-1 break-words font-medium">{value || "—"}</dd>
+                  <dt className="text-[color:var(--theme-text-muted)]">
+                    {label}
+                  </dt>
+                  <dd className="mt-1 break-words font-medium">
+                    {value || "—"}
+                  </dd>
                 </div>
               ))}
             </dl>
@@ -275,26 +317,46 @@ export default function FleetUnitDetailWorkspace({
           <section className={card}>
             <h2 className="text-sm font-semibold">Open requests</h2>
             <div className="mt-3 space-y-2">
-              {data.requests.filter((request) => !["completed", "cancelled"].includes(request.status)).slice(0, 6).map((request) => (
-                <div key={request.id} className="rounded-xl border border-[color:var(--theme-border-soft)] p-3">
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-medium">{request.title}</span>
-                    <span className="text-[10px] uppercase">{request.status}</span>
+              {data.requests
+                .filter(
+                  (request) =>
+                    !["completed", "cancelled"].includes(request.status),
+                )
+                .slice(0, 6)
+                .map((request) => (
+                  <div
+                    key={request.id}
+                    className="rounded-xl border border-[color:var(--theme-border-soft)] p-3"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium">
+                        {request.title}
+                      </span>
+                      <span className="text-[10px] uppercase">
+                        {request.status}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
+                      {request.summary}
+                    </p>
                   </div>
-                  <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">{request.summary}</p>
-                </div>
-              ))}
+                ))}
               {data.metrics.openRequests === 0 ? (
-                <p className="text-sm text-[color:var(--theme-text-secondary)]">No open service requests.</p>
+                <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                  No open service requests.
+                </p>
               ) : null}
             </div>
           </section>
           <section className={`${card} lg:col-span-2`}>
             <div className="flex items-center justify-between gap-3">
               <div>
-                <h2 className="text-sm font-semibold">Tracked pre-trip defects</h2>
+                <h2 className="text-sm font-semibold">
+                  Tracked pre-trip defects
+                </h2>
                 <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                  Durable history from driver report through request, work order, and resolution.
+                  Durable history from driver report through request, work
+                  order, and resolution.
                 </p>
               </div>
               <span className="rounded-full bg-amber-400/10 px-3 py-1 text-[10px] font-semibold uppercase text-amber-100">
@@ -303,10 +365,17 @@ export default function FleetUnitDetailWorkspace({
             </div>
             <div className="mt-3 grid gap-2 md:grid-cols-2">
               {data.defects.slice(0, 12).map((defect) => (
-                <div key={defect.id} className="rounded-xl border border-[color:var(--theme-border-soft)] p-3">
+                <div
+                  key={defect.id}
+                  className="rounded-xl border border-[color:var(--theme-border-soft)] p-3"
+                >
                   <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-semibold">{defect.label}</span>
-                    <span className="text-[10px] uppercase">{defect.severity} • {defect.state}</span>
+                    <span className="text-sm font-semibold">
+                      {defect.label}
+                    </span>
+                    <span className="text-[10px] uppercase">
+                      {defect.severity} • {defect.state}
+                    </span>
                   </div>
                   <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
                     {dateLabel(defect.reportedAt)}
@@ -315,7 +384,9 @@ export default function FleetUnitDetailWorkspace({
                 </div>
               ))}
               {!data.defects.length ? (
-                <p className="text-sm text-[color:var(--theme-text-secondary)]">No defects have been reported for this unit.</p>
+                <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                  No defects have been reported for this unit.
+                </p>
               ) : null}
             </div>
           </section>
@@ -331,13 +402,19 @@ export default function FleetUnitDetailWorkspace({
                 Due evidence, intervals, deferrals, and linked requests.
               </p>
             </div>
-            <Link href={`${routePrefix}/maintenance`} className="text-xs font-semibold text-sky-300">
+            <Link
+              href={maintenanceHref}
+              className="text-xs font-semibold text-sky-300"
+            >
               Open PM workspace
             </Link>
           </div>
           <div className="mt-4 space-y-3">
             {data.maintenance.map((item) => (
-              <article key={item.id} className="rounded-xl border border-[color:var(--theme-border-soft)] p-3">
+              <article
+                key={item.id}
+                className="rounded-xl border border-[color:var(--theme-border-soft)] p-3"
+              >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <h3 className="text-sm font-semibold">{item.name}</h3>
@@ -350,17 +427,25 @@ export default function FleetUnitDetailWorkspace({
                   </span>
                 </div>
                 <div className="mt-2 text-[11px] text-[color:var(--theme-text-muted)]">
-                  Interval: {[
-                    item.intervalKm ? `${item.intervalKm.toLocaleString()} km` : null,
-                    item.intervalHours ? `${item.intervalHours.toLocaleString()} hours` : null,
+                  Interval:{" "}
+                  {[
+                    item.intervalKm
+                      ? `${item.intervalKm.toLocaleString()} km`
+                      : null,
+                    item.intervalHours
+                      ? `${item.intervalHours.toLocaleString()} hours`
+                      : null,
                     item.intervalDays ? `${item.intervalDays} days` : null,
-                  ].filter(Boolean).join(" / ") || "Policy default"}
+                  ]
+                    .filter(Boolean)
+                    .join(" / ") || "Policy default"}
                 </div>
               </article>
             ))}
             {data.maintenance.length === 0 ? (
               <div className="flex items-center gap-2 rounded-xl bg-emerald-500/10 p-3 text-sm text-emerald-100">
-                <CheckCircle2 className="h-4 w-4" /> No PM items are currently due.
+                <CheckCircle2 className="h-4 w-4" /> No PM items are currently
+                due.
               </div>
             ) : null}
           </div>
@@ -369,24 +454,39 @@ export default function FleetUnitDetailWorkspace({
 
       {tab === "history" ? (
         <section className={card}>
-          <h2 className="text-sm font-semibold">Service, approvals, and invoices</h2>
+          <h2 className="text-sm font-semibold">
+            Service, approvals, and invoices
+          </h2>
           <div className="mt-4 space-y-3">
             {data.workOrders.map((workOrder) => (
-              <article key={workOrder.id} className="rounded-xl border border-[color:var(--theme-border-soft)] p-3">
+              <article
+                key={workOrder.id}
+                className="rounded-xl border border-[color:var(--theme-border-soft)] p-3"
+              >
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                   <div>
-                    <h3 className="text-sm font-semibold">{workOrder.reference}</h3>
+                    <h3 className="text-sm font-semibold">
+                      {workOrder.reference}
+                    </h3>
                     <p className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                      {workOrder.status.replaceAll("_", " ")} • {dateLabel(workOrder.createdAt)}
+                      {workOrder.status.replaceAll("_", " ")} •{" "}
+                      {dateLabel(workOrder.createdAt)}
                     </p>
                   </div>
                   {workOrder.invoice ? (
                     <div className="text-left sm:text-right">
                       <div className="text-sm font-semibold">
-                        {money(workOrder.invoice.total, workOrder.invoice.currency)}
+                        {money(
+                          workOrder.invoice.total,
+                          workOrder.invoice.currency,
+                        )}
                       </div>
                       <div className="text-[11px] text-[color:var(--theme-text-muted)]">
-                        Balance {money(workOrder.invoice.outstandingTotal, workOrder.invoice.currency)}
+                        Balance{" "}
+                        {money(
+                          workOrder.invoice.outstandingTotal,
+                          workOrder.invoice.currency,
+                        )}
                       </div>
                     </div>
                   ) : null}
@@ -394,9 +494,14 @@ export default function FleetUnitDetailWorkspace({
                 {workOrder.quoteLines.length ? (
                   <div className="mt-3 space-y-2">
                     {workOrder.quoteLines.map((line) => (
-                      <div key={line.id} className="flex items-start justify-between gap-3 rounded-lg bg-[color:var(--theme-surface-subtle)] p-2 text-xs">
+                      <div
+                        key={line.id}
+                        className="flex items-start justify-between gap-3 rounded-lg bg-[color:var(--theme-surface-subtle)] p-2 text-xs"
+                      >
                         <span>{line.description}</span>
-                        <span className="shrink-0 capitalize">{line.status.replaceAll("_", " ")}</span>
+                        <span className="shrink-0 capitalize">
+                          {line.status.replaceAll("_", " ")}
+                        </span>
                       </div>
                     ))}
                   </div>
@@ -404,12 +509,19 @@ export default function FleetUnitDetailWorkspace({
               </article>
             ))}
             {!data.workOrders.length ? (
-              <p className="text-sm text-[color:var(--theme-text-secondary)]">No service history yet.</p>
+              <p className="text-sm text-[color:var(--theme-text-secondary)]">
+                No service history yet.
+              </p>
             ) : null}
           </div>
           {pendingQuotes.length > 0 ? (
-            <Link href={`${routePrefix}/billing?filter=approvals`} className="mt-4 inline-flex items-center gap-2 rounded-xl bg-amber-400 px-4 py-2 text-xs font-semibold text-slate-950">
-              <AlertTriangle className="h-4 w-4" /> Review {pendingQuotes.length} approval{pendingQuotes.length === 1 ? "" : "s"}
+            <Link
+              href={`${billingHref}?filter=approvals`}
+              className="mt-4 inline-flex items-center gap-2 rounded-xl bg-amber-400 px-4 py-2 text-xs font-semibold text-slate-950"
+            >
+              <AlertTriangle className="h-4 w-4" /> Review{" "}
+              {pendingQuotes.length} approval
+              {pendingQuotes.length === 1 ? "" : "s"}
             </Link>
           ) : null}
         </section>
@@ -423,13 +535,25 @@ export default function FleetUnitDetailWorkspace({
             </h2>
             <div className="mt-3 space-y-2">
               {data.readings.slice(0, 20).map((reading) => (
-                <div key={reading.id} className="rounded-xl border border-[color:var(--theme-border-soft)] p-3 text-xs">
-                  <div className="font-medium">{dateLabel(reading.recordedAt)}</div>
+                <div
+                  key={reading.id}
+                  className="rounded-xl border border-[color:var(--theme-border-soft)] p-3 text-xs"
+                >
+                  <div className="font-medium">
+                    {dateLabel(reading.recordedAt)}
+                  </div>
                   <div className="mt-1 text-[color:var(--theme-text-secondary)]">
-                    {reading.odometerKm == null ? "" : `${reading.odometerKm.toLocaleString()} km`}
-                    {reading.odometerKm != null && reading.engineHours != null ? " • " : ""}
-                    {reading.engineHours == null ? "" : `${reading.engineHours.toLocaleString()} hours`}
-                    {" • "}{reading.sourceType}
+                    {reading.odometerKm == null
+                      ? ""
+                      : `${reading.odometerKm.toLocaleString()} km`}
+                    {reading.odometerKm != null && reading.engineHours != null
+                      ? " • "
+                      : ""}
+                    {reading.engineHours == null
+                      ? ""
+                      : `${reading.engineHours.toLocaleString()} hours`}
+                    {" • "}
+                    {reading.sourceType}
                   </div>
                 </div>
               ))}
@@ -441,16 +565,25 @@ export default function FleetUnitDetailWorkspace({
             </h2>
             <div className="mt-3 space-y-2">
               {data.pretrips.slice(0, 20).map((pretrip) => (
-                <div key={pretrip.id} className="rounded-xl border border-[color:var(--theme-border-soft)] p-3 text-xs">
+                <div
+                  key={pretrip.id}
+                  className="rounded-xl border border-[color:var(--theme-border-soft)] p-3 text-xs"
+                >
                   <div className="flex items-center justify-between gap-3">
                     <span className="font-medium">{pretrip.driverName}</span>
-                    <span className={pretrip.hasDefects ? "text-red-300" : "text-emerald-300"}>
+                    <span
+                      className={
+                        pretrip.hasDefects ? "text-red-300" : "text-emerald-300"
+                      }
+                    >
                       {pretrip.hasDefects ? "Defects" : "Clear"}
                     </span>
                   </div>
                   <div className="mt-1 text-[color:var(--theme-text-secondary)]">
                     {dateLabel(pretrip.inspectionDate)}
-                    {pretrip.odometerKm == null ? "" : ` • ${pretrip.odometerKm.toLocaleString()} km`}
+                    {pretrip.odometerKm == null
+                      ? ""
+                      : ` • ${pretrip.odometerKm.toLocaleString()} km`}
                   </div>
                 </div>
               ))}
@@ -459,14 +592,23 @@ export default function FleetUnitDetailWorkspace({
         </div>
       ) : null}
 
-      <InspectionReportAttachments vehicleId={unitId} title="Completed inspections" />
+      <InspectionReportAttachments
+        vehicleId={unitId}
+        title="Completed inspections"
+      />
       <FleetUnitWorkOrderEvidence unitId={unitId} />
 
       <div className="flex flex-wrap gap-2 text-xs">
-        <Link href={`${routePrefix}/units`} className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2">
+        <Link
+          href={unitsHref}
+          className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2"
+        >
           ← All units
         </Link>
-        <Link href={`${routePrefix}/billing`} className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2">
+        <Link
+          href={billingHref}
+          className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2"
+        >
           <ReceiptText className="h-4 w-4" /> Fleet billing
         </Link>
       </div>

--- a/features/fleet/components/FleetUnitEconomicsPanel.tsx
+++ b/features/fleet/components/FleetUnitEconomicsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 type Recommendation = {
   id: string;
@@ -47,6 +48,8 @@ export default function FleetUnitEconomicsPanel({
   shopId?: string | null;
   routePrefix?: "/fleet" | "/portal/fleet";
 }) {
+  const pathname = usePathname() ?? "";
+  const productRoutes = !pathname.startsWith("/portal/fleet");
   const [payload, setPayload] = useState<Payload | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -129,9 +132,11 @@ export default function FleetUnitEconomicsPanel({
                 <div>
                   <Link
                     href={
-                      routePrefix === "/portal/fleet"
-                        ? `${routePrefix}/units/${unit.unitId}`
-                        : `${routePrefix}/units`
+                      productRoutes
+                        ? `/assets/${encodeURIComponent(unit.unitId)}`
+                        : routePrefix === "/portal/fleet"
+                          ? `${routePrefix}/units/${encodeURIComponent(unit.unitId)}`
+                          : `${routePrefix}/units`
                     }
                     className="text-sm font-semibold hover:underline"
                   >

--- a/features/fleet/components/FleetUnitsPage.tsx
+++ b/features/fleet/components/FleetUnitsPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { Search, Truck, Wrench } from "lucide-react";
 import type { FleetUnitListItem } from "app/api/fleet/units/route";
@@ -50,6 +51,9 @@ export default function FleetUnitsPage({
   uiContext,
   routePrefix = "/fleet",
 }: Props) {
+  const pathname = usePathname() ?? "";
+  const productRoutes =
+    routePrefix === "/portal/fleet" && !pathname.startsWith("/portal/fleet");
   const [units, setUnits] = useState<FleetUnitListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -138,7 +142,9 @@ export default function FleetUnitsPage({
         </p>
         <div className="mt-3 flex flex-wrap gap-2">
           <Link
-            href={`${routePrefix}/pretrip-history`}
+            href={
+              productRoutes ? "/pre-trips" : `${routePrefix}/pretrip-history`
+            }
             className="inline-flex min-h-10 items-center rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold text-sky-300 hover:bg-sky-300/10"
           >
             Fleet-wide pre-trip history
@@ -232,7 +238,11 @@ export default function FleetUnitsPage({
           {visible.map((unit) => (
             <Link
               key={unit.id}
-              href={`${routePrefix}/units/${encodeURIComponent(unit.id)}`}
+              href={
+                productRoutes
+                  ? `/assets/${encodeURIComponent(unit.id)}`
+                  : `${routePrefix}/units/${encodeURIComponent(unit.id)}`
+              }
               className="grid gap-3 p-4 transition hover:bg-white/[0.03] md:grid-cols-[minmax(180px,1.1fr)_minmax(120px,.7fr)_minmax(160px,1fr)_minmax(150px,.8fr)_auto] md:items-center"
             >
               <div>

--- a/features/fleet/components/PretripReportsPage.tsx
+++ b/features/fleet/components/PretripReportsPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
@@ -31,6 +32,9 @@ export default function PretripReportsPage({
   uiContext: FleetUiContext;
   routePrefix?: "/fleet" | "/portal/fleet";
 }) {
+  const pathname = usePathname() ?? "";
+  const productRoutes =
+    routePrefix === "/portal/fleet" && !pathname.startsWith("/portal/fleet");
   const [reports, setReports] = useState<PretripReport[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -112,12 +116,15 @@ export default function PretripReportsPage({
       <div className={ui.container}>
         <div aria-hidden className={ui.backdrop} />
 
-        <div className={`${ui.panel} ${ui.panelPadding} relative overflow-hidden`}>
+        <div
+          className={`${ui.panel} ${ui.panelPadding} relative overflow-hidden`}
+        >
           <div className={ui.headerTop}>
             <div>
               <h1 className={ui.title}>Pre-trip Reports</h1>
               <p className={ui.subtitle}>
-                View and audit daily DVIR / pre-trip reports coming in from drivers.
+                View and audit daily DVIR / pre-trip reports coming in from
+                drivers.
               </p>
               <p className={ui.note}>Actor surface: {uiContext.actorLabel}</p>
             </div>
@@ -145,10 +152,12 @@ export default function PretripReportsPage({
             <div className="text-[11px] text-[color:var(--theme-text-muted)] md:pl-3">
               Drivers submit pre-trips from the{" "}
               <Link
-                href="/mobile/fleet/pretrip"
+                href={productRoutes ? "/assets" : "/mobile/fleet/pretrip"}
                 className="underline decoration-dotted underline-offset-4"
               >
-                mobile pre-trip screen
+                {productRoutes
+                  ? "Today’s pre-trip action on an assigned asset"
+                  : "mobile pre-trip screen"}
               </Link>
               .
             </div>
@@ -235,7 +244,8 @@ export default function PretripReportsPage({
                 No pre-trip reports
               </div>
               <p className="mt-2 text-xs text-[color:var(--theme-text-secondary)]">
-                Once drivers start submitting pre-trips from mobile, they will show up here for review.
+                Once drivers start submitting pre-trips from mobile, they will
+                show up here for review.
               </p>
             </div>
           )}

--- a/supabase/migrations/20260806044318_reconcile_fleet_workspace_columns.sql
+++ b/supabase/migrations/20260806044318_reconcile_fleet_workspace_columns.sql
@@ -1,0 +1,14 @@
+begin;
+
+-- Some production databases predate the canonical Fleet table definition.
+-- Reconcile the additive workspace columns before the Fleet settings and PM
+-- management migrations use them.
+alter table public.fleets
+  add column if not exists contact_phone text,
+  add column if not exists active boolean not null default true,
+  add column if not exists created_by uuid references auth.users(id) on delete set null;
+
+create index if not exists fleets_shop_active_idx
+  on public.fleets (shop_id, active, created_at desc);
+
+commit;

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -86,6 +86,8 @@ describe("premier fleet workspaces", () => {
     expect(workspace).toContain("TERMINAL_REQUEST_STATUSES");
     expect(workspace).toContain("One timeline from fleet request");
     expect(workspace).toContain("Review approval");
+    expect(workspace).toContain("Submitted {dateLabel(item.createdAt)}");
+    expect(workspace).toContain("dateLabel(item.requestedForDate)");
   });
 
   it("protects financial data and records decisions through canonical flows", () => {

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -149,4 +149,53 @@ describe("premier fleet workspaces", () => {
     expect(units).toContain("Fleet-wide pre-trip history");
     expect(dispatch).not.toContain("/fleet/assets/");
   });
+
+  it("ships real driver operations and fleet intelligence instead of placeholders", () => {
+    const driversPage = source("app/portal/fleet/drivers/page.tsx");
+    const drivers = source(
+      "features/fleet/components/FleetDriversWorkspace.tsx",
+    );
+    const reportsPage = source("app/portal/fleet/reports/page.tsx");
+    const reports = source(
+      "features/fleet/components/FleetReportsWorkspace.tsx",
+    );
+
+    expect(driversPage).toContain("FleetDriversWorkspace");
+    expect(driversPage).toContain("FleetPortalAccessManager");
+    expect(driversPage).not.toContain("FleetModuleFoundation");
+    expect(drivers).toContain('fetch("/api/fleet/enrollment"');
+    expect(drivers).toContain("Drivers & assignments");
+    expect(drivers).toContain("Invite driver");
+    expect(drivers).toContain("/assets/new");
+
+    expect(reportsPage).toContain("FleetReportsWorkspace");
+    expect(reportsPage).not.toContain("FleetModuleFoundation");
+    for (const endpoint of [
+      "/api/fleet/maintenance",
+      "/api/fleet/unit-economics",
+      "/api/fleet/billing",
+      "/api/fleet/tower",
+      "/api/fleet/pretrip",
+    ]) {
+      expect(reports).toContain(endpoint);
+    }
+    expect(reports).toContain("Export CSV");
+    expect(reports).toContain("Asset cost and maintenance performance");
+  });
+
+  it("keeps product-domain actions on clean public Fleet routes", () => {
+    const issues = source("features/fleet/components/FleetIssueTables.tsx");
+    const detail = source(
+      "features/fleet/components/FleetUnitDetailWorkspace.tsx",
+    );
+    const economics = source(
+      "features/fleet/components/FleetUnitEconomicsPanel.tsx",
+    );
+
+    expect(issues).toContain("requestHref = productHostRoute");
+    expect(issues).toContain('"/requests/new"');
+    expect(detail).toContain('"/pre-trips/start"');
+    expect(detail).toContain('"/requests/new"');
+    expect(economics).toContain("`/assets/${encodeURIComponent(unit.unitId)}`");
+  });
 });

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -193,11 +193,19 @@ describe("premier fleet workspaces", () => {
     const economics = source(
       "features/fleet/components/FleetUnitEconomicsPanel.tsx",
     );
+    const requests = source(
+      "features/fleet/components/FleetServiceRequestsPage.tsx",
+    );
+    const pretrips = source("features/fleet/components/PretripReportsPage.tsx");
 
     expect(issues).toContain("requestHref = productHostRoute");
     expect(issues).toContain('"/requests/new"');
     expect(detail).toContain('"/pre-trips/start"');
     expect(detail).toContain('"/requests/new"');
     expect(economics).toContain("`/assets/${encodeURIComponent(unit.unitId)}`");
+  expect(requests).toContain("const buildHref = productRoutes");
+  expect(requests).toContain('? "/requests/new"');
+    expect(requests).toContain('productRoutes ? "/history"');
+    expect(pretrips).toContain('productRoutes ? "/assets"');
   });
 });


### PR DESCRIPTION
## What changed

- replaced the Drivers placeholder with live driver, assignment, route, and pre-trip operations plus fleet-scoped invitations
- replaced the Reports placeholder with live PM compliance, cost, reliability, driver-readiness metrics, and CSV export
- corrected product-domain links so Fleet actions stay on clean `fleet.profixiq.com` routes
- added the additive Fleet workspace column reconciliation migration that was applied to production
- added regression coverage for the completed workspaces and public-route actions

## Root cause

Production was ahead of its recorded migration history in one area but missing three Fleet workspace migrations/columns in another. That caused Settings to crash and Maintenance to stall. Drivers and Reports were still foundation placeholders, and several dashboard actions leaked legacy portal or shop paths.

## Validation

- full TypeScript check: passed
- changed-file ESLint: passed
- 30 targeted Fleet tests: passed
- production compilation: passed; local page-data collection then stopped because local Supabase environment variables are intentionally unavailable
- full repository lint/test runs were also attempted and exposed unrelated pre-existing failures outside Fleet

## Database

The additive column reconciliation plus the existing Fleet workspace and PM program migrations were applied and verified against Supabase project `scjjkmuwadwkaaqjoigx`.