### PR TITLE
Harden Fleet tenant boundaries and reporting accuracy

### DIFF
--- a/app/api/fleet/ai-summary/route.ts
+++ b/app/api/fleet/ai-summary/route.ts
@@ -70,7 +70,29 @@ export async function POST(request: Request) {
       await enrollmentQuery;
     if (enrollmentError) throw new Error(enrollmentError.message);
 
-    const enrollments = rows(enrollmentData);
+    let enrollments = rows(enrollmentData);
+    if (actor.actorType === "fleet_driver") {
+      const authorizedFleetIds = Array.from(
+        new Set(enrollments.map((row) => String(row.fleet_id))),
+      );
+      const { data: assignmentData, error: assignmentError } =
+        authorizedFleetIds.length
+          ? await admin
+              .from("fleet_dispatch_assignments")
+              .select("fleet_id,vehicle_id")
+              .eq("shop_id", scope.shopId)
+              .in("fleet_id", authorizedFleetIds)
+              .eq("driver_profile_id", actor.userId)
+              .eq("active", true)
+          : { data: [] as unknown[], error: null };
+      if (assignmentError) throw new Error(assignmentError.message);
+      const assignedVehicles = new Set(
+        rows(assignmentData).map((row) => String(row.vehicle_id)),
+      );
+      enrollments = enrollments.filter((row) =>
+        assignedVehicles.has(String(row.vehicle_id)),
+      );
+    }
     const fleetIds = Array.from(
       new Set(enrollments.map((row) => String(row.fleet_id))),
     );
@@ -98,35 +120,48 @@ export async function POST(request: Request) {
       });
     }
 
