### PR TITLE
Persist Fleet requested service dates

### DIFF
--- a/app/portal/fleet/request/build/page.tsx
+++ b/app/portal/fleet/request/build/page.tsx
@@ -429,7 +429,7 @@ export default function FleetRequestBuilderPage() {
             className={inputClass}
             type="date"
             value={requestedForDate}
-            onChange={(event) => setRequestedForDate(event.target.value)}
+            onInput={(event) => setRequestedForDate(event.currentTarget.value)}
           />
         </label>
       </section>

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -76,6 +76,7 @@ describe("premier fleet workspaces", () => {
 
   it("keeps the service request lifecycle tied to sent estimate facts", () => {
     const route = source("app/api/fleet/service-requests/route.ts");
+    const builder = source("app/portal/fleet/request/build/page.tsx");
     const workspace = source(
       "features/fleet/components/FleetServiceRequestsPage.tsx",
     );
@@ -88,6 +89,9 @@ describe("premier fleet workspaces", () => {
     expect(workspace).toContain("Review approval");
     expect(workspace).toContain("Submitted {dateLabel(item.createdAt)}");
     expect(workspace).toContain("dateLabel(item.requestedForDate)");
+    expect(builder).toContain(
+      "onInput={(event) => setRequestedForDate(event.currentTarget.value)}",
+    );
   });
 
   it("protects financial data and records decisions through canonical flows", () => {


### PR DESCRIPTION
## What changed

- update the controlled Fleet requested-date field from `onChange` to `onInput`
- preserve date entry across request-line edits for native date pickers, keyboard entry, and browser automation
- add a regression assertion to the Fleet workspace contracts

## Validation

- TypeScript: passed
- changed-file ESLint: passed
- exact Fleet CI contract suite: 27 passed