### PR TITLE
Keep Fleet driver actions in permitted routes

### DIFF
--- a/app/api/fleet/ai-summary/route.ts
+++ b/app/api/fleet/ai-summary/route.ts
@@ -52,7 +52,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     if (!scope?.shopId) {
-      return NextResponse.json({ error: "Fleet access required" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Fleet access required" },
+        { status: 403 },
+      );
     }
 
     const admin = createAdminSupabase();
@@ -61,13 +64,19 @@ export async function POST(request: Request) {
       .select("fleet_id,vehicle_id,active")
       .eq("shop_id", scope.shopId)
       .or("active.is.null,active.eq.true");
-    if (scope.fleetIds?.length) enrollmentQuery = enrollmentQuery.in("fleet_id", scope.fleetIds);
-    const { data: enrollmentData, error: enrollmentError } = await enrollmentQuery;
+    if (scope.fleetIds?.length)
+      enrollmentQuery = enrollmentQuery.in("fleet_id", scope.fleetIds);
+    const { data: enrollmentData, error: enrollmentError } =
+      await enrollmentQuery;
     if (enrollmentError) throw new Error(enrollmentError.message);
 
     const enrollments = rows(enrollmentData);
-    const fleetIds = Array.from(new Set(enrollments.map((row) => String(row.fleet_id))));
-    const vehicleIds = Array.from(new Set(enrollments.map((row) => String(row.vehicle_id))));
+    const fleetIds = Array.from(
+      new Set(enrollments.map((row) => String(row.fleet_id))),
+    );
+    const vehicleIds = Array.from(
+      new Set(enrollments.map((row) => String(row.vehicle_id))),
+    );
     const routePrefix =
       body.routePrefix === "/fleet" ? "/fleet" : "/portal/fleet";
 
@@ -80,7 +89,8 @@ export async function POST(request: Request) {
             id: "units",
             priority: "info",
             label: "Add your first fleet unit",
-            detail: "Units become the home for PM, requests, history, and invoices.",
+            detail:
+              "Units become the home for PM, requests, history, and invoices.",
             href: `${routePrefix}/units`,
           },
         ],
@@ -134,7 +144,9 @@ export async function POST(request: Request) {
     const { data: quoteData, error: quoteError } = workOrderIds.length
       ? await admin
           .from("work_order_quote_lines")
-          .select("id,work_order_id,status,sent_to_customer_at,approved_at,declined_at")
+          .select(
+            "id,work_order_id,status,sent_to_customer_at,approved_at,declined_at",
+          )
           .eq("shop_id", scope.shopId)
           .in("work_order_id", workOrderIds)
       : { data: [] as unknown[], error: null };
@@ -172,7 +184,8 @@ export async function POST(request: Request) {
     const points = [
       {
         id: "requests",
-        priority: safety > 0 ? "critical" : requests.length > 0 ? "attention" : "good",
+        priority:
+          safety > 0 ? "critical" : requests.length > 0 ? "attention" : "good",
         label:
           safety > 0
             ? `${safety} safety or compliance request${safety === 1 ? "" : "s"} need attention`
@@ -211,12 +224,14 @@ export async function POST(request: Request) {
           defects > 0
             ? `${defects} recent pre-trip${defects === 1 ? "" : "s"} reported defects`
             : `${vehicleIds.length} active unit${vehicleIds.length === 1 ? "" : "s"} in view`,
-        detail: "Open Units for live readings, history, pre-trips, and evidence.",
+        detail:
+          "Open Units for live readings, history, pre-trips, and evidence.",
         href: `${routePrefix}/units`,
       },
     ];
 
-    let headline = "Fleet activity is summarized below from live operational data.";
+    let headline =
+      "Fleet activity is summarized below from live operational data.";
     let aiGenerated = false;
     const feature = "fleet_operations_summary" as const;
     const endpoint = "/api/fleet/ai-summary";
@@ -282,7 +297,8 @@ export async function POST(request: Request) {
           errorCode: null,
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : "AI summary failed";
+        const message =
+          error instanceof Error ? error.message : "AI summary failed";
         recordAITelemetry({
           feature,
           endpoint,
@@ -312,17 +328,27 @@ export async function POST(request: Request) {
       }
     }
 
+    const visiblePoints =
+      actor.actorType === "fleet_driver"
+        ? points.filter((point) => ["requests", "units"].includes(point.id))
+        : points;
+
     return NextResponse.json({
       headline,
       aiGenerated,
-      points,
+      points: visiblePoints,
       snapshot,
       lastUpdated: new Date().toISOString(),
     });
   } catch (error) {
     console.error("[fleet/ai-summary] error", error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Failed to build fleet summary" },
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to build fleet summary",
+      },
       { status: 500 },
     );
   }

--- a/features/fleet/components/FleetControlTower.tsx
+++ b/features/fleet/components/FleetControlTower.tsx
@@ -266,6 +266,7 @@ export default function FleetControlTower({
             issues={issues}
             assignments={assignments}
             uiContext={uiContext}
+            fleetId={fleetId}
             routePrefix={routePrefix}
           />
         </div>

--- a/features/fleet/components/FleetIssueTables.tsx
+++ b/features/fleet/components/FleetIssueTables.tsx
@@ -11,6 +11,7 @@ type Props = {
   issues: FleetIssue[];
   assignments: DispatchAssignment[];
   uiContext: FleetUiContext;
+  fleetId?: string | null;
   routePrefix?: "/fleet" | "/portal/fleet";
 };
 
@@ -19,6 +20,7 @@ export default function FleetIssueTables({
   issues,
   assignments,
   uiContext,
+  fleetId = null,
   routePrefix = "/fleet",
 }: Props) {
   const pathname = usePathname() ?? "";
@@ -34,6 +36,15 @@ export default function FleetIssueTables({
     productHostRoute
       ? `/assets/${encodeURIComponent(unitId)}`
       : `${routePrefix}/units/${encodeURIComponent(unitId)}`;
+  const pretripHref = (unitId: string) => {
+    const encodedUnitId = encodeURIComponent(unitId);
+    const base = productHostRoute
+      ? `/pre-trips/start/${encodedUnitId}`
+      : routePrefix === "/portal/fleet"
+        ? `/portal/fleet/pretrip/${encodedUnitId}`
+        : `/mobile/fleet/pretrip/${encodedUnitId}`;
+    return fleetId ? `${base}?fleetId=${encodeURIComponent(fleetId)}` : base;
+  };
 
   return (
     <div className="grid gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
@@ -166,7 +177,7 @@ export default function FleetIssueTables({
               <div className="flex flex-wrap gap-2 pt-1">
                 {uiContext.capabilities.canSubmitPretrip && (
                   <Link
-                    href={`/mobile/fleet/pretrip/${a.unitId}`}
+                    href={pretripHref(a.unitId)}
                     className="rounded-full bg-[color:var(--accent-copper)] px-3 py-1 text-[10px] font-semibold text-[color:var(--theme-text-on-accent)] shadow-[0_0_16px_rgba(193,102,59,0.7)] hover:opacity-95"
                   >
                     Send pre-trip link

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -144,6 +144,8 @@ describe("premier fleet workspaces", () => {
     expect(route).not.toContain('from "openai"');
     expect(route).not.toContain("OPENAI_FLEET_SUMMARY_MODEL");
     expect(policy).toContain("fleet_operations_summary");
+    expect(route).toContain('actor.actorType === "fleet_driver"');
+    expect(route).toContain('["requests", "units"].includes(point.id)');
     expect(summary).toContain("live records one click away");
     expect(summary).toContain("point.href");
   });
@@ -207,6 +209,8 @@ describe("premier fleet workspaces", () => {
 
     expect(issues).toContain("requestHref = productHostRoute");
     expect(issues).toContain('"/requests/new"');
+    expect(issues).toContain("`/pre-trips/start/${encodedUnitId}`");
+    expect(issues).toContain("href={pretripHref(a.unitId)}");
     expect(detail).toContain('"/pre-trips/start"');
     expect(detail).toContain('"/requests/new"');
     expect(economics).toContain("`/assets/${encodeURIComponent(unit.unitId)}`");


### PR DESCRIPTION
## What changed

- route the driver dispatch pre-trip action to the canonical product-host pre-trip form
- retain Fleet ID in the action URL
- keep portal and internal route fallbacks intact
- filter AI Fleet brief links for drivers to permitted Requests and Assets pages
- add regression coverage for both driver-only affordances

## Validation

- TypeScript: passed
- changed-file ESLint: passed
- exact Fleet CI contract suite: 27 passed