### PR TITLE
Show the complete Agent mission before approval

### DIFF
--- a/features/agent/agent-console/app/agent/page.tsx
+++ b/features/agent/agent-console/app/agent/page.tsx
@@ -11,6 +11,11 @@ import { Badge } from "@shared/components/ui/badge";
 import { Separator } from "@shared/components/ui/separator";
 import { cn } from "@shared/lib/utils";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  AgentMissionDetails,
+  isMissionReviewComplete,
+  type AgentMissionReview,
+} from "@/features/agent/agent-console/components/AgentMissionDetails";
 
 type AgentRequestStatus =
   | "submitted"
@@ -31,12 +36,6 @@ type AgentResponse = {
   answers?: Record<string, string> | null;
 };
 
-type AgentTeamMission = {
-  id?: string;
-  status?: string;
-  title?: string | null;
-};
-
 type AgentTeamState = {
   engineeringCaseId?: string;
   currentStage?: string;
@@ -45,7 +44,7 @@ type AgentTeamState = {
   summary?: string | null;
   decision?: string | null;
   missingInformation?: string[];
-  mission?: AgentTeamMission | null;
+  mission?: AgentMissionReview | null;
   syncedAt?: string;
 };
 
@@ -231,9 +230,12 @@ export default function AgentConsolePage() {
   }, [selectedContext?.responses]);
 
   const missionAwaitingApproval = selectedTeam?.mission?.status === "awaiting_approval";
+  const missionReviewComplete = isMissionReviewComplete(selectedTeam?.mission);
   const releaseAwaitingApproval = selectedTeam?.caseStatus === "ready_for_human_approval"
     && selectedTeam?.currentStage === "release";
-  const canApprove = Boolean(missionAwaitingApproval || releaseAwaitingApproval);
+  const canApprove = Boolean(
+    (missionAwaitingApproval && missionReviewComplete) || releaseAwaitingApproval,
+  );
   const approvalLabel = missionAwaitingApproval ? "Approve Mission" : "Approve Release";
   const awaitingReporterInput = selectedTeam?.caseStatus === "blocked" && questions.length > 0;
 
@@ -689,14 +691,9 @@ export default function AgentConsolePage() {
                           {selectedTeam.summary}
                         </p>
                       )}