+    const isDriver = actor.actorType === "fleet_driver";
+    const requestQuery = admin
+      .from("fleet_service_requests")
+      .select("id,severity,status")
+      .eq("shop_id", scope.shopId)
+      .in("fleet_id", fleetIds)
+      .in("vehicle_id", vehicleIds)
+      .in("status", ["open", "scheduled"]);
+    let pretripQuery = admin
+      .from("fleet_pretrip_reports")
+      .select("id,has_defects,inspection_date")
+      .eq("shop_id", scope.shopId)
+      .in("fleet_id", fleetIds)
+      .in("vehicle_id", vehicleIds)
+      .gte(
+        "inspection_date",
+        new Date(Date.now() - 7 * 86_400_000).toISOString().slice(0, 10),
+      );
+    if (isDriver) {
+      pretripQuery = pretripQuery.eq("driver_profile_id", actor.userId);
+    }
+
     const [requestResult, pmResult, pretripResult, workOrderResult] =
       await Promise.all([
-        admin
-          .from("fleet_service_requests")
-          .select("id,severity,status")
-          .eq("shop_id", scope.shopId)
-          .in("fleet_id", fleetIds)
-          .in("status", ["open", "scheduled"]),
-        admin
-          .from("fleet_pm_due_events")
-          .select("id,status")
-          .eq("shop_id", scope.shopId)
-          .in("fleet_id", fleetIds)
-          .in("status", ["pending", "deferred", "converted"]),
-        admin
-          .from("fleet_pretrip_reports")
-          .select("id,has_defects,inspection_date")
-          .eq("shop_id", scope.shopId)
-          .in("fleet_id", fleetIds)
-          .gte(
-            "inspection_date",
-            new Date(Date.now() - 7 * 86_400_000).toISOString().slice(0, 10),
-          ),
-        admin
-          .from("work_orders")
-          .select("id,approval_state,outstanding_balance,payment_status")
-          .eq("shop_id", scope.shopId)
-          .in("vehicle_id", vehicleIds)
-          .limit(500),
+        requestQuery,
+        isDriver
+          ? Promise.resolve({ data: [] as unknown[], error: null })
+          : admin
+              .from("fleet_pm_due_events")
+              .select("id,status")
+              .eq("shop_id", scope.shopId)
+              .in("fleet_id", fleetIds)
+              .in("status", ["pending", "deferred", "converted"]),
+        pretripQuery,
+        isDriver
+          ? Promise.resolve({ data: [] as unknown[], error: null })
+          : admin
+              .from("work_orders")
+              .select("id,approval_state,outstanding_balance,payment_status")
+              .eq("shop_id", scope.shopId)
+              .in("vehicle_id", vehicleIds)
+              .limit(500),
       ]);
     const firstError = [
       requestResult.error,
@@ -170,16 +205,21 @@ export async function POST(request: Request) {
       (total, row) => total + numeric(row.outstanding_balance),
       0,
     );
-    const snapshot = {
+    const authorizedSnapshot = {
       activeUnits: vehicleIds.length,
       openRequests: requests.length,
       safetyOrComplianceRequests: safety,
-      pmItems: pmItems.length,
-      approvals,
-      outstandingBalance: outstanding,
       recentPretrips: pretrips.length,
       pretripDefects: defects,
     };
+    const snapshot = isDriver
+      ? authorizedSnapshot
+      : {
+          ...authorizedSnapshot,
+          pmItems: pmItems.length,
+          approvals,
+          outstandingBalance: outstanding,
+        };
 
     const points = [
       {

--- a/app/api/fleet/billing/route.ts
+++ b/app/api/fleet/billing/route.ts
@@ -17,6 +17,7 @@ type Row = Record<string, unknown>;
 type ContactMethod = "phone" | "in_person" | "email" | "other";
 type Body = {
   action?: "list" | "decide";
+  fleetId?: string | null;
   workOrderId?: string;
   quoteLineIds?: string[];
   decision?: "approve" | "decline" | "defer";
@@ -67,10 +68,14 @@ function canApprove(
 
 async function accessibleVehicleContext(
   actor: Awaited<ReturnType<typeof resolveFleetActorContext>>,
-  options?: { financialOnly?: boolean },
+  options?: { financialOnly?: boolean; fleetId?: string | null },
 ) {
-  const scope = resolveFleetActorScope(actor);
+  const fleetId = clean(options?.fleetId);
+  const scope = resolveFleetActorScope(actor, { explicitFleetId: fleetId });
   if (!scope?.shopId) throw new Error("Fleet scope is unavailable");
+  if (fleetId && !canApprove(actor, fleetId)) {
+    throw new Error("Fleet billing access required");
+  }
 
   const admin = createAdminSupabase();
   let query = admin
@@ -78,11 +83,13 @@ async function accessibleVehicleContext(
     .select("fleet_id,vehicle_id,nickname,active")
     .eq("shop_id", scope.shopId)
     .or("active.is.null,active.eq.true");
-  const allowedFleetIds = actor.isInternal
-    ? scope.fleetIds
-    : options?.financialOnly
-      ? manageableFleetIdsForActor(actor)
-      : scope.fleetIds;
+  const allowedFleetIds = fleetId
+    ? [fleetId]
+    : actor.isInternal
+      ? scope.fleetIds
+      : options?.financialOnly
+        ? manageableFleetIdsForActor(actor)
+        : scope.fleetIds;
   if (!actor.isInternal && options?.financialOnly && !allowedFleetIds?.length) {
     throw new Error("Fleet billing access required");
   }
@@ -95,9 +102,11 @@ async function accessibleVehicleContext(
 
 async function listBilling(
   actor: Awaited<ReturnType<typeof resolveFleetActorContext>>,
+  fleetId?: string | null,
 ) {
   const { admin, scope, enrollments } = await accessibleVehicleContext(actor, {
     financialOnly: true,
+    fleetId,
   });
   const vehicleIds = Array.from(
     new Set(enrollments.map((row) => String(row.vehicle_id))),
@@ -202,7 +211,10 @@ async function listBilling(
   const paymentsByWorkOrder = new Map<string, Row[]>();
   for (const payment of rows(paymentResult.data)) {
     const key = String(payment.work_order_id);
-    paymentsByWorkOrder.set(key, [...(paymentsByWorkOrder.get(key) ?? []), payment]);
+    paymentsByWorkOrder.set(key, [
+      ...(paymentsByWorkOrder.get(key) ?? []),
+      payment,
+    ]);
   }
 
   const items = workOrders.map((workOrder) => {
@@ -239,7 +251,11 @@ async function listBilling(
         clean(vehicle.license_plate) ??
         clean(vehicle.vin) ??
         "Unit",
-      vehicleDescription: [vehicle.year, clean(vehicle.make), clean(vehicle.model)]
+      vehicleDescription: [
+        vehicle.year,
+        clean(vehicle.make),
+        clean(vehicle.model),
+      ]
         .filter(Boolean)
         .join(" "),
       reference:
@@ -254,7 +270,8 @@ async function listBilling(
             id: String(invoice.id),
             versionNumber: numeric(invoice.version_number),
             lifecycleStatus: clean(invoice.lifecycle_status) ?? "draft",
-            currency: clean(invoice.currency)?.toUpperCase() === "USD" ? "USD" : "CAD",
+            currency:
+              clean(invoice.currency)?.toUpperCase() === "USD" ? "USD" : "CAD",
             total: numeric(invoice.total),
             paidTotal: numeric(invoice.paid_total),
             refundedTotal: numeric(invoice.refunded_total),
@@ -265,7 +282,8 @@ async function listBilling(
       payments: (paymentsByWorkOrder.get(id) ?? []).map((payment) => ({
         id: String(payment.id),
         amountCents: numeric(payment.amount_cents),
-        currency: clean(payment.currency)?.toUpperCase() === "USD" ? "USD" : "CAD",
+        currency:
+          clean(payment.currency)?.toUpperCase() === "USD" ? "USD" : "CAD",
         status: clean(payment.status) ?? "pending",
         createdAt: iso(payment.created_at),
       })),
@@ -304,32 +322,42 @@ async function listBilling(
 export async function POST(request: Request) {
   try {
     const supabase = createServerSupabaseRoute();
-    const actor = await resolveFleetActorContext(supabase);
+    const body = (await request.json().catch(() => ({}))) as Body;
+    const actor = await resolveFleetActorContext(supabase, {
+      requestedFleetId: body.fleetId ?? null,
+    });
     if (!actor.userId) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     if (actor.actorType === "none") {
-      return NextResponse.json({ error: "Fleet access required" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Fleet access required" },
+        { status: 403 },
+      );
     }
 
-    const body = (await request.json().catch(() => ({}))) as Body;
     if (!body.action || body.action === "list") {
-      if (!canApprove(actor)) {
+      if (!canApprove(actor, clean(body.fleetId) ?? undefined)) {
         return NextResponse.json(
           { error: "Fleet billing access required" },
           { status: 403 },
         );
       }
-      return NextResponse.json(await listBilling(actor));
+      return NextResponse.json(await listBilling(actor, body.fleetId));
     }
     if (!canApprove(actor)) {
-      return NextResponse.json({ error: "Approval access required" }, { status: 403 });
+      return NextResponse.json(
+        { error: "Approval access required" },
+        { status: 403 },
+      );
     }
 
     const workOrderId = clean(body.workOrderId);
     const decision = body.decision;
     const quoteLineIds = Array.from(
-      new Set((body.quoteLineIds ?? []).map((value) => value.trim()).filter(Boolean)),
+      new Set(
+        (body.quoteLineIds ?? []).map((value) => value.trim()).filter(Boolean),
+      ),
     );
     const operationKey = clean(body.operationKey);
     const requestedContactMethod = clean(body.contactMethod);
@@ -344,23 +372,27 @@ export async function POST(request: Request) {
       !quoteLineIds.length ||
       !operationKey
     ) {
-      return NextResponse.json({ error: "Invalid approval decision" }, { status: 400 });
+      return NextResponse.json(
+        { error: "Invalid approval decision" },
+        { status: 400 },
+      );
     }
-    if (
-      actor.isInternal &&
-      (!contactMethod ||
-        !note)
-    ) {
+    if (actor.isInternal && (!contactMethod || !note)) {
       return NextResponse.json(
         { error: "Contact method and decision note are required" },
         { status: 400 },
       );
     }
 
-    const { admin, scope, enrollments } = await accessibleVehicleContext(actor, {
-      financialOnly: true,
-    });
-    const accessibleVehicleIds = enrollments.map((row) => String(row.vehicle_id));
+    const { admin, scope, enrollments } = await accessibleVehicleContext(
+      actor,
+      {
+        financialOnly: true,
+      },
+    );
+    const accessibleVehicleIds = enrollments.map((row) =>
+      String(row.vehicle_id),
+    );
     const { data: workOrder, error: workOrderError } = await admin
       .from("work_orders")
       .select("id,shop_id,vehicle_id,customer_id")
@@ -370,7 +402,10 @@ export async function POST(request: Request) {
       .maybeSingle();
     if (workOrderError) throw new Error(workOrderError.message);
     if (!workOrder) {
-      return NextResponse.json({ error: "Fleet work order not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Fleet work order not found" },
+        { status: 404 },
+      );
     }
 
     const { data: quotes, error: quoteError } = await admin
@@ -381,7 +416,10 @@ export async function POST(request: Request) {
       .in("id", quoteLineIds);
     if (quoteError) throw new Error(quoteError.message);
     if ((quotes ?? []).length !== quoteLineIds.length) {
-      return NextResponse.json({ error: "Estimate line not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Estimate line not found" },
+        { status: 404 },
+      );
     }
 
     if (!actor.isInternal && !workOrder.customer_id) {
@@ -402,14 +440,22 @@ export async function POST(request: Request) {
       actorUserId: actor.userId,
       contactMethod: contactMethod ?? "other",
       decisionNote: note,
-      operationKey: actor.isInternal ? `fleet-staff:${operationKey}` : `fleet:${operationKey}`,
+      operationKey: actor.isInternal
+        ? `fleet-staff:${operationKey}`
+        : `fleet:${operationKey}`,
     });
-    if (!result.ok) throw new Error(result.error ?? "Unable to save estimate decision");
+    if (!result.ok)
+      throw new Error(result.error ?? "Unable to save estimate decision");
     return NextResponse.json({ ok: true, result });
   } catch (error) {
     console.error("[fleet/billing] error", error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : "Unable to load fleet billing" },
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unable to load fleet billing",
+      },
       { status: 500 },
     );
   }

--- a/app/api/fleet/enrollment/route.ts
+++ b/app/api/fleet/enrollment/route.ts
@@ -169,18 +169,22 @@ export async function POST(request: Request) {
             admin
               .from("fleet_members")
               .select("fleet_id,user_id,role")
+              .eq("shop_id", scope.shopId)
               .in("fleet_id", fleetIds)
               .in("role", ["driver", "viewer"]),
             admin
               .from("fleet_vehicles")
               .select("fleet_id,vehicle_id,nickname,active")
+              .eq("shop_id", scope.shopId)
               .in("fleet_id", fleetIds),
             admin
               .from("fleet_dispatch_assignments")
               .select(
                 "id,fleet_id,vehicle_id,driver_profile_id,driver_name,route_label,next_pretrip_due,state",
               )
+              .eq("shop_id", scope.shopId)
               .in("fleet_id", fleetIds)
+              .eq("active", true)
               .neq("state", "completed"),
           ])
         : [

--- a/app/api/fleet/pretrip/route.ts
+++ b/app/api/fleet/pretrip/route.ts
@@ -5,9 +5,11 @@ import { supabaseAdmin } from "@/features/shared/lib/supabase/admin";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import {
+  partitionFleetIdsByManagement,
   resolveFleetActorContext,
   resolveFleetActorScope,
 } from "@/features/fleet/lib/resolveFleetActorContext";
+import { serviceDateInTimeZone } from "@/features/fleet/lib/fleetDate";
 
 type DB = Database;
 type FleetPretripReportRow =
@@ -38,26 +40,6 @@ function numericInput(value: string | null, label: string) {
     throw new Error(`${label} must be a valid non-negative number.`);
   }
   return parsed;
-}
-
-function serviceDateInTimeZone(timeZone: string | null, at = new Date()) {
-  const partsFor = (zone: string) =>
-    new Intl.DateTimeFormat("en-US", {
-      timeZone: zone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    }).formatToParts(at);
-  let parts: Intl.DateTimeFormatPart[];
-  try {
-    parts = partsFor(timeZone?.trim() || "America/Los_Angeles");
-  } catch {
-    parts = partsFor("America/Los_Angeles");
-  }
-  const value = Object.fromEntries(
-    parts.map((part) => [part.type, part.value]),
-  );
-  return `${value.year}-${value.month}-${value.day}`;
 }
 
 export async function POST(req: NextRequest) {
@@ -276,7 +258,7 @@ export async function POST(req: NextRequest) {
     const scope = resolveFleetActorScope(actor, {
       explicitShopId: raw.shopId ?? null,
       explicitFleetId: raw.fleetId ?? null,
-      preferMembershipFleet: true,
+      preferMembershipFleet: Boolean(raw.fleetId),
     });
     if (!scope?.shopId) {
       return NextResponse.json(
@@ -285,47 +267,89 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Authentication and Fleet scope are resolved with the caller's session above.
-    // Read the authorized slice with the server client so RLS cannot turn a
-    // driver's just-submitted report into an empty history result.
-    let query = supabaseAdmin
-      .from("fleet_pretrip_reports")
-      .select(
-        `id,shop_id,vehicle_id,driver_name,has_defects,inspection_date,created_at,status,vehicles!inner(unit_number,license_plate,vin)`,
-      )
-      .order("inspection_date", { ascending: false })
-      .limit(250);
-    query = scope.fleetIds?.length
-      ? query.in("fleet_id", scope.fleetIds)
-      : query.eq("shop_id", scope.shopId);
-    if (actor.actorType === "fleet_driver") {
-      query = query.eq("driver_profile_id", actor.userId);
+    // The service-role client bypasses RLS, so every query keeps the trusted
+    // shop predicate and external access is split by each Fleet membership's
+    // role. A user can manage one Fleet while remaining driver-only in another.
+    const select =
+      "id,shop_id,fleet_id,vehicle_id,driver_profile_id,driver_name,has_defects,inspection_date,created_at,status,vehicles!inner(unit_number,license_plate,vin)";
+    let reportRows: PretripJoinedRow[] = [];
+
+    if (actor.isInternal) {
+      let query = supabaseAdmin
+        .from("fleet_pretrip_reports")
+        .select(select)
+        .eq("shop_id", scope.shopId)
+        .order("inspection_date", { ascending: false })
+        .limit(250);
+      if (scope.fleetIds?.length) {
+        query = query.in("fleet_id", scope.fleetIds);
+      }
+      const { data, error } = await query;
+      if (error) throw new Error(error.message);
+      reportRows = (data ?? []) as unknown as PretripJoinedRow[];
+    } else {
+      const scopedFleetIds = scope.fleetIds ?? [];
+      const { managerFleetIds, driverFleetIds } = partitionFleetIdsByManagement(
+        actor,
+        scopedFleetIds,
+      );
+      const results = await Promise.all([
+        managerFleetIds.length
+          ? supabaseAdmin
+              .from("fleet_pretrip_reports")
+              .select(select)
+              .eq("shop_id", scope.shopId)
+              .in("fleet_id", managerFleetIds)
+              .order("inspection_date", { ascending: false })
+              .limit(250)
+          : Promise.resolve({ data: [] as unknown[], error: null }),
+        driverFleetIds.length
+          ? supabaseAdmin
+              .from("fleet_pretrip_reports")
+              .select(select)
+              .eq("shop_id", scope.shopId)
+              .in("fleet_id", driverFleetIds)
+              .eq("driver_profile_id", actor.userId)
+              .order("inspection_date", { ascending: false })
+              .limit(250)
+          : Promise.resolve({ data: [] as unknown[], error: null }),
+      ]);
+      const error = results.map((result) => result.error).find(Boolean);
+      if (error) throw new Error(error.message);
+      reportRows = Array.from(
+        new Map(
+          results
+            .flatMap((result) => result.data ?? [])
+            .map((row) => [String((row as { id: string }).id), row]),
+        ).values(),
+      ) as unknown as PretripJoinedRow[];
+      reportRows.sort((left, right) =>
+        (right.inspection_date ?? right.created_at).localeCompare(
+          left.inspection_date ?? left.created_at,
+        ),
+      );
+      reportRows = reportRows.slice(0, 250);
     }
 
-    const { data, error } = await query;
-    if (error) throw new Error(error.message);
-
-    const reports = ((data ?? []) as unknown as PretripJoinedRow[]).map(
-      (row) => {
-        const vehicle = row.vehicles;
-        return {
-          id: row.id,
-          shop_id: row.shop_id,
-          unit_id: row.vehicle_id,
-          unit_label:
-            vehicle?.unit_number ||
-            vehicle?.license_plate ||
-            vehicle?.vin ||
-            row.vehicle_id,
-          plate: vehicle?.license_plate ?? null,
-          driver_name: row.driver_name,
-          has_defects: row.has_defects,
-          inspection_date: row.inspection_date,
-          created_at: row.created_at,
-          status: row.status ?? (row.has_defects ? "open" : "reviewed"),
-        };
-      },
-    );
+    const reports = reportRows.map((row) => {
+      const vehicle = row.vehicles;
+      return {
+        id: row.id,
+        shop_id: row.shop_id,
+        unit_id: row.vehicle_id,
+        unit_label:
+          vehicle?.unit_number ||
+          vehicle?.license_plate ||
+          vehicle?.vin ||
+          row.vehicle_id,
+        plate: vehicle?.license_plate ?? null,
+        driver_name: row.driver_name,
+        has_defects: row.has_defects,
+        inspection_date: row.inspection_date,
+        created_at: row.created_at,
+        status: row.status ?? (row.has_defects ? "open" : "reviewed"),
+      };
+    });
     return NextResponse.json({ reports });
   } catch (error) {
     console.error("[fleet/pretrip] list error", error);

--- a/app/api/fleet/unit-economics/route.ts
+++ b/app/api/fleet/unit-economics/route.ts
@@ -1,9 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import {
   resolveFleetActorContext,
   resolveFleetActorScope,
 } from "@/features/fleet/lib/resolveFleetActorContext";
+import type { Database } from "@shared/types/types/supabase";
+
+type InvoiceCurrencyRow = Pick<
+  Database["public"]["Tables"]["invoice_versions"]["Row"],
+  "work_order_id" | "currency" | "total"
+>;
 
 type Body = {
   shopId?: string | null;
@@ -13,6 +22,12 @@ type Body = {
 function asMoney(value: number | string | null | undefined) {
   const parsed = typeof value === "number" ? value : Number(value ?? 0);
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+type FleetCurrency = "CAD" | "USD";
+
+function fleetCurrency(value: unknown, fallback: FleetCurrency): FleetCurrency {
+  return String(value ?? "").toUpperCase() === "USD" ? "USD" : fallback;
 }
 
 export async function POST(req: NextRequest) {
@@ -32,6 +47,7 @@ export async function POST(req: NextRequest) {
   if (!scope?.shopId) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
+  const admin = createAdminSupabase();
 
   let fleetQuery = supabase
     .from("fleet_vehicles")
@@ -135,6 +151,52 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const workOrderIds = (workOrderResult.data ?? []).map((row) => row.id);
+  const [invoiceVersionResult, shopResult] = await Promise.all([
+    workOrderIds.length
+      ? admin
+          .from("invoice_versions")
+          .select("work_order_id,version_number,currency,total")
+          .eq("shop_id", scope.shopId)
+          .in("work_order_id", workOrderIds)
+          .in("lifecycle_status", ["issued", "partially_paid", "paid"])
+          .order("version_number", { ascending: false })
+      : Promise.resolve({ data: [] as unknown[], error: null }),
+    admin
+      .from("shops")
+      .select("stripe_default_currency")
+      .eq("id", scope.shopId)
+      .maybeSingle(),
+  ]);
+  const financialError = invoiceVersionResult.error ?? shopResult.error;
+  if (financialError) {
+    console.error(
+      "[fleet/unit-economics] invoice currency load error",
+      financialError,
+    );
+    return NextResponse.json(
+      { error: "Failed to calculate fleet invoice costs." },
+      { status: 500 },
+    );
+  }
+  const defaultCurrency = fleetCurrency(
+    shopResult.data?.stripe_default_currency,
+    "CAD",
+  );
+  const invoiceVersionByWorkOrder = new Map<
+    string,
+    { currency: FleetCurrency; total: number }
+  >();
+  const invoiceVersionRows = (invoiceVersionResult.data ??
+    []) as InvoiceCurrencyRow[];
+  for (const row of invoiceVersionRows) {
+    if (invoiceVersionByWorkOrder.has(row.work_order_id)) continue;
+    invoiceVersionByWorkOrder.set(row.work_order_id, {
+      currency: fleetCurrency(row.currency, defaultCurrency),
+      total: asMoney(row.total),
+    });
+  }
+
   const payload = units.map((unit) => {
     const vehicle = Array.isArray(unit.vehicles)
       ? unit.vehicles[0]
@@ -155,10 +217,16 @@ export async function POST(req: NextRequest) {
       (row) => row.subject_id === unit.vehicle_id,
     );
 
-    const trailing12MonthSpend = workOrders.reduce(
-      (sum, row) => sum + asMoney(row.invoice_total),
-      0,
-    );
+    const trailing12MonthSpendByCurrency: Record<FleetCurrency, number> = {
+      CAD: 0,
+      USD: 0,
+    };
+    for (const row of workOrders) {
+      const invoiceVersion = invoiceVersionByWorkOrder.get(row.id);
+      const currency = invoiceVersion?.currency ?? defaultCurrency;
+      trailing12MonthSpendByCurrency[currency] +=
+        invoiceVersion?.total ?? asMoney(row.invoice_total);
+    }
     const firstOdometer = readings[0]?.odometer_km ?? null;
     const latestReading = readings.at(-1) ?? null;
     const latestOdometer = latestReading?.odometer_km ?? null;
@@ -166,10 +234,16 @@ export async function POST(req: NextRequest) {
       firstOdometer != null && latestOdometer != null
         ? Math.max(0, latestOdometer - firstOdometer)
         : null;
-    const costPerKm =
-      distanceKm != null && distanceKm >= 100
-        ? trailing12MonthSpend / distanceKm
-        : null;
+    const costPerKmByCurrency: Record<FleetCurrency, number | null> = {
+      CAD:
+        distanceKm != null && distanceKm >= 100
+          ? trailing12MonthSpendByCurrency.CAD / distanceKm
+          : null,
+      USD:
+        distanceKm != null && distanceKm >= 100
+          ? trailing12MonthSpendByCurrency.USD / distanceKm
+          : null,
+    };
 
     return {
       fleetId: unit.fleet_id,
@@ -183,11 +257,11 @@ export async function POST(req: NextRequest) {
       vehicle: [vehicle?.year, vehicle?.make, vehicle?.model]
         .filter(Boolean)
         .join(" "),
-      trailing12MonthSpend,
+      trailing12MonthSpendByCurrency,
       currentOdometerKm: latestOdometer,
       readingRecordedAt: latestReading?.recorded_at ?? null,
       distanceCoveredKm: distanceKm,
-      costPerKm,
+      costPerKmByCurrency,
       completedWorkOrders: workOrders.filter((row) =>
         ["completed", "closed", "invoiced", "paid"].includes(
           (row.status ?? "").toLowerCase(),
@@ -215,13 +289,13 @@ export async function POST(req: NextRequest) {
       (a, b) =>
         b.pmDueCount - a.pmDueCount ||
         b.openServiceRequests - a.openServiceRequests ||
-        b.trailing12MonthSpend - a.trailing12MonthSpend,
+        a.label.localeCompare(b.label),
     ),
     generatedAt: new Date().toISOString(),
     methodology: {
       spendWindow: "trailing_12_months",
       costPerKm:
-        "Trailing 12-month invoice total divided by measured odometer delta; hidden below 100 km of evidence.",
+        "Trailing 12-month finalized invoice totals, kept separate by currency, divided by measured odometer delta; hidden below 100 km of evidence.",
       telematics: "not_used",
     },
   });

--- a/app/portal/fleet/drivers/page.tsx
+++ b/app/portal/fleet/drivers/page.tsx
@@ -10,7 +10,7 @@ export default async function FleetDriversPage() {
   const supabase = createServerSupabaseRSC();
   const actor = await resolveFleetActorContext(supabase);
   const uiContext = getFleetUiContext(actor);
-  if (uiContext.experience === "external_driver") redirect("/portal/fleet");
+  if (!uiContext.capabilities.canManageUnits) redirect("/portal/fleet");
 
   const canInviteDrivers =
     actor.isInternal &&

--- a/app/portal/fleet/layout.tsx
+++ b/app/portal/fleet/layout.tsx
@@ -54,6 +54,7 @@ export default async function PortalFleetLayout({
       subtitle={subtitle}
       actorLabel={actor.actorLabel}
       experience={actor.experience}
+      canAccessManagerWorkspaces={actor.capabilities.canManageUnits}
       userId={actor.userId}
       productHost={productHost}
     >

--- a/app/portal/fleet/pretrip/[unitId]/page.tsx
+++ b/app/portal/fleet/pretrip/[unitId]/page.tsx
@@ -1,7 +1,10 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import PretripForm from "@/features/fleet/components/PretripForm";
-import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import {
+  resolveFleetActorContext,
+  resolveFleetActorScope,
+} from "@/features/fleet/lib/resolveFleetActorContext";
 import {
   createAdminSupabase,
   createServerSupabaseRSC,
@@ -26,7 +29,15 @@ export default async function FleetPortalPretripPage({
   }
 
   const fleetId = query.fleetId ?? actor.primaryFleetId;
-  if (!fleetId || (!actor.isInternal && !actor.fleetIds.includes(fleetId))) {
+  const scope = resolveFleetActorScope(actor, {
+    explicitFleetId: fleetId,
+    preferMembershipFleet: true,
+  });
+  if (
+    !fleetId ||
+    !scope?.shopId ||
+    (!actor.isInternal && !actor.fleetIds.includes(fleetId))
+  ) {
     notFound();
   }
 
@@ -38,6 +49,7 @@ export default async function FleetPortalPretripPage({
         .select(
           "vehicle_id,nickname,vehicles!inner(unit_number,license_plate,vin)",
         )
+        .eq("shop_id", scope.shopId)
         .eq("fleet_id", fleetId)
         .eq("vehicle_id", unitId)
         .or("active.is.null,active.eq.true")
@@ -50,6 +62,7 @@ export default async function FleetPortalPretripPage({
       admin
         .from("fleet_dispatch_assignments")
         .select("id")
+        .eq("shop_id", scope.shopId)
         .eq("fleet_id", fleetId)
         .eq("vehicle_id", unitId)
         .eq("driver_profile_id", actor.userId)

--- a/app/portal/fleet/reports/page.tsx
+++ b/app/portal/fleet/reports/page.tsx
@@ -2,14 +2,26 @@ import { redirect } from "next/navigation";
 
 import FleetReportsWorkspace from "@/features/fleet/components/FleetReportsWorkspace";
 import { getFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
-import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
+import {
+  canManageFleetForActor,
+  resolveFleetActorContext,
+} from "@/features/fleet/lib/resolveFleetActorContext";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 
 export default async function FleetReportsPage() {
   const supabase = createServerSupabaseRSC();
   const actor = await resolveFleetActorContext(supabase);
   const uiContext = getFleetUiContext(actor);
-  if (uiContext.experience === "external_driver") redirect("/portal/fleet");
+  if (!uiContext.capabilities.canManageUnits) redirect("/portal/fleet");
+  const fleetId = actor.isInternal
+    ? actor.primaryFleetId
+    : actor.fleetIds.find((id) => canManageFleetForActor(actor, id));
+  if (!fleetId) redirect("/portal/fleet");
 
-  return <FleetReportsWorkspace actorLabel={uiContext.actorLabel} />;
+  return (
+    <FleetReportsWorkspace
+      actorLabel={uiContext.actorLabel}
+      fleetId={fleetId}
+    />
+  );
 }

--- a/features/fleet/components/FleetAISummary.tsx
+++ b/features/fleet/components/FleetAISummary.tsx
@@ -9,6 +9,7 @@ import { toFleetPublicHref } from "@/features/fleet/lib/fleetProductRouting";
 
 type FleetAISummaryProps = {
   shopId?: string | null;
+  fleetId?: string | null;
   routePrefix?: "/fleet" | "/portal/fleet";
 };
 
@@ -36,6 +37,7 @@ const tones: Record<Point["priority"], string> = {
 
 export default function FleetAISummary({
   shopId,
+  fleetId,
   routePrefix = "/fleet",
 }: FleetAISummaryProps) {
   const pathname = usePathname() ?? "";
@@ -53,7 +55,11 @@ export default function FleetAISummary({
         const response = await fetch("/api/fleet/ai-summary", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ shopId: shopId ?? null, routePrefix }),
+          body: JSON.stringify({
+            shopId: shopId ?? null,
+            fleetId: fleetId ?? null,
+            routePrefix,
+          }),
           cache: "no-store",
         });
         const body = (await response.json().catch(() => ({}))) as
@@ -82,7 +88,7 @@ export default function FleetAISummary({
     return () => {
       cancelled = true;
     };
-  }, [routePrefix, shopId]);
+  }, [fleetId, routePrefix, shopId]);
 
   return (
     <section className="text-xs text-[color:var(--theme-text-primary)]">

--- a/features/fleet/components/FleetControlTower.tsx
+++ b/features/fleet/components/FleetControlTower.tsx
@@ -215,11 +215,16 @@ export default function FleetControlTower({
       aiSummary={
         <div className="space-y-4">
           <div className="metal-card rounded-3xl p-4">
-            <FleetAISummary shopId={shopId ?? null} routePrefix={routePrefix} />
+            <FleetAISummary
+              shopId={shopId ?? null}
+              fleetId={fleetId ?? null}
+              routePrefix={routePrefix}
+            />
           </div>
           <div className="metal-card rounded-3xl p-4">
             <FleetUnitEconomicsPanel
               shopId={shopId ?? null}
+              fleetId={fleetId ?? null}
               routePrefix={routePrefix}
             />
           </div>

--- a/features/fleet/components/FleetDriversWorkspace.tsx
+++ b/features/fleet/components/FleetDriversWorkspace.tsx
@@ -128,10 +128,16 @@ export default function FleetDriversWorkspace({
       ),
     [context?.assignments, fleetId],
   );
+  const fleetDrivers = useMemo(
+    () =>
+      (context?.drivers ?? []).filter(
+        (driver) => fleetId === "all" || driver.fleetId === fleetId,
+      ),
+    [context?.drivers, fleetId],
+  );
   const drivers = useMemo(() => {
     const needle = search.trim().toLowerCase();
-    return (context?.drivers ?? []).filter((driver) => {
-      if (fleetId !== "all" && driver.fleetId !== fleetId) return false;
+    return fleetDrivers.filter((driver) => {
       if (!needle) return true;
       const assigned = assignments.filter(
         (assignment) => assignment.driverProfileId === driver.id,
@@ -149,7 +155,7 @@ export default function FleetDriversWorkspace({
         .toLowerCase()
         .includes(needle);
     });
-  }, [assignments, context?.drivers, fleetId, search]);
+  }, [assignments, fleetDrivers, search]);
   const enrollments = (context?.enrollments ?? []).filter(
     (enrollment) =>
       enrollment.active &&
@@ -224,7 +230,7 @@ export default function FleetDriversWorkspace({
       <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         {(
           [
-            ["Active drivers", context?.drivers.length ?? 0, UsersRound],
+            ["Active drivers", fleetDrivers.length, UsersRound],
             ["Assigned units", assignments.length, Truck],
             ["Pre-trips due", duePretrips, ClipboardCheck],
             ["Unassigned units", unassignedUnits, CalendarClock],

--- a/features/fleet/components/FleetIssueTables.tsx
+++ b/features/fleet/components/FleetIssueTables.tsx
@@ -175,14 +175,16 @@ export default function FleetIssueTables({
               )}
 
               <div className="flex flex-wrap gap-2 pt-1">
-                {uiContext.capabilities.canSubmitPretrip && (
+                {uiContext.capabilities.canSubmitPretrip &&
+                (uiContext.isInternal ||
+                  uiContext.experience === "external_driver") ? (
                   <Link
                     href={pretripHref(a.unitId)}
                     className="rounded-full bg-[color:var(--accent-copper)] px-3 py-1 text-[10px] font-semibold text-[color:var(--theme-text-on-accent)] shadow-[0_0_16px_rgba(193,102,59,0.7)] hover:opacity-95"
                   >
                     Send pre-trip link
                   </Link>
-                )}
+                ) : null}
                 <Link
                   href={unitHref(a.unitId)}
                   className="rounded-full border border-[color:var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] px-3 py-1 text-[10px] font-semibold text-[color:var(--theme-text-primary)] hover:bg-[color:var(--theme-surface-panel)]"

--- a/features/fleet/components/FleetProductShell.tsx
+++ b/features/fleet/components/FleetProductShell.tsx
@@ -190,7 +190,9 @@ function NavItem({
       </span>
       {!compact ? (
         <span className="min-w-0">
-          <span className="block truncate text-sm font-semibold">{item.label}</span>
+          <span className="block truncate text-sm font-semibold">
+            {item.label}
+          </span>
           <span className="mt-0.5 block truncate text-[10px] text-[color:var(--theme-text-muted)]">
             {item.description}
           </span>
@@ -205,6 +207,7 @@ export default function FleetProductShell({
   subtitle,
   actorLabel,
   experience,
+  canAccessManagerWorkspaces,
   userId,
   productHost,
   children,
@@ -213,6 +216,7 @@ export default function FleetProductShell({
   subtitle: string;
   actorLabel: string;
   experience: FleetExperience;
+  canAccessManagerWorkspaces: boolean;
   userId: string | null;
   productHost: boolean;
   children: React.ReactNode;
@@ -252,10 +256,10 @@ export default function FleetProductShell({
       NAV_GROUPS.map((group) => ({
         ...group,
         items: group.items.filter(
-          (item) => experience !== "external_driver" || !item.managerOnly,
+          (item) => canAccessManagerWorkspaces || !item.managerOnly,
         ),
       })).filter((group) => group.items.length > 0),
-    [experience],
+    [canAccessManagerWorkspaces],
   );
 
   const activeItem = useMemo(
@@ -286,7 +290,7 @@ export default function FleetProductShell({
           compact && !isMobile ? "justify-center px-2 py-5" : "gap-3 px-4 py-5",
         )}
       >
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-sky-400/30 bg-sky-400/[0.12] text-sky-300 shadow-[0_0_30px_rgba(56,189,248,0.12)]">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-sky-400/30 bg-sky-400/[0.12] text-sky-300 shadow-[0_0_30px_rgba(56,189,248,0.12)]">
           <Truck className="h-5 w-5" aria-hidden="true" />
         </div>
         {compact && !isMobile ? null : (
@@ -301,7 +305,10 @@ export default function FleetProductShell({
         )}
       </div>
 
-      <nav className="flex-1 space-y-5 overflow-y-auto px-2.5 py-4" aria-label="Fleet workspace">
+      <nav
+        className="flex-1 space-y-5 overflow-y-auto px-2.5 py-4"
+        aria-label="Fleet workspace"
+      >
         {groups.map((group) => (
           <div key={group.label}>
             {compact && !isMobile ? null : (
@@ -316,7 +323,7 @@ export default function FleetProductShell({
                   item={item}
                   href={
                     productHost
-                      ? toFleetPublicPath(item.href) ?? item.href
+                      ? (toFleetPublicPath(item.href) ?? item.href)
                       : item.href
                   }
                   compact={compact && !isMobile}
@@ -340,7 +347,11 @@ export default function FleetProductShell({
           )}
         >
           <LogOut className="h-4 w-4 shrink-0" aria-hidden="true" />
-          {compact && !isMobile ? null : signingOut ? "Signing out…" : "Sign out"}
+          {compact && !isMobile
+            ? null
+            : signingOut
+              ? "Signing out…"
+              : "Sign out"}
         </button>
         {compact && !isMobile ? null : (
           <div className="mt-3 px-3 text-[10px] text-[color:var(--theme-text-muted)]">
@@ -353,7 +364,10 @@ export default function FleetProductShell({
 
   return (
     <div className="min-h-dvh bg-[color:var(--theme-surface-page)] text-[color:var(--theme-text-primary)]">
-      <div className="pointer-events-none fixed inset-0 overflow-hidden" aria-hidden="true">
+      <div
+        className="pointer-events-none fixed inset-0 overflow-hidden"
+        aria-hidden="true"
+      >
         <div className="absolute inset-0 bg-[var(--theme-gradient-panel)]" />
         <div className="absolute -left-60 top-[-22rem] h-[46rem] w-[46rem] rounded-full bg-sky-400/10 blur-3xl" />
         <div className="absolute -right-72 bottom-[-24rem] h-[48rem] w-[48rem] rounded-full bg-blue-600/[0.08] blur-3xl" />
@@ -390,7 +404,12 @@ export default function FleetProductShell({
         </div>
       ) : null}
 
-      <div className={cn("relative min-h-dvh transition-[padding] duration-200", compact ? "lg:pl-[76px]" : "lg:pl-[286px]")}>
+      <div
+        className={cn(
+          "relative min-h-dvh transition-[padding] duration-200",
+          compact ? "lg:pl-[76px]" : "lg:pl-[286px]",
+        )}
+      >
         <header className="sticky top-0 z-30 border-b border-[color:var(--theme-border-soft)] bg-[color:var(--theme-header-bg)]/88 backdrop-blur-xl">
           <div className="flex min-h-16 items-center gap-3 px-3 sm:px-5 lg:px-6">
             <button
@@ -404,10 +423,18 @@ export default function FleetProductShell({
             <button
               type="button"
               onClick={() => setCompact((value) => !value)}
-              aria-label={compact ? "Expand fleet navigation" : "Collapse fleet navigation"}
+              aria-label={
+                compact
+                  ? "Expand fleet navigation"
+                  : "Collapse fleet navigation"
+              }
               className="hidden h-9 w-9 items-center justify-center rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] text-[color:var(--theme-text-secondary)] lg:flex"
             >
-              {compact ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+              {compact ? (
+                <ChevronRight className="h-4 w-4" />
+              ) : (
+                <ChevronLeft className="h-4 w-4" />
+              )}
             </button>
 
             <div className="min-w-0 flex-1">

--- a/features/fleet/components/FleetReportsWorkspace.tsx
+++ b/features/fleet/components/FleetReportsWorkspace.tsx
@@ -13,6 +13,7 @@ import {
   Truck,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { fleetCsvCell } from "@/features/fleet/lib/fleetCsv";
 
 type MaintenancePayload = {
   summary: {
@@ -38,9 +39,9 @@ type EconomicsPayload = {
     unitId: string;
     label: string;
     vehicle: string;
-    trailing12MonthSpend: number;
+    trailing12MonthSpendByCurrency: Record<"CAD" | "USD", number>;
     currentOdometerKm: number | null;
-    costPerKm: number | null;
+    costPerKmByCurrency: Record<"CAD" | "USD", number | null>;
     completedWorkOrders: number;
     openServiceRequests: number;
     deferredRequests: number;
@@ -82,6 +83,15 @@ function money(value: number, currency: "CAD" | "USD" = "CAD") {
   }).format(value);
 }
 
+function moneyPerKm(value: number, currency: "CAD" | "USD") {
+  return new Intl.NumberFormat(currency === "USD" ? "en-US" : "en-CA", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
 async function post<T>(url: string, body: object): Promise<T> {
   const response = await fetch(url, {
     method: "POST",
@@ -100,15 +110,19 @@ async function post<T>(url: string, body: object): Promise<T> {
   return payload;
 }
 
-function csvCell(value: string | number | null) {
-  const normalized = value == null ? "" : String(value);
-  return `"${normalized.replaceAll('"', '""')}"`;
+function visibleCurrencies(values: Record<"CAD" | "USD", number>) {
+  const visible = (["CAD", "USD"] as const).filter(
+    (currency) => values[currency] !== 0,
+  );
+  return visible.length ? visible : (["CAD"] as const);
 }
 
 export default function FleetReportsWorkspace({
   actorLabel,
+  fleetId,
 }: {
   actorLabel: string;
+  fleetId: string;
 }) {
   const pathname = usePathname() ?? "";
   const internalRoutes = pathname.startsWith("/portal/fleet");
@@ -124,14 +138,24 @@ export default function FleetReportsWorkspace({
         await Promise.all([
           post<MaintenancePayload>("/api/fleet/maintenance", {
             action: "list",
+            fleetId,
           }),
-          post<EconomicsPayload>("/api/fleet/unit-economics", { shopId: null }),
-          post<BillingPayload>("/api/fleet/billing", { action: "list" }),
+          post<EconomicsPayload>("/api/fleet/unit-economics", {
+            shopId: null,
+            fleetId,
+          }),
+          post<BillingPayload>("/api/fleet/billing", {
+            action: "list",
+            fleetId,
+          }),
           post<TowerPayload>("/api/fleet/tower", {
             shopId: null,
-            fleetId: null,
+            fleetId,
           }),
-          post<PretripPayload>("/api/fleet/pretrip", { shopId: null }),
+          post<PretripPayload>("/api/fleet/pretrip", {
+            shopId: null,
+            fleetId,
+          }),
         ]);
       setData({ maintenance, economics, billing, tower, pretrips });
     } catch (cause) {
@@ -143,7 +167,7 @@ export default function FleetReportsWorkspace({
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [fleetId]);
 
   useEffect(() => {
     void load();
@@ -151,9 +175,12 @@ export default function FleetReportsWorkspace({
 
   const metrics = useMemo(() => {
     const units = data?.economics.units ?? [];
-    const spend = units.reduce(
-      (total, unit) => total + unit.trailing12MonthSpend,
-      0,
+    const spendByCurrency = units.reduce(
+      (total, unit) => ({
+        CAD: total.CAD + unit.trailing12MonthSpendByCurrency.CAD,
+        USD: total.USD + unit.trailing12MonthSpendByCurrency.USD,
+      }),
+      { CAD: 0, USD: 0 },
     );
     const activeUnits = data?.tower.units.length ?? units.length;
     const clearUnits = data?.maintenance.summary.clearUnits ?? 0;
@@ -161,13 +188,13 @@ export default function FleetReportsWorkspace({
       ? Math.round((clearUnits / activeUnits) * 100)
       : 100;
     const openDefects = (data?.pretrips.reports ?? []).filter(
-      (report) => report.has_defects && report.status !== "reviewed",
+      (report) => report.has_defects && report.status === "open",
     ).length;
     const assignedUnits = new Set(
       (data?.tower.assignments ?? []).map((assignment) => assignment.unitId),
     ).size;
     return {
-      spend,
+      spendByCurrency,
       activeUnits,
       clearUnits,
       compliance,
@@ -197,7 +224,9 @@ export default function FleetReportsWorkspace({
         "Asset",
         "Vehicle",
         "Trailing 12-month spend (CAD)",
-        "Cost per km",
+        "Trailing 12-month spend (USD)",
+        "Cost per km (CAD)",
+        "Cost per km (USD)",
         "Current odometer (km)",
         "Completed work orders",
         "Open requests",
@@ -207,8 +236,10 @@ export default function FleetReportsWorkspace({
       ...data.economics.units.map((unit) => [
         unit.label,
         unit.vehicle,
-        unit.trailing12MonthSpend,
-        unit.costPerKm,
+        unit.trailing12MonthSpendByCurrency.CAD,
+        unit.trailing12MonthSpendByCurrency.USD,
+        unit.costPerKmByCurrency.CAD,
+        unit.costPerKmByCurrency.USD,
         unit.currentOdometerKm,
         unit.completedWorkOrders,
         unit.openServiceRequests,
@@ -216,7 +247,7 @@ export default function FleetReportsWorkspace({
         unit.pmDueCount,
       ]),
     ];
-    const csv = rows.map((row) => row.map(csvCell).join(",")).join("\r\n");
+    const csv = rows.map((row) => row.map(fleetCsvCell).join(",")).join("\r\n");
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");
@@ -298,7 +329,16 @@ export default function FleetReportsWorkspace({
                 ["Active units", metrics.activeUnits, Truck],
                 ["PM compliance", `${metrics.compliance}%`, ShieldCheck],
                 ["Open defects", metrics.openDefects, ClipboardCheck],
-                ["12-month spend", money(metrics.spend), CircleDollarSign],
+                [
+                  "12-month spend",
+                  visibleCurrencies(metrics.spendByCurrency)
+                    .map(
+                      (currency) =>
+                        `${currency} ${money(metrics.spendByCurrency[currency], currency)}`,
+                    )
+                    .join(" · "),
+                  CircleDollarSign,
+                ],
               ] satisfies Array<[string, string | number, LucideIcon]>
             ).map(([label, value, Icon]) => (
               <div key={String(label)} className={`${panel} p-4`}>
@@ -503,12 +543,36 @@ export default function FleetReportsWorkspace({
                           </div>
                         </td>
                         <td className="px-5 py-4 font-medium">
-                          {money(unit.trailing12MonthSpend)}
+                          {visibleCurrencies(
+                            unit.trailing12MonthSpendByCurrency,
+                          ).map((currency) => (
+                            <span key={currency} className="block">
+                              {currency}{" "}
+                              {money(
+                                unit.trailing12MonthSpendByCurrency[currency],
+                                currency,
+                              )}
+                            </span>
+                          ))}
                         </td>
                         <td className="px-5 py-4">
-                          {unit.costPerKm == null
+                          {Object.values(unit.costPerKmByCurrency).every(
+                            (value) => value == null,
+                          )
                             ? "More readings needed"
-                            : `${money(unit.costPerKm)} / km`}
+                            : visibleCurrencies({
+                                CAD: unit.costPerKmByCurrency.CAD ?? 0,
+                                USD: unit.costPerKmByCurrency.USD ?? 0,
+                              }).map((currency) => (
+                                <span key={currency} className="block">
+                                  {currency}{" "}
+                                  {moneyPerKm(
+                                    unit.costPerKmByCurrency[currency] ?? 0,
+                                    currency,
+                                  )}{" "}
+                                  / km
+                                </span>
+                              ))}
                         </td>
                         <td className="px-5 py-4">
                           {unit.completedWorkOrders}

--- a/features/fleet/components/FleetServiceRequestsPage.tsx
+++ b/features/fleet/components/FleetServiceRequestsPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 import { convertFleetServiceRequest } from "@/features/fleet/lib/convertFleetServiceRequest";
+import { formatFleetDate } from "@/features/fleet/lib/fleetDate";
 
 type RequestItem = {
   id: string;
@@ -68,21 +69,10 @@ const TERMINAL_REQUEST_STATUSES = new Set([
 ]);
 
 function dateLabel(value: string | null) {
-  if (!value) return null;
-  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  const date = dateOnly
-    ? new Date(
-        Number(dateOnly[1]),
-        Number(dateOnly[2]) - 1,
-        Number(dateOnly[3]),
-      )
-    : new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  }).format(date);
+  return formatFleetDate(value, {
+    fallback: null,
+    options: { month: "short", day: "numeric", year: "numeric" },
+  });
 }
 
 function statusTone(status: string) {

--- a/features/fleet/components/FleetUnitDetailWorkspace.tsx
+++ b/features/fleet/components/FleetUnitDetailWorkspace.tsx
@@ -20,6 +20,7 @@ import type {
   FleetUnitWorkspacePayload,
 } from "@/features/fleet/types/workspace";
 import FleetUnitWorkOrderEvidence from "@/features/fleet/components/FleetUnitWorkOrderEvidence";
+import { formatFleetDate } from "@/features/fleet/lib/fleetDate";
 import { InspectionReportAttachments } from "@/features/inspections/components/InspectionReportAttachments";
 
 type Tab = "overview" | "maintenance" | "history" | "activity";
@@ -36,9 +37,7 @@ function money(value: number, currency: "CAD" | "USD" = "CAD") {
 }
 
 function dateLabel(value: string | null) {
-  if (!value) return "—";
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleDateString();
+  return formatFleetDate(value) ?? "—";
 }
 
 function priorityClass(priority: FleetPriority) {

--- a/features/fleet/components/FleetUnitEconomicsPanel.tsx
+++ b/features/fleet/components/FleetUnitEconomicsPanel.tsx
@@ -17,9 +17,9 @@ type UnitEconomics = {
   unitId: string;
   label: string;
   vehicle: string;
-  trailing12MonthSpend: number;
+  trailing12MonthSpendByCurrency: Record<"CAD" | "USD", number>;
   currentOdometerKm: number | null;
-  costPerKm: number | null;
+  costPerKmByCurrency: Record<"CAD" | "USD", number | null>;
   openServiceRequests: number;
   deferredRequests: number;
   pmDueCount: number;
@@ -33,23 +33,38 @@ type Payload = {
   generatedAt: string;
 };
 
-function money(value: number) {
-  return value.toLocaleString(undefined, {
+function money(value: number, currency: "CAD" | "USD") {
+  return value.toLocaleString(currency === "USD" ? "en-US" : "en-CA", {
     style: "currency",
-    currency: "CAD",
+    currency,
+    minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
 }
 
+function currencyValues<T extends number | null>(
+  values: Record<"CAD" | "USD", T>,
+  includeZero = false,
+) {
+  const entries = (["CAD", "USD"] as const).filter((currency) => {
+    const value = values[currency];
+    return value != null && (includeZero || value !== 0);
+  });
+  return entries.length ? entries : (["CAD"] as const);
+}
+
 export default function FleetUnitEconomicsPanel({
   shopId,
+  fleetId,
   routePrefix = "/fleet",
 }: {
   shopId?: string | null;
+  fleetId?: string | null;
   routePrefix?: "/fleet" | "/portal/fleet";
 }) {
   const pathname = usePathname() ?? "";
-  const productRoutes = !pathname.startsWith("/portal/fleet");
+  const productRoutes =
+    routePrefix === "/portal/fleet" && !pathname.startsWith("/portal/fleet");
   const [payload, setPayload] = useState<Payload | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -61,7 +76,10 @@ export default function FleetUnitEconomicsPanel({
         const response = await fetch("/api/fleet/unit-economics", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ shopId: shopId ?? null }),
+          body: JSON.stringify({
+            shopId: shopId ?? null,
+            fleetId: fleetId ?? null,
+          }),
         });
         const body = (await response.json().catch(() => ({}))) as
           | Payload
@@ -88,7 +106,7 @@ export default function FleetUnitEconomicsPanel({
     return () => {
       cancelled = true;
     };
-  }, [shopId]);
+  }, [fleetId, shopId]);
 
   if (error) {
     return <div className="text-xs text-red-300">{error}</div>;
@@ -147,9 +165,17 @@ export default function FleetUnitEconomicsPanel({
                   </div>
                 </div>
                 <div className="text-right">
-                  <div className="text-sm font-semibold">
-                    {money(unit.trailing12MonthSpend)}
-                  </div>
+                  {currencyValues(unit.trailing12MonthSpendByCurrency).map(
+                    (currency) => (
+                      <div key={currency} className="text-sm font-semibold">
+                        {currency}{" "}
+                        {money(
+                          unit.trailing12MonthSpendByCurrency[currency],
+                          currency,
+                        )}
+                      </div>
+                    ),
+                  )}
                   <div className="text-[11px] text-[color:var(--theme-text-muted)]">
                     trailing 12 months
                   </div>
@@ -161,9 +187,21 @@ export default function FleetUnitEconomicsPanel({
                     Cost/km
                   </div>
                   <div className="mt-0.5 font-medium">
-                    {unit.costPerKm == null
+                    {Object.values(unit.costPerKmByCurrency).every(
+                      (value) => value == null,
+                    )
                       ? "Needs readings"
-                      : money(unit.costPerKm)}
+                      : currencyValues(unit.costPerKmByCurrency).map(
+                          (currency) => (
+                            <span key={currency} className="block">
+                              {currency}{" "}
+                              {money(
+                                unit.costPerKmByCurrency[currency] ?? 0,
+                                currency,
+                              )}
+                            </span>
+                          ),
+                        )}
                   </div>
                 </div>
                 <div>

--- a/features/fleet/components/PretripReportsPage.tsx
+++ b/features/fleet/components/PretripReportsPage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { FleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
+import { formatFleetDate } from "@/features/fleet/lib/fleetDate";
 import { desktopPrimitives as ui } from "@/features/shared/components/ui/desktopPrimitives";
 
 type PretripStatus = "open" | "reviewed" | "archived" | "all";
@@ -24,20 +25,6 @@ type PretripReport = {
   created_at: string;
   status: string | null;
 };
-
-function dateLabel(value: string | null) {
-  if (!value) return "—";
-  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  const date = dateOnly
-    ? new Date(
-        Number(dateOnly[1]),
-        Number(dateOnly[2]) - 1,
-        Number(dateOnly[3]),
-      )
-    : new Date(value);
-  if (Number.isNaN(date.getTime())) return "—";
-  return date.toLocaleDateString();
-}
 
 export default function PretripReportsPage({
   uiContext,
@@ -282,7 +269,7 @@ export default function PretripReportsPage({
                   {filteredReports.map((r) => (
                     <tr key={r.id} className="align-middle">
                       <td className="px-3 py-1.5 text-[11px] text-[color:var(--theme-text-secondary)]">
-                        {dateLabel(r.inspection_date ?? r.created_at)}
+                        {formatFleetDate(r.inspection_date ?? r.created_at)}
                       </td>
                       <td className="px-3 py-1.5 text-[11px] text-[color:var(--theme-text-primary)]">
                         {r.unit_label ?? "—"}

--- a/features/fleet/lib/fleetCsv.ts
+++ b/features/fleet/lib/fleetCsv.ts
@@ -1,0 +1,8 @@
+const FORMULA_PREFIX = /^[=+\-@]/;
+
+export function fleetCsvCell(value: string | number | null): string {
+  const raw = value == null ? "" : String(value);
+  const safe =
+    typeof value === "string" && FORMULA_PREFIX.test(raw) ? `'${raw}` : raw;
+  return `"${safe.replaceAll('"', '""')}"`;
+}

--- a/features/fleet/lib/fleetDate.ts
+++ b/features/fleet/lib/fleetDate.ts
@@ -1,0 +1,72 @@
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+const DEFAULT_FLEET_TIME_ZONE = "America/Los_Angeles";
+
+type FormatFleetDateOptions = {
+  fallback?: string | null;
+  locale?: Intl.LocalesArgument;
+  options?: Intl.DateTimeFormatOptions;
+};
+
+function dateOnlyValue(value: string): Date | null {
+  const match = DATE_ONLY.exec(value);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+export function formatFleetDate(
+  value: string | null | undefined,
+  input: FormatFleetDateOptions = {},
+): string | null {
+  const fallback = input.fallback === undefined ? "—" : input.fallback;
+  if (!value) return fallback;
+
+  const isDateOnly = DATE_ONLY.test(value);
+  const dateOnly = dateOnlyValue(value);
+  if (isDateOnly && !dateOnly) return fallback;
+  const date = dateOnly ?? new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+
+  return new Intl.DateTimeFormat(input.locale, {
+    ...(input.options ?? {}),
+    ...(dateOnly ? { timeZone: "UTC" } : {}),
+  }).format(date);
+}
+
+export function serviceDateInTimeZone(
+  timeZone: string | null | undefined,
+  at = new Date(),
+): string {
+  const partsFor = (zone: string) =>
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: zone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(at);
+
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = partsFor(timeZone?.trim() || DEFAULT_FLEET_TIME_ZONE);
+  } catch {
+    parts = partsFor(DEFAULT_FLEET_TIME_ZONE);
+  }
+
+  const value = Object.fromEntries(
+    parts.map((part) => [part.type, part.value]),
+  );
+  return `${value.year}-${value.month}-${value.day}`;
+}

--- a/features/fleet/lib/resolveFleetActorContext.ts
+++ b/features/fleet/lib/resolveFleetActorContext.ts
@@ -243,6 +243,22 @@ export function manageableFleetIdsForActor(actor: FleetActorContext): string[] {
   );
 }
 
+export function partitionFleetIdsByManagement(
+  actor: FleetActorContext,
+  fleetIds: string[],
+): { managerFleetIds: string[]; driverFleetIds: string[] } {
+  const managerFleetIds = fleetIds.filter((fleetId) =>
+    canManageFleetForActor(actor, fleetId),
+  );
+  const managerFleetIdSet = new Set(managerFleetIds);
+  return {
+    managerFleetIds,
+    driverFleetIds: fleetIds.filter(
+      (fleetId) => !managerFleetIdSet.has(fleetId),
+    ),
+  };
+}
+
 export type FleetActorScope = {
   shopId: string;
   fleetIds: string[] | null;

--- a/tests/fleet-control-tower-composition.test.ts
+++ b/tests/fleet-control-tower-composition.test.ts
@@ -14,9 +14,7 @@ describe("fleet control tower composition", () => {
 
     expect(fleetTower).toContain('layout="dashboard-first"');
     expect(fleetTower).toContain("renderContentWhenError");
-    expect(sharedTower).toContain(
-      'layout?: "board-first" | "dashboard-first"',
-    );
+    expect(sharedTower).toContain('layout?: "board-first" | "dashboard-first"');
 
     const summaryPosition = sharedTower.indexOf("{summaryCards}");
     const boardPosition = sharedTower.lastIndexOf("{workOrderBoard}");
@@ -32,7 +30,9 @@ describe("fleet control tower composition", () => {
     expect(widget).toContain("useWorkOrderBoard");
     expect(widget).toContain("limit: 5");
     expect(widget).toContain("Open full board");
-    expect(widget).not.toContain('import WorkOrderBoard from "./WorkOrderBoard"');
+    expect(widget).not.toContain(
+      'import WorkOrderBoard from "./WorkOrderBoard"',
+    );
     expect(widget).not.toContain("min-h-[560px]");
   });
 
@@ -48,7 +48,8 @@ describe("fleet control tower composition", () => {
       "const showContent = !isLoading && (!error || renderContentWhenError)",
     );
     expect(fleetTower).toContain(
-      "Dashboard sections remain visible with the data currently available.",
+      "Dashboard sections remain visible with the data currently",
     );
+    expect(fleetTower).toContain("available.");
   });
 });

--- a/tests/fleet-date-and-csv-behavior.test.ts
+++ b/tests/fleet-date-and-csv-behavior.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { fleetCsvCell } from "@/features/fleet/lib/fleetCsv";
+import {
+  formatFleetDate,
+  serviceDateInTimeZone,
+} from "@/features/fleet/lib/fleetDate";
+
+describe("Fleet date behavior", () => {
+  it("renders date-only database values without shifting the calendar day", () => {
+    expect(
+      formatFleetDate("2026-08-06", {
+        locale: "en-US",
+        options: { year: "numeric", month: "long", day: "numeric" },
+      }),
+    ).toBe("August 6, 2026");
+    expect(formatFleetDate("2026-02-30", { fallback: "Invalid" })).toBe(
+      "Invalid",
+    );
+  });
+
+  it("derives the service date at the shop's local midnight boundary", () => {
+    expect(
+      serviceDateInTimeZone(
+        "America/Edmonton",
+        new Date("2026-08-06T05:30:00.000Z"),
+      ),
+    ).toBe("2026-08-05");
+    expect(
+      serviceDateInTimeZone(
+        "America/Edmonton",
+        new Date("2026-08-06T07:30:00.000Z"),
+      ),
+    ).toBe("2026-08-06");
+  });
+
+  it("uses the Fleet fallback timezone when a shop timezone is invalid", () => {
+    const instant = new Date("2026-08-06T06:30:00.000Z");
+    expect(serviceDateInTimeZone("Not/A_Timezone", instant)).toBe(
+      serviceDateInTimeZone("America/Los_Angeles", instant),
+    );
+  });
+});
+
+describe("Fleet CSV behavior", () => {
+  it("quotes values and escapes embedded quotes", () => {
+    expect(fleetCsvCell('Unit "12"')).toBe('"Unit ""12"""');
+    expect(fleetCsvCell(42)).toBe('"42"');
+  });
+
+  it.each(["=1+1", "+SUM(A1:A2)", "-2+3", "@cmd"])(
+    "neutralizes formula-like text: %s",
+    (value) => {
+      expect(fleetCsvCell(value)).toBe(`"'${value}"`);
+    },
+  );
+
+  it("does not alter numeric values", () => {
+    expect(fleetCsvCell(-12.5)).toBe('"-12.5"');
+  });
+});

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -24,7 +24,7 @@ describe("premier fleet workspaces", () => {
       expect(fleetShell).toContain(label);
     }
     expect(fleetShell).toContain("ThemeToggleButton");
-    expect(fleetShell).toContain('experience !== "external_driver"');
+    expect(fleetShell).toContain("canAccessManagerWorkspaces");
     expect(fleetShell).toContain("ProFixIQ");
     expect(fleetShell).toContain("Fleet");
   });
@@ -89,9 +89,7 @@ describe("premier fleet workspaces", () => {
     expect(workspace).toContain("Review approval");
     expect(workspace).toContain("Submitted {dateLabel(item.createdAt)}");
     expect(workspace).toContain("dateLabel(item.requestedForDate)");
-    expect(workspace).toContain(
-      "const dateOnly = /^(\\d{4})-(\\d{2})-(\\d{2})$/",
-    );
+    expect(workspace).toContain("formatFleetDate");
     expect(builder).toContain(
       "onInput={(event) => setRequestedForDate(event.currentTarget.value)}",
     );
@@ -145,7 +143,10 @@ describe("premier fleet workspaces", () => {
     expect(route).not.toContain("OPENAI_FLEET_SUMMARY_MODEL");
     expect(policy).toContain("fleet_operations_summary");
     expect(route).toContain('actor.actorType === "fleet_driver"');
+    expect(route).toContain("assignedVehicles");
+    expect(route).toContain("authorizedSnapshot");
     expect(route).toContain('["requests", "units"].includes(point.id)');
+    expect(summary).toContain("fleetId");
     expect(summary).toContain("live records one click away");
     expect(summary).toContain("point.href");
   });
@@ -170,6 +171,7 @@ describe("premier fleet workspaces", () => {
     const reports = source(
       "features/fleet/components/FleetReportsWorkspace.tsx",
     );
+    const economics = source("app/api/fleet/unit-economics/route.ts");
 
     expect(driversPage).toContain("FleetDriversWorkspace");
     expect(driversPage).toContain("FleetPortalAccessManager");
@@ -180,6 +182,7 @@ describe("premier fleet workspaces", () => {
     expect(drivers).toContain("/assets/new");
 
     expect(reportsPage).toContain("FleetReportsWorkspace");
+    expect(reportsPage).toContain("fleetId={fleetId}");
     expect(reportsPage).not.toContain("FleetModuleFoundation");
     for (const endpoint of [
       "/api/fleet/maintenance",
@@ -192,6 +195,12 @@ describe("premier fleet workspaces", () => {
     }
     expect(reports).toContain("Export CSV");
     expect(reports).toContain("Asset cost and maintenance performance");
+    expect(reports).toContain("fleetCsvCell");
+    expect(reports).toContain('report.status === "open"');
+    expect(reports).toContain("costPerKmByCurrency");
+    expect(economics).toContain('from("invoice_versions")');
+    expect(economics).toContain("trailing12MonthSpendByCurrency");
+    expect(economics).toContain('.eq("shop_id", scope.shopId)');
   });
 
   it("keeps product-domain actions on clean public Fleet routes", () => {
@@ -227,12 +236,12 @@ describe("premier fleet workspaces", () => {
     );
 
     expect(pretripApi).toContain("import { supabaseAdmin }");
-    expect(pretripApi).toContain('actor.actorType === "fleet_driver"');
+    expect(pretripApi).toContain("partitionFleetIdsByManagement");
     expect(pretripApi).toContain('.eq("driver_profile_id", actor.userId)');
-    expect(pretripApi).toContain('query.in("fleet_id", scope.fleetIds)');
-    expect(pretripPage).toContain("/^(\\d{4})-(\\d{2})-(\\d{2})$/");
+    expect(pretripApi).toContain('.eq("shop_id", scope.shopId)');
+    expect(pretripPage).toContain("formatFleetDate");
     expect(pretripPage).toContain(
-      "dateLabel(r.inspection_date ?? r.created_at)",
+      "formatFleetDate(r.inspection_date ?? r.created_at)",
     );
   });
 

--- a/tests/fleet-pretrip-defect-compliance.test.ts
+++ b/tests/fleet-pretrip-defect-compliance.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  partitionFleetIdsByManagement,
   resolveFleetActorScope,
   type FleetActorContext,
 } from "@/features/fleet/lib/resolveFleetActorContext";
@@ -60,6 +61,24 @@ describe("fleet pre-trip, defects, and compliance", () => {
     ).toBeNull();
   });
 
+  it("applies each external membership role only to its own Fleet", () => {
+    const managerFleetId = "30000000-0000-4000-8000-000000000001";
+    const driverFleetId = "30000000-0000-4000-8000-000000000002";
+    const actor = dualRoleActor();
+    actor.isInternal = false;
+    actor.actorType = "fleet_manager";
+    actor.fleetIds = [managerFleetId, driverFleetId];
+    actor.fleetMemberships = [
+      { fleetId: managerFleetId, shopId: actor.shopId, role: "manager" },
+      { fleetId: driverFleetId, shopId: actor.shopId, role: "viewer" },
+    ];
+
+    expect(partitionFleetIdsByManagement(actor, actor.fleetIds)).toEqual({
+      managerFleetIds: [managerFleetId],
+      driverFleetIds: [driverFleetId],
+    });
+  });
+
   it("keeps drivers out of manager conversion and puts pre-trip one click from portal home", () => {
     const form = read("features/fleet/components/PretripForm.tsx");
     const tower = read("features/fleet/components/FleetControlTower.tsx");
@@ -70,6 +89,7 @@ describe("fleet pre-trip, defects, and compliance", () => {
     expect(tower).toContain("Start today’s pre-trip");
     expect(tower).toContain("/portal/fleet/pretrip/");
     expect(page).toContain("const admin = createAdminSupabase()");
+    expect(page).toContain('.eq("shop_id", scope.shopId)');
     expect(page).toContain('.eq("fleet_id", fleetId)');
     expect(page).toContain('.eq("driver_profile_id", actor.userId)');
     expect(page).toContain('.eq("active", true)');

--- a/tests/fleet-requested-date-behavior.test.tsx
+++ b/tests/fleet-requested-date-behavior.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import FleetRequestBuilderPage from "../app/portal/fleet/request/build/page";
+
+const routerReplace = vi.fn();
+const searchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/portal/fleet/request/build",
+  useRouter: () => ({ replace: routerReplace }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("sonner", () => ({
+  Toaster: () => null,
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock(
+  "@/features/portal/components/request/SharedServiceRequestBuilder",
+  () => ({
+    default: ({
+      onAddCatalogItem,
+    }: {
+      onAddCatalogItem: (item: {
+        id: string;
+        kind: "menu";
+        title: string;
+        description: string;
+        category: string;
+        laborHours: number;
+        price: number;
+      }) => void;
+    }) => (
+      <button
+        type="button"
+        onClick={() =>
+          onAddCatalogItem({
+            id: "menu-1",
+            kind: "menu",
+            title: "Oil service",
+            description: "Change oil and filter",
+            category: "Maintenance",
+            laborHours: 1,
+            price: 120,
+          })
+        }
+      >
+        Add oil service
+      </button>
+    ),
+  }),
+);
+
+const builderContext = {
+  fleetId: "fleet-1",
+  shopId: "shop-1",
+  units: [
+    {
+      fleet_id: "fleet-1",
+      vehicle_id: "vehicle-1",
+      nickname: "Unit 12",
+      vehicles: {
+        id: "vehicle-1",
+        unit_number: "12",
+        year: 2025,
+        make: "Ford",
+        model: "Transit",
+        vin: "VIN12",
+        license_plate: "ABC123",
+        engine_hours: 100,
+        mileage: "25000",
+      },
+    },
+  ],
+  menuItems: [
+    {
+      id: "menu-1",
+      name: "Oil service",
+      description: "Change oil and filter",
+      category: "Maintenance",
+      base_labor_hours: 1,
+      labor_hours: null,
+      base_price: 120,
+      total_price: null,
+      vehicle_year: null,
+      vehicle_make: null,
+      vehicle_model: null,
+    },
+  ],
+  inspections: [],
+  pmPackages: [],
+};
+
+beforeEach(() => {
+  routerReplace.mockReset();
+  vi.restoreAllMocks();
+  vi.stubGlobal("crypto", {
+    randomUUID: vi
+      .fn()
+      .mockReturnValueOnce("line-key")
+      .mockReturnValueOnce("operation-key"),
+  });
+});
+
+describe("Fleet request requested date", () => {
+  it("preserves the selected date while lines are added and submits it", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(builderContext), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ serviceRequestId: "request-1" }), {
+          status: 200,
+        }),
+      );
+
+    render(<FleetRequestBuilderPage />);
+
+    const dateInput = await screen.findByLabelText("Requested date");
+    fireEvent.input(dateInput, { target: { value: "2026-08-20" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add oil service" }));
+
+    expect(dateInput).toHaveValue("2026-08-20");
+    fireEvent.click(screen.getByRole("button", { name: "Send to advisor" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const [, submitInit] = fetchMock.mock.calls[1] ?? [];
+    const submitBody = JSON.parse(String(submitInit?.body)) as {
+      requestedForDate: string;
+    };
+    expect(submitBody.requestedForDate).toBe("2026-08-20");
+    expect(routerReplace).toHaveBeenCalledWith(
+      "/portal/fleet/service-requests",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@shared": resolve(__dirname, "features/shared"),
       "@": resolve(__dirname, "."),
       "server-only": resolve(__dirname, "tests/shims/server-only.ts"),
     },


### PR DESCRIPTION
### Root cause

The Fleet shell was already separated, but the eight Codex reviews exposed several incomplete product boundaries:

- service-role reads were authorized first but did not consistently keep the authenticated shop predicate
- a user's broadest Fleet role could leak into another Fleet membership
- driver AI summaries were filtered only after manager-level facts had been assembled
- reporting combined Fleet scope, currency, defect, date, and CSV behavior in ways that could produce inaccurate output
- navigation and assignment surfaces exposed actions that the current actor could not complete

### What changed

- constrains privileged pre-trip, enrollment, dispatch, invoice, and economics reads to the authenticated shop and selected Fleet
- partitions pre-trip visibility by each membership so manager and driver access cannot bleed across Fleets
- limits driver AI input and returned snapshots to assigned units, requests, and the driver's own pre-trips
- hides manager-only workspaces and unavailable pre-trip actions from restricted actors
- excludes inactive assignments and makes active-driver metrics respect the selected Fleet
- gives all report feeds one explicit Fleet scope
- keeps CAD and USD totals separate, uses finalized invoice versions, excludes archived defects, neutralizes CSV formulas, and preserves cost-per-kilometre precision
- centralizes date-only rendering and service-date calculation so western time zones do not shift calendar dates
- keeps legacy economics links inside the legacy Fleet route family
- adds behavioral coverage for requested service dates, mixed Fleet roles, local dates, and CSV safety

### Why this is safe

Every service-role query added or changed here retains a trusted shop predicate after actor resolution. External pre-trip access is split into manager Fleet IDs and driver-only Fleet IDs, with the latter additionally constrained to the authenticated driver profile. No schema, RLS policy, or environment contract changes are included.

### Files changed

- Fleet API routes for AI summary, billing, enrollment, pre-trips, and unit economics
- Fleet portal authorization, navigation, driver, reporting, and dashboard components
- shared Fleet date, CSV, and membership-scope helpers
- Fleet regression and behavioral tests

### Validation

- `tsc --noEmit --pretty false` — passed
- targeted ESLint over all changed TypeScript/TSX files — passed
- Fleet-focused Vitest suite — 86/86 passed
- repository-wide Vitest suite — 1,855 passed; 29 failures remain in untouched Parts, Inspection, Workforce, Agent, and missing-migration checks
- `next build` — production compilation and type/lint validation passed; local page-data collection then stopped because `NEXT_PUBLIC_SUPABASE_URL` is unavailable to an unrelated Agent notification route in this workspace
- remote Git tree SHA matches the locally validated commit tree exactly: `6af440607b911bf187afea550e137c6600609638`

### Database

No migration required.

### Environment variables

No new or changed environment variables.

### Manual/deployment actions

- let the normal Vercel preview build run with the project's configured Supabase environment
- smoke-test one user who manages Fleet A and is driver-only in Fleet B before production promotion

### Remaining risks or unverified assumptions

Production data has not yet been used to exercise the mixed-membership case end to end. The implementation is covered at the role-partition and query-boundary level, but the preview should confirm that real memberships and assignments match those assumptions.
