### PR TITLE
Add automatic full-app regression inventory

### DIFF
--- a/.github/workflows/agent-pr-checks.yml
+++ b/.github/workflows/agent-pr-checks.yml
@@ -43,6 +43,27 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build full-app regression inventory
+        id: regression_inventory
+        continue-on-error: true
+        run: pnpm regression:inventory:check --output-dir "$RUNNER_TEMP/regression-inventory"
+
+      - name: Publish regression inventory summary
+        if: always() && hashFiles('scripts/regression-inventory/critical-flows.json') != ''
+        shell: bash
+        run: |
+          if [[ -f "$RUNNER_TEMP/regression-inventory/summary.md" ]]; then
+            cat "$RUNNER_TEMP/regression-inventory/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload regression inventory
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-app-regression-inventory
+          path: ${{ runner.temp }}/regression-inventory
+          if-no-files-found: warn
+
       - name: Type-check
         run: pnpm typecheck
 
@@ -74,3 +95,9 @@ jobs:
           STRIPE_SECRET_KEY: sk_test_ci_build_placeholder
           NEXT_PUBLIC_SITE_URL: https://ci-build.example.test
         run: pnpm build
+
+      - name: Enforce regression inventory gate
+        if: always() && steps.regression_inventory.outcome == 'failure'
+        run: |
+          echo "Full-app regression inventory found new, expired, or stale findings."
+          exit 1

--- a/.github/workflows/supabase-clean-replay-audit.yml
+++ b/.github/workflows/supabase-clean-replay-audit.yml
@@ -272,6 +272,34 @@ jobs:
             -f tests/invoices/customer-document-numbering.runtime.sql \
             2>&1 | tee customer-document-numbering-runtime.log
 
+      - name: Execute payroll period pipeline integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/payroll-period-pipeline.runtime.sql \
+            2>&1 | tee payroll-period-pipeline-runtime.log
+
+      - name: Execute agent human-approval proof integration
+        shell: bash
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          set -euo pipefail
+          if ! command -v psql >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y postgresql-client
+          fi
+          psql "$DB_URL" -X -v ON_ERROR_STOP=1 \
+            -f tests/security/agent-human-approval-proof.runtime.sql \
+            2>&1 | tee agent-human-approval-proof-runtime.log
+
       - name: Execute P0 schema reconciliation integration
         shell: bash
         env:
@@ -369,6 +397,8 @@ jobs:
             p1-012-stripe-webhook-receipts-runtime.log
             p1-012-stripe-webhook-concurrency.log
             work-order-parts-portal-policy-runtime.log
+            payroll-period-pipeline-runtime.log
+            agent-human-approval-proof-runtime.log
             p0-008-schema-reconciliation-runtime.log
             p0-008-generated-types.diff
             generated-supabase-types.ts

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ tsconfig.tsbuildinfo
 # Live-project type snapshots are diagnostic only; canonical types come from a clean replay.
 features/shared/types/types/supabase.linked.ts
 
+# Generated full-app regression inventory reports
+artifacts/regression-inventory/
+
 # Generated PWA service worker output
 public/sw.js
 public/sw.js.map

--- a/docs/full-app-regression-inventory.md
+++ b/docs/full-app-regression-inventory.md
@@ -1,0 +1,108 @@
+# Full-app regression inventory
+
+## Purpose
+
+The regression inventory replaces manual route-by-route clicking as the first line of regression detection. It catalogs the complete application surface and links four contracts:
+
+1. application Supabase consumers (`from`, select/filter/mutation columns, RPCs, Storage, and Realtime),
+2. the canonical generated schema from a clean migration replay,
+3. executable evidence for critical multi-step flows, and
+4. normalized production error signatures from an optional log export.
+
+It is an inventory and an early-warning gate, not a claim that static analysis replaces browser acceptance testing. Missing browser/API/database evidence remains visible as a critical-flow gap.
+
+## Commands
+
+```bash
+# Generate JSON and Markdown reports; known and new findings are reported.
+pnpm regression:inventory
+
+# CI mode. Fails for a new error, an expired baseline entry, or a stale entry
+# whose underlying issue has been resolved.
+pnpm regression:inventory:check
+
+# Repair-campaign mode. Fails while any current error remains.
+pnpm regression:inventory:strict
+
+# Deliberate baseline update after reviewing every new fingerprint.
+pnpm regression:inventory:baseline
+
+# Add a Supabase/Vercel JSON, JSON-array, or NDJSON log export.
+pnpm regression:inventory --logs /absolute/or/repo-relative/logs.json
+
+# Compare consumers against a separately generated linked/live type contract.
+pnpm regression:inventory --schema /tmp/supabase.live.ts
+```
+
+Reports are written to `artifacts/regression-inventory/inventory.json` and `artifacts/regression-inventory/summary.md` by default. CI writes them to the runner temp directory, adds the Markdown summary to the GitHub job summary, and uploads both as the `full-app-regression-inventory` artifact.
+
+## CI contract
+
+`Agent PR Checks` runs the baseline-aware scanner on every pull request to `main`, regardless of which app domain changed. It intentionally runs before typecheck/test/build with `continue-on-error`, so all validation evidence is still collected; a final step enforces the inventory result.
+
+The existing Supabase clean-replay workflow remains the database-side proof:
+
+```text
+app consumers -> canonical generated types -> clean migration replay
+```
+
+This closes the previous gap where migrations and generated types could reconcile cleanly while untyped or casted app queries still referenced retired columns.
+
+## Exact, expiring baseline
+
+`scripts/regression-inventory/baseline.json` stores exact fingerprints. A fingerprint is based on rule, file, subject, and operation; line numbers are intentionally excluded so harmless line movement does not create a new regression.
+
+Baseline rules:
+
+- Every entry is visible in every report.
+- Every entry expires after 30 days unless it is repaired or deliberately re-reviewed.
+- New errors fail CI.
+- Expired entries fail CI.
+- Resolved entries also fail CI until removed, preventing permanent stale suppressions.
+- Runtime log findings cannot be written into the static baseline.
+
+Never refresh the baseline simply to make CI green. Review the generated Markdown and JSON, fix the consumer when practical, and use the baseline only for confirmed existing debt; link each deliberate refresh to an owner or repair issue in the PR.
+
+## Critical-flow evidence
+
+`scripts/regression-inventory/critical-flows.json` defines 19 supported full-app golden paths. The abandoned property experiment is intentionally excluded while its remaining code is removed. The shared fixture contract uses two shops with equivalent roles and deliberately duplicated display values, SKUs, unit numbers, and supplier names. That makes a missing `shop_id` predicate observable instead of accidentally passing because test data is globally unique.
+
+The sentinel part costs `$40` and sells for `$80`:
+
+- Quote Review must retain and present both internal values.
+- Customer and invoice surfaces use `$80`.
+- Purchase orders use `$40`.
+- Replaying the order creates neither a duplicate PO nor a duplicate line.
+
+Filename matching alone is not accepted for the three currently regressed stages. A proving test must contain the relevant marker:
+
+```text
+@regression-flow quotes.review-cost-and-sell
+@regression-flow parts.request-to-po
+@regression-flow messaging.notification-acknowledgement
+```
+
+Markers belong beside assertions that execute the invariant. A source-text assertion that merely checks whether implementation text contains a string is classified separately and cannot satisfy executable evidence.
+
+## Runtime error classifier
+
+The optional log classifier accepts JSON, arrays, NDJSON, or plain line exports. It writes counts and normalized categories only; it does not copy raw messages or payloads into the report.
+
+Initial signatures cover:
+
+- missing columns, relations, and RPC signatures (`42703`, `42P01`, `42883`, `PGRST202`, `PGRST204`, `PGRST205`),
+- invalid PostgREST filters,
+- RLS and permission drift,
+- database constraint violations,
+- request items that reach PO creation without an inventory link,
+- notification acknowledgement persistence failures,
+- invoice cost-recomputation permission drift, and
+- HTTP 5xx responses.
+
+Production logs are read-only input. Do not commit raw logs; they may contain tenant or customer context.
+
+## Current boundaries and next layer
+
+The scanner resolves inline and file-local constant targets and validates RPC overloads, embedded PostgREST filters, inline/local mutation payloads, Realtime table/filter contracts, and buckets explicitly provisioned by ordered migrations. Dynamic wrappers, row-derived bucket names, imported computed selectors, and runtime-generated filters are reported as warnings rather than treated as proven-safe.
+
+Storage buckets created only through dashboard/manual SQL are reported as migration-chain gaps. A trusted nightly job should additionally generate linked types, query the post-replay `storage.buckets` catalog, and feed normalized Supabase/Vercel logs into this same inventory. That job requires production-scoped secrets and is intentionally separate from untrusted pull-request CI.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "db:check:size": "node shared/types/types/scripts/check-dump-size.cjs",
     "audit:api-routes": "node scripts/audit-api-routes.mjs",
     "seed:demo-shop": "node scripts/seed-demo-shop.mjs",