-                      {selectedTeam.mission?.id && (
-                        <div className="text-xs text-[color:var(--theme-text-secondary)]">
-                          Mission: {selectedTeam.mission.title ?? selectedTeam.mission.id}{" "}
-                          {selectedTeam.mission.status
-                            ? `(${selectedTeam.mission.status.replace(/_/g, " ")})`
-                            : ""}
-                        </div>
-                      )}
+                      {selectedTeam.mission?.id ? (
+                        <AgentMissionDetails mission={selectedTeam.mission} />
+                      ) : null}
                       {selectedTeam.caseStatus === "blocked" && questions.length === 0 && (
                         <div className="text-xs text-[color:var(--theme-text-muted)]">
                           The engineering team is blocked on an internal dependency. No reporter input is requested.

--- a/features/agent/agent-console/components/AgentMissionDetails.tsx
+++ b/features/agent/agent-console/components/AgentMissionDetails.tsx
@@ -1,0 +1,155 @@
+export type AgentMissionPlanStep = {
+  position: number | null;
+  title: string;
+  description: string | null;
+  ownerStage: string | null;
+};
+
+export type AgentMissionReview = {
+  id?: string;
+  status?: string;
+  title?: string | null;
+  desiredOutcome?: string | null;
+  problemStatement?: string | null;
+  acceptanceCriteria?: string[];
+  constraints?: string[];
+  risks?: string[];
+  planSteps?: AgentMissionPlanStep[];
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function isMissionReviewComplete(
+  mission: AgentMissionReview | null | undefined,
+): boolean {
+  return Boolean(
+    mission?.id &&
+      isNonEmptyString(mission.problemStatement) &&
+      isNonEmptyString(mission.desiredOutcome) &&
+      Array.isArray(mission.acceptanceCriteria) &&
+      mission.acceptanceCriteria.length > 0 &&
+      Array.isArray(mission.constraints) &&
+      Array.isArray(mission.risks) &&
+      Array.isArray(mission.planSteps) &&
+      mission.planSteps.length > 0,
+  );
+}
+
+function MissionList({
+  emptyLabel,
+  items,
+  title,
+}: {
+  emptyLabel: string;
+  items: string[];
+  title: string;
+}) {
+  return (
+    <section className="space-y-1" aria-label={title}>
+      <h4 className="font-semibold text-[color:var(--theme-text-primary)]">
+        {title}
+      </h4>
+      {items.length > 0 ? (
+        <ul className="list-disc space-y-1 pl-5 text-[color:var(--theme-text-secondary)]">
+          {items.map((item, index) => (
+            <li key={`${index}-${item}`}>{item}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-[color:var(--theme-text-muted)]">{emptyLabel}</p>
+      )}
+    </section>
+  );
+}
+
+export function AgentMissionDetails({ mission }: { mission: AgentMissionReview }) {
+  const complete = isMissionReviewComplete(mission);
+  const acceptanceCriteria = mission.acceptanceCriteria ?? [];
+  const constraints = mission.constraints ?? [];
+  const risks = mission.risks ?? [];
+  const planSteps = mission.planSteps ?? [];
+
+  return (
+    <details
+      className="rounded-md border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-panel)] p-3"
+      open={mission.status === "awaiting_approval"}
+    >
+      <summary className="cursor-pointer font-semibold text-[color:var(--theme-text-primary)]">
+        Full mission review: {mission.title ?? mission.id ?? "Engineering mission"}
+      </summary>
+
+      <div className="mt-3 space-y-4 text-xs">
+        <section className="space-y-1" aria-label="Diagnosis">
+          <h4 className="font-semibold text-[color:var(--theme-text-primary)]">
+            Diagnosis
+          </h4>
+          <p className="whitespace-pre-wrap text-[color:var(--theme-text-secondary)]">
+            {mission.problemStatement ?? "Diagnosis is not available."}
+          </p>
+        </section>
+
+        <section className="space-y-1" aria-label="Desired outcome">
+          <h4 className="font-semibold text-[color:var(--theme-text-primary)]">
+            Desired outcome
+          </h4>
+          <p className="whitespace-pre-wrap text-[color:var(--theme-text-secondary)]">
+            {mission.desiredOutcome ?? "Desired outcome is not available."}
+          </p>
+        </section>
+
+        <MissionList
+          title="Acceptance criteria"
+          items={acceptanceCriteria}
+          emptyLabel="No acceptance criteria were provided."
+        />
+
+        <section className="space-y-1" aria-label="Engineering plan">
+          <h4 className="font-semibold text-[color:var(--theme-text-primary)]">
+            Engineering plan
+          </h4>
+          {planSteps.length > 0 ? (
+            <ol className="list-decimal space-y-2 pl-5 text-[color:var(--theme-text-secondary)]">
+              {planSteps.map((step, index) => (
+                <li key={`${step.position ?? index + 1}-${step.title}`}>
+                  <span className="font-medium text-[color:var(--theme-text-primary)]">
+                    {step.title}
+                  </span>
+                  {step.description ? ` — ${step.description}` : ""}
+                  {step.ownerStage ? (
+                    <span className="block text-[color:var(--theme-text-muted)]">
+                      Owner stage: {step.ownerStage.replace(/_/g, " ")}
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p className="text-[color:var(--theme-text-muted)]">
+              No engineering plan was provided.
+            </p>
+          )}
+        </section>
+
+        <MissionList
+          title="Constraints"
+          items={constraints}
+          emptyLabel="No additional constraints were recorded."
+        />
+
+        <MissionList
+          title="Risks"
+          items={risks}
+          emptyLabel="No risks were recorded."
+        />
+
+        {mission.status === "awaiting_approval" && !complete ? (
+          <p role="alert" className="font-medium text-amber-300">
+            Approval is disabled until the complete mission contract is available.
+          </p>
+        ) : null}
+      </div>
+    </details>
+  );
+}

--- a/features/agent/server/teamClient.ts
+++ b/features/agent/server/teamClient.ts
@@ -180,23 +180,36 @@ function missionApprovalSummary(
     ?? nullableString(mission.problem_statement);
   const proposedRepair = nullableString(engineeringCase.stages.planning?.result?.summary)
     ?? nullableString(mission.desired_outcome);
-  const recommendedFiles = stageStrings(engineeringCase, "planning", "recommendedFiles").slice(0, 6);
-  const acceptanceCriteria = recordStrings(mission.acceptanceCriteria, "criterion").slice(0, 5);
-  const planSteps = missionPlanSteps(mission.planSteps).slice(0, 5);
+  const allRecommendedFiles = stageStrings(
+    engineeringCase,
+    "planning",
+    "recommendedFiles",
+  );
+  const allAcceptanceCriteria = recordStrings(
+    mission.acceptanceCriteria,
+    "criterion",
+  );
+  const allPlanSteps = missionPlanSteps(mission.planSteps);
+  const recommendedFiles = allRecommendedFiles.slice(0, 6);
+  const acceptanceCriteria = allAcceptanceCriteria.slice(0, 5);
+  const planSteps = allPlanSteps.slice(0, 5);
+  const omittedFiles = allRecommendedFiles.length - recommendedFiles.length;
+  const omittedCriteria = allAcceptanceCriteria.length - acceptanceCriteria.length;
+  const omittedSteps = allPlanSteps.length - planSteps.length;
 
   const lines = [
     diagnosis ? `Diagnosis\n${diagnosis}` : null,
     proposedRepair ? `Proposed repair\n${proposedRepair}` : null,
     recommendedFiles.length > 0
-      ? `Repair scope\n${recommendedFiles.map((path) => `• ${path}`).join("\n")}`
+      ? `Repair scope preview\n${recommendedFiles.map((path) => `• ${path}`).join("\n")}${omittedFiles > 0 ? `\n• +${omittedFiles} more file${omittedFiles === 1 ? "" : "s"} in the full mission review` : ""}`
       : null,
     acceptanceCriteria.length > 0
-      ? `Acceptance checks\n${acceptanceCriteria.map((criterion) => `• ${criterion}`).join("\n")}`
+      ? `Acceptance checks preview\n${acceptanceCriteria.map((criterion) => `• ${criterion}`).join("\n")}${omittedCriteria > 0 ? `\n• +${omittedCriteria} more check${omittedCriteria === 1 ? "" : "s"} in the full mission review` : ""}`
       : null,
     planSteps.length > 0
-      ? `Engineering plan\n${planSteps.map((step, index) => `${step.position ?? index + 1}. ${step.title}${step.description ? ` — ${step.description}` : ""}`).join("\n")}`
+      ? `Engineering plan preview\n${planSteps.map((step, index) => `${step.position ?? index + 1}. ${step.title}${step.description ? ` — ${step.description}` : ""}`).join("\n")}${omittedSteps > 0 ? `\n${planSteps.length + 1}. +${omittedSteps} more step${omittedSteps === 1 ? "" : "s"} in the full mission review` : ""}`
       : null,
-    "Human approval is required before the engineering team can change code. Review the repair mission, then select Approve Mission.",
+    "Human approval is required before the engineering team can change code. Review every item in the full mission review, then select Approve Mission.",
   ].filter((line): line is string => Boolean(line));
 
   return lines.join("\n\n") || fallback;

--- a/features/agent/server/teamClient.ts
+++ b/features/agent/server/teamClient.ts
@@ -7,12 +7,6 @@ const AGENT_SERVICE_URL = String(process.env.PROFIXIQ_AGENT_URL ?? "")
 const BRIDGE_INTEGRATION_ID = "7c2da329-5117-48c0-a1ee-d51b5d63827d";
 const BRIDGE_INTEGRATION_KIND = "profixiq_agent_bridge";
 
-const bridgeSupabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  { auth: { persistSession: false, autoRefreshToken: false } },
-);
-
 export type AgentTeamRequestStatus =
   | "submitted"
   | "in_progress"
@@ -216,6 +210,13 @@ function missionApprovalSummary(
 }
 
 async function readBridgeSecret(): Promise<string> {
+  const supabaseUrl = nullableString(process.env.NEXT_PUBLIC_SUPABASE_URL);
+  const serviceRoleKey = nullableString(process.env.SUPABASE_SERVICE_ROLE_KEY);
+  if (!supabaseUrl || !serviceRoleKey) return "";
+
+  const bridgeSupabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
   const result = await bridgeSupabase
     .from("integrations")
     .select("config")

--- a/tests/agent-mission-approval-completeness.test.tsx
+++ b/tests/agent-mission-approval-completeness.test.tsx
@@ -1,0 +1,125 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  AgentMissionDetails,
+  isMissionReviewComplete,
+  type AgentMissionReview,
+} from "@/features/agent/agent-console/components/AgentMissionDetails";
+import {
+  projectAgentTeamCase,
+  type AgentTeamCaseEnvelope,
+} from "@/features/agent/server/teamClient";
+
+function missionReview(): AgentMissionReview {
+  return {
+    id: "694f5648-c5db-4b73-82a9-fc10e40c93e3",
+    status: "awaiting_approval",
+    title: "Repair mission",
+    problemStatement: "The canonical approval surface hides mission details.",
+    desiredOutcome: "Show the complete review contract before approval.",
+    acceptanceCriteria: Array.from(
+      { length: 7 },
+      (_, index) => `Acceptance criterion ${index + 1}`,
+    ),
+    constraints: ["Preserve shop isolation", "Do not merge automatically"],
+    risks: ["Incomplete context could authorize the wrong scope"],
+    planSteps: Array.from({ length: 7 }, (_, index) => ({
+      position: index + 1,
+      title: `Plan step ${index + 1}`,
+      description: `Complete repair action ${index + 1}`,
+      ownerStage: index === 0 ? "implementation" : "test",
+    })),
+  };
+}
+
+describe("Agent mission approval completeness", () => {
+  it("renders every mission item and blocks incomplete mission contracts", () => {
+    const mission = missionReview();
+    const markup = renderToStaticMarkup(<AgentMissionDetails mission={mission} />);
+
+    for (const criterion of mission.acceptanceCriteria ?? []) {
+      expect(markup).toContain(criterion);
+    }
+    for (const step of mission.planSteps ?? []) {
+      expect(markup).toContain(step.title);
+      expect(markup).toContain(step.description);
+    }
+    for (const constraint of mission.constraints ?? []) {
+      expect(markup).toContain(constraint);
+    }
+    for (const risk of mission.risks ?? []) {
+      expect(markup).toContain(risk);
+    }
+
+    expect(isMissionReviewComplete(mission)).toBe(true);
+    expect(isMissionReviewComplete({ ...mission, planSteps: undefined })).toBe(false);
+    expect(isMissionReviewComplete({ ...mission, acceptanceCriteria: [] })).toBe(false);
+  });
+
+  it("projects the full mission while labeling the compact summary as a preview", () => {
+    const mission = missionReview();
+    const envelope = {
+      engineeringCase: {
+        id: "a2d023e1-704b-4069-bada-5635fcbcf4f4",
+        currentStage: "implementation",
+        status: "blocked",
+        updatedAt: "2026-08-07T00:00:00.000Z",
+        ticket: {
+          id: "8b07673d-a003-462b-a4ef-dfdb9d3d4ed1",
+          metadata: {},
+        },
+        stages: {
+          root_cause: {
+            status: "passed",
+            result: { summary: "Root cause summary" },
+          },
+          planning: {
+            status: "passed",
+            result: {
+              summary: "Repair summary",
+              data: {
+                recommendedFiles: Array.from(
+                  { length: 8 },
+                  (_, index) => `features/example/File${index + 1}.tsx`,
+                ),
+              },
+            },
+          },
+          implementation: {
+            status: "blocked",
+            result: { summary: "Awaiting approval" },
+          },
+        },
+      },
+      mission: {
+        id: mission.id!,
+        status: mission.status!,
+        title: mission.title,
+        problem_statement: mission.problemStatement,
+        desired_outcome: mission.desiredOutcome,
+        acceptanceCriteria: mission.acceptanceCriteria!.map((criterion) => ({
+          criterion,
+        })),
+        constraints: mission.constraints!.map((description) => ({ description })),
+        risks: mission.risks!.map((description) => ({ description })),
+        planSteps: mission.planSteps!.map((step) => ({
+          position: step.position,
+          title: step.title,
+          description: step.description,
+          owner_stage: step.ownerStage,
+        })),
+      },
+    } satisfies AgentTeamCaseEnvelope;
+
+    const projection = projectAgentTeamCase(envelope);
+
+    expect(projection.mission?.acceptanceCriteria).toHaveLength(7);
+    expect(projection.mission?.planSteps).toHaveLength(7);
+    expect(projection.mission?.constraints).toHaveLength(2);
+    expect(projection.mission?.risks).toHaveLength(1);
+    expect(projection.summary).toContain("Repair scope preview");
+    expect(projection.summary).toContain("+2 more files in the full mission review");
+    expect(projection.summary).toContain("+2 more checks in the full mission review");
+    expect(projection.summary).toContain("+2 more steps in the full mission review");
+  });
+});

--- a/tests/agent-production-handoff.test.ts
+++ b/tests/agent-production-handoff.test.ts
@@ -52,9 +52,9 @@ describe("production agent request handoff", () => {
     expect(teamClient).toContain("function missionApprovalSummary(");
     expect(teamClient).toContain("Diagnosis\\n");
     expect(teamClient).toContain("Proposed repair\\n");
-    expect(teamClient).toContain("Repair scope\\n");
-    expect(teamClient).toContain("Acceptance checks\\n");
-    expect(teamClient).toContain("Engineering plan\\n");
+    expect(teamClient).toContain("Repair scope preview\\n");
+    expect(teamClient).toContain("Acceptance checks preview\\n");
+    expect(teamClient).toContain("Engineering plan preview\\n");
     expect(teamClient).toContain("Human approval is required before the engineering team can change code");
     expect(teamClient).toContain("awaitingMissionApproval");
     expect(teamClient).toContain("? []");


### PR DESCRIPTION
## Root cause
The Agent console exposed only a truncated mission summary while still presenting the approval action, so an operator could not review every diagnosis, acceptance criterion, plan step, constraint, and risk before authorizing code changes.

## What changed
- Add a complete, accessible mission review surface in the Agent console.
- Show clear previews with omitted-item counts while keeping the full contract available.
- Disable mission approval until the complete mission payload is present.
- Preserve the one-time approval proof fields added by security #1379 while rebasing the shared Agent client on current main.
- Add focused rendering and approval-gate regression coverage.

## Validation
- Focused component tests: 2 passed.
- TypeScript: passed.
- Changed-file ESLint: passed.
- React review: native details/summary semantics, stable server data rendering, no new effects or client fetches.
- Required full-suite CI/build and Vercel preview on this PR are authoritative.