### PR TITLE
Keep Fleet relationship invitations in Shop

### DIFF
--- a/app/portal/fleet/drivers/page.tsx
+++ b/app/portal/fleet/drivers/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
 
 import FleetDriversWorkspace from "@/features/fleet/components/FleetDriversWorkspace";
-import FleetPortalAccessManager from "@/features/fleet/components/FleetPortalAccessManager";
 import { resolveFleetActorContext } from "@/features/fleet/lib/resolveFleetActorContext";
 import { getFleetUiContext } from "@/features/fleet/lib/fleetUiCapabilities";
 import { createServerSupabaseRSC } from "@/features/shared/lib/supabase/server";
@@ -12,31 +11,5 @@ export default async function FleetDriversPage() {
   const uiContext = getFleetUiContext(actor);
   if (!uiContext.capabilities.canManageUnits) redirect("/portal/fleet");
 
-  const canInviteDrivers =
-    actor.isInternal &&
-    ["owner", "admin", "manager"].includes(actor.canonicalRole);
-
-  return (
-    <div className="space-y-6">
-      <FleetDriversWorkspace
-        actorLabel={uiContext.actorLabel}
-        canInviteDrivers={canInviteDrivers}
-      />
-      {canInviteDrivers ? (
-        <section id="driver-access" className="scroll-mt-24">
-          <FleetPortalAccessManager
-            embedded
-            routePrefix="/portal/fleet"
-            defaultRole="viewer"
-          />
-        </section>
-      ) : (
-        <section className="rounded-2xl border border-sky-300/20 bg-sky-300/[0.08] p-4 text-sm text-[color:var(--theme-text-secondary)]">
-          Driver invitations are issued by the connected Shop administrator.
-          Fleet managers can assign accepted drivers and manage their Fleet-only
-          role from Fleet Settings.
-        </section>
-      )}
-    </div>
-  );
+  return <FleetDriversWorkspace actorLabel={uiContext.actorLabel} />;
 }

