### PR TITLE
Add retry and restart controls to Agent Control

### DIFF
--- a/app/api/agent/requests/[id]/retry/route.ts
+++ b/app/api/agent/requests/[id]/retry/route.ts
@@ -1,0 +1,314 @@
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database, Json } from "@shared/types/types/supabase";
+import { decideAgentRequestRetry } from "@/features/agent/lib/requestRetry";
+import {
+  AgentTeamRequestError,
+  mapAgentTeamRequestStatus,
+  projectAgentTeamCase,
+  readAgentTeamCase,
+  resumeAgentTeamCase,
+  type AgentTeamProjection,
+} from "@/features/agent/server/teamClient";
+import {
+  submitAgentTeamRequest,
+  type AgentIntakeIntent,
+  type AgentServiceResponse,
+} from "@/features/agent/server/requestIntake";
+import { requireOpsOperatorApiAccess } from "@/features/ops/server/operator-access";
+
+const AGENT_INTENTS = new Set<AgentIntakeIntent>([
+  "feature_request",
+  "bug_report",
+  "inspection_catalog_add",
+  "service_catalog_add",
+  "refactor",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function nullableString(value: unknown): string | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text || null;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .map((item) => nullableString(item))
+        .filter((item): item is string => Boolean(item))
+    : [];
+}
+
+function routeId(req: Request): string | null {
+  const segments = new URL(req.url).pathname.split("/").filter(Boolean);
+  const requestsIndex = segments.findIndex((segment) => segment === "requests");
+  const id = requestsIndex >= 0 ? segments[requestsIndex + 1] : null;
+  return nullableString(id);
+}
+
+function normalizeIntent(value: unknown): AgentIntakeIntent {
+  const intent = nullableString(value) as AgentIntakeIntent | null;
+  return intent && AGENT_INTENTS.has(intent) ? intent : "feature_request";
+}
+
+function engineeringCaseId(value: unknown): string | null {
+  if (!isRecord(value) || !isRecord(value.agentTeam)) return null;
+  return nullableString(value.agentTeam.engineeringCaseId);
+}
+
+function projectionQuestions(projection: AgentTeamProjection) {
+  return projection.missingInformation.map((question, index) => ({
+    id: `team-${projection.engineeringCaseId}-${index}`,
+    question,
+  }));
+}
+
+function agentFailure(error: unknown) {
+  if (error instanceof AgentTeamRequestError) {
+    return NextResponse.json(
+      {
+        error: error.message,
+        detail: error.detail,
+        agentStatus: error.status,
+      },
+      { status: error.status === 409 ? 409 : 502 },
+    );
+  }
+  return NextResponse.json(
+    {
+      error: "Agent request retry failed",
+      detail: error instanceof Error ? error.message : String(error),
+    },
+    { status: 502 },
+  );
+}
+
+async function signedScreenshots(
+  supabase: SupabaseClient<Database>,
+  attachmentIds: string[],
+): Promise<{ path: string; url: string; name: string }[]> {
+  if (attachmentIds.length === 0) return [];
+  const result = await supabase.storage
+    .from("agent_uploads")
+    .createSignedUrls(attachmentIds, 60 * 60 * 24 * 7);
+  if (result.error) {
+    throw new Error(`Unable to restore request evidence: ${result.error.message}`);
+  }
+
+  const attachments = (result.data ?? []).flatMap((row, index) => {
+    const url = nullableString(row.signedUrl);
+    if (!url) return [];
+    const path = attachmentIds[index];
+    return [{
+      path,
+      url,
+      name: path.split("/").pop() ?? path,
+    }];
+  });
+  if (attachments.length !== attachmentIds.length) {
+    throw new Error("Unable to restore all request evidence for retry");
+  }
+  return attachments;
+}
+
+/**
+ * POST /api/agent/requests/:id/retry
+ *
+ * Reuses the durable local request and canonical engineering case. Failed
+ * transports are resubmitted with the same request id; blocked cases resume
+ * their current stage; stale failed projections only synchronize.
+ */
+export async function POST(req: Request) {
+  const id = routeId(req);
+  if (!id) {
+    return NextResponse.json({ error: "Missing agent request id" }, { status: 400 });
+  }
+
+  const access = await requireOpsOperatorApiAccess();
+  if (!access.ok) return access.response;
+  const { supabase, user } = access;
+
+  const { data: row, error: selectError } = await supabase
+    .from("agent_requests")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (selectError) {
+    return NextResponse.json(
+      { error: "Failed to load the agent request", detail: selectError.message },
+      { status: 500 },
+    );
+  }
+  if (!row) {
+    return NextResponse.json({ error: "Agent request not found" }, { status: 404 });
+  }
+
+  const normalized = isRecord(row.normalized_json) ? row.normalized_json : {};
+  let caseId = engineeringCaseId(normalized);
+  let projection: AgentTeamProjection | null = null;
+  let agentResponse: AgentServiceResponse | null = null;
+  let action: "resubmit" | "resume" | "synchronize";
+
+  try {
+    if (caseId) {
+      projection = projectAgentTeamCase(await readAgentTeamCase(caseId));
+    }
+
+    let decision = decideAgentRequestRetry({
+      requestStatus: row.status,
+      caseStatus: projection?.caseStatus,
+      stepStatus: projection?.stepStatus,
+    });
+    if (!decision.allowed || !decision.action) {
+      return NextResponse.json(
+        {
+          error: "This request is not retryable",
+          detail: decision.reason,
+          caseStatus: projection?.caseStatus ?? null,
+          stepStatus: projection?.stepStatus ?? null,
+        },
+        { status: 409 },
+      );
+    }
+    action = decision.action;
+
+    if (action === "resubmit") {
+      const attachmentIds = stringArray(normalized.attachmentIds);
+      const attachments = await signedScreenshots(supabase, attachmentIds);
+      const expectedBehavior = nullableString(normalized.expected);
+      const actualBehavior = nullableString(normalized.actual) ?? row.description;
+      const route = nullableString(normalized.location);
+      const browser = nullableString(normalized.device);
+      const rawContext = isRecord(normalized.rawContext)
+        ? normalized.rawContext
+        : {};
+      const context = {
+        ...rawContext,
+        requestId: id,
+        location: route,
+        steps: nullableString(normalized.steps),
+        expected: expectedBehavior,
+        actual: nullableString(normalized.actual),
+        device: browser,
+        attachmentIds,
+        expectedBehavior,
+        actualBehavior,
+        route,
+        browser,
+        platform: browser,
+        screenshots: attachments.map((attachment) => attachment.url),
+        role: row.reporter_role,
+        shopId: row.shop_id,
+      };
+
+      agentResponse = await submitAgentTeamRequest({
+        requestId: id,
+        source: row.reporter_role ?? "owner",
+        reporterId: row.reporter_id ?? user.id,
+        shopId: row.shop_id,
+        role: row.reporter_role,
+        description: row.description,
+        intent: normalizeIntent(row.intent),
+        expectedBehavior,
+        actualBehavior,
+        route,
+        browser,
+        screenshots: attachments.map((attachment) => attachment.url),
+        context,
+      });
+      caseId = String(agentResponse.engineeringCaseId);
+      projection = projectAgentTeamCase(await readAgentTeamCase(caseId));
+
+      decision = decideAgentRequestRetry({
+        requestStatus: row.status,
+        caseStatus: projection.caseStatus,
+        stepStatus: projection.stepStatus,
+      });
+      if (decision.action === "resume") action = "resume";
+    }
+
+    if (action === "resume") {
+      if (!caseId) throw new Error("Retry did not resolve an engineering case");
+      await resumeAgentTeamCase({
+        engineeringCaseId: caseId,
+        resumedBy: user.id,
+        message: "Developer requested a retry from Agent Control. Reuse the original report and evidence, then re-investigate the current code and database schema.",
+      });
+      projection = projectAgentTeamCase(await readAgentTeamCase(caseId));
+    }
+
+    if (!projection || !caseId) {
+      throw new Error("Retry did not return a canonical engineering case");
+    }
+  } catch (error) {
+    return agentFailure(error);
+  }
+
+  const now = new Date().toISOString();
+  const previousRetryHistory = Array.isArray(normalized.retryHistory)
+    ? normalized.retryHistory.filter(isRecord).slice(-19)
+    : [];
+  const llmMeta = agentResponse?.llm ?? agentResponse?.analysis ?? null;
+  const nextNormalized = {
+    ...normalized,
+    questions: projectionQuestions(projection),
+    agentRequest: agentResponse ?? normalized.agentRequest ?? {},
+    agentTeam: { ...projection, syncedAt: now },
+    retryHistory: [
+      ...previousRetryHistory,
+      {
+        action,
+        requestedAt: now,
+        requestedBy: user.id,
+        engineeringCaseId: caseId,
+      },
+    ],
+  } satisfies Record<string, unknown>;
+
+  const { data: updated, error: updateError } = await supabase
+    .from("agent_requests")
+    .update({
+      intent: normalizeIntent(agentResponse?.intent ?? row.intent),
+      status: mapAgentTeamRequestStatus(projection),
+      normalized_json: nextNormalized as Json,
+      github_issue_number: agentResponse?.github?.issueNumber ?? row.github_issue_number,
+      github_issue_url: agentResponse?.github?.issueUrl ?? row.github_issue_url,
+      github_pr_number: projection.pullRequest.number,
+      github_pr_url: projection.pullRequest.url,
+      github_branch: projection.pullRequest.branch,
+      github_commit_sha: projection.pullRequest.headSha,
+      llm_model: llmMeta?.model ?? row.llm_model,
+      llm_confidence: llmMeta?.confidence ?? row.llm_confidence,
+      llm_notes: projection.summary
+        ?? llmMeta?.notes
+        ?? llmMeta?.commentary
+        ?? llmMeta?.summary
+        ?? row.llm_notes,
+      updated_at: now,
+    })
+    .eq("id", id)
+    .select("*")
+    .single();
+
+  if (updateError || !updated) {
+    return NextResponse.json(
+      {
+        error: "The Agent retry started, but the local projection failed to refresh",
+        detail: updateError?.message ?? "Updated request was not returned",
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    action,
+    request: updated,
+    engineeringCaseId: caseId,
+    currentStage: projection.currentStage,
+    caseStatus: projection.caseStatus,
+  });
+}

--- a/app/api/agent/requests/route.ts
+++ b/app/api/agent/requests/route.ts
@@ -6,60 +6,17 @@ import {
 import type { Database } from "@shared/types/types/supabase";
 import {
   AgentTeamRequestError,
-  agentTeamRequest,
   mapAgentTeamRequestStatus,
   projectAgentTeamCase,
   readAgentTeamCase,
   type AgentTeamProjection,
 } from "@/features/agent/server/teamClient";
+import {
+  submitAgentTeamRequest,
+  type AgentIntakeIntent,
+  type AgentServiceResponse,
+} from "@/features/agent/server/requestIntake";
 import { requireOpsOperatorApiAccess } from "@/features/ops/server/operator-access";
-
-type AgentGithubMeta = {
-  issueNumber?: number | null;
-  issueUrl?: string | null;
-  prNumber?: number | null;
-  prUrl?: string | null;
-  branchName?: string | null;
-  commitSha?: string | null;
-  fileUrl?: string | null;
-};
-
-type AgentLLMMeta = {
-  model?: string | null;
-  confidence?: number | null;
-  notes?: string | null;
-  commentary?: string | null;
-  summary?: string | null;
-};
-
-type AgentWorkerKick = {
-  attempted?: boolean;
-  ok?: boolean;
-  status?: number;
-};
-
-type AgentServiceResponse = {
-  ok?: boolean;
-  message?: string;
-  requestId?: string | null;
-  intent?: string | null;
-  request?: Record<string, unknown> | null;
-  engineeringCaseId?: string | null;
-  currentStage?: string | null;
-  status?: string | null;
-  intakeJobId?: string | null;
-  workerKick?: AgentWorkerKick | null;
-  github?: AgentGithubMeta | null;
-  llm?: AgentLLMMeta | null;
-  analysis?: AgentLLMMeta | null;
-};
-
-type AgentIntent =
-  | "feature_request"
-  | "bug_report"
-  | "inspection_catalog_add"
-  | "service_catalog_add"
-  | "refactor";
 
 type AgentRequestStatus =
   | "submitted"
@@ -72,7 +29,7 @@ type AgentRequestStatus =
 
 type AgentRequestRow = Database["public"]["Tables"]["agent_requests"]["Row"];
 
-const AGENT_INTENTS: AgentIntent[] = [
+const AGENT_INTENTS: AgentIntakeIntent[] = [
   "feature_request",
   "bug_report",
   "inspection_catalog_add",
@@ -80,7 +37,7 @@ const AGENT_INTENTS: AgentIntent[] = [
   "refactor",
 ];
 
-function normalizeIntent(raw: unknown): AgentIntent {
+function normalizeIntent(raw: unknown): AgentIntakeIntent {
   if (typeof raw === "string") {
     const match = AGENT_INTENTS.find((value) => value === raw);
     if (match) return match;
@@ -361,50 +318,21 @@ export async function POST(req: NextRequest) {
   let agentFailure: { status: number | null; detail: string } | null = null;
 
   try {
-    const endpoint = intent === "refactor" ? "/refactors" : "/feature-requests";
-    const payload = intent === "refactor"
-      ? {
-          requestId,
-          source: profile.role ?? "user",
-          reporterId: profile.id,
-          shopId: profile.shop_id,
-          title: `Refactor: ${description.slice(0, 80)}`,
-          description,
-          expectedBehavior,
-          actualBehavior,
-          route,
-          platform: browser,
-          context: contextForAgent,
-        }
-      : {
-          requestId,
-          source: profile.role ?? "user",
-          reporterId: profile.id,
-          shopId: profile.shop_id,
-          role: profile.role,
-          description,
-          intent,
-          expectedBehavior,
-          actualBehavior,
-          route,
-          browser,
-          platform: browser,
-          screenshots: signedScreenshotUrls,
-          context: contextForAgent,
-        };
-
-    agentResponse = await agentTeamRequest<AgentServiceResponse>(endpoint, {
-      method: "POST",
-      body: JSON.stringify(payload),
+    agentResponse = await submitAgentTeamRequest({
+      requestId,
+      source: profile.role ?? "user",
+      reporterId: profile.id,
+      shopId: profile.shop_id,
+      role: profile.role,
+      description,
+      intent,
+      expectedBehavior,
+      actualBehavior,
+      route,
+      browser,
+      screenshots: signedScreenshotUrls,
+      context: contextForAgent,
     });
-
-    if (!agentResponse.engineeringCaseId) {
-      throw new AgentTeamRequestError(
-        "ProFixIQ-Agent did not return an engineering case",
-        502,
-        "The Agent accepted the request without a durable engineeringCaseId.",
-      );
-    }
   } catch (error) {
     agentFailure = error instanceof AgentTeamRequestError
       ? { status: error.status, detail: error.detail }

--- a/features/agent/agent-console/app/agent/page.tsx
+++ b/features/agent/agent-console/app/agent/page.tsx
@@ -10,6 +10,7 @@ import Card from "@shared/components/ui/Card";
 import { Badge } from "@shared/components/ui/badge";
 import { Separator } from "@shared/components/ui/separator";
 import { cn } from "@shared/lib/utils";
+import { isAgentRequestRetryVisible } from "@/features/agent/lib/requestRetry";
 import { createBrowserSupabase } from "@/features/shared/lib/supabase/client";
 import {
   AgentMissionDetails,
@@ -136,6 +137,7 @@ export default function AgentConsolePage() {
   // reply UI
   const [replyText, setReplyText] = useState("");
   const [replySending, setReplySending] = useState(false);
+  const [retryingRequestId, setRetryingRequestId] = useState<string | null>(null);
 
   const selectedContext: AgentContext | null = selected?.normalized_json ?? null;
   const selectedTeam = useMemo<AgentTeamState | null>(() => {
@@ -238,6 +240,17 @@ export default function AgentConsolePage() {
   );
   const approvalLabel = missionAwaitingApproval ? "Approve Mission" : "Approve Release";
   const awaitingReporterInput = selectedTeam?.caseStatus === "blocked" && questions.length > 0;
+  const canRetry = selected
+    ? isAgentRequestRetryVisible({
+        requestStatus: selected.status,
+        caseStatus: selectedTeam?.caseStatus,
+        stepStatus: selectedTeam?.stepStatus,
+      })
+    : false;
+  const retryLabel = selectedTeam?.caseStatus === "blocked"
+    ? "Restart Investigation"
+    : "Retry Request";
+  const actionBusy = isPending || retryingRequestId === selected?.id;
 
   async function loadRequests() {
     try {
@@ -425,6 +438,44 @@ export default function AgentConsolePage() {
         window.alert("Notify Discord error (check logs).");
       }
     });
+  }
+
+  async function retryRequest(request: AgentRequest) {
+    const confirmed = window.confirm(
+      "Retry this request using its original description, context, and attachments? The existing engineering case will be reused when one exists.",
+    );
+    if (!confirmed) return;
+
+    setRetryingRequestId(request.id);
+    try {
+      const res = await fetch(`/api/agent/requests/${request.id}/retry`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const json = (await res.json().catch(() => null)) as {
+        request?: AgentRequest;
+        error?: string;
+        detail?: string;
+      } | null;
+
+      if (!res.ok || !json?.request) {
+        const message = json?.detail ?? json?.error ?? "Retry failed.";
+        console.error("Agent request retry failed", json);
+        window.alert(message);
+        return;
+      }
+
+      setRequests((previous) => previous.map((item) =>
+        item.id === json.request?.id ? json.request : item,
+      ));
+      setSelected(json.request);
+    } catch (err) {
+      console.error("Agent request retry error", err);
+      window.alert("Retry failed before the Agent could restart. Please try again.");
+    } finally {
+      setRetryingRequestId(null);
+    }
   }
 
   async function deleteRequest(request: AgentRequest) {
@@ -1016,15 +1067,31 @@ export default function AgentConsolePage() {
 
                 {/* ACTION BUTTONS */}
                 <div className="flex flex-wrap gap-2">
+                  {canRetry && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={!selected || actionBusy}
+                      className={cn(
+                        "border-orange-500/70 text-xs font-semibold text-orange-300 hover:bg-orange-600 hover:text-[color:var(--theme-text-on-accent)] disabled:opacity-50",
+                        actionBusy && "cursor-wait",
+                      )}
+                      onClick={() => selected && void retryRequest(selected)}
+                    >
+                      {retryingRequestId === selected?.id ? "Restarting…" : retryLabel}
+                    </Button>
+                  )}
+
                   {canApprove && (
                     <Button
                       type="button"
                       size="sm"
                       variant="outline"
-                      disabled={!selected || isPending}
+                      disabled={!selected || actionBusy}
                       className={cn(
                         "border-emerald-500/60 text-xs font-semibold text-emerald-300 hover:bg-emerald-600 hover:text-[color:var(--theme-text-on-accent)] disabled:opacity-50",
-                        isPending && "cursor-wait",
+                        actionBusy && "cursor-wait",
                       )}
                       onClick={() => selected && updateStatus("approve", selected)}
                     >
@@ -1036,10 +1103,10 @@ export default function AgentConsolePage() {
                     type="button"
                     size="sm"
                     variant="outline"
-                    disabled={!selected || isPending}
+                    disabled={!selected || actionBusy}
                     className={cn(
                       "border-red-500/70 text-xs font-semibold text-red-300 hover:bg-red-600 hover:text-[color:var(--theme-text-on-accent)] disabled:opacity-50",
-                      isPending && "cursor-wait",
+                      actionBusy && "cursor-wait",
                     )}
                     onClick={() => selected && updateStatus("reject", selected)}
                   >
@@ -1050,10 +1117,10 @@ export default function AgentConsolePage() {
                     type="button"
                     size="sm"
                     variant="outline"
-                    disabled={!selected || isPending}
+                    disabled={!selected || actionBusy}
                     className={cn(
                       "border-indigo-500/60 text-xs font-semibold text-indigo-200 hover:bg-indigo-600 hover:text-[color:var(--theme-text-on-accent)] disabled:opacity-50",
-                      isPending && "cursor-wait",
+                      actionBusy && "cursor-wait",
                     )}
                     onClick={() => selected && notifyDiscord(selected)}
                   >
@@ -1064,10 +1131,10 @@ export default function AgentConsolePage() {
                     type="button"
                     size="sm"
                     variant="outline"
-                    disabled={!selected || isPending}
+                    disabled={!selected || actionBusy}
                     className={cn(
                       "border-[color:var(--theme-border-soft)] text-xs font-semibold text-[color:var(--theme-text-secondary)] hover:bg-red-700 hover:text-[color:var(--theme-text-primary)] disabled:opacity-50",
-                      isPending && "cursor-wait",
+                      actionBusy && "cursor-wait",
                     )}
                     onClick={() => selected && deleteRequest(selected)}
                   >

--- a/features/agent/lib/requestRetry.ts
+++ b/features/agent/lib/requestRetry.ts
@@ -1,0 +1,73 @@
+export type AgentRequestRetryAction = "resubmit" | "resume" | "synchronize";
+
+type RetryState = {
+  requestStatus: string;
+  caseStatus?: string | null;
+  stepStatus?: string | null;
+};
+
+export type AgentRequestRetryDecision = {
+  allowed: boolean;
+  action: AgentRequestRetryAction | null;
+  reason: string;
+};
+
+/**
+ * Keep retry decisions explicit so a double click or stale console projection
+ * cannot duplicate active Agent work.
+ */
+export function decideAgentRequestRetry(
+  state: RetryState,
+): AgentRequestRetryDecision {
+  const requestStatus = state.requestStatus.trim().toLowerCase();
+  const caseStatus = state.caseStatus?.trim().toLowerCase() || null;
+  const stepStatus = state.stepStatus?.trim().toLowerCase() || null;
+
+  if (!caseStatus) {
+    return requestStatus === "failed"
+      ? {
+          allowed: true,
+          action: "resubmit",
+          reason: "The failed request has no engineering case yet.",
+        }
+      : {
+          allowed: false,
+          action: null,
+          reason: "Only failed requests without an engineering case can be resubmitted.",
+        };
+  }
+
+  if (caseStatus === "blocked") {
+    return {
+      allowed: true,
+      action: "resume",
+      reason: "The engineering case is blocked and can resume its current stage.",
+    };
+  }
+
+  if (caseStatus === "active" && stepStatus === "failed") {
+    return {
+      allowed: true,
+      action: "resume",
+      reason: "The active engineering case has a failed current stage.",
+    };
+  }
+
+  if (requestStatus === "failed" && caseStatus === "active") {
+    return {
+      allowed: true,
+      action: "synchronize",
+      reason: "Agent work is already active; refresh the stale local projection only.",
+    };
+  }
+
+  return {
+    allowed: false,
+    action: null,
+    reason: `The engineering case cannot be retried from ${caseStatus}.`,
+  };
+}
+
+export function isAgentRequestRetryVisible(state: RetryState): boolean {
+  return state.requestStatus === "failed" || state.caseStatus === "blocked";
+}

--- a/features/agent/server/requestIntake.ts
+++ b/features/agent/server/requestIntake.ts
@@ -1,0 +1,123 @@
+import {
+  AgentTeamRequestError,
+  agentTeamRequest,
+} from "@/features/agent/server/teamClient";
+
+export type AgentIntakeIntent =
+  | "feature_request"
+  | "bug_report"
+  | "inspection_catalog_add"
+  | "service_catalog_add"
+  | "refactor";
+
+type AgentGithubMeta = {
+  issueNumber?: number | null;
+  issueUrl?: string | null;
+  prNumber?: number | null;
+  prUrl?: string | null;
+  branchName?: string | null;
+  commitSha?: string | null;
+  fileUrl?: string | null;
+};
+
+type AgentLLMMeta = {
+  model?: string | null;
+  confidence?: number | null;
+  notes?: string | null;
+  commentary?: string | null;
+  summary?: string | null;
+};
+
+type AgentWorkerKick = {
+  attempted?: boolean;
+  ok?: boolean;
+  status?: number;
+};
+
+export type AgentServiceResponse = {
+  ok?: boolean;
+  message?: string;
+  requestId?: string | null;
+  intent?: string | null;
+  request?: Record<string, unknown> | null;
+  engineeringCaseId?: string | null;
+  currentStage?: string | null;
+  status?: string | null;
+  intakeJobId?: string | null;
+  workerKick?: AgentWorkerKick | null;
+  github?: AgentGithubMeta | null;
+  llm?: AgentLLMMeta | null;
+  analysis?: AgentLLMMeta | null;
+};
+
+export type SubmitAgentTeamRequestParams = {
+  requestId: string;
+  source: string;
+  reporterId: string;
+  shopId: string | null;
+  role: string | null;
+  description: string;
+  intent: AgentIntakeIntent;
+  expectedBehavior: string | null;
+  actualBehavior: string;
+  route: string | null;
+  browser: string | null;
+  screenshots: string[];
+  context: Record<string, unknown>;
+};
+
+/**
+ * Submit an existing durable ProFixIQ request to the canonical Agent intake.
+ * The Agent service makes requestId idempotent for a repository ticket, so a
+ * transport retry reuses the same engineering case instead of creating one.
+ */
+export async function submitAgentTeamRequest(
+  params: SubmitAgentTeamRequestParams,
+): Promise<AgentServiceResponse> {
+  const endpoint = params.intent === "refactor" ? "/refactors" : "/feature-requests";
+  const payload = params.intent === "refactor"
+    ? {
+        requestId: params.requestId,
+        source: params.source,
+        reporterId: params.reporterId,
+        shopId: params.shopId,
+        title: `Refactor: ${params.description.slice(0, 80)}`,
+        description: params.description,
+        expectedBehavior: params.expectedBehavior,
+        actualBehavior: params.actualBehavior,
+        route: params.route,
+        platform: params.browser,
+        context: params.context,
+      }
+    : {
+        requestId: params.requestId,
+        source: params.source,
+        reporterId: params.reporterId,
+        shopId: params.shopId,
+        role: params.role,
+        description: params.description,
+        intent: params.intent,
+        expectedBehavior: params.expectedBehavior,
+        actualBehavior: params.actualBehavior,
+        route: params.route,
+        browser: params.browser,
+        platform: params.browser,
+        screenshots: params.screenshots,
+        context: params.context,
+      };
+
+  const response = await agentTeamRequest<AgentServiceResponse>(endpoint, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.engineeringCaseId) {
+    throw new AgentTeamRequestError(
+      "ProFixIQ-Agent did not return an engineering case",
+      502,
+      "The Agent accepted the request without a durable engineeringCaseId.",
+    );
+  }
+
+  return response;
+}

--- a/scripts/regression-inventory/baseline.json
+++ b/scripts/regression-inventory/baseline.json
@@ -1123,26 +1123,6 @@
       "expiresOn": "2026-09-06"
     },
     {
-      "fingerprint": "245ebb8510d2db72d89d",
-      "rule": "missing-storage-bucket",
-      "severity": "error",
-      "domain": "ai-automation",
-      "file": "app/api/agent/requests/[id]/route.ts",
-      "subject": "agent_uploads",
-      "message": "Storage bucket agent_uploads is not provisioned by the migration chain",
-      "expiresOn": "2026-09-06"
-    },
-    {
-      "fingerprint": "518d9a4b98236c51f23d",
-      "rule": "missing-storage-bucket",
-      "severity": "error",
-      "domain": "ai-automation",
-      "file": "app/api/agent/requests/route.ts",
-      "subject": "agent_uploads",
-      "message": "Storage bucket agent_uploads is not provisioned by the migration chain",
-      "expiresOn": "2026-09-06"
-    },
-    {
       "fingerprint": "caa79ebe66b653edae8d",
       "rule": "missing-storage-bucket",
       "severity": "error",
@@ -1250,26 +1230,6 @@
       "file": "app/property/requests/[id]/page.tsx",
       "subject": "property_request_attachments",
       "message": "Storage bucket property_request_attachments is not provisioned by the migration chain",
-      "expiresOn": "2026-09-06"
-    },
-    {
-      "fingerprint": "b3ff7d5e0d6f1d92d497",
-      "rule": "missing-storage-bucket",
-      "severity": "error",
-      "domain": "ai-automation",
-      "file": "features/agent/agent-console/app/agent/page.tsx",
-      "subject": "agent_uploads",
-      "message": "Storage bucket agent_uploads is not provisioned by the migration chain",
-      "expiresOn": "2026-09-06"
-    },
-    {
-      "fingerprint": "29a554cdb5afaeee4d04",
-      "rule": "missing-storage-bucket",
-      "severity": "error",
-      "domain": "ai-automation",
-      "file": "features/agent/components/AgentRequestModal.tsx",
-      "subject": "agent_uploads",
-      "message": "Storage bucket agent_uploads is not provisioned by the migration chain",
       "expiresOn": "2026-09-06"
     },
     {

--- a/supabase/migrations/20260808172810_provision_agent_uploads.sql
+++ b/supabase/migrations/20260808172810_provision_agent_uploads.sql
@@ -1,0 +1,80 @@
+-- Provision the private Agent evidence bucket used by request intake and retry.
+-- Object paths are canonicalized as <auth-user-id>/<timestamp>-<filename>.
+
+insert into storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types
+)
+values (
+  'agent_uploads',
+  'agent_uploads',
+  false,
+  20971520,
+  array[
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/gif',
+    'image/heic',
+    'image/heif'
+  ]::text[]
+)
+on conflict (id) do update
+set
+  public = false,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+-- Remove manually-created and superseded policies. Several of the historical
+-- policies granted every authenticated user access to every Agent attachment.
+drop policy if exists agent_uploads_delete on storage.objects;
+drop policy if exists agent_uploads_delete_auth on storage.objects;
+drop policy if exists agent_uploads_insert_auth on storage.objects;
+drop policy if exists agent_uploads_objects_delete on storage.objects;
+drop policy if exists agent_uploads_objects_insert on storage.objects;
+drop policy if exists agent_uploads_objects_select on storage.objects;
+drop policy if exists agent_uploads_objects_update on storage.objects;
+drop policy if exists agent_uploads_read on storage.objects;
+drop policy if exists agent_uploads_select_auth on storage.objects;
+drop policy if exists agent_uploads_update on storage.objects;
+drop policy if exists agent_uploads_update_auth on storage.objects;
+drop policy if exists agent_uploads_write on storage.objects;
+drop policy if exists agent_uploads_insert_own on storage.objects;
+drop policy if exists agent_uploads_select_own_or_operator on storage.objects;
+drop policy if exists agent_uploads_delete_own_or_operator on storage.objects;
+
+create policy agent_uploads_insert_own
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'agent_uploads'
+  and (storage.foldername(name))[1] = (select auth.uid())::text
+);
+
+create policy agent_uploads_select_own_or_operator
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'agent_uploads'
+  and (
+    (storage.foldername(name))[1] = (select auth.uid())::text
+    or lower(coalesce((select auth.jwt()) ->> 'email', '')) = 'edwardlakin35@gmail.com'
+  )
+);
+
+create policy agent_uploads_delete_own_or_operator
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'agent_uploads'
+  and (
+    (storage.foldername(name))[1] = (select auth.uid())::text
+    or lower(coalesce((select auth.jwt()) ->> 'email', '')) = 'edwardlakin35@gmail.com'
+  )
+);

--- a/tests/agent-production-handoff.test.ts
+++ b/tests/agent-production-handoff.test.ts
@@ -10,11 +10,13 @@ describe("production agent request handoff", () => {
   const route = read("app/api/agent/requests/route.ts");
   const detailRoute = read("app/api/agent/requests/[id]/route.ts");
   const teamClient = read("features/agent/server/teamClient.ts");
+  const requestIntake = read("features/agent/server/requestIntake.ts");
   const consolePage = read("features/agent/agent-console/app/agent/page.tsx");
   const replyRoute = read("app/api/agent/requests/[id]/reply/route.ts");
 
   it("uses the canonical authenticated Agent team client", () => {
-    expect(route).toContain("agentTeamRequest<AgentServiceResponse>");
+    expect(route).toContain("submitAgentTeamRequest");
+    expect(requestIntake).toContain("agentTeamRequest<AgentServiceResponse>");
     expect(route).toContain("readAgentTeamCase(engineeringCaseId)");
     expect(route).toContain("projectAgentTeamCase");
     expect(teamClient).toContain("resolveAgentApiSecrets()");

--- a/tests/agent-request-retry.test.ts
+++ b/tests/agent-request-retry.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  decideAgentRequestRetry,
+  isAgentRequestRetryVisible,
+} from "@/features/agent/lib/requestRetry";
+
+const retryRoute = readFileSync(
+  "app/api/agent/requests/[id]/retry/route.ts",
+  "utf8",
+);
+const consolePage = readFileSync(
+  "features/agent/agent-console/app/agent/page.tsx",
+  "utf8",
+);
+const evidenceMigration = readFileSync(
+  "supabase/migrations/20260808172810_provision_agent_uploads.sql",
+  "utf8",
+);
+
+describe("agent request retry policy", () => {
+  it("resubmits a failed transport with no engineering case", () => {
+    expect(decideAgentRequestRetry({ requestStatus: "failed" })).toMatchObject({
+      allowed: true,
+      action: "resubmit",
+    });
+  });
+
+  it("resumes blocked cases and failed current stages", () => {
+    expect(decideAgentRequestRetry({
+      requestStatus: "in_progress",
+      caseStatus: "blocked",
+      stepStatus: "blocked",
+    }).action).toBe("resume");
+    expect(decideAgentRequestRetry({
+      requestStatus: "failed",
+      caseStatus: "active",
+      stepStatus: "failed",
+    }).action).toBe("resume");
+  });
+
+  it("only synchronizes a stale local failure when Agent work is active", () => {
+    expect(decideAgentRequestRetry({
+      requestStatus: "failed",
+      caseStatus: "active",
+      stepStatus: "running",
+    })).toMatchObject({ allowed: true, action: "synchronize" });
+  });
+
+  it("does not retry ordinary active or terminal cases", () => {
+    expect(decideAgentRequestRetry({
+      requestStatus: "in_progress",
+      caseStatus: "active",
+      stepStatus: "running",
+    }).allowed).toBe(false);
+    expect(decideAgentRequestRetry({
+      requestStatus: "merged",
+      caseStatus: "complete",
+      stepStatus: "passed",
+    }).allowed).toBe(false);
+  });
+
+  it("shows the control for failed requests and blocked cases", () => {
+    expect(isAgentRequestRetryVisible({ requestStatus: "failed" })).toBe(true);
+    expect(isAgentRequestRetryVisible({
+      requestStatus: "in_progress",
+      caseStatus: "blocked",
+    })).toBe(true);
+    expect(isAgentRequestRetryVisible({
+      requestStatus: "in_progress",
+      caseStatus: "active",
+    })).toBe(false);
+  });
+});
+
+describe("agent request retry integration contract", () => {
+  it("keeps retry owner-only and delegates execution to the canonical Agent service", () => {
+    expect(retryRoute).toContain("requireOpsOperatorApiAccess");
+    expect(retryRoute).toContain("submitAgentTeamRequest");
+    expect(retryRoute).toContain("resumeAgentTeamCase");
+    expect(retryRoute).toContain("readAgentTeamCase");
+    expect(retryRoute).not.toContain('.from("agent_jobs")');
+  });
+
+  it("reuses original evidence and records retry history", () => {
+    expect(retryRoute).toContain('.from("agent_uploads")');
+    expect(retryRoute).toContain("createSignedUrls");
+    expect(retryRoute).toContain("requestId: id");
+    expect(retryRoute).toContain("retryHistory:");
+  });
+
+  it("provisions private owner-scoped evidence storage from migrations", () => {
+    expect(evidenceMigration).toContain("insert into storage.buckets");
+    expect(evidenceMigration).toContain("'agent_uploads'");
+    expect(evidenceMigration).toContain("false,\n  20971520");
+    expect(evidenceMigration).toContain("agent_uploads_insert_own");
+    expect(evidenceMigration).toContain("agent_uploads_select_own_or_operator");
+    expect(evidenceMigration).toContain("(storage.foldername(name))[1] = (select auth.uid())::text");
+    expect(evidenceMigration).toContain("edwardlakin35@gmail.com");
+    expect(evidenceMigration).not.toContain("for all");
+  });
+
+  it("offers separate retry and restart labels in Agent Control", () => {
+    expect(consolePage).toContain("/retry");
+    expect(consolePage).toContain('"Retry Request"');
+    expect(consolePage).toContain('"Restart Investigation"');
+  });
+});

--- a/tests/agent-request-secret-contract.test.ts
+++ b/tests/agent-request-secret-contract.test.ts
@@ -11,6 +11,10 @@ const requestRouteSource = readFileSync(
   join(process.cwd(), "app/api/agent/requests/route.ts"),
   "utf8",
 );
+const requestIntakeSource = readFileSync(
+  join(process.cwd(), "features/agent/server/requestIntake.ts"),
+  "utf8",
+);
 const controlRouteSource = readFileSync(
   join(process.cwd(), "app/api/agent/requests/[id]/route.ts"),
   "utf8",
@@ -94,7 +98,8 @@ describe("ProFixIQ-Agent team authentication contract", () => {
   });
 
   it("routes the complete UI control plane through the canonical Agent service", () => {
-    expect(requestRouteSource).toContain("agentTeamRequest<AgentServiceResponse>");
+    expect(requestRouteSource).toContain("submitAgentTeamRequest");
+    expect(requestIntakeSource).toContain("agentTeamRequest<AgentServiceResponse>");
     expect(requestRouteSource).toContain("readAgentTeamCase");
     expect(controlRouteSource).toContain("approveAgentTeamMission");
     expect(controlRouteSource).toContain("approveAgentTeamRelease");

--- a/tests/ops-console-access.test.ts
+++ b/tests/ops-console-access.test.ts
@@ -20,6 +20,7 @@ const signIn = read("features/auth/components/SignIn.tsx");
 const protectedRoutes = [
   read("app/api/agent/requests/route.ts"),
   read("app/api/agent/requests/[id]/route.ts"),
+  read("app/api/agent/requests/[id]/retry/route.ts"),
   read("app/api/agent/requests/[id]/reply/route.ts"),
   read("app/api/agent/requests/[id]/notify-discord/route.ts"),
 ];


### PR DESCRIPTION
## Summary

- add **Retry Request** for failed Agent requests and **Restart Investigation** for blocked engineering cases
- reuse the existing local request, original context, attachments, and canonical Agent engineering case instead of creating duplicates
- resubmit old transport failures with the same durable request ID, resume blocked/failed stages through the Agent service, and only resynchronize stale failed rows when work is already active
- record a bounded retry audit trail in the request projection
- provision and secure the private `agent_uploads` evidence bucket through the migration chain

## Root cause

Agent Control exposed approve, reject, reply, Discord, and delete actions, but no recovery control. Historical transport failures never received an engineering case, while current blocked cases already had a canonical resume endpoint. Recreating a request manually lost continuity and could duplicate Agent work.

The evidence bucket also existed only as live/manual configuration. It was missing from migrations and had overlapping policies that let any authenticated user read all Agent attachments.

## Safety and idempotency

- every retry API call is protected by the existing exact-email ops operator boundary
- existing cases are read from the Agent service before a retry decision
- the Agent intake is idempotent on repository + durable request ID
- the Agent resume RPC atomically prevents concurrent duplicate resumes
- active work is synchronized instead of re-enqueued
- terminal and ordinary active cases return a conflict
- screenshots are re-signed from their original storage paths; no attachment is silently dropped
- storage writes are limited to the authenticated user's own path; reads/deletes are limited to the uploader or the exact ops owner identity

## Validation

Exact published tree: `b94814423576ad9115dc495869974fafb8957e45`

- TypeScript: passed
- changed-file ESLint: passed
- focused retry/access/handoff tests: 25 passed
- complete Vitest suite: 746 suites passed; 2,017 tests passed; 2 skipped
- regression inventory gate: passed with 0 new errors/warnings and 0 stale baseline entries
- GitHub production build: passed
- Supabase clean apply/reset/replay and runtime integration workflow: passed
- P0 financial outbox validation: passed
- Vercel deployment check: passed
- live Supabase verification: private 20 MB image bucket plus exactly three scoped policies
- Supabase advisors: no security or performance lint for `agent_uploads`

## Database

Applied to production as migration `20260808172810_provision_agent_uploads`. The committed migration version matches live migration history and is idempotent.

## Environment variables

No new environment variables.

## Manual deployment actions

None. The draft PR is ready for owner review and approval; merge through the normal protected workflow.