### PR TITLE
Brand Fleet portal invitations

### DIFF
--- a/features/email/server/emailEvents.ts
+++ b/features/email/server/emailEvents.ts
@@ -1,6 +1,65 @@
 import type { Json } from "@shared/types/types/supabase";
 import { sendDynamicTemplateEmail } from "./sendDynamicTemplateEmail";
 
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function safeColor(value: string | null | undefined, fallback: string) {
+  const candidate = value?.trim() ?? "";
+  return /^#[0-9a-f]{6}$/i.test(candidate) ? candidate : fallback;
+}
+
+function fleetInviteContent(input: {
+  portalLink: string;
+  shopName?: string | null;
+  fleetName?: string | null;
+  fleetRole?: string | null;
+  brandPrimaryColor?: string | null;
+  brandSecondaryColor?: string | null;
+  year?: number;
+}) {
+  const fleetName = input.fleetName?.trim() || "your fleet";
+  const shopName = input.shopName?.trim() || "ProFixIQ";
+  const role =
+    input.fleetRole === "manager"
+      ? "Fleet manager"
+      : input.fleetRole === "approver"
+        ? "Approver / dispatcher"
+        : "Viewer / driver";
+  const subject = `Your ${fleetName} Fleet invitation`.replace(/[\r\n]+/g, " ");
+  const primary = safeColor(input.brandPrimaryColor, "#c86a32");
+  const secondary = safeColor(input.brandSecondaryColor, "#0f172a");
+  const safeFleetName = escapeHtml(fleetName);
+  const safeShopName = escapeHtml(shopName);
+  const safeRole = escapeHtml(role);
+  const safePortalLink = escapeHtml(input.portalLink);
+  const year = input.year ?? new Date().getFullYear();
+
+  return {
+    subject,
+    text: [
+      "ProFixIQ Fleet",
+      "",
+      `You have been invited to ${fleetName}.`,
+      `Access level: ${role}`,
+      "",
+      "Activate your secure Fleet account:",
+      input.portalLink,
+      "",
+      "This one-time link expires automatically. If you did not expect this invitation, you can safely ignore it.",
+      "",
+      `Sent by ${shopName} with ProFixIQ Fleet.`,
+    ].join("\n"),
+    html: `<!doctype html><html lang="en"><body style="margin:0;background:#020617;color:#e2e8f0;font-family:Arial,sans-serif"><div style="padding:32px 12px"><div style="max-width:560px;margin:0 auto;overflow:hidden;border:1px solid #334155;border-radius:20px;background:#0f172a"><div style="height:6px;background:linear-gradient(90deg,${primary},${secondary})"></div><div style="padding:30px"><div style="font-size:12px;font-weight:700;letter-spacing:.18em;text-transform:uppercase;color:${primary}">ProFixIQ Fleet</div><h1 style="margin:14px 0 0;color:#fff;font-size:28px;line-height:1.2">Activate your Fleet access</h1><p style="margin:16px 0 0;color:#cbd5e1;font-size:15px;line-height:1.65">You have been invited to <strong style="color:#fff">${safeFleetName}</strong>.</p><div style="margin:22px 0;padding:16px;border:1px solid #334155;border-radius:12px;background:#111c30"><div style="font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:#94a3b8">Access level</div><div style="margin-top:6px;color:#fff;font-weight:700">${safeRole}</div></div><p style="margin:24px 0"><a href="${safePortalLink}" style="display:inline-block;padding:14px 20px;border-radius:10px;background:${primary};color:#fff;font-weight:700;text-decoration:none">Activate Fleet account</a></p><p style="margin:20px 0 0;color:#94a3b8;font-size:12px;line-height:1.6">This secure link is single-use and expires automatically. If you did not expect this invitation, you can safely ignore it.</p><div style="margin-top:26px;padding-top:20px;border-top:1px solid #334155;color:#64748b;font-size:11px;line-height:1.6">Sent by ${safeShopName} with ProFixIQ Fleet.<br>&copy; ${year} ProFixIQ</div></div></div></div></body></html>`,
+  };
+}
+
 export async function sendPortalInviteEmail(input: {
   shopId: string;
   to: string;
@@ -15,11 +74,15 @@ export async function sendPortalInviteEmail(input: {
   fleetName?: string | null;
   fleetRole?: string | null;
 }) {
+  const fleetContent =
+    input.portalType === "fleet" ? fleetInviteContent(input) : null;
   return sendDynamicTemplateEmail({
     shopId: input.shopId,
     templateKey: "portal_invite",
     to: input.to,
     createdBy: input.createdBy,
+    subject: fleetContent?.subject ?? null,
+    content: fleetContent,
     metadata: {
       kind: "portal_invite",
       portal_type: input.portalType ?? "customer",

--- a/features/email/server/sendDynamicTemplateEmail.ts
+++ b/features/email/server/sendDynamicTemplateEmail.ts
@@ -1,4 +1,4 @@
-import sgMail from "@sendgrid/mail";
+import sgMail, { type MailDataRequired } from "@sendgrid/mail";
 import { createClient } from "@supabase/supabase-js";
 import type { Database, Json } from "@shared/types/types/supabase";
 import { getTemplateId, type EmailTemplateKey } from "./templateIds";
@@ -12,6 +12,10 @@ type SendDynamicTemplateEmailInput = {
   to: string;
   dynamicTemplateData?: Record<string, unknown>;
   subject?: string | null;
+  content?: {
+    text: string;
+    html: string;
+  } | null;
   createdBy?: string | null;
   metadata?: Json;
 };
@@ -110,16 +114,25 @@ export async function sendDynamicTemplateEmail(
   }
 
   try {
-    const [response] = await sgMail.send({
-      to,
-      from: fromEmail,
-      templateId,
-      dynamicTemplateData: input.dynamicTemplateData ?? {},
-      customArgs: {
-        email_log_id: logRow.id,
-      },
-      ...(input.subject ? { subject: input.subject } : {}),
-    });
+    const customArgs = { email_log_id: logRow.id };
+    const message: MailDataRequired = input.content
+      ? {
+          to,
+          from: fromEmail,
+          subject: input.subject?.trim() || "A message from ProFixIQ",
+          text: input.content.text,
+          html: input.content.html,
+          customArgs,
+        }
+      : {
+          to,
+          from: fromEmail,
+          templateId,
+          dynamicTemplateData: input.dynamicTemplateData ?? {},
+          customArgs,
+          ...(input.subject ? { subject: input.subject } : {}),
+        };
+    const [response] = await sgMail.send(message);
 
     const headerValue =
       response.headers["x-message-id"] ??

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -203,9 +203,21 @@ describe("premier fleet workspaces", () => {
     expect(detail).toContain('"/pre-trips/start"');
     expect(detail).toContain('"/requests/new"');
     expect(economics).toContain("`/assets/${encodeURIComponent(unit.unitId)}`");
-  expect(requests).toContain("const buildHref = productRoutes");
-  expect(requests).toContain('? "/requests/new"');
+    expect(requests).toContain("const buildHref = productRoutes");
+    expect(requests).toContain('? "/requests/new"');
     expect(requests).toContain('productRoutes ? "/history"');
     expect(pretrips).toContain('productRoutes ? "/assets"');
+  });
+
+  it("sends Fleet invitations with a subject and Fleet-specific content", () => {
+    const events = source("features/email/server/emailEvents.ts");
+    const sender = source("features/email/server/sendDynamicTemplateEmail.ts");
+
+    expect(events).toContain("Your ${fleetName} Fleet invitation");
+    expect(events).toContain("Activate your Fleet access");
+    expect(events).toContain('input.portalType === "fleet"');
+    expect(events).toContain("content: fleetContent");
+    expect(sender).toContain("content?: {");
+    expect(sender).toContain("const message: MailDataRequired = input.content");
   });
 });


### PR DESCRIPTION
## What changed

- send Fleet invitations with a clear subject instead of a blank subject
- replace the customer-portal body with a dedicated ProFixIQ Fleet activation email
- include Fleet name, normalized role, premium branded HTML, and a plain-text fallback
- preserve the existing customer portal template path
- add Fleet invitation regression coverage

## Validation

- TypeScript: passed
- changed-file ESLint: passed
- Fleet and portal invitation contract tests: 14 passed