--- a/features/fleet/components/FleetDriversWorkspace.tsx
+++ b/features/fleet/components/FleetDriversWorkspace.tsx
@@ -10,7 +10,6 @@ import {
   Route,
   Search,
   Truck,
-  UserPlus,
   UsersRound,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -72,10 +71,8 @@ function stateLabel(value: string): string {
 
 export default function FleetDriversWorkspace({
   actorLabel,
-  canInviteDrivers,
 }: {
   actorLabel: string;
-  canInviteDrivers: boolean;
 }) {
   const pathname = usePathname() ?? "";
   const internalRoutes = pathname.startsWith("/portal/fleet");
@@ -214,15 +211,6 @@ export default function FleetDriversWorkspace({
               <Route className="h-4 w-4" aria-hidden="true" />
               Assign assets
             </Link>
-            {canInviteDrivers ? (
-              <a
-                href="#driver-access"
-                className="inline-flex min-h-10 items-center gap-2 rounded-xl bg-sky-300 px-3 py-2 text-xs font-semibold text-slate-950"
-              >
-                <UserPlus className="h-4 w-4" aria-hidden="true" />
-                Invite driver
-              </a>
-            ) : null}
           </div>
         </div>
       </header>
@@ -305,8 +293,9 @@ export default function FleetDriversWorkspace({
             <UsersRound className="mx-auto h-7 w-7 text-sky-300" />
             <h2 className="mt-3 font-semibold">No drivers match this view</h2>
             <p className="mt-1 text-sm text-[color:var(--theme-text-secondary)]">
-              Invite a driver, then assign an enrolled asset to activate daily
-              pre-trip tracking.
+              Drivers appear here after their Shop-issued Fleet access is
+              accepted. Manage existing Fleet roles in Fleet Settings, then
+              assign an enrolled asset to activate daily pre-trip tracking.
             </p>
           </div>
         ) : null}

--- a/features/fleet/components/FleetPortalAccessManager.tsx
+++ b/features/fleet/components/FleetPortalAccessManager.tsx
@@ -32,27 +32,15 @@ type InvitePayload = {
 const DEFAULT_CREATE_FLEET_HREF =
   "/fleet/programs?returnTo=%2Ffleet%2Fportal-access";
 
-export default function FleetPortalAccessManager({
-  embedded = false,
-  routePrefix = "/fleet",
-  defaultRole = "viewer",
-}: {
-  embedded?: boolean;
-  routePrefix?: "/fleet" | "/portal/fleet";
-  defaultRole?: InviteRole;
-}) {
+export default function FleetPortalAccessManager() {
   const [fleets, setFleets] = useState<Fleet[]>([]);
   const [invites, setInvites] = useState<Invite[]>([]);
   const [fleetId, setFleetId] = useState("");
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState(defaultRole);
+  const [role, setRole] = useState<InviteRole>("viewer");
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const createFleetHref =
-    routePrefix === "/portal/fleet" ? "/settings" : DEFAULT_CREATE_FLEET_HREF;
-  const manageFleetsHref =
-    routePrefix === "/portal/fleet" ? "/settings" : "/fleet/programs";
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -133,27 +121,19 @@ export default function FleetPortalAccessManager({
   }
 
   return (
-    <div
-      className={
-        embedded
-          ? "w-full space-y-6 text-[color:var(--theme-text-primary)]"
-          : "mx-auto w-full max-w-6xl space-y-6 px-4 py-6 text-[color:var(--theme-text-primary)] xl:px-6"
-      }
-    >
-      {!embedded ? (
-        <header>
-          <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
-            Fleet portal
-          </div>
-          <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">
-            Invite & access
-          </h1>
-          <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
-            Invite fleet managers, approvers, and drivers into the correct
-            fleet-scoped portal.
-          </p>
-        </header>
-      ) : null}
+    <div className="mx-auto w-full max-w-6xl space-y-6 px-4 py-6 text-[color:var(--theme-text-primary)] xl:px-6">
+      <header>
+        <div className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--accent-copper)]">
+          Fleet portal
+        </div>
+        <h1 className="mt-2 text-3xl font-semibold tracking-[-0.035em]">
+          Invite & access
+        </h1>
+        <p className="mt-2 text-sm text-[color:var(--theme-text-secondary)]">
+          Invite fleet managers, approvers, and drivers into the correct
+          fleet-scoped portal.
+        </p>
+      </header>
 
       <div className="grid gap-5 lg:grid-cols-[360px_1fr]">
         <form
@@ -198,7 +178,7 @@ export default function FleetPortalAccessManager({
                 correct units and service records.
               </p>
               <Link
-                href={createFleetHref}
+                href={DEFAULT_CREATE_FLEET_HREF}
                 className="mt-4 inline-flex rounded-xl bg-[var(--accent-copper)] px-4 py-2.5 text-sm font-bold text-[color:var(--theme-text-on-accent)]"
               >
                 Create fleet
@@ -215,7 +195,7 @@ export default function FleetPortalAccessManager({
                     Fleet
                   </label>
                   <Link
-                    href={manageFleetsHref}
+                    href="/fleet/programs"
                     className="text-xs font-semibold text-[var(--accent-copper)] hover:underline"
                   >
                     Manage fleets

--- a/tests/fleet-premier-workspaces.test.ts
+++ b/tests/fleet-premier-workspaces.test.ts
@@ -175,11 +175,14 @@ describe("premier fleet workspaces", () => {
     const economics = source("app/api/fleet/unit-economics/route.ts");
 
     expect(driversPage).toContain("FleetDriversWorkspace");
-    expect(driversPage).toContain("FleetPortalAccessManager");
+    expect(driversPage).not.toContain("FleetPortalAccessManager");
+    expect(driversPage).not.toContain("driver-access");
     expect(driversPage).not.toContain("FleetModuleFoundation");
     expect(drivers).toContain('fetch("/api/fleet/enrollment"');
     expect(drivers).toContain("Drivers & assignments");
-    expect(drivers).toContain("Invite driver");
+    expect(drivers).not.toContain("Invite driver");
+    expect(drivers).toContain("Shop-issued Fleet access");
+    expect(drivers).toContain("Fleet Settings");
     expect(drivers).toContain("/assets/new");
 
     expect(reportsPage).toContain("FleetReportsWorkspace");

--- a/tests/fleet-workspace-ownership.test.ts
+++ b/tests/fleet-workspace-ownership.test.ts
@@ -66,9 +66,18 @@ describe("Fleet workspace ownership", () => {
 
   it("keeps the relationship invitation entry point in Shop", () => {
     const shopInvitePage = read("app/dashboard/owner/fleet-access/page.tsx");
+    const driversPage = read("app/portal/fleet/drivers/page.tsx");
     const settings = read("app/portal/fleet/settings/page.tsx");
+    const shopInvite = read(
+      "features/fleet/components/FleetPortalAccessManager.tsx",
+    );
 
     expect(shopInvitePage).toContain("FleetPortalAccessManager");
+    expect(driversPage).not.toContain("FleetPortalAccessManager");
+    expect(driversPage).not.toContain("driver-access");
     expect(settings).not.toContain("FleetPortalAccessManager");
+    expect(shopInvite).not.toContain("embedded");
+    expect(shopInvite).not.toContain('routePrefix = "/fleet"');
+    expect(shopInvite).not.toContain('routePrefix === "/portal/fleet"');
   });
 });


### PR DESCRIPTION
## Root cause

The Fleet Drivers workspace still embedded the Shop-owned relationship invitation manager for internal Shop actors. That made invitation creation appear to be a Fleet capability and allowed the shared component to render with Fleet-host routing.

## What changed

- removes the invitation manager and “Invite driver” action from Fleet Drivers
- keeps Shop-issued Fleet relationship invitations on the protected Shop access page
- makes the invitation component structurally Shop-only by removing Fleet embedding and route-prefix options
- updates the Fleet Drivers empty state to direct accepted-user role management to Fleet Settings
- adds ownership regression coverage so the Shop invitation surface cannot drift back into Fleet

## Why this is safe

This changes only the presentation and ownership boundary. Existing Shop invite APIs, invitation emails, acceptance flow, and Fleet Settings membership administration remain unchanged.

## Validation

- TypeScript: `tsc --noEmit --pretty false`
- targeted ESLint and Prettier checks
- focused Fleet ownership/workspace tests: 18/18 passed
- full Fleet test suite: 91/91 passed
- full repository test suite: 2,049 passed, 2 skipped
- production Next.js build completed successfully with placeholder build-time credentials

## Database

No schema or migration changes.

## Environment variables

No new or changed environment variables.

## Manual/deployment actions

No special deployment action beyond normal review, merge, and Vercel deployment. After deployment, smoke-test the authenticated Shop invitation page and confirm Fleet Drivers no longer renders invitation controls.

## Remaining risks

An authenticated production visual smoke test was not performed from the local build environment.