### PR TITLE
Use Fleet-local service dates for pre-trips

### DIFF
--- a/app/api/fleet/pretrip/route.ts
+++ b/app/api/fleet/pretrip/route.ts
@@ -40,6 +40,26 @@ function numericInput(value: string | null, label: string) {
   return parsed;
 }
 
+function serviceDateInTimeZone(timeZone: string | null, at = new Date()) {
+  const partsFor = (zone: string) =>
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: zone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(at);
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = partsFor(timeZone?.trim() || "America/Los_Angeles");
+  } catch {
+    parts = partsFor("America/Los_Angeles");
+  }
+  const value = Object.fromEntries(
+    parts.map((part) => [part.type, part.value]),
+  );
+  return `${value.year}-${value.month}-${value.day}`;
+}
+
 export async function POST(req: NextRequest) {
   const supabase = createServerSupabaseRoute();
   const raw = (await req.json().catch(() => ({}))) as Partial<
@@ -140,6 +160,18 @@ export async function POST(req: NextRequest) {
           { status: 400 },
         );
       }
+      const { data: shop, error: shopError } = await supabaseAdmin
+        .from("shops")
+        .select("timezone")
+        .eq("id", scope.shopId)
+        .maybeSingle();
+      if (shopError || !shop) {
+        return NextResponse.json(
+          { error: "Fleet shop timezone is unavailable." },
+          { status: 500 },
+        );
+      }
+      const inspectionDate = serviceDateInTimeZone(shop.timezone);
       const odometer = numericInput(raw.odometer ?? null, "Odometer");
       const engineHours = numericInput(raw.engineHours ?? null, "Engine hours");
       const correctionReason = raw.readingCorrectionReason?.trim() || null;
