### PR TITLE
Show Agent diagnosis and repair plan before mission approval

### DIFF
--- a/features/agent/server/teamClient.ts
+++ b/features/agent/server/teamClient.ts
@@ -91,6 +91,15 @@ export type AgentTeamProjection = {
     problemStatement: string | null;
     approvedAt: string | null;
     approvedBy: string | null;
+    acceptanceCriteria: string[];
+    constraints: string[];
+    risks: string[];
+    planSteps: Array<{
+      position: number | null;
+      title: string;
+      description: string | null;
+      ownerStage: string | null;
+    }>;
   } | null;
   pullRequest: {
     number: number | null;
@@ -124,6 +133,73 @@ function nullableString(value: unknown): string | null {
 function nullableNumber(value: unknown): number | null {
   const number = Number(value);
   return Number.isFinite(number) ? number : null;
+}
+
+function recordStrings(value: unknown, key: string): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(isRecord)
+    .map((row) => nullableString(row[key]))
+    .filter((item): item is string => Boolean(item));
+}
+
+function stageStrings(
+  engineeringCase: AgentTeamEngineeringCase,
+  stage: string,
+  key: string,
+): string[] {
+  const data = engineeringCase.stages[stage]?.result?.data;
+  const value = isRecord(data) ? data[key] : null;
+  return Array.isArray(value)
+    ? value.map((item) => String(item ?? "").trim()).filter(Boolean)
+    : [];
+}
+
+function missionPlanSteps(value: unknown): AgentTeamProjection["mission"] extends infer Mission
+  ? Mission extends { planSteps: infer Steps } ? Steps : never
+  : never {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(isRecord)
+    .map((row) => ({
+      position: nullableNumber(row.position),
+      title: nullableString(row.title) ?? "Plan step",
+      description: nullableString(row.description),
+      ownerStage: nullableString(row.owner_stage ?? row.ownerStage),
+    }));
+}
+
+function missionApprovalSummary(
+  engineeringCase: AgentTeamEngineeringCase,
+  mission: AgentTeamMission,
+  fallback: string | null,
+): string | null {
+  if (mission.status !== "awaiting_approval") return fallback;
+
+  const diagnosis = nullableString(engineeringCase.stages.root_cause?.result?.summary)
+    ?? nullableString(mission.problem_statement);
+  const proposedRepair = nullableString(engineeringCase.stages.planning?.result?.summary)
+    ?? nullableString(mission.desired_outcome);
+  const recommendedFiles = stageStrings(engineeringCase, "planning", "recommendedFiles").slice(0, 6);
+  const acceptanceCriteria = recordStrings(mission.acceptanceCriteria, "criterion").slice(0, 5);
+  const planSteps = missionPlanSteps(mission.planSteps).slice(0, 5);
+
+  const lines = [
+    diagnosis ? `Diagnosis\n${diagnosis}` : null,
+    proposedRepair ? `Proposed repair\n${proposedRepair}` : null,
+    recommendedFiles.length > 0
+      ? `Repair scope\n${recommendedFiles.map((path) => `• ${path}`).join("\n")}`
+      : null,
+    acceptanceCriteria.length > 0
+      ? `Acceptance checks\n${acceptanceCriteria.map((criterion) => `• ${criterion}`).join("\n")}`
+      : null,
+    planSteps.length > 0
+      ? `Engineering plan\n${planSteps.map((step, index) => `${step.position ?? index + 1}. ${step.title}${step.description ? ` — ${step.description}` : ""}`).join("\n")}`
+      : null,
+    "Human approval is required before the engineering team can change code. Review the repair mission, then select Approve Mission.",
+  ].filter((line): line is string => Boolean(line));
+
+  return lines.join("\n\n") || fallback;
 }
 
 async function readBridgeSecret(): Promise<string> {
@@ -309,13 +385,13 @@ export function projectAgentTeamCase(
 ): AgentTeamProjection {
   const engineeringCase = envelope.engineeringCase;
   const currentStep = engineeringCase.stages[engineeringCase.currentStage] ?? null;
-  const summary = envelope.caseSummary?.summary
+  const baseSummary = envelope.caseSummary?.summary
     ?? currentStep?.result?.summary
     ?? null;
   const decision = envelope.caseSummary?.decision
     ?? currentStep?.result?.decision
     ?? null;
-  const missingInformation = envelope.caseSummary?.missingInformation
+  const rawMissingInformation = envelope.caseSummary?.missingInformation
     ?? currentStep?.result?.missingInformation
     ?? [];
   const metadata = isRecord(engineeringCase.ticket.metadata)
@@ -327,6 +403,21 @@ export function projectAgentTeamCase(
   const approvalPackage = isRecord(metadata.approvalPackage)
     ? metadata.approvalPackage
     : {};
+  const mission = envelope.mission;
+  const awaitingMissionApproval = mission?.status === "awaiting_approval";
+  const summary = mission
+    ? missionApprovalSummary(engineeringCase, mission, baseSummary)
+    : baseSummary;
+  const acceptanceCriteria = mission
+    ? recordStrings(mission.acceptanceCriteria, "criterion")
+    : [];
+  const constraints = mission
+    ? recordStrings(mission.constraints, "description")
+    : [];
+  const risks = mission
+    ? recordStrings(mission.risks, "description")
+    : [];
+  const planSteps = mission ? missionPlanSteps(mission.planSteps) : [];
 
   return {
     engineeringCaseId: engineeringCase.id,
@@ -336,19 +427,25 @@ export function projectAgentTeamCase(
     stepStatus: envelope.caseSummary?.stepStatus ?? currentStep?.status ?? null,
     summary,
     decision,
-    missingInformation: Array.isArray(missingInformation)
-      ? missingInformation.filter((value): value is string => typeof value === "string")
-      : [],
+    missingInformation: awaitingMissionApproval
+      ? []
+      : Array.isArray(rawMissingInformation)
+        ? rawMissingInformation.filter((value): value is string => typeof value === "string")
+        : [],
     updatedAt: engineeringCase.updatedAt,
-    mission: envelope.mission
+    mission: mission
       ? {
-          id: envelope.mission.id,
-          status: envelope.mission.status,
-          title: nullableString(envelope.mission.title),
-          desiredOutcome: nullableString(envelope.mission.desired_outcome),
-          problemStatement: nullableString(envelope.mission.problem_statement),
-          approvedAt: nullableString(envelope.mission.approved_at),
-          approvedBy: nullableString(envelope.mission.approved_by),
+          id: mission.id,
+          status: mission.status,
+          title: nullableString(mission.title),
+          desiredOutcome: nullableString(mission.desired_outcome),
+          problemStatement: nullableString(mission.problem_statement),
+          approvedAt: nullableString(mission.approved_at),
+          approvedBy: nullableString(mission.approved_by),
+          acceptanceCriteria,
+          constraints,
+          risks,
+          planSteps,
         }
       : null,
     pullRequest: {

--- a/tests/agent-production-handoff.test.ts
+++ b/tests/agent-production-handoff.test.ts
@@ -47,6 +47,18 @@ describe("production agent request handoff", () => {
     expect(replyRoute).toContain("resumeAgentTeamCase");
   });
 
+  it("projects an awaiting mission as diagnosis plus repair proposal rather than a fake Q&A blocker", () => {
+    expect(teamClient).toContain("function missionApprovalSummary(");
+    expect(teamClient).toContain("Diagnosis\\n");
+    expect(teamClient).toContain("Proposed repair\\n");
+    expect(teamClient).toContain("Repair scope\\n");
+    expect(teamClient).toContain("Acceptance checks\\n");
+    expect(teamClient).toContain("Engineering plan\\n");
+    expect(teamClient).toContain("Human approval is required before the engineering team can change code");
+    expect(teamClient).toContain("awaitingMissionApproval");
+    expect(teamClient).toContain("? []");
+  });
+
   it("only exposes approval when the Agent team has a mission or release gate", () => {
     expect(consolePage).toContain('selectedTeam?.mission?.status === "awaiting_approval"');
     expect(consolePage).toContain('selectedTeam?.caseStatus === "ready_for_human_approval"');


### PR DESCRIPTION
## Problem

The Agent Console receives the canonical Engineering Mission but currently collapses the team state to the current-stage summary. At the mission gate that means the user sees `Implementation is waiting for human approval...` instead of the diagnosis and proposed repair that produced the mission. The same approval gate is also surfaced through `missingInformation`, making it look like an unanswered Q&A prompt.

## Fix

- Project the Root Cause and Planning stage results into the visible Agent summary whenever a mission is `awaiting_approval`.
- Include repair scope, mission acceptance checks, and the ordered engineering plan in that summary.
- Preserve the detailed mission fields in the local Agent-team projection for future UI use.
- Suppress `missingInformation` while the only gate is mission approval; approval is an action, not reporter Q&A.
- Keep existing status mapping and `Approve Mission` gating unchanged.
- Extend the production handoff regression contract.

No database migration is required.