### PR TITLE
Add owner-only ops console

### DIFF
--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -1,4 +1,8 @@
+import { redirect } from "next/navigation";
+
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-export { default } from "@/features/agent/agent-console/app/agent/page";
+export default function AgentPage() {
+  redirect("/ops");
+}

--- a/app/api/agent/requests/[id]/notify-discord/route.ts
+++ b/app/api/agent/requests/[id]/notify-discord/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { requireOpsOperatorApiAccess } from "@/features/ops/server/operator-access";
 import {
   AgentTeamRequestError,
   agentTeamRequest,
 } from "@/features/agent/server/teamClient";
 
-const APPROVER_ROLES = ["developer"];
 
 type PostBody = {
   message?: string;
@@ -34,28 +33,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
   }
 
-  const supabase = createServerSupabaseRoute();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("id, agent_role")
-    .eq("id", user.id)
-    .single();
-  if (profileError || !profile) {
-    return NextResponse.json({ error: "Profile not found" }, { status: 400 });
-  }
-  if (!APPROVER_ROLES.includes(profile.agent_role ?? "")) {
-    return NextResponse.json(
-      { error: "Forbidden – insufficient role to notify Discord" },
-      { status: 403 },
-    );
-  }
+  const access = await requireOpsOperatorApiAccess();
+  if (!access.ok) return access.response;
+  const { supabase } = access;
 
   const { data: requestRow, error: requestError } = await supabase
     .from("agent_requests")

--- a/app/api/agent/requests/[id]/reply/route.ts
+++ b/app/api/agent/requests/[id]/reply/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { requireOpsOperatorApiAccess } from "@/features/ops/server/operator-access";
 import {
   AgentTeamRequestError,
   mapAgentTeamRequestStatus,
@@ -92,13 +92,9 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "message is required" }, { status: 400 });
   }
 
-  const supabase = createServerSupabaseRoute();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const access = await requireOpsOperatorApiAccess();
+  if (!access.ok) return access.response;
+  const { supabase, user } = access;
 
   const { data: row, error: selectError } = await supabase
     .from("agent_requests")

