### PR TITLE
Fix expanded Agent mission projection build contract

### DIFF
--- a/app/api/agent/requests/[id]/route.ts
+++ b/app/api/agent/requests/[id]/route.ts
@@ -44,6 +44,24 @@ function nullableString(value: unknown): string | null {
   return text || null;
 }
 
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map((item) => nullableString(item)).filter((item): item is string => Boolean(item))
+    : [];
+}
+
+function missionPlanSteps(value: unknown): NonNullable<AgentTeamProjection["mission"]>["planSteps"] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(isRecord)
+    .map((step) => ({
+      position: Number.isFinite(Number(step.position)) ? Number(step.position) : null,
+      title: nullableString(step.title) ?? "Plan step",
+      description: nullableString(step.description),
+      ownerStage: nullableString(step.ownerStage ?? step.owner_stage),
+    }));
+}
+
 function projectionFromNormalized(value: unknown): AgentTeamProjection | null {
   if (!isRecord(value) || !isRecord(value.agentTeam)) return null;
   const team = value.agentTeam;
@@ -59,6 +77,10 @@ function projectionFromNormalized(value: unknown): AgentTeamProjection | null {
         problemStatement: nullableString(team.mission.problemStatement),
         approvedAt: nullableString(team.mission.approvedAt),
         approvedBy: nullableString(team.mission.approvedBy),
+        acceptanceCriteria: stringArray(team.mission.acceptanceCriteria),
+        constraints: stringArray(team.mission.constraints),
+        risks: stringArray(team.mission.risks),
+        planSteps: missionPlanSteps(team.mission.planSteps),
       }
     : null;
   const pullRequest = isRecord(team.pullRequest) ? team.pullRequest : {};

--- a/tests/agent-production-handoff.test.ts
+++ b/tests/agent-production-handoff.test.ts
@@ -8,6 +8,7 @@ function read(path: string) {
 
 describe("production agent request handoff", () => {
   const route = read("app/api/agent/requests/route.ts");
+  const detailRoute = read("app/api/agent/requests/[id]/route.ts");
   const teamClient = read("features/agent/server/teamClient.ts");
   const consolePage = read("features/agent/agent-console/app/agent/page.tsx");
   const replyRoute = read("app/api/agent/requests/[id]/reply/route.ts");
@@ -57,6 +58,14 @@ describe("production agent request handoff", () => {
     expect(teamClient).toContain("Human approval is required before the engineering team can change code");
     expect(teamClient).toContain("awaitingMissionApproval");
     expect(teamClient).toContain("? []");
+  });
+
+  it("keeps the expanded mission shape when reading the local request projection", () => {
+    expect(detailRoute).toContain('acceptanceCriteria: stringArray(team.mission.acceptanceCriteria)');
+    expect(detailRoute).toContain('constraints: stringArray(team.mission.constraints)');
+    expect(detailRoute).toContain('risks: stringArray(team.mission.risks)');
+    expect(detailRoute).toContain('planSteps: missionPlanSteps(team.mission.planSteps)');
+    expect(detailRoute).toContain('NonNullable<AgentTeamProjection["mission"]>["planSteps"]');
   });
 
   it("only exposes approval when the Agent team has a mission or release gate", () => {


### PR DESCRIPTION
## Production build blocker

PR #1372 correctly expanded the canonical Agent mission projection with acceptance criteria, constraints, risks, and plan steps. The production Next.js typecheck then caught one stale compatibility parser in `app/api/agent/requests/[id]/route.ts` that still reconstructed the previous smaller mission shape.

## Fix

- Preserve the expanded mission shape when hydrating the local `normalized_json.agentTeam` projection.
- Parse acceptance criteria, constraints, risks, and ordered plan steps defensively.
- Remain backwards compatible with older local rows where those fields are absent by defaulting to empty arrays.
- Add a regression contract covering the request-detail projection shape.

No runtime semantics, approval authorization, database schema, or migration changes.