### PR TITLE
Display Fleet date-only values without timezone drift

### DIFF
--- a/features/fleet/components/FleetServiceRequestsPage.tsx
+++ b/features/fleet/components/FleetServiceRequestsPage.tsx
@@ -69,11 +69,20 @@ const TERMINAL_REQUEST_STATUSES = new Set([
 
 function dateLabel(value: string | null) {
   if (!value) return null;
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  const date = dateOnly
+    ? new Date(
+        Number(dateOnly[1]),
+        Number(dateOnly[2]) - 1,
+        Number(dateOnly[3]),
+      )
+    : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
   return new Intl.DateTimeFormat(undefined, {
     month: "short",
     day: "numeric",
     year: "numeric",
-  }).format(new Date(value));
+  }).format(date);
 }
 
 function statusTone(status: string) {

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -89,6 +89,9 @@ describe("premier fleet workspaces", () => {
     expect(workspace).toContain("Review approval");
     expect(workspace).toContain("Submitted {dateLabel(item.createdAt)}");
     expect(workspace).toContain("dateLabel(item.requestedForDate)");
+    expect(workspace).toContain(
+      "const dateOnly = /^(\\d{4})-(\\d{2})-(\\d{2})$/",
+    );
     expect(builder).toContain(
       "onInput={(event) => setRequestedForDate(event.currentTarget.value)}",
     );


### PR DESCRIPTION
## What changed

- parse `YYYY-MM-DD` requested/scheduled dates as local calendar dates
- keep timestamp values using normal instant-based formatting
- return no label for invalid values
- add Fleet contract coverage for the date-only parser

## Validation

- TypeScript: passed
- changed-file ESLint: passed
- exact Fleet CI contract suite: 27 passed