### PR TITLE
Address post-merge quote and Parts review findings

### DIFF
--- a/app/api/parts/purchase-orders/[poId]/lines/[lineId]/receive-free-text/route.ts
+++ b/app/api/parts/purchase-orders/[poId]/lines/[lineId]/receive-free-text/route.ts
@@ -27,6 +27,15 @@ export async function POST(
       { status: 400 },
     );
   }
+  if (Math.round(qty * 100) / 100 !== qty) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Receipt quantity cannot use more than two decimal places.",
+      },
+      { status: 400 },
+    );
+  }
 
   const access = await requireShopScopedApiAccess({
     requiredCapability: "canManageParts",

--- a/app/api/quotes/approval-webhook/route.ts
+++ b/app/api/quotes/approval-webhook/route.ts
@@ -2,7 +2,10 @@ import "server-only";
 
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import { getActorCapabilities } from "@/features/shared/lib/rbac";
 import {
   isQuotePricingQuarantineError,
@@ -220,6 +223,25 @@ export async function POST(req: Request) {
       declinedQuoteLineIds,
       signatureUrl,
     });
+  const durableOperationKey = `${workOrder.shop_id}:approval-compat:${operationKey}`;
+  const { data: durableReceipt } = await createAdminSupabase()
+    .from("quote_lifecycle_operation_keys")
+    .select("result")
+    .eq("shop_id", workOrder.shop_id)
+    .eq("work_order_id", workOrderId)
+    .eq("operation_name", "approval_compatibility_bundle")
+    .eq("operation_key", durableOperationKey)
+    .maybeSingle<{ result: unknown }>();
+  if (
+    durableReceipt?.result &&
+    typeof durableReceipt.result === "object" &&
+    !Array.isArray(durableReceipt.result)
+  ) {
+    return NextResponse.json({
+      ...(durableReceipt.result as Record<string, unknown>),
+      idempotent: true,
+    });
+  }
 
   const quarantineCheck = await checkQuotePricingQuarantine({
     supabase,
@@ -259,7 +281,7 @@ export async function POST(req: Request) {
       p_approved_quote_line_ids: approvedQuoteLineIds,
       p_declined_quote_line_ids: declinedQuoteLineIds,
       p_signature_url: signatureUrl,
-      p_operation_key: `${workOrder.shop_id}:approval-compat:${operationKey}`,
+      p_operation_key: durableOperationKey,
       p_at: new Date().toISOString(),
     },
   );

--- a/app/api/work-orders/quotes/[id]/pricing-quarantine/route.ts
+++ b/app/api/work-orders/quotes/[id]/pricing-quarantine/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from "next/server";
+import { requireShopScopedApiAccess } from "@/features/shared/lib/server/admin-access";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
+
+type RouteContext = { params: Promise<{ id: string }> };
+type RemediationItem = {
+  id?: string | null;
+  request_id?: string | null;
+  description: string;
+  qty: number;
+  unit_price: number;
+  part_number?: string | null;
+  manufacturer?: string | null;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function text(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized && normalized.length <= maxLength ? normalized : null;
+}
+
+function twoDecimalNonNegative(value: unknown): number | null {
+  const numberValue = typeof value === "number" ? value : Number.NaN;
+  if (
+    !Number.isFinite(numberValue) ||
+    numberValue < 0 ||
+    Math.round(numberValue * 100) / 100 !== numberValue
+  ) {
+    return null;
+  }
+  return numberValue;
+}
+
+function parseItems(value: unknown): RemediationItem[] | null {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 100) {
+    return null;
+  }
+
+  const items: RemediationItem[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+    const item = raw as Record<string, unknown>;
+    const description = text(item.description, 500);
+    const qty = twoDecimalNonNegative(item.qty);
+    const unitPrice = twoDecimalNonNegative(item.unit_price);
+    if (!description || qty == null || qty <= 0 || unitPrice == null) {
+      return null;
+    }
+    items.push({
+      id: text(item.id, 200),
+      request_id: text(item.request_id, 200),
+      description,
+      qty,
+      unit_price: unitPrice,
+      part_number: text(item.part_number, 200),
+      manufacturer: text(item.manufacturer, 200),
+    });
+  }
+  return items;
+}
+
+function statusForError(message: string): number {
+  if (message.includes("not found")) return 404;
+  if (
+    message.includes("TOTAL_MISMATCH") ||
+    message.includes("NOT_QUARANTINED") ||
+    message.includes("IDEMPOTENCY_CONFLICT")
+  ) {
+    return 409;
+  }
+  return 400;
+}
+
+export async function POST(request: Request, context: RouteContext) {
+  const access = await requireShopScopedApiAccess({
+    requiredCapability: "canEditPricing",
+    allowRoles: ["owner", "admin"],
+  });
+  if (!access.ok) return access.response;
+
+  const { id } = await context.params;
+  const quoteLineId = id.trim();
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const operationKey = text(
+    body?.operationKey ?? request.headers.get("idempotency-key"),
+    300,
+  );
+  const note =
+    body?.note == null || body.note === "" ? null : text(body.note, 1000);
+  const items = parseItems(body?.items);
+
+  if (!UUID_PATTERN.test(quoteLineId)) {
+    return NextResponse.json(
+      { error: "Invalid quote line id." },
+      { status: 400 },
+    );
+  }
+  if (!operationKey) {
+    return NextResponse.json(
+      { error: "A stable remediation operation key is required." },
+      { status: 400 },
+    );
+  }
+  if (body?.note != null && body.note !== "" && note == null) {
+    return NextResponse.json(
+      { error: "Remediation note must be 1000 characters or fewer." },
+      { status: 400 },
+    );
+  }
+  if (!items) {
+    return NextResponse.json(
+      {
+        error:
+          "Provide corrected part descriptions, positive quantities, and non-negative sell prices with at most two decimal places.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminSupabase();
+  const { data, error } = await admin.rpc(
+    "remediate_quote_line_pricing_quarantine",
+    {
+      p_shop_id: access.profile.shop_id,
+      p_quote_line_id: quoteLineId,
+      p_actor_user_id: access.authUserId,
+      p_items: items,
+      p_operation_key: operationKey,
+      ...(note ? { p_note: note } : {}),
+    },
+  );
+
+  if (error) {
+    const message = [error.message, error.details, error.hint]
+      .filter(Boolean)
+      .join(" — ");
+    return NextResponse.json(
+      { ok: false, error: message },
+      { status: statusForError(message) },
+    );
+  }
+
+  return NextResponse.json({
+    ...(data && typeof data === "object" ? data : { ok: true }),
+  });
+}

--- a/app/parts/requests/[id]/page.tsx
+++ b/app/parts/requests/[id]/page.tsx
@@ -89,6 +89,7 @@ type UiItem = ItemRow & {
   // PO assignment UI
   ui_po_id?: string; // derived from it.po_id (if exists) else ""
   ui_supplier_id?: string; // for create/select (optional helper)
+  ui_acquisition_cost?: number; // explicit supplier cost for legacy ordering
 };
 
 type CreateInventoryDraft = {
@@ -2775,13 +2776,41 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
                                     {/* PO column */}
                                     <td className="px-3 py-2 align-top">
                                       <div className="grid gap-2">
+                                        <label className="grid gap-1 text-[11px] text-[color:var(--theme-text-muted)]">
+                                          Acquisition unit cost
+                                          <input
+                                            aria-label={`Acquisition unit cost for ${String(it.description ?? "part")}`}
+                                            type="number"
+                                            min={0}
+                                            step={0.01}
+                                            className={`${inputBase} w-[220px] py-1.5 text-right text-xs`}
+                                            value={
+                                              it.ui_acquisition_cost == null
+                                                ? ""
+                                                : String(it.ui_acquisition_cost)
+                                            }
+                                            onChange={(e) => {
+                                              const raw = e.target.value;
+                                              updateItem(r.req.id, String(it.id), {
+                                                ui_acquisition_cost:
+                                                  raw === "" ? undefined : Number(raw),
+                                              });
+                                            }}
+                                            disabled={rowBusy}
+                                          />
+                                        </label>
                                         <select
                                           className={`${selectBase} w-[220px] py-1.5`}
                                           value={uiPoId}
                                           onChange={(e) => {
                                             const next = e.target.value || "";
                                             if (next) {
-                                              void createPoLineForItem(it, next, null);
+                                              void createPoLineForItem(
+                                                it,
+                                                next,
+                                                null,
+                                                it.ui_acquisition_cost ?? null,
+                                              );
                                             } else {
                                               void clearItemPoAssignment(it);
                                             }
@@ -2892,6 +2921,7 @@ export default function PartsRequestsForWorkOrderPage(): JSX.Element {
                                                   it,
                                                   supplierId,
                                                   null,
+                                                  it.ui_acquisition_cost ?? null,
                                                 );
                                               }}
                                             >

--- a/features/ai/components/chat/NewChatModal.tsx
+++ b/features/ai/components/chat/NewChatModal.tsx
@@ -5,10 +5,15 @@ import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { toast } from "sonner";
 import ModalShell from "@/features/shared/components/ModalShell";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
+import {
+  matchesChatRole,
+  workOrderChatRoleFilter,
+  type ChatRoleFilter,
+} from "./chatRoleFilter";
 
 const ROLE_OPTIONS = [
   { value: "all", label: "All roles" },
-  { value: "tech", label: "Tech" },
+  { value: "mechanic", label: "Mechanic" },
   { value: "advisor", label: "Advisor" },
   { value: "parts", label: "Parts" },
   { value: "foreman", label: "Foreman" },
@@ -76,7 +81,7 @@ export default function NewChatModal({
   const [users, setUsers] = useState<UserRow[]>([]);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [search, setSearch] = useState("");
-  const [role, setRole] = useState<"all" | string>("all");
+  const [role, setRole] = useState<ChatRoleFilter>("all");
   const [loadingUsers, setLoadingUsers] = useState(false);
   const [apiError, setApiError] = useState<string | null>(null);
 
@@ -288,9 +293,7 @@ export default function NewChatModal({
     if (!currentUserRole) return;
 
     if (context_type === "work_order") {
-      if (currentUserRole === "tech") setRole("advisor");
-      else if (currentUserRole === "advisor") setRole("tech");
-      else setRole("all");
+      setRole(workOrderChatRoleFilter(currentUserRole) ?? "all");
     }
   }, [isOpen, context_type, currentUserRole]);
 
@@ -414,7 +417,7 @@ export default function NewChatModal({
   const filtered = useMemo(() => {
     const t = search.trim().toLowerCase();
     return users.filter((u) => {
-      if (role !== "all" && (u.role ?? "") !== role) return false;
+      if (!matchesChatRole(u.role, role)) return false;
       if (!t) return true;
       return (
         (u.full_name ?? "").toLowerCase().includes(t) ||

--- a/features/ai/components/chat/chatRoleFilter.test.ts
+++ b/features/ai/components/chat/chatRoleFilter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { matchesChatRole, workOrderChatRoleFilter } from "./chatRoleFilter";
+
+describe("chat role filters", () => {
+  it("matches canonical mechanics and legacy aliases", () => {
+    expect(matchesChatRole("mechanic", "mechanic")).toBe(true);
+    expect(matchesChatRole("tech", "mechanic")).toBe(true);
+    expect(matchesChatRole("technician", "mechanic")).toBe(true);
+    expect(matchesChatRole("advisor", "mechanic")).toBe(false);
+  });
+
+  it("pairs work-order advisors and mechanics using canonical roles", () => {
+    expect(workOrderChatRoleFilter("advisor")).toBe("mechanic");
+    expect(workOrderChatRoleFilter("mechanic")).toBe("advisor");
+    expect(workOrderChatRoleFilter("tech")).toBe("advisor");
+    expect(workOrderChatRoleFilter("parts")).toBeNull();
+  });
+});

--- a/features/ai/components/chat/chatRoleFilter.ts
+++ b/features/ai/components/chat/chatRoleFilter.ts
@@ -1,0 +1,22 @@
+import {
+  canonicalizeRole,
+  type CanonicalRole,
+} from "@/features/shared/lib/rbac";
+
+export type ChatRoleFilter = "all" | CanonicalRole;
+
+export function matchesChatRole(
+  userRole: string | null | undefined,
+  filter: ChatRoleFilter,
+): boolean {
+  return filter === "all" || canonicalizeRole(userRole) === filter;
+}
+
+export function workOrderChatRoleFilter(
+  currentUserRole: string | null | undefined,
+): ChatRoleFilter | null {
+  const canonicalRole = canonicalizeRole(currentUserRole);
+  if (canonicalRole === "mechanic") return "advisor";
+  if (canonicalRole === "advisor") return "mechanic";
+  return null;
+}

--- a/features/portal/app/quotes/[id]/QuotePageClient.tsx
+++ b/features/portal/app/quotes/[id]/QuotePageClient.tsx
@@ -125,8 +125,9 @@ type DirectPartRow = Pick<
 type QuotePartView = {
   name: string;
   qty: number;
-  unitPrice: number;
-  total: number;
+  unitPrice: number | null;
+  total: number | null;
+  pricingUnavailable: boolean;
   meta: string | null;
 };
 
@@ -261,18 +262,20 @@ function getQuoteParts(
     )
     .map((part) => {
       const qty = asNumber(part.qty ?? part.quantity ?? 1) || 1;
-      const unitPrice = asNumber(
+      const unitPrice = nullableNumber(
         part.unitPrice ?? part.unit_price ?? part.quoted_price ?? part.price,
       );
       const total =
         nullableNumber(
           part.totalPrice ?? part.total_price ?? part.line_total ?? part.total,
-        ) ?? qty * unitPrice;
+        ) ?? (unitPrice == null ? null : qty * unitPrice);
       return {
         name: getPartName(part),
         qty,
         unitPrice,
         total,
+        pricingUnavailable:
+          part.pricing_unavailable === true || unitPrice == null,
         meta: getPartMeta(part),
       };
     });
@@ -499,7 +502,7 @@ export default function QuotePageClient(): JSX.Element {
           laborHours * (nullableNumber(metadata.labor_rate) ?? laborRate);
         const partsAmount =
           nullableNumber(line.parts_total) ??
-          parts.reduce((sum, part) => sum + part.total, 0);
+          parts.reduce((sum, part) => sum + (part.total ?? 0), 0);
         const laborAmount = nullableNumber(line.labor_total) ?? computedLabor;
         const subtotalAmount =
           nullableNumber(line.subtotal) ?? laborAmount + partsAmount;
@@ -618,6 +621,7 @@ export default function QuotePageClient(): JSX.Element {
               qty,
               unitPrice,
               total: nullableNumber(part.total_price) ?? qty * unitPrice,
+              pricingUnavailable: false,
               meta:
                 [
                   safeTrim(part.manufacturer_snapshot),
@@ -628,7 +632,7 @@ export default function QuotePageClient(): JSX.Element {
             };
           });
         const partsAmount = directParts.reduce(
-          (sum, part) => sum + part.total,
+          (sum, part) => sum + (part.total ?? 0),
           0,
         );
         const totalAmount = laborAmount + partsAmount;
@@ -1095,11 +1099,15 @@ export default function QuotePageClient(): JSX.Element {
                               ) : null}
                               <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
                                 Qty {part.qty} ×{" "}
-                                {formatCurrency(part.unitPrice)}
+                                {part.pricingUnavailable
+                                  ? "Pricing unavailable"
+                                  : formatCurrency(part.unitPrice)}
                               </div>
                             </div>
                             <div className="text-sm font-medium text-[color:var(--theme-text-primary)]">
-                              {formatCurrency(part.total)}
+                              {part.pricingUnavailable
+                                ? "—"
+                                : formatCurrency(part.total)}
                             </div>
                           </div>
                         </div>

--- a/features/portal/lib/customerVisibleQuoteParts.ts
+++ b/features/portal/lib/customerVisibleQuoteParts.ts
@@ -6,6 +6,45 @@ function metadataArray(
   return Array.isArray(value) ? value : [];
 }
 
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function sanitizedQuarantinedPart(value: unknown): Record<string, unknown> | null {
+  const item = record(value);
+  if (!item) return null;
+
+  const safeKeys = [
+    "id",
+    "request_id",
+    "description",
+    "name",
+    "selected_name",
+    "qty",
+    "quantity",
+    "part_number",
+    "partNumber",
+    "requested_part_number",
+    "sku",
+    "manufacturer",
+    "supplier",
+    "vendor",
+  ] as const;
+  const safe = Object.fromEntries(
+    safeKeys.flatMap((key) =>
+      item[key] == null ? [] : ([[key, item[key]]] as const),
+    ),
+  );
+  return {
+    ...safe,
+    unit_price: null,
+    line_total: null,
+    pricing_unavailable: true,
+  };
+}
+
 export function selectCustomerVisibleQuoteParts(
   metadata: Record<string, unknown>,
   allowCanonicalPartsQuote: boolean,
@@ -22,18 +61,26 @@ export function selectCustomerVisibleQuoteParts(
       ? (sanitization as Record<string, unknown>)
       : null;
 
-  // A protected decision can retain its finalized top-level total while legacy
-  // item pricing is quarantined for staff review. Never coerce those null item
-  // prices to a misleading customer-visible $0 or fall back to stale snapshots.
-  if (sanitizationRecord?.customer_pricing_quarantined === true) {
-    return [];
-  }
-
   const quotedParts = partsQuoteRecord
     ? metadataArray(partsQuoteRecord, "items")
     : [];
 
-  if (allowCanonicalPartsQuote && quotedParts.length > 0) {
+  // Keep the finalized descriptions and quantities visible, but rebuild every
+  // item from a strict non-price allowlist. This cannot leak the legacy price
+  // that caused quarantine and lets the portal say pricing is unavailable
+  // instead of presenting a contradictory zero-item quote.
+  if (sanitizationRecord?.customer_pricing_quarantined === true) {
+    const source = quotedParts.length > 0 ? quotedParts : requestedParts;
+    return source
+      .map(sanitizedQuarantinedPart)
+      .filter((part): part is Record<string, unknown> => part !== null);
+  }
+
+  if (
+    (allowCanonicalPartsQuote ||
+      sanitizationRecord?.customer_pricing_remediated === true) &&
+    quotedParts.length > 0
+  ) {
     return quotedParts;
   }
 

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -27477,3 +27477,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -26326,6 +26326,17 @@ export type Database = {
         }
         Returns: boolean
       }
+      remediate_quote_line_pricing_quarantine: {
+        Args: {
+          p_actor_user_id: string
+          p_items: Json
+          p_note?: string
+          p_operation_key: string
+          p_quote_line_id: string
+          p_shop_id: string
+        }
+        Returns: Json
+      }
       reopen_inspection: {
         Args: { p_inspection_id: string; p_reason: string }
         Returns: Json
@@ -27466,4 +27477,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/features/work-orders/quote-review/PricingQuarantineRemediation.tsx
+++ b/features/work-orders/quote-review/PricingQuarantineRemediation.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import type { ResolvedQuotePart } from "./partsModel";
+
+type DraftItem = {
+  key: string;
+  id: string | null;
+  requestId: string | null;
+  description: string;
+  quantity: string;
+  unitPrice: string;
+  partNumber: string | null;
+  manufacturer: string | null;
+};
+
+function initialDraftItems(
+  quoteLineId: string,
+  parts: ResolvedQuotePart[],
+): DraftItem[] {
+  const initial = parts.map((part, index) => ({
+    key: `${quoteLineId}:${part.requestItemId ?? part.requestId ?? index}`,
+    id: part.requestItemId,
+    requestId: part.requestId,
+    description: part.description,
+    quantity: String(part.quantity),
+    unitPrice: "",
+    partNumber: part.selectedPartNumber ?? part.requestedPartNumber,
+    manufacturer: part.manufacturer,
+  }));
+  return initial.length > 0
+    ? initial
+    : [
+        {
+          key: `${quoteLineId}:manual-0`,
+          id: null,
+          requestId: null,
+          description: "",
+          quantity: "1",
+          unitPrice: "",
+          partNumber: null,
+          manufacturer: null,
+        },
+      ];
+}
+
+function money(value: number): string {
+  return new Intl.NumberFormat("en-CA", {
+    style: "currency",
+    currency: "CAD",
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function twoDecimalNumber(value: string): number | null {
+  if (!value.trim()) return null;
+  const parsed = Number(value);
+  if (
+    !Number.isFinite(parsed) ||
+    parsed < 0 ||
+    Math.round(parsed * 100) / 100 !== parsed
+  ) {
+    return null;
+  }
+  return parsed;
+}
+
+export function PricingQuarantineRemediation({
+  quoteLineId,
+  quoteLineUpdatedAt,
+  finalizedPartsTotal,
+  parts,
+  onRemediated,
+}: {
+  quoteLineId: string;
+  quoteLineUpdatedAt: string | null;
+  finalizedPartsTotal: number | null;
+  parts: ResolvedQuotePart[];
+  onRemediated: () => void | Promise<void>;
+}): JSX.Element {
+  const nextKey = useRef(1);
+  const [drafts, setDrafts] = useState<DraftItem[]>(() =>
+    initialDraftItems(quoteLineId, parts),
+  );
+  const [note, setNote] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  function patchDraft(key: string, patch: Partial<DraftItem>) {
+    setDrafts((current) =>
+      current.map((draft) =>
+        draft.key === key ? { ...draft, ...patch } : draft,
+      ),
+    );
+  }
+
+  const draftTotal = drafts.reduce<number | null>((sum, draft) => {
+    if (sum == null) return null;
+    const quantity = twoDecimalNumber(draft.quantity);
+    const unitPrice = twoDecimalNumber(draft.unitPrice);
+    if (quantity == null || quantity <= 0 || unitPrice == null) return null;
+    return Math.round((sum + quantity * unitPrice) * 100) / 100;
+  }, 0);
+  const totalsMatch =
+    finalizedPartsTotal != null &&
+    draftTotal != null &&
+    Math.round(finalizedPartsTotal * 100) === Math.round(draftTotal * 100);
+
+  async function submit() {
+    if (finalizedPartsTotal == null) {
+      toast.error(
+        "The finalized parts total is unavailable; operator repair is required.",
+      );
+      return;
+    }
+
+    const items = drafts.map((draft) => ({
+      id: draft.id,
+      request_id: draft.requestId,
+      description: draft.description.trim(),
+      qty: twoDecimalNumber(draft.quantity),
+      unit_price: twoDecimalNumber(draft.unitPrice),
+      part_number: draft.partNumber,
+      manufacturer: draft.manufacturer,
+    }));
+    if (
+      items.some(
+        (item) =>
+          !item.description ||
+          item.qty == null ||
+          item.qty <= 0 ||
+          item.unit_price == null,
+      )
+    ) {
+      toast.error(
+        "Every item needs a description, positive quantity, and sell price with at most two decimal places.",
+      );
+      return;
+    }
+    if (!totalsMatch) {
+      toast.error(
+        `Corrected item pricing must total ${money(finalizedPartsTotal)} exactly.`,
+      );
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const operationKey = `quote-pricing-remediation:${quoteLineId}:${quoteLineUpdatedAt ?? "legacy"}`;
+      const response = await fetch(
+        `/api/work-orders/quotes/${quoteLineId}/pricing-quarantine`,
+        {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "content-type": "application/json",
+            "idempotency-key": operationKey,
+          },
+          body: JSON.stringify({
+            operationKey,
+            note: note.trim() || null,
+            items,
+          }),
+        },
+      );
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string;
+      } | null;
+      if (!response.ok) {
+        toast.error(payload?.error ?? "Unable to resolve pricing quarantine.");
+        return;
+      }
+      await onRemediated();
+      toast.success(
+        "Customer part pricing restored; finalized totals were preserved.",
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Unable to resolve pricing quarantine.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="mt-3 rounded-xl border border-amber-200/30 bg-black/10 p-3">
+      <div className="font-semibold text-amber-50">Owner/admin remediation</div>
+      <p className="mt-1 text-amber-50/90">
+        Enter the exact customer sell detail from the finalized decision. The
+        item total must match{" "}
+        {finalizedPartsTotal == null
+          ? "the unavailable finalized total"
+          : money(finalizedPartsTotal)}
+        ; cost, workflow state, and finalized totals will not change.
+      </p>
+      <div className="mt-3 space-y-2">
+        {drafts.map((draft, index) => (
+          <div
+            key={draft.key}
+            className="grid gap-2 rounded-lg border border-amber-200/20 p-2 sm:grid-cols-[minmax(0,1fr)_90px_120px_auto]"
+          >
+            <label className="grid gap-1">
+              <span>Description</span>
+              <input
+                className="desktop-input px-2 py-1.5 text-sm"
+                value={draft.description}
+                onChange={(event) =>
+                  patchDraft(draft.key, { description: event.target.value })
+                }
+              />
+            </label>
+            <label className="grid gap-1">
+              <span>Qty</span>
+              <input
+                className="desktop-input px-2 py-1.5 text-sm"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={draft.quantity}
+                onChange={(event) =>
+                  patchDraft(draft.key, { quantity: event.target.value })
+                }
+              />
+            </label>
+            <label className="grid gap-1">
+              <span>Sell each</span>
+              <input
+                className="desktop-input px-2 py-1.5 text-sm"
+                type="number"
+                min="0"
+                step="0.01"
+                value={draft.unitPrice}
+                onChange={(event) =>
+                  patchDraft(draft.key, { unitPrice: event.target.value })
+                }
+              />
+            </label>
+            <button
+              type="button"
+              className="self-end rounded-lg border border-amber-200/30 px-2 py-1.5 font-semibold disabled:opacity-40"
+              disabled={drafts.length === 1}
+              onClick={() =>
+                setDrafts((current) =>
+                  current.filter((candidate) => candidate.key !== draft.key),
+                )
+              }
+              aria-label={`Remove corrected part ${index + 1}`}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+        <button
+          type="button"
+          className="rounded-lg border border-amber-200/30 px-2.5 py-1.5 font-semibold"
+          onClick={() => {
+            const key = `${quoteLineId}:manual-${nextKey.current}`;
+            nextKey.current += 1;
+            setDrafts((current) => [
+              ...current,
+              {
+                key,
+                id: null,
+                requestId: null,
+                description: "",
+                quantity: "1",
+                unitPrice: "",
+                partNumber: null,
+                manufacturer: null,
+              },
+            ]);
+          }}
+        >
+          Add item
+        </button>
+        <div
+          className={
+            totalsMatch
+              ? "font-semibold text-emerald-100"
+              : "font-semibold text-amber-100"
+          }
+        >
+          Corrected total:{" "}
+          {draftTotal == null ? "Incomplete" : money(draftTotal)}
+        </div>
+      </div>
+      <label className="mt-2 grid gap-1">
+        <span>Audit note (optional)</span>
+        <textarea
+          className="desktop-input min-h-20 px-2 py-1.5 text-sm"
+          maxLength={1000}
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+        />
+      </label>
+      <button
+        type="button"
+        className="desktop-btn-primary mt-3 rounded-xl px-3 py-2 font-semibold disabled:opacity-45"
+        disabled={saving || !totalsMatch}
+        onClick={() => void submit()}
+      >
+        {saving ? "Resolving…" : "Resolve pricing quarantine"}
+      </button>
+    </div>
+  );
+}

--- a/features/work-orders/quote-review/QuoteReviewView.tsx
+++ b/features/work-orders/quote-review/QuoteReviewView.tsx
@@ -27,6 +27,7 @@ import {
   type ResolvedQuotePart,
 } from "./partsModel";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
+import { PricingQuarantineRemediation } from "./PricingQuarantineRemediation";
 
 const COPPER = "#C57A4A";
 const SEND_READY_STAGES = new Set(["advisor_pending", "ready_to_send"]);
@@ -1057,6 +1058,13 @@ export default function QuoteReviewView(props: {
                                   ? "Finalized parts total is unavailable; do not treat it as $0."
                                   : `Finalized parts total: ${fmt(partsTotal)}`}
                               </div>
+                              <PricingQuarantineRemediation
+                                quoteLineId={line.id}
+                                quoteLineUpdatedAt={line.updated_at}
+                                finalizedPartsTotal={partsTotal}
+                                parts={partsByQuoteLine[line.id] ?? []}
+                                onRemediated={reload}
+                              />
                             </div>
                           ) : null}
 

--- a/features/work-orders/quote-review/partsModel.test.ts
+++ b/features/work-orders/quote-review/partsModel.test.ts
@@ -200,6 +200,67 @@ describe("Quote Review parts model", () => {
     });
   });
 
+  it("preserves a procured zero-margin acquisition cost", () => {
+    const selected: CatalogPart = {
+      id: "part-1",
+      name: "Procured part",
+      sku: "PROCURED-1",
+      part_number: "PROCURED-1",
+      supplier: "Supplier",
+      cost: 40,
+      default_cost: 35,
+      price: 80,
+      default_price: 75,
+    };
+    const [part] = resolveQuoteLineParts({
+      line: quoteLine(),
+      liveItems: [
+        liveItem({
+          part_id: selected.id,
+          po_id: "po-1",
+          qty_ordered: 1,
+          unit_cost: 80,
+          quoted_price: 80,
+        }),
+      ],
+      selectedParts: new Map([[selected.id, selected]]),
+    });
+
+    expect(part).toMatchObject({
+      unitCost: 80,
+      unitSellPrice: 80,
+      costLineTotal: 80,
+      sellLineTotal: 80,
+    });
+  });
+
+  it("still rejects an unprocured legacy sell mirror as acquisition cost", () => {
+    const selected: CatalogPart = {
+      id: "part-1",
+      name: "Unprocured part",
+      sku: "UNPROCURED-1",
+      part_number: "UNPROCURED-1",
+      supplier: "Supplier",
+      cost: 40,
+      default_cost: 35,
+      price: 80,
+      default_price: 75,
+    };
+    const [part] = resolveQuoteLineParts({
+      line: quoteLine(),
+      liveItems: [
+        liveItem({
+          part_id: selected.id,
+          unit_cost: 80,
+          quoted_price: 80,
+        }),
+      ],
+      selectedParts: new Map([[selected.id, selected]]),
+    });
+
+    expect(part.unitCost).toBe(40);
+  });
+
   it("does not let a canceled live batch override active synced metadata", () => {
     const parts = resolveQuoteLineParts({
       line: quoteLine({

--- a/features/work-orders/quote-review/partsModel.ts
+++ b/features/work-orders/quote-review/partsModel.ts
@@ -179,7 +179,16 @@ function fromLiveItem(item: PartRequestItem, selectedPart: CatalogPart | null): 
     selectedPart?.cost,
     selectedPart?.default_cost,
   );
-  const unitCost = sameMoney(requestUnitCost, unitSellPrice)
+  const procurementEstablished =
+    Boolean(safeString(item.po_id)) ||
+    Math.max(
+      asNumber(item.qty_ordered) ?? 0,
+      asNumber(item.qty_received) ?? 0,
+      0,
+    ) > 0;
+  const requestCostLooksLikeLegacySellMirror =
+    !procurementEstablished && sameMoney(requestUnitCost, unitSellPrice);
+  const unitCost = requestCostLooksLikeLegacySellMirror
     ? catalogUnitCost
     : requestUnitCost ?? catalogUnitCost;
   return {

--- a/features/work-orders/server/quotePricingQuarantine.test.ts
+++ b/features/work-orders/server/quotePricingQuarantine.test.ts
@@ -36,6 +36,7 @@ function client(input: {
   quoteLines?: unknown[];
   workOrderLines?: unknown[];
   rpcData?: unknown;
+  operationReceipt?: unknown;
 }) {
   const quoteQuery = query({ data: input.quoteLines ?? [], error: null });
   const workOrderQuery = query({
@@ -46,9 +47,23 @@ function client(input: {
     data: input.rpcData ?? { ok: true },
     error: null,
   }));
+  const receiptQuery = {
+    select: vi.fn(),
+    eq: vi.fn(),
+    maybeSingle: vi.fn(async () => ({
+      data:
+        input.operationReceipt === undefined
+          ? null
+          : { result: input.operationReceipt },
+      error: null,
+    })),
+  };
+  receiptQuery.select.mockReturnValue(receiptQuery);
+  receiptQuery.eq.mockReturnValue(receiptQuery);
   const from = vi.fn((table: string) => {
     if (table === "work_order_quote_lines") return quoteQuery;
     if (table === "work_order_lines") return workOrderQuery;
+    if (table === "quote_lifecycle_operation_keys") return receiptQuery;
     throw new Error(`Unexpected table: ${table}`);
   });
 
@@ -57,6 +72,7 @@ function client(input: {
     from,
     quoteQuery,
     workOrderQuery,
+    receiptQuery,
     rpc,
   };
 }
@@ -213,6 +229,7 @@ describe("quote pricing quarantine server guard", () => {
       actorUserId: "actor-a",
       decision: "approve",
       operationKey: "stable-key",
+      operationReceiptSupabase: mock.supabase,
     });
 
     expect(result).toMatchObject({
@@ -245,6 +262,7 @@ describe("quote pricing quarantine server guard", () => {
       actorUserId: "actor-a",
       decision: "approve",
       operationKey: "stable-key",
+      operationReceiptSupabase: mock.supabase,
     });
 
     expect(result.ok).toBe(true);
@@ -253,5 +271,51 @@ describe("quote pricing quarantine server guard", () => {
       "apply_portal_quote_decision_atomic",
       expect.objectContaining({ p_quote_line_ids: ["quote-clean"] }),
     );
+  });
+
+  it("returns a durable decision replay before checking a later quarantine", async () => {
+    const mock = client({
+      quoteLines: [
+        {
+          id: "quote-1",
+          work_order_line_id: "work-line-1",
+          source_work_order_line_id: null,
+          status: "converted",
+          metadata: quarantinedMetadata,
+        },
+      ],
+      operationReceipt: {
+        ok: true,
+        work_order_line_ids: ["work-line-1"],
+        approval_state: "approved",
+        part_relink: { partRequestsRelinked: 1 },
+      },
+    });
+
+    const result = await applyWorkOrderQuoteLineDecision({
+      supabase: mock.supabase,
+      quoteLineIds: ["quote-1"],
+      workOrderId: "work-order-a",
+      shopId: "shop-a",
+      customerId: "customer-a",
+      actorUserId: "actor-a",
+      decision: "approve",
+      operationKey: "stable-key",
+      operationReceiptSupabase: mock.supabase,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      idempotent: true,
+      approvalState: "approved",
+      workOrderLineIds: ["work-line-1"],
+      partRelink: { partRequestsRelinked: 1 },
+    });
+    expect(mock.receiptQuery.eq).toHaveBeenCalledWith(
+      "operation_key",
+      "shop-a:quote-decision:stable-key",
+    );
+    expect(mock.quoteQuery.select).not.toHaveBeenCalled();
+    expect(mock.rpc).not.toHaveBeenCalled();
   });
 });

--- a/features/work-orders/server/workOrderQuoteLineApproval.ts
+++ b/features/work-orders/server/workOrderQuoteLineApproval.ts
@@ -3,6 +3,7 @@ import "server-only";
 import crypto from "node:crypto";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@shared/types/types/supabase";
+import { createAdminSupabase } from "@/features/shared/lib/supabase/server";
 import { isQuotePricingQuarantineError } from "@/features/work-orders/lib/quotes/quotePricingQuarantine";
 import { checkQuotePricingQuarantine } from "@/features/work-orders/server/quotePricingQuarantine";
 
@@ -53,6 +54,18 @@ type RpcResult = {
   error?: string;
 };
 
+type DecisionResult = {
+  ok: boolean;
+  workOrderLineIds: string[];
+  declinedRemainingQuoteLineIds: string[];
+  approvalState: string | null;
+  partRelink: RelinkQuoteLinePartsResult;
+  idempotent?: boolean;
+  expired?: boolean;
+  pricingQuarantined?: boolean;
+  error?: string;
+};
+
 function emptyPartRelinkResult(): RelinkQuoteLinePartsResult {
   return {
     partRequestsRelinked: 0,
@@ -88,6 +101,62 @@ function messageFromRpcError(error: RpcError): string {
   return [error.message, error.details, error.hint].filter(Boolean).join(" — ");
 }
 
+function decisionResultFromData(data: unknown, forceIdempotent = false): DecisionResult {
+  const result = data && typeof data === "object" ? (data as RpcResult) : {};
+  const workOrderLineIds = Array.isArray(result.work_order_line_ids)
+    ? result.work_order_line_ids.filter(
+        (id): id is string => typeof id === "string",
+      )
+    : [];
+  const declinedRemainingQuoteLineIds = Array.isArray(
+    result.declined_remaining_quote_line_ids,
+  )
+    ? result.declined_remaining_quote_line_ids.filter(
+        (id): id is string => typeof id === "string",
+      )
+    : [];
+  const partRelink: RelinkQuoteLinePartsResult = {
+    ...emptyPartRelinkResult(),
+    ...(result.part_relink ?? {}),
+    conflicts: Array.isArray(result.part_relink?.conflicts)
+      ? result.part_relink.conflicts
+      : [],
+  };
+
+  return {
+    ok: result.ok !== false,
+    workOrderLineIds,
+    declinedRemainingQuoteLineIds,
+    approvalState:
+      typeof result.approval_state === "string" ? result.approval_state : null,
+    partRelink,
+    idempotent: forceIdempotent || result.idempotent === true,
+    expired: result.expired === true,
+    error:
+      result.ok === false && typeof result.error === "string"
+        ? result.error
+        : undefined,
+  };
+}
+
+async function readDecisionReplay(params: {
+  supabase: SupabaseClient<DB>;
+  shopId: string;
+  operationName: "customer_quote_decision" | "shop_quote_decision";
+  operationKey: string;
+}): Promise<DecisionResult | null> {
+  const { data, error } = await params.supabase
+    .from("quote_lifecycle_operation_keys")
+    .select("result")
+    .eq("shop_id", params.shopId)
+    .eq("operation_name", params.operationName)
+    .eq("operation_key", params.operationKey)
+    .maybeSingle<{ result: unknown }>();
+
+  if (error || !data) return null;
+  return decisionResultFromData(data.result, true);
+}
+
 export async function applyWorkOrderQuoteLineDecision(params: {
   supabase: SupabaseClient<DB>;
   quoteLineIds: string[];
@@ -102,17 +171,8 @@ export async function applyWorkOrderQuoteLineDecision(params: {
   declineRemaining?: boolean;
   operationKey?: string;
   quarantineCheckSupabase?: SupabaseClient<DB>;
-}): Promise<{
-  ok: boolean;
-  workOrderLineIds: string[];
-  declinedRemainingQuoteLineIds: string[];
-  approvalState: string | null;
-  partRelink: RelinkQuoteLinePartsResult;
-  idempotent?: boolean;
-  expired?: boolean;
-  pricingQuarantined?: boolean;
-  error?: string;
-}> {
+  operationReceiptSupabase?: SupabaseClient<DB>;
+}): Promise<DecisionResult> {
   const quoteLineIds = [
     ...new Set(params.quoteLineIds.map((id) => id.trim()).filter(Boolean)),
   ];
@@ -128,6 +188,31 @@ export async function applyWorkOrderQuoteLineDecision(params: {
   }
 
   const declineRemaining = params.declineRemaining === true;
+  const rawOperationKey =
+    params.operationKey?.trim() ||
+    stableDecisionKey({
+      quoteLineIds,
+      workOrderId: params.workOrderId,
+      shopId: params.shopId,
+      customerId: params.customerId,
+      actorUserId: params.actorUserId,
+      decision: params.decision,
+      declineRemaining,
+    });
+  const isShopDecision = params.decisionSource === "shop";
+  const durableOperationKey = isShopDecision
+    ? `${params.shopId}:shop-quote-decision:${rawOperationKey}`
+    : `${params.shopId}:quote-decision:${rawOperationKey}`;
+  const replay = await readDecisionReplay({
+    supabase: params.operationReceiptSupabase ?? createAdminSupabase(),
+    shopId: params.shopId,
+    operationName: isShopDecision
+      ? "shop_quote_decision"
+      : "customer_quote_decision",
+    operationKey: durableOperationKey,
+  });
+  if (replay) return replay;
+
   const quarantineCheck = await checkQuotePricingQuarantine({
     supabase: params.quarantineCheckSupabase ?? params.supabase,
     shopId: params.shopId,
@@ -148,20 +233,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
     };
   }
 
-  const rawOperationKey =
-    params.operationKey?.trim() ||
-    stableDecisionKey({
-      quoteLineIds,
-      workOrderId: params.workOrderId,
-      shopId: params.shopId,
-      customerId: params.customerId,
-      actorUserId: params.actorUserId,
-      decision: params.decision,
-      declineRemaining,
-    });
-
   const rpc = params.supabase as unknown as RpcClient;
-  const isShopDecision = params.decisionSource === "shop";
   const rpcResult = isShopDecision
     ? await rpc.rpc("apply_shop_quote_decision_atomic", {
         p_shop_id: params.shopId,
@@ -171,7 +243,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
         p_actor_user_id: params.actorUserId,
         p_contact_method: params.contactMethod ?? "other",
         p_note: params.decisionNote?.trim() || null,
-        p_operation_key: `${params.shopId}:shop-quote-decision:${rawOperationKey}`,
+        p_operation_key: durableOperationKey,
         p_at: new Date().toISOString(),
       })
     : await rpc.rpc("apply_portal_quote_decision_atomic", {
@@ -180,7 +252,7 @@ export async function applyWorkOrderQuoteLineDecision(params: {
         p_quote_line_ids: quoteLineIds,
         p_decision: params.decision,
         p_decline_remaining: declineRemaining,
-        p_operation_key: `${params.shopId}:quote-decision:${rawOperationKey}`,
+        p_operation_key: durableOperationKey,
         p_at: new Date().toISOString(),
       });
   const { data, error } = rpcResult;
@@ -198,40 +270,5 @@ export async function applyWorkOrderQuoteLineDecision(params: {
     };
   }
 
-  const result = data && typeof data === "object" ? (data as RpcResult) : {};
-  const workOrderLineIds = Array.isArray(result.work_order_line_ids)
-    ? result.work_order_line_ids.filter(
-        (id): id is string => typeof id === "string",
-      )
-    : [];
-  const declinedRemainingQuoteLineIds = Array.isArray(
-    result.declined_remaining_quote_line_ids,
-  )
-    ? result.declined_remaining_quote_line_ids.filter(
-        (id): id is string => typeof id === "string",
-      )
-    : [];
-
-  const partRelink: RelinkQuoteLinePartsResult = {
-    ...emptyPartRelinkResult(),
-    ...(result.part_relink ?? {}),
-    conflicts: Array.isArray(result.part_relink?.conflicts)
-      ? result.part_relink.conflicts
-      : [],
-  };
-
-  return {
-    ok: result.ok !== false,
-    workOrderLineIds,
-    declinedRemainingQuoteLineIds,
-    approvalState:
-      typeof result.approval_state === "string" ? result.approval_state : null,
-    partRelink,
-    idempotent: result.idempotent === true,
-    expired: result.expired === true,
-    error:
-      result.ok === false && typeof result.error === "string"
-        ? result.error
-        : undefined,
-  };
+  return decisionResultFromData(data);
 }

--- a/supabase/migrations/20260807214202_address_parts_quote_review_followups.sql
+++ b/supabase/migrations/20260807214202_address_parts_quote_review_followups.sql
@@ -1,0 +1,526 @@
+begin;
+
+set local lock_timeout = '10s';
+set local statement_timeout = '120s';
+
+-- Keep request-item and PO-line receipt quantities on the same two-decimal
+-- ledger precision. Patch the deployed function body without duplicating its
+-- lock-order and idempotency implementation in a second migration.
+do $migration$
+declare
+  v_definition text;
+  v_updated text;
+  v_anchor constant text := $anchor$  if nullif(trim(p_idempotency_key), '') is null then$anchor$;
+  v_replacement constant text := $replacement$  if p_qty <> round(p_qty, 2) then
+    raise exception using
+      errcode = '22023',
+      message = 'PARTS_RECEIPT_QUANTITY_PRECISION';
+  end if;
+  if nullif(trim(p_idempotency_key), '') is null then$replacement$;
+begin
+  select pg_get_functiondef(
+    'public.parts_receive_free_text_po_line(uuid, uuid, numeric, text)'::regprocedure
+  )
+    into v_definition;
+
+  if v_definition is null then
+    raise exception 'parts_receive_free_text_po_line is missing';
+  end if;
+  if position('PARTS_RECEIPT_QUANTITY_PRECISION' in v_definition) > 0 then
+    return;
+  end if;
+  if position(v_anchor in v_definition) = 0 then
+    raise exception 'parts_receive_free_text_po_line precision patch anchor is missing';
+  end if;
+  if (
+    length(v_definition) - length(replace(v_definition, v_anchor, ''))
+  ) / length(v_anchor) <> 1 then
+    raise exception 'parts_receive_free_text_po_line precision patch anchor is ambiguous';
+  end if;
+
+  v_updated := replace(v_definition, v_anchor, v_replacement);
+  if v_updated = v_definition then
+    raise exception 'parts_receive_free_text_po_line precision patch did not apply';
+  end if;
+  execute v_updated;
+end;
+$migration$;
+
+comment on function public.parts_receive_free_text_po_line(
+  uuid, uuid, numeric, text
+) is
+  'Atomically receives a free-text PO line with two-decimal quantity precision, tenant authorization, idempotency, and PO/request reconciliation.';
+
+-- Trusted server remediation for protected quote pricing. The public route
+-- performs the user-facing owner/admin check; this service-role-only function
+-- repeats that check from canonical profiles, validates exact customer sell
+-- detail against the durable finalized parts total, and records both an
+-- operation receipt and an operational audit event.
+create or replace function public.remediate_quote_line_pricing_quarantine(
+  p_shop_id uuid,
+  p_quote_line_id uuid,
+  p_actor_user_id uuid,
+  p_items jsonb,
+  p_operation_key text,
+  p_note text default null
+) returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_line public.work_order_quote_lines%rowtype;
+  v_actor_role text;
+  v_existing jsonb;
+  v_item jsonb;
+  v_description text;
+  v_qty numeric;
+  v_unit_price numeric;
+  v_line_total numeric;
+  v_parts_total numeric := 0;
+  v_item_count integer := 0;
+  v_canonical_items jsonb := '[]'::jsonb;
+  v_safe_snapshots jsonb := '[]'::jsonb;
+  v_metadata jsonb := '{}'::jsonb;
+  v_parts_quote jsonb := '{}'::jsonb;
+  v_sanitization jsonb := '{}'::jsonb;
+  v_request_payload jsonb;
+  v_result jsonb;
+  v_correction public.work_order_correction_sessions%rowtype;
+  v_opened_correction boolean := false;
+begin
+  if current_user not in ('service_role', 'postgres') then
+    raise exception using
+      errcode = '42501',
+      message = 'QUOTE_PRICING_REMEDIATION_SERVICE_ROLE_REQUIRED';
+  end if;
+  if p_shop_id is null or p_quote_line_id is null or p_actor_user_id is null then
+    raise exception using
+      errcode = '22023',
+      message = 'Quote line, shop, and actor are required.';
+  end if;
+  if nullif(btrim(coalesce(p_operation_key, '')), '') is null then
+    raise exception using
+      errcode = '22023',
+      message = 'A stable remediation operation key is required.';
+  end if;
+  if length(p_operation_key) > 300 then
+    raise exception using
+      errcode = '22023',
+      message = 'Remediation operation key is too long.';
+  end if;
+  if length(coalesce(p_note, '')) > 1000 then
+    raise exception using
+      errcode = '22023',
+      message = 'Remediation note is too long.';
+  end if;
+
+  select public.canonical_shop_membership_role(profile.role::text)
+    into v_actor_role
+  from public.profiles profile
+  where profile.shop_id = p_shop_id
+    and (
+      profile.id = p_actor_user_id
+      or profile.user_id = p_actor_user_id
+    )
+  order by case when profile.user_id = p_actor_user_id then 0 else 1 end
+  limit 1;
+
+  if coalesce(v_actor_role, '') not in ('owner', 'admin') then
+    raise exception using
+      errcode = '42501',
+      message = 'QUOTE_PRICING_REMEDIATION_ROLE_REQUIRED';
+  end if;
+  if jsonb_typeof(p_items) is distinct from 'array'
+     or jsonb_array_length(p_items) = 0 then
+    raise exception using
+      errcode = '22023',
+      message = 'At least one corrected customer part is required.';
+  end if;
+
+  for v_item in
+    select value
+    from jsonb_array_elements(p_items)
+  loop
+    if jsonb_typeof(v_item) is distinct from 'object' then
+      raise exception using
+        errcode = '22023',
+        message = 'Every corrected customer part must be an object.';
+    end if;
+
+    v_description := nullif(btrim(v_item ->> 'description'), '');
+    if v_description is null or length(v_description) > 500 then
+      raise exception using
+        errcode = '22023',
+        message = 'Every corrected customer part needs a description of 500 characters or fewer.';
+    end if;
+    if coalesce(v_item ->> 'qty', '') !~ '^[0-9]+([.][0-9]+)?$'
+       or coalesce(v_item ->> 'unit_price', '') !~ '^[0-9]+([.][0-9]+)?$' then
+      raise exception using
+        errcode = '22023',
+        message = 'Corrected quantity and sell price must be finite non-negative numbers.';
+    end if;
+
+    v_qty := (v_item ->> 'qty')::numeric;
+    v_unit_price := (v_item ->> 'unit_price')::numeric;
+    if v_qty <= 0 or v_qty <> round(v_qty, 2) then
+      raise exception using
+        errcode = '22023',
+        message = 'Corrected quantity must be positive with at most two decimal places.';
+    end if;
+    if v_unit_price < 0 or v_unit_price <> round(v_unit_price, 2) then
+      raise exception using
+        errcode = '22023',
+        message = 'Corrected sell price must be non-negative with at most two decimal places.';
+    end if;
+
+    v_line_total := round(v_qty * v_unit_price, 2);
+    v_parts_total := round(v_parts_total + v_line_total, 2);
+    v_item_count := v_item_count + 1;
+    v_canonical_items := v_canonical_items || jsonb_build_array(
+      jsonb_strip_nulls(jsonb_build_object(
+        'id', nullif(btrim(v_item ->> 'id'), ''),
+        'request_id', nullif(btrim(v_item ->> 'request_id'), ''),
+        'description', v_description,
+        'qty', v_qty,
+        'unit_price', v_unit_price,
+        'line_total', v_line_total,
+        'quote_ready', true,
+        'sell_price_source', 'manual_quarantine_remediation',
+        'part_number', nullif(btrim(v_item ->> 'part_number'), ''),
+        'manufacturer', nullif(btrim(v_item ->> 'manufacturer'), '')
+      ))
+    );
+    v_safe_snapshots := v_safe_snapshots || jsonb_build_array(
+      jsonb_strip_nulls(jsonb_build_object(
+        'id', nullif(btrim(v_item ->> 'id'), ''),
+        'request_id', nullif(btrim(v_item ->> 'request_id'), ''),
+        'description', v_description,
+        'qty', v_qty,
+        'part_number', nullif(btrim(v_item ->> 'part_number'), ''),
+        'manufacturer', nullif(btrim(v_item ->> 'manufacturer'), '')
+      ))
+    );
+  end loop;
+
+  v_request_payload := jsonb_build_object(
+    'quote_line_id', p_quote_line_id,
+    'items', v_canonical_items,
+    'note', nullif(btrim(coalesce(p_note, '')), '')
+  );
+
+  select operation.result
+    into v_existing
+  from public.quote_lifecycle_operation_keys operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_name = 'quote_pricing_quarantine_remediation'
+    and operation.operation_key = p_operation_key;
+  if found then
+    if v_existing -> '_request' is distinct from v_request_payload then
+      raise exception using
+        errcode = '22023',
+        message = 'QUOTE_PRICING_REMEDIATION_IDEMPOTENCY_CONFLICT';
+    end if;
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  select quote_line.*
+    into v_line
+  from public.work_order_quote_lines quote_line
+  where quote_line.id = p_quote_line_id
+    and quote_line.shop_id = p_shop_id
+  for update;
+  if not found then
+    raise exception using
+      errcode = 'P0002',
+      message = 'Quote line not found for shop.';
+  end if;
+
+  select operation.result
+    into v_existing
+  from public.quote_lifecycle_operation_keys operation
+  where operation.shop_id = p_shop_id
+    and operation.operation_name = 'quote_pricing_quarantine_remediation'
+    and operation.operation_key = p_operation_key
+  for update;
+  if found then
+    if v_existing -> '_request' is distinct from v_request_payload then
+      raise exception using
+        errcode = '22023',
+        message = 'QUOTE_PRICING_REMEDIATION_IDEMPOTENCY_CONFLICT';
+    end if;
+    return v_existing || jsonb_build_object('idempotent', true);
+  end if;
+
+  v_metadata := case
+    when jsonb_typeof(v_line.metadata) = 'object' then v_line.metadata
+    else '{}'::jsonb
+  end;
+  v_parts_quote := case
+    when jsonb_typeof(v_metadata -> 'parts_quote') = 'object'
+      then v_metadata -> 'parts_quote'
+    else '{}'::jsonb
+  end;
+  v_sanitization := case
+    when jsonb_typeof(v_parts_quote -> 'pricing_sanitization') = 'object'
+      then v_parts_quote -> 'pricing_sanitization'
+    else '{}'::jsonb
+  end;
+
+  if coalesce(
+    (v_sanitization ->> 'customer_pricing_quarantined')::boolean,
+    false
+  ) is false then
+    raise exception using
+      errcode = '55000',
+      message = 'QUOTE_PRICING_NOT_QUARANTINED';
+  end if;
+  if not public.quote_line_pricing_is_protected(
+    v_line.status::text,
+    v_line.stage::text,
+    v_line.sent_to_customer_at,
+    v_line.sent_at,
+    v_line.approved_at,
+    v_line.declined_at,
+    v_line.deferred_at,
+    v_line.converted_at,
+    v_line.work_order_line_id
+  ) then
+    raise exception using
+      errcode = '55000',
+      message = 'QUOTE_PRICING_REMEDIATION_REQUIRES_PROTECTED_LINE';
+  end if;
+  if v_line.parts_total is null
+     or round(v_line.parts_total, 2) is distinct from v_parts_total then
+    raise exception using
+      errcode = '23514',
+      message = 'QUOTE_PRICING_REMEDIATION_TOTAL_MISMATCH',
+      detail = format(
+        'Corrected customer part detail totals %s; finalized parts total is %s.',
+        v_parts_total,
+        v_line.parts_total
+      );
+  end if;
+
+  if public.work_order_is_financially_locked(p_shop_id, v_line.work_order_id) then
+    select *
+      into v_correction
+    from public.open_work_order_correction_session(
+      p_shop_id,
+      v_line.work_order_id,
+      p_actor_user_id,
+      'Resolve protected customer quote pricing quarantine',
+      'data_repair',
+      'quote-pricing-remediation:' || p_operation_key,
+      jsonb_build_object(
+        'quote_line_id', p_quote_line_id,
+        'source', 'quote_pricing_quarantine_remediation'
+      )
+    );
+    v_opened_correction := true;
+  end if;
+
+  v_sanitization := v_sanitization || jsonb_strip_nulls(jsonb_build_object(
+    'customer_pricing_quarantined', false,
+    'manual_review_required', false,
+    'customer_pricing_remediated', true,
+    'customer_pricing_remediated_at', now(),
+    'customer_pricing_remediated_by', p_actor_user_id,
+    'customer_pricing_remediation_note', nullif(btrim(coalesce(p_note, '')), ''),
+    'decision_totals_preserved', true
+  ));
+  v_parts_quote := v_parts_quote || jsonb_build_object(
+    'source', 'trusted_manual_pricing_remediation',
+    'items', v_canonical_items,
+    'required_count', v_item_count,
+    'quoted_count', v_item_count,
+    'pending_count', 0,
+    'parts_total', v_parts_total,
+    'synced_at', now(),
+    'pricing_sanitization', v_sanitization
+  );
+  v_metadata := jsonb_set(v_metadata, '{parts_quote}', v_parts_quote, true);
+  v_metadata := jsonb_set(v_metadata, '{parts}', v_safe_snapshots, true);
+
+  update public.work_order_quote_lines
+  set metadata = v_metadata,
+      updated_at = now()
+  where id = p_quote_line_id
+    and shop_id = p_shop_id;
+
+  v_result := jsonb_build_object(
+    'ok', true,
+    'idempotent', false,
+    'quote_line_id', p_quote_line_id,
+    'work_order_id', v_line.work_order_id,
+    'parts_total', v_parts_total,
+    'item_count', v_item_count,
+    'status', v_line.status,
+    'stage', v_line.stage,
+    'correction_session_id', v_correction.id,
+    '_request', v_request_payload
+  );
+
+  insert into public.operational_events(
+    shop_id,
+    event_type,
+    actor_user_id,
+    actor_role,
+    entity_type,
+    entity_id,
+    parent_entity_type,
+    parent_entity_id,
+    correlation_id,
+    idempotency_key,
+    source,
+    severity,
+    metadata
+  ) values (
+    p_shop_id,
+    'quote.pricing_quarantine.remediated',
+    p_actor_user_id,
+    v_actor_role,
+    'work_order_quote_line',
+    p_quote_line_id,
+    'work_order',
+    v_line.work_order_id,
+    v_line.work_order_id,
+    'quote-pricing-remediation:' || p_operation_key,
+    'api:quote_pricing_quarantine_remediation',
+    'warning',
+    jsonb_build_object(
+      'quote_line_id', p_quote_line_id,
+      'work_order_id', v_line.work_order_id,
+      'parts_total', v_parts_total,
+      'item_count', v_item_count,
+      'decision_totals_preserved', true,
+      'note', nullif(btrim(coalesce(p_note, '')), '')
+    )
+  );
+
+  insert into public.quote_lifecycle_operation_keys(
+    shop_id,
+    operation_name,
+    operation_key,
+    actor_user_id,
+    work_order_id,
+    result
+  ) values (
+    p_shop_id,
+    'quote_pricing_quarantine_remediation',
+    p_operation_key,
+    p_actor_user_id,
+    v_line.work_order_id,
+    v_result
+  );
+
+  if v_opened_correction then
+    perform public.close_work_order_correction_session(
+      p_shop_id,
+      v_line.work_order_id,
+      v_correction.id,
+      p_actor_user_id,
+      jsonb_build_object(
+        'quote_line_id', p_quote_line_id,
+        'operation_key', p_operation_key,
+        'result', 'pricing_quarantine_remediated'
+      )
+    );
+  end if;
+
+  return v_result;
+end;
+$$;
+
+revoke all on function public.remediate_quote_line_pricing_quarantine(
+  uuid, uuid, uuid, jsonb, text, text
+) from public, anon, authenticated;
+grant execute on function public.remediate_quote_line_pricing_quarantine(
+  uuid, uuid, uuid, jsonb, text, text
+) to service_role;
+
+comment on function public.remediate_quote_line_pricing_quarantine(
+  uuid, uuid, uuid, jsonb, text, text
+) is
+  'Service-role-only audited remediation for protected customer quote item pricing; preserves durable decision totals and workflow state.';
+
+-- Reconcile historical mutable quote lines whose legacy customer item metadata
+-- outlived every active canonical Parts Request item. The canonical sync moves
+-- these unresolved lines back to pending_parts with zero item totals. Protected
+-- and locked-estimate rows are excluded and remain governed by quarantine.
+do $backfill$
+declare
+  v_quote record;
+begin
+  for v_quote in
+    select quote_line.shop_id, quote_line.id
+    from public.work_order_quote_lines quote_line
+    join public.work_orders work_order
+      on work_order.id = quote_line.work_order_id
+     and work_order.shop_id = quote_line.shop_id
+    where not public.quote_line_pricing_is_protected(
+      quote_line.status::text,
+      quote_line.stage::text,
+      quote_line.sent_to_customer_at,
+      quote_line.sent_at,
+      quote_line.approved_at,
+      quote_line.declined_at,
+      quote_line.deferred_at,
+      quote_line.converted_at,
+      quote_line.work_order_line_id
+    )
+      and (
+        work_order.estimate_number is null
+        or coalesce(work_order.estimate_status, 'draft') in (
+          'draft', 'waiting_for_parts'
+        )
+      )
+      and (
+        coalesce(quote_line.parts_total, 0) <> 0
+        or lower(coalesce(quote_line.status::text, '')) in (
+          'quoted', 'ready_to_send'
+        )
+        or lower(coalesce(quote_line.stage::text, '')) = 'ready_to_send'
+        or coalesce(jsonb_array_length(
+          case
+            when jsonb_typeof(
+              coalesce(quote_line.metadata, '{}'::jsonb)
+                -> 'parts_quote' -> 'items'
+            ) = 'array'
+              then coalesce(quote_line.metadata, '{}'::jsonb)
+                -> 'parts_quote' -> 'items'
+            else '[]'::jsonb
+          end
+        ), 0) > 0
+      )
+      and not exists (
+        select 1
+        from public.part_requests request
+        join public.part_request_items item
+          on item.request_id = request.id
+         and item.shop_id = request.shop_id
+         and item.work_order_id = request.work_order_id
+         and item.quote_line_id = request.quote_line_id
+        where request.shop_id = quote_line.shop_id
+          and request.work_order_id = quote_line.work_order_id
+          and request.quote_line_id = quote_line.id
+          and lower(coalesce(request.status::text, 'requested')) not in (
+            'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+          )
+          and lower(coalesce(item.status::text, 'requested')) not in (
+            'cancelled', 'canceled', 'rejected', 'declined', 'voided'
+          )
+      )
+    order by quote_line.shop_id, quote_line.id
+  loop
+    perform public.sync_quote_line_pricing_from_parts(
+      v_quote.shop_id,
+      v_quote.id
+    );
+  end loop;
+end;
+$backfill$;
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tests/codex-review-followups.test.ts
+++ b/tests/codex-review-followups.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  "supabase/migrations/20260807214202_address_parts_quote_review_followups.sql",
+  "utf8",
+);
+const generatedTypes = readFileSync(
+  "features/shared/types/types/supabase.ts",
+  "utf8",
+);
+const quoteRuntime = readFileSync(
+  "tests/security/quote-review-cost-and-sell.runtime.sql",
+  "utf8",
+);
+
+describe("Codex review follow-up contracts", () => {
+  it("keeps quarantine remediation service-only, audited, and idempotent", () => {
+    expect(migration).toContain(
+      "function public.remediate_quote_line_pricing_quarantine",
+    );
+    expect(migration).toContain("security invoker");
+    expect(migration).toContain("from public, anon, authenticated");
+    expect(migration).toContain("to service_role");
+    expect(migration).toContain("QUOTE_PRICING_REMEDIATION_TOTAL_MISMATCH");
+    expect(migration).toContain("quote_pricing_quarantine_remediation");
+    expect(migration).toContain("quote.pricing_quarantine.remediated");
+    expect(migration).toContain("open_work_order_correction_session");
+    expect(migration).toContain("close_work_order_correction_session");
+    expect(quoteRuntime).toContain("Pricing remediation exact replay");
+    expect(quoteRuntime).toContain("changed durable decision state or totals");
+    expect(generatedTypes).toContain(
+      "remediate_quote_line_pricing_quarantine:",
+    );
+  });
+
+  it("moves mutable orphan pricing back through canonical sync", () => {
+    const backfill = migration.slice(
+      migration.indexOf("-- Reconcile historical mutable quote lines"),
+    );
+    expect(backfill).toContain("not public.quote_line_pricing_is_protected");
+    expect(backfill).toContain("not exists (");
+    expect(backfill).toContain("join public.part_request_items item");
+    expect(backfill).toContain("sync_quote_line_pricing_from_parts");
+    expect(backfill).toContain("'quoted', 'ready_to_send'");
+  });
+
+  it("patches free-text receipt precision without replacing the deployed migration", () => {
+    expect(migration).toContain("pg_get_functiondef");
+    expect(migration).toContain("p_qty <> round(p_qty, 2)");
+    expect(migration).toContain("PARTS_RECEIPT_QUANTITY_PRECISION");
+  });
+});

--- a/tests/inspection-sign-portal-regressions.test.ts
+++ b/tests/inspection-sign-portal-regressions.test.ts
@@ -87,7 +87,7 @@ describe("inspection sign and portal approval regressions", () => {
     expect(selectCustomerVisibleQuoteParts(metadata, false)).toEqual(requested);
   });
 
-  it("hides quarantined protected item pricing instead of displaying $0 or stale parts", () => {
+  it("keeps quarantined descriptions while removing every customer item price", () => {
     const metadata = {
       parts: [{ description: "Legacy snapshot", qty: 1, unitPrice: 80 }],
       parts_quote: {
@@ -107,7 +107,36 @@ describe("inspection sign and portal approval regressions", () => {
       },
     };
 
-    expect(selectCustomerVisibleQuoteParts(metadata, true)).toEqual([]);
-    expect(selectCustomerVisibleQuoteParts(metadata, false)).toEqual([]);
+    const expected = [
+      {
+        description: "Protected item",
+        qty: 1,
+        unit_price: null,
+        line_total: null,
+        pricing_unavailable: true,
+      },
+    ];
+    expect(selectCustomerVisibleQuoteParts(metadata, true)).toEqual(expected);
+    expect(selectCustomerVisibleQuoteParts(metadata, false)).toEqual(expected);
+    expect(JSON.stringify(expected)).not.toContain("Legacy snapshot");
+    expect(JSON.stringify(expected)).not.toContain("80");
+  });
+
+  it("uses remediated canonical items even for non-estimate portal quotes", () => {
+    const remediated = [
+      { description: "Protected item", qty: 1, unit_price: 80, line_total: 80 },
+    ];
+    const metadata = {
+      parts: [{ description: "Stale snapshot", qty: 1 }],
+      parts_quote: {
+        items: remediated,
+        pricing_sanitization: {
+          customer_pricing_quarantined: false,
+          customer_pricing_remediated: true,
+        },
+      },
+    };
+
+    expect(selectCustomerVisibleQuoteParts(metadata, false)).toEqual(remediated);
   });
 });

--- a/tests/parts/parts-request-free-text-receipt-route.test.ts
+++ b/tests/parts/parts-request-free-text-receipt-route.test.ts
@@ -77,6 +77,28 @@ describe("request-backed free-text PO receipt route", () => {
     });
   });
 
+  it("rejects receipt quantities beyond the request ledger precision", async () => {
+    const rpc = vi.fn();
+    mocks.requireShopScopedApiAccess.mockResolvedValue({
+      ok: true,
+      profile: { id: "actor-id", shop_id: SHOP_ID },
+      supabase: { rpc },
+    });
+
+    const response = await callRoute({
+      qty: 0.001,
+      idempotencyKey: "over-precision",
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe(
+      "Receipt quantity cannot use more than two decimal places.",
+    );
+    expect(mocks.requireShopScopedApiAccess).not.toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
   it("returns a stable conflict for a database-enforced cross-shop target", async () => {
     const rpc = vi.fn(async () => ({
       data: null,

--- a/tests/parts/parts-request-purchase-order-regression.test.ts
+++ b/tests/parts/parts-request-purchase-order-regression.test.ts
@@ -9,6 +9,10 @@ const receiptMigration = readFileSync(
   "supabase/migrations/20260807155907_harden_free_text_po_receipt_and_attachment.sql",
   "utf8",
 );
+const followupMigration = readFileSync(
+  "supabase/migrations/20260807214202_address_parts_quote_review_followups.sql",
+  "utf8",
+);
 const runtime = readFileSync(
   "tests/parts/parts-request-purchase-order.runtime.sql",
   "utf8",
@@ -103,6 +107,11 @@ describe("parts request purchase-order regression contract", () => {
     expect(requestPage).toMatch(
       /acquisitionCostOverride\s*\?\?\s*stagedAcquisitionCost\s*\?\?\s*catalogAcquisitionCost/,
     );
+    expect(requestPage).toContain("ui_acquisition_cost?: number");
+    expect(requestPage).toContain("Acquisition unit cost for");
+    expect(
+      requestPage.match(/it\.ui_acquisition_cost \?\? null/g),
+    ).toHaveLength(2);
   });
 
   it("binds idempotency to the full request and returns existing domain identity", () => {
@@ -276,5 +285,8 @@ describe("parts request purchase-order regression contract", () => {
     expect(generatedTypes).toContain(
       "parts_attach_inventory_to_request_item_atomic:",
     );
+    expect(followupMigration).toContain("PARTS_RECEIPT_QUANTITY_PRECISION");
+    expect(runtime).toContain("0.001");
+    expect(runtime).toContain("Over-precision receipt wrote an operation receipt");
   });
 });

--- a/tests/parts/parts-request-purchase-order.runtime.sql
+++ b/tests/parts/parts-request-purchase-order.runtime.sql
@@ -1296,6 +1296,37 @@ select pg_temp.expect_ordered_attach_error(
   'PARTS_ORDERED_FREE_TEXT_ATTACH_BLOCKED'
 );
 
+select pg_temp.expect_free_text_receipt_error(
+  (
+    select line.po_id
+    from public.purchase_order_lines line
+    where line.part_request_item_id =
+      '75000000-0000-4000-8000-000000000003'
+  ),
+  (
+    select line.id
+    from public.purchase_order_lines line
+    where line.part_request_item_id =
+      '75000000-0000-4000-8000-000000000003'
+  ),
+  0.001,
+  '7a000000-0000-4000-8000-000000000001:parts-receipt:over-precision',
+  'PARTS_RECEIPT_QUANTITY_PRECISION'
+);
+
+do $$
+begin
+  if exists (
+    select 1
+    from public.parts_lifecycle_operations operation
+    where operation.idempotency_key =
+      '7a000000-0000-4000-8000-000000000001:parts-receipt:over-precision'
+  ) then
+    raise exception 'Over-precision receipt wrote an operation receipt';
+  end if;
+end;
+$$;
+
 insert into parts_request_to_po_results (attempt, result)
 select
   'manual_receipt_first',

--- a/tests/parts/parts-request-purchase-order.runtime.sql
+++ b/tests/parts/parts-request-purchase-order.runtime.sql
@@ -1314,7 +1314,12 @@ select pg_temp.expect_free_text_receipt_error(
   'PARTS_RECEIPT_QUANTITY_PRECISION'
 );
 
-do $$
+-- The receipt attempt above must run as the authenticated shop actor. Inspect
+-- the protected operation ledger only after restoring the migration runner,
+-- then resume the authenticated flow for the remaining receipt assertions.
+reset role;
+
+do $
 begin
   if exists (
     select 1
@@ -1325,7 +1330,9 @@ begin
     raise exception 'Over-precision receipt wrote an operation receipt';
   end if;
 end;
-$$;
+$;
+
+set local role authenticated;
 
 insert into parts_request_to_po_results (attempt, result)
 select

--- a/tests/parts/parts-request-purchase-order.runtime.sql
+++ b/tests/parts/parts-request-purchase-order.runtime.sql
@@ -1319,7 +1319,7 @@ select pg_temp.expect_free_text_receipt_error(
 -- then resume the authenticated flow for the remaining receipt assertions.
 reset role;
 
-do $
+do $assert_overprecision$
 begin
   if exists (
     select 1
@@ -1330,7 +1330,7 @@ begin
     raise exception 'Over-precision receipt wrote an operation receipt';
   end if;
 end;
-$;
+$assert_overprecision$;
 
 set local role authenticated;
 

--- a/tests/quote-pricing-quarantine-remediation-route.test.ts
+++ b/tests/quote-pricing-quarantine-remediation-route.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const QUOTE_LINE_ID = "11111111-1111-4111-8111-111111111111";
+const SHOP_ID = "22222222-2222-4222-8222-222222222222";
+const ACTOR_ID = "33333333-3333-4333-8333-333333333333";
+
+const mocks = vi.hoisted(() => ({
+  requireShopScopedApiAccess: vi.fn(),
+  createAdminSupabase: vi.fn(),
+}));
+
+vi.mock("@/features/shared/lib/server/admin-access", () => ({
+  requireShopScopedApiAccess: mocks.requireShopScopedApiAccess,
+}));
+vi.mock("@/features/shared/lib/supabase/server", () => ({
+  createAdminSupabase: mocks.createAdminSupabase,
+}));
+
+function request(body: Record<string, unknown>): Request {
+  return new Request(
+    `http://localhost/api/work-orders/quotes/${QUOTE_LINE_ID}/pricing-quarantine`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+async function callRoute(body: Record<string, unknown>) {
+  const { POST } =
+    await import("../app/api/work-orders/quotes/[id]/pricing-quarantine/route");
+  return POST(request(body), {
+    params: Promise.resolve({ id: QUOTE_LINE_ID }),
+  });
+}
+
+describe("quote pricing quarantine remediation route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires owner/admin pricing access before using service role", async () => {
+    mocks.requireShopScopedApiAccess.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    });
+
+    const response = await callRoute({ operationKey: "repair-1", items: [] });
+
+    expect(response.status).toBe(403);
+    expect(mocks.requireShopScopedApiAccess).toHaveBeenCalledWith({
+      requiredCapability: "canEditPricing",
+      allowRoles: ["owner", "admin"],
+    });
+    expect(mocks.createAdminSupabase).not.toHaveBeenCalled();
+  });
+
+  it("passes only corrected sell detail to the audited service-role RPC", async () => {
+    const rpc = vi.fn(async () => ({
+      data: { ok: true, idempotent: false, parts_total: 80 },
+      error: null,
+    }));
+    mocks.requireShopScopedApiAccess.mockResolvedValue({
+      ok: true,
+      profile: { id: "profile-id", shop_id: SHOP_ID },
+      authUserId: ACTOR_ID,
+    });
+    mocks.createAdminSupabase.mockReturnValue({ rpc });
+
+    const response = await callRoute({
+      operationKey: "repair-1",
+      note: "Confirmed against the signed quote",
+      items: [
+        {
+          id: "item-1",
+          description: "Brake pads",
+          qty: 1,
+          unit_price: 80,
+          unit_cost: 40,
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(rpc).toHaveBeenCalledWith(
+      "remediate_quote_line_pricing_quarantine",
+      {
+        p_shop_id: SHOP_ID,
+        p_quote_line_id: QUOTE_LINE_ID,
+        p_actor_user_id: ACTOR_ID,
+        p_items: [
+          {
+            id: "item-1",
+            request_id: null,
+            description: "Brake pads",
+            qty: 1,
+            unit_price: 80,
+            part_number: null,
+            manufacturer: null,
+          },
+        ],
+        p_operation_key: "repair-1",
+        p_note: "Confirmed against the signed quote",
+      },
+    );
+  });
+
+  it("rejects over-precision sell detail before service-role access", async () => {
+    mocks.requireShopScopedApiAccess.mockResolvedValue({
+      ok: true,
+      profile: { id: "profile-id", shop_id: SHOP_ID },
+      authUserId: ACTOR_ID,
+    });
+
+    const response = await callRoute({
+      operationKey: "repair-1",
+      items: [{ description: "Brake pads", qty: 1, unit_price: 80.001 }],
+    });
+
+    expect(response.status).toBe(400);
+    expect(mocks.createAdminSupabase).not.toHaveBeenCalled();
+  });
+
+  it("surfaces durable total mismatches as conflicts", async () => {
+    const rpc = vi.fn(async () => ({
+      data: null,
+      error: { message: "QUOTE_PRICING_REMEDIATION_TOTAL_MISMATCH" },
+    }));
+    mocks.requireShopScopedApiAccess.mockResolvedValue({
+      ok: true,
+      profile: { id: "profile-id", shop_id: SHOP_ID },
+      authUserId: ACTOR_ID,
+    });
+    mocks.createAdminSupabase.mockReturnValue({ rpc });
+
+    const response = await callRoute({
+      operationKey: "repair-1",
+      items: [{ description: "Brake pads", qty: 1, unit_price: 79 }],
+    });
+
+    expect(response.status).toBe(409);
+  });
+});

--- a/tests/quote-pricing-quarantine-server-guards.test.ts
+++ b/tests/quote-pricing-quarantine-server-guards.test.ts
@@ -44,11 +44,18 @@ describe("quote pricing quarantine server entry points", () => {
       "app/api/work-orders/quotes/[id]/approval/route.ts",
     );
 
-    expect(compatibility.indexOf("await checkQuotePricingQuarantine({")).toBeLessThan(
-      compatibility.indexOf(
-        'rpc.rpc(\n    "apply_approval_compatibility_bundle_atomic"',
-      ),
+    const compatibilityReplay = compatibility.indexOf(
+      '.eq("operation_name", "approval_compatibility_bundle")',
     );
+    const compatibilityGuard = compatibility.indexOf(
+      "await checkQuotePricingQuarantine({",
+    );
+    const compatibilityRpc = compatibility.indexOf(
+      'rpc.rpc(\n    "apply_approval_compatibility_bundle_atomic"',
+    );
+    expect(compatibilityReplay).toBeGreaterThan(-1);
+    expect(compatibilityReplay).toBeLessThan(compatibilityGuard);
+    expect(compatibilityGuard).toBeLessThan(compatibilityRpc);
     expect(lineDecision.indexOf("await checkQuotePricingQuarantine({")).toBeLessThan(
       lineDecision.indexOf('rpc.rpc("apply_portal_line_decision_atomic"'),
     );

--- a/tests/security/quote-review-cost-and-sell.runtime.sql
+++ b/tests/security/quote-review-cost-and-sell.runtime.sql
@@ -1450,6 +1450,138 @@ begin
 end;
 $$;
 
+-- A trusted, service-role-only remediation restores exact customer sell detail
+-- without changing the protected decision totals or lifecycle state.
+select set_config('request.jwt.claims', '', true);
+select set_config('request.jwt.claim.role', '', true);
+
+do $$
+declare
+  v_before public.work_order_quote_lines%rowtype;
+  v_after public.work_order_quote_lines%rowtype;
+  v_result jsonb;
+  v_replay jsonb;
+  v_conflict boolean := false;
+begin
+  select *
+    into strict v_before
+  from public.work_order_quote_lines
+  where id = '40400000-0000-4000-8000-000000000002';
+
+  v_result := public.remediate_quote_line_pricing_quarantine(
+    '40200000-0000-4000-8000-000000000001',
+    '40400000-0000-4000-8000-000000000002',
+    '40100000-0000-4000-8000-000000000001',
+    jsonb_build_array(jsonb_build_object(
+      'id', '40700000-0000-4000-8000-000000000003',
+      'description', 'Protected sent sentinel',
+      'qty', 1,
+      'unit_price', 40
+    )),
+    'quote-cost-sell-remediation-1',
+    'Runtime verified finalized customer pricing'
+  );
+
+  select *
+    into strict v_after
+  from public.work_order_quote_lines
+  where id = '40400000-0000-4000-8000-000000000002';
+
+  if coalesce((v_result ->> 'ok')::boolean, false) is not true
+     or coalesce((v_result ->> 'idempotent')::boolean, true) is not false then
+    raise exception 'Pricing remediation did not return a first-write result: %',
+      v_result;
+  end if;
+  if v_after.parts_total is distinct from v_before.parts_total
+     or v_after.subtotal is distinct from v_before.subtotal
+     or v_after.grand_total is distinct from v_before.grand_total
+     or v_after.status is distinct from v_before.status
+     or v_after.stage is distinct from v_before.stage
+     or v_after.sent_to_customer_at is distinct from v_before.sent_to_customer_at then
+    raise exception 'Pricing remediation changed durable decision state or totals';
+  end if;
+  if coalesce(
+    (v_after.metadata -> 'parts_quote' -> 'pricing_sanitization'
+      ->> 'customer_pricing_quarantined')::boolean,
+    true
+  ) is not false
+     or coalesce(
+       (v_after.metadata -> 'parts_quote' -> 'pricing_sanitization'
+         ->> 'customer_pricing_remediated')::boolean,
+       false
+     ) is not true then
+    raise exception 'Pricing remediation did not clear and audit quarantine: %',
+      v_after.metadata -> 'parts_quote' -> 'pricing_sanitization';
+  end if;
+  if v_after.metadata -> 'parts_quote' -> 'items' -> 0 ->> 'unit_price'
+       is distinct from '40'
+     or v_after.metadata -> 'parts_quote' -> 'items' -> 0 ->> 'line_total'
+       is distinct from '40' then
+    raise exception 'Pricing remediation did not restore exact customer sell detail: %',
+      v_after.metadata -> 'parts_quote' -> 'items';
+  end if;
+  if (v_after.metadata -> 'parts' -> 0) ?| array[
+    'unit_cost', 'unitCost', 'cost', 'default_cost',
+    'unit_price', 'unitPrice', 'price', 'line_total'
+  ] then
+    raise exception 'Pricing remediation leaked commercial values to legacy snapshots: %',
+      v_after.metadata -> 'parts';
+  end if;
+  if not exists (
+    select 1
+    from public.operational_events event
+    where event.shop_id = '40200000-0000-4000-8000-000000000001'
+      and event.event_type = 'quote.pricing_quarantine.remediated'
+      and event.entity_id = '40400000-0000-4000-8000-000000000002'
+      and event.idempotency_key =
+        'quote-pricing-remediation:quote-cost-sell-remediation-1'
+  ) then
+    raise exception 'Pricing remediation audit event is missing';
+  end if;
+
+  v_replay := public.remediate_quote_line_pricing_quarantine(
+    '40200000-0000-4000-8000-000000000001',
+    '40400000-0000-4000-8000-000000000002',
+    '40100000-0000-4000-8000-000000000001',
+    jsonb_build_array(jsonb_build_object(
+      'id', '40700000-0000-4000-8000-000000000003',
+      'description', 'Protected sent sentinel',
+      'qty', 1,
+      'unit_price', 40
+    )),
+    'quote-cost-sell-remediation-1',
+    'Runtime verified finalized customer pricing'
+  );
+  if coalesce((v_replay ->> 'idempotent')::boolean, false) is not true then
+    raise exception 'Pricing remediation exact replay was not idempotent: %',
+      v_replay;
+  end if;
+
+  begin
+    perform public.remediate_quote_line_pricing_quarantine(
+      '40200000-0000-4000-8000-000000000001',
+      '40400000-0000-4000-8000-000000000002',
+      '40100000-0000-4000-8000-000000000001',
+      jsonb_build_array(jsonb_build_object(
+        'description', 'Changed replay',
+        'qty', 1,
+        'unit_price', 40
+      )),
+      'quote-cost-sell-remediation-1',
+      'Runtime verified finalized customer pricing'
+    );
+  exception when invalid_parameter_value then
+    if sqlerrm not like '%QUOTE_PRICING_REMEDIATION_IDEMPOTENCY_CONFLICT%' then
+      raise;
+    end if;
+    v_conflict := true;
+  end;
+  if not v_conflict then
+    raise exception 'Changed pricing remediation replay did not conflict';
+  end if;
+end;
+$$;
+
 do $$
 begin
   if has_function_privilege(
@@ -1478,6 +1610,24 @@ begin
     'execute'
   ) then
     raise exception 'Service role unexpectedly has direct private sanitizer access';
+  end if;
+  if has_function_privilege(
+    'anon',
+    'public.remediate_quote_line_pricing_quarantine(uuid,uuid,uuid,jsonb,text,text)',
+    'execute'
+  ) or has_function_privilege(
+    'authenticated',
+    'public.remediate_quote_line_pricing_quarantine(uuid,uuid,uuid,jsonb,text,text)',
+    'execute'
+  ) then
+    raise exception 'Untrusted role can execute quote pricing remediation';
+  end if;
+  if not has_function_privilege(
+    'service_role',
+    'public.remediate_quote_line_pricing_quarantine(uuid,uuid,uuid,jsonb,text,text)',
+    'execute'
+  ) then
+    raise exception 'Service role cannot execute quote pricing remediation';
   end if;
 end;
 $$;

--- a/tests/security/quote-review-cost-and-sell.runtime.sql
+++ b/tests/security/quote-review-cost-and-sell.runtime.sql
@@ -1513,10 +1513,10 @@ begin
     raise exception 'Pricing remediation did not clear and audit quarantine: %',
       v_after.metadata -> 'parts_quote' -> 'pricing_sanitization';
   end if;
-  if v_after.metadata -> 'parts_quote' -> 'items' -> 0 ->> 'unit_price'
-       is distinct from '40'
-     or v_after.metadata -> 'parts_quote' -> 'items' -> 0 ->> 'line_total'
-       is distinct from '40' then
+  if (v_after.metadata -> 'parts_quote' -> 'items' -> 0 ->> 'unit_price')::numeric
+       is distinct from 40::numeric
+     or (v_after.metadata -> 'parts_quote' -> 'items' -> 0 ->> 'line_total')::numeric
+       is distinct from 40::numeric then
     raise exception 'Pricing remediation did not restore exact customer sell detail: %',
       v_after.metadata -> 'parts_quote' -> 'items';
   end if;


### PR DESCRIPTION
### Root cause

PR #1387 repaired the known Parts → PO and Quote Review regressions, but the post-merge review found eight adjacent contract gaps: one stale chat role filter, one incomplete legacy ordering path, missing quarantine remediation, receipt precision drift, ambiguous equal cost/sell provenance, incomplete quarantined portal detail, quarantine checks ahead of idempotent decision replay, and an orphan mutable-quote backfill gap.

### What changed

- Canonicalizes chat recipient filters to `mechanic` while accepting historical aliases.
- Adds acquisition-cost input to the supported legacy Parts request ordering view.
- Rejects free-text receipt quantities beyond two decimals in both API and database layers.
- Preserves equal acquisition/sell values once procurement establishes the acquisition cost.
- Keeps safe quarantined descriptions/quantities visible in the portal while withholding suspect item prices.
- Returns durable quote-decision and compatibility receipts before quarantine enforcement.
- Adds owner/admin-only, service-role-backed, audited pricing-quarantine remediation that preserves finalized totals and workflow state.
- Resyncs unresolved mutable quote lines whose canonical request items no longer exist.

### Why this is safe

The remediation RPC re-verifies the actor role, is executable only by `service_role`, validates exact item totals against the protected durable total, strips acquisition-cost fields from customer metadata, binds idempotent replays to the original payload, records an operational audit event, and uses the existing correction-session contract for financially locked work orders.

### Validation

- Full Vitest suite: 344 files passed, 1 skipped; 1,994 tests passed, 2 skipped.
- TypeScript: `tsc --noEmit` passed.
- Focused ESLint passed.
- Regression inventory: 0 new errors, 0 new warnings; 17/19 critical flows covered.
- PGlite migration compile/behavior harness passed, including financial-lock correction and idempotent remediation.
- `git diff --check` passed.
- Published GitHub tree exactly matches the locally validated commit tree.

### Database

Adds forward migration `20260807214202_address_parts_quote_review_followups.sql` and regenerates the canonical Supabase types. The migration is intentionally **not deployed** by this PR action.

### Environment variables

No new environment variables.

### Manual/deployment actions

After clean-replay CI passes, deployment of the fifth migration requires a separate explicit approval.

### Remaining risks or unverified assumptions

Native Supabase Docker clean replay is delegated to CI because the local Docker socket is unavailable. The migration was independently compiled and behavior-tested with PGlite against the deployed function shape.