### PR TITLE
Certify Fleet-to-Shop handoff and driver progress

### DIFF
--- a/app/api/fleet/driver/dashboard/route.ts
+++ b/app/api/fleet/driver/dashboard/route.ts
@@ -9,6 +9,7 @@ import {
   normalizeFleetPretripTemplateSections,
   type FleetDriverDashboardPayload,
   type FleetDriverIssueStatus,
+  type FleetDriverIssueTimelineStep,
   type FleetPretripTemplate,
 } from "@/features/fleet/types/driverPortal";
 import {
@@ -33,13 +34,23 @@ function joinedRow(value: unknown): Row {
   return value && typeof value === "object" ? (value as Row) : {};
 }
 
-function issueStatus(row: Row): FleetDriverIssueStatus {
+const TERMINAL_SHOP_STATUSES = new Set([
+  "completed",
+  "closed",
+  "invoiced",
+  "paid",
+]);
+
+function issueStatus(row: Row, workOrder: Row): FleetDriverIssueStatus {
   if (text(row.resolved_at)) {
     return text(row.resolution_code) === "completed" || text(row.work_order_id)
       ? "completed"
       : "closed";
   }
-  if (text(row.work_order_id)) return "in_shop";
+  if (TERMINAL_SHOP_STATUSES.has(text(workOrder.status)?.toLowerCase() ?? "")) {
+    return "completed";
+  }
+  if (text(row.work_order_id) || text(workOrder.id)) return "in_shop";
   if (text(row.service_request_id)) return "scheduled";
   if (text(row.acknowledged_at) || text(row.state) === "acknowledged") {
     return "under_review";
@@ -191,6 +202,52 @@ export async function GET(request: Request) {
       );
     }
 
+    const defectRows = rows(defectResult.data);
+    const serviceRequestIds = Array.from(
+      new Set(
+        defectRows
+          .map((row) => text(row.service_request_id))
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+    const serviceRequestResult = serviceRequestIds.length
+      ? await admin
+          .from("fleet_service_requests")
+          .select(
+            "id,submitted_at,created_at,updated_at,scheduled_for_date,work_order_id",
+          )
+          .eq("shop_id", scope.shopId)
+          .eq("fleet_id", fleetId)
+          .in("id", serviceRequestIds)
+      : { data: [] as unknown[], error: null };
+    if (serviceRequestResult.error) {
+      throw new Error(serviceRequestResult.error.message);
+    }
+    const serviceRequestRows = rows(serviceRequestResult.data);
+    const workOrderIds = Array.from(
+      new Set(
+        [
+          ...defectRows.map((row) => text(row.work_order_id)),
+          ...serviceRequestRows.map((row) => text(row.work_order_id)),
+        ].filter((id): id is string => Boolean(id)),
+      ),
+    );
+    const workOrderResult = workOrderIds.length
+      ? await admin
+          .from("work_orders")
+          .select("id,status,created_at,updated_at")
+          .eq("shop_id", scope.shopId)
+          .in("id", workOrderIds)
+      : { data: [] as unknown[], error: null };
+    if (workOrderResult.error) throw new Error(workOrderResult.error.message);
+
+    const serviceRequests = new Map(
+      serviceRequestRows.map((row) => [String(row.id), row]),
+    );
+    const workOrders = new Map(
+      rows(workOrderResult.data).map((row) => [String(row.id), row]),
+    );
+
     const enrollments = rows(enrollmentResult.data);
     const unitLabels = new Map<string, string>();
     const trailerOptions: FleetDriverDashboardPayload["trailers"] = [];
@@ -242,9 +299,41 @@ export async function GET(request: Request) {
       }
     }
 
-    const issues = rows(defectResult.data).map((defect) => {
+    const issues = defectRows.map((defect) => {
       const id = String(defect.id);
       const clarification = clarificationsByDefect.get(id);
+      const serviceRequest = text(defect.service_request_id)
+        ? (serviceRequests.get(String(defect.service_request_id)) ?? {})
+        : {};
+      const linkedWorkOrderId =
+        text(defect.work_order_id) ?? text(serviceRequest.work_order_id);
+      const workOrder = linkedWorkOrderId
+        ? (workOrders.get(linkedWorkOrderId) ?? {})
+        : {};
+      const status = issueStatus(defect, workOrder);
+      const reportedAt = String(defect.reported_at);
+      const acknowledgedAt = text(defect.acknowledged_at);
+      const scheduledAt =
+        text(serviceRequest.submitted_at) ?? text(serviceRequest.created_at);
+      const inShopAt = text(workOrder.created_at);
+      const completedAt =
+        text(defect.resolved_at) ??
+        (TERMINAL_SHOP_STATUSES.has(text(workOrder.status)?.toLowerCase() ?? "")
+          ? text(workOrder.updated_at)
+          : null);
+      const timeline: FleetDriverIssueTimelineStep[] = [
+        { status: "submitted", reachedAt: reportedAt },
+        { status: "under_review", reachedAt: acknowledgedAt },
+        { status: "scheduled", reachedAt: scheduledAt },
+        { status: "in_shop", reachedAt: inShopAt },
+        { status: "completed", reachedAt: completedAt },
+      ];
+      const lastUpdatedAt =
+        completedAt ??
+        text(workOrder.updated_at) ??
+        text(serviceRequest.updated_at) ??
+        acknowledgedAt ??
+        reportedAt;
       return {
         id,
         vehicleId: String(defect.vehicle_id),
@@ -259,12 +348,12 @@ export async function GET(request: Request) {
         ].includes(text(defect.severity) ?? "")
           ? text(defect.severity)
           : "recommend") as FleetDriverDashboardPayload["issues"][number]["severity"],
-        status: issueStatus(defect),
-        reportedAt: String(defect.reported_at),
-        acknowledgedAt: text(defect.acknowledged_at),
+        status,
+        reportedAt,
+        acknowledgedAt,
         resolvedAt: text(defect.resolved_at),
-        serviceRequestId: text(defect.service_request_id),
-        workOrderId: text(defect.work_order_id),
+        lastUpdatedAt,
+        timeline,
         clarification: clarification
           ? {
               id: String(clarification.id),

--- a/app/api/fleet/request-builder/submit/route.ts
+++ b/app/api/fleet/request-builder/submit/route.ts
@@ -79,9 +79,12 @@ export async function POST(req: NextRequest) {
 
   if (error || !data) {
     console.error("[fleet/request-builder/submit] rpc error", error);
+    const replayConflict = /operation key.*different.*payload/i.test(
+      error?.message ?? "",
+    );
     return NextResponse.json(
       { error: error?.message ?? "Failed to create fleet service request." },
-      { status: 500 },
+      { status: replayConflict ? 409 : 500 },
     );
   }
 

--- a/app/api/fleet/service-requests/route.ts
+++ b/app/api/fleet/service-requests/route.ts
@@ -36,6 +36,17 @@ function iso(value: unknown): string | null {
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
+function projectedRequestStatus(requestStatus: unknown, shopStatus: unknown) {
+  const current = clean(requestStatus)?.toLowerCase() ?? "open";
+  const repair = clean(shopStatus)?.toLowerCase() ?? "";
+  if (["completed", "closed", "invoiced", "paid"].includes(repair)) {
+    return "completed";
+  }
+  if (["cancelled", "canceled"].includes(repair)) return "cancelled";
+  if (repair) return "scheduled";
+  return current;
+}
+
 export async function POST(request: Request) {
   try {
     const supabase = createServerSupabaseRoute();
@@ -207,6 +218,7 @@ export async function POST(request: Request) {
       const needsApproval =
         Boolean(clean(workOrder.id)) &&
         (pendingApprovalsByWorkOrder.get(String(workOrder.id)) ?? 0) > 0;
+      const status = projectedRequestStatus(row.status, workOrder.status);
 
       return {
         id: String(row.id),
@@ -229,7 +241,7 @@ export async function POST(request: Request) {
         title: clean(row.title) ?? "Service request",
         summary: clean(row.summary) ?? "",
         severity: clean(row.severity) ?? "recommend",
-        status: clean(row.status)?.toLowerCase() ?? "open",
+        status,
         createdAt: iso(row.created_at) ?? new Date().toISOString(),
         updatedAt: iso(row.updated_at),
         requestedForDate: clean(row.requested_for_date),

--- a/app/portal/fleet/request/build/page.tsx
+++ b/app/portal/fleet/request/build/page.tsx
@@ -158,6 +158,7 @@ export default function FleetRequestBuilderPage() {
   const [lines, setLines] = useState<DraftLine[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const [operationKey] = useState(() => crypto.randomUUID());
 
   useEffect(() => {
     let cancelled = false;
@@ -340,7 +341,10 @@ export default function FleetRequestBuilderPage() {
               : `${unitLabel(selectedUnit)} service request`,
           summary: lines.map((line) => line.description).join("; "),
           requestedForDate: requestedForDate || null,
-          operationKey: crypto.randomUUID(),
+          // Keep this key stable for the life of the draft. If the request is
+          // committed but the browser loses the response, retrying this exact
+          // draft returns the original request instead of creating a second.
+          operationKey,
           lines: lines.map(({ clientId: _clientId, ...line }) => line),
         }),
       });

--- a/features/fleet/components/FleetDriverDashboard.tsx
+++ b/features/fleet/components/FleetDriverDashboard.tsx
@@ -32,18 +32,23 @@ const STATUS_LABELS: Record<FleetDriverIssueStatus, string> = {
   closed: "Closed",
 };
 
-const TIMELINE: FleetDriverIssueStatus[] = [
-  "submitted",
-  "under_review",
-  "scheduled",
-  "in_shop",
-  "completed",
-];
-
 function dateTime(value: string): string {
   const date = new Date(value);
   return Number.isNaN(date.getTime())
     ? value
+    : date.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+}
+
+function timelineTime(value: string | null): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? null
     : date.toLocaleString(undefined, {
         month: "short",
         day: "numeric",
@@ -62,27 +67,38 @@ function DriverIssueTimeline({ issue }: { issue: FleetDriverIssue }) {
     );
   }
 
-  const activeIndex = Math.max(0, TIMELINE.indexOf(issue.status));
+  const activeIndex = Math.max(
+    0,
+    issue.timeline.findIndex((step) => step.status === issue.status),
+  );
   return (
     <ol className="mt-4 grid grid-cols-5 gap-1" aria-label="Issue status">
-      {TIMELINE.map((status, index) => (
-        <li key={status} className="min-w-0 text-center">
-          <div
-            className={`mx-auto h-2.5 w-2.5 rounded-full ${
-              index <= activeIndex ? "bg-sky-400" : "bg-slate-400/25"
-            }`}
-          />
-          <div
-            className={`mt-1 truncate text-[9px] ${
-              index <= activeIndex
-                ? "text-[color:var(--theme-text-secondary)]"
-                : "text-[color:var(--theme-text-muted)]"
-            }`}
-          >
-            {STATUS_LABELS[status]}
-          </div>
-        </li>
-      ))}
+      {issue.timeline.map((step, index) => {
+        const reachedAt = timelineTime(step.reachedAt);
+        return (
+          <li key={step.status} className="min-w-0 text-center">
+            <div
+              className={`mx-auto h-2.5 w-2.5 rounded-full ${
+                index <= activeIndex ? "bg-sky-400" : "bg-slate-400/25"
+              }`}
+            />
+            <div
+              className={`mt-1 truncate text-[9px] ${
+                index <= activeIndex
+                  ? "text-[color:var(--theme-text-secondary)]"
+                  : "text-[color:var(--theme-text-muted)]"
+              }`}
+            >
+              {STATUS_LABELS[step.status]}
+            </div>
+            {reachedAt ? (
+              <div className="mt-0.5 hidden text-[8px] leading-tight text-[color:var(--theme-text-muted)] sm:block">
+                {reachedAt}
+              </div>
+            ) : null}
+          </li>
+        );
+      })}
     </ol>
   );
 }
@@ -454,8 +470,8 @@ export default function FleetDriverDashboard({
                       {issue.unitLabel} · {issue.label}
                     </div>
                     <div className="mt-1 flex items-center gap-1 text-[10px] text-[color:var(--theme-text-muted)]">
-                      <Clock3 className="h-3 w-3" />{" "}
-                      {dateTime(issue.reportedAt)}
+                      <Clock3 className="h-3 w-3" /> Updated{" "}
+                      {dateTime(issue.lastUpdatedAt)}
                     </div>
                   </div>
                   <span className="shrink-0 rounded-full bg-sky-400/10 px-2.5 py-1 text-[9px] font-semibold uppercase text-sky-600 dark:text-sky-200">

--- a/features/fleet/types/driverPortal.ts
+++ b/features/fleet/types/driverPortal.ts
@@ -64,6 +64,16 @@ export type FleetDriverIssueStatus =
   | "completed"
   | "closed";
 
+export type FleetDriverIssueTimelineStatus = Exclude<
+  FleetDriverIssueStatus,
+  "closed"
+>;
+
+export type FleetDriverIssueTimelineStep = {
+  status: FleetDriverIssueTimelineStatus;
+  reachedAt: string | null;
+};
+
 export type FleetDriverIssue = {
   id: string;
   vehicleId: string;
@@ -75,8 +85,8 @@ export type FleetDriverIssue = {
   reportedAt: string;
   acknowledgedAt: string | null;
   resolvedAt: string | null;
-  serviceRequestId: string | null;
-  workOrderId: string | null;
+  lastUpdatedAt: string;
+  timeline: FleetDriverIssueTimelineStep[];
   clarification: FleetDriverClarification | null;
 };
 

--- a/features/shared/types/types/supabase.ts
+++ b/features/shared/types/types/supabase.ts
@@ -5398,6 +5398,7 @@ export type Database = {
           fleet_id: string
           id: string
           operation_key: string | null
+          request_fingerprint: string | null
           requested_for_date: string | null
           scheduled_for_date: string | null
           severity: string
@@ -5418,6 +5419,7 @@ export type Database = {
           fleet_id: string
           id?: string
           operation_key?: string | null
+          request_fingerprint?: string | null
           requested_for_date?: string | null
           scheduled_for_date?: string | null
           severity: string
@@ -5438,6 +5440,7 @@ export type Database = {
           fleet_id?: string
           id?: string
           operation_key?: string | null
+          request_fingerprint?: string | null
           requested_for_date?: string | null
           scheduled_for_date?: string | null
           severity?: string

--- a/supabase/migrations/20260810153000_fleet_handoff_certification.sql
+++ b/supabase/migrations/20260810153000_fleet_handoff_certification.sql
@@ -1,0 +1,327 @@
+-- Certify the Fleet -> Shop handoff for replay safety and Fleet-safe progress.
+--
+-- This migration keeps raw driver findings in Fleet, preserves Shop as the
+-- only work-order creation surface, and makes request retries deterministic.
+
+alter table public.fleet_service_requests
+  add column if not exists request_fingerprint text;
+
+create unique index if not exists work_orders_fleet_service_request_uidx
+  on public.work_orders (source_fleet_service_request_id)
+  where source_fleet_service_request_id is not null;
+
+create or replace function public.create_fleet_service_request_atomic(
+  p_fleet_id uuid,
+  p_vehicle_id uuid,
+  p_title text,
+  p_summary text,
+  p_requested_for_date date,
+  p_lines jsonb,
+  p_operation_key text
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+#variable_conflict use_column
+declare
+  v_user_id uuid := auth.uid();
+  v_shop_id uuid;
+  v_request_id uuid;
+  v_existing_fingerprint text;
+  v_request_fingerprint text;
+  v_line jsonb;
+  v_line_kind text;
+begin
+  if v_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if p_operation_key is null
+     or length(btrim(p_operation_key)) < 8
+     or length(btrim(p_operation_key)) > 200 then
+    raise exception 'A valid operation key is required';
+  end if;
+
+  if jsonb_typeof(p_lines) <> 'array' or jsonb_array_length(p_lines) = 0 then
+    raise exception 'At least one structured request line is required';
+  end if;
+
+  select f.shop_id into v_shop_id
+  from public.fleets f
+  where f.id = p_fleet_id;
+
+  if v_shop_id is null then
+    raise exception 'Fleet not found';
+  end if;
+
+  if not exists (
+    select 1 from public.fleet_vehicles fv
+    where fv.fleet_id = p_fleet_id
+      and fv.vehicle_id = p_vehicle_id
+      and coalesce(fv.active, true)
+  ) then
+    raise exception 'Unit is not active in this fleet';
+  end if;
+
+  if not (
+    exists (
+      select 1 from public.profiles p
+      where p.id = v_user_id
+        and p.shop_id = v_shop_id
+        and p.role in ('owner', 'admin', 'manager')
+    )
+    or exists (
+      select 1 from public.fleet_members m
+      where m.user_id = v_user_id
+        and m.fleet_id = p_fleet_id
+        and m.role in (
+          'owner', 'admin', 'manager', 'fleet_manager', 'dispatcher', 'approver'
+        )
+    )
+  ) then
+    raise exception 'Fleet management access required';
+  end if;
+
+  v_request_fingerprint := md5(
+    jsonb_build_object(
+      'fleetId', p_fleet_id,
+      'vehicleId', p_vehicle_id,
+      'title', left(coalesce(nullif(btrim(p_title), ''), 'Fleet service request'), 160),
+      'summary', left(coalesce(nullif(btrim(p_summary), ''), 'Structured fleet request'), 4000),
+      'requestedForDate', p_requested_for_date,
+      'lines', p_lines
+    )::text
+  );
+
+  -- Serialize all attempts using the same shop-scoped operation key. This
+  -- closes the select-then-insert race as well as the retry-after-commit case.
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      v_shop_id::text || ':' || btrim(p_operation_key),
+      0
+    )
+  );
+
+  select sr.id, sr.request_fingerprint
+    into v_request_id, v_existing_fingerprint
+  from public.fleet_service_requests sr
+  where sr.shop_id = v_shop_id
+    and sr.operation_key = btrim(p_operation_key);
+
+  if v_request_id is not null then
+    if v_existing_fingerprint is null then
+      update public.fleet_service_requests
+      set request_fingerprint = v_request_fingerprint,
+          updated_at = now()
+      where id = v_request_id;
+    elsif v_existing_fingerprint <> v_request_fingerprint then
+      raise exception 'Operation key was already used for a different Fleet request payload';
+    end if;
+    return v_request_id;
+  end if;
+
+  insert into public.fleet_service_requests (
+    shop_id,
+    fleet_id,
+    vehicle_id,
+    title,
+    summary,
+    severity,
+    status,
+    requested_for_date,
+    submitted_at,
+    created_by_profile_id,
+    operation_key,
+    request_fingerprint
+  )
+  values (
+    v_shop_id,
+    p_fleet_id,
+    p_vehicle_id,
+    left(coalesce(nullif(btrim(p_title), ''), 'Fleet service request'), 160),
+    left(coalesce(nullif(btrim(p_summary), ''), 'Structured fleet request'), 4000),
+    'recommend',
+    'open',
+    p_requested_for_date,
+    now(),
+    v_user_id,
+    btrim(p_operation_key),
+    v_request_fingerprint
+  )
+  returning id into v_request_id;
+
+  for v_line in select value from jsonb_array_elements(p_lines)
+  loop
+    v_line_kind := coalesce(v_line ->> 'lineKind', 'custom');
+    if v_line_kind not in (
+      'menu', 'diagnostic', 'inspection', 'pm_package', 'custom'
+    ) then
+      raise exception 'Unsupported request line kind: %', v_line_kind;
+    end if;
+
+    if nullif(v_line ->> 'sourceMenuItemId', '') is not null
+      and not exists (
+        select 1 from public.menu_items mi
+        where mi.id = (v_line ->> 'sourceMenuItemId')::uuid
+          and mi.shop_id = v_shop_id
+          and mi.is_active
+      )
+    then
+      raise exception 'Menu item is not available to this fleet';
+    end if;
+
+    if nullif(v_line ->> 'sourceInspectionTemplateId', '') is not null
+      and not exists (
+        select 1 from public.inspection_templates it
+        where it.id = (v_line ->> 'sourceInspectionTemplateId')::uuid
+          and it.shop_id = v_shop_id
+      )
+    then
+      raise exception 'Inspection template is not available to this fleet';
+    end if;
+
+    if nullif(v_line ->> 'sourceFleetProgramId', '') is not null
+      and not exists (
+        select 1 from public.fleet_programs fp
+        where fp.id = (v_line ->> 'sourceFleetProgramId')::uuid
+          and fp.fleet_id = p_fleet_id
+      )
+    then
+      raise exception 'PM package is not available to this fleet';
+    end if;
+
+    insert into public.fleet_service_request_lines (
+      shop_id,
+      fleet_id,
+      service_request_id,
+      vehicle_id,
+      line_kind,
+      source_menu_item_id,
+      source_inspection_template_id,
+      source_fleet_program_id,
+      description,
+      notes,
+      quantity,
+      requested_labor_hours,
+      unit_price_snapshot,
+      price_status,
+      source_snapshot,
+      created_by
+    )
+    values (
+      v_shop_id,
+      p_fleet_id,
+      v_request_id,
+      p_vehicle_id,
+      v_line_kind,
+      nullif(v_line ->> 'sourceMenuItemId', '')::uuid,
+      nullif(v_line ->> 'sourceInspectionTemplateId', '')::uuid,
+      nullif(v_line ->> 'sourceFleetProgramId', '')::uuid,
+      left(
+        coalesce(nullif(btrim(v_line ->> 'description'), ''), 'Requested service'),
+        1000
+      ),
+      nullif(left(coalesce(v_line ->> 'notes', ''), 4000), ''),
+      greatest(coalesce((v_line ->> 'quantity')::numeric, 1), 0.01),
+      nullif(v_line ->> 'requestedLaborHours', '')::numeric,
+      nullif(v_line ->> 'unitPriceSnapshot', '')::numeric,
+      case
+        when v_line_kind = 'menu'
+          and nullif(v_line ->> 'unitPriceSnapshot', '') is not null
+          then 'priced'
+        else 'advisor_pending'
+      end,
+      coalesce(v_line -> 'sourceSnapshot', '{}'::jsonb),
+      v_user_id
+    );
+  end loop;
+
+  return v_request_id;
+end;
+$function$;
+
+revoke all on function public.create_fleet_service_request_atomic(
+  uuid, uuid, text, text, date, jsonb, text
+) from public, anon;
+grant execute on function public.create_fleet_service_request_atomic(
+  uuid, uuid, text, text, date, jsonb, text
+) to authenticated, service_role;
+
+create or replace function public.sync_fleet_service_request_progress_from_work_order()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $function$
+declare
+  v_request_status text;
+begin
+  if new.source_fleet_service_request_id is null then
+    return new;
+  end if;
+
+  v_request_status := case
+    when lower(coalesce(new.status, '')) in (
+      'completed', 'closed', 'invoiced', 'paid'
+    ) then 'completed'
+    when lower(coalesce(new.status, '')) in ('cancelled', 'canceled')
+      then 'cancelled'
+    else 'scheduled'
+  end;
+
+  update public.fleet_service_requests
+  set work_order_id = new.id,
+      status = v_request_status,
+      scheduled_for_date = coalesce(
+        new.scheduled_at::date,
+        scheduled_for_date
+      ),
+      updated_at = now()
+  where id = new.source_fleet_service_request_id
+    and shop_id = new.shop_id
+    and (
+      work_order_id is distinct from new.id
+      or status is distinct from v_request_status
+      or (
+        new.scheduled_at is not null
+        and scheduled_for_date is distinct from new.scheduled_at::date
+      )
+    );
+
+  return new;
+end;
+$function$;
+
+drop trigger if exists fleet_service_request_work_order_progress
+  on public.work_orders;
+create trigger fleet_service_request_work_order_progress
+after insert or update of status, scheduled_at, source_fleet_service_request_id
+on public.work_orders
+for each row
+execute function public.sync_fleet_service_request_progress_from_work_order();
+
+-- Bring existing linked requests into the same simplified Fleet projection.
+update public.fleet_service_requests sr
+set status = case
+      when lower(coalesce(wo.status, '')) in (
+        'completed', 'closed', 'invoiced', 'paid'
+      ) then 'completed'
+      when lower(coalesce(wo.status, '')) in ('cancelled', 'canceled')
+        then 'cancelled'
+      else 'scheduled'
+    end,
+    scheduled_for_date = coalesce(
+      wo.scheduled_at::date,
+      sr.scheduled_for_date
+    ),
+    updated_at = now()
+from public.work_orders wo
+where wo.id = sr.work_order_id
+  and wo.source_fleet_service_request_id = sr.id;
+
+revoke execute on function public.sync_fleet_service_request_progress_from_work_order()
+  from public, anon, authenticated;
+grant execute on function public.sync_fleet_service_request_progress_from_work_order()
+  to service_role;

--- a/tests/fleet-handoff-certification.test.ts
+++ b/tests/fleet-handoff-certification.test.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) => readFileSync(path, "utf8");
+
+const migration = read(
+  "supabase/migrations/20260810153000_fleet_handoff_certification.sql",
+);
+
+describe("Fleet handoff certification", () => {
+  it("makes Fleet request retries atomic and rejects operation-key drift", () => {
+    expect(migration).toContain("request_fingerprint text");
+    expect(migration).toContain("pg_catalog.pg_advisory_xact_lock");
+    expect(migration).toContain("pg_catalog.hashtextextended");
+    expect(migration).toContain(
+      "Operation key was already used for a different Fleet request payload",
+    );
+
+    const builder = read("app/portal/fleet/request/build/page.tsx");
+    expect(builder).toContain(
+      "const [operationKey] = useState(() => crypto.randomUUID())",
+    );
+    expect(builder).toContain("operationKey,");
+    expect(builder).not.toContain("operationKey: crypto.randomUUID()\n");
+  });
+
+  it("allows only one Shop work order per Fleet request", () => {
+    expect(migration).toContain(
+      "create unique index if not exists work_orders_fleet_service_request_uidx",
+    );
+    expect(migration).toContain("source_fleet_service_request_id is not null");
+
+    const conversion = read(
+      "app/api/fleet/service-requests/convert-to-work-order/route.ts",
+    );
+    expect(conversion).toContain("isFleetProductHostname(requestHost)");
+    expect(conversion).toContain("Work orders are created in ProFixIQ Shop.");
+  });
+
+  it("round-trips a simplified Shop status into Fleet", () => {
+    expect(migration).toContain(
+      "sync_fleet_service_request_progress_from_work_order",
+    );
+    expect(migration).toContain("after insert or update of status");
+    expect(migration).toContain("then 'completed'");
+    expect(migration).toContain("then 'cancelled'");
+    expect(migration).toContain("else 'scheduled'");
+
+    const requestApi = read("app/api/fleet/service-requests/route.ts");
+    expect(requestApi).toContain("function projectedRequestStatus");
+    expect(requestApi).toContain(
+      'if (["completed", "closed", "invoiced", "paid"].includes(repair))',
+    );
+  });
+
+  it("gives drivers a timestamped status timeline without Shop identifiers", () => {
+    const driverApi = read("app/api/fleet/driver/dashboard/route.ts");
+    const dashboard = read(
+      "features/fleet/components/FleetDriverDashboard.tsx",
+    );
+    const types = read("features/fleet/types/driverPortal.ts");
+
+    expect(driverApi).toContain('.select("id,status,created_at,updated_at")');
+    expect(driverApi).toContain("const timeline:");
+    expect(driverApi).toContain(
+      '{ status: "submitted", reachedAt: reportedAt }',
+    );
+    expect(driverApi).not.toContain("workOrderId: text(defect.work_order_id)");
+    expect(driverApi).not.toContain(
+      "serviceRequestId: text(defect.service_request_id)",
+    );
+    expect(types).not.toContain("workOrderId: string | null");
+    expect(types).not.toContain("serviceRequestId: string | null");
+    expect(dashboard).toContain("issue.timeline.map");
+    expect(dashboard).toContain("{dateTime(issue.lastUpdatedAt)}");
+    expect(dashboard.toLowerCase()).not.toContain("work order");
+  });
+});


### PR DESCRIPTION
### Root cause

The Fleet-to-Shop boundary was functionally separated, but the last handoff guarantees were incomplete:

- the manager request builder generated a new operation key on every submit, so a retry after a committed request could create a duplicate;
- an existing operation key was not bound to its original payload;
- the database did not enforce one Shop work order per Fleet service request;
- Fleet request completion could remain stale after Shop work changed state;
- the driver dashboard exposed internal link identifiers in its payload and showed a generic timeline without real transition times.

### What changed

- keeps one stable operation key for the life of a Fleet request draft;
- fingerprints the normalized request payload, serializes same-key attempts with a transaction advisory lock, returns the original request for an exact retry, and rejects key reuse with a different payload;
- adds a partial unique index proving one Shop work order per Fleet service request;
- syncs linked Shop work into the Fleet-safe `scheduled`, `completed`, or `cancelled` projection and backfills existing linked requests;
- projects only safe Shop progress fields into the driver API;
- removes service-request and work-order identifiers from the driver payload;
- gives drivers timestamped Submitted → Under review → Scheduled → In Shop → Completed progress;
- adds focused regression coverage for replay, conversion uniqueness, status round-trip, hostname containment, and driver data isolation.

### Why this is safe

Work-order creation remains inside the guarded ProFixIQ Shop inbox. Fleet-host conversion attempts are still rejected. The conversion RPC still locks the request row, and the new unique index adds a second database-level duplicate barrier. The migration is additive except for replacing the existing request-creation function with the same signature and stricter replay behavior.

Drivers receive only status and timestamps—not Shop notes, parts, labor, estimates, invoices, work-order references, or work-order IDs.

### Files changed

- Fleet driver dashboard API, types, and UI
- Fleet service-request status API
- Fleet request-builder submit API and client
- one additive Supabase migration
- one Fleet handoff regression test file

### Validation

- TypeScript: passed
- ESLint on all touched TypeScript/TSX files: passed
- focused Fleet tests: 13/13 passed
- full test suite: 2,081 passed; 2 intentionally skipped database integration tests
- production build: passed; all 435 routes generated
- `git diff --check`: passed

The production build reported only pre-existing repository warnings outside this change.

### Database

Adds migration `20260810153000_fleet_handoff_certification.sql`.

It adds:

- `fleet_service_requests.request_fingerprint`;
- a unique partial index on `work_orders.source_fleet_service_request_id`;
- replay-safe request creation using an advisory transaction lock and payload fingerprint;
- a Shop-work-to-Fleet-progress trigger;
- a one-time status backfill for existing linked requests.

The production database has not been changed.

### Environment variables

None.

### Manual/deployment actions

After approval and merge:

1. Apply `20260810153000_fleet_handoff_certification.sql` through the normal Supabase production migration process.
2. Confirm the Vercel deployment is using `fleet.profixiq.com`.
3. Desktop manager test: open Requests, build and submit a request, then confirm it appears once.
4. Desktop driver test: submit a failed pre-trip and confirm the issue shows Submitted.
5. Desktop dispatcher test: acknowledge it, request one clarification, then schedule or escalate it.
6. Driver test: answer the clarification and confirm the timeline moves to Under review/Scheduled.
7. Shop test at the ProFixIQ Shop host: open Fleet Requests, accept the request once, and confirm a second acceptance returns the existing work order.
8. Complete the Shop work and confirm Fleet and Driver show Completed without exposing Shop-only repair notes.

### Remaining risks or unverified assumptions

- The migration has not been applied to production. If historical data already contains multiple work orders with the same non-null Fleet service-request source, the unique-index statement will stop the migration and surface that data issue instead of silently choosing a record.
- Authenticated production role switching could not be browser-tested from this isolated workspace; the role routes, API guards, full regression suite, and production build were validated locally.
