### PR TITLE
Fix workforce settings refresh loop

### DIFF
--- a/features/shared/components/ShiftTracker.tsx
+++ b/features/shared/components/ShiftTracker.tsx
@@ -66,7 +66,7 @@ export default function ShiftTracker({
     setErr(null);
 
     try {
-      applyShiftState(await fetchMobileShiftState(), true);
+      applyShiftState(await fetchMobileShiftState(), false);
     } catch (error) {
       setErr(formatErr(error, "Failed to load shift state"));
       setShiftState(null);

--- a/features/workforce/components/MyWorkforceCard.tsx
+++ b/features/workforce/components/MyWorkforceCard.tsx
@@ -218,10 +218,10 @@ export function MyWorkforceCard({ mobile = false }: { mobile?: boolean }) {
         </button>
       </div>
 
-      {loading ? <p className="text-xs text-[color:var(--theme-text-muted)]">Loading workforce details…</p> : null}
+      {loading && !data ? <p className="text-xs text-[color:var(--theme-text-muted)]">Loading workforce details…</p> : null}
       {error ? <p className="rounded-lg border border-red-400/30 bg-red-500/10 p-2 text-xs text-red-200">{error}</p> : null}
 
-      {!loading && data ? (
+      {data ? (
         <>
           <div className="grid grid-cols-2 gap-2 md:grid-cols-5">
             <Stat label="Clocked today" value={hours(data.today_evidence.gross_minutes)} />

--- a/tests/shift-tracker-events.test.tsx
+++ b/tests/shift-tracker-events.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ShiftTracker from "@/features/shared/components/ShiftTracker";
+
+const mocks = vi.hoisted(() => ({
+  fetchMobileShiftState: vi.fn(),
+}));
+
+vi.mock("@/features/mobile/shifts/client", () => ({
+  fetchMobileShiftState: mocks.fetchMobileShiftState,
+}));
+
+const offShiftState = {
+  shiftId: null,
+  shiftStatus: null,
+  activity: "off_shift" as const,
+  startTime: null,
+  endTime: null,
+  latestEventType: null,
+  latestEventAt: null,
+  mode: "none" as const,
+};
+
+describe("ShiftTracker workforce events", () => {
+  beforeEach(() => {
+    mocks.fetchMobileShiftState.mockReset();
+    mocks.fetchMobileShiftState.mockResolvedValue(offShiftState);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not broadcast a workforce change while hydrating its initial state", async () => {
+    const onShiftState = vi.fn();
+    window.addEventListener("workforce:shift-state", onShiftState);
+
+    render(<ShiftTracker userId="employee-1" />);
+
+    await screen.findByRole("button", { name: "Punch in" });
+    expect(mocks.fetchMobileShiftState).toHaveBeenCalledTimes(1);
+    expect(onShiftState).not.toHaveBeenCalled();
+
+    window.removeEventListener("workforce:shift-state", onShiftState);
+  });
+
+  it("broadcasts after a successful shift mutation", async () => {
+    const onShiftState = vi.fn();
+    window.addEventListener("workforce:shift-state", onShiftState);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        shiftId: "shift-1",
+        shiftStatus: "active",
+        activity: "working",
+        startTime: "2026-08-07T15:00:00.000Z",
+        endTime: null,
+        latestEventType: "start_shift",
+        latestEventAt: "2026-08-07T15:00:00.000Z",
+        mode: "shift",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ShiftTracker userId="employee-1" />);
+    fireEvent.click(await screen.findByRole("button", { name: "Punch in" }));
+
+    await waitFor(() => expect(onShiftState).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/mobile/shifts",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    window.removeEventListener("workforce:shift-state", onShiftState);
+  });
+});

--- a/tests/work-order-paid-closeout.test.ts
+++ b/tests/work-order-paid-closeout.test.ts
@@ -94,7 +94,7 @@ describe("work-order paid closeout boundary", () => {
   it("reconciles direct technicians, shift display, approval audits, and PO closeout", () => {
     expect(boardHook).toContain("assigned_tech_id,assigned_to");
     expect(shiftTracker).toContain(
-      "applyShiftState(await fetchMobileShiftState(), true)",
+      "applyShiftState(await fetchMobileShiftState(), false)",
     );
     expect(migration).toContain("trg_work_order_line_approval_audit");
     expect(migration).toContain("insert into public.work_order_approvals(");

--- a/tests/workforce-card-refresh.test.tsx
+++ b/tests/workforce-card-refresh.test.tsx
@@ -1,0 +1,64 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MyWorkforceCard } from "@/features/workforce/components/MyWorkforceCard";
+
+vi.mock("@/features/shared/components/ShiftTracker", () => ({
+  default: () => <div>Shift controls</div>,
+}));
+
+const workforcePayload = {
+  profile: {
+    id: "employee-1",
+    display_name: "Test Mechanic",
+    email: "mechanic@example.com",
+    role: "mechanic",
+  },
+  timezone: "America/Edmonton",
+  current_shift: null,
+  today_evidence: {
+    gross_minutes: 558,
+    break_minutes: 0,
+    lunch_minutes: 0,
+    recorded_minutes: 558,
+    punch_count: 2,
+    punches: [],
+  },
+  next_schedule: null,
+  current_period: null,
+  requests: [],
+};
+
+describe("MyWorkforceCard refresh behavior", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps loaded workforce details mounted during an event refresh", async () => {
+    const pendingRefresh = new Promise(() => undefined);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => workforcePayload,
+      })
+      .mockReturnValueOnce(pendingRefresh);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<MyWorkforceCard />);
+
+    expect(await screen.findByText("Clocked today")).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("workforce:shift-state", {
+          detail: { activity: "working" },
+        }),
+      );
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Clocked today")).toBeInTheDocument();
+    expect(screen.getByText("Shift controls")).toBeInTheDocument();
+    expect(screen.queryByText("Loading workforce details…")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- stop `ShiftTracker` from broadcasting a workforce-change event during initial state hydration
- keep already-loaded workforce metrics mounted during legitimate background refreshes
- preserve workforce-change broadcasts after successful punch, break, lunch, and shift mutations
- add regression coverage for both event behavior and panel stability

## Root cause

`ShiftTracker` broadcast `workforce:shift-state` as soon as it mounted. `MyWorkforceCard` listened for that event, entered its loading state, and unmounted the tracker. When the refresh completed, the tracker mounted and broadcast again, creating the continuous flash seen on Tech Settings and shared workforce surfaces.

## Impact

This repairs desktop and mobile Tech Settings and prevents the same shared-card loop on owner/admin Workforce Overview.

## Validation

- `tsc --noEmit` — passed
- task-scoped ESLint — passed
- focused regression tests — 12 passed
- full Vitest suite — 347 files passed, 2,001 tests passed; 1 integration file / 2 tests intentionally skipped
- production bundle compilation — passed
- full Next.js build reached page-data collection, then stopped because this local environment has no Supabase URL configured
- full repository ESLint remains blocked by 8 pre-existing errors in untouched files

## Database and configuration

- no migration required
- no new environment variables