--- a/app/api/agent/requests/[id]/route.ts
+++ b/app/api/agent/requests/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import { requireOpsOperatorApiAccess } from "@/features/ops/server/operator-access";
 import {
   AgentTeamRequestError,
   approveAgentTeamMission,
@@ -26,7 +26,6 @@ type PatchBody = {
   llm_notes?: string;
 };
 
-const APPROVER_ROLES = ["developer"];
 
 function getIdFromUrl(req: NextRequest): string | null {
   const url = new URL(req.url);
@@ -111,40 +110,6 @@ function projectionFromNormalized(value: unknown): AgentTeamProjection | null {
   };
 }
 
-async function requireDeveloperProfile() {
-  const supabase = createServerSupabaseRoute();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
-  }
-
-  const { data: profile, error: profileError } = await supabase
-    .from("profiles")
-    .select("id, role, agent_role")
-    .eq("id", user.id)
-    .single();
-
-  if (profileError || !profile) {
-    console.error("agent request profile error", profileError);
-    return {
-      error: NextResponse.json({ error: "Profile not found" }, { status: 400 }),
-    };
-  }
-
-  if (!APPROVER_ROLES.includes(profile.agent_role ?? "")) {
-    return {
-      error: NextResponse.json(
-        { error: "Forbidden – insufficient role to manage Agent team cases" },
-        { status: 403 },
-      ),
-    };
-  }
-
-  return { supabase, user, profile };
-}
-
 function agentErrorResponse(error: unknown) {
   if (error instanceof AgentTeamRequestError) {
     return NextResponse.json(
@@ -189,8 +154,8 @@ export async function PATCH(req: NextRequest) {
     );
   }
 
-  const access = await requireDeveloperProfile();
-  if (access.error) return access.error;
+  const access = await requireOpsOperatorApiAccess();
+  if (!access.ok) return access.response;
   const { supabase, user } = access;
 
   const { data: existing, error: existingError } = await supabase
@@ -323,8 +288,8 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
   }
 
-  const access = await requireDeveloperProfile();
-  if (access.error) return access.error;
+  const access = await requireOpsOperatorApiAccess();
+  if (!access.ok) return access.response;
   const { supabase, user } = access;
 
   const { data: existing, error: existingError } = await supabase

--- a/app/api/agent/requests/route.ts
+++ b/app/api/agent/requests/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
-import { createClient } from "@supabase/supabase-js";
+import {
+  createAdminSupabase,
+  createServerSupabaseRoute,
+} from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import {
   AgentTeamRequestError,
@@ -10,12 +12,7 @@ import {
   readAgentTeamCase,
   type AgentTeamProjection,
 } from "@/features/agent/server/teamClient";
-
-const supabaseAdmin = createClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!,
-  { auth: { persistSession: false } },
-);
+import { requireOpsOperatorApiAccess } from "@/features/ops/server/operator-access";
 
 type AgentGithubMeta = {
   issueNumber?: number | null;
@@ -171,7 +168,7 @@ async function syncAgentRequestRow(row: AgentRequestRow): Promise<AgentRequestRo
     const nextStatus = mapAgentTeamRequestStatus(projection);
     const synchronizedAt = new Date().toISOString();
 
-    const { data: updated, error } = await supabaseAdmin
+    const { data: updated, error } = await createAdminSupabase()
       .from("agent_requests")
       .update({
         status: nextStatus,
@@ -220,14 +217,9 @@ type CreateAgentRequestBody = {
 };
 
 export async function GET() {
-  const supabase = createServerSupabaseRoute();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const access = await requireOpsOperatorApiAccess();
+  if (!access.ok) return access.response;
+  const { supabase } = access;
 
   const { data, error } = await supabase
     .from("agent_requests")
@@ -293,7 +285,7 @@ export async function POST(req: NextRequest) {
 
   let signedAttachments: { path: string; url: string; name: string }[] = [];
   if (attachmentIds.length > 0) {
-    const { data, error } = await supabaseAdmin.storage
+    const { data, error } = await createAdminSupabase().storage
       .from("agent_uploads")
       .createSignedUrls(attachmentIds, 60 * 60 * 24 * 7);
 

--- a/app/ops/page.tsx
+++ b/app/ops/page.tsx
@@ -1,0 +1,10 @@
+import AgentConsolePage from "@/features/agent/agent-console/app/agent/page";
+import { requireOpsOperatorPageAccess } from "@/features/ops/server/operator-access";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function OpsPage() {
+  await requireOpsOperatorPageAccess();
+  return <AgentConsolePage />;
+}

--- a/features/auth/components/SignIn.tsx
+++ b/features/auth/components/SignIn.tsx
@@ -62,6 +62,11 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     return `${origin}/auth/callback${params.size ? `?${params.toString()}` : ""}`;
   }, [origin, searchParams]);
 
+  const isOpsSignIn = useMemo(
+    () => safeInternalRedirect(searchParams.get("redirect"), "") === "/ops",
+    [searchParams],
+  );
+
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -152,6 +157,27 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
     }
   }
 
+  async function handleOpsOAuthSignIn() {
+    if (loading) return;
+    setLoading(true);
+    setError("");
+    setNotice("");
+
+    try {
+      const { error: oauthError } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: { redirectTo: emailRedirectTo },
+      });
+      if (oauthError) {
+        setError(
+          "Google sign-in is not available yet. Use email and password for now.",
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
   const isSignIn = mode === "sign-in";
 
   return (
@@ -200,6 +226,18 @@ export default function AuthPage({ initialMode = "sign-in" }: AuthPageProps) {
         {error ? <AuthStatus tone="error">{error}</AuthStatus> : null}
         {notice ? <AuthStatus tone="success">{notice}</AuthStatus> : null}
       </div>
+
+      {isOpsSignIn && isSignIn ? (
+        <button
+          type="button"
+          disabled={loading}
+          onClick={handleOpsOAuthSignIn}
+          className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-xl border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-overlay)] px-4 py-3 text-sm font-bold text-[color:var(--theme-text-primary)] transition hover:border-[var(--accent-copper)] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          Continue with Google
+        </button>
+      ) : null}
 
       <form className="mt-5 space-y-4" onSubmit={handleSubmit}>
         <div>

--- a/features/ops/lib/operatorAccess.ts
+++ b/features/ops/lib/operatorAccess.ts
@@ -1,0 +1,11 @@
+const DEFAULT_OPS_OPERATOR_EMAIL = "edwardlakin35@gmail.com";
+
+export function normalizeOpsOperatorEmail(value: string | null | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+export function isDefaultOpsOperatorEmail(value: string | null | undefined): boolean {
+  return normalizeOpsOperatorEmail(value) === DEFAULT_OPS_OPERATOR_EMAIL;
+}
+
+export const defaultOpsOperatorEmails = [DEFAULT_OPS_OPERATOR_EMAIL] as const;

--- a/features/ops/server/operator-access.ts
+++ b/features/ops/server/operator-access.ts
@@ -1,0 +1,83 @@
+import "server-only";
+
+import { notFound, redirect } from "next/navigation";
+import { NextResponse } from "next/server";
+import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
+import type { Database } from "@shared/types/types/supabase";
+import {
+  defaultOpsOperatorEmails,
+  normalizeOpsOperatorEmail,
+} from "@/features/ops/lib/operatorAccess";
+
+type OpsProfile = Pick<
+  Database["public"]["Tables"]["profiles"]["Row"],
+  "id" | "email" | "full_name" | "role" | "agent_role" | "shop_id"
+>;
+
+function configuredOpsEmails(): Set<string> {
+  const configured = (process.env.PROFIXIQ_OPS_ALLOWED_EMAILS ?? "")
+    .split(",")
+    .map(normalizeOpsOperatorEmail)
+    .filter(Boolean);
+
+  return new Set([...defaultOpsOperatorEmails, ...configured]);
+}
+
+export function isOpsOperatorEmail(value: string | null | undefined): boolean {
+  return configuredOpsEmails().has(normalizeOpsOperatorEmail(value));
+}
+
+export async function resolveOpsOperatorAccess() {
+  const supabase = createServerSupabaseRoute();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id, email, full_name, role, agent_role, shop_id")
+    .eq("id", user.id)
+    .maybeSingle<OpsProfile>();
+
+  if (profileError) {
+    console.error("ops operator profile lookup failed", profileError);
+  }
+
+  const operatorEmail = normalizeOpsOperatorEmail(user.email);
+  if (!isOpsOperatorEmail(operatorEmail)) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+    };
+  }
+
+  return {
+    ok: true as const,
+    supabase,
+    user,
+    profile: profile ?? null,
+    operatorEmail,
+  };
+}
+
+export async function requireOpsOperatorApiAccess() {
+  return resolveOpsOperatorAccess();
+}
+
+export async function requireOpsOperatorPageAccess() {
+  const access = await resolveOpsOperatorAccess();
+  if (!access.ok) {
+    if (access.response.status === 401) {
+      redirect("/sign-in?redirect=/ops");
+    }
+    notFound();
+  }
+  return access;
+}

--- a/features/ops/server/operator-access.ts
+++ b/features/ops/server/operator-access.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 import { createServerSupabaseRoute } from "@/features/shared/lib/supabase/server";
 import type { Database } from "@shared/types/types/supabase";
 import {
-  defaultOpsOperatorEmails,
+  isDefaultOpsOperatorEmail,
   normalizeOpsOperatorEmail,
 } from "@/features/ops/lib/operatorAccess";
 
@@ -14,17 +14,8 @@ type OpsProfile = Pick<
   "id" | "email" | "full_name" | "role" | "agent_role" | "shop_id"
 >;
 
-function configuredOpsEmails(): Set<string> {
-  const configured = (process.env.PROFIXIQ_OPS_ALLOWED_EMAILS ?? "")
-    .split(",")
-    .map(normalizeOpsOperatorEmail)
-    .filter(Boolean);
-
-  return new Set([...defaultOpsOperatorEmails, ...configured]);
-}
-
 export function isOpsOperatorEmail(value: string | null | undefined): boolean {
-  return configuredOpsEmails().has(normalizeOpsOperatorEmail(value));
+  return isDefaultOpsOperatorEmail(value);
 }
 
 export async function resolveOpsOperatorAccess() {

--- a/features/shared/components/AppShell.tsx
+++ b/features/shared/components/AppShell.tsx
@@ -24,6 +24,7 @@ import { useActiveBrand } from "@/features/branding/hooks/useActiveBrand";
 import { isBillingAttentionStatus } from "@/features/stripe/lib/stripe/subscriptionStatus";
 import { isOutsideDesktopAppShell } from "@/features/shared/lib/routes/shellBoundaries";
 import OpsNotificationsBell from "@/features/shared/components/OpsNotificationsBell";
+import { isDefaultOpsOperatorEmail } from "@/features/ops/lib/operatorAccess";
 
 const HEADER_OFFSET_DESKTOP = "pt-14";
 
@@ -53,7 +54,7 @@ const ActionButton = ({
 
 type ProfileScope = Pick<
   Database["public"]["Tables"]["profiles"]["Row"],
-  "role" | "must_change_password" | "shop_id"
+  "email" | "role" | "must_change_password" | "shop_id"
 >;
 
 type ShopBillingScope = Pick<
@@ -99,8 +100,8 @@ export default function AppShell({
   const [userId, setUserId] = useState<string | null>(
     initialIdentity?.userId ?? null,
   );
-  const [userRole, setUserRole] = useState<string | null>(
-    initialIdentity?.role ?? null,
+  const [userEmail, setUserEmail] = useState<string | null>(
+    initialIdentity?.email ?? null,
   );
   const [mustChangePassword, setMustChangePassword] = useState(false);
   const [, setShopId] = useState<string | null>(
@@ -127,9 +128,7 @@ export default function AppShell({
   const isAppRoute =
     !initialOutsideDesktopShell && !isOutsideDesktopAppShell(pathname);
 
-  const canSeeAgentConsole =
-    !!userRole &&
-    ["owner", "manager", "admin", "advisor", "agent_admin"].includes(userRole);
+  const canSeeAgentConsole = isDefaultOpsOperatorEmail(userEmail);
   const isMobileWorkOrderDetail = /^\/mobile\/work-orders\/[^/]+$/i.test(
     pathname,
   );
@@ -173,17 +172,18 @@ export default function AppShell({
 
       const uid = session?.user?.id ?? null;
       setUserId(uid);
+      setUserEmail(session?.user?.email ?? initialIdentity?.email ?? null);
 
       if (!uid) return;
 
       try {
         const { data: profile } = await supabase
           .from("profiles")
-          .select("role, must_change_password, shop_id")
+          .select("email, role, must_change_password, shop_id")
           .eq("id", uid)
           .single<ProfileScope>();
 
-        if (profile?.role) setUserRole(profile.role as string);
+        setUserEmail(profile?.email ?? session?.user?.email ?? null);
         setMustChangePassword(!!profile?.must_change_password);
 
         const sid = (profile?.shop_id as string | null) ?? null;
@@ -258,7 +258,7 @@ export default function AppShell({
     })();
 
     return () => cleanup?.();
-  }, [supabase, isAppRoute]);
+  }, [supabase, isAppRoute, initialIdentity?.email]);
 
   useEffect(() => {
     if (!isAppRoute || !userId) {
@@ -571,10 +571,10 @@ export default function AppShell({
 
               {userId && canSeeAgentConsole ? (
                 <ActionButton
-                  onClick={() => router.push("/agent")}
-                  title="ProFixIQ Agent Console"
+                  onClick={() => router.push("/ops")}
+                  title="ProFixIQ Ops Console"
                 >
-                  <span>Agent Console</span>
+                  <span>Ops Console</span>
                 </ActionButton>
               ) : null}
 

--- a/features/shared/lib/routes/shellBoundaries.ts
+++ b/features/shared/lib/routes/shellBoundaries.ts
@@ -35,6 +35,7 @@ export function isOutsideDesktopAppShell(pathname: string): boolean {
   if (isStandalonePublicRoute(pathname)) return true;
   if (matchesRoutePrefix(pathname, "/portal")) return true;
   if (matchesRoutePrefix(pathname, "/mobile")) return true;
+  if (matchesRoutePrefix(pathname, "/ops")) return true;
   if (matchesRoutePrefix(pathname, "/coming-soon")) return true;
   return pathname === "/auth" || pathname.startsWith("/auth/");
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -62,6 +62,11 @@ function requestHostname(req: NextRequest): string {
   );
 }
 
+function isOpsHostname(hostname: string): boolean {
+  const normalized = hostname.split(":")[0]?.toLowerCase();
+  return normalized === "ops.profixiq.com" || normalized === "ops.localhost";
+}
+
 function productRequestUrl(
   req: NextRequest,
   path: string,
@@ -154,7 +159,9 @@ async function resolvePortalAccessServer(
 export async function middleware(req: NextRequest) {
   const requestPathname = req.nextUrl.pathname;
   const { search } = req.nextUrl;
-  const fleetProductRequest = isFleetProductHostname(requestHostname(req));
+  const hostname = requestHostname(req);
+  const fleetProductRequest = isFleetProductHostname(hostname);
+  const opsProductRequest = isOpsHostname(hostname);
   const mobileDeviceRequest = isMobileDeviceRequest(req);
 
   if (isStaticAssetPath(requestPathname)) {
@@ -202,11 +209,21 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(target);
   }
 
-  const pathname = fleetInternalPath ?? requestPathname;
+  const opsInternalPath =
+    opsProductRequest &&
+    (requestPathname === "/" ||
+      requestPathname === "/ops" ||
+      requestPathname === "/ops/")
+      ? "/ops"
+      : null;
+
+  const pathname = opsInternalPath ?? fleetInternalPath ?? requestPathname;
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-next-pathname", pathname);
   if (fleetProductRequest) {
     requestHeaders.set("x-profixiq-product-host", "fleet");
+  } else if (opsProductRequest) {
+    requestHeaders.set("x-profixiq-product-host", "ops");
   }
 
   if (
@@ -223,8 +240,9 @@ export async function middleware(req: NextRequest) {
 
   const fleetRewriteTarget = req.nextUrl.clone();
   if (fleetInternalPath) fleetRewriteTarget.pathname = fleetInternalPath;
+  if (opsInternalPath) fleetRewriteTarget.pathname = opsInternalPath;
 
-  const res = fleetInternalPath
+  const res = fleetInternalPath || opsInternalPath
     ? NextResponse.rewrite(fleetRewriteTarget, {
         request: { headers: requestHeaders },
       })
@@ -569,6 +587,14 @@ export const config = {
       source: "/((?!_next/static|_next/image|favicon.ico).*)",
       has: [{ type: "host", value: "fleet.localhost" }],
     },
+    {
+      source: "/((?!_next/static|_next/image|favicon.ico).*)",
+      has: [{ type: "host", value: "ops.profixiq.com" }],
+    },
+    {
+      source: "/((?!_next/static|_next/image|favicon.ico).*)",
+      has: [{ type: "host", value: "ops.localhost" }],
+    },
     "/",
     "/sign-in",
     "/compare-plans",
@@ -593,6 +619,7 @@ export const config = {
     "/launch",
     "/offline/:path*",
     "/onboarding/:path*",
+    "/ops/:path*",
     "/dashboard/:path*",
     "/fleet/:path*",
     "/work-orders/:path*",

--- a/tests/guided-onboarding-v2-foundation.test.ts
+++ b/tests/guided-onboarding-v2-foundation.test.ts
@@ -94,7 +94,7 @@ describe("guided onboarding v2 foundation", () => {
     expect(appShellSource).toContain("Shift");
     expect(appShellSource).toContain("Inbox");
     expect(appShellSource).toContain("Agent Request");
-    expect(appShellSource).toContain("Agent Console");
+    expect(appShellSource).toContain("Ops Console");
     expect(appShellSource).toContain("Sign out");
     expect(assistantEntrySource).toContain("Assistant");
     expect(assistantEntrySource).not.toContain("<span>Planner</span>");

--- a/tests/ops-console-access.test.ts
+++ b/tests/ops-console-access.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  isDefaultOpsOperatorEmail,
+  normalizeOpsOperatorEmail,
+} from "@/features/ops/lib/operatorAccess";
+import { isOutsideDesktopAppShell } from "@/features/shared/lib/routes/shellBoundaries";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const opsPage = read("app/ops/page.tsx");
+const legacyAgentPage = read("app/agent/page.tsx");
+const operatorBoundary = read("features/ops/server/operator-access.ts");
+const signIn = read("features/auth/components/SignIn.tsx");
+const protectedRoutes = [
+  read("app/api/agent/requests/route.ts"),
+  read("app/api/agent/requests/[id]/route.ts"),
+  read("app/api/agent/requests/[id]/reply/route.ts"),
+  read("app/api/agent/requests/[id]/notify-discord/route.ts"),
+];
+
+describe("ops console access boundary", () => {
+  it("normalizes and admits only the configured owner identity in the client gate", () => {
+    expect(normalizeOpsOperatorEmail("  EdwardLakin35@GMAIL.COM ")).toBe(
+      "edwardlakin35@gmail.com",
+    );
+    expect(isDefaultOpsOperatorEmail("EdwardLakin35@GMAIL.COM")).toBe(true);
+    expect(isDefaultOpsOperatorEmail("edwardlakin35+ops@gmail.com")).toBe(false);
+    expect(isDefaultOpsOperatorEmail("developer@example.com")).toBe(false);
+    expect(isDefaultOpsOperatorEmail(null)).toBe(false);
+  });
+
+  it("keeps the ops surface outside the tenant dashboard shell", () => {
+    expect(isOutsideDesktopAppShell("/ops")).toBe(true);
+    expect(isOutsideDesktopAppShell("/ops/cases")).toBe(true);
+    expect(opsPage).toContain("requireOpsOperatorPageAccess");
+    expect(legacyAgentPage).toContain('redirect("/ops")');
+  });
+
+  it("authorizes server access from the verified auth email", () => {
+    expect(operatorBoundary).toContain(
+      "normalizeOpsOperatorEmail(user.email)",
+    );
+    expect(operatorBoundary).not.toContain(
+      "user.email ?? profile?.email",
+    );
+    for (const route of protectedRoutes) {
+      expect(route).toContain("requireOpsOperatorApiAccess");
+    }
+  });
+
+  it("offers Google OAuth only for the ops redirect flow", () => {
+    expect(signIn).toContain(
+      'safeInternalRedirect(searchParams.get("redirect"), "") === "/ops"',
+    );
+    expect(signIn).toContain('provider: "google"');
+    expect(signIn).toContain("redirectTo: emailRedirectTo");
+  });
+});


### PR DESCRIPTION
## Summary

- add a dedicated `/ops` surface and route `ops.profixiq.com` to it
- lock console page access and all console read/mutation APIs to the verified Supabase Auth email `edwardlakin35@gmail.com`
- hide the console entry point from every other application user and redirect the legacy `/agent` route through the new gate
- add Google OAuth as an ops-only sign-in option while retaining email/password fallback
- add focused regression coverage for the owner identity, route boundary, API gates, legacy redirect, and OAuth callback contract
- align the existing AppShell source contract with the intentional `Ops Console` label

## Root cause / prior limitation

The Agent Console reused broad staff/developer-role visibility and authorization. It was mounted inside the tenant dashboard shell, the legacy route remained directly reachable, and the console API boundary did not enforce the single owner identity required for a production operations surface.

## Security and compatibility

Authorization is enforced server-side from the verified Supabase Auth user email; profile email is not trusted as the authorization source. Unauthorized API callers receive 401/403 responses, unauthorized page requests are redirected to sign-in or hidden with a 404, and ordinary staff can still submit Agent requests through the existing POST endpoint. No service-role shortcut was added.

## Validation

Exact published head `0067687a295807cb0340e2575e10882cdecf7c89`:

- Agent PR Checks #48: passed
  - TypeScript: passed
  - changed-file ESLint: passed
  - complete Vitest suite: passed
  - production Next.js build: passed
  - regression inventory generated and uploaded; enforcement step skipped by workflow conditions
- P0-006 Stripe Identity Validation #161: passed
- Vercel deployment status: passed

The first run exposed one stale source-contract assertion for the old `Agent Console` label. That assertion was updated to the intentional `Ops Console` label, then the entire gate passed.

## Database

No migration or backfill required.

## Environment variables

No new environment variables required.

## Manual deployment actions

- keep `ops.profixiq.com` attached to the Vercel project
- keep the ops callback URL allowed in Supabase Auth
- enable/configure the Google provider in Supabase Auth if Google OAuth is desired; email/password remains available
