### PR TITLE
Preserve Fleet pre-trip inspection calendar dates

### DIFF
--- a/features/fleet/components/PretripReportsPage.tsx
+++ b/features/fleet/components/PretripReportsPage.tsx
@@ -25,6 +25,20 @@ type PretripReport = {
   status: string | null;
 };
 
+function dateLabel(value: string | null) {
+  if (!value) return "—";
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  const date = dateOnly
+    ? new Date(
+        Number(dateOnly[1]),
+        Number(dateOnly[2]) - 1,
+        Number(dateOnly[3]),
+      )
+    : new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleDateString();
+}
+
 export default function PretripReportsPage({
   uiContext,
   routePrefix = "/fleet",
@@ -268,9 +282,7 @@ export default function PretripReportsPage({
                   {filteredReports.map((r) => (
                     <tr key={r.id} className="align-middle">
                       <td className="px-3 py-1.5 text-[11px] text-[color:var(--theme-text-secondary)]">
-                        {r.inspection_date
-                          ? new Date(r.inspection_date).toLocaleDateString()
-                          : new Date(r.created_at).toLocaleDateString()}
+                        {dateLabel(r.inspection_date ?? r.created_at)}
                       </td>
                       <td className="px-3 py-1.5 text-[11px] text-[color:var(--theme-text-primary)]">
                         {r.unit_label ?? "—"}

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -222,11 +222,18 @@ describe("premier fleet workspaces", () => {
 
   it("keeps driver pre-trip history visible without widening its Fleet scope", () => {
     const pretripApi = source("app/api/fleet/pretrip/route.ts");
+    const pretripPage = source(
+      "features/fleet/components/PretripReportsPage.tsx",
+    );
 
     expect(pretripApi).toContain("import { supabaseAdmin }");
     expect(pretripApi).toContain('actor.actorType === "fleet_driver"');
     expect(pretripApi).toContain('.eq("driver_profile_id", actor.userId)');
     expect(pretripApi).toContain('query.in("fleet_id", scope.fleetIds)');
+    expect(pretripPage).toContain("/^(\\d{4})-(\\d{2})-(\\d{2})$/");
+    expect(pretripPage).toContain(
+      "dateLabel(r.inspection_date ?? r.created_at)",
+    );
   });
 
   it("sends Fleet invitations with a subject and Fleet-specific content", () => {


### PR DESCRIPTION
## Root cause
`inspection_date` is a Postgres date-only value. Constructing `new Date('YYYY-MM-DD')` interprets it at UTC midnight, so the Fleet UI displayed the previous calendar day in western time zones.

## What changed
- Parse date-only values into a local calendar date before formatting.
- Keep timestamp fallback behavior for older records.
- Extend the Fleet workspace contract test.

## Validation
- TypeScript: pass
- ESLint (changed files): pass
- Fleet contracts: 28/28 pass
- Production QA record confirmed the bug before the fix.