### PR TITLE
Fix create-user role type build blocker

### DIFF
--- a/app/api/admin/create-user/route.ts
+++ b/app/api/admin/create-user/route.ts
@@ -21,7 +21,7 @@ type Body = {
   email?: string | null;
   password: string;
   full_name?: string | null;
-  role?: Database["public"]["Enums"]["user_role_enum"] | null;
+  role?: string | null;
   // client can send it but we will ignore unless allowed
   shop_id?: string | null;
   phone?: string | null;


### PR DESCRIPTION
The Agent Console production deployment exposed a pre-existing type error in `app/api/admin/create-user/route.ts`: the request body directly indexed `Database["public"]["Enums"]`, but the current generated Database surface no longer exposes that enum namespace at the top level. The request is already validated through `canonicalizeRole` and the provisionable-role allowlist, so this keeps the external request body as `string | null` while preserving typed database inserts.