### PR TITLE
Fix Agent console engineering state and approval gating

### DIFF
--- a/app/api/agent/requests/route.ts
+++ b/app/api/agent/requests/route.ts
@@ -100,6 +100,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function projectionQuestions(projection: AgentTeamProjection) {
+  return projection.missingInformation.map((question, index) => ({
+    id: `team-${projection.engineeringCaseId}-${index}`,
+    question,
+  }));
+}
+
 function teamCaseId(row: AgentRequestRow): string | null {
   if (!isRecord(row.normalized_json)) return null;
   const team = isRecord(row.normalized_json.agentTeam)
@@ -170,6 +177,7 @@ async function syncAgentRequestRow(row: AgentRequestRow): Promise<AgentRequestRo
         status: nextStatus,
         normalized_json: {
           ...normalized,
+          questions: projectionQuestions(projection),
           agentTeam: { ...projection, syncedAt: synchronizedAt },
         },
         github_pr_number: projection.pullRequest.number,
@@ -486,6 +494,7 @@ export async function POST(req: NextRequest) {
       intent: finalIntent,
       normalized_json: {
         ...structuredContext,
+        questions: projectionQuestions(projection),
         agentRequest: agentResponse ?? {},
         agentTeam: { ...projection, syncedAt: synchronizedAt },
       },

--- a/features/agent/agent-console/app/agent/page.tsx
+++ b/features/agent/agent-console/app/agent/page.tsx
@@ -31,6 +31,24 @@ type AgentResponse = {
   answers?: Record<string, string> | null;
 };
 
+type AgentTeamMission = {
+  id?: string;
+  status?: string;
+  title?: string | null;
+};
+
+type AgentTeamState = {
+  engineeringCaseId?: string;
+  currentStage?: string;
+  caseStatus?: string;
+  stepStatus?: string | null;
+  summary?: string | null;
+  decision?: string | null;
+  missingInformation?: string[];
+  mission?: AgentTeamMission | null;
+  syncedAt?: string;
+};
+
 type AgentContext = {
   location?: string | null;
   steps?: string | null;
@@ -41,6 +59,7 @@ type AgentContext = {
 
   questions?: AgentQuestion[];
   responses?: AgentResponse[];
+  agentTeam?: AgentTeamState;
 
   [key: string]: unknown;
 };
@@ -120,20 +139,43 @@ export default function AgentConsolePage() {
   const [replySending, setReplySending] = useState(false);
 
   const selectedContext: AgentContext | null = selected?.normalized_json ?? null;
+  const selectedTeam = useMemo<AgentTeamState | null>(() => {
+    const raw = selectedContext?.agentTeam;
+    return raw && typeof raw === "object" && !Array.isArray(raw)
+      ? raw
+      : null;
+  }, [selectedContext?.agentTeam]);
 
   const questions = useMemo<AgentQuestion[]>(() => {
     const raw = selectedContext?.questions;
-    if (!raw || !Array.isArray(raw)) return [];
-    return raw
-      .filter((q): q is AgentQuestion => !!q && typeof q === "object")
-      .filter((q) => isString((q as { question?: unknown }).question))
-      .map((q) => ({
-        id: isString((q as { id?: unknown }).id)
-          ? (q as { id: string }).id
-          : undefined,
-        question: (q as { question: string }).question,
-      }));
-  }, [selectedContext?.questions]);
+    const legacy = raw && Array.isArray(raw)
+      ? raw
+          .filter((q): q is AgentQuestion => !!q && typeof q === "object")
+          .filter((q) => isString((q as { question?: unknown }).question))
+          .map((q) => ({
+            id: isString((q as { id?: unknown }).id)
+              ? (q as { id: string }).id
+              : undefined,
+            question: (q as { question: string }).question,
+          }))
+      : [];
+    const teamMissing = Array.isArray(selectedTeam?.missingInformation)
+      ? selectedTeam.missingInformation
+          .filter(isString)
+          .map((question, index) => ({
+            id: `team-${selectedTeam?.engineeringCaseId ?? "case"}-${index}`,
+            question,
+          }))
+      : [];
+
+    const seen = new Set<string>();
+    return [...legacy, ...teamMissing].filter((question) => {
+      const key = question.question.trim().toLowerCase();
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [selectedContext?.questions, selectedTeam]);
 
   const responses = useMemo<AgentResponse[]>(() => {
     const raw = selectedContext?.responses;
@@ -187,6 +229,13 @@ export default function AgentConsolePage() {
       return ta - tb;
     });
   }, [selectedContext?.responses]);
+
+  const missionAwaitingApproval = selectedTeam?.mission?.status === "awaiting_approval";
+  const releaseAwaitingApproval = selectedTeam?.caseStatus === "ready_for_human_approval"
+    && selectedTeam?.currentStage === "release";
+  const canApprove = Boolean(missionAwaitingApproval || releaseAwaitingApproval);
+  const approvalLabel = missionAwaitingApproval ? "Approve Mission" : "Approve Release";
+  const awaitingReporterInput = selectedTeam?.caseStatus === "blocked" && questions.length > 0;
 
   async function loadRequests() {
     try {
@@ -614,6 +663,49 @@ export default function AgentConsolePage() {
                   </div>
                 </div>
 
+                {selectedTeam && (
+                  <>
+                    <Separator className="bg-[color:var(--theme-surface-subtle)]" />
+                    <div className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-3 text-[0.75rem]">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="text-[0.7rem] font-semibold uppercase tracking-[0.13em] text-[color:var(--theme-text-secondary)]">
+                          Engineering Team
+                        </div>
+                        <div className="flex flex-wrap gap-1">
+                          {selectedTeam.currentStage && (
+                            <Badge className="border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] text-[10px] text-[color:var(--theme-text-primary)]">
+                              {selectedTeam.currentStage.replace(/_/g, " ")}
+                            </Badge>
+                          )}
+                          {selectedTeam.caseStatus && (
+                            <Badge className="border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] text-[10px] text-[color:var(--theme-text-primary)]">
+                              {selectedTeam.caseStatus.replace(/_/g, " ")}
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                      {selectedTeam.summary && (
+                        <p className="whitespace-pre-line text-xs text-[color:var(--theme-text-primary)]">
+                          {selectedTeam.summary}
+                        </p>
+                      )}
+                      {selectedTeam.mission?.id && (
+                        <div className="text-xs text-[color:var(--theme-text-secondary)]">
+                          Mission: {selectedTeam.mission.title ?? selectedTeam.mission.id}{" "}
+                          {selectedTeam.mission.status
+                            ? `(${selectedTeam.mission.status.replace(/_/g, " ")})`
+                            : ""}
+                        </div>
+                      )}
+                      {selectedTeam.caseStatus === "blocked" && questions.length === 0 && (
+                        <div className="text-xs text-[color:var(--theme-text-muted)]">
+                          The engineering team is blocked on an internal dependency. No reporter input is requested.
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+
                 <Separator className="bg-[color:var(--theme-surface-subtle)]" />
 
                 {/* CONTEXT */}
@@ -827,9 +919,11 @@ export default function AgentConsolePage() {
                   </div>
 
                   {questions.length > 0 ? (
-                    <div className="rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2">
-                      <div className="text-[0.7rem] text-[color:var(--theme-text-secondary)]">
-                        Questions the agent needs answered:
+                    <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-2">
+                      <div className="text-[0.7rem] font-medium text-[color:var(--theme-text-secondary)]">
+                        {awaitingReporterInput
+                          ? "The engineering team needs this information to continue:"
+                          : "Questions the agent needs answered:"}
                       </div>
                       <ul className="mt-2 space-y-2">
                         {questions.map((q, idx) => (
@@ -849,8 +943,7 @@ export default function AgentConsolePage() {
                     </div>
                   ) : (
                     <div className="text-[0.7rem] text-[color:var(--theme-text-muted)]">
-                      No structured questions yet. (Once the worker starts
-                      asking, they’ll show here.)
+                      No reporter input is currently requested.
                     </div>
                   )}
 
@@ -886,7 +979,9 @@ export default function AgentConsolePage() {
 
                   <div className="space-y-2 rounded-lg border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] p-2">
                     <div className="text-[0.7rem] text-[color:var(--theme-text-secondary)]">
-                      Reply (answer the agent / add missing info)
+                      {awaitingReporterInput
+                        ? "Provide the requested evidence or answer"
+                        : "Reply (answer the agent / add missing info)"}
                     </div>
                     <textarea
                       value={replyText}
@@ -906,7 +1001,11 @@ export default function AgentConsolePage() {
                         )}
                         onClick={() => void sendReply()}
                       >
-                        {replySending ? "Sending…" : "Send Reply"}
+                        {replySending
+                          ? "Sending…"
+                          : awaitingReporterInput
+                            ? "Provide Evidence"
+                            : "Send Reply"}
                       </Button>
                     </div>
                   </div>
@@ -916,19 +1015,21 @@ export default function AgentConsolePage() {
 
                 {/* ACTION BUTTONS */}
                 <div className="flex flex-wrap gap-2">
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    disabled={!selected || isPending}
-                    className={cn(
-                      "border-emerald-500/60 text-xs font-semibold text-emerald-300 hover:bg-emerald-600 hover:text-[color:var(--theme-text-on-accent)] disabled:opacity-50",
-                      isPending && "cursor-wait",
-                    )}
-                    onClick={() => selected && updateStatus("approve", selected)}
-                  >
-                    {isPending ? "Working…" : "Approve"}
-                  </Button>
+                  {canApprove && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={!selected || isPending}
+                      className={cn(
+                        "border-emerald-500/60 text-xs font-semibold text-emerald-300 hover:bg-emerald-600 hover:text-[color:var(--theme-text-on-accent)] disabled:opacity-50",
+                        isPending && "cursor-wait",
+                      )}
+                      onClick={() => selected && updateStatus("approve", selected)}
+                    >
+                      {isPending ? "Working…" : approvalLabel}
+                    </Button>
+                  )}
 
                   <Button
                     type="button"

--- a/tests/agent-production-handoff.test.ts
+++ b/tests/agent-production-handoff.test.ts
@@ -8,17 +8,20 @@ function read(path: string) {
 
 describe("production agent request handoff", () => {
   const route = read("app/api/agent/requests/route.ts");
-  const secrets = read("features/shared/lib/server/agent-api-secrets.ts");
+  const teamClient = read("features/agent/server/teamClient.ts");
+  const consolePage = read("features/agent/agent-console/app/agent/page.tsx");
+  const replyRoute = read("app/api/agent/requests/[id]/reply/route.ts");
 
-  it("uses explicit production configuration and authenticated service calls", () => {
-    expect(route).toContain("PROFIXIQ_AGENT_URL");
-    expect(route).toContain("resolveAgentApiSecrets()");
-    expect(secrets).toContain("PROFIXIQ_AGENT_API_SECRET");
-    expect(route).toContain('"x-agent-api-secret": agentSecrets.canonical');
+  it("uses the canonical authenticated Agent team client", () => {
+    expect(route).toContain("agentTeamRequest<AgentServiceResponse>");
+    expect(route).toContain("readAgentTeamCase(engineeringCaseId)");
+    expect(route).toContain("projectAgentTeamCase");
+    expect(teamClient).toContain("resolveAgentApiSecrets()");
+    expect(teamClient).toContain('"x-agent-api-secret"');
     expect(route).not.toContain("app.github.dev");
   });
 
-  it("sends canonical engineering context to the production workforce", () => {
+  it("sends canonical engineering context and screenshot evidence", () => {
     expect(route).toContain("const expectedBehavior = asNullableString(body.expected)");
     expect(route).toContain("const actualBehavior = asNullableString(body.actual)");
     expect(route).toContain("expectedBehavior,");
@@ -35,9 +38,20 @@ describe("production agent request handoff", () => {
     expect(route).toContain("{ status: 502 }");
   });
 
-  it("marks persisted engineering cases in progress", () => {
-    expect(route).toContain("agentResponse?.engineeringCaseId");
-    expect(route).toContain("agentResponse?.intakeJobId");
-    expect(route).toContain('? "in_progress"');
+  it("projects team blockers into the visible Agent Q&A contract", () => {
+    expect(route).toContain("function projectionQuestions(projection: AgentTeamProjection)");
+    expect(route).toContain("projection.missingInformation.map");
+    expect(route).toContain("questions: projectionQuestions(projection)");
+    expect(consolePage).toContain("selectedTeam?.missingInformation");
+    expect(consolePage).toContain("The engineering team needs this information to continue:");
+    expect(replyRoute).toContain("resumeAgentTeamCase");
+  });
+
+  it("only exposes approval when the Agent team has a mission or release gate", () => {
+    expect(consolePage).toContain('selectedTeam?.mission?.status === "awaiting_approval"');
+    expect(consolePage).toContain('selectedTeam?.caseStatus === "ready_for_human_approval"');
+    expect(consolePage).toContain('selectedTeam?.currentStage === "release"');
+    expect(consolePage).toContain("{canApprove && (");
+    expect(consolePage).toContain('missionAwaitingApproval ? "Approve Mission" : "Approve Release"');
   });
 });


### PR DESCRIPTION
## What changed
- project canonical Agent team `missingInformation` into the Agent Console Q&A contract
- display current engineering stage/case/mission state in the request details
- make blocked reporter questions explicit and use Provide Evidence as the reply action
- hide approval until an Engineering Mission is actually awaiting approval or the final release gate is ready
- distinguish Approve Mission from Approve Release
- update the production Agent handoff contract tests for the canonical team pipeline

## Why
The submit bridge works, but blocked team state was not visible in ProFixIQ and the Approve button was exposed before any mission existed. This made the new team workflow look stalled/broken even when the backend correctly rejected premature approval.