### PR TITLE
Authorize Fleet driver pre-trip form reads

### DIFF
--- a/app/portal/fleet/pretrip/[unitId]/page.tsx
+++ b/app/portal/fleet/pretrip/[unitId]/page.tsx
@@ -2,14 +2,20 @@ import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import PretripForm from "@/features/fleet/components/PretripForm";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
-import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRSC,
+} from "@/features/shared/lib/supabase/server";
 
 type Props = {
   params: Promise<{ unitId: string }>;
   searchParams: Promise<{ fleetId?: string }>;
 };
 
-export default async function FleetPortalPretripPage({ params, searchParams }: Props) {
+export default async function FleetPortalPretripPage({
+  params,
+  searchParams,
+}: Props) {
   const [{ unitId }, query] = await Promise.all([params, searchParams]);
   const supabase = createServerSupabaseRSC();
   const actor = await resolveFleetActorContext(supabase, {
@@ -24,24 +30,32 @@ export default async function FleetPortalPretripPage({ params, searchParams }: P
     notFound();
   }
 
-  const [{ data: enrollment }, { data: profile }, { data: assignment }] = await Promise.all([
-    supabase
-      .from("fleet_vehicles")
-      .select("vehicle_id,nickname,vehicles!inner(unit_number,license_plate,vin)")
-      .eq("fleet_id", fleetId)
-      .eq("vehicle_id", unitId)
-      .or("active.is.null,active.eq.true")
-      .maybeSingle(),
-    supabase.from("profiles").select("full_name,email").eq("id", actor.userId).maybeSingle(),
-    supabase
-      .from("fleet_dispatch_assignments")
-      .select("id")
-      .eq("fleet_id", fleetId)
-      .eq("vehicle_id", unitId)
-      .eq("driver_profile_id", actor.userId)
-      .eq("active", true)
-      .maybeSingle(),
-  ]);
+  const admin = createAdminSupabase();
+  const [{ data: enrollment }, { data: profile }, { data: assignment }] =
+    await Promise.all([
+      admin
+        .from("fleet_vehicles")
+        .select(
+          "vehicle_id,nickname,vehicles!inner(unit_number,license_plate,vin)",
+        )
+        .eq("fleet_id", fleetId)
+        .eq("vehicle_id", unitId)
+        .or("active.is.null,active.eq.true")
+        .maybeSingle(),
+      admin
+        .from("profiles")
+        .select("full_name,email")
+        .eq("id", actor.userId)
+        .maybeSingle(),
+      admin
+        .from("fleet_dispatch_assignments")
+        .select("id")
+        .eq("fleet_id", fleetId)
+        .eq("vehicle_id", unitId)
+        .eq("driver_profile_id", actor.userId)
+        .eq("active", true)
+        .maybeSingle(),
+    ]);
   if (!enrollment || (!actor.isInternal && !assignment)) notFound();
 
   const vehicle = enrollment.vehicles as unknown as {
@@ -49,20 +63,31 @@ export default async function FleetPortalPretripPage({ params, searchParams }: P
     license_plate: string | null;
     vin: string | null;
   };
-  const label = enrollment.nickname || vehicle.unit_number || vehicle.license_plate || vehicle.vin || "Unit";
+  const label =
+    enrollment.nickname ||
+    vehicle.unit_number ||
+    vehicle.license_plate ||
+    vehicle.vin ||
+    "Unit";
   const driverHint = profile?.full_name || profile?.email || null;
 
   return (
     <main className="mx-auto w-full max-w-3xl space-y-4 px-4 py-6 text-[color:var(--theme-text-primary)]">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-300">Fleet driver</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-300">
+            Fleet driver
+          </p>
           <h1 className="mt-1 text-2xl font-semibold">{label}</h1>
           <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-            Today’s inspection, meter readings, and defects stay attached to this unit.
+            Today’s inspection, meter readings, and defects stay attached to
+            this unit.
           </p>
         </div>
-        <Link href="/portal/fleet" className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold">
+        <Link
+          href="/portal/fleet"
+          className="rounded-xl border border-[color:var(--theme-border-soft)] px-3 py-2 text-xs font-semibold"
+        >
           Fleet home
         </Link>
       </div>

--- a/tests/fleet-pretrip-defect-compliance.test.ts
+++ b/tests/fleet-pretrip-defect-compliance.test.ts
@@ -63,39 +63,62 @@ describe("fleet pre-trip, defects, and compliance", () => {
   it("keeps drivers out of manager conversion and puts pre-trip one click from portal home", () => {
     const form = read("features/fleet/components/PretripForm.tsx");
     const tower = read("features/fleet/components/FleetControlTower.tsx");
+    const page = read("app/portal/fleet/pretrip/[unitId]/page.tsx");
     expect(form).not.toContain("convert-to-service-request");
     expect(form).toContain("Fleet managers—not drivers");
     expect(tower).toContain("Start today’s pre-trip");
     expect(tower).toContain("/portal/fleet/pretrip/");
+    expect(page).toContain("const admin = createAdminSupabase()");
+    expect(page).toContain('.eq("fleet_id", fleetId)');
+    expect(page).toContain('.eq("driver_profile_id", actor.userId)');
+    expect(page).toContain('.eq("active", true)');
   });
 
   it("uses one durable defect ledger and manager lifecycle RPC", () => {
     const migration = read(
       "supabase/migrations/20260803023000_fleet_pretrip_defect_compliance.sql",
     );
-    expect(migration).toContain("create table if not exists public.fleet_unit_defects");
-    expect(migration).toContain("create table if not exists public.fleet_pretrip_compliance");
-    expect(migration).toContain("create or replace function public.manage_fleet_unit_defects");
-    expect(migration).toContain("create or replace function public.evaluate_fleet_pretrip_compliance");
+    expect(migration).toContain(
+      "create table if not exists public.fleet_unit_defects",
+    );
+    expect(migration).toContain(
+      "create table if not exists public.fleet_pretrip_compliance",
+    );
+    expect(migration).toContain(
+      "create or replace function public.manage_fleet_unit_defects",
+    );
+    expect(migration).toContain(
+      "create or replace function public.evaluate_fleet_pretrip_compliance",
+    );
     expect(migration).toContain("perform public.evaluate_fleet_pm_due_events");
-    expect(migration).toContain("grant select on table public.fleet_unit_defects to authenticated");
-    expect(migration).toContain("revoke execute on function public.evaluate_fleet_pretrip_compliance");
+    expect(migration).toContain(
+      "grant select on table public.fleet_unit_defects to authenticated",
+    );
+    expect(migration).toContain(
+      "revoke execute on function public.evaluate_fleet_pretrip_compliance",
+    );
   });
 
   it("schedules missed-pretrip evaluation in Supabase and keeps the retired sign-in URL safe", () => {
     const config = JSON.parse(read("vercel.json")) as {
       crons: Array<{ path: string; schedule: string }>;
     };
-    expect(config.crons).not.toContainEqual(expect.objectContaining({
-      path: "/api/internal/fleet/pretrip-compliance",
-    }));
+    expect(config.crons).not.toContainEqual(
+      expect.objectContaining({
+        path: "/api/internal/fleet/pretrip-compliance",
+      }),
+    );
     const scheduler = read(
       "supabase/migrations/20260803041000_schedule_fleet_pretrip_compliance.sql",
     );
     expect(scheduler).toContain("create extension if not exists pg_cron");
     expect(scheduler).toContain("'fleet-pretrip-compliance-hourly'");
-    expect(scheduler).toContain("public.evaluate_fleet_pretrip_compliance(clock_timestamp())");
-    const cronRoute = read("app/api/internal/fleet/pretrip-compliance/route.ts");
+    expect(scheduler).toContain(
+      "public.evaluate_fleet_pretrip_compliance(clock_timestamp())",
+    );
+    const cronRoute = read(
+      "app/api/internal/fleet/pretrip-compliance/route.ts",
+    );
     expect(cronRoute).toContain("process.env.CRON_SECRET");
     expect(cronRoute).toContain("`Bearer ${cronSecret}`");
     expect(cronRoute).toContain('envSecretName: "INTERNAL_CRON_SECRET"');
@@ -105,9 +128,7 @@ describe("fleet pre-trip, defects, and compliance", () => {
   });
 
   it("keeps unit enrollment and assignment behind the atomic server RPC", () => {
-    const page = read(
-      "features/fleet/components/FleetUnitEnrollmentPage.tsx",
-    );
+    const page = read("features/fleet/components/FleetUnitEnrollmentPage.tsx");
     const route = read("app/api/fleet/enrollment/route.ts");
     expect(page).not.toContain(".from(");
     expect(page).toContain("Enroll units & assign drivers");


### PR DESCRIPTION
## What changed

- keep authenticated actor and Fleet capability checks on the server-rendered pre-trip page
- perform enrollment/profile/assignment reads with the server admin client after authorization
- retain explicit Fleet, unit, driver, active, and assignment constraints
- add regression coverage for the authorization boundary

## Root cause

A valid assigned Fleet Driver reached the canonical pre-trip route, but RLS blocked the page's post-authorization enrollment read and caused `notFound()`.

## Validation

- TypeScript: passed
- changed-file ESLint: passed
- exact Fleet CI contract suite: 27 passed