-    "qa:demo-seed": "node scripts/qa-demo-seed.mjs"
+    "qa:demo-seed": "node scripts/qa-demo-seed.mjs",
+    "regression:inventory": "node scripts/regression-inventory/cli.mjs",
+    "regression:inventory:check": "node scripts/regression-inventory/cli.mjs --check",
+    "regression:inventory:strict": "node scripts/regression-inventory/cli.mjs --strict",
+    "regression:inventory:baseline": "node scripts/regression-inventory/cli.mjs --write-baseline"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/scripts/regression-inventory/baseline.json
+++ b/scripts/regression-inventory/baseline.json
@@ -1,0 +1,2766 @@
+{
+  "version": 1,
+  "schema": "features/shared/types/types/supabase.ts",
+  "findings": [
+    {
+      "fingerprint": "8538ceda2083cf38835f",
+      "rule": "critical-flow-evidence-gap",
+      "severity": "error",
+      "domain": "messaging",
+      "file": "scripts/regression-inventory/critical-flows.json",
+      "subject": "messaging-notifications:application-runtime",
+      "message": "Messaging and notification acknowledgement is missing executable message/notification persistence coverage",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "175a8bb9bdc03f3cd312",
+      "rule": "critical-flow-evidence-gap",
+      "severity": "error",
+      "domain": "parts",
+      "file": "scripts/regression-inventory/critical-flows.json",
+      "subject": "parts-request-purchase-order:database-runtime",
+      "message": "Parts request to purchase order is missing an executed request-to-PO database integration",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "937f363fa2990fa398c0",
+      "rule": "critical-flow-evidence-gap",
+      "severity": "error",
+      "domain": "quotes-approvals",
+      "file": "scripts/regression-inventory/critical-flows.json",
+      "subject": "quote-approval:application-runtime",
+      "message": "Quote Review and approval decisions is missing executable Quote Review cost/sell and decision coverage",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "4548e6f4906563f9cf34",
+      "rule": "critical-flow-evidence-gap",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "scripts/regression-inventory/critical-flows.json",
+      "subject": "work-order-intake:application-runtime",
+      "message": "Work-order intake and assignment is missing executable work-order creation coverage",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "a290fbea49852be72dde",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "app/agent/planner/page.tsx",
+      "subject": "vehicles.trim",
+      "message": "select references missing column vehicles.trim",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "6e83811d8f25db78ba33",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/admin/create-user/route.ts",
+      "subject": "profiles.first_name",
+      "message": "select references missing column profiles.first_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "57d170128a3740cdb6c9",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/admin/create-user/route.ts",
+      "subject": "profiles.last_name",
+      "message": "select references missing column profiles.last_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "72fd2ec8da9b614159d7",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/admin/staff-invite-candidates/[id]/create-user/route.ts",
+      "subject": "profiles.first_name",
+      "message": "select references missing column profiles.first_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "21c0cb1ce60715d92323",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/admin/staff-invite-candidates/[id]/create-user/route.ts",
+      "subject": "profiles.last_name",
+      "message": "select references missing column profiles.last_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9b09c0bfb6401f1c74fe",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/admin/staff-invite-candidates/[id]/resend-invite/route.ts",
+      "subject": "profiles.first_name",
+      "message": "select references missing column profiles.first_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "607e7a6c3ced6233fe16",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/admin/staff-invite-candidates/[id]/resend-invite/route.ts",
+      "subject": "profiles.last_name",
+      "message": "select references missing column profiles.last_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "633699a79e544d3d9e48",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/admin/users/[id]/resend-invite/route.ts",
+      "subject": "profiles.first_name",
+      "message": "select references missing column profiles.first_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "72af49f602f9b9f484c0",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/admin/users/[id]/resend-invite/route.ts",
+      "subject": "profiles.last_name",
+      "message": "select references missing column profiles.last_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "610de67c47d4644c13fe",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/assignables/route.ts",
+      "subject": "work_orders.technician_id",
+      "message": "select references missing column work_orders.technician_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "0528e731124ebe000d33",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/maintenance/suggestions/route.ts",
+      "subject": "maintenance_suggestions.id",
+      "message": "select references missing column maintenance_suggestions.id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "040dffccd1b7c971c4ae",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/maintenance/suggestions/route.ts",
+      "subject": "menu_items.price",
+      "message": "select references missing column menu_items.price",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "125f88c8e940ec9d1615",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/hours/route.ts",
+      "subject": "shop_hours.day_of_week",
+      "message": "select references missing column shop_hours.day_of_week",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "21d4ca0a113f5c292a9c",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/hours/route.ts",
+      "subject": "shop_hours.day_of_week",
+      "message": "order references missing column shop_hours.day_of_week",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "229d9318451f75b18e17",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/hours/route.ts",
+      "subject": "shop_hours.is_closed",
+      "message": "select references missing column shop_hours.is_closed",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b06ff62b04f0e468afb2",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/time-off/route.ts",
+      "subject": "shop_time_off.start_date",
+      "message": "order references missing column shop_time_off.start_date",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "17eb7c5916951dc92256",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "app/api/shop-boost/import-reset/route.ts",
+      "subject": "shop_import_files.shop_id",
+      "message": "eq references missing column shop_import_files.shop_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "54b105a6b26b5ceaedde",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/maintenance-suggestions/route.ts",
+      "subject": "menu_items.price",
+      "message": "select references missing column menu_items.price",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "aa9d7aa374a16840351d",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/update-status/list/route.ts",
+      "subject": "work_orders.appointment",
+      "message": "order references missing column work_orders.appointment",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "83d0900f8cff966ee3b9",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/menu/item/[id]/page.tsx",
+      "subject": "parts.unit_cost",
+      "message": "select references missing column parts.unit_cost",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "dd32b13924c3974b76ee",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/menu/page.tsx",
+      "subject": "parts.unit_cost",
+      "message": "select references missing column parts.unit_cost",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b5ab30b194047e169693",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "parts",
+      "file": "app/parts/page.tsx",
+      "subject": "shop_parts_import_match_candidates.staging_id",
+      "message": "select references missing column shop_parts_import_match_candidates.staging_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5188307ca5d91fab4160",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "parts",
+      "file": "app/parts/receive/page.tsx",
+      "subject": "parts.import_confidence",
+      "message": "select references missing column parts.import_confidence",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "79b17e3dc7bc8b802735",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "parts",
+      "file": "app/parts/receiving/page.tsx",
+      "subject": "shop_parts_import_match_candidates.staging_id",
+      "message": "select references missing column shop_parts_import_match_candidates.staging_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "85da6576aee2f976fb03",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "property",
+      "file": "app/portal/property/member/requests/[id]/page.tsx",
+      "subject": "property_request_attachments.visibility",
+      "message": "select references missing column property_request_attachments.visibility",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5e8d7b86c6eff26dc980",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "property",
+      "file": "app/property/members/page.tsx",
+      "subject": "profiles.display_name",
+      "message": "select references missing column profiles.display_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "4d33c8f6b2df71b17138",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "property",
+      "file": "app/property/members/page.tsx",
+      "subject": "profiles.name",
+      "message": "select references missing column profiles.name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "2f10e7b74ea4f071766c",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/tech/queue/page.tsx",
+      "subject": "part_requests.assigned_tech_id",
+      "message": "select references missing column part_requests.assigned_tech_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f19b1c48c23b45ef6095",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/work-orders/[id]/Client.tsx",
+      "subject": "property_units.label",
+      "message": "select references missing column property_units.label",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "30779ae5b713b5767318",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/work-orders/[id]/Client.tsx",
+      "subject": "property_vendor_assignments.property_request_id",
+      "message": "eq references missing column property_vendor_assignments.property_request_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "0c7509784bbb4d019ef4",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "activity_logs.actor_id",
+      "message": "select references missing column activity_logs.actor_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c6762819a98e5fb513bc",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "activity_logs.created_at",
+      "message": "select references missing column activity_logs.created_at",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "2823d83fccd0fecdf91c",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "activity_logs.created_at",
+      "message": "order references missing column activity_logs.created_at",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5a10b2d2925192619a4d",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "activity_logs.details",
+      "message": "select references missing column activity_logs.details",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ca9bb305c511339c4171",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "activity_logs.event",
+      "message": "select references missing column activity_logs.event",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "1e3687387cb04d007be8",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "email_logs.error",
+      "message": "select references missing column email_logs.error",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "244f6487c15d76ce4b7a",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "email_logs.error",
+      "message": "not references missing column email_logs.error",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5a2fda4834066a5531e7",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "email_logs.recipient",
+      "message": "select references missing column email_logs.recipient",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "cc9078a6c7940f8db890",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "parts_requests.needed_by",
+      "message": "select references missing column parts_requests.needed_by",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "7c33b659c333e1ac388b",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "parts_requests.status",
+      "message": "select references missing column parts_requests.status",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d94a9ee094ca8008cf84",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "parts_requests.status",
+      "message": "neq references missing column parts_requests.status",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f4dc98751f2fc2a0a2b8",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "vehicle_photos.reviewed",
+      "message": "select references missing column vehicle_photos.reviewed",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "fc62ae3dc7fdad06ffa5",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "vehicle_photos.reviewed",
+      "message": "or references missing column vehicle_photos.reviewed",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "937113e269e3a78ef4a0",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/agent/assistant/server/answerAssistant.ts",
+      "subject": "work_order_parts.part_name",
+      "message": "select references missing column work_order_parts.part_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "90dd00f96db5a33fc2f9",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/agent/assistant/server/answerAssistant.ts",
+      "subject": "work_order_parts.part_number",
+      "message": "select references missing column work_order_parts.part_number",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "3d604899e2d91140c18b",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/agent/lib/plannerOpenAI.ts",
+      "subject": "menu_items.estimated_hours",
+      "message": "select references missing column menu_items.estimated_hours",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "375771af69802106f9ce",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/agent/lib/plannerOpenAI.ts",
+      "subject": "work_order_lines.labor_hours_actual",
+      "message": "select references missing column work_order_lines.labor_hours_actual",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "fd379bf56a83fb21f87f",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "features/inspections/server/findSmartInspectionMatch.ts",
+      "subject": "menu_items.updated_at",
+      "message": "order references missing column menu_items.updated_at",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b367d5b699889357bb96",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "features/inspections/server/inspectionReportAccess.ts",
+      "subject": "vehicles.fleet_id",
+      "message": "select references missing column vehicles.fleet_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9d6d3e0247e2d97c04f1",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "imports",
+      "file": "features/integrations/imports/runPartsImportPipeline.ts",
+      "subject": "stock_locations.created_at",
+      "message": "order references missing column stock_locations.created_at",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ed907f57daf90b87d751",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/integrations/shopBoost/reviewMaterialization.ts",
+      "subject": "stock_locations.created_at",
+      "message": "order references missing column stock_locations.created_at",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d41666589ad452076b45",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "features/integrations/shopreel/server/buildProFixIQStoryEvents.ts",
+      "subject": "work_order_lines.item",
+      "message": "select references missing column work_order_lines.item",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "2b7bf96802c41004bdfd",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "features/integrations/shopreel/server/buildProFixIQStoryEvents.ts",
+      "subject": "work_order_lines.name",
+      "message": "select references missing column work_order_lines.name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "a4e9e5b5c4db93543d38",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "features/integrations/shopreel/server/buildProFixIQStoryEvents.ts",
+      "subject": "work_order_lines.title",
+      "message": "select references missing column work_order_lines.title",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "1d0c9cf74643d40ee0c5",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "maintenance_suggestions.id",
+      "message": "select references missing column maintenance_suggestions.id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "8b74aac993e4731db406",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "parts",
+      "file": "features/parts/server/buildPartSuggestions.ts",
+      "subject": "part_stock.shop_id",
+      "message": "eq references missing column part_stock.shop_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "abb8c32fc40edad092d4",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "parts",
+      "file": "features/parts/server/buildPartSuggestions.ts",
+      "subject": "parts.supplier_id",
+      "message": "select references missing column parts.supplier_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "097c52c67aeb8712cc06",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "parts",
+      "file": "features/parts/server/buildPartSuggestions.ts",
+      "subject": "work_order_parts.part_name",
+      "message": "select references missing column work_order_parts.part_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "153692070047b1fd1c8b",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "parts",
+      "file": "features/parts/server/buildPartSuggestions.ts",
+      "subject": "work_order_parts.part_number",
+      "message": "select references missing column work_order_parts.part_number",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "15b6949a47b81af08cb5",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/shared/components/AccountPlanPanel.tsx",
+      "subject": "user_plans.plan",
+      "message": "select references missing column user_plans.plan",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e26ed07bb9c043b87710",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "financial",
+      "file": "features/shop-assistant/server/tools/domains/invoices.ts",
+      "subject": "invoices.sent_at",
+      "message": "select references missing column invoices.sent_at",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "885e5f24319c4d72e080",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/lib/generateCustomId.ts",
+      "subject": "profiles.first_name",
+      "message": "select references missing column profiles.first_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "658c9a536de659e8bcf5",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/lib/generateCustomId.ts",
+      "subject": "profiles.last_name",
+      "message": "select references missing column profiles.last_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "7d2e29be63bcfa69ca12",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/authorizeWorkOrderEvidence.ts",
+      "subject": "fleet_vehicles.id",
+      "message": "select references missing column fleet_vehicles.id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "0613af0573363ea682ba",
+      "rule": "missing-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/vehicle-history-import-job.ts",
+      "subject": "history.shop_id",
+      "message": "eq references missing column history.shop_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "99b841610817ac966b37",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/onboarding-v2/guided/sessions/[sessionId]/analysis/route.ts",
+      "subject": "guided_onboarding_events.created_by",
+      "message": "insert payload contains missing column guided_onboarding_events.created_by",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "66619f78f46af6c3ef45",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/time-off/route.ts",
+      "subject": "shop_time_off.end_date",
+      "message": "insert payload contains missing column shop_time_off.end_date",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "41ca8dbaac789fc6380f",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/time-off/route.ts",
+      "subject": "shop_time_off.label",
+      "message": "insert payload contains missing column shop_time_off.label",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "cbf8e18b0b98932d5c76",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/time-off/route.ts",
+      "subject": "shop_time_off.notes",
+      "message": "insert payload contains missing column shop_time_off.notes",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5fda08c91d76876279fe",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/time-off/route.ts",
+      "subject": "shop_time_off.start_date",
+      "message": "insert payload contains missing column shop_time_off.start_date",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c4ef16a64f03bf3d8dfa",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/lines/add-from-menu/route.ts",
+      "subject": "work_order_lines.labor_hours",
+      "message": "insert payload contains missing column work_order_lines.labor_hours",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e155c1154fb34d266687",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/update-status/create/route.ts",
+      "subject": "work_orders.appointment",
+      "message": "insert payload contains missing column work_orders.appointment",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f13bab11b2325b8f4afa",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/update-status/create/route.ts",
+      "subject": "work_orders.complaint",
+      "message": "insert payload contains missing column work_orders.complaint",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "6ae2c94596cb401e53b2",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/update-status/create/route.ts",
+      "subject": "work_orders.location",
+      "message": "insert payload contains missing column work_orders.location",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c502305839e6af6c58eb",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/update-status/create/route.ts",
+      "subject": "work_orders.number",
+      "message": "insert payload contains missing column work_orders.number",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "98991ec180f7171cf95f",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/agent/tools/generateFleetWorkOrders.ts",
+      "subject": "work_order_lines.source",
+      "message": "insert payload contains missing column work_order_lines.source",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "cbf96bbd94052205cbf1",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "reporting",
+      "file": "features/dashboard/app/dashboard/owner/import-customers/page.tsx",
+      "subject": "customers.full_name",
+      "message": "insert payload contains missing column customers.full_name",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5e821242dfb304b55c0f",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "reporting",
+      "file": "features/dashboard/app/dashboard/owner/import-customers/page.tsx",
+      "subject": "vehicles.plate",
+      "message": "insert payload contains missing column vehicles.plate",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "36f4004a94f899c30b3b",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost/index.ts",
+      "subject": "shop_boost_intakes.error",
+      "message": "update payload contains missing column shop_boost_intakes.error",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5c50785176b0f3cbc379",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "imports",
+      "file": "features/integrations/imports/runFullImport.ts",
+      "subject": "staff_invite_suggestions.phone",
+      "message": "insert payload contains missing column staff_invite_suggestions.phone",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e05231e6eb8029b92efe",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "imports",
+      "file": "features/integrations/imports/runFullImport.ts",
+      "subject": "staff_invite_suggestions.username",
+      "message": "insert payload contains missing column staff_invite_suggestions.username",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e0cba95af0bd7b776fd0",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.created_by",
+      "message": "update payload contains missing column work_order_lines.created_by",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5da04febee92c790b698",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.created_by",
+      "message": "insert payload contains missing column work_order_lines.created_by",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "a3da949e9ed2ca1776c9",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.customer_id",
+      "message": "insert payload contains missing column work_order_lines.customer_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "546190b17513aae6ce06",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.estimated_hours",
+      "message": "update payload contains missing column work_order_lines.estimated_hours",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ab3bcd8ceb2fb91f2f46",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.estimated_hours",
+      "message": "insert payload contains missing column work_order_lines.estimated_hours",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e1ac4b329ab8e8605c44",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.note",
+      "message": "update payload contains missing column work_order_lines.note",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "61abe9deff13d48dec47",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.note",
+      "message": "insert payload contains missing column work_order_lines.note",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e092e1212cba2344aa23",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.quoted_hours",
+      "message": "update payload contains missing column work_order_lines.quoted_hours",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d7635d2ac3c3434ec4be",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.quoted_hours",
+      "message": "insert payload contains missing column work_order_lines.quoted_hours",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "81643c7512e6d7a53979",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.source",
+      "message": "update payload contains missing column work_order_lines.source",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ad56d57c5c277a9968a6",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/maintenance/server/addMaintenanceSuggestionToWorkOrder.ts",
+      "subject": "work_order_lines.source",
+      "message": "insert payload contains missing column work_order_lines.source",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "4c985eaad006a75c6bec",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/onboarding-v2/guided/instantAnalysisHandoff.ts",
+      "subject": "guided_onboarding_events.created_by",
+      "message": "insert payload contains missing column guided_onboarding_events.created_by",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b1b4c4a7f2e4f92cbb62",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/onboarding-v2/guided/instantAnalysisHandoff.ts",
+      "subject": "guided_onboarding_sessions.existing_system",
+      "message": "insert payload contains missing column guided_onboarding_sessions.existing_system",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "fc49947a08cedae8c243",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/onboarding-v2/guided/instantAnalysisHandoff.ts",
+      "subject": "guided_onboarding_sessions.existing_system",
+      "message": "update payload contains missing column guided_onboarding_sessions.existing_system",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "413eaae24b805ea2bc2c",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "quotes-approvals",
+      "file": "features/quotes/components/QuoteViewer.tsx",
+      "subject": "quote_lines.labor_hours",
+      "message": "upsert payload contains missing column quote_lines.labor_hours",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e88f2ce0b27287170794",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "quotes-approvals",
+      "file": "features/quotes/components/QuoteViewer.tsx",
+      "subject": "quote_lines.total_price",
+      "message": "upsert payload contains missing column quote_lines.total_price",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "05e9203276439e93b265",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/shared/components/CreateWorkOrderForm.tsx",
+      "subject": "work_orders.customer_address",
+      "message": "insert payload contains missing column work_orders.customer_address",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c27ce33ddf2fa4c3b939",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/shared/components/CreateWorkOrderForm.tsx",
+      "subject": "work_orders.customer_email",
+      "message": "insert payload contains missing column work_orders.customer_email",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "94db9ca62f8daaa6d77c",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/shared/components/CreateWorkOrderForm.tsx",
+      "subject": "work_orders.customer_phone",
+      "message": "insert payload contains missing column work_orders.customer_phone",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "06bf9270661313962b9d",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/logOperationalEvent.ts",
+      "subject": "activity_logs.actor_id",
+      "message": "insert payload contains missing column activity_logs.actor_id",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "72332ade3a20c221c237",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/logOperationalEvent.ts",
+      "subject": "activity_logs.created_at",
+      "message": "insert payload contains missing column activity_logs.created_at",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "0e67f40a267d71264497",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/logOperationalEvent.ts",
+      "subject": "activity_logs.details",
+      "message": "insert payload contains missing column activity_logs.details",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ee54266bd48650d7d2b9",
+      "rule": "missing-mutation-column",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/logOperationalEvent.ts",
+      "subject": "activity_logs.event",
+      "message": "insert payload contains missing column activity_logs.event",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "8139f45281e65ca100a5",
+      "rule": "missing-relation",
+      "severity": "error",
+      "domain": "messaging",
+      "file": "app/api/planner/notifications/[id]/ack/route.ts",
+      "subject": "assistant_notifications",
+      "message": ".from(\"assistant_notifications\") references a relation missing from the schema contract",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "dbaef55051c578e93ce7",
+      "rule": "missing-relation",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/admin/components/AdminQuickPanel.tsx",
+      "subject": "certifications",
+      "message": ".from(\"certifications\") references a relation missing from the schema contract",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "58186a04ed54440d0fce",
+      "rule": "missing-relation",
+      "severity": "error",
+      "domain": "messaging",
+      "file": "features/agent/server/syncAssistantNotifications.ts",
+      "subject": "assistant_notifications",
+      "message": ".from(\"assistant_notifications\") references a relation missing from the schema contract",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "26dfe6186cdd3bb79949",
+      "rule": "missing-relation",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "features/agent/tools/createCustomInspection.ts",
+      "subject": "work_order_inspections",
+      "message": ".from(\"work_order_inspections\") references a relation missing from the schema contract",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "843a229d8736d4bb4160",
+      "rule": "missing-relation",
+      "severity": "error",
+      "domain": "reporting",
+      "file": "features/dashboard/components/ShareBookingLink.tsx",
+      "subject": "shop",
+      "message": ".from(\"shop\") references a relation missing from the schema contract",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "0458b319c8d6cf0c6a32",
+      "rule": "missing-relation",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/operations/server/syncOperationalObservabilityAlerts.ts",
+      "subject": "assistant_notifications",
+      "message": ".from(\"assistant_notifications\") references a relation missing from the schema contract",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "558484473d974a0c0a10",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "app/agent/planner/page.tsx",
+      "subject": "agent-uploads",
+      "message": "Storage bucket agent-uploads is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "245ebb8510d2db72d89d",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "app/api/agent/requests/[id]/route.ts",
+      "subject": "agent_uploads",
+      "message": "Storage bucket agent_uploads is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "518d9a4b98236c51f23d",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "app/api/agent/requests/route.ts",
+      "subject": "agent_uploads",
+      "message": "Storage bucket agent_uploads is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "caa79ebe66b653edae8d",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/assistant/attachments/route.ts",
+      "subject": "work_order_media",
+      "message": "Storage bucket work_order_media is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "18e3e31b06baa0b8dbba",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/branding/assets/upload/route.ts",
+      "subject": "branding",
+      "message": "Storage bucket branding is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "609e194c2b35f80396e1",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/branding/generate/route.ts",
+      "subject": "branding",
+      "message": "Storage bucket branding is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ae0f44b12d20f602a9e9",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "app/api/demo/shop-boost/activate/route.ts",
+      "subject": "shop-imports",
+      "message": "Storage bucket shop-imports is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e0186393f3f949fd9ba8",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "app/api/inspection-form-imports/route.ts",
+      "subject": "fleet-forms",
+      "message": "Storage bucket fleet-forms is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "a27f5ab2ee5633818a21",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "core",
+      "file": "app/api/planner/uploads/sign/route.ts",
+      "subject": "planner_uploads",
+      "message": "Storage bucket planner_uploads is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9ad58ac40994e00c4f54",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "reporting",
+      "file": "app/dashboard/tech/settings/page.tsx",
+      "subject": "signatures",
+      "message": "Storage bucket signatures is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "cd1fa56e35a0596e7580",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "property",
+      "file": "app/portal/property/member/requests/[id]/actions.ts",
+      "subject": "property_request_attachments",
+      "message": "Storage bucket property_request_attachments is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "236f282c07716627b678",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "app/property/inspections/new/actions.ts",
+      "subject": "property_request_attachments",
+      "message": "Storage bucket property_request_attachments is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "40a51a5e2d1f90f898f3",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "property",
+      "file": "app/property/requests/[id]/actions.ts",
+      "subject": "property_request_attachments",
+      "message": "Storage bucket property_request_attachments is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "838ccbebe8dc0d4f4747",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "property",
+      "file": "app/property/requests/[id]/page.tsx",
+      "subject": "property_request_attachments",
+      "message": "Storage bucket property_request_attachments is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b3ff7d5e0d6f1d92d497",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/agent/agent-console/app/agent/page.tsx",
+      "subject": "agent_uploads",
+      "message": "Storage bucket agent_uploads is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "29a554cdb5afaeee4d04",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/agent/components/AgentRequestModal.tsx",
+      "subject": "agent_uploads",
+      "message": "Storage bucket agent_uploads is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "bc5d579e0d5867a09e81",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "features/inspections/components/FleetFormImportCard.tsx",
+      "subject": "fleet-forms",
+      "message": "Storage bucket fleet-forms is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d6a31a92ddfa5aebcf36",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "features/inspections/server/inspection-form-import-job.ts",
+      "subject": "fleet-forms",
+      "message": "Storage bucket fleet-forms is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "dcf68680ebec58306b62",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "features/inspections/server/inspectionReportAccess.ts",
+      "subject": "job-photos",
+      "message": "Storage bucket job-photos is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "1023dbd227be6ad6bf77",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "features/inspections/server/publishInspectionPdf.ts",
+      "subject": "inspection_pdfs",
+      "message": "Storage bucket inspection_pdfs is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "29c193fad23b0da213af",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost.ts",
+      "subject": "shop-imports",
+      "message": "Storage bucket shop-imports is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "14d243e2a28f0ccc6686",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost/index.ts",
+      "subject": "shop-imports",
+      "message": "Storage bucket shop-imports is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "16db014f1eba49e67edb",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "imports",
+      "file": "features/integrations/imports/runFullImport.ts",
+      "subject": "shop-imports",
+      "message": "Storage bucket shop-imports is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d66cba862191df2ec813",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "ai-automation",
+      "file": "features/integrations/shopBoost/runIntakeHandler.ts",
+      "subject": "shop-imports",
+      "message": "Storage bucket shop-imports is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "72dc77e8068be7d5feca",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "inspections",
+      "file": "features/invoices/server/attachInspectionReportToInvoice.ts",
+      "subject": "inspection_pdfs",
+      "message": "Storage bucket inspection_pdfs is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9f93bcf37828783e51de",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "technician",
+      "file": "features/mobile/settings/MobileSettingsScreen.tsx",
+      "subject": "signatures",
+      "message": "Storage bucket signatures is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e89e74621eb0c97c7ada",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "parts",
+      "file": "features/parts/components/VehiclePhotoUploader.tsx",
+      "subject": "vehicle-photos",
+      "message": "Storage bucket vehicle-photos is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "3c2c0872f57bb059da8a",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "technician",
+      "file": "features/shared/lib/offline/replay.ts",
+      "subject": "job-photos",
+      "message": "Storage bucket job-photos is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "4d56021d47149d20f065",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "core",
+      "file": "features/shared/lib/utils/uploadSignature.ts",
+      "subject": "signatures",
+      "message": "Storage bucket signatures is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "289b6b56c4636152f9e6",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/components/workorders/FocusedJobModal.tsx",
+      "subject": "job-photos",
+      "message": "Storage bucket job-photos is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c48640435a3a5ea2706d",
+      "rule": "missing-storage-bucket",
+      "severity": "error",
+      "domain": "work-orders",
+      "file": "features/work-orders/mobile/MobileFocusedJob.tsx",
+      "subject": "job-photos",
+      "message": "Storage bucket job-photos is not provisioned by the migration chain",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d186c853998308e2f955",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/api/branding/assets/[id]/archive/route.ts",
+      "subject": "shop_brand_assets",
+      "message": "update payload for shop_brand_assets cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "77a702bd48d1af717ba2",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "messaging",
+      "file": "app/api/chat/participants/route.ts",
+      "subject": "conversation_participants",
+      "message": "insert payload for conversation_participants cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "237adc7b3b3e7bed01e2",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/api/inspection-form-imports/route.ts",
+      "subject": "import_job_rows",
+      "message": "insert payload for import_job_rows cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f3dd53373088873b67f8",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/api/menu-items/save-from-line/route.ts",
+      "subject": "menu_item_parts",
+      "message": "insert payload for menu_item_parts cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b16bc696ddce79e5ef9b",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/api/menu-repair-items/pricing/apply-batch/route.ts",
+      "subject": "menu_repair_item_pricing_parts",
+      "message": "insert payload for menu_repair_item_pricing_parts cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "2886cb3a5c43defd576e",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "app/api/menu-repair-items/pricing/import-batch-rows/route.ts",
+      "subject": "supplier_quote_batch_rows",
+      "message": "insert payload for supplier_quote_batch_rows cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "59d727909c38e5395563",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "technician",
+      "file": "app/api/mobile/shifts/route.ts",
+      "subject": "punch_events",
+      "message": "insert payload for punch_events cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "a31c7eaa6bd27a1844e2",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "app/api/optimization/apply/route.ts",
+      "subject": "inspection_templates",
+      "message": "insert payload for inspection_templates cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "2ecf45d5bf329f1c177a",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "app/api/optimization/apply/route.ts",
+      "subject": "menu_item_suggestions",
+      "message": "insert payload for menu_item_suggestions cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "97c48a6c83fc366a7cd7",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/api/recalls/fetch/route.ts",
+      "subject": "vehicle_recalls",
+      "message": "upsert payload for vehicle_recalls cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "7e7f18a81fc7163039ca",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "app/api/settings/ai-automation/route.ts",
+      "subject": "ai_automation_capability_settings",
+      "message": "upsert payload for ai_automation_capability_settings cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "420c046f0c71aeb26bb8",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "app/api/settings/update/route.ts",
+      "subject": "shops",
+      "message": "update payload for shops cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "4f7f0104797faf44b8d6",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "app/api/shop-health/accept-suggestion/route.ts",
+      "subject": "inspection_templates",
+      "message": "insert payload for inspection_templates cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "33ced8fa40aec4f337a9",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "app/api/shop-health/accept-suggestion/route.ts",
+      "subject": "menu_items",
+      "message": "insert payload for menu_items cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c15da8f832cb5c2ebc17",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "app/api/stripe/subscription/route.ts",
+      "subject": "shops",
+      "message": "update payload for shops cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "19a3d7ad3c6cba19942b",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/[id]/intake/route.ts",
+      "subject": "work_order_lines",
+      "message": "insert payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "6e3cede7f108f49d2f70",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/assign-all/route.ts",
+      "subject": "work_order_line_technicians",
+      "message": "upsert payload for work_order_line_technicians cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f86d9aaebc97136d9383",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "quotes-approvals",
+      "file": "app/api/work-orders/quotes/add-from-menu-repair/route.ts",
+      "subject": "part_request_items",
+      "message": "insert payload for part_request_items cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f53afa4d229f2a39dd86",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "app/parts/inventory/page.tsx",
+      "subject": "parts",
+      "message": "upsert payload for parts cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "7b4a3b6e97f340eada0d",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "app/parts/inventory/page.tsx",
+      "subject": "parts_barcodes",
+      "message": "upsert payload for parts_barcodes cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "2677ae06191637c468d6",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "app/parts/po/[id]/page.tsx",
+      "subject": "purchase_order_lines",
+      "message": "insert payload for purchase_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e107ef0dc293bc386f01",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "app/parts/po/[id]/page.tsx",
+      "subject": "suppliers",
+      "message": "insert payload for suppliers cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "2e73f2e0a0dd34a83582",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "app/parts/po/page.tsx",
+      "subject": "purchase_order_lines",
+      "message": "insert payload for purchase_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9563f84839181810011c",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "features/billing/server/invoice-import-job.ts",
+      "subject": "import_job_rows",
+      "message": "insert payload for import_job_rows cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "dbc0f0d8fc0f3b423e50",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "features/billing/server/invoice-import-job.ts",
+      "subject": "invoices",
+      "message": "update payload for invoices cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "aeccec69269972b6916f",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "features/billing/server/invoice-import-job.ts",
+      "subject": "invoices",
+      "message": "insert payload for invoices cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b6bb8e4ddbc1a8c054a3",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/customers/app/customers/[id]/page.tsx",
+      "subject": "customers",
+      "message": "insert payload for customers cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "dc5c4f0c0cc5368d8301",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/customers/app/customers/[id]/page.tsx",
+      "subject": "customers",
+      "message": "update payload for customers cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "784c20ffefe3de35c316",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/customers/app/customers/[id]/page.tsx",
+      "subject": "vehicles",
+      "message": "update payload for vehicles cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "330cef63b0d5264c45a9",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/customers/app/customers/[id]/page.tsx",
+      "subject": "vehicles",
+      "message": "insert payload for vehicles cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "10761bd7a22cb47df160",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "features/inspections/app/inspection/custom-draft/page.tsx",
+      "subject": "inspection_templates",
+      "message": "insert payload for inspection_templates cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "10a4338547832545ce16",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "features/inspections/app/inspection/custom-draft/page.tsx",
+      "subject": "inspection_templates",
+      "message": "update payload for inspection_templates cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9eb79e8b68f3e4c46a14",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost.ts",
+      "subject": "inspection_template_suggestions",
+      "message": "insert payload for inspection_template_suggestions cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e0be78c0305773968375",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost.ts",
+      "subject": "menu_item_suggestions",
+      "message": "insert payload for menu_item_suggestions cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f11b471052bfe0c80ad0",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost.ts",
+      "subject": "shop_import_rows",
+      "message": "insert payload for shop_import_rows cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9c34d9e910cde0b4e94f",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost.ts",
+      "subject": "staff_invite_candidates",
+      "message": "upsert payload for staff_invite_candidates cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "fc01de6ef2f730c3709f",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost/index.ts",
+      "subject": "inspection_template_suggestions",
+      "message": "insert payload for inspection_template_suggestions cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f1b230697a4ce8542afd",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost/index.ts",
+      "subject": "menu_item_suggestions",
+      "message": "insert payload for menu_item_suggestions cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "afb1937c8d36d9aec449",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost/index.ts",
+      "subject": "staff_invite_suggestions",
+      "message": "insert payload for staff_invite_suggestions cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c0dba6a7f6fcb0b8cb37",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/ai/shopBoost/index.ts",
+      "subject": "work_order_line_ai",
+      "message": "insert payload for work_order_line_ai cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d8443a19761eba970b56",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/integrations/imports/runFullImport.ts",
+      "subject": "invoices",
+      "message": "update payload for invoices cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ad34bc3549bb1894b7fd",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/integrations/imports/runFullImport.ts",
+      "subject": "shop_import_rows",
+      "message": "insert payload for shop_import_rows cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b78aaeffc4b0c063aa13",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/integrations/imports/runFullImport.ts",
+      "subject": "work_order_lines",
+      "message": "update payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "03855cac1853809c0b25",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/integrations/imports/runFullImport.ts",
+      "subject": "work_order_lines",
+      "message": "insert payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "57df393c710fcb6e4b1a",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/integrations/imports/runPartsImportPipeline.ts",
+      "subject": "shop_import_rows",
+      "message": "insert payload for shop_import_rows cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e3d3e964579285a09684",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/integrations/imports/runPartsImportPipeline.ts",
+      "subject": "shop_parts_import_match_candidates",
+      "message": "insert payload for shop_parts_import_match_candidates cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "1816c441cf3606859d40",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/integrations/imports/runPartsImportPipeline.ts",
+      "subject": "shop_parts_import_staging",
+      "message": "insert payload for shop_parts_import_staging cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "55361d6d71de8b21eae2",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "features/integrations/quickbooks/server/syncInvoice.ts",
+      "subject": "quickbooks_sync_events",
+      "message": "insert payload for quickbooks_sync_events cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "493c6747cdc65ec31120",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/shopBoost/orchestrator/index.ts",
+      "subject": "shop_onboarding_jobs",
+      "message": "update payload for shop_onboarding_jobs cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ca2869167f67631179b3",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/shopBoost/orchestrator/index.ts",
+      "subject": "shop_onboarding_jobs",
+      "message": "upsert payload for shop_onboarding_jobs cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b71b79082738f2eec2b6",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/shopBoost/orchestrator/index.ts",
+      "subject": "shop_onboarding_runs",
+      "message": "upsert payload for shop_onboarding_runs cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "7003d71841ac474cf3bb",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/shopBoost/reviewMaterialization.ts",
+      "subject": "vehicles",
+      "message": "update payload for vehicles cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "57f2c69669c44e23709e",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/shopBoost/reviewMaterialization.ts",
+      "subject": "vehicles",
+      "message": "insert payload for vehicles cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9620acf5f7b0455bc65d",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/maintenance/server/generateMaintenanceRules.ts",
+      "subject": "maintenance_services",
+      "message": "insert payload for maintenance_services cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "055353ae4810dfaeb7af",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/menu-repair-items/server/createPricingSnapshotFromWorkOrderLine.ts",
+      "subject": "menu_repair_item_pricing_parts",
+      "message": "insert payload for menu_repair_item_pricing_parts cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c8e100898d91ee72a4cd",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/menu-repair-items/server/upsertMenuRepairItemFromCompletedLine.ts",
+      "subject": "menu_repair_item_parts",
+      "message": "insert payload for menu_repair_item_parts cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "fb0e497bb735a563e332",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/menu-repair-items/server/upsertMenuRepairItemFromCompletedLine.ts",
+      "subject": "menu_repair_item_pricing_parts",
+      "message": "insert payload for menu_repair_item_pricing_parts cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e84999dc0c578a616427",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/onboarding-v2/guided/instantAnalysisHandoff.ts",
+      "subject": "guided_onboarding_steps",
+      "message": "insert payload for guided_onboarding_steps cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "a12cb3660a93c6871b4c",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "features/parts/actions.ts",
+      "subject": "parts",
+      "message": "insert payload for parts cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "4cb1a7aff24a01c01284",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "features/parts/lib/locations.ts",
+      "subject": "stock_locations",
+      "message": "insert payload for stock_locations cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c32661ef23a0b1a53c51",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "features/parts/lib/suppliers.ts",
+      "subject": "suppliers",
+      "message": "insert payload for suppliers cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "650e247a00fd4187ebbe",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "workforce",
+      "file": "features/payroll-time/server/payrollTime.ts",
+      "subject": "payroll_export_rows",
+      "message": "insert payload for payroll_export_rows cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "03cc2a8ffba6312fb0a8",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "workforce",
+      "file": "features/payroll-time/server/payrollTime.ts",
+      "subject": "payroll_pay_periods",
+      "message": "upsert payload for payroll_pay_periods cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "3c1f126e11f7a64b30af",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/shared/components/CreateWorkOrderForm.tsx",
+      "subject": "work_order_lines",
+      "message": "insert payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e3bad6cdf3dc1cafab61",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "features/stripe/lib/server/canonical-shop-billing.ts",
+      "subject": "shops",
+      "message": "update payload for shops cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "157408ffe90da99a7249",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "features/stripe/lib/server/shop-billing-reconciliation.ts",
+      "subject": "shops",
+      "message": "update payload for shops cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e11da041ef592b331c3d",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "features/stripe/lib/server/shop-payment-settings.ts",
+      "subject": "shop_payment_settings",
+      "message": "upsert payload for shop_payment_settings cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "2d835a8fd7dd95491531",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/vehicles/server/vehicle-import-job.ts",
+      "subject": "vehicles",
+      "message": "update payload for vehicles cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c78396f5d619e044a9f4",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "imports",
+      "file": "features/vehicles/server/vehicle-import-job.ts",
+      "subject": "vehicles",
+      "message": "insert payload for vehicles cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "237ebf4f29baea37f9fe",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/app/work-orders/create/page.tsx",
+      "subject": "customers",
+      "message": "update payload for customers cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d1cac181c12226673afb",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/app/work-orders/create/page.tsx",
+      "subject": "customers",
+      "message": "insert payload for customers cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "fc3e92b100be917a4953",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/app/work-orders/create/page.tsx",
+      "subject": "vehicles",
+      "message": "update payload for vehicles cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "216c397069c9a3cddf62",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/app/work-orders/create/page.tsx",
+      "subject": "vehicles",
+      "message": "insert payload for vehicles cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ea459783927c57489eab",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/app/work-orders/editor/page.tsx",
+      "subject": "work_order_lines",
+      "message": "insert payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "1798df1df953ea078255",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/components/MenuQuickAdd.tsx",
+      "subject": "work_order_lines",
+      "message": "insert payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "708cd1e8aa1236fcb413",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/components/NewWorkOrderLineForm.tsx",
+      "subject": "work_order_lines",
+      "message": "insert payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "37453b360ae73a391867",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/components/workorders/AddJobModal.tsx",
+      "subject": "work_order_lines",
+      "message": "insert payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "bdf2da39c54f727000bd",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/lib/saveWorkOrderLines.ts",
+      "subject": "work_order_lines",
+      "message": "insert payload for work_order_lines cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "8dcae0baff754243f1b8",
+      "rule": "dynamic-mutation-payload",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/vehicle-history-import-job.ts",
+      "subject": "history",
+      "message": "insert payload for history cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "1b34f7c090cfe5b044a4",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "app/api/admin/create-user/route.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "8307022d1532c4b5ec0a",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "app/api/admin/staff-invite-candidates/[id]/create-user/route.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e93faec2b26fa8926540",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/api/inspection-form-imports/route.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "23f4e173539819a1fd58",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "technician",
+      "file": "app/api/mobile/shifts/route.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9798b5069a94581d87fc",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "app/api/shop-boost/import-reset/route.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ff4948f1c0bb5fff8b07",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/ai/server/types.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b1f393f3cf37c11d35f4",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/onboarding-v2/analysis/server.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c0f7a05c5b5cc619a59f",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/onboarding-v2/guided/server.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "61780950387c3b596ab6",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/operations/server/getOperationalObservability.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "69c8c9818bd5972ef2fa",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/shared/hooks/useWorkOrderBoard.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "45eb8246e5bc84abc991",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/shared/lib/hr/uploadEmployeeDoc.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "66b1a1957c7c21958db4",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/vehicle-history-import-job.ts",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "360994a9b0abeba87bc2",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "core",
+      "file": "scripts/qa-demo-seed.mjs",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "7b70e7ecdc954ab8cec4",
+      "rule": "dynamic-relation",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "scripts/seed-demo-shop.mjs",
+      "subject": "dynamic .from()",
+      "message": "Dynamic relation name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "840b3a625a9b9f223b9f",
+      "rule": "dynamic-rpc-arguments",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/api/inspections/sign/route.ts",
+      "subject": "attach_signed_inspection_pdf_atomic",
+      "message": "RPC attach_signed_inspection_pdf_atomic arguments cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "8459c372107e17585d04",
+      "rule": "dynamic-rpc-arguments",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/api/inspections/sign/route.ts",
+      "subject": "sign_inspection",
+      "message": "RPC sign_inspection arguments cannot be checked statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "cc18a200320dd2cfc03c",
+      "rule": "dynamic-rpc",
+      "severity": "warning",
+      "domain": "technician",
+      "file": "app/api/offline/mutations/route.ts",
+      "subject": "dynamic rpc",
+      "message": "Dynamic RPC name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "08c39ce18de7048c876a",
+      "rule": "dynamic-rpc",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "app/api/parts/_lib/lifecycleCommand.ts",
+      "subject": "dynamic rpc",
+      "message": "Dynamic RPC name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "8e149538e8f2308ce17c",
+      "rule": "dynamic-rpc",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/api/portal/enrollment/[slug]/route.ts",
+      "subject": "dynamic rpc",
+      "message": "Dynamic RPC name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "7efc3be916ae3e262bc4",
+      "rule": "dynamic-rpc",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/debug/session/page.tsx",
+      "subject": "dynamic rpc",
+      "message": "Dynamic RPC name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "1e30e7b2ba8b3ca156ea",
+      "rule": "dynamic-rpc",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "features/invoices/server/processFinancialOutbox.ts",
+      "subject": "dynamic rpc",
+      "message": "Dynamic RPC name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "5b14f4ebe7159f1b757f",
+      "rule": "dynamic-rpc",
+      "severity": "warning",
+      "domain": "parts",
+      "file": "features/parts/server/syncQuoteLinePartsStatus.ts",
+      "subject": "dynamic rpc",
+      "message": "Dynamic RPC name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "3344fde2c072d23fc1e4",
+      "rule": "dynamic-rpc",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/portal/server/addPortalRequestLine.ts",
+      "subject": "dynamic rpc",
+      "message": "Dynamic RPC name cannot be checked against the schema",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "bc704cfcdf938cfd5ec4",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/api/menu-repair-items/match/route.ts",
+      "subject": "menu_repair_items",
+      "message": "Dynamic select list for menu_repair_items cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "e8a592639b2b2facb9ca",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/api/menu/match/route.ts",
+      "subject": "menu_items",
+      "message": "Dynamic select list for menu_items cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "46e5e5d2fffac101d208",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "app/api/work-orders/lines/add-from-menu/route.ts",
+      "subject": "menu_items",
+      "message": "Dynamic select list for menu_items cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "1b93acf3f509797f9733",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "app/portal/shop/[slug]/ShopPublicProfileView.tsx",
+      "subject": "shops",
+      "message": "Dynamic select list for shops cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "839dd1b7b52abe77e272",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "features/auth/hooks/useUser.ts",
+      "subject": "profiles",
+      "message": "Dynamic select list for profiles cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ab1303d09a54ce780fc8",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "features/auth/hooks/useUser.ts",
+      "subject": "shops",
+      "message": "Dynamic select list for shops cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "9e163b076a50dcedf76b",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "features/inspections/server/findSmartInspectionMatch.ts",
+      "subject": "menu_items",
+      "message": "Dynamic select list for menu_items cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "10a2bfae93e762c51752",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "features/inspections/server/findSmartInspectionMatch.ts",
+      "subject": "menu_repair_items",
+      "message": "Dynamic select list for menu_repair_items cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c128fa4be443ababd436",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "features/portal/server/portalAuth.ts",
+      "subject": "work_orders",
+      "message": "Dynamic select list for work_orders cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "dfc5bd03601a6b4bcb1f",
+      "rule": "dynamic-select",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "features/shops/components/ShopPublicProfileSection.tsx",
+      "subject": "shops",
+      "message": "Dynamic select list for shops cannot be checked",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "64c541ae14115840dcca",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "core",
+      "file": "app/api/branding/assets/[id]/delete/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b08b38e3ad60353435d3",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "app/api/demo/shop-boost/run/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "3fece318d8252424aa5c",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "app/api/demo/shop-boost/uploads/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ece392f9d3736917b992",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "fleet",
+      "file": "app/api/fleet/evidence/[evidenceId]/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "b349915a5095cca5a423",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/api/inspections/[id]/report/pdf/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "108f8aaa5d1bbe9e9348",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/api/inspections/photos/upload/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "90f089e58894f571a39f",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "financial",
+      "file": "app/api/invoices/[id]/documents/[kind]/signed/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "47980cbdb4bd3f5c9b48",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "workforce",
+      "file": "app/api/payroll-time/exports/[batchId]/download/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "4fc8e8a1a99c0d69e26a",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "workforce",
+      "file": "app/api/workforce/documents-readiness/[id]/signed-url/route.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d8c7d7fd537bfd8eaff2",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/portal/property/member/inspections/[id]/page.tsx",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "6258bf335b70d1d1b2ad",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/portal/property/member/inspections/[id]/print/page.tsx",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "c4b6d04718306258eb30",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "property",
+      "file": "app/portal/property/member/requests/[id]/page.tsx",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "ab77b7d7c911f06a1f06",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/property/inspections/[id]/page.tsx",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "7789deaec736bba30931",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "inspections",
+      "file": "app/property/inspections/[id]/print/page.tsx",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "551961b0d0411f9ea375",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "core",
+      "file": "features/customers/app/customers/[id]/page.tsx",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "0cebac861021dd564fac",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "ai-automation",
+      "file": "features/integrations/shopBoost/stageDemoUploads.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "f250ec7909f7a5a09935",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "identity-tenancy",
+      "file": "features/users/components/ProfileAvatarUploader.tsx",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "50d6077594ed08cdbcae",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/app/work-orders/create/page.tsx",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    },
+    {
+      "fingerprint": "d2c8a509d816a356c721",
+      "rule": "dynamic-storage-bucket",
+      "severity": "warning",
+      "domain": "work-orders",
+      "file": "features/work-orders/server/workOrderEvidenceUrls.ts",
+      "subject": "dynamic storage bucket",
+      "message": "Dynamic storage bucket cannot be inventoried statically",
+      "expiresOn": "2026-09-06"
+    }
+  ]
+}

--- a/scripts/regression-inventory/cli.mjs
+++ b/scripts/regression-inventory/cli.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  DEFAULT_BASELINE_PATH,
+  DEFAULT_FLOW_CONFIG_PATH,
+  DEFAULT_SCHEMA_PATH,
+  assertReadableFile,
+  baselineSnapshot,
+  buildInventory,
+  compareWithBaseline,
+  loadBaseline,
+  renderMarkdown,
+} from "./lib.mjs";
+
+function usage() {
+  return `Usage: node scripts/regression-inventory/cli.mjs [options]
+
+Options:
+  --check                 Fail when an error is not in the committed baseline
+  --strict                Fail when any current error exists
+  --write-baseline        Replace the baseline with the current static findings
+  --schema <path>         Supabase generated-types contract
+  --flows <path>          Critical-flow manifest
+  --baseline <path>       Known-finding baseline
+  --logs <path>           Optional JSON/NDJSON production log export
+  --output-dir <path>     Report directory (default: artifacts/regression-inventory)
+  --help                  Show this help
+`;
+}
+
+function parseArgs(argv) {
+  const options = {
+    check: false,
+    strict: false,
+    writeBaseline: false,
+    schema: DEFAULT_SCHEMA_PATH,
+    flows: DEFAULT_FLOW_CONFIG_PATH,
+    baseline: DEFAULT_BASELINE_PATH,
+    logs: null,
+    outputDir: "artifacts/regression-inventory",
+  };
+  const valueOptions = new Map([
+    ["--schema", "schema"],
+    ["--flows", "flows"],
+    ["--baseline", "baseline"],
+    ["--logs", "logs"],
+    ["--output-dir", "outputDir"],
+  ]);
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help") {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+    if (argument === "--check") options.check = true;
+    else if (argument === "--strict") options.strict = true;
+    else if (argument === "--write-baseline") options.writeBaseline = true;
+    else if (valueOptions.has(argument)) {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${argument} requires a value`);
+      }
+      options[valueOptions.get(argument)] = value;
+      index += 1;
+    } else {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+  if (options.writeBaseline && options.logs) {
+    throw new Error("Refusing to baseline volatile production log findings");
+  }
+  return options;
+}
+
+function main() {
+  const rootDir = process.cwd();
+  const options = parseArgs(process.argv.slice(2));
+  assertReadableFile(rootDir, options.schema, "Schema contract");
+  assertReadableFile(rootDir, options.flows, "Critical-flow manifest");
+  if (options.logs) assertReadableFile(rootDir, options.logs, "Log export");
+
+  const inventory = buildInventory({
+    rootDir,
+    schemaPath: options.schema,
+    flowConfigPath: options.flows,
+    logPath: options.logs,
+  });
+
+  let baseline = loadBaseline(rootDir, options.baseline);
+  if (options.check && !baseline) {
+    throw new Error(
+      `Baseline required for --check but not found: ${options.baseline}`,
+    );
+  }
+
+  if (options.writeBaseline) {
+    const baselinePath = path.resolve(rootDir, options.baseline);
+    mkdirSync(path.dirname(baselinePath), { recursive: true });
+    writeFileSync(
+      baselinePath,
+      `${JSON.stringify(baselineSnapshot(inventory), null, 2)}\n`,
+      "utf8",
+    );
+    baseline = loadBaseline(rootDir, options.baseline);
+  }
+
+  const compared = compareWithBaseline(inventory, baseline);
+  const outputDir = path.resolve(rootDir, options.outputDir);
+  mkdirSync(outputDir, { recursive: true });
+  const jsonPath = path.join(outputDir, "inventory.json");
+  const markdownPath = path.join(outputDir, "summary.md");
+  writeFileSync(jsonPath, `${JSON.stringify(compared, null, 2)}\n`, "utf8");
+  writeFileSync(markdownPath, renderMarkdown(compared), "utf8");
+
+  const summary = [
+    `Regression inventory: ${compared.summary.sourceFiles} source files, ${compared.summary.pages} pages, ${compared.summary.apiRoutes} API routes`,
+    `Contracts: ${compared.summary.relationsUsed} relations, ${compared.summary.rpcsUsed} RPCs, ${compared.summary.dynamicReferences} dynamic references`,
+    `Findings: ${compared.comparison.newErrors} new errors, ${compared.comparison.existingErrors} existing errors, ${compared.comparison.newWarnings} new warnings, ${compared.comparison.existingWarnings} existing warnings, ${compared.comparison.resolved} resolved baseline entries`,
+    `Critical flows: ${compared.summary.criticalFlows - compared.summary.criticalFlowGaps}/${compared.summary.criticalFlows} covered`,
+    `Reports: ${path.relative(rootDir, markdownPath)}, ${path.relative(rootDir, jsonPath)}`,
+  ];
+  process.stdout.write(`${summary.join("\n")}\n`);
+
+  if (
+    options.check &&
+    (compared.comparison.newErrors > 0 ||
+      compared.comparison.resolved > 0 ||
+      compared.comparison.expired > 0)
+  ) {
+    process.exitCode = 1;
+  }
+  if (options.strict && compared.summary.errors > 0) process.exitCode = 1;
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(
+    `Regression inventory failed: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 2;
+}

--- a/scripts/regression-inventory/critical-flows.json
+++ b/scripts/regression-inventory/critical-flows.json
@@ -1,0 +1,530 @@
+{
+  "version": 1,
+  "fixture": {
+    "id": "two-shop-golden-path",
+    "description": "A reusable local-only fixture with two shops, repeated display values/SKUs/unit numbers, and owner, advisor, technician, parts, customer, and fleet identities. Mutations are replayed to prove tenant isolation and idempotency.",
+    "tenants": 2,
+    "sentinelPart": {
+      "cost": 40,
+      "sell": 80,
+      "rule": "Quote Review must keep both values, customer surfaces and invoices use sell, and purchase orders use cost."
+    },
+    "roles": ["owner", "advisor", "technician", "parts", "customer", "fleet"]
+  },
+  "flows": [
+    {
+      "id": "identity-tenant-boundaries",
+      "title": "Identity and tenant boundaries",
+      "domain": "identity-tenancy",
+      "stages": [
+        "sign in",
+        "resolve membership",
+        "select shop",
+        "deny cross-shop read",
+        "deny cross-shop write"
+      ],
+      "evidence": [
+        {
+          "id": "runtime-rls",
+          "label": "an executed cross-shop database boundary test",
+          "globs": ["tests/security/*relation-boundaries.runtime.sql"],
+          "kinds": ["database-runtime"],
+          "minimum": 1,
+          "ciRequired": true
+        },
+        {
+          "id": "membership-runtime",
+          "label": "executable membership/application coverage",
+          "globs": [
+            "**/*membership*.test.ts",
+            "**/*tenant*.test.ts",
+            "**/*auth-normalization*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "work-order-intake",
+      "title": "Work-order intake and assignment",
+      "domain": "work-orders",
+      "stages": [
+        "customer",
+        "vehicle",
+        "work order",
+        "repair line",
+        "technician assignment",
+        "history reload"
+      ],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable work-order creation coverage",
+          "globs": [
+            "**/*create-work-order*.test.ts",
+            "**/*work-order*creation*.test.ts",
+            "**/*work-order*intake*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "inspection-repair-truth",
+      "title": "Inspection to repair truth",
+      "domain": "inspections",
+      "stages": [
+        "start inspection",
+        "capture evidence",
+        "save offline",
+        "complete",
+        "release",
+        "reopen",
+        "report"
+      ],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable inspection lifecycle coverage",
+          "globs": ["**/*inspection*.test.ts", "**/*inspection*.test.tsx"],
+          "kinds": ["vitest"],
+          "minimum": 2
+        }
+      ]
+    },
+    {
+      "id": "quote-approval",
+      "title": "Quote Review and approval decisions",
+      "domain": "quotes-approvals",
+      "stages": [
+        "review labor",
+        "review part cost and sell",
+        "send",
+        "approve",
+        "decline",
+        "defer",
+        "replay decision"
+      ],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable Quote Review cost/sell and decision coverage",
+          "globs": [
+            "**/*quote*review*.test.ts",
+            "**/*quote*approval*.test.ts",
+            "**/*approval*consistency*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "markers": ["quotes.review-cost-and-sell"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "parts-request-purchase-order",
+      "title": "Parts request to purchase order",
+      "domain": "parts",
+      "stages": [
+        "create request",
+        "resolve supplier or inventory part",
+        "approve",
+        "create or reuse PO",
+        "prevent duplicate order"
+      ],
+      "evidence": [
+        {
+          "id": "database-runtime",
+          "label": "an executed request-to-PO database integration",
+          "globs": [
+            "tests/parts/*purchase-order*.runtime.sql",
+            "tests/parts/*ordering*.runtime.sql"
+          ],
+          "kinds": ["database-runtime"],
+          "markers": ["parts.request-to-po"],
+          "minimum": 1,
+          "ciRequired": true
+        }
+      ]
+    },
+    {
+      "id": "parts-receive-handoff",
+      "title": "Parts receive, pick, issue, consume, and return",
+      "domain": "parts",
+      "stages": [
+        "receive",
+        "allocate",
+        "pick",
+        "stage",
+        "handoff",
+        "consume",
+        "return",
+        "replay"
+      ],
+      "evidence": [
+        {
+          "id": "database-runtime",
+          "label": "an executed parts lifecycle database integration",
+          "globs": ["tests/parts/*handoff.runtime.sql"],
+          "kinds": ["database-runtime"],
+          "minimum": 1,
+          "ciRequired": true
+        }
+      ]
+    },
+    {
+      "id": "technician-offline",
+      "title": "Technician labor and offline replay",
+      "domain": "technician",
+      "stages": [
+        "assign",
+        "start labor",
+        "capture offline",
+        "reconnect",
+        "replay once",
+        "complete"
+      ],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable offline/replay coverage",
+          "globs": [
+            "**/*offline*.test.ts",
+            "**/*labor*reliability*.test.ts",
+            "**/*job*punch*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "invoice-payment-receipt",
+      "title": "Invoice, payment, and receipt",
+      "domain": "financial",
+      "stages": [
+        "price approved work",
+        "finalize invoice",
+        "record payment",
+        "post outbox",
+        "issue receipt",
+        "replay"
+      ],
+      "evidence": [
+        {
+          "id": "financial-runtime",
+          "label": "an executed financial database integration",
+          "globs": [
+            "tests/security/p0-007-financial-outbox.runtime.sql",
+            "tests/invoices/*.runtime.sql"
+          ],
+          "kinds": ["database-runtime"],
+          "minimum": 1,
+          "ciRequired": true
+        },
+        {
+          "id": "application-runtime",
+          "label": "executable invoice total/document coverage",
+          "globs": ["**/*invoice*.test.ts", "**/*invoice*.test.tsx"],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "customer-portal",
+      "title": "Customer portal request and approval",
+      "domain": "customer-portal",
+      "stages": [
+        "invite",
+        "authenticate",
+        "view scoped work",
+        "approve lines",
+        "view documents"
+      ],
+      "evidence": [
+        {
+          "id": "portal-policy-runtime",
+          "label": "an executed customer portal policy test",
+          "globs": [
+            "tests/security/work-order-parts-portal-policy.runtime.sql"
+          ],
+          "kinds": ["database-runtime"],
+          "minimum": 1,
+          "ciRequired": true
+        },
+        {
+          "id": "application-runtime",
+          "label": "executable portal application coverage",
+          "globs": ["**/*portal*.test.ts", "**/*portal*.test.tsx"],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "payment-refund-receipt",
+      "title": "Payment posting, refund, and receipt",
+      "domain": "financial",
+      "stages": [
+        "post",
+        "deduplicate",
+        "refund",
+        "correct",
+        "issue receipt",
+        "reconcile"
+      ],
+      "evidence": [
+        {
+          "id": "payment-runtime",
+          "label": "an executed payment lifecycle database integration",
+          "globs": [
+            "tests/security/p0-007-financial-outbox.runtime.sql",
+            "tests/security/p1-012-stripe-webhook-receipts.runtime.sql"
+          ],
+          "kinds": ["database-runtime"],
+          "minimum": 1,
+          "ciRequired": true
+        }
+      ]
+    },
+    {
+      "id": "fleet-portal",
+      "title": "Fleet intake, approval, and service history",
+      "domain": "fleet",
+      "stages": [
+        "enroll unit",
+        "request service",
+        "convert to work order",
+        "approve",
+        "view history"
+      ],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable fleet lifecycle coverage",
+          "globs": ["**/*fleet*.test.ts", "**/*fleet*.test.tsx"],
+          "kinds": ["vitest"],
+          "minimum": 2
+        }
+      ]
+    },
+    {
+      "id": "messaging-notifications",
+      "title": "Messaging and notification acknowledgement",
+      "domain": "messaging",
+      "stages": ["send", "deliver", "list", "read", "acknowledge", "retry"],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable message/notification persistence coverage",
+          "globs": [
+            "**/*message*.test.ts",
+            "**/*notification*.test.ts",
+            "**/*chat*delivery*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "markers": ["messaging.notification-acknowledgement"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "workforce-payroll",
+      "title": "Workforce time and payroll periods",
+      "domain": "workforce",
+      "stages": [
+        "clock",
+        "correct",
+        "approve",
+        "close period",
+        "reopen safely",
+        "export"
+      ],
+      "evidence": [
+        {
+          "id": "payroll-runtime",
+          "label": "an executed payroll period database integration",
+          "globs": ["tests/security/payroll-period-pipeline.runtime.sql"],
+          "kinds": ["database-runtime"],
+          "minimum": 1,
+          "ciRequired": true
+        }
+      ]
+    },
+    {
+      "id": "ai-human-approval",
+      "title": "AI recommendation and human approval",
+      "domain": "ai-automation",
+      "stages": [
+        "collect evidence",
+        "recommend",
+        "preview",
+        "human decision",
+        "execute once",
+        "audit"
+      ],
+      "evidence": [
+        {
+          "id": "approval-runtime",
+          "label": "an executed agent approval database integration",
+          "globs": ["tests/security/agent-human-approval-proof.runtime.sql"],
+          "kinds": ["database-runtime"],
+          "minimum": 1,
+          "ciRequired": true
+        },
+        {
+          "id": "application-runtime",
+          "label": "executable AI approval behavior coverage",
+          "globs": [
+            "**/*action*approval*.test.ts",
+            "**/*agent*approval*.test.ts",
+            "**/*automation*policy*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "imports",
+      "title": "CSV imports and replay-safe activation",
+      "domain": "imports",
+      "stages": [
+        "upload",
+        "map",
+        "validate",
+        "preview",
+        "activate",
+        "retry",
+        "audit failures"
+      ],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable import behavior coverage",
+          "globs": ["**/*csv*import*.test.ts", "**/*import*job*.test.ts"],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "billing-subscription-seats",
+      "title": "Subscription, seat, and webhook billing",
+      "domain": "financial",
+      "stages": [
+        "checkout",
+        "webhook",
+        "subscription snapshot",
+        "seat limit",
+        "replay",
+        "cancellation"
+      ],
+      "evidence": [
+        {
+          "id": "webhook-runtime",
+          "label": "an executed Stripe webhook receipt/concurrency integration",
+          "globs": [
+            "tests/security/p1-012-stripe-webhook-receipts.runtime.sql",
+            "tests/security/p1-012-stripe-webhook-concurrency.runtime.sh"
+          ],
+          "kinds": ["database-runtime", "database-runtime-shell"],
+          "minimum": 1,
+          "ciRequired": true
+        },
+        {
+          "id": "application-runtime",
+          "label": "executable seat and subscription coverage",
+          "globs": [
+            "**/*stripe*seat*.test.ts",
+            "**/*subscription*.test.ts",
+            "**/*billing*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "documents-reporting",
+      "title": "Reviewed documents, reports, and exports",
+      "domain": "reporting",
+      "stages": [
+        "load reviewed truth",
+        "render",
+        "attach evidence",
+        "export",
+        "reload identical document"
+      ],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable document rendering coverage",
+          "globs": [
+            "**/*pdf*.test.ts",
+            "**/*report*.test.ts",
+            "**/*document*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "scheduling-booking",
+      "title": "Scheduling and booking",
+      "domain": "scheduling",
+      "stages": [
+        "request",
+        "select slot",
+        "confirm",
+        "convert",
+        "reschedule",
+        "cancel"
+      ],
+      "evidence": [
+        {
+          "id": "application-runtime",
+          "label": "executable booking lifecycle coverage",
+          "globs": ["**/*booking*.test.ts", "**/*schedule*.test.ts"],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    },
+    {
+      "id": "observability-failure-sink",
+      "title": "Operational correlation and failure sink",
+      "domain": "reporting",
+      "stages": [
+        "correlate request",
+        "record domain event",
+        "classify failure",
+        "alert",
+        "resolve fingerprint"
+      ],
+      "evidence": [
+        {
+          "id": "database-runtime",
+          "label": "an executed operational observability database integration",
+          "globs": ["tests/security/operational-observability.runtime.sql"],
+          "kinds": ["database-runtime"],
+          "minimum": 1,
+          "ciRequired": true
+        },
+        {
+          "id": "application-runtime",
+          "label": "executable observability classification coverage",
+          "globs": [
+            "**/*operational-observability*.test.ts",
+            "**/*observability*.test.ts"
+          ],
+          "kinds": ["vitest"],
+          "minimum": 1
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/regression-inventory/lib.mjs
+++ b/scripts/regression-inventory/lib.mjs
@@ -1,0 +1,1845 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+export const DEFAULT_SCHEMA_PATH = "features/shared/types/types/supabase.ts";
+export const DEFAULT_FLOW_CONFIG_PATH =
+  "scripts/regression-inventory/critical-flows.json";
+export const DEFAULT_BASELINE_PATH =
+  "scripts/regression-inventory/baseline.json";
+
+const SOURCE_ROOTS = [
+  "app",
+  "features",
+  "components",
+  "hooks",
+  "lib",
+  "shared",
+  "scripts",
+  "supabase/functions",
+];
+
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
+
+const QUERY_METHODS = new Set([
+  "select",
+  "insert",
+  "update",
+  "upsert",
+  "delete",
+  "eq",
+  "neq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "like",
+  "ilike",
+  "is",
+  "in",
+  "contains",
+  "containedBy",
+  "overlaps",
+  "match",
+  "not",
+  "or",
+  "filter",
+  "order",
+  "limit",
+  "range",
+  "single",
+  "maybeSingle",
+  "throwOnError",
+]);
+
+const COLUMN_METHODS = new Set([
+  "eq",
+  "neq",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "like",
+  "ilike",
+  "is",
+  "in",
+  "contains",
+  "containedBy",
+  "overlaps",
+  "not",
+  "filter",
+  "order",
+  "textSearch",
+]);
+
+const NON_DATABASE_FROM_RECEIVERS = new Set([
+  "Array",
+  "Buffer",
+  "Object",
+  "Reflect",
+  "String",
+  "Uint8Array",
+]);
+
+const DOMAIN_RULES = [
+  [
+    "parts",
+    /(?:^|\/)(?:parts?|inventory|purchase-orders?|vendors?)(?:\/|[-_.])/,
+  ],
+  ["quotes-approvals", /(?:quote|estimate|approval)/],
+  ["work-orders", /(?:work[-_]?orders?|repair[-_]?orders?)/],
+  ["inspections", /inspection/],
+  ["financial", /(?:invoice|payment|financial|stripe|billing|quickbooks)/],
+  ["messaging", /(?:message|chat|notification|sendgrid|email)/],
+  ["fleet", /fleet/],
+  ["customer-portal", /(?:customer[-_]?portal|portal[-_]?customer)/],
+  ["technician", /(?:technician|mobile|offline|labor|job[-_]?clock)/],
+  ["workforce", /(?:workforce|payroll|attendance|punch|shift)/],
+  [
+    "ai-automation",
+    /(?:^|\/)(?:ai|agent|optimization|shop[-_]?boost)(?:\/|[-_.])/,
+  ],
+  ["reporting", /(?:report|export|analytics|dashboard|pdf)/],
+  ["property", /(?:^|\/)property(?:\/|[-_.])/],
+  ["imports", /(?:import|csv)/],
+  ["identity-tenancy", /(?:auth|membership|profile|shops?|users?|settings)/],
+  ["scheduling", /(?:booking|calendar|schedule)/],
+];
+
+const LOG_RULES = [
+  {
+    id: "runtime-schema-column-missing",
+    severity: "error",
+    domain: "schema-contract",
+    flowId: "schema.consumer-contract",
+    title: "Runtime query references a missing column",
+    pattern:
+      /(?:column\s+[^\n]+\s+does not exist|could not find the ["'][^"']+["'] column|\bPGRST204\b|\b42703\b)/i,
+  },
+  {
+    id: "runtime-schema-relation-missing",
+    severity: "error",
+    domain: "schema-contract",
+    flowId: "schema.consumer-contract",
+    title: "Runtime query references a missing relation",
+    pattern: /(?:relation\s+[^\n]+\s+does not exist|\bPGRST205\b|\b42P01\b)/i,
+  },
+  {
+    id: "runtime-rpc-signature-missing",
+    severity: "error",
+    domain: "schema-contract",
+    flowId: "schema.consumer-contract",
+    title: "Runtime RPC name or signature is missing",
+    pattern: /(?:could not find the function|\bPGRST202\b|\b42883\b)/i,
+  },
+  {
+    id: "runtime-parts-po-unresolved-item",
+    severity: "error",
+    domain: "parts",
+    flowId: "parts.request-to-po",
+    title: "Purchase order request item has no selected inventory part",
+    pattern: /request item has no selected inventory part/i,
+  },
+  {
+    id: "runtime-notification-acknowledgement",
+    severity: "error",
+    domain: "messaging",
+    flowId: "messaging.notification-acknowledgement",
+    title: "Notification acknowledgement persistence failed",
+    pattern:
+      /(?:notification[^\n]*(?:acknowledg|constraint)|acknowledg[^\n]*notification)/i,
+  },
+  {
+    id: "runtime-rls-denied",
+    severity: "error",
+    domain: "security",
+    flowId: "tenant.auth-role-boundary",
+    title: "Row-level security rejected an operation",
+    pattern: /(?:row-level security|row level security)/i,
+  },
+  {
+    id: "runtime-invoice-cost-rpc-permission",
+    severity: "error",
+    domain: "financial",
+    flowId: "invoices.ready-finalize-send",
+    title: "Invoice cost recomputation RPC permission drifted",
+    pattern: /permission denied[^\n]*recompute_live_invoice_costs/i,
+  },
+  {
+    id: "runtime-permission-denied",
+    severity: "error",
+    domain: "security",
+    flowId: "tenant.auth-role-boundary",
+    title: "Database permission was denied",
+    pattern: /(?:permission denied|\b42501\b)/i,
+  },
+  {
+    id: "runtime-constraint-violation",
+    severity: "error",
+    domain: "data-integrity",
+    flowId: "schema.consumer-contract",
+    title: "Database constraint rejected an operation",
+    pattern: /(?:violates[^\n]*constraint|\b2350[235]\b|\b23514\b)/i,
+  },
+  {
+    id: "runtime-invalid-filter",
+    severity: "error",
+    domain: "schema-contract",
+    flowId: "schema.consumer-contract",
+    title: "Runtime query sent an invalid filter",
+    pattern: /(?:failed to parse filter|invalid filter|unexpected.*operator)/i,
+  },
+  {
+    id: "runtime-http-5xx",
+    severity: "error",
+    domain: "runtime",
+    flowId: "observability.correlation-failure-sink",
+    title: "Application or API returned a server error",
+    pattern: /(?:\bstatus(?:_code)?["':=\s]+5\d\d\b|\bHTTP\s+5\d\d\b)/i,
+  },
+];
+
+const SOURCE_INITIALIZERS = new WeakMap();
+
+function toPosix(value) {
+  return value.split(path.sep).join("/");
+}
+
+function getPropertyName(node) {
+  if (!node?.name) return null;
+  if (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)) {
+    return node.name.text;
+  }
+  if (ts.isNumericLiteral(node.name)) return node.name.text;
+  return null;
+}
+
+function asTypeLiteral(node) {
+  return node && ts.isTypeLiteralNode(node) ? node : null;
+}
+
+function findTypeMember(typeNode, name) {
+  const literal = asTypeLiteral(typeNode);
+  if (!literal) return null;
+  return (
+    literal.members.find((member) => getPropertyName(member) === name) ?? null
+  );
+}
+
+function propertyNames(typeNode) {
+  const literal = asTypeLiteral(typeNode);
+  if (!literal) return [];
+  return literal.members
+    .map((member) => getPropertyName(member))
+    .filter((name) => name !== null);
+}
+
+function parseFunctionContract(functionMember) {
+  const contracts = ts.isUnionTypeNode(functionMember.type)
+    ? functionMember.type.types
+    : [functionMember.type];
+  const signatures = [];
+  for (const contractType of contracts) {
+    const contract = asTypeLiteral(contractType);
+    const argsMember = contract ? findTypeMember(contract, "Args") : null;
+    const argsType = argsMember?.type;
+    const args = new Set();
+    const requiredArgs = new Set();
+    if (argsType && ts.isTypeLiteralNode(argsType)) {
+      for (const member of argsType.members) {
+        const name = getPropertyName(member);
+        if (!name) continue;
+        args.add(name);
+        if (!member.questionToken) requiredArgs.add(name);
+      }
+    }
+    signatures.push({ args, requiredArgs });
+  }
+  return { signatures };
+}
+
+export function parseSchemaTypes(schemaPath) {
+  const source = readFileSync(schemaPath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    schemaPath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const databaseAlias = sourceFile.statements.find(
+    (statement) =>
+      ts.isTypeAliasDeclaration(statement) &&
+      statement.name.text === "Database",
+  );
+
+  if (!databaseAlias || !ts.isTypeLiteralNode(databaseAlias.type)) {
+    throw new Error(`Database type alias not found in ${schemaPath}`);
+  }
+
+  const publicMember = findTypeMember(databaseAlias.type, "public");
+  const publicType = publicMember?.type;
+  const tablesMember = findTypeMember(publicType, "Tables");
+  const viewsMember = findTypeMember(publicType, "Views");
+  const functionsMember = findTypeMember(publicType, "Functions");
+  const enumsMember = findTypeMember(publicType, "Enums");
+
+  if (!tablesMember || !functionsMember) {
+    throw new Error(
+      `Public Tables/Functions contract not found in ${schemaPath}`,
+    );
+  }
+
+  const relations = new Map();
+  const addRelations = (container, kind) => {
+    const literal = asTypeLiteral(container?.type);
+    if (!literal) return;
+    for (const member of literal.members) {
+      const name = getPropertyName(member);
+      const relationType = asTypeLiteral(member.type);
+      if (!name || !relationType) continue;
+      const row = findTypeMember(relationType, "Row");
+      const insert = findTypeMember(relationType, "Insert");
+      const update = findTypeMember(relationType, "Update");
+      relations.set(name, {
+        kind,
+        row: new Set(propertyNames(row?.type)),
+        insert: new Set(propertyNames(insert?.type)),
+        update: new Set(propertyNames(update?.type)),
+      });
+    }
+  };
+
+  addRelations(tablesMember, "table");
+  addRelations(viewsMember, "view");
+
+  const functions = new Map();
+  const functionLiteral = asTypeLiteral(functionsMember.type);
+  if (functionLiteral) {
+    for (const member of functionLiteral.members) {
+      const name = getPropertyName(member);
+      if (name) functions.set(name, parseFunctionContract(member));
+    }
+  }
+
+  return {
+    sourcePath: schemaPath,
+    relations,
+    functions,
+    enums: new Set(propertyNames(enumsMember?.type)),
+    storageBuckets: new Set(),
+  };
+}
+
+function walkFiles(directory, predicate, output = []) {
+  if (!existsSync(directory)) return output;
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (
+      entry.name === "node_modules" ||
+      entry.name === ".git" ||
+      entry.name === ".next" ||
+      entry.name === "artifacts" ||
+      entry.name === "dist" ||
+      entry.name === "build"
+    ) {
+      continue;
+    }
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) walkFiles(absolute, predicate, output);
+    else if (entry.isFile() && predicate(absolute)) output.push(absolute);
+  }
+  return output;
+}
+
+export function discoverSourceFiles(rootDir) {
+  const files = [];
+  for (const sourceRoot of SOURCE_ROOTS) {
+    const absoluteRoot = path.join(rootDir, sourceRoot);
+    walkFiles(
+      absoluteRoot,
+      (file) => {
+        const relative = toPosix(path.relative(rootDir, file));
+        const extension = path.extname(file);
+        return (
+          SOURCE_EXTENSIONS.has(extension) &&
+          !/(?:^|\/)(?:tests?|__tests__)(?:\/|$)/.test(relative) &&
+          !/(?:^|\/)_archive(?:\/|$)/.test(relative) &&
+          !/\.(?:test|spec)\.[^.]+$/.test(relative) &&
+          relative !== DEFAULT_SCHEMA_PATH &&
+          relative !== "shared/types/types/supabase.ts" &&
+          !relative.startsWith("scripts/regression-inventory/")
+        );
+      },
+      files,
+    );
+  }
+  return [...new Set(files)].sort();
+}
+
+function scriptKindFor(file) {
+  if (file.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (file.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (file.endsWith(".js") || file.endsWith(".mjs") || file.endsWith(".cjs")) {
+    return ts.ScriptKind.JS;
+  }
+  return ts.ScriptKind.TS;
+}
+
+function literalText(node) {
+  if (!node) return null;
+  let current = node;
+  const seen = new Set();
+  while (ts.isIdentifier(current)) {
+    if (seen.has(current.text)) return null;
+    seen.add(current.text);
+    const initializer = SOURCE_INITIALIZERS.get(current.getSourceFile())?.get(
+      current.text,
+    );
+    if (!initializer) return null;
+    current = unwrapExpression(initializer);
+  }
+  if (
+    ts.isStringLiteral(current) ||
+    ts.isNoSubstitutionTemplateLiteral(current)
+  ) {
+    return current.text;
+  }
+  return null;
+}
+
+function collectSourceInitializers(sourceFile) {
+  const initializers = new Map();
+  const visit = (node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isVariableDeclarationList(node.parent) &&
+      (node.parent.flags & ts.NodeFlags.Const) !== 0
+    ) {
+      if (initializers.has(node.name.text)) {
+        initializers.set(node.name.text, null);
+      } else {
+        initializers.set(node.name.text, node.initializer);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  SOURCE_INITIALIZERS.set(sourceFile, initializers);
+}
+
+function callMethodName(node) {
+  if (!ts.isCallExpression(node)) return null;
+  if (
+    ts.isPropertyAccessExpression(node.expression) ||
+    ts.isPropertyAccessChain(node.expression)
+  ) {
+    return node.expression.name.text;
+  }
+  return null;
+}
+
+function outermostChainCall(start) {
+  let current = start;
+  let outerCall = start;
+  while (current.parent) {
+    const parent = current.parent;
+    if (
+      (ts.isPropertyAccessExpression(parent) ||
+        ts.isPropertyAccessChain(parent)) &&
+      parent.expression === current &&
+      ts.isCallExpression(parent.parent) &&
+      parent.parent.expression === parent
+    ) {
+      outerCall = parent.parent;
+      current = parent.parent;
+      continue;
+    }
+    if (
+      (ts.isParenthesizedExpression(parent) ||
+        ts.isAsExpression(parent) ||
+        ts.isNonNullExpression(parent)) &&
+      parent.expression === current
+    ) {
+      current = parent;
+      continue;
+    }
+    break;
+  }
+  return outerCall;
+}
+
+function decomposeChain(node, output = []) {
+  if (!ts.isCallExpression(node)) return output;
+  const expression = node.expression;
+  if (
+    ts.isPropertyAccessExpression(expression) ||
+    ts.isPropertyAccessChain(expression)
+  ) {
+    decomposeChain(expression.expression, output);
+    output.push({
+      name: expression.name.text,
+      args: [...node.arguments],
+      node,
+    });
+  }
+  return output;
+}
+
+function splitTopLevel(value, separator = ",") {
+  const output = [];
+  let current = "";
+  let depth = 0;
+  let quote = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      current += character;
+      if (character === quote && value[index - 1] !== "\\") quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      current += character;
+      continue;
+    }
+    if (character === "(") depth += 1;
+    if (character === ")") depth = Math.max(0, depth - 1);
+    if (character === separator && depth === 0) {
+      output.push(current);
+      current = "";
+    } else {
+      current += character;
+    }
+  }
+  if (current) output.push(current);
+  return output;
+}
+
+export function parseSelectColumns(select) {
+  const columns = [];
+  for (const rawEntry of splitTopLevel(select)) {
+    let entry = rawEntry.trim();
+    if (!entry || entry === "*" || entry.includes("(")) continue;
+    if (entry.includes(":")) entry = entry.slice(entry.lastIndexOf(":") + 1);
+    entry = entry.trim().replace(/^['"]|['"]$/g, "");
+    entry = entry.split("::")[0].split("->")[0].trim();
+    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(entry)) columns.push(entry);
+  }
+  return columns;
+}
+
+function parseOrFilterColumns(filter) {
+  const columns = [];
+  const matcher =
+    /(?:^|[,(])([A-Za-z_][A-Za-z0-9_]*)(?:->>?[A-Za-z0-9_]+)?\.(?:eq|neq|gt|gte|lt|lte|like|ilike|is|in|cs|cd|ov|fts|plfts|phfts|wfts)\./g;
+  let match;
+  while ((match = matcher.exec(filter)) !== null) columns.push(match[1]);
+  return columns;
+}
+
+function unwrapExpression(node) {
+  let current = node;
+  while (
+    ts.isAsExpression(current) ||
+    ts.isParenthesizedExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function objectKeys(node) {
+  let current = unwrapExpression(node);
+  if (ts.isIdentifier(current)) {
+    const initializer = SOURCE_INITIALIZERS.get(current.getSourceFile())?.get(
+      current.text,
+    );
+    if (initializer) current = unwrapExpression(initializer);
+  }
+  if (ts.isArrayLiteralExpression(current)) {
+    return current.elements.flatMap((element) => objectKeys(element));
+  }
+  if (!ts.isObjectLiteralExpression(current)) return [];
+  return current.properties.flatMap((property) => {
+    if (ts.isSpreadAssignment(property)) return objectKeys(property.expression);
+    const name = getPropertyName(property);
+    return name ? [name] : [];
+  });
+}
+
+function isStaticallyObjectLike(node) {
+  let current = unwrapExpression(node);
+  if (ts.isIdentifier(current)) {
+    const initializer = SOURCE_INITIALIZERS.get(current.getSourceFile())?.get(
+      current.text,
+    );
+    if (initializer) current = unwrapExpression(initializer);
+  }
+  return (
+    ts.isObjectLiteralExpression(current) ||
+    ts.isArrayLiteralExpression(current)
+  );
+}
+
+function objectPropertyValue(node, name) {
+  let current = unwrapExpression(node);
+  if (ts.isIdentifier(current)) {
+    const initializer = SOURCE_INITIALIZERS.get(current.getSourceFile())?.get(
+      current.text,
+    );
+    if (initializer) current = unwrapExpression(initializer);
+  }
+  if (!ts.isObjectLiteralExpression(current)) return null;
+  const property = current.properties.find(
+    (candidate) => getPropertyName(candidate) === name,
+  );
+  if (!property || !ts.isPropertyAssignment(property)) return null;
+  return property.initializer;
+}
+
+function receiverName(call) {
+  if (!ts.isCallExpression(call)) return "";
+  const expression = call.expression;
+  if (
+    !ts.isPropertyAccessExpression(expression) &&
+    !ts.isPropertyAccessChain(expression)
+  ) {
+    return "";
+  }
+  return expression.expression.getText();
+}
+
+function domainFromPath(file) {
+  const normalized = file.toLowerCase();
+  for (const [domain, pattern] of DOMAIN_RULES) {
+    if (pattern.test(normalized)) return domain;
+  }
+  return "core";
+}
+
+function findingFingerprint(finding) {
+  const stable = [
+    finding.rule,
+    finding.file ?? "",
+    finding.subject ?? "",
+    finding.operation ?? "",
+  ].join("\u0000");
+  return createHash("sha256").update(stable).digest("hex").slice(0, 20);
+}
+
+export function createFinding(input) {
+  const finding = {
+    severity: "error",
+    domain: input.file ? domainFromPath(input.file) : "core",
+    ...input,
+  };
+  return { ...finding, fingerprint: findingFingerprint(finding) };
+}
+
+function validateColumn({
+  column,
+  operation,
+  relationName,
+  relationContract,
+  relativeFile,
+  line,
+  findings,
+}) {
+  if (!column || column === "*") return;
+  if (column.includes(".")) return;
+  const normalized = column.split("->")[0].split(".")[0].trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(normalized)) return;
+  if (relationContract.row.has(normalized)) return;
+  findings.push(
+    createFinding({
+      rule: "missing-column",
+      severity: "error",
+      file: relativeFile,
+      line,
+      subject: `${relationName}.${normalized}`,
+      operation,
+      message: `${operation} references missing column ${relationName}.${normalized}`,
+    }),
+  );
+}
+
+function isDatabaseFromCall(call, schema, chain) {
+  const receiver = receiverName(call);
+  const firstReceiver = receiver.split(".")[0];
+  if (NON_DATABASE_FROM_RECEIVERS.has(firstReceiver)) return false;
+  const relationName = literalText(call.arguments[0]);
+  if (relationName && schema.relations.has(relationName)) return true;
+  if (chain.some((entry) => QUERY_METHODS.has(entry.name))) return true;
+  return /(?:supabase|postgres|database|client|admin|\bdb\b)/i.test(receiver);
+}
+
+function scanRelationCall({ call, sourceFile, schema, relativeFile }) {
+  const findings = [];
+  const references = [];
+  const line =
+    sourceFile.getLineAndCharacterOfPosition(call.getStart()).line + 1;
+  const chain = decomposeChain(outermostChainCall(call));
+  const relationName = literalText(call.arguments[0]);
+
+  if (!isDatabaseFromCall(call, schema, chain)) return { findings, references };
+
+  if (!relationName) {
+    findings.push(
+      createFinding({
+        rule: "dynamic-relation",
+        severity: "warning",
+        file: relativeFile,
+        line,
+        subject: "dynamic .from()",
+        operation: "from",
+        message: "Dynamic relation name cannot be checked against the schema",
+      }),
+    );
+    references.push({
+      kind: "relation",
+      name: null,
+      dynamic: true,
+      file: relativeFile,
+      line,
+      operations: chain.map((entry) => entry.name),
+    });
+    return { findings, references };
+  }
+
+  references.push({
+    kind: "relation",
+    name: relationName,
+    dynamic: false,
+    file: relativeFile,
+    line,
+    operations: chain.map((entry) => entry.name),
+  });
+
+  const relationContract = schema.relations.get(relationName);
+  if (!relationContract) {
+    findings.push(
+      createFinding({
+        rule: "missing-relation",
+        severity: "error",
+        file: relativeFile,
+        line,
+        subject: relationName,
+        operation: "from",
+        message: `.from(${JSON.stringify(relationName)}) references a relation missing from the schema contract`,
+      }),
+    );
+    return { findings, references };
+  }
+
+  for (const entry of chain) {
+    if (entry.name === "select" && entry.args[0]) {
+      const select = literalText(entry.args[0]);
+      if (select === null) {
+        findings.push(
+          createFinding({
+            rule: "dynamic-select",
+            severity: "warning",
+            file: relativeFile,
+            line,
+            subject: relationName,
+            operation: "select",
+            message: `Dynamic select list for ${relationName} cannot be checked`,
+          }),
+        );
+      } else {
+        for (const column of parseSelectColumns(select)) {
+          validateColumn({
+            column,
+            operation: "select",
+            relationName,
+            relationContract,
+            relativeFile,
+            line,
+            findings,
+          });
+        }
+      }
+    }
+
+    if (COLUMN_METHODS.has(entry.name) && entry.args[0]) {
+      const column = literalText(entry.args[0]);
+      if (column !== null) {
+        validateColumn({
+          column,
+          operation: entry.name,
+          relationName,
+          relationContract,
+          relativeFile,
+          line,
+          findings,
+        });
+      }
+    }
+
+    if (entry.name === "or" && entry.args[0]) {
+      const filter = literalText(entry.args[0]);
+      if (filter !== null) {
+        for (const column of parseOrFilterColumns(filter)) {
+          validateColumn({
+            column,
+            operation: "or",
+            relationName,
+            relationContract,
+            relativeFile,
+            line,
+            findings,
+          });
+        }
+      }
+    }
+
+    if (entry.name === "match" && entry.args[0]) {
+      for (const column of objectKeys(entry.args[0])) {
+        validateColumn({
+          column,
+          operation: "match",
+          relationName,
+          relationContract,
+          relativeFile,
+          line,
+          findings,
+        });
+      }
+    }
+
+    if (["insert", "update", "upsert"].includes(entry.name) && entry.args[0]) {
+      const allowed =
+        entry.name === "update"
+          ? relationContract.update
+          : relationContract.insert;
+      const payloadKeys = objectKeys(entry.args[0]);
+      if (payloadKeys.length === 0 && !isStaticallyObjectLike(entry.args[0])) {
+        findings.push(
+          createFinding({
+            rule: "dynamic-mutation-payload",
+            severity: "warning",
+            file: relativeFile,
+            line,
+            subject: relationName,
+            operation: entry.name,
+            message: `${entry.name} payload for ${relationName} cannot be checked statically`,
+          }),
+        );
+      }
+      for (const column of payloadKeys) {
+        if (allowed.has(column)) continue;
+        findings.push(
+          createFinding({
+            rule: "missing-mutation-column",
+            severity: "error",
+            file: relativeFile,
+            line,
+            subject: `${relationName}.${column}`,
+            operation: entry.name,
+            message: `${entry.name} payload contains missing column ${relationName}.${column}`,
+          }),
+        );
+      }
+    }
+  }
+
+  return { findings, references };
+}
+
+function scanStorageCall({ call, sourceFile, relativeFile, schema }) {
+  const line =
+    sourceFile.getLineAndCharacterOfPosition(call.getStart()).line + 1;
+  const bucket = literalText(call.arguments[0]);
+  const chain = decomposeChain(outermostChainCall(call));
+  const findings = [];
+  if (!bucket) {
+    findings.push(
+      createFinding({
+        rule: "dynamic-storage-bucket",
+        severity: "warning",
+        file: relativeFile,
+        line,
+        subject: "dynamic storage bucket",
+        operation: "storage.from",
+        message: "Dynamic storage bucket cannot be inventoried statically",
+      }),
+    );
+  } else if (schema.storageBuckets && !schema.storageBuckets.has(bucket)) {
+    findings.push(
+      createFinding({
+        rule: "missing-storage-bucket",
+        severity: "error",
+        file: relativeFile,
+        line,
+        subject: bucket,
+        operation: "storage.from",
+        message: `Storage bucket ${bucket} is not provisioned by the migration chain`,
+      }),
+    );
+  }
+  return {
+    findings,
+    references: [
+      {
+        kind: "storage",
+        name: bucket,
+        dynamic: bucket === null,
+        file: relativeFile,
+        line,
+        operations: chain.map((entry) => entry.name),
+      },
+    ],
+  };
+}
+
+function scanRealtimeCall({ call, sourceFile, schema, relativeFile }) {
+  const findings = [];
+  const references = [];
+  if (literalText(call.arguments[0]) !== "postgres_changes") {
+    return { findings, references };
+  }
+  const config = call.arguments[1];
+  if (!config) return { findings, references };
+  const line =
+    sourceFile.getLineAndCharacterOfPosition(call.getStart()).line + 1;
+  const tableNode = objectPropertyValue(config, "table");
+  const table = tableNode ? literalText(tableNode) : null;
+  references.push({
+    kind: "realtime",
+    name: table,
+    dynamic: !table,
+    file: relativeFile,
+    line,
+    operations: ["postgres_changes"],
+  });
+  if (!table) {
+    findings.push(
+      createFinding({
+        rule: "dynamic-realtime-relation",
+        severity: "warning",
+        file: relativeFile,
+        line,
+        subject: "dynamic realtime relation",
+        operation: "postgres_changes",
+        message:
+          "Dynamic Realtime relation cannot be checked against the schema",
+      }),
+    );
+    return { findings, references };
+  }
+  const contract = schema.relations.get(table);
+  if (!contract) {
+    findings.push(
+      createFinding({
+        rule: "missing-realtime-relation",
+        severity: "error",
+        file: relativeFile,
+        line,
+        subject: table,
+        operation: "postgres_changes",
+        message: `Realtime subscription references missing relation ${table}`,
+      }),
+    );
+    return { findings, references };
+  }
+  const filterNode = objectPropertyValue(config, "filter");
+  const filter = filterNode ? literalText(filterNode) : null;
+  const filterColumn = filter?.split("=")[0]?.trim();
+  if (filterColumn) {
+    validateColumn({
+      column: filterColumn,
+      operation: "realtime-filter",
+      relationName: table,
+      relationContract: contract,
+      relativeFile,
+      line,
+      findings,
+    });
+  }
+  return { findings, references };
+}
+
+function scanRpcCall({ call, sourceFile, schema, relativeFile }) {
+  const findings = [];
+  const line =
+    sourceFile.getLineAndCharacterOfPosition(call.getStart()).line + 1;
+  const rpcName = literalText(call.arguments[0]);
+  if (!rpcName) {
+    findings.push(
+      createFinding({
+        rule: "dynamic-rpc",
+        severity: "warning",
+        file: relativeFile,
+        line,
+        subject: "dynamic rpc",
+        operation: "rpc",
+        message: "Dynamic RPC name cannot be checked against the schema",
+      }),
+    );
+    return {
+      findings,
+      references: [
+        {
+          kind: "rpc",
+          name: null,
+          dynamic: true,
+          file: relativeFile,
+          line,
+          operations: ["rpc"],
+        },
+      ],
+    };
+  }
+
+  const references = [
+    {
+      kind: "rpc",
+      name: rpcName,
+      dynamic: false,
+      file: relativeFile,
+      line,
+      operations: ["rpc"],
+    },
+  ];
+  const contract = schema.functions.get(rpcName);
+  if (!contract) {
+    findings.push(
+      createFinding({
+        rule: "missing-rpc",
+        severity: "error",
+        file: relativeFile,
+        line,
+        subject: rpcName,
+        operation: "rpc",
+        message: `.rpc(${JSON.stringify(rpcName)}) is missing from the schema contract`,
+      }),
+    );
+    return { findings, references };
+  }
+
+  const suppliedArgument = call.arguments[1];
+  if (suppliedArgument) {
+    const supplied = new Set(objectKeys(call.arguments[1]));
+    if (supplied.size === 0 && !isStaticallyObjectLike(suppliedArgument)) {
+      findings.push(
+        createFinding({
+          rule: "dynamic-rpc-arguments",
+          severity: "warning",
+          file: relativeFile,
+          line,
+          subject: rpcName,
+          operation: "rpc",
+          message: `RPC ${rpcName} arguments cannot be checked statically`,
+        }),
+      );
+    }
+    if (supplied.size > 0) {
+      const exactSignature = contract.signatures.find(
+        (signature) =>
+          [...supplied].every((argument) => signature.args.has(argument)) &&
+          [...signature.requiredArgs].every((argument) =>
+            supplied.has(argument),
+          ),
+      );
+      if (exactSignature) return { findings, references };
+
+      for (const argument of supplied) {
+        if (
+          contract.signatures.some((signature) => signature.args.has(argument))
+        ) {
+          continue;
+        }
+        findings.push(
+          createFinding({
+            rule: "unknown-rpc-argument",
+            severity: "error",
+            file: relativeFile,
+            line,
+            subject: `${rpcName}.${argument}`,
+            operation: "rpc",
+            message: `RPC ${rpcName} does not declare argument ${argument}`,
+          }),
+        );
+      }
+      const compatible = contract.signatures
+        .filter((signature) =>
+          [...supplied].every((argument) => signature.args.has(argument)),
+        )
+        .map((signature) => ({
+          signature,
+          missing: [...signature.requiredArgs].filter(
+            (argument) => !supplied.has(argument),
+          ),
+        }))
+        .sort((left, right) => left.missing.length - right.missing.length)[0];
+      for (const required of compatible?.missing ?? []) {
+        findings.push(
+          createFinding({
+            rule: "missing-rpc-argument",
+            severity: "error",
+            file: relativeFile,
+            line,
+            subject: `${rpcName}.${required}`,
+            operation: "rpc",
+            message: `RPC ${rpcName} call omits required argument ${required}`,
+          }),
+        );
+      }
+    }
+  } else if (
+    !contract.signatures.some((signature) => signature.requiredArgs.size === 0)
+  ) {
+    const smallest = [...contract.signatures].sort(
+      (left, right) => left.requiredArgs.size - right.requiredArgs.size,
+    )[0];
+    for (const required of smallest?.requiredArgs ?? []) {
+      findings.push(
+        createFinding({
+          rule: "missing-rpc-argument",
+          severity: "error",
+          file: relativeFile,
+          line,
+          subject: `${rpcName}.${required}`,
+          operation: "rpc",
+          message: `RPC ${rpcName} call omits required argument ${required}`,
+        }),
+      );
+    }
+  }
+
+  return { findings, references };
+}
+
+export function scanSourceText({ source, file, schema }) {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(file),
+  );
+  collectSourceInitializers(sourceFile);
+  const findings = [];
+  const references = [];
+  const visit = (node) => {
+    if (ts.isCallExpression(node)) {
+      const method = callMethodName(node);
+      if (method === "from") {
+        const receiver = receiverName(node);
+        const result = /(?:^|\.)storage$/.test(receiver)
+          ? scanStorageCall({
+              call: node,
+              sourceFile,
+              relativeFile: file,
+              schema,
+            })
+          : scanRelationCall({
+              call: node,
+              sourceFile,
+              schema,
+              relativeFile: file,
+            });
+        findings.push(...result.findings);
+        references.push(...result.references);
+      } else if (method === "on") {
+        const result = scanRealtimeCall({
+          call: node,
+          sourceFile,
+          schema,
+          relativeFile: file,
+        });
+        findings.push(...result.findings);
+        references.push(...result.references);
+      } else if (method === "rpc") {
+        const result = scanRpcCall({
+          call: node,
+          sourceFile,
+          schema,
+          relativeFile: file,
+        });
+        findings.push(...result.findings);
+        references.push(...result.references);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return { findings, references };
+}
+
+function deduplicateFindings(findings) {
+  const byFingerprint = new Map();
+  for (const finding of findings) {
+    const existing = byFingerprint.get(finding.fingerprint);
+    if (!existing) {
+      byFingerprint.set(finding.fingerprint, {
+        ...finding,
+        occurrences: 1,
+        locations: finding.file
+          ? [{ file: finding.file, line: finding.line }]
+          : [],
+      });
+      continue;
+    }
+    existing.occurrences += 1;
+    if (
+      finding.file &&
+      !existing.locations.some(
+        (location) =>
+          location.file === finding.file && location.line === finding.line,
+      )
+    ) {
+      existing.locations.push({ file: finding.file, line: finding.line });
+    }
+  }
+  return [...byFingerprint.values()].sort((left, right) =>
+    `${left.severity}:${left.rule}:${left.file}:${left.subject}`.localeCompare(
+      `${right.severity}:${right.rule}:${right.file}:${right.subject}`,
+    ),
+  );
+}
+
+function routePathFor(relativeFile) {
+  let route = relativeFile
+    .replace(/^app/, "")
+    .replace(/\/(?:page|route)\.[^.]+$/, "");
+  route = route
+    .split("/")
+    .filter(
+      (segment) =>
+        segment && !/^\(.*\)$/.test(segment) && !segment.startsWith("@"),
+    )
+    .join("/");
+  return `/${route}`.replace(/\/+/g, "/");
+}
+
+export function discoverRoutes(rootDir) {
+  const appRoot = path.join(rootDir, "app");
+  return walkFiles(appRoot, (file) =>
+    /\/(?:page|route)\.(?:ts|tsx|js|jsx)$/.test(toPosix(file)),
+  )
+    .map((absolute) => {
+      const file = toPosix(path.relative(rootDir, absolute));
+      return {
+        file,
+        route: routePathFor(file),
+        kind: /\/route\.[^.]+$/.test(file) ? "api" : "page",
+        domain: domainFromPath(file),
+      };
+    })
+    .sort((left, right) => left.file.localeCompare(right.file));
+}
+
+export function discoverTests(rootDir) {
+  const workflowRoot = path.join(rootDir, ".github", "workflows");
+  const workflowText = walkFiles(workflowRoot, (file) => /\.ya?ml$/.test(file))
+    .map((file) => readFileSync(file, "utf8"))
+    .join("\n");
+  const candidates = walkFiles(rootDir, (file) =>
+    /(?:\.(?:test|spec)\.(?:ts|tsx|js|jsx)|\.runtime\.sql|\.runtime\.sh)$/.test(
+      file,
+    ),
+  );
+  return candidates
+    .map((absolute) => {
+      const file = toPosix(path.relative(rootDir, absolute));
+      const source = readFileSync(absolute, "utf8");
+      const markers = [
+        ...source.matchAll(/@regression-flow\s+([A-Za-z0-9_.-]+)/g),
+      ].map((match) => match[1]);
+      if (file.endsWith(".runtime.sql")) {
+        return {
+          file,
+          kind: "database-runtime",
+          domain: domainFromPath(file),
+          ciInvoked: workflowText.includes(file),
+          markers,
+        };
+      }
+      if (file.endsWith(".runtime.sh")) {
+        return {
+          file,
+          kind: "database-runtime-shell",
+          domain: domainFromPath(file),
+          ciInvoked: workflowText.includes(file),
+          markers,
+        };
+      }
+      const sourceContract =
+        /(?:readFileSync|readFile)\s*\(/.test(source) &&
+        /\.toContain\s*\(/.test(source);
+      return {
+        file,
+        kind: sourceContract ? "source-contract" : "vitest",
+        domain: domainFromPath(file),
+        ciInvoked: true,
+        markers,
+      };
+    })
+    .sort((left, right) => left.file.localeCompare(right.file));
+}
+
+export function discoverMigrationStorageBuckets(rootDir) {
+  const migrationRoot = path.join(rootDir, "supabase", "migrations");
+  const buckets = new Set();
+  for (const file of walkFiles(migrationRoot, (candidate) =>
+    candidate.endsWith(".sql"),
+  )) {
+    const source = readFileSync(file, "utf8");
+    const insert =
+      /insert\s+into\s+storage\.buckets\s*\(\s*id\b[\s\S]{0,500}?\)\s*values\s*\(\s*'([^']+)'/gi;
+    let match;
+    while ((match = insert.exec(source)) !== null) buckets.add(match[1]);
+  }
+  return buckets;
+}
+
+function globToRegExp(glob) {
+  let expression = "^";
+  for (let index = 0; index < glob.length; index += 1) {
+    const character = glob[index];
+    if (character === "*") {
+      if (glob[index + 1] === "*") {
+        expression += ".*";
+        index += 1;
+      } else {
+        expression += "[^/]*";
+      }
+    } else if (character === "?") {
+      expression += ".";
+    } else {
+      expression += character.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+    }
+  }
+  return new RegExp(`${expression}$`);
+}
+
+function matchesAnyGlob(file, globs) {
+  return globs.some((glob) => globToRegExp(glob).test(file));
+}
+
+export function evaluateCriticalFlows(flowConfig, tests) {
+  const findings = [];
+  const flows = flowConfig.flows.map((flow) => {
+    const requirements = flow.evidence.map((requirement) => {
+      const matches = tests.filter(
+        (test) =>
+          requirement.kinds.includes(test.kind) &&
+          (!requirement.ciRequired || test.ciInvoked) &&
+          (!requirement.markers ||
+            requirement.markers.some((marker) =>
+              test.markers.includes(marker),
+            )) &&
+          matchesAnyGlob(test.file, requirement.globs),
+      );
+      const satisfied = matches.length >= requirement.minimum;
+      if (!satisfied) {
+        findings.push(
+          createFinding({
+            rule: "critical-flow-evidence-gap",
+            severity: "error",
+            domain: flow.domain,
+            file: DEFAULT_FLOW_CONFIG_PATH,
+            line: null,
+            subject: `${flow.id}:${requirement.id}`,
+            operation: "coverage",
+            message: `${flow.title} is missing ${requirement.label}`,
+          }),
+        );
+      }
+      return {
+        ...requirement,
+        satisfied,
+        matches: matches.map((test) => test.file),
+      };
+    });
+    const allSatisfied = requirements.every(
+      (requirement) => requirement.satisfied,
+    );
+    return { ...flow, requirements, status: allSatisfied ? "covered" : "gap" };
+  });
+  return { flows, findings };
+}
+
+function collectStrings(value, output = []) {
+  if (typeof value === "string") {
+    output.push(value);
+    return output;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectStrings(entry, output);
+    return output;
+  }
+  if (value && typeof value === "object") {
+    const preferred = [
+      "event_message",
+      "message",
+      "error",
+      "error_description",
+      "detail",
+      "msg",
+    ];
+    let usedPreferred = false;
+    for (const key of preferred) {
+      if (typeof value[key] === "string") {
+        output.push(value[key]);
+        usedPreferred = true;
+      }
+    }
+    if (!usedPreferred) {
+      for (const entry of Object.values(value)) collectStrings(entry, output);
+    }
+  }
+  return output;
+}
+
+function extractLogMessages(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) return [];
+  try {
+    return collectStrings(JSON.parse(trimmed));
+  } catch {
+    const messages = [];
+    for (const line of trimmed.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        collectStrings(JSON.parse(line), messages);
+      } catch {
+        messages.push(line);
+      }
+    }
+    return messages;
+  }
+}
+
+export function classifyLogs(raw) {
+  const messages = extractLogMessages(raw);
+  const categories = new Map();
+  for (const message of messages) {
+    for (const rule of LOG_RULES) {
+      if (!rule.pattern.test(message)) continue;
+      const current = categories.get(rule.id) ?? { ...rule, count: 0 };
+      current.count += 1;
+      categories.set(rule.id, current);
+      break;
+    }
+  }
+  const findings = [...categories.values()].map((category) =>
+    createFinding({
+      rule: category.id,
+      severity: category.severity,
+      domain: category.domain,
+      file: "runtime-log-export",
+      line: null,
+      subject: category.id,
+      operation: "runtime",
+      message: `${category.title} (${category.count} event${category.count === 1 ? "" : "s"})`,
+    }),
+  );
+  return {
+    messagesInspected: messages.length,
+    matchedEvents: [...categories.values()].reduce(
+      (sum, category) => sum + category.count,
+      0,
+    ),
+    categories: [...categories.values()]
+      .map(({ pattern: _pattern, ...category }) => category)
+      .sort((left, right) => right.count - left.count),
+    findings,
+  };
+}
+
+function aggregateDomains(routes, references, tests, flows) {
+  const domains = new Map();
+  const ensure = (domain) => {
+    if (!domains.has(domain)) {
+      domains.set(domain, {
+        domain,
+        pages: 0,
+        apiRoutes: 0,
+        databaseReferences: 0,
+        vitest: 0,
+        sourceContracts: 0,
+        databaseRuntime: 0,
+        criticalFlows: 0,
+        flowGaps: 0,
+      });
+    }
+    return domains.get(domain);
+  };
+  for (const route of routes) {
+    const domain = ensure(route.domain);
+    if (route.kind === "page") domain.pages += 1;
+    else domain.apiRoutes += 1;
+  }
+  for (const reference of references) {
+    ensure(domainFromPath(reference.file)).databaseReferences += 1;
+  }
+  for (const test of tests) {
+    const domain = ensure(test.domain);
+    if (test.kind === "vitest") domain.vitest += 1;
+    else if (test.kind === "source-contract") domain.sourceContracts += 1;
+    else domain.databaseRuntime += 1;
+  }
+  for (const flow of flows) {
+    const domain = ensure(flow.domain);
+    domain.criticalFlows += 1;
+    if (flow.status !== "covered") domain.flowGaps += 1;
+  }
+  return [...domains.values()].sort((left, right) =>
+    left.domain.localeCompare(right.domain),
+  );
+}
+
+export function buildInventory({
+  rootDir,
+  schemaPath = DEFAULT_SCHEMA_PATH,
+  flowConfigPath = DEFAULT_FLOW_CONFIG_PATH,
+  logPath = null,
+}) {
+  const absoluteSchema = path.resolve(rootDir, schemaPath);
+  const schema = parseSchemaTypes(absoluteSchema);
+  schema.storageBuckets = discoverMigrationStorageBuckets(rootDir);
+  const sourceFiles = discoverSourceFiles(rootDir);
+  const findings = [];
+  const references = [];
+
+  for (const absoluteFile of sourceFiles) {
+    const relativeFile = toPosix(path.relative(rootDir, absoluteFile));
+    const result = scanSourceText({
+      source: readFileSync(absoluteFile, "utf8"),
+      file: relativeFile,
+      schema,
+    });
+    findings.push(...result.findings);
+    references.push(...result.references);
+  }
+
+  const routes = discoverRoutes(rootDir);
+  const tests = discoverTests(rootDir);
+  for (const test of tests) {
+    if (!test.kind.startsWith("database-runtime") || test.ciInvoked) continue;
+    findings.push(
+      createFinding({
+        rule: "database-runtime-not-in-ci",
+        severity: "error",
+        domain: test.domain,
+        file: test.file,
+        line: null,
+        subject: test.file,
+        operation: "ci-coverage",
+        message: `${test.file} exists but no GitHub workflow executes it`,
+      }),
+    );
+  }
+  const flowConfig = JSON.parse(
+    readFileSync(path.resolve(rootDir, flowConfigPath), "utf8"),
+  );
+  const criticalFlows = evaluateCriticalFlows(flowConfig, tests);
+  findings.push(...criticalFlows.findings);
+
+  let runtime = null;
+  if (logPath) {
+    runtime = classifyLogs(
+      readFileSync(path.resolve(rootDir, logPath), "utf8"),
+    );
+    findings.push(...runtime.findings);
+  }
+
+  const deduplicated = deduplicateFindings(findings);
+  const staticReferences = references.filter((reference) => !reference.dynamic);
+  const relationNames = new Set(
+    staticReferences
+      .filter((reference) => reference.kind === "relation")
+      .map((reference) => reference.name),
+  );
+  const rpcNames = new Set(
+    staticReferences
+      .filter((reference) => reference.kind === "rpc")
+      .map((reference) => reference.name),
+  );
+  const storageBuckets = new Set(
+    staticReferences
+      .filter((reference) => reference.kind === "storage")
+      .map((reference) => reference.name),
+  );
+
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    schema: {
+      path: schemaPath,
+      tablesAndViews: schema.relations.size,
+      functions: schema.functions.size,
+      enums: schema.enums.size,
+      storageBuckets: schema.storageBuckets.size,
+    },
+    fixture: flowConfig.fixture,
+    summary: {
+      sourceFiles: sourceFiles.length,
+      pages: routes.filter((route) => route.kind === "page").length,
+      apiRoutes: routes.filter((route) => route.kind === "api").length,
+      tests: tests.length,
+      sourceContractTests: tests.filter(
+        (test) => test.kind === "source-contract",
+      ).length,
+      databaseRuntimeTests: tests.filter((test) =>
+        test.kind.startsWith("database-runtime"),
+      ).length,
+      references: references.length,
+      dynamicReferences: references.filter((reference) => reference.dynamic)
+        .length,
+      relationsUsed: relationNames.size,
+      rpcsUsed: rpcNames.size,
+      storageBucketsUsed: storageBuckets.size,
+      criticalFlows: criticalFlows.flows.length,
+      criticalFlowGaps: criticalFlows.flows.filter(
+        (flow) => flow.status !== "covered",
+      ).length,
+      errors: deduplicated.filter((finding) => finding.severity === "error")
+        .length,
+      warnings: deduplicated.filter((finding) => finding.severity === "warning")
+        .length,
+    },
+    domains: aggregateDomains(routes, references, tests, criticalFlows.flows),
+    routes,
+    tests,
+    references,
+    criticalFlows: criticalFlows.flows,
+    runtime,
+    findings: deduplicated,
+  };
+}
+
+export function loadBaseline(rootDir, baselinePath = DEFAULT_BASELINE_PATH) {
+  const absolute = path.resolve(rootDir, baselinePath);
+  if (!existsSync(absolute)) return null;
+  const parsed = JSON.parse(readFileSync(absolute, "utf8"));
+  if (
+    parsed.version !== 1 ||
+    !Array.isArray(parsed.findings) ||
+    parsed.findings.some((finding) => typeof finding.fingerprint !== "string")
+  ) {
+    throw new Error(`Invalid regression inventory baseline: ${baselinePath}`);
+  }
+  return parsed;
+}
+
+export function baselineSnapshot(inventory) {
+  const expiresAt = new Date(inventory.generatedAt);
+  expiresAt.setUTCDate(expiresAt.getUTCDate() + 30);
+  const expiresOn = expiresAt.toISOString().slice(0, 10);
+  return {
+    version: 1,
+    schema: inventory.schema.path,
+    findings: inventory.findings.map((finding) => ({
+      fingerprint: finding.fingerprint,
+      rule: finding.rule,
+      severity: finding.severity,
+      domain: finding.domain,
+      file: finding.file,
+      subject: finding.subject,
+      message: finding.message,
+      expiresOn,
+    })),
+  };
+}
+
+export function compareWithBaseline(inventory, baseline) {
+  const today = inventory.generatedAt.slice(0, 10);
+  const expiredFindings = (baseline?.findings ?? []).filter(
+    (finding) => finding.expiresOn && finding.expiresOn < today,
+  );
+  const baselineByFingerprint = new Map(
+    (baseline?.findings ?? [])
+      .filter((finding) => !finding.expiresOn || finding.expiresOn >= today)
+      .map((finding) => [finding.fingerprint, finding]),
+  );
+  const currentFingerprints = new Set(
+    inventory.findings.map((finding) => finding.fingerprint),
+  );
+  const findings = inventory.findings.map((finding) => ({
+    ...finding,
+    status: baselineByFingerprint.has(finding.fingerprint) ? "existing" : "new",
+  }));
+  const resolved = (baseline?.findings ?? []).filter(
+    (finding) => !currentFingerprints.has(finding.fingerprint),
+  );
+  return {
+    ...inventory,
+    findings,
+    comparison: {
+      baselineLoaded: Boolean(baseline),
+      newErrors: findings.filter(
+        (finding) => finding.status === "new" && finding.severity === "error",
+      ).length,
+      newWarnings: findings.filter(
+        (finding) => finding.status === "new" && finding.severity === "warning",
+      ).length,
+      existingErrors: findings.filter(
+        (finding) =>
+          finding.status === "existing" && finding.severity === "error",
+      ).length,
+      existingWarnings: findings.filter(
+        (finding) =>
+          finding.status === "existing" && finding.severity === "warning",
+      ).length,
+      resolved: resolved.length,
+      expired: expiredFindings.length,
+    },
+    resolvedFindings: resolved,
+  };
+}
+
+function markdownCell(value) {
+  return String(value ?? "")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ");
+}
+
+function findingLocation(finding) {
+  if (!finding.file) return "—";
+  return finding.line ? `${finding.file}:${finding.line}` : finding.file;
+}
+
+export function renderMarkdown(inventory) {
+  const comparison = inventory.comparison ?? {
+    newErrors: inventory.summary.errors,
+    newWarnings: inventory.summary.warnings,
+    existingErrors: 0,
+    existingWarnings: 0,
+    resolved: 0,
+    expired: 0,
+  };
+  const lines = [
+    "# Full-app regression inventory",
+    "",
+    `Generated: ${inventory.generatedAt}`,
+    "",
+    "## Gate summary",
+    "",
+    "| New errors | Existing errors | New warnings | Existing warnings | Resolved baseline | Expired baseline |",
+    "| ---: | ---: | ---: | ---: | ---: | ---: |",
+    `| ${comparison.newErrors} | ${comparison.existingErrors} | ${comparison.newWarnings} | ${comparison.existingWarnings} | ${comparison.resolved} | ${comparison.expired} |`,
+    "",
+    "The exact, expiring baseline keeps known debt visible while the CI gate rejects new errors, expired entries, and stale entries for already-resolved debt. `--strict` rejects all current errors.",
+    "",
+    "## Inventory scope",
+    "",
+    "| Source files | UI pages | API routes | DB references | Relations used | RPCs used | Storage buckets | Tests | Source-text contracts | DB runtime tests |",
+    "| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    `| ${inventory.summary.sourceFiles} | ${inventory.summary.pages} | ${inventory.summary.apiRoutes} | ${inventory.summary.references} | ${inventory.summary.relationsUsed} | ${inventory.summary.rpcsUsed} | ${inventory.summary.storageBucketsUsed} | ${inventory.summary.tests} | ${inventory.summary.sourceContractTests} | ${inventory.summary.databaseRuntimeTests} |`,
+    "",
+    `Schema contract: \`${inventory.schema.path}\` (${inventory.schema.tablesAndViews} tables/views, ${inventory.schema.functions} functions, ${inventory.schema.enums} enums, ${inventory.schema.storageBuckets} migration-provisioned storage buckets).`,
+    "",
+    "## Domain coverage",
+    "",
+    "| Domain | Pages | APIs | DB refs | Vitest | Source contracts | DB runtime | Critical flows | Flow gaps |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  ];
+
+  for (const domain of inventory.domains) {
+    lines.push(
+      `| ${markdownCell(domain.domain)} | ${domain.pages} | ${domain.apiRoutes} | ${domain.databaseReferences} | ${domain.vitest} | ${domain.sourceContracts} | ${domain.databaseRuntime} | ${domain.criticalFlows} | ${domain.flowGaps} |`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Critical golden paths",
+    "",
+    `Seed fixture: ${inventory.fixture.description}`,
+    "",
+    "| Flow | Domain | Stages | Automated evidence | Status |",
+    "| --- | --- | ---: | ---: | --- |",
+  );
+  for (const flow of inventory.criticalFlows) {
+    const evidenceCount = flow.requirements.reduce(
+      (sum, requirement) => sum + requirement.matches.length,
+      0,
+    );
+    lines.push(
+      `| ${markdownCell(flow.title)} | ${markdownCell(flow.domain)} | ${flow.stages.length} | ${evidenceCount} | ${flow.status} |`,
+    );
+  }
+
+  if (inventory.runtime) {
+    lines.push(
+      "",
+      "## Runtime log classification",
+      "",
+      `${inventory.runtime.messagesInspected} messages inspected; ${inventory.runtime.matchedEvents} matched a known regression signature. Raw log text is not included in this report.`,
+      "",
+      "| Category | Domain | Severity | Events |",
+      "| --- | --- | --- | ---: |",
+    );
+    for (const category of inventory.runtime.categories) {
+      lines.push(
+        `| ${markdownCell(category.title)} | ${markdownCell(category.domain)} | ${category.severity} | ${category.count} |`,
+      );
+    }
+  }
+
+  lines.push("", "## Findings", "");
+  if (inventory.findings.length === 0) {
+    lines.push("No findings.");
+  } else {
+    lines.push(
+      "| Status | Severity | Rule | Domain | Location | Finding |",
+      "| --- | --- | --- | --- | --- | --- |",
+    );
+    const ordered = [...inventory.findings].sort((left, right) => {
+      const statusOrder = { new: 0, existing: 1 };
+      const severityOrder = { error: 0, warning: 1 };
+      return (
+        (statusOrder[left.status] ?? 0) - (statusOrder[right.status] ?? 0) ||
+        (severityOrder[left.severity] ?? 2) -
+          (severityOrder[right.severity] ?? 2) ||
+        left.fingerprint.localeCompare(right.fingerprint)
+      );
+    });
+    for (const finding of ordered) {
+      lines.push(
+        `| ${finding.status ?? "current"} | ${finding.severity} | ${markdownCell(finding.rule)} | ${markdownCell(finding.domain)} | ${markdownCell(findingLocation(finding))} | ${markdownCell(finding.message)} |`,
+      );
+    }
+  }
+
+  if (inventory.resolvedFindings?.length) {
+    lines.push("", "## Resolved baseline findings", "");
+    for (const finding of inventory.resolvedFindings) {
+      lines.push(`- ${finding.rule}: ${finding.message}`);
+    }
+  }
+
+  lines.push(
+    "",
+    "## Interpretation",
+    "",
+    "- Schema errors are derived from literal Supabase table, column, mutation, filter, and RPC consumers across the application.",
+    "- Dynamic references remain warnings because their runtime target cannot be proven statically.",
+    "- Source-text contract tests are inventoried separately from executable Vitest and database-runtime evidence.",
+    "- The existing clean-replay workflow proves that the committed generated types match a fresh migration replay; this inventory proves that app consumers match those types.",
+    "",
+  );
+  return lines.join("\n");
+}
+
+export function assertReadableFile(rootDir, file, label) {
+  const absolute = path.resolve(rootDir, file);
+  if (!existsSync(absolute) || !statSync(absolute).isFile()) {
+    throw new Error(`${label} not found: ${file}`);
+  }
+}

--- a/tests/regression-inventory.test.ts
+++ b/tests/regression-inventory.test.ts
@@ -1,0 +1,213 @@
+// @vitest-environment node
+
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  classifyLogs,
+  discoverMigrationStorageBuckets,
+  evaluateCriticalFlows,
+  parseSchemaTypes,
+  scanSourceText,
+} from "../scripts/regression-inventory/lib.mjs";
+
+const rootDir = process.cwd();
+
+function schemaContract() {
+  const schema = parseSchemaTypes(
+    path.join(rootDir, "features/shared/types/types/supabase.ts"),
+  );
+  schema.storageBuckets = discoverMigrationStorageBuckets(rootDir);
+  return schema;
+}
+
+describe("full-app regression inventory", () => {
+  it("loads the canonical clean-replay schema and migration bucket contract", () => {
+    const schema = schemaContract();
+
+    expect(schema.relations.get("work_orders")?.row.has("shop_id")).toBe(true);
+    expect(schema.functions.has("apply_stock_move")).toBe(true);
+    expect(schema.storageBuckets.has("employee_docs")).toBe(true);
+  });
+
+  it("finds a retired column even when the relation is a local constant", () => {
+    const result = scanSourceText({
+      file: "app/example.ts",
+      schema: schemaContract(),
+      source: `
+        const TABLE = "work_orders";
+        await supabase
+          .from(TABLE)
+          .select("id, technician_id")
+          .eq("shop_id", shopId);
+      `,
+    });
+
+    expect(
+      result.findings.some(
+        (finding) =>
+          finding.rule === "missing-column" &&
+          finding.subject === "work_orders.technician_id",
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a valid generated RPC overload and ignores embedded filters", () => {
+    const result = scanSourceText({
+      file: "features/example.ts",
+      schema: schemaContract(),
+      source: `
+        await supabase.rpc("apply_stock_move", {
+          p_loc: locationId,
+          p_part: partId,
+          p_qty: 1,
+          p_reason: "receive_po",
+          p_ref_id: poId,
+          p_ref_kind: "purchase_order",
+        });
+        await supabase
+          .from("work_order_lines")
+          .select("id, work_orders!inner(shop_id)")
+          .eq("work_orders.shop_id", shopId);
+      `,
+    });
+
+    expect(
+      result.findings.filter((finding) =>
+        ["unknown-rpc-argument", "missing-rpc-argument"].includes(finding.rule),
+      ),
+    ).toEqual([]);
+    expect(
+      result.findings.some(
+        (finding) => finding.subject === "work_order_lines.work_orders",
+      ),
+    ).toBe(false);
+  });
+
+  it("checks storage buckets provisioned by the migration chain", () => {
+    const result = scanSourceText({
+      file: "app/storage.ts",
+      schema: schemaContract(),
+      source: `
+        const GOOD_BUCKET = "employee_docs";
+        await supabase.storage.from(GOOD_BUCKET).upload(path, file);
+        await supabase.storage.from("dashboard-only-bucket").upload(path, file);
+      `,
+    });
+
+    expect(
+      result.findings.some(
+        (finding) =>
+          finding.rule === "missing-storage-bucket" &&
+          finding.subject === "dashboard-only-bucket",
+      ),
+    ).toBe(true);
+    expect(
+      result.findings.some((finding) => finding.subject === "employee_docs"),
+    ).toBe(false);
+  });
+
+  it("checks Realtime relation and filter contracts", () => {
+    const result = scanSourceText({
+      file: "features/realtime.ts",
+      schema: schemaContract(),
+      source: `
+        supabase.channel("work-orders").on("postgres_changes", {
+          event: "*",
+          schema: "public",
+          table: "work_orders",
+          filter: "technician_id=eq.123",
+        }, handler);
+      `,
+    });
+
+    expect(
+      result.findings.some(
+        (finding) =>
+          finding.rule === "missing-column" &&
+          finding.operation === "realtime-filter",
+      ),
+    ).toBe(true);
+  });
+
+  it("classifies sanitized runtime signatures without copying raw log text", () => {
+    const result = classifyLogs(
+      JSON.stringify([
+        { event_message: "Request item has no selected inventory part" },
+        {
+          message:
+            "permission denied for function recompute_live_invoice_costs",
+        },
+        { message: "PGRST204 Could not find the 'technician_id' column" },
+      ]),
+    );
+
+    expect(result.messagesInspected).toBe(3);
+    expect(result.categories.map((category) => category.id)).toEqual(
+      expect.arrayContaining([
+        "runtime-parts-po-unresolved-item",
+        "runtime-invoice-cost-rpc-permission",
+        "runtime-schema-column-missing",
+      ]),
+    );
+    expect(JSON.stringify(result)).not.toContain("technician_id");
+  });
+
+  it("requires explicit proof markers for regression-sensitive stages", () => {
+    const config = {
+      flows: [
+        {
+          id: "quote-review",
+          title: "Quote Review",
+          domain: "quotes-approvals",
+          stages: ["cost", "sell"],
+          evidence: [
+            {
+              id: "cost-sell",
+              label: "cost and sell assertion",
+              globs: ["tests/*quote-review*.test.ts"],
+              kinds: ["vitest"],
+              markers: ["quotes.review-cost-and-sell"],
+              minimum: 1,
+            },
+          ],
+        },
+      ],
+    };
+    const unproven = evaluateCriticalFlows(config, [
+      {
+        file: "tests/quote-review.test.ts",
+        kind: "vitest",
+        ciInvoked: true,
+        markers: [],
+      },
+    ]);
+    const proven = evaluateCriticalFlows(config, [
+      {
+        file: "tests/quote-review.test.ts",
+        kind: "vitest",
+        ciInvoked: true,
+        markers: ["quotes.review-cost-and-sell"],
+      },
+    ]);
+
+    expect(unproven.flows[0].status).toBe("gap");
+    expect(proven.flows[0].status).toBe("covered");
+  });
+
+  it("keeps finding fingerprints stable when line numbers move", () => {
+    const schema = schemaContract();
+    const first = scanSourceText({
+      file: "app/stable.ts",
+      schema,
+      source: 'supabase.from("work_orders").select("technician_id");',
+    });
+    const moved = scanSourceText({
+      file: "app/stable.ts",
+      schema,
+      source: '\n\n\nsupabase.from("work_orders").select("technician_id");',
+    });
+
+    expect(first.findings[0].fingerprint).toBe(moved.findings[0].fingerprint);
+    expect(first.findings[0].line).not.toBe(moved.findings[0].line);
+  });
+});

--- a/tests/security/payroll-period-pipeline.runtime.sql
+++ b/tests/security/payroll-period-pipeline.runtime.sql
@@ -1,8 +1,43 @@
+\set ON_ERROR_STOP on
+
 begin;
+
+insert into auth.users (id, email, raw_user_meta_data)
+values (
+  'e7000000-0000-4000-8000-000000000001',
+  'payroll-period-runtime-owner@example.com',
+  '{"full_name":"Payroll Period Runtime Owner"}'::jsonb
+)
+on conflict (id) do nothing;
+
+insert into public.profiles (id, user_id, role, full_name)
+values (
+  'e7000000-0000-4000-8000-000000000001',
+  'e7000000-0000-4000-8000-000000000001',
+  'owner',
+  'Payroll Period Runtime Owner'
+)
+on conflict (id) do update
+set user_id = excluded.user_id,
+    role = excluded.role,
+    full_name = excluded.full_name;
+
+insert into public.shops (id, owner_id, business_name, name)
+values (
+  'e7000000-0000-4000-8000-000000000002',
+  'e7000000-0000-4000-8000-000000000001',
+  'Payroll Period Runtime Shop',
+  'Payroll Period Runtime Shop'
+)
+on conflict (id) do nothing;
+
+update public.profiles
+set shop_id = 'e7000000-0000-4000-8000-000000000002'
+where id = 'e7000000-0000-4000-8000-000000000001';
 
 do $payroll_period_pipeline$
 declare
-  v_shop_id uuid;
+  v_shop_id uuid := 'e7000000-0000-4000-8000-000000000002';
   v_period_id uuid;
   v_period public.payroll_pay_periods%rowtype;
 begin
@@ -82,15 +117,6 @@ begin
        'EXECUTE'
      ) then
     raise exception 'Payroll snapshot RPC grants are unsafe';
-  end if;
-
-  select shop.id
-  into v_shop_id
-  from public.shops shop
-  order by shop.created_at
-  limit 1;
-  if v_shop_id is null then
-    raise exception 'A shop is required for the payroll period trigger runtime test';
   end if;
 
   insert into public.payroll_pay_periods (


### PR DESCRIPTION
## Summary

- Adds a deterministic full-app regression inventory covering Supabase schema consumers, RPCs, Storage, Realtime, tests, critical flows, and optional normalized runtime logs.
- Catalogs 1,998 source files, 270 pages, 425 API routes, and 3,162 database references.
- Defines 19 supported golden paths and requires executable evidence for Parts → PO, Quote Review cost/sell, and notification acknowledgement.
- Adds an exact, expiring baseline and a global PR gate that rejects new, expired, or stale findings.
- Runs two previously orphaned runtime SQL suites in clean-replay CI.
- Excludes the abandoned property experiment from supported golden-path coverage; its remaining code/UI will be removed separately.

## Root cause

Clean migration replay can pass while loosely typed application queries still reference retired schema contracts. Source-text tests also cannot prove that the affected workflows execute successfully.

## Current inventory

- 145 existing high-confidence error occurrences
- 131 dynamic-analysis warnings
- 15 of 19 supported critical flows covered
- uncovered: work-order intake, Quote Review pricing, Parts request → PO, and notification acknowledgement
- baseline expiry: September 6, 2026

This PR adds detection only; it changes no application business behavior or production data.

## Validation

- inventory baseline check passed
- inventory tests: 8/8
- full Vitest suite: 1,932 passed, 2 skipped
- TypeScript, changed-file ESLint/Prettier, production build, and diff check passed
- repository-wide ESLint retains 8 pre-existing errors and 158 warnings in untouched files

## Database

No migrations or production writes. Clean-replay CI only gains execution of existing runtime SQL coverage.