@@ -159,6 +191,7 @@ export async function POST(req: NextRequest) {
           vehicle_id: raw.unitId,
           driver_profile_id: actor.userId,
           driver_name: driverName,
+          inspection_date: inspectionDate,
           odometer_km: odometer,
           checklist: {
             defects,

--- a/supabase/migrations/20260806063000_fleet_pretrip_assignment_start_boundary.sql
+++ b/supabase/migrations/20260806063000_fleet_pretrip_assignment_start_boundary.sql
@@ -1,26 +1,34 @@
 -- Do not count a pre-trip as missed when the assignment began after that
 -- day's local due time. The first required service date is the next day.
 
-update public.assistant_notifications n
-set status = 'resolved',
-    resolved_at = coalesce(n.resolved_at, now()),
-    updated_at = now()
-where n.status = 'active'
-  and exists (
-    select 1
-    from public.fleet_pretrip_compliance c
-    join public.fleet_dispatch_assignments a on a.id = c.assignment_id
-    join public.shops s on s.id = a.shop_id
-    where c.notification_fingerprint = n.fingerprint
-      and c.pretrip_report_id is null
-      and c.status in ('due', 'missed')
-      and c.service_date = (
-        a.assigned_at at time zone coalesce(nullif(s.timezone, ''), 'America/Los_Angeles')
-      )::date
-      and (
-        a.assigned_at at time zone coalesce(nullif(s.timezone, ''), 'America/Los_Angeles')
-      )::time > a.pretrip_due_local_time
-  );
+do $cleanup$
+begin
+  if to_regclass('public.assistant_notifications') is not null then
+    execute $sql$
+      update public.assistant_notifications n
+      set status = 'resolved',
+          resolved_at = coalesce(n.resolved_at, now()),
+          updated_at = now()
+      where n.status = 'active'
+        and exists (
+          select 1
+          from public.fleet_pretrip_compliance c
+          join public.fleet_dispatch_assignments a on a.id = c.assignment_id
+          join public.shops s on s.id = a.shop_id
+          where c.notification_fingerprint = n.fingerprint
+            and c.pretrip_report_id is null
+            and c.status in ('due', 'missed')
+            and c.service_date = (
+              a.assigned_at at time zone coalesce(nullif(s.timezone, ''), 'America/Los_Angeles')
+            )::date
+            and (
+              a.assigned_at at time zone coalesce(nullif(s.timezone, ''), 'America/Los_Angeles')
+            )::time > a.pretrip_due_local_time
+        )
+    $sql$;
+  end if;
+end;
+$cleanup$;
 
 delete from public.fleet_pretrip_compliance c
 using public.fleet_dispatch_assignments a, public.shops s

--- a/supabase/migrations/20260806063000_fleet_pretrip_assignment_start_boundary.sql
+++ b/supabase/migrations/20260806063000_fleet_pretrip_assignment_start_boundary.sql
@@ -1,0 +1,150 @@
+-- Do not count a pre-trip as missed when the assignment began after that
+-- day's local due time. The first required service date is the next day.
+
+update public.assistant_notifications n
+set status = 'resolved',
+    resolved_at = coalesce(n.resolved_at, now()),
+    updated_at = now()
+where n.status = 'active'
+  and exists (
+    select 1
+    from public.fleet_pretrip_compliance c
+    join public.fleet_dispatch_assignments a on a.id = c.assignment_id
+    join public.shops s on s.id = a.shop_id
+    where c.notification_fingerprint = n.fingerprint
+      and c.pretrip_report_id is null
+      and c.status in ('due', 'missed')
+      and c.service_date = (
+        a.assigned_at at time zone coalesce(nullif(s.timezone, ''), 'America/Los_Angeles')
+      )::date
+      and (
+        a.assigned_at at time zone coalesce(nullif(s.timezone, ''), 'America/Los_Angeles')
+      )::time > a.pretrip_due_local_time
+  );
+
+delete from public.fleet_pretrip_compliance c
+using public.fleet_dispatch_assignments a, public.shops s
+where a.id = c.assignment_id
+  and s.id = a.shop_id
+  and c.pretrip_report_id is null
+  and c.status in ('due', 'missed')
+  and c.service_date = (
+    a.assigned_at at time zone coalesce(nullif(s.timezone, ''), 'America/Los_Angeles')
+  )::date
+  and (
+    a.assigned_at at time zone coalesce(nullif(s.timezone, ''), 'America/Los_Angeles')
+  )::time > a.pretrip_due_local_time;
+
+create or replace function public.evaluate_fleet_pretrip_compliance(p_at timestamptz default now())
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_assignment record;
+  v_service_date date;
+  v_due_at timestamptz;
+  v_timezone text;
+  v_report_id uuid;
+  v_status text;
+  v_fingerprint text;
+  v_checked integer := 0;
+  v_missed integer := 0;
+  v_completed integer := 0;
+begin
+  for v_assignment in
+    select a.*, coalesce(nullif(s.timezone,''),'America/Los_Angeles') as shop_timezone
+    from public.fleet_dispatch_assignments a
+    join public.shops s on s.id=a.shop_id
+    where a.active and a.pretrip_required
+  loop
+    v_timezone := v_assignment.shop_timezone;
+    v_status := null;
+    for v_service_date in
+      select d::date from generate_series(
+        greatest(
+          (v_assignment.assigned_at at time zone v_timezone)::date
+            + case
+                when (v_assignment.assigned_at at time zone v_timezone)::time
+                  > v_assignment.pretrip_due_local_time then 1
+                else 0
+              end,
+          (p_at at time zone v_timezone)::date - 1
+        ),
+        (p_at at time zone v_timezone)::date,
+        interval '1 day'
+      ) d
+    loop
+      v_checked := v_checked+1;
+      v_due_at := (v_service_date + v_assignment.pretrip_due_local_time) at time zone v_timezone;
+
+      select r.id into v_report_id
+      from public.fleet_pretrip_reports r
+      where r.fleet_id=v_assignment.fleet_id
+        and r.vehicle_id=v_assignment.vehicle_id
+        and r.driver_profile_id=v_assignment.driver_profile_id
+        and r.inspection_date=v_service_date
+      order by r.created_at desc limit 1;
+
+      v_status := case when v_report_id is not null then 'completed'
+                       when p_at>v_due_at then 'missed' else 'due' end;
+      if v_status='completed' then v_completed:=v_completed+1; end if;
+      if v_status='missed' then v_missed:=v_missed+1; end if;
+
+      insert into public.fleet_pretrip_compliance (
+        shop_id,fleet_id,assignment_id,vehicle_id,driver_profile_id,
+        service_date,due_at,status,pretrip_report_id,completed_at,
+        notification_fingerprint,updated_at
+      )
+      values (
+        v_assignment.shop_id,v_assignment.fleet_id,v_assignment.id,
+        v_assignment.vehicle_id,v_assignment.driver_profile_id,v_service_date,
+        v_due_at,v_status,v_report_id,case when v_report_id is not null then now() end,
+        'fleet-pretrip-missed:'||v_assignment.id::text||':'||v_service_date::text,now()
+      )
+      on conflict (assignment_id,service_date) do update set
+        status=case when public.fleet_pretrip_compliance.status in ('completed','excused')
+                    then public.fleet_pretrip_compliance.status else excluded.status end,
+        pretrip_report_id=coalesce(public.fleet_pretrip_compliance.pretrip_report_id,excluded.pretrip_report_id),
+        completed_at=coalesce(public.fleet_pretrip_compliance.completed_at,excluded.completed_at),
+        updated_at=now();
+
+      if v_status='missed' then
+        v_fingerprint := 'fleet-pretrip-missed:'||v_assignment.id::text||':'||v_service_date::text;
+        insert into public.assistant_notifications (
+          shop_id,role,source,fingerprint,code,level,title,message,href,
+          entity_type,entity_id,status,metadata,first_seen_at,last_seen_at,created_at,updated_at
+        ) values (
+          v_assignment.shop_id,'manager','fleet',v_fingerprint,'fleet_pretrip_missed',
+          'critical','Daily pre-trip missed',
+          coalesce(v_assignment.driver_name,'Driver')||' missed the '||v_service_date::text||
+            ' pre-trip for '||coalesce(v_assignment.unit_label,'Unit')||'.',
+          '/fleet?focus=defects','fleet_dispatch_assignment',v_assignment.id,'active',
+          jsonb_build_object('fleet_id',v_assignment.fleet_id,'vehicle_id',v_assignment.vehicle_id,'driver_profile_id',v_assignment.driver_profile_id,'service_date',v_service_date),
+          now(),now(),now(),now()
+        )
+        on conflict (shop_id,fingerprint) do update
+        set status='active',resolved_at=null,last_seen_at=now(),updated_at=now(),message=excluded.message,metadata=excluded.metadata;
+      end if;
+    end loop;
+
+    update public.fleet_dispatch_assignments
+    set state=case
+          when v_status is null then state
+          when v_status='completed' then 'en_route'
+          else 'pretrip_due'
+        end,
+        next_pretrip_due=((((p_at at time zone v_timezone)::date+1)+pretrip_due_local_time) at time zone v_timezone),
+        updated_at=now()
+    where id=v_assignment.id;
+  end loop;
+
+  return jsonb_build_object('ok',true,'checked',v_checked,'missed',v_missed,'completed',v_completed,'evaluatedAt',p_at);
+end;
+$function$;
+
+revoke execute on function public.evaluate_fleet_pretrip_compliance(timestamptz)
+  from public, anon, authenticated;
+grant execute on function public.evaluate_fleet_pretrip_compliance(timestamptz)
+  to service_role;

--- a/tests/fleet-pretrip-defect-compliance.test.ts
+++ b/tests/fleet-pretrip-defect-compliance.test.ts
@@ -101,6 +101,16 @@ describe("fleet pre-trip, defects, and compliance", () => {
     expect(migration).toContain(
       "revoke execute on function public.evaluate_fleet_pretrip_compliance",
     );
+    const assignmentBoundary = read(
+      "supabase/migrations/20260806063000_fleet_pretrip_assignment_start_boundary.sql",
+    );
+    expect(assignmentBoundary).toContain(
+      "> v_assignment.pretrip_due_local_time then 1",
+    );
+    expect(assignmentBoundary).toContain("when v_status is null then state");
+    expect(assignmentBoundary).toContain(
+      "delete from public.fleet_pretrip_compliance",
+    );
   });
 
   it("schedules missed-pretrip evaluation in Supabase and keeps the retired sign-in URL safe", () => {

--- a/tests/fleet-pretrip-defect-compliance.test.ts
+++ b/tests/fleet-pretrip-defect-compliance.test.ts
@@ -111,6 +111,9 @@ describe("fleet pre-trip, defects, and compliance", () => {
     expect(assignmentBoundary).toContain(
       "delete from public.fleet_pretrip_compliance",
     );
+    expect(assignmentBoundary).toContain(
+      "to_regclass('public.assistant_notifications')",
+    );
   });
 
   it("schedules missed-pretrip evaluation in Supabase and keeps the retired sign-in URL safe", () => {

--- a/tests/fleet-pretrip-defect-compliance.test.ts
+++ b/tests/fleet-pretrip-defect-compliance.test.ts
@@ -64,6 +64,7 @@ describe("fleet pre-trip, defects, and compliance", () => {
     const form = read("features/fleet/components/PretripForm.tsx");
     const tower = read("features/fleet/components/FleetControlTower.tsx");
     const page = read("app/portal/fleet/pretrip/[unitId]/page.tsx");
+    const route = read("app/api/fleet/pretrip/route.ts");
     expect(form).not.toContain("convert-to-service-request");
     expect(form).toContain("Fleet managers—not drivers");
     expect(tower).toContain("Start today’s pre-trip");
@@ -72,6 +73,9 @@ describe("fleet pre-trip, defects, and compliance", () => {
     expect(page).toContain('.eq("fleet_id", fleetId)');
     expect(page).toContain('.eq("driver_profile_id", actor.userId)');
     expect(page).toContain('.eq("active", true)');
+    expect(route).toContain("serviceDateInTimeZone(shop.timezone)");
+    expect(route).toContain("inspection_date: inspectionDate");
+    expect(route).toContain('.select("timezone")');
   });
 
   it("uses one durable defect ledger and manager lifecycle RPC", () => {


### PR DESCRIPTION
## Root causes
1. `inspection_date` relied on PostgreSQL `current_date` (UTC), which can differ from the Fleet shop's calendar date near North American evening boundaries.
2. Compliance evaluated the assignment's first local date even when the assignment began after that day's pre-trip due time. A driver assigned at 11:37 PM was therefore marked as having missed a 7:00 AM deadline that predated the assignment.

## What changed
- Resolve the authorized shop timezone on the server and stamp the Fleet-local service date.
- Keep the date server-controlled rather than trusting client input.
- Start compliance on the next service day when assignment begins after the due time.
- Preserve assignment state when no service date is eligible yet.
- Reconcile only empty due/missed rows created by the old boundary and resolve their matching notification.
- Extend the Fleet compliance contract.

## Validation
- TypeScript: pass
- ESLint (changed files): pass
- Fleet contracts: 28/28 pass
- Live QA reproduced the after-due assignment boundary before this fix.