### PR TITLE
Add meaningful checks for Agent pull requests

### DIFF
--- a/.github/workflows/agent-pr-checks.yml
+++ b/.github/workflows/agent-pr-checks.yml
@@ -1,0 +1,62 @@
+name: Agent PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agent-pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check
+        run: pnpm typecheck
+
+      - name: Lint changed JavaScript and TypeScript files
+        shell: bash
+        run: |
+          mapfile -t changed_files < <(
+            git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- \
+              '*.js' '*.jsx' '*.mjs' '*.cjs' '*.ts' '*.tsx'
+          )
+          if (( ${#changed_files[@]} == 0 )); then
+            echo "No changed JavaScript or TypeScript files."
+            exit 0
+          fi
+          pnpm exec eslint "${changed_files[@]}"
+
+      - name: Run tests related to the pull request
+        run: pnpm exec vitest run --changed "$BASE_SHA" --passWithNoTests


### PR DESCRIPTION
## Root cause
The Agent Test and Approval gates require a successful check matching `checks`, but ProFixIQ had no pull-request CI workflow. Vercel preview deployments are disabled for non-main branches, so a canceled preview status could not serve as test evidence.

## What changed
- Add one bounded `checks` job for pull requests targeting `main`.
- Install from the committed pnpm lockfile.
- Run the complete TypeScript type-check.
- Lint only changed JavaScript and TypeScript files so unrelated repository lint debt does not hide new regressions.
- Run Vitest tests related to the pull-request diff.

## Safety
The workflow has read-only repository permissions, a 30-minute timeout, and concurrency cancellation for superseded revisions. It does not receive deployment credentials or mutate repository contents.

## Validation
The workflow contract was checked against the current package scripts and Vitest 4 CLI (`--changed [since]` and `--passWithNoTests`).