### PR TITLE
Keep work orders primary across invoice views

### DIFF
--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -8,6 +8,7 @@ import { format } from "date-fns";
 import { toast } from "sonner";
 import GuidedPageStepPanel from "@/features/onboarding-v2/components/GuidedPageStepPanel";
 import { InvoiceCsvImportCard } from "@/features/billing/components/InvoiceCsvImportCard";
+import { invoiceDisplayIdentity } from "@/features/invoices/lib/invoiceDisplayIdentity";
 
 type DB = Database;
 type WorkOrder = DB["public"]["Tables"]["work_orders"]["Row"];
@@ -885,9 +886,9 @@ export default function BillingPage(): JSX.Element {
             <table className="w-full min-w-[920px] text-left text-sm">
               <thead className="border-b border-amber-500/15 text-xs uppercase tracking-[0.14em] text-[color:var(--theme-text-muted)]">
                 <tr>
-                  <th className="px-5 py-3">Invoice</th>
+                  <th className="px-5 py-3">Work order / invoice</th>
                   <th className="px-5 py-3">Customer</th>
-                  <th className="px-5 py-3">Work order / VIN</th>
+                  <th className="px-5 py-3">VIN</th>
                   <th className="px-5 py-3">Status</th>
                   <th className="px-5 py-3 text-right">Total</th>
                   <th className="px-5 py-3">Issued</th>
@@ -911,11 +912,16 @@ export default function BillingPage(): JSX.Element {
                     (legacyCustomerId
                       ? `Unknown customer · ${legacyCustomerId}`
                       : "Unknown customer");
-                  const workOrderText =
-                    metadata?.work_order_number ??
-                    String(rawRow.work_order_number ?? "No work order number");
+                  const workOrderText = String(
+                    metadata?.work_order_number ?? rawRow.work_order_number ?? "",
+                  );
                   const vinText =
                     metadata?.vin ?? String(rawRow.vin ?? "No VIN");
+                  const identity = invoiceDisplayIdentity({
+                    workOrderNumber: workOrderText,
+                    invoiceNumber: invoice.invoice_number,
+                    workOrderId: invoice.work_order_id,
+                  });
 
                   return (
                     <Fragment key={invoice.id}>
@@ -929,8 +935,10 @@ export default function BillingPage(): JSX.Element {
                       >
                         <td className="px-5 py-4">
                           <div className="font-semibold text-[color:var(--theme-text-primary)]">
-                            {invoice.invoice_number ??
-                              `#${invoice.id.slice(0, 8)}`}
+                            {identity.primary}
+                          </div>
+                          <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
+                            {identity.secondary}
                           </div>
                           <div className="mt-1 inline-flex rounded-full border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-100">
                             Read-only historical
@@ -945,10 +953,7 @@ export default function BillingPage(): JSX.Element {
                           ) : null}
                         </td>
                         <td className="px-5 py-4">
-                          <div>{workOrderText}</div>
-                          <div className="text-xs text-[color:var(--theme-text-muted)]">
-                            VIN {vinText}
-                          </div>
+                          <div>{vinText}</div>
                         </td>
                         <td className="px-5 py-4">
                           <span className="inline-flex rounded-full border border-amber-400/30 bg-amber-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.12em] text-amber-100">

--- a/app/portal/invoices/[id]/page.tsx
+++ b/app/portal/invoices/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
   getCanonicalDocumentIdentity,
   overlayCanonicalDocumentIdentity,
 } from "@/features/invoices/server/canonicalDocumentIdentity";
+import { invoiceDisplayIdentity } from "@/features/invoices/lib/invoiceDisplayIdentity";
 
 export const dynamic = "force-dynamic";
 
@@ -85,9 +86,11 @@ export default async function PortalInvoicePage({
     const payable =
       ["issued", "partially_paid"].includes(selectedVersion.lifecycle_status) &&
       Number(selectedVersion.outstanding_total) >= 0.5;
-    const title = identity.invoiceNumber || "Invoice";
-    const workOrderNumber =
-      identity.workOrderNumber || `#${workOrderId.slice(0, 8)}`;
+    const displayIdentity = invoiceDisplayIdentity({
+      workOrderNumber: identity.workOrderNumber,
+      invoiceNumber: identity.invoiceNumber,
+      workOrderId,
+    });
 
     return (
       <div className="min-h-screen bg-background px-4 py-10 text-foreground">
@@ -112,9 +115,9 @@ export default async function PortalInvoicePage({
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div>
                 <div className="text-xs uppercase tracking-[0.2em] text-[color:var(--theme-text-muted)]">Invoice</div>
-                <h1 className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{title}</h1>
+                <h1 className="mt-1 text-2xl font-semibold text-[color:var(--theme-text-primary)]">{displayIdentity.primary}</h1>
                 <div className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-                  Work order {workOrderNumber} · Issued {dateLabel(selectedVersion.issued_at)}
+                  {displayIdentity.secondary} · Issued {dateLabel(selectedVersion.issued_at)}
                 </div>
               </div>
               <div className="rounded-full border border-[color:var(--theme-border-soft)] bg-[color:var(--theme-surface-inset)] px-4 py-2 text-sm capitalize text-[color:var(--theme-text-primary)]">

--- a/app/portal/invoices/page.tsx
+++ b/app/portal/invoices/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
 import { requirePortalCustomerActor } from "@/features/portal/server/requirePortalActor";
 import { listCustomerVisibleInvoiceVersions } from "@/features/invoices/server/invoiceVersionQueries";
+import { invoiceDisplayIdentity } from "@/features/invoices/lib/invoiceDisplayIdentity";
 
 export const dynamic = "force-dynamic";
 
@@ -77,13 +78,13 @@ export default async function PortalInvoicesPage() {
           ) : (
             <div className="space-y-3">
               {versions.map((version) => {
-                const workOrderLabel =
-                  workOrderLabels.get(version.work_order_id) ||
-                  `Work order ${version.work_order_id.slice(0, 8)}`;
-                const invoiceLabel =
-                  (version.invoice_id
+                const identity = invoiceDisplayIdentity({
+                  workOrderNumber: workOrderLabels.get(version.work_order_id),
+                  invoiceNumber: version.invoice_id
                     ? invoiceLabels.get(version.invoice_id)
-                    : null) || "Invoice";
+                    : null,
+                  workOrderId: version.work_order_id,
+                });
                 return (
                   <Link
                     key={version.id}
@@ -92,9 +93,9 @@ export default async function PortalInvoicesPage() {
                   >
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                       <div>
-                        <div className="font-semibold text-[color:var(--theme-text-primary)]">{invoiceLabel}</div>
+                        <div className="font-semibold text-[color:var(--theme-text-primary)]">{identity.primary}</div>
                         <div className="mt-1 text-xs text-[color:var(--theme-text-muted)]">
-                          {workOrderLabel} • Version {version.version_number} • Issued {dateLabel(version.issued_at)}
+                          {identity.secondary} • Version {version.version_number} • Issued {dateLabel(version.issued_at)}
                         </div>
                         <div className="mt-1 text-xs capitalize text-[color:var(--theme-text-secondary)]">
                           {version.lifecycle_status.replaceAll("_", " ")}

--- a/features/invoices/lib/invoiceDisplayIdentity.test.ts
+++ b/features/invoices/lib/invoiceDisplayIdentity.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { invoiceDisplayIdentity } from "./invoiceDisplayIdentity";
+
+describe("invoiceDisplayIdentity", () => {
+  it("keeps the work order number primary and invoice number secondary", () => {
+    expect(
+      invoiceDisplayIdentity({
+        workOrderNumber: " EL00118 ",
+        invoiceNumber: " INV-0042 ",
+        workOrderId: "work-order-id",
+      }),
+    ).toEqual({
+      primary: "EL00118",
+      secondary: "Invoice INV-0042",
+    });
+  });
+
+  it("uses a readable work order fallback without exposing an invoice database id", () => {
+    expect(
+      invoiceDisplayIdentity({
+        workOrderId: "12345678-abcd-4000-8000-123456789abc",
+      }),
+    ).toEqual({
+      primary: "Work order 12345678",
+      secondary: "Invoice number pending",
+    });
+  });
+
+  it("labels an unnumbered draft invoice beneath the work order", () => {
+    expect(
+      invoiceDisplayIdentity({
+        workOrderNumber: "EL00118",
+        draft: true,
+      }),
+    ).toEqual({
+      primary: "EL00118",
+      secondary: "Draft invoice",
+    });
+  });
+});

--- a/features/invoices/lib/invoiceDisplayIdentity.ts
+++ b/features/invoices/lib/invoiceDisplayIdentity.ts
@@ -1,0 +1,32 @@
+export type InvoiceDisplayIdentity = {
+  primary: string;
+  secondary: string;
+};
+
+function clean(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+export function invoiceDisplayIdentity(input: {
+  workOrderNumber?: string | null;
+  invoiceNumber?: string | null;
+  workOrderId?: string | null;
+  draft?: boolean;
+}): InvoiceDisplayIdentity {
+  const workOrderNumber = clean(input.workOrderNumber);
+  const invoiceNumber = clean(input.invoiceNumber);
+  const workOrderId = clean(input.workOrderId);
+
+  return {
+    primary:
+      workOrderNumber ||
+      (workOrderId
+        ? `Work order ${workOrderId.slice(0, 8)}`
+        : "Work order unavailable"),
+    secondary: invoiceNumber
+      ? `Invoice ${invoiceNumber}`
+      : input.draft
+        ? "Draft invoice"
+        : "Invoice number pending",
+  };
+}

--- a/features/work-orders/components/InvoicePreviewPageClient.tsx
+++ b/features/work-orders/components/InvoicePreviewPageClient.tsx
@@ -15,6 +15,7 @@ import { WorkOrderInvoiceDownloadButton } from "@work-orders/components/WorkOrde
 import SyncInvoiceToQuickBooksButton from "@/features/integrations/quickbooks/components/SyncInvoiceToQuickBooksButton";
 import RecordManualPayment from "@/features/invoices/components/RecordManualPayment";
 import InvoicePricingEditor from "@/features/invoices/components/InvoicePricingEditor";
+import { invoiceDisplayIdentity } from "@/features/invoices/lib/invoiceDisplayIdentity";
 import { useTabs } from "@/features/shared/components/tabs/TabsProvider";
 
 type DB = Database;
@@ -347,11 +348,16 @@ export default function InvoicePreviewPageClient({
 
   const effectiveVehicleInfo = vehicleInfo ?? fVehicleInfo;
   const effectiveCustomerInfo = customerInfo ?? fCustomerInfo;
+  const displayIdentity = invoiceDisplayIdentity({
+    workOrderNumber: workOrderLabel,
+    invoiceNumber,
+    workOrderId,
+    draft: !invoiceNumber,
+  });
 
   useEffect(() => {
-    const label = invoiceNumber || workOrderLabel || "Draft invoice";
     updateActiveTab({
-      title: `Invoice · ${label}`,
+      title: `Invoice · ${displayIdentity.primary}`,
       subtitle:
         effectiveCustomerInfo?.name?.trim() ||
         effectiveCustomerInfo?.business_name?.trim() ||
@@ -364,12 +370,10 @@ export default function InvoicePreviewPageClient({
     activeInvoiceVersion?.lifecycle_status,
     effectiveCustomerInfo?.business_name,
     effectiveCustomerInfo?.name,
+    displayIdentity.primary,
     reviewLoading,
     reviewOk,
     updateActiveTab,
-    invoiceNumber,
-    workOrderId,
-    workOrderLabel,
   ]);
 
   const effectiveLines = useMemo(() => {
@@ -1035,13 +1039,11 @@ export default function InvoicePreviewPageClient({
             <div className="text-[0.7rem] uppercase tracking-[0.22em] text-[color:var(--theme-text-secondary)]">
               Invoice
               <span className="ml-2 rounded-full border border-[var(--metal-border-soft)] bg-[color:var(--theme-surface-inset)] px-2 py-0.5 text-[0.65rem] text-[color:var(--theme-text-primary)]">
-                {invoiceNumber || "Draft invoice"}
+                {displayIdentity.primary}
               </span>
-              {workOrderLabel ? (
-                <span className="ml-2 text-[0.65rem] normal-case tracking-normal text-[color:var(--theme-text-muted)]">
-                  Work order {workOrderLabel}
-                </span>
-              ) : null}
+              <span className="ml-2 text-[0.65rem] normal-case tracking-normal text-[color:var(--theme-text-muted)]">
+                {displayIdentity.secondary}
+              </span>
             </div>
 
             {loading ? (
@@ -1220,10 +1222,10 @@ export default function InvoicePreviewPageClient({
                   Document
                 </div>
                 <div className="mt-1 text-sm font-semibold text-[color:var(--theme-text-primary)]">
-                  {invoiceNumber || "Draft invoice"}
+                  {displayIdentity.primary}
                 </div>
                 <div className="mt-1 text-xs text-[color:var(--theme-text-secondary)]">
-                  {workOrderLabel ? `Work order ${workOrderLabel}` : "Work order number pending"}
+                  {displayIdentity.secondary}
                   {` · ${formatInvoiceDate(invoiceIssuedAt)}`}
                 </div>
               </div>

--- a/tests/customer-document-consistency.test.ts
+++ b/tests/customer-document-consistency.test.ts
@@ -9,6 +9,9 @@ const migration = read(
 const invoicePreview = read(
   "features/work-orders/components/InvoicePreviewPageClient.tsx",
 );
+const invoiceDisplayIdentity = read(
+  "features/invoices/lib/invoiceDisplayIdentity.ts",
+);
 const portalInvoice = read("app/portal/invoices/[id]/page.tsx");
 const portalInvoiceList = read("app/portal/invoices/page.tsx");
 const billing = read("app/billing/page.tsx");
@@ -67,14 +70,22 @@ describe("customer document consistency", () => {
   });
 
   it("shows customer-facing identity and narratives throughout invoice views", () => {
-    expect(invoicePreview).toContain('{invoiceNumber || "Draft invoice"}');
+    expect(invoiceDisplayIdentity).toContain("workOrderNumber ||");
+    expect(invoiceDisplayIdentity).toContain("`Invoice ${invoiceNumber}`");
+    expect(invoicePreview).toContain("displayIdentity.primary");
+    expect(invoicePreview).toContain("displayIdentity.secondary");
     expect(invoicePreview).toContain('["Complaint", line.complaint]');
     expect(invoicePreview).toContain('["Cause", line.cause]');
     expect(invoicePreview).toContain('["Correction", line.correction]');
     expect(invoicePreview).toContain("inspectionPdfLoading || inspectionPdf");
-    expect(portalInvoice).toContain("identity.invoiceNumber");
+    expect(portalInvoice).toContain("displayIdentity.primary");
+    expect(portalInvoice).toContain("displayIdentity.secondary");
     expect(portalInvoice).toContain("Complaint:");
     expect(portalInvoiceList).toContain("invoiceLabels");
+    expect(portalInvoiceList).toContain("identity.primary");
+    expect(portalInvoiceList).toContain("identity.secondary");
+    expect(billing).toContain("identity.primary");
+    expect(billing).toContain("identity.secondary");
     expect(billing).toContain("resolved_shop_supplies_total");
     expect(billing).toContain("Shop supplies");
     expect(billing).toContain("resolved_tax_total");


### PR DESCRIPTION
## Summary

- Make the work order number the primary user-facing identity on invoice lists, invoice detail, invoice preview, active tabs, and imported billing history.
- Keep the invoice number directly underneath as the secondary document reference.
- Preserve search by both work order number and invoice number, with a readable fallback for historical invoices that are not linked to a work order.

## Scope

- UI and display-contract changes only.
- No database, migration, invoice lifecycle, or numbering logic changes.
- Builds on the work-order-first PO identity delivered in #1394.

## Validation

- Full Vitest suite: 2,036 passed, 2 skipped.
- TypeScript: `tsc --noEmit` passed.
- ESLint passed for all touched files.
- `git diff --check` passed.