### PR TITLE
Cancel domain CI when PR returns to draft

### DIFF
--- a/.github/workflows/mobile-command-validation.yml
+++ b/.github/workflows/mobile-command-validation.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - ui/mobile-command-refactor
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "app/mobile/**"
       - "components/layout/MobileBottomNav.tsx"

--- a/.github/workflows/mobile-dispatch-validation.yml
+++ b/.github/workflows/mobile-dispatch-validation.yml
@@ -2,7 +2,7 @@ name: Mobile Dispatch Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     branches:
       - main
 

--- a/.github/workflows/operational-observability-clean-replay-validation.yml
+++ b/.github/workflows/operational-observability-clean-replay-validation.yml
@@ -2,7 +2,7 @@ name: Operational Observability Clean Replay
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "features/shared/types/types/supabase.ts"
       - "supabase/migrations/20260802101400_ai_operating_intelligence_substrate_reconciliation.sql"

--- a/.github/workflows/operational-observability-validation.yml
+++ b/.github/workflows/operational-observability-validation.yml
@@ -2,7 +2,7 @@ name: Operational Observability Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "app/api/dashboard/operational-observability/**"
       - "app/api/internal/observability/**"

--- a/.github/workflows/p0-004-vehicle-recall-validation.yml
+++ b/.github/workflows/p0-004-vehicle-recall-validation.yml
@@ -2,7 +2,7 @@ name: P0-004 Vehicle Recall Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "app/api/recalls/fetch/**"
       - "app/vehicle/VinCaptureModal.tsx"

--- a/.github/workflows/p0-005-ai-route-validation.yml
+++ b/.github/workflows/p0-005-ai-route-validation.yml
@@ -2,7 +2,7 @@ name: P0-005 AI Route Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "app/api/ai/interpret/**"
       - "app/api/dtc-suggest/**"

--- a/.github/workflows/p0-007-financial-outbox-validation.yml
+++ b/.github/workflows/p0-007-financial-outbox-validation.yml
@@ -2,7 +2,7 @@ name: P0-007 Financial Outbox Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "app/api/internal/financial-outbox/**"
       - "app/api/webhooks/sendgrid/**"

--- a/.github/workflows/p1-012-stripe-webhook-validation.yml
+++ b/.github/workflows/p1-012-stripe-webhook-validation.yml
@@ -2,7 +2,7 @@ name: P1-012 Stripe Webhook Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "app/api/stripe/webhook/**"
       - "app/api/stripe/checkout/webhook/**"

--- a/.github/workflows/phase-6-technician-mobile-reliability.yml
+++ b/.github/workflows/phase-6-technician-mobile-reliability.yml
@@ -2,7 +2,7 @@ name: Phase 6 Technician Mobile Reliability
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     paths:
       - "features/shared/lib/offline/**"
       - "features/work-orders/lib/jobPunchTransitionsClient.ts"

--- a/.github/workflows/universal-scheduler-validation.yml
+++ b/.github/workflows/universal-scheduler-validation.yml
@@ -2,7 +2,7 @@ name: Universal Scheduler Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     branches:
       - main
 


### PR DESCRIPTION
## Summary

Follow-up to #1405 Codex review.

Adds `converted_to_draft` to the pull-request event list for the 10 expensive domain workflows that already skip while a PR is draft.

This means a Ready PR with domain validation still running can be converted back to Draft and GitHub immediately starts a skipped generation in the same concurrency group, cancelling the obsolete in-flight work instead of letting it consume the full job budget.

No application code, database schema, migrations, tests, or runtime business logic changes.